### PR TITLE
feat: add type-safe overloads for sendGAEvent with GA4 recommended event types

### DIFF
--- a/packages/third-parties/src/google/ga.tsx
+++ b/packages/third-parties/src/google/ga.tsx
@@ -3,7 +3,11 @@
 import React, { useEffect } from 'react'
 import Script from 'next/script'
 
-import type { GAParams } from '../types/google'
+import type {
+  GAParams,
+  GARecommendedEventName,
+  GARecommendedEventParams,
+} from '../types/google'
 
 declare global {
   interface Window {
@@ -56,7 +60,22 @@ export function GoogleAnalytics(props: GAParams) {
   )
 }
 
-export function sendGAEvent(..._args: Object[]) {
+// Typed overload: recommended GA4 events with autocomplete
+export function sendGAEvent<T extends GARecommendedEventName>(
+  command: 'event',
+  eventName: T,
+  eventParameters?: GARecommendedEventParams[T]
+): void
+// Typed overload: custom events
+export function sendGAEvent(
+  command: 'event',
+  eventName: string,
+  eventParameters?: { [key: string]: string | number | boolean }
+): void
+// Legacy overload: backward compatible with any arguments
+export function sendGAEvent(..._args: Object[]): void
+ 
+export function sendGAEvent(..._args: any[]) {
   if (currDataLayerName === undefined) {
     console.warn(`@next/third-parties: GA has not been initialized`)
     return

--- a/packages/third-parties/src/types/google.ts
+++ b/packages/third-parties/src/types/google.ts
@@ -64,3 +64,218 @@ export type YouTubeEmbed = {
   params?: string
   style?: string
 }
+
+// https://developers.google.com/tag-platform/gtagjs/reference/events
+type GAEventItemParam = {
+  item_id: string
+  item_name: string
+  affiliation?: string
+  coupon?: string
+  discount?: number
+  index?: number
+  item_brand?: string
+  item_category?: string
+  item_category2?: string
+  item_category3?: string
+  item_category4?: string
+  item_category5?: string
+  item_list_id?: string
+  item_list_name?: string
+  item_variant?: string
+  location_id?: string
+  price?: number
+  quantity?: number
+  [key: string]: any
+}
+
+export type GARecommendedEventParams = {
+  // Online Sales
+  add_payment_info: {
+    currency: string
+    value: number
+    coupon?: string
+    payment_type?: string
+    items: GAEventItemParam[]
+  }
+  add_shipping_info: {
+    currency: string
+    value: number
+    coupon?: string
+    shipping_tier?: string
+    items: GAEventItemParam[]
+  }
+  add_to_cart: {
+    currency: string
+    value: number
+    items: GAEventItemParam[]
+  }
+  add_to_wishlist: {
+    currency: string
+    value: number
+    items: GAEventItemParam[]
+  }
+  begin_checkout: {
+    currency: string
+    value: number
+    coupon?: string
+    items: GAEventItemParam[]
+  }
+  purchase: {
+    currency: string
+    value: number
+    transaction_id: string
+    customer_type?: string
+    coupon?: string
+    shipping?: number
+    tax?: number
+    items: GAEventItemParam[]
+  }
+  refund: {
+    currency: string
+    transaction_id: string
+    value: number
+    coupon?: string
+    shipping?: number
+    tax?: number
+    items?: GAEventItemParam[]
+  }
+  remove_from_cart: {
+    currency: string
+    value: number
+    items: GAEventItemParam[]
+  }
+  select_item: {
+    item_list_id?: string
+    item_list_name?: string
+    items: GAEventItemParam[]
+  }
+  select_promotion: {
+    creative_name?: string
+    creative_slot?: string
+    promotion_id?: string
+    promotion_name?: string
+    items?: GAEventItemParam[]
+  }
+  view_cart: {
+    currency: string
+    value: number
+    items: GAEventItemParam[]
+  }
+  view_item: {
+    currency: string
+    value: number
+    items: GAEventItemParam[]
+  }
+  view_item_list: {
+    currency: string
+    item_list_id?: string
+    item_list_name?: string
+    items: GAEventItemParam[]
+  }
+  view_promotion: {
+    creative_name?: string
+    creative_slot?: string
+    promotion_id?: string
+    promotion_name?: string
+    items: GAEventItemParam[]
+  }
+  // Lead Generation
+  close_convert_lead: {
+    currency: string
+    value: number
+  }
+  close_unconvert_lead: {
+    currency: string
+    value: number
+    unconvert_lead_reason?: string
+  }
+  disqualify_lead: {
+    currency: string
+    value: number
+    disqualified_lead_reason?: string
+  }
+  generate_lead: {
+    currency: string
+    value: number
+    lead_source?: string
+  }
+  qualify_lead: {
+    currency: string
+    value: number
+  }
+  working_lead: {
+    currency: string
+    value: number
+    lead_status?: string
+  }
+  // Games
+  level_end: {
+    level_name?: string
+    success?: boolean
+  }
+  level_start: {
+    level_name?: string
+  }
+  level_up: {
+    level?: number
+    character?: string
+  }
+  post_score: {
+    score: number
+    level?: number
+    character?: string
+  }
+  unlock_achievement: {
+    achievement_id: string
+  }
+  // All Properties
+  earn_virtual_currency: {
+    virtual_currency_name?: string
+    value?: number
+  }
+  exception: {
+    description?: string
+    fatal?: boolean
+  }
+  join_group: {
+    group_id?: string
+  }
+  login: {
+    method?: string
+  }
+  page_view: {
+    page_location?: string
+    client_id?: string
+    language?: string
+    page_encoding?: string
+    page_title?: string
+    user_agent?: string
+  }
+  search: {
+    search_term: string
+  }
+  select_content: {
+    content_type?: string
+    content_id?: string
+  }
+  share: {
+    method?: string
+    content_type?: string
+    item_id?: string
+  }
+  sign_up: {
+    method?: string
+  }
+  spend_virtual_currency: {
+    value: number
+    virtual_currency_name: string
+    item_name?: string
+  }
+  tutorial_begin: Record<string, never>
+  tutorial_complete: Record<string, never>
+  view_search_results: {
+    search_term?: string
+  }
+}
+
+export type GARecommendedEventName = keyof GARecommendedEventParams


### PR DESCRIPTION
### What?

Add TypeScript overload signatures to the `sendGAEvent` function in `@next/third-parties/google` and define GA4 recommended event types for autocomplete support.

### Why?

The current `sendGAEvent` function accepts `...args: Object[]`, which is too ambiguous — it provides no autocomplete or type checking for GA4 event parameters. This makes it easy to pass incorrect arguments without any IDE feedback.

Related: #63226, #62065

According to the [GA4 gtag.js event reference](https://developers.google.com/tag-platform/gtagjs/reference/events), events should follow the pattern:
```js
gtag('event', '<event_name>', { <event_parameters> })
```

### How?

**TypeScript overloads (no runtime changes):**

1. **Recommended event overload** — provides autocomplete for 37 GA4 recommended events (`purchase`, `add_to_cart`, `login`, etc.) with their exact parameter types
2. **Custom event overload** — typed signature for custom events: `sendGAEvent('event', 'my_event', { key: 'value' })`
3. **Legacy overload** — `sendGAEvent(...args: Object[])` preserved for full backward compatibility

The runtime implementation remains unchanged (`window[dataLayer].push(arguments)`), so existing code continues to work without modification.

**GA4 recommended event types include:**
- Online Sales: `add_payment_info`, `add_shipping_info`, `add_to_cart`, `add_to_wishlist`, `begin_checkout`, `purchase`, `refund`, `remove_from_cart`, `select_item`, `select_promotion`, `view_cart`, `view_item`, `view_item_list`, `view_promotion`
- Lead Generation: `close_convert_lead`, `close_unconvert_lead`, `disqualify_lead`, `generate_lead`, `qualify_lead`, `working_lead`
- Games: `level_end`, `level_start`, `level_up`, `post_score`, `unlock_achievement`
- All Properties: `earn_virtual_currency`, `exception`, `join_group`, `login`, `page_view`, `search`, `select_content`, `share`, `sign_up`, `spend_virtual_currency`, `tutorial_begin`, `tutorial_complete`, `view_search_results`

**Usage example:**
```tsx
// Recommended event — full autocomplete for event name and parameters
sendGAEvent('event', 'purchase', {
  currency: 'USD',
  value: 99.99,
  transaction_id: 'T12345',
  items: [{ item_id: 'SKU1', item_name: 'Product' }],
})

// Custom event — typed but flexible
sendGAEvent('event', 'newsletter_signup', { method: 'popup' })

// Legacy usage — still works
sendGAEvent({ event: 'buttonClicked', value: 'xyz' })
```

## For Contributors

### Adding a feature

- [x] Related issues/discussions are linked using `fixes #number`
- [x] No runtime behavior changes — type-only enhancement
- [x] Existing e2e tests continue to pass (legacy overload preserves backward compatibility)