### PR TITLE
fix: pin 19 unpinned action(s),extract 7 unsafe expression(s) to env vars

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -237,7 +237,7 @@ jobs:
 
       - name: Cache on ${{ github.ref_name }}
         if: ${{ !matrix.docker }}
-        uses: ijjk/rust-cache@turbo-cache-v1.0.9
+        uses: ijjk/rust-cache@a34594c450817c9860143c79797a8770c4e587f5 # turbo-cache-v1.0.9
         with:
           save-if: 'true'
           cache-provider: 'turbo'
@@ -558,7 +558,9 @@ jobs:
         run: pnpx turbo@canary run build --only --filter='./turbopack/packages/*'
 
       - name: Write NPM_TOKEN
-        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN_ELEVATED }}" > ~/.npmrc
+        run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN_ELEVATED}" > ~/.npmrc
+        env:
+          NPM_TOKEN_ELEVATED: ${{ secrets.NPM_TOKEN_ELEVATED }}
 
       - name: Publish
         run: cargo xtask workspace --publish

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -239,7 +239,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: ast-grep lint step
-        uses: ast-grep/action@v1.5.0
+        uses: ast-grep/action@cf62e780f0c88301228978d593a7784427a097a6 # v1.5.0
         with:
           # Keep in sync with the next.js repo's root package.json
           version: 0.31.0

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -236,7 +236,7 @@ jobs:
 
       - name: Install nextest
         if: ${{ inputs.needsNextest == 'yes' }}
-        uses: taiki-e/install-action@nextest
+        uses: taiki-e/install-action@3a0adc33ab45d7b9b9da91822dd2b3c0151704be # nextest
 
       - run: rustc --version
         if: ${{ inputs.skipNativeBuild != 'yes' || inputs.needsNextest == 'yes' || inputs.needsRust == 'yes' }}
@@ -244,7 +244,7 @@ jobs:
       - run: corepack prepare --activate yarn@1.22.19 && npm i -g "@napi-rs/cli@${NAPI_CLI_VERSION}"
 
       - name: Cache on ${{ github.ref_name }}
-        uses: ijjk/rust-cache@turbo-cache-v1.0.9
+        uses: ijjk/rust-cache@a34594c450817c9860143c79797a8770c4e587f5 # turbo-cache-v1.0.9
         if: ${{ inputs.rustCacheKey }}
         with:
           cache-provider: 'turbo'

--- a/.github/workflows/code_freeze.yml
+++ b/.github/workflows/code_freeze.yml
@@ -42,6 +42,7 @@ jobs:
       - name: tune linux network
         run: sudo ethtool -K eth0 tx off rx off
 
-      - run: node ./scripts/code-freeze.js --type ${{ github.event.inputs.type }}
+      - run: node ./scripts/code-freeze.js --type ${INPUT_TYPE}
         env:
           CODE_FREEZE_TOKEN: ${{ secrets.CODE_FREEZE_TOKEN }}
+          INPUT_TYPE: ${{ github.event.inputs.type }}

--- a/.github/workflows/create_release_branch.yml
+++ b/.github/workflows/create_release_branch.yml
@@ -70,6 +70,8 @@ jobs:
 
       - run: pnpm install
 
-      - run: node ./scripts/create-release-branch.js --branch-name ${{ github.event.inputs.branchName }} --tag-name ${{ github.event.inputs.tagName }}
+      - run: node ./scripts/create-release-branch.js --branch-name ${INPUT_BRANCHNAME} --tag-name ${INPUT_TAGNAME}
         env:
           RELEASE_BOT_GITHUB_TOKEN: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
+          INPUT_BRANCHNAME: ${{ github.event.inputs.branchName }}
+          INPUT_TAGNAME: ${{ github.event.inputs.tagName }}

--- a/.github/workflows/graphite_ci_optimizer.yml
+++ b/.github/workflows/graphite_ci_optimizer.yml
@@ -40,12 +40,15 @@ jobs:
     steps:
       - name: Optimize CI
         id: check-skip
-        uses: withgraphite/graphite-ci-action@main
+        uses: withgraphite/graphite-ci-action@ee395f3a78254c006d11339669c6cabddf196f72 # main
         with:
           graphite_token: ${{ secrets.GRAPHITE_TOKEN }}
       - name: Debug Output
         run: |
           echo 'github.event_name: ${{ github.event_name }}'
-          echo "secrets.GRAPHITE_TOKEN != '': ${{ secrets.GRAPHITE_TOKEN != '' }}"
+          echo "secrets.GRAPHITE_TOKEN != '': ${GRAPHITE_TOKEN}"
           echo 'env.HAS_BYPASS_LABEL: ${{ env.HAS_BYPASS_LABEL }}'
           echo 'steps.check-skip.outputs.skip: ${{ steps.check-skip.outputs.skip }}'
+
+        env:
+          GRAPHITE_TOKEN: ${{ secrets.GRAPHITE_TOKEN != '' }}

--- a/.github/workflows/issue_lock.yml
+++ b/.github/workflows/issue_lock.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'vercel'
     steps:
-      - uses: dessant/lock-threads@v5
+      - uses: dessant/lock-threads@1bf7ec25051fe7c00bdd17e6a7cf3d7bfb7dc771 # v5
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           add-issue-labels: 'locked'

--- a/.github/workflows/retry_deploy_test.yml
+++ b/.github/workflows/retry_deploy_test.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: send webhook
-        uses: slackapi/slack-github-action@v1.25.0
+        uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001 # v1.25.0
         with:
           payload: |
             {

--- a/.github/workflows/retry_test.yml
+++ b/.github/workflows/retry_test.yml
@@ -138,7 +138,7 @@ jobs:
             return await rerunIfRequiredNotSuccessful()
       - name: send webhook
         if: ${{ steps.required_job_conclusion.outputs.result != '"success"' }}
-        uses: slackapi/slack-github-action@v1.25.0
+        uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001 # v1.25.0
         with:
           # These urls are intentionally missing the protocol,
           # allowing them to be transformed into actual links in the Slack workflow

--- a/.github/workflows/setup-nextjs-build.yml
+++ b/.github/workflows/setup-nextjs-build.yml
@@ -30,11 +30,11 @@ jobs:
           node-version: ${{ inputs.nodeVersion || env.NODE_LTS_VERSION }}
           check-latest: true
       - name: Get number of CPU cores
-        uses: SimenB/github-actions-cpu-cores@v2
+        uses: SimenB/github-actions-cpu-cores@97ba232459a8e02ff6121db9362b09661c875ab8 # v2
         id: cpu-cores
 
       - name: 'Setup Rust toolchain'
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
 
       - name: Display runner information
         run: echo runner cpu count ${{ steps.cpu-cores.outputs.count }}

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -23,7 +23,7 @@ jobs:
         github.event.issue.type.name != 'Documentation'
       }}
     steps:
-      - uses: balazsorban44/nissuer@1.10.0
+      - uses: balazsorban44/nissuer@92ef22afd6a75e5e588f5d689a1fd3433f596f82 # 1.10.0
         with:
           label-area-prefix: ''
           label-area-match: 'name'

--- a/.github/workflows/trigger_release.yml
+++ b/.github/workflows/trigger_release.yml
@@ -101,6 +101,8 @@ jobs:
 
       - run: pnpm install
 
-      - run: node ./scripts/start-release.js --release-type ${{ github.event.inputs.releaseType || 'canary' }} --semver-type ${{ github.event.inputs.semverType }}
+      - run: node ./scripts/start-release.js --release-type ${INPUT_RELEASETYPE} --semver-type ${INPUT_SEMVERTYPE}
         env:
           RELEASE_BOT_GITHUB_TOKEN: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
+          INPUT_RELEASETYPE: ${{ github.event.inputs.releaseType || 'canary' }}
+          INPUT_SEMVERTYPE: ${{ github.event.inputs.semverType }}

--- a/.github/workflows/turbopack-benchmark.yml
+++ b/.github/workflows/turbopack-benchmark.yml
@@ -36,12 +36,12 @@ jobs:
         uses: ./.github/actions/setup-rust
 
       - name: Install cargo-codspeed
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@7627fb428e65e78e2ec9a24ae5c5bd5f8553f182 # v2
         with:
           tool: cargo-codspeed@3.0.5
 
       - name: Cache on ${{ github.ref_name }}
-        uses: ijjk/rust-cache@turbo-cache-v1.0.9
+        uses: ijjk/rust-cache@a34594c450817c9860143c79797a8770c4e587f5 # turbo-cache-v1.0.9
         with:
           save-if: 'true'
           cache-provider: 'turbo'
@@ -60,7 +60,7 @@ jobs:
         run: cargo codspeed build -p turbopack-cli small_apps
 
       - name: Run the benchmarks
-        uses: CodSpeedHQ/action@v4
+        uses: CodSpeedHQ/action@1c8ae4843586d3ba879736b7f6b7b0c990757fab # v4
         with:
           mode: instrumentation
           run: cargo codspeed run -p turbopack-cli small_apps
@@ -76,12 +76,12 @@ jobs:
         uses: ./.github/actions/setup-rust
 
       - name: Install cargo-codspeed
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@7627fb428e65e78e2ec9a24ae5c5bd5f8553f182 # v2
         with:
           tool: cargo-codspeed@3.0.5
 
       - name: Cache on ${{ github.ref_name }}
-        uses: ijjk/rust-cache@turbo-cache-v1.0.9
+        uses: ijjk/rust-cache@a34594c450817c9860143c79797a8770c4e587f5 # turbo-cache-v1.0.9
         with:
           save-if: 'true'
           cache-provider: 'turbo'
@@ -100,7 +100,7 @@ jobs:
         run: cargo codspeed build -p turbopack-ecmascript references
 
       - name: Run the benchmarks
-        uses: CodSpeedHQ/action@v4
+        uses: CodSpeedHQ/action@1c8ae4843586d3ba879736b7f6b7b0c990757fab # v4
         with:
           mode: instrumentation
           run: cargo codspeed run -p turbopack-ecmascript references
@@ -117,7 +117,7 @@ jobs:
         uses: ./.github/actions/setup-rust
 
       - name: Install cargo-codspeed
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@7627fb428e65e78e2ec9a24ae5c5bd5f8553f182 # v2
         with:
           tool: cargo-codspeed@3.0.5
 
@@ -127,7 +127,7 @@ jobs:
         run: cargo codspeed build -p turbopack -p turbopack-bench
 
       - name: Run the benchmarks
-        uses: CodSpeedHQ/action@v4
+        uses: CodSpeedHQ/action@1c8ae4843586d3ba879736b7f6b7b0c990757fab # v4
         with:
           mode: instrumentation
           run: cargo codspeed run


### PR DESCRIPTION
## Fix: CI/CD Security Vulnerabilities in GitHub Actions

Hi! [Runner Guard](https://github.com/Vigilant-LLC/runner-guard), an open-source
CI/CD security scanner by [Vigilant Cyber Security](https://www.vigilantdefense.com),
identified security vulnerabilities in this repository's GitHub Actions workflows.

This PR applies automated fixes where possible and reports additional findings
for your review.

### Fixes applied (in this PR)

| Rule | Severity | File | Description |
|------|----------|------|-------------|
| RGS-007 | high | `.github/workflows/build_and_deploy.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-002 | high | `.github/workflows/build_and_deploy.yml` | Extracted 1 unsafe expression(s) to env vars |
| RGS-007 | high | `.github/workflows/build_and_test.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/build_reusable.yml` | Pinned 2 third-party action(s) to commit SHA |
| RGS-002 | high | `.github/workflows/code_freeze.yml` | Extracted 1 unsafe expression(s) to env vars |
| RGS-002 | high | `.github/workflows/create_release_branch.yml` | Extracted 2 unsafe expression(s) to env vars |
| RGS-007 | high | `.github/workflows/graphite_ci_optimizer.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-002 | high | `.github/workflows/graphite_ci_optimizer.yml` | Extracted 1 unsafe expression(s) to env vars |
| RGS-007 | high | `.github/workflows/issue_lock.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/retry_deploy_test.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/retry_test.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/setup-nextjs-build.yml` | Pinned 2 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/triage.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-002 | high | `.github/workflows/trigger_release.yml` | Extracted 2 unsafe expression(s) to env vars |
| RGS-007 | high | `.github/workflows/turbopack-benchmark.yml` | Pinned 8 third-party action(s) to commit SHA |


### Advisory: additional findings (manual review recommended)

| Rule | Severity | File | Description |
| RGS-002 | critical | `.github/workflows/build_and_deploy.yml` | Expression Injection via Branch Name or Untrusted Input |
| RGS-018 | high | `.github/workflows/build_and_deploy.yml` | Suspicious Payload Execution Pattern |
| RGS-017 | high | `.github/workflows/build_and_test.yml` | Unicode Steganography in Referenced Script |
| RGS-018 | high | `.github/workflows/build_reusable.yml` | Suspicious Payload Execution Pattern |
| RGS-004 | high | `.github/workflows/retry_deploy_test.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/retry_test.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/retry_test.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/retry_test.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/retry_test.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/triage.yml` | Comment-Triggered Workflow Without Author Authorization Check |


### Why this matters

GitHub Actions workflows that use untrusted input in `run:` blocks, expose
secrets inline, or use unpinned third-party actions are vulnerable to
code injection, credential theft, and supply chain attacks. These are the same
vulnerability classes exploited in the [tj-actions/changed-files incident](https://www.vigilantdefense.com/resources/runner-guard)
and subsequent supply chain attacks, which compromised CI secrets across
thousands of repositories.

### How to verify

Review the diff — each change is mechanical and preserves workflow behavior:
- **Expression extraction** (RGS-002/008/014): Moves `${{ }}` expressions from
  `run:` blocks into `env:` mappings, preventing shell injection
- **SHA pinning** (RGS-007): Pins third-party actions to immutable commit SHAs
  (original version tag preserved as comment)
- **Debug env removal** (RGS-015): Removes `ACTIONS_RUNNER_DEBUG`/`ACTIONS_STEP_DEBUG`
  which leak secrets in workflow logs

Run `brew install Vigilant-LLC/tap/runner-guard && runner-guard scan .` or install from the
[repo](https://github.com/Vigilant-LLC/runner-guard) to verify.

---

Found by [Runner Guard](https://github.com/Vigilant-LLC/runner-guard) | Built by [Vigilant Cyber Security](https://www.vigilantdefense.com) | [Learn more](https://www.vigilantdefense.com/resources/runner-guard)

If this PR is not welcome, just close it -- we won't send another.