### PR TITLE
test: scope css data-url typing to fixture

### DIFF
--- a/test/e2e/css-data-url-global-pages/data-url-css.d.ts
+++ b/test/e2e/css-data-url-global-pages/data-url-css.d.ts
@@ -1,0 +1,2 @@
+// Test-local typing for Turbopack's CSS data URL side-effect import.
+declare module 'data:text/css,*' {}


### PR DESCRIPTION
In the latest TypeScript version these imports now fail so updating the assertion to handle them

x-ref: https://github.com/vercel/next.js/actions/runs/23508766037/job/68431989897#step:35:443