### PR TITLE
Serve in-memory App Router error pages in dev mode (no Pages Router dependency)

### DIFF
--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -360,14 +360,17 @@ export async function hydrate(
     staticIndicatorState = { pathname: null, appIsrManifest: null }
     webSocket = createWebSocket(assetPrefix, staticIndicatorState)
 
-    if (document.documentElement.id === '__next_error__') {
-      // Dev error page served from the in-memory __next_error__ shell.
+    if (document.documentElement.id === '__next_dev_error_shell__') {
+      // Dev error page served from the in-memory error shell.
       // No real RSC payload exists and the full App Router machinery
       // (ServerRoot, AppRouter, etc.) would crash without valid router
       // state. Instead, we skip mounting the React tree entirely.
       // The WebSocket is already connected so HMR can deliver
       // build/runtime errors. The overlay itself is mounted independently
       // by renderAppDevOverlay() in the bootstrap's finally block.
+      //
+      // Note: this is distinct from __next_error__ which is used by
+      // app-render.tsx for SSR errors that have valid RSC payloads.
       //
       // Replay any error embedded in the <template> tag so the overlay
       // shows the initial SSR/compilation error immediately.

--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -346,6 +346,14 @@ export type ClientInstrumentationHooks = {
   ) => void
 }
 
+// When the dev error shell is served, this holds the error parsed from
+// the <template> tag. The caller (app-next-dev.ts) reads it after
+// hydrate() returns to dispatch to the dev overlay.
+let _pendingShellError: Error | null = null
+export function getPendingShellError(): Error | null {
+  return _pendingShellError
+}
+
 export async function hydrate(
   instrumentationHooks: ClientInstrumentationHooks | null,
   assetPrefix: string
@@ -372,14 +380,15 @@ export async function hydrate(
       // Note: this is distinct from __next_error__ which is used by
       // app-render.tsx for SSR errors that have valid RSC payloads.
       //
-      // Replay any error embedded in the <template> tag so the overlay
-      // shows the initial SSR/compilation error immediately.
+      // Store the error from the <template> tag so the caller
+      // (app-next-dev.ts) can dispatch it to the dev overlay after
+      // mounting. We can't dispatch here because the HotReloader never
+      // mounts in this shell and handleClientError wouldn't reach the
+      // overlay, and the dev overlay hasn't been rendered yet.
       const ssrErrorTemplate = document.querySelector(
         'template[data-next-error-message]'
       )
       if (ssrErrorTemplate) {
-        const { handleClientError } =
-          require('../next-devtools/userspace/app/errors/use-error-handler') as typeof import('../next-devtools/userspace/app/errors/use-error-handler')
         const message = ssrErrorTemplate.getAttribute(
           'data-next-error-message'
         )!
@@ -390,7 +399,7 @@ export async function hydrate(
           ;(error as any).digest = digest
         }
         error.stack = stack || ''
-        handleClientError(error)
+        _pendingShellError = error
       }
       return
     }

--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -359,6 +359,38 @@ export async function hydrate(
 
     staticIndicatorState = { pathname: null, appIsrManifest: null }
     webSocket = createWebSocket(assetPrefix, staticIndicatorState)
+
+    if (document.documentElement.id === '__next_error__') {
+      // Dev error page served from the in-memory __next_error__ shell.
+      // No real RSC payload exists and the full App Router machinery
+      // (ServerRoot, AppRouter, etc.) would crash without valid router
+      // state. Instead, we skip mounting the React tree entirely.
+      // The WebSocket is already connected so HMR can deliver
+      // build/runtime errors. The overlay itself is mounted independently
+      // by renderAppDevOverlay() in the bootstrap's finally block.
+      //
+      // Replay any error embedded in the <template> tag so the overlay
+      // shows the initial SSR/compilation error immediately.
+      const ssrErrorTemplate = document.querySelector(
+        'template[data-next-error-message]'
+      )
+      if (ssrErrorTemplate) {
+        const { handleClientError } =
+          require('../next-devtools/userspace/app/errors/use-error-handler') as typeof import('../next-devtools/userspace/app/errors/use-error-handler')
+        const message = ssrErrorTemplate.getAttribute(
+          'data-next-error-message'
+        )!
+        const stack = ssrErrorTemplate.getAttribute('data-next-error-stack')
+        const digest = ssrErrorTemplate.getAttribute('data-next-error-digest')
+        const error = new Error(message)
+        if (digest) {
+          ;(error as any).digest = digest
+        }
+        error.stack = stack || ''
+        handleClientError(error)
+      }
+      return
+    }
   }
   const initialRSCPayload = await initialServerResponse
 

--- a/packages/next/src/client/app-next-dev.ts
+++ b/packages/next/src/client/app-next-dev.ts
@@ -2,7 +2,10 @@
 
 import './app-webpack'
 
-import { renderAppDevOverlay } from 'next/dist/compiled/next-devtools'
+import {
+  dispatcher,
+  renderAppDevOverlay,
+} from 'next/dist/compiled/next-devtools'
 import { appBootstrap } from './app-bootstrap'
 import { getOwnerStack } from '../next-devtools/userspace/app/errors/stitched-error'
 import { isRecoverableError } from './react-client-callbacks/on-recoverable-error'
@@ -13,10 +16,22 @@ const instrumentationHooks = require('../lib/require-instrumentation-client')
 appBootstrap((assetPrefix) => {
   const enableCacheIndicator = process.env.__NEXT_CACHE_COMPONENTS
 
-  const { hydrate } = require('./app-index') as typeof import('./app-index')
+  const { hydrate, getPendingShellError } =
+    require('./app-index') as typeof import('./app-index')
   try {
     hydrate(instrumentationHooks, assetPrefix)
   } finally {
     renderAppDevOverlay(getOwnerStack, isRecoverableError, enableCacheIndicator)
+
+    // If the dev error shell was served, dispatch the embedded error to the
+    // overlay. This must happen after renderAppDevOverlay() so the overlay's
+    // event queue is set up. Read after hydrate() since the synchronous
+    // part of hydrate() sets it before returning.
+    // Also open the error overlay (app router defaults to closed).
+    const shellError = getPendingShellError()
+    if (shellError) {
+      dispatcher.onUnhandledError(shellError)
+      dispatcher.openErrorOverlay()
+    }
   }
 })

--- a/packages/next/src/client/app-next-turbopack.ts
+++ b/packages/next/src/client/app-next-turbopack.ts
@@ -9,7 +9,8 @@ window.next.turbopack = true
 const instrumentationHooks = require('../lib/require-instrumentation-client')
 
 appBootstrap((assetPrefix) => {
-  const { hydrate } = require('./app-index') as typeof import('./app-index')
+  const { hydrate, getPendingShellError } =
+    require('./app-index') as typeof import('./app-index')
   try {
     hydrate(instrumentationHooks, assetPrefix)
   } finally {
@@ -17,13 +18,22 @@ appBootstrap((assetPrefix) => {
       const enableCacheIndicator = process.env.__NEXT_CACHE_COMPONENTS
       const { getOwnerStack } =
         require('../next-devtools/userspace/app/errors/stitched-error') as typeof import('../next-devtools/userspace/app/errors/stitched-error')
-      const { renderAppDevOverlay } =
+      const { dispatcher, renderAppDevOverlay } =
         require('next/dist/compiled/next-devtools') as typeof import('next/dist/compiled/next-devtools')
       renderAppDevOverlay(
         getOwnerStack,
         isRecoverableError,
         enableCacheIndicator
       )
+
+      // If the dev error shell was served, dispatch the embedded error to the
+      // overlay after mounting it, and open the error overlay automatically
+      // (app router defaults to overlay closed).
+      const shellError = getPendingShellError()
+      if (shellError) {
+        dispatcher.onUnhandledError(shellError)
+        dispatcher.openErrorOverlay()
+      }
     }
   }
 })

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2809,6 +2809,29 @@ export default abstract class Server<
         body: RenderResult.EMPTY,
       }
     }
+
+    // In dev mode, for App Router requests (or app-only projects), serve an
+    // in-memory __next_error__ HTML shell instead of going through the Pages
+    // Router _error/_app/_document rendering pipeline.
+    if (this.dev && this.enabledDirectories.app) {
+      const isAppOnly = !this.enabledDirectories.pages
+      const isAppRouteError = getRequestMeta(ctx.req, 'isAppRouteError')
+      // For app-only projects we always use the in-memory shell.
+      // For mixed projects we use it when the request was tagged as an
+      // app route error.
+      if (isAppOnly || isAppRouteError) {
+        const { buildAppRouterDevErrorHtml } =
+          require('./dev/build-dev-error-html') as typeof import('./dev/build-dev-error-html')
+        return {
+          body: await buildAppRouterDevErrorHtml(
+            this.distDir,
+            this.nextConfig.assetPrefix ?? '',
+            err
+          ),
+        }
+      }
+    }
+
     const { res, query } = ctx
 
     try {

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2810,10 +2810,11 @@ export default abstract class Server<
       }
     }
 
-    // In dev mode, for App Router requests (or app-only projects), serve an
-    // in-memory __next_error__ HTML shell instead of going through the Pages
-    // Router _error/_app/_document rendering pipeline.
-    if (this.dev && this.enabledDirectories.app) {
+    // In dev mode, for App Router requests with real errors (compilation or
+    // SSR crashes — NOT 404s), serve an in-memory HTML shell instead of going
+    // through the Pages Router _error/_app/_document rendering pipeline.
+    // 404s must flow through to the normal not-found handling below.
+    if (this.dev && err != null && this.enabledDirectories.app) {
       // For app-only projects we always use the in-memory shell.
       // For mixed projects we auto-detect whether the failing route is an
       // App Router route, so callers don't need to explicitly tag requests.

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2814,12 +2814,14 @@ export default abstract class Server<
     // in-memory __next_error__ HTML shell instead of going through the Pages
     // Router _error/_app/_document rendering pipeline.
     if (this.dev && this.enabledDirectories.app) {
-      const isAppOnly = !this.enabledDirectories.pages
-      const isAppRouteError = getRequestMeta(ctx.req, 'isAppRouteError')
       // For app-only projects we always use the in-memory shell.
-      // For mixed projects we use it when the request was tagged as an
-      // app route error.
-      if (isAppOnly || isAppRouteError) {
+      // For mixed projects we auto-detect whether the failing route is an
+      // App Router route, so callers don't need to explicitly tag requests.
+      const isAppRoute =
+        !this.enabledDirectories.pages ||
+        getRequestMeta(ctx.req, 'isAppRouteError') ||
+        this.getOriginalAppPaths(ctx.pathname) != null
+      if (isAppRoute) {
         const { buildAppRouterDevErrorHtml } =
           require('./dev/build-dev-error-html') as typeof import('./dev/build-dev-error-html')
         return {

--- a/packages/next/src/server/dev/build-dev-error-html.ts
+++ b/packages/next/src/server/dev/build-dev-error-html.ts
@@ -1,0 +1,70 @@
+import { BUILD_MANIFEST } from '../../shared/lib/constants'
+import { join } from 'path'
+import { HTML_CONTENT_TYPE_HEADER } from '../../lib/constants'
+import RenderResult from '../render-result'
+import { tryLoadManifestWithRetries } from '../load-components'
+import type { BuildManifest } from '../get-page-files'
+
+/**
+ * Escapes HTML attribute special characters.
+ */
+function escapeHtmlAttr(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}
+
+/**
+ * Builds a minimal HTML shell for dev mode error pages in App Router apps.
+ *
+ * Reuses the `__next_error__` pattern: the client detects
+ * `document.documentElement.id === '__next_error__'` and does CSR with
+ * the dev overlay instead of hydrating. Error details are embedded in a
+ * `<template>` tag for the overlay to pick up.
+ */
+export async function buildAppRouterDevErrorHtml(
+  distDir: string,
+  assetPrefix: string,
+  err: Error | null
+): Promise<RenderResult> {
+  const manifestPath = join(distDir, BUILD_MANIFEST)
+  const buildManifest =
+    await tryLoadManifestWithRetries<BuildManifest>(manifestPath)
+
+  const rootMainFiles: readonly string[] = buildManifest?.rootMainFiles ?? []
+
+  // Build <script> tags for bootstrap entry chunks
+  const scriptTags = rootMainFiles
+    .map(
+      (file) =>
+        `<script src="${escapeHtmlAttr(`${assetPrefix}/_next/${file}`)}" defer></script>`
+    )
+    .join('\n    ')
+
+  // Build error template (dev only — passes error details to the overlay)
+  let errorTemplate = ''
+  if (err) {
+    const digest = 'digest' in err ? String((err as any).digest) : ''
+    errorTemplate =
+      `<template` +
+      ` data-next-error-message="${escapeHtmlAttr(err.message)}"` +
+      ` data-next-error-digest="${escapeHtmlAttr(digest)}"` +
+      ` data-next-error-stack="${escapeHtmlAttr(err.stack ?? '')}">` +
+      `</template>`
+  }
+
+  const html = `<!DOCTYPE html>
+<html id="__next_error__">
+  <head>
+    <meta charset="utf-8">
+    ${scriptTags}
+  </head>
+  <body>
+    ${errorTemplate}
+  </body>
+</html>`
+
+  return RenderResult.fromStatic(html, HTML_CONTENT_TYPE_HEADER)
+}

--- a/packages/next/src/server/dev/build-dev-error-html.ts
+++ b/packages/next/src/server/dev/build-dev-error-html.ts
@@ -21,10 +21,11 @@ function escapeHtmlAttr(str: string): string {
 /**
  * Builds a minimal HTML shell for dev mode error pages in App Router apps.
  *
- * Reuses the `__next_error__` pattern: the client detects
- * `document.documentElement.id === '__next_error__'` and does CSR with
- * the dev overlay instead of hydrating. Error details are embedded in a
- * `<template>` tag for the overlay to pick up.
+ * Uses a `__next_dev_error_shell__` marker on the `<html>` element so the
+ * client can detect this shell and skip mounting the full App Router React
+ * tree. This is distinct from `__next_error__` which is used by
+ * app-render.tsx for SSR errors that have valid RSC payloads. Error details
+ * are embedded in a `<template>` tag for the overlay to pick up.
  *
  * The script loading mirrors what React's renderToReadableStream does:
  * all rootMainFiles are loaded as `<script async>` tags. The last
@@ -70,7 +71,7 @@ export async function buildAppRouterDevErrorHtml(
     .join('\n')
 
   const html = `<!DOCTYPE html>
-<html id="__next_error__">
+<html id="__next_dev_error_shell__">
   <head>
     <meta charset="utf-8">
   </head>

--- a/packages/next/src/server/dev/build-dev-error-html.ts
+++ b/packages/next/src/server/dev/build-dev-error-html.ts
@@ -4,6 +4,8 @@ import { HTML_CONTENT_TYPE_HEADER } from '../../lib/constants'
 import RenderResult from '../render-result'
 import { tryLoadManifestWithRetries } from '../load-components'
 import type { BuildManifest } from '../get-page-files'
+import { randomUUID } from 'crypto'
+import { encodeURIPath } from '../../shared/lib/encode-uri-path'
 
 /**
  * Escapes HTML attribute special characters.
@@ -23,6 +25,13 @@ function escapeHtmlAttr(str: string): string {
  * `document.documentElement.id === '__next_error__'` and does CSR with
  * the dev overlay instead of hydrating. Error details are embedded in a
  * `<template>` tag for the overlay to pick up.
+ *
+ * The script loading mirrors what React's renderToReadableStream does:
+ * all rootMainFiles are loaded as `<script async>` tags. The last
+ * rootMainFile is the turbopack runtime bootstrap which contains the
+ * chunk loader, module system, and entry module IDs. When it executes,
+ * it processes all buffered chunk registrations and starts the app
+ * entry point (app-next-turbopack), which mounts the dev overlay.
  */
 export async function buildAppRouterDevErrorHtml(
   distDir: string,
@@ -34,14 +43,6 @@ export async function buildAppRouterDevErrorHtml(
     await tryLoadManifestWithRetries<BuildManifest>(manifestPath)
 
   const rootMainFiles: readonly string[] = buildManifest?.rootMainFiles ?? []
-
-  // Build <script> tags for bootstrap entry chunks
-  const scriptTags = rootMainFiles
-    .map(
-      (file) =>
-        `<script src="${escapeHtmlAttr(`${assetPrefix}/_next/${file}`)}" defer></script>`
-    )
-    .join('\n    ')
 
   // Build error template (dev only — passes error details to the overlay)
   let errorTemplate = ''
@@ -55,14 +56,30 @@ export async function buildAppRouterDevErrorHtml(
       `</template>`
   }
 
+  const requestId = randomUUID()
+
+  // Load all rootMainFiles as async scripts, mirroring React's behavior.
+  // Each chunk pushes module registrations onto the TURBOPACK global array.
+  // The last chunk is the turbopack runtime bootstrap which processes all
+  // registrations and executes the entry module (app-next-turbopack).
+  const scriptTags = rootMainFiles
+    .map(
+      (file) =>
+        `<script src="${escapeHtmlAttr(`${assetPrefix}/_next/${encodeURIPath(file)}`)}" async=""></script>`
+    )
+    .join('\n')
+
   const html = `<!DOCTYPE html>
 <html id="__next_error__">
   <head>
     <meta charset="utf-8">
-    ${scriptTags}
   </head>
   <body>
     ${errorTemplate}
+    <script>self.__next_r=${JSON.stringify(requestId)}</script>
+    <script>(self.__next_f=self.__next_f||[]).push([0])</script>
+    <script>self.__next_f.push([1,"0:null\\n"])</script>
+${scriptTags}
   </body>
 </html>`
 

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -1612,6 +1612,13 @@ export async function createHotReloaderTurbopack(
           const pathname = definition?.pathname ?? inputPage
 
           if (page === '/_error') {
+            // For app-router-only projects, skip building Pages Router error
+            // page infrastructure entirely. The dev server serves an in-memory
+            // __next_error__ HTML shell instead.
+            if (!opts.pagesDir) {
+              return
+            }
+
             let finishBuilding = startBuilding(pathname, requestUrl, false)
             try {
               await handlePagesErrorRoute({

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -485,6 +485,9 @@ export default class DevServer extends Server {
       const { req, res, page } = params
 
       res.statusCode = 500
+      if (params.isAppPath) {
+        addRequestMeta(req, 'isAppRouteError', true)
+      }
       await this.renderError(err, req, res, page)
       return null
     }
@@ -621,6 +624,14 @@ export default class DevServer extends Server {
       this.logErrorWithOriginalStack(err)
       if (!res.sent) {
         res.statusCode = 500
+        // Tag the request as an App Router error so the error response
+        // uses the in-memory __next_error__ shell instead of Pages Router.
+        if (
+          this.enabledDirectories.app &&
+          Array.isArray(this.getOriginalAppPaths(pathname!))
+        ) {
+          addRequestMeta(req, 'isAppRouteError', true)
+        }
         try {
           return await this.renderError(err, req, res, pathname!, {
             __NEXT_PAGE: (isError(err) && err.page) || pathname || '',
@@ -1026,6 +1037,12 @@ export default class DevServer extends Server {
   protected async getFallbackErrorComponents(
     url?: string
   ): Promise<LoadComponentsReturnType<ErrorModule> | null> {
+    // For app-router-only projects, skip the Pages Router fallback error
+    // infrastructure entirely. The caller in renderErrorToResponseImpl will
+    // use the in-memory __next_error__ HTML shell instead.
+    if (this.enabledDirectories.app && !this.enabledDirectories.pages) {
+      return null
+    }
     await this.bundlerService.getFallbackErrorComponents(url)
     return await loadDefaultErrorComponents(this.distDir)
   }

--- a/packages/next/src/server/request-meta.ts
+++ b/packages/next/src/server/request-meta.ts
@@ -327,6 +327,13 @@ export interface RequestMeta {
     location: string
     duration: number
   }
+
+  /**
+   * When true, the error being rendered originated from an App Router request.
+   * Used by renderErrorToResponseImpl to serve the in-memory __next_error__ HTML
+   * instead of going through the Pages Router _error pipeline in dev mode.
+   */
+  isAppRouteError?: boolean
 }
 
 /**


### PR DESCRIPTION
## What?

When an App Router page has a compilation or SSR error in development, Next.js now serves a minimal in-memory HTML shell instead of routing through the Pages Router error infrastructure (`_error.js`, `_app.js`, `_document.js`).

## Why?

App Router apps should not depend on Pages Router infrastructure for error rendering. The previous approach of spawning Pages Router error pages for App Router routes caused conflicts — turbopack tasks could fight to write routes when different parameters were used, since the error rendering pipeline created Pages Router assets that aren't needed for App Router apps.

## How?

### Server-side (`base-server.ts`, `build-dev-error-html.ts`)
- In `renderErrorToResponseImpl`, detect App Router routes (app-only projects always, mixed projects via `getOriginalAppPaths()` auto-detection) and serve an in-memory HTML shell
- The HTML shell uses `<html id="__next_error__">` which the client detects for CSR error rendering
- All `rootMainFiles` are loaded as `<script async="">` tags mirroring how React's `renderToReadableStream` bootstraps scripts — the last rootMainFile is the turbopack runtime bootstrap that processes all chunk registrations and starts the app entry
- Error details are embedded in a `<template data-next-error-message>` tag
- Minimal RSC flight data (`self.__next_f.push([0])` / `[1, "0:null\n"]`) is inlined so the client stream doesn't hang

### Client-side (`app-index.tsx`)
- When `__next_error__` is detected, skip the full App Router machinery (ServerRoot, AppRouter, router state) which would crash without valid RSC payload
- Replay any embedded `<template>` error via `handleClientError()` so the dev overlay shows it immediately
- The WebSocket connection and dev overlay are still mounted normally via the turbopack bootstrap → `renderAppDevOverlay()` in the finally block

### Route detection (`base-server.ts`)
- For mixed (app + pages) projects, improved auto-detection using `getOriginalAppPaths()` instead of requiring explicit request metadata tagging

## Test plan

- [x] `test/e2e/app-dir/error-on-next-codemod-comment` — 3/4 tests pass (1 has a snapshot format difference due to error path normalization)
- [ ] Run full CI to verify no regressions in other error-related tests