### PR TITLE
fix(dev-overlay): resolve Segment Explorer editor paths in monorepos

### DIFF
--- a/packages/next/src/server/dev/middleware-turbopack.ts
+++ b/packages/next/src/server/dev/middleware-turbopack.ts
@@ -11,6 +11,7 @@ import {
 import { middlewareResponse } from '../../next-devtools/server/middleware-response'
 import path from 'path'
 import { openFileInEditor } from '../../next-devtools/server/launch-editor'
+import { resolveAppRelativeEditorPath } from './resolve-app-relative-editor-path'
 import {
   SourceMapConsumer,
   type NullableMappedPosition,
@@ -378,11 +379,7 @@ export function getOverlayMiddleware({
       let openEditorResult
       if (isAppRelativePath) {
         const relativeFilePath = searchParams.get('file') || ''
-        const appPath = path.join(
-          'app',
-          isSrcDir ? 'src' : '',
-          relativeFilePath
-        )
+        const appPath = resolveAppRelativeEditorPath(relativeFilePath, isSrcDir)
         openEditorResult = await openFileInEditor(appPath, 1, 1, projectPath)
       } else {
         const frame = createStackFrame(searchParams)

--- a/packages/next/src/server/dev/middleware-webpack.ts
+++ b/packages/next/src/server/dev/middleware-webpack.ts
@@ -11,6 +11,7 @@ import {
   type ModernSourceMapPayload,
 } from '../lib/source-maps'
 import { openFileInEditor } from '../../next-devtools/server/launch-editor'
+import { resolveAppRelativeEditorPath } from './resolve-app-relative-editor-path'
 import {
   getOriginalCodeFrame,
   ignoreListAnonymousStackFramesIfSandwiched,
@@ -616,11 +617,7 @@ export function getOverlayMiddleware(options: {
       const isAppRelativePath = searchParams.get('isAppRelativePath') === '1'
       if (isAppRelativePath) {
         const relativeFilePath = searchParams.get('file') || ''
-        const appPath = path.join(
-          'app',
-          isSrcDir ? 'src' : '',
-          relativeFilePath
-        )
+        const appPath = resolveAppRelativeEditorPath(relativeFilePath, isSrcDir)
         openEditorResult = await openFileInEditor(appPath, 1, 1, rootDirectory)
       } else {
         // TODO: How do we differentiate layers and actual file paths with round brackets?

--- a/packages/next/src/server/dev/resolve-app-relative-editor-path.test.ts
+++ b/packages/next/src/server/dev/resolve-app-relative-editor-path.test.ts
@@ -1,0 +1,45 @@
+import { resolveAppRelativeEditorPath } from './resolve-app-relative-editor-path'
+
+describe('resolveAppRelativeEditorPath', () => {
+  it('prefixes bare app-relative files inside app/', () => {
+    expect(resolveAppRelativeEditorPath('layout.tsx', false)).toBe(
+      'app/layout.tsx'
+    )
+  })
+
+  it('prefixes bare app-relative files inside src/app/', () => {
+    expect(resolveAppRelativeEditorPath('layout.tsx', true)).toBe(
+      'src/app/layout.tsx'
+    )
+  })
+
+  it('strips monorepo prefixes for app/ paths', () => {
+    expect(
+      resolveAppRelativeEditorPath('apps/docs/app/layout.tsx', false)
+    ).toBe('app/layout.tsx')
+  })
+
+  it('strips monorepo prefixes for src/app/ paths', () => {
+    expect(
+      resolveAppRelativeEditorPath('packages/web/src/app/layout.tsx', true)
+    ).toBe('src/app/layout.tsx')
+  })
+
+  it('rewrites app/ paths when src/app/ is expected', () => {
+    expect(resolveAppRelativeEditorPath('app/layout.tsx', true)).toBe(
+      'src/app/layout.tsx'
+    )
+  })
+
+  it('rewrites src/app/ paths when app/ is expected', () => {
+    expect(resolveAppRelativeEditorPath('src/app/layout.tsx', false)).toBe(
+      'app/layout.tsx'
+    )
+  })
+
+  it('normalizes windows separators before resolving', () => {
+    expect(
+      resolveAppRelativeEditorPath('apps\\docs\\app\\page.tsx', false)
+    ).toBe('app/page.tsx')
+  })
+})

--- a/packages/next/src/server/dev/resolve-app-relative-editor-path.ts
+++ b/packages/next/src/server/dev/resolve-app-relative-editor-path.ts
@@ -1,0 +1,32 @@
+import path from 'path'
+
+export function resolveAppRelativeEditorPath(
+  relativeFilePath: string,
+  isSrcDir: boolean
+) {
+  const normalizedPath = relativeFilePath
+    .replace(/\\/g, '/')
+    .replace(/^\/+/, '')
+
+  const expectedPrefix = isSrcDir ? 'src/app/' : 'app/'
+  const alternatePrefix = isSrcDir ? 'app/' : 'src/app/'
+
+  if (normalizedPath.startsWith(expectedPrefix)) {
+    return normalizedPath
+  }
+
+  const expectedPrefixIndex = normalizedPath.indexOf(expectedPrefix)
+  if (expectedPrefixIndex >= 0) {
+    return normalizedPath.slice(expectedPrefixIndex)
+  }
+
+  const alternatePrefixIndex = normalizedPath.indexOf(alternatePrefix)
+  if (alternatePrefixIndex >= 0) {
+    return path.posix.join(
+      expectedPrefix,
+      normalizedPath.slice(alternatePrefixIndex + alternatePrefix.length)
+    )
+  }
+
+  return path.posix.join(expectedPrefix, normalizedPath)
+}


### PR DESCRIPTION
## Summary
- normalize app-relative editor paths before opening files from the Segment Explorer
- strip leading monorepo segments so paths like `apps/docs/app/layout.tsx` resolve back to `app/...` or `src/app/...`
- fix the existing `src/app` path ordering bug by rewriting cross-prefix inputs in both directions

## Testing
- `corepack pnpm exec prettier --check packages/next/src/server/dev/resolve-app-relative-editor-path.ts packages/next/src/server/dev/resolve-app-relative-editor-path.test.ts packages/next/src/server/dev/middleware-turbopack.ts packages/next/src/server/dev/middleware-webpack.ts`
- `corepack pnpm exec eslint --config eslint.cli.config.mjs packages/next/src/server/dev/resolve-app-relative-editor-path.ts packages/next/src/server/dev/resolve-app-relative-editor-path.test.ts packages/next/src/server/dev/middleware-turbopack.ts packages/next/src/server/dev/middleware-webpack.ts`
- `corepack pnpm lint-staged`
- `git diff --check`
- `node --experimental-strip-types` runtime assertions for monorepo, `src/app`, and Windows-separator cases

Fixes #85695