### PR TITLE
fix(rsc): add charset=utf-8 to text/x-component Content-Type header

### DIFF
--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -54,6 +54,7 @@ import {
   NEXT_DID_POSTPONE_HEADER,
   RSC_CONTENT_TYPE_HEADER,
   NEXT_HMR_REFRESH_HEADER,
+  RSC_CONTENT_TYPE_HEADER_FULL,
 } from '../../client/components/app-router-headers' with { 'turbopack-transition': 'next-server-utility' }
 import {
   getBotType,
@@ -1741,7 +1742,7 @@ export async function handler(
             poweredByHeader: nextConfig.poweredByHeader,
             result: RenderResult.fromStatic(
               matchedSegment,
-              RSC_CONTENT_TYPE_HEADER
+              RSC_CONTENT_TYPE_HEADER_FULL
             ),
             cacheControl: cacheEntry.cacheControl,
           })
@@ -1852,7 +1853,7 @@ export async function handler(
         // If this is a dynamic RSC request, then stream the response.
         if (typeof cachedData.rscData === 'undefined') {
           // If the response is not an RSC response, then we can't serve it.
-          if (cachedData.html.contentType !== RSC_CONTENT_TYPE_HEADER) {
+          if (!cachedData.html.contentType?.startsWith(RSC_CONTENT_TYPE_HEADER)) {
             if (nextConfig.cacheComponents) {
               res.statusCode = 404
               return sendRenderResult({
@@ -1890,7 +1891,7 @@ export async function handler(
           poweredByHeader: nextConfig.poweredByHeader,
           result: RenderResult.fromStatic(
             cachedData.rscData,
-            RSC_CONTENT_TYPE_HEADER
+            RSC_CONTENT_TYPE_HEADER_FULL
           ),
           cacheControl: cacheEntry.cacheControl,
         })

--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -49,6 +49,7 @@ import {
   NEXT_IS_PRERENDER_HEADER,
   NEXT_DID_POSTPONE_HEADER,
   RSC_CONTENT_TYPE_HEADER,
+  RSC_CONTENT_TYPE_HEADER_FULL,
 } from '../../client/components/app-router-headers' with { 'turbopack-transition': 'next-server-utility' }
 import {
   getBotType,
@@ -1556,7 +1557,7 @@ export async function handler(
             poweredByHeader: nextConfig.poweredByHeader,
             result: RenderResult.fromStatic(
               matchedSegment,
-              RSC_CONTENT_TYPE_HEADER
+              RSC_CONTENT_TYPE_HEADER_FULL
             ),
             cacheControl: cacheEntry.cacheControl,
           })
@@ -1661,7 +1662,7 @@ export async function handler(
         // If this is a dynamic RSC request, then stream the response.
         if (typeof cachedData.rscData === 'undefined') {
           // If the response is not an RSC response, then we can't serve it.
-          if (cachedData.html.contentType !== RSC_CONTENT_TYPE_HEADER) {
+          if (!cachedData.html.contentType?.startsWith(RSC_CONTENT_TYPE_HEADER)) {
             if (nextConfig.cacheComponents) {
               res.statusCode = 404
               return sendRenderResult({
@@ -1699,7 +1700,7 @@ export async function handler(
           poweredByHeader: nextConfig.poweredByHeader,
           result: RenderResult.fromStatic(
             cachedData.rscData,
-            RSC_CONTENT_TYPE_HEADER
+            RSC_CONTENT_TYPE_HEADER_FULL
           ),
           cacheControl: cacheEntry.cacheControl,
         })

--- a/packages/next/src/client/components/app-router-headers.ts
+++ b/packages/next/src/client/components/app-router-headers.ts
@@ -15,6 +15,8 @@ export const NEXT_HMR_REFRESH_HEADER = 'next-hmr-refresh' as const
 export const NEXT_HMR_REFRESH_HASH_COOKIE = '__next_hmr_refresh_hash__' as const
 export const NEXT_URL = 'next-url' as const
 export const RSC_CONTENT_TYPE_HEADER = 'text/x-component' as const
+// Full Content-Type value including charset, used when setting response headers.
+export const RSC_CONTENT_TYPE_HEADER_FULL = 'text/x-component; charset=utf-8' as const
 
 // Cookie for the Instant Navigation Testing API. Sent automatically with all
 // requests while a navigation lock is held; the server uses its presence to

--- a/packages/next/src/client/components/app-router-headers.ts
+++ b/packages/next/src/client/components/app-router-headers.ts
@@ -15,6 +15,8 @@ export const NEXT_HMR_REFRESH_HEADER = 'next-hmr-refresh' as const
 export const NEXT_HMR_REFRESH_HASH_COOKIE = '__next_hmr_refresh_hash__' as const
 export const NEXT_URL = 'next-url' as const
 export const RSC_CONTENT_TYPE_HEADER = 'text/x-component' as const
+// Full Content-Type value including charset, used when setting response headers.
+export const RSC_CONTENT_TYPE_HEADER_FULL = 'text/x-component; charset=utf-8' as const
 
 // Header for the Instant Navigation Testing API. In development and testing
 // builds, static pre-renders normally don't happen. This header tells the

--- a/packages/next/src/server/app-render/flight-render-result.ts
+++ b/packages/next/src/server/app-render/flight-render-result.ts
@@ -1,9 +1,9 @@
-import { RSC_CONTENT_TYPE_HEADER } from '../../client/components/app-router-headers'
+import { RSC_CONTENT_TYPE_HEADER_FULL } from '../../client/components/app-router-headers'
 import RenderResult, { type RenderResultMetadata } from '../render-result'
 import type { AnyStream } from './stream-ops'
 
 /**
- * Flight Response is always set to RSC_CONTENT_TYPE_HEADER to ensure it does not get interpreted as HTML.
+ * Flight Response is always set to RSC_CONTENT_TYPE_HEADER_FULL (text/x-component; charset=utf-8) to ensure it does not get interpreted as HTML.
  */
 export class FlightRenderResult extends RenderResult {
   constructor(
@@ -12,7 +12,7 @@ export class FlightRenderResult extends RenderResult {
     waitUntil?: Promise<unknown>
   ) {
     super(response, {
-      contentType: RSC_CONTENT_TYPE_HEADER,
+      contentType: RSC_CONTENT_TYPE_HEADER_FULL,
       metadata,
       waitUntil,
     })

--- a/packages/next/src/server/app-render/flight-render-result.ts
+++ b/packages/next/src/server/app-render/flight-render-result.ts
@@ -1,8 +1,8 @@
-import { RSC_CONTENT_TYPE_HEADER } from '../../client/components/app-router-headers'
+import { RSC_CONTENT_TYPE_HEADER_FULL } from '../../client/components/app-router-headers'
 import RenderResult, { type RenderResultMetadata } from '../render-result'
 
 /**
- * Flight Response is always set to RSC_CONTENT_TYPE_HEADER to ensure it does not get interpreted as HTML.
+ * Flight Response is always set to RSC_CONTENT_TYPE_HEADER_FULL (text/x-component; charset=utf-8) to ensure it does not get interpreted as HTML.
  */
 export class FlightRenderResult extends RenderResult {
   constructor(
@@ -11,7 +11,7 @@ export class FlightRenderResult extends RenderResult {
     waitUntil?: Promise<unknown>
   ) {
     super(response, {
-      contentType: RSC_CONTENT_TYPE_HEADER,
+      contentType: RSC_CONTENT_TYPE_HEADER_FULL,
       metadata,
       waitUntil,
     })

--- a/packages/next/src/server/render-result.ts
+++ b/packages/next/src/server/render-result.ts
@@ -22,10 +22,11 @@ import type {
   JSON_CONTENT_TYPE_HEADER,
   TEXT_PLAIN_CONTENT_TYPE_HEADER,
 } from '../lib/constants'
-import type { RSC_CONTENT_TYPE_HEADER } from '../client/components/app-router-headers'
+import type { RSC_CONTENT_TYPE_HEADER, RSC_CONTENT_TYPE_HEADER_FULL } from '../client/components/app-router-headers'
 
 type ContentTypeOption =
-  | typeof RSC_CONTENT_TYPE_HEADER // For App Page RSC responses
+  | typeof RSC_CONTENT_TYPE_HEADER // For App Page RSC responses (detection)
+  | typeof RSC_CONTENT_TYPE_HEADER_FULL // For App Page RSC response Content-Type headers
   | typeof HTML_CONTENT_TYPE_HEADER // For App Page, Pages HTML responses
   | typeof JSON_CONTENT_TYPE_HEADER // For API routes, Next.js data requests
   | typeof TEXT_PLAIN_CONTENT_TYPE_HEADER // For simplified errors

--- a/packages/next/src/server/render-result.ts
+++ b/packages/next/src/server/render-result.ts
@@ -17,10 +17,11 @@ import type {
   JSON_CONTENT_TYPE_HEADER,
   TEXT_PLAIN_CONTENT_TYPE_HEADER,
 } from '../lib/constants'
-import type { RSC_CONTENT_TYPE_HEADER } from '../client/components/app-router-headers'
+import type { RSC_CONTENT_TYPE_HEADER, RSC_CONTENT_TYPE_HEADER_FULL } from '../client/components/app-router-headers'
 
 type ContentTypeOption =
-  | typeof RSC_CONTENT_TYPE_HEADER // For App Page RSC responses
+  | typeof RSC_CONTENT_TYPE_HEADER // For App Page RSC responses (detection)
+  | typeof RSC_CONTENT_TYPE_HEADER_FULL // For App Page RSC response Content-Type headers
   | typeof HTML_CONTENT_TYPE_HEADER // For App Page, Pages HTML responses
   | typeof JSON_CONTENT_TYPE_HEADER // For API routes, Next.js data requests
   | typeof TEXT_PLAIN_CONTENT_TYPE_HEADER // For simplified errors


### PR DESCRIPTION
## What

RSC flight responses were missing the `charset=utf-8` encoding declaration in their `Content-Type` header. HTML responses use `text/html; charset=utf-8` and JSON responses use `application/json`, but RSC responses only set `text/x-component` — making it impossible for proxies and middleware to reliably patch the Content-Type downstream.

## Why

The `RSC_CONTENT_TYPE_HEADER` constant is used for two different purposes:
1. **Setting** the response `Content-Type` header (server-side)
2. **Detecting** RSC responses via `startsWith()` on incoming headers (client-side)

These had conflicting requirements — the set value needs `; charset=utf-8`, but the detection pattern should match the base MIME type to handle both old and new cached responses.

## How

- Add `RSC_CONTENT_TYPE_HEADER_FULL = 'text/x-component; charset=utf-8'` for use when setting response headers
- Use `RSC_CONTENT_TYPE_HEADER_FULL` in `FlightRenderResult` and `RenderResult.fromStatic()` calls that set the `Content-Type` response header
- Keep `RSC_CONTENT_TYPE_HEADER = 'text/x-component'` for client-side detection and routes manifest (infra compatibility)
- Update the cached contentType comparison to `startsWith()` to handle both old cached values (without charset) and new ones (with charset)

Fixes #91942