### PR TITLE
fix: improve error message consistency in getStaticPaths

### DIFF
--- a/packages/next/src/build/static-paths/pages.ts
+++ b/packages/next/src/build/static-paths/pages.ts
@@ -168,9 +168,10 @@ export async function buildPagesStaticPaths({
           typeof paramValue === 'undefined'
         ) {
           throw new Error(
-            `A required parameter (${validParamKey}) was not provided as ${
-              repeat ? 'an array' : 'a string'
-            } received ${typeof paramValue} in getStaticPaths for ${page}`
+            `Invalid \`params\` value returned from getStaticPaths for ${page}. ` +
+              `A required parameter (${validParamKey}) was not provided as ${
+                repeat ? 'an array' : 'a string'
+              }, received ${typeof paramValue} instead.`
           )
         }
 


### PR DESCRIPTION
Fixes #41281

## Description

This PR improves the error message consistency and clarity when invalid parameter types are returned from \getStaticPaths\.

### Before
The error message was grammatically awkward and hard to read:
\\\
A required parameter (page) was not provided as a string received number in getStaticPaths for /articles/[page]
\\\

### After
The error message is now clear and consistent with other Next.js error messages:
\\\
Invalid \params\ value returned from getStaticPaths for /articles/[page]. A required parameter (page) was not provided as a string, received number instead.
\\\

## Changes

- Updated error message format in \packages/next/src/build/static-paths/pages.ts\
- Added clear indication of expected vs received types
- Made error message consistent with other Next.js error messaging patterns

## Testing

This change only affects error messaging and does not change any functionality. The error will still be thrown in the same circumstances, but with a clearer message to help developers debug their code faster.