### PR TITLE
Backport/docs fixes post release

### DIFF
--- a/docs/01-app/01-getting-started/03-layouts-and-pages.mdx
+++ b/docs/01-app/01-getting-started/03-layouts-and-pages.mdx
@@ -129,7 +129,7 @@ export default async function Page() {
 }
 ```
 
-```jsx filename="app/blog/[slug]/page.js" switcher
+```jsx filename="app/blog/page.js" switcher
 // Dummy imports
 import { getPosts } from '@/lib/posts'
 import { Post } from '@/ui/post'

--- a/docs/01-app/01-getting-started/04-linking-and-navigating.mdx
+++ b/docs/01-app/01-getting-started/04-linking-and-navigating.mdx
@@ -218,6 +218,7 @@ export async function generateStaticParams() {
   return posts.map((post) => ({
     slug: post.slug,
   }))
+}
 
 export default async function Page({ params }) {
   const { slug } = await params

--- a/docs/01-app/01-getting-started/09-revalidating.mdx
+++ b/docs/01-app/01-getting-started/09-revalidating.mdx
@@ -119,7 +119,7 @@ See the [`revalidateTag` API reference](/docs/app/api-reference/functions/revali
 
 `updateTag` immediately expires cached data for read-your-own-writes scenarios — the user sees their change right away instead of stale content. Unlike `revalidateTag`, it can only be used in [Server Actions](/docs/app/getting-started/mutating-data).
 
-```tsx filename="app/lib/actions.ts" highlight={1,6} switcher
+```tsx filename="app/lib/actions.ts" highlight={1,12} switcher
 import { updateTag } from 'next/cache'
 import { redirect } from 'next/navigation'
 
@@ -136,7 +136,7 @@ export async function createPost(formData: FormData) {
 }
 ```
 
-```jsx filename="app/lib/actions.js" highlight={1,6} switcher
+```jsx filename="app/lib/actions.js" highlight={1,12} switcher
 import { updateTag } from 'next/cache'
 import { redirect } from 'next/navigation'
 

--- a/docs/01-app/01-getting-started/10-error-handling.mdx
+++ b/docs/01-app/01-getting-started/10-error-handling.mdx
@@ -151,9 +151,14 @@ export default async function Page() {
 You can call the [`notFound`](/docs/app/api-reference/functions/not-found) function within a route segment and use the [`not-found.js`](/docs/app/api-reference/file-conventions/not-found) file to show a 404 UI.
 
 ```tsx filename="app/blog/[slug]/page.tsx" switcher
+import { notFound } from 'next/navigation'
 import { getPostBySlug } from '@/lib/posts'
 
-export default async function Page({ params }: { params: { slug: string } }) {
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
   const { slug } = await params
   const post = getPostBySlug(slug)
 
@@ -166,6 +171,7 @@ export default async function Page({ params }: { params: { slug: string } }) {
 ```
 
 ```jsx filename="app/blog/[slug]/page.js" switcher
+import { notFound } from 'next/navigation'
 import { getPostBySlug } from '@/lib/posts'
 
 export default async function Page({ params }) {

--- a/docs/01-app/01-getting-started/11-css.mdx
+++ b/docs/01-app/01-getting-started/11-css.mdx
@@ -210,7 +210,7 @@ export default function Page() {
 ```jsx filename="app/blog/page.js" switcher
 import styles from './blog.module.css'
 
-export default function Layout() {
+export default function Page() {
   return <main className={styles.blog}></main>
 }
 ```

--- a/docs/01-app/02-guides/ai-agents.mdx
+++ b/docs/01-app/02-guides/ai-agents.mdx
@@ -79,6 +79,19 @@ Before any Next.js work, find and read the relevant doc in `node_modules/next/di
 @AGENTS.md
 ```
 
+<details>
+<summary>For earlier versions</summary>
+
+On version 16.1 and earlier, use the codemod to generate these files automatically:
+
+```bash
+npx @next/codemod@latest agents-md
+```
+
+The codemod outputs the bundled docs to `.next-docs/` in the project root instead of `node_modules/next/dist/docs/`, and the generated agent files will point to that directory.
+
+</details>
+
 ## Understanding AGENTS.md
 
 The default `AGENTS.md` contains a single, focused instruction: **read the bundled docs before writing code**. This is intentionally minimal — the goal is to redirect agents from stale training data to the accurate, version-matched documentation in `node_modules/next/dist/docs/`.

--- a/docs/01-app/02-guides/content-security-policy.mdx
+++ b/docs/01-app/02-guides/content-security-policy.mdx
@@ -534,7 +534,6 @@ module.exports = {
 ### Limitations of SRI
 
 - **Experimental**: Feature may change or be removed
-- **Webpack only**: Not available with Turbopack
 - **App Router only**: Not supported in Pages Router
 - **Build-time only**: Cannot handle dynamically generated scripts
 

--- a/docs/01-app/02-guides/preserving-ui-state.mdx
+++ b/docs/01-app/02-guides/preserving-ui-state.mdx
@@ -496,7 +496,7 @@ The ref persists across hide/show cycles (refs aren't cleaned up), so `hasMounte
 
 ## Examples
 
-The [Activity Patterns Demo](https://react-activity-patterns.vercel.app/) ([source](https://github.com/vercel-labs/react-activity-patterns)) is a Next.js app with Cache Components enabled and three routes. Navigate between them to see state preservation in action:
+The [Activity Patterns Demo](https://react-activity-patterns.labs.vercel.dev) ([source](https://github.com/vercel-labs/react-activity-patterns)) is a Next.js app with Cache Components enabled and three routes. Navigate between them to see state preservation in action:
 
 - **Data** — sortable table and selectable list that keep their state across navigations, plus a reviews section that prerenders in the background
 - **Forms** — filter panel with DOM state (`<details>`, checkboxes, text inputs) that persists, and a newsletter form that resets after submission using `useLayoutEffect` cleanup

--- a/docs/01-app/03-api-reference/04-functions/catchError.mdx
+++ b/docs/01-app/03-api-reference/04-functions/catchError.mdx
@@ -112,7 +112,7 @@ Use `retry()` to prompt the user to recover from the error. When called, the fun
 
 In most cases, use `retry()` instead of `reset()`. The `reset()` function only clears the error state and re-renders without re-fetching, which means it won't recover from Server Component errors.
 
-```tsx filename="app/custom-error-boundary.tsx" highlight={9,12} switcher
+```tsx filename="app/custom-error-boundary.tsx" highlight={16,17} switcher
 'use client'
 
 import { unstable_catchError } from 'next/error'
@@ -137,7 +137,7 @@ function ErrorFallback(
 export default unstable_catchError(ErrorFallback)
 ```
 
-```jsx filename="app/custom-error-boundary.js" highlight={7,10} switcher
+```jsx filename="app/custom-error-boundary.js" highlight={9,10} switcher
 'use client'
 
 import { unstable_catchError } from 'next/error'


### PR DESCRIPTION
Backports documentation fixes from canary to `next-16-2`.

### Included commits:
- `883d93c893` docs: fix broken Activity Patterns demo link in preserving UI state guide (#91698)
- `04cc2f2ed2` docs: post release amends (#91715)

### Changes:
- Fix broken Activity Patterns demo link to correct URL
- Fix incorrect filename in blog page example (`app/blog/[slug]/page.js` → `app/blog/page.js`)
- Add missing closing brace in `generateStaticParams` example
- Fix incorrect `highlight` line numbers in revalidating and catchError docs
- Add missing `notFound` import and fix `params` type to `Promise` in error handling example
- Fix `Layout` → `Page` export name in CSS module example
- Add note about `agents-md` codemod for versions ≤16.1
- Remove outdated "Webpack only" SRI limitation (now works with Turbopack)