### PR TITLE
fix(types): apply AppType generic to component props instead of pageProps

### DIFF
--- a/packages/next/src/shared/lib/utils.ts
+++ b/packages/next/src/shared/lib/utils.ts
@@ -31,7 +31,7 @@ export type DocumentType = NextComponentType<
 export type AppType<P = {}> = NextComponentType<
   AppContextType,
   P,
-  AppPropsType<any, P>
+  AppPropsType<any> & P
 >
 
 export type AppTreeType = ComponentType<


### PR DESCRIPTION
## Summary

- Fix `AppType<P>` generic parameter being incorrectly applied to `pageProps` instead of the component's top-level props
- Change `AppPropsType<any, P>` to `AppPropsType & P` so custom props from `getInitialProps` are typed at the correct level

Fixes #42846

## Details

The `AppType<P>` type passes `P` as the `PageProps` argument to `AppPropsType<any, P>`, which causes custom properties returned from `_app`'s `getInitialProps` to appear under `props.pageProps` in the type system. At runtime, these properties exist at the top level of `props`, not nested under `pageProps`.

**Before (incorrect):**
```ts
// P goes into pageProps — doesn't match runtime
type AppType<P = {}> = NextComponentType<AppContextType, P, AppPropsType<any, P>>
```

**After (correct):**
```ts
// P is intersected at the top level — matches runtime
type AppType<P = {}> = NextComponentType<AppContextType, P, AppPropsType & P>
```

This is a minimal, non-breaking change. All internal usages of `AppType` use the default parameter (`AppType` without `<P>`), so `AppPropsType & {}` is equivalent to the previous `AppPropsType<any, {}>`.

## Test plan

- [ ] Verify that `AppType<MyCustomProps>` correctly types custom props at `props.myProp` (not `props.pageProps.myProp`)
- [ ] Verify that `AppType` (without generic) continues to work as before
- [ ] Existing TypeScript compilation of the Next.js codebase passes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)