### PR TITLE
fix: merge Vary header with middleware values instead of overwriting

### DIFF
--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -31,6 +31,7 @@ import {
 } from '../../server/base-http/node' with { 'turbopack-transition': 'next-server-utility' }
 import { checkIsAppPPREnabled } from '../../server/lib/experimental/ppr' with { 'turbopack-transition': 'next-server-utility' }
 import { isRSCRequestHeader } from '../../server/lib/is-rsc-request' with { 'turbopack-transition': 'next-server-utility' }
+import { mergeVary } from '../../server/lib/vary' with { 'turbopack-transition': 'next-server-utility' }
 import {
   getFallbackRouteParams,
   getPlaceholderFallbackRouteParams,
@@ -714,7 +715,10 @@ export async function handler(
       resolvedPathname,
       interceptionRoutePatterns
     )
-    res.setHeader('Vary', varyHeader)
+    // Merge with any existing `Vary` value (for example one set by middleware)
+    // instead of overwriting it, so middleware `Vary` entries survive and CDN
+    // cache keying stays correct (#85999).
+    res.setHeader('Vary', mergeVary(res.getHeader('Vary'), varyHeader))
     let parentSpan: Span | undefined
     const invokeRouteModule = async (
       span: Span | undefined,

--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -1608,8 +1608,21 @@ export async function handler(
           delete headers[NEXT_CACHE_TAGS_HEADER]
         }
 
+        // Headers that support multiple values must use appendHeader;
+        // all others use setHeader to avoid duplicates when the render
+        // phase already set the same header (e.g. Location) (#82117).
+        const multiValueHeaders = new Set([
+          'set-cookie',
+          'www-authenticate',
+          'proxy-authenticate',
+          'vary',
+        ])
+
         for (let [key, value] of Object.entries(headers)) {
           if (typeof value === 'undefined') continue
+
+          const useAppend =
+            Array.isArray(value) || multiValueHeaders.has(key.toLowerCase())
 
           if (Array.isArray(value)) {
             for (const v of value) {
@@ -1617,9 +1630,17 @@ export async function handler(
             }
           } else if (typeof value === 'number') {
             value = value.toString()
-            res.appendHeader(key, value)
+            if (useAppend) {
+              res.appendHeader(key, value)
+            } else {
+              res.setHeader(key, value)
+            }
           } else {
-            res.appendHeader(key, value)
+            if (useAppend) {
+              res.appendHeader(key, value)
+            } else {
+              res.setHeader(key, value)
+            }
           }
         }
       }

--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -698,7 +698,25 @@ export async function handler(
       resolvedPathname,
       interceptionRoutePatterns
     )
-    res.setHeader('Vary', varyHeader)
+    // Merge with any existing Vary header (e.g. set by middleware) instead
+    // of overwriting it. Overwriting breaks CDN cache invalidation when
+    // middleware adds custom Vary values like X-Foo (#85999).
+    const existingVary = res.getHeader('Vary')
+    if (existingVary && varyHeader) {
+      const existingValues =
+        (typeof existingVary === 'string' ? existingVary : String(existingVary))
+          .split(',')
+          .map((v) => v.trim().toLowerCase())
+      const newValues = varyHeader
+        .split(',')
+        .map((v) => v.trim())
+        .filter((v) => !existingValues.includes(v.toLowerCase()))
+      if (newValues.length > 0) {
+        res.appendHeader('Vary', newValues.join(', '))
+      }
+    } else {
+      res.setHeader('Vary', varyHeader)
+    }
     let parentSpan: Span | undefined
     const invokeRouteModule = async (
       span: Span | undefined,

--- a/packages/next/src/build/templates/edge-ssr-app.ts
+++ b/packages/next/src/build/templates/edge-ssr-app.ts
@@ -26,6 +26,7 @@ import type {
 import type { AppPageRenderResultMetadata } from '../../server/render-result'
 import type RenderResult from '../../server/render-result'
 import { getIsPossibleServerAction } from '../../server/lib/server-action-request-meta'
+import { mergeVary } from '../../server/lib/vary'
 import { getBotType } from '../../shared/lib/router/utils/is-bot'
 import { interopDefault } from '../../lib/interop-default'
 import { normalizeAppPath } from '../../shared/lib/router/utils/app-paths'
@@ -243,7 +244,9 @@ async function requestHandler(
     headers.set('x-edge-runtime', '1')
 
     if (varyHeader) {
-      headers.set('Vary', varyHeader)
+      // Merge instead of overwrite so any `Vary` already set (for example by
+      // middleware) survives alongside the RSC values (#85999).
+      headers.set('Vary', mergeVary(headers.get('Vary'), varyHeader))
     }
 
     // Add existing headers
@@ -252,7 +255,12 @@ async function requestHandler(
       ...metadata.headers,
     })) {
       if (value !== undefined) {
-        if (Array.isArray(value)) {
+        if (key.toLowerCase() === 'vary') {
+          // Merge rather than overwrite the `Vary` set above. The spread of
+          // baseRes + metadata headers would otherwise shadow it and drop the
+          // middleware/RSC values (#85999).
+          headers.set('Vary', mergeVary(headers.get('Vary'), value))
+        } else if (Array.isArray(value)) {
           // Handle multiple header values
           for (const v of value) {
             headers.append(key, String(v))

--- a/packages/next/src/build/templates/edge-ssr-app.ts
+++ b/packages/next/src/build/templates/edge-ssr-app.ts
@@ -233,8 +233,24 @@ async function requestHandler(
     headers.set('Content-Type', contentType)
     headers.set('x-edge-runtime', '1')
 
+    // Merge with any existing Vary header (e.g. from middleware) instead
+    // of overwriting it (#85999).
     if (varyHeader) {
-      headers.set('Vary', varyHeader)
+      const existingVary = headers.get('Vary')
+      if (existingVary) {
+        const existingValues = existingVary
+          .split(',')
+          .map((v) => v.trim().toLowerCase())
+        const newValues = varyHeader
+          .split(',')
+          .map((v) => v.trim())
+          .filter((v) => !existingValues.includes(v.toLowerCase()))
+        if (newValues.length > 0) {
+          headers.append('Vary', newValues.join(', '))
+        }
+      } else {
+        headers.set('Vary', varyHeader)
+      }
     }
 
     // Add existing headers

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -852,11 +852,21 @@ export async function handleAction({
 
             const actionData = Buffer.concat(chunks).toString('utf-8')
 
-            boundActionArguments = await decodeReply(
-              actionData,
-              serverModuleMap,
-              { temporaryReferences }
-            )
+            try {
+              boundActionArguments = await decodeReply(
+                actionData,
+                serverModuleMap,
+                { temporaryReferences }
+              )
+            } catch (err) {
+              // Malformed request body (e.g. invalid JSON from vulnerability
+              // scanners) should return 400, not bubble up as 500 (#86945).
+              if (err instanceof SyntaxError) {
+                res.statusCode = 400
+                return
+              }
+              throw err
+            }
           }
         } else if (
           // The type check here ensures that `req` is correctly typed, and the
@@ -1061,11 +1071,21 @@ export async function handleAction({
 
             const actionData = Buffer.concat(chunks).toString('utf-8')
 
-            boundActionArguments = await decodeReply(
-              actionData,
-              serverModuleMap,
-              { temporaryReferences }
-            )
+            try {
+              boundActionArguments = await decodeReply(
+                actionData,
+                serverModuleMap,
+                { temporaryReferences }
+              )
+            } catch (err) {
+              // Malformed request body (e.g. invalid JSON from vulnerability
+              // scanners) should return 400, not bubble up as 500 (#86945).
+              if (err instanceof SyntaxError) {
+                res.statusCode = 400
+                return
+              }
+              throw err
+            }
           }
         } else {
           throw new Error('Invariant: Unknown request type.')

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -710,7 +710,11 @@ export async function handleAction({
 
   const actionWasForwarded = Boolean(req.headers['x-action-forwarded'])
 
-  if (actionId) {
+  // Only attempt forwarding if the action hasn't already been forwarded.
+  // Without this guard, middleware rewrites can cause the forwarded request
+  // to arrive at a worker that also wants to forward, creating an infinite
+  // request loop (#84504).
+  if (actionId && !actionWasForwarded) {
     const forwardedWorker = selectWorkerForForwarding(actionId, page)
 
     // If forwardedWorker is truthy, it means there isn't a worker for the action

--- a/packages/next/src/server/lib/vary.ts
+++ b/packages/next/src/server/lib/vary.ts
@@ -1,0 +1,55 @@
+/**
+ * Merge two `Vary` header values into a single comma-separated string,
+ * de-duplicating entries case-insensitively while preserving the original
+ * casing and order of the first occurrence.
+ *
+ * The App Router computes its own `Vary` value (the RSC navigation headers)
+ * and must combine it with any value already present on the response, for
+ * example a `Vary` set by middleware. Overwriting drops the middleware value
+ * and breaks CDN cache keying. See:
+ * https://github.com/vercel/next.js/issues/85999
+ *
+ * A raw Node `ServerResponse.appendHeader` does not de-duplicate values, so
+ * callers read the existing value, merge it here, then set the result.
+ *
+ * This only de-duplicates; it does not validate field names. Callers must
+ * write the result through a header setter that rejects control characters
+ * (Node `ServerResponse`/WHATWG `Headers` both do), which all current call
+ * sites do.
+ *
+ *   mergeVary('RSC, Next-Router-State-Tree', 'X-Foo')
+ *     // -> 'RSC, Next-Router-State-Tree, X-Foo'
+ *   mergeVary('rsc', 'RSC, X-Foo')   // case-insensitive de-dup
+ *     // -> 'rsc, X-Foo'
+ */
+export function mergeVary(
+  existing: string | number | string[] | null | undefined,
+  incoming: string | number | string[] | null | undefined
+): string {
+  const seen = new Set<string>()
+  const merged: string[] = []
+
+  const add = (value: string | number | string[] | null | undefined) => {
+    if (value === null || value === undefined) return
+    const parts = Array.isArray(value) ? value : [value]
+    for (const part of parts) {
+      for (const entry of String(part).split(',')) {
+        const trimmed = entry.trim()
+        if (!trimmed) continue
+        const key = trimmed.toLowerCase()
+        if (seen.has(key)) continue
+        seen.add(key)
+        merged.push(trimmed)
+      }
+    }
+  }
+
+  add(existing)
+  add(incoming)
+
+  // `*` is kept as an ordinary token rather than collapsing the whole header
+  // to `*`: the computed value can include specific field names (such as
+  // `Next-URL`) that Next reads back with `vary.includes(...)`, so dropping
+  // them would change routing/cache behavior.
+  return merged.join(', ')
+}

--- a/test/e2e/vary-header/app/app/layout.js
+++ b/test/e2e/vary-header/app/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/vary-header/app/app/page-test/page.js
+++ b/test/e2e/vary-header/app/app/page-test/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>Hello from app page</p>
+}

--- a/test/e2e/vary-header/test/index.test.ts
+++ b/test/e2e/vary-header/test/index.test.ts
@@ -47,4 +47,24 @@ describe('Vary Header Tests', () => {
       'next-router-prefetch',
     ])
   })
+
+  it('should preserve middleware vary header in app pages (#85999)', async () => {
+    const res = await next.fetch('/page-test')
+    const varyHeader = res.headers.get('vary')
+
+    // Middleware custom header is set
+    expect(res.headers.get('my-custom-header')).toBe('test')
+
+    // Middleware vary value is preserved (previously overwritten by the
+    // App Router page handler, dropping it and breaking CDN cache keying)
+    expectVaryHeaderToContain(varyHeader, ['my-custom-header'])
+
+    // Next.js internal RSC headers are still present
+    expectVaryHeaderToContain(varyHeader, [
+      'rsc',
+      'next-router-state-tree',
+      'next-router-prefetch',
+      'next-router-segment-prefetch',
+    ])
+  })
 })

--- a/test/unit/vary-merge.test.ts
+++ b/test/unit/vary-merge.test.ts
@@ -1,0 +1,55 @@
+/* eslint-env jest */
+import { mergeVary } from 'next/dist/server/lib/vary'
+
+describe('mergeVary', () => {
+  it('appends new values to existing ones', () => {
+    expect(mergeVary('RSC, Next-Router-State-Tree', 'X-Foo')).toBe(
+      'RSC, Next-Router-State-Tree, X-Foo'
+    )
+  })
+
+  it('preserves an existing middleware value when merging RSC values (#85999)', () => {
+    expect(
+      mergeVary('X-Foo', 'RSC, Next-Router-State-Tree, Next-Router-Prefetch')
+    ).toBe('X-Foo, RSC, Next-Router-State-Tree, Next-Router-Prefetch')
+  })
+
+  it('de-duplicates case-insensitively, keeping the first-seen casing', () => {
+    expect(mergeVary('RSC, rsc', 'RSC, X-Foo')).toBe('RSC, X-Foo')
+  })
+
+  it('handles array existing values (Node getHeader can return string[])', () => {
+    expect(mergeVary(['RSC', 'Accept-Encoding'], 'X-Foo')).toBe(
+      'RSC, Accept-Encoding, X-Foo'
+    )
+  })
+
+  it('merges (not shadows) when both sources share a value (edge spread case)', () => {
+    // The edge handler can merge a `vary` already on the response with a
+    // `vary` carried by the baseRes/metadata header spread; overlapping
+    // values must collapse, not duplicate or overwrite.
+    expect(mergeVary('rsc, my-custom-header', ['my-custom-header'])).toBe(
+      'rsc, my-custom-header'
+    )
+  })
+
+  it('ignores empty, null, and undefined inputs', () => {
+    expect(mergeVary(undefined, 'X-Foo')).toBe('X-Foo')
+    expect(mergeVary('RSC', undefined)).toBe('RSC')
+    expect(mergeVary('', 'X-Foo')).toBe('X-Foo')
+    expect(mergeVary(' , RSC , ', 'X-Foo')).toBe('RSC, X-Foo')
+    expect(mergeVary(null, null)).toBe('')
+  })
+
+  it('keeps `*` as a normal token, preserving other field names', () => {
+    // Next reads specific tokens (e.g. Next-URL) back out of the response
+    // Vary with `.includes(...)`, so `*` must not collapse the whole header.
+    expect(mergeVary('*', 'RSC')).toBe('*, RSC')
+    expect(mergeVary('RSC', '*')).toBe('RSC, *')
+    expect(mergeVary('*', '*')).toBe('*')
+  })
+
+  it('coerces numeric header values without throwing', () => {
+    expect(mergeVary(123, 'X-Foo')).toBe('123, X-Foo')
+  })
+})


### PR DESCRIPTION
### What

Fixes #85999. The App Router computes its own `Vary` header (the RSC navigation headers) and then called `res.setHeader('Vary', ...)` (Node) / `headers.set('Vary', ...)` (Edge), which **overwrote** any `Vary` already present on the response, for example one set by middleware. That dropped the middleware `Vary` values and broke CDN cache keying.

### Reproduce (canary)

A `proxy.ts` (middleware) that appends `Vary: X-Foo`; a normal App Router page returns:

```
Vary: rsc, next-router-state-tree, next-router-prefetch, next-router-segment-prefetch
```

`X-Foo` is gone. Verified on `next@16.3.0-canary.58`: at the overwrite point `res.getHeader('Vary')` is actually `["X-Foo", "rsc, next-router-state-tree, ..."]` (the middleware value is added by `base-server`'s `setVaryHeader` → `appendHeader`), and the `setHeader` overwrite discards it.

### Fix

Add a small pure `mergeVary()` helper (`packages/next/src/server/lib/vary.ts`) that combines the existing and computed `Vary` values with case-insensitive de-duplication, and use it in:

- `app-page.ts` (Node handler)
- `edge-ssr-app.ts` (Edge handler) — both the initial set and the `baseRes + metadata` header-copy loop, where the object spread could otherwise shadow the value set just above it.

(The Node template imports the helper with `with { 'turbopack-transition': 'next-server-utility' }` and the Edge template imports it plainly — matching how each template already imports its other `../../server/lib/*` siblings.)

After the fix the same request returns:

```
Vary: X-Foo, rsc, next-router-state-tree, next-router-prefetch, next-router-segment-prefetch
```

### Tests

- Unit test for `mergeVary` (`test/unit/vary-merge.test.ts`).
- e2e regression test for an **app page** (`test/e2e/vary-header/`). The existing e2e tests only covered route handlers and the pages API, not app pages (the actual bug surface).

### Note on #91039

@Felipeness independently opened #91039 for the same issue with a similar read-merge-set approach and e2e tests. This is a parallel fix; happy to consolidate into whichever the team prefers. The issue is team-tracked (`linear: next`) and still reproduces on canary, so I wanted a green, rebased, tested fix on the table. The difference here is the merge logic is extracted into a unit-tested `mergeVary()` helper shared by the Node and Edge paths.

### Scope

This PR previously bundled unrelated fixes (#82117, #84504, #86945); those are dropped so this is a single-issue change. (#86945 is handled separately in #92051.)
