### PR TITLE
[DevServer] Add global lockfile for server discovery

### DIFF
--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -10,6 +10,7 @@ import type { NextJsHotReloaderInterface } from '../../dev/hot-reloader-types'
 import { createDefineEnv } from '../../../build/swc'
 import { installBindings } from '../../../build/swc/install-bindings'
 import fs from 'fs'
+import os from 'os'
 import path from 'path'
 import qs from 'querystring'
 import Watchpack from 'next/dist/compiled/watchpack'
@@ -217,6 +218,31 @@ async function startWatcher(
       opts.nextConfig.distDir
     )
   }
+
+  // Create a global lockfile at ~/.next/dev/<port>/lock so external tools can
+  // enumerate all running dev servers by scanning ~/.next/dev/*/lock.
+  const globalLockDir = path.join(
+    os.homedir(),
+    '.next',
+    'dev',
+    String(opts.port)
+  )
+  fs.mkdirSync(globalLockDir, { recursive: true })
+  const globalServerInfo: DevServerInfo = {
+    pid: process.pid,
+    port: opts.port,
+    hostname: 'localhost',
+    appUrl: `http://localhost:${opts.port}`,
+    startedAt: Date.now(),
+  }
+  const globalLockfile = Lockfile.tryAcquire(
+    path.join(globalLockDir, 'lock'),
+    true,
+    JSON.stringify(globalServerInfo)
+  )
+  opts.onDevServerCleanup?.(async () => {
+    await globalLockfile?.unlock()
+  })
 
   const validFileMatcher = createValidFileMatcher(
     nextConfig.pageExtensions,

--- a/test/development/lockfile/lockfile.test.ts
+++ b/test/development/lockfile/lockfile.test.ts
@@ -1,12 +1,19 @@
 import { nextTestSetup } from 'e2e-utils'
 import execa from 'execa'
 import fs from 'fs'
+import os from 'os'
 import path from 'path'
 import stripAnsi from 'strip-ansi'
 
 describe('lockfile', () => {
   const { next, isTurbopack, isRspack } = nextTestSetup({
     files: __dirname,
+  })
+
+  afterAll(() => {
+    // Clean up global lockfile created during test
+    const globalLockDir = path.join(os.homedir(), '.next', 'dev', next.appPort)
+    fs.rmSync(globalLockDir, { recursive: true, force: true })
   })
 
   it('only allows a single instance of `next dev` to run at a time', async () => {
@@ -66,5 +73,37 @@ describe('lockfile', () => {
     // Make sure the other instance of `next dev` didn't mess anything up
     await browser.refresh()
     expect(await browser.elementByCss('p').text()).toBe('Page')
+  })
+
+  it('creates a global lockfile at ~/.next/dev/<port>/lock with flock held', async () => {
+    const globalLockfilePath = path.join(
+      os.homedir(),
+      '.next',
+      'dev',
+      next.appPort,
+      'lock'
+    )
+    expect(fs.existsSync(globalLockfilePath)).toBe(true)
+
+    // Verify lockfile content has correct server info
+    const serverInfo = JSON.parse(fs.readFileSync(globalLockfilePath, 'utf-8'))
+    expect(serverInfo).toMatchObject({
+      pid: expect.any(Number),
+      port: Number(next.appPort),
+      hostname: 'localhost',
+      appUrl: expect.stringContaining(next.appPort),
+      startedAt: expect.any(Number),
+    })
+
+    // Verify the process from the lockfile is actually alive
+    const isAlive = (() => {
+      try {
+        process.kill(serverInfo.pid, 0)
+        return true
+      } catch {
+        return false
+      }
+    })()
+    expect(isAlive).toBe(true)
   })
 })


### PR DESCRIPTION
There's currently no way for external tooling to discover all running `next dev` servers across different projects. Each server only acquires a per-project lockfile at `<distDir>/lock`.

This adds a global lockfile at `~/.next/dev/<port>/lock` containing `DevServerInfo` JSON (pid, port, hostname, appUrl, startedAt). The lock is acquired via `Lockfile.tryAcquire` with `unlockOnExit: true`, so the OS releases the `flock` automatically on process exit including `kill -9`. Cleanup on graceful shutdown is handled via the existing `onDevServerCleanup` callback.

External tools can discover running servers by scanning `~/.next/dev/*/lock` and attempting `flock` on each — a held lock means the server is alive, and the file contents provide connection details.