### PR TITLE
ci: relax adapter results upload gate

### DIFF
--- a/.github/workflows/test_e2e_deploy_release.yml
+++ b/.github/workflows/test_e2e_deploy_release.yml
@@ -254,9 +254,9 @@ jobs:
         always() &&
         github.event.inputs.deployScriptPath == '' &&
         github.repository_owner == 'vercel' &&
-        (
-          (github.event_name == 'workflow_dispatch' && github.ref_name == 'canary') ||
-          (github.event_name == 'release' && github.event.release.target_commitish == 'canary')
+        !startsWith(
+          github.event.inputs.nextVersion || github.event.release.tag_name || 'canary',
+          'http'
         )
       }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- simplify `upload-adapter-test-results` condition to use the effective Next version value
- run upload when version does not start with `http` (allows `canary` and release tags)
- keep existing owner and deploy-script safeguards

## Why
- release runs can have `target_commitish` as a commit SHA, which caused valid canary release runs to skip upload
