### PR TITLE
[test] Deflake `allowed-dev-origins`

### DIFF
--- a/test/development/basic/allowed-dev-origins.test.ts
+++ b/test/development/basic/allowed-dev-origins.test.ts
@@ -78,8 +78,8 @@ function requestInternalDevMiddleware(
   )
 }
 
-function expectBlockedDevResourceMessage(
-  output: string,
+async function expectBlockedDevResourceMessage(
+  next: NextInstance,
   options: {
     resourcePath: string
     source?: string
@@ -88,7 +88,11 @@ function expectBlockedDevResourceMessage(
     opaqueOrigin?: true
   }
 ) {
-  expect(output).toContain(options.resourcePath)
+  // I/O may not be flushed immediately, so retry until we see the message in the output.
+  await retry(() => {
+    expect(next.cliOutput).toContain(options.resourcePath)
+  })
+  const output = next.cliOutput
   expect(output).toContain(
     'Cross-origin access to Next.js dev resources is blocked by default for safety.'
   )
@@ -182,7 +186,7 @@ describe.each(['', '/docs'])(
             expect(await browser.elementByCss('#status').text()).toBe('error')
           })
 
-          expectBlockedDevResourceMessage(next.cliOutput, {
+          await expectBlockedDevResourceMessage(next, {
             resourcePath: withBasePath(basePath, '/_next/hmr'),
             source: 'example.vercel.sh',
           })
@@ -212,7 +216,7 @@ describe.each(['', '/docs'])(
         )
         expect(differentHostRes.status).toBe(403)
 
-        expectBlockedDevResourceMessage(next.cliOutput, {
+        await expectBlockedDevResourceMessage(next, {
           resourcePath: withBasePath(
             basePath,
             '/_next/static/chunks/pages/_app.js'
@@ -238,7 +242,7 @@ describe.each(['', '/docs'])(
         )
         expect(differentHostRes.status).toBe(403)
 
-        expectBlockedDevResourceMessage(next.cliOutput, {
+        await expectBlockedDevResourceMessage(next, {
           resourcePath: withBasePath(basePath, '/__nextjs_error_feedback'),
           source: 'example.vercel.sh',
         })
@@ -411,7 +415,7 @@ describe.each(['', '/docs'])(
         const res = await requestInternalDevScript(next.appPort, basePath)
         expect(res.status).toBe(403)
 
-        expectBlockedDevResourceMessage(next.cliOutput, {
+        await expectBlockedDevResourceMessage(next, {
           resourcePath: withBasePath(
             basePath,
             '/_next/static/chunks/pages/_app.js'
@@ -511,7 +515,7 @@ describe.each(['', '/docs'])(
             expect(await browser.elementByCss('#status').text()).toBe('error')
           })
 
-          expectBlockedDevResourceMessage(next.cliOutput, {
+          await expectBlockedDevResourceMessage(next, {
             resourcePath: withBasePath(basePath, '/_next/hmr'),
             opaqueOrigin: true,
           })


### PR DESCRIPTION
[`@test.source.file:test/development/basic/allowed-dev-origins.test.ts -@test.status:skip @test.is_known_flaky:true `](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40test.source.file%3Atest%2Fdevelopment%2Fbasic%2Fallowed-dev-origins.test.ts%20-%40test.status%3Askip%20%40test.is_known_flaky%3Atrue&agg_m=count&agg_m_source=base&agg_t=count&currentTab=overview&eventStack=&fromUser=true&index=citest&start=1774448155422&end=1775052955422&paused=true)

I suspect flakiness is caused by asserting on I/O in the terminal that may not be flushed by the time we assert on it.