### PR TITLE
fix: apply AppType generic parameter to top-level props instead of pageProps

### DIFF
--- a/packages/next/src/shared/lib/utils.ts
+++ b/packages/next/src/shared/lib/utils.ts
@@ -31,7 +31,7 @@ export type DocumentType = NextComponentType<
 export type AppType<P = {}> = NextComponentType<
   AppContextType,
   P,
-  AppPropsType<any, P>
+  AppPropsType & P
 >
 
 export type AppTreeType = ComponentType<

--- a/test/integration/typescript/pages/_app.tsx
+++ b/test/integration/typescript/pages/_app.tsx
@@ -1,6 +1,6 @@
 import type { AppType } from 'next/app'
 
-const MyApp: AppType<{ foo: string }> = ({ Component, pageProps }) => {
+const MyApp: AppType<{ foo: string }> = ({ Component, pageProps, foo }) => {
   return <Component {...pageProps} />
 }
 


### PR DESCRIPTION
## Summary

Fixes #42846

The generic parameter `P` in `AppType<P>` was incorrectly being passed as the `PageProps` type parameter to `AppPropsType<any, P>`, which nested custom props inside `props.pageProps`. At runtime, `App.getInitialProps` returns custom properties at the top level of `props` (alongside `pageProps`), not inside `pageProps`.

**Before (broken):**
```ts
// AppType<P> = NextComponentType<AppContextType, P, AppPropsType<any, P>>
// Props type = { pageProps: P, Component, router }

const MyApp: AppType<{ foo: string }> = (props) => {
  props.pageProps.foo // TS: OK (wrong - doesn't exist at runtime)
  props.foo           // TS: Error (wrong - exists at runtime)
}
```

**After (fixed):**
```ts
// AppType<P> = NextComponentType<AppContextType, P, AppPropsType & P>
// Props type = { pageProps: any, Component, router } & P

const MyApp: AppType<{ foo: string }> = (props) => {
  props.foo           // TS: OK (correct - exists at runtime)
}
```

## Changes

- `packages/next/src/shared/lib/utils.ts`: Changed `AppPropsType<any, P>` to `AppPropsType & P` so that the generic parameter is applied at the top level of component props
- `test/integration/typescript/pages/_app.tsx`: Updated test to destructure `foo` from top-level props (validating the fix)

## Test plan

- Verified type correctness matches runtime behavior as described in #42846
- Updated existing TypeScript integration test to validate the fix