### PR TITLE
docs: add AI agents guide reference to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,8 @@
 
 > **Note:** `CLAUDE.md` is a symlink to `AGENTS.md`. They are the same file.
 
+> **See also:** `docs/01-app/02-guides/ai-agents.mdx` — explains how Next.js bundles version-matched documentation inside `node_modules/next/dist/docs/` and how to configure `AGENTS.md` in user projects so AI coding agents read the right docs.
+
 ## Codebase structure
 
 ### Monorepo Overview


### PR DESCRIPTION
### What?

Add a "See also" reference at the top of `AGENTS.md` pointing to `docs/01-app/02-guides/ai-agents.mdx` — the guide that explains how Next.js bundles version-matched documentation and how to configure per-project `AGENTS.md` files.

### Why?

An agent (or human) reading `AGENTS.md` currently learns about the repo structure and development workflow, but has no pointer to the guide that explains *how the bundled docs system works*. This means agents don't discover the canonical explanation of how `AGENTS.md` is set up in user projects, or how `node_modules/next/dist/docs/` is structured. Adding this cross-reference closes the discoverability gap for both AI coding agents and human contributors.

### How?

Added a single `> **See also:**` blockquote line after the existing `CLAUDE.md` symlink note, matching the existing blockquote style. The reference links to the source MDX file and briefly describes what it covers.

## PR checklist (Improving Documentation)

- [x] Run `pnpm prettier-fix` to fix formatting issues before opening the PR
- [x] Follow the docs contribution guide: https://nextjs.org/docs/community/contribution-guide


Made with [Cursor](https://cursor.com)