### PR TITLE
Turbopack: use moduleLoading.prefix in client-reference-manifest

### DIFF
--- a/crates/next-core/src/next_manifests/client_reference_manifest.rs
+++ b/crates/next-core/src/next_manifests/client_reference_manifest.rs
@@ -177,8 +177,7 @@ async fn build_manifest(
             rcstr!("")
         };
 
-        entry_manifest.module_loading.prefix =
-            format!("{}static/chunks", prefix_path).into();
+        entry_manifest.module_loading.prefix = prefix_path;
         entry_manifest.module_loading.cross_origin = next_config.cross_origin().owned().await?;
         let ClientReferencesChunks {
             client_component_client_chunks,
@@ -284,15 +283,9 @@ async fn build_manifest(
                     // be handled separately.
                     .filter(|path| path.ends_with(".js"))
                     .map(|path| {
-                        // All client JS chunks are under `static/chunks/`. Strip
-                        // that prefix here since `moduleLoading.prefix` already
-                        // contains it, saving one repetition per entry.
-                        let relative = path
-                            .strip_prefix("static/chunks")
-                            .unwrap_or(&path);
                         format!(
                             "{}{}",
-                            relative.split('/').map(encode_uri_component).format("/"),
+                            path.split('/').map(encode_uri_component).format("/"),
                             suffix_path
                         )
                     })

--- a/crates/next-core/src/next_manifests/client_reference_manifest.rs
+++ b/crates/next-core/src/next_manifests/client_reference_manifest.rs
@@ -177,6 +177,8 @@ async fn build_manifest(
             rcstr!("")
         };
 
+        entry_manifest.module_loading.prefix =
+            format!("{}static/chunks", prefix_path).into();
         entry_manifest.module_loading.cross_origin = next_config.cross_origin().owned().await?;
         let ClientReferencesChunks {
             client_component_client_chunks,
@@ -282,10 +284,15 @@ async fn build_manifest(
                     // be handled separately.
                     .filter(|path| path.ends_with(".js"))
                     .map(|path| {
+                        // All client JS chunks are under `static/chunks/`. Strip
+                        // that prefix here since `moduleLoading.prefix` already
+                        // contains it, saving one repetition per entry.
+                        let relative = path
+                            .strip_prefix("static/chunks")
+                            .unwrap_or(&path);
                         format!(
-                            "{}{}{}",
-                            prefix_path,
-                            path.split('/').map(encode_uri_component).format("/"),
+                            "{}{}",
+                            relative.split('/').map(encode_uri_component).format("/"),
                             suffix_path
                         )
                     })

--- a/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-client.browser.development.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-client.browser.development.js
@@ -87,7 +87,7 @@
         i < chunks.length;
         i++
       ) {
-        var thenable = __turbopack_load_by_url__(chunks[i]);
+        var thenable = __turbopack_load__(chunks[i]);
         loadedChunks.has(thenable) || promises.push(thenable);
         if (!instrumentedChunks.has(thenable)) {
           var resolve = loadedChunks.add.bind(loadedChunks, thenable);

--- a/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-client.browser.production.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-client.browser.production.js
@@ -74,7 +74,7 @@ var instrumentedChunks = new WeakSet(),
 function ignoreReject() {}
 function preloadModule(metadata) {
   for (var chunks = metadata[1], promises = [], i = 0; i < chunks.length; i++) {
-    var thenable = __turbopack_load_by_url__(chunks[i]);
+    var thenable = __turbopack_load__(chunks[i]);
     loadedChunks.has(thenable) || promises.push(thenable);
     if (!instrumentedChunks.has(thenable)) {
       var resolve = loadedChunks.add.bind(loadedChunks, thenable);

--- a/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-client.browser.development.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-client.browser.development.js
@@ -87,7 +87,7 @@
         i < chunks.length;
         i++
       ) {
-        var thenable = __turbopack_load_by_url__(chunks[i]);
+        var thenable = __turbopack_load__(chunks[i]);
         loadedChunks.has(thenable) || promises.push(thenable);
         if (!instrumentedChunks.has(thenable)) {
           var resolve = loadedChunks.add.bind(loadedChunks, thenable);

--- a/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-client.browser.production.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-client.browser.production.js
@@ -74,7 +74,7 @@ var instrumentedChunks = new WeakSet(),
 function ignoreReject() {}
 function preloadModule(metadata) {
   for (var chunks = metadata[1], promises = [], i = 0; i < chunks.length; i++) {
-    var thenable = __turbopack_load_by_url__(chunks[i]);
+    var thenable = __turbopack_load__(chunks[i]);
     loadedChunks.has(thenable) || promises.push(thenable);
     if (!instrumentedChunks.has(thenable)) {
       var resolve = loadedChunks.add.bind(loadedChunks, thenable);

--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -1715,7 +1715,15 @@ export async function copy_vendor_react(task_) {
         // package will be bundled alongside user code and we don't need to introduce the extra
         // indirection
 
-        if (
+        if (file.base.startsWith('react-server-dom-turbopack-client.browser')) {
+          const source = file.data.toString()
+          let newSource = source.replace(
+            /__turbopack_load_by_url__/g,
+            '__turbopack_load__'
+          )
+
+          file.data = newSource
+        } else if (
           (file.base.startsWith('react-server-dom-turbopack-client') ||
             file.base.startsWith('react-server-dom-turbopack-server')) &&
           !file.base.includes('.browser.')

--- a/test/production/app-dir/actions-tree-shaking/client-actions-tree-shaking/client-actions-tree-shaking.test.ts
+++ b/test/production/app-dir/actions-tree-shaking/client-actions-tree-shaking/client-actions-tree-shaking.test.ts
@@ -43,11 +43,13 @@ describe('app-dir - client-actions-tree-shaking', () => {
           chunks.add(chunk)
         }
       }
-      // clientModules is a mapping from module name to a set of URLs
-      // So strip that prefix and add it to the chunks
+      // clientModules is a mapping from module name to a set of chunk paths
+      // relative to moduleLoading.prefix. Reconstruct the full URL and strip
+      // the /_next/ prefix to get the path relative to the dist directory.
       for (const clientModule of Object.values(clientManifest.clientModules)) {
         for (const chunk of clientModule.chunks) {
-          chunks.add(parseRelativeUrl(chunk).pathname.replace('/_next/', ''))
+          const fullPath = clientManifest.moduleLoading.prefix + chunk
+          chunks.add(parseRelativeUrl(fullPath).pathname.replace('/_next/', ''))
         }
       }
     } else {


### PR DESCRIPTION
Set moduleLoading.prefix to `{assetPrefix}/_next` so that each entry in the chunks array only needs to store the filename (e.g. `static/chunks/foo.js`) rather than the full URL (e.g. `/_next/foo.js`), matching the intent of the moduleLoading.prefix field and reducing manifest size. Update the actions-tree-shaking test to reconstruct the full path via moduleLoading.prefix before stripping the /_next/ prefix.

It appears that `moduleLoading.prefix` can only really be easily used when it's the same value as the bundler's public chunk path. 
It works like this in webpack because the prefix is "coincidentally" the same value as
```
/******/ 	/* webpack/runtime/publicPath */
/******/ 	(() => {
/******/ 		__webpack_require__.p = "/app-router-server/_next/";
/******/ 	})();
```