### PR TITLE
Skip generating fallback shells for routes with undefined root params

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2909,19 +2909,14 @@ export default async function build(
                   : false
 
                 routes.forEach((route) => {
-                  // If the route has any dynamic root segments, we need to skip
-                  // rendering the route. This is because we don't support
-                  // revalidating the shells without the parameters present.
-                  // Note that we only have fallback root params if we also have
-                  // PPR enabled for this route/app already.
+                  // Skip rendering fallback shells for routes with undefined
+                  // root params. These routes always use BLOCKING_STATIC_RENDER
+                  // (or NOT_FOUND when dynamicParams is false), so the server
+                  // does a full on-demand prerender instead of resuming a
+                  // prebuilt fallback shell.
                   if (
                     route.fallbackRootParams &&
-                    route.fallbackRootParams.length > 0 &&
-                    // We don't skip rendering the route if we have the
-                    // following enabled. This is because the flight data now
-                    // does not contain any of the route params and is instead
-                    // completely static.
-                    !config.cacheComponents
+                    route.fallbackRootParams.length > 0
                   ) {
                     return
                   }

--- a/test/e2e/app-dir/app-root-params-getters/simple.test.ts
+++ b/test/e2e/app-dir/app-root-params-getters/simple.test.ts
@@ -1,9 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 import { waitForNoRedbox, retry } from 'next-test-utils'
+import { readdir } from 'fs/promises'
 import { join } from 'path'
 import { createSandbox } from 'development-sandbox'
 import { outdent } from 'outdent'
 import { createRequestTracker } from '../../../lib/e2e-utils/request-tracker'
+
+const isCacheComponentsEnabled = process.env.__NEXT_CACHE_COMPONENTS === 'true'
 
 describe('app-root-param-getters - simple', () => {
   let currentCliOutputIndex = 0
@@ -174,6 +177,48 @@ describe('app-root-param-getters - simple', () => {
       `${params.lang} ${params.locale}`
     )
   })
+
+  if (!isNextDev && !isNextDeploy) {
+    it('should not generate fallback shells for routes with undefined root params', async () => {
+      const serverAppDir = join(next.testDir, '.next/server/app')
+      const allFiles = await readdir(serverAppDir, { recursive: true })
+      const htmlFiles = allFiles
+        .filter((f) => f.endsWith('.html'))
+        .map((f) => f.replace(/\\/g, '/'))
+        .sort()
+
+      // Fallback shells with undefined root params use BLOCKING_STATIC_RENDER
+      // and are never served, so they should not be generated at build time.
+      expect(htmlFiles).not.toContainEqual(
+        expect.stringMatching(/^\[lang\]\/\[locale\]/)
+      )
+      expect(htmlFiles).not.toContainEqual(expect.stringContaining('[...path]'))
+
+      // Concrete prerendered shells and shells without undefined root params
+      // should still be generated.
+      const alwaysExpected = [
+        'en/us.html',
+        'en/us/other.html',
+        'en/us/server-action.html',
+        'catch-all/foo.html',
+        'optional-catch-all.html',
+      ]
+
+      // With Cache Components enabled we also generate partially static shells.
+      const cacheComponentsOnly = [
+        'en/us/other/[slug].html',
+        'en/us/rerender-after-server-action.html',
+      ]
+
+      expect(htmlFiles).toEqual(
+        expect.arrayContaining(
+          isCacheComponentsEnabled
+            ? [...alwaysExpected, ...cacheComponentsOnly]
+            : alwaysExpected
+        )
+      )
+    })
+  }
 
   // TODO(root-params): add support for route handlers
   it('should error when used in a route handler (until we implement it)', async () => {


### PR DESCRIPTION
Routes with undefined root params always use `BLOCKING_STATIC_RENDER` (or `NOT_FOUND` when `dynamicParams` is `false`), which means the server does a full on-demand prerender instead of serving a prebuilt shell. The fallback shell HTML was therefore dead output that was never served at runtime.

The previous code already skipped this generation when `cacheComponents` was disabled, but the `cacheComponents` exception (added in #82621 for `clientParamParsing`) was unnecessary because `calculateFallbackMode` was never updated to return `PRERENDER` for these routes. The generated shells also contained incorrect content due to the Resume Data Cache (RDC) leaking values from a previous specific shell prerender.

When we want to serve these fallback shells in the future, we will also need to overhaul how the RDC is shared between specific shell prerendering and fallback shell prerendering, similar to the cache key upgrades already done for cache handlers. Cache functions that access root fallback params would then likely become dynamic holes in the fallback shell, the same as for normal route fallback params today.