### PR TITLE
fix(eslint-plugin-next): account for pageExtensions in no-html-link-for-pages rule

### DIFF
--- a/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
+++ b/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
@@ -8,6 +8,7 @@ import {
   normalizeURL,
   execOnce,
   getUrlFromAppDirectory,
+  ALLOWED_PAGE_EXTENSIONS,
 } from '../utils/url'
 
 const pagesDirWarning = execOnce((pagesDirs) => {
@@ -74,12 +75,8 @@ export default defineRule({
 
     const rootDirs = getRootDirs(context)
     const nextSettings = context.settings.next || {}
-    const pageExtensions = nextSettings.pageExtensions || [
-      'js',
-      'jsx',
-      'ts',
-      'tsx',
-    ]
+    const pageExtensions =
+      nextSettings.pageExtensions || ALLOWED_PAGE_EXTENSIONS
 
     const pagesDirs = (
       customPagesDirectory

--- a/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
+++ b/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
@@ -73,6 +73,13 @@ export default defineRule({
     const [customPagesDirectory] = ruleOptions
 
     const rootDirs = getRootDirs(context)
+    const nextSettings = context.settings.next || {}
+    const pageExtensions = nextSettings.pageExtensions || [
+      'js',
+      'jsx',
+      'ts',
+      'tsx',
+    ]
 
     const pagesDirs = (
       customPagesDirectory
@@ -107,8 +114,16 @@ export default defineRule({
       return {}
     }
 
-    const pageUrls = cachedGetUrlFromPagesDirectories('/', foundPagesDirs)
-    const appDirUrls = cachedGetUrlFromAppDirectory('/', foundAppDirs)
+    const pageUrls = cachedGetUrlFromPagesDirectories(
+      '/',
+      foundPagesDirs,
+      pageExtensions
+    )
+    const appDirUrls = cachedGetUrlFromAppDirectory(
+      '/',
+      foundAppDirs,
+      pageExtensions
+    )
     const allUrlRegex = [...pageUrls, ...appDirUrls]
 
     return {

--- a/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
+++ b/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
@@ -74,9 +74,11 @@ export default defineRule({
     const [customPagesDirectory] = ruleOptions
 
     const rootDirs = getRootDirs(context)
-    const nextSettings = context.settings.next || {}
+    const nextSettings = context.settings.next as
+      | { pageExtensions?: string[] }
+      | undefined
     const pageExtensions =
-      nextSettings.pageExtensions || ALLOWED_PAGE_EXTENSIONS
+      nextSettings?.pageExtensions || ALLOWED_PAGE_EXTENSIONS
 
     const pagesDirs = (
       customPagesDirectory

--- a/packages/eslint-plugin-next/src/utils/url.ts
+++ b/packages/eslint-plugin-next/src/utils/url.ts
@@ -8,25 +8,34 @@ const fsReadDirSyncCache = {}
 /**
  * Recursively parse directory for page URLs.
  */
-function parseUrlForPages(urlprefix: string, directory: string) {
+function parseUrlForPages(
+  urlprefix: string,
+  directory: string,
+  pageExtensions: string[] = ['js', 'jsx', 'ts', 'tsx']
+) {
   fsReadDirSyncCache[directory] ??= fs.readdirSync(directory, {
     withFileTypes: true,
   })
   const res = []
+  const extensionsRegex = new RegExp(`\\.(${pageExtensions.join('|')})$`)
+
   fsReadDirSyncCache[directory].forEach((dirent) => {
-    // TODO: this should account for all page extensions
-    // not just js(x) and ts(x)
-    if (/(\.(j|t)sx?)$/.test(dirent.name)) {
-      if (/^index(\.(j|t)sx?)$/.test(dirent.name)) {
+    if (extensionsRegex.test(dirent.name)) {
+      if (new RegExp(`^index${extensionsRegex.source}`).test(dirent.name)) {
         res.push(
-          `${urlprefix}${dirent.name.replace(/^index(\.(j|t)sx?)$/, '')}`
+          `${urlprefix}${dirent.name.replace(
+            new RegExp(`^index${extensionsRegex.source}`),
+            ''
+          )}`
         )
       }
-      res.push(`${urlprefix}${dirent.name.replace(/(\.(j|t)sx?)$/, '')}`)
+      res.push(`${urlprefix}${dirent.name.replace(extensionsRegex, '')}`)
     } else {
       const dirPath = path.join(directory, dirent.name)
       if (dirent.isDirectory() && !dirent.isSymbolicLink()) {
-        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath))
+        res.push(
+          ...parseUrlForPages(urlprefix + dirent.name + '/', dirPath, pageExtensions)
+        )
       }
     }
   })
@@ -36,24 +45,35 @@ function parseUrlForPages(urlprefix: string, directory: string) {
 /**
  * Recursively parse app directory for URLs.
  */
-function parseUrlForAppDir(urlprefix: string, directory: string) {
+function parseUrlForAppDir(
+  urlprefix: string,
+  directory: string,
+  pageExtensions: string[] = ['js', 'jsx', 'ts', 'tsx']
+) {
   fsReadDirSyncCache[directory] ??= fs.readdirSync(directory, {
     withFileTypes: true,
   })
   const res = []
+  const extensionsRegex = new RegExp(`\\.(${pageExtensions.join('|')})$`)
+
   fsReadDirSyncCache[directory].forEach((dirent) => {
-    // TODO: this should account for all page extensions
-    // not just js(x) and ts(x)
-    if (/(\.(j|t)sx?)$/.test(dirent.name)) {
-      if (/^page(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(`${urlprefix}${dirent.name.replace(/^page(\.(j|t)sx?)$/, '')}`)
-      } else if (!/^layout(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(`${urlprefix}${dirent.name.replace(/(\.(j|t)sx?)$/, '')}`)
+    if (extensionsRegex.test(dirent.name)) {
+      if (new RegExp(`^page${extensionsRegex.source}`).test(dirent.name)) {
+        res.push(
+          `${urlprefix}${dirent.name.replace(
+            new RegExp(`^page${extensionsRegex.source}`),
+            ''
+          )}`
+        )
+      } else if (!new RegExp(`^layout${extensionsRegex.source}`).test(dirent.name)) {
+        res.push(`${urlprefix}${dirent.name.replace(extensionsRegex, '')}`)
       }
     } else {
       const dirPath = path.join(directory, dirent.name)
-      if (dirent.isDirectory(dirPath) && !dirent.isSymbolicLink()) {
-        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath))
+      if (dirent.isDirectory() && !dirent.isSymbolicLink()) {
+        res.push(
+          ...parseUrlForPages(urlprefix + dirent.name + '/', dirPath, pageExtensions)
+        )
       }
     }
   })
@@ -136,13 +156,16 @@ export function normalizeAppPath(route: string) {
  */
 export function getUrlFromPagesDirectories(
   urlPrefix: string,
-  directories: string[]
+  directories: string[],
+  pageExtensions: string[] = ['js', 'jsx', 'ts', 'tsx']
 ) {
   return Array.from(
     // De-duplicate similar pages across multiple directories.
     new Set(
       directories
-        .flatMap((directory) => parseUrlForPages(urlPrefix, directory))
+        .flatMap((directory) =>
+          parseUrlForPages(urlPrefix, directory, pageExtensions)
+        )
         .map(
           // Since the URLs are normalized we add `^` and `$` to the RegExp to make sure they match exactly.
           (url) => `^${normalizeURL(url)}$`
@@ -156,13 +179,16 @@ export function getUrlFromPagesDirectories(
 
 export function getUrlFromAppDirectory(
   urlPrefix: string,
-  directories: string[]
+  directories: string[],
+  pageExtensions: string[] = ['js', 'jsx', 'ts', 'tsx']
 ) {
   return Array.from(
     // De-duplicate similar pages across multiple directories.
     new Set(
       directories
-        .map((directory) => parseUrlForAppDir(urlPrefix, directory))
+        .map((directory) =>
+          parseUrlForAppDir(urlPrefix, directory, pageExtensions)
+        )
         .flat()
         .map(
           // Since the URLs are normalized we add `^` and `$` to the RegExp to make sure they match exactly.

--- a/packages/eslint-plugin-next/src/utils/url.ts
+++ b/packages/eslint-plugin-next/src/utils/url.ts
@@ -80,7 +80,7 @@ function parseUrlForAppDir(
       const dirPath = path.join(directory, dirent.name)
       if (dirent.isDirectory() && !dirent.isSymbolicLink()) {
         res.push(
-          ...parseUrlForPages(
+          ...parseUrlForAppDir(
             urlprefix + dirent.name + '/',
             dirPath,
             pageExtensions

--- a/packages/eslint-plugin-next/src/utils/url.ts
+++ b/packages/eslint-plugin-next/src/utils/url.ts
@@ -1,6 +1,8 @@
 import * as path from 'path'
 import * as fs from 'fs'
 
+export const ALLOWED_PAGE_EXTENSIONS = ['js', 'jsx', 'ts', 'tsx']
+
 // Cache for fs.readdirSync lookup.
 // Prevent multiple blocking IO requests that have already been calculated.
 const fsReadDirSyncCache = {}
@@ -11,7 +13,7 @@ const fsReadDirSyncCache = {}
 function parseUrlForPages(
   urlprefix: string,
   directory: string,
-  pageExtensions: string[] = ['js', 'jsx', 'ts', 'tsx']
+  pageExtensions: string[] = ALLOWED_PAGE_EXTENSIONS
 ) {
   fsReadDirSyncCache[directory] ??= fs.readdirSync(directory, {
     withFileTypes: true,
@@ -34,7 +36,11 @@ function parseUrlForPages(
       const dirPath = path.join(directory, dirent.name)
       if (dirent.isDirectory() && !dirent.isSymbolicLink()) {
         res.push(
-          ...parseUrlForPages(urlprefix + dirent.name + '/', dirPath, pageExtensions)
+          ...parseUrlForPages(
+            urlprefix + dirent.name + '/',
+            dirPath,
+            pageExtensions
+          )
         )
       }
     }
@@ -48,7 +54,7 @@ function parseUrlForPages(
 function parseUrlForAppDir(
   urlprefix: string,
   directory: string,
-  pageExtensions: string[] = ['js', 'jsx', 'ts', 'tsx']
+  pageExtensions: string[] = ALLOWED_PAGE_EXTENSIONS
 ) {
   fsReadDirSyncCache[directory] ??= fs.readdirSync(directory, {
     withFileTypes: true,
@@ -65,14 +71,20 @@ function parseUrlForAppDir(
             ''
           )}`
         )
-      } else if (!new RegExp(`^layout${extensionsRegex.source}`).test(dirent.name)) {
+      } else if (
+        !new RegExp(`^layout${extensionsRegex.source}`).test(dirent.name)
+      ) {
         res.push(`${urlprefix}${dirent.name.replace(extensionsRegex, '')}`)
       }
     } else {
       const dirPath = path.join(directory, dirent.name)
       if (dirent.isDirectory() && !dirent.isSymbolicLink()) {
         res.push(
-          ...parseUrlForPages(urlprefix + dirent.name + '/', dirPath, pageExtensions)
+          ...parseUrlForPages(
+            urlprefix + dirent.name + '/',
+            dirPath,
+            pageExtensions
+          )
         )
       }
     }
@@ -157,7 +169,7 @@ export function normalizeAppPath(route: string) {
 export function getUrlFromPagesDirectories(
   urlPrefix: string,
   directories: string[],
-  pageExtensions: string[] = ['js', 'jsx', 'ts', 'tsx']
+  pageExtensions: string[] = ALLOWED_PAGE_EXTENSIONS
 ) {
   return Array.from(
     // De-duplicate similar pages across multiple directories.
@@ -180,7 +192,7 @@ export function getUrlFromPagesDirectories(
 export function getUrlFromAppDirectory(
   urlPrefix: string,
   directories: string[],
-  pageExtensions: string[] = ['js', 'jsx', 'ts', 'tsx']
+  pageExtensions: string[] = ALLOWED_PAGE_EXTENSIONS
 ) {
   return Array.from(
     // De-duplicate similar pages across multiple directories.


### PR DESCRIPTION
This PR addresses issue #53473 by allowing the `no-html-link-for-pages` rule to respect custom `pageExtensions` defined in `next.config.js` (via ESLint settings). It updates the page scanning logic to use the provided extensions instead of hardcoded defaults.