### PR TITLE
fix: pin 19 actions to commit SHA, extract 7 expressions to env vars

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -65,7 +65,7 @@ jobs:
           if [[ $(node ./scripts/check-is-release.js 2> /dev/null || :) == v* ]];
           then
             echo "value=production" >> $GITHUB_OUTPUT
-          elif [ '${{ github.ref }}' == 'refs/heads/canary' ]
+          elif [ ''"${GIT_REF}"'' == 'refs/heads/canary' ]
           then
             echo "value=staging" >> $GITHUB_OUTPUT
           elif [ '${{ github.event_name }}' == 'workflow_dispatch' ]
@@ -77,6 +77,8 @@ jobs:
           else
             echo "value=automated-preview" >> $GITHUB_OUTPUT
           fi
+        env:
+          GIT_REF: ${{ github.ref }}
       - name: Print deploy target
         run: echo "Deploy target is '${{ steps.deploy-target.outputs.value }}'"
 
@@ -237,7 +239,7 @@ jobs:
 
       - name: Cache on ${{ github.ref_name }}
         if: ${{ !matrix.docker }}
-        uses: ijjk/rust-cache@turbo-cache-v1.0.9
+        uses: ijjk/rust-cache@a34594c450817c9860143c79797a8770c4e587f5 # turbo-cache-v1.0.9
         with:
           save-if: 'true'
           cache-provider: 'turbo'
@@ -554,7 +556,9 @@ jobs:
         run: pnpx turbo@canary run build --only --filter='./turbopack/packages/*'
 
       - name: Write NPM_TOKEN
-        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN_ELEVATED }}" > ~/.npmrc
+        run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN_ELEVATED}" > ~/.npmrc
+        env:
+          NPM_TOKEN_ELEVATED: ${{ secrets.NPM_TOKEN_ELEVATED }}
 
       - name: Publish
         run: cargo xtask workspace --publish

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -239,7 +239,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: ast-grep lint step
-        uses: ast-grep/action@v1.5.0
+        uses: ast-grep/action@cf62e780f0c88301228978d593a7784427a097a6 # v1.5.0
         with:
           # Keep in sync with the next.js repo's root package.json
           version: 0.31.0

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -236,7 +236,7 @@ jobs:
 
       - name: Install nextest
         if: ${{ inputs.needsNextest == 'yes' }}
-        uses: taiki-e/install-action@nextest
+        uses: taiki-e/install-action@3a0adc33ab45d7b9b9da91822dd2b3c0151704be # nextest
 
       - run: rustc --version
         if: ${{ inputs.skipNativeBuild != 'yes' || inputs.needsNextest == 'yes' || inputs.needsRust == 'yes' }}
@@ -244,7 +244,7 @@ jobs:
       - run: corepack prepare --activate yarn@1.22.19 && npm i -g "@napi-rs/cli@${NAPI_CLI_VERSION}"
 
       - name: Cache on ${{ github.ref_name }}
-        uses: ijjk/rust-cache@turbo-cache-v1.0.9
+        uses: ijjk/rust-cache@a34594c450817c9860143c79797a8770c4e587f5 # turbo-cache-v1.0.9
         if: ${{ inputs.rustCacheKey }}
         with:
           cache-provider: 'turbo'

--- a/.github/workflows/code_freeze.yml
+++ b/.github/workflows/code_freeze.yml
@@ -42,6 +42,7 @@ jobs:
       - name: tune linux network
         run: sudo ethtool -K eth0 tx off rx off
 
-      - run: node ./scripts/code-freeze.js --type ${{ github.event.inputs.type }}
+      - run: node ./scripts/code-freeze.js --type "${INPUT_TYPE}"
         env:
           CODE_FREEZE_TOKEN: ${{ secrets.CODE_FREEZE_TOKEN }}
+          INPUT_TYPE: ${{ github.event.inputs.type }}

--- a/.github/workflows/create_release_branch.yml
+++ b/.github/workflows/create_release_branch.yml
@@ -70,6 +70,8 @@ jobs:
 
       - run: pnpm install
 
-      - run: node ./scripts/create-release-branch.js --branch-name ${{ github.event.inputs.branchName }} --tag-name ${{ github.event.inputs.tagName }}
+      - run: node ./scripts/create-release-branch.js --branch-name "${INPUT_BRANCHNAME}" --tag-name "${INPUT_TAGNAME}"
         env:
           RELEASE_BOT_GITHUB_TOKEN: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
+          INPUT_BRANCHNAME: ${{ github.event.inputs.branchName }}
+          INPUT_TAGNAME: ${{ github.event.inputs.tagName }}

--- a/.github/workflows/graphite_ci_optimizer.yml
+++ b/.github/workflows/graphite_ci_optimizer.yml
@@ -40,12 +40,15 @@ jobs:
     steps:
       - name: Optimize CI
         id: check-skip
-        uses: withgraphite/graphite-ci-action@main
+        uses: withgraphite/graphite-ci-action@ee395f3a78254c006d11339669c6cabddf196f72 # main
         with:
           graphite_token: ${{ secrets.GRAPHITE_TOKEN }}
       - name: Debug Output
         run: |
           echo 'github.event_name: ${{ github.event_name }}'
-          echo "secrets.GRAPHITE_TOKEN != '': ${{ secrets.GRAPHITE_TOKEN != '' }}"
+          echo "secrets.GRAPHITE_TOKEN != '': ${GRAPHITE_TOKEN}"
           echo 'env.HAS_BYPASS_LABEL: ${{ env.HAS_BYPASS_LABEL }}'
           echo 'steps.check-skip.outputs.skip: ${{ steps.check-skip.outputs.skip }}'
+
+        env:
+          GRAPHITE_TOKEN: ${{ secrets.GRAPHITE_TOKEN != '' }}

--- a/.github/workflows/integration_tests_reusable.yml
+++ b/.github/workflows/integration_tests_reusable.yml
@@ -60,12 +60,10 @@ jobs:
     steps:
       - id: out
         run: |
-          printf 'e2e=[%s]
-' \
+          printf 'e2e=[%s]\n' \
             "$(seq -s, 1 ${{ inputs.e2e_groups }})" | \
             tee -a "$GITHUB_OUTPUT"
-          printf 'integration=[%s]
-' \
+          printf 'integration=[%s]\n' \
             "$(seq -s, 1 ${{ inputs.integration_groups }})" | \
             tee -a "$GITHUB_OUTPUT"
     outputs:

--- a/.github/workflows/integration_tests_reusable.yml
+++ b/.github/workflows/integration_tests_reusable.yml
@@ -60,10 +60,12 @@ jobs:
     steps:
       - id: out
         run: |
-          printf 'e2e=[%s]\n' \
+          printf 'e2e=[%s]
+' \
             "$(seq -s, 1 ${{ inputs.e2e_groups }})" | \
             tee -a "$GITHUB_OUTPUT"
-          printf 'integration=[%s]\n' \
+          printf 'integration=[%s]
+' \
             "$(seq -s, 1 ${{ inputs.integration_groups }})" | \
             tee -a "$GITHUB_OUTPUT"
     outputs:

--- a/.github/workflows/issue_lock.yml
+++ b/.github/workflows/issue_lock.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'vercel'
     steps:
-      - uses: dessant/lock-threads@1bf7ec25051fe7c00bdd17e6a7cf3d7bfb7dc771 # v5
+      - uses: dessant/lock-threads@1bf7ec25051fe7c00bdd17e6a7cf3d7bfb7dc771 # v5.0.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           add-issue-labels: 'locked'

--- a/.github/workflows/issue_lock.yml
+++ b/.github/workflows/issue_lock.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'vercel'
     steps:
-      - uses: dessant/lock-threads@v5
+      - uses: dessant/lock-threads@1bf7ec25051fe7c00bdd17e6a7cf3d7bfb7dc771 # v5
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           add-issue-labels: 'locked'

--- a/.github/workflows/retry_deploy_test.yml
+++ b/.github/workflows/retry_deploy_test.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: send webhook
-        uses: slackapi/slack-github-action@v1.25.0
+        uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001 # v1.25.0
         with:
           payload: |
             {

--- a/.github/workflows/retry_test.yml
+++ b/.github/workflows/retry_test.yml
@@ -138,7 +138,7 @@ jobs:
             return await rerunIfRequiredNotSuccessful()
       - name: send webhook
         if: ${{ steps.required_job_conclusion.outputs.result != '"success"' }}
-        uses: slackapi/slack-github-action@v1.25.0
+        uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001 # v1.25.0
         with:
           # These urls are intentionally missing the protocol,
           # allowing them to be transformed into actual links in the Slack workflow

--- a/.github/workflows/setup-nextjs-build.yml
+++ b/.github/workflows/setup-nextjs-build.yml
@@ -30,11 +30,11 @@ jobs:
           node-version: ${{ inputs.nodeVersion || env.NODE_LTS_VERSION }}
           check-latest: true
       - name: Get number of CPU cores
-        uses: SimenB/github-actions-cpu-cores@v2
+        uses: SimenB/github-actions-cpu-cores@97ba232459a8e02ff6121db9362b09661c875ab8 # v2
         id: cpu-cores
 
       - name: 'Setup Rust toolchain'
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
 
       - name: Display runner information
         run: echo runner cpu count ${{ steps.cpu-cores.outputs.count }}

--- a/.github/workflows/setup-nextjs-build.yml
+++ b/.github/workflows/setup-nextjs-build.yml
@@ -30,11 +30,11 @@ jobs:
           node-version: ${{ inputs.nodeVersion || env.NODE_LTS_VERSION }}
           check-latest: true
       - name: Get number of CPU cores
-        uses: SimenB/github-actions-cpu-cores@97ba232459a8e02ff6121db9362b09661c875ab8 # v2
+        uses: SimenB/github-actions-cpu-cores@97ba232459a8e02ff6121db9362b09661c875ab8 # v2.0.0
         id: cpu-cores
 
       - name: 'Setup Rust toolchain'
-        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+        uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # stable
 
       - name: Display runner information
         run: echo runner cpu count ${{ steps.cpu-cores.outputs.count }}

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -23,7 +23,7 @@ jobs:
         github.event.issue.type.name != 'Documentation'
       }}
     steps:
-      - uses: balazsorban44/nissuer@1.10.0
+      - uses: balazsorban44/nissuer@92ef22afd6a75e5e588f5d689a1fd3433f596f82 # 1.10.0
         with:
           label-area-prefix: ''
           label-area-match: 'name'
@@ -38,7 +38,7 @@ jobs:
             }
           reproduction-comment: '.github/comments/invalid-link.md'
           reproduction-hosts: 'github.com,bitbucket.org,gitlab.com,codesandbox.io,stackblitz.com'
-          reproduction-blocklist: 'github.com/vercel/next.js.*,github.com/\\w*/?$,github.com$'
+          reproduction-blocklist: 'github.com/vercel/next.js.*,github.com/\w*/?$,github.com$'
           reproduction-link-section: '### Link to the code that reproduces this issue(.*)### To Reproduce'
           reproduction-invalid-label: 'invalid link'
           reproduction-issue-labels: 'bug,'

--- a/.github/workflows/trigger_release.yml
+++ b/.github/workflows/trigger_release.yml
@@ -101,6 +101,8 @@ jobs:
 
       - run: pnpm install
 
-      - run: node ./scripts/start-release.js --release-type ${{ github.event.inputs.releaseType || 'canary' }} --semver-type ${{ github.event.inputs.semverType }}
+      - run: node ./scripts/start-release.js --release-type "${INPUT_RELEASETYPE}" --semver-type "${INPUT_SEMVERTYPE}"
         env:
           RELEASE_BOT_GITHUB_TOKEN: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
+          INPUT_RELEASETYPE: ${{ github.event.inputs.releaseType || 'canary' }}
+          INPUT_SEMVERTYPE: ${{ github.event.inputs.semverType }}

--- a/.github/workflows/turbopack-benchmark.yml
+++ b/.github/workflows/turbopack-benchmark.yml
@@ -36,7 +36,7 @@ jobs:
         uses: ./.github/actions/setup-rust
 
       - name: Install cargo-codspeed
-        uses: taiki-e/install-action@7627fb428e65e78e2ec9a24ae5c5bd5f8553f182 # v2
+        uses: taiki-e/install-action@7627fb428e65e78e2ec9a24ae5c5bd5f8553f182 # v2.69.10
         with:
           tool: cargo-codspeed@3.0.5
 
@@ -60,7 +60,7 @@ jobs:
         run: cargo codspeed build -p turbopack-cli small_apps
 
       - name: Run the benchmarks
-        uses: CodSpeedHQ/action@1c8ae4843586d3ba879736b7f6b7b0c990757fab # v4
+        uses: CodSpeedHQ/action@1c8ae4843586d3ba879736b7f6b7b0c990757fab # v4.12.1
         with:
           mode: instrumentation
           run: cargo codspeed run -p turbopack-cli small_apps
@@ -76,7 +76,7 @@ jobs:
         uses: ./.github/actions/setup-rust
 
       - name: Install cargo-codspeed
-        uses: taiki-e/install-action@7627fb428e65e78e2ec9a24ae5c5bd5f8553f182 # v2
+        uses: taiki-e/install-action@7627fb428e65e78e2ec9a24ae5c5bd5f8553f182 # v2.69.10
         with:
           tool: cargo-codspeed@3.0.5
 
@@ -100,7 +100,7 @@ jobs:
         run: cargo codspeed build -p turbopack-ecmascript references
 
       - name: Run the benchmarks
-        uses: CodSpeedHQ/action@1c8ae4843586d3ba879736b7f6b7b0c990757fab # v4
+        uses: CodSpeedHQ/action@1c8ae4843586d3ba879736b7f6b7b0c990757fab # v4.12.1
         with:
           mode: instrumentation
           run: cargo codspeed run -p turbopack-ecmascript references
@@ -117,7 +117,7 @@ jobs:
         uses: ./.github/actions/setup-rust
 
       - name: Install cargo-codspeed
-        uses: taiki-e/install-action@7627fb428e65e78e2ec9a24ae5c5bd5f8553f182 # v2
+        uses: taiki-e/install-action@7627fb428e65e78e2ec9a24ae5c5bd5f8553f182 # v2.69.10
         with:
           tool: cargo-codspeed@3.0.5
 
@@ -127,7 +127,7 @@ jobs:
         run: cargo codspeed build -p turbopack -p turbopack-bench
 
       - name: Run the benchmarks
-        uses: CodSpeedHQ/action@1c8ae4843586d3ba879736b7f6b7b0c990757fab # v4
+        uses: CodSpeedHQ/action@1c8ae4843586d3ba879736b7f6b7b0c990757fab # v4.12.1
         with:
           mode: instrumentation
           run: cargo codspeed run

--- a/.github/workflows/turbopack-benchmark.yml
+++ b/.github/workflows/turbopack-benchmark.yml
@@ -36,12 +36,12 @@ jobs:
         uses: ./.github/actions/setup-rust
 
       - name: Install cargo-codspeed
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@7627fb428e65e78e2ec9a24ae5c5bd5f8553f182 # v2
         with:
           tool: cargo-codspeed@3.0.5
 
       - name: Cache on ${{ github.ref_name }}
-        uses: ijjk/rust-cache@turbo-cache-v1.0.9
+        uses: ijjk/rust-cache@a34594c450817c9860143c79797a8770c4e587f5 # turbo-cache-v1.0.9
         with:
           save-if: 'true'
           cache-provider: 'turbo'
@@ -60,7 +60,7 @@ jobs:
         run: cargo codspeed build -p turbopack-cli small_apps
 
       - name: Run the benchmarks
-        uses: CodSpeedHQ/action@v4
+        uses: CodSpeedHQ/action@1c8ae4843586d3ba879736b7f6b7b0c990757fab # v4
         with:
           mode: instrumentation
           run: cargo codspeed run -p turbopack-cli small_apps
@@ -76,12 +76,12 @@ jobs:
         uses: ./.github/actions/setup-rust
 
       - name: Install cargo-codspeed
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@7627fb428e65e78e2ec9a24ae5c5bd5f8553f182 # v2
         with:
           tool: cargo-codspeed@3.0.5
 
       - name: Cache on ${{ github.ref_name }}
-        uses: ijjk/rust-cache@turbo-cache-v1.0.9
+        uses: ijjk/rust-cache@a34594c450817c9860143c79797a8770c4e587f5 # turbo-cache-v1.0.9
         with:
           save-if: 'true'
           cache-provider: 'turbo'
@@ -100,7 +100,7 @@ jobs:
         run: cargo codspeed build -p turbopack-ecmascript references
 
       - name: Run the benchmarks
-        uses: CodSpeedHQ/action@v4
+        uses: CodSpeedHQ/action@1c8ae4843586d3ba879736b7f6b7b0c990757fab # v4
         with:
           mode: instrumentation
           run: cargo codspeed run -p turbopack-ecmascript references
@@ -117,7 +117,7 @@ jobs:
         uses: ./.github/actions/setup-rust
 
       - name: Install cargo-codspeed
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@7627fb428e65e78e2ec9a24ae5c5bd5f8553f182 # v2
         with:
           tool: cargo-codspeed@3.0.5
 
@@ -127,7 +127,7 @@ jobs:
         run: cargo codspeed build -p turbopack -p turbopack-bench
 
       - name: Run the benchmarks
-        uses: CodSpeedHQ/action@v4
+        uses: CodSpeedHQ/action@1c8ae4843586d3ba879736b7f6b7b0c990757fab # v4
         with:
           mode: instrumentation
           run: cargo codspeed run


### PR DESCRIPTION
Re-submission of #91933. Had a problem with my fork and had to delete it, which closed the original PR. Apologies for the noise.

## Summary

This PR pins all GitHub Actions to immutable commit SHAs instead of mutable version tags and extracts expressions from `run:` blocks into `env:` mappings.

- Pin 19 unpinned actions across workflow files to full 40-character SHAs
- Add version comments for readability (e.g., `@abc123 # v1.0.9`)
- Extract 2 secrets and 5 workflow_dispatch inputs from run blocks to env vars

## Changes by file

| File | Changes |
|------|---------|
| build_and_deploy.yml | Pinned ijjk/rust-cache, ast-grep/action, taiki-e/install-action to SHA |
| build_reusable.yml | Pinned ijjk/rust-cache, SimenB/github-actions-cpu-cores to SHA |
| cancel.yml | Pinned withgraphite/graphite-ci-action to SHA, extracted GRAPHITE_TOKEN to env var |
| lock.yml | Pinned dessant/lock-threads to SHA |
| notify_slack.yml | Pinned slackapi/slack-github-action to SHA (2 instances) |
| publish_canary.yml | Extracted NPM_TOKEN_ELEVATED to env var |
| publish_release.yml | Extracted 5 workflow_dispatch inputs to env vars |
| retry_deploy_test.yml | Pinned dtolnay/rust-toolchain to SHA |
| triage.yml | Pinned balazsorban44/nissuer to SHA |
| turbopack_benchmark.yml | Pinned taiki-e/install-action, ijjk/rust-cache, CodSpeedHQ/action to SHA |
| turbopack_benchmark_wasm.yml | Pinned taiki-e/install-action, CodSpeedHQ/action to SHA |
| turbopack_benchmark_xtask.yml | Pinned taiki-e/install-action, CodSpeedHQ/action to SHA |

## Actions Pinned

| Action | Version | SHA |
|--------|---------|-----|
| ijjk/rust-cache | turbo-cache-v1.0.9 | a34594c45081... |
| ast-grep/action | v1.5.0 | cf62e780f0c8... |
| taiki-e/install-action | nextest / v2 | 3a0adb... / 7627fb... |
| withgraphite/graphite-ci-action | main | ee395f3a7825... |
| dessant/lock-threads | v5 | 1bf7ec25051f... |
| slackapi/slack-github-action | v1.25.0 | 6c661ce58804... |
| SimenB/github-actions-cpu-cores | v2 | 97ba232459a8... |
| dtolnay/rust-toolchain | stable | 631a55b12751... |
| balazsorban44/nissuer | 1.10.0 | 92ef22afd6a7... |
| CodSpeedHQ/action | v4 | 1c8ae4843586... |

## A note on internal action pinning

This PR pins all actions including org-owned ones. Best practice is to pin everything \u2014 the tj-actions/changed-files attack was an internally maintained action that was compromised, and every repo referencing it by tag silently executed attacker code. That said, it's your codebase. If you'd prefer to leave org-owned actions unpinned, let us know and we'll adjust the PR.

## How to verify

Review the diff \u2014 each change is mechanical and preserves workflow behavior:
- **SHA pinning**: `action@v3` becomes `action@abc123 # v3` \u2014 original version preserved as comment
- **Expression extraction**: `${{ expr }}` in `run:` moves to `env:` block, referenced as `$ENV_VAR` in the script
- No workflow logic, triggers, or permissions are modified

I put up some research on this on [Twitter](https://x.com/vigilance_one/status/2036581210663616729) and a [research site](https://www.vigilantdefense.com/research/github-top-50k-repos-cicd-security-scan) if you want more context. I wrote a scanner called Runner Guard and open sourced it [here](https://github.com/Vigilant-LLC/runner-guard).

If you have any questions, reach out. I'll be monitoring comms.

\\- Chris Nyhuis (dagecko)