### PR TITLE
fix(lib): support file:// URLs in formatDynamicImportPath for ESM cache handlers

### DIFF
--- a/packages/next/src/lib/format-dynamic-import-path.test.ts
+++ b/packages/next/src/lib/format-dynamic-import-path.test.ts
@@ -1,0 +1,36 @@
+import { formatDynamicImportPath } from './format-dynamic-import-path'
+
+describe('formatDynamicImportPath', () => {
+  it('should format relative paths correctly', () => {
+    const result = formatDynamicImportPath('/app/.next', './cache-handler.js')
+    expect(result).toBe('file:///app/.next/cache-handler.js')
+  })
+
+  it('should format absolute paths correctly', () => {
+    const result = formatDynamicImportPath(
+      '/app/.next',
+      '/app/cache-handler.js'
+    )
+    expect(result).toBe('file:///app/cache-handler.js')
+  })
+
+  it('should return file:// URLs as-is', () => {
+    const fileUrl = 'file:///app/cache-handler.js'
+    const result = formatDynamicImportPath('/app/.next', fileUrl)
+    expect(result).toBe(fileUrl)
+  })
+
+  it('should handle file:// URLs with different paths', () => {
+    const fileUrl = 'file:///Users/test/project/cache-handler.cjs'
+    const result = formatDynamicImportPath('/any/dir', fileUrl)
+    expect(result).toBe(fileUrl)
+  })
+
+  it('should handle Windows-style absolute paths', () => {
+    const result = formatDynamicImportPath(
+      'C:\\app\\.next',
+      'C:\\app\\cache-handler.js'
+    )
+    expect(result).toBe('file:///C:/app/cache-handler.js')
+  })
+})

--- a/packages/next/src/lib/format-dynamic-import-path.test.ts
+++ b/packages/next/src/lib/format-dynamic-import-path.test.ts
@@ -33,4 +33,16 @@ describe('formatDynamicImportPath', () => {
     )
     expect(result).toBe('file:///C:/app/cache-handler.js')
   })
+
+  it('should handle uppercase FILE:// URLs case-insensitively', () => {
+    const fileUrl = 'FILE:///app/cache-handler.js'
+    const result = formatDynamicImportPath('/any/dir', fileUrl)
+    expect(result).toBe(fileUrl)
+  })
+
+  it('should handle Windows-style file:///C:/ paths passed directly', () => {
+    const fileUrl = 'file:///C:/app/cache-handler.js'
+    const result = formatDynamicImportPath('C:\\app\\.next', fileUrl)
+    expect(result).toBe(fileUrl)
+  })
 })

--- a/packages/next/src/lib/format-dynamic-import-path.ts
+++ b/packages/next/src/lib/format-dynamic-import-path.ts
@@ -7,9 +7,15 @@ import { pathToFileURL } from 'url'
  * When an absolute Windows path is passed to it, it interprets the beginning of the path as a protocol (`C:`).
  * Therefore, it is important to always construct a complete path.
  * @param dir File directory
- * @param filePath Absolute or relative path
+ * @param filePath Absolute or relative path, or a file:// URL
  */
 export const formatDynamicImportPath = (dir: string, filePath: string) => {
+  // If the filePath is already a file:// URL, return it as-is
+  // This handles cases where users pass import.meta.resolve() results in ESM projects
+  if (filePath.startsWith('file://')) {
+    return filePath
+  }
+
   const absoluteFilePath = path.isAbsolute(filePath)
     ? filePath
     : path.join(dir, filePath)

--- a/packages/next/src/lib/format-dynamic-import-path.ts
+++ b/packages/next/src/lib/format-dynamic-import-path.ts
@@ -12,7 +12,8 @@ import { pathToFileURL } from 'url'
 export const formatDynamicImportPath = (dir: string, filePath: string) => {
   // If the filePath is already a file:// URL, return it as-is
   // This handles cases where users pass import.meta.resolve() results in ESM projects
-  if (filePath.startsWith('file://')) {
+  // Note: We use lowercase check because Node.js and browsers always emit lowercase 'file://'
+  if (filePath.toLowerCase().startsWith('file://')) {
     return filePath
   }
 


### PR DESCRIPTION
Fixes #73796

When using ESM modules with "type": "module", users use import.meta.resolve() which returns file:// URLs. These were incorrectly joined with distDir, creating broken paths like .next/file:///Users/project/cache-handler.js

Changes:
- Detect file:// URLs and return them as-is
- Added unit tests