### PR TITLE
Remove unused 'loading' field from CacheNodeSeedData

### DIFF
--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -2552,7 +2552,7 @@ function writeSeedDataIntoCache(
   // (CacheNodeSeedData) into the prefetch cache.
   const rsc = seedData[0]
   const isPartial = rsc === null || isResponsePartial
-  const varyParamsThenable = seedData[4]
+  const varyParamsThenable = seedData[3]
   // Each segment carries its own vary params thenable in the seed data. The
   // thenable resolves to the set of params the segment accessed during render.
   // A null thenable means tracking was not enabled (not a prerender).

--- a/packages/next/src/server/app-render/collect-segment-data.tsx
+++ b/packages/next/src/server/app-render/collect-segment-data.tsx
@@ -438,7 +438,7 @@ async function collectPrefetchHintsImpl(
   // segments with static prefetching disabled since they contribute nothing.
   let currentGzipSize: number | null = null
   if (!isStaticPrefetchDisabled && seedData !== null) {
-    const varyParamsThenable = seedData[4]
+    const varyParamsThenable = seedData[3]
     const varyParams =
       varyParamsThenable !== null ? readVaryParams(varyParamsThenable) : null
 
@@ -795,7 +795,7 @@ function collectSegmentDataImpl(
     ~PrefetchHint.InliningHintsStale
 
   // Determine which params this segment varies on.
-  const varyParamsThenable = seedData !== null ? seedData[4] : null
+  const varyParamsThenable = seedData !== null ? seedData[3] : null
   const varyParams =
     varyParamsThenable !== null ? readVaryParams(varyParamsThenable) : null
 

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -1356,7 +1356,6 @@ function createSeedData(
   return [
     rsc,
     parallelRoutes,
-    null,
     isPossiblyPartialResponse,
     varyParamsAccumulator ? getVaryParamsThenable(varyParamsAccumulator) : null,
   ]

--- a/packages/next/src/server/app-render/instant-validation/instant-validation.tsx
+++ b/packages/next/src/server/app-render/instant-validation/instant-validation.tsx
@@ -134,7 +134,7 @@ function traverseCacheNodeSegments(
   processSegment(path, seedData)
 
   const [_segment, childRoutes] = route
-  const [_node, parallelRoutesData, _loading, _isPartial] = seedData
+  const [_node, parallelRoutesData, _isPartial] = seedData
 
   for (const parallelRouteKey in childRoutes) {
     const childSeedData = parallelRoutesData[parallelRouteKey]
@@ -712,7 +712,7 @@ type SegmentData = {
 }
 
 function createSegmentData(seedData: CacheNodeSeedData): SegmentData {
-  const [node, _parallelRoutesData, _unused, isPartial, varyParams] = seedData
+  const [node, _parallelRoutesData, isPartial, varyParams] = seedData
   return {
     node,
     isPartial,
@@ -725,13 +725,7 @@ function getCacheNodeSeedDataFromSegment(
   data: SegmentData,
   slots: CacheNodeSeedDataSlots
 ): CacheNodeSeedData {
-  return [
-    data.node,
-    slots,
-    /* unused (previously `loading`) */ null,
-    data.isPartial,
-    data.varyParams,
-  ]
+  return [data.node, slots, data.isPartial, data.varyParams]
 }
 
 function createSegmentCache(): SegmentCache {
@@ -940,15 +934,13 @@ export async function createCombinedPayloadAtDepth(
       const markerIndex = slotStacks.length
       slotStacks.push(result?.createInstantStack ?? null)
       const markerName = `${INSTANT_SLOT_MARKER_PREFIX}${markerIndex - 1}${INSTANT_SLOT_MARKER_SUFFIX}`
-      const [node, parallelRoutesData, unused, isPartial, varyParams] =
-        slotSeedData
+      const [node, parallelRoutesData, isPartial, varyParams] = slotSeedData
       slots[key] = [
         // eslint-disable-next-line @next/internal/no-ambiguous-jsx -- bundled in the server layer
         <SlotMarker name={markerName} key="sm">
           {node}
         </SlotMarker>,
         parallelRoutesData,
-        unused,
         isPartial,
         varyParams,
       ]

--- a/packages/next/src/shared/lib/app-router-types.ts
+++ b/packages/next/src/shared/lib/app-router-types.ts
@@ -251,8 +251,7 @@ export type CacheNodeSeedData = [
   parallelRoutes: {
     [parallelRouterKey: string]: CacheNodeSeedData | null
   },
-  // TODO: This field is no longer used. Remove it.
-  loading: null,
+  // isPartial represents whether this segment's data possibly contains holes.
   isPartial: boolean,
   /**
    * A thenable that resolves to the set of route params this segment accessed


### PR DESCRIPTION
This PR removes the unused 'loading: null' field from CacheNodeSeedData as indicated by a TODO in packages/next/src/shared/lib/app-router-types.ts. This cleanup improves payload size and internal code quality by removing a legacy field and updating the index-based access in the App Router's seed data serialization.