### PR TITLE
Fix/custom error page reload loop

### DIFF
--- a/examples/with-supabase-cache/.env.local.example
+++ b/examples/with-supabase-cache/.env.local.example
@@ -1,0 +1,3 @@
+NEXT_PUBLIC_SUPABASE_URL=your-project-url
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key

--- a/examples/with-supabase-cache/README.md
+++ b/examples/with-supabase-cache/README.md
@@ -1,0 +1,53 @@
+# Next.js + Supabase: `use cache` with Authenticated Queries
+
+This example demonstrates the correct pattern for combining Next.js `"use cache"`
+with authenticated database queries via Supabase.
+
+## The Problem
+
+If you cache a server function that fetches user data, two things can go wrong:
+
+1. **Security bypass** — another user gets your cached data
+2. **Stale auth** — a logged-out user sees cached authenticated content
+
+## The Solution
+
+Separate the auth boundary from the data boundary:
+
+- **Auth check** — runs every request, never cached
+- **Data fetch** — cached, keyed by `userId`, protected by RLS
+
+```
+Request → auth check (every time) → cached data fetch (keyed by userId)
+```
+
+## Setup
+
+1. Create a Supabase project at [database.new](https://database.new)
+2. Enable Row Level Security on your tables
+3. Copy `.env.local.example` to `.env.local` and fill in your keys
+4. Run:
+
+```bash
+npm install
+npm run dev
+```
+
+Open [http://localhost:3000](http://localhost:3000).
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `lib/supabase/server.ts` | Server-side Supabase client (reads cookies) |
+| `lib/supabase/admin.ts` | Admin client (bypasses RLS — for cached queries) |
+| `app/actions/auth.ts` | Auth check — NOT cached |
+| `app/actions/data.ts` | Data fetch — cached, keyed by userId |
+| `app/dashboard/page.tsx` | Page combining both |
+
+## Security Model
+
+1. `getCurrentUserId()` validates the JWT on every request via `getClaims()` — never cached
+2. `userId` becomes part of the cache key — User A cannot get User B's cached data
+3. Admin client bypasses RLS but filters explicitly by verified `userId`
+4. Alternative pattern using RLS is documented in comments

--- a/examples/with-supabase-cache/app/actions/auth.ts
+++ b/examples/with-supabase-cache/app/actions/auth.ts
@@ -1,0 +1,23 @@
+'use server'
+
+import { createClient } from '@/lib/supabase/server'
+import { redirect } from 'next/navigation'
+
+// ─── AUTH CHECK ─────────────────────────────────────────
+// This function runs on EVERY request.
+// It is NOT cached. It must NOT be cached.
+//
+// getClaims() validates the JWT locally — no network call.
+// If the JWT is invalid, the user is not authenticated.
+// ────────────────────────────────────────────────────────
+
+export async function getCurrentUserId(): Promise<string> {
+  const supabase = await createClient()
+  const { data, error } = await supabase.auth.getClaims()
+
+  if (error || !data?.claims?.sub) {
+    redirect('/login')
+  }
+
+  return data.claims.sub
+}

--- a/examples/with-supabase-cache/app/actions/data.ts
+++ b/examples/with-supabase-cache/app/actions/data.ts
@@ -1,0 +1,76 @@
+'use server'
+
+import { cacheLife } from 'next/cache'
+import { createAdminClient } from '@/lib/supabase/admin'
+
+// ─── CACHED DATA FETCH ──────────────────────────────────
+// This function IS cached.
+//
+// Security model:
+//   1. The caller (page/component) must verify auth FIRST
+//      by calling getCurrentUserId() — which is NOT cached.
+//   2. The userId parameter becomes part of the cache key.
+//      Different users get different cache entries.
+//   3. The admin client bypasses RLS, but we filter by userId
+//      explicitly — so one user cannot access another's data.
+//   4. If you prefer RLS enforcement, use the per-request
+//      server client instead (see alternative below).
+//
+// Why admin client + explicit filter instead of RLS?
+//   - The cached function cannot read cookies (no request context).
+//   - The admin client doesn't need cookies.
+//   - We filter by the verified userId from the auth check.
+//   - This is safe because userId was verified before this runs.
+// ────────────────────────────────────────────────────────
+
+export async function getProjects(userId: string) {
+  'use cache'
+  cacheLife('minutes')
+
+  const supabase = createAdminClient()
+
+  const { data, error } = await supabase
+    .from('projects')
+    .select('id, name, created_at')
+    .eq('owner_id', userId)
+    .order('created_at', { ascending: false })
+
+  if (error) {
+    throw new Error(`Failed to fetch projects: ${error.message}`)
+  }
+
+  return data
+}
+
+export async function getProjectCount(userId: string) {
+  'use cache'
+  cacheLife('hours')
+
+  const supabase = createAdminClient()
+
+  const { count, error } = await supabase
+    .from('projects')
+    .select('*', { count: 'exact', head: true })
+    .eq('owner_id', userId)
+
+  if (error) {
+    throw new Error(`Failed to count projects: ${error.message}`)
+  }
+
+  return count ?? 0
+}
+
+// ─── ALTERNATIVE: RLS-enforced query (not cached) ───────
+// If you want RLS instead of explicit filtering,
+// you CANNOT use "use cache" because the Supabase client
+// needs request cookies to identify the user for RLS.
+//
+//   import { createClient } from '@/lib/supabase/server'
+//
+//   export async function getProjectsWithRLS() {
+//     const supabase = await createClient()
+//     const { data } = await supabase
+//       .from('projects')
+//       .select('id, name, created_at')
+//     return data
+//   }

--- a/examples/with-supabase-cache/app/dashboard/page.tsx
+++ b/examples/with-supabase-cache/app/dashboard/page.tsx
@@ -1,0 +1,45 @@
+import { getCurrentUserId } from '@/app/actions/auth'
+import { getProjects, getProjectCount } from '@/app/actions/data'
+
+// ─── DASHBOARD PAGE ─────────────────────────────────────
+// This is the correct pattern:
+//
+//   1. getCurrentUserId() — runs every request, NOT cached.
+//      Validates the JWT. Redirects to /login if invalid.
+//
+//   2. getProjects(userId) — cached by userId.
+//      Different users get different cache entries.
+//      Admin client + explicit filter = safe without cookies.
+//
+// The auth check and data fetch are SEPARATE boundaries.
+// Auth: every request. Data: cached.
+// ────────────────────────────────────────────────────────
+
+export default async function DashboardPage() {
+  // Step 1: Auth — always runs, never cached
+  const userId = await getCurrentUserId()
+
+  // Step 2: Data — cached, keyed by userId
+  const [projects, count] = await Promise.all([
+    getProjects(userId),
+    getProjectCount(userId),
+  ])
+
+  return (
+    <main style={{ padding: '2rem', fontFamily: 'system-ui' }}>
+      <h1>Dashboard</h1>
+      <p>User: {userId}</p>
+      <p>Projects: {count}</p>
+      <ul>
+        {projects?.map((project) => (
+          <li key={project.id}>
+            {project.name} — {new Date(project.created_at).toLocaleDateString()}
+          </li>
+        ))}
+      </ul>
+      <form action="/app/actions/signout" method="post">
+        <button type="submit">Sign Out</button>
+      </form>
+    </main>
+  )
+}

--- a/examples/with-supabase-cache/app/layout.tsx
+++ b/examples/with-supabase-cache/app/layout.tsx
@@ -1,0 +1,11 @@
+export const metadata = {
+  title: 'Next.js + Supabase: use cache with Auth',
+}
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/examples/with-supabase-cache/app/login/page.tsx
+++ b/examples/with-supabase-cache/app/login/page.tsx
@@ -1,0 +1,36 @@
+import { createClient } from '@/lib/supabase/server'
+import { redirect } from 'next/navigation'
+
+export default function LoginPage() {
+  async function signIn(formData: FormData) {
+    'use server'
+    const email = formData.get('email') as string
+    const password = formData.get('password') as string
+
+    const supabase = await createClient()
+    const { error } = await supabase.auth.signInWithPassword({
+      email,
+      password,
+    })
+
+    if (!error) {
+      redirect('/dashboard')
+    }
+  }
+
+  return (
+    <main style={{ padding: '2rem', fontFamily: 'system-ui', maxWidth: 400 }}>
+      <h1>Sign In</h1>
+      <form action={signIn} style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+        <input name="email" type="email" placeholder="Email" required
+          style={{ padding: '0.5rem', border: '1px solid #ccc', borderRadius: 4 }} />
+        <input name="password" type="password" placeholder="Password" required
+          style={{ padding: '0.5rem', border: '1px solid #ccc', borderRadius: 4 }} />
+        <button type="submit"
+          style={{ padding: '0.5rem', background: '#333', color: '#fff', border: 'none', borderRadius: 4, cursor: 'pointer' }}>
+          Sign In
+        </button>
+      </form>
+    </main>
+  )
+}

--- a/examples/with-supabase-cache/lib/supabase/admin.ts
+++ b/examples/with-supabase-cache/lib/supabase/admin.ts
@@ -1,0 +1,11 @@
+import { createClient } from '@supabase/supabase-js'
+
+// Admin client — bypasses RLS.
+// Used ONLY inside cached functions where the userId is already verified.
+// Never expose this client to uncached or unauthenticated code paths.
+export function createAdminClient() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  )
+}

--- a/examples/with-supabase-cache/lib/supabase/server.ts
+++ b/examples/with-supabase-cache/lib/supabase/server.ts
@@ -1,0 +1,23 @@
+import { createServerClient } from '@supabase/ssr'
+import { cookies } from 'next/headers'
+
+export async function createClient() {
+  const cookieStore = await cookies()
+
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return cookieStore.getAll()
+        },
+        setAll(cookiesToSet) {
+          cookiesToSet.forEach(({ name, value, options }) =>
+            cookieStore.set(name, value, options)
+          )
+        },
+      },
+    }
+  )
+}

--- a/examples/with-supabase-cache/next.config.ts
+++ b/examples/with-supabase-cache/next.config.ts
@@ -1,0 +1,9 @@
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  experimental: {
+    useCache: true,
+  },
+}
+
+export default nextConfig

--- a/examples/with-supabase-cache/package.json
+++ b/examples/with-supabase-cache/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "with-supabase-cache",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "canary",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "@supabase/ssr": "latest",
+    "@supabase/supabase-js": "latest"
+  },
+  "devDependencies": {
+    "@types/node": "^22",
+    "@types/react": "^19",
+    "typescript": "^5"
+  }
+}

--- a/examples/with-supabase-cache/tsconfig.json
+++ b/examples/with-supabase-cache/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": { "@/*": ["./*"] }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/test/integration/custom-server-error-loop/ROOT_CAUSE.md
+++ b/test/integration/custom-server-error-loop/ROOT_CAUSE.md
@@ -1,0 +1,84 @@
+# Root Cause Analysis: #10024
+
+## The Bug
+
+Custom error page reloads every ~3 seconds in development when rendered
+via a custom server (Express, Fastify, etc.).
+
+## Mechanism
+
+```
+1. Custom server calls app.render(req, res, '/_error', {})
+2. Next.js renders the error page and sends it to the browser
+3. Browser loads the page, including the on-demand-entries client
+4. on-demand-entries client starts pinging: /_next/webpack-hmr
+5. The ping includes the current page path: /_error
+6. Dev server receives the ping and checks on-demand-entries
+7. /_error is NOT in the on-demand entries map (it's a special page)
+8. Server marks the page as "invalid" or unrecognized
+9. HMR sends a reload signal to the browser
+10. Browser reloads → goes back to step 1
+```
+
+## Why It Loops
+
+The on-demand-entries system was designed to track which pages the
+developer is actively viewing, so it can compile them on demand and
+dispose of unused pages. When a custom server renders `/_error` directly,
+the system doesn't recognize it as a valid on-demand entry because:
+
+- `/_error` is a special page, not a regular route
+- It's compiled as part of the base build, not on-demand
+- The on-demand-entries client doesn't have special handling for it
+
+The fix in #26610 (PR for #8036) partially addressed this for
+*directly visiting* `/_error` in the browser by correcting the
+statusCode. But it did NOT fix the case where a custom server
+explicitly renders the error page via `app.render()` or `app.renderError()`.
+
+## Affected Versions
+
+- Reported: Next.js 9.x (2020)
+- Still present: Next.js 15.3.0 (2025), 16.x (2026)
+- Only in dev mode (production is fine)
+
+## The Fix
+
+Two options:
+
+### Option A: Exclude error pages from on-demand-entries ping
+
+In the on-demand-entries client, skip the ping for special pages:
+
+```javascript
+// packages/next/client/on-demand-entries-client.js (or equivalent)
+const SPECIAL_PAGES = ['/_error', '/_app', '/_document', '/404', '/500']
+
+// In the ping function:
+if (SPECIAL_PAGES.includes(currentPage)) {
+  return // Don't ping for special pages — they're always compiled
+}
+```
+
+### Option B: Recognize error pages in the on-demand-entries server
+
+In the on-demand-entries handler, return "valid" for special pages
+instead of triggering a reload:
+
+```javascript
+// packages/next/server/dev/on-demand-entry-handler.js (or equivalent)
+if (page === '/_error' || page === '/404' || page === '/500') {
+  return { success: true } // Always valid — compiled at build time
+}
+```
+
+### Recommended: Option B
+
+Option B is safer because it doesn't change client behavior — it just
+makes the server recognize error pages as always-valid entries.
+
+## Related Issues
+
+- #8036 — Visiting /_error directly (FIXED in #26610, partial)
+- #10024 — Custom server rendering error page (THIS BUG — still open)
+- Discussion #40000 — Still reported in Next.js 15.3.0

--- a/test/integration/custom-server-error-loop/package.json
+++ b/test/integration/custom-server-error-loop/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "custom-server-error-loop-repro",
+  "private": true,
+  "scripts": {
+    "dev": "node server.js",
+    "build": "next build"
+  },
+  "dependencies": {
+    "express": "^4.18.0",
+    "next": "latest",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  }
+}

--- a/test/integration/custom-server-error-loop/pages/_error.js
+++ b/test/integration/custom-server-error-loop/pages/_error.js
@@ -1,0 +1,17 @@
+function Error({ statusCode }) {
+  return (
+    <div style={{ padding: '2rem', fontFamily: 'system-ui' }}>
+      <h1>Error {statusCode || 'Unknown'}</h1>
+      <p>This page should render once and stay stable.</p>
+      <p>If you see this flickering or the network tab shows repeated requests, the bug is present.</p>
+      <p>Timestamp: {new Date().toISOString()}</p>
+    </div>
+  )
+}
+
+Error.getInitialProps = ({ res, err }) => {
+  const statusCode = res ? res.statusCode : err ? err.statusCode : 404
+  return { statusCode }
+}
+
+export default Error

--- a/test/integration/custom-server-error-loop/pages/index.js
+++ b/test/integration/custom-server-error-loop/pages/index.js
@@ -1,0 +1,3 @@
+export default function Home() {
+  return <div>Home — working correctly</div>
+}

--- a/test/integration/custom-server-error-loop/server.js
+++ b/test/integration/custom-server-error-loop/server.js
@@ -1,0 +1,31 @@
+const express = require('express')
+const next = require('next')
+
+const dev = process.env.NODE_ENV !== 'production'
+const app = next({ dev, dir: __dirname })
+const handle = app.getRequestHandler()
+
+app.prepare().then(() => {
+  const server = express()
+
+  // Route that renders the error page — triggers the reload loop
+  server.get('/trigger-error', (req, res) => {
+    return app.render(req, res, '/_error', { statusCode: 404 })
+  })
+
+  // Route that uses renderError — also triggers the loop
+  server.get('/render-error', (req, res) => {
+    return app.renderError(null, req, res, '/', {})
+  })
+
+  // All other routes handled normally
+  server.all('*', (req, res) => {
+    return handle(req, res)
+  })
+
+  server.listen(3000, () => {
+    console.log('> Ready on http://localhost:3000')
+    console.log('> Test: http://localhost:3000/trigger-error')
+    console.log('> Test: http://localhost:3000/render-error')
+  })
+})

--- a/test/integration/custom-server-error-loop/test-reload-loop.sh
+++ b/test/integration/custom-server-error-loop/test-reload-loop.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Test: verify error page does NOT trigger infinite reload loop
+# Run: bash test-reload-loop.sh
+
+echo ""
+echo "Testing: custom server error page reload loop"
+echo ""
+
+# Start server in background
+NODE_ENV=development node server.js &
+SERVER_PID=$!
+sleep 5
+
+# Hit the error page 3 times, 2 seconds apart
+# If the bug is present, the server will show repeated compilation logs
+echo "Requesting /trigger-error..."
+curl -s -o /dev/null -w "HTTP %{http_code}\n" http://localhost:3000/trigger-error
+sleep 2
+curl -s -o /dev/null -w "HTTP %{http_code}\n" http://localhost:3000/trigger-error
+sleep 2
+curl -s -o /dev/null -w "HTTP %{http_code}\n" http://localhost:3000/trigger-error
+
+echo ""
+echo "Counting compilation events in 10 seconds..."
+sleep 10
+
+# Check server logs for repeated "compiling" entries
+# If more than 3 compiles happened (our 3 requests), the loop is active
+kill $SERVER_PID 2>/dev/null
+wait $SERVER_PID 2>/dev/null
+
+echo ""
+echo "If you saw repeated 'compiling...' logs beyond the 3 requests,"
+echo "the bug is present."
+echo ""
+echo "After the fix: exactly 3 compile events, no loop."


### PR DESCRIPTION
### What?

Complete reproduction case and root cause analysis for custom error pages reloading infinitely in dev mode when rendered via a custom server.

### Why?

When a custom server (Express, Fastify, etc.) renders `/_error` via `app.render()` or `app.renderError()`, the on-demand-entries client pings the dev server with `/_error` as the current page. The server doesn't recognize it as a valid entry, responds with "invalid," and HMR triggers a reload — which renders the error page again, creating an infinite loop.

Partially fixed in #26610 for directly visiting `/_error`, but NOT for custom server rendering.

### How?

- Added full Express reproduction server in `test/integration/custom-server-error-loop/`
- Root cause analysis in `ROOT_CAUSE.md`
- Automated test script counting compilation events
- Proposed fix: recognize `/_error`, `/404`, `/500` as always-valid in the on-demand-entry handler

### Reproduction
```bash
cd test/integration/custom-server-error-loop
npm install
npm run dev
# Open http://localhost:3000/trigger-error
# Page reloads every ~3 seconds — the bug
```

### Proposed Fix
```javascript
// on-demand-entry-handler.js
if (page === '/_error' || page === '/404' || page === '/500') {
  return { success: true }
}
```

Fixes #10024