### PR TITLE
docs: add TS example to allowedDevOrigins

### DIFF
--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/allowedDevOrigins.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/allowedDevOrigins.mdx
@@ -9,7 +9,7 @@ Next.js blocks cross-origin requests to dev-only assets and endpoints during dev
 
 To configure a Next.js application to allow requests from origins other than the hostname the server was initialized with (`localhost` by default), use the `allowedDevOrigins` config option.
 
-`allowedDevOrigins` lets you set additional origins that can request the dev server in development mode. 
+`allowedDevOrigins` lets you set additional origins that can request the dev server in development mode.
 
 ## TypeScript
 

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/allowedDevOrigins.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/allowedDevOrigins.mdx
@@ -9,7 +9,25 @@ Next.js blocks cross-origin requests to dev-only assets and endpoints during dev
 
 To configure a Next.js application to allow requests from origins other than the hostname the server was initialized with (`localhost` by default), use the `allowedDevOrigins` config option.
 
-`allowedDevOrigins` lets you set additional origins that can request the dev server in development mode. For example, to use `local-origin.dev` instead of only `localhost`, open `next.config.js` and add the `allowedDevOrigins` config:
+`allowedDevOrigins` lets you set additional origins that can request the dev server in development mode. 
+
+## TypeScript
+
+For example, to use `local-origin.dev` instead of only `localhost`, open `next.config.ts` and add the `allowedDevOrigins` config:
+
+```ts filename="next.config.ts"
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  allowedDevOrigins: ['local-origin.dev', '*.local-origin.dev'],
+}
+
+export default nextConfig
+```
+
+## JavaScript
+
+For example, to use `local-origin.dev` instead of only `localhost`, open `next.config.js` and add the `allowedDevOrigins` config:
 
 ```js filename="next.config.js"
 module.exports = {


### PR DESCRIPTION
- Added note about TypeScript configuration, current implementation only showed JavaScript.
- Ran `pnpm prettier-fix` tp ensure consistency, like told in instructions. 



If this change seems useful, I can create a new PR that also fixes the console log found in `block-cross-site-dev.ts`

<img width="1426" height="328" alt="image" src="https://github.com/user-attachments/assets/43725120-f2b4-47fb-aee3-1da19885c291" />

