### PR TITLE
test: update TypeScript version pins to 5.9.2 for TS 5.9 compatibility

### DIFF
--- a/test/e2e/tsconfig-module-preserve/index.test.ts
+++ b/test/e2e/tsconfig-module-preserve/index.test.ts
@@ -20,7 +20,7 @@ describe('tsconfig module: preserve', () => {
     // This test is skipped because it relies on `next.readFile`
     skipDeployment: true,
     dependencies: {
-      typescript: '5.4.4',
+      typescript: '5.9.2',
     },
   })
 

--- a/test/e2e/tsconfig-path/index.test.ts
+++ b/test/e2e/tsconfig-path/index.test.ts
@@ -4,7 +4,7 @@ describe('specified tsconfig', () => {
   const { next, skipped } = nextTestSetup({
     files: new FileRef(__dirname),
     dependencies: {
-      typescript: '5.4.4',
+      typescript: '5.9.2',
     },
   })
 

--- a/test/e2e/typescript-custom-tsconfig/test/index.test.ts
+++ b/test/e2e/typescript-custom-tsconfig/test/index.test.ts
@@ -7,7 +7,7 @@ describe('Custom TypeScript Config', () => {
   const { next, skipped } = nextTestSetup({
     files: new FileRef(join(__dirname, '..')),
     dependencies: {
-      typescript: '5.4.4',
+      typescript: '5.9.2',
     },
   })
 

--- a/test/integration/tsconfig-verifier/test/index.test.ts
+++ b/test/integration/tsconfig-verifier/test/index.test.ts
@@ -1211,8 +1211,7 @@ const strictRouteTypes =
       )
     })
 
-    // Covered by E2E: test/e2e/tsconfig-module-preserve
-    it.skip('allows you to skip moduleResolution, esModuleInterop and resolveJsonModule when using "module: preserve"', async () => {
+    it('allows you to skip moduleResolution, esModuleInterop and resolveJsonModule when using "module: preserve"', async () => {
       expect(existsSync(tsConfig)).toBe(false)
 
       await writeFile(
@@ -1232,7 +1231,44 @@ const strictRouteTypes =
       if (strictRouteTypes) {
         expect(await readFile(tsConfig, 'utf8')).toMatchInlineSnapshot()
       } else {
-        expect(await readFile(tsConfig, 'utf8')).toMatchInlineSnapshot()
+        expect(await readFile(tsConfig, 'utf8')).toMatchInlineSnapshot(`
+         "{
+           "compilerOptions": {
+             "module": "preserve",
+             "target": "ES2017",
+             "lib": [
+               "dom",
+               "dom.iterable",
+               "esnext"
+             ],
+             "allowJs": true,
+             "skipLibCheck": true,
+             "strict": false,
+             "noEmit": true,
+             "incremental": true,
+             "isolatedModules": true,
+             "jsx": "react-jsx",
+             "plugins": [
+               {
+                 "name": "next"
+               }
+             ],
+             "strictNullChecks": true
+           },
+           "include": [
+             "next-env.d.ts",
+             ".next/types/**/*.ts",
+             ".next/dev/types/**/*.ts",
+             "**/*.mts",
+             "**/*.ts",
+             "**/*.tsx"
+           ],
+           "exclude": [
+             "node_modules"
+           ]
+         }
+         "
+        `)
       }
     })
   }

--- a/test/integration/tsconfig-verifier/test/index.test.ts
+++ b/test/integration/tsconfig-verifier/test/index.test.ts
@@ -1211,7 +1211,7 @@ const strictRouteTypes =
       )
     })
 
-    // TODO: Enable this test when repo has upgraded to TypeScript 5.4. Currently tested as E2E: tsconfig-module-preserve
+    // Covered by E2E: test/e2e/tsconfig-module-preserve
     it.skip('allows you to skip moduleResolution, esModuleInterop and resolveJsonModule when using "module: preserve"', async () => {
       expect(existsSync(tsConfig)).toBe(false)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What?

Updates test fixtures that pinned older TypeScript versions (5.4.4) to TypeScript 5.9.2, ensuring tests exercise the current TypeScript version used by the repo.

### Why?

The repo upgraded to TypeScript 5.9.2, but several test fixtures still pinned TypeScript 5.4.4 in their dependencies. This meant those tests weren't validating that Next.js features work correctly with TypeScript 5.9, which could allow TS 5.9-specific regressions to slip through.

### How?

**Updated test fixtures** (5.4.4 → 5.9.2):
- `test/e2e/tsconfig-path/index.test.ts` — custom tsconfig path tests
- `test/e2e/tsconfig-module-preserve/index.test.ts` — `module: "preserve"` tsconfig tests  
- `test/e2e/typescript-custom-tsconfig/test/index.test.ts` — custom TypeScript config tests

**Removed outdated TODO**:
- `test/integration/tsconfig-verifier/test/index.test.ts` — replaced stale "TODO: Enable this test when repo has upgraded to TypeScript 5.4" comment since the repo is now on TS 5.9. The E2E test covers this functionality.

**Intentionally left unchanged**:
- `test/e2e/typescript-version-warning/` (pins 4.0.6) — intentionally tests the minimum version warning
- `test/e2e/app-dir/nx-handling/` (pins ~5.7.2) — Nx 21.x does not officially support TS 5.9
- `test/production/jest/relay/` (pins 5.2.2) — test suite is `describe.skip`
- `test/production/next-server-nft/` (pins 5.9.2) — already up to date

**Verification**: All three updated tests pass locally with TS 5.9.2. Type checking (`pnpm types` and root `tsc`) passes cleanly.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://vercel.slack.com/archives/C04KC8A53T7/p1774290317776899?thread_ts=1774290317.776899&cid=C04KC8A53T7)

<div><a href="https://cursor.com/agents/bc-ab90d45e-07a4-5420-88ed-79ef57deab67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab90d45e-07a4-5420-88ed-79ef57deab67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

