### PR TITLE
fix: allow empty array from generateStaticParams with output: export

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2369,8 +2369,8 @@ export default async function build(
                           const appConfig = workerResult.appConfig || {}
                           if (appConfig.revalidate !== 0) {
                             const hasGenerateStaticParams =
-                              workerResult.prerenderedRoutes &&
-                              workerResult.prerenderedRoutes.length > 0
+                              workerResult.prerenderedRoutes !== undefined &&
+                              workerResult.prerenderedRoutes !== null
 
                             if (
                               config.output === 'export' &&


### PR DESCRIPTION
Fixes #61213 - Allows pages with generateStaticParams returning an empty array to be successfully built with output export config.