### PR TITLE
fix(create-next-app): add pnpm 10.0–10.4 workspace.yaml compatibility

### DIFF
--- a/packages/create-next-app/helpers/get-pkg-manager.ts
+++ b/packages/create-next-app/helpers/get-pkg-manager.ts
@@ -27,12 +27,15 @@ export function getPkgManager(): PackageManager {
  * First tries to parse from npm_config_user_agent (e.g., "pnpm/9.13.2 npm/? ..."),
  * then falls back to spawning `pnpm --version --silent`.
  */
-export function getPnpmMajorVersion(): number | null {
+export function getPnpmVersion(): { major: number; minor: number } | null {
   // Try to get version from user agent first (e.g., "pnpm/9.13.2 npm/? node/v20.x linux x64")
   const userAgent = process.env.npm_config_user_agent || ''
-  const pnpmVersionMatch = userAgent.match(/pnpm\/(\d+)/)
+  const pnpmVersionMatch = userAgent.match(/pnpm\/(\d+)\.(\d+)/)
   if (pnpmVersionMatch) {
-    return parseInt(pnpmVersionMatch[1], 10)
+    return {
+      major: parseInt(pnpmVersionMatch[1], 10),
+      minor: parseInt(pnpmVersionMatch[2], 10),
+    }
   }
 
   // Fall back to spawning pnpm --version
@@ -42,8 +45,12 @@ export function getPnpmMajorVersion(): number | null {
       stdio: ['pipe', 'pipe', 'ignore'],
     }).trim()
     const majorVersion = parseInt(version.split('.')[0], 10)
-    if (!Number.isNaN(majorVersion)) {
-      return majorVersion
+    const minorVersion = parseInt(version.split('.')[1], 10)
+    if (!Number.isNaN(majorVersion) && !Number.isNaN(minorVersion)) {
+      return {
+        major: majorVersion,
+        minor: minorVersion,
+      }
     }
   } catch {
     // pnpm not available or failed to run

--- a/packages/create-next-app/templates/index.ts
+++ b/packages/create-next-app/templates/index.ts
@@ -1,7 +1,7 @@
 import { install } from "../helpers/install";
 import { runTypegen } from "../helpers/typegen";
 import { copy } from "../helpers/copy";
-import { getPnpmMajorVersion } from "../helpers/get-pkg-manager";
+import { getPnpmVersion } from "../helpers/get-pkg-manager";
 
 import { async as glob } from "fast-glob";
 import os from "os";
@@ -324,13 +324,18 @@ export const installTemplate = async ({
     // Only create pnpm-workspace.yaml for pnpm v10+.
     // In v9, having a pnpm-workspace.yaml (even with packages: []) causes
     // ERR_PNPM_ADDING_TO_ROOT errors when running `pnpm add`.
-    // In v10, the packages field can be omitted entirely.
+    // In v10.5.0 and above, the packages field can be omitted entirely.
     // If we can't determine the version, assume latest (v10+) since we already
     // know pnpm is being used at this point.
-    const pnpmMajorVersion = getPnpmMajorVersion();
-    if (pnpmMajorVersion === null || pnpmMajorVersion >= 10) {
+    const pnpmVersion = getPnpmVersion();
+    if (pnpmVersion === null || pnpmVersion.major >= 10) {
       const pnpmWorkspaceYaml = [
         "ignoredBuiltDependencies:",
+        // In v10.5.0 below, the packages field is required
+        // or else ` ERROR  packages field missing or empty` occurs when running `pnpm add`.
+        pnpmVersion?.minor && pnpmVersion?.minor < 5
+          ? "packages: []"
+          : undefined,
         // Sharp has prebuilt binaries for the platforms next-swc has binaries.
         // If it needs to build binaries from source, next-swc wouldn't work either.
         // See https://sharp.pixelplumbing.com/install/#:~:text=When%20using%20pnpm%2C%20add%20sharp%20to%20ignoredBuiltDependencies%20to%20silence%20warnings

--- a/packages/create-next-app/templates/index.ts
+++ b/packages/create-next-app/templates/index.ts
@@ -330,12 +330,12 @@ export const installTemplate = async ({
     const pnpmVersion = getPnpmVersion();
     if (pnpmVersion === null || pnpmVersion.major >= 10) {
       const pnpmWorkspaceYaml = [
-        "ignoredBuiltDependencies:",
         // In v10.5.0 below, the packages field is required
         // or else ` ERROR  packages field missing or empty` occurs when running `pnpm add`.
-        pnpmVersion?.minor && pnpmVersion?.minor < 5
+        pnpmVersion && pnpmVersion.major === 10 && pnpmVersion.minor < 5
           ? "packages: []"
           : undefined,
+        "ignoredBuiltDependencies:",
         // Sharp has prebuilt binaries for the platforms next-swc has binaries.
         // If it needs to build binaries from source, next-swc wouldn't work either.
         // See https://sharp.pixelplumbing.com/install/#:~:text=When%20using%20pnpm%2C%20add%20sharp%20to%20ignoredBuiltDependencies%20to%20silence%20warnings

--- a/packages/create-next-app/templates/index.ts
+++ b/packages/create-next-app/templates/index.ts
@@ -332,9 +332,9 @@ export const installTemplate = async ({
       const pnpmWorkspaceYaml = [
         // In v10.5.0 below, the packages field is required
         // or else ` ERROR  packages field missing or empty` occurs when running `pnpm add`.
-        pnpmVersion && pnpmVersion.major === 10 && pnpmVersion.minor < 5
-          ? "packages: []"
-          : undefined,
+        ...(pnpmVersion && pnpmVersion.major === 10 && pnpmVersion.minor < 5
+          ? ["packages: []", ""]
+          : []),
         "ignoredBuiltDependencies:",
         // Sharp has prebuilt binaries for the platforms next-swc has binaries.
         // If it needs to build binaries from source, next-swc wouldn't work either.
@@ -344,6 +344,7 @@ export const installTemplate = async ({
         "  - unrs-resolver",
         "",
       ].join(os.EOL);
+
       await fs.writeFile(
         path.join(root, "pnpm-workspace.yaml"),
         pnpmWorkspaceYaml,


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?



### Why?

### How?

Closes NEXT-
Fixes #

-->


Fixes #91954 

Problem occurs when trying to create `pnpm add` on a freshly installed next.js app using `pnpm create next-app@latest .` using a semi-outdated pnpm, specifically version between 10.0 and 10.4.5. 

The `package` field was required in the generated `pnpm-workspace.yaml` up until version 10.4.5 where they had removed the requirement afterwards.

A check on pnpm minor version <10.5 was added to include `package: []` on generated `pnpm-workspace.yaml`.

