### PR TITLE
Turbopack: fix panic on CPUs without BMI2 instructions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2362,6 +2362,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "foldhash-portable"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "631c01cdb9b602a84f0ef5e813d3691936aade6d390dba117f28aa03eb4d0e09"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5674,13 +5680,13 @@ dependencies = [
 
 [[package]]
 name = "qfilter"
-version = "0.3.0-alpha.2"
+version = "0.3.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd0ea20afc2eab082dde00f58d9e83ed70dcb693fa88c23890e122e19355635"
+checksum = "edd9c903cd64233eb97cf95d96d58645c2b1c0154d30ff835f3bb4be417158b1"
 dependencies = [
+ "foldhash-portable",
  "serde",
  "serde_bytes",
- "xxhash-rust",
 ]
 
 [[package]]

--- a/turbopack/crates/turbo-persistence/Cargo.toml
+++ b/turbopack/crates/turbo-persistence/Cargo.toml
@@ -26,7 +26,7 @@ memmap2 = "0.9.5"
 nohash-hasher = { workspace = true }
 parking_lot = { workspace = true }
 pot = "3.0.0"
-qfilter = { version = "0.3.0-alpha.2", features = ["serde"] }
+qfilter = { version = "0.3.0-alpha.4", features = ["serde", "legacy_x86_64_support"] }
 quick_cache = { workspace = true }
 rustc-hash = { workspace = true }
 smallvec = { workspace = true }


### PR DESCRIPTION
### What?

Updates `qfilter` from `0.3.0-alpha.2` to `0.3.0-alpha.4` and enables the `legacy_x86_64_support` feature in `turbo-persistence`.

### Why?

`qfilter` calls `check_cpu_support()` at filter construction time, which asserts `is_x86_feature_detected!("bmi2")`. On pre-Haswell CPUs (i3/i5-3xxx, Celeron, Pentium), VMs with CPU compatibility mode enabled, and some ARM environments, that assertion panics and kills tokio worker threads.

This started showing up consistently in 16.2.0 because `turbopackFileSystemCacheForDev` now defaults to `true` in `defaultConfig`, making qfilter active in every dev session by default.

### How?

`qfilter 0.3.0-alpha.3` added `legacy_x86_64_support`, which puts the BMI2 runtime assertion behind `#[cfg(not(feature = "legacy_x86_64_support"))]` and compiles in a software PDEP/PEXT fallback. Enabling it means the panic path never gets compiled in.

One tradeoff: the turbopack binary targets generic x86_64 without `+bmi2`, so all x86_64 builds use the software PDEP path regardless of whether the hardware instruction is available. For dependency tracking the difference is not meaningful.

Fixes #91708