### PR TITLE
docs: local images referenced by remote source

### DIFF
--- a/docs/01-app/01-getting-started/12-images.mdx
+++ b/docs/01-app/01-getting-started/12-images.mdx
@@ -117,6 +117,50 @@ export default function Page() {
 }
 ```
 
+### Images without static imports
+
+If you can't use a static `import` for your images, you can use a dynamic `import()` in a Server Component to still get automatic `width`, `height`, and `blurDataURL`:
+
+```tsx filename="app/blog/[slug]/page.tsx" switcher
+import Image from 'next/image'
+
+async function PostImage({
+  imageFilename,
+  alt,
+}: {
+  imageFilename: string
+  alt: string
+}) {
+  const { default: image } = await import(
+    `../content/blog/images/${imageFilename}`
+  )
+  // image contains width, height, and blurDataURL
+  return <Image src={image} alt={alt} />
+}
+```
+
+```jsx filename="app/blog/[slug]/page.js" switcher
+import Image from 'next/image'
+
+async function PostImage({ imageFilename, alt }) {
+  const { default: image } = await import(
+    `../content/blog/images/${imageFilename}`
+  )
+  // image contains width, height, and blurDataURL
+  return <Image src={image} alt={alt} />
+}
+```
+
+If you have a [path alias](https://www.typescriptlang.org/tsconfig/#paths) configured (e.g. `@/`), you can use it instead of a relative path:
+
+```tsx
+const { default: image } = await import(
+  `@/content/blog/images/${imageFilename}`
+)
+```
+
+The path must include a static prefix (like `../content/blog/images/`). Be as specific as possible, since **all** files matching that prefix are bundled. Only files in your specified directory are included, so external input cannot reach outside of it.
+
 ## Remote images
 
 To use a remote image, you can provide a URL string for the `src` property.
@@ -190,49 +234,3 @@ module.exports = {
   },
 }
 ```
-
-### Remote references to local images
-
-If your remote source provides image filenames that reference local images, you can use a dynamic `import()` in a Server Component to resolve the image automatically, so you don't have to declare `width`, `height`, or `blurDataURL` manually:
-
-```tsx filename="app/blog/[slug]/page.tsx" switcher
-import Image from 'next/image'
-
-async function PostImage({
-  imageFilename,
-  alt,
-}: {
-  imageFilename: string
-  alt: string
-}) {
-  const { default: image } = await import(
-    `../content/blog/images/${imageFilename}`
-  )
-  // image contains width, height, and blurDataURL
-  return <Image src={image} alt={alt} />
-}
-```
-
-```jsx filename="app/blog/[slug]/page.js" switcher
-import Image from 'next/image'
-
-async function PostImage({ imageFilename, alt }) {
-  const { default: image } = await import(
-    `../content/blog/images/${imageFilename}`
-  )
-  // image contains width, height, and blurDataURL
-  return <Image src={image} alt={alt} />
-}
-```
-
-If you have a [path alias](https://www.typescriptlang.org/tsconfig/#paths) configured (e.g. `@/`), you can use it instead of a relative path:
-
-```tsx
-const { default: image } = await import(
-  `@/content/blog/images/${imageFilename}`
-)
-```
-
-The path must include a static prefix (like `../content/blog/images/`). Be as specific as possible, since **all** files matching that prefix are resolved at dev and build time.
-
-Matching files are grouped into a finite lookup, so only files in your specified directory are included. A remote source cannot reach outside of it.

--- a/docs/01-app/01-getting-started/12-images.mdx
+++ b/docs/01-app/01-getting-started/12-images.mdx
@@ -190,3 +190,49 @@ module.exports = {
   },
 }
 ```
+
+### Remote references to local images
+
+If your remote source provides image filenames that reference local images, you can use a dynamic `import()` in a Server Component to resolve the image automatically, so you don't have to declare `width`, `height`, or `blurDataURL` manually:
+
+```tsx filename="app/blog/[slug]/page.tsx" switcher
+import Image from 'next/image'
+
+async function PostImage({
+  imageFilename,
+  alt,
+}: {
+  imageFilename: string
+  alt: string
+}) {
+  const { default: image } = await import(
+    `../content/blog/images/${imageFilename}`
+  )
+  // image contains width, height, and blurDataURL
+  return <Image src={image} alt={alt} />
+}
+```
+
+```jsx filename="app/blog/[slug]/page.js" switcher
+import Image from 'next/image'
+
+async function PostImage({ imageFilename, alt }) {
+  const { default: image } = await import(
+    `../content/blog/images/${imageFilename}`
+  )
+  // image contains width, height, and blurDataURL
+  return <Image src={image} alt={alt} />
+}
+```
+
+If you have a [path alias](https://www.typescriptlang.org/tsconfig/#paths) configured (e.g. `@/`), you can use it instead of a relative path:
+
+```tsx
+const { default: image } = await import(
+  `@/content/blog/images/${imageFilename}`
+)
+```
+
+The path must include a static prefix (like `../content/blog/images/`). Be as specific as possible, since **all** files matching that prefix are resolved at dev and build time.
+
+Matching files are grouped into a finite lookup, so only files in your specified directory are included. A remote source cannot reach outside of it.


### PR DESCRIPTION
It was discovered that one could let a remote source, safely-ish, load local images, which has the benefit of providing, width, height, src, and blur-* props which we could pass to next/image. 

Closes: https://linear.app/vercel/issue/DOC-6288/local-images-referenced-by-a-remote-source