### PR TITLE
use a guard to ensure that failed writes don't prevent all future persistence attempts

### DIFF
--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -6,7 +6,7 @@ use std::{
     mem::take,
     ops::RangeInclusive,
     path::{Path, PathBuf},
-    sync::atomic::{AtomicBool, AtomicU32, Ordering},
+    sync::atomic::{AtomicU32, Ordering},
 };
 
 use anyhow::{Context, Result, bail};
@@ -106,6 +106,26 @@ struct TrackedStats {
     miss_global: std::sync::atomic::AtomicU64,
 }
 
+/// Describes the currently-active write operation, if any.
+#[derive(Debug, Clone)]
+pub(crate) enum ActiveOperation {
+    WriteBatch,
+    Compact,
+}
+
+/// RAII guard that resets the active write operation to `None` on drop.
+/// This ensures the flag is always cleared, even on error paths or when a `WriteBatch` is dropped
+/// without being committed.
+pub(crate) struct WriteOperationGuard<'a> {
+    state: &'a Mutex<Option<ActiveOperation>>,
+}
+
+impl Drop for WriteOperationGuard<'_> {
+    fn drop(&mut self) {
+        *self.state.lock() = None;
+    }
+}
+
 /// TurboPersistence is a persistent key-value store. It is limited to a single writer at a time
 /// using a single write batch. It allows for concurrent reads.
 pub struct TurboPersistence<S: ParallelScheduler, const FAMILIES: usize> {
@@ -117,9 +137,9 @@ pub struct TurboPersistence<S: ParallelScheduler, const FAMILIES: usize> {
     read_only: bool,
     /// The inner state of the database. Writing will update that.
     inner: RwLock<Inner<FAMILIES>>,
-    /// A flag to indicate if a write operation is currently active. Prevents multiple concurrent
-    /// write operations.
-    active_write_operation: AtomicBool,
+    /// Tracks the currently-active write operation, if any. Prevents multiple concurrent write
+    /// operations. Protected by a Mutex so the guard can reset it on drop.
+    active_write_operation: Mutex<Option<ActiveOperation>>,
     /// A cache for decompressed key blocks.
     key_block_cache: BlockCache,
     /// A cache for decompressed value blocks.
@@ -191,7 +211,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                 accessed_key_hashes: [(); FAMILIES]
                     .map(|_| DashSet::with_hasher(BuildNoHashHasher::default())),
             }),
-            active_write_operation: AtomicBool::new(false),
+            active_write_operation: Mutex::new(None),
             key_block_cache: BlockCache::with(
                 KEY_BLOCK_CACHE_SIZE as usize / KEY_BLOCK_AVG_SIZE,
                 KEY_BLOCK_CACHE_SIZE,
@@ -445,26 +465,34 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
         self.inner.read().meta_files.is_empty()
     }
 
+    /// Acquires the write operation lock, returning an RAII guard that releases it on drop.
+    /// Only one write operation (write batch or compaction) is allowed at a time.
+    fn acquire_write_operation(&self, op: ActiveOperation) -> Result<WriteOperationGuard<'_>> {
+        if self.read_only {
+            bail!("Cannot perform write operations on a read-only database");
+        }
+        let mut guard = self.active_write_operation.lock();
+        if let Some(existing) = &*guard {
+            bail!(
+                "Cannot start {op:?}: {existing:?} is already active (only a single write \
+                 operation is allowed at a time)"
+            );
+        }
+        *guard = Some(op);
+        Ok(WriteOperationGuard {
+            state: &self.active_write_operation,
+        })
+    }
+
     /// Starts a new WriteBatch for the database. Only a single write operation is allowed at a
     /// time. The WriteBatch need to be committed with [`TurboPersistence::commit_write_batch`].
     /// Note that the WriteBatch might start writing data to disk while it's filled up with data.
     /// This data will only become visible after the WriteBatch is committed.
-    pub fn write_batch<K: StoreKey + Send + Sync>(&self) -> Result<WriteBatch<K, S, FAMILIES>> {
-        if self.read_only {
-            bail!("Cannot write to a read-only database");
-        }
-        if self
-            .active_write_operation
-            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-            .is_err()
-        {
-            bail!(
-                "Another write batch or compaction is already active (Only a single write \
-                 operations is allowed at a time)"
-            );
-        }
+    pub fn write_batch<K: StoreKey + Send + Sync>(&self) -> Result<WriteBatch<'_, K, S, FAMILIES>> {
+        let guard = self.acquire_write_operation(ActiveOperation::WriteBatch)?;
         let current = self.inner.read().current_sequence_number;
         Ok(WriteBatch::new(
+            guard,
             self.path.clone(),
             current,
             self.parallel_scheduler.clone(),
@@ -511,11 +539,8 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
     /// visible to readers.
     pub fn commit_write_batch<K: StoreKey + Send + Sync>(
         &self,
-        mut write_batch: WriteBatch<K, S, FAMILIES>,
+        mut write_batch: WriteBatch<'_, K, S, FAMILIES>,
     ) -> Result<()> {
-        if self.read_only {
-            unreachable!("It's not possible to create a write batch for a read-only database");
-        }
         let FinishResult {
             sequence_number,
             new_meta_files,
@@ -552,7 +577,6 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
             sequence_number,
             keys_written,
         })?;
-        self.active_write_operation.store(false, Ordering::Release);
         Ok(())
     }
 
@@ -811,19 +835,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
     /// need to be read to find a key. It also limits the maximum number of SST files that are
     /// merged at once, which is the main factor for the runtime of the compaction.
     pub fn compact(&self, compact_config: &CompactConfig) -> Result<bool> {
-        if self.read_only {
-            bail!("Compaction is not allowed on a read only database");
-        }
-        if self
-            .active_write_operation
-            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-            .is_err()
-        {
-            bail!(
-                "Another write batch or compaction is already active (Only a single write \
-                 operations is allowed at a time)"
-            );
-        }
+        let _guard = self.acquire_write_operation(ActiveOperation::Compact)?;
 
         // Free block caches and SST mmaps before compaction. The block caches
         // are not used during compaction (we iterate uncached), and any cached
@@ -867,8 +879,6 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
             })
             .context("Failed to commit the database compaction")?;
         }
-
-        self.active_write_operation.store(false, Ordering::Release);
 
         Ok(has_changes)
     }

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -108,7 +108,7 @@ struct TrackedStats {
 
 /// Describes the currently-active write operation, if any.
 #[derive(Debug, Clone)]
-pub(crate) enum ActiveOperation {
+enum ActiveOperation {
     WriteBatch,
     Compact,
 }
@@ -138,7 +138,7 @@ pub struct TurboPersistence<S: ParallelScheduler, const FAMILIES: usize> {
     /// The inner state of the database. Writing will update that.
     inner: RwLock<Inner<FAMILIES>>,
     /// Tracks the currently-active write operation, if any. Prevents multiple concurrent write
-    /// operations. Protected by a Mutex so the guard can reset it on drop.
+    /// operations.
     active_write_operation: Mutex<Option<ActiveOperation>>,
     /// A cache for decompressed key blocks.
     key_block_cache: BlockCache,

--- a/turbopack/crates/turbo-persistence/src/tests.rs
+++ b/turbopack/crates/turbo-persistence/src/tests.rs
@@ -2187,3 +2187,32 @@ fn compaction_preserves_active_blob() -> Result<()> {
     db.shutdown()?;
     Ok(())
 }
+
+#[test]
+fn write_batch_drop_without_commit_recovers() -> Result<()> {
+    let tempdir = tempfile::tempdir()?;
+    let path = tempdir.path();
+
+    let db = TurboPersistence::<_, 1>::open_with_parallel_scheduler(
+        path.to_path_buf(),
+        RayonParallelScheduler,
+    )?;
+
+    // Create a write batch and drop it without committing
+    {
+        let _batch = db.write_batch::<Vec<u8>>()?;
+        // batch is dropped here without commit
+    }
+
+    // Should be able to create a new write batch — the lock must have been released
+    let batch = db.write_batch::<Vec<u8>>()?;
+    batch.put(0, vec![1u8], vec![42u8].into())?;
+    db.commit_write_batch(batch)?;
+
+    // Verify the write succeeded
+    let value = db.get(0, &[1u8])?;
+    assert_eq!(value.as_deref(), Some(&[42u8][..]));
+
+    db.shutdown()?;
+    Ok(())
+}

--- a/turbopack/crates/turbo-persistence/src/write_batch.rs
+++ b/turbopack/crates/turbo-persistence/src/write_batch.rs
@@ -20,6 +20,7 @@ use crate::{
     collector_entry::CollectorEntry,
     compression::{checksum_block, compress_into_buffer},
     constants::{MAX_MEDIUM_VALUE_SIZE, THREAD_LOCAL_SIZE_SHIFT},
+    db::WriteOperationGuard,
     key::StoreKey,
     meta_file::MetaEntryFlags,
     meta_file_builder::MetaFileBuilder,
@@ -66,7 +67,9 @@ enum GlobalCollectorState<K: StoreKey + Send> {
 }
 
 /// A write batch.
-pub struct WriteBatch<K: StoreKey + Send, S: ParallelScheduler, const FAMILIES: usize> {
+pub struct WriteBatch<'db, K: StoreKey + Send, S: ParallelScheduler, const FAMILIES: usize> {
+    /// RAII guard that releases the write operation lock on drop.
+    _write_guard: WriteOperationGuard<'db>,
     /// Parallel scheduler
     parallel_scheduler: S,
     /// The database path
@@ -87,11 +90,12 @@ pub struct WriteBatch<K: StoreKey + Send, S: ParallelScheduler, const FAMILIES: 
     new_sst_files: Mutex<Vec<(u32, File)>>,
 }
 
-impl<K: StoreKey + Send + Sync, S: ParallelScheduler, const FAMILIES: usize>
-    WriteBatch<K, S, FAMILIES>
+impl<'db, K: StoreKey + Send + Sync, S: ParallelScheduler, const FAMILIES: usize>
+    WriteBatch<'db, K, S, FAMILIES>
 {
     /// Creates a new write batch for a database with per-family configuration.
     pub(crate) fn new(
+        write_guard: WriteOperationGuard<'db>,
         path: PathBuf,
         current: u32,
         parallel_scheduler: S,
@@ -101,6 +105,7 @@ impl<K: StoreKey + Send + Sync, S: ParallelScheduler, const FAMILIES: usize>
             assert!(FAMILIES <= usize_from_u32(u32::MAX));
         };
         Self {
+            _write_guard: write_guard,
             parallel_scheduler,
             db_path: path,
             family_configs,

--- a/turbopack/crates/turbo-tasks-backend/src/database/turbo/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/turbo/mod.rs
@@ -195,8 +195,12 @@ fn do_compact(
 }
 
 pub struct TurboWriteBatch<'a> {
-    batch:
-        turbo_persistence::WriteBatch<WriteBuffer<'static>, TurboTasksParallelScheduler, FAMILIES>,
+    batch: turbo_persistence::WriteBatch<
+        'a,
+        WriteBuffer<'static>,
+        TurboTasksParallelScheduler,
+        FAMILIES,
+    >,
     db: &'a Arc<TurboPersistence<TurboTasksParallelScheduler, FAMILIES>>,
 }
 


### PR DESCRIPTION
## Bug

`TurboPersistence` uses an `AtomicBool` flag to prevent concurrent writes. If a write batch or compaction fails (I/O error, etc.), the flag is never reset — permanently locking the DB for all future writes.

In practice this is silent: `save_snapshot` errors are printed to stderr and swallowed, so the system keeps running with a dead persistence layer.

## Fix

Replace the `AtomicBool` with an RAII `WriteOperationGuard` that resets the lock on drop. The guard is embedded in `WriteBatch` via a lifetime, so it's released automatically whether the batch is committed, errors out, or is dropped without committing.

Also consolidates the duplicated acquire/release logic from `write_batch()` and `compact()` into a single `acquire_write_operation()` method, and replaces the bare boolean with an `ActiveOperation` enum for better error messages.

Includes a regression test that fails on the old code and passes with the fix.