### PR TITLE
fix(eslint-plugin-next): respect pageExtensions in link rule

### DIFF
--- a/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
+++ b/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
@@ -20,6 +20,7 @@ const pagesDirWarning = execOnce((pagesDirs) => {
 // Cache for fs.existsSync lookup.
 // Prevent multiple blocking IO requests that have already been calculated.
 const fsExistsSyncCache = {}
+const defaultPageExtensions = ['tsx', 'ts', 'jsx', 'js']
 
 const memoize = <T = any>(fn: (...args: any[]) => T) => {
   const cache = {}
@@ -34,6 +35,32 @@ const memoize = <T = any>(fn: (...args: any[]) => T) => {
 
 const cachedGetUrlFromPagesDirectories = memoize(getUrlFromPagesDirectories)
 const cachedGetUrlFromAppDirectory = memoize(getUrlFromAppDirectory)
+
+const getPageExtensionsForRootDir = (rootDir: string) => {
+  for (const configFile of ['next.config.js', 'next.config.cjs']) {
+    const configPath = path.join(rootDir, configFile)
+    if (!fs.existsSync(configPath)) {
+      continue
+    }
+
+    try {
+      const loadedConfig = require(configPath)
+      const nextConfig = loadedConfig?.default ?? loadedConfig
+      const customPageExtensions = nextConfig?.pageExtensions
+
+      if (Array.isArray(customPageExtensions)) {
+        return customPageExtensions.filter(
+          (extension): extension is string =>
+            typeof extension === 'string' && extension.length > 0
+        )
+      }
+    } catch {
+      continue
+    }
+  }
+
+  return defaultPageExtensions
+}
 
 const url = 'https://nextjs.org/docs/messages/no-html-link-for-pages'
 
@@ -73,6 +100,9 @@ export default defineRule({
     const [customPagesDirectory] = ruleOptions
 
     const rootDirs = getRootDirs(context)
+    const pageExtensions = Array.from(
+      new Set(rootDirs.flatMap((rootDir) => getPageExtensionsForRootDir(rootDir)))
+    )
 
     const pagesDirs = (
       customPagesDirectory
@@ -107,8 +137,16 @@ export default defineRule({
       return {}
     }
 
-    const pageUrls = cachedGetUrlFromPagesDirectories('/', foundPagesDirs)
-    const appDirUrls = cachedGetUrlFromAppDirectory('/', foundAppDirs)
+    const pageUrls = cachedGetUrlFromPagesDirectories(
+      '/',
+      foundPagesDirs,
+      pageExtensions
+    )
+    const appDirUrls = cachedGetUrlFromAppDirectory(
+      '/',
+      foundAppDirs,
+      pageExtensions
+    )
     const allUrlRegex = [...pageUrls, ...appDirUrls]
 
     return {

--- a/packages/eslint-plugin-next/src/utils/url.ts
+++ b/packages/eslint-plugin-next/src/utils/url.ts
@@ -5,28 +5,37 @@ import * as fs from 'fs'
 // Prevent multiple blocking IO requests that have already been calculated.
 const fsReadDirSyncCache = {}
 
+const escapeRegExp = (value: string) =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
+const createExtensionPattern = (pageExtensions: string[]) =>
+  `(?:${pageExtensions.map(escapeRegExp).join('|')})`
+
 /**
  * Recursively parse directory for page URLs.
  */
-function parseUrlForPages(urlprefix: string, directory: string) {
+function parseUrlForPages(
+  urlprefix: string,
+  directory: string,
+  pageExtensions: string[]
+) {
   fsReadDirSyncCache[directory] ??= fs.readdirSync(directory, {
     withFileTypes: true,
   })
   const res = []
+  const extPattern = createExtensionPattern(pageExtensions)
+  const pageFileRegex = new RegExp(`\\.${extPattern}$`)
+  const indexFileRegex = new RegExp(`^index\\.${extPattern}$`)
   fsReadDirSyncCache[directory].forEach((dirent) => {
-    // TODO: this should account for all page extensions
-    // not just js(x) and ts(x)
-    if (/(\.(j|t)sx?)$/.test(dirent.name)) {
-      if (/^index(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(
-          `${urlprefix}${dirent.name.replace(/^index(\.(j|t)sx?)$/, '')}`
-        )
+    if (pageFileRegex.test(dirent.name)) {
+      if (indexFileRegex.test(dirent.name)) {
+        res.push(`${urlprefix}${dirent.name.replace(indexFileRegex, '')}`)
       }
-      res.push(`${urlprefix}${dirent.name.replace(/(\.(j|t)sx?)$/, '')}`)
+      res.push(`${urlprefix}${dirent.name.replace(pageFileRegex, '')}`)
     } else {
       const dirPath = path.join(directory, dirent.name)
       if (dirent.isDirectory() && !dirent.isSymbolicLink()) {
-        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath))
+        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath, pageExtensions))
       }
     }
   })
@@ -36,24 +45,25 @@ function parseUrlForPages(urlprefix: string, directory: string) {
 /**
  * Recursively parse app directory for URLs.
  */
-function parseUrlForAppDir(urlprefix: string, directory: string) {
+function parseUrlForAppDir(
+  urlprefix: string,
+  directory: string,
+  pageExtensions: string[]
+) {
   fsReadDirSyncCache[directory] ??= fs.readdirSync(directory, {
     withFileTypes: true,
   })
   const res = []
+  const extPattern = createExtensionPattern(pageExtensions)
+  const pageFileRegex = new RegExp(`(^page|[\\\\/]page)\\.${extPattern}$`)
+  const layoutFileRegex = new RegExp(`(^layout|[\\\\/]layout)\\.${extPattern}$`)
   fsReadDirSyncCache[directory].forEach((dirent) => {
-    // TODO: this should account for all page extensions
-    // not just js(x) and ts(x)
-    if (/(\.(j|t)sx?)$/.test(dirent.name)) {
-      if (/^page(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(`${urlprefix}${dirent.name.replace(/^page(\.(j|t)sx?)$/, '')}`)
-      } else if (!/^layout(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(`${urlprefix}${dirent.name.replace(/(\.(j|t)sx?)$/, '')}`)
-      }
-    } else {
+    if (pageFileRegex.test(dirent.name)) {
+      res.push(`${urlprefix}${dirent.name.replace(pageFileRegex, '')}`)
+    } else if (!layoutFileRegex.test(dirent.name)) {
       const dirPath = path.join(directory, dirent.name)
-      if (dirent.isDirectory(dirPath) && !dirent.isSymbolicLink()) {
-        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath))
+      if (dirent.isDirectory() && !dirent.isSymbolicLink()) {
+        res.push(...parseUrlForAppDir(urlprefix + dirent.name + '/', dirPath, pageExtensions))
       }
     }
   })
@@ -136,13 +146,14 @@ export function normalizeAppPath(route: string) {
  */
 export function getUrlFromPagesDirectories(
   urlPrefix: string,
-  directories: string[]
+  directories: string[],
+  pageExtensions: string[]
 ) {
   return Array.from(
     // De-duplicate similar pages across multiple directories.
     new Set(
       directories
-        .flatMap((directory) => parseUrlForPages(urlPrefix, directory))
+        .flatMap((directory) => parseUrlForPages(urlPrefix, directory, pageExtensions))
         .map(
           // Since the URLs are normalized we add `^` and `$` to the RegExp to make sure they match exactly.
           (url) => `^${normalizeURL(url)}$`
@@ -156,13 +167,14 @@ export function getUrlFromPagesDirectories(
 
 export function getUrlFromAppDirectory(
   urlPrefix: string,
-  directories: string[]
+  directories: string[],
+  pageExtensions: string[]
 ) {
   return Array.from(
     // De-duplicate similar pages across multiple directories.
     new Set(
       directories
-        .map((directory) => parseUrlForAppDir(urlPrefix, directory))
+        .map((directory) => parseUrlForAppDir(urlPrefix, directory, pageExtensions))
         .flat()
         .map(
           // Since the URLs are normalized we add `^` and `$` to the RegExp to make sure they match exactly.

--- a/test/unit/eslint-plugin-next/no-html-link-for-pages.test.ts
+++ b/test/unit/eslint-plugin-next/no-html-link-for-pages.test.ts
@@ -7,6 +7,7 @@ import path from 'path'
 const NextESLintRule = rules['no-html-link-for-pages']
 
 const withCustomPagesDir = path.join(__dirname, 'with-custom-pages-dir')
+const withPageExtensionsDir = path.join(__dirname, 'with-page-extensions')
 const withNestedPagesDir = path.join(__dirname, 'with-nested-pages-dir')
 const withoutPagesDir = path.join(__dirname, 'without-pages-dir')
 const withAppDir = path.join(__dirname, 'with-app-dir')
@@ -26,6 +27,10 @@ const linters = {
   }),
   withCustomPages: new Linter({
     cwd: withCustomPagesDir,
+    configType: 'eslintrc',
+  }),
+  withPageExtensions: new Linter({
+    cwd: withPageExtensionsDir,
     configType: 'eslintrc',
   }),
 }
@@ -170,6 +175,21 @@ export class Blah extends Head {
 }
 `
 
+const validPlainTsxLink = `
+import Link from 'next/link';
+
+export class Blah extends Head {
+  render() {
+    return (
+      <div>
+        <a href='/plain'>Plain</a>
+        <h1>Hello title</h1>
+      </div>
+    );
+  }
+}
+`
+
 const invalidStaticCode = `
 import Link from 'next/link';
 
@@ -295,6 +315,26 @@ describe('no-html-link-for-pages', function () {
     const report = linters.withCustomPages.verify(
       validCode,
       linterConfigWithCustomDirectory,
+      { filename: 'foo.js' }
+    )
+    assert.deepEqual(report, [])
+  })
+  it('invalid link element with pageExtensions', function () {
+    const [report] = linters.withPageExtensions.verify(
+      invalidStaticCode,
+      linterConfig,
+      { filename: 'foo.js' }
+    )
+    assert.notEqual(report, undefined, 'No lint errors found.')
+    assert.equal(
+      report.message,
+      'Do not use an `<a>` element to navigate to `/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages'
+    )
+  })
+  it('does not treat default extensions as pages when pageExtensions is configured', function () {
+    const report = linters.withPageExtensions.verify(
+      validPlainTsxLink,
+      linterConfig,
       { filename: 'foo.js' }
     )
     assert.deepEqual(report, [])

--- a/test/unit/eslint-plugin-next/with-page-extensions/next.config.js
+++ b/test/unit/eslint-plugin-next/with-page-extensions/next.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  pageExtensions: ['page.tsx'],
+}

--- a/test/unit/eslint-plugin-next/with-page-extensions/pages/index.page.tsx
+++ b/test/unit/eslint-plugin-next/with-page-extensions/pages/index.page.tsx
@@ -1,0 +1,3 @@
+export default function Home() {
+  return null
+}

--- a/test/unit/eslint-plugin-next/with-page-extensions/pages/list/foo.page.tsx
+++ b/test/unit/eslint-plugin-next/with-page-extensions/pages/list/foo.page.tsx
@@ -1,0 +1,3 @@
+export default function Foo() {
+  return null
+}

--- a/test/unit/eslint-plugin-next/with-page-extensions/pages/plain.tsx
+++ b/test/unit/eslint-plugin-next/with-page-extensions/pages/plain.tsx
@@ -1,0 +1,3 @@
+export default function Plain() {
+  return null
+}


### PR DESCRIPTION
Load pageExtensions from next.config.js when checking internal links so custom page suffixes are recognized.

Added a regression test that covers custom pageExtensions and verifies default extensions are not treated as pages when a custom list is configured.

Fixes #53473
Co-Authored-By: Claude <noreply@anthropic.com>