### PR TITLE
ci: only upload adapter results for canary runs

### DIFF
--- a/.github/workflows/test_e2e_deploy_release.yml
+++ b/.github/workflows/test_e2e_deploy_release.yml
@@ -254,8 +254,10 @@ jobs:
         always() &&
         github.event.inputs.deployScriptPath == '' &&
         github.repository_owner == 'vercel' &&
-        github.ref_name == 'canary' &&
-        (github.event.inputs.nextVersion || 'canary') == 'canary'
+        (
+          (github.event_name == 'workflow_dispatch' && github.ref_name == 'canary') ||
+          (github.event_name == 'release' && github.event.release.target_commitish == 'canary')
+        )
       }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test_e2e_deploy_release.yml
+++ b/.github/workflows/test_e2e_deploy_release.yml
@@ -249,7 +249,14 @@ jobs:
   upload-adapter-test-results:
     name: Upload adapter test results
     needs: [test-deploy-adapter]
-    if: ${{ always() && github.event.inputs.deployScriptPath == '' && github.repository_owner == 'vercel' }}
+    if: >-
+      ${{
+        always() &&
+        github.event.inputs.deployScriptPath == '' &&
+        github.repository_owner == 'vercel' &&
+        github.ref_name == 'canary' &&
+        (github.event.inputs.nextVersion || 'canary') == 'canary'
+      }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- gate `upload-adapter-test-results` to only run when triggered from the `canary` branch
- support both trigger paths:
  - `workflow_dispatch` on `canary`
  - `release` where `target_commitish` is `canary`
- keep existing deploy-script and owner safeguards
