### PR TITLE
Generate a CLI warning if using Rosetta 2 on Apple Silicon

### DIFF
--- a/packages/next/src/bin/next.ts
+++ b/packages/next/src/bin/next.ts
@@ -96,7 +96,7 @@ class NextRootCommand extends Command {
         os.cpus().some((cpu) => cpu.model.includes('Apple'))
       ) {
         warn(
-          'You are running Next.js on an Apple Silicon Mac with Rosetta 2 translation. For better performance, install a native arm64 build of Node.js. https://nextjs.org/docs/getting-started/installation#rosetta'
+          'You are running Next.js on an Apple Silicon Mac with Rosetta 2 translation, which may cause degraded performance.'
         )
       }
 

--- a/packages/next/src/bin/next.ts
+++ b/packages/next/src/bin/next.ts
@@ -2,6 +2,7 @@
 
 import '../server/require-hook'
 
+import os from 'os'
 import {
   Argument,
   Command,
@@ -88,6 +89,16 @@ class NextRootCommand extends Command {
 
       ;(process.env as any).NODE_ENV = process.env.NODE_ENV || defaultEnv
       ;(process.env as any).NEXT_RUNTIME = 'nodejs'
+
+      if (
+        process.platform === 'darwin' &&
+        process.arch === 'x64' &&
+        os.cpus().some((cpu) => cpu.model.includes('Apple'))
+      ) {
+        warn(
+          'You are running Next.js on an Apple Silicon Mac with Rosetta 2 translation. For better performance, install a native arm64 build of Node.js. https://nextjs.org/docs/getting-started/installation#rosetta'
+        )
+      }
 
       if (
         commandName !== 'dev' &&


### PR DESCRIPTION
This PR is AI generated.

Test plan (following https://github.com/vercel/next.js/pull/81950):

- Build a preview deployment: https://github.com/vercel/next.js/actions/runs/23858712091/job/69559813673
- Enable Rosetta
- Download a standalone x64 macos binary from https://nodejs.org/en/download

```
export PATH=/Users/bgw/Downloads/node-v22.17.1-darwin-x64/bin/:"$PATH"`
pnpm dlx create-next-app@canary --yes intel-app
cd intel-app
nvim package.json # edit the next.js version to point to the preview deployment
pnpm i
pnpm dev
```

<img width="723" height="192" alt="Screenshot 2026-04-01 at 9 25 04 AM" src="https://github.com/user-attachments/assets/a953ef8f-7fee-4aa0-9ef8-36ef667de734" />

<img width="1022" height="278" alt="Screenshot 2026-04-01 at 9 26 35 AM" src="https://github.com/user-attachments/assets/a0d4b3bd-f8b7-4bbc-a7be-9113dabe189f" />

(the bmi2 issue should be fixed by https://github.com/vercel/next.js/pull/92177, I just hadn't rebased)