### PR TITLE
fix(test): increase elementByCssInstant timeout from 10ms to 100ms

### DIFF
--- a/test/lib/browsers/playwright.ts
+++ b/test/lib/browsers/playwright.ts
@@ -437,7 +437,7 @@ export class Playwright<TCurrent = undefined> {
   /** A replacement for the default `browser.elementByCss` that doesn't wait for the page to fire "load". */
   elementByCssInstant(selector: string, opts?: ElementByCssOpts) {
     return this.waitForElementByCss(selector, {
-      timeout: 10,
+      timeout: 100,
       waitUntil: false,
       ...opts,
     })


### PR DESCRIPTION
### What?

Increase the `timeout` in `elementByCssInstant` from 10ms to 100ms in `test/lib/browsers/playwright.ts`.

### Why?

`elementByCssInstant` was introduced in #82742 to provide a variant of `browser.elementByCss` that skips waiting for the page `load` event (`waitUntil: false`). It was given a 10ms timeout, presumably under the assumption that elements would always already be in the DOM by the time it's called.

In practice, 10ms is too short: Playwright's internal overhead for `waitForSelector` (IPC round-trips, selector evaluation) can exceed 10ms on busy CI machines — even when the target element is already visible. This causes intermittent failures in `test/development/app-dir/instant-navs-devtools/instant-navs-devtools.test.ts`. The CI error makes the race condition obvious:

```
page.waitForSelector: Timeout 10ms exceeded.
Call log:
  - waiting for locator('[data-instant-nav-client]') to be visible
    - locator resolved to visible <button data-instant-nav-client="true">…</button>
```

The element **is** visible — Playwright found it — but the 10ms timer expired before its internal promise could settle.

### How?

Changed `timeout: 10` → `timeout: 100` in `elementByCssInstant`. The defining feature of `elementByCssInstant` is `waitUntil: false` (no page load wait), which is untouched. 100ms is still fast enough to distinguish "element already present" from "waiting for navigation to complete", while absorbing CI jitter.

The change benefits all callers:
- `clickStartClientNav`, `getInstantNavPanelText`, `hasInstantNavPanelOpen` in `instant-navs-devtools.test.ts`
- Several `elementByCssInstant` calls inside `retry()` loops in `ppr-partial-hydration.test.ts`