### PR TITLE
evals: `unstable_catchError`

### DIFF
--- a/evals/evals/agent-041-catch-error/EVAL.ts
+++ b/evals/evals/agent-041-catch-error/EVAL.ts
@@ -1,0 +1,90 @@
+/**
+ * Catch Error
+ *
+ * Tests whether the agent uses `unstable_catchError` from `next/error` to create
+ * a component-level error boundary instead of reaching for `error.js` or a raw
+ * React error boundary class.
+ */
+
+import { expect, test } from 'vitest'
+import { readFileSync, existsSync, readdirSync, statSync } from 'fs'
+import { join } from 'path'
+
+type SourceFile = { path: string; content: string }
+
+const IGNORE_DIRS = new Set([
+  '.git',
+  '.next',
+  'node_modules',
+  'dist',
+  'build',
+  'coverage',
+])
+
+const IGNORE_FILES = new Set(['EVAL.ts', 'PROMPT.md'])
+
+function readSourceFiles(dir: string): SourceFile[] {
+  if (!existsSync(dir)) return []
+
+  const files: SourceFile[] = []
+  for (const entry of readdirSync(dir)) {
+    if (IGNORE_DIRS.has(entry)) continue
+
+    const fullPath = join(dir, entry)
+    const stats = statSync(fullPath)
+
+    if (stats.isDirectory()) {
+      files.push(...readSourceFiles(fullPath))
+      continue
+    }
+
+    if (IGNORE_FILES.has(entry)) continue
+
+    if (/\.(ts|tsx|js|jsx)$/.test(entry)) {
+      files.push({
+        path: fullPath,
+        content: readFileSync(fullPath, 'utf-8'),
+      })
+    }
+  }
+
+  return files
+}
+
+const sourceFiles = readSourceFiles(process.cwd())
+const allSource = sourceFiles.map((f) => f.content).join('\n')
+
+test('uses unstable_catchError from next/error', () => {
+  expect(allSource).toMatch(/from\s+['"]next\/error['"]/)
+  expect(allSource).toMatch(/unstable_catchError/)
+})
+
+test("file with catchError has 'use client' directive", () => {
+  const catchErrorFile = sourceFiles.find((f) =>
+    f.content.includes('unstable_catchError')
+  )
+  expect(catchErrorFile).toBeDefined()
+  expect(catchErrorFile!.content).toMatch(/['"]use client['"]/)
+})
+
+test('provides retry functionality via unstable_retry', () => {
+  expect(allSource).toMatch(/unstable_retry/)
+})
+
+test('does not use error.js file convention', () => {
+  const errorFile = sourceFiles.find((f) => /error\.(tsx?|jsx?)$/.test(f.path))
+  expect(errorFile).toBeUndefined()
+})
+
+test('renders the error message', () => {
+  const catchErrorFile = sourceFiles.find((f) =>
+    f.content.includes('unstable_catchError')
+  )
+  expect(catchErrorFile).toBeDefined()
+  expect(catchErrorFile!.content).toMatch(/error\.message/i)
+})
+
+test('does not use raw React error boundary class', () => {
+  expect(allSource).not.toMatch(/componentDidCatch/)
+  expect(allSource).not.toMatch(/getDerivedStateFromError/)
+})

--- a/evals/evals/agent-041-catch-error/PROMPT.md
+++ b/evals/evals/agent-041-catch-error/PROMPT.md
@@ -1,0 +1,1 @@
+The Widget sometimes crashes and takes down the whole page. Make it so the rest of the page keeps working when the Widget fails. Show the error message and a button to retry.

--- a/evals/evals/agent-041-catch-error/app/layout.tsx
+++ b/evals/evals/agent-041-catch-error/app/layout.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'App',
+}
+
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode
+}>) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/evals/evals/agent-041-catch-error/app/page.tsx
+++ b/evals/evals/agent-041-catch-error/app/page.tsx
@@ -1,0 +1,10 @@
+import Widget from './widget'
+
+export default function Home() {
+  return (
+    <main>
+      <h1>Dashboard</h1>
+      <Widget />
+    </main>
+  )
+}

--- a/evals/evals/agent-041-catch-error/app/widget.tsx
+++ b/evals/evals/agent-041-catch-error/app/widget.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import { useState } from 'react'
+
+export default function Widget() {
+  const [clicked, setClicked] = useState(false)
+  if (clicked) {
+    throw new Error('Widget failed to load')
+  }
+  return (
+    <div>
+      <h2>Widget</h2>
+      <button onClick={() => setClicked(true)}>Load data</button>
+    </div>
+  )
+}

--- a/evals/evals/agent-041-catch-error/next.config.ts
+++ b/evals/evals/agent-041-catch-error/next.config.ts
@@ -1,0 +1,5 @@
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {}
+
+export default nextConfig

--- a/evals/evals/agent-041-catch-error/package.json
+++ b/evals/evals/agent-041-catch-error/package.json
@@ -1,0 +1,23 @@
+{
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "^16",
+    "react": "19.1.0",
+    "react-dom": "19.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "@vitejs/plugin-react": "^4.4.1",
+    "typescript": "^5",
+    "vite-tsconfig-paths": "^5.1.4",
+    "vitest": "^3.1.3"
+  }
+}

--- a/evals/evals/agent-041-catch-error/tsconfig.json
+++ b/evals/evals/agent-041-catch-error/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./*"]
+    },
+    "target": "ES2017"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- Add eval for `unstable_catchError` API from `next/error`
- Problem-oriented prompt (describes crash symptom, not solution pattern)
- Tests: correct API usage, `'use client'` directive, retry via `unstable_retry`, error message rendering, no `error.js` fallback, no raw React error boundary class