### PR TITLE
Turbopack: Write trace file to .next-profiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ test/node_modules
 pids
 *.cpuprofile
 *.heapsnapshot
+.next-profiles
 
 # coverage
 .nyc_output

--- a/contributing/turbopack/tracing.md
+++ b/contributing/turbopack/tracing.md
@@ -20,7 +20,7 @@ Alternatively, any directives syntax supported by [`tracing_subscriber::filter::
 >
 > For the more detailed tracing a custom Next.js build is required. See [Developing] for more information how to create one.
 
-With this environment variable, Next.js will write a `.next/trace-turbopack` file with the tracing information in a binary format.
+With this environment variable, Next.js will write a `.next-profiles/trace-turbopack` file with the tracing information in a binary format.
 
 [presets]: https://github.com/vercel/next.js/blob/c506c0de1d6f17ad400ad5aa85edaae23b6b44d2/packages/next-swc/crates/napi/src/next_api/project.rs#L218
 [directives]: https://tracing.rs/tracing_subscriber/filter/struct.envfilter#directives
@@ -28,7 +28,7 @@ With this environment variable, Next.js will write a `.next/trace-turbopack` fil
 
 ## Viewer
 
-To visualize the content of `.next/trace-turbopack`, use the [turbo-trace-viewer].
+To visualize the content of `.next-profiles/trace-turbopack`, use the [turbo-trace-viewer].
 
 A video showing how to use the tool [is available here][youtube-tutorial].
 
@@ -38,7 +38,7 @@ This tool connects a WebSocket on port 57475 on localhost to connect to the trac
 cargo run --bin turbo-trace-server --release -- /path/to/your/trace-turbopack
 
 # or
-pnpm next internal trace .next/trace-turbopack
+pnpm next internal trace .next-profiles/trace-turbopack
 ```
 
 Once the server is started, open <https://trace.nextjs.org/> in your browser.

--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -468,7 +468,7 @@ pub fn project_new(
     if let Some(mut trace) = trace {
         let internal_dir = PathBuf::from(&options.root_path)
             .join(&options.project_path)
-            .join(&options.dist_dir);
+            .join(".next-profiles");
         let trace_file = internal_dir.join("trace-turbopack");
 
         println!("Turbopack tracing enabled with targets: {trace}");
@@ -509,7 +509,7 @@ pub fn project_new(
         let subscriber = subscriber.with(FilterLayer::try_new(&trace).unwrap());
 
         std::fs::create_dir_all(&internal_dir)
-            .context("Unable to create .next directory")
+            .context("Unable to create .next-profiles directory")
             .unwrap();
         let (trace_writer, trace_writer_guard) = match compress {
             Compression::None => {

--- a/docs/01-app/02-guides/local-development.mdx
+++ b/docs/01-app/02-guides/local-development.mdx
@@ -253,23 +253,23 @@ It provides detailed information about the time taken for each module to compile
 
 1. Navigate around your application or make edits to files to reproduce the problem.
 1. Stop the Next.js development server.
-1. A file called `trace-turbopack` will be available in the `.next/dev` folder.
+1. A file called `trace-turbopack` will be available in the `.next-profiles` folder.
 1. You can interpret the file using `npx next internal trace [path-to-file]`:
 
    ```bash
-   npx next internal trace .next/dev/trace-turbopack
+   npx next internal trace .next-profiles/trace-turbopack
    ```
 
    On versions where `trace` is not available, the command was named `turbo-trace-server`:
 
    ```bash
-   npx next internal turbo-trace-server .next/dev/trace-turbopack
+   npx next internal turbo-trace-server .next-profiles/trace-turbopack
    ```
 
 1. Once the trace server is running you can view the trace at https://trace.nextjs.org/.
 1. By default the trace viewer will aggregate timings, in order to see each individual time you can switch from "Aggregated in order" to "Spans in order" at the top right of the viewer.
 
-> **Good to know**: The trace file is placed under the development server directory, which defaults to `.next/dev`.
+> **Good to know**: The trace file is placed in the `.next-profiles` directory at the project root.
 
 ### Still having problems?
 

--- a/docs/01-app/02-guides/upgrading/version-16.mdx
+++ b/docs/01-app/02-guides/upgrading/version-16.mdx
@@ -921,22 +921,22 @@ module.exports = {
 
 Additionally, a lockfile mechanism prevents multiple `next dev` or `next build` instances on the same project.
 
-Since the development server outputs to `.next/dev`, the [Turbopack tracing command](/docs/app/guides/local-development#turbopack-tracing) should be:
+The [Turbopack tracing command](/docs/app/guides/local-development#turbopack-tracing) should be:
 
 ```bash package="pnpm"
-pnpm next internal trace .next/dev/trace-turbopack
+pnpm next internal trace .next-profiles/trace-turbopack
 ```
 
 ```bash package="npm"
-npx next internal trace .next/dev/trace-turbopack
+npx next internal trace .next-profiles/trace-turbopack
 ```
 
 ```bash package="yarn"
-yarn next internal trace .next/dev/trace-turbopack
+yarn next internal trace .next-profiles/trace-turbopack
 ```
 
 ```bash package="bun"
-bunx next internal trace .next/dev/trace-turbopack
+bunx next internal trace .next-profiles/trace-turbopack
 ```
 
 ## Parallel Routes `default.js` requirement

--- a/docs/01-app/03-api-reference/08-turbopack.mdx
+++ b/docs/01-app/03-api-reference/08-turbopack.mdx
@@ -304,9 +304,7 @@ If you encounter performance or memory issues and want to help the Next.js team 
 NEXT_TURBOPACK_TRACING=1 next dev
 ```
 
-This will produce a `.next/dev/trace-turbopack` file. Include that file when creating a GitHub issue on the [Next.js repo](https://github.com/vercel/next.js) to help us investigate.
-
-By default the development server outputs to `.next/dev`.
+This will produce a `.next-profiles/trace-turbopack` file. Include that file when creating a GitHub issue on the [Next.js repo](https://github.com/vercel/next.js) to help us investigate.
 
 ## Summary
 


### PR DESCRIPTION
## What?

Builds on #92078. Also writes the Turbopack trace to the same .next-profiles directory.