### PR TITLE
fix: return 400 instead of 500 for malformed server action request body

### DIFF
--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -852,11 +852,21 @@ export async function handleAction({
 
             const actionData = Buffer.concat(chunks).toString('utf-8')
 
-            boundActionArguments = await decodeReply(
-              actionData,
-              serverModuleMap,
-              { temporaryReferences }
-            )
+            try {
+              boundActionArguments = await decodeReply(
+                actionData,
+                serverModuleMap,
+                { temporaryReferences }
+              )
+            } catch (err) {
+              // Malformed request body (e.g. invalid JSON from vulnerability
+              // scanners) should return 400, not bubble up as 500 (#86945).
+              if (err instanceof SyntaxError) {
+                res.statusCode = 400
+                return
+              }
+              throw err
+            }
           }
         } else if (
           // The type check here ensures that `req` is correctly typed, and the
@@ -1061,11 +1071,21 @@ export async function handleAction({
 
             const actionData = Buffer.concat(chunks).toString('utf-8')
 
-            boundActionArguments = await decodeReply(
-              actionData,
-              serverModuleMap,
-              { temporaryReferences }
-            )
+            try {
+              boundActionArguments = await decodeReply(
+                actionData,
+                serverModuleMap,
+                { temporaryReferences }
+              )
+            } catch (err) {
+              // Malformed request body (e.g. invalid JSON from vulnerability
+              // scanners) should return 400, not bubble up as 500 (#86945).
+              if (err instanceof SyntaxError) {
+                res.statusCode = 400
+                return
+              }
+              throw err
+            }
           }
         } else {
           throw new Error('Invariant: Unknown request type.')

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -586,6 +586,20 @@ export async function handleAction({
     }
   }
 
+  const handleMalformedActionRequest = (): HandleActionResult => {
+    // React's flight decoders throw a `SyntaxError` when the request body
+    // isn't valid JSON. That's a malformed request from the client (commonly
+    // vulnerability scanners probing Server Action endpoints, e.g. around
+    // CVE-2025-55182), so we respond with 400 Bad Request instead of letting
+    // it bubble up to the generic catch below as a 500. (#86945)
+    res.statusCode = 400
+    metadata.statusCode = 400
+    return {
+      type: 'done',
+      result: RenderResult.fromStatic('Bad Request', 'text/plain'),
+    }
+  }
+
   // If it can't be a Server Action, skip handling.
   // Note that this can be a false positive -- any multipart/urlencoded POST can get us here,
   // But won't know if it's an MPA action or not until we call `decodeAction` below.
@@ -780,11 +794,18 @@ export async function handleAction({
                 return handleUnrecognizedFetchAction(err)
               }
 
-              boundActionArguments = await decodeReply(
-                formData,
-                serverModuleMap,
-                { temporaryReferences }
-              )
+              try {
+                boundActionArguments = await decodeReply(
+                  formData,
+                  serverModuleMap,
+                  { temporaryReferences }
+                )
+              } catch (err) {
+                if (err instanceof SyntaxError) {
+                  return handleMalformedActionRequest()
+                }
+                throw err
+              }
             } else {
               // Multipart POST, but not a fetch action.
               // Potentially an MPA action, we have to try decoding it to check.
@@ -861,11 +882,18 @@ export async function handleAction({
 
             const actionData = Buffer.concat(chunks).toString('utf-8')
 
-            boundActionArguments = await decodeReply(
-              actionData,
-              serverModuleMap,
-              { temporaryReferences }
-            )
+            try {
+              boundActionArguments = await decodeReply(
+                actionData,
+                serverModuleMap,
+                { temporaryReferences }
+              )
+            } catch (err) {
+              if (err instanceof SyntaxError) {
+                return handleMalformedActionRequest()
+              }
+              throw err
+            }
           }
         } else if (
           // The type check here ensures that `req` is correctly typed, and the
@@ -960,6 +988,9 @@ export async function handleAction({
                 ])
               } catch (err) {
                 abortController.abort()
+                if (err instanceof SyntaxError) {
+                  return handleMalformedActionRequest()
+                }
                 throw err
               }
             } else {
@@ -1070,11 +1101,18 @@ export async function handleAction({
 
             const actionData = Buffer.concat(chunks).toString('utf-8')
 
-            boundActionArguments = await decodeReply(
-              actionData,
-              serverModuleMap,
-              { temporaryReferences }
-            )
+            try {
+              boundActionArguments = await decodeReply(
+                actionData,
+                serverModuleMap,
+                { temporaryReferences }
+              )
+            } catch (err) {
+              if (err instanceof SyntaxError) {
+                return handleMalformedActionRequest()
+              }
+              throw err
+            }
           }
         } else {
           throw new Error('Invariant: Unknown request type.')

--- a/test/e2e/app-dir/actions-malformed-body/actions-malformed-body.test.ts
+++ b/test/e2e/app-dir/actions-malformed-body/actions-malformed-body.test.ts
@@ -1,0 +1,89 @@
+import { nextTestSetup } from 'e2e-utils'
+
+// Regression test for https://github.com/vercel/next.js/issues/86945
+//
+// A malformed Server Action request body (invalid JSON, e.g. from a
+// vulnerability scanner probing the endpoint) makes React's flight decoder
+// throw a `SyntaxError`. Previously that bubbled up to the generic catch in
+// `handleAction` and returned HTTP 500. It should be a 400 Bad Request, since
+// the fault is in the client's request, not the server.
+//
+// We exercise all four fetch-action decode sites:
+//   - node  runtime, text/plain body      -> decodeReply(string)
+//   - node  runtime, multipart body       -> decodeReplyFromBusboy
+//   - edge  runtime, text/plain body      -> decodeReply(string)
+//   - edge  runtime, multipart body       -> decodeReply(formData)
+describe('server action malformed request body', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  // The action id is rendered into the page as a `$ACTION_ID_<hash>` field.
+  // Scrape it so we can target a *recognized* action with a malformed body.
+  async function getActionId(pathname: string): Promise<string> {
+    const html = await next.render(pathname)
+    const match = html.match(/\$ACTION_ID_([0-9a-f]+)/)
+    if (!match) {
+      throw new Error(`Could not find an action id in the HTML for ${pathname}`)
+    }
+    return match[1]
+  }
+
+  describe.each([
+    { runtime: 'nodejs', pathname: '/' },
+    { runtime: 'edge', pathname: '/edge' },
+  ])('$runtime runtime', ({ pathname }) => {
+    it('returns 400 for a malformed non-multipart (text) body', async () => {
+      const actionId = await getActionId(pathname)
+
+      const res = await next.fetch(pathname, {
+        method: 'POST',
+        headers: {
+          'next-action': actionId,
+          'content-type': 'text/plain;charset=UTF-8',
+        },
+        body: '[', // invalid JSON
+      })
+
+      expect(res.status).toBe(400)
+    })
+
+    it('returns 400 for a malformed multipart body', async () => {
+      const actionId = await getActionId(pathname)
+
+      const boundary = '----nextMalformedBodyBoundary'
+      const body =
+        `--${boundary}\r\n` +
+        `Content-Disposition: form-data; name="0"\r\n\r\n` +
+        `[zxc]\r\n` + // invalid JSON inside the form field
+        `--${boundary}--\r\n`
+
+      const res = await next.fetch(pathname, {
+        method: 'POST',
+        headers: {
+          'next-action': actionId,
+          'content-type': `multipart/form-data; boundary=${boundary}`,
+        },
+        body,
+      })
+
+      expect(res.status).toBe(400)
+    })
+  })
+
+  // Guard the ordering: an *unrecognized* action id is rejected (404) before we
+  // ever try to decode the body, so a malformed body must not turn that into a
+  // 400. This proves the 400 only applies to recognized actions with bad input.
+  it('still returns 404 for an unrecognized action id, even with a malformed body', async () => {
+    const res = await next.fetch('/', {
+      method: 'POST',
+      headers: {
+        'next-action': 'decafc0ffeebad01',
+        'content-type': 'text/plain;charset=UTF-8',
+      },
+      body: '[',
+    })
+
+    expect(res.status).toBe(404)
+  })
+})

--- a/test/e2e/app-dir/actions-malformed-body/app/actions.ts
+++ b/test/e2e/app-dir/actions-malformed-body/app/actions.ts
@@ -1,0 +1,9 @@
+'use server'
+
+// A trivial, recognized Server Action. We only need it to exist so that its
+// action id is registered in the server module map -- the tests then send
+// *malformed* request bodies to this valid id to exercise the decode error
+// paths in `handleAction`.
+export async function echo(formData: FormData) {
+  return { received: formData.get('value') }
+}

--- a/test/e2e/app-dir/actions-malformed-body/app/edge/page.tsx
+++ b/test/e2e/app-dir/actions-malformed-body/app/edge/page.tsx
@@ -1,0 +1,5 @@
+// Same page as the node runtime, but served from the edge runtime so the
+// edge decode paths in `handleAction` are exercised too.
+export const runtime = 'edge'
+
+export { default } from '../page'

--- a/test/e2e/app-dir/actions-malformed-body/app/layout.tsx
+++ b/test/e2e/app-dir/actions-malformed-body/app/layout.tsx
@@ -1,0 +1,12 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html>
+      <head />
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/actions-malformed-body/app/page.tsx
+++ b/test/e2e/app-dir/actions-malformed-body/app/page.tsx
@@ -1,0 +1,14 @@
+import { echo } from './actions'
+
+// Binding the action directly to a form makes React render the action id into
+// the page (as a `$ACTION_ID_<hash>` hidden field) for progressive
+// enhancement. The tests scrape that id so they can POST a malformed body to a
+// *recognized* action.
+export default function Page() {
+  return (
+    <form action={echo}>
+      <input name="value" defaultValue="hi" />
+      <button type="submit">Submit</button>
+    </form>
+  )
+}

--- a/test/e2e/app-dir/actions-malformed-body/next.config.js
+++ b/test/e2e/app-dir/actions-malformed-body/next.config.js
@@ -1,0 +1,2 @@
+/** @type {import('next').NextConfig} */
+module.exports = {}


### PR DESCRIPTION
## What

Malformed Server Action request bodies now return **HTTP 400 Bad Request** instead of **500 Internal Server Error**.

Fixes #86945

## Problem

When a Server Action endpoint receives a request body that isn't valid JSON, React's flight decoder (`decodeReply` / `decodeReplyFromBusboy`) throws a `SyntaxError`. It bubbled up to the generic catch in `action-handler.ts` and returned **500**, even though the fault is in the client's request, so the correct status is **400**.

This is actively triggered by vulnerability scanners probing Server Action endpoints (commonly in the wake of CVE-2025-55182). Every probe registers as a 5xx in production error monitoring, drowning out real server errors. Multiple users on the issue confirmed it as recently as `16.1.6` and the `16.x` canaries.

Reproduced on `next@16.3.0-canary.58` (text vector):

```
⨯ SyntaxError: Unexpected token 'z', "[zxc]" is not valid JSON
    at JSON.parse (<anonymous>)
 POST / 500
```

## Fix

Map a flight-decoder `SyntaxError` to `400` at all **four** fetch-action decode sites:

| Runtime | Body | Call |
|---|---|---|
| edge | multipart | `decodeReply(formData)` |
| edge | text | `decodeReply(string)` |
| node | multipart | `decodeReplyFromBusboy` |
| node | text | `decodeReply(string)` |

A small local helper (`handleMalformedActionRequest`, parallel to the existing `handleUnrecognizedFetchAction`) sets `res.statusCode` / `metadata.statusCode` to 400 and returns a terminal `Bad Request` response. Each site:

- `SyntaxError` (invalid JSON) → **400**
- any other error → **re-thrown unchanged** (preserves the existing 500 path)

The busboy site keeps its existing `abortController.abort()` cleanup before branching.

### Scope (deliberate)

This converts the **flight-decoder `SyntaxError`** — the exact symptom in #86945 — to 400. It is intentionally narrow:

- A syntactically-valid-but-incomplete flight payload (e.g. `["$1:a:a"]`) throws a different `Error` ("Connection closed"), **not** a `SyntaxError`, and is left as 500 so genuine internal errors are never masked.
- A malformed multipart **envelope** (bad boundary) fails during `formData()` / busboy parsing with a non-`SyntaxError` and likewise remains 500.
- The fix runs **after** action-id validation, so the unrecognized-action **404** path is unchanged.

In other words: invalid request *content* (bad JSON) is now a 400; everything else keeps its prior status.

## Tests

New e2e suite `test/e2e/app-dir/actions-malformed-body`:

- node + edge runtimes × text + multipart malformed bodies → **400**
- unrecognized action id + malformed body → still **404** (ordering guard)

## Verification

On `16.3.0-canary.58`, a malformed body returns 500 on `canary`; with this change it returns 400 for both the text and multipart vectors, while a well-formed-but-app-erroring request stays 500 and an unrecognized id stays 404.

---

This PR was rebased onto current `canary`, which had drifted since it was opened — `action-handler.ts` grew a third `decodeReply` call site plus the multipart `decodeReplyFromBusboy` path, and the original bare `return` was no longer valid against `handleAction`'s `Promise<HandleActionResult>` return type. It addresses the same issue as #90109; this version restricts the catch to `SyntaxError` (rather than catching all errors) so it can't mask genuine server failures.
