### PR TITLE
docs: add catchError pages router documentation

### DIFF
--- a/docs/01-app/03-api-reference/04-functions/catchError.mdx
+++ b/docs/01-app/03-api-reference/04-functions/catchError.mdx
@@ -8,11 +8,25 @@ related:
     - app/api-reference/file-conventions/error
 ---
 
+{/* The content of this doc is shared between the app and pages router. You can use the `<PagesOnly>Content</PagesOnly>` component to add content that is specific to the Pages Router. Any shared content should not be wrapped in a component. */}
+
+<AppOnly>
+
 The `unstable_catchError` function creates a component that wraps its children in an error boundary. It provides a programmatic alternative to the [`error.js`](/docs/app/api-reference/file-conventions/error) file convention, enabling component-level error recovery anywhere in your component tree.
+
+</AppOnly>
+
+<PagesOnly>
+
+The `unstable_catchError` function creates a component that wraps its children in an error boundary. It provides a programmatic alternative to writing a [custom React error boundary class](https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary), enabling component-level error recovery anywhere in your component tree.
+
+</PagesOnly>
 
 Compared to a custom React error boundary, `unstable_catchError` is designed to work with Next.js out of the box:
 
-- **Built-in error recovery** — [`unstable_retry()`](/docs/app/api-reference/file-conventions/error#unstable_retry) re-fetches and re-renders the error boundary's children, including Server Components.
+<AppOnly>
+
+- **Built-in error recovery** — [`unstable_retry()`](/docs/app/api-reference/file-conventions/error#unstable_retry) re-renders the page from the server in transition.
 - **Framework-aware integration** — APIs like `redirect()` and `notFound()` work by throwing special errors under the hood. `unstable_catchError` handles these seamlessly, so they're not accidentally caught by your error boundary.
 - **Client navigation handling** — The error state automatically clears when you do a client navigation to a different route.
 
@@ -57,6 +71,47 @@ function ErrorFallback(props, { error, unstable_retry }) {
 export default unstable_catchError(ErrorFallback)
 ```
 
+</AppOnly>
+
+<PagesOnly>
+
+- **Built-in error recovery** — `reset()` re-renders the error boundary's children, letting users recover from errors without a full page reload.
+- **Client navigation handling** — The error state automatically clears when you do a client navigation to a different route.
+
+```tsx filename="components/custom-error-boundary.tsx" switcher
+import { unstable_catchError, type ErrorInfo } from 'next/error'
+
+function ErrorFallback(props: { title: string }, { error, reset }: ErrorInfo) {
+  return (
+    <div>
+      <h2>{props.title}</h2>
+      <p>{error.message}</p>
+      <button onClick={() => reset()}>Try again</button>
+    </div>
+  )
+}
+
+export default unstable_catchError(ErrorFallback)
+```
+
+```jsx filename="components/custom-error-boundary.js" switcher
+import { unstable_catchError } from 'next/error'
+
+function ErrorFallback(props, { error, reset }) {
+  return (
+    <div>
+      <h2>{props.title}</h2>
+      <p>{error.message}</p>
+      <button onClick={() => reset()}>Try again</button>
+    </div>
+  )
+}
+
+export default unstable_catchError(ErrorFallback)
+```
+
+</PagesOnly>
+
 ## Reference
 
 ### Parameters
@@ -74,6 +129,8 @@ A function that renders the error UI when an error is caught. It receives two ar
 - `props` — The props passed to the wrapper component (excluding `children`).
 - `errorInfo` — An object containing information about the error:
 
+<AppOnly>
+
 | Property         | Type                                                                                        | Description                                                                                                                                                       |
 | ---------------- | ------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `error`          | [`Error`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error) | The error instance that was caught.                                                                                                                               |
@@ -81,6 +138,17 @@ A function that renders the error UI when an error is caught. It receives two ar
 | `reset`          | `() => void`                                                                                | Resets the error state and re-renders without re-fetching. Use [`unstable_retry()`](/docs/app/api-reference/file-conventions/error#unstable_retry) in most cases. |
 
 The `fallback` function must be a Client Component (or defined in a `'use client'` module).
+
+</AppOnly>
+
+<PagesOnly>
+
+| Property | Type                                                                                        | Description                                                          |
+| -------- | ------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| `error`  | [`Error`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error) | The error instance that was caught.                                  |
+| `reset`  | `() => void`                                                                                | Resets the error state and re-renders the error boundary's children. |
+
+</PagesOnly>
 
 ### Returns
 
@@ -92,9 +160,21 @@ The `fallback` function must be a Client Component (or defined in a `'use client
 
 ## Examples
 
+<AppOnly>
+
 ### Client Component
 
+</AppOnly>
+
+<PagesOnly>
+
+### Basic usage
+
+</PagesOnly>
+
 Define a fallback and use the returned component to wrap parts of your UI:
+
+<AppOnly>
 
 ```tsx filename="app/some-component.tsx" switcher
 import ErrorWrapper from '../custom-error-boundary'
@@ -112,7 +192,31 @@ export default function Component({ children }) {
 }
 ```
 
+</AppOnly>
+
+<PagesOnly>
+
+```tsx filename="components/some-component.tsx" switcher
+import ErrorWrapper from './custom-error-boundary'
+
+export default function Component({ children }: { children: React.ReactNode }) {
+  return <ErrorWrapper title="Dashboard Error">{children}</ErrorWrapper>
+}
+```
+
+```jsx filename="components/some-component.js" switcher
+import ErrorWrapper from './custom-error-boundary'
+
+export default function Component({ children }) {
+  return <ErrorWrapper title="Dashboard Error">{children}</ErrorWrapper>
+}
+```
+
+</PagesOnly>
+
 ### Recovering from errors
+
+<AppOnly>
 
 Use `unstable_retry()` to prompt the user to recover from the error. When called, the function re-fetches and re-renders the error boundary's children. If successful, the fallback is replaced with the re-rendered result.
 
@@ -153,6 +257,46 @@ function ErrorFallback(props, { error, unstable_retry, reset }) {
 
 export default unstable_catchError(ErrorFallback)
 ```
+
+</AppOnly>
+
+<PagesOnly>
+
+Use `reset()` to prompt the user to recover from the error. When called, the function clears the error state and re-renders the error boundary's children.
+
+```tsx filename="components/custom-error-boundary.tsx" switcher
+import { unstable_catchError, type ErrorInfo } from 'next/error'
+
+function ErrorFallback(props: {}, { error, reset }: ErrorInfo) {
+  return (
+    <div>
+      <p>{error.message}</p>
+      <button onClick={() => reset()}>Try again</button>
+    </div>
+  )
+}
+
+export default unstable_catchError(ErrorFallback)
+```
+
+```jsx filename="components/custom-error-boundary.js" switcher
+import { unstable_catchError } from 'next/error'
+
+function ErrorFallback(props, { error, reset }) {
+  return (
+    <div>
+      <p>{error.message}</p>
+      <button onClick={() => reset()}>Try again</button>
+    </div>
+  )
+}
+
+export default unstable_catchError(ErrorFallback)
+```
+
+</PagesOnly>
+
+<AppOnly>
 
 ### Server-rendered error fallback
 
@@ -218,6 +362,14 @@ export default function Component({ children }) {
 > - Unlike the `error.js` file convention which is scoped to route segments, `unstable_catchError` can be used to wrap any part of your component tree for component-level error recovery.
 > - Props passed to the wrapper component are forwarded to the fallback function, making it easy to create reusable error UIs with different configurations.
 > - You don't need to wrap `error.js` default exports with `unstable_catchError`. The [`error.js`](/docs/app/api-reference/file-conventions/error) file convention already renders inside a built-in error boundary provided by Next.js.
+
+</AppOnly>
+
+<PagesOnly>
+
+> **Good to know**: Props passed to the wrapper component are forwarded to the fallback function, making it easy to create reusable error UIs with different configurations.
+
+</PagesOnly>
 
 ## Version History
 

--- a/docs/01-app/03-api-reference/04-functions/catchError.mdx
+++ b/docs/01-app/03-api-reference/04-functions/catchError.mdx
@@ -26,7 +26,7 @@ Compared to a custom React error boundary, `unstable_catchError` is designed to 
 
 <AppOnly>
 
-- **Built-in error recovery** — [`unstable_retry()`](/docs/app/api-reference/file-conventions/error#unstable_retry) re-renders the page from the server in transition.
+- **Built-in error recovery** — [`unstable_retry()`](/docs/app/api-reference/file-conventions/error#unstable_retry) re-renders the page inside a [Transition](https://react.dev/reference/react/startTransition), preserving Client Components state outside of the error boundary.
 - **Framework-aware integration** — APIs like `redirect()` and `notFound()` work by throwing special errors under the hood. `unstable_catchError` handles these seamlessly, so they're not accidentally caught by your error boundary.
 - **Client navigation handling** — The error state automatically clears when you do a client navigation to a different route.
 

--- a/docs/02-pages/04-api-reference/03-functions/catchError.mdx
+++ b/docs/02-pages/04-api-reference/03-functions/catchError.mdx
@@ -1,0 +1,7 @@
+---
+title: unstable_catchError
+description: API Reference for the unstable_catchError function.
+source: app/api-reference/functions/catchError
+---
+
+{/* DO NOT EDIT. The content of this doc is generated from the source above. To edit the content of this page, navigate to the source page in your editor. You can use the `<PagesOnly>Content</PagesOnly>` component to add content that is specific to the Pages Router. Any shared content should not be wrapped in a component. */}


### PR DESCRIPTION
## Summary

- Add Pages Router documentation for `unstable_catchError` with `source:` stub pointing to the App Router doc
- Add `<AppOnly>` / `<PagesOnly>` blocks throughout the existing catchError doc to differentiate router-specific content
- Pages Router uses `reset` instead of `unstable_retry` (which is App Router-only), omits `'use client'` directive, and uses `components/` file paths