### PR TITLE
fix(next/font): add font metrics alias for renamed Google Fonts

### DIFF
--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -151,6 +151,23 @@ export async function capsize_metrics() {
   const {
     entireMetricsCollection,
   } = require('@capsizecss/metrics/entireMetricsCollection')
+
+  // Handle Google Fonts that have been renamed/rebranded but are not yet
+  // updated in @capsizecss/metrics.
+  // Key: new camelCase name, Value: old camelCase name
+  const FONT_ALIASES = {
+    montserratUnderline: 'montserratSubrayada',
+  }
+
+  for (const [newKey, oldKey] of Object.entries(FONT_ALIASES)) {
+    if (!entireMetricsCollection[newKey] && entireMetricsCollection[oldKey]) {
+      entireMetricsCollection[newKey] = {
+        ...entireMetricsCollection[oldKey],
+        familyName: entireMetricsCollection[oldKey].familyName,
+      }
+    }
+  }
+
   const outputPathDist = join(
     __dirname,
     'dist/server/capsize-font-metrics.json'


### PR DESCRIPTION
### What?

Added a `FONT_ALIASES` map in `capsize_metrics()` within `taskfile.js` so that renamed Google Fonts can resolve their font override metrics at build time.

### Why?

Google Fonts renamed "Montserrat Subrayada" to "Montserrat Underline". The `@capsizecss/metrics` package still uses the old key (`montserratSubrayada`), so the generated `capsize-font-metrics.json` has no entry for `montserratUnderline`. This causes:
```
⨯ Failed to find font override values for font `Montserrat Underline`
```

### How?

Before writing `capsize-font-metrics.json`, the build step now checks a `FONT_ALIASES` map. If a new font name key is missing but the old key exists, it copies the metrics under the new key. This is a minimal fix that doesn't require waiting for upstream `@capsizecss/metrics` to update.

Fixes #91692