### PR TITLE
fix(dev): return JS content type/body for turbopack middleware manifest in dev

### DIFF
--- a/packages/next/src/lib/constants.ts
+++ b/packages/next/src/lib/constants.ts
@@ -3,6 +3,7 @@ import type { ServerRuntime } from '../types'
 export const TEXT_PLAIN_CONTENT_TYPE_HEADER = 'text/plain'
 export const HTML_CONTENT_TYPE_HEADER = 'text/html; charset=utf-8'
 export const JSON_CONTENT_TYPE_HEADER = 'application/json; charset=utf-8'
+export const JAVASCRIPT_CONTENT_TYPE_HEADER = 'text/javascript; charset=utf-8'
 export const NEXT_QUERY_PARAM_PREFIX = 'nxtP'
 export const NEXT_INTERCEPTION_MARKER_PREFIX = 'nxtI'
 

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -78,6 +78,7 @@ import { getDefineEnv } from '../../../build/define-env'
 import { TurbopackInternalError } from '../../../shared/lib/turbopack/internal-error'
 import { normalizePath } from '../../../lib/normalize-path'
 import {
+  JAVASCRIPT_CONTENT_TYPE_HEADER,
   JSON_CONTENT_TYPE_HEADER,
   MIDDLEWARE_FILENAME,
   PROXY_FILENAME,
@@ -1242,8 +1243,28 @@ async function startWatcher(
         pathname.includes(devTurbopackMiddlewareManifestPath))
     ) {
       res.statusCode = 200
-      res.setHeader('Content-Type', JSON_CONTENT_TYPE_HEADER)
-      res.end(JSON.stringify(serverFields.middleware?.matchers || []))
+      const isTurbopackManifestRequest = pathname.includes(
+        devTurbopackMiddlewareManifestPath
+      )
+      res.setHeader(
+        'Content-Type',
+        isTurbopackManifestRequest
+          ? JAVASCRIPT_CONTENT_TYPE_HEADER
+          : JSON_CONTENT_TYPE_HEADER
+      )
+
+      const middlewareMatchers = JSON.stringify(
+        serverFields.middleware?.matchers || []
+      )
+      if (isTurbopackManifestRequest) {
+        res.end(
+          'self.__MIDDLEWARE_MATCHERS = ' +
+            middlewareMatchers +
+            ';self.__MIDDLEWARE_MATCHERS_CB && self.__MIDDLEWARE_MATCHERS_CB()'
+        )
+      } else {
+        res.end(middlewareMatchers)
+      }
       return { finished: true }
     }
     return { finished: false }


### PR DESCRIPTION
## What?

When handling dev middleware manifest requests in `setup-dev-bundler`, both:

- `/_next/static/development/_devMiddlewareManifest.json`
- `/_next/static/development/_clientMiddlewareManifest.js`

were returned as JSON (`application/json`) and with a JSON body.

For Turbopack, `_clientMiddlewareManifest.js` is loaded as a script and should be served as JavaScript. Under `X-Content-Type-Options: nosniff`, browsers can refuse to execute it when the MIME type is JSON.

## Changes

- add `JAVASCRIPT_CONTENT_TYPE_HEADER` constant
- in `setup-dev-bundler`:
  - detect requests for `devTurbopackMiddlewareManifestPath`
  - set `Content-Type: text/javascript; charset=utf-8` for `.js` manifest
  - return JS assignment body:
    `self.__MIDDLEWARE_MATCHERS = ...; self.__MIDDLEWARE_MATCHERS_CB && self.__MIDDLEWARE_MATCHERS_CB()`
  - keep existing JSON response for `_devMiddlewareManifest.json`

## Why

This aligns runtime behavior with how the Turbopack client middleware manifest is consumed and fixes strict MIME type failures in dev.

Fixes #92180
