### PR TITLE
fix(next): prevent cached fallback shell from intercepting server actions on dynamic routes

### DIFF
--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -1073,6 +1073,7 @@ export async function handler(
         // contains param references, and therefore we can't use the fallback.
         if (
           isRoutePPREnabled &&
+          !isPossibleServerAction &&
           (nextConfig.cacheComponents ? !isDynamicRSCRequest : !isRSCRequest)
         ) {
           const cacheKey =

--- a/test/e2e/app-dir/cache-components/app/server-action-dynamic/[[...slug]]/action.ts
+++ b/test/e2e/app-dir/cache-components/app/server-action-dynamic/[[...slug]]/action.ts
@@ -1,0 +1,5 @@
+'use server'
+
+export async function dynamicAction(value: string) {
+  return value
+}

--- a/test/e2e/app-dir/cache-components/app/server-action-dynamic/[[...slug]]/page.tsx
+++ b/test/e2e/app-dir/cache-components/app/server-action-dynamic/[[...slug]]/page.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { dynamicAction } from './action'
+
+export default function Page() {
+  const [result, setResult] = useState('initial')
+  const [isPending, startTransition] = useTransition()
+
+  return (
+    <div>
+      <h1>Server Action on Optional Catch-All Route</h1>
+      <button
+        id="action-button"
+        onClick={() => {
+          startTransition(async () => {
+            const res = await dynamicAction('action-result')
+            setResult(res)
+          })
+        }}
+      >
+        {isPending ? 'Pending...' : 'Call Action'}
+      </button>
+      <p id="action-result">{result}</p>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/cache-components/cache-components.server-action.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.server-action.test.ts
@@ -44,4 +44,37 @@ describe('cache-components', () => {
       expect($('#page').text()).toBe('at buildtime')
     }
   })
+
+  it('should not serve cached HTML for server action POST on optional catch-all routes', async () => {
+    // Regression: with cacheComponents enabled, POST requests for server
+    // actions on dynamic routes (e.g. [[...slug]]) were incorrectly served
+    // the cached fallback shell HTML instead of executing the action.
+    // This verifies the response to a server action POST is NOT text/html.
+    const res = await next.fetch('/server-action-dynamic', {
+      method: 'POST',
+      headers: {
+        'next-action': 'test-action-id',
+        'content-type': 'text/plain;charset=UTF-8',
+      },
+      body: '',
+    })
+
+    const contentType = res.headers.get('content-type') || ''
+    expect(contentType).not.toContain('text/html')
+  })
+
+  it('should not serve cached HTML for server action POST on optional catch-all routes with params', async () => {
+    // Same regression but when the catch-all has actual path segments.
+    const res = await next.fetch('/server-action-dynamic/foo/bar', {
+      method: 'POST',
+      headers: {
+        'next-action': 'test-action-id',
+        'content-type': 'text/plain;charset=UTF-8',
+      },
+      body: '',
+    })
+
+    const contentType = res.headers.get('content-type') || ''
+    expect(contentType).not.toContain('text/html')
+  })
 })


### PR DESCRIPTION
Fixing a Bug

### What?

When cacheComponents is enabled, the build creates fallbackRouteParams for
  dynamic routes. This caused the fallback shell serving path in app-page.ts
  to trigger for server action POST requests, returning the prerendered HTML
  instead of executing the action. The condition at line 1076 now checks
  !isPossibleServerAction to skip the fallback shell for action requests.




Fixes #91662 

