### PR TITLE
fix(turbopack): handle unresolvable browserslist via Targets::Query

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10465,6 +10465,7 @@ dependencies = [
  "parking_lot",
  "petgraph 0.8.3",
  "phf",
+ "preset_env_base",
  "regex",
  "rustc-hash 2.1.1",
  "serde",

--- a/turbopack/crates/turbopack-ecmascript/Cargo.toml
+++ b/turbopack/crates/turbopack-ecmascript/Cargo.toml
@@ -53,6 +53,7 @@ turbo-frozenmap = { workspace = true }
 turbo-rcstr = { workspace = true }
 turbo-tasks = { workspace = true }
 turbo-tasks-fs = { workspace = true }
+preset_env_base = { workspace = true }
 turbo-tasks-hash = { workspace = true }
 turbopack-core = { workspace = true }
 turbopack-resolve = { workspace = true }

--- a/turbopack/crates/turbopack-ecmascript/src/transform/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/transform/mod.rs
@@ -2,6 +2,7 @@ use std::{fmt::Debug, hash::Hash, sync::Arc};
 
 use anyhow::{Result, bail};
 use async_trait::async_trait;
+use preset_env_base::query::Query;
 use swc_core::{
     atoms::{Atom, atom},
     base::SwcComments,
@@ -283,9 +284,28 @@ impl EcmascriptInputTransform {
                     }
                 }
 
+                // When browserslist-rs returns an empty result (the query references
+                // versions newer than its bundled caniuse-lite, or the user wrote
+                // `chrome 99999`), every Versions field is None and SWC treats that
+                // as `is_any_target == true` — which enables every feature transform
+                // and panics on unsupported nodes like `**`. Re-route those queries
+                // through `Targets::Query` so SWC's own resolver can detect the
+                // empty result and set `unknown_version`, matching the design from
+                // swc-project/swc#11457.
+                let targets = if versions.is_any_target() {
+                    let query = env.browserslist_query().await?;
+                    if query.is_empty() {
+                        Some(Targets::Versions(*versions))
+                    } else {
+                        Some(Targets::Query(Query::Single(query.to_string())))
+                    }
+                } else {
+                    Some(Targets::Versions(*versions))
+                };
+
                 let config = swc_core::ecma::preset_env::EnvConfig::from(
                     swc_core::ecma::preset_env::Config {
-                        targets: Some(Targets::Versions(*versions)),
+                        targets,
                         mode,
                         core_js,
                         skip,
@@ -299,8 +319,8 @@ impl EcmascriptInputTransform {
                     },
                 );
 
-                // Explicit type annotation to ensure that we don't duplicate transforms in the
-                // final binary
+                // Explicit type annotation to ensure that we don't duplicate
+                // transforms in the final binary
                 apply_transform(
                     program,
                     helpers,

--- a/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env_unknown_browserslist/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env_unknown_browserslist/input/index.js
@@ -1,0 +1,12 @@
+// When browserslist-rs can't resolve the target (e.g. "chrome 99999"),
+// preset-env should treat it as `unknown_version` instead of enabling every
+// transform. Without the fix this panics: the generator transform has a
+// todo!() for **.
+
+async function compute() {
+  return 10n ** 18n
+}
+
+console.log(compute())
+
+export default 123

--- a/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env_unknown_browserslist/options.json
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env_unknown_browserslist/options.json
@@ -1,0 +1,3 @@
+{
+  "browserslist": "chrome 99999"
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env_unknown_browserslist/output/0p5q_snapshot_swc_transforms_preset_env_unknown_browserslist_input_index_02kg1w1.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env_unknown_browserslist/output/0p5q_snapshot_swc_transforms_preset_env_unknown_browserslist_input_index_02kg1w1.js
@@ -1,0 +1,21 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push(["output/0p5q_snapshot_swc_transforms_preset_env_unknown_browserslist_input_index_02kg1w1.js",
+"[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env_unknown_browserslist/input/index.js [test] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+__turbopack_context__.s([
+    "default",
+    ()=>__TURBOPACK__default__export__
+]);
+// When browserslist-rs can't resolve the target (e.g. "chrome 99999"),
+// preset-env should treat it as `unknown_version` instead of enabling every
+// transform. Without the fix this panics: the generator transform has a
+// todo!() for **.
+async function compute() {
+    return 10n ** 18n;
+}
+console.log(compute());
+const __TURBOPACK__default__export__ = 123;
+}),
+]);
+
+//# sourceMappingURL=0p5q_snapshot_swc_transforms_preset_env_unknown_browserslist_input_index_02kg1w1.js.map

--- a/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env_unknown_browserslist/output/0p5q_snapshot_swc_transforms_preset_env_unknown_browserslist_input_index_02kg1w1.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env_unknown_browserslist/output/0p5q_snapshot_swc_transforms_preset_env_unknown_browserslist_input_index_02kg1w1.js.map
@@ -1,0 +1,6 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 4, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env_unknown_browserslist/input/index.js"],"sourcesContent":["// When browserslist-rs can't resolve the target (e.g. \"chrome 99999\"),\n// preset-env should treat it as `unknown_version` instead of enabling every\n// transform. Without the fix this panics: the generator transform has a\n// todo!() for **.\n\nasync function compute() {\n  return 10n ** 18n\n}\n\nconsole.log(compute())\n\nexport default 123\n"],"names":["compute","console","log"],"mappings":";;;;AAAA,uEAAuE;AACvE,4EAA4E;AAC5E,wEAAwE;AACxE,kBAAkB;AAElB,eAAeA;IACb,OAAO,GAAG,IAAI,GAAG;AACnB;AAEAC,QAAQC,GAAG,CAACF;uCAEG"}}]
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env_unknown_browserslist/output/0p5q_snapshot_swc_transforms_preset_env_unknown_browserslist_input_index_1qbivst.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env_unknown_browserslist/output/0p5q_snapshot_swc_transforms_preset_env_unknown_browserslist_input_index_1qbivst.js.map
@@ -1,0 +1,5 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": []
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env_unknown_browserslist/output/17f0_snapshot_swc_transforms_preset_env_unknown_browserslist_input_index_1qbivst.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env_unknown_browserslist/output/17f0_snapshot_swc_transforms_preset_env_unknown_browserslist_input_index_1qbivst.js
@@ -1,0 +1,5 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([
+    "output/17f0_snapshot_swc_transforms_preset_env_unknown_browserslist_input_index_1qbivst.js",
+    {"otherChunks":["output/0p5q_snapshot_swc_transforms_preset_env_unknown_browserslist_input_index_02kg1w1.js"],"runtimeModuleIds":["[project]/turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/preset_env_unknown_browserslist/input/index.js [test] (ecmascript)"]}
+]);
+// Dummy runtime


### PR DESCRIPTION
Fixes #92091

### What?

When a project has a browserslist like `>0.2%, not dead` (the CRA default), Turbopack panics with `not yet implemented: right-associative binary expression` on any code that uses `async` + `**` together.

### Why?

Next.js resolves the browserslist on the JS side using an up-to-date `caniuse-lite` (which knows about Chrome 146, Firefox 149, etc.), then sends the resolved browser strings to Turbopack. Turbopack re-resolves them using `browserslist-rs` v0.19.0, which only knows up to about Chrome 141. Unknown versions are silently dropped because of `ignore_unknown_versions: true` in `environment.rs`.

With all versions dropped, `Versions::parse_versions` returns all-`None` fields. SWC's `preset_env` then sees `is_any_target() == true` and short-circuits its `caniuse` to "transform every feature", which includes `async-to-generator` and the ES2015 generator transform — and that transform has a `todo!()` for the `**` operator at `generator.rs:507`.

SWC already handles this case for the raw browserslist path via the `unknown_version` flag added in swc-project/swc#11457. But Turbopack bypasses that flag because it passes pre-resolved `Targets::Versions(versions)` directly, and `targets_to_versions` always sets `unknown_version: false` on that variant.

### How?

When `versions.is_any_target()` is true and a browserslist query string is available on the `Environment`, re-route through `Targets::Query(Query::Single(query))` instead of `Targets::Versions(empty)`. SWC's own resolver runs the query, observes the empty result, and sets `unknown_version: true` — the documented "modern browser, supports everything" semantics from swc#11457.

The user's `experimental.swcEnvOptions` (`mode`, `coreJs`, `include`, `exclude`, `shippedProposals`, `forceAllTransforms`, `debug`, `loose`) continue to flow through to SWC's `Config` unchanged, so SWC remains the source of truth for how those options interact with `unknown_version`.

### Test plan

- New snapshot test `swc_transforms/preset_env_unknown_browserslist` covers an explicit `chrome 99999` query. Without the fix it panics on the same `todo!()`; with the fix the `async function ... return 10n ** 18n` is preserved verbatim in the chunk output.
- Verified against the [reproduction project](https://github.com/mhdsdt/turbopack-bigint-exponentiation-repro): rebuilt the SWC binary against this branch, ran `next dev --turbopack`, page renders with status `200`, and the emitted chunk contains the original `async function compute() { return 10n ** 18n; }` with no transforms applied.
- `cargo check`, `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and the full `turbopack-tests` snapshot suite all clean.
