### PR TITLE
Add instant validation tests for parallel slot config attribution and detect incompatible configs at runtime

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1140,5 +1140,8 @@
   "1139": "`unstable_catchError` can only be used in Client Components.",
   "1140": "Route %s used \\`import('next/root-params').%s()\\` inside \\`\"use cache\"\\` nested within \\`unstable_cache\\`. Root params are not available in this context.",
   "1141": "Route %s used \\`import('next/root-params').%s()\\` inside \\`unstable_cache\\`. This is not supported. Use \\`\"use cache\"\\` instead.",
-  "1142": "Route %s used \\`import('next/root-params').%s()\\` inside \\`generateStaticParams\\`, but the \\`%s\\` parameter was not provided by a parent \\`generateStaticParams\\`. In \\`generateStaticParams\\`, root params are only available for segments nested below the segment that provides them."
+  "1142": "Route %s used \\`import('next/root-params').%s()\\` inside \\`generateStaticParams\\`, but the \\`%s\\` parameter was not provided by a parent \\`generateStaticParams\\`. In \\`generateStaticParams\\`, root params are only available for segments nested below the segment that provides them.",
+  "1143": "Route \"%s/\": Incompatible \\`unstable_instant\\` configurations. %s has \\`unstable_instant = false\\` which expects blocking navigations, while %s has an \\`unstable_instant\\` config which expects instant navigations.",
+  "1144": "Route \"%s/\": The other conflicting \\`unstable_instant\\` configuration is defined here.",
+  "1145": "Route \"%s/\": Incompatible \\`unstable_instant\\` configurations. %s has \\`unstable_instant = false\\` which expects blocking navigations, while %s has an \\`unstable_instant\\` config which expects instant navigations.\\n\\nTo see the exact locations of the conflicting configurations, try one of the following:\\n  - Start the app in development mode by running \\`next dev\\`, then open \"%s/\" in your browser to investigate the error.\\n  - Rerun the production build with \\`next build --debug-prerender\\` to generate better stack traces."
 }

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -4731,20 +4731,30 @@ async function validateInstantConfigs(
       }
     }
 
-    const payloadResult = await createCombinedPayloadAtDepth(
-      initialRscPayload,
-      cache,
-      loaderTree,
-      ctx.getDynamicParamFromSegment,
-      ctx.query,
-      depth,
-      groupDepthForValidation,
-      extraChunksController.signal,
-      boundaryState,
-      clientReferenceManifest,
-      stageEndTimes,
-      useRuntimeStageForPartialSegments
-    )
+    let payloadResult: Awaited<ReturnType<typeof createCombinedPayloadAtDepth>>
+    try {
+      payloadResult = await createCombinedPayloadAtDepth(
+        initialRscPayload,
+        cache,
+        loaderTree,
+        ctx.getDynamicParamFromSegment,
+        ctx.query,
+        depth,
+        groupDepthForValidation,
+        extraChunksController.signal,
+        boundaryState,
+        clientReferenceManifest,
+        stageEndTimes,
+        useRuntimeStageForPartialSegments
+      )
+    } catch (err) {
+      // Incompatible config errors (e.g. false + instant on sibling slots)
+      // are thrown during tree construction. Surface them as validation errors.
+      if (err instanceof AggregateError) {
+        return err.errors
+      }
+      return [err]
+    }
 
     if (payloadResult === null) {
       return null

--- a/packages/next/src/server/app-render/instant-validation/instant-validation.tsx
+++ b/packages/next/src/server/app-render/instant-validation/instant-validation.tsx
@@ -759,10 +759,19 @@ type SegmentCacheItem = {
   debugChunks: Uint8Array[] | null
 }
 
+const enum InstantExpectation {
+  /** No unstable_instant config in this subtree. */
+  None = 0,
+  /** unstable_instant = { prefetch: ... } — expects instant navigations. */
+  Instant = 1,
+  /** unstable_instant = false — expects blocking navigations. */
+  Blocking = 2,
+}
+
 type TreeResult = {
   seedData: CacheNodeSeedData
-  requiresInstantUI: boolean
-  createInstantStack: (() => Error) | null
+  expectation: InstantExpectation
+  createConfigStack: (() => Error) | null
   /** How deep in the tree the config was found. Higher = more specific.
    * Used to prefer deeper configs over shallower ones when multiple
    * slots have configs. */
@@ -938,7 +947,11 @@ export async function createCombinedPayloadAtDepth(
       if (slotSeedData === null) continue
       const result = results.get(key)
       const markerIndex = slotStacks.length
-      slotStacks.push(result?.createInstantStack ?? null)
+      slotStacks.push(
+        result?.expectation === InstantExpectation.Instant
+          ? result.createConfigStack
+          : null
+      )
       const markerName = `${INSTANT_SLOT_MARKER_PREFIX}${markerIndex - 1}${INSTANT_SLOT_MARKER_SUFFIX}`
       const [node, parallelRoutesData, unused, isPartial, varyParams] =
         slotSeedData
@@ -952,6 +965,83 @@ export async function createCombinedPayloadAtDepth(
         isPartial,
         varyParams,
       ]
+    }
+  }
+
+  /**
+   * After collecting results from all parallel slots at a fork point,
+   * check if any slot has `unstable_instant = false` while a sibling
+   * has a non-false config. This is an incompatible configuration —
+   * one slot says the navigation should block while the other requires
+   * it to be instant.
+   */
+  function throwIfIncompatibleConfigs(
+    slotResults: Map<string, TreeResult>,
+    path: SegmentPath
+  ): void {
+    if (slotResults.size <= 1) return
+
+    let hasBlocking = false
+    let hasInstant = false
+    let blockingKey: string | null = null
+    let instantKey: string | null = null
+    let blockingStack: (() => Error) | null = null
+    let instantStack: (() => Error) | null = null
+
+    for (const [key, result] of slotResults) {
+      if (result.expectation === InstantExpectation.Blocking) {
+        hasBlocking = true
+        blockingKey = key
+        blockingStack = result.createConfigStack
+      }
+      if (result.expectation === InstantExpectation.Instant) {
+        hasInstant = true
+        instantKey = key
+        instantStack = result.createConfigStack
+      }
+    }
+
+    if (hasBlocking && hasInstant) {
+      const blockingDesc =
+        blockingKey === 'children'
+          ? 'This route'
+          : `Parallel route "@${blockingKey}"`
+      const instantDesc =
+        instantKey === 'children'
+          ? 'this route'
+          : `parallel route "@${instantKey}"`
+      const message =
+        `Route "${path || '/'}": Incompatible \`unstable_instant\` configurations. ` +
+        `${blockingDesc} has \`unstable_instant = false\` which expects blocking navigations, ` +
+        `while ${instantDesc} has an \`unstable_instant\` config which expects instant navigations.`
+      if (process.env.NODE_ENV === 'development') {
+        // In dev or --debug-prerender, throw two errors so both config
+        // locations get codeframes in the error overlay / CLI output.
+        // TODO: Switch to AggregateError when the CLI output and dev
+        // error overlay support rendering them nicely.
+        const blockingError = new Error(message)
+        if (blockingStack) {
+          blockingError.cause = blockingStack()
+        }
+        const instantError = new Error(
+          `Route "${path || '/'}": The other conflicting \`unstable_instant\` configuration is defined here.`
+        )
+        if (instantStack) {
+          instantError.cause = instantStack()
+        }
+        throw new AggregateError([blockingError, instantError])
+      } else {
+        // In production builds without --debug-prerender, source maps
+        // are unavailable so codeframes won't be useful. Throw a single
+        // error with guidance on how to get better diagnostics.
+        const error = new Error(
+          message +
+            `\n\nTo see the exact locations of the conflicting configurations, try one of the following:` +
+            `\n  - Start the app in development mode by running \`next dev\`, then open "${path || '/'}" in your browser to investigate the error.` +
+            `\n  - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.`
+        )
+        throw error
+      }
     }
   }
 
@@ -1034,8 +1124,8 @@ export async function createCombinedPayloadAtDepth(
 
       const slots: CacheNodeSeedDataSlots = {}
       const slotResults = new Map<string, TreeResult>()
-      let requiresInstantUI = false
-      let createInstantStack: (() => Error) | null = null
+      let expectation = InstantExpectation.None
+      let createConfigStack: (() => Error) | null = null
       let bestConfigDepth = -1
 
       for (const parallelRouteKey in parallelRoutes) {
@@ -1048,25 +1138,33 @@ export async function createCombinedPayloadAtDepth(
         )
         slotResults.set(parallelRouteKey, result)
         slots[parallelRouteKey] = result.seedData
-        if (result.requiresInstantUI) {
-          requiresInstantUI = true
+        if (result.expectation === InstantExpectation.Instant) {
+          expectation = InstantExpectation.Instant
           if (
             result.configDepth > bestConfigDepth ||
             (result.configDepth === bestConfigDepth &&
               parallelRouteKey === 'children')
           ) {
             bestConfigDepth = result.configDepth
-            createInstantStack = result.createInstantStack
+            createConfigStack = result.createConfigStack
           }
+        }
+        if (
+          result.expectation === InstantExpectation.Blocking &&
+          expectation !== InstantExpectation.Instant
+        ) {
+          expectation = InstantExpectation.Blocking
+          createConfigStack = result.createConfigStack
         }
       }
 
+      throwIfIncompatibleConfigs(slotResults, path)
       wrapSlotsWithMarkers(slots, slotResults)
 
       return {
         seedData: getCacheNodeSeedDataFromSegment(finalSegmentData, slots),
-        requiresInstantUI,
-        createInstantStack,
+        expectation,
+        createConfigStack,
         configDepth: bestConfigDepth,
       }
     }
@@ -1074,8 +1172,8 @@ export async function createCombinedPayloadAtDepth(
     // Not at the boundary yet — keep walking as shared.
     const slots: CacheNodeSeedDataSlots = {}
     const slotResults = new Map<string, TreeResult>()
-    let requiresInstantUI = false
-    let createInstantStack: (() => Error) | null = null
+    let expectation = InstantExpectation.None
+    let createConfigStack: (() => Error) | null = null
     let bestConfigDepth = -1
     for (const parallelRouteKey in parallelRoutes) {
       const result = await buildSharedTreeSeedData(
@@ -1087,25 +1185,33 @@ export async function createCombinedPayloadAtDepth(
       )
       slotResults.set(parallelRouteKey, result)
       slots[parallelRouteKey] = result.seedData
-      if (result.requiresInstantUI) {
-        requiresInstantUI = true
+      if (result.expectation === InstantExpectation.Instant) {
+        expectation = InstantExpectation.Instant
         if (
           result.configDepth > bestConfigDepth ||
           (result.configDepth === bestConfigDepth &&
             parallelRouteKey === 'children')
         ) {
           bestConfigDepth = result.configDepth
-          createInstantStack = result.createInstantStack
+          createConfigStack = result.createConfigStack
         }
+      }
+      if (
+        result.expectation === InstantExpectation.Blocking &&
+        expectation !== InstantExpectation.Instant
+      ) {
+        expectation = InstantExpectation.Blocking
+        createConfigStack = result.createConfigStack
       }
     }
 
+    throwIfIncompatibleConfigs(slotResults, path)
     wrapSlotsWithMarkers(slots, slotResults)
 
     return {
       seedData: getCacheNodeSeedDataFromSegment(segmentData, slots),
-      requiresInstantUI,
-      createInstantStack,
+      expectation,
+      createConfigStack,
       configDepth: bestConfigDepth,
     }
   }
@@ -1131,7 +1237,7 @@ export async function createCombinedPayloadAtDepth(
     if (layoutOrPageMod !== undefined) {
       instantConfig =
         (layoutOrPageMod as AppSegmentConfig).unstable_instant ?? null
-      if (instantConfig && typeof instantConfig === 'object') {
+      if (instantConfig !== null) {
         const rawFactory: unknown = (layoutOrPageMod as any)
           .__debugCreateInstantConfigStack
         localCreateInstantStack =
@@ -1179,11 +1285,11 @@ export async function createCombinedPayloadAtDepth(
       { startTime: undefined, endTime: stageEndTimes[stage] }
     )
 
-    // Build children first, then determine requiresInstantUI.
+    // Build children first, then determine expectation.
     const slots: CacheNodeSeedDataSlots = {}
     const slotResults = new Map<string, TreeResult>()
-    let childrenRequireInstantUI = false
-    let childCreateInstantStack: (() => Error) | null = null
+    let childExpectation = InstantExpectation.None
+    let childCreateConfigStack: (() => Error) | null = null
     let bestChildConfigDepth = -1
     for (const parallelRouteKey in parallelRoutes) {
       const childSegmentDepth = segmentConsumesURLDepth(segment)
@@ -1198,48 +1304,56 @@ export async function createCombinedPayloadAtDepth(
       )
       slotResults.set(parallelRouteKey, result)
       slots[parallelRouteKey] = result.seedData
-      if (result.requiresInstantUI) {
-        childrenRequireInstantUI = true
+      if (result.expectation === InstantExpectation.Instant) {
+        childExpectation = InstantExpectation.Instant
         if (
           result.configDepth > bestChildConfigDepth ||
           (result.configDepth === bestChildConfigDepth &&
             parallelRouteKey === 'children')
         ) {
           bestChildConfigDepth = result.configDepth
-          childCreateInstantStack = result.createInstantStack
+          childCreateConfigStack = result.createConfigStack
         }
+      }
+      if (
+        result.expectation === InstantExpectation.Blocking &&
+        childExpectation !== InstantExpectation.Instant
+      ) {
+        childExpectation = InstantExpectation.Blocking
+        childCreateConfigStack = result.createConfigStack
       }
     }
 
+    throwIfIncompatibleConfigs(slotResults, path)
     wrapSlotsWithMarkers(slots, slotResults)
 
     // Local config takes precedence over children.
-    let requiresInstantUI: boolean
-    let createInstantStack: (() => Error) | null
+    let expectation: InstantExpectation
+    let createConfigStack: (() => Error) | null
     let configDepth: number
     if (instantConfig === false) {
-      requiresInstantUI = false
-      createInstantStack = null
+      expectation = InstantExpectation.Blocking
+      createConfigStack = localCreateInstantStack
       configDepth = -1
     } else if (instantConfig && typeof instantConfig === 'object') {
-      requiresInstantUI = true
-      createInstantStack = localCreateInstantStack
+      expectation = InstantExpectation.Instant
+      createConfigStack = localCreateInstantStack
       configDepth = segmentDepth
     } else {
-      requiresInstantUI = childrenRequireInstantUI
-      createInstantStack = childCreateInstantStack
+      expectation = childExpectation
+      createConfigStack = childCreateConfigStack
       configDepth = bestChildConfigDepth
     }
 
     return {
       seedData: getCacheNodeSeedDataFromSegment(segmentData, slots),
-      requiresInstantUI,
-      createInstantStack,
+      expectation,
+      createConfigStack,
       configDepth,
     }
   }
 
-  const { seedData, requiresInstantUI, createInstantStack } =
+  const { seedData, expectation, createConfigStack } =
     await buildSharedTreeSeedData(
       initialLoaderTree,
       null /* parentPath */,
@@ -1248,13 +1362,13 @@ export async function createCombinedPayloadAtDepth(
       0 /* groupDepthConsumed */
     )
 
-  if (!requiresInstantUI) {
+  if (expectation !== InstantExpectation.Instant) {
     return null
   }
 
   // Set the root config at index 0. This is the fallback for errors
   // that occur above any fork (no slot marker in the component stack).
-  slotStacks[0] = createInstantStack
+  slotStacks[0] = createConfigStack
 
   const { flightRouterState } = getRootDataFromPayload(initialRSCPayload)
 

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/page.tsx
@@ -165,6 +165,12 @@ export default async function Page() {
         <li>
           <DebugLinks href="/suspense-in-root/parallel/slot-config-children-suspended" />
         </li>
+        <li>
+          <DebugLinks href="/suspense-in-root/parallel/false-conflict" />
+        </li>
+        <li>
+          <DebugLinks href="/suspense-in-root/parallel/false-conflict-deep/inner" />
+        </li>
       </ul>
 
       <h2>Head</h2>

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/false-conflict-deep/@slot/default.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/false-conflict-deep/@slot/default.tsx
@@ -1,0 +1,3 @@
+export default function SlotDefault() {
+  return <p>Slot default</p>
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/false-conflict-deep/@slot/inner/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/false-conflict-deep/@slot/inner/page.tsx
@@ -1,0 +1,12 @@
+import { cookies } from 'next/headers'
+
+export const unstable_instant = false
+
+export default async function SlotInnerPage() {
+  await cookies()
+  return (
+    <p style={{ color: 'blue' }}>
+      Slot inner page with unstable_instant = false, allowed to block
+    </p>
+  )
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/false-conflict-deep/inner/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/false-conflict-deep/inner/page.tsx
@@ -1,0 +1,9 @@
+export const unstable_instant = { prefetch: 'static' }
+
+export default function InnerPage() {
+  return (
+    <main>
+      <p>Children inner page with unstable_instant (static)</p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/false-conflict-deep/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/false-conflict-deep/layout.tsx
@@ -1,0 +1,16 @@
+import { ReactNode } from 'react'
+
+export default function Layout({
+  children,
+  slot,
+}: {
+  children: ReactNode
+  slot: ReactNode
+}) {
+  return (
+    <>
+      <div style={{ border: '1px solid blue', padding: '1em' }}>{slot}</div>
+      {children}
+    </>
+  )
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/false-conflict-deep/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/false-conflict-deep/page.tsx
@@ -1,0 +1,7 @@
+export default function Page() {
+  return (
+    <main>
+      <p>Index page for deep false conflict test</p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/false-conflict/@slot/default.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/false-conflict/@slot/default.tsx
@@ -1,0 +1,3 @@
+export default function SlotDefault() {
+  return <p>Slot default</p>
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/false-conflict/@slot/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/false-conflict/@slot/page.tsx
@@ -1,0 +1,9 @@
+export const unstable_instant = { prefetch: 'static' }
+
+export default function SlotPage() {
+  return (
+    <p style={{ color: 'blue' }}>
+      This is a parallel slot page with unstable_instant (static)
+    </p>
+  )
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/false-conflict/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/false-conflict/layout.tsx
@@ -1,0 +1,16 @@
+import { ReactNode } from 'react'
+
+export default function Layout({
+  children,
+  slot,
+}: {
+  children: ReactNode
+  slot: ReactNode
+}) {
+  return (
+    <>
+      <div style={{ border: '1px solid blue', padding: '1em' }}>{slot}</div>
+      {children}
+    </>
+  )
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/false-conflict/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/false-conflict/page.tsx
@@ -1,0 +1,15 @@
+import { cookies } from 'next/headers'
+
+export const unstable_instant = false
+
+export default async function ChildrenPage() {
+  await cookies()
+  return (
+    <main>
+      <p>
+        This is the children page with unstable_instant = false, allowing it to
+        block
+      </p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/instant-validation/instant-validation-parallel-slots.test.ts
+++ b/test/e2e/app-dir/instant-validation/instant-validation-parallel-slots.test.ts
@@ -464,6 +464,151 @@ describe('instant validation - parallel slot configs', () => {
       })
     })
 
+    describe('incompatible configs', () => {
+      it('errors when one slot has false and sibling has instant config', async () => {
+        if (isNextDev) {
+          const browser = await navigateTo(
+            '/suspense-in-root/parallel/false-conflict'
+          )
+          await expect(browser).toDisplayCollapsedRedbox(`
+           [
+             {
+               "cause": [
+                 {
+                   "label": "Caused by: Instant Validation",
+                   "source": "app/suspense-in-root/parallel/false-conflict/page.tsx (3:33) @ unstable_instant
+           > 3 | export const unstable_instant = false
+               |                                 ^",
+                   "stack": [
+                     "unstable_instant app/suspense-in-root/parallel/false-conflict/page.tsx (3:33)",
+                   ],
+                 },
+               ],
+               "code": "E1143",
+               "description": "Route "/suspense-in-root/parallel/false-conflict": Incompatible \`unstable_instant\` configurations. This route has \`unstable_instant = false\` which expects blocking navigations, while parallel route "@slot" has an \`unstable_instant\` config which expects instant navigations.",
+               "environmentLabel": "Server",
+               "label": "Console Error",
+               "source": "app/suspense-in-root/parallel/false-conflict/page.tsx (3:33) @ unstable_instant
+           > 3 | export const unstable_instant = false
+               |                                 ^",
+               "stack": [],
+             },
+             {
+               "cause": [
+                 {
+                   "label": "Caused by: Instant Validation",
+                   "source": "app/suspense-in-root/parallel/false-conflict/@slot/page.tsx (1:33) @ unstable_instant
+           > 1 | export const unstable_instant = { prefetch: 'static' }
+               |                                 ^",
+                   "stack": [
+                     "unstable_instant app/suspense-in-root/parallel/false-conflict/@slot/page.tsx (1:33)",
+                   ],
+                 },
+               ],
+               "code": "E1144",
+               "description": "Route "/suspense-in-root/parallel/false-conflict": The other conflicting \`unstable_instant\` configuration is defined here.",
+               "environmentLabel": "Server",
+               "label": "Console Error",
+               "source": "app/suspense-in-root/parallel/false-conflict/@slot/page.tsx (1:33) @ unstable_instant
+           > 1 | export const unstable_instant = { prefetch: 'static' }
+               |                                 ^",
+               "stack": [],
+             },
+           ]
+          `)
+        } else {
+          const result = await prerender(
+            '/suspense-in-root/parallel/false-conflict'
+          )
+          expect(extractBuildValidationError(result.cliOutput))
+            .toMatchInlineSnapshot(`
+           "Error: Route "/suspense-in-root/parallel/false-conflict": Incompatible \`unstable_instant\` configurations. This route has \`unstable_instant = false\` which expects blocking navigations, while parallel route "@slot" has an \`unstable_instant\` config which expects instant navigations.
+
+           To see the exact locations of the conflicting configurations, try one of the following:
+             - Start the app in development mode by running \`next dev\`, then open "/suspense-in-root/parallel/false-conflict" in your browser to investigate the error.
+             - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+               at ignore-listed frames
+           Build-time instant validation failed for route "/suspense-in-root/parallel/false-conflict".
+           Stopping prerender due to instant validation errors."
+          `)
+          expect(result.exitCode).toBe(1)
+        }
+      })
+
+      it('errors when configs conflict across deeper independent paths', async () => {
+        // children/inner has instant static, @slot/inner has instant false.
+        // Even though the configs are at different paths, without Suspense
+        // between the slots a suspending slot blocks the sibling.
+        if (isNextDev) {
+          const browser = await navigateTo(
+            '/suspense-in-root/parallel/false-conflict-deep/inner'
+          )
+          await expect(browser).toDisplayCollapsedRedbox(`
+           [
+             {
+               "cause": [
+                 {
+                   "label": "Caused by: Instant Validation",
+                   "source": "app/suspense-in-root/parallel/false-conflict-deep/@slot/inner/page.tsx (3:33) @ unstable_instant
+           > 3 | export const unstable_instant = false
+               |                                 ^",
+                   "stack": [
+                     "unstable_instant app/suspense-in-root/parallel/false-conflict-deep/@slot/inner/page.tsx (3:33)",
+                   ],
+                 },
+               ],
+               "code": "E1143",
+               "description": "Route "/suspense-in-root/parallel/false-conflict-deep": Incompatible \`unstable_instant\` configurations. Parallel route "@slot" has \`unstable_instant = false\` which expects blocking navigations, while this route has an \`unstable_instant\` config which expects instant navigations.",
+               "environmentLabel": "Server",
+               "label": "Console Error",
+               "source": "app/suspense-in-root/parallel/false-conflict-deep/@slot/inner/page.tsx (3:33) @ unstable_instant
+           > 3 | export const unstable_instant = false
+               |                                 ^",
+               "stack": [],
+             },
+             {
+               "cause": [
+                 {
+                   "label": "Caused by: Instant Validation",
+                   "source": "app/suspense-in-root/parallel/false-conflict-deep/inner/page.tsx (1:33) @ unstable_instant
+           > 1 | export const unstable_instant = { prefetch: 'static' }
+               |                                 ^",
+                   "stack": [
+                     "unstable_instant app/suspense-in-root/parallel/false-conflict-deep/inner/page.tsx (1:33)",
+                   ],
+                 },
+               ],
+               "code": "E1144",
+               "description": "Route "/suspense-in-root/parallel/false-conflict-deep": The other conflicting \`unstable_instant\` configuration is defined here.",
+               "environmentLabel": "Server",
+               "label": "Console Error",
+               "source": "app/suspense-in-root/parallel/false-conflict-deep/inner/page.tsx (1:33) @ unstable_instant
+           > 1 | export const unstable_instant = { prefetch: 'static' }
+               |                                 ^",
+               "stack": [],
+             },
+           ]
+          `)
+        } else {
+          const result = await prerender(
+            '/suspense-in-root/parallel/false-conflict-deep/inner'
+          )
+          expect(extractBuildValidationError(result.cliOutput))
+            .toMatchInlineSnapshot(`
+           "Error: Route "/suspense-in-root/parallel/false-conflict-deep": Incompatible \`unstable_instant\` configurations. Parallel route "@slot" has \`unstable_instant = false\` which expects blocking navigations, while this route has an \`unstable_instant\` config which expects instant navigations.
+
+           To see the exact locations of the conflicting configurations, try one of the following:
+             - Start the app in development mode by running \`next dev\`, then open "/suspense-in-root/parallel/false-conflict-deep" in your browser to investigate the error.
+             - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+               at ignore-listed frames
+           Build-time instant validation failed for route "/suspense-in-root/parallel/false-conflict-deep/inner".
+           Stopping prerender due to instant validation errors."
+          `)
+          expect(result.exitCode).toBe(1)
+        }
+      })
+    })
+
     describe('valid parallel slot configs', () => {
       it('valid - config on both children and slot pages', async () => {
         if (isNextDev) {


### PR DESCRIPTION
Tests that unstable_instant configs placed at different positions across a parallel route fork correctly attribute errors to the blocking segment, with the cause pointing to the config that requires instant behavior. Includes valid cases where both slots have configs or children wraps dynamic content in Suspense.

Also adds runtime detection of incompatible unstable_instant configurations across parallel slots. When one slot has unstable_instant = false (expects blocking) while a sibling has an instant config, validation now throws with codeframes pointing to both conflicting configs. Without Suspense between slots, a suspending slot blocks the sibling's update, so mixed configs are always a conflict regardless of depth. In production builds without --debug-prerender, a single error with guidance on how to get better diagnostics is shown instead.