### PR TITLE
Fix stale dev page list during rewrite adoption

### DIFF
--- a/packages/next/src/client/page-loader.ts
+++ b/packages/next/src/client/page-loader.ts
@@ -61,29 +61,36 @@ export default class PageLoader {
     })
   }
 
-  getPageList() {
+  getPageList(refresh = false) {
     if (process.env.NODE_ENV === 'production') {
       return getClientBuildManifest().then((manifest) => manifest.sortedPages)
     } else {
-      if (window.__DEV_PAGES_MANIFEST) {
+      // Reuse the current dev page list unless the caller explicitly refreshes it.
+      if (window.__DEV_PAGES_MANIFEST && !refresh) {
         return window.__DEV_PAGES_MANIFEST.pages
       } else {
-        this.promisedDevPagesManifest ||= fetch(
-          `${this.assetPrefix}/_next/static/development/${DEV_CLIENT_PAGES_MANIFEST}`,
-          { credentials: 'same-origin' }
-        )
-          .then((res) => res.json())
-          .then((manifest: { pages: string[] }) => {
-            window.__DEV_PAGES_MANIFEST = manifest
-            return manifest.pages
-          })
-          .catch((err) => {
-            console.log(`Failed to fetch devPagesManifest:`, err)
-            throw new Error(
-              `Failed to fetch _devPagesManifest.json. Is something blocking that network request?\n` +
-                'Read more: https://nextjs.org/docs/messages/failed-to-fetch-devpagesmanifest'
-            )
-          })
+        // A refresh should not reuse the cached manifest or an existing fetch promise.
+        if (!this.promisedDevPagesManifest || refresh) {
+          this.promisedDevPagesManifest = fetch(
+            `${this.assetPrefix}/_next/static/development/${DEV_CLIENT_PAGES_MANIFEST}`,
+            // A refresh should fetch the latest dev manifest instead of a cached response.
+            refresh
+              ? { credentials: 'same-origin', cache: 'no-store' }
+              : { credentials: 'same-origin' }
+          )
+            .then((res) => res.json())
+            .then((manifest: { pages: string[] }) => {
+              window.__DEV_PAGES_MANIFEST = manifest
+              return manifest.pages
+            })
+            .catch((err) => {
+              console.log(`Failed to fetch devPagesManifest:`, err)
+              throw new Error(
+                `Failed to fetch _devPagesManifest.json. Is something blocking that network request?\n` +
+                  'Read more: https://nextjs.org/docs/messages/failed-to-fetch-devpagesmanifest'
+              )
+            })
+        }
         return this.promisedDevPagesManifest
       }
     }

--- a/packages/next/src/shared/lib/router/router.ts
+++ b/packages/next/src/shared/lib/router/router.ts
@@ -213,7 +213,12 @@ function getMiddlewareData<T extends FetchDataOutput>(
       return Promise.all([
         options.router.pageLoader.getPageList(),
         getClientBuildManifest(),
-      ]).then(([pages, { __rewrites: rewrites }]: any) => {
+      ]).then(async ([pages, { __rewrites: rewrites }]: any) => {
+        // Refresh once if the rewritten target is missing from the current page list.
+        if (rewriteHeader && !pages.includes(fsPathname)) {
+          pages = await options.router.pageLoader.getPageList(true)
+        }
+
         let as = addLocale(pathnameInfo.pathname, pathnameInfo.locale)
 
         if (

--- a/test/development/pages-dir/stale-dev-pages-manifest/fixture/components/RewrittenRouteComponent.js
+++ b/test/development/pages-dir/stale-dev-pages-manifest/fixture/components/RewrittenRouteComponent.js
@@ -1,0 +1,3 @@
+export default function RewrittenRouteComponent() {
+  return <p id="rewritten-route-component">Loaded rewritten route component</p>
+}

--- a/test/development/pages-dir/stale-dev-pages-manifest/fixture/components/RouteRenderer.js
+++ b/test/development/pages-dir/stale-dev-pages-manifest/fixture/components/RouteRenderer.js
@@ -1,0 +1,23 @@
+export default function RouteRenderer({
+  titleId,
+  title,
+  requiredComponentName,
+  componentMap,
+}) {
+  const RequiredComponent = requiredComponentName
+    ? componentMap[requiredComponentName]
+    : null
+
+  if (requiredComponentName && !RequiredComponent) {
+    throw new Error(
+      `Expected component "${requiredComponentName}" to be defined.`
+    )
+  }
+
+  return (
+    <main>
+      <h1 id={titleId}>{title}</h1>
+      {RequiredComponent ? <RequiredComponent /> : null}
+    </main>
+  )
+}

--- a/test/development/pages-dir/stale-dev-pages-manifest/fixture/components/StartPageControls.js
+++ b/test/development/pages-dir/stale-dev-pages-manifest/fixture/components/StartPageControls.js
@@ -1,0 +1,26 @@
+import Link from 'next/link'
+
+export default function StartPageControls() {
+  const materializeHandler = async () => {
+    const response = await fetch('/api/materialize-handler', { method: 'POST' })
+
+    if (!response.ok) {
+      throw new Error(`Request failed with status ${response.status}`)
+    }
+  }
+
+  return (
+    <div>
+      <button
+        id="materialize-example"
+        type="button"
+        onClick={materializeHandler}
+      >
+        Materialize example
+      </button>
+      <Link href="/docs/example" prefetch={false} id="go-to-example">
+        Go to example
+      </Link>
+    </div>
+  )
+}

--- a/test/development/pages-dir/stale-dev-pages-manifest/fixture/page-sources/example-rewritten-page.js
+++ b/test/development/pages-dir/stale-dev-pages-manifest/fixture/page-sources/example-rewritten-page.js
@@ -1,0 +1,23 @@
+// These imports are written for the page's final location under
+// pages/docs/_handlers, not this source file's current page-sources folder.
+import RewrittenRouteComponent from '../../../components/RewrittenRouteComponent'
+import RouteRenderer from '../../../components/RouteRenderer'
+
+export default function ExampleRewrittenPage({ requiredComponentName }) {
+  return (
+    <RouteRenderer
+      titleId="rewritten-route-page"
+      title="Rewritten route page"
+      requiredComponentName={requiredComponentName}
+      componentMap={{ RewrittenRouteComponent }}
+    />
+  )
+}
+
+export async function getStaticProps() {
+  return {
+    props: {
+      requiredComponentName: 'RewrittenRouteComponent',
+    },
+  }
+}

--- a/test/development/pages-dir/stale-dev-pages-manifest/fixture/pages/api/materialize-handler.js
+++ b/test/development/pages-dir/stale-dev-pages-manifest/fixture/pages/api/materialize-handler.js
@@ -1,0 +1,20 @@
+import { copyFile, mkdir } from 'fs/promises'
+import path from 'path'
+
+const HANDLER_FIXTURE_PATH = path.join(
+  process.cwd(),
+  'page-sources/example-rewritten-page.js'
+)
+const HANDLER_PAGE_PATH = path.join(
+  process.cwd(),
+  'pages/docs/_handlers/example.js'
+)
+
+export default async function materializeHandler(_req, res) {
+  // Materialize the rewritten page only when the test asks for it.
+  await mkdir(path.dirname(HANDLER_PAGE_PATH), { recursive: true })
+  await copyFile(HANDLER_FIXTURE_PATH, HANDLER_PAGE_PATH)
+
+  // The client only checks that the request succeeded.
+  res.status(204).end()
+}

--- a/test/development/pages-dir/stale-dev-pages-manifest/fixture/pages/docs/[...slug].js
+++ b/test/development/pages-dir/stale-dev-pages-manifest/fixture/pages/docs/[...slug].js
@@ -1,0 +1,54 @@
+import StartPageControls from '../../components/StartPageControls'
+import RouteRenderer from '../../components/RouteRenderer'
+
+export default function DocsCatchAllPage({ mode, requiredComponentName }) {
+  if (mode === 'start') {
+    return (
+      <main>
+        <h1>Docs start page</h1>
+        <p>
+          This tab should already be open before the rewritten page is added.
+        </p>
+        <StartPageControls />
+      </main>
+    )
+  }
+
+  return (
+    // Keep the catch-all and rewritten page on the same renderer so a stale
+    // rewrite adoption fails as a missing component instead of silently
+    // rendering the wrong page.
+    <RouteRenderer
+      title="Catch-all page"
+      requiredComponentName={requiredComponentName}
+      componentMap={{}}
+    />
+  )
+}
+
+export async function getStaticProps({ params }) {
+  const slug = params.slug.join('/')
+
+  if (slug === 'start') {
+    return {
+      props: {
+        // Boot the browser on a stable public route before the handler exists.
+        mode: 'start',
+      },
+    }
+  }
+
+  return {
+    props: {
+      mode: 'catch-all',
+      requiredComponentName: null,
+    },
+  }
+}
+
+export async function getStaticPaths() {
+  return {
+    paths: [{ params: { slug: ['start'] } }, { params: { slug: ['example'] } }],
+    fallback: false,
+  }
+}

--- a/test/development/pages-dir/stale-dev-pages-manifest/fixture/proxy.js
+++ b/test/development/pages-dir/stale-dev-pages-manifest/fixture/proxy.js
@@ -1,0 +1,48 @@
+import { access } from 'fs/promises'
+import path from 'path'
+import { NextResponse } from 'next/server'
+
+const PUBLIC_ROUTE = '/docs/example'
+const REWRITTEN_ROUTE = '/docs/_handlers/example'
+const GENERATED_HANDLER_PATH = path.join(
+  process.cwd(),
+  'pages',
+  'docs',
+  '_handlers',
+  'example.js'
+)
+
+async function doesGeneratedHandlerExist() {
+  try {
+    await access(GENERATED_HANDLER_PATH)
+    return true
+  } catch {
+    return false
+  }
+}
+
+export async function proxy(request) {
+  const { pathname } = request.nextUrl
+
+  if (pathname === REWRITTEN_ROUTE) {
+    return NextResponse.next()
+  }
+
+  if (pathname !== PUBLIC_ROUTE) {
+    return NextResponse.next()
+  }
+
+  // Only rewrite once the handler page has actually been materialized.
+  if (!(await doesGeneratedHandlerExist())) {
+    return NextResponse.next()
+  }
+
+  const rewriteUrl = request.nextUrl.clone()
+  rewriteUrl.pathname = REWRITTEN_ROUTE
+
+  return NextResponse.rewrite(rewriteUrl)
+}
+
+export const config = {
+  matcher: ['/docs/:path*'],
+}

--- a/test/development/pages-dir/stale-dev-pages-manifest/fixture/public/favicon.ico
+++ b/test/development/pages-dir/stale-dev-pages-manifest/fixture/public/favicon.ico
@@ -1,0 +1,1 @@
+placeholder

--- a/test/development/pages-dir/stale-dev-pages-manifest/index.test.ts
+++ b/test/development/pages-dir/stale-dev-pages-manifest/index.test.ts
@@ -1,0 +1,47 @@
+/* eslint-env jest */
+
+import path from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import { waitForNoRedbox } from 'next-test-utils'
+
+describe('stale dev pages manifest during rewrite adoption', () => {
+  const { next } = nextTestSetup({
+    files: path.join(__dirname, 'fixture'),
+  })
+
+  it('should adopt a rewritten route that becomes available after boot', async () => {
+    const browser = await next.browser('/docs/start')
+
+    try {
+      // 1. Materialize the rewritten target after the tab has already booted.
+      const materializeButton = await browser.elementByCss(
+        '#materialize-example'
+      )
+      await materializeButton.click()
+
+      // 2. Trigger the client-side navigation through the public route.
+      await browser.elementByCss('#go-to-example').click()
+
+      // 3. The rewritten page should render while the browser stays on the public URL.
+      const rewrittenRoutePage = await browser.elementByCss(
+        '#rewritten-route-page'
+      )
+      expect(await rewrittenRoutePage.text()).toBe('Rewritten route page')
+
+      const publicPathname = await browser.eval(`window.location.pathname`)
+      expect(publicPathname).toBe('/docs/example')
+
+      const rewrittenRouteComponent = await browser.elementByCss(
+        '#rewritten-route-component'
+      )
+      expect(await rewrittenRouteComponent.text()).toBe(
+        'Loaded rewritten route component'
+      )
+
+      // 4. The rewritten navigation should complete without surfacing a dev error overlay.
+      await waitForNoRedbox(browser)
+    } finally {
+      await browser.close()
+    }
+  })
+})


### PR DESCRIPTION
### What?

Fix a Pages Router development bug where the client can keep rendering the previously loaded page after a rewrite resolves to a route that became available later.

This change:
- lets `PageLoader` refresh the dev page list on demand
- avoids reusing cached dev manifest state during an explicit refresh
- retries rewrite resolution once when the rewritten target is missing from the current page list
- adds a development regression that materializes the rewritten target during the test flow and verifies client-side navigation still adopts it correctly

### Why?

This fixes a stale client page-list problem reported in #91724.

In the reported case:
1. `/docs/start` is loaded first.
2. The rewritten target page does not exist yet.
3. The rewritten target is materialized afterward.
4. A client-side navigation to `/docs/example` is rewritten to `/docs/_handlers/example`.
5. The server can already serve the rewritten target.
6. The client can still continue with stale page-list state and keep rendering the previously loaded page.

That leaves the client resolving the rewrite against stale route information instead of switching to the rewritten page immediately.

### How?

`PageLoader` now supports an explicit dev page-list refresh that bypasses both the cached manifest and any existing dev-manifest fetch promise.

The router only does that refresh in the rewrite path, when the rewritten target is missing from the current client page list.

The regression test covers the same sequence in `next dev` by:
- starting on `/docs/start`
- materializing the rewritten target through an API route
- navigating client-side through `/docs/example`
- asserting that the rewritten route renders while the public URL stays the same
- asserting that no dev redbox appears

Fixes #91724