### PR TITLE
[test] Unflake app prefetch test

### DIFF
--- a/test/e2e/app-dir/app-prefetch/prefetching.test.ts
+++ b/test/e2e/app-dir/app-prefetch/prefetching.test.ts
@@ -366,9 +366,11 @@ describe('app dir - prefetching', () => {
     await browser.elementById('prefetch-via-link').click()
 
     // Assert that we're on the homepage (check for accordion since links are hidden)
-    expect(
-      await browser.hasElementByCssSelector('#accordion-to-dashboard')
-    ).toBe(true)
+    await retry(async () => {
+      expect(await browser.hasElementByCss('#accordion-to-dashboard')).toBe(
+        true
+      )
+    })
 
     await browser.waitForIdleNetwork()
 


### PR DESCRIPTION
[Flakiness metric](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40git.repository.id%3A%22github.com%2Fvercel%2Fnext.js%22%20%40test.type%3A%22nextjs%22%20%40test.status%3A%22fail%22%20%40test.name%3A%22app%20dir%20-%20prefetching%20should%20not%20unintentionally%20modify%20the%20requested%20prefetch%20by%20escaping%20the%20uri%20encoded%20query%20params%22&agg_m=count&agg_m_source=base&agg_t=count&fromUser=false&index=citest&start=1773424617562&end=1774029417562&paused=false)

Another victim of the Playwright upgrade. Adding a `retry` to the assertion should fix the flakiness, as it seems that the element is not always immediately visible after the click.