### PR TITLE
Fix compilerOptions.paths not resolving when using TypeScript's ${configDir} template variable

### DIFF
--- a/packages/next/src/build/webpack/plugins/jsconfig-paths-plugin.test.ts
+++ b/packages/next/src/build/webpack/plugins/jsconfig-paths-plugin.test.ts
@@ -1,0 +1,37 @@
+import path from 'path'
+import { resolveCandidatePath } from './jsconfig-paths-plugin'
+
+describe('jsconfig-paths-plugin', () => {
+  describe('resolveCandidatePath', () => {
+    const base = path.resolve('/project')
+
+    it('joins a bare relative path with the base URL', () => {
+      expect(resolveCandidatePath(base, 'src/foo')).toBe(
+        path.join(base, 'src/foo')
+      )
+    })
+
+    it('joins a dot-relative path with the base URL', () => {
+      expect(resolveCandidatePath(base, './src/foo')).toBe(
+        path.join(base, './src/foo')
+      )
+    })
+
+    it('returns an absolute path as-is without joining with base URL', () => {
+      // TypeScript 5.5+ resolves the ${configDir} template variable in
+      // compilerOptions.paths to an absolute path before Next.js reads
+      // tsconfig.options.paths. Calling path.join(baseUrl, absolutePath)
+      // would produce a wrong doubled path; the absolute value must be
+      // used directly.
+      const absolute = path.resolve('/project/src/foo')
+      expect(resolveCandidatePath('/different/base', absolute)).toBe(absolute)
+    })
+
+    it('does not modify an absolute path even when base equals the path root', () => {
+      const absolute = path.resolve('/project/src/foo')
+      expect(resolveCandidatePath(path.resolve('/project'), absolute)).toBe(
+        absolute
+      )
+    })
+  })
+})

--- a/packages/next/src/build/webpack/plugins/jsconfig-paths-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/jsconfig-paths-plugin.ts
@@ -129,6 +129,19 @@ export function patternText({ prefix, suffix }: Pattern): string {
 }
 
 /**
+ * Resolves the candidate filesystem path for a matched tsconfig/jsconfig
+ * path substitution.
+ *
+ * When TypeScript 5.5+ resolves the `${configDir}` template variable in
+ * `compilerOptions.paths`, it stores absolute paths in `options.paths`.
+ * An absolute `curPath` must be used as-is; joining it with `baseUrl` via
+ * `path.join` produces an incorrect result on both POSIX and Windows.
+ */
+export function resolveCandidatePath(baseUrl: string, curPath: string): string {
+  return path.isAbsolute(curPath) ? curPath : path.join(baseUrl, curPath)
+}
+
+/**
  * Calls the iterator function for each entry of the array
  * until the first result or error is reached
  */
@@ -258,7 +271,10 @@ export class JsConfigPathsPlugin implements ResolvePluginPlugin {
                 // try next path candidate
                 return pathCallback()
               }
-              const candidate = path.join(resolvedBaseUrl.baseUrl, curPath)
+              const candidate = resolveCandidatePath(
+                resolvedBaseUrl.baseUrl,
+                curPath
+              )
               const obj = Object.assign({}, request, {
                 request: candidate,
               })


### PR DESCRIPTION
### What?

Fix `compilerOptions.paths` aliases not resolving when values use TypeScript 5.5's `${configDir}` template variable.

### Why?

TypeScript 5.5 added `${configDir}` so tsconfig files can be shared across projects. When TypeScript parses the config, it expands `${configDir}` to an absolute path and stores the result in `options.paths`:

```json
{
  "compilerOptions": {
    "paths": { "@/*": ["${configDir}/src/*"] }
  }
}
```

After parsing, `options.paths` holds `{ "@/*": ["/project/src/*"] }`.

`jsconfig-paths-plugin.ts` builds the candidate path with:

```js
const candidate = path.join(resolvedBaseUrl.baseUrl, curPath)
```

`path.join` does not treat an absolute second argument as an override; it concatenates. On POSIX, `path.join('/project', '/project/src/foo')` returns `/project/project/src/foo`. On Windows the result is similarly mangled. The webpack resolver never finds the module.

TypeScript's own module resolution handles absolute paths correctly, which is why `tsc --noEmit` passes and IDE navigation works. `next dev` and `next build` fail.

### How?

Added `resolveCandidatePath(baseUrl, curPath)`, a small exported helper: when `curPath` is already absolute, it returns `curPath` directly; otherwise it returns `path.join(baseUrl, curPath)`. The existing call site uses this helper.

Added a unit test file covering the relative, dot-relative, and absolute input cases.

Fixes #70912