### PR TITLE
Fix race conditions in dev error page compilation for turbopack

### DIFF
--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -42,6 +42,7 @@ import {
   clearAllModuleContexts,
   clearModuleContext,
 } from '../lib/render-server'
+import { Batcher } from '../../lib/batcher'
 import { denormalizePagePath } from '../../shared/lib/page-path/denormalize-page-path'
 import { trace } from '../../trace'
 import {
@@ -52,6 +53,7 @@ import {
   handlePagesErrorRoute,
   handleRouteType,
   hasEntrypointForKey,
+  type HandleWrittenEndpoint,
   msToNs,
   type ReadyIds,
   type SendHmr,
@@ -481,6 +483,23 @@ export async function createHotReloaderTurbopack(
   )
 
   const assetMapper = new AssetMapper()
+
+  // Deduplicate concurrent ensurePage('/_error') calls so that concurrent
+  // requests do not race to call handlePagesErrorRoute simultaneously.
+  const ensureErrorPageBatcher = Batcher.create<string, void>()
+
+  // Shared handleWrittenEndpoint implementation used by both the entrypoints
+  // subscription and on-demand ensurePage calls, so that assetMapper is always
+  // updated consistently.
+  const handleWrittenEndpoint: HandleWrittenEndpoint = (
+    id,
+    result,
+    forceDeleteCache
+  ) => {
+    currentWrittenEntrypoints.set(id, result)
+    assetMapper.setPathsForKey(id, result.clientPaths)
+    return clearRequireCache(id, result, { force: forceDeleteCache })
+  }
 
   // Deferred entries state management
   const deferredEntriesConfig = nextConfig.experimental.deferredEntries
@@ -944,10 +963,7 @@ export async function createHotReloaderTurbopack(
           serverFields,
 
           hooks: {
-            handleWrittenEndpoint: (id, result, forceDeleteCache) => {
-              currentWrittenEntrypoints.set(id, result)
-              return clearRequireCache(id, result, { force: forceDeleteCache })
-            },
+            handleWrittenEndpoint,
             propagateServerField: propagateServerField.bind(null, opts),
             sendHmr,
             startBuilding,
@@ -1612,29 +1628,25 @@ export async function createHotReloaderTurbopack(
           const pathname = definition?.pathname ?? inputPage
 
           if (page === '/_error') {
-            let finishBuilding = startBuilding(pathname, requestUrl, false)
-            try {
-              await handlePagesErrorRoute({
-                currentEntryIssues,
-                entrypoints: currentEntrypoints,
-                manifestLoader,
-                devRewrites: opts.fsChecker.rewrites,
-                productionRewrites: undefined,
-                logErrors: true,
-                hooks: {
-                  subscribeToChanges: subscribeToClientChanges,
-                  handleWrittenEndpoint: (id, result, forceDeleteCache) => {
-                    currentWrittenEntrypoints.set(id, result)
-                    assetMapper.setPathsForKey(id, result.clientPaths)
-                    return clearRequireCache(id, result, {
-                      force: forceDeleteCache,
-                    })
+            await ensureErrorPageBatcher.batch('/_error', async () => {
+              let finishBuilding = startBuilding(pathname, requestUrl, false)
+              try {
+                await handlePagesErrorRoute({
+                  currentEntryIssues,
+                  entrypoints: currentEntrypoints,
+                  manifestLoader,
+                  devRewrites: opts.fsChecker.rewrites,
+                  productionRewrites: undefined,
+                  logErrors: true,
+                  hooks: {
+                    subscribeToChanges: subscribeToClientChanges,
+                    handleWrittenEndpoint,
                   },
-                },
-              })
-            } finally {
-              finishBuilding()
-            }
+                })
+              } finally {
+                finishBuilding()
+              }
+            })
             return
           }
 
@@ -1691,13 +1703,7 @@ export async function createHotReloaderTurbopack(
 
               hooks: {
                 subscribeToChanges: subscribeToClientChanges,
-                handleWrittenEndpoint: (id, result, forceDeleteCache) => {
-                  currentWrittenEntrypoints.set(id, result)
-                  assetMapper.setPathsForKey(id, result.clientPaths)
-                  return clearRequireCache(id, result, {
-                    force: forceDeleteCache,
-                  })
-                },
+                handleWrittenEndpoint,
               },
             })
           } finally {

--- a/packages/next/src/server/dev/turbopack-utils.ts
+++ b/packages/next/src/server/dev/turbopack-utils.ts
@@ -38,6 +38,29 @@ import {
 import { MIDDLEWARE_FILENAME, PROXY_FILENAME } from '../../lib/constants'
 
 const onceErrorSet = new Set()
+
+// Guards against concurrent writeToDisk() on the same Endpoint object.
+// This prevents handleRouteType and handlePagesErrorRoute from racing on
+// shared _app/_document endpoint writes.
+const writeToDiskInFlight = new WeakMap<
+  object,
+  Promise<TurbopackResult<WrittenEndpoint>>
+>()
+
+async function writeToDiskOnce(
+  endpoint: Endpoint
+): Promise<TurbopackResult<WrittenEndpoint>> {
+  const existing = writeToDiskInFlight.get(endpoint)
+  if (existing) return existing
+  const promise = endpoint.writeToDisk()
+  writeToDiskInFlight.set(endpoint, promise)
+  try {
+    return await promise
+  } finally {
+    writeToDiskInFlight.delete(endpoint)
+  }
+}
+
 /**
  * Check if given issue is a warning to be display only once.
  * This mimics behavior of get-page-static-info's warnOnce.
@@ -183,7 +206,7 @@ export async function handleRouteType({
         if (entrypoints.global.app) {
           const key = getEntryKey('pages', 'server', '_app')
 
-          const writtenEndpoint = await entrypoints.global.app.writeToDisk()
+          const writtenEndpoint = await writeToDiskOnce(entrypoints.global.app)
           documentOrAppChanged ||=
             hooks?.handleWrittenEndpoint(key, writtenEndpoint, false) ?? false
           processIssues(
@@ -200,8 +223,9 @@ export async function handleRouteType({
         if (entrypoints.global.document) {
           const key = getEntryKey('pages', 'server', '_document')
 
-          const writtenEndpoint =
-            await entrypoints.global.document.writeToDisk()
+          const writtenEndpoint = await writeToDiskOnce(
+            entrypoints.global.document
+          )
           documentOrAppChanged ||=
             hooks?.handleWrittenEndpoint(key, writtenEndpoint, false) ?? false
           processIssues(
@@ -862,7 +886,7 @@ export async function handlePagesErrorRoute({
   if (entrypoints.global.app) {
     const key = getEntryKey('pages', 'server', '_app')
 
-    const writtenEndpoint = await entrypoints.global.app.writeToDisk()
+    const writtenEndpoint = await writeToDiskOnce(entrypoints.global.app)
     hooks.handleWrittenEndpoint(key, writtenEndpoint, false)
     hooks.subscribeToChanges(
       key,
@@ -891,7 +915,7 @@ export async function handlePagesErrorRoute({
   if (entrypoints.global.document) {
     const key = getEntryKey('pages', 'server', '_document')
 
-    const writtenEndpoint = await entrypoints.global.document.writeToDisk()
+    const writtenEndpoint = await writeToDiskOnce(entrypoints.global.document)
     hooks.handleWrittenEndpoint(key, writtenEndpoint, false)
     hooks.subscribeToChanges(
       key,
@@ -917,7 +941,7 @@ export async function handlePagesErrorRoute({
   if (entrypoints.global.error) {
     const key = getEntryKey('pages', 'server', '_error')
 
-    const writtenEndpoint = await entrypoints.global.error.writeToDisk()
+    const writtenEndpoint = await writeToDiskOnce(entrypoints.global.error)
     hooks.handleWrittenEndpoint(key, writtenEndpoint, false)
     hooks.subscribeToChanges(
       key,

--- a/packages/next/src/server/dev/turbopack-utils.ts
+++ b/packages/next/src/server/dev/turbopack-utils.ts
@@ -39,25 +39,32 @@ import { MIDDLEWARE_FILENAME, PROXY_FILENAME } from '../../lib/constants'
 
 const onceErrorSet = new Set()
 
-// Guards against concurrent writeToDisk() on the same Endpoint object.
-// This prevents handleRouteType and handlePagesErrorRoute from racing on
-// shared _app/_document endpoint writes.
-const writeToDiskInFlight = new WeakMap<
+// Guards against concurrent writeToDisk() on shared global Endpoint objects
+// (_app, _document, _error). Both handleRouteType (for any pages-router page)
+// and handlePagesErrorRoute write these same endpoints, so concurrent
+// ensurePage() calls can race. Per-route endpoints (page HTML, app-page,
+// app-route, middleware, instrumentation) don't need this guard because they
+// are unique to a single route and are not written from multiple code paths.
+//
+// When a second caller coalesces onto an in-flight write, it receives the same
+// WrittenEndpoint result. Its subsequent handleWrittenEndpoint/clearRequireCache
+// call is effectively a no-op because serverPathState hashes already match.
+const sharedEndpointWriteInFlight = new WeakMap<
   object,
   Promise<TurbopackResult<WrittenEndpoint>>
 >()
 
-async function writeToDiskOnce(
+async function writeSharedEndpointToDisk(
   endpoint: Endpoint
 ): Promise<TurbopackResult<WrittenEndpoint>> {
-  const existing = writeToDiskInFlight.get(endpoint)
+  const existing = sharedEndpointWriteInFlight.get(endpoint)
   if (existing) return existing
   const promise = endpoint.writeToDisk()
-  writeToDiskInFlight.set(endpoint, promise)
+  sharedEndpointWriteInFlight.set(endpoint, promise)
   try {
     return await promise
   } finally {
-    writeToDiskInFlight.delete(endpoint)
+    sharedEndpointWriteInFlight.delete(endpoint)
   }
 }
 
@@ -206,7 +213,9 @@ export async function handleRouteType({
         if (entrypoints.global.app) {
           const key = getEntryKey('pages', 'server', '_app')
 
-          const writtenEndpoint = await writeToDiskOnce(entrypoints.global.app)
+          const writtenEndpoint = await writeSharedEndpointToDisk(
+            entrypoints.global.app
+          )
           documentOrAppChanged ||=
             hooks?.handleWrittenEndpoint(key, writtenEndpoint, false) ?? false
           processIssues(
@@ -223,7 +232,7 @@ export async function handleRouteType({
         if (entrypoints.global.document) {
           const key = getEntryKey('pages', 'server', '_document')
 
-          const writtenEndpoint = await writeToDiskOnce(
+          const writtenEndpoint = await writeSharedEndpointToDisk(
             entrypoints.global.document
           )
           documentOrAppChanged ||=
@@ -886,7 +895,9 @@ export async function handlePagesErrorRoute({
   if (entrypoints.global.app) {
     const key = getEntryKey('pages', 'server', '_app')
 
-    const writtenEndpoint = await writeToDiskOnce(entrypoints.global.app)
+    const writtenEndpoint = await writeSharedEndpointToDisk(
+      entrypoints.global.app
+    )
     hooks.handleWrittenEndpoint(key, writtenEndpoint, false)
     hooks.subscribeToChanges(
       key,
@@ -915,7 +926,9 @@ export async function handlePagesErrorRoute({
   if (entrypoints.global.document) {
     const key = getEntryKey('pages', 'server', '_document')
 
-    const writtenEndpoint = await writeToDiskOnce(entrypoints.global.document)
+    const writtenEndpoint = await writeSharedEndpointToDisk(
+      entrypoints.global.document
+    )
     hooks.handleWrittenEndpoint(key, writtenEndpoint, false)
     hooks.subscribeToChanges(
       key,
@@ -941,7 +954,9 @@ export async function handlePagesErrorRoute({
   if (entrypoints.global.error) {
     const key = getEntryKey('pages', 'server', '_error')
 
-    const writtenEndpoint = await writeToDiskOnce(entrypoints.global.error)
+    const writtenEndpoint = await writeSharedEndpointToDisk(
+      entrypoints.global.error
+    )
     hooks.handleWrittenEndpoint(key, writtenEndpoint, false)
     hooks.subscribeToChanges(
       key,

--- a/test/development/app-dir/dev-error-page-race/app/layout.tsx
+++ b/test/development/app-dir/dev-error-page-race/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/dev-error-page-race/app/page.tsx
+++ b/test/development/app-dir/dev-error-page-race/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/development/app-dir/dev-error-page-race/dev-error-page-race.test.ts
+++ b/test/development/app-dir/dev-error-page-race/dev-error-page-race.test.ts
@@ -1,0 +1,44 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+describe('dev-error-page-race', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should handle concurrent requests to an erroring page without hanging', async () => {
+    // First, verify the page works normally
+    const html = await next.render('/')
+    expect(html).toContain('hello world')
+
+    // Introduce a syntax error to trigger the fallback error page path
+    await next.patchFile('app/page.tsx', 'export default () => <div/')
+
+    // Fire multiple concurrent requests to trigger concurrent ensurePage('/_error') calls.
+    // Before the fix, this could cause an invalidation storm in turbopack as multiple
+    // tasks raced to write the same error page endpoints with different parameters.
+    const results = await Promise.all([
+      next.fetch('/'),
+      next.fetch('/'),
+      next.fetch('/'),
+    ])
+
+    // All requests should complete (not hang) and return 500
+    for (const res of results) {
+      expect(res.status).toBe(500)
+    }
+
+    // Fix the error and verify recovery
+    await next.patchFile(
+      'app/page.tsx',
+      `export default function Page() {
+  return <p>recovered</p>
+}`
+    )
+
+    await retry(async () => {
+      const recovered = await next.render('/')
+      expect(recovered).toContain('recovered')
+    })
+  })
+})


### PR DESCRIPTION
### What?

Fixes race conditions where concurrent requests in dev mode cause conflicting turbopack task writes when compiling the fallback pages-router error page (`/_error`, `_app`, `_document`).

### Why?

In app router apps during development, when an SSR or compilation error occurs, Next.js serves a pages-router error page. This triggers `ensurePage('/_error')` which calls `handlePagesErrorRoute`, writing `_app`, `_document`, and `_error` endpoints to disk.

The problem is threefold:

1. **Concurrent `ensurePage('/_error')` calls race.** Multiple simultaneous requests (e.g. the page request + RSC request + prefetch) each independently call `handlePagesErrorRoute`, causing parallel `writeToDisk()` calls on the same endpoints. This creates conflicting turbopack tasks fighting to write the same routes.

2. **Inconsistent `handleWrittenEndpoint` implementations.** There were three separate inline closures: the `handleEntrypoints` one was missing `assetMapper.setPathsForKey()` while the two `ensurePage` closures included it. This meant routes compiled via the entrypoints subscription had no asset-mapper entries, while on-demand routes did.

3. **`handleRouteType` and `handlePagesErrorRoute` both write `_app`/`_document`.** When a pages-router page is being compiled at the same time as the error route (or the error route is triggered during page compilation), both functions call `writeToDisk()` on the shared global `_app` and `_document` endpoints concurrently.

### How?

Three targeted fixes:

1. **Batcher deduplication for `/_error`** — Wraps the `ensurePage('/_error')` path in a `Batcher.batch()` call so concurrent requests coalesce into a single `handlePagesErrorRoute` execution.

2. **Unified `handleWrittenEndpoint`** — Extracts the three inline closures into a single shared `const handleWrittenEndpoint` that consistently calls `currentWrittenEntrypoints.set()`, `assetMapper.setPathsForKey()`, and `clearRequireCache()` in all code paths.

3. **`writeSharedEndpointToDisk()` guard** — Adds a `WeakMap`-based in-flight guard in `turbopack-utils.ts` that deduplicates concurrent `writeToDisk()` calls on the same shared global `Endpoint` object (`_app`, `_document`, `_error`). If a write is already in-flight for a given endpoint, subsequent callers await the existing promise instead of starting a new write. This guard is intentionally scoped to shared global endpoints only — per-route endpoints (page HTML, app-page, app-route, middleware, instrumentation) are unique to a single route and don't need deduplication. When a second caller coalesces onto an in-flight write, its subsequent `clearRequireCache` call is effectively a no-op because `serverPathState` hashes were already updated by the first caller.

Both dedup layers are needed: the `Batcher` prevents concurrent `handlePagesErrorRoute` invocations from racing with each other, while `writeSharedEndpointToDisk` prevents `handleRouteType` (for any pages-router page) from racing with `handlePagesErrorRoute` on the shared `_app`/`_document` endpoints.

### Test plan

- Added regression test `test/development/app-dir/dev-error-page-race` that introduces a syntax error in an app-router page and fires 3 concurrent requests, verifying they all complete with 500 status (no hang/infinite loop) and that the app recovers after fixing the error.

### Fixing a bug

- Tests added: `test/development/app-dir/dev-error-page-race/dev-error-page-race.test.ts`