### PR TITLE
fix: return 405 for non-GET/HEAD requests to static files (#92141)

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -1926,6 +1926,17 @@ export default abstract class Server<
       (req.url?.match(/^\/_next\//) ||
         (this.hasStaticDir && req.url!.match(/^\/static\//)))
     ) {
+      // Static files only support GET and HEAD methods.
+      // Return 405 Method Not Allowed for any other method to prevent
+      // the request from falling into the page rendering pipeline,
+      // which would result in a 500 error. (see: #92141)
+      if (req.method !== 'GET' && req.method !== 'HEAD') {
+        res.statusCode = 405
+        res.setHeader('Allow', ['GET', 'HEAD'])
+        res.body('Method Not Allowed').send()
+        return
+      }
+
       return this.handleRequest(req, res, parsedUrl)
     }
 

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -537,11 +537,10 @@ export async function initialize(opts: {
           }
         }
         if (!(req.method === 'GET' || req.method === 'HEAD')) {
-          res.setHeader('Allow', ['GET', 'HEAD'])
           res.statusCode = 405
-          return await invokeRender(parseUrlUtil('/405'), '/405', handleIndex, {
-            invokeStatus: 405,
-          })
+          res.setHeader('Allow', 'GET, HEAD')
+          res.end('Method Not Allowed')
+          return
         }
 
         try {

--- a/test/production/options-request/options-request.test.ts
+++ b/test/production/options-request/options-request.test.ts
@@ -46,4 +46,36 @@ describe('options-request', () => {
     const res = await next.fetch('/non-existent-route', { method: 'OPTIONS' })
     expect(res.status).toBe(404)
   })
+
+  describe('static file paths (_next/static)', () => {
+    async function getStaticFileUrl(): Promise<string> {
+      const res = await next.fetch('/')
+      const html = await res.text()
+      const match = html.match(/\/_next\/static\/[^"']+\.js/)
+      if (!match) throw new Error('Could not find static file URL in HTML')
+      return match[0]
+    }
+
+    it('should return 200 for GET request to _next/static', async () => {
+      const url = await getStaticFileUrl()
+      const res = await next.fetch(url)
+      expect(res.status).toBe(200)
+    })
+
+    it('should return 200 for HEAD request to _next/static', async () => {
+      const url = await getStaticFileUrl()
+      const res = await next.fetch(url, { method: 'HEAD' })
+      expect(res.status).toBe(200)
+    })
+
+    it.each(['OPTIONS', 'POST', 'PUT', 'DELETE', 'PATCH'])(
+      'should return 405 for %s request to _next/static',
+      async (method) => {
+        const url = await getStaticFileUrl()
+        const res = await next.fetch(url, { method })
+        expect(res.status).toBe(405)
+        expect(res.headers.get('allow')).toBe('GET, HEAD')
+      }
+    )
+  })
 })


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

### What?

Return **405 Method Not Allowed** instead of 500/400 for non-GET/HEAD requests (e.g. `OPTIONS`, `POST`) to `/_next/static/` and `/static/` paths.

### Why?

Fixes #92141

In production mode (`next start`), sending a non-GET/HEAD request to a static file path caused incorrect responses:

- **`OPTIONS`** → **400** — the render pipeline's blanket OPTIONS guard (`base-server.ts:2397`) overrode the 405 that `router-server.ts` intended to return via `invokeRender`
- **`POST`, `PUT`, etc.** → **500** — the request fell through to the page rendering pipeline and crashed

Static files should only be served via `GET` or `HEAD`. Any other method should be cleanly rejected with `405` and an `Allow: GET, HEAD` header, per [RFC 9110 §15.5.6](https://httpwg.org/specs/rfc9110.html#status.405).

### How?

Two layers of fix:

1. **`packages/next/src/server/lib/router-server.ts`** — Send the 405 response directly via `res.end('Method Not Allowed')` instead of calling `invokeRender()`. This avoids entering the render pipeline entirely, which was the root cause of the OPTIONS→400 override.

2. **`packages/next/src/server/base-server.ts`** — Add a method check in `renderImpl()` before `this.handleRequest()` as defense-in-depth for custom server scenarios that call `render()` directly.

3. **`test/production/options-request/options-request.test.ts`** — Added 7 test cases to the existing suite covering `_next/static` paths for GET, HEAD, OPTIONS, POST, PUT, DELETE, and PATCH.

### Test Plan

- [x] All 14 tests pass (7 existing + 7 new) via `pnpm test-start-turbo test/production/options-request/`
- [x] `GET` / `HEAD` → 200
- [x] `OPTIONS` / `POST` / `PUT` / `DELETE` / `PATCH` → 405 with `Allow: GET, HEAD` header