### PR TITLE
[devtools] Make instant navs panel draggable

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/menu/panel-router.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/menu/panel-router.tsx
@@ -261,6 +261,8 @@ export const PanelRouter = () => {
         <PanelRoute name="instant-navs">
           <DynamicPanel
             sharePanelSizeGlobally={false}
+            sharePanelPositionGlobally={false}
+            draggable
             sizeConfig={{
               kind: 'fixed',
               height: 300 / state.scale,


### PR DESCRIPTION
You need to be able to see the link to have it use the cookie since we remove the cookie once you exit the panel.
Now you can drag it around after you openend the menu instead of having to close, drag, and open again.


https://github.com/user-attachments/assets/f6d19f3d-2c9f-45ce-84d9-cd89089ce84b

