### PR TITLE
fix: non-ASCII slugs with output: export and generateStaticParams

### DIFF
--- a/packages/next/src/build/static-paths/utils.test.ts
+++ b/packages/next/src/build/static-paths/utils.test.ts
@@ -1,7 +1,10 @@
 import type { Params } from '../../server/request/params'
 import { parseAppRoute } from '../../shared/lib/router/routes/app'
 import type { FallbackRouteParam } from './types'
-import { resolveRouteParamsFromTree } from './utils'
+import {
+  prerenderedRouteMatchesRequestPath,
+  resolveRouteParamsFromTree,
+} from './utils'
 
 // Helper to create LoaderTree structures for testing
 type TestLoaderTree = [
@@ -969,5 +972,36 @@ describe('resolveRouteParamsFromTree', () => {
       expect(params.id).toBe('image-123')
       expect(fallbackRouteParams).toHaveLength(0)
     })
+  })
+})
+
+describe('prerenderedRouteMatchesRequestPath', () => {
+  const slug = 'café'
+  const route = {
+    params: { slug },
+    pathname: `/blog/${slug}`,
+    encodedPathname: `/blog/${encodeURIComponent(slug)}`,
+    fallbackRouteParams: undefined,
+    fallbackMode: undefined,
+    fallbackRootParams: undefined,
+    throwOnEmptyStaticShell: undefined,
+  } as const
+
+  it('matches decoded and encoded request pathnames', () => {
+    expect(prerenderedRouteMatchesRequestPath(route, `/blog/${slug}`)).toBe(
+      true
+    )
+    expect(
+      prerenderedRouteMatchesRequestPath(
+        route,
+        `/blog/${encodeURIComponent(slug)}`
+      )
+    ).toBe(true)
+  })
+
+  it('returns false for unrelated paths', () => {
+    expect(prerenderedRouteMatchesRequestPath(route, '/blog/other')).toBe(
+      false
+    )
   })
 })

--- a/packages/next/src/build/static-paths/utils.ts
+++ b/packages/next/src/build/static-paths/utils.ts
@@ -12,7 +12,7 @@ import { parseLoaderTree } from '../../shared/lib/router/utils/parse-loader-tree
 import type { AppSegment } from '../segment-config/app/app-segments'
 import { extractPathnameRouteParamSegmentsFromLoaderTree } from './app/extract-pathname-route-param-segments-from-loader-tree'
 import { resolveParamValue } from '../../shared/lib/router/utils/resolve-param-value'
-import type { FallbackRouteParam } from './types'
+import type { FallbackRouteParam, PrerenderedRoute } from './types'
 
 /**
  * Encodes a parameter value using the provided encoder.
@@ -43,6 +43,32 @@ export function encodeParam(
  */
 export function normalizePathname(pathname: string) {
   return pathname.replace(/\\/g, '/').replace(/(?!^)\/$/, '')
+}
+
+/**
+ * Returns whether a request pathname matches a prerendered route from
+ * generateStaticParams. Request URLs may use percent-encoded segments while
+ * route.pathname uses decoded Unicode; route.encodedPathname covers the
+ * encoded form.
+ */
+export function prerenderedRouteMatchesRequestPath(
+  route: PrerenderedRoute,
+  requestPathname: string
+): boolean {
+  if (
+    route.pathname === requestPathname ||
+    route.encodedPathname === requestPathname
+  ) {
+    return true
+  }
+  if (requestPathname.includes('%')) {
+    try {
+      return route.pathname === decodeURIComponent(requestPathname)
+    } catch {
+      return false
+    }
+  }
+  return false
 }
 
 /**

--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -138,7 +138,8 @@ async function exportPageImpl(
 
   const filePath = normalizePagePath(path)
 
-  let updatedPath = exportPath._ssgPath || path
+  let updatedPath =
+    isAppDir && isDynamic && path ? path : exportPath._ssgPath || path
   let locale = exportPath._locale || commonRenderOpts.locale
 
   if (commonRenderOpts.locale) {

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -87,6 +87,7 @@ import {
 import type { PrerenderManifest } from '../../build'
 import { getRouteRegex } from '../../shared/lib/router/utils/route-regex'
 import type { PrerenderedRoute } from '../../build/static-paths/types'
+import { prerenderedRouteMatchesRequestPath } from '../../build/static-paths/utils'
 import { HMR_MESSAGE_SENT_TO_BROWSER } from './hot-reloader-types'
 
 // Load ReactDevOverlay only when needed
@@ -845,10 +846,12 @@ export default class DevServer extends Server {
             }
 
             if (
-              !prerenderedRoutes.some((item) => item.pathname === urlPathname)
+              !prerenderedRoutes.some((item) =>
+                prerenderedRouteMatchesRequestPath(item, urlPathname)
+              )
             ) {
               throw new Error(
-                `Page "${page}" is missing param "${pathname}" in "generateStaticParams()", which is required with "output: export" config.`
+                `Page "${page}" is missing param "${urlPathname}" in "generateStaticParams()", which is required with "output: export" config.`
               )
             }
           }


### PR DESCRIPTION
### What?

- Fix non-ASCII slugs with output: "export" + generateStaticParams.

### Why?

- Encoded URL params and raw generated params were mismatched.

### How?

- Match both encoded/decoded path variants in dev.
- Use decoded app export path during render.
- Add focused test coverage.


Fixes #92192