### PR TITLE
examples: add with-pompelmi-upload example

### DIFF
--- a/examples/with-pompelmi-upload/README.md
+++ b/examples/with-pompelmi-upload/README.md
@@ -1,0 +1,23 @@
+# with-pompelmi-upload
+
+A minimal Next.js App Router example showing how to scan uploaded files with Pompelmi before storage or further processing.
+
+## Features
+
+- App Router
+- Route Handler upload endpoint
+- In-process file scanning
+- Simple JSON verdict response
+
+## Run locally
+
+```bash
+pnpm install
+pnpm dev
+```
+
+Open http://localhost:3000 and upload a file.
+
+Notes
+
+This example demonstrates how to place scanning logic at the upload boundary using @pompelmi/next-upload.

--- a/examples/with-pompelmi-upload/README.md
+++ b/examples/with-pompelmi-upload/README.md
@@ -18,6 +18,6 @@ pnpm dev
 
 Open http://localhost:3000 and upload a file.
 
-Notes
+## Notes
 
 This example demonstrates how to place scanning logic at the upload boundary using @pompelmi/next-upload.

--- a/examples/with-pompelmi-upload/app/api/upload/route.ts
+++ b/examples/with-pompelmi-upload/app/api/upload/route.ts
@@ -1,0 +1,42 @@
+import { createNextUploadHandler } from '@pompelmi/next-upload'
+import {
+  CommonHeuristicsScanner,
+  composeScanners,
+  createZipBombGuard,
+} from 'pompelmi'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+const policy = {
+  includeExtensions: ['zip', 'png', 'jpg', 'jpeg', 'pdf', 'txt'],
+  allowedMimeTypes: [
+    'application/zip',
+    'image/png',
+    'image/jpeg',
+    'application/pdf',
+    'text/plain',
+  ],
+  maxFileSizeBytes: 20 * 1024 * 1024,
+  failClosed: true,
+}
+
+const scanner = composeScanners(
+  [
+    [
+      'zipGuard',
+      createZipBombGuard({
+        maxEntries: 512,
+        maxTotalUncompressedBytes: 100 * 1024 * 1024,
+        maxCompressionRatio: 12,
+      }),
+    ],
+    ['heuristics', CommonHeuristicsScanner],
+  ],
+  { stopOn: 'suspicious' }
+)
+
+export const POST = createNextUploadHandler({
+  ...policy,
+  scanner,
+})

--- a/examples/with-pompelmi-upload/app/api/upload/route.ts
+++ b/examples/with-pompelmi-upload/app/api/upload/route.ts
@@ -1,42 +1,42 @@
-import { createNextUploadHandler } from '@pompelmi/next-upload'
+import { createNextUploadHandler } from "@pompelmi/next-upload";
 import {
   CommonHeuristicsScanner,
   composeScanners,
   createZipBombGuard,
-} from 'pompelmi'
+} from "pompelmi";
 
-export const runtime = 'nodejs'
-export const dynamic = 'force-dynamic'
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
 
 const policy = {
-  includeExtensions: ['zip', 'png', 'jpg', 'jpeg', 'pdf', 'txt'],
+  includeExtensions: ["zip", "png", "jpg", "jpeg", "pdf", "txt"],
   allowedMimeTypes: [
-    'application/zip',
-    'image/png',
-    'image/jpeg',
-    'application/pdf',
-    'text/plain',
+    "application/zip",
+    "image/png",
+    "image/jpeg",
+    "application/pdf",
+    "text/plain",
   ],
   maxFileSizeBytes: 20 * 1024 * 1024,
   failClosed: true,
-}
+};
 
 const scanner = composeScanners(
   [
     [
-      'zipGuard',
+      "zipGuard",
       createZipBombGuard({
         maxEntries: 512,
         maxTotalUncompressedBytes: 100 * 1024 * 1024,
         maxCompressionRatio: 12,
       }),
     ],
-    ['heuristics', CommonHeuristicsScanner],
+    ["heuristics", CommonHeuristicsScanner],
   ],
-  { stopOn: 'suspicious' }
-)
+  { stopOn: "suspicious" }
+);
 
 export const POST = createNextUploadHandler({
   ...policy,
   scanner,
-})
+});

--- a/examples/with-pompelmi-upload/app/layout.tsx
+++ b/examples/with-pompelmi-upload/app/layout.tsx
@@ -1,0 +1,14 @@
+import type { ReactNode } from 'react'
+
+export const metadata = {
+  title: 'with-pompelmi-upload',
+  description: 'Minimal Next.js upload scanning example with Pompelmi',
+}
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/examples/with-pompelmi-upload/app/layout.tsx
+++ b/examples/with-pompelmi-upload/app/layout.tsx
@@ -1,14 +1,14 @@
-import type { ReactNode } from 'react'
+import type { ReactNode } from "react";
 
 export const metadata = {
-  title: 'with-pompelmi-upload',
-  description: 'Minimal Next.js upload scanning example with Pompelmi',
-}
+  title: "with-pompelmi-upload",
+  description: "Minimal Next.js upload scanning example with Pompelmi",
+};
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
       <body>{children}</body>
     </html>
-  )
+  );
 }

--- a/examples/with-pompelmi-upload/app/page.tsx
+++ b/examples/with-pompelmi-upload/app/page.tsx
@@ -1,48 +1,50 @@
-'use client'
+"use client";
 
-import { FormEvent, useState } from 'react'
+import { FormEvent, useState } from "react";
 
-type ApiResult = unknown
+type ApiResult = unknown;
 
 export default function Page() {
-  const [loading, setLoading] = useState(false)
-  const [result, setResult] = useState<ApiResult | null>(null)
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<ApiResult | null>(null);
 
   async function onSubmit(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault()
-    setLoading(true)
-    setResult(null)
+    event.preventDefault();
+    setLoading(true);
+    setResult(null);
 
-    const form = event.currentTarget
-    const input = form.elements.namedItem('file') as HTMLInputElement | null
-    const file = input?.files?.[0]
+    const form = event.currentTarget;
+    const input = form.elements.namedItem("file") as HTMLInputElement | null;
+    const file = input?.files?.[0];
 
     if (!file) {
-      setLoading(false)
-      return
+      setLoading(false);
+      return;
     }
 
-    const formData = new FormData()
-    formData.append('file', file)
+    const formData = new FormData();
+    formData.append("file", file);
 
     try {
-      const response = await fetch('/api/upload', {
-        method: 'POST',
+      const response = await fetch("/api/upload", {
+        method: "POST",
         body: formData,
-      })
+      });
 
       if (!response.ok) {
-        throw new Error(`Upload failed with status ${response.status}`)
+        throw new Error(`Upload failed with status ${response.status}`);
       }
 
-      const json = await response.json()
-      setResult(json)
+      const json = await response.json();
+      setResult(json);
     } catch (error: unknown) {
       const message =
-        error instanceof Error ? error.message : 'An unexpected error occurred during upload.'
-      setResult({ error: message })
+        error instanceof Error
+          ? error.message
+          : "An unexpected error occurred during upload.";
+      setResult({ error: message });
     } finally {
-      setLoading(false)
+      setLoading(false);
     }
   }
 
@@ -50,18 +52,18 @@ export default function Page() {
     <main
       style={{
         maxWidth: 760,
-        margin: '40px auto',
-        padding: '0 16px',
-        fontFamily: 'Arial, sans-serif',
+        margin: "40px auto",
+        padding: "0 16px",
+        fontFamily: "Arial, sans-serif",
       }}
     >
       <h1>Next.js + Pompelmi</h1>
       <p>Upload a file and inspect it before storage.</p>
 
-      <form onSubmit={onSubmit} style={{ display: 'flex', gap: 12, alignItems: 'center' }}>
+      <form onSubmit={onSubmit} style={{ display: "flex", gap: 12, alignItems: "center" }}>
         <input name="file" type="file" />
         <button type="submit" disabled={loading}>
-          {loading ? 'Scanning...' : 'Upload'}
+          {loading ? "Scanning..." : "Upload"}
         </button>
       </form>
 
@@ -70,14 +72,14 @@ export default function Page() {
           style={{
             marginTop: 24,
             padding: 16,
-            background: '#f5f5f5',
+            background: "#f5f5f5",
             borderRadius: 8,
-            overflowX: 'auto',
+            overflowX: "auto",
           }}
         >
           {JSON.stringify(result, null, 2)}
         </pre>
       )}
     </main>
-  )
+  );
 }

--- a/examples/with-pompelmi-upload/app/page.tsx
+++ b/examples/with-pompelmi-upload/app/page.tsx
@@ -25,14 +25,25 @@ export default function Page() {
     const formData = new FormData()
     formData.append('file', file)
 
-    const response = await fetch('/api/upload', {
-      method: 'POST',
-      body: formData,
-    })
+    try {
+      const response = await fetch('/api/upload', {
+        method: 'POST',
+        body: formData,
+      })
 
-    const json = await response.json()
-    setResult(json)
-    setLoading(false)
+      if (!response.ok) {
+        throw new Error(`Upload failed with status ${response.status}`)
+      }
+
+      const json = await response.json()
+      setResult(json)
+    } catch (error: unknown) {
+      const message =
+        error instanceof Error ? error.message : 'An unexpected error occurred during upload.'
+      setResult({ error: message })
+    } finally {
+      setLoading(false)
+    }
   }
 
   return (

--- a/examples/with-pompelmi-upload/app/page.tsx
+++ b/examples/with-pompelmi-upload/app/page.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+import { FormEvent, useState } from 'react'
+
+type ApiResult = unknown
+
+export default function Page() {
+  const [loading, setLoading] = useState(false)
+  const [result, setResult] = useState<ApiResult | null>(null)
+
+  async function onSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    setLoading(true)
+    setResult(null)
+
+    const form = event.currentTarget
+    const input = form.elements.namedItem('file') as HTMLInputElement | null
+    const file = input?.files?.[0]
+
+    if (!file) {
+      setLoading(false)
+      return
+    }
+
+    const formData = new FormData()
+    formData.append('file', file)
+
+    const response = await fetch('/api/upload', {
+      method: 'POST',
+      body: formData,
+    })
+
+    const json = await response.json()
+    setResult(json)
+    setLoading(false)
+  }
+
+  return (
+    <main
+      style={{
+        maxWidth: 760,
+        margin: '40px auto',
+        padding: '0 16px',
+        fontFamily: 'Arial, sans-serif',
+      }}
+    >
+      <h1>Next.js + Pompelmi</h1>
+      <p>Upload a file and inspect it before storage.</p>
+
+      <form onSubmit={onSubmit} style={{ display: 'flex', gap: 12, alignItems: 'center' }}>
+        <input name="file" type="file" />
+        <button type="submit" disabled={loading}>
+          {loading ? 'Scanning...' : 'Upload'}
+        </button>
+      </form>
+
+      {result && (
+        <pre
+          style={{
+            marginTop: 24,
+            padding: 16,
+            background: '#f5f5f5',
+            borderRadius: 8,
+            overflowX: 'auto',
+          }}
+        >
+          {JSON.stringify(result, null, 2)}
+        </pre>
+      )}
+    </main>
+  )
+}

--- a/examples/with-pompelmi-upload/next-env.d.ts
+++ b/examples/with-pompelmi-upload/next-env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />

--- a/examples/with-pompelmi-upload/next.config.ts
+++ b/examples/with-pompelmi-upload/next.config.ts
@@ -1,0 +1,5 @@
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {}
+
+export default nextConfig

--- a/examples/with-pompelmi-upload/next.config.ts
+++ b/examples/with-pompelmi-upload/next.config.ts
@@ -1,5 +1,5 @@
-import type { NextConfig } from 'next'
+import type { NextConfig } from "next";
 
-const nextConfig: NextConfig = {}
+const nextConfig: NextConfig = {};
 
-export default nextConfig
+export default nextConfig;

--- a/examples/with-pompelmi-upload/package.json
+++ b/examples/with-pompelmi-upload/package.json
@@ -1,0 +1,21 @@
+{
+  "private": true,
+  "scripts": {
+    "dev": "next dev --turbopack",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "pompelmi": "latest",
+    "@pompelmi/next-upload": "latest"
+  },
+  "devDependencies": {
+    "@types/node": "20.10.8",
+    "@types/react": "18.2.47",
+    "@types/react-dom": "18.2.18",
+    "typescript": "^5.3.3"
+  }
+}

--- a/examples/with-pompelmi-upload/tsconfig.json
+++ b/examples/with-pompelmi-upload/tsconfig.json
@@ -17,6 +17,6 @@
       { "name": "next" }
     ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", ".next/dev/types/**/*.ts"],
   "exclude": ["node_modules"]
 }

--- a/examples/with-pompelmi-upload/tsconfig.json
+++ b/examples/with-pompelmi-upload/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      { "name": "next" }
+    ]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary

Add a minimal example showing how to scan uploaded files in a Next.js App Router project using Pompelmi.

## Why

File uploads are a common production use case, but many examples stop at parsing and storing files.
This example shows how to inspect untrusted uploads before storage or downstream processing.

## What the example includes

* App Router setup
* upload form
* Route Handler for POST uploads
* integration with `@pompelmi/next-upload`
* JSON response with a simple verdict flow

## Package

https://github.com/pompelmi/pompelmi/tree/main/packages/next-upload
