### PR TITLE
Add agent detection to telemetry metadata

### DIFF
--- a/packages/next/src/telemetry/anonymous-meta.ts
+++ b/packages/next/src/telemetry/anonymous-meta.ts
@@ -3,6 +3,7 @@ import isWslBoolean from 'next/dist/compiled/is-wsl'
 import os from 'os'
 
 import * as ciEnvironment from '../server/ci-info'
+import { detectAgent } from './detect-agent'
 
 type AnonymousMeta = {
   systemPlatform: NodeJS.Platform
@@ -18,6 +19,7 @@ type AnonymousMeta = {
   isCI: boolean
   ciName: string | null
   nextVersion: string
+  agentName: string | null
 }
 
 let traits: AnonymousMeta | undefined
@@ -46,6 +48,7 @@ export function getAnonymousMeta(): AnonymousMeta {
     isCI: ciEnvironment.isCI,
     ciName: (ciEnvironment.isCI && ciEnvironment.name) || null,
     nextVersion: process.env.__NEXT_VERSION as string,
+    agentName: detectAgent(),
   }
 
   return traits

--- a/packages/next/src/telemetry/detect-agent.ts
+++ b/packages/next/src/telemetry/detect-agent.ts
@@ -1,0 +1,76 @@
+export type AgentName =
+  | 'cursor'
+  | 'cursor-cli'
+  | 'claude'
+  | 'cowork'
+  | 'devin'
+  | 'replit'
+  | 'gemini'
+  | 'codex'
+  | 'antigravity'
+  | 'augment-cli'
+  | 'opencode'
+  | 'github-copilot'
+
+export function detectAgent(): AgentName | null {
+  if (process.env.AI_AGENT) {
+    const name = process.env.AI_AGENT.trim()
+    if (name) {
+      const normalized = name === 'github-copilot-cli' ? 'github-copilot' : name
+      return normalized as AgentName
+    }
+  }
+
+  if (process.env.CURSOR_TRACE_ID) {
+    return 'cursor'
+  }
+
+  if (process.env.CURSOR_AGENT) {
+    return 'cursor-cli'
+  }
+
+  if (process.env.GEMINI_CLI) {
+    return 'gemini'
+  }
+
+  if (
+    process.env.CODEX_SANDBOX ||
+    process.env.CODEX_CI ||
+    process.env.CODEX_THREAD_ID
+  ) {
+    return 'codex'
+  }
+
+  if (process.env.ANTIGRAVITY_AGENT) {
+    return 'antigravity'
+  }
+
+  if (process.env.AUGMENT_AGENT) {
+    return 'augment-cli'
+  }
+
+  if (process.env.OPENCODE_CLIENT) {
+    return 'opencode'
+  }
+
+  if (process.env.CLAUDECODE || process.env.CLAUDE_CODE) {
+    if (process.env.CLAUDE_CODE_IS_COWORK) {
+      return 'cowork'
+    }
+    return 'claude'
+  }
+
+  if (process.env.REPL_ID) {
+    return 'replit'
+  }
+
+  if (
+    process.env.COPILOT_MODEL ||
+    process.env.COPILOT_ALLOW_ALL ||
+    process.env.COPILOT_GITHUB_TOKEN
+  ) {
+    return 'github-copilot'
+  }
+
+  return null
+}


### PR DESCRIPTION
Track which AI agent (if any) is running when telemetry events are sent. Adds agentName field to anonymous metadata, detected via environment variables set by known agents (Cursor, Claude, Codex, etc.).
The env variable checks are copied from the exact same functionality in the `vercel` CLI
