### PR TITLE
fix: align prefetched navigation URL with target search params

### DIFF
--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -658,11 +658,11 @@ export function deprecated_requestOptimisticRouteCacheEntry(
   optimisticUrl.search = optimisticCanonicalSearch
   const optimisticCanonicalUrl = createHrefFromUrl(optimisticUrl)
 
-  const optimisticRouteTree = deprecated_createOptimisticRouteTree(
+  const optimisticRouteTree = cloneRouteTreeWithRenderedSearch(
     routeWithNoSearchParams.tree,
     optimisticRenderedSearch
   )
-  const optimisticMetadataTree = deprecated_createOptimisticRouteTree(
+  const optimisticMetadataTree = cloneRouteTreeWithRenderedSearch(
     routeWithNoSearchParams.metadata,
     optimisticRenderedSearch
   )
@@ -697,7 +697,7 @@ export function deprecated_requestOptimisticRouteCacheEntry(
   return optimisticEntry
 }
 
-function deprecated_createOptimisticRouteTree(
+export function cloneRouteTreeWithRenderedSearch(
   tree: RouteTree,
   newRenderedSearch: NormalizedSearch
 ): RouteTree {
@@ -710,7 +710,7 @@ function deprecated_createOptimisticRouteTree(
     clonedSlots = {}
     for (const parallelRouteKey in originalSlots) {
       const childTree = originalSlots[parallelRouteKey]
-      clonedSlots[parallelRouteKey] = deprecated_createOptimisticRouteTree(
+      clonedSlots[parallelRouteKey] = cloneRouteTreeWithRenderedSearch(
         childTree,
         newRenderedSearch
       )

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -21,6 +21,7 @@ import {
   readRouteCacheEntry,
   deprecated_requestOptimisticRouteCacheEntry,
   convertRootFlightRouterStateToRouteTree,
+  cloneRouteTreeWithRenderedSearch,
   getStaleAt,
   writeStaticStageResponseIntoCache,
   processRuntimePrefetchStream,
@@ -307,13 +308,29 @@ function navigateUsingPrefetchedRouteTree(
   navigateType: 'push' | 'replace',
   route: FulfilledRouteCacheEntry
 ): AppRouterState {
-  const routeTree = route.tree
-  const canonicalUrl = route.canonicalUrl + url.hash
-  const renderedSearch = route.renderedSearch
+  const navigationSearch = url.search as NormalizedSearch
+  const canonicalFromRoute = new URL(route.canonicalUrl, location.origin)
+  const samePathname = url.pathname === canonicalFromRoute.pathname
+  const searchMismatch =
+    samePathname && navigationSearch !== route.renderedSearch
+
+  const routeTree = searchMismatch
+    ? cloneRouteTreeWithRenderedSearch(route.tree, navigationSearch)
+    : route.tree
+  const metadataTree = searchMismatch
+    ? cloneRouteTreeWithRenderedSearch(route.metadata, navigationSearch)
+    : route.metadata
+
+  const canonicalUrl = searchMismatch
+    ? createHrefFromUrl(url)
+    : route.canonicalUrl + url.hash
+  const renderedSearch = searchMismatch
+    ? navigationSearch
+    : route.renderedSearch
   const prefetchSeed: NavigationSeed = {
     renderedSearch,
     routeTree,
-    metadataVaryPath: route.metadata.varyPath as any,
+    metadataVaryPath: metadataTree.varyPath as PageVaryPath,
     data: null,
     head: null,
     dynamicStaleAt: computeDynamicStaleAt(now, UnknownDynamicStaleTime),


### PR DESCRIPTION
### What?
Fix stale query params being restored on router.push/router.replace in static export navigation.

### Why?
Cached prefetched entries reused old search state for the same pathname (regression in 16.2.0+).

### How?
On same-path, different-search navigation, use target URL search as source of truth.
Update route/metadata search state before applying cached navigation.


Fixes #92187
