### PR TITLE
[test] Skip flaky `client-cache.parallel-routes` in production and deploy

### DIFF
--- a/test/e2e/app-dir/app-client-cache/client-cache.parallel-routes.test.ts
+++ b/test/e2e/app-dir/app-client-cache/client-cache.parallel-routes.test.ts
@@ -5,7 +5,7 @@ import { Playwright } from 'next-webdriver'
 import type { Page as PlaywrightPage } from 'playwright'
 
 describe('app dir client cache with parallel routes', () => {
-  const { next, isNextDev } = nextTestSetup({
+  const { next, isNextDev, isNextStart, isNextDeploy } = nextTestSetup({
     files: path.join(__dirname, 'fixtures', 'parallel-routes'),
   })
 
@@ -53,7 +53,10 @@ describe('app dir client cache with parallel routes', () => {
       }, 'no-requests')
     })
 
-    it('should re-use the cache for the full page, only for 5 mins', async () => {
+    // TODO: This test is flaky in production and deploy modes, skip until stabilized.
+    it.skipIf(isNextStart || isNextDeploy)(
+      'should re-use the cache for the full page, only for 5 mins',
+      async () => {
       let page: PlaywrightPage
       const browser = await next.browser('/', {
         async beforePageLoad(p) {

--- a/test/e2e/app-dir/app-client-cache/client-cache.parallel-routes.test.ts
+++ b/test/e2e/app-dir/app-client-cache/client-cache.parallel-routes.test.ts
@@ -4,7 +4,8 @@ import path from 'path'
 import { Playwright } from 'next-webdriver'
 import type { Page as PlaywrightPage } from 'playwright'
 
-describe('app dir client cache with parallel routes', () => {
+// TODO: This suite is flaky in production and deploy modes, skip until stabilized.
+describe.skip('app dir client cache with parallel routes', () => {
   const { next, isNextDev } = nextTestSetup({
     files: path.join(__dirname, 'fixtures', 'parallel-routes'),
   })
@@ -53,8 +54,7 @@ describe('app dir client cache with parallel routes', () => {
       }, 'no-requests')
     })
 
-    // TODO: This test is flaky in production and deploy modes, skip until stabilized.
-    it.skip('should re-use the cache for the full page, only for 5 mins', async () => {
+    it('should re-use the cache for the full page, only for 5 mins', async () => {
       let page: PlaywrightPage
       const browser = await next.browser('/', {
         async beforePageLoad(p) {

--- a/test/e2e/app-dir/app-client-cache/client-cache.parallel-routes.test.ts
+++ b/test/e2e/app-dir/app-client-cache/client-cache.parallel-routes.test.ts
@@ -5,7 +5,7 @@ import { Playwright } from 'next-webdriver'
 import type { Page as PlaywrightPage } from 'playwright'
 
 describe('app dir client cache with parallel routes', () => {
-  const { next, isNextDev, isNextStart, isNextDeploy } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: path.join(__dirname, 'fixtures', 'parallel-routes'),
   })
 
@@ -54,9 +54,7 @@ describe('app dir client cache with parallel routes', () => {
     })
 
     // TODO: This test is flaky in production and deploy modes, skip until stabilized.
-    it.skipIf(isNextStart || isNextDeploy)(
-      'should re-use the cache for the full page, only for 5 mins',
-      async () => {
+    it.skip('should re-use the cache for the full page, only for 5 mins', async () => {
       let page: PlaywrightPage
       const browser = await next.browser('/', {
         async beforePageLoad(p) {


### PR DESCRIPTION
Skips the whole test suite: https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40test.source.file%3Atest%2Fe2e%2Fapp-dir%2Fapp-client-cache%2Fclient-cache.parallel-routes.test.ts&agg_m=count&agg_m_source=base&agg_t=count&currentTab=overview&eventStack=&fromUser=true&index=citest&start=1774438369141&end=1775043169141&paused=true