### PR TITLE
fix: Updated the server span to be compliant with at least 1.20.0 of the semantic conventions

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -900,7 +900,7 @@ export default abstract class Server<
       try {
         const url = new URL(`${httpScheme}://${req.headers.host}${req.url}`)
         attributes['http.url'] = url.href
-        attributes['net.host.name'] = url.host
+        attributes['net.host.name'] = url.hostname
         if (url.port !== '') {
           attributes['net.host.port'] = url.port
         }

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -885,16 +885,42 @@ export default abstract class Server<
       // to this parent span so APM tools (e.g. Datadog) can derive the
       // resource name correctly.
       const parentSpan = tracer.getActiveScopeSpan()
+      const httpScheme =
+        req.headers['x-forwarded-proto'] ??
+        (req?.body?.socket?.encrypted ? 'https' : 'http')
+      const attributes: Record<
+        `http.${string}` | `net.${string}`,
+        string | undefined
+      > = {
+        'http.scheme': httpScheme as string,
+        'http.method': method,
+        'http.target': req.url,
+      }
+
+      try {
+        const url = new URL(`${httpScheme}://${req.headers.host}${req.url}`)
+        attributes['http.url'] = url.href
+        attributes['net.host.name'] = url.host
+        if (url.port !== '') {
+          attributes['net.host.port'] = url.port
+        }
+      } catch (err) {
+        console.error('Failed construct url', err)
+        const [host, port] = req.headers.host?.split(':') ?? []
+        if (host) {
+          attributes['net.host.name'] = host
+        }
+        if (port) {
+          attributes['net.host.port'] = port
+        }
+      }
 
       return tracer.trace(
         BaseServerSpan.handleRequest,
         {
           spanName: `${method}`,
           kind: SpanKind.SERVER,
-          attributes: {
-            'http.method': method,
-            'http.target': req.url,
-          },
+          attributes,
         },
         async (span) =>
           this.handleRequestImpl(req, res, parsedUrl).finally(() => {


### PR DESCRIPTION
This PR adds `net.host.name` to the next server span, as it is required by [1.20.0](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/specification/trace/semantic_conventions/http.md#http-server) for HTTP server spans.  I also added `net.host.port` when applicable and also the optional `http.url`. I'm definitely open to suggestions on this but `net.host.name` is a must.  I work at New Relic on the Node.js agent and we have a feature that synthesizes New Relic telemetry from Otel spans, and since `net.host.name` is missing it cannot properly handle key data points.  I didn't add tests because I don't see any other tests for the otel spans and frankly it's very hard to navigate this code base but open to tests suggestions.

Fixes #92006 


