### PR TITLE
fix: preserve HTTP access fallbacks during prerender recovery

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -113,7 +113,11 @@ import {
   walkTreeWithFlightRouterState,
   createFullTreeFlightDataForNavigation,
 } from './walk-tree-with-flight-router-state'
-import { createComponentTree, getRootParams } from './create-component-tree'
+import {
+  createComponentTree,
+  getRootParams,
+  type PrerenderHTTPErrorState,
+} from './create-component-tree'
 import { getAssetQueryString } from './get-asset-query-string'
 import {
   getClientReferenceManifest,
@@ -504,6 +508,54 @@ function createNotFoundLoaderTree(loaderTree: LoaderTree): LoaderTree {
       : { 'global-error': components['global-error'] },
     null, // staticSiblings
   ]
+}
+
+type HTTPAccessErrorStatusCode = 404 | 403 | 401
+
+function hasPrerenderHTTPErrorBoundary(
+  loaderTree: LoaderTree,
+  triggeredStatus: HTTPAccessErrorStatusCode,
+  authInterrupts: boolean
+): boolean {
+  switch (triggeredStatus) {
+    case 404:
+      return !!loaderTree[2]['not-found']
+    case 403:
+      return authInterrupts && !!loaderTree[2].forbidden
+    case 401:
+      return authInterrupts && !!loaderTree[2].unauthorized
+    default:
+      return false
+  }
+}
+
+function findPrerenderHTTPErrorBoundaryTree(
+  loaderTree: LoaderTree,
+  triggeredStatus: HTTPAccessErrorStatusCode,
+  authInterrupts: boolean
+): LoaderTree | null {
+  let boundaryTree: LoaderTree | null = hasPrerenderHTTPErrorBoundary(
+    loaderTree,
+    triggeredStatus,
+    authInterrupts
+  )
+    ? loaderTree
+    : null
+
+  const childrenTree = loaderTree[1].children
+  if (childrenTree) {
+    const deeperBoundaryTree = findPrerenderHTTPErrorBoundaryTree(
+      childrenTree,
+      triggeredStatus,
+      authInterrupts
+    )
+
+    if (deeperBoundaryTree) {
+      boundaryTree = deeperBoundaryTree
+    }
+  }
+
+  return boundaryTree
 }
 
 /**
@@ -1709,6 +1761,9 @@ async function getRSCPayload(
   ctx: AppRenderContext,
   options: {
     is404: boolean
+    // When set, rerender a segment-scoped HTTP fallback inside the normal app
+    // router tree instead of falling back to the generic error shell payload.
+    prerenderHTTPError?: PrerenderHTTPErrorState
     staleTimeIterable?: AsyncIterable<number>
     staticStageByteLengthPromise?: Promise<number>
     runtimePrefetchStream?: ReadableStream<Uint8Array>
@@ -1716,6 +1771,7 @@ async function getRSCPayload(
 ): Promise<InitialRSCPayload & { P: ReactNode }> {
   const {
     is404,
+    prerenderHTTPError,
     staleTimeIterable,
     staticStageByteLengthPromise,
     runtimePrefetchStream,
@@ -1789,6 +1845,7 @@ async function getRSCPayload(
     preloadCallbacks,
     authInterrupts: ctx.renderOpts.experimental.authInterrupts,
     MetadataOutlet,
+    prerenderHTTPError,
   })
 
   // When the `vary` response header is present with `Next-URL`, that means there's a chance
@@ -7117,16 +7174,46 @@ async function prerenderToStream(
           : INFINITE_CACHE,
       tags: [...(prerenderStore?.tags || implicitTags.tags)],
     })
-    const errorRSCPayload = await workUnitAsyncStorage.run(
-      prerenderLegacyStore,
-      getErrorRSCPayload,
-      tree,
-      ctx,
-      reactServerErrorsByDigest.has((err as any).digest) ? undefined : err,
-      errorType
-    )
+    let prerenderHTTPError: PrerenderHTTPErrorState | undefined
+    if (cacheComponents && isHTTPAccessFallbackError(err)) {
+      const triggeredStatus = getAccessFallbackHTTPStatus(
+        err
+      ) as HTTPAccessErrorStatusCode
+      const boundaryTree = findPrerenderHTTPErrorBoundaryTree(
+        tree,
+        triggeredStatus,
+        ctx.renderOpts.experimental.authInterrupts
+      )
 
-    const errorServerStream = workUnitAsyncStorage.run(
+      if (boundaryTree) {
+        prerenderHTTPError = {
+          boundaryTree,
+          triggeredStatus,
+        }
+      }
+    }
+
+    const errorRSCPayload = prerenderHTTPError
+      ? await workUnitAsyncStorage.run(
+          prerenderLegacyStore,
+          getRSCPayload,
+          tree,
+          ctx,
+          {
+            is404: errorType === 'not-found',
+            prerenderHTTPError,
+          }
+        )
+      : await workUnitAsyncStorage.run(
+          prerenderLegacyStore,
+          getErrorRSCPayload,
+          tree,
+          ctx,
+          reactServerErrorsByDigest.has((err as any).digest) ? undefined : err,
+          errorType
+        )
+
+    const errorServerStreamRaw = workUnitAsyncStorage.run(
       prerenderLegacyStore,
       renderToFlightStream,
       ComponentMod,
@@ -7137,6 +7224,19 @@ async function prerenderToStream(
         onError: serverComponentsErrorHandler,
       }
     )
+
+    let errorServerStream = errorServerStreamRaw
+    const errorFlightResultPromise = prerenderHTTPError
+      ? (() => {
+          // Fizz still needs to read the Flight stream to render ErrorApp, but
+          // the prerender path also needs a buffered Flight result for the HTML
+          // prelude and segment data collectors. Tee the stream so each consumer
+          // gets its own copy.
+          const [appStream, flightStream] = teeStream(errorServerStreamRaw)
+          errorServerStream = appStream
+          return createReactServerPrerenderResultFromRender(flightStream)
+        })()
+      : null
 
     try {
       const { stream: errorHtmlStream } = await workUnitAsyncStorage.run(
@@ -7157,10 +7257,15 @@ async function prerenderToStream(
         }
       )
 
+      const resolvedFlightResult = errorFlightResultPromise
+        ? await errorFlightResultPromise
+        : reactServerPrerenderResult
+      if (errorFlightResultPromise) {
+        reactServerPrerenderResult.consume()
+      }
+
       if (shouldGenerateStaticFlightData(workStore)) {
-        const flightData = await streamToBuffer(
-          reactServerPrerenderResult.asStream()
-        )
+        const flightData = await streamToBuffer(resolvedFlightResult.asStream())
         metadata.flightData = flightData
         await collectSegmentData(
           flightData,
@@ -7172,9 +7277,7 @@ async function prerenderToStream(
         )
       }
 
-      // This is intentionally using the readable datastream from the main
-      // render rather than the flight data from the error page render
-      const flightStream = reactServerPrerenderResult.consumeAsStream()
+      const flightStream = resolvedFlightResult.consumeAsStream()
 
       return {
         digestErrorsMap: reactServerErrorsByDigest,

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -44,6 +44,13 @@ import {
 import type { AppSegmentConfig } from '../../build/segment-config/app/app-segment-config'
 import { RenderStage, type StagedRenderingController } from './staged-rendering'
 
+type HTTPAccessErrorStatusCode = 404 | 403 | 401
+
+export type PrerenderHTTPErrorState = {
+  boundaryTree: LoaderTree
+  triggeredStatus: HTTPAccessErrorStatusCode
+}
+
 /**
  * Use the provided loader tree to create the React Component tree.
  */
@@ -62,6 +69,7 @@ export function createComponentTree(props: {
   preloadCallbacks: PreloadCallbacks
   authInterrupts: boolean
   MetadataOutlet: ComponentType
+  prerenderHTTPError?: PrerenderHTTPErrorState
 }): Promise<CacheNodeSeedData> {
   return getTracer().trace(
     NextNodeServerSpan.createComponentTree,
@@ -99,6 +107,7 @@ async function createComponentTreeInternal(
     preloadCallbacks,
     authInterrupts,
     MetadataOutlet,
+    prerenderHTTPError,
   }: {
     loaderTree: LoaderTree
     parentParams: Params
@@ -113,6 +122,7 @@ async function createComponentTreeInternal(
     preloadCallbacks: PreloadCallbacks
     authInterrupts: boolean
     MetadataOutlet: ComponentType | null
+    prerenderHTTPError?: PrerenderHTTPErrorState
   },
   isRoot: boolean
 ): Promise<CacheNodeSeedData> {
@@ -595,28 +605,72 @@ async function createComponentTreeInternal(
             }
           }
 
-          const seedData = await createComponentTreeInternal(
-            {
-              loaderTree: parallelRoute,
-              parentParams: currentParams,
-              parentOptionalCatchAllParamName: optionalCatchAllParamName,
-              parentRuntimePrefetchable: isRuntimePrefetchable,
-              rootLayoutIncluded: rootLayoutIncludedAtThisLevelOrAbove,
-              injectedCSS: injectedCSSWithCurrentLayout,
-              injectedJS: injectedJSWithCurrentLayout,
-              injectedFontPreloadTags: injectedFontPreloadTagsWithCurrentLayout,
-              ctx,
-              missingSlots,
-              preloadCallbacks,
-              authInterrupts,
-              // `StreamingMetadataOutlet` is used to conditionally throw. In the case of parallel routes we will have more than one page
-              // but we only want to throw on the first one.
-              MetadataOutlet: isChildrenRouteKey ? MetadataOutlet : null,
-            },
-            false
-          )
+          // The outer prerender catch already found the deepest segment whose
+          // HTTP fallback should replace the throwing page. When we reach that
+          // segment's `children` slot, render the fallback directly instead of
+          // descending back into the subtree that threw during deserialization.
 
-          childCacheNodeSeedData = seedData
+          // Like the other segment-level boundary props below, HTTP access
+          // fallbacks are attached to the default `children` slot, not to named
+          // parallel routes.
+          const shouldRenderPrerenderHTTPFallback =
+            prerenderHTTPError?.boundaryTree === tree && isChildrenRouteKey
+
+          if (shouldRenderPrerenderHTTPFallback) {
+            let fallbackElement: React.ReactNode | undefined
+            switch (prerenderHTTPError.triggeredStatus) {
+              case 404:
+                fallbackElement = notFoundElement
+                break
+              case 403:
+                fallbackElement = forbiddenElement
+                break
+              case 401:
+                fallbackElement = unauthorizedElement
+                break
+              default:
+                break
+            }
+
+            if (fallbackElement) {
+              childCacheNodeSeedData = createSeedData(
+                ctx,
+                fallbackElement,
+                {},
+                null,
+                isPossiblyPartialResponse,
+                false,
+                emptyVaryParamsAccumulator
+              )
+            }
+          }
+
+          if (childCacheNodeSeedData === null) {
+            const seedData = await createComponentTreeInternal(
+              {
+                loaderTree: parallelRoute,
+                parentParams: currentParams,
+                parentOptionalCatchAllParamName: optionalCatchAllParamName,
+                parentRuntimePrefetchable: isRuntimePrefetchable,
+                rootLayoutIncluded: rootLayoutIncludedAtThisLevelOrAbove,
+                injectedCSS: injectedCSSWithCurrentLayout,
+                injectedJS: injectedJSWithCurrentLayout,
+                injectedFontPreloadTags:
+                  injectedFontPreloadTagsWithCurrentLayout,
+                ctx,
+                missingSlots,
+                preloadCallbacks,
+                authInterrupts,
+                // `StreamingMetadataOutlet` is used to conditionally throw. In the case of parallel routes we will have more than one page
+                // but we only want to throw on the first one.
+                MetadataOutlet: isChildrenRouteKey ? MetadataOutlet : null,
+                prerenderHTTPError,
+              },
+              false
+            )
+
+            childCacheNodeSeedData = seedData
+          }
         }
 
         const templateNode = createElement(

--- a/test/e2e/app-dir/cache-components/app/cases/not-found-suspense/layout.tsx
+++ b/test/e2e/app-dir/cache-components/app/cases/not-found-suspense/layout.tsx
@@ -1,0 +1,17 @@
+import { Suspense } from 'react'
+
+async function AsyncComponent() {
+  await new Promise<void>((resolve) => setTimeout(resolve, 100))
+  return <div id="async-data">Async Data Loaded</div>
+}
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <div>
+      {children}
+      <Suspense fallback={<div>Loading async...</div>}>
+        <AsyncComponent />
+      </Suspense>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/cache-components/app/cases/not-found-suspense/not-found.tsx
+++ b/test/e2e/app-dir/cache-components/app/cases/not-found-suspense/not-found.tsx
@@ -1,0 +1,3 @@
+export default function NotFound() {
+  return <div id="not-found-text">Custom 404 - Not Found</div>
+}

--- a/test/e2e/app-dir/cache-components/app/cases/not-found-suspense/page.tsx
+++ b/test/e2e/app-dir/cache-components/app/cases/not-found-suspense/page.tsx
@@ -1,0 +1,7 @@
+import { notFound } from 'next/navigation'
+
+export default async function Page() {
+  notFound()
+
+  return <p>This will never render</p>
+}

--- a/test/e2e/app-dir/cache-components/cache-components.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.test.ts
@@ -64,6 +64,20 @@ describe('cache-components', () => {
     }
   })
 
+  it('should render not-found with Suspense in layout without connection errors', async () => {
+    const browser = await next.browser('/cases/not-found-suspense')
+
+    // The custom not-found component should render
+    expect(await browser.elementById('not-found-text').text()).toBe(
+      'Custom 404 - Not Found'
+    )
+
+    // The async Suspense content in the layout should also render
+    expect(await browser.elementById('async-data').text()).toBe(
+      'Async Data Loaded'
+    )
+  })
+
   it('should prerender pages that render in a microtask', async () => {
     let $ = await next.render$('/cases/microtask', {})
     if (isNextDev) {


### PR DESCRIPTION
When a `notFound()`, `forbidden()`, or `unauthorized()` error escapes into the outer prerender recovery path, we were falling back to the generic error shell flow.

In the `cacheComponents` case, that could leave us with:
- error HTML rendered from `ErrorApp`
- Flight data reused from the aborted prerender prelude
- references to Flight chunks that were never emitted

That is what caused the client-side `Connection closed` failure in #86251.

Instead of rerendering the full Flight tree or always using the generic error RSC payload, this change:

- finds the deepest matching HTTP fallback boundary
- rerenders the normal app router payload with that segment-scoped fallback
- tees the replacement Flight stream so Fizz can render from one copy while prerender buffering consumes the other
- only takes this path for recoverable HTTP access fallbacks that have a real boundary (ie a defined not-found/unauthorized/etc)

If no matching boundary exists, we keep the existing generic error handling.

Fixes #86251
Fixes #90837
Closes #87041
Closes #86251

Closes NAR-711
Closes NEXT-4876