### PR TITLE
fix(swc): replace async generator in subscribe() with manual iterator to prevent pendingOperations Map overflow

### DIFF
--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -737,32 +737,77 @@ function bindingToApi(binding: any, _wasm: boolean) {
       }
     }
 
-    const iterator = (async function* () {
-      const task = await withErrorCause(() => nativeFunction(emitResult))
-      try {
-        while (!canceled) {
-          if (buffer.length > 0) {
-            const item = buffer.shift()!
-            if (item.err) throw item.err
-            yield item.value
-          } else {
-            // eslint-disable-next-line no-loop-func
-            yield new Promise<T>((resolve, reject) => {
-              waiting = { resolve, reject }
-            })
-          }
-        }
-      } catch (e) {
-        if (e === cancel) return
-        throw e
-      } finally {
-        binding.rootTaskDispose(task)
+    // Manual async iterator instead of an async generator to avoid creating
+    // multiple async hook IDs per iteration.
+    //
+    // Async generators register a long-lived "AsyncGeneratorObject" async
+    // resource plus a generator step-Promise for every `.next()` call. When the
+    // generator yields a Promise (as done below for the "waiting" path), the
+    // `for await…of` consumer also wraps that value in `Promise.resolve()`,
+    // producing yet another async resource. Under heavy Turbopack HMR activity
+    // (many subscriptions × many events) these resources accumulate inside
+    // React's dev-mode `pendingOperations` Map — which tracks every async
+    // resource with a captured stack trace — faster than V8's GC can fire the
+    // `destroy` hook to clean them up, eventually causing:
+    //
+    //   RangeError: Map maximum size exceeded
+    //     at Map.set (…)
+    //     at AsyncHook.init (…app-page-turbo.runtime.dev.js…)
+    //
+    // This manual implementation returns one `Promise<IteratorResult<T>>`
+    // directly from `next()` — no generator object overhead, no extra
+    // step-Promise wrapping — which keeps the async-resource pressure
+    // proportional to the number of active subscriptions rather than to the
+    // total number of events ever processed.
+    let task: void | undefined
+    withErrorCause(() => nativeFunction(emitResult)).then(
+      (t) => {
+        task = t
+      },
+      (err: Error) => {
+        emitResult(err, undefined)
       }
-    })()
-    iterator.return = async () => {
-      canceled = true
-      if (waiting) waiting.reject(cancel)
-      return { value: undefined, done: true } as IteratorReturnResult<never>
+    )
+
+    const iterator: AsyncIterableIterator<T> = {
+      [Symbol.asyncIterator]() {
+        return this
+      },
+      next(): Promise<IteratorResult<T>> {
+        if (canceled) {
+          return Promise.resolve({
+            value: undefined,
+            done: true,
+          } as IteratorReturnResult<never>)
+        }
+        if (buffer.length > 0) {
+          const item = buffer.shift()!
+          if (item.err) return Promise.reject(item.err)
+          return Promise.resolve({ value: item.value!, done: false })
+        }
+        // eslint-disable-next-line no-loop-func
+        return new Promise<IteratorResult<T>>((resolve, reject) => {
+          waiting = {
+            resolve: (value: T) => resolve({ value, done: false }),
+            reject: (e: Error) => {
+              if (e === cancel) {
+                resolve({
+                  value: undefined,
+                  done: true,
+                } as IteratorReturnResult<never>)
+              } else {
+                reject(e)
+              }
+            },
+          }
+        })
+      },
+      return: async () => {
+        canceled = true
+        if (waiting) waiting.reject(cancel)
+        if (task) binding.rootTaskDispose(task)
+        return { value: undefined, done: true } as IteratorReturnResult<never>
+      },
     }
     return iterator
   }


### PR DESCRIPTION
## What

Replaces the `async function*` generator inside `subscribe()` in `packages/next/src/build/swc/index.ts` with a manually-implemented `AsyncIterableIterator` that returns `Promise<IteratorResult<T>>` directly from `next()`.

## Why

### The crash

In dev mode (Turbopack), `subscribe()` is used to create one HMR subscription per compiled server chunk (via `project.hmrEvents()`). For a large application — many routes, many concurrent file watches — dozens or hundreds of these subscriptions run simultaneously, each as an infinite `for await…of` loop:

```
hot-reloader-turbopack.js
  └─ for await (const result of subscription) { … }
       └─ subscription = project.hmrEvents(chunkPath, HmrTarget.Server)
            └─ subscribe(true, …)  ← async generator here
```

React 19's dev-mode async profiler registers a Node.js `AsyncHook` (in the compiled `app-page-turbo.runtime.dev.js`) that tracks **every** async resource in a `pendingOperations` Map, capturing a full stack trace per entry. The `destroy` hook is supposed to remove entries when async resources are garbage-collected, but under heavy HMR activity GC can't keep up with creation.

### Why async generators make it worse

An `async function*` generator creates **multiple** async hook IDs per event:

| Async resource | Created by |
|---|---|
| `AsyncGeneratorObject` | The generator itself (lives for the full subscription lifetime) |
| Generator step-Promise | Each internal `.next()` call |
| Yielded inner-Promise | `yield new Promise(…)` on the "waiting" path |
| `Promise.resolve()` wrapper | `for await…of` unwrapping the yielded thenable |

That's **3–4 async IDs per event**, each stored in `pendingOperations` with a captured stack trace (≈1–5 KB per entry). With many active subscriptions producing frequent events, the Map grows faster than GC can drain it until V8 can no longer allocate memory for the Map's hash table:

```
RangeError: Map maximum size exceeded
    at Map.set (<anonymous>)
    at AsyncHook.init (…/app-page-turbo.runtime.dev.js:53:268561)
    at emitInitNative (node:internal/async_hooks:206:43)
    at promiseInitHookWithDestroyTracking (node:internal/async_hooks:336:3)
    at createIterator (…/next/dist/build/swc/index.js:512:31)
    at …/next/dist/server/dev/hot-reloader-turbopack.js:127:30
```

### The fix

A manual async iterator returns exactly **one** `Promise<IteratorResult<T>>` from `next()` — no generator object, no step-Promise wrapping, no extra `Promise.resolve()` from `for await…of`. This reduces async-resource creation from O(events × 3–4) to O(events × 1), keeping `pendingOperations` proportional to active subscriptions rather than to total events processed.

The observable behaviour is identical: buffered events are drained synchronously via `Promise.resolve()`, and the "waiting" path resolves/rejects the returned Promise when `emitResult` fires.

## Test

Start the dev server for a large Next.js app (many routes) with Turbopack and leave it running while making repeated file edits. Before this fix the server crashes with `RangeError: Map maximum size exceeded` after a few minutes. After this fix the server remains stable.

Verified against Node.js v24.11.1 + Next.js 16.2.0.