### PR TITLE
fix(next/jest): respect images.loaderFile config in Jest tests

### DIFF
--- a/packages/next/src/build/jest/jest.ts
+++ b/packages/next/src/build/jest/jest.ts
@@ -171,6 +171,16 @@ export default function nextJest(options: { dir?: string } = {}) {
           // Disable server-only
           '^server-only$': require.resolve('./__mocks__/empty.js'),
 
+          // Handle custom image loader - alias the default image loader to
+          // the user's loaderFile so that `next/image` uses the custom loader
+          // in Jest tests (mirrors the webpack/turbopack alias behavior).
+          ...(nextConfig?.images?.loaderFile
+            ? {
+                'next/dist/shared/lib/image-loader':
+                  nextConfig.images.loaderFile,
+              }
+            : undefined),
+
           // custom config comes last to ensure the above rules are matched,
           // fixes the case where @pages/(.*) -> src/pages/$! doesn't break
           // CSS/image mocks

--- a/test/production/app-dir/image-jest-custom-loader/app/app/page.tsx
+++ b/test/production/app-dir/image-jest-custom-loader/app/app/page.tsx
@@ -1,0 +1,8 @@
+export default function Page() {
+  return (
+    <main>
+      <h1>Image Jest Custom Loader Test</h1>
+      <p>Testing custom image loader in Jest environment</p>
+    </main>
+  )
+}

--- a/test/production/app-dir/image-jest-custom-loader/image-jest-custom-loader.test.ts
+++ b/test/production/app-dir/image-jest-custom-loader/image-jest-custom-loader.test.ts
@@ -1,0 +1,105 @@
+import { createNext, FileRef } from 'e2e-utils'
+import { NextInstance } from 'e2e-utils'
+import path from 'path'
+import execa from 'execa'
+
+const appDir = path.join(__dirname, 'app')
+
+describe('next/jest custom image loader', () => {
+  let next: NextInstance
+
+  beforeAll(async () => {
+    next = await createNext({
+      skipStart: true,
+      files: {
+        'next.config.js': `
+module.exports = {
+  images: {
+    loader: 'custom',
+    loaderFile: './image-loader.js',
+  },
+}
+        `,
+        'image-loader.js': `
+export default function customLoader({ src, width, quality }) {
+  return \`https://cdn.example.com\${src}?w=\${width}&q=\${quality || 75}\`
+}
+        `,
+        app: new FileRef(path.join(appDir, 'app')),
+        'jest.config.js': `
+const nextJest = require('next/jest')
+
+const createJestConfig = nextJest({
+  dir: './',
+})
+
+const customJestConfig = {
+  testEnvironment: 'jsdom',
+}
+
+module.exports = createJestConfig(customJestConfig)
+        `,
+        [`tests/image.test.tsx`]: `
+import Image from 'next/image'
+import { render, screen } from '@testing-library/react'
+
+describe('Image custom loader', () => {
+  it('renders without the missing loader error when loaderFile is configured', () => {
+    render(
+      <Image
+        src="/images/test.jpg"
+        alt="test"
+        width={500}
+        height={500}
+      />
+    )
+
+    const img = screen.getByRole('img')
+    // The custom loader should produce a URL with cdn.example.com
+    expect(img.getAttribute('src')).toContain('cdn.example.com')
+  })
+
+  it('uses the custom loader for srcset generation', () => {
+    render(
+      <Image
+        src="/images/test.jpg"
+        alt="test"
+        width={500}
+        height={500}
+      />
+    )
+
+    const img = screen.getByRole('img')
+    const srcSet = img.getAttribute('srcset') || ''
+    // All srcset entries should use the custom loader URL
+    expect(srcSet).toContain('cdn.example.com')
+  })
+})
+        `,
+      },
+      dependencies: {
+        jest: '29.7.0',
+        'jest-environment-jsdom': '29.7.0',
+        '@testing-library/react': '15.0.2',
+        '@testing-library/jest-dom': '5.17.0',
+      },
+    })
+  })
+
+  afterAll(() => next.destroy())
+
+  it('should pass jest tests with custom image loader', async () => {
+    const result = await execa(
+      'pnpm',
+      ['jest', 'tests/image.test.tsx', '--forceExit', '--verbose'],
+      {
+        cwd: next.testDir,
+        reject: false,
+      }
+    )
+    const output = result.stdout || result.stderr || ''
+    console.log('Jest output:', output)
+    expect(output).toContain('PASS')
+    expect(output).toMatch(/2 passed/)
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #91876

When `images.loaderFile` is configured in `next.config.js`, webpack and Turbopack alias the default image loader (`next/dist/shared/lib/image-loader`) to the user's custom loader file at build time. However, the `next/jest` configuration did not set up a corresponding `moduleNameMapper` entry, so the default image loader (which carries `__next_img_default = true`) was always imported during Jest tests.

Combined with the image config reporting `loader: 'custom'`, this caused `next/image` to throw:
```
Image with src "..." is missing "loader" prop.
```

### Changes

- **`packages/next/src/build/jest/jest.ts`**: Added a `moduleNameMapper` entry that aliases `next/dist/shared/lib/image-loader` to the user's `loaderFile` when configured, mirroring the webpack/turbopack alias in `create-compiler-aliases.ts`.
- **`test/production/app-dir/image-jest-custom-loader/`**: Added a test that verifies `next/image` works correctly in Jest when a custom `loaderFile` is configured.

### How it works

The root cause is that `get-img-props.ts` checks `'__next_img_default' in loader` (line 352) alongside `config.loader === 'custom'` (line 355). During builds, the `loaderFile` alias replaces the default loader import with the user's custom loader (which lacks the `__next_img_default` marker), so the check passes. In Jest, this alias was missing, so the default loader was always used while the config still said `loader: 'custom'`, triggering the error.

## Test plan

- [ ] New test `test/production/app-dir/image-jest-custom-loader/image-jest-custom-loader.test.ts` validates that `next/image` renders successfully in a Jest environment with a custom `loaderFile` configured
- [ ] Existing test `test/production/app-dir/image-jest-qualities/` continues to pass (no regression for non-custom-loader setups)