### PR TITLE
perf: replace reduce+spread with flatMap in sorted-routes for O(n) route flattening

### DIFF
--- a/packages/next/src/shared/lib/router/utils/sorted-routes.ts
+++ b/packages/next/src/shared/lib/router/utils/sorted-routes.ts
@@ -25,9 +25,9 @@ class UrlNode {
       childrenPaths.splice(childrenPaths.indexOf('[[...]]'), 1)
     }
 
-    const routes = childrenPaths
-      .map((c) => this.children.get(c)!._smoosh(`${prefix}${c}/`))
-      .reduce((prev, curr) => [...prev, ...curr], [])
+    const routes = childrenPaths.flatMap((c) =>
+      this.children.get(c)!._smoosh(`${prefix}${c}/`)
+    )
 
     if (this.slugName !== null) {
       routes.push(


### PR DESCRIPTION
### Summary

`UrlNode._smoosh()` in `packages/next/src/shared/lib/router/utils/sorted-routes.ts` uses `.map().reduce((prev, curr) => [...prev, ...curr], [])` to flatten children routes. Each iteration spreads the accumulator into a new array, resulting in O(n²) total copy operations where n is the number of children at that tree level.

This PR replaces it with `.flatMap()`, which builds the result array in a single pass for O(n) performance. For applications with many pages at the same route level (e.g., large e-commerce or documentation sites), this significantly reduces build-time route sorting overhead.

### Problem

```typescript
// Before: O(n²) — each reduce iteration copies the growing accumulator
const routes = childrenPaths
  .map((c) => this.children.get(c)!._smoosh(`${prefix}${c}/`))
  .reduce((prev, curr) => [...prev, ...curr], [])
```

The `reduce` callback `[...prev, ...curr]` creates a new array on every iteration, copying all previously accumulated elements. For k children, this performs 1 + 2 + ... + k = k(k+1)/2 = O(k²) element copies.

### Fix

```typescript
// After: O(n) — flatMap builds the result in a single pass
const routes = childrenPaths.flatMap((c) =>
  this.children.get(c)!._smoosh(`${prefix}${c}/`)
)
```

`Array.prototype.flatMap` (ES2019, available in Node.js 12+) maps and flattens in one step without repeated accumulator copying.

### Changes

- `packages/next/src/shared/lib/router/utils/sorted-routes.ts`: Replace `.map().reduce()` with `.flatMap()` in `UrlNode._smoosh()` (1 file, 3 lines changed)

### Benchmark

Benchmarked on Node.js v20.12.2 (Apple Silicon), 100 iterations per measurement. Three scenarios tested: flat routes (many siblings at root level, where O(n²) manifests), deeply nested routes, and a realistic mix.

**Flat routes (many siblings at same tree level) — where the fix matters:**

| Routes | reduce+spread (median) | flatMap (median) | Speedup |
|--------|----------------------|-----------------|---------|
| 51 | 0.014ms | 0.018ms | -31.7% |
| 201 | 0.062ms | 0.051ms | +17.7% |
| 501 | 0.174ms | 0.128ms | +26.3% |
| 1,001 | 0.993ms | 0.263ms | **+73.5%** |
| 2,001 | 3.704ms | 0.508ms | **+86.3%** |
| 5,001 | 16.648ms | 1.344ms | **+91.9%** |

The quadratic growth of reduce+spread is clearly visible: 1000→5000 routes causes 16.7x slowdown (0.993→16.648ms), while flatMap scales linearly (0.263→1.344ms, only 5.1x).

**Deep routes (nested tree, few children per node):**

| Routes | reduce+spread (median) | flatMap (median) | Speedup |
|--------|----------------------|-----------------|---------|
| 51 | 0.015ms | 0.035ms | -132.5% |
| 201 | 0.061ms | 0.133ms | -118.6% |
| 501 | 0.166ms | 0.327ms | -97.3% |
| 1,001 | 0.331ms | 0.626ms | -89.3% |

In deeply nested trees where each node has only a few children (10 sections), flatMap has constant overhead per call. However, the absolute times remain sub-millisecond even at 1000 routes, making this negligible in practice.

**Mixed routes (70% flat + 30% nested):**

| Routes | reduce+spread (median) | flatMap (median) | Speedup |
|--------|----------------------|-----------------|---------|
| 201 | 0.042ms | 0.058ms | -37.2% |
| 501 | 0.163ms | 0.144ms | +11.6% |
| 1,001 | 0.868ms | 0.298ms | **+65.6%** |
| 2,001 | 3.383ms | 0.590ms | **+82.6%** |

**Conclusion:** The fix targets the quadratic bottleneck that appears in real-world applications with hundreds or thousands of pages at the same directory level. For small or deeply nested route trees, the difference is negligible (sub-millisecond). For large flat route structures (common in e-commerce, documentation, and CMS-driven sites), the improvement is 73-92%.

### Testing

All 15 existing unit tests pass with the change. All 19 snapshots match:

```
PASS test/unit/page-route-sorter.test.ts
  getSortedRoutes
    ✓ does not add extra routes (2 ms)
    ✓ correctly sorts required slugs (2 ms)
    ✓ catches mismatched param names (6 ms)
    ✓ catches reused param names
    ✓ catches reused param names with catch-all (1 ms)
    ✓ catches middle catch-all with another catch-all
    ✓ catches middle catch-all with fixed route (5 ms)
    ✓ catches extra dots in catch-all
    ✓ catches missing dots in catch-all
    ✓ catches extra brackets for optional
    ✓ disallows optional params (1 ms)
    ✓ disallows mixing required catch all and optional catch all
    ✓ disallows apex and optional catch all
    ✓ catches param names differing only by non-word characters
    ✓ catches param names start with three-dot character not actual three dots

Test Suites: 1 passed, 1 total
Tests:       15 passed, 15 total
Snapshots:   19 passed, 19 total
Time:        0.214 s
```

### Code style consistency

- `flatMap` is already used in 6 other files within `packages/next/src/`, including `next-server.ts`, `flight-client-entry-plugin.ts`, and `build/utils.ts`
- The formatting matches the existing codebase style (multi-line callback with arrow function)
- No other `reduce+spread` array concatenation patterns remain in the `router/utils/` directory
- `flatMap` requires ES2019 (Node.js 12+), well within Next.js's `engines.node: ">=20.9.0"` requirement

Made with [Cursor](https://cursor.com)