### PR TITLE
[test] Skip flaky `segment-cache-refresh` suite

### DIFF
--- a/test/e2e/app-dir/segment-cache/refresh/segment-cache-refresh.test.ts
+++ b/test/e2e/app-dir/segment-cache/refresh/segment-cache-refresh.test.ts
@@ -2,7 +2,8 @@ import { nextTestSetup } from 'e2e-utils'
 import type * as Playwright from 'playwright'
 import { createRouterAct } from 'router-act'
 
-describe('segment cache (refresh)', () => {
+// Disabled because too flaky
+describe.skip('segment cache (refresh)', () => {
   const { next, isNextDev } = nextTestSetup({
     files: __dirname,
   })


### PR DESCRIPTION
See https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40test.source.file%3Atest%2Fe2e%2Fapp-dir%2Fsegment-cache%2Frefresh%2Fsegment-cache-refresh.test.ts&agg_m=count&agg_m_source=base&agg_t=count&citest_explorer_sort=timestamp%2Cdesc&cols=%40test.status%2Ctimestamp%2C%40duration%2C%40test.type%2C%40test.name%2C%40test_session.name&currentTab=overview&eventStack=&fromUser=true&index=citest&start=1769792928107&end=1774976928107&paused=true