### PR TITLE
Turbopack: Include a random sample of matched paths in error messages when TOO_MANY_MATCHES_LIMIT is exceeded

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10094,6 +10094,7 @@ dependencies = [
  "parking_lot",
  "petgraph 0.8.3",
  "phf",
+ "rand 0.10.0",
  "regex",
  "rustc-hash 2.1.1",
  "serde",

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -18,7 +18,7 @@ use turbo_frozenmap::{FrozenMap, FrozenSet};
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     FxIndexMap, FxIndexSet, NonLocalValue, ReadRef, ResolvedVc, TaskInput, TryFlatJoinIterExt,
-    TryJoinIterExt, ValueToString, Vc, trace::TraceRawVcs,
+    TryJoinIterExt, ValueToString, ValueToStringRef, Vc, trace::TraceRawVcs,
 };
 use turbo_tasks_fs::{FileSystemEntryType, FileSystemPath};
 use turbo_unix_path::normalize_request;
@@ -108,21 +108,28 @@ pub enum ModuleResolveResultItem {
     Custom(u8),
 }
 
-impl ModuleResolveResultItem {
-    /// Returns a short description of this item, suitable for display in diagnostics.
-    pub async fn description(&self) -> Result<RcStr> {
+impl ValueToStringRef for ModuleResolveResultItem {
+    async fn to_string_ref(&self) -> Result<RcStr> {
         Ok(match self {
-            ModuleResolveResultItem::Module(module) => module.ident().await?.path.path.clone(),
-            ModuleResolveResultItem::OutputAsset(asset) => asset.path().await?.path.clone(),
+            ModuleResolveResultItem::Module(module) => {
+                module.ident().await?.path.to_string_ref().await?
+            }
+            ModuleResolveResultItem::OutputAsset(asset) => {
+                asset.path().await?.to_string_ref().await?
+            }
             ModuleResolveResultItem::External { name, .. } => name.clone(),
-            ModuleResolveResultItem::Unknown(source) => source.ident().await?.path.path.clone(),
+            ModuleResolveResultItem::Unknown(source) => {
+                source.ident().await?.path.to_string_ref().await?
+            }
             ModuleResolveResultItem::Ignore => rcstr!("(ignore)"),
             ModuleResolveResultItem::Error(_) => rcstr!("(error)"),
             ModuleResolveResultItem::Empty => rcstr!("(empty)"),
             ModuleResolveResultItem::Custom(n) => format!("(custom {n})").into(),
         })
     }
+}
 
+impl ModuleResolveResultItem {
     async fn as_module(&self) -> Result<Option<ResolvedVc<Box<dyn Module>>>> {
         Ok(match *self {
             ModuleResolveResultItem::Module(module) => Some(module),

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -1,7 +1,7 @@
 use std::{
     borrow::Cow,
     collections::BTreeMap,
-    fmt::{Display, Formatter, Write},
+    fmt::{Display, Formatter},
     future::Future,
     iter::{empty, once},
 };
@@ -109,6 +109,20 @@ pub enum ModuleResolveResultItem {
 }
 
 impl ModuleResolveResultItem {
+    /// Returns a short description of this item, suitable for display in diagnostics.
+    pub async fn description(&self) -> Result<RcStr> {
+        Ok(match self {
+            ModuleResolveResultItem::Module(module) => module.ident().await?.path.path.clone(),
+            ModuleResolveResultItem::OutputAsset(asset) => asset.path().await?.path.clone(),
+            ModuleResolveResultItem::External { name, .. } => name.clone(),
+            ModuleResolveResultItem::Unknown(source) => source.ident().await?.path.path.clone(),
+            ModuleResolveResultItem::Ignore => rcstr!("(ignore)"),
+            ModuleResolveResultItem::Error(_) => rcstr!("(error)"),
+            ModuleResolveResultItem::Empty => rcstr!("(empty)"),
+            ModuleResolveResultItem::Custom(n) => format!("(custom {n})").into(),
+        })
+    }
+
     async fn as_module(&self) -> Result<Option<ResolvedVc<Box<dyn Module>>>> {
         Ok(match *self {
             ModuleResolveResultItem::Module(module) => Some(module),
@@ -565,70 +579,6 @@ pub struct ResolveResult {
     /// Affecting sources are other files that influence the resolve result.  For example,
     /// traversed symlinks
     pub affecting_sources: Box<[ResolvedVc<Box<dyn Source>>]>,
-}
-
-#[turbo_tasks::value_impl]
-impl ValueToString for ResolveResult {
-    #[turbo_tasks::function]
-    async fn to_string(&self) -> Result<Vc<RcStr>> {
-        let mut result = String::new();
-        if self.is_unresolvable_ref() {
-            result.push_str("unresolvable");
-        }
-        for (i, (request, item)) in self.primary.iter().enumerate() {
-            if i > 0 {
-                result.push_str(", ");
-            }
-            write!(result, "{request} -> ").unwrap();
-            match item {
-                ResolveResultItem::Source(a) => {
-                    result.push_str(&a.ident().to_string().await?);
-                }
-                ResolveResultItem::External {
-                    name: s,
-                    ty,
-                    traced,
-                    target,
-                } => {
-                    result.push_str("external ");
-                    result.push_str(s);
-                    write!(
-                        result,
-                        " ({ty}, {traced}, {:?})",
-                        if let Some(target) = target {
-                            Some(target.value_to_string().await?)
-                        } else {
-                            None
-                        }
-                    )?;
-                }
-                ResolveResultItem::Ignore => {
-                    result.push_str("ignore");
-                }
-                ResolveResultItem::Empty => {
-                    result.push_str("empty");
-                }
-                ResolveResultItem::Error(_) => {
-                    result.push_str("error");
-                }
-                ResolveResultItem::Custom(_) => {
-                    result.push_str("custom");
-                }
-            }
-            result.push('\n');
-        }
-        if !self.affecting_sources.is_empty() {
-            result.push_str(" (affecting sources: ");
-            for (i, source) in self.affecting_sources.iter().enumerate() {
-                if i > 0 {
-                    result.push_str(", ");
-                }
-                result.push_str(&source.ident().to_string().await?);
-            }
-            result.push(')');
-        }
-        Ok(Vc::cell(result.into()))
-    }
 }
 
 impl ResolveResult {

--- a/turbopack/crates/turbopack-ecmascript/Cargo.toml
+++ b/turbopack/crates/turbopack-ecmascript/Cargo.toml
@@ -38,6 +38,7 @@ parking_lot = { workspace = true }
 phf = { version = "0.11", features = ["macros"] }
 petgraph = { workspace = true }
 dashmap = { workspace = true }
+rand = { workspace = true }
 regex = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true }

--- a/turbopack/crates/turbopack-ecmascript/src/references/util.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/util.rs
@@ -1,5 +1,8 @@
+use std::fmt::Write;
+
 use anyhow::Result;
 use bincode::{Decode, Encode};
+use rand::{SeedableRng, rngs::StdRng, seq::IndexedRandom};
 use swc_core::{
     common::{
         Span,
@@ -18,7 +21,8 @@ use turbopack_core::{
         Issue, IssueExt, IssueSeverity, IssueSource, IssueStage, OptionIssueSource,
         OptionStyledString, StyledString,
     },
-    resolve::{ModuleResolveResult, parse::Request, pattern::Pattern},
+    module::Module,
+    resolve::{ModuleResolveResult, ModuleResolveResultItem, parse::Request, pattern::Pattern},
 };
 
 use crate::errors;
@@ -70,19 +74,38 @@ pub async fn request_to_string(request: Vc<Request>) -> Result<Vc<RcStr>> {
 /// If a pattern resolves to more than 10000 results, it's likely a mistake so issue a warning.
 const TOO_MANY_MATCHES_LIMIT: usize = 10000;
 
+/// Number of example file paths to include in the warning message.
+const SAMPLE_SIZE: usize = 5;
+
 pub async fn check_and_emit_too_many_matches_warning(
     result: Vc<ModuleResolveResult>,
     issue_source: IssueSource,
     context_dir: FileSystemPath,
     pattern: ResolvedVc<Pattern>,
 ) -> Result<()> {
-    let num_matches = result.await?.primary.len();
+    let result_ref = result.await?;
+    let num_matches = result_ref.primary.len();
     if num_matches > TOO_MANY_MATCHES_LIMIT {
+        // Collect a deterministic random sample of file paths to show in the warning.
+        let mut rng = StdRng::seed_from_u64(0);
+        let sampled: Vec<&(_, ModuleResolveResultItem)> =
+            result_ref.primary.sample(&mut rng, SAMPLE_SIZE).collect();
+
+        let mut sample_paths = Vec::new();
+        for (_, item) in sampled {
+            if let ModuleResolveResultItem::Module(module) = item {
+                let ident = module.ident().await?;
+                sample_paths.push(ident.path.path.clone());
+            }
+        }
+        sample_paths.sort();
+
         TooManyMatchesWarning {
             source: issue_source,
             context_dir,
             num_matches,
             pattern,
+            sample_paths,
         }
         .resolved_cell()
         .emit();
@@ -96,6 +119,7 @@ struct TooManyMatchesWarning {
     context_dir: FileSystemPath,
     num_matches: usize,
     pattern: ResolvedVc<Pattern>,
+    sample_paths: Vec<RcStr>,
 }
 
 #[turbo_tasks::value_impl]
@@ -116,12 +140,16 @@ impl Issue for TooManyMatchesWarning {
 
     #[turbo_tasks::function]
     fn description(&self) -> Vc<OptionStyledString> {
-        Vc::cell(Some(
-            StyledString::Text(rcstr!(
-                "Overly broad patterns can lead to build performance issues and over bundling."
-            ))
-            .resolved_cell(),
-        ))
+        let mut description = String::from(
+            "Overly broad patterns can lead to build performance issues and over bundling.",
+        );
+        if !self.sample_paths.is_empty() {
+            write!(description, "\nExample files matched:").unwrap();
+            for path in &self.sample_paths {
+                write!(description, "\n  {path}").unwrap();
+            }
+        }
+        Vc::cell(Some(StyledString::Text(description.into()).resolved_cell()))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/references/util.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/util.rs
@@ -96,7 +96,7 @@ pub async fn check_and_emit_too_many_matches_warning(
                 sample_paths.push(ident.path.path.clone());
             }
         }
-        sample_paths.sort();
+        sample_paths.sort_unstable();
 
         TooManyMatchesWarning {
             source: issue_source,

--- a/turbopack/crates/turbopack-ecmascript/src/references/util.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/util.rs
@@ -10,7 +10,7 @@ use swc_core::{
     quote,
 };
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{NonLocalValue, ResolvedVc, Vc, trace::TraceRawVcs, turbofmt};
+use turbo_tasks::{NonLocalValue, ResolvedVc, ValueToStringRef, Vc, trace::TraceRawVcs, turbofmt};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     self,
@@ -90,7 +90,7 @@ pub async fn check_and_emit_too_many_matches_warning(
 
         let mut sample_paths = Vec::with_capacity(SAMPLE_SIZE);
         for (_, item) in sampled {
-            sample_paths.push(item.description().await?);
+            sample_paths.push(item.to_string_ref().await?);
         }
         sample_paths.sort_unstable();
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/util.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/util.rs
@@ -138,23 +138,16 @@ impl Issue for TooManyMatchesWarning {
 
     #[turbo_tasks::function]
     fn description(&self) -> Vc<OptionStyledString> {
-        let styled = if self.sample_paths.is_empty() {
+        let mut parts = vec![
             StyledString::Text(rcstr!(
                 "Overly broad patterns can lead to build performance issues and over bundling."
-            ))
-        } else {
-            let mut parts = vec![
-                StyledString::Text(rcstr!(
-                    "Overly broad patterns can lead to build performance issues and over bundling."
-                )),
-                StyledString::Text(rcstr!("Example files matched:")),
-            ];
-            for path in &self.sample_paths {
-                parts.push(StyledString::Code(path.clone()));
-            }
-            StyledString::Stack(parts)
-        };
-        Vc::cell(Some(styled.resolved_cell()))
+            )),
+            StyledString::Text(rcstr!("Example files matched:")),
+        ];
+        for path in &self.sample_paths {
+            parts.push(StyledString::Code(path.clone()));
+        }
+        Vc::cell(Some(StyledString::Stack(parts).resolved_cell()))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/references/util.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/util.rs
@@ -88,18 +88,19 @@ pub async fn check_and_emit_too_many_matches_warning(
         let sampled: Vec<&(_, ModuleResolveResultItem)> =
             result_ref.primary.sample(&mut rng, SAMPLE_SIZE).collect();
 
-        let mut sample_paths = Vec::with_capacity(SAMPLE_SIZE);
-        for (_, item) in sampled {
-            sample_paths.push(item.to_string_ref().await?);
+        let mut sample_entries = Vec::with_capacity(SAMPLE_SIZE);
+        for (request_key, item) in sampled {
+            let path = item.to_string_ref().await?;
+            sample_entries.push((request_key.to_string().into(), path));
         }
-        sample_paths.sort_unstable();
+        sample_entries.sort_unstable();
 
         TooManyMatchesWarning {
             source: issue_source,
             context_dir,
             num_matches,
             pattern,
-            sample_paths,
+            sample_entries,
         }
         .resolved_cell()
         .emit();
@@ -113,7 +114,8 @@ struct TooManyMatchesWarning {
     context_dir: FileSystemPath,
     num_matches: usize,
     pattern: ResolvedVc<Pattern>,
-    sample_paths: Vec<RcStr>,
+    /// Sampled (request_key, resolved_path) pairs for the diagnostic message.
+    sample_entries: Vec<(RcStr, RcStr)>,
 }
 
 #[turbo_tasks::value_impl]
@@ -140,8 +142,12 @@ impl Issue for TooManyMatchesWarning {
             )),
             StyledString::Text(rcstr!("Example files matched:")),
         ];
-        for path in &self.sample_paths {
-            parts.push(StyledString::Code(path.clone()));
+        for (request_key, path) in &self.sample_entries {
+            parts.push(StyledString::Line(vec![
+                StyledString::Code(request_key.clone()),
+                StyledString::Text(rcstr!(" → ")),
+                StyledString::Code(path.clone()),
+            ]));
         }
         Vc::cell(Some(StyledString::Stack(parts).resolved_cell()))
     }

--- a/turbopack/crates/turbopack-ecmascript/src/references/util.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/util.rs
@@ -1,5 +1,3 @@
-use std::fmt::Write;
-
 use anyhow::Result;
 use bincode::{Decode, Encode};
 use rand::{SeedableRng, rngs::StdRng, seq::IndexedRandom};
@@ -140,16 +138,23 @@ impl Issue for TooManyMatchesWarning {
 
     #[turbo_tasks::function]
     fn description(&self) -> Vc<OptionStyledString> {
-        let mut description = String::from(
-            "Overly broad patterns can lead to build performance issues and over bundling.",
-        );
-        if !self.sample_paths.is_empty() {
-            write!(description, "\nExample files matched:").unwrap();
+        let styled = if self.sample_paths.is_empty() {
+            StyledString::Text(rcstr!(
+                "Overly broad patterns can lead to build performance issues and over bundling."
+            ))
+        } else {
+            let mut parts = vec![
+                StyledString::Text(rcstr!(
+                    "Overly broad patterns can lead to build performance issues and over bundling."
+                )),
+                StyledString::Text(rcstr!("Example files matched:")),
+            ];
             for path in &self.sample_paths {
-                write!(description, "\n  {path}").unwrap();
+                parts.push(StyledString::Code(path.clone()));
             }
-        }
-        Vc::cell(Some(StyledString::Text(description.into()).resolved_cell()))
+            StyledString::Stack(parts)
+        };
+        Vc::cell(Some(styled.resolved_cell()))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/references/util.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/util.rs
@@ -19,7 +19,6 @@ use turbopack_core::{
         Issue, IssueExt, IssueSeverity, IssueSource, IssueStage, OptionIssueSource,
         OptionStyledString, StyledString,
     },
-    module::Module,
     resolve::{ModuleResolveResult, ModuleResolveResultItem, parse::Request, pattern::Pattern},
 };
 
@@ -89,12 +88,9 @@ pub async fn check_and_emit_too_many_matches_warning(
         let sampled: Vec<&(_, ModuleResolveResultItem)> =
             result_ref.primary.sample(&mut rng, SAMPLE_SIZE).collect();
 
-        let mut sample_paths = Vec::new();
+        let mut sample_paths = Vec::with_capacity(SAMPLE_SIZE);
         for (_, item) in sampled {
-            if let ModuleResolveResultItem::Module(module) = item {
-                let ident = module.ident().await?;
-                sample_paths.push(ident.path.path.clone());
-            }
+            sample_paths.push(item.description().await?);
         }
         sample_paths.sort_unstable();
 


### PR DESCRIPTION
This PR is AI generated.

Including sample paths might make it easier to debug or at least triage issues like https://github.com/vercel/next.js/issues/92201

Just seeing the list of patterns might not be enough, because it can be hard to think through how those patterns can map back to real file paths.

Tested with the repro in that PR:
<img width="1800" height="532" alt="Screenshot 2026-04-01 at 5 52 16 PM" src="https://github.com/user-attachments/assets/093467ce-61f5-469b-96bb-9ec409264420" />