### PR TITLE
fix(build): improve getStaticPaths error messages for non-string params

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1145,5 +1145,7 @@
   "1144": "Prefetch inlining is enabled but no hints were found for route \"%s\". This is a bug in the Next.js build pipeline — prefetch-hints.json should contain an entry for every route that produces segment data.",
   "1145": "Internal Next.js Error: Prefetch inlining is enabled but no hints were found for route \"%s\". prefetch-hints.json should contain an entry for every route that produces segment data. This is a bug in Next.js.",
   "1146": "Internal Next.js Error: Prefetch inlining is enabled but no hint tree was provided during incremental static revalidation. The prefetch-hints.json manifest should contain an entry for this route. This is a bug in Next.js.",
-  "1147": "Turbopack database compaction is not supported on this platform"
+  "1147": "Turbopack database compaction is not supported on this platform",
+  "1148": "Parameter \"%s\" from getStaticPaths for %s must be %s, but received %s (%s). See more info here: https://nextjs.org/docs/messages/invalid-getstaticpaths-value",
+  "1149": "Parameter \"%s[%s]\" from getStaticPaths for %s must be a string, but received %s (%s). All elements in catch-all parameter arrays must be strings."
 }

--- a/packages/next/src/build/static-paths/pages.ts
+++ b/packages/next/src/build/static-paths/pages.ts
@@ -9,6 +9,14 @@ import { getRouteMatcher } from '../../shared/lib/router/utils/route-matcher'
 import { getRouteRegex } from '../../shared/lib/router/utils/route-regex'
 import { encodeParam, normalizePathname } from './utils'
 
+function safeStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value)
+  } catch {
+    return String(value)
+  }
+}
+
 export async function buildPagesStaticPaths({
   page,
   getStaticPaths,
@@ -170,7 +178,7 @@ export async function buildPagesStaticPaths({
           throw new Error(
             `Parameter "${validParamKey}" from getStaticPaths for ${page} must be ${
               repeat ? 'an array' : 'a string'
-            }, but received ${typeof paramValue} (${JSON.stringify(paramValue)}). ` +
+            }, but received ${typeof paramValue} (${safeStringify(paramValue)}). ` +
             `See more info here: https://nextjs.org/docs/messages/invalid-getstaticpaths-value`
           )
         }
@@ -180,7 +188,7 @@ export async function buildPagesStaticPaths({
             if (typeof paramValue[i] !== 'string') {
               throw new Error(
                 `Parameter "${validParamKey}[${i}]" from getStaticPaths for ${page} must be a string, ` +
-                `but received ${typeof paramValue[i]} (${JSON.stringify(paramValue[i])}). ` +
+                `but received ${typeof paramValue[i]} (${safeStringify(paramValue[i])}). ` +
                 `All elements in catch-all parameter arrays must be strings.`
               )
             }

--- a/packages/next/src/build/static-paths/pages.ts
+++ b/packages/next/src/build/static-paths/pages.ts
@@ -168,10 +168,23 @@ export async function buildPagesStaticPaths({
           typeof paramValue === 'undefined'
         ) {
           throw new Error(
-            `A required parameter (${validParamKey}) was not provided as ${
+            `Parameter "${validParamKey}" from getStaticPaths for ${page} must be ${
               repeat ? 'an array' : 'a string'
-            } received ${typeof paramValue} in getStaticPaths for ${page}`
+            }, but received ${typeof paramValue} (${JSON.stringify(paramValue)}). ` +
+            `See more info here: https://nextjs.org/docs/messages/invalid-getstaticpaths-value`
           )
+        }
+
+        if (repeat && Array.isArray(paramValue)) {
+          for (let i = 0; i < paramValue.length; i++) {
+            if (typeof paramValue[i] !== 'string') {
+              throw new Error(
+                `Parameter "${validParamKey}[${i}]" from getStaticPaths for ${page} must be a string, ` +
+                `but received ${typeof paramValue[i]} (${JSON.stringify(paramValue[i])}). ` +
+                `All elements in catch-all parameter arrays must be strings.`
+              )
+            }
+          }
         }
 
         let replaced = `[${repeat ? '...' : ''}${validParamKey}]`

--- a/test/integration/dynamic-optional-routing/test/index.test.ts
+++ b/test/integration/dynamic-optional-routing/test/index.test.ts
@@ -314,7 +314,7 @@ describe('Dynamic Optional Routing', () => {
           )
           const { stderr } = await nextBuild(appDir, [], { stderr: true })
           await expect(stderr).toMatch(
-            'A required parameter (slug) was not provided as an array received undefined in getStaticPaths for /invalid/[[...slug]]'
+            'Parameter "slug" from getStaticPaths for /invalid/[[...slug]] must be an array, but received undefined (undefined)'
           )
         } finally {
           await fs.unlink(invalidRoute)

--- a/test/integration/prerender-invalid-array-params/pages/[...slug].js
+++ b/test/integration/prerender-invalid-array-params/pages/[...slug].js
@@ -1,0 +1,21 @@
+import React from 'react'
+
+export async function getStaticPaths() {
+  return {
+    paths: [{ params: { slug: ['hello', 123, 'world'] } }],
+    fallback: true,
+  }
+}
+
+export async function getStaticProps({ params }) {
+  return {
+    props: {
+      slug: params.slug,
+      time: (await import('perf_hooks')).performance.now(),
+    },
+  }
+}
+
+export default () => {
+  return <div />
+}

--- a/test/integration/prerender-invalid-array-params/test/index.test.ts
+++ b/test/integration/prerender-invalid-array-params/test/index.test.ts
@@ -5,15 +5,15 @@ import { nextBuild } from 'next-test-utils'
 
 const appDir = join(__dirname, '..')
 
-describe('Invalid Prerender Catchall Params', () => {
+describe('Invalid Prerender Array Element Params', () => {
   ;(process.env.TURBOPACK_DEV ? describe.skip : describe)(
     'production mode',
     () => {
-      it('should fail the build', async () => {
+      it('should fail the build with array element type error', async () => {
         const out = await nextBuild(appDir, [], { stderr: true })
         expect(out.stderr).toMatch(`Build error occurred`)
         expect(out.stderr).toMatch(
-          'Parameter "slug" from getStaticPaths for /[...slug] must be an array, but received string ("hello")'
+          'Parameter "slug[1]" from getStaticPaths for /[...slug] must be a string, but received number (123)'
         )
       })
     }


### PR DESCRIPTION
## What?

Improves error messages in `getStaticPaths` when non-string values are supplied as route parameters. The current messages are vague and hard to debug.

## Why?

Fixes #41281 - When a developer accidentally passes a non-string value (e.g., a number) as a dynamic route parameter in `getStaticPaths`, the current error message is confusing:

``nA required parameter (slug) was not provided as an array received string in getStaticPaths for /[...slug]
``n
This makes it unclear what actually went wrong and how to fix it.

## How?

### 1. Clearer error message format

**Before:**
``nA required parameter (slug) was not provided as an array received string in getStaticPaths for /[...slug]
``n
**After:**
``nParameter "slug" from getStaticPaths for /[...slug] must be an array, but received string ("hello"). See more info here: https://nextjs.org/docs/messages/invalid-getstaticpaths-value
``n
The new format:
- Names the parameter clearly with quotes
- Shows the actual value received (via `JSON.stringify`)
- Links to Next.js error documentation

### 2. Validate array elements in catch-all routes

Previously, passing `["hello", 123, "world"]` to a catch-all route would cause a confusing runtime error deep in `escapePathDelimiters`. Now it catches the issue early with a precise message:

``nParameter "slug[1]" from getStaticPaths for /[...slug] must be a string, but received number (123). All elements in catch-all parameter arrays must be strings.
``n
### 3. New test coverage

Added `test/integration/prerender-invalid-array-params` to verify that non-string elements inside catch-all arrays produce the correct error.

## Changes

| File | Change |
|------|--------|
| `packages/next/src/build/static-paths/pages.ts` | Improved error format + array element validation |
| `test/integration/prerender-invalid-catchall-params` | Updated expected error string |
| `test/integration/dynamic-optional-routing` | Updated expected error string |
| `test/integration/prerender-invalid-array-params` | **New** test for non-string array elements |