### PR TITLE
docs: clarify id, filePath, and pathname in STATIC_FILE adapter output

### DIFF
--- a/docs/01-app/03-api-reference/07-adapters/09-output-types.mdx
+++ b/docs/01-app/03-api-reference/07-adapters/09-output-types.mdx
@@ -166,9 +166,9 @@ Static assets and auto-statically optimized pages:
 ```typescript
 {
   type: 'STATIC_FILE'
-  id: string // Route identifier
-  filePath: string // Path to the built file
-  pathname: string // URL pathname
+  id: string // Unique identifier for this static file output
+  filePath: string // Absolute filesystem path to the built file
+  pathname: string // The routable URL pathname for this static file
   immutableHash: string | undefined // Content hash when the filename contains a hash, indicating the file is immutable
 }
 ```

--- a/packages/next/src/build/adapter/build-complete.ts
+++ b/packages/next/src/build/adapter/build-complete.ts
@@ -275,8 +275,17 @@ export interface AdapterOutput {
    * that does not use ISR
    */
   STATIC_FILE: {
+    /**
+     * Unique identifier for this static file output
+     */
     id: string
+    /**
+     * Absolute filesystem path to the built file
+     */
     filePath: string
+    /**
+     * The routable URL pathname for this static file
+     */
     pathname: string
     type: AdapterOutputType.STATIC_FILE
     /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds documentation for the `id`, `filePath`, and `pathname` properties in the `STATIC_FILE` adapter output type.

## Why

These three string properties were previously undocumented or had ambiguous descriptions. Based on feedback from the team:
- `id` is a unique identifier for the static file output
- `filePath` is the absolute filesystem path to the built file
- `pathname` is the routable URL pathname

## Changes

- Added JSDoc comments to the `STATIC_FILE` type definition in `build-complete.ts`
- Updated the MDX documentation in `output-types.mdx` with clearer inline comments

## Related

Addresses feedback from Slack thread in #project-next-adapters
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://vercel.slack.com/archives/C07TN1KLN5V/p1775050243619039?thread_ts=1775050243.619039&cid=C07TN1KLN5V)

<div><a href="https://cursor.com/agents/bc-ede1cb33-98d1-5287-9061-99dcf4788aa7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ede1cb33-98d1-5287-9061-99dcf4788aa7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

