### PR TITLE
docs: add verified adapters section

### DIFF
--- a/docs/01-app/01-getting-started/17-deploying.mdx
+++ b/docs/01-app/01-getting-started/17-deploying.mdx
@@ -5,12 +5,12 @@ description: Learn how to deploy your Next.js application.
 
 Next.js can be deployed as a Node.js server, Docker container, static export, or adapted to run on different platforms.
 
-| Deployment Option                | Feature Support   |
-| -------------------------------- | ----------------- |
-| [Node.js server](#nodejs-server) | All               |
-| [Docker container](#docker)      | All               |
-| [Static export](#static-export)  | Limited           |
-| [Adapters](#adapters)            | Platform-specific |
+| Deployment Option                | Feature Support                                                     |
+| -------------------------------- | ------------------------------------------------------------------- |
+| [Node.js server](#nodejs-server) | All                                                                 |
+| [Docker container](#docker)      | All                                                                 |
+| [Static export](#static-export)  | Limited                                                             |
+| [Adapters](#adapters)            | Varies ([verified](#verified-adapters) adapters run the test suite) |
 
 ## Node.js server
 
@@ -75,9 +75,20 @@ Running as a [static export](/docs/app/guides/static-exports) **does not** suppo
 
 ## Adapters
 
-Next.js can be adapted to run on different platforms to support their infrastructure capabilities.
+Next.js can be adapted to run on different platforms to support their infrastructure capabilities. The [Deployment Adapter API](/docs/app/api-reference/config/next-config-js/adapterPath) lets platforms customize how Next.js applications are built and deployed.
 
-Refer to each provider's documentation for information on supported Next.js features:
+### Verified Adapters
+
+Verified adapters are open source, run the full [Next.js compatibility test suite](/docs/app/api-reference/config/next-config-js/adapterPath#testing-adapters), and are hosted under the [Next.js GitHub organization](https://github.com/nextjs). The Next.js team coordinates testing with these platforms before major releases. Publicly visible test results for each adapter are coming soon. [Learn more about verified adapters](/docs/app/guides/deploying-to-platforms#verified-adapters).
+
+- [Vercel](https://vercel.com/docs/frameworks/nextjs)
+- [Bun](https://bun.sh/docs/frameworks/nextjs)
+
+Cloudflare and Netlify are working on verified adapters built on the Adapter API. In the meantime, they offer their own Next.js integrations (see below).
+
+### Other Platforms
+
+The following platforms offer their own Next.js integrations. These are not built on the public [Adapter API](/docs/app/api-reference/config/next-config-js/adapterPath) and are not verified by the Next.js team, so feature support and compatibility may vary. Refer to each provider's documentation for details:
 
 - [Appwrite Sites](https://appwrite.io/docs/products/sites/quick-start/nextjs)
 - [AWS Amplify Hosting](https://docs.amplify.aws/nextjs/start/quickstart/nextjs-app-router-client-components)
@@ -85,6 +96,5 @@ Refer to each provider's documentation for information on supported Next.js feat
 - [Deno Deploy](https://docs.deno.com/examples/next_tutorial)
 - [Firebase App Hosting](https://firebase.google.com/docs/app-hosting/get-started)
 - [Netlify](https://docs.netlify.com/frameworks/next-js/overview/#next-js-support-on-netlify)
-- [Vercel](https://vercel.com/docs/frameworks/nextjs)
 
-The [Deployment Adapter API](/docs/app/api-reference/config/next-config-js/adapterPath) lets platforms customize how Next.js applications are built and deployed. For details on which Next.js features require specific platform capabilities, see [Deploying to Platforms](/docs/app/guides/deploying-to-platforms).
+For details on which Next.js features require specific platform capabilities, see [Deploying to Platforms](/docs/app/guides/deploying-to-platforms).

--- a/docs/01-app/02-guides/deploying-to-platforms.mdx
+++ b/docs/01-app/02-guides/deploying-to-platforms.mdx
@@ -67,7 +67,7 @@ These are available building blocks, not finished integrations. Most community a
 
 ## Adapters
 
-Next.js provides a [Deployment Adapter API](/docs/app/api-reference/config/next-config-js/adapterPath) that lets platforms customize how Next.js applications are built and deployed for their infrastructure. Adapters run at build time and produce platform-specific output from the standard Next.js build. Anyone can build an adapter against the public API with no special access required.
+Next.js provides a [Deployment Adapter API](/docs/app/api-reference/config/next-config-js/adapterPath) that lets platforms customize how Next.js applications are built and deployed for their infrastructure. Adapters run at build time and produce platform-specific output from the standard Next.js build. Anyone can build an adapter using the public API with no special access required.
 
 The adapter API plus Next.js caching interfaces form the complete platform integration surface. The adapter handles build-time output, while `cacheHandler` and `cacheHandlers` cover different runtime caching paths. `cacheHandler` (singular) covers server cache paths like ISR, route handlers, patched `fetch`/`unstable_cache`, and image optimization. `cacheHandlers` (plural) configures `'use cache'` directive backends.
 

--- a/docs/01-app/02-guides/deploying-to-platforms.mdx
+++ b/docs/01-app/02-guides/deploying-to-platforms.mdx
@@ -67,11 +67,26 @@ These are available building blocks, not finished integrations. Most community a
 
 ## Adapters
 
-Next.js provides a [Deployment Adapter API](/docs/app/api-reference/config/next-config-js/adapterPath) that lets platforms customize how Next.js applications are built and deployed for their infrastructure. Adapters run at build time and produce platform-specific output from the standard Next.js build.
+Next.js provides a [Deployment Adapter API](/docs/app/api-reference/config/next-config-js/adapterPath) that lets platforms customize how Next.js applications are built and deployed for their infrastructure. Adapters run at build time and produce platform-specific output from the standard Next.js build. Anyone can build an adapter against the public API with no special access required.
 
 The adapter API plus Next.js caching interfaces form the complete platform integration surface. The adapter handles build-time output, while `cacheHandler` and `cacheHandlers` cover different runtime caching paths. `cacheHandler` (singular) covers server cache paths like ISR, route handlers, patched `fetch`/`unstable_cache`, and image optimization. `cacheHandlers` (plural) configures `'use cache'` directive backends.
 
-For a list of available platform adapters, see the [Deploying](/docs/app/getting-started/deploying#adapters) page.
+### Verified Adapters
+
+A **verified adapter** is one that meets two requirements:
+
+1. **Open source.** The adapter source code is publicly available so the community and the Next.js team can inspect, contribute to, and verify it.
+2. **Runs the compatibility test suite.** The platform provides a way to run the full [Next.js compatibility test suite](/docs/app/api-reference/config/next-config-js/adapterPath#testing-adapters) against their adapter. This gives visibility into which features work, which are in progress, and where gaps remain.
+
+Verified adapters are hosted under the [Next.js GitHub organization](https://github.com/nextjs), listed as supported deployment targets in the Next.js documentation, and maintained by their respective platform teams. There are no private framework hooks or integration paths: Vercel's adapter uses the same public API as every other adapter.
+
+For verified adapters and platforms working toward verified status through the [Ecosystem Working Group](https://nextjs.org/ecosystem-working-group), the Next.js team commits to:
+
+- **Coordinated testing.** Before major releases, we work with platform teams to run the compatibility test suite and surface issues early.
+- **Early access.** Adapter authors receive early access to API changes during RFCs and release candidates.
+- **Direct support.** When the adapter contract needs updating, we work directly with adapter teams.
+
+> **Good to know:** Platforms can build closed-source adapters on the same public API and test suite. However, closed-source adapters will not be listed as verified, since the Next.js team cannot verify what it cannot inspect.
 
 ## A Note on Infrastructure Requirements
 


### PR DESCRIPTION
## Summary

- Introduces the **verified adapter** concept to deployment docs: open source adapters that run the Next.js compatibility test suite, hosted under the Next.js GitHub org
- Splits the adapter list on the deploying page into **Verified Adapters** (Vercel, Bun) and **Other Platforms** (unverified integrations)
- Documents the Next.js team's commitments for verified adapters and Ecosystem Working Group participants (coordinated testing, early access, direct support)
- Notes that Cloudflare and Netlify are working on verified adapters built on the Adapter API

## Test plan

- [ ] Verify links resolve correctly (adapter API reference, test suite anchor, ecosystem working group page)
- [ ] Confirm markdown table renders properly with the longer "Varies" cell
- [ ] Review wording with stakeholders (Cloudflare, Netlify, Bun)