### PR TITLE
fix(typescript-plugin): warn on non-serializable props for export default variable

### DIFF
--- a/packages/next/src/server/typescript/index.ts
+++ b/packages/next/src/server/typescript/index.ts
@@ -16,6 +16,7 @@ import {
   isPositionInsideNode,
   getSource,
   isInsideApp,
+  getTypeChecker,
 } from './utils'
 import { NEXT_TS_ERRORS } from './constant'
 
@@ -336,6 +337,41 @@ export const createTSPlugin: tsModule.server.PluginModuleFactory = ({
                 node
               )
             )
+          }
+        } else if (ts.isExportAssignment(node) && !node.isExportEquals) {
+          // export default <expr> — covers arrow functions assigned to a const
+          // and then re-exported. `export default function` is handled above via
+          // isDefaultFunctionExport; this branch catches the remaining cases.
+          if (isClientEntry) {
+            const expr = node.expression
+            let fnNode: tsModule.ArrowFunction | undefined
+
+            if (ts.isArrowFunction(expr)) {
+              fnNode = expr
+            } else if (ts.isIdentifier(expr)) {
+              const typeChecker = getTypeChecker()
+              if (typeChecker) {
+                const symbol = typeChecker.getSymbolAtLocation(expr)
+                const decl = symbol?.getDeclarations()?.[0]
+                if (
+                  decl &&
+                  ts.isVariableDeclaration(decl) &&
+                  decl.initializer &&
+                  ts.isArrowFunction(decl.initializer)
+                ) {
+                  fnNode = decl.initializer
+                }
+              }
+            }
+
+            if (fnNode) {
+              prior.push(
+                ...clientBoundary.getSemanticDiagnosticsForFunctionExport(
+                  source,
+                  fnNode
+                )
+              )
+            }
           }
         }
       })

--- a/test/development/typescript-plugin/client-boundary/app/non-serializable-export-default-variable-props.tsx
+++ b/test/development/typescript-plugin/client-boundary/app/non-serializable-export-default-variable-props.tsx
@@ -1,0 +1,11 @@
+'use client'
+
+type MyProps = {
+  myFunc: () => void
+}
+
+const MyComponent = ({ myFunc }: MyProps) => {
+  return <p>hello world</p>
+}
+
+export default MyComponent

--- a/test/development/typescript-plugin/client-boundary/client-boundary.test.ts
+++ b/test/development/typescript-plugin/client-boundary/client-boundary.test.ts
@@ -123,4 +123,34 @@ describe('typescript-plugin - client-boundary', () => {
      }
     `)
   })
+
+  it('should have diagnostics for non-serializable props on export default variable', () => {
+    const tsFile = resolve(
+      __dirname,
+      'app/non-serializable-export-default-variable-props.tsx'
+    )
+    const totalDiagnostics: Record<string, PartialDiagnostic[]> = {}
+
+    totalDiagnostics[relative(__dirname, tsFile)] = languageService
+      .getSemanticDiagnostics(tsFile)
+      .map((diagnostic) => ({
+        code: diagnostic.code,
+        messageText: diagnostic.messageText,
+        start: diagnostic.start,
+        length: diagnostic.length,
+      }))
+
+    expect(totalDiagnostics).toMatchInlineSnapshot(`
+     {
+       "app/non-serializable-export-default-variable-props.tsx": [
+         {
+           "code": 71007,
+           "length": 10,
+           "messageText": "Props must be serializable for components in the "use client" entry file. "myFunc" is a function that's not a Server Action. Rename "myFunc" either to "action" or have its name end with "Action" e.g. "myFuncAction" to indicate it is a Server Action.",
+           "start": 41,
+         },
+       ],
+     }
+    `)
+  })
 })


### PR DESCRIPTION
### What?

The TypeScript plugin's `"use client"` boundary check misses components assigned to a `const` and then re-exported via `export default`:

```tsx
'use client'

const MyComponent = ({ myFunc }: { myFunc: () => void }) => <p />

export default MyComponent  // TS71007 never fires here
```

TS71007 fires correctly for `export default function`, `export const`, and `export function`, but not for this pattern.

### Why?

The diagnostic loop in `packages/next/src/server/typescript/index.ts` walks the file's top-level AST nodes. It has branches for `VariableStatement` (export const), `FunctionDeclaration` with export+default modifiers, and `FunctionDeclaration` with export modifier, but no branch for `ExportAssignment`, which is what `export default someIdentifier` produces.

### How?

Added an `ExportAssignment` branch. When the expression is an `Identifier`, it resolves through the type checker to its `VariableDeclaration` initializer. If that initializer is an `ArrowFunction`, the existing `clientBoundary.getSemanticDiagnosticsForFunctionExport` is called on it. The inline arrow function case (`export default () => {}`) is also handled.

Adds a test fixture and inline snapshot for the unhandled pattern.

Fixes #55332