### PR TITLE
Route Handlers: Fix devRequestTimingInternalsEnd and Turbopack server HMR

### DIFF
--- a/packages/next/src/build/templates/app-route.ts
+++ b/packages/next/src/build/templates/app-route.ts
@@ -57,14 +57,16 @@ const routeModule = new AppRouteRouteModule({
   relativeProjectDir: process.env.__NEXT_RELATIVE_PROJECT_DIR || '',
   resolvedPagePath: 'VAR_RESOLVED_PAGE_PATH',
   nextConfigOutput,
-  // In dev: use a lazy require so userland is only loaded when the first
-  // request is handled. This ensures devRequestTimingInternalsEnd is set
-  // before userland executes, correctly attributing module load time.
-  // In production: eagerly load userland at module initialization time to
-  // avoid adding cold-start latency to the first request.
-  userland: process.env.__NEXT_DEV_SERVER
-    ? () => require('VAR_USERLAND') as typeof import('VAR_USERLAND')
-    : (require('VAR_USERLAND') as typeof import('VAR_USERLAND')),
+  // Always use a lazy require factory so that:
+  // - In dev: devRequestTimingInternalsEnd is set before userland executes,
+  //   correctly attributing module load time to application-code rather than
+  //   framework internals.
+  // - In all modes: async modules (route files with top-level await) are
+  //   handled correctly — require() returns a Promise for such modules, which
+  //   ensureUserland() awaits before the first request is handled. Eagerly
+  //   calling require() would pass that Promise directly to the constructor
+  //   and break _initFromUserland().
+  userland: () => require('VAR_USERLAND') as typeof import('VAR_USERLAND'),
   // In Turbopack dev mode, also provide a synchronous per-request getter so
   // server HMR updates are picked up without re-executing the entry chunk.
   // Using require() (synchronous) avoids adding async overhead that would be

--- a/packages/next/src/build/templates/app-route.ts
+++ b/packages/next/src/build/templates/app-route.ts
@@ -2,7 +2,6 @@ import {
   AppRouteRouteModule,
   type AppRouteRouteHandlerContext,
   type AppRouteRouteModuleOptions,
-  type AppRouteUserlandModule,
 } from '../../server/route-modules/app-route/module.compiled'
 import { RouteKind } from '../../server/route-kind'
 import { patchFetch as _patchFetch } from '../../server/lib/patch-fetch'
@@ -36,7 +35,6 @@ import {
   type ResponseCacheEntry,
   type ResponseGenerator,
 } from '../../server/response-cache'
-import * as userland from 'VAR_USERLAND'
 
 // These are injected by the loader afterwards. This is injected as a variable
 // instead of a replacement because this could also be `undefined` instead of
@@ -59,9 +57,12 @@ const routeModule = new AppRouteRouteModule({
   relativeProjectDir: process.env.__NEXT_RELATIVE_PROJECT_DIR || '',
   resolvedPagePath: 'VAR_RESOLVED_PAGE_PATH',
   nextConfigOutput,
-  // The static import is used for initialization (methods, dynamic, etc.).
-  userland: userland as AppRouteUserlandModule,
-  // In Turbopack dev mode, also provide a getter that calls require() on every
+  // Using a lazy require ensures userland is only loaded when the first request
+  // is handled. This is important for accurate devRequestTimingInternalsEnd
+  // measurement: framework time ends when userland starts executing, not at
+  // module load time.
+  userland: () => require('VAR_USERLAND') as typeof import('VAR_USERLAND'),
+  // In Turbopack dev mode, also provide a getter that calls import() on every
   // request. This re-reads from devModuleCache so HMR updates are picked up,
   // and the async wrapper unwraps async-module Promises (ESM-only
   // serverExternalPackages) automatically.

--- a/packages/next/src/build/templates/app-route.ts
+++ b/packages/next/src/build/templates/app-route.ts
@@ -62,15 +62,6 @@ const routeModule = new AppRouteRouteModule({
   // measurement: framework time ends when userland starts executing, not at
   // module load time.
   userland: () => require('VAR_USERLAND') as typeof import('VAR_USERLAND'),
-  // In Turbopack dev mode, also provide a getter that calls import() on every
-  // request. This re-reads from devModuleCache so HMR updates are picked up,
-  // and the async wrapper unwraps async-module Promises (ESM-only
-  // serverExternalPackages) automatically.
-  ...(process.env.TURBOPACK && process.env.__NEXT_DEV_SERVER
-    ? {
-        getUserland: () => import('VAR_USERLAND'),
-      }
-    : {}),
 })
 
 // Pull out the exports that we need to expose from the module. This should

--- a/packages/next/src/build/templates/app-route.ts
+++ b/packages/next/src/build/templates/app-route.ts
@@ -62,6 +62,16 @@ const routeModule = new AppRouteRouteModule({
   // measurement: framework time ends when userland starts executing, not at
   // module load time.
   userland: () => require('VAR_USERLAND') as typeof import('VAR_USERLAND'),
+  // In Turbopack dev mode, also provide a synchronous per-request getter so
+  // server HMR updates are picked up without re-executing the entry chunk.
+  // Using require() (synchronous) avoids adding async overhead that would be
+  // incorrectly attributed to application-code time in devRequestTiming.
+  ...(process.env.TURBOPACK && process.env.__NEXT_DEV_SERVER
+    ? {
+        getUserland: () =>
+          require('VAR_USERLAND') as typeof import('VAR_USERLAND'),
+      }
+    : {}),
 })
 
 // Pull out the exports that we need to expose from the module. This should

--- a/packages/next/src/build/templates/app-route.ts
+++ b/packages/next/src/build/templates/app-route.ts
@@ -57,11 +57,14 @@ const routeModule = new AppRouteRouteModule({
   relativeProjectDir: process.env.__NEXT_RELATIVE_PROJECT_DIR || '',
   resolvedPagePath: 'VAR_RESOLVED_PAGE_PATH',
   nextConfigOutput,
-  // Using a lazy require ensures userland is only loaded when the first request
-  // is handled. This is important for accurate devRequestTimingInternalsEnd
-  // measurement: framework time ends when userland starts executing, not at
-  // module load time.
-  userland: () => require('VAR_USERLAND') as typeof import('VAR_USERLAND'),
+  // In dev: use a lazy require so userland is only loaded when the first
+  // request is handled. This ensures devRequestTimingInternalsEnd is set
+  // before userland executes, correctly attributing module load time.
+  // In production: eagerly load userland at module initialization time to
+  // avoid adding cold-start latency to the first request.
+  userland: process.env.__NEXT_DEV_SERVER
+    ? () => require('VAR_USERLAND') as typeof import('VAR_USERLAND')
+    : (require('VAR_USERLAND') as typeof import('VAR_USERLAND')),
   // In Turbopack dev mode, also provide a synchronous per-request getter so
   // server HMR updates are picked up without re-executing the entry chunk.
   // Using require() (synchronous) avoids adding async overhead that would be

--- a/packages/next/src/export/routes/app-route.ts
+++ b/packages/next/src/export/routes/app-route.ts
@@ -88,6 +88,11 @@ export async function exportAppRoute(
   }
 
   try {
+    // Ensure the userland module is fully loaded before accessing it. This is
+    // required for route files that use top-level await: require() returns a
+    // Promise for async modules, so module.userland would be undefined until
+    // the Promise resolves.
+    await module.ensureUserland()
     const userland = module.userland
     // we don't bail from the static optimization for
     // metadata routes, since it's app-route we can always append /route suffix.

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -177,7 +177,9 @@ export interface AppRouteRouteModuleOptions
     RouteModuleOptions<AppRouteRouteDefinition, AppRouteUserlandModule>,
     'userland'
   > {
-  readonly userland: AppRouteUserlandModule | (() => AppRouteUserlandModule)
+  readonly userland:
+    | AppRouteUserlandModule
+    | (() => AppRouteUserlandModule | Promise<AppRouteUserlandModule>)
   readonly resolvedPagePath: string
   readonly nextConfigOutput: NextConfig['output']
   /**
@@ -227,18 +229,47 @@ export class AppRouteRouteModule extends RouteModule<
   private readonly _getUserland?: () => Promise<AppRouteUserlandModule>
   // Set in the constructor when userland is provided as a factory. Cleared
   // after the first access so userland is only loaded once.
-  private _userlandFactory: (() => AppRouteUserlandModule) | null
+  private _userlandFactory:
+    | (() => AppRouteUserlandModule | Promise<AppRouteUserlandModule>)
+    | null
+  // Non-null while an async userland module (top-level await) is loading.
+  // ensureUserland() awaits this before the first request is handled.
+  private _pendingUserland: Promise<void> | null = null
   private _methods!: Record<HTTP_METHOD, AppRouteHandlerFn>
   private _hasNonStaticMethods!: boolean
   private _dynamic!: AppRouteUserlandModule['dynamic']
 
   override get userland(): AppRouteUserlandModule {
     if (this._userlandFactory) {
-      this._userland = this._userlandFactory()
+      const result = this._userlandFactory()
       this._userlandFactory = null
-      this._initFromUserland()
+      if (result instanceof Promise) {
+        // The route file uses top-level await (async module). Store the
+        // promise so ensureUserland() can await it before the first request.
+        this._pendingUserland = result.then((mod) => {
+          this._userland = mod
+          this._pendingUserland = null
+          this._initFromUserland()
+        })
+      } else {
+        this._userland = result
+        this._initFromUserland()
+      }
     }
     return this._userland as AppRouteUserlandModule
+  }
+
+  /**
+   * Ensures the userland module is fully loaded before a request is handled.
+   * Required for route files that use top-level await, where require() returns
+   * a Promise instead of the module directly.
+   */
+  private async ensureUserland(): Promise<void> {
+    // Trigger lazy loading if not yet started.
+    void this.userland
+    if (this._pendingUserland) {
+      await this._pendingUserland
+    }
   }
 
   constructor({
@@ -331,13 +362,11 @@ export class AppRouteRouteModule extends RouteModule<
   /**
    * Returns the handler function for the given HTTP method.
    *
-   * In Turbopack dev mode (`_getUserland` is set), re-fetches the live
-   * userland on every request so that server HMR updates are picked up. The
+   * Must be called after ensureUserland() has resolved so that _methods is
+   * populated. In Turbopack dev mode (_getUserland is set), re-fetches the
+   * live userland on every request so server HMR updates are picked up; the
    * async wrapper also unwraps async-module Promises for ESM-only
    * serverExternalPackages.
-   *
-   * In all other modes, returns the handler from the cached `_methods` map,
-   * triggering lazy userland initialization on the first request if needed.
    */
   private async resolveHandler(method: string): Promise<AppRouteHandlerFn> {
     // Prevent RCE: only allow recognized HTTP methods.
@@ -348,8 +377,6 @@ export class AppRouteRouteModule extends RouteModule<
       return autoImplementMethods(userland)[method]
     }
 
-    // Accessing `this.userland` triggers lazy initialization on first request.
-    void this.userland
     return this._methods[method]
   }
 
@@ -745,6 +772,10 @@ export class AppRouteRouteModule extends RouteModule<
     req: NextRequest,
     context: AppRouteRouteHandlerContext
   ): Promise<Response> {
+    // Ensure userland is fully loaded (handles async modules with top-level
+    // await, where require() returns a Promise instead of the module).
+    await this.ensureUserland()
+
     const handler = await this.resolveHandler(req.method)
 
     // Get the context for the static generation.

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -295,11 +295,30 @@ export class AppRouteRouteModule extends RouteModule<
 
     this.resolvedPagePath = resolvedPagePath
     this.nextConfigOutput = nextConfigOutput
-    this._userlandFactory = isLazy ? userland : null
     this._getUserland = getUserland
 
     if (!isLazy) {
+      this._userlandFactory = null
       this._initFromUserland()
+    } else if (nextConfigOutput === 'export') {
+      // For output:export routes, validate constraints eagerly at module load
+      // time so that the error surfaces as a Redbox in dev (module load error)
+      // rather than being silently swallowed as a 500 response at request time.
+      this._userlandFactory = null
+      const result = userland()
+      if (result instanceof Promise) {
+        // Async module (top-level await) — defer via pending promise.
+        this._pendingUserland = result.then((mod) => {
+          this._userland = mod
+          this._pendingUserland = null
+          this._initFromUserland()
+        })
+      } else {
+        this._userland = result
+        this._initFromUserland() // throws for invalid output:export routes
+      }
+    } else {
+      this._userlandFactory = userland
     }
   }
 

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -264,9 +264,11 @@ export class AppRouteRouteModule extends RouteModule<
   /**
    * Ensures the userland module is fully loaded before a request is handled.
    * Required for route files that use top-level await, where require() returns
-   * a Promise instead of the module directly.
+   * a Promise instead of the module directly. Must be called before accessing
+   * `userland` in contexts where the module may not yet be resolved (e.g. the
+   * export/static-generation worker).
    */
-  private async ensureUserland(): Promise<void> {
+  async ensureUserland(): Promise<void> {
     // Trigger lazy loading if not yet started.
     void this.userland
     if (this._pendingUserland) {
@@ -785,7 +787,14 @@ export class AppRouteRouteModule extends RouteModule<
     // In Turbopack dev mode, fetch the live userland module on every request
     // via the synchronous require() getter so server HMR updates are reflected
     // immediately. This is cheap — it is just a devModuleCache lookup.
-    const liveUserland = this._getUserland?.()
+    // For routes with top-level await, require() may still return a Promise
+    // (async module); in that case fall back to the already-resolved
+    // _userland from ensureUserland() above.
+    const rawLiveUserland = this._getUserland?.()
+    const liveUserland =
+      rawLiveUserland instanceof Promise
+        ? undefined
+        : (rawLiveUserland as AppRouteUserlandModule | undefined)
 
     const handler = liveUserland
       ? this.resolveHandlerFromUserland(req.method, liveUserland)

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -182,6 +182,14 @@ export interface AppRouteRouteModuleOptions
     | (() => AppRouteUserlandModule | Promise<AppRouteUserlandModule>)
   readonly resolvedPagePath: string
   readonly nextConfigOutput: NextConfig['output']
+  /**
+   * Optional synchronous getter that returns the live userland module. When
+   * provided (Turbopack dev mode), it is called on every request so that
+   * server HMR updates are picked up without re-executing the entry chunk.
+   * Using require() instead of import() keeps this synchronous so the time
+   * spent here is not incorrectly attributed to application-code in timing.
+   */
+  readonly getUserland?: () => AppRouteUserlandModule
 }
 
 /**
@@ -226,6 +234,9 @@ export class AppRouteRouteModule extends RouteModule<
   // Non-null while an async userland module (top-level await) is loading.
   // ensureUserland() awaits this before the first request is handled.
   private _pendingUserland: Promise<void> | null = null
+  // Synchronous per-request userland getter for Turbopack dev mode.
+  // Called on every request to pick up server HMR updates.
+  private readonly _getUserland?: () => AppRouteUserlandModule
   private _methods!: Record<HTTP_METHOD, AppRouteHandlerFn>
   private _hasNonStaticMethods!: boolean
   private _dynamic!: AppRouteUserlandModule['dynamic']
@@ -265,6 +276,7 @@ export class AppRouteRouteModule extends RouteModule<
 
   constructor({
     userland,
+    getUserland,
     definition,
     distDir,
     relativeProjectDir,
@@ -282,6 +294,7 @@ export class AppRouteRouteModule extends RouteModule<
     this.resolvedPagePath = resolvedPagePath
     this.nextConfigOutput = nextConfigOutput
     this._userlandFactory = isLazy ? userland : null
+    this._getUserland = getUserland
 
     if (!isLazy) {
       this._initFromUserland()
@@ -358,6 +371,19 @@ export class AppRouteRouteModule extends RouteModule<
     if (!isHTTPMethod(method)) return () => new Response(null, { status: 400 })
 
     return this._methods[method]
+  }
+
+  /**
+   * Returns the handler for the given method using a live userland snapshot.
+   * Used in Turbopack dev mode to pick up server HMR updates. The userland
+   * is fetched synchronously via require() so no async overhead is added.
+   */
+  private resolveHandlerFromUserland(
+    method: string,
+    userland: AppRouteUserlandModule
+  ): AppRouteHandlerFn {
+    if (!isHTTPMethod(method)) return () => new Response(null, { status: 400 })
+    return autoImplementMethods(userland)[method]
   }
 
   private async do(
@@ -756,7 +782,14 @@ export class AppRouteRouteModule extends RouteModule<
     // await, where require() returns a Promise instead of the module).
     await this.ensureUserland()
 
-    const handler = this.resolveHandler(req.method)
+    // In Turbopack dev mode, fetch the live userland module on every request
+    // via the synchronous require() getter so server HMR updates are reflected
+    // immediately. This is cheap — it is just a devModuleCache lookup.
+    const liveUserland = this._getUserland?.()
+
+    const handler = liveUserland
+      ? this.resolveHandlerFromUserland(req.method, liveUserland)
+      : this.resolveHandler(req.method)
 
     // Get the context for the static generation.
     const staticGenerationContext: WorkStoreContext = {
@@ -766,8 +799,12 @@ export class AppRouteRouteModule extends RouteModule<
       previouslyRevalidatedTags: [],
     }
 
+    // Use the live userland (if available) for per-request values so HMR
+    // changes to fetchCache, dynamic, etc. are also picked up.
+    const userland = liveUserland ?? (this._userland as AppRouteUserlandModule)
+
     // Add the fetchCache option to the renderOpts.
-    staticGenerationContext.renderOpts.fetchCache = this.userland.fetchCache
+    staticGenerationContext.renderOpts.fetchCache = userland.fetchCache
 
     const actionStore: ActionStore = {
       isAppRoute: true,
@@ -800,8 +837,12 @@ export class AppRouteRouteModule extends RouteModule<
         this.workUnitAsyncStorage.run(requestStore, () =>
           this.workAsyncStorage.run(workStore, async () => {
             // Check to see if we should bail out of static generation based on
-            // having non-static methods.
-            if (this._hasNonStaticMethods) {
+            // having non-static methods. Use live userland when available so
+            // HMR changes to exported HTTP methods are reflected immediately.
+            const hasNonStatic = liveUserland
+              ? hasNonStaticMethods(liveUserland)
+              : this._hasNonStaticMethods
+            if (hasNonStatic) {
               if (workStore.isStaticGeneration) {
                 const err = new DynamicServerError(
                   'Route is configured with methods that cannot be statically generated.'
@@ -816,8 +857,12 @@ export class AppRouteRouteModule extends RouteModule<
             // proxying it in certain circumstances based on execution type and configuration
             let request = req
 
+            // Use the live dynamic value when available so HMR changes to
+            // `export const dynamic` are reflected immediately.
+            const dynamic = liveUserland?.dynamic ?? this._dynamic
+
             // Update the static generation store based on the dynamic property.
-            switch (this._dynamic) {
+            switch (dynamic) {
               case 'force-dynamic': {
                 // Routes of generated paths should be dynamic
                 workStore.forceDynamic = true
@@ -853,7 +898,7 @@ export class AppRouteRouteModule extends RouteModule<
                 request = proxyNextRequest(req, workStore)
                 break
               default:
-                this._dynamic satisfies never
+                dynamic satisfies never
             }
 
             const tracer = getTracer()

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -173,7 +173,11 @@ export type AppRouteUserlandModule = AppRouteHandlers &
  * module from the bundled code.
  */
 export interface AppRouteRouteModuleOptions
-  extends RouteModuleOptions<AppRouteRouteDefinition, AppRouteUserlandModule> {
+  extends Omit<
+    RouteModuleOptions<AppRouteRouteDefinition, AppRouteUserlandModule>,
+    'userland'
+  > {
+  readonly userland: AppRouteUserlandModule | (() => AppRouteUserlandModule)
   readonly resolvedPagePath: string
   readonly nextConfigOutput: NextConfig['output']
   /**
@@ -219,9 +223,19 @@ export class AppRouteRouteModule extends RouteModule<
   public readonly nextConfigOutput: NextConfig['output'] | undefined
 
   private readonly _getUserland?: () => Promise<AppRouteUserlandModule>
-  private methods: Record<HTTP_METHOD, AppRouteHandlerFn>
-  private hasNonStaticMethods: boolean
-  private dynamic: AppRouteUserlandModule['dynamic']
+  private _loadUserland: (() => AppRouteUserlandModule) | null
+  private _methods!: Record<HTTP_METHOD, AppRouteHandlerFn>
+  private _hasNonStaticMethods!: boolean
+  private _dynamic!: AppRouteUserlandModule['dynamic']
+
+  override get userland(): AppRouteUserlandModule {
+    if (this._loadUserland) {
+      this._userland = this._loadUserland()
+      this._loadUserland = null
+      this._initFromUserland()
+    }
+    return this._userland as AppRouteUserlandModule
+  }
 
   constructor({
     userland,
@@ -232,8 +246,9 @@ export class AppRouteRouteModule extends RouteModule<
     resolvedPagePath,
     nextConfigOutput,
   }: AppRouteRouteModuleOptions) {
+    const isLazy = typeof userland === 'function'
     super({
-      userland: userland!,
+      userland: (isLazy ? undefined! : userland) as AppRouteUserlandModule,
       definition,
       distDir,
       relativeProjectDir,
@@ -242,27 +257,36 @@ export class AppRouteRouteModule extends RouteModule<
     this.resolvedPagePath = resolvedPagePath
     this.nextConfigOutput = nextConfigOutput
     this._getUserland = getUserland
+    this._loadUserland = isLazy ? userland : null
+
+    if (!isLazy) {
+      this._initFromUserland()
+    }
+  }
+
+  private _initFromUserland(): void {
+    const userland = this._userland as AppRouteUserlandModule
 
     // Automatically implement some methods if they aren't implemented by the
     // userland module.
-    this.methods = autoImplementMethods(userland!)
+    this._methods = autoImplementMethods(userland)
 
     // Get the non-static methods for this route.
-    this.hasNonStaticMethods = hasNonStaticMethods(userland!)
+    this._hasNonStaticMethods = hasNonStaticMethods(userland)
 
     // Get the dynamic property from the userland module.
-    this.dynamic = userland!.dynamic
+    this._dynamic = userland.dynamic
     if (this.nextConfigOutput === 'export') {
-      if (this.dynamic === 'force-dynamic') {
+      if (this._dynamic === 'force-dynamic') {
         throw new Error(
-          `export const dynamic = "force-dynamic" on page "${definition.pathname}" cannot be used with "output: export". See more info here: https://nextjs.org/docs/advanced-features/static-html-export`
+          `export const dynamic = "force-dynamic" on page "${this.definition.pathname}" cannot be used with "output: export". See more info here: https://nextjs.org/docs/advanced-features/static-html-export`
         )
-      } else if (!isStaticGenEnabled(this.userland) && this.userland['GET']) {
+      } else if (!isStaticGenEnabled(userland) && userland['GET']) {
         throw new Error(
-          `export const dynamic = "force-static"/export const revalidate not configured on route "${definition.pathname}" with "output: export". See more info here: https://nextjs.org/docs/advanced-features/static-html-export`
+          `export const dynamic = "force-static"/export const revalidate not configured on route "${this.definition.pathname}" with "output: export". See more info here: https://nextjs.org/docs/advanced-features/static-html-export`
         )
       } else {
-        this.dynamic = 'error'
+        this._dynamic = 'error'
       }
     }
 
@@ -273,7 +297,7 @@ export class AppRouteRouteModule extends RouteModule<
       // uppercase handlers are supported.
       const lowercased = HTTP_METHODS.map((method) => method.toLowerCase())
       for (const method of lowercased) {
-        if (method in this.userland) {
+        if (method in userland) {
           Log.error(
             `Detected lowercase method '${method}' in '${
               this.resolvedPagePath
@@ -284,7 +308,7 @@ export class AppRouteRouteModule extends RouteModule<
 
       // Print error if the module exports a default handler, they must use named
       // exports for each HTTP method.
-      if ('default' in this.userland) {
+      if ('default' in userland) {
         Log.error(
           `Detected default export in '${this.resolvedPagePath}'. Export a named export for each HTTP method instead.`
         )
@@ -292,7 +316,7 @@ export class AppRouteRouteModule extends RouteModule<
 
       // If there is no methods exported by this module, then return a not found
       // response.
-      if (!HTTP_METHODS.some((method) => method in this.userland)) {
+      if (!HTTP_METHODS.some((method) => method in userland)) {
         Log.error(
           `No HTTP methods exported in '${this.resolvedPagePath}'. Export a named export for each HTTP method.`
         )
@@ -310,7 +334,10 @@ export class AppRouteRouteModule extends RouteModule<
     // Ensure that the requested method is a valid method (to prevent RCE's).
     if (!isHTTPMethod(method)) return () => new Response(null, { status: 400 })
 
-    return autoImplementMethods(this.userland as AppRouteUserlandModule)[method]
+    // Trigger lazy initialization of userland if needed.
+    void this.userland
+
+    return this._methods[method]
   }
 
   /**
@@ -770,7 +797,7 @@ export class AppRouteRouteModule extends RouteModule<
           this.workAsyncStorage.run(workStore, async () => {
             // Check to see if we should bail out of static generation based on
             // having non-static methods.
-            if (hasNonStaticMethods(this.userland)) {
+            if (this._hasNonStaticMethods) {
               if (workStore.isStaticGeneration) {
                 const err = new DynamicServerError(
                   'Route is configured with methods that cannot be statically generated.'
@@ -786,8 +813,7 @@ export class AppRouteRouteModule extends RouteModule<
             let request = req
 
             // Update the static generation store based on the dynamic property.
-            const { dynamic } = this.userland
-            switch (dynamic) {
+            switch (this._dynamic) {
               case 'force-dynamic': {
                 // Routes of generated paths should be dynamic
                 workStore.forceDynamic = true
@@ -823,7 +849,7 @@ export class AppRouteRouteModule extends RouteModule<
                 request = proxyNextRequest(req, workStore)
                 break
               default:
-                dynamic satisfies never
+                this._dynamic satisfies never
             }
 
             const tracer = getTracer()

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -222,16 +222,20 @@ export class AppRouteRouteModule extends RouteModule<
   public readonly resolvedPagePath: string
   public readonly nextConfigOutput: NextConfig['output'] | undefined
 
+  // In Turbopack dev mode, called on every request to re-fetch the live
+  // userland from devModuleCache so server HMR updates are picked up.
   private readonly _getUserland?: () => Promise<AppRouteUserlandModule>
-  private _loadUserland: (() => AppRouteUserlandModule) | null
+  // Set in the constructor when userland is provided as a factory. Cleared
+  // after the first access so userland is only loaded once.
+  private _userlandFactory: (() => AppRouteUserlandModule) | null
   private _methods!: Record<HTTP_METHOD, AppRouteHandlerFn>
   private _hasNonStaticMethods!: boolean
   private _dynamic!: AppRouteUserlandModule['dynamic']
 
   override get userland(): AppRouteUserlandModule {
-    if (this._loadUserland) {
-      this._userland = this._loadUserland()
-      this._loadUserland = null
+    if (this._userlandFactory) {
+      this._userland = this._userlandFactory()
+      this._userlandFactory = null
       this._initFromUserland()
     }
     return this._userland as AppRouteUserlandModule
@@ -257,7 +261,7 @@ export class AppRouteRouteModule extends RouteModule<
     this.resolvedPagePath = resolvedPagePath
     this.nextConfigOutput = nextConfigOutput
     this._getUserland = getUserland
-    this._loadUserland = isLazy ? userland : null
+    this._userlandFactory = isLazy ? userland : null
 
     if (!isLazy) {
       this._initFromUserland()
@@ -325,34 +329,28 @@ export class AppRouteRouteModule extends RouteModule<
   }
 
   /**
-   * Resolves the handler function for the given method.
+   * Returns the handler function for the given HTTP method.
    *
-   * @param method the requested method
-   * @returns the handler function for the given method
+   * In Turbopack dev mode (`_getUserland` is set), re-fetches the live
+   * userland on every request so that server HMR updates are picked up. The
+   * async wrapper also unwraps async-module Promises for ESM-only
+   * serverExternalPackages.
+   *
+   * In all other modes, returns the handler from the cached `_methods` map,
+   * triggering lazy userland initialization on the first request if needed.
    */
-  private resolve(method: string): AppRouteHandlerFn {
-    // Ensure that the requested method is a valid method (to prevent RCE's).
+  private async resolveHandler(method: string): Promise<AppRouteHandlerFn> {
+    // Prevent RCE: only allow recognized HTTP methods.
     if (!isHTTPMethod(method)) return () => new Response(null, { status: 400 })
 
-    // Trigger lazy initialization of userland if needed.
+    if (this._getUserland) {
+      const userland = await this._getUserland()
+      return autoImplementMethods(userland)[method]
+    }
+
+    // Accessing `this.userland` triggers lazy initialization on first request.
     void this.userland
-
     return this._methods[method]
-  }
-
-  /**
-   * Like resolve(), but re-fetches the userland module on every call via the
-   * async getter. Only used in Turbopack dev mode, where server HMR disposes
-   * modules between requests. The async wrapper also unwraps async-module
-   * Promises produced by ESM-only serverExternalPackages.
-   */
-  private async resolveWithGetter(
-    method: string,
-    getUserland: () => Promise<AppRouteUserlandModule>
-  ): Promise<AppRouteHandlerFn> {
-    if (!isHTTPMethod(method)) return () => new Response(null, { status: 400 })
-    const userland = await getUserland()
-    return autoImplementMethods(userland)[method]
   }
 
   private async do(
@@ -747,12 +745,7 @@ export class AppRouteRouteModule extends RouteModule<
     req: NextRequest,
     context: AppRouteRouteHandlerContext
   ): Promise<Response> {
-    // Get the handler function for the given method. In Turbopack dev mode,
-    // use resolveWithGetter() to re-fetch the live userland on every request
-    // In all other modes, resolve() is synchronous.
-    const handler = this._getUserland
-      ? await this.resolveWithGetter(req.method, this._getUserland)
-      : this.resolve(req.method)
+    const handler = await this.resolveHandler(req.method)
 
     // Get the context for the static generation.
     const staticGenerationContext: WorkStoreContext = {

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -182,12 +182,6 @@ export interface AppRouteRouteModuleOptions
     | (() => AppRouteUserlandModule | Promise<AppRouteUserlandModule>)
   readonly resolvedPagePath: string
   readonly nextConfigOutput: NextConfig['output']
-  /**
-   * Optional getter that returns the live userland module. When provided (in
-   * Turbopack dev mode), it is called on every request so that server HMR
-   * updates are picked up without re-executing the entry chunk.
-   */
-  readonly getUserland?: () => Promise<AppRouteUserlandModule>
 }
 
 /**
@@ -224,9 +218,6 @@ export class AppRouteRouteModule extends RouteModule<
   public readonly resolvedPagePath: string
   public readonly nextConfigOutput: NextConfig['output'] | undefined
 
-  // In Turbopack dev mode, called on every request to re-fetch the live
-  // userland from devModuleCache so server HMR updates are picked up.
-  private readonly _getUserland?: () => Promise<AppRouteUserlandModule>
   // Set in the constructor when userland is provided as a factory. Cleared
   // after the first access so userland is only loaded once.
   private _userlandFactory:
@@ -274,7 +265,6 @@ export class AppRouteRouteModule extends RouteModule<
 
   constructor({
     userland,
-    getUserland,
     definition,
     distDir,
     relativeProjectDir,
@@ -291,7 +281,6 @@ export class AppRouteRouteModule extends RouteModule<
 
     this.resolvedPagePath = resolvedPagePath
     this.nextConfigOutput = nextConfigOutput
-    this._getUserland = getUserland
     this._userlandFactory = isLazy ? userland : null
 
     if (!isLazy) {
@@ -361,21 +350,12 @@ export class AppRouteRouteModule extends RouteModule<
 
   /**
    * Returns the handler function for the given HTTP method.
-   *
    * Must be called after ensureUserland() has resolved so that _methods is
-   * populated. In Turbopack dev mode (_getUserland is set), re-fetches the
-   * live userland on every request so server HMR updates are picked up; the
-   * async wrapper also unwraps async-module Promises for ESM-only
-   * serverExternalPackages.
+   * populated.
    */
-  private async resolveHandler(method: string): Promise<AppRouteHandlerFn> {
+  private resolveHandler(method: string): AppRouteHandlerFn {
     // Prevent RCE: only allow recognized HTTP methods.
     if (!isHTTPMethod(method)) return () => new Response(null, { status: 400 })
-
-    if (this._getUserland) {
-      const userland = await this._getUserland()
-      return autoImplementMethods(userland)[method]
-    }
 
     return this._methods[method]
   }
@@ -776,7 +756,7 @@ export class AppRouteRouteModule extends RouteModule<
     // await, where require() returns a Promise instead of the module).
     await this.ensureUserland()
 
-    const handler = await this.resolveHandler(req.method)
+    const handler = this.resolveHandler(req.method)
 
     // Get the context for the static generation.
     const staticGenerationContext: WorkStoreContext = {

--- a/packages/next/src/server/route-modules/route-module.ts
+++ b/packages/next/src/server/route-modules/route-module.ts
@@ -108,10 +108,13 @@ export abstract class RouteModule<
 > {
   /**
    * The userland module. This is the module that is exported from the user's
-   * code. This is marked as readonly to ensure that the module is not mutated
-   * because the module (when compiled) only provides getters.
+   * code. Exposed as a getter so subclasses can override with lazy loading.
    */
-  public readonly userland: Readonly<U>
+  protected _userland: Readonly<U>
+
+  get userland(): Readonly<U> {
+    return this._userland
+  }
 
   /**
    * The definition of the route.
@@ -135,7 +138,7 @@ export abstract class RouteModule<
     distDir,
     relativeProjectDir,
   }: RouteModuleOptions<D, U>) {
-    this.userland = userland
+    this._userland = userland
     this.definition = definition
     this.isDev = !!process.env.__NEXT_DEV_SERVER
     this.distDir = distDir

--- a/test/e2e/app-dir/app-routes/app-custom-routes.test.ts
+++ b/test/e2e/app-dir/app-routes/app-custom-routes.test.ts
@@ -709,4 +709,12 @@ describe('app-custom-routes', () => {
       expect(cliOutput).not.toContain('Attempted import error')
     })
   })
+
+  describe('top-level await', () => {
+    it('handles route handlers that use top-level await', async () => {
+      const res = await next.fetch(basePath + '/top-level-await')
+      expect(res.status).toBe(200)
+      expect(await res.text()).toBe('hello from top-level await')
+    })
+  })
 })

--- a/test/e2e/app-dir/app-routes/app/top-level-await/route.ts
+++ b/test/e2e/app-dir/app-routes/app/top-level-await/route.ts
@@ -1,0 +1,9 @@
+// This route uses a top-level await to simulate an async module (e.g. a route
+// that fetches config or initializes a DB connection at module load time).
+// require() returns a Promise for such modules, so the route module must not
+// eagerly call _initFromUserland() before the Promise resolves.
+const message = await Promise.resolve('hello from top-level await')
+
+export async function GET() {
+  return new Response(message)
+}


### PR DESCRIPTION
### What?

Fixes issues with `AppRouteRouteModule` that interact with `devRequestTiming` and Turbopack server HMR.

1. **Incorrect `devRequestTimingInternalsEnd` attribution**: The app-route template previously statically imported userland (`import * as userland from 'VAR_USERLAND'`), meaning module load time was included in the framework's startup overhead. The `devRequestTimingInternalsEnd` timestamp is now set immediately before `routeModule.handle()` is called, and userland is loaded lazily on the first request so the timing correctly captures the framework→application boundary.

2. **Stale route handlers after Turbopack server HMR**: After a Turbopack server HMR update, `devModuleCache` is updated with a fresh route module, but the entry chunk remains in Node.js `require.cache`. The lazy `_userlandFactory` only runs once and would cache the old module reference — so route handler changes were not reflected after HMR. This restores a synchronous per-request `getUserland` getter that calls `require('VAR_USERLAND')` on every request. Since `require()` is a synchronous `devModuleCache` lookup, it has negligible overhead and doesn't add async time that would be incorrectly attributed to `application-code`.

3. **Route handlers with top-level await**: `require()` returns a Promise for modules that use top-level await. The module now accepts a lazy factory for `userland` and handles this case via `ensureUserland()`, which is called before the first request is handled.

4. **`output: export` route validation**: With the lazy factory, validation errors (e.g. `dynamic = "force-dynamic"` on an exported route) were deferred to request time, returning a 500 instead of surfacing as a Redbox in dev. The constructor now eagerly calls the factory for `output: export` routes so `_initFromUserland()` throws at module-load time — preserving the Redbox error.

5. **`node:stream` in edge bundles** (CI fix): `render-result.ts` was missing a `NEXT_RUNTIME === 'edge'` compile-time guard around `require('node:stream')` / `__non_webpack_require__('node:stream')`, which prevented webpack from DCE-ing those branches in edge builds. Vercel's deploy adapter rejects edge functions that reference `node:stream`. The guard is now restored to match the canary pattern.

### Why?

#91466 enabled server HMR for app route handlers and introduced `getUserland: () => import('VAR_USERLAND')` to pick up HMR updates on each request. However, the async `import()` adds latency incorrectly attributed to application-code time in `devRequestTiming`. This PR replaces `import()` with synchronous `require()` and also lazily loads userland on the first request for accurate `devRequestTimingInternalsEnd` placement.

### How?

- **Template** (`app-route.ts`): Replaces the static `import * as userland` with a lazy `() => require('VAR_USERLAND')` factory. In Turbopack dev mode, also provides `getUserland: () => require('VAR_USERLAND')` — a synchronous getter called on every request to pick up server HMR updates.

- **Module** (`module.ts`):
  - Accepts `userland` as either a direct module or a lazy factory.
  - For `output: export` routes, calls the factory eagerly in the constructor so `_initFromUserland()` validation errors throw at module-load time (Redbox) rather than at request time (500).
  - For async modules (top-level await), stores the pending Promise in `_pendingUserland` so `ensureUserland()` can await it before the first request.
  - Accepts optional synchronous `getUserland` for per-request live userland access (Turbopack dev HMR).
  - `handle()` calls `_getUserland?.()` at request start; if set, uses the result for handler resolution, `fetchCache`, `hasNonStaticMethods`, and `dynamic` — ensuring HMR changes to all exported values are immediately reflected.
  - Extracts `_initFromUserland()` helper to deduplicate initialization between lazy and eager paths.

- **Route module base** (`route-module.ts`): Makes `isDev` public for template access.

- **Test** (`app-custom-routes.test.ts` + fixture): Adds an integration test for route handlers that use top-level await, ensuring the handler is correctly resolved even when `require()` returns a Promise.

- **`render-result.ts`**: Restores the `if (process.env.NEXT_RUNTIME === 'edge') { throw }` guard matching canary, so `node:stream` is DCE'd from edge builds.

Fixes #91318