### PR TITLE
fix: place image preload links in `<head>` instead of `<body>`

### DIFF
--- a/packages/next/src/client/image-component.tsx
+++ b/packages/next/src/client/image-component.tsx
@@ -27,7 +27,6 @@ import type {
 import { imageConfigDefault } from '../shared/lib/image-config'
 import { ImageConfigContext } from '../shared/lib/image-config-context.shared-runtime'
 import { warnOnce } from '../shared/lib/utils/warn-once'
-import { RouterContext } from '../shared/lib/router-context.shared-runtime'
 
 // This is replaced by webpack alias
 import defaultLoader from 'next/dist/shared/lib/image-loader'
@@ -307,13 +306,7 @@ const ImageElement = forwardRef<HTMLImageElement | null, ImageElementProps>(
   }
 )
 
-function ImagePreload({
-  isAppRouter,
-  imgAttributes,
-}: {
-  isAppRouter: boolean
-  imgAttributes: ImgProps
-}) {
+function ImagePreload({ imgAttributes }: { imgAttributes: ImgProps }) {
   const opts: ReactDOM.PreloadOptions = {
     as: 'image',
     imageSrcSet: imgAttributes.srcSet,
@@ -323,7 +316,7 @@ function ImagePreload({
     ...getDynamicProps(imgAttributes.fetchPriority),
   }
 
-  if (isAppRouter && ReactDOM.preload) {
+  if (ReactDOM.preload) {
     ReactDOM.preload(imgAttributes.src, opts)
     return null
   }
@@ -357,10 +350,6 @@ function ImagePreload({
  */
 export const Image = forwardRef<HTMLImageElement | null, ImageProps>(
   (props, forwardedRef) => {
-    const pagesRouter = useContext(RouterContext)
-    // We're in the app directory if there is no pages router.
-    const isAppRouter = !pagesRouter
-
     const configContext = useContext(ImageConfigContext)
     const config = useMemo(() => {
       const c = configEnv || configContext || imageConfigDefault
@@ -423,10 +412,7 @@ export const Image = forwardRef<HTMLImageElement | null, ImageProps>(
           />
         }
         {imgMeta.preload ? (
-          <ImagePreload
-            isAppRouter={isAppRouter}
-            imgAttributes={imgAttributes}
-          />
+          <ImagePreload imgAttributes={imgAttributes} />
         ) : null}
       </>
     )

--- a/packages/next/src/client/legacy/image.tsx
+++ b/packages/next/src/client/legacy/image.tsx
@@ -1168,26 +1168,39 @@ export default function Image({
         ) : null}
         <ImageElement {...imgElementArgs} />
       </span>
-      {!supportsFloat && priority ? (
+      {priority ? (
         // Note how we omit the `href` attribute, as it would only be relevant
         // for browsers that do not support `imagesrcset`, and in those cases
         // it would likely cause the incorrect image to be preloaded.
         //
         // https://html.spec.whatwg.org/multipage/semantics.html#attr-link-imagesrcset
-        <Head>
-          <link
-            key={
-              '__nimg-' +
-              imgAttributes.src +
-              imgAttributes.srcSet +
-              imgAttributes.sizes
-            }
-            rel="preload"
-            as="image"
-            href={imgAttributes.srcSet ? undefined : imgAttributes.src}
-            {...linkProps}
-          />
-        </Head>
+        supportsFloat ? (
+          (() => {
+            ReactDOM.preload(imgAttributes.src, {
+              as: 'image',
+              imageSrcSet: imgAttributes.srcSet,
+              imageSizes: imgAttributes.sizes,
+              crossOrigin: rest.crossOrigin,
+              referrerPolicy: rest.referrerPolicy,
+            })
+            return null
+          })()
+        ) : (
+          <Head>
+            <link
+              key={
+                '__nimg-' +
+                imgAttributes.src +
+                imgAttributes.srcSet +
+                imgAttributes.sizes
+              }
+              rel="preload"
+              as="image"
+              href={imgAttributes.srcSet ? undefined : imgAttributes.src}
+              {...linkProps}
+            />
+          </Head>
+        )
       ) : null}
     </>
   )

--- a/test/unit/next-image-legacy.test.ts
+++ b/test/unit/next-image-legacy.test.ts
@@ -213,4 +213,21 @@ describe('Image Legacy Rendering', () => {
       }
     }
   )
+
+  it('should preload priority images with srcset without href', async () => {
+    const element = React.createElement(Image, {
+      src: '/test.png',
+      width: 100,
+      height: 100,
+      priority: true,
+    })
+    const $ = cheerio.load(ReactDOM.renderToString(element))
+    const img = $('img[data-nimg]')
+    const preload = $('link[rel="preload"][as="image"]')
+    const preloadAttrs = preload.get(0)?.attribs
+
+    expect(preload.length).toBe(1)
+    expect(preloadAttrs?.href).toBeUndefined()
+    expect(preloadAttrs?.imagesrcset).toBe(img.attr('srcset'))
+  })
 })

--- a/test/unit/next-image-new.test.ts
+++ b/test/unit/next-image-new.test.ts
@@ -97,4 +97,23 @@ describe('Image rendering', () => {
     expect($2('noscript').length).toBe(0)
     expect($3('noscript').length).toBe(0)
   })
+
+  it('should preload priority images with srcset without href', async () => {
+    const element = React.createElement(Image, {
+      alt: 'priority image',
+      src: '/test.png',
+      width: 100,
+      height: 100,
+      priority: true,
+    })
+    const html = ReactDOMServer.renderToString(element)
+    const $ = cheerio.load(html)
+    const img = $('img[data-nimg]')
+    const preload = $('link[rel="preload"][as="image"]')
+    const preloadAttrs = preload.get(0)?.attribs
+
+    expect(preload.length).toBe(1)
+    expect(preloadAttrs?.href).toBeUndefined()
+    expect(preloadAttrs?.imagesrcset).toBe(img.attr('srcset'))
+  })
 })


### PR DESCRIPTION
Fixes #82254. 

React 19 + Next.js 15 incorrectly place image preload links in the `<body>` rather than the `<head>` while using the Pages router. 

### Changes
- Modified `ImagePreload` component to use `ReactDOM.preload` for both App Router and Pages router when available, instead of relying on `<Head>` component which had placement issues.

### Reproducing
The old issue was reproduced in this StackBlitz instance: https://stackblitz.com/edit/stackblitz-starters-evf7wdnm?file=pages/pages-router.tsx

If someone can approve the CI, we can point the stackblitz instance at the preview instance.
