### PR TITLE
Turbopack: use same hash for immutable-static-hashes.json

### DIFF
--- a/crates/next-api/src/project_asset_hashes_manifest.rs
+++ b/crates/next-api/src/project_asset_hashes_manifest.rs
@@ -142,7 +142,7 @@ impl Asset for AssetHashesManifestAsset {
             .map(async |(asset, path)| {
                 Ok((
                     path,
-                    asset.content_hash(HashAlgorithm::Xxh3Hash128Hex).await?,
+                    asset.content_hash(HashAlgorithm::Xxh3Hash128Base38).await?,
                 ))
             })
             .try_join()

--- a/test/production/deployment-id-handling/app/my-adapter.mjs
+++ b/test/production/deployment-id-handling/app/my-adapter.mjs
@@ -1,0 +1,9 @@
+import fs from 'fs/promises'
+
+/** @type {import('next').NextAdapter } */
+export default {
+  name: 'deployment-id-handling',
+  async onBuildComplete(ctx) {
+    await fs.writeFile('build-complete.json', JSON.stringify(ctx, null, 2))
+  },
+}

--- a/test/production/deployment-id-handling/app/next.config.js
+++ b/test/production/deployment-id-handling/app/next.config.js
@@ -9,4 +9,6 @@ module.exports = {
       ? `imm-${process.env.IMMUTABLE_ASSET_TOKEN}`
       : undefined,
   },
+  adapterPath:
+    process.env.NEXT_ADAPTER_PATH ?? require.resolve('./my-adapter.mjs'),
 }

--- a/test/production/deployment-id-handling/deployment-id-handling.test.ts
+++ b/test/production/deployment-id-handling/deployment-id-handling.test.ts
@@ -1,4 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
+import { NextAdapter } from 'next'
 import { retry } from 'next-test-utils'
 import { join } from 'node:path'
 
@@ -182,6 +183,29 @@ describe.each([
         (headers) => headers['x-deployment-id'] === deploymentId
       )
     })
+
+    if (envKey === 'IMMUTABLE_ASSET_TOKEN') {
+      it('should emit hashes to adapter', async () => {
+        const { outputs }: Parameters<NextAdapter['onBuildComplete']>[0] =
+          await next.readJSON('build-complete.json')
+
+        const immutableAssets = outputs.staticFiles.filter(
+          (a) =>
+            a.pathname.startsWith('/_next/static/') &&
+            !(
+              a.pathname.endsWith('/_buildManifest.js') ||
+              a.pathname.endsWith('/_clientMiddlewareManifest.js') ||
+              a.pathname.endsWith('/_ssgManifest.js')
+            )
+        )
+        expect(immutableAssets).not.toBeEmpty()
+        expect(immutableAssets).toSatisfyAll(
+          (f) =>
+            // Should be same hash as in the filename, for better build performance
+            f.immutableHash && f.pathname.includes(f.immutableHash.slice(0, 13))
+        )
+      })
+    }
   }
 )
 


### PR DESCRIPTION
Use the same hash in the manifest as we use for the filenames. Otherwise the hash isn't actually free as we need to hash every file content twice.

Regression from https://github.com/vercel/next.js/pull/91137

Previously it looked like this
<img width="781" height="437" alt="Bildschirmfoto 2026-03-31 um 16 24 00" src="https://github.com/user-attachments/assets/76e2befb-0419-4012-9878-b4f7e3df54d0" />


<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows 
the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
