### PR TITLE
docs: clarify standalone output paths in monorepos

### DIFF
--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/output.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/output.mdx
@@ -35,16 +35,35 @@ This will create a folder at `.next/standalone` which can then be deployed on it
 
 Additionally, a minimal `server.js` file is also output which can be used instead of `next start`. This minimal server does not copy the `public` or `.next/static` folders by default as these should ideally be handled by a CDN instead, although these folders can be copied to the `standalone/public` and `standalone/.next/static` folders manually, after which `server.js` file will serve these automatically.
 
+In monorepos, the `standalone` folder preserves the relative path of your app so traced dependencies can stay in the right place. For example, an app at `apps/web` would produce:
+
+```txt filename=".next/standalone"
+node_modules/
+apps/
+  web/
+    server.js
+```
+
+In that case, the commands below should use the same relative app path, for example `node .next/standalone/apps/web/server.js` from the monorepo root. If you copy `public` or `.next/static` manually, copy them into that same relative location inside `.next/standalone`.
+
 To copy these manually, you can use the `cp` command-line tool after you `next build`:
 
 ```bash filename="Terminal"
+# If your app is at the repository root
 cp -r public .next/standalone/ && cp -r .next/static .next/standalone/.next/
+
+# If your app is in a monorepo, for example apps/web
+cp -r public .next/standalone/apps/web/ && cp -r .next/static .next/standalone/apps/web/.next/
 ```
 
 To start your minimal `server.js` file locally, run the following command:
 
 ```bash filename="Terminal"
+# If your app is at the repository root
 node .next/standalone/server.js
+
+# If your app is in a monorepo, for example apps/web
+node .next/standalone/apps/web/server.js
 ```
 
 <AppOnly>


### PR DESCRIPTION
## Summary
- explain that standalone output preserves an app's relative path inside monorepos
- show where `server.js` ends up for apps like `apps/web`
- add matching copy/run command examples for repo-root apps and monorepo apps

Closes #78446