### PR TITLE
turbo-persistence: remove Unmergeable mmap advice

### DIFF
--- a/turbopack/crates/turbo-persistence/src/mmap_helper.rs
+++ b/turbopack/crates/turbo-persistence/src/mmap_helper.rs
@@ -2,15 +2,11 @@
 ///
 /// - `DontFork`: prevents mmap regions from being copied into child processes on `fork()`, avoiding
 ///   unnecessary memory duplication and potential SIGBUS.
-/// - `Unmergeable`: opts pages out of KSM (Kernel Same-page Merging) since our data is unique
-///   compressed content that won't benefit from deduplication scanning.
 #[cfg(target_os = "linux")]
 pub fn advise_mmap_for_persistence(mmap: &memmap2::Mmap) -> anyhow::Result<()> {
     use anyhow::Context;
     mmap.advise(memmap2::Advice::DontFork)
         .context("Failed to advise mmap DontFork")?;
-    mmap.advise(memmap2::Advice::Unmergeable)
-        .context("Failed to advise mmap Unmergeable")?;
     Ok(())
 }
 


### PR DESCRIPTION
### What?

Remove the `MADV_UNMERGEABLE` (Unmergeable) mmap advice from `turbo-persistence`'s `advise_mmap_for_persistence` helper in `mmap_helper.rs`.

### Why?

The WSL (Windows Subsystem for Linux) kernel does not support `MADV_UNMERGEABLE` and returns an error when it is applied, causing turbo-persistence to fail on WSL. See: https://x.com/von_cronen/status/2034944304712392891

Additionally, `MADV_UNMERGEABLE` is already the **default** state for memory pages — KSM (Kernel Same-page Merging) is opt-in via `MADV_MERGEABLE`. Explicitly setting `MADV_UNMERGEABLE` on pages that were never marked mergeable is a no-op on standard kernels, so the call provides no benefit while breaking WSL users.

The `MADV_DONTFORK` advice is retained, as it has a clear correctness benefit (prevents mmap regions from being inherited by child processes on `fork()`).

### How?

Removed the `mmap.advise(memmap2::Advice::Unmergeable)` call and its associated doc comment from `turbopack/crates/turbo-persistence/src/mmap_helper.rs`.