### PR TITLE
[ci] Allow "rerun failed jobs" to work up until 5 days

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -138,7 +138,8 @@ jobs:
         with:
           name: test-timings
           path: test-timings.json
-          retention-days: 1
+          # Allows "rerun failed jobs" for N days 
+          retention-days: 5
           if-no-files-found: error
 
   lint:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -138,7 +138,7 @@ jobs:
         with:
           name: test-timings
           path: test-timings.json
-          # Allows "rerun failed jobs" for N days 
+          # Allows "rerun failed jobs" for N days
           retention-days: 5
           if-no-files-found: error
 


### PR DESCRIPTION
We fail CI if test timings are no longer available. However, 1 day seems too short of a retention period. A job started on Friday, could not be rerun on Monday.

We'll keep an eye on cost. 23 kB seem negligible compared to e.g. persisting tarballs of native binaries.