### PR TITLE
[test] Skip flaky `cached-navigations` tests

### DIFF
--- a/test/e2e/app-dir/segment-cache/cached-navigations/cached-navigations.test.ts
+++ b/test/e2e/app-dir/segment-cache/cached-navigations/cached-navigations.test.ts
@@ -13,7 +13,8 @@ describe('cached navigations', () => {
     return
   }
 
-  it('serves cached static segments instantly on the second navigation', async () => {
+  // TODO: flaky
+  it.skip('serves cached static segments instantly on the second navigation', async () => {
     let page: Playwright.Page
     const browser = await next.browser('/', {
       async beforePageLoad(p: Playwright.Page) {
@@ -181,7 +182,8 @@ describe('cached navigations', () => {
     )
   })
 
-  it('caches static segments when navigating to a known route without a prefetch', async () => {
+  // TODO: flaky
+  it.skip('caches static segments when navigating to a known route without a prefetch', async () => {
     let page: Playwright.Page
     const browser = await next.browser('/', {
       async beforePageLoad(p: Playwright.Page) {
@@ -274,7 +276,8 @@ describe('cached navigations', () => {
     )
   })
 
-  it('includes static params in the cached static stage', async () => {
+  // TODO: flaky
+  it.skip('includes static params in the cached static stage', async () => {
     let page: Playwright.Page
     const browser = await next.browser('/', {
       async beforePageLoad(p: Playwright.Page) {
@@ -334,7 +337,8 @@ describe('cached navigations', () => {
     )
   })
 
-  it('defers fallback params to the runtime stage', async () => {
+  // TODO: flaky
+  it.skip('defers fallback params to the runtime stage', async () => {
     let page: Playwright.Page
     const browser = await next.browser('/', {
       async beforePageLoad(p: Playwright.Page) {
@@ -403,7 +407,8 @@ describe('cached navigations', () => {
     )
   })
 
-  it('caches runtime-prefetchable content from a navigation for instant second visit', async () => {
+  // TODO: flaky
+  it.skip('caches runtime-prefetchable content from a navigation for instant second visit', async () => {
     let page: Playwright.Page
     const browser = await next.browser('/', {
       async beforePageLoad(p: Playwright.Page) {
@@ -557,7 +562,8 @@ describe('cached navigations', () => {
     )
   })
 
-  it('caches runtime-prefetchable content from the initial HTML for subsequent navigations', async () => {
+  // TODO: flaky
+  it.skip('caches runtime-prefetchable content from the initial HTML for subsequent navigations', async () => {
     let page: Playwright.Page
     // Start directly at /runtime-prefetchable — full HTML load, not a
     // client-side navigation. The RSC payload is inlined in the HTML and
@@ -751,7 +757,8 @@ describe('cached navigations', () => {
     )
   })
 
-  it('caches a partially static page from the initial HTML for subsequent navigations', async () => {
+  // TODO: flaky
+  it.skip('caches a partially static page from the initial HTML for subsequent navigations', async () => {
     let page: Playwright.Page
     // Start directly at /partially-static — full HTML load. The RSC payload
     // inlined in the HTML contains both cached and dynamic content.
@@ -817,7 +824,8 @@ describe('cached navigations', () => {
     )
   })
 
-  it('reuses cached page segment across different fallback params after navigation', async () => {
+  // TODO: flaky
+  it.skip('reuses cached page segment across different fallback params after navigation', async () => {
     let page: Playwright.Page
     const browser = await next.browser('/', {
       async beforePageLoad(p: Playwright.Page) {
@@ -878,7 +886,8 @@ describe('cached navigations', () => {
     )
   })
 
-  it('reuses cached page segment across different fallback params after initial HTML load', async () => {
+  // TODO: flaky
+  it.skip('reuses cached page segment across different fallback params after initial HTML load', async () => {
     let page: Playwright.Page
     // Start directly at /with-fallback-params/foo — full HTML load. The RSC
     // payload inlined in the HTML seeds the segment cache with the page


### PR DESCRIPTION
Skips all [`@test.source.file:test/e2e/app-dir/segment-cache/cached-navigations/cached-navigations.test.ts @git.branch:canary -@test.status:skip @ci.pipeline.url:*/attempts/1 @test.is_known_flaky:true `](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40test.source.file%3Atest%2Fe2e%2Fapp-dir%2Fsegment-cache%2Fcached-navigations%2Fcached-navigations.test.ts%20%40git.branch%3Acanary%20-%40test.status%3Askip%20%40ci.pipeline.url%3A%2A%2Fattempts%2F1%20%40test.is_known_flaky%3Atrue&agg_m=count&agg_m_source=base&agg_q=%40test.name&agg_q_source=base&agg_t=count&citest_explorer_sort=timestamp%2Cdesc&cols=%40test.status%2Ctimestamp%2C%40duration%2C%40test.type%2C%40test.name%3A619%2C%40test_session.name&currentTab=overview&eventStack=&fromUser=false&index=citest&top_n=15&top_o=top&viz=toplist&x_missing=true&start=1774438780635&end=1775043580635&paused=true)