### PR TITLE
fix(test): increase timeout for hard navigate pages->app in app-basepath test

### DIFF
--- a/test/e2e/app-dir/app-basepath/index.test.ts
+++ b/test/e2e/app-dir/app-basepath/index.test.ts
@@ -13,7 +13,9 @@ describe('app dir - basepath', () => {
   it('should successfully hard navigate from pages -> app', async () => {
     const browser = await next.browser('/base/pages-path')
     await browser.elementByCss('#to-another').click()
-    await browser.waitForElementByCss('#page-2')
+    // First load of an App Router page in dev mode triggers on-demand compilation.
+    // Give it extra time so slow CI runners don't hit the 10s default timeout.
+    await browser.waitForElementByCss('#page-2', 30000)
   })
 
   it('should support `basePath`', async () => {


### PR DESCRIPTION
### What?

Increase the `waitForElementByCss` timeout from the default 10,000 ms to 30,000 ms for the `#page-2` assertion in the `should successfully hard navigate from pages -> app` test case in `test/e2e/app-dir/app-basepath/index.test.ts`. A short explanatory comment is added alongside the change.

### Why?

[Datadog test runs](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40test.source.file%3Atest%2Fe2e%2Fapp-dir%2Fapp-basepath%2Findex.test.ts%20%40test.status%3Afail%20%40test.name%3A%22app%20dir%20-%20basepath%20should%20successfully%20hard%20navigate%20from%20pages%20-%3E%20app%22&agg_m=count&agg_m_source=base&agg_t=count&cols=%40test.status%2Ctimestamp%2C%40duration%2C%40test.type%2C%40test.is_known_flaky%2C%40test.name&currentTab=overview&eventStack=&fromUser=false&index=citest&start=1773951895836&end=1774556695836&paused=false)

This test was confirmed flaky in CI — it failed independently on two unrelated branches (`update/react/19.3.0-canary-3cb2c420-20260324` and `optimized_change_tracking`), which is a strong signal of genuine flakiness rather than a branch-specific regression.

The failure mode is always the same:

```
page.waitForSelector: Timeout 10000ms exceeded
```

The test hard-navigates from a Pages Router page (`/base/pages-path`) to an App Router page (`/base/another`). In dev mode, the very first request to an App Router segment triggers on-demand compilation. On slower CI runners, that compilation + page load exceeds the default 10 s Playwright `waitForElementByCss` timeout, causing the test to fail non-deterministically on all three retries.

### How?

Pass `30000` as the second argument to `waitForElementByCss`. The `BrowserInterface` implementation in `test/lib/browsers/playwright.ts` accepts a plain number as a millisecond timeout. 30 s is the established pattern in the Next.js test suite for waits that involve dev-mode compilation (e.g., `next-test-utils.ts` uses it for version-checker waits), and it is well within the global 60 s per-page Playwright timeout.

No test semantics change — the assertion still verifies that the hard navigation from Pages Router to App Router completes successfully.