### PR TITLE
Improve revalidateTag JSDoc to include guidance about required second parameter

### DIFF
--- a/packages/next/src/server/web/spec-extension/revalidate.ts
+++ b/packages/next/src/server/web/spec-extension/revalidate.ts
@@ -24,6 +24,10 @@ type CacheLifeConfig = {
 /**
  * This function allows you to purge [cached data](https://nextjs.org/docs/app/building-your-application/caching) on-demand for a specific cache tag.
  *
+ * The second argument specifies a [`cacheLife`](https://nextjs.org/docs/app/api-reference/functions/cacheLife#reference) profile
+ * (e.g. `"max"`), or a `{ expire }` object. For immediate expiration in Server Actions, use
+ * [`updateTag`](https://nextjs.org/docs/app/api-reference/functions/updateTag) instead.
+ *
  * Read more: [Next.js Docs: `revalidateTag`](https://nextjs.org/docs/app/api-reference/functions/revalidateTag)
  */
 export function revalidateTag(tag: string, profile: string | CacheLifeConfig) {


### PR DESCRIPTION
### What?

Improved the JSDoc comment on `revalidateTag` to explain the required second `profile` parameter, linking to `cacheLife` profile docs and mentioning `updateTag` as an alternative for immediate expiration.

### Why?

The TypeScript error "Expected 2 arguments, but got 1" at `revalidateTag` call sites gives no actionable guidance. When users hover over the function in their IDE, the existing JSDoc only says "purge cached data on-demand" — nothing about what the second argument should be or what alternatives exist.

### How?

Added a prose paragraph to the JSDoc describing the `profile` parameter (a `cacheLife` profile like `"max"` or a `{ expire }` object) and pointing users to `updateTag` for immediate expiration in Server Actions. Follows the established JSDoc conventions in the file (no `@param`, `@example`, or `@see` tags).

## PR checklist (Fixing a bug)

- Errors have a helpful link attached: links to `cacheLife` reference, `updateTag` docs, and `revalidateTag` docs