### PR TITLE
Allow multi-level .localhost subdomains in dev origin check

### DIFF
--- a/packages/next/src/server/lib/router-utils/block-cross-site-dev.ts
+++ b/packages/next/src/server/lib/router-utils/block-cross-site-dev.ts
@@ -119,7 +119,7 @@ export const blockCrossSiteDEV = (
   hostname: string | undefined
 ): boolean => {
   const allowedOrigins = [
-    '*.localhost',
+    '**.localhost',
     'localhost',
     ...(allowedDevOrigins ?? []),
   ]

--- a/test/development/basic/allowed-dev-origins.test.ts
+++ b/test/development/basic/allowed-dev-origins.test.ts
@@ -248,6 +248,14 @@ describe.each(['', '/docs'])(
         })
       })
 
+      it('should allow requests from multi-level localhost subdomains', async () => {
+        const res = await requestInternalDevMiddleware(
+          next.appPort,
+          basePath,
+          'https://sub.app.localhost'
+        )
+        expect(res.status).not.toBe(403)
+      })
       it('should allow same-site requests without an origin header', async () => {
         const res = await fetchViaHTTP(
           next.appPort,


### PR DESCRIPTION
## Summary

The built-in dev origin allowlist uses `*.localhost`, but `*` only matches a single subdomain level. Multi-level `.localhost` subdomains like `sub.app.localhost` are blocked even though all `.localhost` domains resolve to loopback per RFC 6761.

This changes `*.localhost` to `**.localhost` so any depth of `.localhost` subdomain is auto-allowed. The `**` glob is already supported by `matchWildcardDomain` in `csrf-protection.ts`.

- `**.localhost` matches `app.localhost` (single level, same as before)
- `**.localhost` matches `sub.app.localhost` (multi-level, previously blocked)
- Bare `localhost` is already separately in the allowlist, unaffected