### PR TITLE
Restart the `next dev` server if `.next` is deleted

### DIFF
--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -524,18 +524,27 @@ export async function startServer(
     server.listen(port, hostname)
   })
 
+  // Watch config files for changes and distDir ancestors for deletion.
   if (isDev) {
-    // Watch config files for changes and distDir ancestors for deletion.
-    // Ancestors are watched so that deleting a parent (e.g. `rm -rf .next`)
-    // is detected by a DirectoryWatcher that still exists on the project root.
+    // Note: dir is absolute and normalized (`..` segments removed), `absDistDir`
+    // is also normalized because `path.join()` performs normalization. `distDir`
+    // does not have to be inside of `dir`!
     const absDistDir = path.join(dir, distDir)
-    const distDirWatchPaths: string[] = []
-    for (
-      let current = absDistDir;
-      current !== dir && current.startsWith(dir + path.sep);
-      current = path.dirname(current)
-    ) {
-      distDirWatchPaths.push(current)
+    // always watch dir and absDistDir
+    const dirWatchPaths: string[] = [dir, absDistDir]
+    // also watch ancestors of absDistDir that are inside of dir.
+    let prevAncestor = absDistDir
+    while (true) {
+      const nextAncestor = path.dirname(prevAncestor)
+      // note: `dirname('/') === '/'` if we happen to reach the FS root
+      if (
+        !nextAncestor.startsWith(dir + path.sep) ||
+        nextAncestor === prevAncestor
+      ) {
+        break
+      }
+      dirWatchPaths.push(nextAncestor)
+      prevAncestor = nextAncestor
     }
 
     const configFiles = CONFIG_FILES.map((file) => path.join(dir, file))
@@ -543,7 +552,7 @@ export async function startServer(
     const wp = new Watchpack()
     wp.watch({
       files: configFiles,
-      missing: distDirWatchPaths,
+      missing: dirWatchPaths,
     })
     wp.on('change', async (filename) => {
       if (!configFiles.includes(filename)) {
@@ -557,9 +566,11 @@ export async function startServer(
       process.exit(RESTART_EXIT_CODE)
     })
     wp.on('remove', (removedPath: string) => {
-      if (distDirWatchPaths.includes(removedPath)) {
-        Log.warn(
-          `The ${path.basename(absDistDir)} directory was deleted. Restarting the server...`
+      if (dirWatchPaths.includes(removedPath)) {
+        Log.error(
+          `The directory at "${removedPath}" was deleted.\n\n` +
+            'Deleting this directory while Next.js is running can lead to ' +
+            'undefined behavior. Restarting the server to recover...'
         )
         process.exit(RESTART_EXIT_CODE)
       }

--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -532,7 +532,7 @@ export async function startServer(
     const distDirWatchPaths: string[] = []
     for (
       let current = absDistDir;
-      current !== dir;
+      current !== dir && current.startsWith(dir + path.sep);
       current = path.dirname(current)
     ) {
       distDirWatchPaths.push(current)

--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -549,13 +549,6 @@ export async function startServer(
       if (!configFiles.includes(filename)) {
         return
       }
-      if (process.env.__NEXT_DISABLE_MEMORY_WATCHER) {
-        Log.info(
-          `Detected change, manual restart required due to '__NEXT_DISABLE_MEMORY_WATCHER' usage`
-        )
-        return
-      }
-
       Log.warn(
         `Found a change in ${path.basename(
           filename

--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -525,17 +525,30 @@ export async function startServer(
   })
 
   if (isDev) {
-    function watchConfigFiles(
-      dirToWatch: string,
-      onChange: (filename: string) => void
+    // Watch config files for changes and distDir ancestors for deletion.
+    // Ancestors are watched so that deleting a parent (e.g. `rm -rf .next`)
+    // is detected by a DirectoryWatcher that still exists on the project root.
+    const absDistDir = path.join(dir, distDir)
+    const distDirWatchPaths: string[] = []
+    for (
+      let current = absDistDir;
+      current !== dir;
+      current = path.dirname(current)
     ) {
-      const wp = new Watchpack()
-      wp.watch({
-        files: CONFIG_FILES.map((file) => path.join(dirToWatch, file)),
-      })
-      wp.on('change', onChange)
+      distDirWatchPaths.push(current)
     }
-    watchConfigFiles(dir, async (filename) => {
+
+    const configFiles = CONFIG_FILES.map((file) => path.join(dir, file))
+
+    const wp = new Watchpack()
+    wp.watch({
+      files: configFiles,
+      missing: distDirWatchPaths,
+    })
+    wp.on('change', async (filename) => {
+      if (!configFiles.includes(filename)) {
+        return
+      }
       if (process.env.__NEXT_DISABLE_MEMORY_WATCHER) {
         Log.info(
           `Detected change, manual restart required due to '__NEXT_DISABLE_MEMORY_WATCHER' usage`
@@ -550,30 +563,7 @@ export async function startServer(
       )
       process.exit(RESTART_EXIT_CODE)
     })
-
-    // Watch for deletion of the distDir (e.g. `rm -rf .next`). When the
-    // build output directory is removed the dev server cannot serve
-    // correctly, so we trigger a full restart to rebuild it.
-    //
-    // Watchpack creates a DirectoryWatcher on the *parent* of each watched
-    // path. If we only watched `.next/dev`, the DirectoryWatcher would be on
-    // `.next` — but when `.next` itself is deleted, the inotify fd is
-    // destroyed and no event fires for `.next/dev`. By also watching all
-    // ancestor directories up to (but not including) the project root, we
-    // ensure there is always a DirectoryWatcher on a surviving parent that
-    // can detect the deletion.
-    const absDistDir = path.join(dir, distDir)
-    const distDirWatchPaths: string[] = []
-    for (
-      let current = absDistDir;
-      current !== dir;
-      current = path.dirname(current)
-    ) {
-      distDirWatchPaths.push(current)
-    }
-    const distDirWp = new Watchpack()
-    distDirWp.watch({ missing: distDirWatchPaths })
-    distDirWp.on('remove', (removedPath: string) => {
+    wp.on('remove', (removedPath: string) => {
       if (distDirWatchPaths.includes(removedPath)) {
         Log.warn(
           `The ${path.basename(absDistDir)} directory was deleted. Restarting the server...`

--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -550,6 +550,24 @@ export async function startServer(
       )
       process.exit(RESTART_EXIT_CODE)
     })
+
+    // Watch for deletion of the distDir (e.g. `rm -rf .next`). When the
+    // build output directory is removed the dev server cannot serve
+    // correctly, so we trigger a full restart to rebuild it.
+    const absDistDir = path.join(dir, distDir)
+    let distDirExists = fs.existsSync(absDistDir)
+    const distDirPollInterval = setInterval(() => {
+      const exists = fs.existsSync(absDistDir)
+      if (distDirExists && !exists) {
+        clearInterval(distDirPollInterval)
+        Log.warn(
+          `The ${path.basename(absDistDir)} directory was deleted. Restarting the server...`
+        )
+        process.exit(RESTART_EXIT_CODE)
+      }
+      distDirExists = exists
+    }, 500)
+    distDirPollInterval.unref()
   }
 
   return { distDir }

--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -554,20 +554,33 @@ export async function startServer(
     // Watch for deletion of the distDir (e.g. `rm -rf .next`). When the
     // build output directory is removed the dev server cannot serve
     // correctly, so we trigger a full restart to rebuild it.
+    //
+    // Watchpack creates a DirectoryWatcher on the *parent* of each watched
+    // path. If we only watched `.next/dev`, the DirectoryWatcher would be on
+    // `.next` — but when `.next` itself is deleted, the inotify fd is
+    // destroyed and no event fires for `.next/dev`. By also watching all
+    // ancestor directories up to (but not including) the project root, we
+    // ensure there is always a DirectoryWatcher on a surviving parent that
+    // can detect the deletion.
     const absDistDir = path.join(dir, distDir)
-    let distDirExists = fs.existsSync(absDistDir)
-    const distDirPollInterval = setInterval(() => {
-      const exists = fs.existsSync(absDistDir)
-      if (distDirExists && !exists) {
-        clearInterval(distDirPollInterval)
+    const distDirWatchPaths: string[] = []
+    for (
+      let current = absDistDir;
+      current !== dir;
+      current = path.dirname(current)
+    ) {
+      distDirWatchPaths.push(current)
+    }
+    const distDirWp = new Watchpack()
+    distDirWp.watch({ missing: distDirWatchPaths })
+    distDirWp.on('remove', (removedPath: string) => {
+      if (distDirWatchPaths.includes(removedPath)) {
         Log.warn(
           `The ${path.basename(absDistDir)} directory was deleted. Restarting the server...`
         )
         process.exit(RESTART_EXIT_CODE)
       }
-      distDirExists = exists
-    }, 500)
-    distDirPollInterval.unref()
+    })
   }
 
   return { distDir }

--- a/test/development/app-dir/watch-distdir-deletion/fixture/app/layout.js
+++ b/test/development/app-dir/watch-distdir-deletion/fixture/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/watch-distdir-deletion/fixture/app/page.js
+++ b/test/development/app-dir/watch-distdir-deletion/fixture/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/development/app-dir/watch-distdir-deletion/fixture/next.config.js
+++ b/test/development/app-dir/watch-distdir-deletion/fixture/next.config.js
@@ -1,0 +1,5 @@
+const nextConfig = {
+  reactStrictMode: true,
+}
+
+module.exports = nextConfig

--- a/test/development/app-dir/watch-distdir-deletion/index.test.ts
+++ b/test/development/app-dir/watch-distdir-deletion/index.test.ts
@@ -28,7 +28,7 @@ describe('app-dir watch-distdir-deletion', () => {
     await retry(
       async () => {
         expect(next.cliOutput).toMatch(
-          /The .* directory was deleted\. Restarting the server\.\.\./
+          /The directory at .* was deleted/
         )
       },
       30_000,

--- a/test/development/app-dir/watch-distdir-deletion/index.test.ts
+++ b/test/development/app-dir/watch-distdir-deletion/index.test.ts
@@ -1,0 +1,48 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+import fs from 'fs'
+import path from 'path'
+
+describe('app-dir watch-distdir-deletion', () => {
+  const { next } = nextTestSetup({
+    files: path.join(__dirname, 'fixture'),
+  })
+
+  it('should restart the server when distDir is deleted', async () => {
+    // Wait for the dev server to be ready
+    await retry(async () => {
+      expect(next.cliOutput).toMatch(/ready/i)
+    })
+
+    // Make a request first to ensure the dev server has compiled
+    const warmupRes = await next.fetch('/')
+    expect(warmupRes.status).toBe(200)
+
+    // Delete .next (which also removes .next/dev, the watched distDir)
+    await fs.promises.rm(path.join(next.testDir, '.next'), {
+      recursive: true,
+      force: true,
+    })
+
+    // Wait for restart message and server to come back up
+    await retry(
+      async () => {
+        expect(next.cliOutput).toMatch(
+          /The .* directory was deleted\. Restarting the server\.\.\./
+        )
+      },
+      30_000,
+      1000
+    )
+
+    // Server should come back up and serve pages
+    await retry(
+      async () => {
+        const res = await next.fetch('/')
+        expect(res.status).toBe(200)
+      },
+      30_000,
+      1000
+    )
+  })
+})

--- a/test/development/app-dir/watch-distdir-deletion/index.test.ts
+++ b/test/development/app-dir/watch-distdir-deletion/index.test.ts
@@ -27,9 +27,7 @@ describe('app-dir watch-distdir-deletion', () => {
     // Wait for restart message and server to come back up
     await retry(
       async () => {
-        expect(next.cliOutput).toMatch(
-          /The directory at .* was deleted/
-        )
+        expect(next.cliOutput).toMatch(/The directory at .* was deleted/)
       },
       30_000,
       1000


### PR DESCRIPTION
This PR is AI generated.

If this directory is deleted while the dev server is running, we can't reasonably recover, so we should restart the process.

Addresses https://vercel.slack.com/archives/C03KAR5DCKC/p1774757692640999