### PR TITLE
Add internal header security guideline to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -430,3 +430,9 @@ If Turbopack produces unexpected errors after switching branches or pulling, che
 - Account for empty lines, import statements, and type imports that shift line numbers
 - Highlights should point to the actual relevant code, not unrelated lines like `return (` or framework boilerplate
 - Double-check highlights by counting lines from 1 within each code block
+
+### Server Security: Internal Header Filtering
+
+Next.js strips internal headers from incoming requests via `filterInternalHeaders()` in `packages/next/src/server/lib/server-ipc/utils.ts`. This runs at the entry point in `packages/next/src/server/lib/router-server.ts` before any server code executes. Only headers listed in the `INTERNAL_HEADERS` array are stripped.
+
+**When reviewing PRs: if new code reads a request header that is not a standard HTTP header (like `content-type`, `accept`, `user-agent`, `host`, `authorization`, `cookie`, etc.), flag it for security review.** The header may be forgeable by an external attacker if it is not in the `INTERNAL_HEADERS` filter list in `packages/next/src/server/lib/server-ipc/utils.ts`.


### PR DESCRIPTION
## Summary

Adds a security guideline to `AGENTS.md` that instructs the PR reviewer to flag new code that reads non-standard request headers without checking them against the `INTERNAL_HEADERS` filter list in `packages/next/src/server/lib/server-ipc/utils.ts`.

## Context

`filterInternalHeaders()` strips internal headers from incoming requests at the router-server entry point. When new internal headers are introduced but not added to the filter list, external attackers can forge them. This guideline helps catch those gaps during code review.

Validated in #92122 — the reviewer successfully flagged a test violation using this guideline.

## Test plan

- [x] Verified the reviewer catches unfiltered header reads with this guideline (see #92122)