### PR TITLE
fix(rsc): don’t flag MDX metadata export when file lacks "use client" in client layer

### DIFF
--- a/crates/next-custom-transforms/src/transforms/react_server_components.rs
+++ b/crates/next-custom-transforms/src/transforms/react_server_components.rs
@@ -1162,7 +1162,7 @@ impl Visit for ReactServerComponentValidator {
                 && directive != Some(ModuleDirective::UseCache)
             {
                 self.assert_client_graph(&imports);
-                self.assert_invalid_api(module, true);
+                self.assert_invalid_api(module, directive == Some(ModuleDirective::UseClient));
             }
         }
 

--- a/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/metadata/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/metadata/output.stderr
@@ -3,7 +3,9 @@
   | component-only
   | 
   | 
-   ,-[input.js:1:1]
- 1 | export const metadata = {}
+   ,-[page.js:3:7]
+ 1 | "use client"
+ 2 | 
+ 3 | export const metadata = {}
    :              ^^^^^^^^
    `----

--- a/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/metadata/page.js
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/metadata/page.js
@@ -1,3 +1,5 @@
+"use client"
+
 export const metadata = {}
 
 export default function () {

--- a/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/multiple/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/multiple/output.stderr
@@ -3,8 +3,10 @@
   | component-only
   | 
   | 
-   ,-[input.js:1:1]
- 1 | export const metadata = {}
+   ,-[page.js:3:7]
+ 1 | "use client"
+ 2 | 
+ 3 | export const metadata = {}
    :              ^^^^^^^^
    `----
   x You are attempting to export "generateMetadata" from a component marked with "use client", which is disallowed. "generateMetadata" must be resolved on the server before the page component is
@@ -12,16 +14,18 @@
   | generatemetadata-is-server-component-only
   | 
   | 
-   ,-[input.js:3:1]
- 2 | 
- 3 | export function generateMetadata() {}
+   ,-[page.js:5:7]
+ 3 | export const metadata = {}
+ 4 | 
+ 5 | export function generateMetadata() {}
    :                 ^^^^^^^^^^^^^^^^
    `----
   x "getServerSideProps" is not supported in app/. Read more: https://nextjs.org/docs/app/building-your-application/data-fetching
   | 
   | 
-   ,-[input.js:5:1]
- 4 | 
- 5 | export function getServerSideProps() {}
+   ,-[page.js:7:7]
+ 5 | export function generateMetadata() {}
+ 6 | 
+ 7 | export function getServerSideProps() {}
    :                 ^^^^^^^^^^^^^^^^^^
    `----

--- a/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/multiple/page.js
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/multiple/page.js
@@ -1,3 +1,5 @@
+"use client"
+
 export const metadata = {}
 
 export function generateMetadata() {}


### PR DESCRIPTION
### What?

- Only treat metadata / generateMetadata as invalid in the client layer when the file has "use client".

### Why?

- Webpack can run server MDX pages through the client layer; false positives broke export const metadata.

### How?

- assert_invalid_api(..., directive == UseClient) + update fixtures.

Fixes #91735
