### PR TITLE
fix: prevent intercepting routes from re-triggering on same-URL navigation (#82934)

### DIFF
--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
@@ -42,12 +42,6 @@ export function navigateReducer(
   const currentUrl = new URL(state.canonicalUrl, location.origin)
   const currentRenderedSearch = state.renderedSearch
 
-  // Clear nextUrl for same-page navigations to avoid re-triggering
-  // interception rewrites. When the user navigates to the same URL they're
-  // already on, we should not send the Next-Url header that would cause the
-  // server to apply interception rewrites again.
-  const nextUrl = url.href === currentUrl.href ? null : state.nextUrl
-
   return navigateUsingSegmentCache(
     state,
     url,
@@ -55,7 +49,7 @@ export function navigateReducer(
     currentRenderedSearch,
     state.cache,
     state.tree,
-    nextUrl,
+    state.nextUrl,
     FreshnessPolicy.Default,
     scrollBehavior,
     navigateType

--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
@@ -41,6 +41,13 @@ export function navigateReducer(
   // state machine.
   const currentUrl = new URL(state.canonicalUrl, location.origin)
   const currentRenderedSearch = state.renderedSearch
+
+  // Clear nextUrl for same-page navigations to avoid re-triggering
+  // interception rewrites. When the user navigates to the same URL they're
+  // already on, we should not send the Next-Url header that would cause the
+  // server to apply interception rewrites again.
+  const nextUrl = url.href === currentUrl.href ? null : state.nextUrl
+
   return navigateUsingSegmentCache(
     state,
     url,
@@ -48,7 +55,7 @@ export function navigateReducer(
     currentRenderedSearch,
     state.cache,
     state.tree,
-    state.nextUrl,
+    nextUrl,
     FreshnessPolicy.Default,
     scrollBehavior,
     navigateType

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -60,6 +60,13 @@ export function navigate(
   scrollBehavior: ScrollBehavior,
   navigateType: 'push' | 'replace'
 ): AppRouterState | Promise<AppRouterState> {
+  // Clear nextUrl for same-page navigations to avoid re-triggering
+  // interception rewrites. This applies to both link clicks and programmatic
+  // navigations (e.g. router.push, router.replace).
+  if (url.href === currentUrl.href) {
+    nextUrl = null
+  }
+
   // Instant Navigation Testing API: when the lock is active, ensure a
   // prefetch task has been initiated before proceeding with the navigation.
   // This guarantees that segment data requests are at least pending, even

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -60,12 +60,12 @@ export function navigate(
   scrollBehavior: ScrollBehavior,
   navigateType: 'push' | 'replace'
 ): AppRouterState | Promise<AppRouterState> {
-  // Clear nextUrl for same-page navigations to avoid re-triggering
-  // interception rewrites. This applies to both link clicks and programmatic
-  // navigations (e.g. router.push, router.replace).
-  if (url.href === currentUrl.href) {
-    nextUrl = null
-  }
+  // When navigating to the same URL, clear nextUrl so the Next-Url header is
+  // not sent. This prevents the server from re-applying interception rewrites,
+  // which would incorrectly re-trigger intercepting routes on same-page
+  // navigations (e.g. router.push, router.replace, link clicks).
+  // See: https://github.com/vercel/next.js/issues/82934
+  const effectiveNextUrl = url.href === currentUrl.href ? null : nextUrl
 
   // Instant Navigation Testing API: when the lock is active, ensure a
   // prefetch task has been initiated before proceeding with the navigation.
@@ -84,7 +84,7 @@ export function navigate(
         currentRenderedSearch,
         currentCacheNode,
         currentFlightRouterState,
-        nextUrl,
+        effectiveNextUrl,
         freshnessPolicy,
         scrollBehavior,
         navigateType
@@ -99,7 +99,7 @@ export function navigate(
     currentRenderedSearch,
     currentCacheNode,
     currentFlightRouterState,
-    nextUrl,
+    effectiveNextUrl,
     freshnessPolicy,
     scrollBehavior,
     navigateType

--- a/test/e2e/app-dir/intercepting-route-same-url/app/@modal/(.)signin/page.tsx
+++ b/test/e2e/app-dir/intercepting-route-same-url/app/@modal/(.)signin/page.tsx
@@ -1,0 +1,3 @@
+export default function InterceptedSignIn() {
+  return <div id="intercepted-modal">Intercepted Modal</div>
+}

--- a/test/e2e/app-dir/intercepting-route-same-url/app/@modal/default.tsx
+++ b/test/e2e/app-dir/intercepting-route-same-url/app/@modal/default.tsx
@@ -1,0 +1,3 @@
+export default function ModalDefault() {
+  return null
+}

--- a/test/e2e/app-dir/intercepting-route-same-url/app/default.tsx
+++ b/test/e2e/app-dir/intercepting-route-same-url/app/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return null
+}

--- a/test/e2e/app-dir/intercepting-route-same-url/app/layout.tsx
+++ b/test/e2e/app-dir/intercepting-route-same-url/app/layout.tsx
@@ -1,0 +1,16 @@
+export default function RootLayout({
+  children,
+  modal,
+}: {
+  children: React.ReactNode
+  modal: React.ReactNode
+}) {
+  return (
+    <html>
+      <body>
+        {children}
+        {modal}
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/intercepting-route-same-url/app/page.tsx
+++ b/test/e2e/app-dir/intercepting-route-same-url/app/page.tsx
@@ -1,0 +1,12 @@
+import Link from 'next/link'
+
+export default function Home() {
+  return (
+    <div>
+      <h1 id="home-page">Home Page</h1>
+      <Link href="/signin" id="signin-link">
+        Go to Sign In
+      </Link>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/intercepting-route-same-url/app/signin/page.tsx
+++ b/test/e2e/app-dir/intercepting-route-same-url/app/signin/page.tsx
@@ -1,0 +1,3 @@
+export default function SignInPage() {
+  return <div id="full-signin">Full Signin Page</div>
+}

--- a/test/e2e/app-dir/intercepting-route-same-url/intercepting-route-same-url.test.ts
+++ b/test/e2e/app-dir/intercepting-route-same-url/intercepting-route-same-url.test.ts
@@ -1,0 +1,49 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+describe('intercepting-route-same-url', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should intercept when navigating from a different route', async () => {
+    const browser = await next.browser('/')
+
+    // Click the link to /signin from the home page
+    await browser.elementByCss('#signin-link').click()
+
+    // The intercepted modal should appear
+    await retry(async () => {
+      const text = await browser.elementByCss('#intercepted-modal').text()
+      expect(text).toBe('Intercepted Modal')
+    })
+  })
+
+  it('should not re-intercept when pushing the same intercepted route', async () => {
+    const browser = await next.browser('/')
+
+    // Click the link to /signin from the home page, triggering interception
+    await browser.elementByCss('#signin-link').click()
+
+    // Verify the intercepted modal appears
+    await retry(async () => {
+      const text = await browser.elementByCss('#intercepted-modal').text()
+      expect(text).toBe('Intercepted Modal')
+    })
+
+    // Now push the same route again via router.push - should NOT re-intercept
+    await browser.eval('window.next.router.push("/signin")')
+
+    // The intercepted modal should disappear and the full page should render
+    await retry(async () => {
+      const text = await browser.elementByCss('#full-signin').text()
+      expect(text).toBe('Full Signin Page')
+    })
+
+    // The intercepted modal should NOT be present
+    const hasModal = await browser.eval(
+      'document.querySelector("#intercepted-modal") !== null'
+    )
+    expect(hasModal).toBe(false)
+  })
+})

--- a/test/e2e/app-dir/intercepting-route-same-url/next.config.js
+++ b/test/e2e/app-dir/intercepting-route-same-url/next.config.js
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {}
+
+module.exports = nextConfig


### PR DESCRIPTION
## Summary

Fixes #82934

When an intercepting route is active and the user navigates to the same URL (via `router.push`, `router.replace`, or a `<Link>` click), the interception logic incorrectly fires again. This causes the intercepted modal to re-render instead of resolving to the full page.

## User-Facing Scenario

Consider a sign-in modal implemented with intercepting routes:

1. User is on `/` (home page) and clicks a link to `/signin`
2. The intercepting route `@modal/(.)signin/page.tsx` matches, rendering a modal overlay (expected)
3. While the modal is open (URL is `/signin`), the user or app calls `router.push("/signin")`, for example from a "retry" button or a redirect guard
4. **Before this fix:** the intercepting route fires again, re-rendering the modal instead of navigating to the full `/signin` page
5. **After this fix:** the navigation resolves to the full `app/signin/page.tsx` because same-URL navigations no longer trigger interception

## Root Cause

Next.js uses a `Next-Url` request header to tell the server which page the user is navigating *from*. The server uses this header to decide whether an intercepting route pattern (like `(.)signin`) should match. After an interception navigation, the router state retains a `nextUrl` value pointing to the original page (e.g., `/`). When the user then navigates to the same URL they are already on, that stale `nextUrl` is sent to the server, causing the interception rewrite to match again, even though the user is not actually navigating *from* a different page.

The fix: when the target URL matches the current URL (`url.href === currentUrl.href`), clear `nextUrl` to `null` so the `Next-Url` header is not sent. Without this header, the server treats it as a direct navigation and serves the full page instead of the intercepted version.

## Code Changes

Two files are modified, both applying the same logic at different layers:

### `packages/next/src/client/components/segment-cache/navigation.ts`

The `navigate()` function, which handles all client-side navigations through the segment cache, now checks `url.href === currentUrl.href` at the top and sets `nextUrl = null` for same-URL navigations. This covers both link clicks and programmatic navigations (`router.push`, `router.replace`).

### `packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts`

The `navigateReducer()` function applies the same check before passing `nextUrl` into `navigateUsingSegmentCache()`. This is the glue layer between the router reducer and the segment cache navigation implementation. The guard here ensures the fix applies regardless of which code path initiates the navigation.

## Test Fixture Structure

```
test/e2e/app-dir/intercepting-route-same-url/
├── app/
│   ├── layout.tsx              # Root layout with {children} + {modal} slots
│   ├── page.tsx                # Home page with <Link href="/signin">
│   ├── default.tsx             # Default export for root (returns null)
│   ├── signin/
│   │   └── page.tsx            # Full sign-in page (#full-signin)
│   └── @modal/
│       ├── default.tsx         # Default modal slot (returns null)
│       └── (.)signin/
│           └── page.tsx        # Intercepted modal (#intercepted-modal)
├── intercepting-route-same-url.test.ts
├── next.config.js
└── tsconfig.json
```

## Test Cases

1. **Intercept from a different route**: Navigate from `/` to `/signin` via link click. The intercepted modal (`#intercepted-modal`) should render. Confirms interception still works correctly.

2. **Same-URL push should not re-intercept**: Navigate from `/` to `/signin` (triggering interception), then call `router.push("/signin")` while already on `/signin`. The full page (`#full-signin`) should render and the intercepted modal (`#intercepted-modal`) should no longer be present.

## Edge Cases Considered

- **`router.replace` on same URL**: Covered by the fix in `navigation.ts`, which handles both push and replace
- **Link clicks to same URL**: Also covered, since all navigation types flow through the same `navigate()` function
- **Different routes**: Unaffected, because `url.href !== currentUrl.href` leaves `nextUrl` unchanged
- **Hash-only changes**: These are same-URL navigations and will also clear `nextUrl`, which is correct since interception should not apply for hash changes
- **Query parameter differences**: A navigation from `/signin` to `/signin?foo=bar` has a different `href`, so `nextUrl` is preserved and interception can still apply, which matches expected behavior