### PR TITLE
Add MCP `get_compilation_issues` tool and NAPI method

### DIFF
--- a/.config/eslintignore.mjs
+++ b/.config/eslintignore.mjs
@@ -47,6 +47,7 @@ export default globalIgnores([
   'examples/with-typescript-graphql/lib/gql/',
   'test/development/basic/hmr/components/parse-error.js',
   'test/development/mcp-server/fixtures/default-template/app/build-error/page.tsx',
+  'test/development/mcp-server/fixtures/compilation-errors-app/app/syntax-error/page.tsx',
   'test/production/debug-build-path/fixtures/with-compile-error/app/broken/page.tsx',
   'packages/next-swc/native/index.d.ts',
   'packages/next-swc/docs/assets/**/*',

--- a/.prettierignore
+++ b/.prettierignore
@@ -59,6 +59,7 @@ test/e2e/app-dir/server-source-maps/fixtures/default/internal-pkg/ignored.js
 test/e2e/app-dir/server-source-maps/fixtures/default/internal-pkg/sourcemapped.js
 test/e2e/app-dir/server-source-maps/fixtures/default/external-pkg/sourcemapped.js
 test/development/mcp-server/fixtures/default-template/app/build-error/page.tsx
+test/development/mcp-server/fixtures/compilation-errors-app/app/syntax-error/page.tsx
 # Tested against auto-generated content that isn't formatted
 test/integration/typescript-app-type-declarations/next-env.strictRouteTypes.d.ts
 

--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -2519,9 +2519,13 @@ async fn get_all_compilation_issues_inner_operation(
     // Per-endpoint module_graphs() calls are not subject to that suppression, so issues like
     // missing modules and transform errors are properly collected as collectables here.
     let endpoint_groups = project.get_all_endpoint_groups(false).await?;
-    for (_, endpoint_group) in endpoint_groups.iter() {
-        endpoint_group.module_graphs().as_side_effect().await?;
-    }
+    endpoint_groups
+        .iter()
+        .map(|(_, endpoint_group)| async move {
+            endpoint_group.module_graphs().as_side_effect().await
+        })
+        .try_join()
+        .await?;
     Ok(Vc::cell(()))
 }
 

--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -2508,6 +2508,66 @@ pub async fn project_write_analyze_data(
     })
 }
 
+#[turbo_tasks::function(operation)]
+async fn get_all_compilation_issues_inner_operation(
+    container: ResolvedVc<ProjectContainer>,
+) -> Result<Vc<()>> {
+    let project = container.project();
+    // Build the module graph for all endpoints without chunking, code gen, or disk emission.
+    // whole_app_module_graphs() triggers module resolution + transformation for all entrypoints.
+    // Issues (resolve errors, transform errors, missing modules) are emitted as collectables.
+    let whole_app_module_graphs = project.whole_app_module_graphs();
+    whole_app_module_graphs.as_side_effect().await?;
+    Ok(Vc::cell(()))
+}
+
+#[turbo_tasks::function(operation)]
+async fn get_all_compilation_issues_operation(
+    container: ResolvedVc<ProjectContainer>,
+) -> Result<Vc<OperationResult>> {
+    let inner_op = get_all_compilation_issues_inner_operation(container);
+    let filter = issue_filter_from_container(container);
+    let (_, issues, diagnostics, effects) =
+        strongly_consistent_catch_collectables(inner_op, filter).await?;
+    Ok(OperationResult {
+        issues,
+        diagnostics,
+        effects,
+    }
+    .cell())
+}
+
+#[tracing::instrument(level = "info", name = "get all compilation issues", skip_all)]
+#[napi]
+pub async fn project_get_all_compilation_issues(
+    #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: External<ProjectInstance>,
+) -> napi::Result<TurbopackResult<()>> {
+    let container = project.container;
+    let (issues, diagnostics) = project
+        .turbopack_ctx
+        .turbo_tasks()
+        .run_once(async move {
+            let op = get_all_compilation_issues_operation(container);
+            let OperationResult {
+                issues,
+                diagnostics,
+                effects: _,
+            } = &*op.read_strongly_consistent().await?;
+            Ok((issues.clone(), diagnostics.clone()))
+        })
+        .await
+        .map_err(|e| napi::Error::from_reason(PrettyPrintError(&e).to_string()))?;
+
+    Ok(TurbopackResult {
+        result: (),
+        issues: issues.iter().map(|i| NapiIssue::from(&**i)).collect(),
+        diagnostics: diagnostics
+            .iter()
+            .map(|d| NapiDiagnostic::from(d))
+            .collect(),
+    })
+}
+
 /// Opens the Turbopack persistent cache database at the given path and performs a full compaction.
 ///
 /// The `path` should point to the `<distDir>/cache/turbopack` directory.

--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -2513,11 +2513,15 @@ async fn get_all_compilation_issues_inner_operation(
     container: ResolvedVc<ProjectContainer>,
 ) -> Result<Vc<()>> {
     let project = container.project();
-    // Build the module graph for all endpoints without chunking, code gen, or disk emission.
-    // whole_app_module_graphs() triggers module resolution + transformation for all entrypoints.
-    // Issues (resolve errors, transform errors, missing modules) are emitted as collectables.
-    let whole_app_module_graphs = project.whole_app_module_graphs();
-    whole_app_module_graphs.as_side_effect().await?;
+    // Build the module graph for every endpoint without chunking, code gen, or disk emission.
+    // We iterate endpoints rather than calling project.whole_app_module_graphs() because the
+    // latter calls drop_issues() in development mode (to avoid duplicate per-route HMR noise).
+    // Per-endpoint module_graphs() calls are not subject to that suppression, so issues like
+    // missing modules and transform errors are properly collected as collectables here.
+    let endpoint_groups = project.get_all_endpoint_groups(false).await?;
+    for (_, endpoint_group) in endpoint_groups.iter() {
+        endpoint_group.module_graphs().as_side_effect().await?;
+    }
     Ok(Vc::cell(()))
 }
 

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -491,6 +491,9 @@ export declare function projectWriteAnalyzeData(
   project: { __napiType: 'Project' },
   appDirOnly: boolean
 ): Promise<TurbopackResult>
+export declare function projectGetAllCompilationIssues(project: {
+  __napiType: 'Project'
+}): Promise<TurbopackResult>
 /**
  * Opens the Turbopack persistent cache database at the given path and performs a full compaction.
  *

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -708,6 +708,13 @@ function bindingToApi(
       return napiResult
     }
 
+    async getAllCompilationIssues(): Promise<TurbopackResult<void>> {
+      const napiResult = (await binding.projectGetAllCompilationIssues(
+        this._nativeProject
+      )) as TurbopackResult<void>
+      return napiResult
+    }
+
     async writeAllEntrypointsToDisk(
       appDirOnly: boolean
     ): Promise<TurbopackResult<Partial<RawEntrypoints>>> {

--- a/packages/next/src/build/swc/types.ts
+++ b/packages/next/src/build/swc/types.ts
@@ -290,6 +290,8 @@ export interface Project {
 
   writeAnalyzeData(appDirOnly: boolean): Promise<TurbopackResult<void>>
 
+  getAllCompilationIssues(): Promise<TurbopackResult<void>>
+
   writeAllEntrypointsToDisk(
     appDirOnly: boolean
   ): Promise<TurbopackResult<Partial<RawEntrypoints>>>

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -1049,6 +1049,7 @@ export async function createHotReloaderTurbopack(
             getActiveConnectionCount: () =>
               clientsWithoutHtmlRequestId.size + clientsByHtmlRequestId.size,
             getDevServerUrl: () => process.env.__NEXT_PRIVATE_ORIGIN,
+            getTurbopackProject: () => project,
           }),
         ]
       : []),

--- a/packages/next/src/server/mcp/get-or-create-mcp-server.ts
+++ b/packages/next/src/server/mcp/get-or-create-mcp-server.ts
@@ -8,6 +8,7 @@ import { registerGetRoutesTool } from './tools/get-routes'
 import { registerGetCompilationIssuesTool } from './tools/get-compilation-issues'
 import type { HmrMessageSentToBrowser } from '../dev/hot-reloader-types'
 import type { NextConfigComplete } from '../config-shared'
+import type { Project } from '../../build/swc/types'
 
 export interface McpServerOptions {
   projectPath: string
@@ -18,9 +19,7 @@ export interface McpServerOptions {
   sendHmrMessage: (message: HmrMessageSentToBrowser) => void
   getActiveConnectionCount: () => number
   getDevServerUrl: () => string | undefined
-  getTurbopackProject?: () =>
-    | import('../../build/swc/types').Project
-    | undefined
+  getTurbopackProject?: () => Project | undefined
 }
 
 let mcpServer: McpServer | undefined

--- a/packages/next/src/server/mcp/get-or-create-mcp-server.ts
+++ b/packages/next/src/server/mcp/get-or-create-mcp-server.ts
@@ -5,6 +5,7 @@ import { registerGetPageMetadataTool } from './tools/get-page-metadata'
 import { registerGetLogsTool } from './tools/get-logs'
 import { registerGetActionByIdTool } from './tools/get-server-action-by-id'
 import { registerGetRoutesTool } from './tools/get-routes'
+import { registerGetCompilationIssuesTool } from './tools/get-compilation-issues'
 import type { HmrMessageSentToBrowser } from '../dev/hot-reloader-types'
 import type { NextConfigComplete } from '../config-shared'
 
@@ -17,6 +18,9 @@ export interface McpServerOptions {
   sendHmrMessage: (message: HmrMessageSentToBrowser) => void
   getActiveConnectionCount: () => number
   getDevServerUrl: () => string | undefined
+  getTurbopackProject?: () =>
+    | import('../../build/swc/types').Project
+    | undefined
 }
 
 let mcpServer: McpServer | undefined
@@ -54,6 +58,10 @@ export const getOrCreateMcpServer = (options: McpServerOptions) => {
     pagesDir: options.pagesDir,
     appDir: options.appDir,
   })
+
+  if (options.getTurbopackProject) {
+    registerGetCompilationIssuesTool(mcpServer, options.getTurbopackProject)
+  }
 
   return mcpServer
 }

--- a/packages/next/src/server/mcp/tools/get-compilation-issues.ts
+++ b/packages/next/src/server/mcp/tools/get-compilation-issues.ts
@@ -10,6 +10,7 @@
 import type { McpServer } from 'next/dist/compiled/@modelcontextprotocol/sdk/server/mcp'
 import type { Project } from '../../../build/swc/types'
 import { mcpTelemetryTracker } from '../mcp-telemetry-tracker'
+import { formatCompilationIssues } from './utils/format-compilation-issues'
 
 export function registerGetCompilationIssuesTool(
   server: McpServer,
@@ -42,12 +43,13 @@ export function registerGetCompilationIssuesTool(
         }
 
         const { issues, diagnostics } = await project.getAllCompilationIssues()
+        const result = formatCompilationIssues(issues, diagnostics)
 
         return {
           content: [
             {
               type: 'text',
-              text: JSON.stringify({ issues, diagnostics }),
+              text: JSON.stringify(result),
             },
           ],
         }

--- a/packages/next/src/server/mcp/tools/get-compilation-issues.ts
+++ b/packages/next/src/server/mcp/tools/get-compilation-issues.ts
@@ -42,14 +42,14 @@ export function registerGetCompilationIssuesTool(
           }
         }
 
-        const { issues, diagnostics } = await project.getAllCompilationIssues()
-        const result = formatCompilationIssues(issues, diagnostics)
+        const { issues } = await project.getAllCompilationIssues()
+        const formattedIssues = formatCompilationIssues(issues)
 
         return {
           content: [
             {
               type: 'text',
-              text: JSON.stringify(result),
+              text: JSON.stringify({ issues: formattedIssues }),
             },
           ],
         }

--- a/packages/next/src/server/mcp/tools/get-compilation-issues.ts
+++ b/packages/next/src/server/mcp/tools/get-compilation-issues.ts
@@ -1,0 +1,64 @@
+import type { McpServer } from 'next/dist/compiled/@modelcontextprotocol/sdk/server/mcp'
+import type { Project } from '../../../build/swc/types'
+import { mcpTelemetryTracker } from '../mcp-telemetry-tracker'
+
+export function registerGetCompilationIssuesTool(
+  server: McpServer,
+  getProject: () => Project | undefined
+) {
+  server.registerTool(
+    'get_compilation_issues',
+    {
+      description:
+        'Build the module graph for all routes and return all compilation issues ' +
+        '(resolve errors, missing modules, transform errors, etc.). ' +
+        'Does not require a browser session. Covers all routes proactively.',
+      inputSchema: {},
+    },
+    async () => {
+      mcpTelemetryTracker.recordToolCall('mcp/get_compilation_issues')
+
+      try {
+        const project = getProject()
+        if (!project) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: JSON.stringify({
+                  error:
+                    'Turbopack project is not available. This tool requires the Turbopack bundler.',
+                }),
+              },
+            ],
+          }
+        }
+
+        const result = await project.getAllCompilationIssues()
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                issues: result.issues,
+                diagnostics: result.diagnostics,
+              }),
+            },
+          ],
+        }
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                error: error instanceof Error ? error.message : String(error),
+              }),
+            },
+          ],
+        }
+      }
+    }
+  )
+}

--- a/packages/next/src/server/mcp/tools/get-compilation-issues.ts
+++ b/packages/next/src/server/mcp/tools/get-compilation-issues.ts
@@ -1,3 +1,12 @@
+/**
+ * MCP tool for getting compilation issues from all routes via Turbopack.
+ *
+ * Unlike get_errors (which requires a browser session and reflects the runtime
+ * error overlay), this tool builds the module graph for every endpoint and
+ * collects Turbopack issues directly — no browser needed. Covers
+ * module-not-found, syntax errors, and other transform failures across all
+ * routes.
+ */
 import type { McpServer } from 'next/dist/compiled/@modelcontextprotocol/sdk/server/mcp'
 import type { Project } from '../../../build/swc/types'
 import { mcpTelemetryTracker } from '../mcp-telemetry-tracker'
@@ -10,9 +19,7 @@ export function registerGetCompilationIssuesTool(
     'get_compilation_issues',
     {
       description:
-        'Build the module graph for all routes and return all compilation issues ' +
-        '(resolve errors, missing modules, transform errors, etc.). ' +
-        'Does not require a browser session. Covers all routes proactively.',
+        'Build the module graph for all routes and return all compilation issues (resolve errors, missing modules, transform errors, etc.). Does not require a browser session. Covers all routes proactively.',
       inputSchema: {},
     },
     async () => {
@@ -24,7 +31,7 @@ export function registerGetCompilationIssuesTool(
           return {
             content: [
               {
-                type: 'text' as const,
+                type: 'text',
                 text: JSON.stringify({
                   error:
                     'Turbopack project is not available. This tool requires the Turbopack bundler.',
@@ -34,16 +41,13 @@ export function registerGetCompilationIssuesTool(
           }
         }
 
-        const result = await project.getAllCompilationIssues()
+        const { issues, diagnostics } = await project.getAllCompilationIssues()
 
         return {
           content: [
             {
-              type: 'text' as const,
-              text: JSON.stringify({
-                issues: result.issues,
-                diagnostics: result.diagnostics,
-              }),
+              type: 'text',
+              text: JSON.stringify({ issues, diagnostics }),
             },
           ],
         }
@@ -51,7 +55,7 @@ export function registerGetCompilationIssuesTool(
         return {
           content: [
             {
-              type: 'text' as const,
+              type: 'text',
               text: JSON.stringify({
                 error: error instanceof Error ? error.message : String(error),
               }),

--- a/packages/next/src/server/mcp/tools/utils/format-compilation-issues.ts
+++ b/packages/next/src/server/mcp/tools/utils/format-compilation-issues.ts
@@ -1,0 +1,110 @@
+import type {
+  Diagnostics,
+  Issue,
+  StyledString,
+} from '../../../../build/swc/types'
+import stripAnsi from 'next/dist/compiled/strip-ansi'
+
+/** Flatten a StyledString tree to plain text, discarding all styling. */
+function flattenStyledString(s: StyledString): string {
+  switch (s.type) {
+    case 'text':
+    case 'code':
+    case 'strong':
+      return s.value
+    case 'line':
+      return s.value.map(flattenStyledString).join('')
+    case 'stack':
+      return s.value.map(flattenStyledString).join('\n')
+    default:
+      return ''
+  }
+}
+
+export interface FormattedIssue {
+  severity: string
+  filePath: string
+  title: string
+  description?: string
+  detail?: string
+  source?: {
+    filePath: string
+    range?: {
+      /** 1-indexed */
+      start: { line: number; column: number }
+      /** 1-indexed */
+      end: { line: number; column: number }
+    }
+  }
+  /** Plain-text code frame (ANSI codes stripped) */
+  codeFrame?: string
+}
+
+/**
+ * Turbopack telemetry diagnostics (EVENT_BUILD_FEATURE_USAGE) track feature
+ * adoption internally and are not actionable for the user.
+ */
+const TELEMETRY_DIAGNOSTIC_NAME = 'EVENT_BUILD_FEATURE_USAGE'
+
+/**
+ * Transform raw Turbopack issues and diagnostics into a clean format for MCP
+ * consumers:
+ * - Flattens StyledString trees (title/description/detail) to plain strings
+ * - Strips ANSI codes from code frames
+ * - Converts 0-indexed source positions to 1-indexed
+ * - Deduplicates issues (same error can surface from multiple endpoints)
+ * - Excludes telemetry diagnostics (EVENT_BUILD_FEATURE_USAGE)
+ */
+export function formatCompilationIssues(
+  issues: Issue[],
+  diagnostics: Diagnostics[]
+): { issues: FormattedIssue[]; diagnostics: Diagnostics[] } {
+  const seen = new Set<string>()
+  const formattedIssues: FormattedIssue[] = []
+
+  for (const issue of issues) {
+    const title = flattenStyledString(issue.title)
+    // Include source position in the key so two distinct errors in the same
+    // file with the same message are not collapsed into one.
+    const startLine = issue.source?.range?.start.line ?? ''
+    const startCol = issue.source?.range?.start.column ?? ''
+    const key = `${issue.severity}|${issue.filePath}|${title}|${startLine}:${startCol}`
+    if (seen.has(key)) continue
+    seen.add(key)
+
+    const { range } = issue.source ?? {}
+    formattedIssues.push({
+      severity: issue.severity,
+      filePath: issue.filePath,
+      title,
+      description: issue.description
+        ? flattenStyledString(issue.description)
+        : undefined,
+      detail: issue.detail ? flattenStyledString(issue.detail) : undefined,
+      source: issue.source
+        ? {
+            filePath: issue.source.source.filePath,
+            range: range
+              ? {
+                  start: {
+                    line: range.start.line + 1,
+                    column: range.start.column + 1,
+                  },
+                  end: {
+                    line: range.end.line + 1,
+                    column: range.end.column + 1,
+                  },
+                }
+              : undefined,
+          }
+        : undefined,
+      codeFrame: issue.codeFrame ? stripAnsi(issue.codeFrame) : undefined,
+    })
+  }
+
+  const filteredDiagnostics = diagnostics.filter(
+    (d) => d.name !== TELEMETRY_DIAGNOSTIC_NAME
+  )
+
+  return { issues: formattedIssues, diagnostics: filteredDiagnostics }
+}

--- a/packages/next/src/server/mcp/tools/utils/format-compilation-issues.ts
+++ b/packages/next/src/server/mcp/tools/utils/format-compilation-issues.ts
@@ -1,8 +1,4 @@
-import type {
-  Diagnostics,
-  Issue,
-  StyledString,
-} from '../../../../build/swc/types'
+import type { Issue, StyledString } from '../../../../build/swc/types'
 import stripAnsi from 'next/dist/compiled/strip-ansi'
 
 /** Flatten a StyledString tree to plain text, discarding all styling. */
@@ -41,24 +37,13 @@ export interface FormattedIssue {
 }
 
 /**
- * Turbopack telemetry diagnostics (EVENT_BUILD_FEATURE_USAGE) track feature
- * adoption internally and are not actionable for the user.
- */
-const TELEMETRY_DIAGNOSTIC_NAME = 'EVENT_BUILD_FEATURE_USAGE'
-
-/**
- * Transform raw Turbopack issues and diagnostics into a clean format for MCP
- * consumers:
+ * Transform raw Turbopack issues into a clean format for MCP consumers:
  * - Flattens StyledString trees (title/description/detail) to plain strings
  * - Strips ANSI codes from code frames
  * - Converts 0-indexed source positions to 1-indexed
  * - Deduplicates issues (same error can surface from multiple endpoints)
- * - Excludes telemetry diagnostics (EVENT_BUILD_FEATURE_USAGE)
  */
-export function formatCompilationIssues(
-  issues: Issue[],
-  diagnostics: Diagnostics[]
-): { issues: FormattedIssue[]; diagnostics: Diagnostics[] } {
+export function formatCompilationIssues(issues: Issue[]): FormattedIssue[] {
   const seen = new Set<string>()
   const formattedIssues: FormattedIssue[] = []
 
@@ -102,9 +87,5 @@ export function formatCompilationIssues(
     })
   }
 
-  const filteredDiagnostics = diagnostics.filter(
-    (d) => d.name !== TELEMETRY_DIAGNOSTIC_NAME
-  )
-
-  return { issues: formattedIssues, diagnostics: filteredDiagnostics }
+  return formattedIssues
 }

--- a/packages/next/src/server/mcp/tools/utils/format-compilation-issues.ts
+++ b/packages/next/src/server/mcp/tools/utils/format-compilation-issues.ts
@@ -1,17 +1,19 @@
 import type { Issue, StyledString } from '../../../../build/swc/types'
 import stripAnsi from 'next/dist/compiled/strip-ansi'
 
-/** Flatten a StyledString tree to plain text, discarding all styling. */
-function flattenStyledString(s: StyledString): string {
+/** Convert a StyledString tree to Markdown. */
+function styledStringToMarkdown(s: StyledString): string {
   switch (s.type) {
     case 'text':
-    case 'code':
-    case 'strong':
       return s.value
+    case 'code':
+      return `\`${s.value}\``
+    case 'strong':
+      return `**${s.value}**`
     case 'line':
-      return s.value.map(flattenStyledString).join('')
+      return s.value.map(styledStringToMarkdown).join('')
     case 'stack':
-      return s.value.map(flattenStyledString).join('\n')
+      return s.value.map(styledStringToMarkdown).join('\n')
     default:
       return ''
   }
@@ -32,13 +34,13 @@ export interface FormattedIssue {
       end: { line: number; column: number }
     }
   }
-  /** Plain-text code frame (ANSI codes stripped) */
+  /** Code frame with ANSI codes stripped */
   codeFrame?: string
 }
 
 /**
  * Transform raw Turbopack issues into a clean format for MCP consumers:
- * - Flattens StyledString trees (title/description/detail) to plain strings
+ * - Converts StyledString trees (title/description/detail) to Markdown
  * - Strips ANSI codes from code frames
  * - Converts 0-indexed source positions to 1-indexed
  * - Deduplicates issues (same error can surface from multiple endpoints)
@@ -48,7 +50,7 @@ export function formatCompilationIssues(issues: Issue[]): FormattedIssue[] {
   const formattedIssues: FormattedIssue[] = []
 
   for (const issue of issues) {
-    const title = flattenStyledString(issue.title)
+    const title = styledStringToMarkdown(issue.title)
     // Include source position in the key so two distinct errors in the same
     // file with the same message are not collapsed into one.
     const startLine = issue.source?.range?.start.line ?? ''
@@ -63,9 +65,9 @@ export function formatCompilationIssues(issues: Issue[]): FormattedIssue[] {
       filePath: issue.filePath,
       title,
       description: issue.description
-        ? flattenStyledString(issue.description)
+        ? styledStringToMarkdown(issue.description)
         : undefined,
-      detail: issue.detail ? flattenStyledString(issue.detail) : undefined,
+      detail: issue.detail ? styledStringToMarkdown(issue.detail) : undefined,
       source: issue.source
         ? {
             filePath: issue.source.source.filePath,

--- a/packages/next/src/telemetry/events/build.ts
+++ b/packages/next/src/telemetry/events/build.ts
@@ -259,6 +259,7 @@ export type McpToolName =
   | 'mcp/get_project_metadata'
   | 'mcp/get_routes'
   | 'mcp/get_server_action_by_id'
+  | 'mcp/get_compilation_issues'
 
 export type EventMcpToolUsage = {
   toolName: McpToolName

--- a/test/development/mcp-server/fixtures/compilation-errors-app/app/layout.tsx
+++ b/test/development/mcp-server/fixtures/compilation-errors-app/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/mcp-server/fixtures/compilation-errors-app/app/missing-module/page.tsx
+++ b/test/development/mcp-server/fixtures/compilation-errors-app/app/missing-module/page.tsx
@@ -1,0 +1,5 @@
+import { something } from './non-existent-module'
+
+export default function MissingModulePage() {
+  return <div>{something}</div>
+}

--- a/test/development/mcp-server/fixtures/compilation-errors-app/app/page.tsx
+++ b/test/development/mcp-server/fixtures/compilation-errors-app/app/page.tsx
@@ -1,0 +1,3 @@
+export default function HomePage() {
+  return <div>Home Page - No Errors</div>
+}

--- a/test/development/mcp-server/fixtures/compilation-errors-app/app/syntax-error/page.tsx
+++ b/test/development/mcp-server/fixtures/compilation-errors-app/app/syntax-error/page.tsx
@@ -1,0 +1,3 @@
+export default function SyntaxErrorPage() {
+  return <div>Broken JSX
+}

--- a/test/development/mcp-server/fixtures/compilation-errors-app/next.config.js
+++ b/test/development/mcp-server/fixtures/compilation-errors-app/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  experimental: {
+    mcpServer: true,
+  },
+}

--- a/test/development/mcp-server/mcp-server-get-compilation-issues.test.ts
+++ b/test/development/mcp-server/mcp-server-get-compilation-issues.test.ts
@@ -33,7 +33,7 @@ describe('mcp-server get_compilation_issues tool', () => {
     return JSON.parse(result.result?.content?.[0]?.text)
   }
 
-  type Issue = { severity: string; filePath: string; title: unknown }
+  type Issue = { severity: string; filePath: string; title: string }
 
   let compilationResult: { issues: Issue[]; diagnostics: unknown[] }
 
@@ -60,7 +60,7 @@ describe('mcp-server get_compilation_issues tool', () => {
     const moduleNotFoundIssue = errors.find(
       (issue) =>
         issue.filePath.includes('missing-module') ||
-        JSON.stringify(issue.title).includes('non-existent-module')
+        issue.title.includes('non-existent-module')
     )
     expect(moduleNotFoundIssue).toBeDefined()
   })
@@ -83,5 +83,7 @@ describe('mcp-server get_compilation_issues tool', () => {
     expect(issue).toHaveProperty('title')
     expect(typeof issue.severity).toBe('string')
     expect(typeof issue.filePath).toBe('string')
+    // title must be a plain string, not a StyledString object
+    expect(typeof issue.title).toBe('string')
   })
 })

--- a/test/development/mcp-server/mcp-server-get-compilation-issues.test.ts
+++ b/test/development/mcp-server/mcp-server-get-compilation-issues.test.ts
@@ -1,0 +1,87 @@
+import path from 'path'
+import { nextTestSetup } from 'e2e-utils'
+
+describe('mcp-server get_compilation_issues tool', () => {
+  const { next, skipped } = nextTestSetup({
+    files: path.join(__dirname, 'fixtures', 'compilation-errors-app'),
+    skipDeployment: true,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  async function callMcpTool(id: string) {
+    const response = await fetch(`${next.url}/_next/mcp`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id,
+        method: 'tools/call',
+        params: { name: 'get_compilation_issues', arguments: {} },
+      }),
+    })
+
+    const text = await response.text()
+    const match = text.match(/data: ({.*})/s)
+    expect(match).toBeTruthy()
+    const result = JSON.parse(match![1])
+    return JSON.parse(result.result?.content?.[0]?.text)
+  }
+
+  it('should return compilation issues without requiring a browser session', async () => {
+    const response = await callMcpTool('test-no-session')
+    expect(response).toHaveProperty('issues')
+    expect(response).toHaveProperty('diagnostics')
+    expect(Array.isArray(response.issues)).toBe(true)
+  })
+
+  it('should detect module-not-found errors', async () => {
+    const response = await callMcpTool('test-module-not-found')
+
+    const errorIssues = response.issues.filter(
+      (issue: any) => issue.severity === 'error' || issue.severity === 'fatal'
+    )
+    expect(errorIssues.length).toBeGreaterThan(0)
+
+    const moduleNotFoundIssue = errorIssues.find(
+      (issue: any) =>
+        issue.filePath.includes('missing-module') ||
+        JSON.stringify(issue.title).includes('non-existent-module')
+    )
+    expect(moduleNotFoundIssue).toBeDefined()
+  })
+
+  it('should detect syntax errors', async () => {
+    const response = await callMcpTool('test-syntax-error')
+
+    const errorIssues = response.issues.filter(
+      (issue: any) => issue.severity === 'error' || issue.severity === 'fatal'
+    )
+
+    const syntaxErrorIssue = errorIssues.find((issue: any) =>
+      issue.filePath.includes('syntax-error')
+    )
+    expect(syntaxErrorIssue).toBeDefined()
+  })
+
+  it('should include issue metadata fields', async () => {
+    const response = await callMcpTool('test-issue-shape')
+
+    const errorIssues = response.issues.filter(
+      (issue: any) => issue.severity === 'error' || issue.severity === 'fatal'
+    )
+    expect(errorIssues.length).toBeGreaterThan(0)
+
+    const issue = errorIssues[0]
+    expect(issue).toHaveProperty('severity')
+    expect(issue).toHaveProperty('filePath')
+    expect(issue).toHaveProperty('title')
+    expect(typeof issue.severity).toBe('string')
+    expect(typeof issue.filePath).toBe('string')
+  })
+})

--- a/test/development/mcp-server/mcp-server-get-compilation-issues.test.ts
+++ b/test/development/mcp-server/mcp-server-get-compilation-issues.test.ts
@@ -11,7 +11,7 @@ describe('mcp-server get_compilation_issues tool', () => {
     return
   }
 
-  async function callMcpTool(id: string) {
+  async function callMcpTool() {
     const response = await fetch(`${next.url}/_next/mcp`, {
       method: 'POST',
       headers: {
@@ -20,7 +20,7 @@ describe('mcp-server get_compilation_issues tool', () => {
       },
       body: JSON.stringify({
         jsonrpc: '2.0',
-        id,
+        id: 'get-compilation-issues',
         method: 'tools/call',
         params: { name: 'get_compilation_issues', arguments: {} },
       }),
@@ -33,51 +33,51 @@ describe('mcp-server get_compilation_issues tool', () => {
     return JSON.parse(result.result?.content?.[0]?.text)
   }
 
-  it('should return compilation issues without requiring a browser session', async () => {
-    const response = await callMcpTool('test-no-session')
-    expect(response).toHaveProperty('issues')
-    expect(response).toHaveProperty('diagnostics')
-    expect(Array.isArray(response.issues)).toBe(true)
+  type Issue = { severity: string; filePath: string; title: unknown }
+
+  let compilationResult: { issues: Issue[]; diagnostics: unknown[] }
+
+  beforeAll(async () => {
+    compilationResult = await callMcpTool()
   })
 
-  it('should detect module-not-found errors', async () => {
-    const response = await callMcpTool('test-module-not-found')
-
-    const errorIssues = response.issues.filter(
-      (issue: any) => issue.severity === 'error' || issue.severity === 'fatal'
+  function errorIssues() {
+    return compilationResult.issues.filter(
+      (issue) => issue.severity === 'error' || issue.severity === 'fatal'
     )
-    expect(errorIssues.length).toBeGreaterThan(0)
+  }
 
-    const moduleNotFoundIssue = errorIssues.find(
-      (issue: any) =>
+  it('should return compilation issues without requiring a browser session', () => {
+    expect(compilationResult).toHaveProperty('issues')
+    expect(compilationResult).toHaveProperty('diagnostics')
+    expect(Array.isArray(compilationResult.issues)).toBe(true)
+  })
+
+  it('should detect module-not-found errors', () => {
+    const errors = errorIssues()
+    expect(errors.length).toBeGreaterThan(0)
+
+    const moduleNotFoundIssue = errors.find(
+      (issue) =>
         issue.filePath.includes('missing-module') ||
         JSON.stringify(issue.title).includes('non-existent-module')
     )
     expect(moduleNotFoundIssue).toBeDefined()
   })
 
-  it('should detect syntax errors', async () => {
-    const response = await callMcpTool('test-syntax-error')
-
-    const errorIssues = response.issues.filter(
-      (issue: any) => issue.severity === 'error' || issue.severity === 'fatal'
-    )
-
-    const syntaxErrorIssue = errorIssues.find((issue: any) =>
+  it('should detect syntax errors', () => {
+    const errors = errorIssues()
+    const syntaxErrorIssue = errors.find((issue) =>
       issue.filePath.includes('syntax-error')
     )
     expect(syntaxErrorIssue).toBeDefined()
   })
 
-  it('should include issue metadata fields', async () => {
-    const response = await callMcpTool('test-issue-shape')
+  it('should include issue metadata fields', () => {
+    const errors = errorIssues()
+    expect(errors.length).toBeGreaterThan(0)
 
-    const errorIssues = response.issues.filter(
-      (issue: any) => issue.severity === 'error' || issue.severity === 'fatal'
-    )
-    expect(errorIssues.length).toBeGreaterThan(0)
-
-    const issue = errorIssues[0]
+    const issue = errors[0]
     expect(issue).toHaveProperty('severity')
     expect(issue).toHaveProperty('filePath')
     expect(issue).toHaveProperty('title')

--- a/test/development/mcp-server/mcp-server-get-compilation-issues.test.ts
+++ b/test/development/mcp-server/mcp-server-get-compilation-issues.test.ts
@@ -35,7 +35,7 @@ describe('mcp-server get_compilation_issues tool', () => {
 
   type Issue = { severity: string; filePath: string; title: string }
 
-  let compilationResult: { issues: Issue[]; diagnostics: unknown[] }
+  let compilationResult: { issues: Issue[] }
 
   beforeAll(async () => {
     compilationResult = await callMcpTool()
@@ -49,7 +49,6 @@ describe('mcp-server get_compilation_issues tool', () => {
 
   it('should return compilation issues without requiring a browser session', () => {
     expect(compilationResult).toHaveProperty('issues')
-    expect(compilationResult).toHaveProperty('diagnostics')
     expect(Array.isArray(compilationResult.issues)).toBe(true)
   })
 

--- a/test/development/mcp-server/mcp-server-get-compilation-issues.test.ts
+++ b/test/development/mcp-server/mcp-server-get-compilation-issues.test.ts
@@ -1,88 +1,92 @@
 import path from 'path'
 import { nextTestSetup } from 'e2e-utils'
 
-describe('mcp-server get_compilation_issues tool', () => {
-  const { next, skipped } = nextTestSetup({
-    files: path.join(__dirname, 'fixtures', 'compilation-errors-app'),
-    skipDeployment: true,
-  })
-
-  if (skipped) {
-    return
-  }
-
-  async function callMcpTool() {
-    const response = await fetch(`${next.url}/_next/mcp`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Accept: 'application/json, text/event-stream',
-      },
-      body: JSON.stringify({
-        jsonrpc: '2.0',
-        id: 'get-compilation-issues',
-        method: 'tools/call',
-        params: { name: 'get_compilation_issues', arguments: {} },
-      }),
+// get_compilation_issues is a Turbopack-only feature (requires NAPI project handle)
+;(process.env.IS_TURBOPACK_TEST ? describe : describe.skip)(
+  'mcp-server get_compilation_issues tool',
+  () => {
+    const { next, skipped } = nextTestSetup({
+      files: path.join(__dirname, 'fixtures', 'compilation-errors-app'),
+      skipDeployment: true,
     })
 
-    const text = await response.text()
-    const match = text.match(/data: ({.*})/s)
-    expect(match).toBeTruthy()
-    const result = JSON.parse(match![1])
-    return JSON.parse(result.result?.content?.[0]?.text)
+    if (skipped) {
+      return
+    }
+
+    async function callMcpTool() {
+      const response = await fetch(`${next.url}/_next/mcp`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json, text/event-stream',
+        },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 'get-compilation-issues',
+          method: 'tools/call',
+          params: { name: 'get_compilation_issues', arguments: {} },
+        }),
+      })
+
+      const text = await response.text()
+      const match = text.match(/data: ({.*})/s)
+      expect(match).toBeTruthy()
+      const result = JSON.parse(match![1])
+      return JSON.parse(result.result?.content?.[0]?.text)
+    }
+
+    type Issue = { severity: string; filePath: string; title: string }
+
+    let compilationResult: { issues: Issue[] }
+
+    beforeAll(async () => {
+      compilationResult = await callMcpTool()
+    })
+
+    function errorIssues() {
+      return compilationResult.issues.filter(
+        (issue) => issue.severity === 'error' || issue.severity === 'fatal'
+      )
+    }
+
+    it('should return compilation issues without requiring a browser session', () => {
+      expect(compilationResult).toHaveProperty('issues')
+      expect(Array.isArray(compilationResult.issues)).toBe(true)
+    })
+
+    it('should detect module-not-found errors', () => {
+      const errors = errorIssues()
+      expect(errors.length).toBeGreaterThan(0)
+
+      const moduleNotFoundIssue = errors.find(
+        (issue) =>
+          issue.filePath.includes('missing-module') ||
+          issue.title.includes('non-existent-module')
+      )
+      expect(moduleNotFoundIssue).toBeDefined()
+    })
+
+    it('should detect syntax errors', () => {
+      const errors = errorIssues()
+      const syntaxErrorIssue = errors.find((issue) =>
+        issue.filePath.includes('syntax-error')
+      )
+      expect(syntaxErrorIssue).toBeDefined()
+    })
+
+    it('should include issue metadata fields', () => {
+      const errors = errorIssues()
+      expect(errors.length).toBeGreaterThan(0)
+
+      const issue = errors[0]
+      expect(issue).toHaveProperty('severity')
+      expect(issue).toHaveProperty('filePath')
+      expect(issue).toHaveProperty('title')
+      expect(typeof issue.severity).toBe('string')
+      expect(typeof issue.filePath).toBe('string')
+      // title must be a plain string, not a StyledString object
+      expect(typeof issue.title).toBe('string')
+    })
   }
-
-  type Issue = { severity: string; filePath: string; title: string }
-
-  let compilationResult: { issues: Issue[] }
-
-  beforeAll(async () => {
-    compilationResult = await callMcpTool()
-  })
-
-  function errorIssues() {
-    return compilationResult.issues.filter(
-      (issue) => issue.severity === 'error' || issue.severity === 'fatal'
-    )
-  }
-
-  it('should return compilation issues without requiring a browser session', () => {
-    expect(compilationResult).toHaveProperty('issues')
-    expect(Array.isArray(compilationResult.issues)).toBe(true)
-  })
-
-  it('should detect module-not-found errors', () => {
-    const errors = errorIssues()
-    expect(errors.length).toBeGreaterThan(0)
-
-    const moduleNotFoundIssue = errors.find(
-      (issue) =>
-        issue.filePath.includes('missing-module') ||
-        issue.title.includes('non-existent-module')
-    )
-    expect(moduleNotFoundIssue).toBeDefined()
-  })
-
-  it('should detect syntax errors', () => {
-    const errors = errorIssues()
-    const syntaxErrorIssue = errors.find((issue) =>
-      issue.filePath.includes('syntax-error')
-    )
-    expect(syntaxErrorIssue).toBeDefined()
-  })
-
-  it('should include issue metadata fields', () => {
-    const errors = errorIssues()
-    expect(errors.length).toBeGreaterThan(0)
-
-    const issue = errors[0]
-    expect(issue).toHaveProperty('severity')
-    expect(issue).toHaveProperty('filePath')
-    expect(issue).toHaveProperty('title')
-    expect(typeof issue.severity).toBe('string')
-    expect(typeof issue.filePath).toBe('string')
-    // title must be a plain string, not a StyledString object
-    expect(typeof issue.title).toBe('string')
-  })
-})
+)


### PR DESCRIPTION
### What?

Adds a new \`get_compilation_issues\` MCP tool (and the underlying \`projectGetAllCompilationIssues\` NAPI method) that returns all compilation issues from all routes in a single call.

**New files:**
- \`crates/next-napi-bindings/src/next_api/project.rs\` — \`project_get_all_compilation_issues\` NAPI function + \`get_all_compilation_issues_operation\` / \`get_all_compilation_issues_inner_operation\` turbo-tasks operations
- \`packages/next/src/server/mcp/tools/get-compilation-issues.ts\` — MCP tool implementation
- \`packages/next/src/server/mcp/tools/utils/format-compilation-issues.ts\` — output formatter
- \`test/development/mcp-server/mcp-server-get-compilation-issues.test.ts\` — e2e test
- \`test/development/mcp-server/fixtures/compilation-errors-app/\` — fixture app with three routes (valid page, missing-module error, syntax error)

**Modified files:**
- \`packages/next/src/build/swc/generated-native.d.ts\` + \`types.ts\` + \`index.ts\` — expose the new NAPI method
- \`packages/next/src/server/mcp/get-or-create-mcp-server.ts\` — register the new tool, accept \`getTurbopackProject\` option
- \`packages/next/src/server/dev/hot-reloader-turbopack.ts\` — pass \`project\` to MCP middleware
- \`packages/next/src/telemetry/events/build.ts\` — add \`'mcp/get_compilation_issues'\` to the \`McpToolName\` union

### Why?

The existing MCP tools require a browser session (and thus a specific route to be rendered) to surface compilation errors. \`get_compilation_issues\` works without a browser session and covers all routes proactively — useful for AI coding agents that want to check for errors across the whole app before trying to render a page.

### How?

**NAPI layer:**  
\`project_get_all_compilation_issues\` calls a two-level turbo-tasks operation pair:

1. \`get_all_compilation_issues_inner_operation\` — iterates all endpoint groups via \`project.get_all_endpoint_groups(false)\` and calls \`endpoint_group.module_graphs().as_side_effect()\` on each. This builds the module graph (resolution + transformation) for every entrypoint without chunking, emitting, or code generation. Issues are emitted as turbo-tasks collectables.

2. \`get_all_compilation_issues_operation\` — wraps the inner op in \`strongly_consistent_catch_collectables\` to harvest issues/diagnostics/effects, then returns an \`OperationResult\`.

> **Why not \`project.whole_app_module_graphs()\`?**  
> \`whole_app_module_graphs()\` calls \`drop_issues()\` in development mode to prevent every per-route HMR subscription from seeing all global issues. Calling it here would return zero issues in dev. Per-endpoint \`module_graphs()\` calls don't have this suppression.

**Output formatting (\`format-compilation-issues.ts\`):**  
The raw Turbopack wire types are transformed before being returned to MCP consumers:

- **StyledString → plain string**: \`title\`, \`description\`, and \`detail\` are \`StyledString\` union trees (recursive \`{type, value}\` objects). These are flattened to plain strings — \`text\`/\`code\`/\`strong\` variants return their \`.value\` directly, \`line\` joins with \`""\`, \`stack\` joins with \`"\n"\`.
- **ANSI codes stripped**: \`codeFrame\` is a pre-rendered string from the Rust NAPI layer that contains ANSI terminal colour codes. These are stripped via \`next/dist/compiled/strip-ansi\`.
- **1-indexed source positions**: Turbopack's \`SourcePos\` is 0-indexed for both \`line\` and \`column\`. The formatter adds \`+1\` to each so consumers get the conventional editor-style 1-indexed values.
- **Deduplication**: the same issue can surface from multiple endpoints during the module graph traversal. Issues are deduplicated by a \`severity|filePath|title|startLine:startCol\` key.
- **No diagnostics**: Turbopack diagnostics are internal telemetry (\`EVENT_BUILD_FEATURE_USAGE\` feature-adoption counters). They are not actionable for the user, so the \`diagnostics\` field is omitted entirely from the response.

**MCP tool (\`get_compilation_issues\`):**  
Calls \`project.getAllCompilationIssues()\`, passes the issues through \`formatCompilationIssues()\`, and returns \`{ issues: FormattedIssue[] }\` as JSON. Works without a browser session.

**Test:**  
A fixture app with three routes (valid \`app/page.tsx\`, \`app/missing-module/page.tsx\` importing a non-existent package, \`app/syntax-error/page.tsx\` with unclosed JSX) is used to verify:
1. The tool returns a result without any browser session
2. Module-not-found errors are detected
3. Syntax errors are detected
4. Issues include \`severity\`, \`title\`, \`filePath\` metadata — all as plain strings (not StyledString objects)

e2e tests: added — \`test/development/mcp-server/mcp-server-get-compilation-issues.test.ts\`