### PR TITLE
docs: clarify opengraph-image return type and add Response fallback e…

### DIFF
--- a/docs/01-app/03-api-reference/03-file-conventions/01-metadata/opengraph-image.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/01-metadata/opengraph-image.mdx
@@ -206,6 +206,20 @@ export default async function Image() {
 }
 ```
 
+> **Note**: While `ImageResponse` satisfies the return type, in some environments returning it directly may cause build failures. In such cases, you can wrap it in a standard `Response` object.
+
+```js filename="app/about/opengraph-image-wrap.js"
+export default async function Image() {
+  const image = await getImageResponse() // returns ImageResponse
+
+  return new Response(image.body, {
+    headers: {
+      'Content-Type': 'image/png',
+    },
+  })
+}
+```
+
 ```html filename="<head> output"
 <meta property="og:image" content="<generated>" />
 <meta property="og:image:alt" content="About Acme" />
@@ -250,9 +264,9 @@ export default async function Image({ params }) {
 
 ### Returns
 
-The default export function must return a `Response` object.
+The default export function should return a `Blob` | `ArrayBuffer` | `TypedArray` | `DataView` | `ReadableStream` | `Response`.
 
-> **Good to know**: `ImageResponse` extends `Response` and is valid as well.
+> **Good to know**: `ImageResponse` satisfies this return type.
 
 ### Config exports
 
@@ -466,7 +480,7 @@ export default async function Image() {
     )
   )
 }
-
+```
 
 Passing an `ArrayBuffer` to the `src` attribute of an `<img>` element is not part of the HTML spec. The rendering engine used by `next/og` supports it, but because TypeScript definitions follow the spec, you need a `@ts-expect-error` directive or similar to use this [feature](https://github.com/vercel/satori/issues/606#issuecomment-2144000453).
 

--- a/docs/01-app/03-api-reference/03-file-conventions/01-metadata/opengraph-image.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/01-metadata/opengraph-image.mdx
@@ -250,9 +250,9 @@ export default async function Image({ params }) {
 
 ### Returns
 
-The default export function should return a `Blob` | `ArrayBuffer` | `TypedArray` | `DataView` | `ReadableStream` | `Response`.
+The default export function must return a `Response` object.
 
-> **Good to know**: `ImageResponse` satisfies this return type.
+> **Good to know**: `ImageResponse` extends `Response` and is valid as well.
 
 ### Config exports
 
@@ -466,7 +466,7 @@ export default async function Image() {
     )
   )
 }
-```
+
 
 Passing an `ArrayBuffer` to the `src` attribute of an `<img>` element is not part of the HTML spec. The rendering engine used by `next/og` supports it, but because TypeScript definitions follow the spec, you need a `@ts-expect-error` directive or similar to use this [feature](https://github.com/vercel/satori/issues/606#issuecomment-2144000453).
 
@@ -518,6 +518,26 @@ export default async function Image() {
       </div>
     )
   )
+}
+```
+
+> **Note**: While `ImageResponse` satisfies the return type, in some environments returning it directly may cause build failures. In such cases, you can wrap it in a standard `Response` object.
+
+```jsx filename="app/opengraph-image.js"
+import { ImageResponse } from 'next/og'
+
+export const contentType = 'image/png'
+
+export default async function Image() {
+  const image = new ImageResponse(
+    <div>Hello</div>
+  )
+
+  return new Response(image.body, {
+    headers: {
+      'Content-Type': 'image/png',
+    },
+  })
 }
 ```
 

--- a/test/e2e/url/app/opengraph-image.js
+++ b/test/e2e/url/app/opengraph-image.js
@@ -1,9 +1,13 @@
 import imported from '../public/vercel.png'
 const url = new URL('../public/vercel.png', import.meta.url).toString()
 
-export const contentType = 'text/json'
+export const contentType = 'application/json'
 
 // Image generation
 export default async function Image() {
-  return Response.json({ imported: imported.src, url })
+  return new Response(JSON.stringify({ imported: imported.src, url }), {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  })
 }


### PR DESCRIPTION
### What?

Improves the `opengraph-image` documentation by adding a clarification note and an alternative example that wraps `ImageResponse` in a standard `Response`.

### Why?

Although `ImageResponse` satisfies the return type, returning it directly may cause build failures in some environments. This can confuse developers following the current documentation.

### How?

- Added a note explaining the potential issue
- Provided an alternative example using `Response` to ensure compatibility