### PR TITLE
Turbopack: Add --internal-trace cli flag

### DIFF
--- a/packages/next/src/bin/next.ts
+++ b/packages/next/src/bin/next.ts
@@ -386,7 +386,9 @@ program
       }
       if (options.internalTrace) {
         process.env.NEXT_TURBOPACK_TRACING =
-          options.internalTrace === 'overview' ? '1' : 'turbo-tasks'
+          options.internalTrace === 'all'
+            ? 'turbo-tasks'
+            : options.internalTrace
       }
       const portSource = _optionValueSources.port
       import('../cli/next-dev.js').then((mod) =>

--- a/packages/next/src/bin/next.ts
+++ b/packages/next/src/bin/next.ts
@@ -208,6 +208,14 @@ program
     '--experimental-cpu-prof',
     'Enable CPU profiling. Profile is saved to .next-profiles/ on exit.'
   )
+  .addOption(
+    new Option(
+      '--internal-trace [level]',
+      'Enable Turbopack tracing. "all" (default) enables turbo-tasks level tracing, "overview" enables overview tracing.'
+    )
+      .choices(['all', 'overview'])
+      .preset('all')
+  )
   .action((directory: string, options: NextBuildOptions) => {
     if (options.debugPrerender) {
       // @ts-expect-error not readonly
@@ -224,6 +232,10 @@ program
       const cpuProfileDir = join(dir, '.next-profiles')
       mkdirSync(cpuProfileDir, { recursive: true })
       process.env.NEXT_CPU_PROF_DIR = cpuProfileDir
+    }
+    if (options.internalTrace) {
+      process.env.NEXT_TURBOPACK_TRACING =
+        options.internalTrace === 'overview' ? '1' : 'turbo-tasks'
     }
 
     // ensure process exits after build completes so open handles/connections
@@ -350,6 +362,14 @@ program
     '--experimental-cpu-prof',
     'Enable CPU profiling. Profiles are saved to .next-profiles/ on exit.'
   )
+  .addOption(
+    new Option(
+      '--internal-trace [level]',
+      'Enable Turbopack tracing. "all" (default) enables turbo-tasks level tracing, "overview" enables overview tracing.'
+    )
+      .choices(['all', 'overview'])
+      .preset('all')
+  )
   .action(
     (directory: string, options: NextDevOptions, { _optionValueSources }) => {
       if (options.experimentalNextConfigStripTypes) {
@@ -363,6 +383,10 @@ program
         const cpuProfileDir = join(dir, '.next-profiles')
         mkdirSync(cpuProfileDir, { recursive: true })
         process.env.NEXT_CPU_PROF_DIR = cpuProfileDir
+      }
+      if (options.internalTrace) {
+        process.env.NEXT_TURBOPACK_TRACING =
+          options.internalTrace === 'overview' ? '1' : 'turbo-tasks'
       }
       const portSource = _optionValueSources.port
       import('../cli/next-dev.js').then((mod) =>

--- a/packages/next/src/bin/next.ts
+++ b/packages/next/src/bin/next.ts
@@ -235,7 +235,9 @@ program
     }
     if (options.internalTrace) {
       process.env.NEXT_TURBOPACK_TRACING =
-        options.internalTrace === 'overview' ? '1' : 'turbo-tasks'
+        options.internalTrace === 'all'
+          ? 'turbo-tasks'
+          : String(options.internalTrace)
     }
 
     // ensure process exits after build completes so open handles/connections
@@ -388,7 +390,7 @@ program
         process.env.NEXT_TURBOPACK_TRACING =
           options.internalTrace === 'all'
             ? 'turbo-tasks'
-            : options.internalTrace
+            : String(options.internalTrace)
       }
       const portSource = _optionValueSources.port
       import('../cli/next-dev.js').then((mod) =>

--- a/packages/next/src/cli/next-build.ts
+++ b/packages/next/src/cli/next-build.ts
@@ -33,6 +33,7 @@ export type NextBuildOptions = {
   experimentalNextConfigStripTypes?: boolean
   debugBuildPaths?: string
   experimentalCpuProf?: boolean
+  internalTrace?: string | boolean
 }
 
 const nextBuild = async (options: NextBuildOptions, directory?: string) => {

--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -56,6 +56,7 @@ export type NextDevOptions = {
   experimentalNextConfigStripTypes?: boolean
   experimentalCpuProf?: boolean
   serverFastRefresh?: boolean
+  internalTrace?: string | boolean
 }
 
 type PortSource = 'cli' | 'default' | 'env'
@@ -347,6 +348,9 @@ const nextDev = async (
                 NEXT_CPU_PROF_DIR: path.join(dir, '.next-profiles'),
                 __NEXT_PRIVATE_CPU_PROFILE: 'dev-server',
               }
+            : undefined),
+          ...(process.env.NEXT_TURBOPACK_TRACING
+            ? { NEXT_TURBOPACK_TRACING: process.env.NEXT_TURBOPACK_TRACING }
             : undefined),
         },
       })


### PR DESCRIPTION
## What?

Adds `--internal-trace` to both `dev` and `build` that enables `NEXT_TURBOPACK_TRACING=turbo-tasks`.

Optionally supports `minimal` and `all` (all is the default).

When `minimal` is provided it passes `NEXT_TURBOPACK_TRACING=1` and the trace file won't include turbo-tasks spans.