### PR TITLE
fix: warn about invalid elements inside next/head instead of misleading error

### DIFF
--- a/errors/next-head-count-missing.mdx
+++ b/errors/next-head-count-missing.mdx
@@ -4,10 +4,36 @@ title: '`next-head-count` is missing'
 
 ## Why This Error Occurred
 
-You have a custom `pages/_document.js` that doesn't have the components required for Next.js to render correctly.
+This error can happen for one of two reasons:
+
+1. You have a custom `pages/_document.js` that doesn't include the required `<Head>` component from `next/document`.
+
+2. You are using an invalid HTML element inside the `<Head>` component from `next/head`. Only valid `<head>` child elements are allowed: `<title>`, `<base>`, `<meta>`, `<link>`, `<style>`, `<script>`, and `<noscript>`. Elements like `<html>`, `<body>`, `<div>`, `<p>`, or other non-head elements will cause the head content to be misplaced into the document body, resulting in this error.
 
 ## Possible Ways to Fix It
 
-Ensure that your `_document.js` is importing and rendering all of the [required components](/docs/pages/building-your-application/routing/custom-document).
+### Missing `<Head>` in `_document.js`
 
-In this case you are most likely not rendering the `<Head>` component imported from `next/document`.
+Ensure that your `_document.js` is importing and rendering all of the [required components](/docs/pages/building-your-application/routing/custom-document), including the `<Head>` component imported from `next/document`.
+
+### Invalid elements in `<Head>`
+
+Check the children of your `<Head>` component (from `next/head`) and remove any elements that are not valid inside `<head>`. For example:
+
+```jsx
+import Head from 'next/head'
+
+// ❌ Wrong — <html> is not a valid child of <head>
+<Head>
+  <html lang="en" />
+  <title>My Page</title>
+</Head>
+
+// ✅ Correct — only valid head elements
+<Head>
+  <title>My Page</title>
+  <meta name="description" content="My page description" />
+</Head>
+```
+
+To set the `lang` attribute on the `<html>` element, use a [custom `_document.js`](/docs/pages/building-your-application/routing/custom-document) instead.

--- a/packages/next/src/shared/lib/head.tsx
+++ b/packages/next/src/shared/lib/head.tsx
@@ -46,6 +46,17 @@ function onlyReactElement(
   return list.concat(child)
 }
 
+// Valid HTML elements that are allowed inside <head>
+const VALID_HEAD_ELEMENTS = new Set([
+  'title',
+  'base',
+  'meta',
+  'link',
+  'style',
+  'script',
+  'noscript',
+])
+
 const METATYPES = ['name', 'httpEquiv', 'charSet', 'itemProp']
 
 /*
@@ -128,6 +139,17 @@ function reduceComponents(
     .map((c: React.ReactElement<any>, i: number) => {
       const key = c.key || i
       if (process.env.NODE_ENV === 'development') {
+        if (
+          typeof c.type === 'string' &&
+          !VALID_HEAD_ELEMENTS.has(c.type)
+        ) {
+          warnOnce(
+            `Found <${c.type}> tag inside next/head. <${c.type}> is not a valid ` +
+              `element in <head> and will cause the "next-head-count is missing" ` +
+              `error. Only the following elements are allowed: ${[...VALID_HEAD_ELEMENTS].join(', ')}. ` +
+              `\nSee more info here: https://nextjs.org/docs/messages/next-head-count-missing`
+          )
+        }
         // omit JSON-LD structured data snippets from the warning
         if (c.type === 'script' && c.props['type'] !== 'application/ld+json') {
           const srcMessage = c.props['src']


### PR DESCRIPTION
## Description

Fixes #20924

When invalid HTML elements (e.g., `<html>`, `<body>`, `<div>`) are placed inside the `<Head>` component from `next/head`, the browser moves them out of `<head>` into `<body>`, which causes the confusing `next-head-count is missing` error. The original error message gives no indication of which element caused the issue or why it happened.

### Changes

1. **Added a development-mode warning** in `packages/next/src/shared/lib/head.tsx` that identifies the specific invalid element and lists all valid head elements (`title`, `base`, `meta`, `link`, `style`, `script`, `noscript`).

2. **Improved error documentation** in `errors/next-head-count-missing.mdx` to explain both causes of the error:
   - Missing `<Head>` component in `_document.js`
   - Invalid elements inside `<Head>` from `next/head`

### Example

Before this change, using `<html lang="en" />` inside `<Head>` would produce:
```
next-head-count is missing. https://nextjs.org/docs/messages/next-head-count-missing
```

After this change, the console will show:
```
Found <html> tag inside next/head. <html> is not a valid element in <head> and will cause the "next-head-count is missing" error. Only the following elements are allowed: title, base, meta, link, style, script, noscript.
See more info here: https://nextjs.org/docs/messages/next-head-count-missing
```

### How it works

The fix validates each element type against the set of valid HTML `<head>` child elements during the `reduceComponents` phase. Since this uses the existing `warnOnce` utility, each invalid element type only triggers a single warning, keeping the console clean.

The warning only runs in development mode (`process.env.NODE_ENV === "development"`), so there is zero production impact.