### PR TITLE
turbo-tasks: fix hashed cell mode crash on task error (re-land #91576)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9717,6 +9717,7 @@ dependencies = [
  "bincode 2.0.1",
  "data-encoding",
  "sha2",
+ "smallvec",
  "turbo-tasks-macros",
  "xxhash-rust",
 ]

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -3022,6 +3022,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         is_serializable_cell_content: bool,
         content: CellContent,
         updated_key_hashes: Option<SmallVec<[u64; 2]>>,
+        content_hash: Option<[u8; 16]>,
         verification_mode: VerificationMode,
         turbo_tasks: &dyn TurboTasksBackendApi<TurboTasksBackend<B>>,
     ) {
@@ -3031,6 +3032,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
             content,
             is_serializable_cell_content,
             updated_key_hashes,
+            content_hash,
             verification_mode,
             self.execute_context(turbo_tasks),
         );
@@ -3584,6 +3586,7 @@ impl<B: BackingStorage> Backend for TurboTasksBackend<B> {
         is_serializable_cell_content: bool,
         content: CellContent,
         updated_key_hashes: Option<SmallVec<[u64; 2]>>,
+        content_hash: Option<[u8; 16]>,
         verification_mode: VerificationMode,
         turbo_tasks: &dyn TurboTasksBackendApi<Self>,
     ) {
@@ -3593,6 +3596,7 @@ impl<B: BackingStorage> Backend for TurboTasksBackend<B> {
             is_serializable_cell_content,
             content,
             updated_key_hashes,
+            content_hash,
             verification_mode,
             turbo_tasks,
         );

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -31,7 +31,7 @@ use turbo_tasks::{
     ReadOutputOptions, ReadTracking, SharedReference, TRANSIENT_TASK_BIT, TaskExecutionReason,
     TaskId, TaskPriority, TraitTypeId, TurboTasksBackendApi, TurboTasksPanic, ValueTypeId,
     backend::{
-        Backend, CachedTaskType, CellContent, TaskExecutionSpec, TransientTaskType,
+        Backend, CachedTaskType, CellContent, CellHash, TaskExecutionSpec, TransientTaskType,
         TurboTaskContextError, TurboTaskLocalContextError, TurboTasksError,
         TurboTasksExecutionError, TurboTasksExecutionErrorMessage, TypedCellContent,
         VerificationMode,
@@ -3022,7 +3022,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         is_serializable_cell_content: bool,
         content: CellContent,
         updated_key_hashes: Option<SmallVec<[u64; 2]>>,
-        content_hash: Option<[u8; 16]>,
+        content_hash: Option<CellHash>,
         verification_mode: VerificationMode,
         turbo_tasks: &dyn TurboTasksBackendApi<TurboTasksBackend<B>>,
     ) {
@@ -3586,7 +3586,7 @@ impl<B: BackingStorage> Backend for TurboTasksBackend<B> {
         is_serializable_cell_content: bool,
         content: CellContent,
         updated_key_hashes: Option<SmallVec<[u64; 2]>>,
-        content_hash: Option<[u8; 16]>,
+        content_hash: Option<CellHash>,
         verification_mode: VerificationMode,
         turbo_tasks: &dyn TurboTasksBackendApi<Self>,
     ) {

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -2732,6 +2732,19 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                     removed_cell_data.push(data);
                 }
             }
+            // Remove cell_data_hash entries for cells that no longer exist
+            let to_remove_hash: Vec<_> = task
+                .iter_cell_data_hash()
+                .filter_map(|(cell, _)| {
+                    cell_counters
+                        .get(&cell.type_id)
+                        .is_none_or(|start_index| cell.index >= *start_index)
+                        .then_some(*cell)
+                })
+                .collect();
+            for cell in to_remove_hash {
+                task.remove_cell_data_hash(&cell);
+            }
         }
 
         // Clean up task storage after execution:

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_cell.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_cell.rs
@@ -56,10 +56,17 @@ impl UpdateCellOperation {
         content: CellContent,
         is_serializable_cell_content: bool,
         updated_key_hashes: Option<SmallVec<[u64; 2]>>,
+        content_hash: Option<[u8; 16]>,
         #[cfg(feature = "verify_determinism")] verification_mode: VerificationMode,
         #[cfg(not(feature = "verify_determinism"))] _verification_mode: VerificationMode,
         mut ctx: impl ExecuteContext<'_>,
     ) {
+        // content_hash is only meaningful for transient (non-serializable) cells
+        debug_assert!(
+            !is_serializable_cell_content || content_hash.is_none(),
+            "content_hash must be None for serializable cell content"
+        );
+
         let content = if let CellContent(Some(new_content)) = content {
             Some(new_content.into_typed(cell.type_id))
         } else {
@@ -107,27 +114,46 @@ impl UpdateCellOperation {
             // When not recomputing, we need to notify dependent tasks if the content actually
             // changes.
 
+            // For transient cells without available content, use hash-based comparison to
+            // detect whether the value actually changed—avoiding unnecessary invalidation.
+            let skip_invalidation = !is_serializable_cell_content && {
+                let has_old_content = task.has_cell_data(false, cell);
+                if !has_old_content {
+                    match (content_hash, task.get_cell_data_hash(&cell)) {
+                        (Some(new_hash), Some(old_hash)) => new_hash == *old_hash,
+                        _ => false,
+                    }
+                } else {
+                    false
+                }
+            };
+
             #[cfg(feature = "trace_task_dirty")]
             let has_updated_key_hashes = updated_key_hashes.is_some();
             let updated_key_hashes_set = updated_key_hashes.map(|updated_key_hashes| {
                 Lazy::new(|| updated_key_hashes.into_iter().collect::<FxHashSet<u64>>())
             });
 
-            let tasks_with_keys =
-                task.iter_cell_dependents()
-                    .filter_map(|(dependent_cell, key, task)| {
-                        (dependent_cell == cell
-                            && key.is_none_or(|key_hash| {
-                                updated_key_hashes_set
-                                    .as_ref()
-                                    .is_none_or(|set| set.contains(&key_hash))
-                            }))
-                        .then_some((task, key))
-                    });
+            // Collect dependent tasks only when not skipping invalidation.
+            // The iterator borrows from `task`, so it must be scoped to drop before
+            // we mutably borrow `task` again in the fast path.
             let mut dependent_tasks: FxIndexMap<TaskId, SmallVec<[Option<u64>; 2]>> =
                 FxIndexMap::default();
-            for (task, key) in tasks_with_keys {
-                dependent_tasks.entry(task).or_default().push(key);
+            if !skip_invalidation {
+                let tasks_with_keys =
+                    task.iter_cell_dependents()
+                        .filter_map(|(dependent_cell, key, task)| {
+                            (dependent_cell == cell
+                                && key.is_none_or(|key_hash| {
+                                    updated_key_hashes_set
+                                        .as_ref()
+                                        .is_none_or(|set| set.contains(&key_hash))
+                                }))
+                            .then_some((task, key))
+                        });
+                for (task, key) in tasks_with_keys {
+                    dependent_tasks.entry(task).or_default().push(key);
+                }
             }
 
             if !dependent_tasks.is_empty() {
@@ -145,6 +171,18 @@ impl UpdateCellOperation {
                 // readers will wait for it to be set via InProgressCell.
 
                 let old_content = task.remove_cell_data(is_serializable_cell_content, cell);
+
+                // Update cell_data_hash before dropping the task lock
+                if !is_serializable_cell_content {
+                    let old_hash = task.get_cell_data_hash(&cell).copied();
+                    if old_hash != content_hash {
+                        if let Some(hash) = content_hash {
+                            task.insert_cell_data_hash(cell, hash);
+                        } else {
+                            task.remove_cell_data_hash(&cell);
+                        }
+                    }
+                }
 
                 drop(task);
                 drop(old_content);
@@ -180,6 +218,18 @@ impl UpdateCellOperation {
         } else {
             task.remove_cell_data(is_serializable_cell_content, cell)
         };
+
+        // Update cell_data_hash for non-serializable cells when not recomputing.
+        if !is_serializable_cell_content {
+            let old_hash = task.get_cell_data_hash(&cell).copied();
+            if old_hash != content_hash {
+                if let Some(hash) = content_hash {
+                    task.insert_cell_data_hash(cell, hash);
+                } else {
+                    task.remove_cell_data_hash(&cell);
+                }
+            }
+        }
 
         let in_progress_cell = task.remove_in_progress_cells(&cell);
 

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_cell.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_cell.rs
@@ -6,7 +6,7 @@ use rustc_hash::FxHashSet;
 use smallvec::SmallVec;
 use turbo_tasks::{
     CellId, FxIndexMap, TaskId, TypedSharedReference,
-    backend::{CellContent, VerificationMode},
+    backend::{CellContent, CellHash, VerificationMode},
 };
 
 #[cfg(feature = "trace_task_dirty")]
@@ -56,7 +56,7 @@ impl UpdateCellOperation {
         content: CellContent,
         is_serializable_cell_content: bool,
         updated_key_hashes: Option<SmallVec<[u64; 2]>>,
-        content_hash: Option<[u8; 16]>,
+        content_hash: Option<CellHash>,
         #[cfg(feature = "verify_determinism")] verification_mode: VerificationMode,
         #[cfg(not(feature = "verify_determinism"))] _verification_mode: VerificationMode,
         mut ctx: impl ExecuteContext<'_>,

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_cell.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_cell.rs
@@ -173,16 +173,7 @@ impl UpdateCellOperation {
                 let old_content = task.remove_cell_data(is_serializable_cell_content, cell);
 
                 // Update cell_data_hash before dropping the task lock
-                if !is_serializable_cell_content {
-                    let old_hash = task.get_cell_data_hash(&cell).copied();
-                    if old_hash != content_hash {
-                        if let Some(hash) = content_hash {
-                            task.insert_cell_data_hash(cell, hash);
-                        } else {
-                            task.remove_cell_data_hash(&cell);
-                        }
-                    }
-                }
+                update_cell_data_hash(&mut task, &cell, is_serializable_cell_content, content_hash);
 
                 drop(task);
                 drop(old_content);
@@ -219,17 +210,8 @@ impl UpdateCellOperation {
             task.remove_cell_data(is_serializable_cell_content, cell)
         };
 
-        // Update cell_data_hash for non-serializable cells when not recomputing.
-        if !is_serializable_cell_content {
-            let old_hash = task.get_cell_data_hash(&cell).copied();
-            if old_hash != content_hash {
-                if let Some(hash) = content_hash {
-                    task.insert_cell_data_hash(cell, hash);
-                } else {
-                    task.remove_cell_data_hash(&cell);
-                }
-            }
-        }
+        // Update cell_data_hash for non-serializable cells.
+        update_cell_data_hash(&mut task, &cell, is_serializable_cell_content, content_hash);
 
         let in_progress_cell = task.remove_in_progress_cells(&cell);
 
@@ -253,6 +235,26 @@ impl UpdateCellOperation {
             } => *is_serializable_cell_content,
             UpdateCellOperation::AggregationUpdate { .. } => true,
             UpdateCellOperation::Done => true,
+        }
+    }
+}
+
+/// Updates the stored cell_data_hash for a non-serializable cell.
+/// Skips the update if the hash hasn't changed to avoid unnecessary writes.
+fn update_cell_data_hash(
+    task: &mut impl TaskGuard,
+    cell: &CellId,
+    is_serializable_cell_content: bool,
+    content_hash: Option<CellHash>,
+) {
+    if !is_serializable_cell_content {
+        let old_hash = task.get_cell_data_hash(cell).copied();
+        if old_hash != content_hash {
+            if let Some(hash) = content_hash {
+                task.insert_cell_data_hash(*cell, hash);
+            } else {
+                task.remove_cell_data_hash(cell);
+            }
         }
     }
 }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
@@ -275,6 +275,16 @@ struct TaskStorageSchema {
     #[field(storage = "auto_map", category = "transient", shrink_on_completion)]
     transient_cell_data: AutoMap<CellId, SharedReference>,
 
+    /// Hash of transient cell data, persisted for hash-based change detection when
+    /// transient data has been evicted from memory.
+    ///
+    /// Stored as `[u8; 16]` (little-endian bytes of a u128) rather than `u128` to keep
+    /// the 1-byte alignment out of the `AutoMap` and therefore out of the `LazyField`
+    /// enum; a bare `u128` would grow the enum from 56 to 64 bytes due to its 16-byte
+    /// alignment requirement.
+    #[field(storage = "auto_map", category = "data", shrink_on_completion)]
+    cell_data_hash: AutoMap<CellId, [u8; 16]>,
+
     /// Maximum cell index per cell type.
     #[field(storage = "auto_map", category = "data", shrink_on_completion)]
     cell_type_max_index: AutoMap<ValueTypeId, u32>,

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
@@ -23,7 +23,7 @@ use parking_lot::Mutex;
 use turbo_tasks::{
     CellId, SharedReference, TaskExecutionReason, TaskId, TraitTypeId, TypedSharedReference,
     ValueTypeId,
-    backend::{CachedTaskType, TransientTaskType},
+    backend::{CachedTaskType, CellHash, TransientTaskType},
     event::Event,
     task_storage,
 };
@@ -283,7 +283,7 @@ struct TaskStorageSchema {
     /// enum; a bare `u128` would grow the enum from 56 to 64 bytes due to its 16-byte
     /// alignment requirement.
     #[field(storage = "auto_map", category = "data", shrink_on_completion)]
-    cell_data_hash: AutoMap<CellId, [u8; 16]>,
+    cell_data_hash: AutoMap<CellId, CellHash>,
 
     /// Maximum cell index per cell type.
     #[field(storage = "auto_map", category = "data", shrink_on_completion)]

--- a/turbopack/crates/turbo-tasks-backend/tests/hashed_cell_mode.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/hashed_cell_mode.rs
@@ -1,0 +1,129 @@
+#![feature(arbitrary_self_types)]
+#![feature(arbitrary_self_types_pointers)]
+#![allow(clippy::needless_return)] // tokio macro-generated code doesn't respect this
+
+use anyhow::Result;
+use turbo_tasks::{ResolvedVc, State, Vc};
+use turbo_tasks_hash::{DeterministicHash, DeterministicHasher};
+use turbo_tasks_testing::{Registration, register, run};
+
+static REGISTRATION: Registration = register!();
+
+/// A value type using `serialization = "hash"` mode.
+/// Only `value` participates in DeterministicHash/Eq; `noise` does not.
+#[turbo_tasks::value(serialization = "hash", eq = "manual", hash = "manual")]
+#[derive(Debug)]
+struct HashedValue {
+    value: u32,
+    noise: u64,
+}
+
+impl DeterministicHash for HashedValue {
+    fn deterministic_hash<H: DeterministicHasher>(&self, state: &mut H) {
+        self.value.deterministic_hash(state);
+    }
+}
+
+impl PartialEq for HashedValue {
+    fn eq(&self, other: &Self) -> bool {
+        self.value == other.value
+    }
+}
+
+impl Eq for HashedValue {}
+
+#[turbo_tasks::value(transparent)]
+struct Step(State<u32>);
+
+#[turbo_tasks::value]
+struct ConsumeResult {
+    value: u32,
+    random: u32,
+}
+
+#[turbo_tasks::function(operation)]
+fn create_state_operation() -> Vc<Step> {
+    Step(State::new(0)).cell()
+}
+
+/// Produces a HashedValue from a state. The noise field changes each execution
+/// but does not affect hash or equality.
+#[turbo_tasks::function(operation)]
+async fn produce_hashed(input: ResolvedVc<Step>) -> Result<Vc<HashedValue>> {
+    let value = *input.await?.get();
+    let noise = rand::random::<u64>();
+    Ok(HashedValue { value, noise }.cell())
+}
+
+/// Consumes the HashedValue and records a random number to detect re-execution.
+#[turbo_tasks::function(operation)]
+async fn consume_hashed(input: ResolvedVc<Step>) -> Result<Vc<ConsumeResult>> {
+    let hashed = produce_hashed(input).connect();
+    let v = hashed.await?;
+    let value = v.value;
+    let random = rand::random::<u32>();
+    Ok(ConsumeResult { value, random }.cell())
+}
+
+/// Test 1: When the value changes, the consumer SHOULD be invalidated and re-execute.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_hashed_cell_mode_change_triggers_invalidation() {
+    run(&REGISTRATION, || async {
+        let state_op = create_state_operation();
+        let state_vc = state_op.resolve_strongly_consistent().await?;
+        let state = state_op.read_strongly_consistent().await?;
+        state.set(42);
+
+        let consumer = consume_hashed(state_vc);
+        let result1 = consumer.read_strongly_consistent().await?;
+        assert_eq!(result1.value, 42);
+
+        // Change the value — this should invalidate the consumer.
+        state.set(99);
+        let result2 = consumer.read_strongly_consistent().await?;
+        assert_eq!(result2.value, 99);
+        // Consumer must have re-executed (different random).
+        assert_ne!(
+            result1.random, result2.random,
+            "consumer should re-execute when value changes"
+        );
+
+        anyhow::Ok(())
+    })
+    .await
+    .unwrap();
+}
+
+/// Test 2: When the value stays the same, the consumer should NOT be invalidated.
+/// The producer re-runs (state.set triggers it) but produces an equal HashedValue.
+/// With `serialization = "hash"`, the consumer should not be re-executed.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_hashed_cell_mode_equal_value_no_invalidation() {
+    run(&REGISTRATION, || async {
+        let state_op = create_state_operation();
+        let state_vc = state_op.resolve_strongly_consistent().await?;
+        let state = state_op.read_strongly_consistent().await?;
+        state.set(42);
+
+        let consumer = consume_hashed(state_vc);
+        let result1 = consumer.read_strongly_consistent().await?;
+        assert_eq!(result1.value, 42);
+
+        // Re-trigger the producer with the same value.
+        // State::set unconditionally invalidates, so the producer re-runs.
+        // But it produces an equal HashedValue (same `value`, different `noise`).
+        // Since DeterministicHash and PartialEq only check `value`, the consumer should NOT
+        // re-execute.
+        state.set(42);
+        let result2 = consumer.read_strongly_consistent().await?;
+        assert_eq!(result2.value, 42);
+        assert_eq!(
+            result1.random, result2.random,
+            "consumer should not re-execute when value (and hash) are the same"
+        );
+
+        anyhow::Ok(())
+    })
+    .await
+    .unwrap();
+}

--- a/turbopack/crates/turbo-tasks-backend/tests/hashed_cell_mode.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/hashed_cell_mode.rs
@@ -2,12 +2,16 @@
 #![feature(arbitrary_self_types_pointers)]
 #![allow(clippy::needless_return)] // tokio macro-generated code doesn't respect this
 
+use std::sync::atomic::{AtomicU32, Ordering};
+
 use anyhow::Result;
 use turbo_tasks::{ResolvedVc, State, Vc};
 use turbo_tasks_hash::{DeterministicHash, DeterministicHasher};
 use turbo_tasks_testing::{Registration, register, run};
 
 static REGISTRATION: Registration = register!();
+
+static EXECUTION_COUNTER: AtomicU32 = AtomicU32::new(0);
 
 /// A value type using `serialization = "hash"` mode.
 /// Only `value` participates in DeterministicHash/Eq; `noise` does not.
@@ -51,7 +55,7 @@ fn create_state_operation() -> Vc<Step> {
 #[turbo_tasks::function(operation)]
 async fn produce_hashed(input: ResolvedVc<Step>) -> Result<Vc<HashedValue>> {
     let value = *input.await?.get();
-    let noise = rand::random::<u64>();
+    let noise = EXECUTION_COUNTER.fetch_add(1, Ordering::Relaxed) as u64;
     Ok(HashedValue { value, noise }.cell())
 }
 
@@ -61,7 +65,7 @@ async fn consume_hashed(input: ResolvedVc<Step>) -> Result<Vc<ConsumeResult>> {
     let hashed = produce_hashed(input).connect();
     let v = hashed.await?;
     let value = v.value;
-    let random = rand::random::<u32>();
+    let random = EXECUTION_COUNTER.fetch_add(1, Ordering::Relaxed);
     Ok(ConsumeResult { value, random }.cell())
 }
 

--- a/turbopack/crates/turbo-tasks-backend/tests/hashed_cell_mode.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/hashed_cell_mode.rs
@@ -70,7 +70,7 @@ async fn consume_hashed(input: ResolvedVc<Step>) -> Result<Vc<ConsumeResult>> {
 async fn test_hashed_cell_mode_change_triggers_invalidation() {
     run(&REGISTRATION, || async {
         let state_op = create_state_operation();
-        let state_vc = state_op.resolve_strongly_consistent().await?;
+        let state_vc = state_op.resolve().strongly_consistent().await?;
         let state = state_op.read_strongly_consistent().await?;
         state.set(42);
 
@@ -101,7 +101,7 @@ async fn test_hashed_cell_mode_change_triggers_invalidation() {
 async fn test_hashed_cell_mode_equal_value_no_invalidation() {
     run(&REGISTRATION, || async {
         let state_op = create_state_operation();
-        let state_vc = state_op.resolve_strongly_consistent().await?;
+        let state_vc = state_op.resolve().strongly_consistent().await?;
         let state = state_op.read_strongly_consistent().await?;
         state.set(42);
 

--- a/turbopack/crates/turbo-tasks-fs/src/invalidator_map.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/invalidator_map.rs
@@ -8,11 +8,11 @@ use concurrent_queue::ConcurrentQueue;
 use rustc_hash::FxHashMap;
 use turbo_tasks::{Invalidator, ReadRef};
 
-use crate::{FileContent, LinkContent};
+use crate::{LinkContent, PersistedFileContent};
 
 #[derive(PartialEq, Eq)]
 pub enum WriteContent {
-    File(ReadRef<FileContent>),
+    File(ReadRef<PersistedFileContent>),
     Link(ReadRef<LinkContent>),
 }
 

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -969,7 +969,12 @@ impl FileSystem for DiskFileSystem {
         }
         let full_path = self.to_sys_path(&fs_path);
 
-        let content = content.await?;
+        // Persist the file content so it is stored in the persistent cache.
+        // Since FileContent uses serialization = "hash", persisting it here ensures the full
+        // content is available in the persistent cache (via PersistedFileContent) and does not
+        // require recomputing the content on cache restore — avoiding unnecessary downstream
+        // recomputation.
+        let content = content.persist().await?;
 
         let inner = self.inner.clone();
         let invalidator = turbo_tasks::get_invalidator();
@@ -979,7 +984,7 @@ impl FileSystem for DiskFileSystem {
             full_path: PathBuf,
             inner: Arc<DiskFileSystemInner>,
             invalidator: Option<Invalidator>,
-            content: ReadRef<FileContent>,
+            content: ReadRef<PersistedFileContent>,
         }
 
         impl Effect for WriteEffect {
@@ -1028,7 +1033,7 @@ impl FileSystem for DiskFileSystem {
                 }
 
                 match &*self.content {
-                    FileContent::Content(..) => {
+                    PersistedFileContent::Content(..) => {
                         let create_directory = compare == FileComparison::Create;
                         if create_directory && let Some(parent) = full_path.parent() {
                             self.inner.create_directory(parent).await.with_context(|| {
@@ -1042,7 +1047,7 @@ impl FileSystem for DiskFileSystem {
                         let content = self.content.clone();
                         retry_blocking(|| {
                             let mut f = std::fs::File::create(&full_path)?;
-                            let FileContent::Content(file) = &*content else {
+                            let PersistedFileContent::Content(file) = &*content else {
                                 unreachable!()
                             };
                             std::io::copy(&mut file.read(), &mut f)?;
@@ -1077,7 +1082,7 @@ impl FileSystem for DiskFileSystem {
                         .await
                         .with_context(|| format!("failed to write to {full_path:?}"))?;
                     }
-                    FileContent::NotFound => {
+                    PersistedFileContent::NotFound => {
                         retry_blocking(|| std::fs::remove_file(&full_path))
                             .instrument(tracing::info_span!("remove file", name = ?full_path))
                             .concurrency_limited(&self.inner.write_semaphore)
@@ -1958,8 +1963,8 @@ impl From<std::fs::Permissions> for Permissions {
     }
 }
 
-#[turbo_tasks::value(shared)]
-#[derive(Clone, Debug, DeterministicHash, PartialOrd, Ord)]
+#[turbo_tasks::value(shared, serialization = "hash")]
+#[derive(Clone, Debug, PartialOrd, Ord)]
 pub enum FileContent {
     Content(File),
     NotFound,
@@ -1971,35 +1976,39 @@ impl From<File> for FileContent {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
-enum FileComparison {
-    Create,
-    Equal,
-    NotEqual,
+/// A persisted version of [`FileContent`] that stores the full file content in the task cache.
+///
+/// [`FileContent`] uses `serialization = "hash"`, so only a hash is kept in the persistent cache.
+/// When reading the file content back from the cache, the hash is compared to detect changes, but
+/// the actual data is not available. `PersistedFileContent` provides the full data so that
+/// [`DiskFileSystem::write`] can retrieve it without re-reading from disk.
+#[turbo_tasks::value(shared)]
+#[derive(Clone, Debug, DeterministicHash, PartialOrd, Ord)]
+pub enum PersistedFileContent {
+    Content(File),
+    NotFound,
 }
 
-impl FileContent {
-    /// Performs a comparison of self's data against a disk file's streamed
-    /// read.
+impl PersistedFileContent {
+    /// Performs a comparison of self's data against a disk file's streamed read.
     async fn streaming_compare(&self, path: &Path) -> Result<FileComparison> {
         let old_file =
             extract_disk_access(retry_blocking(|| std::fs::File::open(path)).await, path)?;
         let Some(old_file) = old_file else {
             return Ok(match self {
-                FileContent::NotFound => FileComparison::Equal,
+                PersistedFileContent::NotFound => FileComparison::Equal,
                 _ => FileComparison::Create,
             });
         };
         // We know old file exists, does the new file?
-        let FileContent::Content(new_file) = self else {
+        let PersistedFileContent::Content(new_file) = self else {
             return Ok(FileComparison::NotEqual);
         };
 
         let old_meta = extract_disk_access(retry_blocking(|| old_file.metadata()).await, path)?;
         let Some(old_meta) = old_meta else {
             // If we failed to get meta, then the old file has been deleted between the
-            // handle open. In which case, we just pretend the file never
-            // existed.
+            // handle open. In which case, we just pretend the file never existed.
             return Ok(FileComparison::Create);
         };
         // If the meta is different, we need to rewrite the file to update it.
@@ -2034,6 +2043,13 @@ impl FileContent {
             old_contents.consume(len);
         })
     }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum FileComparison {
+    Create,
+    Equal,
+    NotEqual,
 }
 
 bitflags! {
@@ -2401,6 +2417,18 @@ impl FileContent {
     #[turbo_tasks::function]
     pub async fn hash(&self) -> Result<Vc<u64>> {
         Ok(Vc::cell(hash_xxh3_hash64(self)))
+    }
+
+    /// Converts this [`FileContent`] into a [`PersistedFileContent`] by cloning.
+    ///
+    /// Use this in contexts where the full file content must be serialized to the persistent
+    /// task cache (e.g., in [`DiskFileSystem::write`]).
+    #[turbo_tasks::function]
+    pub fn persist(&self) -> Vc<PersistedFileContent> {
+        match self {
+            FileContent::Content(file) => PersistedFileContent::Content(file.clone()).cell(),
+            FileContent::NotFound => PersistedFileContent::NotFound.cell(),
+        }
     }
 
     /// Compared to [FileContent::hash], this hashes only the bytes of the file content and

--- a/turbopack/crates/turbo-tasks-hash/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-hash/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 [dependencies]
 bincode = { workspace = true }
 data-encoding = { workspace = true }
+smallvec = { workspace = true }
 sha2 = { workspace = true }
 turbo-tasks-macros = { workspace = true }
 xxhash-rust = { workspace = true }

--- a/turbopack/crates/turbo-tasks-hash/src/deterministic_hash.rs
+++ b/turbopack/crates/turbo-tasks-hash/src/deterministic_hash.rs
@@ -1,5 +1,6 @@
 use std::mem::Discriminant;
 
+use smallvec::SmallVec;
 pub use turbo_tasks_macros::DeterministicHash;
 
 macro_rules! deterministic_hash_number {
@@ -150,6 +151,19 @@ impl<T: DeterministicHash> DeterministicHash for Vec<T> {
             v.deterministic_hash(state);
         }
     }
+}
+
+impl<T: DeterministicHash, const N: usize> DeterministicHash for SmallVec<[T; N]> {
+    fn deterministic_hash<H: DeterministicHasher>(&self, state: &mut H) {
+        state.write_usize(self.len());
+        for v in self {
+            v.deterministic_hash(state);
+        }
+    }
+}
+
+impl DeterministicHash for () {
+    fn deterministic_hash<H: DeterministicHasher>(&self, _state: &mut H) {}
 }
 
 macro_rules! tuple_impls {

--- a/turbopack/crates/turbo-tasks-hash/src/xxh3_hash128.rs
+++ b/turbopack/crates/turbo-tasks-hash/src/xxh3_hash128.rs
@@ -5,10 +5,10 @@ use xxhash_rust::xxh3::Xxh3Default;
 use crate::{DeterministicHash, DeterministicHasher};
 
 /// Hash some content with the Xxh3Hash128 non-cryptographic hash function.
-pub fn hash_xxh3_hash128<T: DeterministicHash>(input: T) -> u128 {
+pub fn hash_xxh3_hash128<T: DeterministicHash>(input: T) -> [u8; 16] {
     let mut hasher = Xxh3Hash128Hasher::new();
     input.deterministic_hash(&mut hasher);
-    hasher.finish()
+    hasher.finish_bytes()
 }
 
 /// Xxh3Hash128 hasher.
@@ -32,7 +32,12 @@ impl Xxh3Hash128Hasher {
         input.deterministic_hash(self);
     }
 
-    /// Finish the hash computation and return the digest.
+    /// Finish the hash computation and return the digest as bytes.
+    pub fn finish_bytes(&self) -> [u8; 16] {
+        self.0.digest128().to_ne_bytes()
+    }
+
+    /// Finish the hash computation and return the digest as u128.
     pub fn finish(&self) -> u128 {
         self.0.digest128()
     }

--- a/turbopack/crates/turbo-tasks-hash/src/xxh3_hash128.rs
+++ b/turbopack/crates/turbo-tasks-hash/src/xxh3_hash128.rs
@@ -34,7 +34,7 @@ impl Xxh3Hash128Hasher {
 
     /// Finish the hash computation and return the digest as bytes.
     pub fn finish_bytes(&self) -> [u8; 16] {
-        self.0.digest128().to_ne_bytes()
+        self.0.digest128().to_le_bytes()
     }
 
     /// Finish the hash computation and return the digest as u128.

--- a/turbopack/crates/turbo-tasks-macros/src/value_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/value_macro.rs
@@ -45,6 +45,10 @@ impl TryFrom<LitStr> for CellMode {
 
 enum SerializationMode {
     None,
+    /// Like `None` (no bincode serialization), but also stores a hash of the cell value so that
+    /// changes can be detected even when the transient cell data has been evicted from memory.
+    /// Only valid with `cell = "compare"` (or the default).
+    Hash,
     Auto,
     Custom,
 }
@@ -62,11 +66,12 @@ impl TryFrom<LitStr> for SerializationMode {
     fn try_from(lit: LitStr) -> Result<Self, Self::Error> {
         match lit.value().as_str() {
             "none" => Ok(SerializationMode::None),
+            "hash" => Ok(SerializationMode::Hash),
             "auto" => Ok(SerializationMode::Auto),
             "custom" => Ok(SerializationMode::Custom),
             _ => Err(Error::new_spanned(
                 &lit,
-                "expected \"none\", \"auto\", or \"custom\"",
+                "expected \"none\", \"hash\", \"auto\", or \"custom\"",
             )),
         }
     }
@@ -77,6 +82,7 @@ struct ValueArguments {
     shared: bool,
     cell_mode: CellMode,
     manual_eq: bool,
+    manual_hash: bool,
     transparent: bool,
     /// Should we `#[derive(turbo_tasks::OperationValue)]`?
     operation: Option<Span>,
@@ -89,6 +95,7 @@ impl Parse for ValueArguments {
             shared: false,
             cell_mode: CellMode::Compare,
             manual_eq: false,
+            manual_hash: false,
             transparent: false,
             operation: None,
         };
@@ -145,6 +152,22 @@ impl Parse for ValueArguments {
                         return Err(Error::new_spanned(&str, "expected \"manual\""));
                     };
                 }
+                (
+                    "hash",
+                    Meta::NameValue(MetaNameValue {
+                        value:
+                            Expr::Lit(ExprLit {
+                                lit: Lit::Str(str), ..
+                            }),
+                        ..
+                    }),
+                ) => {
+                    result.manual_hash = if str.value() == "manual" {
+                        true
+                    } else {
+                        return Err(Error::new_spanned(&str, "expected \"manual\""));
+                    };
+                }
                 ("transparent", Meta::Path(_)) => {
                     result.transparent = true;
                 }
@@ -156,7 +179,7 @@ impl Parse for ValueArguments {
                         &meta,
                         format!(
                             "unexpected {meta:?}, expected \"shared\", \"into\", \
-                             \"serialization\", \"cell\", \"eq\", \"transparent\", or \
+                             \"serialization\", \"cell\", \"eq\", \"hash\", \"transparent\", or \
                              \"operation\""
                         ),
                     ));
@@ -175,9 +198,32 @@ pub fn value(args: TokenStream, input: TokenStream) -> TokenStream {
         shared,
         cell_mode,
         manual_eq,
+        manual_hash,
         transparent,
         operation,
     } = parse_macro_input!(args as ValueArguments);
+
+    // `serialization = "hash"` only makes sense with `cell = "compare"` (the default).
+    if matches!(serialization_mode, SerializationMode::Hash)
+        && !matches!(cell_mode, CellMode::Compare)
+    {
+        return syn::Error::new(
+            proc_macro2::Span::call_site(),
+            "serialization = \"hash\" only makes sense with cell = \"compare\" (or default)",
+        )
+        .to_compile_error()
+        .into();
+    }
+
+    // `hash = "manual"` only makes sense with `serialization = "hash"`.
+    if manual_hash && !matches!(serialization_mode, SerializationMode::Hash) {
+        return syn::Error::new(
+            proc_macro2::Span::call_site(),
+            "hash = \"manual\" only makes sense with serialization = \"hash\"",
+        )
+        .to_compile_error()
+        .into();
+    }
 
     let mut struct_attributes = vec![quote! {
         #[derive(
@@ -277,6 +323,9 @@ pub fn value(args: TokenStream, input: TokenStream) -> TokenStream {
         CellMode::New => quote! {
             turbo_tasks::VcCellNewMode<#ident>
         },
+        CellMode::Compare if matches!(serialization_mode, SerializationMode::Hash) => quote! {
+            turbo_tasks::VcCellHashedCompareMode<#ident>
+        },
         CellMode::Compare => quote! {
             turbo_tasks::VcCellCompareMode<#ident>
         },
@@ -314,7 +363,7 @@ pub fn value(args: TokenStream, input: TokenStream) -> TokenStream {
                 #[bincode(crate = "turbo_tasks::macro_helpers::bincode")]
             });
         }
-        SerializationMode::None | SerializationMode::Custom => {}
+        SerializationMode::None | SerializationMode::Hash | SerializationMode::Custom => {}
     };
     if inner_type.is_some() {
         // Transparent structs have their own manual `ValueDebug` implementation.
@@ -334,6 +383,11 @@ pub fn value(args: TokenStream, input: TokenStream) -> TokenStream {
             #[derive(PartialEq, Eq)]
         });
     }
+    if matches!(serialization_mode, SerializationMode::Hash) && !manual_hash {
+        struct_attributes.push(quote! {
+            #[derive(turbo_tasks::DeterministicHash)]
+        });
+    }
     if let Some(span) = operation {
         struct_attributes.push(quote_spanned! {
             span =>
@@ -343,7 +397,7 @@ pub fn value(args: TokenStream, input: TokenStream) -> TokenStream {
 
     let name = global_name_for_type(ident);
     let new_value_type = match serialization_mode {
-        SerializationMode::None => quote! {
+        SerializationMode::None | SerializationMode::Hash => quote! {
             turbo_tasks::ValueType::new::<#ident>(#name)
         },
         SerializationMode::Auto | SerializationMode::Custom => {
@@ -353,7 +407,7 @@ pub fn value(args: TokenStream, input: TokenStream) -> TokenStream {
         }
     };
     let has_serialization = match serialization_mode {
-        SerializationMode::None => quote! { false },
+        SerializationMode::None | SerializationMode::Hash => quote! { false },
         SerializationMode::Auto | SerializationMode::Custom => quote! { true },
     };
 

--- a/turbopack/crates/turbo-tasks-testing/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-testing/src/lib.rs
@@ -279,6 +279,7 @@ impl TurboTasksApi for VcStorage {
         _is_serializable_cell_content: bool,
         content: CellContent,
         _updated_key_hashes: Option<SmallVec<[u64; 2]>>,
+        _content_hash: Option<[u8; 16]>,
         _verification_mode: VerificationMode,
     ) {
         let mut map = self.cells.lock().unwrap();

--- a/turbopack/crates/turbo-tasks/src/backend.rs
+++ b/turbopack/crates/turbo-tasks/src/backend.rs
@@ -591,6 +591,7 @@ pub trait Backend: Sync + Send {
         is_serializable_cell_content: bool,
         content: CellContent,
         updated_key_hashes: Option<SmallVec<[u64; 2]>>,
+        content_hash: Option<[u8; 16]>,
         verification_mode: VerificationMode,
         turbo_tasks: &dyn TurboTasksBackendApi<Self>,
     );

--- a/turbopack/crates/turbo-tasks/src/backend.rs
+++ b/turbopack/crates/turbo-tasks/src/backend.rs
@@ -288,6 +288,13 @@ impl TryFrom<CellContent> for SharedReference {
 
 pub type TaskCollectiblesMap = AutoMap<RawVc, i32, BuildHasherDefault<FxHasher>, 1>;
 
+/// A 128-bit content hash stored as little-endian bytes.
+///
+/// Using a byte array rather than `u128` keeps the alignment at 1 byte, which avoids padding
+/// in structures such as `AutoMap`/`LazyField` enums that would otherwise grow to accommodate
+/// `u128`'s 16-byte alignment requirement.
+pub type CellHash = [u8; 16];
+
 // Structurally and functionally similar to Cow<&'static, str> but explicitly notes the importance
 // of non-static strings potentially containing PII (Personal Identifiable Information).
 #[derive(Debug, Clone, Encode, Decode, PartialEq, Eq)]
@@ -591,7 +598,7 @@ pub trait Backend: Sync + Send {
         is_serializable_cell_content: bool,
         content: CellContent,
         updated_key_hashes: Option<SmallVec<[u64; 2]>>,
-        content_hash: Option<[u8; 16]>,
+        content_hash: Option<CellHash>,
         verification_mode: VerificationMode,
         turbo_tasks: &dyn TurboTasksBackendApi<Self>,
     );

--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -69,7 +69,7 @@ pub use anyhow::{Error, Result};
 use auto_hash_map::AutoSet;
 use rustc_hash::FxHasher;
 pub use shrink_to_fit::ShrinkToFit;
-pub use turbo_tasks_macros::{turbobail, turbofmt};
+pub use turbo_tasks_macros::{DeterministicHash, turbobail, turbofmt};
 
 pub use crate::{
     capture_future::TurboTasksPanic,
@@ -112,9 +112,9 @@ pub use crate::{
     vc::{
         Dynamic, NonLocalValue, OperationValue, OperationVc, OptionVcExt, ReadVcFuture,
         ResolveOperationVcFuture, ResolveVcFuture, ResolvedVc, ToResolvedVcFuture, Upcast,
-        UpcastStrict, ValueDefault, Vc, VcCast, VcCellCompareMode, VcCellKeyedCompareMode,
-        VcCellNewMode, VcDefaultRead, VcRead, VcTransparentRead, VcValueTrait, VcValueTraitCast,
-        VcValueType, VcValueTypeCast,
+        UpcastStrict, ValueDefault, Vc, VcCast, VcCellCompareMode, VcCellHashedCompareMode,
+        VcCellKeyedCompareMode, VcCellNewMode, VcDefaultRead, VcRead, VcTransparentRead,
+        VcValueTrait, VcValueTraitCast, VcValueType, VcValueTypeCast,
     },
 };
 
@@ -189,6 +189,7 @@ pub use turbo_tasks_macros::function;
 /// - **`"new"`:** Always overrides the value in the cell, invalidating all dependent tasks.
 /// - **`"compare"` *(default)*:** Compares with the existing value in the cell, before overriding it.
 ///   Requires the value to implement [`Eq`].
+/// - **`"keyed"`:** Like `"compare"`, but uses per-key invalidation for transparent map types.
 ///
 /// Avoiding unnecessary invalidation is important to reduce downstream recomputation of tasks that
 /// depend on this cell's value.
@@ -212,7 +213,20 @@ pub use turbo_tasks_macros::function;
 /// - **`"auto"` *(default)*:** Derives the bincode traits and enables serialization.
 /// - **`"custom"`:** Prevents deriving the bincode traits, but still enables serialization
 ///   (you must manually implement [`bincode::Encode`] and [`bincode::Decode`]).
+/// - **`"hash"`:** Like `"none"` (no bincode serialization), but instead stores a hash of the cell
+///   value so that changes can be detected even when the transient cell data has been evicted
+///   from memory or was never stored in the cache—avoiding unnecessary downstream invalidation.
+///   Only valid with `cell = "compare"`.
+///   Requires the value to implement both [`Eq`] and [`DeterministicHash`][turbo_tasks_hash::DeterministicHash].
 /// - **`"none"`:** Disables serialization and prevents deriving the traits.
+///
+/// ## `hash = "..."`
+///
+/// By default, when using `serialization = "hash"`, we `#[derive(DeterministicHash)]`. This argument allows
+/// overriding that default implementation behavior.
+///
+/// - **`"manual"`:** Prevents deriving [`DeterministicHash`][turbo_tasks_hash::DeterministicHash] so you can do it manually.
+///   Only valid with `serialization = "hash"`.
 ///
 /// ## `shared`
 ///

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -29,7 +29,7 @@ use crate::{
     ReadOutputOptions, ResolvedVc, SharedReference, TaskId, TraitMethod, ValueTypeId, Vc, VcRead,
     VcValueTrait, VcValueType,
     backend::{
-        Backend, CachedTaskType, CellContent, TaskCollectiblesMap, TaskExecutionSpec,
+        Backend, CachedTaskType, CellContent, CellHash, TaskCollectiblesMap, TaskExecutionSpec,
         TransientTaskType, TurboTasksExecutionError, TypedCellContent, VerificationMode,
     },
     capture_future::CaptureFuture,
@@ -175,7 +175,7 @@ pub trait TurboTasksApi: TurboTasksCallApi + Sync + Send {
         is_serializable_cell_content: bool,
         content: CellContent,
         updated_key_hashes: Option<SmallVec<[u64; 2]>>,
-        content_hash: Option<[u8; 16]>,
+        content_hash: Option<CellHash>,
         verification_mode: VerificationMode,
     );
     fn mark_own_task_as_finished(&self, task: TaskId);
@@ -1574,7 +1574,7 @@ impl<B: Backend + 'static> TurboTasksApi for TurboTasks<B> {
         is_serializable_cell_content: bool,
         content: CellContent,
         updated_key_hashes: Option<SmallVec<[u64; 2]>>,
-        content_hash: Option<[u8; 16]>,
+        content_hash: Option<CellHash>,
         verification_mode: VerificationMode,
     ) {
         self.backend.update_task_cell(
@@ -2051,7 +2051,7 @@ impl CurrentCellRef {
     /// Updates the cell if the given `functor` returns a value.
     fn conditional_update<T>(
         &self,
-        functor: impl FnOnce(Option<&T>) -> Option<(T, Option<SmallVec<[u64; 2]>>, Option<[u8; 16]>)>,
+        functor: impl FnOnce(Option<&T>) -> Option<(T, Option<SmallVec<[u64; 2]>>, Option<CellHash>)>,
     ) where
         T: VcValueType,
     {
@@ -2074,7 +2074,7 @@ impl CurrentCellRef {
         ) -> Option<(
             SharedReference,
             Option<SmallVec<[u64; 2]>>,
-            Option<[u8; 16]>,
+            Option<CellHash>,
         )>,
     ) {
         let tt = turbo_tasks();

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -22,6 +22,7 @@ use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 use tokio::{select, sync::mpsc::Receiver, task_local};
 use tracing::{Instrument, Span, instrument};
+use turbo_tasks_hash::{DeterministicHash, hash_xxh3_hash128};
 
 use crate::{
     Completion, InvalidationReason, InvalidationReasonSet, OutputContent, ReadCellOptions,
@@ -174,6 +175,7 @@ pub trait TurboTasksApi: TurboTasksCallApi + Sync + Send {
         is_serializable_cell_content: bool,
         content: CellContent,
         updated_key_hashes: Option<SmallVec<[u64; 2]>>,
+        content_hash: Option<[u8; 16]>,
         verification_mode: VerificationMode,
     );
     fn mark_own_task_as_finished(&self, task: TaskId);
@@ -1572,6 +1574,7 @@ impl<B: Backend + 'static> TurboTasksApi for TurboTasks<B> {
         is_serializable_cell_content: bool,
         content: CellContent,
         updated_key_hashes: Option<SmallVec<[u64; 2]>>,
+        content_hash: Option<[u8; 16]>,
         verification_mode: VerificationMode,
     ) {
         self.backend.update_task_cell(
@@ -1580,6 +1583,7 @@ impl<B: Backend + 'static> TurboTasksApi for TurboTasks<B> {
             is_serializable_cell_content,
             content,
             updated_key_hashes,
+            content_hash,
             verification_mode,
             self,
         );
@@ -2047,16 +2051,17 @@ impl CurrentCellRef {
     /// Updates the cell if the given `functor` returns a value.
     fn conditional_update<T>(
         &self,
-        functor: impl FnOnce(Option<&T>) -> Option<(T, Option<SmallVec<[u64; 2]>>)>,
+        functor: impl FnOnce(Option<&T>) -> Option<(T, Option<SmallVec<[u64; 2]>>, Option<[u8; 16]>)>,
     ) where
         T: VcValueType,
     {
         self.conditional_update_with_shared_reference(|old_shared_reference| {
             let old_ref = old_shared_reference.and_then(|sr| sr.0.downcast_ref::<T>());
-            let (new_value, updated_key_hashes) = functor(old_ref)?;
+            let (new_value, updated_key_hashes, content_hash) = functor(old_ref)?;
             Some((
                 SharedReference::new(triomphe::Arc::new(new_value)),
                 updated_key_hashes,
+                content_hash,
             ))
         })
     }
@@ -2066,7 +2071,11 @@ impl CurrentCellRef {
         &self,
         functor: impl FnOnce(
             Option<&SharedReference>,
-        ) -> Option<(SharedReference, Option<SmallVec<[u64; 2]>>)>,
+        ) -> Option<(
+            SharedReference,
+            Option<SmallVec<[u64; 2]>>,
+            Option<[u8; 16]>,
+        )>,
     ) {
         let tt = turbo_tasks();
         let cell_content = tt
@@ -2082,13 +2091,14 @@ impl CurrentCellRef {
             )
             .ok();
         let update = functor(cell_content.as_ref().and_then(|cc| cc.1.0.as_ref()));
-        if let Some((update, updated_key_hashes)) = update {
+        if let Some((update, updated_key_hashes, content_hash)) = update {
             tt.update_own_task_cell(
                 self.current_task,
                 self.index,
                 self.is_serializable_cell_content,
                 CellContent(Some(update)),
                 updated_key_hashes,
+                content_hash,
                 VerificationMode::EqualityCheck,
             )
         }
@@ -2137,7 +2147,7 @@ impl CurrentCellRef {
             {
                 return None;
             }
-            Some((new_value, None))
+            Some((new_value, None, None))
         });
     }
 
@@ -2160,7 +2170,54 @@ impl CurrentCellRef {
                     return None;
                 }
             }
-            Some((new_shared_reference, None))
+            Some((new_shared_reference, None, None))
+        });
+    }
+
+    /// Replace the current cell's content if the new value is different.
+    ///
+    /// Like [`Self::compare_and_update`], but also computes and stores a hash of the value.
+    /// When the cell's transient data is evicted, the stored hash enables the backend to detect
+    /// whether the value actually changed without re-comparing values—avoiding unnecessary
+    /// downstream invalidation.
+    ///
+    /// Requires `T: DeterministicHash` in addition to `T: PartialEq`.
+    pub fn hashed_compare_and_update<T>(&self, new_value: T)
+    where
+        T: PartialEq + DeterministicHash + VcValueType,
+    {
+        self.conditional_update(|old_value| {
+            if let Some(old_value) = old_value
+                && old_value == &new_value
+            {
+                return None;
+            }
+            let content_hash = hash_xxh3_hash128(&new_value);
+            Some((new_value, None, Some(content_hash)))
+        });
+    }
+
+    /// Replace the current cell's content if the new value (from a pre-existing
+    /// [`SharedReference`]) is different.
+    ///
+    /// Like [`Self::compare_and_update_with_shared_reference`], but also passes a hash
+    /// for hash-based change detection when transient data has been evicted.
+    pub fn hashed_compare_and_update_with_shared_reference<T>(
+        &self,
+        new_shared_reference: SharedReference,
+    ) where
+        T: VcValueType + PartialEq + DeterministicHash,
+    {
+        self.conditional_update_with_shared_reference(move |old_sr| {
+            if let Some(old_sr) = old_sr {
+                let old_value = extract_sr_value::<T>(old_sr);
+                let new_value = extract_sr_value::<T>(&new_shared_reference);
+                if old_value == new_value {
+                    return None;
+                }
+            }
+            let content_hash = hash_xxh3_hash128(extract_sr_value::<T>(&new_shared_reference));
+            Some((new_shared_reference, None, Some(content_hash)))
         });
     }
 
@@ -2173,7 +2230,7 @@ impl CurrentCellRef {
     {
         self.conditional_update(|old_value| {
             let Some(old_value) = old_value else {
-                return Some((new_value, None));
+                return Some((new_value, None, None));
             };
             let old_value = <T as VcValueType>::Read::value_to_target_ref(old_value);
             let new_value_ref = <T as VcValueType>::Read::value_to_target_ref(&new_value);
@@ -2186,7 +2243,7 @@ impl CurrentCellRef {
                 .into_iter()
                 .map(|key| FxBuildHasher.hash_one(key))
                 .collect();
-            Some((new_value, Some(updated_key_hashes)))
+            Some((new_value, Some(updated_key_hashes), None))
         });
     }
 
@@ -2202,7 +2259,7 @@ impl CurrentCellRef {
     {
         self.conditional_update_with_shared_reference(|old_sr| {
             let Some(old_sr) = old_sr else {
-                return Some((new_shared_reference, None));
+                return Some((new_shared_reference, None, None));
             };
             let old_value = extract_sr_value::<T>(old_sr);
             let old_value = <T as VcValueType>::Read::value_to_target_ref(old_value);
@@ -2217,7 +2274,7 @@ impl CurrentCellRef {
                 .into_iter()
                 .map(|key| FxBuildHasher.hash_one(key))
                 .collect();
-            Some((new_shared_reference, Some(updated_key_hashes)))
+            Some((new_shared_reference, Some(updated_key_hashes), None))
         });
     }
 
@@ -2232,6 +2289,7 @@ impl CurrentCellRef {
             self.index,
             self.is_serializable_cell_content,
             CellContent(Some(SharedReference::new(triomphe::Arc::new(new_value)))),
+            None,
             None,
             verification_mode,
         )
@@ -2278,6 +2336,7 @@ impl CurrentCellRef {
                 self.index,
                 self.is_serializable_cell_content,
                 CellContent(Some(shared_ref)),
+                None,
                 None,
                 verification_mode,
             )

--- a/turbopack/crates/turbo-tasks/src/vc/cell_mode.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/cell_mode.rs
@@ -1,5 +1,7 @@
 use std::{any::type_name, marker::PhantomData};
 
+use turbo_tasks_hash::DeterministicHash;
+
 use super::{read::VcRead, traits::VcValueType};
 use crate::{
     RawVc, Vc, backend::VerificationMode, keyed::KeyedEq, manager::find_cell_by_type,
@@ -119,4 +121,32 @@ fn debug_assert_type<T: VcValueType>(content: &TypedSharedReference) {
         "SharedReference for type {} must contain data matching that type",
         type_name::<T>(),
     );
+}
+
+/// Mode that compares the cell's content with the new value and only updates
+/// if the new value is different, using both PartialEq (when old content is available)
+/// and a stored hash (when old content has been evicted from memory) for comparison.
+pub struct VcCellHashedCompareMode<T> {
+    _phantom: PhantomData<T>,
+}
+
+impl<T> VcCellMode<T> for VcCellHashedCompareMode<T>
+where
+    T: VcValueType + PartialEq + DeterministicHash,
+{
+    fn cell(inner: VcReadTarget<T>) -> Vc<T> {
+        let cell = find_cell_by_type::<T>();
+        cell.hashed_compare_and_update(<T::Read as VcRead<T>>::target_to_value(inner));
+        Vc {
+            node: cell.into(),
+            _t: PhantomData,
+        }
+    }
+
+    fn raw_cell(content: TypedSharedReference) -> RawVc {
+        debug_assert_type::<T>(&content);
+        let cell = find_cell_by_type::<T>();
+        cell.hashed_compare_and_update_with_shared_reference::<T>(content.reference);
+        cell.into()
+    }
 }

--- a/turbopack/crates/turbo-tasks/src/vc/mod.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/mod.rs
@@ -25,7 +25,10 @@ use shrink_to_fit::ShrinkToFit;
 
 pub use self::{
     cast::{VcCast, VcValueTraitCast, VcValueTypeCast},
-    cell_mode::{VcCellCompareMode, VcCellKeyedCompareMode, VcCellMode, VcCellNewMode},
+    cell_mode::{
+        VcCellCompareMode, VcCellHashedCompareMode, VcCellKeyedCompareMode, VcCellMode,
+        VcCellNewMode,
+    },
     default::ValueDefault,
     local::NonLocalValue,
     operation::{OperationValue, OperationVc, ResolveOperationVcFuture},

--- a/turbopack/crates/turbopack-core/src/code_builder.rs
+++ b/turbopack/crates/turbopack-core/src/code_builder.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use anyhow::Result;
+use bincode::{Decode, Encode};
 use tracing::instrument;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, Vc};
@@ -25,13 +26,17 @@ use crate::{
 pub type Mapping = (usize, Option<Rope>);
 
 /// Code stores combined output code and the source map of that output code.
-#[turbo_tasks::value(shared)]
-#[derive(Debug, Clone)]
+#[turbo_tasks::value(shared, serialization = "hash")]
+#[derive(Debug, Clone, Encode, Decode)]
 pub struct Code {
     code: Rope,
     mappings: Vec<Mapping>,
     should_generate_debug_id: bool,
 }
+
+#[turbo_tasks::value(transparent)]
+#[derive(Debug, Clone)]
+pub struct PersistedCode(Code);
 
 impl Code {
     pub fn source_code(&self) -> &Rope {
@@ -284,6 +289,16 @@ impl Code {
         } else {
             None
         })
+    }
+
+    #[turbo_tasks::function]
+    pub async fn persisted(self: Vc<Self>) -> Result<Vc<Code>> {
+        Ok(self.persisted_internal().owned().await?.cell())
+    }
+
+    #[turbo_tasks::function]
+    fn persisted_internal(&self) -> Vc<PersistedCode> {
+        Vc::cell(self.clone())
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/code_builder.rs
+++ b/turbopack/crates/turbopack-core/src/code_builder.rs
@@ -2,6 +2,7 @@ use std::{
     cmp::min,
     io::{BufRead, Result as IoResult, Write},
     ops,
+    sync::Arc,
 };
 
 use anyhow::Result;
@@ -30,13 +31,22 @@ pub type Mapping = (usize, Option<Rope>);
 #[derive(Debug, Clone, Encode, Decode)]
 pub struct Code {
     code: Rope,
-    mappings: Vec<Mapping>,
+    mappings: Arc<Vec<Mapping>>,
     should_generate_debug_id: bool,
 }
 
 #[turbo_tasks::value(transparent)]
 #[derive(Debug, Clone)]
 pub struct PersistedCode(Code);
+
+#[turbo_tasks::value_impl]
+impl PersistedCode {
+    #[turbo_tasks::function]
+    async fn to_code(self: Vc<Self>) -> Result<Vc<Code>> {
+        // PersistedCode is transparent over Code; owned() yields Code directly.
+        Ok(self.owned().await?.cell())
+    }
+}
 
 impl Code {
     pub fn source_code(&self) -> &Rope {
@@ -55,6 +65,12 @@ impl Code {
     /// Take the source code out of the Code.
     pub fn into_source_code(self) -> Rope {
         self.code
+    }
+
+    /// Stores this `Code` as a [`PersistedCode`] (fully serialized) and returns a `Vc<Code>`
+    /// backed by the persisted version, avoiding an intermediate hash-mode `Code` cell.
+    pub fn cell_persisted(self) -> Vc<Code> {
+        PersistedCode::to_code(PersistedCode(self).cell())
     }
 
     // Formats the code with the source map and debug id comments as
@@ -215,7 +231,7 @@ impl CodeBuilder {
     pub fn build(self) -> Code {
         Code {
             code: self.code.build(),
-            mappings: self.mappings.unwrap_or_default(),
+            mappings: Arc::new(self.mappings.unwrap_or_default()),
             should_generate_debug_id: self.should_generate_debug_id,
         }
     }
@@ -290,16 +306,6 @@ impl Code {
             None
         })
     }
-
-    #[turbo_tasks::function]
-    pub async fn persisted(self: Vc<Self>) -> Result<Vc<Code>> {
-        Ok(self.persisted_internal().owned().await?.cell())
-    }
-
-    #[turbo_tasks::function]
-    fn persisted_internal(&self) -> Vc<PersistedCode> {
-        Vc::cell(self.clone())
-    }
 }
 
 impl Code {
@@ -317,7 +323,7 @@ impl Code {
 
         let mut sections = Vec::with_capacity(self.mappings.len());
         let mut read = self.code.read();
-        for (byte_pos, map) in &self.mappings {
+        for (byte_pos, map) in self.mappings.iter() {
             let mut want = byte_pos - last_byte_pos;
             while want > 0 {
                 // `fill_buf` never returns an error.

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
@@ -327,7 +327,7 @@ async fn module_factory_with_code_generation_issue(
             code += "(() => {{\n\n";
             writeln!(code, "throw new Error({error});", error = &js_error_message)?;
             code += "\n}})";
-            code.build().cell().persisted()
+            code.build().cell_persisted()
         }
     })
 }

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
@@ -327,7 +327,7 @@ async fn module_factory_with_code_generation_issue(
             code += "(() => {{\n\n";
             writeln!(code, "throw new Error({error});", error = &js_error_message)?;
             code += "\n}})";
-            code.build().cell()
+            code.build().cell().persisted()
         }
     })
 }


### PR DESCRIPTION
### What?

Re-lands #91576 ("turbo-tasks: add hashed cell mode for hash-based change detection without cell data"), which was reverted in #92103 due to a `FATAL` crash in the `filesystem-cache` test suite.

Includes a bug fix on top: in `task_execution_completed_prepare`, skip updating `cell_type_max_index` when the task completed with an error.

Also adds a `CellHash = [u8; 16]` type alias (requested in review) used throughout the hash pipeline.

### Why?

**The original feature** (`serialization = "hash"` on `FileContent` and `Code`) stores a hash of the cell data instead of the full serialized value. On session restore, the hash is used to detect whether cell content has changed without needing the full data in memory. This avoids a large persistent cache size increase.

**The bug** that caused the revert: When a task fails partway through re-execution (before recreating all the cells from its previous run), `cell_counters` only reflects the partially-executed state. The old code used those partial counters to update `cell_type_max_index`, removing entries for cell types that were not yet created at the point of failure. This caused downstream tasks that still held cell dependencies from the previous successful run to hit a hard "Cell no longer exists" error.

**Concrete failure path** in `filesystem-cache rename app page` test:

1. `get_app_page_entry` runs for `/remove-me/page`, creating two `FileContent` cells (indices 0 and 1). `cell_type_max_index[FileContent] = 2` is persisted.
2. The folder is renamed (`app/remove-me` → `app/add-me`), dirtying the task.
3. On re-execution, `get_app_page_entry` fails at `config.await?` (the loader tree errors because the directory is gone) — before any `FileContent::cell()` calls.
4. `cell_counters` has no `FileContent` entry → old code removed `cell_type_max_index[FileContent]`.
5. The `parse` task tries to read `FileContent` cell 1 from `get_app_page_entry` → `cell_type_max_index` is `None` → **"Cell no longer exists" panic → FATAL error**.

**Why it didn't crash before** `serialization = "hash"`: `FileContent` was previously serializable, so `parse` read stale cell data directly from `persistent_cell_data`, which `task_execution_completed_cleanup` already preserves on error. With `serialization = "hash"`, data is transient — readers fall back to `cell_type_max_index` for range validation, where a stale `None` caused the crash.

### How?

#### Core feature: `serialization = "hash"` cell mode

- New `SerializationMode::Hash` variant in `turbo-tasks-macros` — marks a value type as non-serializable but stores a `DeterministicHash` of the cell data for change detection.
- `VcCellHashedCompareMode<T>` cell mode: compares values via `PartialEq` when available, falls back to hash comparison when transient data has been evicted.
- `hashed_compare_and_update` / `hashed_compare_and_update_with_shared_reference` on `CurrentCellRef` compute and pass content hashes through the update pipeline.
- Backend `update_cell` uses hash-based comparison to skip invalidation when the old cell data is unavailable but the hash matches.
- `cell_data_hash: AutoMap<CellId, CellHash>` field in task storage persists hashes across sessions.
- Stale `cell_data_hash` entries are cleaned up in `task_execution_completed_cleanup` alongside cell data removal.
- `CellHash = [u8; 16]` type alias keeps alignment at 1 byte to avoid padding growth in `AutoMap`/`LazyField` enum variants.
- Hash bytes use little-endian encoding (`to_le_bytes`) for cross-platform cache portability.

#### Bug fix: preserve `cell_type_max_index` on task error

In `task_execution_completed_prepare`, guard the `cell_type_max_index` update block with `if result.is_ok()`. This mirrors the existing `task_execution_completed_cleanup` behavior that already skips cell data removal when `is_error` is true, keeping `cell_type_max_index` consistent with the preserved transient cell data.

#### Applied to `FileContent` and `Code`

- `FileContent` uses `serialization = "hash"` — full content is persisted via a separate `PersistedFileContent` type when needed (e.g., in `DiskFileSystem::write`).
- `Code` uses `serialization = "hash"` with `Arc<Vec<Mapping>>` for cheap cloning. `Code::cell_persisted()` creates a `PersistedCode` cell directly and returns `Vc<Code>` via `PersistedCode::to_code()`, avoiding an intermediate hash-mode cell.

#### Other improvements

- `DeterministicHash` impls for `SmallVec` and `()`.
- `Xxh3Hash128Hasher::finish_bytes()` method returning `[u8; 16]`.
- `hash = "manual"` option on `#[turbo_tasks::value]` to opt out of auto-deriving `DeterministicHash`.

**Note:** The shutdown hang and cache poisoning fixes that were previously on this branch have been merged separately via #92254.

### Test plan

- [x] `test/e2e/filesystem-cache/filesystem-cache.test.ts` passes (all 17 tests)
- [x] New `turbopack/crates/turbo-tasks-backend/tests/hashed_cell_mode.rs` integration test verifies hash-based change detection: value changes trigger invalidation, equal values (same hash) do not
- [x] `cargo check` passes for `turbo-tasks`, `turbo-tasks-backend`, `turbo-tasks-fs`, `turbopack-core`, `turbopack-ecmascript`
- [x] CI green (attempt 2)

<!-- NEXT_JS_LLM_PR -->