### PR TITLE
Add MCP `get_compilation_issues` tool for Turbopack dev server

### DIFF
--- a/.config/eslintignore.mjs
+++ b/.config/eslintignore.mjs
@@ -47,6 +47,7 @@ export default globalIgnores([
   'examples/with-typescript-graphql/lib/gql/',
   'test/development/basic/hmr/components/parse-error.js',
   'test/development/mcp-server/fixtures/default-template/app/build-error/page.tsx',
+  // Intentionally broken fixture (syntax error for MCP compilation-issues test)
   'test/development/mcp-server/fixtures/compilation-issues-app/app/broken/page.tsx',
   'test/production/debug-build-path/fixtures/with-compile-error/app/broken/page.tsx',
   'packages/next-swc/native/index.d.ts',

--- a/.config/eslintignore.mjs
+++ b/.config/eslintignore.mjs
@@ -47,6 +47,7 @@ export default globalIgnores([
   'examples/with-typescript-graphql/lib/gql/',
   'test/development/basic/hmr/components/parse-error.js',
   'test/development/mcp-server/fixtures/default-template/app/build-error/page.tsx',
+  'test/development/mcp-server/fixtures/compilation-issues-app/app/broken/page.tsx',
   'test/production/debug-build-path/fixtures/with-compile-error/app/broken/page.tsx',
   'packages/next-swc/native/index.d.ts',
   'packages/next-swc/docs/assets/**/*',

--- a/.prettierignore
+++ b/.prettierignore
@@ -59,6 +59,7 @@ test/e2e/app-dir/server-source-maps/fixtures/default/internal-pkg/ignored.js
 test/e2e/app-dir/server-source-maps/fixtures/default/internal-pkg/sourcemapped.js
 test/e2e/app-dir/server-source-maps/fixtures/default/external-pkg/sourcemapped.js
 test/development/mcp-server/fixtures/default-template/app/build-error/page.tsx
+# Intentionally broken fixture (syntax error for MCP compilation-issues test)
 test/development/mcp-server/fixtures/compilation-issues-app/app/broken/page.tsx
 # Tested against auto-generated content that isn't formatted
 test/integration/typescript-app-type-declarations/next-env.strictRouteTypes.d.ts

--- a/.prettierignore
+++ b/.prettierignore
@@ -59,6 +59,7 @@ test/e2e/app-dir/server-source-maps/fixtures/default/internal-pkg/ignored.js
 test/e2e/app-dir/server-source-maps/fixtures/default/internal-pkg/sourcemapped.js
 test/e2e/app-dir/server-source-maps/fixtures/default/external-pkg/sourcemapped.js
 test/development/mcp-server/fixtures/default-template/app/build-error/page.tsx
+test/development/mcp-server/fixtures/compilation-issues-app/app/broken/page.tsx
 # Tested against auto-generated content that isn't formatted
 test/integration/typescript-app-type-declarations/next-env.strictRouteTypes.d.ts
 

--- a/crates/next-napi-bindings/src/next_api/endpoint.rs
+++ b/crates/next-napi-bindings/src/next_api/endpoint.rs
@@ -300,12 +300,16 @@ pub fn endpoint_client_changed_subscribe(
     )
 }
 
+/// Like [`WrittenEndpointWithIssues`] but without writing to disk or collecting
+/// effects. Used for a read-only peek at current compilation issues.
 #[turbo_tasks::value(serialization = "none")]
 struct EndpointIssuesPeek {
     issues: Arc<Vec<ReadRef<PlainIssue>>>,
     diagnostics: Arc<Vec<ReadRef<PlainDiagnostic>>>,
 }
 
+/// Peeks issues from [`endpoint_server_changed_operation`] without triggering a
+/// disk write (unlike [`get_written_endpoint_with_issues_operation`]).
 #[turbo_tasks::function(operation)]
 async fn peek_endpoint_issues_operation(
     endpoint_op: OperationVc<OptionEndpoint>,
@@ -328,8 +332,7 @@ pub async fn endpoint_get_issues(
 ) -> napi::Result<TurbopackResult<()>> {
     let ctx = endpoint.turbopack_ctx();
     let endpoint_op = ***endpoint;
-    let (issues, diags) = endpoint
-        .turbopack_ctx()
+    let (issues, diags) = ctx
         .turbo_tasks()
         .run(async move {
             let peek_op = peek_endpoint_issues_operation(endpoint_op);

--- a/crates/next-napi-bindings/src/next_api/endpoint.rs
+++ b/crates/next-napi-bindings/src/next_api/endpoint.rs
@@ -20,7 +20,7 @@ use turbopack_core::{
 };
 
 use crate::next_api::utils::{
-    DetachedVc, NapiDiagnostic, NapiIssue, RootTask, TurbopackResult,
+    DetachedVc, NapiDiagnostic, NapiIssue, RootTask, TurbopackResult, get_diagnostics, get_issues,
     strongly_consistent_catch_collectables, subscribe,
 };
 
@@ -298,4 +298,52 @@ pub fn endpoint_client_changed_subscribe(
             }])
         },
     )
+}
+
+#[turbo_tasks::value(serialization = "none")]
+struct EndpointIssuesPeek {
+    issues: Arc<Vec<ReadRef<PlainIssue>>>,
+    diagnostics: Arc<Vec<ReadRef<PlainDiagnostic>>>,
+}
+
+#[turbo_tasks::function(operation)]
+async fn peek_endpoint_issues_operation(
+    endpoint_op: OperationVc<OptionEndpoint>,
+) -> Result<Vc<EndpointIssuesPeek>> {
+    let changed_op = endpoint_server_changed_operation(endpoint_op);
+    let filter = issue_filter_from_endpoint(endpoint_op).await?;
+    let issues = get_issues(changed_op, filter).await?;
+    let diagnostics = get_diagnostics(changed_op).await?;
+    Ok(EndpointIssuesPeek {
+        issues,
+        diagnostics,
+    }
+    .cell())
+}
+
+#[tracing::instrument(level = "info", name = "get endpoint issues", skip_all)]
+#[napi]
+pub async fn endpoint_get_issues(
+    #[napi(ts_arg_type = "{ __napiType: \"Endpoint\" }")] endpoint: External<ExternalEndpoint>,
+) -> napi::Result<TurbopackResult<()>> {
+    let ctx = endpoint.turbopack_ctx();
+    let endpoint_op = ***endpoint;
+    let (issues, diags) = endpoint
+        .turbopack_ctx()
+        .turbo_tasks()
+        .run(async move {
+            let peek_op = peek_endpoint_issues_operation(endpoint_op);
+            let EndpointIssuesPeek {
+                issues,
+                diagnostics,
+            } = &*peek_op.read_strongly_consistent().await?;
+            Ok((issues.clone(), diagnostics.clone()))
+        })
+        .or_else(|e| ctx.throw_turbopack_internal_result(&e.into()))
+        .await?;
+    Ok(TurbopackResult {
+        result: (),
+        issues: issues.iter().map(|i| NapiIssue::from(&**i)).collect(),
+        diagnostics: diags.iter().map(|d| NapiDiagnostic::from(d)).collect(),
+    })
 }

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -175,6 +175,9 @@ export declare function endpointClientChangedSubscribe(
   endpoint: { __napiType: 'Endpoint' },
   func: (...args: any[]) => any
 ): { __napiType: 'RootTask' }
+export declare function endpointGetIssues(endpoint: {
+  __napiType: 'Endpoint'
+}): Promise<TurbopackResult>
 export interface NapiEnvVar {
   name: RcStr
   value: RcStr

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -857,6 +857,12 @@ function bindingToApi(
       )) as TurbopackResult<WrittenEndpoint>
     }
 
+    async getIssues(): Promise<TurbopackResult> {
+      return (await binding.endpointGetIssues(
+        this._nativeEndpoint
+      )) as TurbopackResult
+    }
+
     async clientChanged(): Promise<AsyncIterableIterator<TurbopackResult>> {
       const clientSubscription = subscribe<TurbopackResult>(
         false,

--- a/packages/next/src/build/swc/types.ts
+++ b/packages/next/src/build/swc/types.ts
@@ -368,6 +368,12 @@ export interface Endpoint {
   writeToDisk(): Promise<TurbopackResult<WrittenEndpoint>>
 
   /**
+   * Peek the current compilation issues for this endpoint without writing to disk.
+   * Returns fresh issues from the last compilation.
+   */
+  getIssues(): Promise<TurbopackResult>
+
+  /**
    * Listen to client-side changes to the endpoint.
    * After clientChanged() has been awaited it will listen to changes.
    * The async iterator will yield for each change.

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -1041,6 +1041,8 @@ export async function createHotReloaderTurbopack(
             getActiveConnectionCount: () =>
               clientsWithoutHtmlRequestId.size + clientsByHtmlRequestId.size,
             getDevServerUrl: () => process.env.__NEXT_PRIVATE_ORIGIN,
+            getCurrentEntrypoints: () => currentEntrypoints,
+            getWrittenEntrypoints: () => currentWrittenEntrypoints,
           }),
         ]
       : []),

--- a/packages/next/src/server/mcp/get-or-create-mcp-server.ts
+++ b/packages/next/src/server/mcp/get-or-create-mcp-server.ts
@@ -60,6 +60,8 @@ export const getOrCreateMcpServer = (options: McpServerOptions) => {
     appDir: options.appDir,
   })
 
+  // Turbopack-only: these options provide live access to compiled endpoint
+  // state that the webpack dev server does not expose.
   if (options.getCurrentEntrypoints && options.getWrittenEntrypoints) {
     registerGetCompilationIssuesTool(mcpServer, {
       getCurrentEntrypoints: options.getCurrentEntrypoints,

--- a/packages/next/src/server/mcp/get-or-create-mcp-server.ts
+++ b/packages/next/src/server/mcp/get-or-create-mcp-server.ts
@@ -5,8 +5,11 @@ import { registerGetPageMetadataTool } from './tools/get-page-metadata'
 import { registerGetLogsTool } from './tools/get-logs'
 import { registerGetActionByIdTool } from './tools/get-server-action-by-id'
 import { registerGetRoutesTool } from './tools/get-routes'
+import { registerGetCompilationIssuesTool } from './tools/get-compilation-issues'
 import type { HmrMessageSentToBrowser } from '../dev/hot-reloader-types'
 import type { NextConfigComplete } from '../config-shared'
+import type { Entrypoints } from '../../build/swc/types'
+import type { EntryKey } from '../../shared/lib/turbopack/entry-key'
 
 export interface McpServerOptions {
   projectPath: string
@@ -17,6 +20,8 @@ export interface McpServerOptions {
   sendHmrMessage: (message: HmrMessageSentToBrowser) => void
   getActiveConnectionCount: () => number
   getDevServerUrl: () => string | undefined
+  getCurrentEntrypoints?: () => Entrypoints
+  getWrittenEntrypoints?: () => ReadonlyMap<EntryKey, unknown>
 }
 
 let mcpServer: McpServer | undefined
@@ -54,6 +59,13 @@ export const getOrCreateMcpServer = (options: McpServerOptions) => {
     pagesDir: options.pagesDir,
     appDir: options.appDir,
   })
+
+  if (options.getCurrentEntrypoints && options.getWrittenEntrypoints) {
+    registerGetCompilationIssuesTool(mcpServer, {
+      getCurrentEntrypoints: options.getCurrentEntrypoints,
+      getWrittenEntrypoints: options.getWrittenEntrypoints,
+    })
+  }
 
   return mcpServer
 }

--- a/packages/next/src/server/mcp/tools/get-compilation-issues.ts
+++ b/packages/next/src/server/mcp/tools/get-compilation-issues.ts
@@ -11,48 +11,44 @@
  *   return JSON grouped by route.
  */
 import type { McpServer } from 'next/dist/compiled/@modelcontextprotocol/sdk/server/mcp'
-import type { Entrypoints, Issue } from '../../../build/swc/types'
+import type {
+  AppRoute,
+  Endpoint,
+  Entrypoints,
+  Issue,
+  PageRoute,
+} from '../../../build/swc/types'
 import type { EntryKey } from '../../../shared/lib/turbopack/entry-key'
 import { splitEntryKey } from '../../../shared/lib/turbopack/entry-key'
 import { mcpTelemetryTracker } from '../mcp-telemetry-tracker'
 
 export interface GetCompilationIssuesOptions {
   getCurrentEntrypoints: () => Entrypoints
+  /**
+   * Only the keys are used to determine which routes have been compiled;
+   * the value type is intentionally opaque.
+   */
   getWrittenEntrypoints: () => ReadonlyMap<EntryKey, unknown>
 }
 
-interface CompilationIssueOutput {
-  severity: string
-  stage: string
-  filePath: string
-  title: unknown
-  description?: unknown
-  detail?: unknown
-  source?: unknown
-  additionalSources?: unknown[]
-  documentationLink: string
-  importTraces?: unknown
-  codeFrame?: string
-}
-
-interface CompilationIssuesOutput {
-  routes: Record<string, { issues: CompilationIssueOutput[] }>
-  message?: string
-}
-
-function formatIssue(issue: Issue): CompilationIssueOutput {
-  return {
-    severity: issue.severity,
-    stage: issue.stage,
-    filePath: issue.filePath,
-    title: issue.title,
-    description: issue.description,
-    detail: issue.detail,
-    source: issue.source,
-    additionalSources: issue.additionalSources ?? [],
-    documentationLink: issue.documentationLink,
-    importTraces: issue.importTraces,
-    codeFrame: issue.codeFrame,
+/**
+ * Returns the primary endpoint for a route entry.
+ *
+ * For page-rendering routes (`app-page`, `page`), `htmlEndpoint` is used because
+ * it is the primary compilation unit that aggregates issues from both client and
+ * server components. For API-style routes (`app-route`, `page-api`), `endpoint`
+ * is the only compilation unit.
+ */
+function getRouteEndpoint(route: AppRoute | PageRoute): Endpoint | null {
+  switch (route.type) {
+    case 'app-page':
+    case 'page':
+      return route.htmlEndpoint
+    case 'app-route':
+    case 'page-api':
+      return route.endpoint
+    default:
+      return null
   }
 }
 
@@ -97,57 +93,25 @@ export function registerGetCompilationIssuesTool(
           }
         }
 
-        // For each compiled route, find the Endpoint(s) and call getIssues()
-        const output: CompilationIssuesOutput = { routes: {} }
+        const routes: Record<string, { issues: Issue[] }> = {}
 
         await Promise.all(
           Array.from(compiledPages).map(async (page) => {
-            const appRoute = entrypoints.app.get(page)
-            const pageRoute = entrypoints.page.get(page)
-            const routeEntry = appRoute ?? pageRoute
+            const routeEntry =
+              entrypoints.app.get(page) ?? entrypoints.page.get(page)
+            if (!routeEntry) return
 
-            if (!routeEntry) {
-              // Route not found in current entrypoints (may have been removed)
-              return
-            }
-
-            const allIssues: Issue[] = []
+            const endpoint = getRouteEndpoint(routeEntry)
+            if (!endpoint) return
 
             try {
-              switch (routeEntry.type) {
-                case 'app-page': {
-                  const result = await routeEntry.htmlEndpoint.getIssues()
-                  allIssues.push(...result.issues)
-                  break
-                }
-                case 'app-route': {
-                  const result = await routeEntry.endpoint.getIssues()
-                  allIssues.push(...result.issues)
-                  break
-                }
-                case 'page': {
-                  const result = await routeEntry.htmlEndpoint.getIssues()
-                  allIssues.push(...result.issues)
-                  break
-                }
-                case 'page-api': {
-                  const result = await routeEntry.endpoint.getIssues()
-                  allIssues.push(...result.issues)
-                  break
-                }
-                default:
-                  break
-              }
+              const result = await endpoint.getIssues()
+              routes[page] = { issues: result.issues }
             } catch (err) {
               console.error(
                 `[MCP get_compilation_issues] Error getting issues for route ${page}:`,
                 err
               )
-              return
-            }
-
-            output.routes[page] = {
-              issues: allIssues.map(formatIssue),
             }
           })
         )
@@ -156,7 +120,7 @@ export function registerGetCompilationIssuesTool(
           content: [
             {
               type: 'text' as const,
-              text: JSON.stringify(output, null, 2),
+              text: JSON.stringify({ routes }, null, 2),
             },
           ],
         }

--- a/packages/next/src/server/mcp/tools/get-compilation-issues.ts
+++ b/packages/next/src/server/mcp/tools/get-compilation-issues.ts
@@ -1,0 +1,177 @@
+/**
+ * MCP tool for retrieving Turbopack compilation issues from the Next.js dev server.
+ *
+ * This tool provides fresh compilation issues (errors, warnings, all severities)
+ * grouped by route, for all routes that have been compiled in the current dev session.
+ *
+ * Flow:
+ *   MCP client → determine compiled routes from written entrypoints →
+ *   look up Endpoint objects from currentEntrypoints →
+ *   call endpoint.getIssues() (NAPI) for fresh issues →
+ *   return JSON grouped by route.
+ */
+import type { McpServer } from 'next/dist/compiled/@modelcontextprotocol/sdk/server/mcp'
+import type { Entrypoints, Issue } from '../../../build/swc/types'
+import type { EntryKey } from '../../../shared/lib/turbopack/entry-key'
+import { splitEntryKey } from '../../../shared/lib/turbopack/entry-key'
+import { mcpTelemetryTracker } from '../mcp-telemetry-tracker'
+
+export interface GetCompilationIssuesOptions {
+  getCurrentEntrypoints: () => Entrypoints
+  getWrittenEntrypoints: () => ReadonlyMap<EntryKey, unknown>
+}
+
+interface CompilationIssueOutput {
+  severity: string
+  stage: string
+  filePath: string
+  title: unknown
+  description?: unknown
+  detail?: unknown
+  source?: unknown
+  additionalSources?: unknown[]
+  documentationLink: string
+  importTraces?: unknown
+  codeFrame?: string
+}
+
+interface CompilationIssuesOutput {
+  routes: Record<string, { issues: CompilationIssueOutput[] }>
+  message?: string
+}
+
+function formatIssue(issue: Issue): CompilationIssueOutput {
+  return {
+    severity: issue.severity,
+    stage: issue.stage,
+    filePath: issue.filePath,
+    title: issue.title,
+    description: issue.description,
+    detail: issue.detail,
+    source: issue.source,
+    additionalSources: issue.additionalSources ?? [],
+    documentationLink: issue.documentationLink,
+    importTraces: issue.importTraces,
+    codeFrame: issue.codeFrame,
+  }
+}
+
+export function registerGetCompilationIssuesTool(
+  server: McpServer,
+  options: GetCompilationIssuesOptions
+) {
+  server.registerTool(
+    'get_compilation_issues',
+    {
+      description:
+        'Get current Turbopack compilation issues (errors, warnings) for all routes that have been compiled in the current dev session, grouped by route',
+      inputSchema: {},
+    },
+    async (_request) => {
+      mcpTelemetryTracker.recordToolCall('mcp/get_compilation_issues')
+
+      try {
+        const entrypoints = options.getCurrentEntrypoints()
+        const writtenEntrypoints = options.getWrittenEntrypoints()
+
+        // Determine compiled routes from written entrypoints.
+        // Each EntryKey is JSON like {"type":"app","side":"server","page":"/page"}.
+        // Extract unique page names and look them up in currentEntrypoints.
+        const compiledPages = new Set<string>()
+        for (const key of writtenEntrypoints.keys()) {
+          const { page } = splitEntryKey(key)
+          compiledPages.add(page)
+        }
+
+        if (compiledPages.size === 0) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: JSON.stringify({
+                  routes: {},
+                  message: 'No routes have been compiled yet.',
+                }),
+              },
+            ],
+          }
+        }
+
+        // For each compiled route, find the Endpoint(s) and call getIssues()
+        const output: CompilationIssuesOutput = { routes: {} }
+
+        await Promise.all(
+          Array.from(compiledPages).map(async (page) => {
+            const appRoute = entrypoints.app.get(page)
+            const pageRoute = entrypoints.page.get(page)
+            const routeEntry = appRoute ?? pageRoute
+
+            if (!routeEntry) {
+              // Route not found in current entrypoints (may have been removed)
+              return
+            }
+
+            const allIssues: Issue[] = []
+
+            try {
+              switch (routeEntry.type) {
+                case 'app-page': {
+                  const result = await routeEntry.htmlEndpoint.getIssues()
+                  allIssues.push(...result.issues)
+                  break
+                }
+                case 'app-route': {
+                  const result = await routeEntry.endpoint.getIssues()
+                  allIssues.push(...result.issues)
+                  break
+                }
+                case 'page': {
+                  const result = await routeEntry.htmlEndpoint.getIssues()
+                  allIssues.push(...result.issues)
+                  break
+                }
+                case 'page-api': {
+                  const result = await routeEntry.endpoint.getIssues()
+                  allIssues.push(...result.issues)
+                  break
+                }
+                default:
+                  break
+              }
+            } catch (err) {
+              console.error(
+                `[MCP get_compilation_issues] Error getting issues for route ${page}:`,
+                err
+              )
+              return
+            }
+
+            output.routes[page] = {
+              issues: allIssues.map(formatIssue),
+            }
+          })
+        )
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(output, null, 2),
+            },
+          ],
+        }
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                error: error instanceof Error ? error.message : String(error),
+              }),
+            },
+          ],
+        }
+      }
+    }
+  )
+}

--- a/packages/next/src/telemetry/events/build.ts
+++ b/packages/next/src/telemetry/events/build.ts
@@ -259,6 +259,7 @@ export type McpToolName =
   | 'mcp/get_project_metadata'
   | 'mcp/get_routes'
   | 'mcp/get_server_action_by_id'
+  | 'mcp/get_compilation_issues'
 
 export type EventMcpToolUsage = {
   toolName: McpToolName

--- a/test/development/mcp-server/fixtures/compilation-issues-app/app/broken/page.tsx
+++ b/test/development/mcp-server/fixtures/compilation-issues-app/app/broken/page.tsx
@@ -1,0 +1,4 @@
+export default function BrokenPage() {
+  // Syntax error - missing closing tag
+  return <div>Page
+}

--- a/test/development/mcp-server/fixtures/compilation-issues-app/app/layout.tsx
+++ b/test/development/mcp-server/fixtures/compilation-issues-app/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/mcp-server/fixtures/compilation-issues-app/app/page.tsx
+++ b/test/development/mcp-server/fixtures/compilation-issues-app/app/page.tsx
@@ -1,0 +1,3 @@
+export default function HomePage() {
+  return <div>Home Page</div>
+}

--- a/test/development/mcp-server/fixtures/compilation-issues-app/next.config.js
+++ b/test/development/mcp-server/fixtures/compilation-issues-app/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  experimental: {
+    mcpServer: true,
+  },
+}

--- a/test/development/mcp-server/mcp-server-get-compilation-issues.test.ts
+++ b/test/development/mcp-server/mcp-server-get-compilation-issues.test.ts
@@ -14,7 +14,7 @@ describe('mcp-server get_compilation_issues tool', () => {
     return
   }
 
-  async function callGetCompilationIssues(id: string): Promise<string> {
+  async function callGetCompilationIssues(): Promise<string> {
     const response = await fetch(`${next.url}/_next/mcp`, {
       method: 'POST',
       headers: {
@@ -23,7 +23,7 @@ describe('mcp-server get_compilation_issues tool', () => {
       },
       body: JSON.stringify({
         jsonrpc: '2.0',
-        id,
+        id: `test-${Date.now()}`,
         method: 'tools/call',
         params: { name: 'get_compilation_issues', arguments: {} },
       }),
@@ -40,8 +40,7 @@ describe('mcp-server get_compilation_issues tool', () => {
 
     let response: any = null
     await retry(async () => {
-      const sessionId = 'test-clean-' + Date.now()
-      const responseText = await callGetCompilationIssues(sessionId)
+      const responseText = await callGetCompilationIssues()
       response = JSON.parse(responseText)
       // The '/page' route should be present once the page has been compiled
       expect(response.routes).toHaveProperty('/page')
@@ -55,8 +54,7 @@ describe('mcp-server get_compilation_issues tool', () => {
 
     let response: any = null
     await retry(async () => {
-      const sessionId = 'test-broken-' + Date.now()
-      const responseText = await callGetCompilationIssues(sessionId)
+      const responseText = await callGetCompilationIssues()
       response = JSON.parse(responseText)
       expect(response.routes['/broken/page']?.issues?.length).toBeGreaterThan(0)
     })
@@ -73,9 +71,7 @@ describe('mcp-server get_compilation_issues tool', () => {
 
     // Confirm there are issues before patching
     await retry(async () => {
-      const sessionId = 'test-before-fix-' + Date.now()
-      const responseText = await callGetCompilationIssues(sessionId)
-      const resp = JSON.parse(responseText)
+      const resp = JSON.parse(await callGetCompilationIssues())
       expect(resp.routes['/broken/page']?.issues?.length).toBeGreaterThan(0)
     })
 
@@ -89,9 +85,7 @@ describe('mcp-server get_compilation_issues tool', () => {
 
     // After the fix, the issues for '/broken/page' should be empty
     await retry(async () => {
-      const sessionId = 'test-after-fix-' + Date.now()
-      const responseText = await callGetCompilationIssues(sessionId)
-      const resp = JSON.parse(responseText)
+      const resp = JSON.parse(await callGetCompilationIssues())
       expect(
         resp.routes['/broken/page'] == null ||
           resp.routes['/broken/page'].issues.length === 0

--- a/test/development/mcp-server/mcp-server-get-compilation-issues.test.ts
+++ b/test/development/mcp-server/mcp-server-get-compilation-issues.test.ts
@@ -1,0 +1,101 @@
+import { FileRef, nextTestSetup } from 'e2e-utils'
+import path from 'path'
+import { retry } from 'next-test-utils'
+
+describe('mcp-server get_compilation_issues tool', () => {
+  const { next, skipped } = nextTestSetup({
+    files: new FileRef(
+      path.join(__dirname, 'fixtures', 'compilation-issues-app')
+    ),
+    skipDeployment: true,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  async function callGetCompilationIssues(id: string): Promise<string> {
+    const response = await fetch(`${next.url}/_next/mcp`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id,
+        method: 'tools/call',
+        params: { name: 'get_compilation_issues', arguments: {} },
+      }),
+    })
+
+    const text = await response.text()
+    const match = text.match(/data: ({.*})/s)
+    const result = JSON.parse(match![1])
+    return result.result?.content?.[0]?.text
+  }
+
+  it('should return empty issues for a page with no errors', async () => {
+    await next.browser('/')
+
+    let response: any = null
+    await retry(async () => {
+      const sessionId = 'test-clean-' + Date.now()
+      const responseText = await callGetCompilationIssues(sessionId)
+      response = JSON.parse(responseText)
+      // The '/page' route should be present once the page has been compiled
+      expect(response.routes).toHaveProperty('/page')
+    })
+
+    expect(response.routes['/page'].issues).toEqual([])
+  })
+
+  it('should return compilation issues for a page with a syntax error', async () => {
+    await next.browser('/broken')
+
+    let response: any = null
+    await retry(async () => {
+      const sessionId = 'test-broken-' + Date.now()
+      const responseText = await callGetCompilationIssues(sessionId)
+      response = JSON.parse(responseText)
+      expect(response.routes['/broken/page']?.issues?.length).toBeGreaterThan(0)
+    })
+
+    const issue = response.routes['/broken/page'].issues[0]
+    expect(issue).toMatchObject({
+      severity: 'error',
+      filePath: expect.stringContaining('broken/page.tsx'),
+    })
+  })
+
+  it('should reflect fixed issues after the file is patched', async () => {
+    await next.browser('/broken')
+
+    // Confirm there are issues before patching
+    await retry(async () => {
+      const sessionId = 'test-before-fix-' + Date.now()
+      const responseText = await callGetCompilationIssues(sessionId)
+      const resp = JSON.parse(responseText)
+      expect(resp.routes['/broken/page']?.issues?.length).toBeGreaterThan(0)
+    })
+
+    // Patch the broken page to a valid implementation
+    await next.patchFile(
+      'app/broken/page.tsx',
+      `export default function BrokenPage() {
+  return <div>Fixed</div>
+}`
+    )
+
+    // After the fix, the issues for '/broken/page' should be empty
+    await retry(async () => {
+      const sessionId = 'test-after-fix-' + Date.now()
+      const responseText = await callGetCompilationIssues(sessionId)
+      const resp = JSON.parse(responseText)
+      expect(
+        resp.routes['/broken/page'] == null ||
+          resp.routes['/broken/page'].issues.length === 0
+      ).toBe(true)
+    })
+  })
+})

--- a/test/development/mcp-server/mcp-server-get-compilation-issues.test.ts
+++ b/test/development/mcp-server/mcp-server-get-compilation-issues.test.ts
@@ -2,94 +2,100 @@ import { FileRef, nextTestSetup } from 'e2e-utils'
 import path from 'path'
 import { retry } from 'next-test-utils'
 
-describe('mcp-server get_compilation_issues tool', () => {
-  const { next, skipped } = nextTestSetup({
-    files: new FileRef(
-      path.join(__dirname, 'fixtures', 'compilation-issues-app')
-    ),
-    skipDeployment: true,
-  })
-
-  if (skipped) {
-    return
-  }
-
-  async function callGetCompilationIssues(): Promise<string> {
-    const response = await fetch(`${next.url}/_next/mcp`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Accept: 'application/json, text/event-stream',
-      },
-      body: JSON.stringify({
-        jsonrpc: '2.0',
-        id: `test-${Date.now()}`,
-        method: 'tools/call',
-        params: { name: 'get_compilation_issues', arguments: {} },
-      }),
+// get_compilation_issues is Turbopack-only (requires live endpoint state)
+;(process.env.IS_TURBOPACK_TEST ? describe : describe.skip)(
+  'mcp-server get_compilation_issues tool',
+  () => {
+    const { next, skipped } = nextTestSetup({
+      files: new FileRef(
+        path.join(__dirname, 'fixtures', 'compilation-issues-app')
+      ),
+      skipDeployment: true,
     })
 
-    const text = await response.text()
-    const match = text.match(/data: ({.*})/s)
-    const result = JSON.parse(match![1])
-    return result.result?.content?.[0]?.text
-  }
+    if (skipped) {
+      return
+    }
 
-  it('should return empty issues for a page with no errors', async () => {
-    await next.browser('/')
+    async function callGetCompilationIssues(): Promise<string> {
+      const response = await fetch(`${next.url}/_next/mcp`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json, text/event-stream',
+        },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: `test-${Date.now()}`,
+          method: 'tools/call',
+          params: { name: 'get_compilation_issues', arguments: {} },
+        }),
+      })
 
-    let response: any = null
-    await retry(async () => {
-      const responseText = await callGetCompilationIssues()
-      response = JSON.parse(responseText)
-      // The '/page' route should be present once the page has been compiled
-      expect(response.routes).toHaveProperty('/page')
+      const text = await response.text()
+      const match = text.match(/data: ({.*})/s)
+      const result = JSON.parse(match![1])
+      return result.result?.content?.[0]?.text
+    }
+
+    it('should return empty issues for a page with no errors', async () => {
+      await next.browser('/')
+
+      let response: any = null
+      await retry(async () => {
+        const responseText = await callGetCompilationIssues()
+        response = JSON.parse(responseText)
+        // The '/page' route should be present once the page has been compiled
+        expect(response.routes).toHaveProperty('/page')
+      })
+
+      expect(response.routes['/page'].issues).toEqual([])
     })
 
-    expect(response.routes['/page'].issues).toEqual([])
-  })
+    it('should return compilation issues for a page with a syntax error', async () => {
+      await next.browser('/broken')
 
-  it('should return compilation issues for a page with a syntax error', async () => {
-    await next.browser('/broken')
+      let response: any = null
+      await retry(async () => {
+        const responseText = await callGetCompilationIssues()
+        response = JSON.parse(responseText)
+        expect(response.routes['/broken/page']?.issues?.length).toBeGreaterThan(
+          0
+        )
+      })
 
-    let response: any = null
-    await retry(async () => {
-      const responseText = await callGetCompilationIssues()
-      response = JSON.parse(responseText)
-      expect(response.routes['/broken/page']?.issues?.length).toBeGreaterThan(0)
+      const issue = response.routes['/broken/page'].issues[0]
+      expect(issue).toMatchObject({
+        severity: 'error',
+        filePath: expect.stringContaining('broken/page.tsx'),
+      })
     })
 
-    const issue = response.routes['/broken/page'].issues[0]
-    expect(issue).toMatchObject({
-      severity: 'error',
-      filePath: expect.stringContaining('broken/page.tsx'),
-    })
-  })
+    it('should reflect fixed issues after the file is patched', async () => {
+      await next.browser('/broken')
 
-  it('should reflect fixed issues after the file is patched', async () => {
-    await next.browser('/broken')
+      // Confirm there are issues before patching
+      await retry(async () => {
+        const resp = JSON.parse(await callGetCompilationIssues())
+        expect(resp.routes['/broken/page']?.issues?.length).toBeGreaterThan(0)
+      })
 
-    // Confirm there are issues before patching
-    await retry(async () => {
-      const resp = JSON.parse(await callGetCompilationIssues())
-      expect(resp.routes['/broken/page']?.issues?.length).toBeGreaterThan(0)
-    })
-
-    // Patch the broken page to a valid implementation
-    await next.patchFile(
-      'app/broken/page.tsx',
-      `export default function BrokenPage() {
+      // Patch the broken page to a valid implementation
+      await next.patchFile(
+        'app/broken/page.tsx',
+        `export default function BrokenPage() {
   return <div>Fixed</div>
 }`
-    )
+      )
 
-    // After the fix, the issues for '/broken/page' should be empty
-    await retry(async () => {
-      const resp = JSON.parse(await callGetCompilationIssues())
-      expect(
-        resp.routes['/broken/page'] == null ||
-          resp.routes['/broken/page'].issues.length === 0
-      ).toBe(true)
+      // After the fix, the issues for '/broken/page' should be empty
+      await retry(async () => {
+        const resp = JSON.parse(await callGetCompilationIssues())
+        expect(
+          resp.routes['/broken/page'] == null ||
+            resp.routes['/broken/page'].issues.length === 0
+        ).toBe(true)
+      })
     })
-  })
-})
+  }
+)


### PR DESCRIPTION
### What?

Adds a new MCP tool `get_compilation_issues` to the Next.js dev server MCP interface. The tool returns fresh Turbopack compilation issues (errors, warnings, all severities) as JSON, grouped by route, for all routes compiled in the current dev session.

### Why?

AI coding agents using the MCP server need a reliable way to query the current compilation state of a Next.js app — specifically to know which routes have errors and what those errors are. Previously the only way to surface compilation errors was through browser HMR messages or log inspection. A dedicated MCP tool lets agents poll for issues programmatically without needing to open a browser.

### How?

**New Rust NAPI binding** (`crates/next-napi-bindings/src/next_api/endpoint.rs`):
- Adds `EndpointIssuesPeek` value type (like `WrittenEndpointWithIssues` but without writing to disk or collecting effects)
- Adds `peek_endpoint_issues_operation` turbo-tasks operation that peeks issues from `endpoint_server_changed_operation` — read-only, no side effects
- Exposes `endpoint_get_issues` as a `#[napi]` function

**TypeScript wiring** (`packages/next/src/build/swc/`):
- Adds `getIssues()` to the `Endpoint` interface in `types.ts`
- Implements `getIssues()` in `EndpointImpl` in `index.ts`
- Adds the generated declaration in `generated-native.d.ts`

**MCP tool** (`packages/next/src/server/mcp/tools/get-compilation-issues.ts`):
- Reads the set of compiled routes from `writtenEntrypoints` (the map of `EntryKey → WrittenEndpoint` maintained by the Turbopack hot-reloader)
- For each compiled route, looks up the `Endpoint` from `currentEntrypoints` and calls `endpoint.getIssues()`
- Uses `htmlEndpoint` for page-rendering routes (`app-page`, `page`) as the primary compilation unit; `endpoint` for API routes (`app-route`, `page-api`)
- Returns issues grouped by route as JSON

**MCP server registration** (`packages/next/src/server/mcp/get-or-create-mcp-server.ts`):
- Extends `McpServerOptions` with optional `getCurrentEntrypoints` and `getWrittenEntrypoints` accessors
- Conditionally registers the tool only when running with Turbopack (webpack dev server does not expose endpoint state)

**Hot-reloader integration** (`packages/next/src/server/dev/hot-reloader-turbopack.ts`):
- Passes `currentEntrypoints` and `currentWrittenEntrypoints` closures to the MCP middleware

**Telemetry**: Added `'mcp/get_compilation_issues'` to the `McpToolName` union.

**Tests** (`test/development/mcp-server/mcp-server-get-compilation-issues.test.ts`):
- E2e tests covering three scenarios:
  - Clean page → empty issues list
  - Page with syntax error → issues present with correct severity/filePath
  - File patched to fix the error → issues clear after recompile

### Checklist

- [x] e2e tests added
- [x] Telemetry added (`mcp/get_compilation_issues`)
- [x] Turbopack-only (guarded by `if (getCurrentEntrypoints && getWrittenEntrypoints)`)
- [x] No webpack regression (tool simply not registered for webpack)