### PR TITLE
fix: use AppInitialProps<P> instead of P for AppType (#42846)

### DIFF
--- a/packages/next/src/shared/lib/utils.ts
+++ b/packages/next/src/shared/lib/utils.ts
@@ -30,7 +30,7 @@ export type DocumentType = NextComponentType<
 
 export type AppType<P = {}> = NextComponentType<
   AppContextType,
-  P,
+  AppInitialProps<P>,
   AppPropsType<any, P>
 >
 

--- a/test/integration/typescript/pages/_app.tsx
+++ b/test/integration/typescript/pages/_app.tsx
@@ -4,6 +4,6 @@ const MyApp: AppType<{ foo: string }> = ({ Component, pageProps }) => {
   return <Component {...pageProps} />
 }
 
-MyApp.getInitialProps = () => ({ foo: 'bar' })
+MyApp.getInitialProps = () => ({ pageProps: { foo: 'bar' } })
 
 export default MyApp


### PR DESCRIPTION
## Problem

AppType<P> was incorrectly using P as the InitialProps type parameter of NextComponentType, which meant TypeScript accepted App.getInitialProps returning just P instead of { pageProps: P }.

This is a type-safety bug because the actual App contract requires getInitialProps to return AppInitialProps<P> (i.e., { pageProps: P }), not the raw page props.

## Changes

- packages/next/src/shared/lib/utils.ts: Changed P to AppInitialProps<P> in AppType definition
- test/integration/typescript/pages/_app.tsx: Updated test fixture to use the correct return shape

## Verification

TypeScript now correctly rejects:
MyApp.getInitialProps = () => ({ foo: 'bar' })  // Type error

And correctly requires:
MyApp.getInitialProps = () => ({ pageProps: { foo: 'bar' } })  // Correct

Fixes #42846