### PR TITLE
Turbopack: fix webpack loader runner layer

### DIFF
--- a/test/development/app-dir/turbopack-import-assertions-use/app/page.tsx
+++ b/test/development/app-dir/turbopack-import-assertions-use/app/page.tsx
@@ -11,6 +11,7 @@ import jsonData from '../data.jsonlike' with { turbopackLoader: 'test-identity-l
 // Normal rules should still work at the same time
 import jsonData2 from '../data.jsonlike2'
 
+console.log(jsonData, jsonData2)
 export default function Page() {
   return (
     <div>

--- a/test/development/app-dir/turbopack-import-assertions-use/app/page.tsx
+++ b/test/development/app-dir/turbopack-import-assertions-use/app/page.tsx
@@ -8,6 +8,8 @@ import replacedValue from '../data-with-placeholder.js' with { turbopackLoader: 
 import rawTextViaModuleType from '../data2.txt' with { turbopackLoader: '../node_modules/test-raw-loader/index.js', turbopackModuleType: 'ecmascript' }
 // Import a non-.json file and treat it as JSON via turbopackModuleType
 import jsonData from '../data.jsonlike' with { turbopackLoader: 'test-identity-loader', turbopackModuleType: 'json' }
+// Normal rules should still work at the same time
+import jsonData2 from '../data.jsonlike2'
 
 export default function Page() {
   return (
@@ -16,6 +18,7 @@ export default function Page() {
       <p id="replaced">{replacedValue}</p>
       <p id="module-type">{rawTextViaModuleType}</p>
       <p id="json-type">{jsonData.greeting}</p>
+      <p id="json-type-2">{jsonData2.greeting}</p>
     </div>
   )
 }

--- a/test/development/app-dir/turbopack-import-assertions-use/data.jsonlike2
+++ b/test/development/app-dir/turbopack-import-assertions-use/data.jsonlike2
@@ -1,0 +1,1 @@
+{"greeting": "Hello from JSON module type 2"}

--- a/test/development/app-dir/turbopack-import-assertions-use/next.config.js
+++ b/test/development/app-dir/turbopack-import-assertions-use/next.config.js
@@ -1,6 +1,14 @@
 /**
  * @type {import('next').NextConfig}
  */
-const nextConfig = {}
+const nextConfig = {
+  turbopack: {
+    rules: {
+      '*.jsonlike2': {
+        loaders: ['test-identity-loader'],
+      },
+    },
+  },
+}
 
 module.exports = nextConfig

--- a/test/development/app-dir/turbopack-import-assertions-use/next.config.js
+++ b/test/development/app-dir/turbopack-import-assertions-use/next.config.js
@@ -6,6 +6,7 @@ const nextConfig = {
     rules: {
       '*.jsonlike2': {
         loaders: ['test-identity-loader'],
+        as: '*.json',
       },
     },
   },

--- a/test/development/app-dir/turbopack-import-assertions-use/turbopack-import-assertions-use.test.ts
+++ b/test/development/app-dir/turbopack-import-assertions-use/turbopack-import-assertions-use.test.ts
@@ -34,6 +34,6 @@ describe('turbopack-import-assertions-use', () => {
 
   it('should apply identity with loader rules', async () => {
     const $ = await next.render$('/')
-    expect($('#json-type2').text()).toBe('Hello from JSON module type 2')
+    expect($('#json-type-2').text()).toBe('Hello from JSON module type 2')
   })
 })

--- a/test/development/app-dir/turbopack-import-assertions-use/turbopack-import-assertions-use.test.ts
+++ b/test/development/app-dir/turbopack-import-assertions-use/turbopack-import-assertions-use.test.ts
@@ -31,4 +31,9 @@ describe('turbopack-import-assertions-use', () => {
     const $ = await next.render$('/')
     expect($('#json-type').text()).toBe('Hello from JSON module type')
   })
+
+  it('should apply identity with loader rules', async () => {
+    const $ = await next.render$('/')
+    expect($('#json-type2').text()).toBe('Hello from JSON module type 2')
+  })
 })

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -716,7 +716,7 @@ async fn process_default_internal(
             *execution_context,
             Some(import_map),
             None,
-            Layer::new(rcstr!("turbopack_use_loaders")),
+            Layer::new(rcstr!("webpack_loaders")),
             false,
         )
         .to_resolved()


### PR DESCRIPTION
Otherwise you get a `Dependency tracking is disabled` / infinite loop when trying to use both turbopack.rules.loader and turbopackLoader at the same time