### PR TITLE
[test] Skip flaky `prefetch-layout-sharing` suite

### DIFF
--- a/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/prefetch-layout-sharing.test.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/prefetch-layout-sharing.test.ts
@@ -3,7 +3,8 @@ import { Playwright as NextBrowser } from '../../../../lib/next-webdriver'
 import type * as Playwright from 'playwright'
 import { createRouterAct } from 'router-act'
 
-describe('layout sharing in non-static prefetches', () => {
+// TODO: Skipped due to flakiness
+describe.skip('layout sharing in non-static prefetches', () => {
   const { next, isNextDev } = nextTestSetup({
     files: __dirname,
   })


### PR DESCRIPTION
1 out of 9 tests fails: [`@test.source.file:test/e2e/app-dir/segment-cache/prefetch-layout-sharing/prefetch-layout-sharing.test.ts @git.branch:canary -@test_session.name:*development* -@test.status:skip @ci.pipeline.url:*/attempts/1 `](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40test.source.file%3Atest%2Fe2e%2Fapp-dir%2Fsegment-cache%2Fprefetch-layout-sharing%2Fprefetch-layout-sharing.test.ts%20%40git.branch%3Acanary%20-%40test_session.name%3A%2Adevelopment%2A%20-%40test.status%3Askip%20%40ci.pipeline.url%3A%2A%2Fattempts%2F1&agg_m=count&agg_m_source=base&agg_q=%40test.name&agg_q_source=base&agg_t=count&citest_explorer_sort=timestamp%2Cdesc&cols=%40test.status%2Ctimestamp%2C%40duration%2C%40test.type%2C%40test.name%3A619%2C%40test_session.name&currentTab=overview&eventStack=&fromUser=true&index=citest&top_n=10&top_o=top&viz=stream&x_missing=true&start=1774438780635&end=1775043580635&paused=true)