### PR TITLE
[Webpack] Transpile external TypeScript files imported by instrumentation-client in pages layer

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -1767,6 +1767,16 @@ export default async function getBaseWebpackConfig(
                 ]
               : []),
             {
+              test: codeCondition.test,
+              exclude: codeCondition.exclude,
+              issuerLayer: WEBPACK_LAYERS.pagesDirBrowser,
+              use: [
+                ...reactRefreshLoaders,
+                defaultLoaders.babel,
+                reactCompilerLoader,
+              ].filter(Boolean),
+            },
+            {
               ...codeCondition,
               use: [
                 ...reactRefreshLoaders,

--- a/test/e2e/app-dir/instrumentation-client-external-dir/app/layout.tsx
+++ b/test/e2e/app-dir/instrumentation-client-external-dir/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/instrumentation-client-external-dir/app/page.tsx
+++ b/test/e2e/app-dir/instrumentation-client-external-dir/app/page.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+export default function Page() {
+  const [result, setResult] = useState<string>('')
+
+  useEffect(() => {
+    setResult((window as any).__INSTRUMENTATION_CLIENT_RESULT || 'not-set')
+  }, [])
+
+  return <p id="result">{result}</p>
+}

--- a/test/e2e/app-dir/instrumentation-client-external-dir/instrumentation-client-external-dir.test.ts
+++ b/test/e2e/app-dir/instrumentation-client-external-dir/instrumentation-client-external-dir.test.ts
@@ -1,0 +1,44 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+import fs from 'fs'
+import path from 'path'
+
+describe('instrumentation-client-external-dir', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+    skipStart: true,
+  })
+
+  beforeAll(async () => {
+    // Create the external package directory outside the project root
+    // to simulate a monorepo sibling package with TypeScript files
+    const externalDir = path.join(next.testDir, '..', 'external-package')
+    await fs.promises.mkdir(externalDir, { recursive: true })
+    await fs.promises.writeFile(
+      path.join(externalDir, 'utils.ts'),
+      `
+interface InitOptions {
+  debug: boolean
+}
+
+export function initClient(options: InitOptions): string {
+  const message: string = options.debug
+    ? 'external-package-init-debug'
+    : 'external-package-init'
+  return message
+}
+`
+    )
+    await next.start()
+  })
+
+  it('should transpile TypeScript files imported from outside the project root in instrumentation-client', async () => {
+    const browser = await next.browser('/')
+
+    await retry(async () => {
+      const result = await browser.elementById('result').text()
+      expect(result).toBe('external-package-init-debug')
+    })
+  })
+})

--- a/test/e2e/app-dir/instrumentation-client-external-dir/instrumentation-client.ts
+++ b/test/e2e/app-dir/instrumentation-client-external-dir/instrumentation-client.ts
@@ -1,0 +1,4 @@
+import { initClient } from '../external-package/utils'
+
+const result = initClient({ debug: true })
+;(window as any).__INSTRUMENTATION_CLIENT_RESULT = result

--- a/test/e2e/app-dir/instrumentation-client-external-dir/next.config.js
+++ b/test/e2e/app-dir/instrumentation-client-external-dir/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig


### PR DESCRIPTION
When `instrumentation-client.ts` imports TypeScript files from outside the project root (common in monorepos), `next build --webpack` fails with `Module parse failed: The keyword 'interface' is reserved`.

The `instrumentation-client` module is imported from both the `main` (pages) and `main-app` (app) client entries. The `appPagesBrowser` layer has an explicit `issuerLayer` rule that uses `codeCondition.test` without the `include: [dir]` restriction, so external files transpile fine. However, `pagesDirBrowser` has no explicit rule — it falls through to the catch-all which spreads `...codeCondition`, including `include: [dir, ...babelIncludeRegexes]`. This blocks transpilation of any file outside the project root.

Even in app-only projects, the `main` pages entry always exists and imports `require-instrumentation-client`, so the `pagesDirBrowser` compilation of `instrumentation-client.ts` and its external imports hits the `include` restriction.

This adds an explicit `issuerLayer: WEBPACK_LAYERS.pagesDirBrowser` rule matching the pattern of all other layer rules. It uses `codeCondition.test` (drops the `include` restriction to allow external files) with `codeCondition.exclude` (preserves the node_modules skip). The loaders are the same as the existing catch-all.