### PR TITLE
fix(@next/env): include dir in loadEnvConfig cache key

### DIFF
--- a/packages/next-env/index.ts
+++ b/packages/next-env/index.ts
@@ -16,6 +16,7 @@ let combinedEnv: Env | undefined = undefined
 let parsedEnv: Env | undefined = undefined
 let cachedLoadedEnvFiles: LoadedEnvFiles = []
 let previousLoadedEnvFiles: LoadedEnvFiles = []
+let cachedDir: string | undefined = undefined
 
 export function updateInitialEnv(newEnv: Env) {
   Object.assign(initialEnv || {}, newEnv)
@@ -125,13 +126,14 @@ export function loadEnvConfig(
   if (!initialEnv) {
     initialEnv = Object.assign({}, process.env)
   }
-  // only reload env when forceReload is specified
-  if (combinedEnv && !forceReload) {
+  // only reload env when forceReload is specified or dir has changed
+  if (combinedEnv && !forceReload && cachedDir === dir) {
     return { combinedEnv, parsedEnv, loadedEnvFiles: cachedLoadedEnvFiles }
   }
   replaceProcessEnv(initialEnv)
   previousLoadedEnvFiles = cachedLoadedEnvFiles
   cachedLoadedEnvFiles = []
+  cachedDir = dir
 
   const isTest = process.env.NODE_ENV === 'test'
   const mode = isTest ? 'test' : dev ? 'development' : 'production'

--- a/test/unit/load-env-config-dir-cache.test.ts
+++ b/test/unit/load-env-config-dir-cache.test.ts
@@ -1,0 +1,56 @@
+import os from 'node:os'
+import path from 'node:path'
+import fs from 'node:fs'
+import { loadEnvConfig } from '../../packages/next-env/'
+
+function makeTempDir(envContents?: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'next-env-test-'))
+  if (envContents !== undefined) {
+    fs.writeFileSync(path.join(dir, '.env'), envContents)
+  }
+  return dir
+}
+
+afterEach(() => {
+  // Reset module-level cache between tests
+  loadEnvConfig(os.tmpdir(), false, undefined, true)
+})
+
+describe('loadEnvConfig dir cache key', () => {
+  it('loads env from new dir when dir changes between calls', () => {
+    const emptyDir = makeTempDir()
+    const envDir = makeTempDir('DATABASE_URL=postgres://test')
+
+    // First call: dir with no .env (simulates Next.js internal call with app dir)
+    // Snapshot values immediately — combinedEnv is process.env by reference
+    // and will reflect mutations from subsequent calls
+    const r1 = loadEnvConfig(emptyDir, false, undefined, true)
+    const r1FileCount = r1.loadedEnvFiles.length
+    const r1Url = r1.combinedEnv.DATABASE_URL
+
+    // Second call: different dir that has a .env (simulates user envConfig.ts with monorepo root)
+    // Before the fix this would return the stale cached empty result
+    const r2 = loadEnvConfig(envDir)
+
+    expect(r1FileCount).toBe(0)
+    expect(r1Url).toBeUndefined()
+    expect(r2.loadedEnvFiles).toHaveLength(1)
+    expect(r2.combinedEnv.DATABASE_URL).toBe('postgres://test')
+  })
+
+  it('returns cached result when the same dir is called twice', () => {
+    const envDir = makeTempDir('DATABASE_URL=postgres://cached')
+
+    const r1 = loadEnvConfig(envDir, false, undefined, true)
+    expect(r1.combinedEnv.DATABASE_URL).toBe('postgres://cached')
+
+    // Write a different value to the .env — cache should prevent re-read
+    fs.writeFileSync(
+      path.join(envDir, '.env'),
+      'DATABASE_URL=postgres://updated'
+    )
+
+    const r2 = loadEnvConfig(envDir)
+    expect(r2.combinedEnv.DATABASE_URL).toBe('postgres://cached')
+  })
+})


### PR DESCRIPTION
### What?

Include `dir` as part of the `loadEnvConfig` cache key in `@next/env`.

### Why?

`loadEnvConfig` caches its result in module-level state, but the cache check only tested whether _any_ load had happened — it never compared the `dir` argument:

```ts
// Before (broken)
if (combinedEnv && !forceReload) {
  return { combinedEnv, parsedEnv, loadedEnvFiles: cachedLoadedEnvFiles }
}
```

In a monorepo where `.env` lives at the workspace root, Next.js internally calls `loadEnvConfig` with the app directory first (no `.env` there, so `loadedEnvFiles: []`). When user code then calls it with the monorepo root — a common pattern to load shared env vars — it silently hits the stale cache and returns empty results. `DATABASE_URL` (and all other vars) are `undefined` with no error and no warning.

The only workaround was the undocumented `forceReload: true` 4th argument, which also requires passing `undefined` twice to reach it.

Reproduction: https://github.com/aynaitlamine/loadenvconfig-nextjs-issue-reproduction

### How?

Added a module-level `cachedDir` variable. The cache is now only returned when `cachedDir === dir`, and `cachedDir` is updated whenever a fresh load runs. The `forceReload` path is unchanged.

```ts
// After (fixed)
if (combinedEnv && !forceReload && cachedDir === dir) {
  return { combinedEnv, parsedEnv, loadedEnvFiles: cachedLoadedEnvFiles }
}
```

- Related issues linked using `fixes #92040`
- Tests added: `test/unit/load-env-config-dir-cache.test.ts`

fixes #92040 