### PR TITLE
[next] Add `@takumi-rs/core` to server-external-packages

### DIFF
--- a/packages/next/src/lib/server-external-packages.jsonc
+++ b/packages/next/src/lib/server-external-packages.jsonc
@@ -23,6 +23,8 @@
   "@statsig/statsig-node-core",
   // Native Node.js addons
   "@swc/core",
+  // Native Node.js addons
+  "@takumi-rs/core",
   "@xenova/transformers",
   // Builds on top of @prisma/client so dynamically loads the version.
   "@zenstackhq/runtime",


### PR DESCRIPTION
### Why?

Improve [Takumi](https://github.com/kane50613/takumi) DX when used with Turbopack.