### PR TITLE
feat: support root params in route handlers

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -3,8 +3,8 @@ use bincode::{Decode, Encode};
 use next_core::{
     app_structure::{
         AppPageLoaderTree, CollectedRootParams, Entrypoint as AppEntrypoint,
-        Entrypoints as AppEntrypoints, FileSystemPathVec, MetadataItem, collect_root_params,
-        get_entrypoints,
+        Entrypoints as AppEntrypoints, FileSystemPathVec, MetadataItem, RootParamVecOption,
+        collect_root_params, get_entrypoints,
     },
     get_edge_resolve_options_context, get_next_package,
     next_app::{
@@ -1029,7 +1029,10 @@ pub fn app_entry_point_to_route(
 ) -> Vc<Route> {
     match entrypoint {
         AppEntrypoint::AppPage {
-            pages, loader_tree, ..
+            pages,
+            loader_tree,
+            root_params,
+            ..
         } => Route::AppPage(
             pages
                 .into_iter()
@@ -1043,6 +1046,7 @@ pub fn app_entry_point_to_route(
                             },
                             app_project,
                             page: page.clone(),
+                            root_params,
                         }
                         .resolved_cell(),
                     ),
@@ -1054,6 +1058,7 @@ pub fn app_entry_point_to_route(
                             },
                             app_project,
                             page,
+                            root_params,
                         }
                         .resolved_cell(),
                     ),
@@ -1064,6 +1069,7 @@ pub fn app_entry_point_to_route(
             page,
             path,
             root_layouts,
+            root_params,
             ..
         } => Route::AppRoute {
             original_name: page.to_string().into(),
@@ -1072,17 +1078,24 @@ pub fn app_entry_point_to_route(
                     ty: AppEndpointType::Route { path, root_layouts },
                     app_project,
                     page,
+                    root_params,
                 }
                 .resolved_cell(),
             ),
         },
-        AppEntrypoint::AppMetadata { page, metadata, .. } => Route::AppRoute {
+        AppEntrypoint::AppMetadata {
+            page,
+            metadata,
+            root_params,
+            ..
+        } => Route::AppRoute {
             original_name: page.to_string().into(),
             endpoint: ResolvedVc::upcast(
                 AppEndpoint {
                     ty: AppEndpointType::Metadata { metadata },
                     app_project,
                     page,
+                    root_params,
                 }
                 .resolved_cell(),
             ),
@@ -1117,6 +1130,7 @@ struct AppEndpoint {
     ty: AppEndpointType,
     app_project: ResolvedVc<AppProject>,
     page: AppPage,
+    root_params: ResolvedVc<RootParamVecOption>,
 }
 
 #[turbo_tasks::value_impl]
@@ -1163,6 +1177,7 @@ impl AppEndpoint {
             self.app_project.project().project_path().owned().await?,
             config,
             next_config,
+            *self.root_params,
         ))
     }
 

--- a/crates/next-core/src/next_app/app_route_entry.rs
+++ b/crates/next-core/src/next_app/app_route_entry.rs
@@ -36,6 +36,7 @@ pub async fn get_app_route_entry(
     project_root: FileSystemPath,
     original_segment_config: Option<Vc<NextSegmentConfig>>,
     next_config: Vc<NextConfig>,
+    root_params: Vc<crate::app_structure::RootParamVecOption>,
 ) -> Result<Vc<AppEntry>> {
     let segment_from_source = parse_segment_config_from_source(source, ParseSegmentMode::App);
     let config = if let Some(original_segment_config) = original_segment_config {
@@ -70,6 +71,18 @@ pub async fn get_app_route_entry(
         })
         .unwrap_or("\"\"");
 
+    // Convert root params to JSON array of parameter names
+    let root_param_names = if let Some(root_params_vec) = &*root_params.await? {
+        serde_json::to_string(
+            &root_params_vec
+                .iter()
+                .map(|param| param.param.as_str())
+                .collect::<Vec<_>>(),
+        )?
+    } else {
+        "[]".to_string()
+    };
+
     // Load the file from the next.js codebase.
     let virtual_source = load_next_js_template(
         "app-route.js",
@@ -85,7 +98,7 @@ pub async fn get_app_route_entry(
         ],
         [
             ("nextConfigOutput", output_type),
-            // "rootParamNames" => ... // TODO(root-params)
+            ("rootParamNames", &root_param_names),
         ],
         [],
     )

--- a/crates/next-core/src/next_app/app_route_entry.rs
+++ b/crates/next-core/src/next_app/app_route_entry.rs
@@ -83,7 +83,10 @@ pub async fn get_app_route_entry(
             ("VAR_RESOLVED_PAGE_PATH", &path.to_string_ref().await?),
             ("VAR_USERLAND", &inner),
         ],
-        [("nextConfigOutput", output_type)],
+        [
+            ("nextConfigOutput", output_type),
+            // "rootParamNames" => ... // TODO(root-params)
+        ],
         [],
     )
     .await?;

--- a/crates/next-core/src/next_app/app_route_entry.rs
+++ b/crates/next-core/src/next_app/app_route_entry.rs
@@ -76,7 +76,7 @@ pub async fn get_app_route_entry(
         serde_json::to_string(
             &root_params_vec
                 .iter()
-                .map(|param| param.param.as_str())
+                .map(|param| param.as_str())
                 .collect::<Vec<_>>(),
         )?
     } else {

--- a/crates/next-core/src/next_app/metadata/route.rs
+++ b/crates/next-core/src/next_app/metadata/route.rs
@@ -108,7 +108,7 @@ pub async fn get_app_metadata_route_entry(
         project_root,
         Some(segment_config),
         next_config,
-        Vc::cell(None), // Metadata routes don't have root params
+        Vc::cell(None), // TODO(root-params): wire up root params for metadata routes
     ))
 }
 

--- a/crates/next-core/src/next_app/metadata/route.rs
+++ b/crates/next-core/src/next_app/metadata/route.rs
@@ -108,6 +108,7 @@ pub async fn get_app_metadata_route_entry(
         project_root,
         Some(segment_config),
         next_config,
+        Vc::cell(None), // Metadata routes don't have root params
     ))
 }
 

--- a/packages/next/src/build/analysis/get-page-static-info.ts
+++ b/packages/next/src/build/analysis/get-page-static-info.ts
@@ -38,7 +38,6 @@ import {
 import { normalizeAppPath } from '../../shared/lib/router/utils/app-paths'
 import { normalizePagePath } from '../../shared/lib/page-path/normalize-page-path'
 import { isProxyFile } from '../utils'
-import type { ParamInfo } from '../webpack/loaders/next-root-params-loader'
 
 const PARSE_PATTERN =
   /(?<!(_jsx|jsx-))runtime|preferredRegion|getStaticProps|getServerSideProps|generateStaticParams|export const|generateImageMetadata|generateSitemaps|middleware|proxy/
@@ -84,7 +83,6 @@ export interface AppPageStaticInfo {
   preferredRegion: AppSegmentConfig['preferredRegion'] | undefined
   maxDuration: number | undefined
   hadUnsupportedValue: boolean
-  rootParams: ParamInfo[] | undefined
 }
 
 export interface PagesPageStaticInfo {
@@ -623,7 +621,6 @@ export async function getAppPageStaticInfo({
       preferredRegion: undefined,
       maxDuration: undefined,
       hadUnsupportedValue: false,
-      rootParams: undefined,
     }
   }
 
@@ -723,7 +720,6 @@ export async function getAppPageStaticInfo({
     preferredRegion: config.preferredRegion,
     maxDuration: config.maxDuration,
     hadUnsupportedValue,
-    rootParams: undefined,
   }
 }
 

--- a/packages/next/src/build/analysis/get-page-static-info.ts
+++ b/packages/next/src/build/analysis/get-page-static-info.ts
@@ -38,6 +38,7 @@ import {
 import { normalizeAppPath } from '../../shared/lib/router/utils/app-paths'
 import { normalizePagePath } from '../../shared/lib/page-path/normalize-page-path'
 import { isProxyFile } from '../utils'
+import type { ParamInfo } from '../webpack/loaders/next-root-params-loader'
 
 const PARSE_PATTERN =
   /(?<!(_jsx|jsx-))runtime|preferredRegion|getStaticProps|getServerSideProps|generateStaticParams|export const|generateImageMetadata|generateSitemaps|middleware|proxy/
@@ -83,6 +84,7 @@ export interface AppPageStaticInfo {
   preferredRegion: AppSegmentConfig['preferredRegion'] | undefined
   maxDuration: number | undefined
   hadUnsupportedValue: boolean
+  rootParams: ParamInfo[] | undefined
 }
 
 export interface PagesPageStaticInfo {
@@ -621,6 +623,7 @@ export async function getAppPageStaticInfo({
       preferredRegion: undefined,
       maxDuration: undefined,
       hadUnsupportedValue: false,
+      rootParams: undefined,
     }
   }
 
@@ -720,6 +723,7 @@ export async function getAppPageStaticInfo({
     preferredRegion: config.preferredRegion,
     maxDuration: config.maxDuration,
     hadUnsupportedValue,
+    rootParams: undefined,
   }
 }
 

--- a/packages/next/src/build/entries.ts
+++ b/packages/next/src/build/entries.ts
@@ -4,12 +4,7 @@ import type { EdgeSSRLoaderQuery } from './webpack/loaders/next-edge-ssr-loader'
 import type { EdgeAppRouteLoaderQuery } from './webpack/loaders/next-edge-app-route-loader'
 import type { NextConfigComplete } from '../server/config-shared'
 import type { webpack } from 'next/dist/compiled/webpack/webpack'
-import type {
-  AppPageStaticInfo,
-  ProxyConfig,
-  ProxyMatcher,
-  PageStaticInfo,
-} from './analysis/get-page-static-info'
+import type { ProxyConfig, ProxyMatcher } from './analysis/get-page-static-info'
 import type { LoadedEnvFiles } from '@next/env'
 import type { AppLoaderOptions } from './webpack/loaders/next-app-loader'
 
@@ -473,7 +468,7 @@ export async function createEntrypoints(
         (absolutePagePath.startsWith(APP_DIR_ALIAS) ||
           absolutePagePath.startsWith(appDir))
 
-      const staticInfo: PageStaticInfo = await getStaticInfoIncludingLayouts({
+      const staticInfo = await getStaticInfoIncludingLayouts({
         isInsideAppDir,
         pageExtensions,
         pageFilePath,
@@ -518,10 +513,7 @@ export async function createEntrypoints(
               page,
               name: serverBundlePath,
               pagePath: absolutePagePath,
-              rootParams:
-                (staticInfo as AppPageStaticInfo).rootParams?.map(
-                  (p) => p.param
-                ) || [],
+              rootParams: staticInfo.rootParams || [],
               appDir,
               appPaths: matchedAppPaths,
               allNormalizedAppPaths: Object.keys(appPathsPerRoute),
@@ -601,10 +593,7 @@ export async function createEntrypoints(
                 name: serverBundlePath,
                 page,
                 pagePath: absolutePagePath,
-                rootParams:
-                  (staticInfo as AppPageStaticInfo).rootParams?.map(
-                    (p) => p.param
-                  ) || [],
+                rootParams: staticInfo.rootParams || [],
                 appDir: appDir!,
                 appPaths: matchedAppPaths,
                 allNormalizedAppPaths: Object.keys(appPathsPerRoute),

--- a/packages/next/src/build/entries.ts
+++ b/packages/next/src/build/entries.ts
@@ -518,7 +518,10 @@ export async function createEntrypoints(
               page,
               name: serverBundlePath,
               pagePath: absolutePagePath,
-              rootParams: (staticInfo as AppPageStaticInfo).rootParams!,
+              rootParams:
+                (staticInfo as AppPageStaticInfo).rootParams?.map(
+                  (p) => p.param
+                ) || [],
               appDir,
               appPaths: matchedAppPaths,
               allNormalizedAppPaths: Object.keys(appPathsPerRoute),
@@ -598,7 +601,10 @@ export async function createEntrypoints(
                 name: serverBundlePath,
                 page,
                 pagePath: absolutePagePath,
-                rootParams: (staticInfo as AppPageStaticInfo).rootParams!,
+                rootParams:
+                  (staticInfo as AppPageStaticInfo).rootParams?.map(
+                    (p) => p.param
+                  ) || [],
                 appDir: appDir!,
                 appPaths: matchedAppPaths,
                 allNormalizedAppPaths: Object.keys(appPathsPerRoute),

--- a/packages/next/src/build/entries.ts
+++ b/packages/next/src/build/entries.ts
@@ -5,6 +5,7 @@ import type { EdgeAppRouteLoaderQuery } from './webpack/loaders/next-edge-app-ro
 import type { NextConfigComplete } from '../server/config-shared'
 import type { webpack } from 'next/dist/compiled/webpack/webpack'
 import type {
+  AppPageStaticInfo,
   ProxyConfig,
   ProxyMatcher,
   PageStaticInfo,
@@ -517,6 +518,7 @@ export async function createEntrypoints(
               page,
               name: serverBundlePath,
               pagePath: absolutePagePath,
+              rootParams: (staticInfo as AppPageStaticInfo).rootParams!,
               appDir,
               appPaths: matchedAppPaths,
               allNormalizedAppPaths: Object.keys(appPathsPerRoute),
@@ -596,6 +598,7 @@ export async function createEntrypoints(
                 name: serverBundlePath,
                 page,
                 pagePath: absolutePagePath,
+                rootParams: (staticInfo as AppPageStaticInfo).rootParams!,
                 appDir: appDir!,
                 appPaths: matchedAppPaths,
                 allNormalizedAppPaths: Object.keys(appPathsPerRoute),

--- a/packages/next/src/build/get-static-info-including-layouts.ts
+++ b/packages/next/src/build/get-static-info-including-layouts.ts
@@ -32,7 +32,7 @@ export async function getStaticInfoIncludingLayouts({
   config: NextConfigComplete
   isDev: boolean
   page: string
-}): Promise<PageStaticInfo> {
+}): Promise<PageStaticInfo & { rootParams?: string[] }> {
   // TODO: sync types for pages: PAGE_TYPES, ROUTER_TYPE, 'app' | 'pages', etc.
   const pageType = isInsideAppDir ? PAGE_TYPES.APP : PAGE_TYPES.PAGES
 

--- a/packages/next/src/build/get-static-info-including-layouts.ts
+++ b/packages/next/src/build/get-static-info-including-layouts.ts
@@ -14,6 +14,7 @@ import { PAGE_TYPES } from '../lib/page-types'
 import { isAppPageRoute } from '../lib/is-app-page-route'
 
 import { UNDERSCORE_GLOBAL_ERROR_ROUTE_ENTRY } from '../shared/lib/entry-constants'
+import { getParamsFromLayoutFilePath } from './webpack/loaders/next-root-params-loader'
 
 export async function getStaticInfoIncludingLayouts({
   isInsideAppDir,
@@ -54,25 +55,26 @@ export async function getStaticInfoIncludingLayouts({
 
   const segments = [pageStaticInfo]
 
+  const layoutFiles: string[] = []
+  const potentialLayoutFiles = pageExtensions.map((ext) => 'layout.' + ext)
+  let dir = dirname(pageFilePath)
+
+  // We need to find the root layout for both pages and route handlers.
+  // Uses startsWith to not include directories further up.
+  while (dir.startsWith(appDir)) {
+    for (const potentialLayoutFile of potentialLayoutFiles) {
+      const layoutFile = join(dir, potentialLayoutFile)
+      if (!fs.existsSync(layoutFile)) {
+        continue
+      }
+      layoutFiles.push(layoutFile)
+    }
+    // Walk up the directory tree
+    dir = join(dir, '..')
+  }
+
   // inherit from layout files only if it's a page route and not a builtin page
   if (isAppPageRoute(page) && !isAppBuiltinPage(pageFilePath)) {
-    const layoutFiles = []
-    const potentialLayoutFiles = pageExtensions.map((ext) => 'layout.' + ext)
-    let dir = dirname(pageFilePath)
-
-    // Uses startsWith to not include directories further up.
-    while (dir.startsWith(appDir)) {
-      for (const potentialLayoutFile of potentialLayoutFiles) {
-        const layoutFile = join(dir, potentialLayoutFile)
-        if (!fs.existsSync(layoutFile)) {
-          continue
-        }
-        layoutFiles.push(layoutFile)
-      }
-      // Walk up the directory tree
-      dir = join(dir, '..')
-    }
-
     for (const layoutFile of layoutFiles) {
       const layoutStaticInfo = await getAppPageStaticInfo({
         nextConfig,
@@ -86,6 +88,11 @@ export async function getStaticInfoIncludingLayouts({
     }
   }
 
+  const rootLayout = layoutFiles.at(-1)
+  const rootParams = rootLayout
+    ? getParamsFromLayoutFilePath({ appDir, layoutFilePath: rootLayout })
+    : []
+
   const config = reduceAppConfig(segments)
 
   return {
@@ -94,5 +101,6 @@ export async function getStaticInfoIncludingLayouts({
     runtime: config.runtime,
     preferredRegion: config.preferredRegion,
     maxDuration: config.maxDuration,
+    rootParams,
   }
 }

--- a/packages/next/src/build/segment-config/app/collect-root-param-keys.ts
+++ b/packages/next/src/build/segment-config/app/collect-root-param-keys.ts
@@ -48,7 +48,7 @@ export function collectRootParamKeys(
   routeModule: RouteModule
 ): readonly string[] {
   if (isAppRouteRouteModule(routeModule)) {
-    return []
+    return routeModule.rootParamNames
   }
 
   if (isAppPageRouteModule(routeModule)) {

--- a/packages/next/src/build/templates/app-route.ts
+++ b/packages/next/src/build/templates/app-route.ts
@@ -40,10 +40,12 @@ import {
 // instead of a replacement because this could also be `undefined` instead of
 // an empty string.
 declare const nextConfigOutput: AppRouteRouteModuleOptions['nextConfigOutput']
+declare const rootParamNames: AppRouteRouteModuleOptions['rootParamNames']
 
-// We inject the nextConfigOutput here so that we can use them in the route
+// We inject nextConfigOutput and rootParamNames here so that we can use them in the route
 // module.
 // INJECT:nextConfigOutput
+// INJECT:rootParamNames
 
 const routeModule = new AppRouteRouteModule({
   definition: {
@@ -56,6 +58,7 @@ const routeModule = new AppRouteRouteModule({
   distDir: process.env.__NEXT_RELATIVE_DIST_DIR || '',
   relativeProjectDir: process.env.__NEXT_RELATIVE_PROJECT_DIR || '',
   resolvedPagePath: 'VAR_RESOLVED_PAGE_PATH',
+  rootParamNames,
   nextConfigOutput,
   // Always use a lazy require factory so that:
   // - In dev: devRequestTimingInternalsEnd is set before userland executes,

--- a/packages/next/src/build/webpack/loaders/next-app-loader/create-app-route-code.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader/create-app-route-code.ts
@@ -11,7 +11,6 @@ import { AppPathnameNormalizer } from '../../../../server/normalizers/built/app/
 import { loadEntrypoint } from '../../../load-entrypoint'
 import type { PageExtensions } from '../../../page-extensions-type'
 import { getFilenameAndExtension } from '../next-metadata-route-loader'
-import type { ParamInfo } from '../next-root-params-loader'
 
 export async function createAppRouteCode({
   appDir,
@@ -27,7 +26,7 @@ export async function createAppRouteCode({
   name: string
   page: string
   pagePath: string
-  rootParams: ParamInfo[]
+  rootParams: string[]
   resolveAppRoute: (
     pathname: string
   ) => Promise<string | undefined> | string | undefined
@@ -81,7 +80,7 @@ export async function createAppRouteCode({
     },
     {
       nextConfigOutput: JSON.stringify(nextConfigOutput),
-      rootParamNames: JSON.stringify(rootParams.map((p) => p.param)),
+      rootParamNames: JSON.stringify(rootParams),
     }
   )
 }

--- a/packages/next/src/build/webpack/loaders/next-app-loader/create-app-route-code.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader/create-app-route-code.ts
@@ -11,12 +11,14 @@ import { AppPathnameNormalizer } from '../../../../server/normalizers/built/app/
 import { loadEntrypoint } from '../../../load-entrypoint'
 import type { PageExtensions } from '../../../page-extensions-type'
 import { getFilenameAndExtension } from '../next-metadata-route-loader'
+import type { ParamInfo } from '../next-root-params-loader'
 
 export async function createAppRouteCode({
   appDir,
   name,
   page,
   pagePath,
+  rootParams,
   resolveAppRoute,
   pageExtensions,
   nextConfigOutput,
@@ -25,6 +27,7 @@ export async function createAppRouteCode({
   name: string
   page: string
   pagePath: string
+  rootParams: ParamInfo[]
   resolveAppRoute: (
     pathname: string
   ) => Promise<string | undefined> | string | undefined
@@ -78,6 +81,7 @@ export async function createAppRouteCode({
     },
     {
       nextConfigOutput: JSON.stringify(nextConfigOutput),
+      rootParamNames: JSON.stringify(rootParams.map((p) => p.param)),
     }
   )
 }

--- a/packages/next/src/build/webpack/loaders/next-app-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader/index.ts
@@ -729,6 +729,9 @@ const nextAppLoader: AppLoader = async function nextAppLoader() {
   const normalizedAppPaths =
     typeof appPaths === 'string' ? [appPaths] : appPaths || []
 
+  const normalizedRootParams =
+    typeof rootParams === 'string' ? [rootParams] : rootParams || []
+
   // All normalized app paths for computing static siblings across route groups
   const allNormalizedAppPaths = allNormalizedAppPathsOption ?? []
 
@@ -1007,7 +1010,7 @@ const nextAppLoader: AppLoader = async function nextAppLoader() {
       page: loaderOptions.page,
       name,
       pagePath,
-      rootParams,
+      rootParams: normalizedRootParams,
       resolveAppRoute,
       pageExtensions,
       nextConfigOutput,

--- a/packages/next/src/build/webpack/loaders/next-app-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader/index.ts
@@ -44,11 +44,13 @@ import { normalizeAppPath } from '../../../../shared/lib/router/utils/app-paths'
 
 import { normalizePathSep } from '../../../../shared/lib/page-path/normalize-path-sep'
 import { installBindings } from '../../../swc/install-bindings'
+import type { ParamInfo } from '../next-root-params-loader'
 
 export type AppLoaderOptions = {
   name: string
   page: string
   pagePath: string
+  rootParams: ParamInfo[]
   appDir: string
   appPaths: readonly string[] | null
   // All normalized app paths across the entire app, used for computing
@@ -680,6 +682,7 @@ const nextAppLoader: AppLoader = async function nextAppLoader() {
     appPaths,
     allNormalizedAppPaths: allNormalizedAppPathsOption,
     pagePath,
+    rootParams,
     pageExtensions,
     rootDir,
     tsconfigPath,
@@ -1005,6 +1008,7 @@ const nextAppLoader: AppLoader = async function nextAppLoader() {
       page: loaderOptions.page,
       name,
       pagePath,
+      rootParams,
       resolveAppRoute,
       pageExtensions,
       nextConfigOutput,

--- a/packages/next/src/build/webpack/loaders/next-app-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader/index.ts
@@ -44,13 +44,12 @@ import { normalizeAppPath } from '../../../../shared/lib/router/utils/app-paths'
 
 import { normalizePathSep } from '../../../../shared/lib/page-path/normalize-path-sep'
 import { installBindings } from '../../../swc/install-bindings'
-import type { ParamInfo } from '../next-root-params-loader'
 
 export type AppLoaderOptions = {
   name: string
   page: string
   pagePath: string
-  rootParams: ParamInfo[]
+  rootParams: string[]
   appDir: string
   appPaths: readonly string[] | null
   // All normalized app paths across the entire app, used for computing

--- a/packages/next/src/build/webpack/loaders/next-root-params-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-root-params-loader.ts
@@ -4,7 +4,6 @@ import * as fs from 'node:fs/promises'
 import { normalizeAppPath } from '../../../shared/lib/router/utils/app-paths'
 import { ensureLeadingSlash } from '../../../shared/lib/page-path/ensure-leading-slash'
 import { getSegmentParam } from '../../../shared/lib/router/utils/get-segment-param'
-import type { DynamicParamTypes } from '../../../shared/lib/app-router-types'
 
 export type RootParamsLoaderOpts = {
   appDir: string
@@ -144,8 +143,6 @@ async function findRootLayouts({
 
   return visit(appDir)
 }
-
-export type ParamInfo = { param: string; type: DynamicParamTypes }
 
 export function getParamsFromLayoutFilePath({
   appDir,

--- a/packages/next/src/build/webpack/loaders/next-root-params-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-root-params-loader.ts
@@ -4,6 +4,7 @@ import * as fs from 'node:fs/promises'
 import { normalizeAppPath } from '../../../shared/lib/router/utils/app-paths'
 import { ensureLeadingSlash } from '../../../shared/lib/page-path/ensure-leading-slash'
 import { getSegmentParam } from '../../../shared/lib/router/utils/get-segment-param'
+import type { DynamicParamTypes } from '../../../shared/lib/app-router-types'
 
 export type RootParamsLoaderOpts = {
   appDir: string
@@ -144,7 +145,9 @@ async function findRootLayouts({
   return visit(appDir)
 }
 
-function getParamsFromLayoutFilePath({
+export type ParamInfo = { param: string; type: DynamicParamTypes }
+
+export function getParamsFromLayoutFilePath({
   appDir,
   layoutFilePath,
 }: {

--- a/packages/next/src/server/async-storage/request-store.ts
+++ b/packages/next/src/server/async-storage/request-store.ts
@@ -138,6 +138,7 @@ export function createRequestStoreForRender(
 export function createRequestStoreForAPI(
   req: RequestContext['req'],
   url: RequestContext['url'],
+  rootParams: Params,
   implicitTags: RequestContext['implicitTags'],
   onUpdateCookies: RenderOpts['onUpdateCookies'],
   previewProps: WrapperRenderOpts['previewProps']
@@ -148,7 +149,7 @@ export function createRequestStoreForAPI(
     req,
     undefined,
     url,
-    {},
+    rootParams,
     implicitTags,
     onUpdateCookies,
     null,

--- a/packages/next/src/server/dev/hot-reloader-webpack.ts
+++ b/packages/next/src/server/dev/hot-reloader-webpack.ts
@@ -1039,7 +1039,10 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
                           entryData.absolutePagePath
                         ).replace(/\\/g, '/')
                       ),
-                      rootParams: (staticInfo as AppPageStaticInfo).rootParams!,
+                      rootParams:
+                        (staticInfo as AppPageStaticInfo).rootParams?.map(
+                          (p) => p.param
+                        ) || [],
                       appDir: this.appDir!,
                       pageExtensions: this.config.pageExtensions,
                       rootDir: this.dir,
@@ -1164,7 +1167,10 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
                     appPaths: entryData.appPaths,
                     allNormalizedAppPaths: null, // Not available in dev mode
                     pagePath,
-                    rootParams: (staticInfo as AppPageStaticInfo).rootParams!,
+                    rootParams:
+                      (staticInfo as AppPageStaticInfo).rootParams?.map(
+                        (p) => p.param
+                      ) || [],
                     appDir: this.appDir!,
                     pageExtensions: this.config.pageExtensions,
                     rootDir: this.dir,

--- a/packages/next/src/server/dev/hot-reloader-webpack.ts
+++ b/packages/next/src/server/dev/hot-reloader-webpack.ts
@@ -121,7 +121,6 @@ import {
   sendSerializedErrorsToClientForHtmlRequest,
   setErrorsRscStreamForHtmlRequest,
 } from './serialized-errors'
-import type { AppPageStaticInfo } from '../../build/analysis/get-page-static-info'
 
 const MILLISECONDS_IN_NANOSECOND = BigInt(1_000_000)
 
@@ -1039,10 +1038,7 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
                           entryData.absolutePagePath
                         ).replace(/\\/g, '/')
                       ),
-                      rootParams:
-                        (staticInfo as AppPageStaticInfo).rootParams?.map(
-                          (p) => p.param
-                        ) || [],
+                      rootParams: staticInfo?.rootParams || [],
                       appDir: this.appDir!,
                       pageExtensions: this.config.pageExtensions,
                       rootDir: this.dir,
@@ -1167,10 +1163,7 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
                     appPaths: entryData.appPaths,
                     allNormalizedAppPaths: null, // Not available in dev mode
                     pagePath,
-                    rootParams:
-                      (staticInfo as AppPageStaticInfo).rootParams?.map(
-                        (p) => p.param
-                      ) || [],
+                    rootParams: staticInfo?.rootParams || [],
                     appDir: this.appDir!,
                     pageExtensions: this.config.pageExtensions,
                     rootDir: this.dir,

--- a/packages/next/src/server/dev/hot-reloader-webpack.ts
+++ b/packages/next/src/server/dev/hot-reloader-webpack.ts
@@ -121,6 +121,7 @@ import {
   sendSerializedErrorsToClientForHtmlRequest,
   setErrorsRscStreamForHtmlRequest,
 } from './serialized-errors'
+import type { AppPageStaticInfo } from '../../build/analysis/get-page-static-info'
 
 const MILLISECONDS_IN_NANOSECOND = BigInt(1_000_000)
 
@@ -1038,6 +1039,7 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
                           entryData.absolutePagePath
                         ).replace(/\\/g, '/')
                       ),
+                      rootParams: (staticInfo as AppPageStaticInfo).rootParams!,
                       appDir: this.appDir!,
                       pageExtensions: this.config.pageExtensions,
                       rootDir: this.dir,
@@ -1162,6 +1164,7 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
                     appPaths: entryData.appPaths,
                     allNormalizedAppPaths: null, // Not available in dev mode
                     pagePath,
+                    rootParams: (staticInfo as AppPageStaticInfo).rootParams!,
                     appDir: this.appDir!,
                     pageExtensions: this.config.pageExtensions,
                     rootDir: this.dir,

--- a/packages/next/src/server/request/root-params.ts
+++ b/packages/next/src/server/request/root-params.ts
@@ -40,12 +40,6 @@ export function getRootParam(paramName: string): Promise<ParamValue> {
 
   const actionStore = actionAsyncStorage.getStore()
   if (actionStore) {
-    if (actionStore.isAppRoute) {
-      // TODO(root-params): add support for route handlers
-      throw new Error(
-        `Route ${workStore.route} used ${apiName} inside a Route Handler. Support for this API in Route Handlers is planned for a future version of Next.js.`
-      )
-    }
     if (actionStore.isAction && workUnitStore.phase === 'action') {
       // Actions are not fundamentally tied to a route (even if they're always submitted from some page),
       // so root params would be inconsistent if an action is called from multiple roots.

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -190,6 +190,7 @@ export interface AppRouteRouteModuleOptions
    * spent here is not incorrectly attributed to application-code in timing.
    */
   readonly getUserland?: () => AppRouteUserlandModule
+  readonly rootParamNames: string[]
 }
 
 /**
@@ -225,6 +226,7 @@ export class AppRouteRouteModule extends RouteModule<
 
   public readonly resolvedPagePath: string
   public readonly nextConfigOutput: NextConfig['output'] | undefined
+  public readonly rootParamNames: AppRouteRouteModuleOptions['rootParamNames']
 
   // Set in the constructor when userland is provided as a factory. Cleared
   // after the first access so userland is only loaded once.
@@ -283,6 +285,7 @@ export class AppRouteRouteModule extends RouteModule<
     distDir,
     relativeProjectDir,
     resolvedPagePath,
+    rootParamNames,
     nextConfigOutput,
   }: AppRouteRouteModuleOptions) {
     const isLazy = typeof userland === 'function'
@@ -296,6 +299,7 @@ export class AppRouteRouteModule extends RouteModule<
     this.resolvedPagePath = resolvedPagePath
     this.nextConfigOutput = nextConfigOutput
     this._getUserland = getUserland
+    this.rootParamNames = rootParamNames
 
     if (!isLazy) {
       this._userlandFactory = null
@@ -849,6 +853,7 @@ export class AppRouteRouteModule extends RouteModule<
     const requestStore = createRequestStoreForAPI(
       req,
       req.nextUrl,
+      {}, // TODO: real rootParams
       implicitTags,
       undefined,
       context.previewProps

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -509,9 +509,7 @@ export class AppRouteRouteModule extends RouteModule<
             (prerenderStore = {
               type: 'prerender',
               phase: 'action',
-              // This replicates prior behavior where rootParams is empty in routes
-              // TODO we need to make this have the proper rootParams for this route
-              rootParams: {},
+              rootParams: requestStore.rootParams,
               fallbackRouteParams: null,
               implicitTags,
               renderSignal: prospectiveController.signal,
@@ -610,7 +608,7 @@ export class AppRouteRouteModule extends RouteModule<
           const finalRoutePrerenderStore: PrerenderStore = (prerenderStore = {
             type: 'prerender',
             phase: 'action',
-            rootParams: {},
+            rootParams: requestStore.rootParams,
             fallbackRouteParams: null,
             implicitTags,
             renderSignal: finalController.signal,
@@ -695,7 +693,7 @@ export class AppRouteRouteModule extends RouteModule<
           prerenderStore = {
             type: 'prerender-legacy',
             phase: 'action',
-            rootParams: {},
+            rootParams: requestStore.rootParams,
             implicitTags,
             revalidate: defaultRevalidate,
             expire: INFINITE_CACHE,
@@ -850,10 +848,20 @@ export class AppRouteRouteModule extends RouteModule<
       null
     )
 
+    // Extract root params from context.params based on rootParamNames
+    const rootParams: Record<string, string | string[] | undefined> = {}
+    if (context.params && this.rootParamNames.length > 0) {
+      for (const paramName of this.rootParamNames) {
+        if (paramName in context.params) {
+          rootParams[paramName] = context.params[paramName]
+        }
+      }
+    }
+
     const requestStore = createRequestStoreForAPI(
       req,
       req.nextUrl,
-      {}, // TODO: real rootParams
+      rootParams,
       implicitTags,
       undefined,
       context.previewProps

--- a/packages/next/src/server/web/adapter.ts
+++ b/packages/next/src/server/web/adapter.ts
@@ -292,7 +292,7 @@ export async function adapter(
             const requestStore = createRequestStoreForAPI(
               request,
               request.nextUrl,
-              {}, // TODO(root-params): compute and pass real rootParams
+              {}, // TODO(root-params): proxy doesn't know which route it's handling, so root params aren't available yet.
               implicitTags,
               onUpdateCookies,
               previewProps

--- a/packages/next/src/server/web/adapter.ts
+++ b/packages/next/src/server/web/adapter.ts
@@ -292,6 +292,7 @@ export async function adapter(
             const requestStore = createRequestStoreForAPI(
               request,
               request.nextUrl,
+              {}, // TODO(root-params): compute and pass real rootParams
               implicitTags,
               onUpdateCookies,
               previewProps

--- a/test/e2e/app-dir/app-root-params-getters/fixtures/simple/app/[lang]/[locale]/route-handler/route.tsx
+++ b/test/e2e/app-dir/app-root-params-getters/fixtures/simple/app/[lang]/[locale]/route-handler/route.tsx
@@ -1,9 +1,5 @@
 import { lang, locale } from 'next/root-params'
 
 export async function GET() {
-  return Response.json(
-    // TODO(root-params): We're missing some wiring to set `requestStore.rootParams`,
-    // so both of these will currently return undefined
-    { lang: await lang(), locale: await locale() }
-  )
+  return Response.json({ lang: await lang(), locale: await locale() })
 }

--- a/test/e2e/app-dir/app-root-params-getters/simple.test.ts
+++ b/test/e2e/app-dir/app-root-params-getters/simple.test.ts
@@ -175,18 +175,13 @@ describe('app-root-param-getters - simple', () => {
     )
   })
 
-  // TODO(root-params): add support for route handlers
-  it('should error when used in a route handler (until we implement it)', async () => {
+  it('should allow reading params in a route handler', async () => {
     const params = { lang: 'en', locale: 'us' }
     const response = await next.fetch(
       `/${params.lang}/${params.locale}/route-handler`
     )
-    expect(response.status).toBe(500)
-    if (!isNextDeploy) {
-      expect(getCliOutput()).toInclude(
-        "Route /[lang]/[locale]/route-handler used `import('next/root-params').lang()` inside a Route Handler. Support for this API in Route Handlers is planned for a future version of Next.js."
-      )
-    }
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual(params)
   })
 })
 


### PR DESCRIPTION
## Summary

Enables `next/root-params` getters (e.g. `lang()`, `locale()`) inside route handlers. Previously these threw an error saying support was "planned for a future version."

This was originally part of a stacked PR chain (#80618 → #80684 → #81086) by @lubieowoce and myself, but the base infrastructure landed in canary via other paths while the route handler piece never did. This PR extracts just the route handler support and applies it to current canary.

## Changes

- **Build (webpack):** Thread `rootParams` string array through `getStaticInfoIncludingLayouts` → `entries.ts` → `next-app-loader` → `app-route.ts` template via `INJECT:rootParamNames`
- **Build (turbopack):** Plumb `root_params` through `AppEndpoint` → `app_route_entry.rs`, serialized as a JSON array of param names
- **Runtime:** `AppRouteRouteModule` extracts root param values from `context.params` using the injected name list, passes them into `createRequestStoreForAPI`
- **Root params getter:** Remove the "not supported in route handlers" error
- **Static analysis:** `collectRootParamKeys` returns `routeModule.rootParamNames` for app routes instead of `[]`