### PR TITLE
feat(turbopack): add watchOptions.ignoredPaths

### DIFF
--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -149,6 +149,13 @@ pub struct WatchOptions {
     /// Enable polling at a certain interval if the native file watching doesn't work (e.g.
     /// docker).
     pub poll_interval: Option<Duration>,
+
+    /// Additional paths (relative to project root) whose filesystem events should be ignored.
+    /// Useful when multiple dev servers share the same project directory (e.g. multi-target
+    /// setups) to prevent one server's build output from triggering file watcher cascades
+    /// in another.
+    #[serde(default)]
+    pub ignored_paths: Vec<RcStr>,
 }
 
 #[derive(
@@ -1045,8 +1052,11 @@ impl Project {
 
     #[turbo_tasks::function]
     pub fn project_fs(&self) -> Result<Vc<DiskFileSystem>> {
-        let denied_path = match join_path(&self.project_path, &self.dist_dir_root) {
-            Some(dist_dir_root) => dist_dir_root.into(),
+        let mut denied_paths = Vec::new();
+
+        // Always deny own dist dir
+        match join_path(&self.project_path, &self.dist_dir_root) {
+            Some(dist_dir_root) => denied_paths.push(dist_dir_root.into()),
             None => {
                 bail!(
                     "Invalid distDirRoot: {:?}. distDirRoot should not navigate out of the \
@@ -1056,10 +1066,17 @@ impl Project {
             }
         };
 
+        // Deny additional paths from watchOptions.ignoredPaths
+        for ignored in &self.watch.ignored_paths {
+            if let Some(path) = join_path(&self.project_path, ignored) {
+                denied_paths.push(path.into());
+            }
+        }
+
         Ok(DiskFileSystem::new_with_denied_paths(
             rcstr!(PROJECT_FILESYSTEM_NAME),
             self.root_path.clone(),
-            vec![denied_path],
+            denied_paths,
         ))
     }
 

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/watchOptions.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/watchOptions.mdx
@@ -1,0 +1,52 @@
+---
+title: watchOptions
+description: Configure filesystem watcher behavior for the Next.js development server.
+---
+
+{/* The content of this doc is shared between the app and pages router. You can use the `<PagesOnly>Content</PagesOnly>` component to add content that is specific to the Pages Router. Any shared content should not be wrapped in a component. */}
+
+The `watchOptions` configuration controls how the development server watches the filesystem for changes.
+
+```js filename="next.config.js"
+module.exports = {
+  watchOptions: {
+    // ...
+  },
+}
+```
+
+## Options
+
+| Option           | Type       | Description                                                                                        |
+| ---------------- | ---------- | -------------------------------------------------------------------------------------------------- |
+| `pollIntervalMs` | `number`   | Enable polling at the specified interval (in milliseconds). Useful when native file watching doesn't work, e.g. inside Docker containers or network-mounted filesystems. |
+| `ignoredPaths`   | `string[]` | Additional paths (relative to the project root) whose filesystem events should be ignored by the file watcher. |
+
+## `ignoredPaths`
+
+By default, Next.js ignores the `distDir` (`.next` by default) from the filesystem watcher. The `ignoredPaths` option lets you specify additional directories to ignore.
+
+This is useful when multiple development servers share the same project directory with separate `distDir` values. Without it, one server's build output can trigger excessive file watcher events in the other server, leading to unnecessary recompilation.
+
+```js filename="next.config.js"
+module.exports = {
+  distDir: '.next-darwin',
+  watchOptions: {
+    ignoredPaths: ['.next-linux', '.next'],
+  },
+}
+```
+
+Paths are relative to the project root directory.
+
+## `pollIntervalMs`
+
+When native file watching doesn't work reliably (e.g. inside Docker containers or on network-mounted filesystems), you can fall back to polling:
+
+```js filename="next.config.js"
+module.exports = {
+  watchOptions: {
+    pollIntervalMs: 1000,
+  },
+}
+```

--- a/docs/02-pages/04-api-reference/04-config/01-next-config-js/watchOptions.mdx
+++ b/docs/02-pages/04-api-reference/04-config/01-next-config-js/watchOptions.mdx
@@ -1,0 +1,52 @@
+---
+title: watchOptions
+description: Configure filesystem watcher behavior for the Next.js development server.
+---
+
+{/* The content of this doc is shared between the app and pages router. You can use the `<PagesOnly>Content</PagesOnly>` component to add content that is specific to the Pages Router. Any shared content should not be wrapped in a component. */}
+
+The `watchOptions` configuration controls how the development server watches the filesystem for changes.
+
+```js filename="next.config.js"
+module.exports = {
+  watchOptions: {
+    // ...
+  },
+}
+```
+
+## Options
+
+| Option           | Type       | Description                                                                                        |
+| ---------------- | ---------- | -------------------------------------------------------------------------------------------------- |
+| `pollIntervalMs` | `number`   | Enable polling at the specified interval (in milliseconds). Useful when native file watching doesn't work, e.g. inside Docker containers or network-mounted filesystems. |
+| `ignoredPaths`   | `string[]` | Additional paths (relative to the project root) whose filesystem events should be ignored by the file watcher. |
+
+## `ignoredPaths`
+
+By default, Next.js ignores the `distDir` (`.next` by default) from the filesystem watcher. The `ignoredPaths` option lets you specify additional directories to ignore.
+
+This is useful when multiple development servers share the same project directory with separate `distDir` values. Without it, one server's build output can trigger excessive file watcher events in the other server, leading to unnecessary recompilation.
+
+```js filename="next.config.js"
+module.exports = {
+  distDir: '.next-darwin',
+  watchOptions: {
+    ignoredPaths: ['.next-linux', '.next'],
+  },
+}
+```
+
+Paths are relative to the project root directory.
+
+## `pollIntervalMs`
+
+When native file watching doesn't work reliably (e.g. inside Docker containers or on network-mounted filesystems), you can fall back to polling:
+
+```js filename="next.config.js"
+module.exports = {
+  watchOptions: {
+    pollIntervalMs: 1000,
+  },
+}
+```

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -196,6 +196,11 @@ export interface NapiWatchOptions {
    * docker).
    */
   pollIntervalMs?: number
+  /**
+   * Additional paths (relative to project root) whose filesystem events should
+   * be ignored. Analogous to webpack's `watchOptions.ignored`.
+   */
+  ignoredPaths?: string[]
 }
 export interface NapiProjectOptions {
   /**

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -779,6 +779,7 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
     watchOptions: z
       .strictObject({
         pollIntervalMs: z.number().positive().finite().optional(),
+        ignoredPaths: z.array(z.string()).optional(),
       })
       .optional(),
   })

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1589,6 +1589,19 @@ export interface NextConfig {
 
   watchOptions?: {
     pollIntervalMs?: number
+    /**
+     * Additional paths (relative to project root) whose filesystem events
+     * should be ignored by Turbopack's file watcher. This is the Turbopack
+     * equivalent of webpack's `watchOptions.ignored`.
+     *
+     * Useful when multiple dev servers share the same project directory
+     * (e.g. multi-target setups with separate distDir values) to prevent
+     * one server's build output from triggering file watcher cascades in
+     * another.
+     *
+     * @example ['.next-linux', '.next']
+     */
+    ignoredPaths?: string[]
   }
 
   /**

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -386,6 +386,7 @@ export async function createHotReloaderTurbopack(
       watch: {
         enable: dev,
         pollIntervalMs: nextConfig.watchOptions?.pollIntervalMs,
+        ignoredPaths: nextConfig.watchOptions?.ignoredPaths,
       },
       dev,
       env: process.env as Record<string, string>,


### PR DESCRIPTION
Adds `watchOptions.ignoredPaths` to `next.config.ts`, allowing users to specify additional directories that Turbopack's filesystem watcher should ignore.

There is a race condition in `directory_tree_to_loader_tree` where FSEvents queue overflow (from watcher noise caused by another server's build output) triggers a full rescan that temporarily observes an empty directory tree, causing the `AppPageLoaderTree` cell to be removed while other tasks still hold references to it.

Currently, Turbopack only ignores its own `distDir` from the project filesystem. There is no way to exclude additional directories. This is a problem for multi-target setups where multiple dev servers share the same project directory with separate `distDir` values (e.g. `.next-darwin`, `.next-linux`). Without this option, one server's build output triggers FSEvents cascades in the other server's watcher, causing `AppPageLoaderTree` cell invalidation panics.

**Usage**

```js
// next.config.js
module.exports = {
  distDir: '.next-darwin',
  watchOptions: {
    ignoredPaths: ['.next-linux', '.next'],
  },
}
```

Fixes https://github.com/vercel/next.js/discussions/77005 and https://github.com/vercel/next.js/discussions/90915, https://github.com/vercel/next.js/discussions/89367, https://github.com/vercel/next.js/discussions/88723
