### PR TITLE
Turbopack: Dedupe our two filesystempath extension/extension_ref functions

### DIFF
--- a/crates/next-api/src/next_server_nft.rs
+++ b/crates/next-api/src/next_server_nft.rs
@@ -142,7 +142,7 @@ impl Asset for ServerNftJsonAsset {
                 let DirectoryEntry::File(file) = entry else {
                     continue;
                 };
-                if file.extension() == "js" {
+                if file.extension() == Some("js") {
                     server_output_assets.push(
                         base_dir
                             .get_relative_path_to(file)

--- a/crates/next-core/src/next_app/metadata/image.rs
+++ b/crates/next-core/src/next_app/metadata/image.rs
@@ -32,7 +32,7 @@ async fn dynamic_image_metadata_with_generator_source(
 ) -> Result<Vc<Box<dyn Source>>> {
     let stem = path.file_stem();
     let stem = stem.unwrap_or_default();
-    let ext = path.extension();
+    let ext = path.extension().unwrap_or_default();
 
     let hash = path
         .read()
@@ -110,7 +110,7 @@ async fn dynamic_image_metadata_without_generator_source(
 ) -> Result<Vc<Box<dyn Source>>> {
     let stem = path.file_stem();
     let stem = stem.unwrap_or_default();
-    let ext = path.extension();
+    let ext = path.extension().unwrap_or_default();
 
     let hash = path
         .read()

--- a/crates/next-core/src/next_app/metadata/image.rs
+++ b/crates/next-core/src/next_app/metadata/image.rs
@@ -43,7 +43,7 @@ async fn dynamic_image_metadata_with_generator_source(
     let sizes = if use_numeric_sizes {
         "data.width = size.width; data.height = size.height;".to_string()
     } else {
-        let sizes = if path.has_extension("svg") {
+        let sizes = if path.has_extension(".svg") {
             "any"
         } else {
             "${size.width}x${size.height}"
@@ -120,7 +120,7 @@ async fn dynamic_image_metadata_without_generator_source(
     let sizes = if use_numeric_sizes {
         "data.width = size.width; data.height = size.height;".to_string()
     } else {
-        let sizes = if path.has_extension("svg") {
+        let sizes = if path.has_extension(".svg") {
             "any"
         } else {
             "${size.width}x${size.height}"

--- a/crates/next-core/src/next_app/metadata/image.rs
+++ b/crates/next-core/src/next_app/metadata/image.rs
@@ -32,7 +32,6 @@ async fn dynamic_image_metadata_with_generator_source(
 ) -> Result<Vc<Box<dyn Source>>> {
     let stem = path.file_stem();
     let stem = stem.unwrap_or_default();
-    let ext = path.extension();
 
     let hash = path
         .read()
@@ -44,7 +43,7 @@ async fn dynamic_image_metadata_with_generator_source(
     let sizes = if use_numeric_sizes {
         "data.width = size.width; data.height = size.height;".to_string()
     } else {
-        let sizes = if ext == Some("svg") {
+        let sizes = if path.has_extension("svg") {
             "any"
         } else {
             "${size.width}x${size.height}"
@@ -86,7 +85,7 @@ async fn dynamic_image_metadata_with_generator_source(
             }}
         "#,
         exported_fields_excluding_default = exported_fields_excluding_default,
-        resource_path = StringifyJs(&format!("./{stem}.{}", ext.unwrap_or(""))),
+        resource_path = StringifyJs(&format!("./{}", path.file_name())),
         pathname_prefix = StringifyJs(&page.to_string()),
         page_segment = StringifyJs(stem),
         sizes = sizes,
@@ -110,7 +109,6 @@ async fn dynamic_image_metadata_without_generator_source(
 ) -> Result<Vc<Box<dyn Source>>> {
     let stem = path.file_stem();
     let stem = stem.unwrap_or_default();
-    let ext = path.extension();
 
     let hash = path
         .read()
@@ -122,7 +120,7 @@ async fn dynamic_image_metadata_without_generator_source(
     let sizes = if use_numeric_sizes {
         "data.width = size.width; data.height = size.height;".to_string()
     } else {
-        let sizes = if ext == Some("svg") {
+        let sizes = if path.has_extension("svg") {
             "any"
         } else {
             "${size.width}x${size.height}"
@@ -158,7 +156,7 @@ async fn dynamic_image_metadata_without_generator_source(
             }}
         "#,
         exported_fields_excluding_default = exported_fields_excluding_default,
-        resource_path = StringifyJs(&format!("./{stem}.{}", ext.unwrap_or(""))),
+        resource_path = StringifyJs(&format!("./{}", path.file_name())),
         pathname_prefix = StringifyJs(&page.to_string()),
         page_segment = StringifyJs(stem),
         sizes = sizes,

--- a/crates/next-core/src/next_app/metadata/image.rs
+++ b/crates/next-core/src/next_app/metadata/image.rs
@@ -32,7 +32,7 @@ async fn dynamic_image_metadata_with_generator_source(
 ) -> Result<Vc<Box<dyn Source>>> {
     let stem = path.file_stem();
     let stem = stem.unwrap_or_default();
-    let ext = path.extension().unwrap_or_default();
+    let ext = path.extension();
 
     let hash = path
         .read()
@@ -44,7 +44,7 @@ async fn dynamic_image_metadata_with_generator_source(
     let sizes = if use_numeric_sizes {
         "data.width = size.width; data.height = size.height;".to_string()
     } else {
-        let sizes = if ext == "svg" {
+        let sizes = if ext == Some("svg") {
             "any"
         } else {
             "${size.width}x${size.height}"
@@ -86,7 +86,7 @@ async fn dynamic_image_metadata_with_generator_source(
             }}
         "#,
         exported_fields_excluding_default = exported_fields_excluding_default,
-        resource_path = StringifyJs(&format!("./{stem}.{ext}")),
+        resource_path = StringifyJs(&format!("./{stem}.{}", ext.unwrap_or(""))),
         pathname_prefix = StringifyJs(&page.to_string()),
         page_segment = StringifyJs(stem),
         sizes = sizes,
@@ -110,7 +110,7 @@ async fn dynamic_image_metadata_without_generator_source(
 ) -> Result<Vc<Box<dyn Source>>> {
     let stem = path.file_stem();
     let stem = stem.unwrap_or_default();
-    let ext = path.extension().unwrap_or_default();
+    let ext = path.extension();
 
     let hash = path
         .read()
@@ -122,7 +122,7 @@ async fn dynamic_image_metadata_without_generator_source(
     let sizes = if use_numeric_sizes {
         "data.width = size.width; data.height = size.height;".to_string()
     } else {
-        let sizes = if ext == "svg" {
+        let sizes = if ext == Some("svg") {
             "any"
         } else {
             "${size.width}x${size.height}"
@@ -158,7 +158,7 @@ async fn dynamic_image_metadata_without_generator_source(
             }}
         "#,
         exported_fields_excluding_default = exported_fields_excluding_default,
-        resource_path = StringifyJs(&format!("./{stem}.{ext}")),
+        resource_path = StringifyJs(&format!("./{stem}.{}", ext.unwrap_or(""))),
         pathname_prefix = StringifyJs(&page.to_string()),
         page_segment = StringifyJs(stem),
         sizes = sizes,

--- a/crates/next-core/src/next_app/metadata/mod.rs
+++ b/crates/next-core/src/next_app/metadata/mod.rs
@@ -89,7 +89,7 @@ fn match_metadata_file<'a>(
 
 pub(crate) async fn get_content_type(path: FileSystemPath) -> Result<String> {
     let stem = path.file_stem();
-    let mut ext = path.extension();
+    let mut ext = path.extension().unwrap_or_default();
 
     let name = stem.unwrap_or_default();
     if ext == "jpg" {

--- a/crates/next-core/src/next_app/metadata/mod.rs
+++ b/crates/next-core/src/next_app/metadata/mod.rs
@@ -89,14 +89,14 @@ fn match_metadata_file<'a>(
 
 pub(crate) async fn get_content_type(path: FileSystemPath) -> Result<String> {
     let stem = path.file_stem();
-    let mut ext = path.extension().unwrap_or_default();
+    let mut ext = path.extension();
 
     let name = stem.unwrap_or_default();
-    if ext == "jpg" {
-        ext = "jpeg"
+    if ext == Some("jpg") {
+        ext = Some("jpeg");
     }
 
-    if name == "favicon" && ext == "ico" {
+    if name == "favicon" && ext == Some("ico") {
         return Ok("image/x-icon".to_string());
     }
     if name == "sitemap" {
@@ -109,7 +109,9 @@ pub(crate) async fn get_content_type(path: FileSystemPath) -> Result<String> {
         return Ok("application/manifest+json".to_string());
     }
 
-    if ext == "png" || ext == "jpeg" || ext == "ico" || ext == "svg" {
+    if let Some(ext) = ext
+        && matches!(ext, "png" | "jpeg" | "ico" | "svg")
+    {
         return Ok(mime_guess::from_ext(ext)
             .first_or_octet_stream()
             .to_string());

--- a/crates/next-core/src/next_app/metadata/route.rs
+++ b/crates/next-core/src/next_app/metadata/route.rs
@@ -215,7 +215,7 @@ async fn static_route_source(mode: NextMode, path: FileSystemPath) -> Result<Vc<
 async fn dynamic_text_route_source(path: FileSystemPath) -> Result<Vc<Box<dyn Source>>> {
     let stem = path.file_stem();
     let stem = stem.unwrap_or_default();
-    let ext = path.extension();
+    let ext = path.extension().unwrap_or_default();
 
     let content_type = get_content_type(path.clone()).await?;
 
@@ -270,7 +270,7 @@ async fn dynamic_sitemap_route_with_generate_source(
 ) -> Result<Vc<Box<dyn Source>>> {
     let stem = path.file_stem();
     let stem = stem.unwrap_or_default();
-    let ext = path.extension();
+    let ext = path.extension().unwrap_or_default();
     let content_type = get_content_type(path.clone()).await?;
 
     let code = formatdoc! {
@@ -360,7 +360,7 @@ async fn dynamic_sitemap_route_without_generate_source(
 ) -> Result<Vc<Box<dyn Source>>> {
     let stem = path.file_stem();
     let stem = stem.unwrap_or_default();
-    let ext = path.extension();
+    let ext = path.extension().unwrap_or_default();
     let content_type = get_content_type(path.clone()).await?;
 
     let code = formatdoc! {
@@ -423,7 +423,7 @@ async fn dynamic_image_route_with_metadata_source(
 ) -> Result<Vc<Box<dyn Source>>> {
     let stem = path.file_stem();
     let stem = stem.unwrap_or_default();
-    let ext = path.extension();
+    let ext = path.extension().unwrap_or_default();
 
     let code = formatdoc! {
         r#"
@@ -495,7 +495,7 @@ async fn dynamic_image_route_without_metadata_source(
 ) -> Result<Vc<Box<dyn Source>>> {
     let stem = path.file_stem();
     let stem = stem.unwrap_or_default();
-    let ext = path.extension();
+    let ext = path.extension().unwrap_or_default();
 
     let code = formatdoc! {
         r#"

--- a/crates/next-core/src/next_app/metadata/route.rs
+++ b/crates/next-core/src/next_app/metadata/route.rs
@@ -215,7 +215,6 @@ async fn static_route_source(mode: NextMode, path: FileSystemPath) -> Result<Vc<
 async fn dynamic_text_route_source(path: FileSystemPath) -> Result<Vc<Box<dyn Source>>> {
     let stem = path.file_stem();
     let stem = stem.unwrap_or_default();
-    let ext = path.extension().unwrap_or_default();
 
     let content_type = get_content_type(path.clone()).await?;
 
@@ -250,7 +249,7 @@ async fn dynamic_text_route_source(path: FileSystemPath) -> Result<Vc<Box<dyn So
 
             export * from {resource_path}
         "#,
-        resource_path = StringifyJs(&format!("./{stem}.{ext}")),
+        resource_path = StringifyJs(&format!("./{}", path.file_name())),
         content_type = StringifyJs(&content_type),
         file_type = StringifyJs(&stem),
         cache_control = StringifyJs(CACHE_HEADER_REVALIDATE),
@@ -270,7 +269,6 @@ async fn dynamic_sitemap_route_with_generate_source(
 ) -> Result<Vc<Box<dyn Source>>> {
     let stem = path.file_stem();
     let stem = stem.unwrap_or_default();
-    let ext = path.extension().unwrap_or_default();
     let content_type = get_content_type(path.clone()).await?;
 
     let code = formatdoc! {
@@ -340,7 +338,7 @@ async fn dynamic_sitemap_route_with_generate_source(
                 return params
             }}
         "#,
-        resource_path = StringifyJs(&format!("./{stem}.{ext}")),
+        resource_path = StringifyJs(&format!("./{}", path.file_name())),
         content_type = StringifyJs(&content_type),
         file_type = StringifyJs(&stem),
         cache_control = StringifyJs(CACHE_HEADER_REVALIDATE),
@@ -360,7 +358,6 @@ async fn dynamic_sitemap_route_without_generate_source(
 ) -> Result<Vc<Box<dyn Source>>> {
     let stem = path.file_stem();
     let stem = stem.unwrap_or_default();
-    let ext = path.extension().unwrap_or_default();
     let content_type = get_content_type(path.clone()).await?;
 
     let code = formatdoc! {
@@ -391,7 +388,7 @@ async fn dynamic_sitemap_route_without_generate_source(
 
             export * from {resource_path}
         "#,
-        resource_path = StringifyJs(&format!("./{stem}.{ext}")),
+        resource_path = StringifyJs(&format!("./{}", path.file_name())),
         content_type = StringifyJs(&content_type),
         file_type = StringifyJs(&stem),
         cache_control = StringifyJs(CACHE_HEADER_REVALIDATE),
@@ -423,7 +420,6 @@ async fn dynamic_image_route_with_metadata_source(
 ) -> Result<Vc<Box<dyn Source>>> {
     let stem = path.file_stem();
     let stem = stem.unwrap_or_default();
-    let ext = path.extension().unwrap_or_default();
 
     let code = formatdoc! {
         r#"
@@ -478,7 +474,7 @@ async fn dynamic_image_route_with_metadata_source(
                 return staticParams
             }}
         "#,
-        resource_path = StringifyJs(&format!("./{stem}.{ext}")),
+        resource_path = StringifyJs(&format!("./{}", path.file_name())),
     };
 
     let file = File::from(code);
@@ -495,7 +491,6 @@ async fn dynamic_image_route_without_metadata_source(
 ) -> Result<Vc<Box<dyn Source>>> {
     let stem = path.file_stem();
     let stem = stem.unwrap_or_default();
-    let ext = path.extension().unwrap_or_default();
 
     let code = formatdoc! {
         r#"
@@ -512,7 +507,7 @@ async fn dynamic_image_route_without_metadata_source(
 
             export * from {resource_path}
         "#,
-        resource_path = StringifyJs(&format!("./{stem}.{ext}")),
+        resource_path = StringifyJs(&format!("./{}", path.file_name())),
     };
 
     let file = File::from(code);

--- a/crates/next-core/src/next_server/resolve.rs
+++ b/crates/next-core/src/next_server/resolve.rs
@@ -171,7 +171,7 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
         ) -> Result<FileType> {
             // node.js only supports these file extensions
             // mjs is an esm module and we can't bundle that yet
-            Ok(match raw_fs_path.extension_ref() {
+            Ok(match raw_fs_path.extension() {
                 Some("cjs" | "node" | "json") => FileType::CommonJs,
                 Some("mjs") => FileType::EcmaScriptModule,
                 Some("js") => {

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -1499,7 +1499,7 @@ impl FileSystemPath {
 
     /// Returns true if this path has the given extension
     ///
-    /// slightly faster than `self.extension_ref() == Some(extension)` as we can simply match a
+    /// slightly faster than `self.extension() == Some(extension)` as we can simply match a
     /// suffix
     pub fn has_extension(&self, extension: &str) -> bool {
         debug_assert!(!extension.contains('/') && extension.starts_with('.'));
@@ -1507,7 +1507,7 @@ impl FileSystemPath {
     }
 
     /// Returns the extension (without a leading `.`)
-    pub fn extension_ref(&self) -> Option<&str> {
+    pub fn extension(&self) -> Option<&str> {
         let (_, extension) = self.split_extension();
         extension
     }
@@ -1683,10 +1683,6 @@ impl FileSystemPath {
 impl FileSystemPath {
     pub fn fs(&self) -> Vc<Box<dyn FileSystem>> {
         *self.fs
-    }
-
-    pub fn extension(&self) -> &str {
-        self.extension_ref().unwrap_or_default()
     }
 
     pub fn is_inside(&self, other: &FileSystemPath) -> bool {

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -653,7 +653,7 @@ impl ChunkingContext for BrowserChunkingContext {
             .as_ref()
             .context("Missing content when trying to generate the content hash for static asset")?;
         let short_hash = &hash[..length as usize];
-        let asset_path = match source_path.extension_ref() {
+        let asset_path = match source_path.extension() {
             Some(ext) => format!(
                 "{basename}.{short_hash}.{ext}",
                 basename = &basename[..basename.len() - ext.len() - 1],

--- a/turbopack/crates/turbopack-image/src/process/mod.rs
+++ b/turbopack/crates/turbopack-image/src/process/mod.rs
@@ -348,7 +348,7 @@ pub async fn get_meta_data(
     };
     let bytes = content.content().to_bytes();
     let path = image.ident().path().await?;
-    let extension = path.extension();
+    let extension = path.extension().unwrap_or_default();
 
     if extension == "svg" {
         let content = result_to_issue(
@@ -431,7 +431,7 @@ pub async fn optimize(
     };
     let bytes = content.content().to_bytes();
     let path = source.ident().path().await?;
-    let extension = path.extension();
+    let extension = path.extension().unwrap_or_default();
 
     let Some((image, format)) = load_image(source, &bytes, extension) else {
         return Ok(FileContent::NotFound.cell());

--- a/turbopack/crates/turbopack-image/src/process/mod.rs
+++ b/turbopack/crates/turbopack-image/src/process/mod.rs
@@ -125,7 +125,7 @@ fn result_to_issue<T>(source: ResolvedVc<Box<dyn Source>>, result: Result<T>) ->
 fn load_image(
     path: ResolvedVc<Box<dyn Source>>,
     bytes: &[u8],
-    extension: &str,
+    extension: Option<&str>,
 ) -> Option<(ImageBuffer, Option<ImageFormat>)> {
     result_to_issue(path, load_image_internal(path, bytes, extension))
 }
@@ -140,7 +140,7 @@ enum ImageBuffer {
 fn load_image_internal(
     image: ResolvedVc<Box<dyn Source>>,
     bytes: &[u8],
-    extension: &str,
+    extension: Option<&str>,
 ) -> Result<(ImageBuffer, Option<ImageFormat>)> {
     let reader = image::ImageReader::new(Cursor::new(&bytes));
     let mut reader = reader
@@ -148,7 +148,8 @@ fn load_image_internal(
         .context("unable to determine image format from file content")?;
     let mut format = reader.format();
     if format.is_none()
-        && let Some(new_format) = extension_to_image_format(extension)
+        && let Some(ext) = extension
+        && let Some(new_format) = extension_to_image_format(ext)
     {
         format = Some(new_format);
         reader.set_format(new_format);
@@ -348,9 +349,9 @@ pub async fn get_meta_data(
     };
     let bytes = content.content().to_bytes();
     let path = image.ident().path().await?;
-    let extension = path.extension().unwrap_or_default();
+    let extension = path.extension();
 
-    if extension == "svg" {
+    if extension == Some("svg") {
         let content = result_to_issue(
             image,
             std::str::from_utf8(&bytes).context("Input image is not valid utf-8"),
@@ -431,7 +432,7 @@ pub async fn optimize(
     };
     let bytes = content.content().to_bytes();
     let path = source.ident().path().await?;
-    let extension = path.extension().unwrap_or_default();
+    let extension = path.extension();
 
     let Some((image, format)) = load_image(source, &bytes, extension) else {
         return Ok(FileContent::NotFound.cell());

--- a/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
@@ -492,7 +492,7 @@ impl ChunkingContext for NodeJsChunkingContext {
             .as_ref()
             .context("Missing content when trying to generate the content hash for static asset")?;
         let short_hash = &hash[..length as usize];
-        let asset_path = match source_path.extension_ref() {
+        let asset_path = match source_path.extension() {
             Some(ext) => format!(
                 "{basename}.{short_hash}.{ext}",
                 basename = &basename[..basename.len() - ext.len() - 1],


### PR DESCRIPTION
PR is AI-generated

- `extension` and `extension_ref` do the same thing.
- `extension_ref`'s API that returns an `Option` was better than `extension`'s API that returns a potentially-empty string.
- In some places we were splitting into a stem and extension, and joining them back to a filename, but those places could just get the original path's filename.