### PR TITLE
docs: add middleware bypass note to CDN caching guide

### DIFF
--- a/docs/01-app/02-guides/cdn-caching.mdx
+++ b/docs/01-app/02-guides/cdn-caching.mdx
@@ -52,7 +52,7 @@ App Router responses can vary based on several custom request headers. Next.js s
 - `next-router-segment-prefetch` — the specific segment being prefetched
 - `next-url` — added only for routes that use [interception routes](/docs/app/api-reference/file-conventions/intercepting-routes), carries the URL being intercepted
 
-> **Good to know:** If your deployment runs Proxy/Middleware behind your CDN (instead of in front of the cache), configure your CDN or cache layer to bypass caching for requests that depend on Proxy/Middleware decisions. Otherwise, the CDN can serve a cached response without running Proxy/Middleware first, and it will stop being the source of truth for auth, redirects, and rewrites.
+> **Good to know:** [`proxy.js`](/docs/app/api-reference/file-conventions/proxy) (previously Middleware) should run before the CDN cache so it remains the source of truth for auth, redirects, and rewrites. If your deployment places `proxy.js` behind the CDN, configure the cache layer to bypass caching for routes that depend on `proxy.js` decisions.
 
 Many CDNs don't support `Vary` without additional configuration. Next.js addresses this with the `_rsc` search parameter: a hash of the relevant request header values that acts as a cache-key, ensuring different response variants get different cache keys. This ensures correct responses even on CDNs that ignore `Vary`.
 

--- a/docs/01-app/02-guides/cdn-caching.mdx
+++ b/docs/01-app/02-guides/cdn-caching.mdx
@@ -52,6 +52,8 @@ App Router responses can vary based on several custom request headers. Next.js s
 - `next-router-segment-prefetch` — the specific segment being prefetched
 - `next-url` — added only for routes that use [interception routes](/docs/app/api-reference/file-conventions/intercepting-routes), carries the URL being intercepted
 
+> **Good to know:** If your deployment runs Proxy/Middleware behind your CDN (instead of in front of the cache), configure your CDN or cache layer to bypass caching for requests that depend on Proxy/Middleware decisions. Otherwise, the CDN can serve a cached response without running Proxy/Middleware first, and it will stop being the source of truth for auth, redirects, and rewrites.
+
 Many CDNs don't support `Vary` without additional configuration. Next.js addresses this with the `_rsc` search parameter: a hash of the relevant request header values that acts as a cache-key, ensuring different response variants get different cache keys. This ensures correct responses even on CDNs that ignore `Vary`.
 
 ## Handling Headers at the CDN


### PR DESCRIPTION
## Summary
- add a Good to know note in the CDN Caching guide
- clarify that if Proxy/Middleware runs behind the CDN cache, middleware-dependent requests should bypass cache so Proxy/Middleware remains the source of truth