### PR TITLE
turbo-persistence: stop background persisting after unrecoverable failure

### DIFF
--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -6,7 +6,7 @@ use std::{
     mem::take,
     ops::RangeInclusive,
     path::{Path, PathBuf},
-    sync::atomic::{AtomicU32, Ordering},
+    sync::atomic::{AtomicBool, AtomicU32, Ordering},
     time::{Duration, Instant},
 };
 
@@ -858,7 +858,6 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
             // (A3) Compute the final sequence number that will be written to
             // CURRENT. A .del file is created only when there are files to
             // delete, which consumes one extra sequence number.
->>>>>>> 92d68435 (Defer inner mutation in commit() until after CURRENT is durable)
             has_delete_file = !sst_seq_numbers_to_delete.is_empty()
                 || !blob_seq_numbers_to_delete.is_empty()
                 || !meta_seq_numbers_to_delete.is_empty();

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -148,6 +148,17 @@ impl WriteOperationGuard<'_> {
 /// Called on rollback to clean up any SST, meta, blob, or del files written during a
 /// failed write operation or compaction.
 fn delete_orphan_files(path: &Path, seq_before: u32) -> Result<()> {
+    // Restore CURRENT to seq_before first. The failure may have happened mid-write
+    // to CURRENT, leaving it partially written. Writing seq_before makes the
+    // on-disk state consistent before we start deleting orphan files.
+    let mut current_file = OpenOptions::new()
+        .write(true)
+        .truncate(false)
+        .read(false)
+        .open(path.join("CURRENT"))?;
+    current_file.write_u32::<BE>(seq_before)?;
+    current_file.sync_all()?;
+
     for entry in fs::read_dir(path)? {
         let entry = entry?;
         let path = entry.path();

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -6,7 +6,7 @@ use std::{
     mem::take,
     ops::RangeInclusive,
     path::{Path, PathBuf},
-    sync::atomic::{AtomicBool, AtomicU32, Ordering},
+    sync::atomic::{AtomicU32, Ordering},
 };
 
 use anyhow::{Context, Result, bail};
@@ -106,6 +106,82 @@ struct TrackedStats {
     miss_global: std::sync::atomic::AtomicU64,
 }
 
+/// State of the active write slot.
+enum ActiveWriteState {
+    /// A write operation or compaction is in progress.
+    Active,
+    /// A previous write or compaction failed and recovery also failed.
+    /// No further writes are possible.
+    Error,
+}
+
+/// RAII guard for an active write operation.
+///
+/// When dropped without [`WriteOperationGuard::success`] being called first, the guard rolls back
+/// the operation by deleting any files whose sequence number exceeds `seq_before` (the sequence
+/// number at the time the operation started). If rollback itself fails the write slot is set to
+/// [`ActiveWriteState::Error`], permanently disabling further writes.
+pub(crate) struct WriteOperationGuard<'a> {
+    /// Reference to the active-write-operation slot, so we can clear or error it on drop.
+    active: &'a Mutex<Option<ActiveWriteState>>,
+    /// Database directory path, needed for orphan-file deletion during rollback.
+    path: &'a Path,
+    /// Sequence number at the time the operation started (= the last committed seq on disk).
+    /// Files with seq > this were created by the current operation and must be deleted on
+    /// rollback.
+    seq_before: u32,
+    /// Set to `true` by [`WriteOperationGuard::success`] to skip rollback on drop.
+    succeeded: bool,
+}
+
+impl WriteOperationGuard<'_> {
+    /// Mark the operation as successfully completed.
+    ///
+    /// After this call the guard's `Drop` impl will release the write slot without rolling back.
+    pub(crate) fn success(&mut self) {
+        self.succeeded = true;
+    }
+}
+
+impl Drop for WriteOperationGuard<'_> {
+    fn drop(&mut self) {
+        if self.succeeded {
+            // Happy path: just release the slot.
+            *self.active.lock() = None;
+            return;
+        }
+
+        // Unhappy path: the operation failed (or was dropped without commit).
+        // Delete every file that was created during this operation (seq > seq_before).
+        let result = (|| -> Result<()> {
+            for entry in fs::read_dir(self.path)? {
+                let entry = entry?;
+                let path = entry.path();
+                if let Some(ext) = path.extension().and_then(|s| s.to_str()) {
+                    if let Some(seq) = path
+                        .file_stem()
+                        .and_then(|s| s.to_str())
+                        .and_then(|s| s.parse::<u32>().ok())
+                    {
+                        if seq > self.seq_before {
+                            match ext {
+                                "sst" | "meta" | "blob" | "del" => fs::remove_file(&path)?,
+                                _ => {}
+                            }
+                        }
+                    }
+                }
+            }
+            Ok(())
+        })();
+
+        match result {
+            Ok(()) => *self.active.lock() = None,
+            Err(_) => *self.active.lock() = Some(ActiveWriteState::Error),
+        }
+    }
+}
+
 /// TurboPersistence is a persistent key-value store. It is limited to a single writer at a time
 /// using a single write batch. It allows for concurrent reads.
 pub struct TurboPersistence<S: ParallelScheduler, const FAMILIES: usize> {
@@ -120,9 +196,9 @@ pub struct TurboPersistence<S: ParallelScheduler, const FAMILIES: usize> {
     /// A flag to indicate if the database is empty (no meta files). This is an atomic mirror of
     /// `inner.meta_files.is_empty()` to avoid taking a lock on the hot path.
     is_empty: AtomicBool,
-    /// A flag to indicate if a write operation is currently active. Prevents multiple concurrent
-    /// write operations.
-    active_write_operation: AtomicBool,
+    /// Tracks whether a write operation is in progress or has permanently failed.
+    /// `None` = idle, `Some(Active)` = in progress, `Some(Error)` = permanently disabled.
+    active_write_operation: Mutex<Option<ActiveWriteState>>,
     /// A cache for decompressed key blocks.
     key_block_cache: BlockCache,
     /// A cache for decompressed value blocks.
@@ -195,7 +271,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                     .map(|_| DashSet::with_hasher(BuildNoHashHasher::default())),
             }),
             is_empty: AtomicBool::new(true),
-            active_write_operation: AtomicBool::new(false),
+            active_write_operation: Mutex::new(None),
             key_block_cache: BlockCache::with(
                 KEY_BLOCK_CACHE_SIZE as usize / KEY_BLOCK_AVG_SIZE,
                 KEY_BLOCK_CACHE_SIZE,
@@ -451,33 +527,57 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
         self.is_empty.load(Ordering::Relaxed)
     }
 
-    /// Returns true if a write operation or compaction is currently active. If this returns true
-    /// after a failed persist or compaction, it means recovery failed and no further write
-    /// operations are possible.
+    /// Returns true if a previous write or compaction failed with an unrecoverable error,
+    /// permanently disabling further write operations.
     pub fn is_write_operation_active(&self) -> bool {
-        self.active_write_operation.load(Ordering::Acquire)
+        matches!(
+            *self.active_write_operation.lock(),
+            Some(ActiveWriteState::Error)
+        )
+    }
+
+    /// Acquires the write-operation slot, returning an RAII guard that rolls back and releases it
+    /// on drop. Only one write operation (write batch or compaction) is allowed at a time.
+    fn acquire_write_operation(&self) -> Result<WriteOperationGuard<'_>> {
+        if self.read_only {
+            bail!("Cannot perform write operations on a read-only database");
+        }
+        let mut slot = self.active_write_operation.lock();
+        match &*slot {
+            None => {}
+            Some(ActiveWriteState::Active) => {
+                bail!(
+                    "Another write batch or compaction is already active (only a single write \
+                     operation is allowed at a time)"
+                );
+            }
+            Some(ActiveWriteState::Error) => {
+                bail!(
+                    "A previous write operation failed with an unrecoverable error; no further \
+                     writes are possible"
+                );
+            }
+        }
+        *slot = Some(ActiveWriteState::Active);
+        let seq_before = self.inner.read().current_sequence_number;
+        drop(slot);
+        Ok(WriteOperationGuard {
+            active: &self.active_write_operation,
+            path: &self.path,
+            seq_before,
+            succeeded: false,
+        })
     }
 
     /// Starts a new WriteBatch for the database. Only a single write operation is allowed at a
     /// time. The WriteBatch need to be committed with [`TurboPersistence::commit_write_batch`].
     /// Note that the WriteBatch might start writing data to disk while it's filled up with data.
     /// This data will only become visible after the WriteBatch is committed.
-    pub fn write_batch<K: StoreKey + Send + Sync>(&self) -> Result<WriteBatch<K, S, FAMILIES>> {
-        if self.read_only {
-            bail!("Cannot write to a read-only database");
-        }
-        if self
-            .active_write_operation
-            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-            .is_err()
-        {
-            bail!(
-                "Another write batch or compaction is already active (Only a single write \
-                 operations is allowed at a time)"
-            );
-        }
+    pub fn write_batch<K: StoreKey + Send + Sync>(&self) -> Result<WriteBatch<'_, K, S, FAMILIES>> {
+        let guard = self.acquire_write_operation()?;
         let current = self.inner.read().current_sequence_number;
         Ok(WriteBatch::new(
+            guard,
             self.path.clone(),
             current,
             self.parallel_scheduler.clone(),
@@ -520,130 +620,22 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
         Ok(BufWriter::new(log_file))
     }
 
-    /// Calls `try_recover_after_failed_write` when `result` is an error, then returns `result`
-    /// unchanged. Callers can simply write `self.recover_on_error(fallible_op())?`.
-    ///
-    /// Must be called without holding `self.inner`'s read lock, because recovery acquires the
-    /// write lock.
-    fn recover_on_error<T>(&self, result: Result<T>) -> Result<T> {
-        if result.is_err() {
-            let _ = self.try_recover_after_failed_write();
-        }
-        result
-    }
-
-    /// Attempts to recover the database to a consistent state after a failed write or compaction.
-    ///
-    /// Reads the last committed sequence number from the CURRENT file on disk, deletes any orphan
-    /// files (seq > current), processes any pending .del files, and reloads the in-memory meta
-    /// file list from disk.
-    ///
-    /// If recovery succeeds, `active_write_operation` is reset to `false`. If recovery fails,
-    /// `active_write_operation` remains `true` and further writes are permanently disabled.
-    fn try_recover_after_failed_write(&self) -> Result<()> {
-        // Read the last successfully committed sequence number from disk.
-        let current_seq = {
-            let mut file = File::open(self.path.join("CURRENT"))?;
-            file.read_u32::<BE>()?
-        };
-
-        // Walk the directory, categorizing files by their sequence number.
-        let mut orphan_paths = Vec::new(); // seq > current_seq: partial commit artifacts to delete
-        let mut del_file_paths = Vec::new(); // seq <= current_seq, .del: pending deletions to finish
-        let mut meta_seqs = Vec::new(); // seq <= current_seq, .meta: to reload into memory
-
-        for entry in fs::read_dir(&self.path)? {
-            let entry = entry?;
-            let path = entry.path();
-            if let Some(ext) = path.extension().and_then(|s| s.to_str()) {
-                if let Some(seq) = path
-                    .file_stem()
-                    .and_then(|s| s.to_str())
-                    .and_then(|s| s.parse::<u32>().ok())
-                {
-                    if seq > current_seq {
-                        match ext {
-                            "sst" | "meta" | "blob" | "del" => orphan_paths.push(path),
-                            _ => {}
-                        }
-                    } else {
-                        match ext {
-                            "del" => del_file_paths.push(path),
-                            "meta" => meta_seqs.push(seq),
-                            _ => {}
-                        }
-                    }
-                }
-            }
-        }
-
-        // Delete orphan files left by the failed partial commit.
-        for path in orphan_paths {
-            fs::remove_file(path)?;
-        }
-
-        // Process .del files: collect which files should be deleted, then delete them.
-        // .del files are written before CURRENT is updated; if CURRENT was already updated they are
-        // committed state and must be fully applied.
-        let mut deleted_seqs = HashSet::new();
-        for del_path in &del_file_paths {
-            let content = fs::read(del_path)?;
-            let mut cursor = content.as_slice();
-            while !cursor.is_empty() {
-                deleted_seqs.insert(cursor.read_u32::<BE>()?);
-            }
-        }
-        for &del_seq in &deleted_seqs {
-            for ext in ["sst", "meta", "blob"] {
-                let p = self.path.join(format!("{del_seq:08}.{ext}"));
-                match fs::remove_file(&p) {
-                    Ok(()) => {}
-                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-                    Err(e) => return Err(e.into()),
-                }
-            }
-        }
-        for del_path in del_file_paths {
-            fs::remove_file(del_path)?;
-        }
-
-        // Load MetaFile objects for the surviving .meta files.
-        meta_seqs.retain(|seq| !deleted_seqs.contains(seq));
-        meta_seqs.sort_unstable();
-        let mut meta_files = self
-            .parallel_scheduler
-            .parallel_map_collect::<_, _, Result<Vec<MetaFile>>>(&meta_seqs, |&seq| {
-                MetaFile::open(&self.path, seq)
-            })?;
-
-        // Apply SST filter to mark obsolete entries within each meta file.
-        let mut sst_filter = SstFilter::new();
-        for meta_file in meta_files.iter_mut().rev() {
-            sst_filter.apply_filter(meta_file);
-        }
-
-        // Update in-memory state under write lock.
-        {
-            let mut inner = self.inner.write();
-            inner.meta_files = meta_files;
-            inner.current_sequence_number = current_seq;
-        }
-
-        // Recovery succeeded — release the exclusive write lock.
-        self.active_write_operation.store(false, Ordering::Release);
-        Ok(())
-    }
-
     /// Commits a WriteBatch to the database. This will finish writing the data to disk and make it
     /// visible to readers.
     pub fn commit_write_batch<K: StoreKey + Send + Sync>(
         &self,
-        mut write_batch: WriteBatch<K, S, FAMILIES>,
+        mut write_batch: WriteBatch<'_, K, S, FAMILIES>,
     ) -> Result<()> {
         if self.read_only {
             unreachable!("It's not possible to create a write batch for a read-only database");
         }
-        let finish_result = write_batch.finish(|family| {
+        let FinishResult {
+            sequence_number,
+            new_meta_files,
+            new_sst_files,
+            new_blob_files,
+            keys_written,
+        } = write_batch.finish(|family| {
             let inner = self.inner.read();
             let set = &inner.accessed_key_hashes[family as usize];
             // len is only a snapshot at that time and it can change while we create the filter.
@@ -668,15 +660,8 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                 false
             });
             amqf
-        });
-        let FinishResult {
-            sequence_number,
-            new_meta_files,
-            new_sst_files,
-            new_blob_files,
-            keys_written,
-        } = self.recover_on_error(finish_result)?;
-        self.recover_on_error(self.commit(CommitOptions {
+        })?;
+        self.commit(CommitOptions {
             new_meta_files,
             new_sst_files,
             new_blob_files,
@@ -684,8 +669,9 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
             blob_seq_numbers_to_delete: vec![],
             sequence_number,
             keys_written,
-        }))?;
-        self.active_write_operation.store(false, Ordering::Release);
+        })?;
+        // Mark the guard inside the write batch as succeeded so it skips the rollback on drop.
+        write_batch.mark_succeeded();
         Ok(())
     }
 
@@ -985,19 +971,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
     /// need to be read to find a key. It also limits the maximum number of SST files that are
     /// merged at once, which is the main factor for the runtime of the compaction.
     pub fn compact(&self, compact_config: &CompactConfig) -> Result<bool> {
-        if self.read_only {
-            bail!("Compaction is not allowed on a read only database");
-        }
-        if self
-            .active_write_operation
-            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-            .is_err()
-        {
-            bail!(
-                "Another write batch or compaction is already active (Only a single write \
-                 operations is allowed at a time)"
-            );
-        }
+        let mut guard = self.acquire_write_operation()?;
 
         // Free block caches and SST mmaps before compaction. The block caches
         // are not used during compaction (we iterate uncached), and any cached
@@ -1012,9 +986,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
         let mut blob_seq_numbers_to_delete = Vec::new();
         let mut keys_written = 0;
 
-        // Scope the read lock so it is released before `recover_on_error` below,
-        // which acquires the write lock during recovery.
-        let compact_result = {
+        {
             let inner = self.inner.read();
             sequence_number = AtomicU32::new(inner.current_sequence_number);
             self.compact_internal(
@@ -1027,28 +999,24 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                 &mut keys_written,
                 compact_config,
             )
-            .context("Failed to compact database")
-        };
-        self.recover_on_error(compact_result)?;
+            .context("Failed to compact database")?;
+        }
 
         let has_changes = !new_meta_files.is_empty();
         if has_changes {
-            self.recover_on_error(
-                self.commit(CommitOptions {
-                    new_meta_files,
-                    new_sst_files,
-                    new_blob_files: Vec::new(),
-                    sst_seq_numbers_to_delete,
-                    blob_seq_numbers_to_delete,
-                    sequence_number: *sequence_number.get_mut(),
-                    keys_written,
-                })
-                .context("Failed to commit the database compaction"),
-            )?;
+            self.commit(CommitOptions {
+                new_meta_files,
+                new_sst_files,
+                new_blob_files: Vec::new(),
+                sst_seq_numbers_to_delete,
+                blob_seq_numbers_to_delete,
+                sequence_number: *sequence_number.get_mut(),
+                keys_written,
+            })
+            .context("Failed to commit the database compaction")?;
         }
 
-        self.active_write_operation.store(false, Ordering::Release);
-
+        guard.success();
         Ok(has_changes)
     }
 

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -825,33 +825,30 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
         let entries_to_remove;
 
         {
+            let inner = self.inner.read();
+
             // (A1) Run the SST filter on existing meta files. This only
             // updates the SstFilter state — the MetaFile in-memory layout is
             // not modified yet (that happens in Phase C via retain_entries).
             // Collects the set of SST entry sequence numbers to remove from
             // each meta file, keyed by position in `inner.meta_files`.
-            let inner = self.inner.read();
             entries_to_remove = inner
                 .meta_files
                 .iter()
                 .rev()
                 .map(|meta_file| sst_filter.apply_filter_collect(meta_file))
                 .collect::<Vec<_>>();
-        }
 
-        {
             // (A2) Determine which meta files are fully obsolete by running
-            // `apply_and_get_remove` in newest-first order. Only reads
-            // `inner.meta_files`, so a read lock suffices.
-            //
-            // Process new metas first (they are newer than existing ones) to
-            // advance the filter state, then existing ones. New metas are never
-            // candidates for removal (just created), so only their filter-state
-            // side-effects matter.
-            let inner = self.inner.read();
+            // `apply_and_get_remove` in newest-first order. Process new metas
+            // first (they are newer than existing ones) to advance the filter
+            // state, then existing ones. New metas are never candidates for
+            // removal (just created), so only their filter-state side-effects
+            // matter.
             for meta_file in new_meta_files.iter().rev() {
+                let should_remove = sst_filter.apply_and_get_remove(meta_file);
                 debug_assert!(
-                    !sst_filter.apply_and_get_remove(meta_file),
+                    !should_remove,
                     "newly created meta file should never be a candidate for removal"
                 );
             }

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -1002,8 +1002,10 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
             // entries from active to obsolete inside each MetaFile.
             // entries_to_remove was collected in reverse order, so iterate it
             // in reverse to match the forward order of inner.meta_files.
-            for (meta_file, to_remove) in
-                inner.meta_files.iter_mut().zip(entries_to_remove.into_iter().rev())
+            for (meta_file, to_remove) in inner
+                .meta_files
+                .iter_mut()
+                .zip(entries_to_remove.into_iter().rev())
             {
                 if !to_remove.is_empty() {
                     meta_file.retain_entries(|seq| !to_remove.contains(&seq));

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -520,6 +520,18 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
         Ok(BufWriter::new(log_file))
     }
 
+    /// Calls `try_recover_after_failed_write` when `result` is an error, then returns `result`
+    /// unchanged. Callers can simply write `self.recover_on_error(fallible_op())?`.
+    ///
+    /// Must be called without holding `self.inner`'s read lock, because recovery acquires the
+    /// write lock.
+    fn recover_on_error<T>(&self, result: Result<T>) -> Result<T> {
+        if result.is_err() {
+            let _ = self.try_recover_after_failed_write();
+        }
+        result
+    }
+
     /// Attempts to recover the database to a consistent state after a failed write or compaction.
     ///
     /// Reads the last committed sequence number from the CURRENT file on disk, deletes any orphan
@@ -663,14 +675,8 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
             new_sst_files,
             new_blob_files,
             keys_written,
-        } = match finish_result {
-            Ok(r) => r,
-            Err(e) => {
-                let _ = self.try_recover_after_failed_write();
-                return Err(e);
-            }
-        };
-        if let Err(e) = self.commit(CommitOptions {
+        } = self.recover_on_error(finish_result)?;
+        self.recover_on_error(self.commit(CommitOptions {
             new_meta_files,
             new_sst_files,
             new_blob_files,
@@ -678,10 +684,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
             blob_seq_numbers_to_delete: vec![],
             sequence_number,
             keys_written,
-        }) {
-            let _ = self.try_recover_after_failed_write();
-            return Err(e);
-        }
+        }))?;
         self.active_write_operation.store(false, Ordering::Release);
         Ok(())
     }
@@ -1009,31 +1012,29 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
         let mut blob_seq_numbers_to_delete = Vec::new();
         let mut keys_written = 0;
 
-        {
+        // Scope the read lock so it is released before `recover_on_error` below,
+        // which acquires the write lock during recovery.
+        let compact_result = {
             let inner = self.inner.read();
             sequence_number = AtomicU32::new(inner.current_sequence_number);
-            if let Err(e) = self
-                .compact_internal(
-                    &inner.meta_files,
-                    &sequence_number,
-                    &mut new_meta_files,
-                    &mut new_sst_files,
-                    &mut sst_seq_numbers_to_delete,
-                    &mut blob_seq_numbers_to_delete,
-                    &mut keys_written,
-                    compact_config,
-                )
-                .context("Failed to compact database")
-            {
-                let _ = self.try_recover_after_failed_write();
-                return Err(e);
-            }
-        }
+            self.compact_internal(
+                &inner.meta_files,
+                &sequence_number,
+                &mut new_meta_files,
+                &mut new_sst_files,
+                &mut sst_seq_numbers_to_delete,
+                &mut blob_seq_numbers_to_delete,
+                &mut keys_written,
+                compact_config,
+            )
+            .context("Failed to compact database")
+        };
+        self.recover_on_error(compact_result)?;
 
         let has_changes = !new_meta_files.is_empty();
         if has_changes {
-            if let Err(e) = self
-                .commit(CommitOptions {
+            self.recover_on_error(
+                self.commit(CommitOptions {
                     new_meta_files,
                     new_sst_files,
                     new_blob_files: Vec::new(),
@@ -1042,11 +1043,8 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                     sequence_number: *sequence_number.get_mut(),
                     keys_written,
                 })
-                .context("Failed to commit the database compaction")
-            {
-                let _ = self.try_recover_after_failed_write();
-                return Err(e);
-            }
+                .context("Failed to commit the database compaction"),
+            )?;
         }
 
         self.active_write_operation.store(false, Ordering::Release);

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -110,7 +110,8 @@ struct TrackedStats {
 /// State of the active write slot.
 enum ActiveWriteState {
     /// A write operation or compaction is in progress.
-    Active,
+    /// The string is a human-readable name used in error messages.
+    Active(&'static str),
     /// A previous write or compaction failed and recovery also failed.
     /// No further writes are possible.
     Error,
@@ -573,16 +574,17 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
 
     /// Acquires the write-operation slot, returning an RAII guard that rolls back and releases it
     /// on drop. Only one write operation (write batch or compaction) is allowed at a time.
-    fn acquire_write_operation(&self) -> Result<WriteOperationGuard<'_>> {
+    /// `name` is a short human-readable label used in error messages (e.g. `"write batch"`).
+    fn acquire_write_operation(&self, name: &'static str) -> Result<WriteOperationGuard<'_>> {
         if self.read_only {
             bail!("Cannot perform write operations on a read-only database");
         }
         let mut slot = self.active_write_operation.lock();
         match &*slot {
-            Some(ActiveWriteState::Active) => {
+            Some(ActiveWriteState::Active(active_name)) => {
                 bail!(
-                    "Another write batch or compaction is already active (only a single write \
-                     operation is allowed at a time)"
+                    "Another {active_name} is already active (only a single write operation is \
+                     allowed at a time)"
                 );
             }
             Some(ActiveWriteState::Error) => {
@@ -593,7 +595,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
             }
             None => {}
         }
-        *slot = Some(ActiveWriteState::Active);
+        *slot = Some(ActiveWriteState::Active(name));
         drop(slot); // release before acquiring inner read lock
         let seq_before = self.inner.read().current_sequence_number;
         Ok(WriteOperationGuard {
@@ -609,7 +611,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
     /// Note that the WriteBatch might start writing data to disk while it's filled up with data.
     /// This data will only become visible after the WriteBatch is committed.
     pub fn write_batch<K: StoreKey + Send + Sync>(&self) -> Result<WriteBatch<'_, K, S, FAMILIES>> {
-        let guard = self.acquire_write_operation()?;
+        let guard = self.acquire_write_operation("write batch")?;
         // seq_before is already the current sequence number, no second read needed.
         let current = guard.seq_before;
         Ok(WriteBatch::new(
@@ -1082,7 +1084,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
     /// need to be read to find a key. It also limits the maximum number of SST files that are
     /// merged at once, which is the main factor for the runtime of the compaction.
     pub fn compact(&self, compact_config: &CompactConfig) -> Result<bool> {
-        let mut guard = self.acquire_write_operation()?;
+        let mut guard = self.acquire_write_operation("compaction")?;
 
         // Free block caches and SST mmaps before compaction. The block caches
         // are not used during compaction (we iterate uncached), and any cached

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -451,6 +451,13 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
         self.is_empty.load(Ordering::Relaxed)
     }
 
+    /// Returns true if a write operation or compaction is currently active. If this returns true
+    /// after a failed persist or compaction, it means recovery failed and no further write
+    /// operations are possible.
+    pub fn is_write_operation_active(&self) -> bool {
+        self.active_write_operation.load(Ordering::Acquire)
+    }
+
     /// Starts a new WriteBatch for the database. Only a single write operation is allowed at a
     /// time. The WriteBatch need to be committed with [`TurboPersistence::commit_write_batch`].
     /// Note that the WriteBatch might start writing data to disk while it's filled up with data.
@@ -513,6 +520,108 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
         Ok(BufWriter::new(log_file))
     }
 
+    /// Attempts to recover the database to a consistent state after a failed write or compaction.
+    ///
+    /// Reads the last committed sequence number from the CURRENT file on disk, deletes any orphan
+    /// files (seq > current), processes any pending .del files, and reloads the in-memory meta
+    /// file list from disk.
+    ///
+    /// If recovery succeeds, `active_write_operation` is reset to `false`. If recovery fails,
+    /// `active_write_operation` remains `true` and further writes are permanently disabled.
+    fn try_recover_after_failed_write(&self) -> Result<()> {
+        // Read the last successfully committed sequence number from disk.
+        let current_seq = {
+            let mut file = File::open(self.path.join("CURRENT"))?;
+            file.read_u32::<BE>()?
+        };
+
+        // Walk the directory, categorizing files by their sequence number.
+        let mut orphan_paths = Vec::new(); // seq > current_seq: partial commit artifacts to delete
+        let mut del_file_paths = Vec::new(); // seq <= current_seq, .del: pending deletions to finish
+        let mut meta_seqs = Vec::new(); // seq <= current_seq, .meta: to reload into memory
+
+        for entry in fs::read_dir(&self.path)? {
+            let entry = entry?;
+            let path = entry.path();
+            if let Some(ext) = path.extension().and_then(|s| s.to_str()) {
+                if let Some(seq) = path
+                    .file_stem()
+                    .and_then(|s| s.to_str())
+                    .and_then(|s| s.parse::<u32>().ok())
+                {
+                    if seq > current_seq {
+                        match ext {
+                            "sst" | "meta" | "blob" | "del" => orphan_paths.push(path),
+                            _ => {}
+                        }
+                    } else {
+                        match ext {
+                            "del" => del_file_paths.push(path),
+                            "meta" => meta_seqs.push(seq),
+                            _ => {}
+                        }
+                    }
+                }
+            }
+        }
+
+        // Delete orphan files left by the failed partial commit.
+        for path in orphan_paths {
+            fs::remove_file(path)?;
+        }
+
+        // Process .del files: collect which files should be deleted, then delete them.
+        // .del files are written before CURRENT is updated; if CURRENT was already updated they are
+        // committed state and must be fully applied.
+        let mut deleted_seqs = HashSet::new();
+        for del_path in &del_file_paths {
+            let content = fs::read(del_path)?;
+            let mut cursor = content.as_slice();
+            while !cursor.is_empty() {
+                deleted_seqs.insert(cursor.read_u32::<BE>()?);
+            }
+        }
+        for &del_seq in &deleted_seqs {
+            for ext in ["sst", "meta", "blob"] {
+                let p = self.path.join(format!("{del_seq:08}.{ext}"));
+                match fs::remove_file(&p) {
+                    Ok(()) => {}
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                    Err(e) => return Err(e.into()),
+                }
+            }
+        }
+        for del_path in del_file_paths {
+            fs::remove_file(del_path)?;
+        }
+
+        // Load MetaFile objects for the surviving .meta files.
+        meta_seqs.retain(|seq| !deleted_seqs.contains(seq));
+        meta_seqs.sort_unstable();
+        let mut meta_files = self
+            .parallel_scheduler
+            .parallel_map_collect::<_, _, Result<Vec<MetaFile>>>(&meta_seqs, |&seq| {
+                MetaFile::open(&self.path, seq)
+            })?;
+
+        // Apply SST filter to mark obsolete entries within each meta file.
+        let mut sst_filter = SstFilter::new();
+        for meta_file in meta_files.iter_mut().rev() {
+            sst_filter.apply_filter(meta_file);
+        }
+
+        // Update in-memory state under write lock.
+        {
+            let mut inner = self.inner.write();
+            inner.meta_files = meta_files;
+            inner.current_sequence_number = current_seq;
+        }
+
+        // Recovery succeeded — release the exclusive write lock.
+        self.active_write_operation.store(false, Ordering::Release);
+        Ok(())
+    }
+
     /// Commits a WriteBatch to the database. This will finish writing the data to disk and make it
     /// visible to readers.
     pub fn commit_write_batch<K: StoreKey + Send + Sync>(
@@ -522,13 +631,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
         if self.read_only {
             unreachable!("It's not possible to create a write batch for a read-only database");
         }
-        let FinishResult {
-            sequence_number,
-            new_meta_files,
-            new_sst_files,
-            new_blob_files,
-            keys_written,
-        } = write_batch.finish(|family| {
+        let finish_result = write_batch.finish(|family| {
             let inner = self.inner.read();
             let set = &inner.accessed_key_hashes[family as usize];
             // len is only a snapshot at that time and it can change while we create the filter.
@@ -553,8 +656,21 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                 false
             });
             amqf
-        })?;
-        self.commit(CommitOptions {
+        });
+        let FinishResult {
+            sequence_number,
+            new_meta_files,
+            new_sst_files,
+            new_blob_files,
+            keys_written,
+        } = match finish_result {
+            Ok(r) => r,
+            Err(e) => {
+                let _ = self.try_recover_after_failed_write();
+                return Err(e);
+            }
+        };
+        if let Err(e) = self.commit(CommitOptions {
             new_meta_files,
             new_sst_files,
             new_blob_files,
@@ -562,7 +678,10 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
             blob_seq_numbers_to_delete: vec![],
             sequence_number,
             keys_written,
-        })?;
+        }) {
+            let _ = self.try_recover_after_failed_write();
+            return Err(e);
+        }
         self.active_write_operation.store(false, Ordering::Release);
         Ok(())
     }
@@ -893,31 +1012,41 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
         {
             let inner = self.inner.read();
             sequence_number = AtomicU32::new(inner.current_sequence_number);
-            self.compact_internal(
-                &inner.meta_files,
-                &sequence_number,
-                &mut new_meta_files,
-                &mut new_sst_files,
-                &mut sst_seq_numbers_to_delete,
-                &mut blob_seq_numbers_to_delete,
-                &mut keys_written,
-                compact_config,
-            )
-            .context("Failed to compact database")?;
+            if let Err(e) = self
+                .compact_internal(
+                    &inner.meta_files,
+                    &sequence_number,
+                    &mut new_meta_files,
+                    &mut new_sst_files,
+                    &mut sst_seq_numbers_to_delete,
+                    &mut blob_seq_numbers_to_delete,
+                    &mut keys_written,
+                    compact_config,
+                )
+                .context("Failed to compact database")
+            {
+                let _ = self.try_recover_after_failed_write();
+                return Err(e);
+            }
         }
 
         let has_changes = !new_meta_files.is_empty();
         if has_changes {
-            self.commit(CommitOptions {
-                new_meta_files,
-                new_sst_files,
-                new_blob_files: Vec::new(),
-                sst_seq_numbers_to_delete,
-                blob_seq_numbers_to_delete,
-                sequence_number: *sequence_number.get_mut(),
-                keys_written,
-            })
-            .context("Failed to commit the database compaction")?;
+            if let Err(e) = self
+                .commit(CommitOptions {
+                    new_meta_files,
+                    new_sst_files,
+                    new_blob_files: Vec::new(),
+                    sst_seq_numbers_to_delete,
+                    blob_seq_numbers_to_delete,
+                    sequence_number: *sequence_number.get_mut(),
+                    keys_written,
+                })
+                .context("Failed to commit the database compaction")
+            {
+                let _ = self.try_recover_after_failed_write();
+                return Err(e);
+            }
         }
 
         self.active_write_operation.store(false, Ordering::Release);

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -143,6 +143,32 @@ impl WriteOperationGuard<'_> {
     }
 }
 
+/// Deletes all files in `path` whose numeric stem is greater than `seq_before`.
+///
+/// Called on rollback to clean up any SST, meta, blob, or del files written during a
+/// failed write operation or compaction.
+fn delete_orphan_files(path: &Path, seq_before: u32) -> Result<()> {
+    for entry in fs::read_dir(path)? {
+        let entry = entry?;
+        let path = entry.path();
+        if let Some(ext) = path.extension().and_then(|s| s.to_str()) {
+            if let Some(seq) = path
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .and_then(|s| s.parse::<u32>().ok())
+            {
+                if seq > seq_before {
+                    match ext {
+                        "sst" | "meta" | "blob" | "del" => fs::remove_file(&path)?,
+                        _ => {}
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
 impl Drop for WriteOperationGuard<'_> {
     fn drop(&mut self) {
         if self.succeeded {
@@ -153,29 +179,7 @@ impl Drop for WriteOperationGuard<'_> {
 
         // Unhappy path: the operation failed (or was dropped without commit).
         // Delete every file that was created during this operation (seq > seq_before).
-        let result = (|| -> Result<()> {
-            for entry in fs::read_dir(self.path)? {
-                let entry = entry?;
-                let path = entry.path();
-                if let Some(ext) = path.extension().and_then(|s| s.to_str()) {
-                    if let Some(seq) = path
-                        .file_stem()
-                        .and_then(|s| s.to_str())
-                        .and_then(|s| s.parse::<u32>().ok())
-                    {
-                        if seq > self.seq_before {
-                            match ext {
-                                "sst" | "meta" | "blob" | "del" => fs::remove_file(&path)?,
-                                _ => {}
-                            }
-                        }
-                    }
-                }
-            }
-            Ok(())
-        })();
-
-        match result {
+        match delete_orphan_files(self.path, self.seq_before) {
             Ok(()) => *self.active.lock() = None,
             Err(_) => *self.active.lock() = Some(ActiveWriteState::Error),
         }
@@ -527,9 +531,9 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
         self.is_empty.load(Ordering::Relaxed)
     }
 
-    /// Returns true if a previous write or compaction failed with an unrecoverable error,
-    /// permanently disabling further write operations.
-    pub fn is_write_operation_active(&self) -> bool {
+    /// Returns `true` if a previous write or compaction left the database in an unrecoverable error
+    /// state, permanently disabling further writes.
+    pub fn has_unrecoverable_write_error(&self) -> bool {
         matches!(
             *self.active_write_operation.lock(),
             Some(ActiveWriteState::Error)
@@ -544,7 +548,6 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
         }
         let mut slot = self.active_write_operation.lock();
         match &*slot {
-            None => {}
             Some(ActiveWriteState::Active) => {
                 bail!(
                     "Another write batch or compaction is already active (only a single write \
@@ -557,10 +560,11 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                      writes are possible"
                 );
             }
+            None => {}
         }
         *slot = Some(ActiveWriteState::Active);
+        drop(slot); // release before acquiring inner read lock
         let seq_before = self.inner.read().current_sequence_number;
-        drop(slot);
         Ok(WriteOperationGuard {
             active: &self.active_write_operation,
             path: &self.path,
@@ -575,7 +579,8 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
     /// This data will only become visible after the WriteBatch is committed.
     pub fn write_batch<K: StoreKey + Send + Sync>(&self) -> Result<WriteBatch<'_, K, S, FAMILIES>> {
         let guard = self.acquire_write_operation()?;
-        let current = self.inner.read().current_sequence_number;
+        // seq_before is already the current sequence number, no second read needed.
+        let current = guard.seq_before;
         Ok(WriteBatch::new(
             guard,
             self.path.clone(),

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -783,35 +783,57 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
             })
             .collect::<Vec<_>>();
 
+        // ── Phase A: compute what will change without structurally modifying
+        //    inner (no append, no retain, no seq bump). ──
+        //
+        // We need `meta_seq_numbers_to_delete` and `has_delete_file` to write
+        // the .del file BEFORE writing CURRENT. But we must not modify
+        // `inner.meta_files` or `inner.current_sequence_number` yet — if a disk
+        // error occurs before CURRENT is durable, the WriteOperationGuard
+        // rollback can only clean up orphan files, not undo in-memory mutations.
         let has_delete_file;
         let mut meta_seq_numbers_to_delete = Vec::new();
 
         {
             let mut inner = self.inner.write();
+
+            // (A1) Run the SST filter on existing meta files. This calls
+            // `retain_entries()` which moves superseded entries into
+            // `obsolete_entries` — a benign read optimization that doesn't
+            // change which meta files exist or the sequence number. Safe to
+            // apply pre-CURRENT: on crash/rollback the MetaFile is re-opened
+            // from disk with its original layout.
             for meta_file in inner.meta_files.iter_mut().rev() {
                 sst_filter.apply_filter(meta_file);
             }
-            inner.meta_files.append(&mut new_meta_files);
-            // apply_and_get_remove need to run in reverse order
-            inner.meta_files.reverse();
-            inner.meta_files.retain(|meta| {
-                if sst_filter.apply_and_get_remove(meta) {
-                    meta_seq_numbers_to_delete.push(meta.sequence_number());
-                    false
-                } else {
-                    true
+
+            // (A2) Determine which meta files are fully obsolete by running
+            // `apply_and_get_remove` in newest-first order. Process new metas
+            // first (they are newer than existing ones) to advance the filter
+            // state, then existing ones. New metas are never candidates for
+            // removal (just created), so only their filter-state side-effects
+            // matter.
+            for meta_file in new_meta_files.iter().rev() {
+                sst_filter.apply_and_get_remove(meta_file);
+            }
+            for i in (0..inner.meta_files.len()).rev() {
+                if sst_filter.apply_and_get_remove(&inner.meta_files[i]) {
+                    meta_seq_numbers_to_delete.push(inner.meta_files[i].sequence_number());
                 }
-            });
-            inner.meta_files.reverse();
-            self.is_empty
-                .store(inner.meta_files.is_empty(), Ordering::Relaxed);
+            }
+
+            // (A3) Compute the final sequence number that will be written to
+            // CURRENT. A .del file is created only when there are files to
+            // delete, which consumes one extra sequence number.
+>>>>>>> 92d68435 (Defer inner mutation in commit() until after CURRENT is durable)
             has_delete_file = !sst_seq_numbers_to_delete.is_empty()
                 || !blob_seq_numbers_to_delete.is_empty()
                 || !meta_seq_numbers_to_delete.is_empty();
             if has_delete_file {
                 seq += 1;
             }
-            inner.current_sequence_number = seq;
+
+            // inner.write() is dropped here — inner is NOT structurally changed.
         }
 
         self.parallel_scheduler.block_in_place(|| {
@@ -899,16 +921,12 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                     }
                 }
 
-                fn write_seq_numbers<W: std::io::Write, T, I>(
+                fn write_seq_numbers<W: std::io::Write, T>(
                     log: &mut W,
-                    items: I,
+                    items: &[T],
                     label: &str,
                     extract_seq: fn(&T) -> u32,
-                ) -> std::io::Result<()>
-                where
-                    I: IntoIterator<Item = T>,
-                {
-                    let items: Vec<T> = items.into_iter().collect();
+                ) -> std::io::Result<()> {
                     for chunk in items.chunks(15) {
                         write!(log, "    |          |")?;
                         for item in chunk {
@@ -920,55 +938,84 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                 }
 
                 new_blob_files.sort_unstable_by_key(|(seq, _)| *seq);
-                write_seq_numbers(&mut log, new_blob_files, "NEW BLOB", |&(seq, _)| seq)?;
+                write_seq_numbers(&mut log, &new_blob_files, "NEW BLOB", |&(seq, _)| seq)?;
                 write_seq_numbers(
                     &mut log,
-                    blob_seq_numbers_to_delete,
+                    &blob_seq_numbers_to_delete,
                     "BLOB DELETED",
                     |&seq| seq,
                 )?;
-                write_seq_numbers(&mut log, sst_seq_numbers_to_delete, "SST DELETED", |&seq| {
-                    seq
-                })?;
                 write_seq_numbers(
                     &mut log,
-                    meta_seq_numbers_to_delete,
+                    &sst_seq_numbers_to_delete,
+                    "SST DELETED",
+                    |&seq| seq,
+                )?;
+                write_seq_numbers(
+                    &mut log,
+                    &meta_seq_numbers_to_delete,
                     "META DELETED",
                     |&seq| seq,
                 )?;
-                #[cfg(feature = "verbose_log")]
-                {
-                    writeln!(log, "New database state:")?;
-                    writeln!(log, "FAM | META SEQ | SST SEQ  FLAGS | RANGE")?;
-                    let inner = self.inner.read();
-                    let families = inner.meta_files.iter().map(|meta| meta.family()).filter({
-                        let mut set = HashSet::new();
-                        move |family| set.insert(*family)
-                    });
-                    for family in families {
-                        for meta in inner.meta_files.iter() {
-                            if meta.family() != family {
-                                continue;
-                            }
-                            let meta_seq = meta.sequence_number();
-                            for entry in meta.entries().iter() {
-                                let seq = entry.sequence_number();
-                                let range = entry.range();
-                                writeln!(
-                                    log,
-                                    "{family:3} | {meta_seq:08} | {seq:08} {:>6} | {}",
-                                    entry.flags(),
-                                    range_to_str(range.min_hash, range.max_hash)
-                                )?;
-                            }
-                        }
-                    }
-                }
                 anyhow::Ok(())
             })();
 
             anyhow::Ok(())
         })?;
+
+        // ── Phase C: structurally update inner (CURRENT is already durable). ──
+        //
+        // Between Phase A's write-lock drop and this point no other writer can
+        // run (WriteOperationGuard ensures exclusivity) and readers never mutate
+        // inner, so the snapshot from Phase A is still valid.
+        {
+            let mut inner = self.inner.write();
+            inner.meta_files.append(&mut new_meta_files);
+            if !meta_seq_numbers_to_delete.is_empty() {
+                let to_delete: HashSet<u32> = meta_seq_numbers_to_delete.iter().copied().collect();
+                inner
+                    .meta_files
+                    .retain(|meta| !to_delete.contains(&meta.sequence_number()));
+            }
+            inner.current_sequence_number = seq;
+            self.is_empty
+                .store(inner.meta_files.is_empty(), Ordering::Relaxed);
+        }
+
+        // Best-effort verbose log of the new database state after Phase C.
+        #[cfg(feature = "verbose_log")]
+        {
+            let _: Result<(), _> = (|| -> anyhow::Result<()> {
+                let mut log = self.open_log()?;
+                writeln!(log, "New database state:")?;
+                writeln!(log, "FAM | META SEQ | SST SEQ  FLAGS | RANGE")?;
+                let inner = self.inner.read();
+                let families = inner.meta_files.iter().map(|meta| meta.family()).filter({
+                    let mut set = HashSet::new();
+                    move |family| set.insert(*family)
+                });
+                for family in families {
+                    for meta in inner.meta_files.iter() {
+                        if meta.family() != family {
+                            continue;
+                        }
+                        let meta_seq = meta.sequence_number();
+                        for entry in meta.entries().iter() {
+                            let seq = entry.sequence_number();
+                            let range = entry.range();
+                            writeln!(
+                                log,
+                                "{family:3} | {meta_seq:08} | {seq:08} {:>6} | {}",
+                                entry.flags(),
+                                range_to_str(range.min_hash, range.max_hash)
+                            )?;
+                        }
+                    }
+                }
+                Ok(())
+            })();
+        }
+
         Ok(())
     }
 

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -116,18 +116,15 @@ enum ActiveWriteState {
     Error,
 }
 
-/// A batch of superseded files whose deletion failed and is being retried.
+/// A single superseded file whose deletion failed and is being retried.
 ///
-/// On Linux/macOS, deleting a memory-mapped file is safe and these lists are
+/// On Linux/macOS, deleting a memory-mapped file is safe and this list is
 /// normally empty. On Windows, open memory maps prevent deletion; failed files
 /// are collected here and retried on the next commit or shutdown.
-struct DeferredDeletion {
-    /// Sequence numbers of `.sst` files that could not be deleted yet.
-    sst: Vec<u32>,
-    /// Sequence numbers of `.meta` files that could not be deleted yet.
-    meta: Vec<u32>,
-    /// Sequence numbers of `.blob` files that could not be deleted yet.
-    blob: Vec<u32>,
+enum DeferredDeletion {
+    Sst(u32),
+    Meta(u32),
+    Blob(u32),
 }
 
 /// RAII guard for an active write operation.
@@ -1008,16 +1005,18 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
         // works even if readers have the files memory-mapped. On Windows, open
         // memory maps prevent deletion; any file that fails is kept in
         // `deferred_deletions` and retried on the next commit or at shutdown.
-        let failed_sst = Self::try_delete_files(&self.path, &sst_seq_numbers_to_delete, "sst");
-        let failed_meta = Self::try_delete_files(&self.path, &meta_seq_numbers_to_delete, "meta");
-        let failed_blob = Self::try_delete_files(&self.path, &blob_seq_numbers_to_delete, "blob");
-        if !failed_sst.is_empty() || !failed_meta.is_empty() || !failed_blob.is_empty() {
-            self.deferred_deletions.lock().push(DeferredDeletion {
-                sst: failed_sst,
-                meta: failed_meta,
-                blob: failed_blob,
-            });
-        }
+        self.deferred_deletions.lock().extend(
+            Self::try_delete_files(&self.path, &sst_seq_numbers_to_delete, "sst")
+                .map(DeferredDeletion::Sst)
+                .chain(
+                    Self::try_delete_files(&self.path, &meta_seq_numbers_to_delete, "meta")
+                        .map(DeferredDeletion::Meta),
+                )
+                .chain(
+                    Self::try_delete_files(&self.path, &blob_seq_numbers_to_delete, "blob")
+                        .map(DeferredDeletion::Blob),
+                ),
+        );
 
         // Retry any deletions that failed in earlier commits.
         self.retry_deferred_deletions();
@@ -1989,12 +1988,16 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
         Ok(())
     }
 
-    /// Attempts to delete a list of files with the given extension, returning those that failed.
-    fn try_delete_files(dir: &Path, seqs: &[u32], ext: &str) -> Vec<u32> {
+    /// Attempts to delete files with the given extension, returning an iterator of sequence
+    /// numbers for files that could not be deleted (e.g. due to open memory maps on Windows).
+    fn try_delete_files<'a>(
+        dir: &'a Path,
+        seqs: &'a [u32],
+        ext: &'a str,
+    ) -> impl Iterator<Item = u32> + 'a {
         seqs.iter()
-            .filter(|&&seq| fs::remove_file(dir.join(format!("{seq:08}.{ext}"))).is_err())
             .copied()
-            .collect()
+            .filter(move |&seq| fs::remove_file(dir.join(format!("{seq:08}.{ext}"))).is_err())
     }
 
     /// Retries deletion of files that previously failed (typically due to open memory maps on
@@ -2003,18 +2006,14 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
     /// any leftover files on the next open via the `.del` file.
     fn retry_deferred_deletions(&self) {
         let mut deferred = self.deferred_deletions.lock();
-        deferred.retain_mut(|batch| {
-            batch.sst.retain(|&seq| {
-                fs::remove_file(self.path.join(format!("{seq:08}.sst"))).is_err()
-            });
-            batch.meta.retain(|&seq| {
-                fs::remove_file(self.path.join(format!("{seq:08}.meta"))).is_err()
-            });
-            batch.blob.retain(|&seq| {
-                fs::remove_file(self.path.join(format!("{seq:08}.blob"))).is_err()
-            });
-            // Keep the batch only if some files still couldn't be deleted.
-            !batch.sst.is_empty() || !batch.meta.is_empty() || !batch.blob.is_empty()
+        deferred.retain(|entry| {
+            let (seq, ext) = match *entry {
+                DeferredDeletion::Sst(seq) => (seq, "sst"),
+                DeferredDeletion::Meta(seq) => (seq, "meta"),
+                DeferredDeletion::Blob(seq) => (seq, "blob"),
+            };
+            // Keep the entry only if deletion still fails.
+            fs::remove_file(self.path.join(format!("{seq:08}.{ext}"))).is_err()
         });
     }
 }

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -812,38 +812,49 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
             })
             .collect::<Vec<_>>();
 
-        // ── Phase A: compute what will change without structurally modifying
-        //    inner (no append, no retain, no seq bump). ──
+        // ── Phase A: compute what will change without adding/removing meta
+        //    files or bumping the sequence number. ──
         //
         // We need `meta_seq_numbers_to_delete` and `has_delete_file` to write
-        // the .del file BEFORE writing CURRENT. But we must not modify
-        // `inner.meta_files` or `inner.current_sequence_number` yet — if a disk
-        // error occurs before CURRENT is durable, the WriteOperationGuard
-        // rollback can only clean up orphan files, not undo in-memory mutations.
+        // the .del file BEFORE writing CURRENT. We must not append/retain
+        // `inner.meta_files` or update `inner.current_sequence_number` yet —
+        // if a disk error occurs before CURRENT is durable, the
+        // WriteOperationGuard rollback can only clean up orphan files, not undo
+        // in-memory mutations to the file list or sequence number.
+        //
+        // A1 (apply_filter) does mutate MetaFile internals in-memory, but that
+        // is safe: it is a read optimization (moving superseded entries to
+        // `obsolete_entries`) and on crash/rollback the MetaFile is re-opened
+        // from disk with its original layout.
         let has_delete_file;
         let mut meta_seq_numbers_to_delete = Vec::new();
 
         {
-            let mut inner = self.inner.write();
-
             // (A1) Run the SST filter on existing meta files. This calls
             // `retain_entries()` which moves superseded entries into
-            // `obsolete_entries` — a benign read optimization that doesn't
-            // change which meta files exist or the sequence number. Safe to
-            // apply pre-CURRENT: on crash/rollback the MetaFile is re-opened
-            // from disk with its original layout.
+            // `obsolete_entries`. Requires a write lock because it mutates the
+            // MetaFile in-memory layout. Released immediately after.
+            let mut inner = self.inner.write();
             for meta_file in inner.meta_files.iter_mut().rev() {
                 sst_filter.apply_filter(meta_file);
             }
+        }
 
+        {
             // (A2) Determine which meta files are fully obsolete by running
-            // `apply_and_get_remove` in newest-first order. Process new metas
-            // first (they are newer than existing ones) to advance the filter
-            // state, then existing ones. New metas are never candidates for
-            // removal (just created), so only their filter-state side-effects
-            // matter.
+            // `apply_and_get_remove` in newest-first order. Only reads
+            // `inner.meta_files`, so a read lock suffices.
+            //
+            // Process new metas first (they are newer than existing ones) to
+            // advance the filter state, then existing ones. New metas are never
+            // candidates for removal (just created), so only their filter-state
+            // side-effects matter.
+            let inner = self.inner.read();
             for meta_file in new_meta_files.iter().rev() {
-                sst_filter.apply_and_get_remove(meta_file);
+                debug_assert!(
+                    !sst_filter.apply_and_get_remove(meta_file),
+                    "newly created meta file should never be a candidate for removal"
+                );
             }
             for i in (0..inner.meta_files.len()).rev() {
                 if sst_filter.apply_and_get_remove(&inner.meta_files[i]) {
@@ -857,11 +868,9 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
             has_delete_file = !sst_seq_numbers_to_delete.is_empty()
                 || !blob_seq_numbers_to_delete.is_empty()
                 || !meta_seq_numbers_to_delete.is_empty();
-            if has_delete_file {
-                seq += 1;
-            }
-
-            // inner.write() is dropped here — inner is NOT structurally changed.
+        }
+        if has_delete_file {
+            seq += 1;
         }
 
         self.parallel_scheduler.block_in_place(|| {
@@ -915,7 +924,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
             // would then run its rollback and delete the *newly committed*
             // files, corrupting the database.
 
-            let _: Result<(), _> = (|| {
+            if let Err(e) = (|| {
                 let mut log = self.open_log()?;
                 writeln!(log, "Time {time}")?;
                 let span = time.until(Timestamp::now())?;
@@ -977,7 +986,9 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                     |&seq| seq,
                 )?;
                 anyhow::Ok(())
-            })();
+            })() {
+                eprintln!("turbo-persistence: failed to write LOG after commit {seq:08}: {e:#}");
+            }
 
             anyhow::Ok(())
         })?;

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -812,32 +812,31 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
             })
             .collect::<Vec<_>>();
 
-        // ── Phase A: compute what will change without adding/removing meta
-        //    files or bumping the sequence number. ──
+        // ── Phase A: compute what will change without modifying inner. ──
         //
         // We need `meta_seq_numbers_to_delete` and `has_delete_file` to write
-        // the .del file BEFORE writing CURRENT. We must not append/retain
-        // `inner.meta_files` or update `inner.current_sequence_number` yet —
-        // if a disk error occurs before CURRENT is durable, the
+        // the .del file BEFORE writing CURRENT. We must not modify `inner` at
+        // all — if a disk error occurs before CURRENT is durable, the
         // WriteOperationGuard rollback can only clean up orphan files, not undo
-        // in-memory mutations to the file list or sequence number.
-        //
-        // A1 (apply_filter) does mutate MetaFile internals in-memory, but that
-        // is safe: it is a read optimization (moving superseded entries to
-        // `obsolete_entries`) and on crash/rollback the MetaFile is re-opened
-        // from disk with its original layout.
+        // in-memory mutations. The MetaFile in-memory optimization
+        // (retain_entries) is deferred to Phase C.
         let has_delete_file;
         let mut meta_seq_numbers_to_delete = Vec::new();
+        let entries_to_remove;
 
         {
-            // (A1) Run the SST filter on existing meta files. This calls
-            // `retain_entries()` which moves superseded entries into
-            // `obsolete_entries`. Requires a write lock because it mutates the
-            // MetaFile in-memory layout. Released immediately after.
-            let mut inner = self.inner.write();
-            for meta_file in inner.meta_files.iter_mut().rev() {
-                sst_filter.apply_filter(meta_file);
-            }
+            // (A1) Run the SST filter on existing meta files. This only
+            // updates the SstFilter state — the MetaFile in-memory layout is
+            // not modified yet (that happens in Phase C via retain_entries).
+            // Collects the set of SST entry sequence numbers to remove from
+            // each meta file, keyed by position in `inner.meta_files`.
+            let inner = self.inner.read();
+            entries_to_remove = inner
+                .meta_files
+                .iter()
+                .rev()
+                .map(|meta_file| sst_filter.apply_filter_collect(meta_file))
+                .collect::<Vec<_>>();
         }
 
         {
@@ -995,11 +994,25 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
 
         // ── Phase C: structurally update inner (CURRENT is already durable). ──
         //
-        // Between Phase A's write-lock drop and this point no other writer can
+        // Between Phase A's read-lock drop and this point no other writer can
         // run (WriteOperationGuard ensures exclusivity) and readers never mutate
         // inner, so the snapshot from Phase A is still valid.
         {
             let mut inner = self.inner.write();
+
+            // Apply the deferred MetaFile mutations from Phase A1. apply_filter
+            // was called read-only earlier; now we actually move superseded
+            // entries from active to obsolete inside each MetaFile.
+            // entries_to_remove was collected in reverse order, so iterate it
+            // in reverse to match the forward order of inner.meta_files.
+            for (meta_file, to_remove) in
+                inner.meta_files.iter_mut().zip(entries_to_remove.into_iter().rev())
+            {
+                if !to_remove.is_empty() {
+                    meta_file.retain_entries(|seq| !to_remove.contains(&seq));
+                }
+            }
+
             inner.meta_files.append(&mut new_meta_files);
             if !meta_seq_numbers_to_delete.is_empty() {
                 let to_delete: HashSet<u32> = meta_seq_numbers_to_delete.iter().copied().collect();

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -151,18 +151,16 @@ fn delete_orphan_files(path: &Path, seq_before: u32) -> Result<()> {
     for entry in fs::read_dir(path)? {
         let entry = entry?;
         let path = entry.path();
-        if let Some(ext) = path.extension().and_then(|s| s.to_str()) {
-            if let Some(seq) = path
+        if let Some(ext) = path.extension().and_then(|s| s.to_str())
+            && let Some(seq) = path
                 .file_stem()
                 .and_then(|s| s.to_str())
                 .and_then(|s| s.parse::<u32>().ok())
-            {
-                if seq > seq_before {
-                    match ext {
-                        "sst" | "meta" | "blob" | "del" => fs::remove_file(&path)?,
-                        _ => {}
-                    }
-                }
+            && seq > seq_before
+        {
+            match ext {
+                "sst" | "meta" | "blob" | "del" => fs::remove_file(&path)?,
+                _ => {}
             }
         }
     }

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -7,7 +7,6 @@ use std::{
     ops::RangeInclusive,
     path::{Path, PathBuf},
     sync::atomic::{AtomicBool, AtomicU32, Ordering},
-    time::{Duration, Instant},
 };
 
 use anyhow::{Context, Result, bail};
@@ -117,20 +116,17 @@ enum ActiveWriteState {
     Error,
 }
 
-/// A batch of superseded files whose deletion is deferred.
+/// A batch of superseded files whose deletion failed and is being retried.
 ///
-/// After a commit, the old `.sst`, `.meta`, and `.blob` files cannot be deleted
-/// immediately because concurrent readers may still have them memory-mapped.
-/// Instead we record them here and delete them once enough time has passed
-/// (currently 60 s) or on shutdown.
+/// On Linux/macOS, deleting a memory-mapped file is safe and these lists are
+/// normally empty. On Windows, open memory maps prevent deletion; failed files
+/// are collected here and retried on the next commit or shutdown.
 struct DeferredDeletion {
-    /// When the commit that superseded these files completed.
-    committed_at: Instant,
-    /// Sequence numbers of `.sst` files to delete.
+    /// Sequence numbers of `.sst` files that could not be deleted yet.
     sst: Vec<u32>,
-    /// Sequence numbers of `.meta` files to delete.
+    /// Sequence numbers of `.meta` files that could not be deleted yet.
     meta: Vec<u32>,
-    /// Sequence numbers of `.blob` files to delete.
+    /// Sequence numbers of `.blob` files that could not be deleted yet.
     blob: Vec<u32>,
 }
 
@@ -231,7 +227,8 @@ pub struct TurboPersistence<S: ParallelScheduler, const FAMILIES: usize> {
     /// Tracks whether a write operation is in progress or has permanently failed.
     /// `None` = idle, `Some(Active)` = in progress, `Some(Error)` = permanently disabled.
     active_write_operation: Mutex<Option<ActiveWriteState>>,
-    /// Superseded files whose deletion is deferred until readers have finished.
+    /// Files from superseded commits whose deletion failed (e.g. on Windows due to open memory
+    /// maps) and will be retried on the next commit or at shutdown.
     /// Protected by `active_write_operation` (only mutated inside a write operation).
     deferred_deletions: Mutex<Vec<DeferredDeletion>>,
     /// A cache for decompressed key blocks.
@@ -912,11 +909,10 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
             //
             // • Writing the LOG is purely informational.
             //
-            // • Superseded files are NOT deleted here. Concurrent readers may
-            //   still have them memory-mapped. Instead they are enqueued in
-            //   `deferred_deletions` (see Phase C) and deleted later — either
-            //   at the start of the next commit (after a grace period) or on
-            //   shutdown.
+            // • Superseded files are NOT deleted here — Phase C handles that
+            //   after `inner` is updated. On Linux/macOS they are deleted
+            //   immediately; on Windows (where open memory maps prevent
+            //   deletion) they are retried on the next commit or shutdown.
             //
             // Errors here must NOT propagate, because the WriteOperationGuard
             // would then run its rollback and delete the *newly committed*
@@ -1008,24 +1004,23 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                 .store(inner.meta_files.is_empty(), Ordering::Relaxed);
         }
 
-        // Enqueue superseded files for deferred deletion. Concurrent readers may
-        // still have these files memory-mapped, so we wait at least 60 s before
-        // actually removing them (see `delete_deferred_files`).
-        if !sst_seq_numbers_to_delete.is_empty()
-            || !meta_seq_numbers_to_delete.is_empty()
-            || !blob_seq_numbers_to_delete.is_empty()
-        {
+        // Try to delete superseded files immediately. On Linux/macOS this always
+        // works even if readers have the files memory-mapped. On Windows, open
+        // memory maps prevent deletion; any file that fails is kept in
+        // `deferred_deletions` and retried on the next commit or at shutdown.
+        let failed_sst = Self::try_delete_files(&self.path, &sst_seq_numbers_to_delete, "sst");
+        let failed_meta = Self::try_delete_files(&self.path, &meta_seq_numbers_to_delete, "meta");
+        let failed_blob = Self::try_delete_files(&self.path, &blob_seq_numbers_to_delete, "blob");
+        if !failed_sst.is_empty() || !failed_meta.is_empty() || !failed_blob.is_empty() {
             self.deferred_deletions.lock().push(DeferredDeletion {
-                committed_at: Instant::now(),
-                sst: sst_seq_numbers_to_delete,
-                meta: meta_seq_numbers_to_delete,
-                blob: blob_seq_numbers_to_delete,
+                sst: failed_sst,
+                meta: failed_meta,
+                blob: failed_blob,
             });
         }
 
-        // Delete deferred files from previous commits that have aged past the
-        // grace period.
-        self.delete_deferred_files(Self::DEFERRED_DELETION_GRACE_PERIOD);
+        // Retry any deletions that failed in earlier commits.
+        self.retry_deferred_deletions();
 
         // Best-effort verbose log of the new database state after Phase C.
         #[cfg(feature = "verbose_log")]
@@ -1986,38 +1981,40 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
     }
 
     /// Shuts down the database. This will print statistics if the `print_stats` feature is enabled.
-    /// Deletes all deferred files unconditionally (readers are gone at shutdown).
+    /// Retries deletion of all previously-deferred files and clears successfully deleted batches.
     pub fn shutdown(&self) -> Result<()> {
         #[cfg(feature = "print_stats")]
         println!("{:#?}", self.statistics());
-        self.delete_deferred_files(Duration::ZERO);
+        self.retry_deferred_deletions();
         Ok(())
     }
 
-    /// Minimum age before deferred files are eligible for deletion.
-    /// Readers that started before the commit may still be accessing these files
-    /// via memory-mapped I/O.
-    const DEFERRED_DELETION_GRACE_PERIOD: Duration = Duration::from_secs(60);
+    /// Attempts to delete a list of files with the given extension, returning those that failed.
+    fn try_delete_files(dir: &Path, seqs: &[u32], ext: &str) -> Vec<u32> {
+        seqs.iter()
+            .filter(|&&seq| fs::remove_file(dir.join(format!("{seq:08}.{ext}"))).is_err())
+            .copied()
+            .collect()
+    }
 
-    /// Deletes deferred files whose commit timestamp is older than `min_age`.
-    /// Best-effort: errors from individual `remove_file` calls are ignored
-    /// because `load_directory` will finish the cleanup on next open via `.del`.
-    fn delete_deferred_files(&self, min_age: Duration) {
+    /// Retries deletion of files that previously failed (typically due to open memory maps on
+    /// Windows). Any file that still fails is kept for the next retry.
+    /// Best-effort: persistent failures are acceptable because `load_directory` cleans up
+    /// any leftover files on the next open via the `.del` file.
+    fn retry_deferred_deletions(&self) {
         let mut deferred = self.deferred_deletions.lock();
-        deferred.retain(|batch| {
-            if batch.committed_at.elapsed() < min_age {
-                return true; // keep — not old enough
-            }
-            for seq in &batch.sst {
-                let _ = fs::remove_file(self.path.join(format!("{seq:08}.sst")));
-            }
-            for seq in &batch.meta {
-                let _ = fs::remove_file(self.path.join(format!("{seq:08}.meta")));
-            }
-            for seq in &batch.blob {
-                let _ = fs::remove_file(self.path.join(format!("{seq:08}.blob")));
-            }
-            false // remove from list
+        deferred.retain_mut(|batch| {
+            batch.sst.retain(|&seq| {
+                fs::remove_file(self.path.join(format!("{seq:08}.sst"))).is_err()
+            });
+            batch.meta.retain(|&seq| {
+                fs::remove_file(self.path.join(format!("{seq:08}.meta"))).is_err()
+            });
+            batch.blob.retain(|&seq| {
+                fs::remove_file(self.path.join(format!("{seq:08}.blob"))).is_err()
+            });
+            // Keep the batch only if some files still couldn't be deleted.
+            !batch.sst.is_empty() || !batch.meta.is_empty() || !batch.blob.is_empty()
         });
     }
 }

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -848,17 +848,33 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
             current_file.write_u32::<BE>(seq)?;
             current_file.sync_data()?;
 
+            // ── Point of no return ──────────────────────────────────────────
+            //
+            // CURRENT has been durably updated. The commit is now visible to
+            // future readers (including after a crash/restart via
+            // `load_directory`). Everything below is best-effort cleanup:
+            //
+            // • Deleting superseded .sst/.meta/.blob files frees disk space
+            //   but is not required for correctness — `load_directory` will
+            //   finish the cleanup on the next open using the .del file.
+            //
+            // • Writing the LOG is purely informational.
+            //
+            // Errors here must NOT propagate, because the WriteOperationGuard
+            // would then run its rollback and delete the *newly committed*
+            // files, corrupting the database.
+
             for seq in sst_seq_numbers_to_delete.iter() {
-                fs::remove_file(self.path.join(format!("{seq:08}.sst")))?;
+                let _ = fs::remove_file(self.path.join(format!("{seq:08}.sst")));
             }
             for seq in meta_seq_numbers_to_delete.iter() {
-                fs::remove_file(self.path.join(format!("{seq:08}.meta")))?;
+                let _ = fs::remove_file(self.path.join(format!("{seq:08}.meta")));
             }
             for seq in blob_seq_numbers_to_delete.iter() {
-                fs::remove_file(self.path.join(format!("{seq:08}.blob")))?;
+                let _ = fs::remove_file(self.path.join(format!("{seq:08}.blob")));
             }
 
-            {
+            let _: Result<(), _> = (|| {
                 let mut log = self.open_log()?;
                 writeln!(log, "Time {time}")?;
                 let span = time.until(Timestamp::now())?;
@@ -948,7 +964,9 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                         }
                     }
                 }
-            }
+                anyhow::Ok(())
+            })();
+
             anyhow::Ok(())
         })?;
         Ok(())

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -7,6 +7,7 @@ use std::{
     ops::RangeInclusive,
     path::{Path, PathBuf},
     sync::atomic::{AtomicU32, Ordering},
+    time::{Duration, Instant},
 };
 
 use anyhow::{Context, Result, bail};
@@ -115,6 +116,23 @@ enum ActiveWriteState {
     Error,
 }
 
+/// A batch of superseded files whose deletion is deferred.
+///
+/// After a commit, the old `.sst`, `.meta`, and `.blob` files cannot be deleted
+/// immediately because concurrent readers may still have them memory-mapped.
+/// Instead we record them here and delete them once enough time has passed
+/// (currently 60 s) or on shutdown.
+struct DeferredDeletion {
+    /// When the commit that superseded these files completed.
+    committed_at: Instant,
+    /// Sequence numbers of `.sst` files to delete.
+    sst: Vec<u32>,
+    /// Sequence numbers of `.meta` files to delete.
+    meta: Vec<u32>,
+    /// Sequence numbers of `.blob` files to delete.
+    blob: Vec<u32>,
+}
+
 /// RAII guard for an active write operation.
 ///
 /// When dropped without [`WriteOperationGuard::success`] being called first, the guard rolls back
@@ -212,6 +230,9 @@ pub struct TurboPersistence<S: ParallelScheduler, const FAMILIES: usize> {
     /// Tracks whether a write operation is in progress or has permanently failed.
     /// `None` = idle, `Some(Active)` = in progress, `Some(Error)` = permanently disabled.
     active_write_operation: Mutex<Option<ActiveWriteState>>,
+    /// Superseded files whose deletion is deferred until readers have finished.
+    /// Protected by `active_write_operation` (only mutated inside a write operation).
+    deferred_deletions: Mutex<Vec<DeferredDeletion>>,
     /// A cache for decompressed key blocks.
     key_block_cache: BlockCache,
     /// A cache for decompressed value blocks.
@@ -285,6 +306,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
             }),
             is_empty: AtomicBool::new(true),
             active_write_operation: Mutex::new(None),
+            deferred_deletions: Mutex::new(Vec::new()),
             key_block_cache: BlockCache::with(
                 KEY_BLOCK_CACHE_SIZE as usize / KEY_BLOCK_AVG_SIZE,
                 KEY_BLOCK_CACHE_SIZE,
@@ -887,25 +909,17 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
             // future readers (including after a crash/restart via
             // `load_directory`). Everything below is best-effort cleanup:
             //
-            // • Deleting superseded .sst/.meta/.blob files frees disk space
-            //   but is not required for correctness — `load_directory` will
-            //   finish the cleanup on the next open using the .del file.
-            //
             // • Writing the LOG is purely informational.
+            //
+            // • Superseded files are NOT deleted here. Concurrent readers may
+            //   still have them memory-mapped. Instead they are enqueued in
+            //   `deferred_deletions` (see Phase C) and deleted later — either
+            //   at the start of the next commit (after a grace period) or on
+            //   shutdown.
             //
             // Errors here must NOT propagate, because the WriteOperationGuard
             // would then run its rollback and delete the *newly committed*
             // files, corrupting the database.
-
-            for seq in sst_seq_numbers_to_delete.iter() {
-                let _ = fs::remove_file(self.path.join(format!("{seq:08}.sst")));
-            }
-            for seq in meta_seq_numbers_to_delete.iter() {
-                let _ = fs::remove_file(self.path.join(format!("{seq:08}.meta")));
-            }
-            for seq in blob_seq_numbers_to_delete.iter() {
-                let _ = fs::remove_file(self.path.join(format!("{seq:08}.blob")));
-            }
 
             let _: Result<(), _> = (|| {
                 let mut log = self.open_log()?;
@@ -992,6 +1006,25 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
             self.is_empty
                 .store(inner.meta_files.is_empty(), Ordering::Relaxed);
         }
+
+        // Enqueue superseded files for deferred deletion. Concurrent readers may
+        // still have these files memory-mapped, so we wait at least 60 s before
+        // actually removing them (see `delete_deferred_files`).
+        if !sst_seq_numbers_to_delete.is_empty()
+            || !meta_seq_numbers_to_delete.is_empty()
+            || !blob_seq_numbers_to_delete.is_empty()
+        {
+            self.deferred_deletions.lock().push(DeferredDeletion {
+                committed_at: Instant::now(),
+                sst: sst_seq_numbers_to_delete,
+                meta: meta_seq_numbers_to_delete,
+                blob: blob_seq_numbers_to_delete,
+            });
+        }
+
+        // Delete deferred files from previous commits that have aged past the
+        // grace period.
+        self.delete_deferred_files(Self::DEFERRED_DELETION_GRACE_PERIOD);
 
         // Best-effort verbose log of the new database state after Phase C.
         #[cfg(feature = "verbose_log")]
@@ -1952,10 +1985,39 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
     }
 
     /// Shuts down the database. This will print statistics if the `print_stats` feature is enabled.
+    /// Deletes all deferred files unconditionally (readers are gone at shutdown).
     pub fn shutdown(&self) -> Result<()> {
         #[cfg(feature = "print_stats")]
         println!("{:#?}", self.statistics());
+        self.delete_deferred_files(Duration::ZERO);
         Ok(())
+    }
+
+    /// Minimum age before deferred files are eligible for deletion.
+    /// Readers that started before the commit may still be accessing these files
+    /// via memory-mapped I/O.
+    const DEFERRED_DELETION_GRACE_PERIOD: Duration = Duration::from_secs(60);
+
+    /// Deletes deferred files whose commit timestamp is older than `min_age`.
+    /// Best-effort: errors from individual `remove_file` calls are ignored
+    /// because `load_directory` will finish the cleanup on next open via `.del`.
+    fn delete_deferred_files(&self, min_age: Duration) {
+        let mut deferred = self.deferred_deletions.lock();
+        deferred.retain(|batch| {
+            if batch.committed_at.elapsed() < min_age {
+                return true; // keep — not old enough
+            }
+            for seq in &batch.sst {
+                let _ = fs::remove_file(self.path.join(format!("{seq:08}.sst")));
+            }
+            for seq in &batch.meta {
+                let _ = fs::remove_file(self.path.join(format!("{seq:08}.meta")));
+            }
+            for seq in &batch.blob {
+                let _ = fs::remove_file(self.path.join(format!("{seq:08}.blob")));
+            }
+            false // remove from list
+        });
     }
 }
 

--- a/turbopack/crates/turbo-persistence/src/sst_filter.rs
+++ b/turbopack/crates/turbo-persistence/src/sst_filter.rs
@@ -1,6 +1,6 @@
 use std::collections::hash_map::Entry;
 
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::meta_file::MetaFile;
 
@@ -45,6 +45,42 @@ impl SstFilter {
         for seq in meta.obsolete_sst_files() {
             self.0.entry(*seq).or_insert(SstState::UnusedObsolete);
         }
+    }
+
+    /// Like [`apply_filter`](Self::apply_filter) but only updates the filter state without
+    /// modifying the MetaFile. Returns the set of SST sequence numbers that should be removed
+    /// from this meta file's entries (they are superseded by a newer meta). Call
+    /// `meta.retain_entries(|seq| !obsolete.contains(&seq))` later to apply.
+    pub fn apply_filter_collect(&mut self, meta: &MetaFile) -> FxHashSet<u32> {
+        let mut to_remove = FxHashSet::default();
+        // Already obsolete entries need to be considered for usage computation
+        for seq in meta.obsolete_entries() {
+            if let Some(state) = self.0.get_mut(seq)
+                && matches!(state, SstState::UnusedObsolete)
+            {
+                // the obsolete state is used now
+                *state = SstState::Obsolete;
+            }
+        }
+        for entry in meta.entries() {
+            let seq = entry.sequence_number();
+            match self.0.entry(seq) {
+                Entry::Occupied(mut e) => {
+                    let state = e.get_mut();
+                    if matches!(state, SstState::UnusedObsolete) {
+                        *state = SstState::Obsolete;
+                    }
+                    to_remove.insert(seq);
+                }
+                Entry::Vacant(e) => {
+                    e.insert(SstState::Active);
+                }
+            }
+        }
+        for seq in meta.obsolete_sst_files() {
+            self.0.entry(*seq).or_insert(SstState::UnusedObsolete);
+        }
+        to_remove
     }
 
     /// Phase 2: Check if the meta file can be removed based on the filter state after phase 1.

--- a/turbopack/crates/turbo-persistence/src/tests.rs
+++ b/turbopack/crates/turbo-persistence/src/tests.rs
@@ -2023,18 +2023,20 @@ fn compaction_deletes_superseded_blob() -> Result<()> {
     // Compact — the old blob entry is superseded by the newer small value
     db.full_compact()?;
 
-    // After compaction, the old blob file should be deleted
-    assert_eq!(
-        count_blob_files(path),
-        0,
-        "Old blob file should be deleted after compaction"
-    );
-
     // The new value should still be readable
     let result = db.get(0, &vec![1u8])?;
     assert_eq!(result.as_deref(), Some(&[99u8][..]));
 
+    // Shutdown flushes deferred deletions, removing the old blob file.
     db.shutdown()?;
+
+    // After shutdown, the old blob file should be deleted
+    assert_eq!(
+        count_blob_files(path),
+        0,
+        "Old blob file should be deleted after compaction + shutdown"
+    );
+
     Ok(())
 }
 
@@ -2074,18 +2076,20 @@ fn compaction_deletes_blob_on_tombstone() -> Result<()> {
     // Compact — tombstone supersedes the blob entry
     db.full_compact()?;
 
-    // After compaction, the blob file should be deleted
-    assert_eq!(
-        count_blob_files(path),
-        0,
-        "Blob file should be deleted after compaction"
-    );
-
     // Key should not be found
     let result = db.get(0, &vec![1u8])?;
     assert!(result.is_none());
 
+    // Shutdown flushes deferred deletions, removing the blob file.
     db.shutdown()?;
+
+    // After shutdown, the blob file should be deleted
+    assert_eq!(
+        count_blob_files(path),
+        0,
+        "Blob file should be deleted after compaction + shutdown"
+    );
+
     Ok(())
 }
 
@@ -2130,19 +2134,21 @@ fn compaction_deletes_blob_multi_value_tombstone() -> Result<()> {
     // Compact — tombstone prunes the old blob entry
     db.full_compact()?;
 
-    // After compaction, the old blob file should be deleted
-    assert_eq!(
-        count_blob_files(path),
-        0,
-        "Blob file should be deleted after compaction"
-    );
-
     // The new value should still be readable
     let results = db.get_multiple(0, &vec![1u8].as_slice())?;
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].as_ref(), &[99u8]);
 
+    // Shutdown flushes deferred deletions, removing the old blob file.
     db.shutdown()?;
+
+    // After shutdown, the old blob file should be deleted
+    assert_eq!(
+        count_blob_files(path),
+        0,
+        "Blob file should be deleted after compaction + shutdown"
+    );
+
     Ok(())
 }
 

--- a/turbopack/crates/turbo-persistence/src/tests.rs
+++ b/turbopack/crates/turbo-persistence/src/tests.rs
@@ -2027,15 +2027,14 @@ fn compaction_deletes_superseded_blob() -> Result<()> {
     let result = db.get(0, &vec![1u8])?;
     assert_eq!(result.as_deref(), Some(&[99u8][..]));
 
-    // Shutdown flushes deferred deletions, removing the old blob file.
-    db.shutdown()?;
-
-    // After shutdown, the old blob file should be deleted
+    // After compaction, the old blob file should be deleted immediately.
     assert_eq!(
         count_blob_files(path),
         0,
-        "Old blob file should be deleted after compaction + shutdown"
+        "Old blob file should be deleted after compaction"
     );
+
+    db.shutdown()?;
 
     Ok(())
 }
@@ -2080,15 +2079,14 @@ fn compaction_deletes_blob_on_tombstone() -> Result<()> {
     let result = db.get(0, &vec![1u8])?;
     assert!(result.is_none());
 
-    // Shutdown flushes deferred deletions, removing the blob file.
-    db.shutdown()?;
-
-    // After shutdown, the blob file should be deleted
+    // After compaction, the blob file should be deleted immediately.
     assert_eq!(
         count_blob_files(path),
         0,
-        "Blob file should be deleted after compaction + shutdown"
+        "Blob file should be deleted after compaction"
     );
+
+    db.shutdown()?;
 
     Ok(())
 }
@@ -2139,15 +2137,14 @@ fn compaction_deletes_blob_multi_value_tombstone() -> Result<()> {
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].as_ref(), &[99u8]);
 
-    // Shutdown flushes deferred deletions, removing the old blob file.
-    db.shutdown()?;
-
-    // After shutdown, the old blob file should be deleted
+    // After compaction, the old blob file should be deleted immediately.
     assert_eq!(
         count_blob_files(path),
         0,
-        "Blob file should be deleted after compaction + shutdown"
+        "Blob file should be deleted after compaction"
     );
+
+    db.shutdown()?;
 
     Ok(())
 }

--- a/turbopack/crates/turbo-persistence/src/write_batch.rs
+++ b/turbopack/crates/turbo-persistence/src/write_batch.rs
@@ -20,6 +20,7 @@ use crate::{
     collector_entry::CollectorEntry,
     compression::{checksum_block, compress_into_buffer},
     constants::{MAX_MEDIUM_VALUE_SIZE, THREAD_LOCAL_SIZE_SHIFT},
+    db::WriteOperationGuard,
     key::StoreKey,
     meta_file::MetaEntryFlags,
     meta_file_builder::MetaFileBuilder,
@@ -66,7 +67,9 @@ enum GlobalCollectorState<K: StoreKey + Send> {
 }
 
 /// A write batch.
-pub struct WriteBatch<K: StoreKey + Send, S: ParallelScheduler, const FAMILIES: usize> {
+pub struct WriteBatch<'db, K: StoreKey + Send, S: ParallelScheduler, const FAMILIES: usize> {
+    /// RAII guard that releases the write-operation slot (and rolls back on failure) on drop.
+    _write_guard: WriteOperationGuard<'db>,
     /// Parallel scheduler
     parallel_scheduler: S,
     /// The database path
@@ -87,11 +90,12 @@ pub struct WriteBatch<K: StoreKey + Send, S: ParallelScheduler, const FAMILIES: 
     new_sst_files: Mutex<Vec<(u32, File)>>,
 }
 
-impl<K: StoreKey + Send + Sync, S: ParallelScheduler, const FAMILIES: usize>
-    WriteBatch<K, S, FAMILIES>
+impl<'db, K: StoreKey + Send + Sync, S: ParallelScheduler, const FAMILIES: usize>
+    WriteBatch<'db, K, S, FAMILIES>
 {
     /// Creates a new write batch for a database with per-family configuration.
     pub(crate) fn new(
+        write_guard: WriteOperationGuard<'db>,
         path: PathBuf,
         current: u32,
         parallel_scheduler: S,
@@ -101,6 +105,7 @@ impl<K: StoreKey + Send + Sync, S: ParallelScheduler, const FAMILIES: usize>
             assert!(FAMILIES <= usize_from_u32(u32::MAX));
         };
         Self {
+            _write_guard: write_guard,
             parallel_scheduler,
             db_path: path,
             family_configs,
@@ -111,6 +116,14 @@ impl<K: StoreKey + Send + Sync, S: ParallelScheduler, const FAMILIES: usize>
             meta_collectors: [(); FAMILIES].map(|_| Mutex::new(Vec::new())),
             new_sst_files: Mutex::new(Vec::new()),
         }
+    }
+
+    /// Marks the write operation as successfully completed.
+    ///
+    /// Must be called before dropping the `WriteBatch` to skip the rollback in the guard's `Drop`
+    /// impl. Typically called by `TurboPersistence::commit_write_batch` after a successful commit.
+    pub(crate) fn mark_succeeded(&mut self) {
+        self._write_guard.success();
     }
 
     /// Returns the thread local state for the current thread.

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -2781,7 +2781,6 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                     let mut idle_start_listener = self.idle_start_event.listen();
                     let mut idle_end_listener = self.idle_end_event.listen();
                     let mut fresh_idle = true;
-                    let mut compaction_disabled = false;
                     loop {
                         const FIRST_SNAPSHOT_WAIT: Duration = Duration::from_secs(300);
                         const SNAPSHOT_INTERVAL: Duration = Duration::from_secs(120);
@@ -2848,42 +2847,41 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                             // `EnteredSpan` is `!Send` and would prevent the
                             // future from being sent across threads when it
                             // suspends at the `select!` await below.
-                            if !compaction_disabled {
-                                const MAX_IDLE_COMPACTION_PASSES: usize = 10;
-                                for _ in 0..MAX_IDLE_COMPACTION_PASSES {
-                                    let idle_ended = tokio::select! {
-                                        biased;
-                                        _ = &mut idle_end_listener => {
-                                            idle_end_listener = self.idle_end_event.listen();
-                                            true
-                                        },
-                                        _ = std::future::ready(()) => false,
-                                    };
-                                    if idle_ended {
-                                        break;
-                                    }
-                                    // Enter the span only around the synchronous
-                                    // compact() call so we never hold an
-                                    // `EnteredSpan` across an await point.
-                                    let _compact_span = tracing::info_span!(
-                                        parent: background_span.id(),
-                                        "compact database"
-                                    )
-                                    .entered();
-                                    match self.backing_storage.compact() {
-                                        Ok(true) => {}
-                                        Ok(false) => break,
-                                        Err(err) => {
-                                            eprintln!("Compaction failed: {err:?}");
-                                            if self.backing_storage.is_write_operation_active() {
-                                                eprintln!(
-                                                    "Compaction is permanently disabled due to an \
-                                                     unrecoverable error."
-                                                );
-                                                compaction_disabled = true;
-                                            }
-                                            break;
+                            const MAX_IDLE_COMPACTION_PASSES: usize = 10;
+                            for _ in 0..MAX_IDLE_COMPACTION_PASSES {
+                                let idle_ended = tokio::select! {
+                                    biased;
+                                    _ = &mut idle_end_listener => {
+                                        idle_end_listener = self.idle_end_event.listen();
+                                        true
+                                    },
+                                    _ = std::future::ready(()) => false,
+                                };
+                                if idle_ended {
+                                    break;
+                                }
+                                // Enter the span only around the synchronous
+                                // compact() call so we never hold an
+                                // `EnteredSpan` across an await point.
+                                let _compact_span = tracing::info_span!(
+                                    parent: background_span.id(),
+                                    "compact database"
+                                )
+                                .entered();
+                                match self.backing_storage.compact() {
+                                    Ok(true) => {}
+                                    Ok(false) => break,
+                                    Err(err) => {
+                                        eprintln!("Compaction failed: {err:?}");
+                                        if self.backing_storage.is_write_operation_active() {
+                                            eprintln!(
+                                                "Persisting is permanently disabled due to an \
+                                                 unrecoverable error. Stopping the background \
+                                                 persisting process."
+                                            );
+                                            return;
                                         }
+                                        break;
                                     }
                                 }
                             }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -2766,6 +2766,15 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         removed_cell_data
     }
 
+    /// Prints the standard message emitted when the background persisting process stops due to an
+    /// unrecoverable write error. The caller is responsible for returning from the background job.
+    fn log_unrecoverable_persist_error() {
+        eprintln!(
+            "Persisting is permanently disabled due to an unrecoverable error. Stopping the \
+             background persisting process."
+        );
+    }
+
     fn run_backend_job<'a>(
         self: &'a Arc<Self>,
         job: TurboTasksBackendJob,
@@ -2873,12 +2882,8 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                                     Ok(false) => break,
                                     Err(err) => {
                                         eprintln!("Compaction failed: {err:?}");
-                                        if self.backing_storage.is_write_operation_active() {
-                                            eprintln!(
-                                                "Persisting is permanently disabled due to an \
-                                                 unrecoverable error. Stopping the background \
-                                                 persisting process."
-                                            );
+                                        if self.backing_storage.has_unrecoverable_write_error() {
+                                            Self::log_unrecoverable_persist_error();
                                             return;
                                         }
                                         break;
@@ -2900,11 +2905,8 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                                 TurboTasksBackendJob::FollowUpSnapshot,
                             );
                             return;
-                        } else if self.backing_storage.is_write_operation_active() {
-                            eprintln!(
-                                "Persisting is permanently disabled due to an unrecoverable \
-                                 error. Stopping the background persisting process."
-                            );
+                        } else if self.backing_storage.has_unrecoverable_write_error() {
+                            Self::log_unrecoverable_persist_error();
                             return;
                         }
                     }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -2770,7 +2770,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
     /// unrecoverable write error. The caller is responsible for returning from the background job.
     fn log_unrecoverable_persist_error() {
         eprintln!(
-            "Persisting is permanently disabled due to an unrecoverable error. Stopping the \
+            "Persisting is disabled for this session due to an unrecoverable error. Stopping the \
              background persisting process."
         );
     }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1035,7 +1035,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
             // No tasks modified since the last snapshot — drop the guard (which
             // calls end_snapshot) and skip the expensive O(N) scan.
             drop(snapshot_guard);
-            return Some((start, false));
+            return Ok((start, false));
         }
 
         #[cfg(feature = "print_cache_item_size")]

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -988,7 +988,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         parent_span: Option<tracing::Id>,
         reason: &str,
         turbo_tasks: &dyn TurboTasksBackendApi<TurboTasksBackend<B>>,
-    ) -> Option<(Instant, bool)> {
+    ) -> Result<(Instant, bool), anyhow::Error> {
         let snapshot_span =
             tracing::trace_span!(parent: parent_span.clone(), "snapshot", reason = reason)
                 .entered();
@@ -1297,19 +1297,17 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
             // This should be impossible — if we got here, modified_count was nonzero, and every
             // modification that increments the count also failed during encoding.
             std::hint::cold_path();
-            return Some((snapshot_time, false));
+            return Ok((snapshot_time, false));
         }
 
         let persist_start = Instant::now();
         let _span = tracing::info_span!(parent: parent_span, "persist", reason = reason).entered();
         {
-            if let Err(err) = self
-                .backing_storage
-                .save_snapshot(suspended_operations, task_snapshots)
-            {
-                eprintln!("Persisting failed: {err:?}");
-                return None;
-            }
+            // Tasks were already consumed by take_snapshot, so a future snapshot
+            // would not re-persist them — returning an error signals to the caller
+            // that further persist attempts would corrupt the task graph in storage.
+            self.backing_storage
+                .save_snapshot(suspended_operations, task_snapshots)?;
             #[cfg(feature = "print_cache_item_size")]
             {
                 let mut task_cache_stats = task_cache_stats
@@ -1420,7 +1418,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
             ],
         )));
 
-        Some((snapshot_time, true))
+        Ok((snapshot_time, true))
     }
 
     fn startup(&self, turbo_tasks: &dyn TurboTasksBackendApi<TurboTasksBackend<B>>) {
@@ -1462,8 +1460,10 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
             self.is_idle.store(false, Ordering::Release);
             self.verify_aggregation_graph(turbo_tasks, false);
         }
-        if self.should_persist() {
-            self.snapshot_and_persist(Span::current().into(), "stop", turbo_tasks);
+        if self.should_persist()
+            && let Err(err) = self.snapshot_and_persist(Span::current().into(), "stop", turbo_tasks)
+        {
+            eprintln!("Persisting failed during shutdown: {err:?}");
         }
         drop_contents(&self.task_cache);
         self.storage.drop_contents();
@@ -2818,7 +2818,6 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                                         return;
                                     },
                                     _ = &mut idle_start_listener => {
-                                        fresh_idle = true;
                                         idle_time = Instant::now() + idle_timeout;
                                         idle_start_listener = self.idle_start_event.listen()
                                     },
@@ -2845,69 +2844,74 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                         // grouped together in trace viewers.
                         let background_span =
                             tracing::info_span!(parent: None, "background snapshot");
-                        let snapshot =
-                            this.snapshot_and_persist(background_span.id(), reason, turbo_tasks);
-                        if let Some((snapshot_start, new_data)) = snapshot {
-                            last_snapshot = snapshot_start;
+                        match this.snapshot_and_persist(background_span.id(), reason, turbo_tasks) {
+                            Err(err) => {
+                                // save_snapshot consumed persisted_task_cache_log entries;
+                                // further snapshots would corrupt the task graph.
+                                eprintln!("Persisting failed: {err:?}");
+                                Self::log_unrecoverable_persist_error();
+                                return;
+                            }
+                            Ok((snapshot_start, new_data)) => {
+                                last_snapshot = snapshot_start;
 
-                            // Compact while idle (up to limit), regardless of
-                            // whether the snapshot had new data.
-                            // `background_span` is not entered here because
-                            // `EnteredSpan` is `!Send` and would prevent the
-                            // future from being sent across threads when it
-                            // suspends at the `select!` await below.
-                            const MAX_IDLE_COMPACTION_PASSES: usize = 10;
-                            for _ in 0..MAX_IDLE_COMPACTION_PASSES {
-                                let idle_ended = tokio::select! {
-                                    biased;
-                                    _ = &mut idle_end_listener => {
-                                        idle_end_listener = self.idle_end_event.listen();
-                                        true
-                                    },
-                                    _ = std::future::ready(()) => false,
-                                };
-                                if idle_ended {
-                                    break;
-                                }
-                                // Enter the span only around the synchronous
-                                // compact() call so we never hold an
-                                // `EnteredSpan` across an await point.
-                                let _compact_span = tracing::info_span!(
-                                    parent: background_span.id(),
-                                    "compact database"
-                                )
-                                .entered();
-                                match self.backing_storage.compact() {
-                                    Ok(true) => {}
-                                    Ok(false) => break,
-                                    Err(err) => {
-                                        eprintln!("Compaction failed: {err:?}");
-                                        if self.backing_storage.has_unrecoverable_write_error() {
-                                            Self::log_unrecoverable_persist_error();
-                                            return;
-                                        }
+                                // Compact while idle (up to limit), regardless of
+                                // whether the snapshot had new data.
+                                // `background_span` is not entered here because
+                                // `EnteredSpan` is `!Send` and would prevent the
+                                // future from being sent across threads when it
+                                // suspends at the `select!` await below.
+                                const MAX_IDLE_COMPACTION_PASSES: usize = 10;
+                                for _ in 0..MAX_IDLE_COMPACTION_PASSES {
+                                    let idle_ended = tokio::select! {
+                                        biased;
+                                        _ = &mut idle_end_listener => {
+                                            idle_end_listener = self.idle_end_event.listen();
+                                            true
+                                        },
+                                        _ = std::future::ready(()) => false,
+                                    };
+                                    if idle_ended {
                                         break;
                                     }
+                                    // Enter the span only around the synchronous
+                                    // compact() call so we never hold an
+                                    // `EnteredSpan` across an await point.
+                                    let _compact_span = tracing::info_span!(
+                                        parent: background_span.id(),
+                                        "compact database"
+                                    )
+                                    .entered();
+                                    match self.backing_storage.compact() {
+                                        Ok(true) => {}
+                                        Ok(false) => break,
+                                        Err(err) => {
+                                            eprintln!("Compaction failed: {err:?}");
+                                            if self.backing_storage.has_unrecoverable_write_error()
+                                            {
+                                                Self::log_unrecoverable_persist_error();
+                                                return;
+                                            }
+                                            break;
+                                        }
+                                    }
                                 }
-                            }
 
-                            if !new_data {
-                                fresh_idle = false;
-                                continue;
-                            }
-                            let last_snapshot = last_snapshot.duration_since(self.start_time);
-                            self.last_snapshot.store(
-                                last_snapshot.as_millis().try_into().unwrap(),
-                                Ordering::Relaxed,
-                            );
+                                if !new_data {
+                                    fresh_idle = false;
+                                    continue;
+                                }
+                                let last_snapshot = last_snapshot.duration_since(self.start_time);
+                                self.last_snapshot.store(
+                                    last_snapshot.as_millis().try_into().unwrap(),
+                                    Ordering::Relaxed,
+                                );
 
-                            turbo_tasks.schedule_backend_background_job(
-                                TurboTasksBackendJob::FollowUpSnapshot,
-                            );
-                            return;
-                        } else if self.backing_storage.has_unrecoverable_write_error() {
-                            Self::log_unrecoverable_persist_error();
-                            return;
+                                turbo_tasks.schedule_backend_background_job(
+                                    TurboTasksBackendJob::FollowUpSnapshot,
+                                );
+                                return;
+                            }
                         }
                     }
                 }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -2781,6 +2781,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                     let mut idle_start_listener = self.idle_start_event.listen();
                     let mut idle_end_listener = self.idle_end_event.listen();
                     let mut fresh_idle = true;
+                    let mut compaction_disabled = false;
                     loop {
                         const FIRST_SNAPSHOT_WAIT: Duration = Duration::from_secs(300);
                         const SNAPSHOT_INTERVAL: Duration = Duration::from_secs(120);
@@ -2847,33 +2848,42 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                             // `EnteredSpan` is `!Send` and would prevent the
                             // future from being sent across threads when it
                             // suspends at the `select!` await below.
-                            const MAX_IDLE_COMPACTION_PASSES: usize = 10;
-                            for _ in 0..MAX_IDLE_COMPACTION_PASSES {
-                                let idle_ended = tokio::select! {
-                                    biased;
-                                    _ = &mut idle_end_listener => {
-                                        idle_end_listener = self.idle_end_event.listen();
-                                        true
-                                    },
-                                    _ = std::future::ready(()) => false,
-                                };
-                                if idle_ended {
-                                    break;
-                                }
-                                // Enter the span only around the synchronous
-                                // compact() call so we never hold an
-                                // `EnteredSpan` across an await point.
-                                let _compact_span = tracing::info_span!(
-                                    parent: background_span.id(),
-                                    "compact database"
-                                )
-                                .entered();
-                                match self.backing_storage.compact() {
-                                    Ok(true) => {}
-                                    Ok(false) => break,
-                                    Err(err) => {
-                                        eprintln!("Compaction failed: {err:?}");
+                            if !compaction_disabled {
+                                const MAX_IDLE_COMPACTION_PASSES: usize = 10;
+                                for _ in 0..MAX_IDLE_COMPACTION_PASSES {
+                                    let idle_ended = tokio::select! {
+                                        biased;
+                                        _ = &mut idle_end_listener => {
+                                            idle_end_listener = self.idle_end_event.listen();
+                                            true
+                                        },
+                                        _ = std::future::ready(()) => false,
+                                    };
+                                    if idle_ended {
                                         break;
+                                    }
+                                    // Enter the span only around the synchronous
+                                    // compact() call so we never hold an
+                                    // `EnteredSpan` across an await point.
+                                    let _compact_span = tracing::info_span!(
+                                        parent: background_span.id(),
+                                        "compact database"
+                                    )
+                                    .entered();
+                                    match self.backing_storage.compact() {
+                                        Ok(true) => {}
+                                        Ok(false) => break,
+                                        Err(err) => {
+                                            eprintln!("Compaction failed: {err:?}");
+                                            if self.backing_storage.is_write_operation_active() {
+                                                eprintln!(
+                                                    "Compaction is permanently disabled due to an \
+                                                     unrecoverable error."
+                                                );
+                                                compaction_disabled = true;
+                                            }
+                                            break;
+                                        }
                                     }
                                 }
                             }
@@ -2890,6 +2900,12 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
 
                             turbo_tasks.schedule_backend_background_job(
                                 TurboTasksBackendJob::FollowUpSnapshot,
+                            );
+                            return;
+                        } else if self.backing_storage.is_write_operation_active() {
+                            eprintln!(
+                                "Persisting is permanently disabled due to an unrecoverable \
+                                 error. Stopping the background persisting process."
                             );
                             return;
                         }

--- a/turbopack/crates/turbo-tasks-backend/src/backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backing_storage.rs
@@ -111,7 +111,7 @@ pub trait BackingStorageSealed: 'static + Send + Sync {
 
     /// Returns true if a write operation or compaction is currently active. This can happen if a
     /// previous write or compaction failed and recovery also failed, permanently disabling writes.
-    fn is_write_operation_active(&self) -> bool {
+    fn has_unrecoverable_write_error(&self) -> bool {
         false
     }
 }
@@ -178,7 +178,7 @@ where
         either::for_both!(self, this => this.shutdown())
     }
 
-    fn is_write_operation_active(&self) -> bool {
-        either::for_both!(self, this => this.is_write_operation_active())
+    fn has_unrecoverable_write_error(&self) -> bool {
+        either::for_both!(self, this => this.has_unrecoverable_write_error())
     }
 }

--- a/turbopack/crates/turbo-tasks-backend/src/backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backing_storage.rs
@@ -108,6 +108,12 @@ pub trait BackingStorageSealed: 'static + Send + Sync {
     fn shutdown(&self) -> Result<()> {
         Ok(())
     }
+
+    /// Returns true if a write operation or compaction is currently active. This can happen if a
+    /// previous write or compaction failed and recovery also failed, permanently disabling writes.
+    fn is_write_operation_active(&self) -> bool {
+        false
+    }
 }
 
 impl<L, R> BackingStorage for Either<L, R>
@@ -170,5 +176,9 @@ where
 
     fn shutdown(&self) -> Result<()> {
         either::for_both!(self, this => this.shutdown())
+    }
+
+    fn is_write_operation_active(&self) -> bool {
+        either::for_both!(self, this => this.is_write_operation_active())
     }
 }

--- a/turbopack/crates/turbo-tasks-backend/src/backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backing_storage.rs
@@ -109,8 +109,8 @@ pub trait BackingStorageSealed: 'static + Send + Sync {
         Ok(())
     }
 
-    /// Returns true if a write operation or compaction is currently active. This can happen if a
-    /// previous write or compaction failed and recovery also failed, permanently disabling writes.
+    /// Returns true if the database is in an unrecoverable error state where a previous write or
+    /// compaction failed and the rollback also failed, permanently disabling further writes.
     fn has_unrecoverable_write_error(&self) -> bool {
         false
     }

--- a/turbopack/crates/turbo-tasks-backend/src/database/key_value_database.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/key_value_database.rs
@@ -122,7 +122,7 @@ pub trait KeyValueDatabase {
 
     /// Returns true if a write operation or compaction is currently active. This can happen if a
     /// previous write or compaction failed and recovery also failed, permanently disabling writes.
-    fn is_write_operation_active(&self) -> bool {
+    fn has_unrecoverable_write_error(&self) -> bool {
         false
     }
 }

--- a/turbopack/crates/turbo-tasks-backend/src/database/key_value_database.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/key_value_database.rs
@@ -119,4 +119,10 @@ pub trait KeyValueDatabase {
     fn shutdown(&self) -> Result<()> {
         Ok(())
     }
+
+    /// Returns true if a write operation or compaction is currently active. This can happen if a
+    /// previous write or compaction failed and recovery also failed, permanently disabling writes.
+    fn is_write_operation_active(&self) -> bool {
+        false
+    }
 }

--- a/turbopack/crates/turbo-tasks-backend/src/database/key_value_database.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/key_value_database.rs
@@ -120,8 +120,8 @@ pub trait KeyValueDatabase {
         Ok(())
     }
 
-    /// Returns true if a write operation or compaction is currently active. This can happen if a
-    /// previous write or compaction failed and recovery also failed, permanently disabling writes.
+    /// Returns true if the database is in an unrecoverable error state where a previous write or
+    /// compaction failed and the rollback also failed, permanently disabling further writes.
     fn has_unrecoverable_write_error(&self) -> bool {
         false
     }

--- a/turbopack/crates/turbo-tasks-backend/src/database/turbo/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/turbo/mod.rs
@@ -137,8 +137,8 @@ impl KeyValueDatabase for TurboKeyValueDatabase {
         )
     }
 
-    fn is_write_operation_active(&self) -> bool {
-        self.db.is_write_operation_active()
+    fn has_unrecoverable_write_error(&self) -> bool {
+        self.db.has_unrecoverable_write_error()
     }
 
     fn shutdown(&self) -> Result<()> {

--- a/turbopack/crates/turbo-tasks-backend/src/database/turbo/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/turbo/mod.rs
@@ -137,6 +137,10 @@ impl KeyValueDatabase for TurboKeyValueDatabase {
         )
     }
 
+    fn is_write_operation_active(&self) -> bool {
+        self.db.is_write_operation_active()
+    }
+
     fn shutdown(&self) -> Result<()> {
         // Compact the database on shutdown
         // (Avoid compacting a fresh database since we don't have any usage info yet)

--- a/turbopack/crates/turbo-tasks-backend/src/database/turbo/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/turbo/mod.rs
@@ -199,8 +199,12 @@ fn do_compact(
 }
 
 pub struct TurboWriteBatch<'a> {
-    batch:
-        turbo_persistence::WriteBatch<WriteBuffer<'static>, TurboTasksParallelScheduler, FAMILIES>,
+    batch: turbo_persistence::WriteBatch<
+        'a,
+        WriteBuffer<'static>,
+        TurboTasksParallelScheduler,
+        FAMILIES,
+    >,
     db: &'a Arc<TurboPersistence<TurboTasksParallelScheduler, FAMILIES>>,
 }
 

--- a/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
@@ -381,6 +381,10 @@ impl<T: KeyValueDatabase + Send + Sync + 'static> BackingStorageSealed
     fn shutdown(&self) -> Result<()> {
         self.inner.database.shutdown()
     }
+
+    fn is_write_operation_active(&self) -> bool {
+        self.inner.database.is_write_operation_active()
+    }
 }
 
 fn get_next_free_task_id<'a>(batch: &impl ConcurrentWriteBatch<'a>) -> Result<u32, anyhow::Error> {

--- a/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
@@ -382,8 +382,8 @@ impl<T: KeyValueDatabase + Send + Sync + 'static> BackingStorageSealed
         self.inner.database.shutdown()
     }
 
-    fn is_write_operation_active(&self) -> bool {
-        self.inner.database.is_write_operation_active()
+    fn has_unrecoverable_write_error(&self) -> bool {
+        self.inner.database.has_unrecoverable_write_error()
     }
 }
 


### PR DESCRIPTION
### What?

When a persist or compaction operation fails in `turbo-persistence`, the database now:
- Rolls back cleanly (deletes orphan files, restores CURRENT)
- Stops the background persisting process for the session
- Keeps in-memory state consistent with on-disk state at all times
- Deletes superseded files safely (with Windows fallback for open memory maps)

### Why?

Previously, a failed write operation (e.g. disk full, I/O error) would leave the database in a broken state:

1. **Misleading error loop** — The `active_write_operation` `AtomicBool` was left set to `true` after failure, so every subsequent snapshot cycle printed _"another write operation is already in progress"_ forever, hiding the real error.

2. **In-memory corruption** — `commit()` mutated `inner.meta_files` and `inner.current_sequence_number` *before* writing the CURRENT file to disk. If a disk error occurred between those two steps, the in-memory state was inconsistent with disk and the rollback had no way to fix it.

3. **Rollback could corrupt committed data** — If `commit()` failed *after* writing CURRENT (e.g. during old-file deletion or LOG writing), the rollback would delete the *newly committed* files, corrupting the database.

4. **Task graph corruption** — `save_snapshot` consumes task cache log entries. If it failed, those entries were lost, but the background loop would continue trying to persist — silently skipping those tasks and corrupting the task graph in storage.

5. **Partially written CURRENT** — If the failure happened mid-write to the CURRENT file, it could be left with partial/corrupt content, but nothing restored it.

### How?

**`WriteOperationGuard` RAII (db.rs)**

A new `WriteOperationGuard<'a>` replaces the `AtomicBool` + manual `try_recover_after_failed_write()` pattern. The guard holds:
- `&'a Mutex<Option<ActiveWriteState>>` — the write slot (`None` = idle, `Some(Active("write batch"))` = in progress, `Some(Error)` = permanently disabled)
- `path: &'a Path` — database directory for rollback
- `seq_before: u32` — sequence number at operation start
- `succeeded: bool` — set by `guard.success()`

On `drop`, if not succeeded:
1. Writes `seq_before` back to CURRENT (repairs a partially-written CURRENT)
2. Deletes all files with `seq > seq_before` (orphans from the failed operation)
3. Sets the slot to `None` (success) or `Some(Error)` (if cleanup itself failed)

The `Active` variant carries a `&'static str` name (e.g. `"write batch"`, `"compaction"`) used in error messages.

**Three-phase `commit()` (db.rs)**

`commit()` is restructured so `inner` is completely unmodified before the point of no return:

| Phase | What happens | `inner` state | On failure |
|-------|-------------|---------------|------------|
| **A** | Compute `meta_seq_numbers_to_delete` via `sst_filter`. Uses `apply_filter_collect` (read-only) to update filter state and collect per-meta-file removal sets without modifying any MetaFile. Only a read lock on `inner` is needed. | Unchanged | Guard deletes orphan files + restores CURRENT; `inner` is intact |
| **B** | Write `.del` file and CURRENT to disk. | Unchanged | Same as above |
| **C** | Apply deferred `retain_entries` (from A's removal sets), append new metas, remove obsolete metas, bump `current_sequence_number`. Try to delete superseded files; defer failures. | Updated | CURRENT is already durable; commit is irreversible |

After CURRENT is written (point of no return), LOG writing errors are caught and reported via `eprintln!` — they must not propagate because the `WriteOperationGuard` would then run its rollback and delete the *newly committed* files.

**`SstFilter::apply_filter_collect` (sst_filter.rs)**

A new read-only variant of `apply_filter` that updates the filter state and returns a `FxHashSet<u32>` of SST entry sequence numbers to remove from each meta file, without calling `retain_entries`. The original `apply_filter` (which mutates the MetaFile) is still used by `load_directory` and during new-meta-file construction where immediate mutation is appropriate.

**Deferred file deletion (db.rs)**

Superseded `.sst`/`.meta`/`.blob` files are deleted immediately after Phase C (once `inner` is updated). On Linux/macOS this always succeeds, even if concurrent readers have the files memory-mapped. On Windows, open memory maps prevent deletion — any file that fails is stored as a `DeferredDeletion` enum (`Sst(u32)` / `Meta(u32)` / `Blob(u32)`) and retried on the next commit or at shutdown. The `.del` file written during Phase B ensures crash recovery via `load_directory` regardless.

**Background loop error handling (backend/mod.rs)**

- `snapshot_and_persist()` returns `Result<(Instant, bool), anyhow::Error>` instead of `Option`. When `save_snapshot` fails, the error propagates with `?`.
- The background loop matches on the `Result`: on `Err`, it logs the error and a message that persisting is disabled for this session, then returns (permanently stopping the background job).
- `has_unrecoverable_write_error()` checks the `ActiveWriteState::Error` variant to detect permanent failure after compaction errors.

<!-- NEXT_JS_LLM_PR -->