### PR TITLE
docs: fix broken Activity Patterns demo link in preserving UI state guide

### DIFF
--- a/docs/01-app/02-guides/preserving-ui-state.mdx
+++ b/docs/01-app/02-guides/preserving-ui-state.mdx
@@ -496,7 +496,7 @@ The ref persists across hide/show cycles (refs aren't cleaned up), so `hasMounte
 
 ## Examples
 
-The [Activity Patterns Demo](https://react-activity-patterns.vercel.app/) ([source](https://github.com/vercel-labs/react-activity-patterns)) is a Next.js app with Cache Components enabled and three routes. Navigate between them to see state preservation in action:
+The [Activity Patterns Demo](https://react-activity-patterns.labs.vercel.dev) ([source](https://github.com/vercel-labs/react-activity-patterns)) is a Next.js app with Cache Components enabled and three routes. Navigate between them to see state preservation in action:
 
 - **Data** — sortable table and selectable list that keep their state across navigations, plus a reviews section that prerenders in the background
 - **Forms** — filter panel with DOM state (`<details>`, checkboxes, text inputs) that persists, and a newsletter form that resets after submission using `useLayoutEffect` cleanup


### PR DESCRIPTION
## What?

Fixes a broken link in the Preserving UI State guide:
https://nextjs.org/docs/app/guides/preserving-ui-state#examples

The "Activity Patterns demo" link currently points to a non-working URL.

## Why?

The demo link returns a 404 / invalid page, which makes the example section confusing for readers.

## Changes

- Updated the Activity Patterns demo link to the correct URL.

## Notes

No functional changes, docs only.

@icyJoseph @delbaoliveira 