### PR TITLE
fix(turbopack): ignore type-only import edges

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
@@ -673,6 +673,10 @@ impl Visit for Analyzer<'_> {
     fn visit_export_all(&mut self, export: &ExportAll) {
         self.data.has_exports = true;
 
+        if export.type_only {
+            return;
+        }
+
         let annotations = ImportAnnotations::parse(export.with.as_deref());
 
         self.ensure_reference(
@@ -705,8 +709,14 @@ impl Visit for Analyzer<'_> {
         let annotations = ImportAnnotations::parse(export.with.as_deref());
 
         let internal_symbol = parse_with(export.with.as_deref());
+        let has_runtime_export = !export.type_only
+            && (export.specifiers.is_empty()
+                || export
+                    .specifiers
+                    .iter()
+                    .any(|specifier| !is_type_only_export_specifier(specifier)));
 
-        if internal_symbol.is_none() || export.specifiers.is_empty() {
+        if has_runtime_export && (internal_symbol.is_none() || export.specifiers.is_empty()) {
             self.ensure_reference(
                 export.span,
                 src.value.clone(),
@@ -715,7 +725,15 @@ impl Visit for Analyzer<'_> {
             );
         }
 
+        if !has_runtime_export {
+            return;
+        }
+
         for spec in export.specifiers.iter() {
+            if is_type_only_export_specifier(spec) {
+                continue;
+            }
+
             let symbol = internal_symbol
                 .clone()
                 .unwrap_or_else(|| get_import_symbol_from_export(spec));
@@ -1045,6 +1063,16 @@ fn is_type_only_import_specifier(specifier: &ImportSpecifier) -> bool {
     )
 }
 
+fn is_type_only_export_specifier(specifier: &ExportSpecifier) -> bool {
+    matches!(
+        specifier,
+        ExportSpecifier::Named(ExportNamedSpecifier {
+            is_type_only: true,
+            ..
+        })
+    )
+}
+
 fn get_import_symbol_from_export(specifier: &ExportSpecifier) -> ImportedSymbol {
     match specifier {
         ExportSpecifier::Named(ExportNamedSpecifier { orig, .. }) => {
@@ -1185,6 +1213,33 @@ mod tests {
     }
 
     #[test]
+    fn test_analyze_skips_full_type_only_re_exports() {
+        let program = parse_typescript_program("export type { Foo } from 'pkg';");
+        let import_map = ImportMap::analyze(&program, None, None);
+
+        assert!(import_map.references.is_empty());
+        assert!(import_map.reexports.is_empty());
+    }
+
+    #[test]
+    fn test_analyze_skips_named_type_only_re_exports() {
+        let program = parse_typescript_program("export { type Foo } from 'pkg';");
+        let import_map = ImportMap::analyze(&program, None, None);
+
+        assert!(import_map.references.is_empty());
+        assert!(import_map.reexports.is_empty());
+    }
+
+    #[test]
+    fn test_analyze_skips_type_only_export_star() {
+        let program = parse_typescript_program("export type * from 'pkg';");
+        let import_map = ImportMap::analyze(&program, None, None);
+
+        assert!(import_map.references.is_empty());
+        assert!(import_map.reexports.is_empty());
+    }
+
+    #[test]
     fn test_analyze_keeps_runtime_edges_for_mixed_imports() {
         let program = parse_typescript_program("import { type Foo, bar as baz } from 'pkg';");
         let import_map = ImportMap::analyze(&program, None, None);
@@ -1209,5 +1264,31 @@ mod tests {
 
         assert_eq!(import_map.imports.len(), 1);
         assert!(import_map.namespace_imports.is_empty());
+    }
+
+    #[test]
+    fn test_analyze_keeps_runtime_edges_for_mixed_re_exports() {
+        let program = parse_typescript_program("export { type Foo, bar as baz } from 'pkg';");
+        let import_map = ImportMap::analyze(&program, None, None);
+
+        assert_eq!(import_map.references.len(), 2);
+        assert_eq!(
+            import_map.references[0].imported_symbol,
+            ImportedSymbol::ModuleEvaluation
+        );
+        assert_eq!(
+            import_map.references[1].imported_symbol,
+            ImportedSymbol::Symbol(atom!("bar"))
+        );
+        assert_eq!(
+            import_map.references[0].module_path.to_string_lossy(),
+            "pkg"
+        );
+        assert_eq!(
+            import_map.references[1].module_path.to_string_lossy(),
+            "pkg"
+        );
+
+        assert_eq!(import_map.reexports.len(), 1);
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
@@ -603,7 +603,14 @@ impl Visit for Analyzer<'_> {
 
         let internal_symbol = parse_with(import.with.as_deref());
 
-        if internal_symbol.is_none() {
+        let has_runtime_import = !import.type_only
+            && (import.specifiers.is_empty()
+                || import
+                    .specifiers
+                    .iter()
+                    .any(|specifier| !is_type_only_import_specifier(specifier)));
+
+        if internal_symbol.is_none() && has_runtime_import {
             self.ensure_reference(
                 import.span,
                 import.src.value.clone(),
@@ -612,7 +619,15 @@ impl Visit for Analyzer<'_> {
             );
         }
 
+        if import.type_only {
+            return;
+        }
+
         for s in &import.specifiers {
+            if is_type_only_import_specifier(s) {
+                continue;
+            }
+
             let symbol = internal_symbol
                 .clone()
                 .unwrap_or_else(|| get_import_symbol_from_import(s));
@@ -1020,6 +1035,16 @@ fn get_import_symbol_from_import(specifier: &ImportSpecifier) -> ImportedSymbol 
     }
 }
 
+fn is_type_only_import_specifier(specifier: &ImportSpecifier) -> bool {
+    matches!(
+        specifier,
+        ImportSpecifier::Named(ImportNamedSpecifier {
+            is_type_only: true,
+            ..
+        })
+    )
+}
+
 fn get_import_symbol_from_export(specifier: &ExportSpecifier) -> ImportedSymbol {
     match specifier {
         ExportSpecifier::Named(ExportNamedSpecifier { orig, .. }) => {
@@ -1032,7 +1057,16 @@ fn get_import_symbol_from_export(specifier: &ExportSpecifier) -> ImportedSymbol 
 
 #[cfg(test)]
 mod tests {
-    use swc_core::{atoms::Atom, common::DUMMY_SP, ecma::ast::*};
+    use std::sync::Arc;
+
+    use swc_core::{
+        atoms::Atom,
+        common::{DUMMY_SP, FileName, SourceMap},
+        ecma::{
+            ast::*,
+            parser::{Parser, StringInput, Syntax, TsSyntax},
+        },
+    };
 
     use super::*;
 
@@ -1113,5 +1147,67 @@ mod tests {
     fn test_parse_empty_with() {
         let annotations = ImportAnnotations::parse(None);
         assert!(annotations.is_none());
+    }
+
+    fn parse_typescript_program(source: &str) -> Program {
+        let source_map = Arc::<SourceMap>::default();
+        let file = source_map.new_source_file(
+            FileName::Custom("test.ts".into()).into(),
+            source.to_string(),
+        );
+        let mut parser = Parser::new(
+            Syntax::Typescript(TsSyntax::default()),
+            StringInput::from(&*file),
+            None,
+        );
+
+        parser.parse_program().expect("valid program")
+    }
+
+    #[test]
+    fn test_analyze_skips_full_type_only_imports() {
+        let program = parse_typescript_program("import type { Foo } from 'pkg';");
+        let import_map = ImportMap::analyze(&program, None, None);
+
+        assert!(import_map.references.is_empty());
+        assert!(import_map.imports.is_empty());
+        assert!(import_map.namespace_imports.is_empty());
+    }
+
+    #[test]
+    fn test_analyze_skips_named_type_only_imports() {
+        let program = parse_typescript_program("import { type Foo } from 'pkg';");
+        let import_map = ImportMap::analyze(&program, None, None);
+
+        assert!(import_map.references.is_empty());
+        assert!(import_map.imports.is_empty());
+        assert!(import_map.namespace_imports.is_empty());
+    }
+
+    #[test]
+    fn test_analyze_keeps_runtime_edges_for_mixed_imports() {
+        let program = parse_typescript_program("import { type Foo, bar as baz } from 'pkg';");
+        let import_map = ImportMap::analyze(&program, None, None);
+
+        assert_eq!(import_map.references.len(), 2);
+        assert_eq!(
+            import_map.references[0].imported_symbol,
+            ImportedSymbol::ModuleEvaluation
+        );
+        assert_eq!(
+            import_map.references[1].imported_symbol,
+            ImportedSymbol::Symbol(atom!("bar"))
+        );
+        assert_eq!(
+            import_map.references[0].module_path.to_string_lossy(),
+            "pkg"
+        );
+        assert_eq!(
+            import_map.references[1].module_path.to_string_lossy(),
+            "pkg"
+        );
+
+        assert_eq!(import_map.imports.len(), 1);
+        assert!(import_map.namespace_imports.is_empty());
     }
 }


### PR DESCRIPTION
## Summary
- skip Turbopack module-evaluation edges for imports that are erased at runtime because they are entirely type-only
- ignore named type-only specifiers when recording imported symbols so client graphs do not keep server-only modules alive through `import { type X }`
- add focused analyzer tests for full type-only, named type-only, and mixed runtime imports

Fixes #92025.

## Testing
- cargo test -p turbopack-ecmascript test_analyze -- --nocapture
- cargo fmt --check --all -- turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs