### PR TITLE
feat(turbopack): add CSS modules `exportLocalsConvention` support

### DIFF
--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -344,6 +344,7 @@ pub async fn get_client_module_options_context(
             source_maps,
             module_css_condition: Some(module_styles_rule_condition()),
             lightningcss_features: *next_config.lightningcss_feature_flags().await?,
+            export_convention: *next_config.css_module_export_convention().await?,
             ..Default::default()
         },
         static_url_tag: Some(rcstr!("client")),

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -617,6 +617,32 @@ pub struct TurbopackConfig {
     /// Issue patterns to ignore (suppress) from Turbopack output.
     #[serde(default)]
     pub ignore_issue: Option<Vec<TurbopackIgnoreIssueRule>>,
+    /// CSS Modules configuration.
+    pub css_modules: Option<TurbopackCssModulesConfig>,
+}
+
+#[derive(
+    Deserialize,
+    Clone,
+    PartialEq,
+    Eq,
+    Debug,
+    TraceRawVcs,
+    NonLocalValue,
+    OperationValue,
+    Encode,
+    Decode,
+)]
+#[serde(rename_all = "camelCase")]
+pub struct TurbopackCssModulesConfig {
+    /// Controls how CSS module class names are exported to JavaScript.
+    ///
+    /// - `"asIs"` (default): export as-is
+    /// - `"camelCase"`: export both original and camelCase
+    /// - `"camelCaseOnly"`: export only camelCase
+    /// - `"dashes"`: export both original and dashes-to-camelCase
+    /// - `"dashesOnly"`: export only dashes-to-camelCase
+    pub export_locals_convention: Option<RcStr>,
 }
 
 #[derive(
@@ -2173,6 +2199,34 @@ impl NextConfig {
             )?,
         }
         .cell())
+    }
+
+    #[turbo_tasks::function]
+    pub fn css_module_export_convention(
+        &self,
+    ) -> Result<Vc<turbopack_css::CssModuleExportConvention>> {
+        let convention = self
+            .turbopack
+            .as_ref()
+            .and_then(|t| t.css_modules.as_ref())
+            .and_then(|c| c.export_locals_convention.as_ref());
+
+        let result = match convention.map(|s| s.as_str()) {
+            Some("camelCase") => turbopack_css::CssModuleExportConvention::CamelCase,
+            Some("camelCaseOnly") => turbopack_css::CssModuleExportConvention::CamelCaseOnly,
+            Some("dashes") => turbopack_css::CssModuleExportConvention::Dashes,
+            Some("dashesOnly") => turbopack_css::CssModuleExportConvention::DashesOnly,
+            Some("asIs") | None => turbopack_css::CssModuleExportConvention::AsIs,
+            Some(other) => {
+                anyhow::bail!(
+                    "Invalid turbopack.cssModules.exportLocalsConvention value: {:?}. Valid \
+                     values are: asIs, camelCase, camelCaseOnly, dashes, dashesOnly",
+                    other
+                );
+            }
+        };
+
+        Ok(result.cell())
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -572,6 +572,7 @@ pub async fn get_server_module_options_context(
             source_maps,
             module_css_condition: Some(module_styles_rule_condition()),
             lightningcss_features: *next_config.lightningcss_feature_flags().await?,
+            export_convention: *next_config.css_module_export_convention().await?,
             ..Default::default()
         },
         tree_shaking_mode: tree_shaking_mode_for_user_code,

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopack.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopack.mdx
@@ -51,6 +51,7 @@ The following options are available for the `turbopack` configuration:
 | `resolveAlias`      | Map aliased imports to modules to load in their place.                                                                                   |
 | `resolveExtensions` | List of extensions to resolve when importing files.                                                                                      |
 | `debugIds`          | Enable generation of [debug IDs](https://github.com/tc39/ecma426/blob/main/proposals/debug-id.md) in JavaScript bundles and source maps. |
+| `cssModules`        | Configure CSS Modules behavior.                                                                                                          |
 
 ### Supported loaders
 
@@ -384,10 +385,45 @@ module.exports = {
 
 The option automatically adds a polyfill for debug IDs to the JavaScript bundle to ensure compatibility. The debug IDs are available in the `globalThis._debugIds` global variable.
 
+### CSS Modules
+
+The `cssModules` option controls how [CSS Module](https://github.com/css-modules/css-modules) class names are exported to JavaScript. By default, class names are exported as-is, matching the original CSS. You can configure this with `exportLocalsConvention` to automatically convert class names to camelCase.
+
+This is useful for projects that use kebab-case in CSS (e.g. `.main-content`) but prefer camelCase in JavaScript (e.g. `styles.mainContent`).
+
+```js filename="next.config.js"
+module.exports = {
+  turbopack: {
+    cssModules: {
+      exportLocalsConvention: 'camelCaseOnly',
+    },
+  },
+}
+```
+
+Available values for `exportLocalsConvention`:
+
+| Value           | Input class     | Exported keys                                  |
+| --------------- | --------------- | ---------------------------------------------- |
+| `asIs`          | `.main-content` | `styles["main-content"]`                       |
+| `camelCase`     | `.main-content` | `styles["main-content"]`, `styles.mainContent` |
+| `camelCaseOnly` | `.main-content` | `styles.mainContent`                           |
+| `dashes`        | `.main-content` | `styles["main-content"]`, `styles.mainContent` |
+| `dashesOnly`    | `.main-content` | `styles.mainContent`                           |
+
+- **`asIs`** (default): Export class names exactly as written in CSS.
+- **`camelCase`**: Export both the original name and a camelCased version. Converts all delimiters (`-`, `_`, `.`, space).
+- **`camelCaseOnly`**: Export only the camelCased version.
+- **`dashes`**: Export both the original name and a camelCased version. Only converts hyphens (`-`).
+- **`dashesOnly`**: Export only the hyphen-converted camelCased version.
+
+> **Good to know**: The difference between `camelCase` and `dashes` is which delimiters are converted. `camelCase` converts hyphens, underscores, dots, and spaces, while `dashes` only converts hyphens. For example, `with_underscore` becomes `withUnderscore` with `camelCase` but stays `with_underscore` with `dashes`.
+
 ## Version History
 
 | Version  | Changes                                              |
 | -------- | ---------------------------------------------------- |
+| `16.2.x` | `turbopack.cssModules` was added.                    |
 | `16.2.0` | `turbopackLoader` import attributes were added.      |
 | `16.2.0` | `turbopack.rules.*.type` was added.                  |
 | `16.2.0` | `turbopack.rules.*.condition.contentType` was added. |

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -185,6 +185,13 @@ const zTurbopackConfig: zod.ZodType<TurbopackOptions> = z.strictObject({
       })
     )
     .optional(),
+  cssModules: z
+    .object({
+      exportLocalsConvention: z
+        .enum(['asIs', 'camelCase', 'camelCaseOnly', 'dashes', 'dashesOnly'])
+        .optional(),
+    })
+    .optional(),
 })
 
 export const experimentalSchema = {

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -239,6 +239,27 @@ export interface TurbopackOptions {
     title?: string | RegExp
     description?: string | RegExp
   }>
+
+  /**
+   * CSS Modules configuration for Turbopack.
+   */
+  cssModules?: {
+    /**
+     * Controls how CSS module class names are exported to JavaScript.
+     *
+     * - `'asIs'` (default) — export class names exactly as written in CSS.
+     * - `'camelCase'` — export both the original and a camelCased version.
+     * - `'camelCaseOnly'` — export only the camelCased version.
+     * - `'dashes'` — export both the original and a dashes-to-camelCase version.
+     * - `'dashesOnly'` — export only the dashes-to-camelCase version.
+     */
+    exportLocalsConvention?:
+      | 'asIs'
+      | 'camelCase'
+      | 'camelCaseOnly'
+      | 'dashes'
+      | 'dashesOnly'
+  }
 }
 
 export interface WebpackConfigContext {

--- a/test/e2e/app-dir/css-modules-export-convention/app/layout.tsx
+++ b/test/e2e/app-dir/css-modules-export-convention/app/layout.tsx
@@ -1,0 +1,7 @@
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/css-modules-export-convention/app/page.tsx
+++ b/test/e2e/app-dir/css-modules-export-convention/app/page.tsx
@@ -1,0 +1,22 @@
+import styles from './styles.module.css'
+
+export default function Page() {
+  const keys = Object.keys(styles).sort()
+  return (
+    <div>
+      <p id="keys">{keys.join(',')}</p>
+      <p id="main" className={styles.mainContent}>
+        main
+      </p>
+      <p id="nav" className={styles.navBar}>
+        nav
+      </p>
+      <p id="simple" className={styles.simple}>
+        simple
+      </p>
+      <p id="underscore" className={styles.withUnderscore}>
+        underscore
+      </p>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/css-modules-export-convention/app/styles.module.css
+++ b/test/e2e/app-dir/css-modules-export-convention/app/styles.module.css
@@ -1,0 +1,15 @@
+.main-content {
+  color: red;
+}
+
+.nav-bar {
+  color: blue;
+}
+
+.simple {
+  color: green;
+}
+
+.with_underscore {
+  color: orange;
+}

--- a/test/e2e/app-dir/css-modules-export-convention/css-modules-export-convention.test.ts
+++ b/test/e2e/app-dir/css-modules-export-convention/css-modules-export-convention.test.ts
@@ -1,0 +1,52 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+describe('css-modules-export-convention', () => {
+  const { next, isTurbopack } = nextTestSetup({
+    files: __dirname,
+  })
+
+  // This feature is Turbopack-only. Webpack uses its own css-loader convention.
+  ;(isTurbopack ? describe : describe.skip)('turbopack', () => {
+    it('should export camelCased keys with camelCaseOnly convention', async () => {
+      const browser = await next.browser('/')
+
+      await retry(async () => {
+        const keys = await browser.elementByCss('#keys').text()
+        // With camelCaseOnly: kebab-case and underscore names are camelCased,
+        // "simple" stays the same since it has no delimiters.
+        expect(keys).toBe('mainContent,navBar,simple,withUnderscore')
+      })
+    })
+
+    it('should apply styles via camelCased class names', async () => {
+      const browser = await next.browser('/')
+
+      await retry(async () => {
+        const mainColor = await browser
+          .elementByCss('#main')
+          .getComputedCss('color')
+        // red = rgb(255, 0, 0)
+        expect(mainColor).toBe('rgb(255, 0, 0)')
+      })
+
+      const navColor = await browser
+        .elementByCss('#nav')
+        .getComputedCss('color')
+      // blue = rgb(0, 0, 255)
+      expect(navColor).toBe('rgb(0, 0, 255)')
+
+      const simpleColor = await browser
+        .elementByCss('#simple')
+        .getComputedCss('color')
+      // green = rgb(0, 128, 0)
+      expect(simpleColor).toBe('rgb(0, 128, 0)')
+
+      const underscoreColor = await browser
+        .elementByCss('#underscore')
+        .getComputedCss('color')
+      // orange = rgb(255, 165, 0)
+      expect(underscoreColor).toBe('rgb(255, 165, 0)')
+    })
+  })
+})

--- a/test/e2e/app-dir/css-modules-export-convention/next.config.ts
+++ b/test/e2e/app-dir/css-modules-export-convention/next.config.ts
@@ -1,0 +1,11 @@
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  turbopack: {
+    cssModules: {
+      exportLocalsConvention: 'camelCaseOnly',
+    },
+  },
+}
+
+export default nextConfig

--- a/turbopack/crates/turbopack-css/src/lib.rs
+++ b/turbopack/crates/turbopack-css/src/lib.rs
@@ -13,6 +13,7 @@ mod lifetime_util;
 mod module_asset;
 pub(crate) mod process;
 pub(crate) mod references;
+pub(crate) mod util;
 
 use bincode::{Decode, Encode};
 use turbo_tasks::{NonLocalValue, TaskInput, trace::TraceRawVcs};
@@ -42,6 +43,25 @@ pub enum CssModuleType {
     Default,
     /// The CSS is parsed as CSS modules.
     Module,
+}
+
+/// Controls how CSS module class names are exported to JavaScript.
+///
+/// Matches the behavior of webpack's `css-loader` `modules.exportLocalsConvention` option.
+#[turbo_tasks::value(shared, serialization = "auto")]
+#[derive(PartialOrd, Ord, Hash, Copy, Clone, Debug, Default, TaskInput)]
+pub enum CssModuleExportConvention {
+    /// Export class names as-is (e.g. `.main-content` → `styles["main-content"]`).
+    #[default]
+    AsIs,
+    /// Export both the original and camelCased name (all delimiters: `-`, `_`, `.`, ` `).
+    CamelCase,
+    /// Export only the camelCased name.
+    CamelCaseOnly,
+    /// Export both the original and dashes-to-camelCase name (hyphens only).
+    Dashes,
+    /// Export only the dashes-to-camelCase name.
+    DashesOnly,
 }
 
 /// User-specified lightningcss feature flags (from `experimental.lightningCssFeatures`).

--- a/turbopack/crates/turbopack-css/src/module_asset.rs
+++ b/turbopack/crates/turbopack-css/src/module_asset.rs
@@ -32,8 +32,10 @@ use turbopack_ecmascript::{
 };
 
 use crate::{
+    CssModuleExportConvention,
     process::{CssWithPlaceholderResult, ProcessCss},
     references::{compose::CssModuleComposeReference, internal::InternalCssAssetReference},
+    util::{camel_case, dashes_camel_case},
 };
 
 /// A [CSS Module, as in `.module.css`][spec]. For a global CSS module, see [`CssModule`].
@@ -45,6 +47,7 @@ use crate::{
 pub struct EcmascriptCssModule {
     pub source: ResolvedVc<Box<dyn Source>>,
     pub asset_context: ResolvedVc<Box<dyn AssetContext>>,
+    pub export_convention: CssModuleExportConvention,
 }
 
 #[turbo_tasks::value_impl]
@@ -53,10 +56,12 @@ impl EcmascriptCssModule {
     pub fn new(
         source: ResolvedVc<Box<dyn Source>>,
         asset_context: ResolvedVc<Box<dyn AssetContext>>,
+        export_convention: CssModuleExportConvention,
     ) -> Vc<Self> {
         Self::cell(EcmascriptCssModule {
             source,
             asset_context,
+            export_convention,
         })
     }
 }
@@ -273,7 +278,9 @@ impl EcmascriptChunkPlaceable for EcmascriptCssModule {
         _async_module_info: Option<Vc<AsyncModuleInfo>>,
         _estimated: bool,
     ) -> Result<Vc<EcmascriptChunkItemContent>> {
+        let this = self.await?;
         let classes = self.classes().await?;
+        let convention = this.export_convention;
 
         let mut code = format!("{TURBOPACK_EXPORT_VALUE}({{\n");
         for (export_name, class_names) in &*classes {
@@ -292,7 +299,7 @@ impl EcmascriptChunkPlaceable for EcmascriptCssModule {
                                 severity: IssueSeverity::Error,
                                 // TODO(PACK-4879): this should include detailed location
                                 // information
-                                source: IssueSource::from_source_only(self.await?.source),
+                                source: IssueSource::from_source_only(this.source),
                                 message: turbofmt!(
                                     "Module {} referenced in `composes: ... from ...;` can't be \
                                      resolved.\n",
@@ -312,7 +319,7 @@ impl EcmascriptChunkPlaceable for EcmascriptCssModule {
                                 severity: IssueSeverity::Error,
                                 // TODO(PACK-4879): this should include detailed location
                                 // information
-                                source: IssueSource::from_source_only(self.await?.source),
+                                source: IssueSource::from_source_only(this.source),
                                 message: turbofmt!(
                                     "Module {} referenced in `composes: ... from ...;` is not a \
                                      CSS module.\n",
@@ -344,12 +351,36 @@ impl EcmascriptChunkPlaceable for EcmascriptCssModule {
                 }
             }
 
-            writeln!(
-                code,
-                "  {}: {},",
-                StringifyJs(export_name),
-                exported_class_names.join(" + \" \" + ")
-            )?;
+            let class_value = exported_class_names.join(" + \" \" + ");
+
+            // Emit export entries based on the configured convention.
+            match convention {
+                CssModuleExportConvention::AsIs => {
+                    writeln!(code, "  {}: {},", StringifyJs(export_name), class_value)?;
+                }
+                CssModuleExportConvention::CamelCase => {
+                    writeln!(code, "  {}: {},", StringifyJs(export_name), class_value)?;
+                    let camel = camel_case(export_name);
+                    if camel != *export_name {
+                        writeln!(code, "  {}: {},", StringifyJs(&camel), class_value)?;
+                    }
+                }
+                CssModuleExportConvention::CamelCaseOnly => {
+                    let camel = camel_case(export_name);
+                    writeln!(code, "  {}: {},", StringifyJs(&camel), class_value)?;
+                }
+                CssModuleExportConvention::Dashes => {
+                    writeln!(code, "  {}: {},", StringifyJs(export_name), class_value)?;
+                    let dashed = dashes_camel_case(export_name);
+                    if dashed != *export_name {
+                        writeln!(code, "  {}: {},", StringifyJs(&dashed), class_value)?;
+                    }
+                }
+                CssModuleExportConvention::DashesOnly => {
+                    let dashed = dashes_camel_case(export_name);
+                    writeln!(code, "  {}: {},", StringifyJs(&dashed), class_value)?;
+                }
+            }
         }
         code += "});\n";
         let source_map = *chunking_context

--- a/turbopack/crates/turbopack-css/src/util.rs
+++ b/turbopack/crates/turbopack-css/src/util.rs
@@ -1,0 +1,193 @@
+/// Converts a string to camelCase by treating `-`, `_`, `.`, and ` ` as word boundaries.
+///
+/// This matches the behavior of webpack's `css-loader` `camelCase` function from
+/// `camelcase.ts`. Unlike the full `camelCase` npm package, this implementation
+/// focuses on the common CSS class name patterns and does not handle
+/// `preserveConsecutiveUppercase` or `pascalCase` options (neither does webpack's
+/// css-loader for export convention).
+///
+/// # Examples
+/// ```ignore
+/// assert_eq!(camel_case("main-content"), "mainContent");
+/// assert_eq!(camel_case("my_class"), "myClass");
+/// assert_eq!(camel_case("FOO-bar"), "fooBar");
+/// assert_eq!(camel_case("--foo"), "foo");
+/// ```
+pub fn camel_case(s: &str) -> String {
+    if s.is_empty() {
+        return String::new();
+    }
+
+    // Strip leading delimiters
+    let s = s.trim_start_matches(|c| c == '-' || c == '_' || c == '.' || c == ' ');
+    if s.is_empty() {
+        return String::new();
+    }
+
+    let mut result = String::with_capacity(s.len());
+    let mut capitalize_next = false;
+    let mut first = true;
+
+    for ch in s.chars() {
+        if ch == '-' || ch == '_' || ch == '.' || ch == ' ' {
+            capitalize_next = true;
+        } else if capitalize_next {
+            result.extend(ch.to_uppercase());
+            capitalize_next = false;
+            first = false;
+        } else if first {
+            // First real character is always lowercase
+            result.extend(ch.to_lowercase());
+            first = false;
+        } else {
+            result.push(ch);
+        }
+    }
+
+    result
+}
+
+/// Converts hyphens followed by a word character to camelCase.
+///
+/// Only transforms hyphens (`-`), unlike [`camel_case`] which also handles
+/// `_`, `.`, and space. This matches webpack's `dashesCamelCase` function.
+///
+/// # Examples
+/// ```ignore
+/// assert_eq!(dashes_camel_case("main-content"), "mainContent");
+/// assert_eq!(dashes_camel_case("my_class"), "my_class");  // underscore preserved
+/// ```
+pub fn dashes_camel_case(s: &str) -> String {
+    if s.is_empty() {
+        return String::new();
+    }
+
+    let mut result = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        if ch == '-' {
+            // Consume consecutive hyphens
+            while chars.peek() == Some(&'-') {
+                chars.next();
+            }
+            // Capitalize the next character if it exists
+            if let Some(next) = chars.next() {
+                result.extend(next.to_uppercase());
+            }
+        } else {
+            result.push(ch);
+        }
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_camel_case_basic() {
+        assert_eq!(camel_case("main-content"), "mainContent");
+        assert_eq!(camel_case("nav-bar"), "navBar");
+        assert_eq!(camel_case("foo-bar-baz"), "fooBarBaz");
+    }
+
+    #[test]
+    fn test_camel_case_underscores() {
+        assert_eq!(camel_case("my_class"), "myClass");
+        assert_eq!(camel_case("foo_bar_baz"), "fooBarBaz");
+    }
+
+    #[test]
+    fn test_camel_case_dots_and_spaces() {
+        assert_eq!(camel_case("my.class"), "myClass");
+        assert_eq!(camel_case("my class"), "myClass");
+    }
+
+    #[test]
+    fn test_camel_case_mixed_delimiters() {
+        assert_eq!(camel_case("foo-bar_baz"), "fooBarBaz");
+        assert_eq!(camel_case("a-b_c.d e"), "aBCDE");
+    }
+
+    #[test]
+    fn test_camel_case_leading_delimiters() {
+        assert_eq!(camel_case("--foo"), "foo");
+        assert_eq!(camel_case("__foo"), "foo");
+        assert_eq!(camel_case("-foo-bar"), "fooBar");
+    }
+
+    #[test]
+    fn test_camel_case_uppercase_input() {
+        assert_eq!(camel_case("FOO-BAR"), "fOOBAR");
+        assert_eq!(camel_case("Foo-Bar"), "fooBar");
+    }
+
+    #[test]
+    fn test_camel_case_single_char() {
+        assert_eq!(camel_case("a"), "a");
+        assert_eq!(camel_case("A"), "a");
+    }
+
+    #[test]
+    fn test_camel_case_empty() {
+        assert_eq!(camel_case(""), "");
+        assert_eq!(camel_case("---"), "");
+    }
+
+    #[test]
+    fn test_camel_case_no_delimiters() {
+        assert_eq!(camel_case("foobar"), "foobar");
+        assert_eq!(camel_case("fooBar"), "fooBar");
+    }
+
+    #[test]
+    fn test_dashes_camel_case_basic() {
+        assert_eq!(dashes_camel_case("main-content"), "mainContent");
+        assert_eq!(dashes_camel_case("nav-bar"), "navBar");
+        assert_eq!(dashes_camel_case("foo-bar-baz"), "fooBarBaz");
+    }
+
+    #[test]
+    fn test_dashes_preserves_underscores() {
+        assert_eq!(dashes_camel_case("my_class"), "my_class");
+        assert_eq!(dashes_camel_case("foo_bar"), "foo_bar");
+    }
+
+    #[test]
+    fn test_dashes_preserves_dots() {
+        assert_eq!(dashes_camel_case("my.class"), "my.class");
+    }
+
+    #[test]
+    fn test_dashes_consecutive_hyphens() {
+        assert_eq!(dashes_camel_case("foo--bar"), "fooBar");
+        assert_eq!(dashes_camel_case("foo---bar"), "fooBar");
+    }
+
+    #[test]
+    fn test_dashes_leading_hyphen() {
+        // Leading hyphen with no preceding char — next char is capitalized
+        assert_eq!(dashes_camel_case("-foo"), "Foo");
+        assert_eq!(dashes_camel_case("--foo"), "Foo");
+    }
+
+    #[test]
+    fn test_dashes_trailing_hyphen() {
+        assert_eq!(dashes_camel_case("foo-"), "foo");
+    }
+
+    #[test]
+    fn test_dashes_empty() {
+        assert_eq!(dashes_camel_case(""), "");
+        assert_eq!(dashes_camel_case("---"), "");
+    }
+
+    #[test]
+    fn test_dashes_no_hyphens() {
+        assert_eq!(dashes_camel_case("foobar"), "foobar");
+        assert_eq!(dashes_camel_case("fooBar"), "fooBar");
+    }
+}

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -248,10 +248,14 @@ async fn apply_module_type(
         ModuleType::NodeAddon => {
             ResolvedVc::upcast(NodeAddonModule::new(*source).to_resolved().await?)
         }
-        ModuleType::CssModule => ResolvedVc::upcast(
-            EcmascriptCssModule::new(*source, Vc::upcast(module_asset_context))
-                .to_resolved()
-                .await?,
+        ModuleType::CssModule { export_convention } => ResolvedVc::upcast(
+            EcmascriptCssModule::new(
+                *source,
+                Vc::upcast(module_asset_context),
+                *export_convention,
+            )
+            .to_resolved()
+            .await?,
         ),
 
         ModuleType::Css {
@@ -761,6 +765,7 @@ async fn process_default_internal(
                     empty_transforms,
                     default_options,
                     None,
+                    Default::default(),
                     Default::default(),
                 )
                 .await?;

--- a/turbopack/crates/turbopack/src/module_options/mod.rs
+++ b/turbopack/crates/turbopack/src/module_options/mod.rs
@@ -254,6 +254,7 @@ impl ModuleOptions {
                     source_maps: css_source_maps,
                     ref module_css_condition,
                     lightningcss_features,
+                    export_convention,
                     ..
                 },
             ref static_url_tag,
@@ -493,6 +494,7 @@ impl ModuleOptions {
                                     ecmascript_options_vc,
                                     environment,
                                     lightningcss_features,
+                                    export_convention,
                                 )
                                 .await?,
                         )
@@ -929,7 +931,9 @@ impl ModuleOptions {
                 ),
                 ModuleRule::new(
                     RuleCondition::all(vec![module_css_condition.clone()]),
-                    vec![ModuleRuleEffect::ModuleType(ModuleType::CssModule)],
+                    vec![ModuleRuleEffect::ModuleType(ModuleType::CssModule {
+                        export_convention,
+                    })],
                 ),
                 ModuleRule::new_all(
                     RuleCondition::Any(vec![

--- a/turbopack/crates/turbopack/src/module_options/module_options_context.rs
+++ b/turbopack/crates/turbopack/src/module_options/module_options_context.rs
@@ -320,6 +320,9 @@ pub struct CssOptionsContext {
     /// User-specified lightningcss feature flags (include/exclude bitmasks).
     pub lightningcss_features: turbopack_css::LightningCssFeatureFlags,
 
+    /// Controls how CSS module class names are exported to JavaScript.
+    pub export_convention: turbopack_css::CssModuleExportConvention,
+
     pub placeholder_for_future_extensions: (),
 }
 

--- a/turbopack/crates/turbopack/src/module_options/module_rule.rs
+++ b/turbopack/crates/turbopack/src/module_options/module_rule.rs
@@ -9,7 +9,7 @@ use turbopack_core::{
     environment::Environment, reference_type::ReferenceType, source::Source,
     source_transform::SourceTransforms,
 };
-use turbopack_css::CssModuleType;
+use turbopack_css::{CssModuleExportConvention, CssModuleType};
 use turbopack_ecmascript::{
     EcmascriptInputTransforms, EcmascriptOptions, bytes_source_transform::BytesSourceTransform,
     json_source_transform::JsonSourceTransform,
@@ -138,7 +138,9 @@ pub enum ModuleType {
     },
     Raw,
     NodeAddon,
-    CssModule,
+    CssModule {
+        export_convention: CssModuleExportConvention,
+    },
     Css {
         ty: CssModuleType,
         environment: Option<ResolvedVc<Environment>>,
@@ -167,7 +169,7 @@ impl Display for ModuleType {
             ModuleType::EcmascriptExtensionless { .. } => write!(f, "EcmascriptExtensionless"),
             ModuleType::Raw => write!(f, "Raw"),
             ModuleType::NodeAddon => write!(f, "NodeAddon"),
-            ModuleType::CssModule => write!(f, "CssModule"),
+            ModuleType::CssModule { .. } => write!(f, "CssModule"),
             ModuleType::Css { .. } => write!(f, "Css"),
             ModuleType::StaticUrlJs { .. } => write!(f, "StaticUrlJs"),
             ModuleType::StaticUrlCss { .. } => write!(f, "StaticUrlCss"),
@@ -233,6 +235,7 @@ impl ConfiguredModuleType {
         options: ResolvedVc<EcmascriptOptions>,
         environment: Option<ResolvedVc<Environment>>,
         lightningcss_features: turbopack_css::LightningCssFeatureFlags,
+        export_convention: CssModuleExportConvention,
     ) -> Result<ModuleRuleEffect> {
         Ok(match self {
             ConfiguredModuleType::Bytes => {
@@ -268,7 +271,9 @@ impl ConfiguredModuleType {
                 environment,
                 lightningcss_features,
             }),
-            ConfiguredModuleType::CssModule => ModuleRuleEffect::ModuleType(ModuleType::CssModule),
+            ConfiguredModuleType::CssModule => {
+                ModuleRuleEffect::ModuleType(ModuleType::CssModule { export_convention })
+            }
             ConfiguredModuleType::Json => {
                 ModuleRuleEffect::SourceTransforms(ResolvedVc::cell(vec![ResolvedVc::upcast(
                     // TODO: can we switch this to `new_esm`?


### PR DESCRIPTION
## What?

Add `turbopack.cssModules.exportLocalsConvention` config option, allowing users to control how CSS module class names are exported to JavaScript — matching webpack's `css-loader` `modules.exportLocalsConvention` behavior.

## Why?

Turbopack hardcodes CSS module exports as-is, so `.main-content` is only accessible as `styles["main-content"]`. Projects using kebab-case in CSS and camelCase in JS (a very common SCSS pattern) cannot migrate to Turbopack without rewriting all style imports.

Fixes #91838

## How?

**Rust (`turbopack-css` crate):**
- Added `CssModuleExportConvention` enum with 5 variants: `AsIs`, `CamelCase`, `CamelCaseOnly`, `Dashes`, `DashesOnly`
- Added `camel_case()` and `dashes_camel_case()` transform functions in `util.rs` with unit tests
- Applied the convention in `EcmascriptCssModule::chunk_item_content()` when writing JS export keys

**Config threading (`turbopack`, `next-core` crates):**
- Added `export_convention` field to `CssOptionsContext` and `ModuleType::CssModule`
- Added `TurbopackCssModulesConfig` struct and `css_module_export_convention()` getter on `NextConfig`
- Wired through both client and server context builders

**Next.js config (`packages/next`):**
- Added `cssModules.exportLocalsConvention` to `TurbopackOptions` type and zod schema
- Validated enum values: `asIs`, `camelCase`, `camelCaseOnly`, `dashes`, `dashesOnly`

**Usage:**

```js
// next.config.js
module.exports = {
  turbopack: {
    cssModules: {
      exportLocalsConvention: 'camelCaseOnly'
    }
  }
}
```

### Test plan

- [x] e2e test with `camelCaseOnly` convention verifying exported keys and applied styles
- [x] Test correctly skips in webpack mode (Turbopack-only feature)
- [x] Rust unit tests for `camel_case()` and `dashes_camel_case()` transforms
- [x] Manually verified with a test app: styles applied, correct keys exported
- [ ] CI passes
