### PR TITLE
Enable `varyParams` tracking for Cached Navigations

### DIFF
--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -41,7 +41,10 @@ import type { NormalizedSearch } from '../segment-cache/cache-key'
 import { getDeploymentId } from '../../../shared/lib/deployment-id'
 import { getNavigationBuildId } from '../../navigation-build-id'
 import { NEXT_NAV_DEPLOYMENT_ID_HEADER } from '../../../lib/constants'
-import { stripIsPartialByte } from '../segment-cache/cache'
+import {
+  stripIsPartialByte,
+  createNonTaskyPrefetchResponseStream,
+} from '../segment-cache/cache'
 import { UnknownDynamicStaleTime } from '../segment-cache/bfcache'
 
 const createFromReadableStream =
@@ -461,9 +464,9 @@ export async function resolveStaticStageData<
 }
 
 /**
- * Truncates a Flight stream clone at the given byte boundary and decodes the
- * static stage prefix. Used by both the navigation path and the initial HTML
- * hydration path.
+ * Truncates and buffers a Flight stream clone at the given byte boundary and
+ * decodes the static stage prefix. Used by both the navigation path and the
+ * initial HTML hydration path.
  */
 export async function decodeStaticStage<T>(
   responseBodyClone: ReadableStream<Uint8Array>,
@@ -472,12 +475,15 @@ export async function decodeStaticStage<T>(
 ): Promise<T> {
   const staticStageByteLength = await staticStageByteLengthPromise
 
-  const truncatedStream = truncateStream(
+  // Buffer the truncated stream into a single chunk before passing it to
+  // Flight. This ensures all model data is available synchronously, which is
+  // required for readVaryParams to synchronously read the thenable status.
+  const { stream } = await createNonTaskyPrefetchResponseStream(
     responseBodyClone,
     staticStageByteLength
   )
 
-  return createFromNextReadableStream<T>(truncatedStream, headers, {
+  return createFromNextReadableStream<T>(stream, headers, {
     allowPartialStream: true,
   })
 }
@@ -662,43 +668,5 @@ function createFromNextFetch<T>(
     callServer,
     findSourceMapURL,
     debugChannel: createDebugChannel && createDebugChannel(requestHeaders),
-  })
-}
-
-function truncateStream(
-  stream: ReadableStream<Uint8Array>,
-  byteLength: number
-): ReadableStream<Uint8Array> {
-  const reader = stream.getReader()
-  let remaining = byteLength
-
-  return new ReadableStream({
-    async pull(controller) {
-      if (remaining <= 0) {
-        reader.cancel()
-        controller.close()
-        return
-      }
-
-      const { done, value } = await reader.read()
-
-      if (done) {
-        controller.close()
-        return
-      }
-
-      if (value.byteLength <= remaining) {
-        controller.enqueue(value)
-        remaining -= value.byteLength
-      } else {
-        controller.enqueue(value.subarray(0, remaining))
-        remaining = 0
-        reader.cancel()
-        controller.close()
-      }
-    },
-    cancel() {
-      reader.cancel()
-    },
   })
 }

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -2727,8 +2727,9 @@ async function fetchPrefetchResponse<T>(
   return response
 }
 
-async function createNonTaskyPrefetchResponseStream(
-  body: ReadableStream<Uint8Array>
+export async function createNonTaskyPrefetchResponseStream(
+  body: ReadableStream<Uint8Array>,
+  byteLimit?: number
 ): Promise<{ stream: ReadableStream<Uint8Array>; size: number }> {
   // Buffer the entire response before passing it to the Flight client. This
   // ensures that when Flight processes the stream, all model data is available
@@ -2741,13 +2742,24 @@ async function createNonTaskyPrefetchResponseStream(
   // These could all be consolidated into a single transformation. Refactor
   // once the cached navigations experiment lands.
   //
-  // Read the entire response from the network.
+  // Read the response from the network, optionally truncating at byteLimit.
   const reader = body.getReader()
   const chunks: Uint8Array[] = []
   let size = 0
   while (true) {
     const { done, value } = await reader.read()
     if (done) break
+    if (byteLimit !== undefined && size + value.byteLength >= byteLimit) {
+      const remaining = byteLimit - size
+      if (remaining > 0) {
+        chunks.push(
+          value.byteLength > remaining ? value.subarray(0, remaining) : value
+        )
+        size += remaining
+      }
+      reader.cancel()
+      break
+    }
     chunks.push(value)
     size += value.byteLength
   }

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -3154,6 +3154,8 @@ async function renderToStream(
 
         requestStore.stale = INFINITE_CACHE
         requestStore.stagedRendering = stageController
+        requestStore.varyParamsAccumulator =
+          createResponseVaryParamsAccumulator()
 
         trackStaleTime(
           requestStore as { stale: number },
@@ -3237,9 +3239,15 @@ async function renderToStream(
           },
           () => {
             // This is a separate task that doesn't advance a stage. It forces
-            // draining the microtask queue so that the stale time iterable is
-            // closed before we advance to the dynamic stage.
+            // draining the microtask queue so that the stale time iterable and
+            // vary params accumulators are closed before we advance to the
+            // dynamic stage.
             void finishStaleTimeTracking(staleTimeIterable)
+            if (requestStore.varyParamsAccumulator) {
+              void finishAccumulatingVaryParams(
+                requestStore.varyParamsAccumulator
+              )
+            }
           },
           () => {
             stageController.advanceStage(RenderStage.Dynamic)

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -871,6 +871,7 @@ async function generateStagedDynamicFlightRenderResult(
   // Initialize stale time tracking on the request store.
   requestStore.stale = INFINITE_CACHE
   requestStore.stagedRendering = stageController
+  requestStore.varyParamsAccumulator = createResponseVaryParamsAccumulator()
   requestStore.asyncApiPromises = createAsyncApiPromises(
     stageController,
     requestStore.cookies,
@@ -965,9 +966,12 @@ async function generateStagedDynamicFlightRenderResult(
     },
     () => {
       // This is a separate task that doesn't advance a stage. It forces
-      // draining the microtask queue so that the stale time iterable is closed
-      // before we advance to the dynamic stage.
+      // draining the microtask queue so that the stale time iterable and vary
+      // params accumulators are closed before we advance to the dynamic stage.
       void finishStaleTimeTracking(staleTimeIterable)
+      if (requestStore.varyParamsAccumulator) {
+        void finishAccumulatingVaryParams(requestStore.varyParamsAccumulator)
+      }
     },
     () => {
       stageController.advanceStage(RenderStage.Dynamic)

--- a/packages/next/src/server/app-render/vary-params.ts
+++ b/packages/next/src/server/app-render/vary-params.ts
@@ -117,9 +117,10 @@ export function createVaryParamsAccumulator(): VaryParamsAccumulator | null {
   if (workUnitStore) {
     switch (workUnitStore.type) {
       case 'prerender':
-      case 'prerender-runtime': {
+      case 'prerender-runtime':
+      case 'request': {
         const responseAccumulator = workUnitStore.varyParamsAccumulator
-        if (responseAccumulator !== null) {
+        if (responseAccumulator) {
           const accumulator = createSegmentVaryParamsAccumulator()
           responseAccumulator.segments.add(accumulator)
           return accumulator
@@ -128,7 +129,6 @@ export function createVaryParamsAccumulator(): VaryParamsAccumulator | null {
       }
       case 'prerender-ppr':
       case 'prerender-legacy':
-      case 'request':
       case 'cache':
       case 'private-cache':
       case 'prerender-client':
@@ -148,16 +148,16 @@ export function getMetadataVaryParamsAccumulator(): VaryParamsAccumulator | null
   if (workUnitStore) {
     switch (workUnitStore.type) {
       case 'prerender':
-      case 'prerender-runtime': {
+      case 'prerender-runtime':
+      case 'request': {
         const responseAccumulator = workUnitStore.varyParamsAccumulator
-        if (responseAccumulator !== null) {
+        if (responseAccumulator) {
           return responseAccumulator.head
         }
         return null
       }
       case 'prerender-ppr':
       case 'prerender-legacy':
-      case 'request':
       case 'cache':
       case 'private-cache':
       case 'prerender-client':

--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -76,6 +76,7 @@ export interface RequestStore extends CommonWorkUnitStore {
   cacheSignal?: CacheSignal | null
   prerenderResumeDataCache?: PrerenderResumeDataCache | null
   fallbackParams?: OpaqueFallbackRouteParams | null
+  varyParamsAccumulator?: ResponseVaryParamsAccumulator | null
 
   // Only in build-time instant-validation
   // We mirror the controller/renderSignal from prerender stores to allow aborting the render

--- a/test/e2e/app-dir/segment-cache/cached-navigations/app/with-fallback-params/[slug]/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/cached-navigations/app/with-fallback-params/[slug]/layout.tsx
@@ -1,0 +1,22 @@
+import Link from 'next/link'
+import { ReactNode } from 'react'
+
+export default function ParamsLayout({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <ul>
+        <li>
+          <Link href="/with-fallback-params/foo" prefetch={false}>
+            /with-fallback-params/foo
+          </Link>
+        </li>
+        <li>
+          <Link href="/with-fallback-params/bar" prefetch={false}>
+            /with-fallback-params/bar
+          </Link>
+        </li>
+      </ul>
+      {children}
+    </>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/cached-navigations/cached-navigations.test.ts
+++ b/test/e2e/app-dir/segment-cache/cached-navigations/cached-navigations.test.ts
@@ -816,4 +816,123 @@ describe('cached navigations', () => {
       'Dynamic content'
     )
   })
+
+  it('reuses cached page segment across different fallback params after navigation', async () => {
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      async beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page)
+
+    // First navigation to /with-fallback-params/foo — seeds the segment cache.
+    // Since slug is a fallback param, the page segment's varyParams is empty,
+    // meaning the cached segment contains only the Suspense fallback and no
+    // param-specific data.
+    await act(
+      async () => {
+        await browser
+          .elementByCss('a[href="/with-fallback-params/foo"]')
+          .click()
+      },
+      { includes: 'Dynamic content' }
+    )
+    expect(await browser.elementById('params-boundary').text()).toContain(
+      'Param: foo'
+    )
+
+    // Click the bar link. The page segment should be reused from cache (empty
+    // varyParams), so the Suspense fallback for params should appear instantly.
+    await act(async () => {
+      await act(
+        async () => {
+          await browser
+            .elementByCss('a[href="/with-fallback-params/bar"]')
+            .click()
+        },
+        {
+          includes: 'Dynamic content',
+          block: true,
+        }
+      )
+
+      expect(await browser.elementById('cached-content').text()).toContain(
+        'Cached content'
+      )
+      // The page segment is reused — params boundary shows Suspense fallback
+      expect(await browser.elementById('params-boundary').text()).toBe(
+        'Loading params...'
+      )
+      expect(await browser.elementById('connection-boundary').text()).toBe(
+        'Loading connection...'
+      )
+    })
+
+    // After unblocking, all content should be visible with the new param
+    expect(await browser.elementById('params-boundary').text()).toContain(
+      'Param: bar'
+    )
+    expect(await browser.elementById('connection-boundary').text()).toContain(
+      'Dynamic content'
+    )
+  })
+
+  it('reuses cached page segment across different fallback params after initial HTML load', async () => {
+    let page: Playwright.Page
+    // Start directly at /with-fallback-params/foo — full HTML load. The RSC
+    // payload inlined in the HTML seeds the segment cache with the page
+    // segment, which has empty varyParams because slug is a fallback param.
+    const browser = await next.browser('/with-fallback-params/foo', {
+      async beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page)
+
+    // Wait for all content to stream in
+    await retry(async () => {
+      expect(await browser.elementById('connection-boundary').text()).toContain(
+        'Dynamic content'
+      )
+    })
+    expect(await browser.elementById('params-boundary').text()).toContain(
+      'Param: foo'
+    )
+
+    // Click the bar link. The page segment should be reused from the cache
+    // seeded by the initial HTML load.
+    await act(async () => {
+      await act(
+        async () => {
+          await browser
+            .elementByCss('a[href="/with-fallback-params/bar"]')
+            .click()
+        },
+        {
+          includes: 'Dynamic content',
+          block: true,
+        }
+      )
+
+      expect(await browser.elementById('cached-content').text()).toContain(
+        'Cached content'
+      )
+      // The page segment is reused — params boundary shows Suspense fallback
+      expect(await browser.elementById('params-boundary').text()).toBe(
+        'Loading params...'
+      )
+      expect(await browser.elementById('connection-boundary').text()).toBe(
+        'Loading connection...'
+      )
+    })
+
+    // After unblocking, all content should be visible with the new param
+    expect(await browser.elementById('params-boundary').text()).toContain(
+      'Param: bar'
+    )
+    expect(await browser.elementById('connection-boundary').text()).toContain(
+      'Dynamic content'
+    )
+  })
 })

--- a/test/e2e/app-dir/segment-cache/cached-navigations/next.config.ts
+++ b/test/e2e/app-dir/segment-cache/cached-navigations/next.config.ts
@@ -6,6 +6,10 @@ const nextConfig: NextConfig = {
   experimental: {
     cachedNavigations: true,
     exposeTestingApiInProductionBuild: true,
+    instantNavigationDevToolsToggle: true,
+    optimisticRouting: true,
+    useOffline: true,
+    varyParams: true,
   },
 }
 

--- a/test/e2e/app-dir/segment-cache/vary-params/app/(main)/in-page-loading-boundary/[slug]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params/app/(main)/in-page-loading-boundary/[slug]/page.tsx
@@ -1,0 +1,26 @@
+import { Suspense } from 'react'
+
+type Params = { slug: string }
+
+async function ItemContent({ params }: { params: Promise<Params> }) {
+  const { slug } = await params
+  return (
+    <div id="in-page-loading-boundary-content">
+      <div data-slug={slug}>Item: {slug}</div>
+    </div>
+  )
+}
+
+export default function InPageLoadingBoundaryPage({
+  params,
+}: {
+  params: Promise<Params>
+}) {
+  return (
+    <div id="in-page-loading-boundary-page">
+      <Suspense fallback={<div data-loading="true">Loading item...</div>}>
+        <ItemContent params={params} />
+      </Suspense>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/vary-params/app/(main)/in-page-loading-boundary/page.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params/app/(main)/in-page-loading-boundary/page.tsx
@@ -1,0 +1,39 @@
+import { LinkAccordion } from '../../../components/link-accordion'
+
+export default function InPageLoadingBoundaryIndexPage() {
+  return (
+    <div id="in-page-loading-boundary-index">
+      <h1>In-Page Loading Boundary Test</h1>
+      <p>
+        Verifies that a page with an in-page Suspense boundary (instead of a
+        separate loading.tsx) produces a shareable prefetch. Since there is no
+        generateStaticParams, the segment prefetch is generated from a prerender
+        where params are unresolved (hanging). The child component that awaits
+        params suspends, so the prefetch contains only the Suspense fallback
+        with empty varyParams — making it reusable across all slug values.
+      </p>
+      <ul>
+        <li>
+          <LinkAccordion href="/in-page-loading-boundary/phone">
+            Phone
+          </LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/in-page-loading-boundary/tablet">
+            Tablet
+          </LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/in-page-loading-boundary/laptop">
+            Laptop
+          </LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/in-page-loading-boundary/headphones">
+            Headphones
+          </LinkAccordion>
+        </li>
+      </ul>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/vary-params/vary-params.test.ts
+++ b/test/e2e/app-dir/segment-cache/vary-params/vary-params.test.ts
@@ -83,6 +83,67 @@ describe('segment cache - vary params', () => {
     expect(await page.text()).toContain('Item: headphones')
   })
 
+  it('reuses prefetched page segment with in-page loading boundary across different params', async () => {
+    // Setup: Page uses an in-page Suspense boundary instead of loading.tsx. The
+    // page's default export wraps a child component in <Suspense>. The child
+    // awaits params, but during prerendering the params are fallback params
+    // (hanging promise), so the child suspends and the segment prefetch
+    // contains only the Suspense fallback with empty varyParams — making it
+    // reusable across all slug values.
+    let act: ReturnType<typeof createRouterAct>
+    const browser = await next.browser('/in-page-loading-boundary', {
+      beforePageLoad(p: Playwright.Page) {
+        act = createRouterAct(p)
+      },
+    })
+
+    // Prefetch the first link - page segment is fetched
+    await act(
+      async () => {
+        const toggle = await browser.elementByCss(
+          'input[data-link-accordion="/in-page-loading-boundary/phone"]'
+        )
+        await toggle.click()
+      },
+      { includes: 'Loading item' }
+    )
+
+    // Prefetch remaining links - all cache hits (page prefetch is shared)
+    await act(async () => {
+      const tablet = await browser.elementByCss(
+        'input[data-link-accordion="/in-page-loading-boundary/tablet"]'
+      )
+      await tablet.click()
+      const laptop = await browser.elementByCss(
+        'input[data-link-accordion="/in-page-loading-boundary/laptop"]'
+      )
+      await laptop.click()
+      const headphones = await browser.elementByCss(
+        'input[data-link-accordion="/in-page-loading-boundary/headphones"]'
+      )
+      await headphones.click()
+    }, 'no-requests')
+
+    // Navigate to headphones. The loading state renders instantly from the
+    // cached page shell (Suspense fallback), before the dynamic request
+    // resolves.
+    await act(async () => {
+      const link = await browser.elementByCss(
+        'a[href="/in-page-loading-boundary/headphones"]'
+      )
+      await link.click()
+
+      const loading = await browser.elementByCss('[data-loading="true"]')
+      expect(await loading.text()).toContain('Loading item')
+    })
+
+    // Dynamic content eventually loads
+    const content = await browser.elementById(
+      'in-page-loading-boundary-content'
+    )
+    expect(await content.text()).toContain('Item: headphones')
+  })
+
   it('renders cached loading state instantly with runtime prefetching', async () => {
     // Setup: Page accesses `category` in static portion (tracked in varyParams),
     // but accesses `itemId` only after connection() (not tracked).


### PR DESCRIPTION
When a page uses fallback params (no `generateStaticParams`), the segment prefetch contains all the static and cached content up to the Suspense boundary above the params access, along with its fallback. Since no params were accessed during prerendering, `varyParams` is empty, making the prefetch shareable across all param values. This already worked for per-segment prefetches, but not for the static stage embedded in navigation responses or the initial HTML document. As a result, navigating between sibling routes with different fallback params could not reuse the cached page segment.

This requires `experimental.cachedNavigations`, `experimental.optimisticRouting`, and `experimental.varyParams` to be enabled.

This PR fixes two issues that prevented `varyParams` from flowing through cached navigations:

The server was not tracking `varyParams` during request-mode renders. The `varyParamsAccumulator` only existed on `PrerenderStoreModernRuntime`, so `createVaryParamsAccumulator()` returned `null` for all request-mode renders. This PR adds `varyParamsAccumulator` to `RequestStore` and creates it in both the dynamic navigation and resume render paths in `app-render.tsx`. The accumulator is finalized at the end of the static stage, alongside `finishStaleTimeTracking`.

On the client side, `decodeStaticStage` was passing the truncated Flight stream directly to the Flight client without buffering. When Flight processed the stream in multiple chunks, `varyParams` thenables could still be in `resolved_model` state when `readVaryParams` checked them synchronously, causing it to return `null`. This PR replaces the separate `truncateStream` helper with the existing `createNonTaskyPrefetchResponseStream` (which buffers the entire response into a single chunk), extended with an optional `byteLimit` parameter for truncation.