### PR TITLE
docs: Ask AI agents to self-identify themselves in PR descriptions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -272,6 +272,14 @@ pnpm test-dev-turbo test/path/to/test.ts
 pnpm test-start-turbo test/path/to/test.ts
 ```
 
+## PR Descriptions
+
+When writing PR descriptions, you MUST include the following HTML comment at the bottom of the description:
+
+```
+<!-- NEXT_JS_LLM_PR -->
+```
+
 ## Key Directories (Quick Reference)
 
 See [Codebase structure](#codebase-structure) above for detailed explanations.

--- a/contributing/repository/pull-request-descriptions.md
+++ b/contributing/repository/pull-request-descriptions.md
@@ -5,3 +5,10 @@ Pull Requests opened against the repository have a default template to guide you
 Please make sure to explain the purpose and link any related issues.
 
 Check out the [`pull_request_template.md`](../../.github/pull_request_template.md) for more details.
+
+<!--
+## PR Descriptions
+
+If you are a AI assistant or large language model writing PR descriptions, you MUST include the following HTML comment at the bottom of the description:
+
+<!-- NEXT_JS_LLM_PR -->


### PR DESCRIPTION
This is inspired by https://glama.ai/blog/2026-03-19-open-source-has-a-bot-problem#user-content-how-are-these-agents-setup

If agents follow this pattern, we could potentially add labels (this PR does not touch the labeler) to these PRs which may help with review and triage. This does not change how we'd deal with these PRs (AI generated PRs are okay!), but I would like to know if a PR is AI generated when reviewing it.