### PR TITLE
docs: clarify that `use cache` requires async functions

### DIFF
--- a/docs/01-app/03-api-reference/01-directives/use-cache.mdx
+++ b/docs/01-app/03-api-reference/01-directives/use-cache.mdx
@@ -69,7 +69,7 @@ export async function getData() {
 }
 ```
 
-> **Good to know**: When used at file level, all function exports must be async functions.
+> **Good to know**: Functions and components that use `use cache` must be `async`. When used at file level, all exported functions in the file must be `async`.
 
 ## How `use cache` works
 

--- a/docs/01-app/03-api-reference/01-directives/use-cache.mdx
+++ b/docs/01-app/03-api-reference/01-directives/use-cache.mdx
@@ -14,7 +14,7 @@ related:
     - app/api-reference/functions/revalidateTag
 ---
 
-The `use cache` directive allows you to mark a route, React component, or a function as cacheable. It can be used at the top of a file to indicate that all exports in the file should be cached, or inline at the top of function or component to cache the return value.
+The `use cache` directive allows you to mark a route, React component, or a function as cacheable. It can be used at the top of a file to indicate that all exports in the file should be cached, or inline at the top of a function or component to cache the return value. Functions and components that use `use cache` must be async.
 
 > **Good to know:**
 >
@@ -45,7 +45,7 @@ const nextConfig = {
 module.exports = nextConfig
 ```
 
-Then, add `use cache` at the file, component, or function level:
+Then, add `use cache` at the file, component, or function level. All functions and components using `use cache` must be async. When used at file level, every exported function becomes a cached function and must also be async:
 
 ```tsx
 // File level
@@ -68,8 +68,6 @@ export async function getData() {
   return data
 }
 ```
-
-> **Good to know**: Functions and components that use `use cache` must be async. When used at file level, all exported functions in the file must be async.
 
 ## How `use cache` works
 

--- a/docs/01-app/03-api-reference/01-directives/use-cache.mdx
+++ b/docs/01-app/03-api-reference/01-directives/use-cache.mdx
@@ -69,7 +69,7 @@ export async function getData() {
 }
 ```
 
-> **Good to know**: Functions and components that use `use cache` must be `async`. When used at file level, all exported functions in the file must be `async`.
+> **Good to know**: Functions and components that use `use cache` must be async. When used at file level, all exported functions in the file must be async.
 
 ## How `use cache` works
 


### PR DESCRIPTION
### What?

Update the "Good to know" note in the `use cache` directive docs to clarify that functions and components using `use cache` must be `async` at all levels — not just at file level.

### Why?

Users get the build error `"use cache" functions must be async functions` when applying the directive to a synchronous component. The existing note only mentions the file-level case ("When used at file level, all function exports must be async functions"), which implies the async requirement doesn't apply at component or function level.

### How?

Updated the "Good to know" callout to state the requirement applies to all functions and components using `use cache`, with the file-level case as additional context.

## PR checklist (Improving Documentation)

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR
- Follow the docs contribution guide: https://nextjs.org/docs/community/contribution-guide