### PR TITLE
turbopack: Remove Vc::resolve(), migrate all callsites to Vc::to_resolved()

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -860,7 +860,7 @@ impl AppProject {
             None,
             ResolveErrorMode::Error,
         )
-        .resolve()
+        .to_resolved()
         .await?
         .first_module()
         .await?

--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -347,7 +347,7 @@ async fn parse_actions(module: ResolvedVc<Box<dyn Module>>) -> Result<Vc<OptionA
         return Ok(Vc::cell(None));
     }
 
-    let original_parsed = ecmascript_asset.parse_original().resolve().await?;
+    let original_parsed = *ecmascript_asset.parse_original().to_resolved().await?;
 
     let ParseResult::Ok {
         program: original,
@@ -364,7 +364,7 @@ async fn parse_actions(module: ResolvedVc<Box<dyn Module>>) -> Result<Vc<OptionA
         return Ok(Vc::cell(None));
     };
 
-    let fragment = ecmascript_asset.failsafe_parse().resolve().await?;
+    let fragment = *ecmascript_asset.failsafe_parse().to_resolved().await?;
 
     if fragment != original_parsed {
         let ParseResult::Ok {

--- a/crates/next-core/src/emit.rs
+++ b/crates/next-core/src/emit.rs
@@ -84,7 +84,7 @@ pub async fn emit_assets(
 async fn emit(asset: Vc<Box<dyn OutputAsset>>) -> Result<()> {
     asset
         .content()
-        .resolve()
+        .to_resolved()
         .await?
         .write(asset.path().owned().await?)
         .as_side_effect()
@@ -103,7 +103,7 @@ async fn emit_rebase(
         .await?;
     let content = asset.content();
     content
-        .resolve()
+        .to_resolved()
         .await?
         .write(path)
         .as_side_effect()

--- a/crates/next-core/src/next_app/app_client_shared_chunks.rs
+++ b/crates/next-core/src/next_app/app_client_shared_chunks.rs
@@ -35,8 +35,9 @@ pub async fn get_app_client_shared_chunk_group(
                 module_graph,
                 AvailabilityInfo::root(),
             )
-            .resolve()
+            .to_resolved()
             .await
+            .map(|r| *r)
     }
     .instrument(span)
     .await?;

--- a/crates/next-core/src/next_client/runtime_entry.rs
+++ b/crates/next-core/src/next_client/runtime_entry.rs
@@ -40,7 +40,7 @@ impl RuntimeEntry {
             None,
             ResolveErrorMode::Error,
         )
-        .resolve()
+        .to_resolved()
         .await?
         .primary_modules()
         .await?;

--- a/crates/next-core/src/next_server/resolve.rs
+++ b/crates/next-core/src/next_server/resolve.rs
@@ -240,7 +240,7 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
                     // have an extension in the request we try to append ".js"
                     // automatically
                     request_str.push_str(".js");
-                    request = request.append_path(rcstr!(".js")).resolve().await?;
+                    request = *request.append_path(rcstr!(".js")).to_resolved().await?;
                     continue;
                 }
                 // this can't resolve with node.js from the original location, so bundle it

--- a/turbopack/crates/turbo-tasks-backend/fuzz/src/graph.rs
+++ b/turbopack/crates/turbo-tasks-backend/fuzz/src/graph.rs
@@ -146,7 +146,7 @@ fn actual_operation(spec: Arc<Vec<TaskSpec>>, iterations: usize) {
             for i in 0..iterations {
                 let spec = spec.clone();
                 tt.run(async move {
-                    let it = create_state().resolve().await?;
+                    let it = *create_state().to_resolved().await?;
                     it.await?.set(i);
                     let task = run_task(spec.clone(), it, 0);
                     task.strongly_consistent().await?;

--- a/turbopack/crates/turbo-tasks-backend/tests/all_in_one.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/all_in_one.rs
@@ -71,7 +71,7 @@ async fn test_all_in_one_operation(nonce: u32) -> Result<Vc<()>> {
 
     let b_erased_other: Vc<Box<dyn Add>> = Vc::upcast(Vc::<NumberB>::cell(10));
     let c_erased_invalid: Vc<Box<dyn Add>> = a_erased.add(b_erased_other);
-    assert!(c_erased_invalid.resolve().await.is_err());
+    assert!(c_erased_invalid.to_resolved().await.is_err());
 
     Ok(Vc::cell(()))
 }

--- a/turbopack/crates/turbo-tasks-backend/tests/bug2.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/bug2.rs
@@ -80,7 +80,7 @@ async fn test_graph_bug_operation(nonce: u32) -> Result<Vc<()>> {
         },
     ];
 
-    let it = create_iteration().resolve().await?;
+    let it = *create_iteration().to_resolved().await?;
     it.await?.set(0);
     println!("🚀 Initial");
     let task = run_task(Arc::new(spec), it, 0);

--- a/turbopack/crates/turbo-tasks-backend/tests/immutable.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/immutable.rs
@@ -12,12 +12,12 @@ static REGISTRATION: Registration = register!();
 async fn test_hidden_mutate() {
     run_once(&REGISTRATION, || async {
         unmark_top_level_task_may_leak_eventually_consistent_state();
-        let input = create_input().resolve().await?;
+        let input = *create_input().to_resolved().await?;
         input.await?.state.set(1);
         let changing_value = compute(input);
         assert_eq!(changing_value.await?.value, 1);
 
-        let changing_value_resolved = changing_value.resolve().await?;
+        let changing_value_resolved = *changing_value.to_resolved().await?;
         let read_input = read_input(changing_value_resolved);
         let static_immutable = immutable_fn(changing_value_resolved);
         let read_self = changing_value_resolved.read_self();

--- a/turbopack/crates/turbo-tasks-backend/tests/recompute.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/recompute.rs
@@ -151,7 +151,7 @@ async fn compute2(input: Vc<ChangingInput>) -> Result<Vc<u32>> {
 async fn recompute_dependency() {
     run(&REGISTRATION, || async {
         unmark_top_level_task_may_leak_eventually_consistent_state();
-        let input = get_dependency_input().resolve().await?;
+        let input = *get_dependency_input().to_resolved().await?;
         // Reset state to 1 at the start of each iteration (important for multi-run tests)
         input.await?.state.set(1);
 

--- a/turbopack/crates/turbo-tasks-backend/tests/recompute_collectibles.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/recompute_collectibles.rs
@@ -16,8 +16,8 @@ static REGISTRATION: Registration = register!();
 async fn recompute() {
     run_once(&REGISTRATION, || async {
         unmark_top_level_task_may_leak_eventually_consistent_state();
-        let input = ChangingInput::new(1).resolve().await?;
-        let input2 = ChangingInput::new(2).resolve().await?;
+        let input = *ChangingInput::new(1).to_resolved().await?;
+        let input2 = *ChangingInput::new(2).to_resolved().await?;
         input.await?.state.set(1);
         input2.await?.state.set(1000);
         let output = compute(input, input2, 1);

--- a/turbopack/crates/turbo-tasks-backend/tests/task_statistics.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/task_statistics.rs
@@ -139,14 +139,16 @@ async fn test_dyn_trait_methods() -> Result<()> {
         enable_stats();
         for i in 0..10 {
             let wvc: Vc<Box<dyn Doublable>> = Vc::upcast(wrap(i));
-            let _ = tokio::try_join!(wvc.double().resolve(), wvc.double().resolve()).unwrap();
-            let _ = tokio::try_join!(wvc.double_vc().resolve(), wvc.double_vc().resolve()).unwrap();
+            let _ =
+                tokio::try_join!(wvc.double().to_resolved(), wvc.double().to_resolved()).unwrap();
+            let _ = tokio::try_join!(wvc.double_vc().to_resolved(), wvc.double_vc().to_resolved())
+                .unwrap();
         }
         // use cached results
         for i in 0..5 {
             let wvc: Vc<Box<dyn Doublable>> = Vc::upcast(wrap(i));
-            let _ = wvc.double().resolve().await.unwrap();
-            let _ = wvc.double_vc().resolve().await.unwrap();
+            let _ = wvc.double().to_resolved().await.unwrap();
+            let _ = wvc.double_vc().to_resolved().await.unwrap();
         }
         // use cached results without dynamic dispatch
         for i in 0..2 {

--- a/turbopack/crates/turbo-tasks/src/raw_vc.rs
+++ b/turbopack/crates/turbo-tasks/src/raw_vc.rs
@@ -152,7 +152,7 @@ impl RawVc {
         ReadRawVcFuture::new(self, None)
     }
 
-    /// See [`crate::Vc::resolve`].
+    /// See [`crate::Vc::to_resolved`].
     pub(crate) async fn resolve(self) -> Result<RawVc> {
         self.resolve_inner(ReadOutputOptions {
             consistency: ReadConsistency::Eventual,

--- a/turbopack/crates/turbo-tasks/src/task/task_input.rs
+++ b/turbopack/crates/turbo-tasks/src/task/task_input.rs
@@ -259,7 +259,7 @@ where
     }
 
     async fn resolve_input(&self) -> Result<Self> {
-        Vc::resolve(*self).await
+        Ok(*(*self).to_resolved().await?)
     }
 }
 

--- a/turbopack/crates/turbo-tasks/src/vc/cell_mode.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/cell_mode.rs
@@ -23,7 +23,7 @@ where
     /// [`SharedReference`][crate::task::SharedReference].
     ///
     /// This is used in APIs that already have a `SharedReference`, such as in
-    /// [`ReadRef::cell`][crate::ReadRef::cell] or in [`Vc::resolve`] when
+    /// [`ReadRef::cell`][crate::ReadRef::cell] or in [`Vc::to_resolved`] when
     /// resolving a local [`Vc`]. This avoids unnecessary cloning.
     fn raw_cell(value: TypedSharedReference) -> RawVc;
 }

--- a/turbopack/crates/turbo-tasks/src/vc/mod.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/mod.rs
@@ -274,8 +274,8 @@ where
 {
     /// Returns a debug identifier for this `Vc`.
     pub async fn debug_identifier(vc: Self) -> Result<String> {
-        let resolved = vc.resolve().await?;
-        let raw_vc: RawVc = resolved.node;
+        let resolved = vc.to_resolved().await?;
+        let raw_vc: RawVc = resolved.node.node;
         if let RawVc::TaskCell(task_id, CellId { type_id, index }) = raw_vc {
             let value_ty = registry::get_value_type(type_id);
             Ok(format!("{}#{}: {}", value_ty.ty.name, index, task_id))
@@ -337,21 +337,15 @@ where
         Ok(())
     }
 
-    /// Do not use this: Use [`Vc::to_resolved`] instead. If you must have a resolved [`Vc`] type
-    /// and not a [`ResolvedVc`] type, simply deref the result of [`Vc::to_resolved`].
-    pub async fn resolve(self) -> Result<Vc<T>> {
-        Ok(Self {
-            node: self.node.resolve().await?,
-            _t: PhantomData,
-        })
-    }
-
     /// Resolve the reference until it points to a cell directly, and wrap the
     /// result in a [`ResolvedVc`], which statically guarantees that the
     /// [`Vc`] was resolved.
     pub async fn to_resolved(self) -> Result<ResolvedVc<T>> {
         Ok(ResolvedVc {
-            node: self.resolve().await?,
+            node: Vc {
+                node: self.node.resolve().await?,
+                _t: PhantomData,
+            },
         })
     }
 

--- a/turbopack/crates/turbopack-browser/src/ecmascript/list/content.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/list/content.rs
@@ -110,7 +110,7 @@ impl EcmascriptDevChunkListContent {
             if let Some(mergeable) =
                 ResolvedVc::try_sidecast::<Box<dyn MergeableVersionedContent>>(*chunk_content)
             {
-                let merger = mergeable.get_merger().resolve().await?;
+                let merger = mergeable.get_merger().to_resolved().await?;
                 by_merger.entry(merger).or_default().push(*chunk_content);
             } else {
                 by_path.insert(

--- a/turbopack/crates/turbopack-browser/src/ecmascript/list/content.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/list/content.rs
@@ -125,7 +125,7 @@ impl EcmascriptDevChunkListContent {
             .map(|(merger, contents)| (merger, Vc::cell(contents)))
             .map(async |(merger, contents)| {
                 Ok((
-                    merger.to_resolved().await?,
+                    merger,
                     merger.merge(contents).version().into_trait_ref().await?,
                 ))
             })

--- a/turbopack/crates/turbopack-cli-utils/src/runtime_entry.rs
+++ b/turbopack/crates/turbopack-cli-utils/src/runtime_entry.rs
@@ -40,7 +40,7 @@ impl RuntimeEntry {
             None,
             ResolveErrorMode::Error,
         )
-        .resolve()
+        .to_resolved()
         .await?
         .primary_modules()
         .await?;

--- a/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
+++ b/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
@@ -141,7 +141,7 @@ pub async fn create_web_entry_source(
             Ok(origin
                 .resolve_asset(request, origin.resolve_options(), ty)
                 .await?
-                .resolve()
+                .to_resolved()
                 .await?
                 .primary_modules()
                 .await?

--- a/turbopack/crates/turbopack-core/src/introspect/utils.rs
+++ b/turbopack/crates/turbopack-core/src/introspect/utils.rs
@@ -86,7 +86,7 @@ pub async fn children_from_module_references(
 
         for &module in reference
             .resolve_reference()
-            .resolve()
+            .to_resolved()
             .await?
             .primary_modules()
             .await?

--- a/turbopack/crates/turbopack-core/src/reference/mod.rs
+++ b/turbopack/crates/turbopack-core/src/reference/mod.rs
@@ -245,7 +245,7 @@ pub async fn primary_referenced_modules(module: Vc<Box<dyn Module>>) -> Result<V
         .map(|reference| async {
             reference
                 .resolve_reference()
-                .resolve()
+                .to_resolved()
                 .await?
                 .primary_modules()
                 .owned()

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -84,7 +84,7 @@ pub enum ResolveErrorMode {
 /// Type alias for a resolved after-resolve plugin paired with its condition.
 type AfterResolvePluginWithCondition = (
     ResolvedVc<Box<dyn AfterResolvePlugin>>,
-    Vc<AfterResolvePluginCondition>,
+    ResolvedVc<AfterResolvePluginCondition>,
 );
 
 #[turbo_tasks::value(shared)]
@@ -1224,7 +1224,7 @@ enum ImportsFieldResult {
 async fn imports_field(lookup_path: FileSystemPath) -> Result<Vc<ImportsFieldResult>> {
     // We don't need to collect affecting sources here because we don't use them
     let package_json_context =
-        find_context_file(lookup_path, package_json().resolve().await?, false).await?;
+        find_context_file(lookup_path, *package_json().to_resolved().await?, false).await?;
     let FindContextFileResult::Found(package_json_path, _refs) = &*package_json_context else {
         return Ok(ImportsFieldResult::None.cell());
     };
@@ -1664,8 +1664,8 @@ pub async fn resolve_inline(
         let raw_result = match before_plugins_result {
             Some(result) => result,
             None => {
-                resolve_internal(lookup_path.clone(), request, options)
-                    .resolve()
+                *resolve_internal(lookup_path.clone(), request, options)
+                    .to_resolved()
                     .await?
             }
         };
@@ -1700,28 +1700,28 @@ pub async fn url_resolve(
         rel_request,
         resolve_options,
     );
-    let result = if *rel_result.is_unresolvable().await? && rel_request.resolve().await? != request
-    {
-        let result = resolve(
-            origin_path_parent,
-            reference_type.clone(),
-            request,
-            resolve_options,
-        );
-        if resolve_options.await?.collect_affecting_sources {
-            result.with_affecting_sources(
-                rel_result
-                    .await?
-                    .get_affecting_sources()
-                    .map(|src| *src)
-                    .collect(),
-            )
+    let result =
+        if *rel_result.is_unresolvable().await? && *rel_request.to_resolved().await? != request {
+            let result = resolve(
+                origin_path_parent,
+                reference_type.clone(),
+                request,
+                resolve_options,
+            );
+            if resolve_options.await?.collect_affecting_sources {
+                result.with_affecting_sources(
+                    rel_result
+                        .await?
+                        .get_affecting_sources()
+                        .map(|src| *src)
+                        .collect(),
+                )
+            } else {
+                result
+            }
         } else {
-            result
-        }
-    } else {
-        rel_result
-    };
+            rel_result
+        };
     let result = origin
         .asset_context()
         .process_resolve_result(result, reference_type.clone());
@@ -1747,7 +1747,7 @@ async fn get_matching_before_resolve_plugins(
 ) -> Result<Vc<MatchingBeforeResolvePlugins>> {
     let mut matching_plugins = Vec::new();
     for &plugin in &options.await?.before_resolve_plugins {
-        let condition = plugin.before_resolve_condition().resolve().await?;
+        let condition = plugin.before_resolve_condition().to_resolved().await?;
         if *condition.matches(request).await? {
             matching_plugins.push(plugin);
         }
@@ -1788,7 +1788,7 @@ async fn handle_after_resolve_plugins(
     let resolved_conditions = options_value
         .after_resolve_plugins
         .iter()
-        .map(async |p| Ok((*p, p.after_resolve_condition().resolve().await?)))
+        .map(async |p| Ok((*p, p.after_resolve_condition().to_resolved().await?)))
         .try_join()
         .await?;
 
@@ -1957,7 +1957,7 @@ async fn resolve_internal_inline(
                     lookup_path.clone(),
                     rcstr!(""),
                     *force_in_lookup_dir,
-                    Pattern::new(path.clone()).resolve().await?,
+                    *Pattern::new(path.clone()).to_resolved().await?,
                 )
                 .await?;
 
@@ -2249,7 +2249,7 @@ async fn resolve_into_folder(
 
                         // main field will always resolve not fully specified
                         let options = if options_value.fully_specified {
-                            options.with_fully_specified(false).resolve().await?
+                            *options.with_fully_specified(false).to_resolved().await?
                         } else {
                             options
                         };
@@ -2560,7 +2560,7 @@ async fn resolve_relative_request(
         lookup_path.clone(),
         rcstr!(""),
         force_in_lookup_dir,
-        Pattern::new(new_path.clone()).resolve().await?,
+        *Pattern::new(new_path.clone()).to_resolved().await?,
     )
     .await?;
 
@@ -2634,7 +2634,7 @@ async fn apply_in_package(
 
         let FindContextFileResult::Found(package_json_path, refs) = &*find_context_file(
             lookup_path.clone(),
-            package_json().resolve().await?,
+            *package_json().to_resolved().await?,
             options_value.collect_affecting_sources,
         )
         .await?
@@ -2738,7 +2738,7 @@ async fn find_self_reference(
     lookup_path: FileSystemPath,
 ) -> Result<Vc<FindSelfReferencePackageResult>> {
     let package_json_context =
-        find_context_file(lookup_path, package_json().resolve().await?, false).await?;
+        find_context_file(lookup_path, *package_json().to_resolved().await?, false).await?;
     if let FindContextFileResult::Found(package_json_path, _refs) = &*package_json_context {
         let read =
             read_package_json(Vc::upcast(FileSource::new(package_json_path.clone()))).await?;
@@ -2808,7 +2808,7 @@ async fn resolve_module_request(
     let result = find_package(
         lookup_path.clone(),
         module.clone(),
-        resolve_modules_options(options).resolve().await?,
+        *resolve_modules_options(options).to_resolved().await?,
         options_value.collect_affecting_sources,
     )
     .await?;
@@ -3015,7 +3015,7 @@ async fn resolve_import_map_result(
             let request = Request::parse_string(name.clone());
 
             // We must avoid cycles during resolving
-            if request.resolve().await? == original_request
+            if *request.to_resolved().await? == original_request
                 && *alias_lookup_path == original_lookup_path
             {
                 None
@@ -3234,11 +3234,11 @@ async fn handle_exports_imports_field(
     } in results
     {
         if let Some(result_path) = result_path.with_normalized_path() {
-            let request = Request::parse(Pattern::Concatenation(vec![
+            let request = *Request::parse(Pattern::Concatenation(vec![
                 Pattern::Constant(rcstr!("./")),
                 result_path.clone(),
             ]))
-            .resolve()
+            .to_resolved()
             .await?;
 
             let resolve_result = Box::pin(resolve_internal_inline(

--- a/turbopack/crates/turbopack-core/src/resolve/origin.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/origin.rs
@@ -98,12 +98,12 @@ async fn resolve_asset(
     }
     Ok(resolve_origin
         .asset_context()
-        .resolve()
+        .to_resolved()
         .await?
         .resolve_asset(
             resolve_origin.origin_path().owned().await?,
-            request.resolve().await?,
-            options.resolve().await?,
+            *request.to_resolved().await?,
+            *options.to_resolved().await?,
             reference_type,
         ))
 }

--- a/turbopack/crates/turbopack-css/src/asset.rs
+++ b/turbopack/crates/turbopack-css/src/asset.rs
@@ -276,7 +276,7 @@ impl CssChunkItem for CssModuleChunkItem {
             {
                 for &module in import_ref
                     .resolve_reference()
-                    .resolve()
+                    .to_resolved()
                     .await?
                     .primary_modules()
                     .await?
@@ -298,7 +298,7 @@ impl CssChunkItem for CssModuleChunkItem {
             {
                 for &module in compose_ref
                     .resolve_reference()
-                    .resolve()
+                    .to_resolved()
                     .await?
                     .primary_modules()
                     .await?

--- a/turbopack/crates/turbopack-ecmascript-runtime/src/browser_runtime.rs
+++ b/turbopack/crates/turbopack-ecmascript-runtime/src/browser_runtime.rs
@@ -26,7 +26,9 @@ pub async fn get_browser_runtime_code(
     generate_source_map: bool,
     chunk_loading_global: Vc<RcStr>,
 ) -> Result<Vc<Code>> {
-    let asset_context = get_runtime_asset_context(*environment).resolve().await?;
+    let asset_context = *get_runtime_asset_context(*environment)
+        .to_resolved()
+        .await?;
 
     let shared_runtime_utils_code = embed_static_code(
         asset_context,

--- a/turbopack/crates/turbopack-ecmascript-runtime/src/nodejs_runtime.rs
+++ b/turbopack/crates/turbopack-ecmascript-runtime/src/nodejs_runtime.rs
@@ -15,7 +15,9 @@ pub async fn get_nodejs_runtime_code(
     runtime_type: RuntimeType,
     generate_source_map: bool,
 ) -> Result<Vc<Code>> {
-    let asset_context = get_runtime_asset_context(*environment).resolve().await?;
+    let asset_context = *get_runtime_asset_context(*environment)
+        .to_resolved()
+        .await?;
 
     let shared_runtime_utils_code = embed_static_code(
         asset_context,

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
@@ -129,8 +129,8 @@ async fn side_effects_from_package_json(
                 .map(|glob| async move {
                     Ok(match glob {
                         Either::Left(glob) => {
-                            match glob.resolve().await {
-                                Ok(glob) => Either::Left(glob),
+                            match glob.to_resolved().await {
+                                Ok(glob) => Either::Left(*glob),
                                 Err(err) => {
                                     Either::Right(SideEffectsInPackageJsonIssue {
                                         // TODO(PACK-4879): This should point at the buggy glob

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -597,7 +597,7 @@ async fn determine_module_type_for_directory(
     context_path: FileSystemPath,
 ) -> Result<Vc<ModuleTypeResult>> {
     let find_package_json =
-        find_context_file(context_path, package_json().resolve().await?, false).await?;
+        find_context_file(context_path, *package_json().to_resolved().await?, false).await?;
     let FindContextFileResult::Found(package_json, _) = &*find_package_json else {
         return Ok(ModuleTypeResult::new(SpecifiedModuleType::Automatic));
     };
@@ -822,8 +822,9 @@ impl EcmascriptChunkPlaceable for EcmascriptModuleAsset {
             let async_module_options = self.get_async_module().module_options(async_module_info);
             let content = self.module_content(chunking_context, async_module_info);
             EcmascriptChunkItemContent::new(content, chunking_context, async_module_options)
-                .resolve()
+                .to_resolved()
                 .await
+                .map(|r| *r)
         }
         .instrument(span)
         .await

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/dynamic.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/dynamic.rs
@@ -85,7 +85,7 @@ impl ModuleReference for EsmAsyncAssetReference {
     #[turbo_tasks::function]
     async fn resolve_reference(&self) -> Result<Vc<ModuleResolveResult>> {
         esm_resolve(
-            self.get_origin().resolve().await?,
+            *self.get_origin().to_resolved().await?,
             *self.request,
             EcmaScriptModulesReferenceSubType::DynamicImport,
             self.error_mode,

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -3715,7 +3715,7 @@ async fn require_resolve_visitor(
             None,
             ResolveErrorMode::Warn,
         )
-        .resolve()
+        .to_resolved()
         .await?;
         let mut values = resolved
             .primary_sources()

--- a/turbopack/crates/turbopack-ecmascript/src/references/raw.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/raw.rs
@@ -62,17 +62,17 @@ impl ModuleReference for FileSourceReference {
                 /* force_in_lookup_dir */ false,
             )
             .as_raw_module_result()
-            .resolve()
+            .to_resolved()
             .await?;
             check_and_emit_too_many_matches_warning(
-                result,
+                *result,
                 self.issue_source,
                 self.context_dir.clone(),
                 self.path,
             )
             .await?;
 
-            Ok(result)
+            Ok(*result)
         }
         .instrument(span)
         .await

--- a/turbopack/crates/turbopack-ecmascript/src/rename/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/rename/module.rs
@@ -133,12 +133,12 @@ impl Module for EcmascriptModuleRenameModule {
         let async_module = self.async_module();
         let references = self.references();
         let is_self_async = async_module
-            .resolve()
+            .to_resolved()
             .await?
-            .is_self_async(references.resolve().await?)
-            .resolve()
+            .is_self_async(*references.to_resolved().await?)
+            .to_resolved()
             .await?;
-        Ok(is_self_async)
+        Ok(*is_self_async)
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
@@ -126,12 +126,12 @@ impl Module for EcmascriptModuleFacadeModule {
         let async_module = self.async_module();
         let references = self.references();
         let is_self_async = async_module
-            .resolve()
+            .to_resolved()
             .await?
-            .is_self_async(references.resolve().await?)
-            .resolve()
+            .is_self_async(*references.to_resolved().await?)
+            .to_resolved()
             .await?;
-        Ok(is_self_async)
+        Ok(*is_self_async)
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-node/src/lib.rs
+++ b/turbopack/crates/turbopack-node/src/lib.rs
@@ -46,7 +46,7 @@ async fn emit(
         let _ = asset
             .content()
             .write(asset.path().owned().await?)
-            .resolve()
+            .to_resolved()
             .await?;
     }
     Ok(())

--- a/turbopack/crates/turbopack-resolve/src/ecmascript.rs
+++ b/turbopack/crates/turbopack-resolve/src/ecmascript.rs
@@ -95,8 +95,8 @@ pub async fn esm_resolve(
     issue_source: Option<IssueSource>,
 ) -> Result<Vc<ModuleResolveResult>> {
     let ty = ReferenceType::EcmaScriptModules(ty);
-    let options = apply_esm_specific_options(origin.resolve_options(), &ty)
-        .resolve()
+    let options = *apply_esm_specific_options(origin.resolve_options(), &ty)
+        .to_resolved()
         .await?;
     specific_resolve(origin, request, options, ty, error_mode, issue_source).await
 }
@@ -110,8 +110,8 @@ pub async fn cjs_resolve(
     error_mode: ResolveErrorMode,
 ) -> Result<Vc<ModuleResolveResult>> {
     let ty = ReferenceType::CommonJs(ty);
-    let options = apply_cjs_specific_options(origin.resolve_options())
-        .resolve()
+    let options = *apply_cjs_specific_options(origin.resolve_options())
+        .to_resolved()
         .await?;
     specific_resolve(origin, request, options, ty, error_mode, issue_source).await
 }
@@ -125,8 +125,8 @@ pub async fn cjs_resolve_source(
     error_mode: ResolveErrorMode,
 ) -> Result<Vc<ResolveResult>> {
     let ty = ReferenceType::CommonJs(ty);
-    let options = apply_cjs_specific_options(origin.resolve_options())
-        .resolve()
+    let options = *apply_cjs_specific_options(origin.resolve_options())
+        .to_resolved()
         .await?;
     let result = resolve(
         origin.origin_path().await?.parent(),

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -215,10 +215,10 @@ async fn apply_module_type(
                                     ModulePart::Export(_) => {
                                         apply_reexport_tree_shaking(
                                             Vc::upcast(
-                                                EcmascriptModuleFacadeModule::new(Vc::upcast(
+                                                *EcmascriptModuleFacadeModule::new(Vc::upcast(
                                                     *module,
                                                 ))
-                                                .resolve()
+                                                .to_resolved()
                                                 .await?,
                                             ),
                                             part.clone(),
@@ -436,10 +436,10 @@ impl ModuleAssetContext {
             return Ok(self);
         }
         let this = self.await?;
-        let resolve_options_context = this
+        let resolve_options_context = *this
             .resolve_options_context
             .with_types_enabled()
-            .resolve()
+            .to_resolved()
             .await?;
 
         Ok(ModuleAssetContext::new(
@@ -1017,7 +1017,7 @@ impl AssetContext for ModuleAssetContext {
             resolve_options,
         );
 
-        let mut result = self.process_resolve_result(result.resolve().await?, reference_type);
+        let mut result = self.process_resolve_result(*result.to_resolved().await?, reference_type);
 
         if *self.is_types_resolving_enabled().await? {
             let types_result = type_resolve(


### PR DESCRIPTION
### What?

Remove the `Vc::resolve()` method and migrate all ~37 callsites across the turbopack and next crates to use `Vc::to_resolved()` instead.

### Why?

`Vc::resolve()` returned `Result<Vc<T>>` — a resolved `Vc` with no static guarantee that it is resolved. This is a footgun: the type is indistinguishable from any other unresolved `Vc<T>`, so it's easy to accidentally lose the "resolved" property at a type boundary or store it in a struct without the compiler enforcing invariants.

`Vc::to_resolved()` returns `Result<ResolvedVc<T>>`, which statically encodes the resolved guarantee in the type. `ResolvedVc<T>` implements `Deref<Target = Vc<T>>`, so it coerces seamlessly to `Vc<T>` at call sites that still need the plain type. Removing `Vc::resolve()` eliminates this footgun entirely and pushes callers toward the type-safe API.

### How?

- Removed the `Vc::resolve()` method from `turbo-tasks/src/vc/mod.rs`.
- Updated `Vc::to_resolved()` to construct the inner `Vc` directly via `self.node.resolve()` rather than calling `self.resolve()`.
- Updated `Vc::debug_identifier` to go through `to_resolved()`.
- Updated `TaskInput::resolve_input` for `Vc<T>` to use `to_resolved()`.
- Updated all callsites across turbopack-core, turbopack-ecmascript, turbopack-resolve, turbopack-browser, turbopack-css, turbopack-node, turbopack-ecmascript-runtime, next-api, next-core, and test/fuzz files:
  - Where `ResolvedVc<T>` is usable (deref coercion handles method calls, or the value is stored in a `HashMap` etc.), simply replaced `.resolve()` with `.to_resolved()`.
  - Where a plain `Vc<T>` is strictly required by a callee signature, dereferenced with `*x.to_resolved().await?`.
- Updated the `AfterResolvePluginWithCondition` type alias in `resolve/mod.rs` to use `ResolvedVc<AfterResolvePluginCondition>` now that the tuple member is produced by `to_resolved()`.
- Updated doc comments referencing `Vc::resolve` to point to `Vc::to_resolved`.

Verified with `cargo check --all-targets` — compiles cleanly with no errors.