### PR TITLE
Docs/adapters review

### DIFF
--- a/docs/01-app/03-api-reference/07-adapters/04-testing-adapters.mdx
+++ b/docs/01-app/03-api-reference/07-adapters/04-testing-adapters.mdx
@@ -168,6 +168,9 @@ require('fs').writeFileSync('package.json',JSON.stringify(pkg,null,2));
 # Set the adapter path so that the app uses it.
 export NEXT_ADAPTER_PATH="${ADAPTER_DIR}/dist/index.js"
 
+# Build the app
+pnpm build
+
 # Write any metadata needed later to files in the working directory.
 BUILD_ID="$(cat .next/BUILD_ID)"
 DEPLOYMENT_ID="my-adapter-local"
@@ -180,9 +183,6 @@ IMMUTABLE_ASSET_TOKEN="undefined"
   echo "DEPLOYMENT_ID: $DEPLOYMENT_ID"
   echo "IMMUTABLE_ASSET_TOKEN: $IMMUTABLE_ASSET_TOKEN"
 } >> .adapter-build.log
-
-# Build the app
-pnpm build
 
 # Start or deploy the app. Capture the URL at this point or make the script output the URL to stdout.
 provider-cli-to-deploy

--- a/docs/01-app/03-api-reference/07-adapters/05-routing-with-next-routing.mdx
+++ b/docs/01-app/03-api-reference/07-adapters/05-routing-with-next-routing.mdx
@@ -20,12 +20,12 @@ const pathnames = [
 ].map((output) => output.pathname)
 
 const result = await resolveRoutes({
-  url: requestUrl,
+  url: new URL(requestUrl),
   buildId,
   basePath: config.basePath || '',
   i18n: config.i18n,
-  headers: requestHeaders,
-  requestBody,
+  headers: new Headers(requestHeaders),
+  requestBody, // ReadableStream
   pathnames,
   routes: routing,
   invokeMiddleware: async (ctx) => {
@@ -43,8 +43,14 @@ if (result.resolvedPathname) {
 
 `resolveRoutes()` returns:
 
+- `middlewareResponded`: `true` when middleware already sent a response (the adapter should not invoke an entrypoint).
+- `externalRewrite`: A `URL` when routing resolved to an external rewrite destination.
+- `redirect`: An object with `url` (`URL`) and `status` when the request should be redirected.
 - `resolvedPathname`: The route pathname selected by Next.js routing. For dynamic routes, this is the matched route template such as `/blog/[slug]`.
 - `resolvedQuery`: The final query after rewrites or middleware have added or replaced search params.
 - `invocationTarget`: The concrete pathname and query to invoke for the matched route.
+- `resolvedHeaders`: A `Headers` object containing any headers added or modified during routing.
+- `status`: An HTTP status code set by routing (for example from a redirect or rewrite rule).
+- `routeMatches`: A record of named matches extracted from dynamic route segments.
 
 For example, if `/blog/post-1?draft=1` matches `/blog/[slug]?slug=post-1`, `resolvedPathname` is `/blog/[slug]` while `invocationTarget.pathname` is `/blog/post-1`.

--- a/docs/01-app/03-api-reference/07-adapters/09-output-types.mdx
+++ b/docs/01-app/03-api-reference/07-adapters/09-output-types.mdx
@@ -80,7 +80,7 @@ React pages from the `app/` directory:
   type: 'APP_PAGE'
   id: string           // Route identifier
   filePath: string     // Path to the built file
-  pathname: string     // URL pathname.Includes .rsc suffix for RSC routes
+  pathname: string     // URL pathname. Includes .rsc suffix for RSC routes
   sourcePage: string   // Original relative source file path
   runtime: 'nodejs' | 'edge' // Runtime the route is built for
   assets: Record<string, string>  // Traced dependencies (key: relative path from repo root, value: absolute path)


### PR DESCRIPTION
Some corrections to the adapters docs.

- The example deploy script ran `cat .next/BUILD_ID` before `pnpm build`. Under `set -euo pipefail` that kills the script immediately since the file doesn't exist yet. Moved the build step first.

- `resolveRoutes` requires `URL` and `Headers` objects, not strings. The example would cause TypeScript/runtime errors. 

- Also documented the 6 return fields ~ other adapters might need to use all of them for redirects, external rewrites, and middleware short-circuiting.

