### PR TITLE
fix : add ESLint v10 support to eslint-config-next

### DIFF
--- a/packages/eslint-config-next/package.json
+++ b/packages/eslint-config-next/package.json
@@ -15,10 +15,10 @@
     "@next/eslint-plugin-next": "16.2.1-canary.2",
     "eslint-import-resolver-node": "^0.3.6",
     "eslint-import-resolver-typescript": "^3.5.2",
-    "eslint-plugin-import": "^2.32.0",
+    "eslint-plugin-import-x": "^4.16.0",
     "eslint-plugin-jsx-a11y": "^6.10.0",
     "eslint-plugin-react": "^7.37.0",
-    "eslint-plugin-react-hooks": "^7.0.0",
+    "eslint-plugin-react-hooks": "7.1.0-canary-e8c63626-20260213",
     "globals": "16.4.0",
     "typescript-eslint": "^8.46.0"
   },


### PR DESCRIPTION
Fixes #91702

### What?

- Switched to eslint-plugin-import-x.
- Updated import rules/settings to import-x.
- Updated lint plugin versions in eslint-config-next.

### Why?

- Reduce ESLint v10 peer dependency warnings.
- Align with plugins that support ESLint v10.

### How?

- Edited packages/eslint-config-next/package.json.
- Edited packages/eslint-config-next/src/index.ts.
