### PR TITLE
Update revalidateTag examples to use the new two-argument signature

### DIFF
--- a/docs/01-app/02-guides/backend-for-frontend.mdx
+++ b/docs/01-app/02-guides/backend-for-frontend.mdx
@@ -575,7 +575,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ success: false }, { status: 400 })
   }
 
-  revalidateTag(tag)
+  revalidateTag(tag, 'max')
 
   return NextResponse.json({ success: true })
 }
@@ -597,7 +597,7 @@ export async function GET(request) {
     return NextResponse.json({ success: false }, { status: 400 })
   }
 
-  revalidateTag(tag)
+  revalidateTag(tag, 'max')
 
   return NextResponse.json({ success: true })
 }

--- a/docs/01-app/02-guides/caching-without-cache-components.mdx
+++ b/docs/01-app/02-guides/caching-without-cache-components.mdx
@@ -226,7 +226,7 @@ import { revalidateTag } from 'next/cache'
 
 export async function updateUser(id: string) {
   // Mutate data
-  revalidateTag('user')
+  revalidateTag('user', 'max')
 }
 ```
 
@@ -235,7 +235,7 @@ import { revalidateTag } from 'next/cache'
 
 export async function updateUser(id) {
   // Mutate data
-  revalidateTag('user')
+  revalidateTag('user', 'max')
 }
 ```
 

--- a/docs/01-app/02-guides/how-revalidation-works.mdx
+++ b/docs/01-app/02-guides/how-revalidation-works.mdx
@@ -42,7 +42,7 @@ Next.js uses a tag-based system to track which cached content needs to be invali
 
 ### Explicit tags
 
-Explicit tags are set by the developer using [`cacheTag()`](/docs/app/api-reference/functions/cacheTag) inside a `use cache` function, or via `next: { tags: [...] }` on a `fetch` call. When [`revalidateTag('my-tag')`](/docs/app/api-reference/functions/revalidateTag) is called, all cache entries with that tag are invalidated.
+Explicit tags are set by the developer using [`cacheTag()`](/docs/app/api-reference/functions/cacheTag) inside a `use cache` function, or via `next: { tags: [...] }` on a `fetch` call. When [`revalidateTag('my-tag', 'max')`](/docs/app/api-reference/functions/revalidateTag) is called, all cache entries with that tag are invalidated.
 
 ### Soft tags
 

--- a/docs/01-app/02-guides/incremental-static-regeneration.mdx
+++ b/docs/01-app/02-guides/incremental-static-regeneration.mdx
@@ -382,7 +382,7 @@ import { revalidateTag } from 'next/cache'
 
 export async function createPost() {
   // Invalidate all data tagged with 'posts'
-  revalidateTag('posts')
+  revalidateTag('posts', 'max')
 }
 ```
 
@@ -393,7 +393,7 @@ import { revalidateTag } from 'next/cache'
 
 export async function createPost() {
   // Invalidate all data tagged with 'posts'
-  revalidateTag('posts')
+  revalidateTag('posts', 'max')
 }
 ```
 

--- a/docs/01-app/02-guides/redirecting.mdx
+++ b/docs/01-app/02-guides/redirecting.mdx
@@ -107,7 +107,7 @@ export async function updateUsername(username: string, formData: FormData) {
     // Handle errors
   }
 
-  revalidateTag('username') // Update all references to the username
+  revalidateTag('username', 'max') // Update all references to the username
   permanentRedirect(`/profile/${username}`) // Navigate to the new user profile
 }
 ```
@@ -125,7 +125,7 @@ export async function updateUsername(username, formData) {
     // Handle errors
   }
 
-  revalidateTag('username') // Update all references to the username
+  revalidateTag('username', 'max') // Update all references to the username
   permanentRedirect(`/profile/${username}`) // Navigate to the new user profile
 }
 ```

--- a/docs/01-app/03-api-reference/04-functions/cacheTag.mdx
+++ b/docs/01-app/03-api-reference/04-functions/cacheTag.mdx
@@ -68,7 +68,7 @@ import { revalidateTag } from 'next/cache'
 
 export default async function submit() {
   await addPost()
-  revalidateTag('my-data')
+  revalidateTag('my-data', 'max')
 }
 ```
 
@@ -79,7 +79,7 @@ import { revalidateTag } from 'next/cache'
 
 export default async function submit() {
   await addPost()
-  revalidateTag('my-data')
+  revalidateTag('my-data', 'max')
 }
 ```
 
@@ -183,7 +183,7 @@ import { revalidateTag } from 'next/cache'
 
 export async function updateBookings() {
   await updateBookingData()
-  revalidateTag('bookings-data')
+  revalidateTag('bookings-data', 'max')
 }
 ```
 
@@ -194,6 +194,6 @@ import { revalidateTag } from 'next/cache'
 
 export async function updateBookings() {
   await updateBookingData()
-  revalidateTag('bookings-data')
+  revalidateTag('bookings-data', 'max')
 }
 ```


### PR DESCRIPTION
### What?

Updated all documentation examples of `revalidateTag` to use the new two-argument signature (`revalidateTag(tag, 'max')`) instead of the deprecated single-argument form (`revalidateTag(tag)`).

### Why?

The `revalidateTag` API now requires a second `profile` argument. Using the old single-argument form causes a TypeScript build error: "Expected 2 arguments, but got 1". Several documentation pages still showed the old signature, which would lead developers to write code that fails to compile.

### How?

Updated 14 call sites across 6 documentation files to pass `'max'` as the second argument, which is the recommended default for stale-while-revalidate semantics:

- `docs/01-app/02-guides/incremental-static-regeneration.mdx`
- `docs/01-app/02-guides/redirecting.mdx`
- `docs/01-app/02-guides/caching-without-cache-components.mdx`
- `docs/01-app/02-guides/backend-for-frontend.mdx`
- `docs/01-app/02-guides/how-revalidation-works.mdx`
- `docs/01-app/03-api-reference/04-functions/cacheTag.mdx`

The `revalidateTag.mdx` API reference page and `09-revalidating.mdx` getting started page were already updated. The `self-hosting.mdx` cache handler method signature (`async revalidateTag(tags)`) is unrelated and left unchanged.
