### PR TITLE
[test] Reduce `elementByCssInstant` timeout to 1ms

### DIFF
--- a/test/development/app-dir/instant-navs-devtools/instant-navs-devtools.test.ts
+++ b/test/development/app-dir/instant-navs-devtools/instant-navs-devtools.test.ts
@@ -2,6 +2,7 @@ import { nextTestSetup } from 'e2e-utils'
 import { retry, toggleDevToolsIndicatorPopover } from 'next-test-utils'
 import { Playwright } from 'next-webdriver'
 
+// force full test run
 describe('instant-nav-panel', () => {
   const { isNextDev, isTurbopack, next } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/ppr-partial-hydration/ppr-partial-hydration.test.ts
+++ b/test/e2e/app-dir/ppr-partial-hydration/ppr-partial-hydration.test.ts
@@ -7,6 +7,7 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
+// force full test run
 describe('PPR - partial hydration', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,

--- a/test/lib/browsers/playwright.ts
+++ b/test/lib/browsers/playwright.ts
@@ -437,7 +437,7 @@ export class Playwright<TCurrent = undefined> {
   /** A replacement for the default `browser.elementByCss` that doesn't wait for the page to fire "load". */
   elementByCssInstant(selector: string, opts?: ElementByCssOpts) {
     return this.waitForElementByCss(selector, {
-      timeout: 10,
+      timeout: 0,
       waitUntil: false,
       ...opts,
     })

--- a/test/lib/browsers/playwright.ts
+++ b/test/lib/browsers/playwright.ts
@@ -437,7 +437,7 @@ export class Playwright<TCurrent = undefined> {
   /** A replacement for the default `browser.elementByCss` that doesn't wait for the page to fire "load". */
   elementByCssInstant(selector: string, opts?: ElementByCssOpts) {
     return this.waitForElementByCss(selector, {
-      timeout: 0,
+      timeout: 1,
       waitUntil: false,
       ...opts,
     })


### PR DESCRIPTION
Just checking if it's possible. Opus 4.6 claims that the timeout is racing PW's IPC channel. That would be a bug imo. But if it still passes with 1ms timeout, it's less likely a race.