### PR TITLE
[test] Deflake instant-navs-devtools

### DIFF
--- a/test/development/app-dir/instant-navs-devtools/instant-navs-devtools.test.ts
+++ b/test/development/app-dir/instant-navs-devtools/instant-navs-devtools.test.ts
@@ -38,7 +38,10 @@ describe('instant-nav-panel', () => {
   }
 
   async function clickStartClientNav(browser: Playwright) {
-    await browser.elementByCssInstant('[data-instant-nav-client]').click()
+    await browser
+      // TODO: Monitor if we need to increase timeouts for all *instant calls
+      .elementByCss('[data-instant-nav-client]', { timeout: 50 })
+      .click()
     await waitForInstantModeCookie(browser)
   }
 


### PR DESCRIPTION
Apparently `timeout` is racing Playwright's IPC communication. I've never seen `*instant` selectors timeout though so I'm just increasing the `*instant` timeout for this specific test. Chances are the problem is some (css) transition that didn't finish in time.