### PR TITLE
docs: add catchError benefits over userspace error boundaries

### DIFF
--- a/docs/01-app/03-api-reference/04-functions/catchError.mdx
+++ b/docs/01-app/03-api-reference/04-functions/catchError.mdx
@@ -10,6 +10,12 @@ related:
 
 The `unstable_catchError` function creates a component that wraps its children in an error boundary. It provides a programmatic alternative to the [`error.js`](/docs/app/api-reference/file-conventions/error) file convention, enabling component-level error recovery anywhere in your component tree.
 
+Compared to a custom React error boundary, `unstable_catchError` is designed to work with Next.js out of the box:
+
+- **Built-in error recovery** — [`unstable_retry()`](/docs/app/api-reference/file-conventions/error#unstable_retry) re-fetches and re-renders the error boundary's children, including Server Components.
+- **Framework-aware integration** — APIs like `redirect()` and `notFound()` work by throwing special errors under the hood. `unstable_catchError` handles these seamlessly, so they're not accidentally caught by your error boundary.
+- **Client navigation handling** — The error state automatically clears when you do a client navigation to a different route.
+
 `unstable_catchError` can be called from [Client Components](/docs/app/getting-started/server-and-client-components).
 
 ```tsx filename="app/custom-error-boundary.tsx" switcher


### PR DESCRIPTION
## Summary

- Add bullet list explaining three key benefits of `unstable_catchError` over a plain React error boundary: built-in error recovery via `retry()`, framework-aware handling of `redirect()`/`notFound()`, and automatic error state clearing on client navigation.

[slack thread](https://vercel.slack.com/archives/C02CDC2ALJH/p1774047269162799)