### PR TITLE
 fix: avoid `/index` cache-key collision for root dynamic routes

### DIFF
--- a/packages/next/src/server/route-modules/route-module.ts
+++ b/packages/next/src/server/route-modules/route-module.ts
@@ -999,9 +999,10 @@ export abstract class RouteModule<
       )
     }
 
-    if (resolvedPathname === '/index') {
-      resolvedPathname = '/'
-    }
+    resolvedPathname = normalizeResolvedPathname(
+      resolvedPathname,
+      normalizedSrcPage
+    )
 
     if (
       res &&
@@ -1135,4 +1136,21 @@ export abstract class RouteModule<
     }
     return cacheEntry
   }
+}
+
+/**
+ * Normalizes resolvedPathname for ISR cache key usage.
+ *
+ * Only normalizes /index to / when the source page is not a dynamic route.
+ * For dynamic routes (e.g., [slug] with slug="index"), resolvedPathname
+ * must remain /index to avoid colliding with the / page's ISR cache key.
+ */
+export function normalizeResolvedPathname(
+  resolvedPathname: string,
+  normalizedSrcPage: string
+): string {
+  if (resolvedPathname === '/index' && !isDynamicRoute(normalizedSrcPage)) {
+    resolvedPathname = '/'
+  }
+  return resolvedPathname
 }

--- a/test/unit/resolve-pathname-index-collision.test.ts
+++ b/test/unit/resolve-pathname-index-collision.test.ts
@@ -1,0 +1,19 @@
+import { normalizeResolvedPathname } from 'next/dist/server/route-modules/route-module'
+
+describe('normalizeResolvedPathname (route-module.ts)', () => {
+  it('should normalize /index to / for static page', () => {
+    expect(normalizeResolvedPathname('/index', '/')).toBe('/')
+  })
+
+  it('should NOT normalize /index to / for [slug] route', () => {
+    expect(normalizeResolvedPathname('/index', '/[slug]')).toBe('/index')
+  })
+
+  it('should NOT normalize /index to / for [...slug] route', () => {
+    expect(normalizeResolvedPathname('/index', '/[...slug]')).toBe('/index')
+  })
+
+  it('should NOT normalize /index to / for [[...slug]] route', () => {
+    expect(normalizeResolvedPathname('/index', '/[[...slug]]')).toBe('/index')
+  })
+})


### PR DESCRIPTION
## Fixing a bug

- Related issues linked: fixes https://github.com/vercel/next.js/issues/92296
- Tests added: `test/unit/resolve-pathname-index-collision.test.ts`

When a root-level dynamic route (e.g., `[slug]` with `dynamicParams: true`) coexists with `/` and the `/` page has a stale ISR cache, a request to `/index` is handled by `[slug]` but its `resolvedPathname` is normalized to `/`, causing the ISR cache key (`ssgCacheKey`) to collide with the `/` page. The `[slug]` `notFound()` result overwrites the `/` page's cache, making `/` unexpectedly return 404.

This PR extracts the `/index` → `/` normalization in `route-module.ts` into `normalizeResolvedPathname()` and adds a guard: the normalization is skipped when `normalizedSrcPage` is a dynamic route, keeping the cache key as `/index` and avoiding the collision.

This is one possible approach. Happy to close this if there's a better solution.