### PR TITLE
Narrow the opengraph-image function return type

### DIFF
--- a/docs/01-app/03-api-reference/03-file-conventions/01-metadata/opengraph-image.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/01-metadata/opengraph-image.mdx
@@ -250,7 +250,7 @@ export default async function Image({ params }) {
 
 ### Returns
 
-The default export function should return a `Blob` | `ArrayBuffer` | `TypedArray` | `DataView` | `ReadableStream` | `Response`.
+The default export function should return a `Response`.
 
 > **Good to know**: `ImageResponse` satisfies this return type.
 


### PR DESCRIPTION
### What?

Change the `opengraph-image` return type to only `Response`.

### Why?

This function must return a `Response` object. The other documented types cause Next.js builds to fail. I found this out the hard way by following the documentation.

### How?

