### PR TITLE
[turbopack] Remove incorrect debug_assert in try_read_task_cell

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/tests/top_level_task_consistency.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/top_level_task_consistency.rs
@@ -36,13 +36,13 @@ async fn test_eventual_read_in_top_level_task_fails() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[should_panic]
-async fn test_cell_read_in_top_level_task_fails() {
+async fn test_cell_read_in_top_level_task_succeeds() {
     run_once(&REGISTRATION, || async {
         let cell = returns_value_operation()
             .resolve_strongly_consistent()
             .await?;
-        let _ = cell.await?;
+        let value = cell.await?;
+        assert_eq!(value.value, 42);
         Ok(())
     })
     .await

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -1473,9 +1473,6 @@ impl<B: Backend + 'static> TurboTasksApi for TurboTasks<B> {
         options: ReadCellOptions,
     ) -> Result<Result<TypedCellContent, EventListener>> {
         let reader = current_task_if_available("reading Vcs");
-        if cfg!(debug_assertions) && reader != Some(task) {
-            debug_assert_not_in_top_level_task("read_task_cell");
-        }
         self.backend
             .try_read_task_cell(task, index, reader, options, self)
     }


### PR DESCRIPTION
### What?

Removes the `debug_assert_not_in_top_level_task` call from `try_read_task_cell` in `turbopack/crates/turbo-tasks/src/manager.rs`.

### Why?

The assertion was wrong. `debug_assert_not_in_top_level_task` panics with the message:

> "Eventually consistent read cannot be performed from a top-level task."

The restriction only applies to **eventually consistent** reads (e.g. task output reads), which can return stale data if called from a top-level task (`.run_once(...)`). Cell reads, however, are **strongly consistent** — they always return up-to-date data. There is no semantic reason to forbid reading a cell from a top-level task, and the assert was producing false positives in valid call sites.

### How?

Delete the three lines that guard and invoke `debug_assert_not_in_top_level_task` inside `try_read_task_cell`. The function itself and its usage in `try_read_task_output` / `try_read_local_output` (which are genuinely eventually-consistent) are unchanged.