### PR TITLE
fix: propagate dynamic segments across parallel route slots (#62656)

### DIFF
--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -1354,7 +1354,11 @@ async fn directory_tree_to_loader_tree_internal(
         // However, if a static subdirectory at this level directly matches the
         // target path, dynamic segment subdirectories should not use dynamic
         // matching (static routes take priority over dynamic ones).
-        let child_match_dynamic = if has_static_match_at_this_level
+        // Catch-all directories (e.g. [...slug]) are also excluded from dynamic
+        // matching because they have their own catch-all matching logic.
+        let child_match_dynamic = if subdir_name.contains("...") {
+            false
+        } else if has_static_match_at_this_level
             && is_dynamic_segment(subdir_name)
             && parallel_route_key.is_none()
         {

--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -18,7 +18,7 @@ use turbopack_core::issue::{
 use crate::{
     mode::NextMode,
     next_app::{
-        AppPage, AppPath, PageSegment, PageType,
+        AppPage, AppPath, PageSegment, PageType, PathSegment,
         metadata::{
             GlobalMetadataFileMatch, MetadataFileMatch, match_global_metadata_file,
             match_local_metadata_file, normalize_metadata_route,
@@ -1303,6 +1303,30 @@ async fn directory_tree_to_loader_tree_internal(
 
     let mut duplicate = FxHashMap::default();
 
+    // When match_dynamic is true and we're inside a parallel slot subtree,
+    // check if any static subdirectory at the current level directly matches
+    // the next segment of for_app_path. If so, dynamic segment subdirectories
+    // at this level should NOT use dynamic matching, because the static match
+    // should take priority. For example, if @panel has both "settings" and
+    // "[id]" subdirectories, and we're building for /dashboard/settings, the
+    // "settings" directory should be used, not "[id]".
+    let has_static_match_at_this_level = if match_dynamic {
+        let current_app_path = AppPath::from(app_page.clone());
+        if let Some(target_segment) = for_app_path.0.get(current_app_path.0.len()) {
+            if let PathSegment::Static(target_name) = target_segment {
+                directory_tree
+                    .subdirectories
+                    .contains_key(target_name.as_str())
+            } else {
+                false
+            }
+        } else {
+            false
+        }
+    } else {
+        false
+    };
+
     for (subdir_name, subdirectory) in &directory_tree.subdirectories {
         let parallel_route_key = match_parallel_route(subdir_name);
 
@@ -1327,7 +1351,17 @@ async fn directory_tree_to_loader_tree_internal(
         // For parallel route slots, use dynamic matching so that a slot with
         // e.g. @parallel/test/[param] can match the static path /test/static.
         // The match_dynamic flag propagates down the entire parallel subtree.
-        let child_match_dynamic = match_dynamic || parallel_route_key.is_some();
+        // However, if a static subdirectory at this level directly matches the
+        // target path, dynamic segment subdirectories should not use dynamic
+        // matching (static routes take priority over dynamic ones).
+        let child_match_dynamic = if has_static_match_at_this_level
+            && is_dynamic_segment(subdir_name)
+            && parallel_route_key.is_none()
+        {
+            false
+        } else {
+            match_dynamic || parallel_route_key.is_some()
+        };
 
         let subtree = Box::pin(directory_tree_to_loader_tree_internal(
             app_dir.clone(),

--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -1096,6 +1096,7 @@ async fn directory_tree_to_loader_tree(
         for_app_path,
         AppDirModules::default(),
         Some(&plain_tree.url_tree),
+        false,
     )
     .await?;
 
@@ -1176,10 +1177,20 @@ async fn directory_tree_to_loader_tree_internal(
     for_app_path: AppPath,
     mut parent_modules: AppDirModules,
     url_tree: Option<&UrlSegmentTree>,
+    // When true, Dynamic segments in app_path are treated as matching any Static
+    // segment in for_app_path. Used for parallel route slots so that e.g.
+    // @parallel/test/[param] can match the static path /test/static.
+    match_dynamic: bool,
 ) -> Result<Option<AppPageLoaderTree>> {
     let app_path = AppPath::from(app_page.clone());
 
-    if !for_app_path.contains(&app_path) {
+    let is_contained = if match_dynamic {
+        for_app_path.contains_dynamic(&app_path)
+    } else {
+        for_app_path.contains(&app_path)
+    };
+
+    if !is_contained {
         return Ok(None);
     }
 
@@ -1267,9 +1278,11 @@ async fn directory_tree_to_loader_tree_internal(
         tree.segment = rcstr!("(__SLOT__)");
     }
 
-    if let Some(page) = (app_path == for_app_path || app_path.is_catchall())
-        .then_some(modules.page)
-        .flatten()
+    if let Some(page) = (app_path == for_app_path
+        || app_path.is_catchall()
+        || (match_dynamic && app_path.matches_dynamic(&for_app_path)))
+    .then_some(modules.page)
+    .flatten()
     {
         tree.parallel_routes.insert(
             rcstr!("children"),
@@ -1311,6 +1324,11 @@ async fn directory_tree_to_loader_tree_internal(
                 url_tree.and_then(|t| t.get_child(&directory_name))
             };
 
+        // For parallel route slots, use dynamic matching so that a slot with
+        // e.g. @parallel/test/[param] can match the static path /test/static.
+        // The match_dynamic flag propagates down the entire parallel subtree.
+        let child_match_dynamic = match_dynamic || parallel_route_key.is_some();
+
         let subtree = Box::pin(directory_tree_to_loader_tree_internal(
             app_dir.clone(),
             global_metadata,
@@ -1320,6 +1338,7 @@ async fn directory_tree_to_loader_tree_internal(
             for_app_path.clone(),
             parent_modules.clone(),
             child_url_tree,
+            child_match_dynamic,
         ))
         .await?;
 

--- a/crates/next-core/src/next_app/mod.rs
+++ b/crates/next-core/src/next_app/mod.rs
@@ -448,7 +448,44 @@ impl AppPath {
         )
     }
 
+    /// Returns true if `self` has at least one Dynamic segment and each segment
+    /// in `self` either equals the corresponding segment in `other` or is a
+    /// Dynamic segment (which matches any single segment). Both paths must have
+    /// the same length. This is used to allow parallel routes with dynamic
+    /// segments to match static paths from other slots.
+    pub fn matches_dynamic(&self, other: &AppPath) -> bool {
+        if self.0.len() != other.0.len() {
+            return false;
+        }
+
+        let mut has_dynamic = false;
+
+        for (self_seg, other_seg) in self.0.iter().zip(other.0.iter()) {
+            if self_seg == other_seg {
+                continue;
+            }
+            if matches!(self_seg, PathSegment::Dynamic(_)) {
+                has_dynamic = true;
+                continue;
+            }
+            return false;
+        }
+
+        has_dynamic
+    }
+
     pub fn contains(&self, other: &AppPath) -> bool {
+        self.contains_impl(other, false)
+    }
+
+    /// Like `contains` but also treats Dynamic segments in `other` as matching
+    /// any single Static segment in `self`. Used when checking if a parallel
+    /// route with a dynamic segment could serve a static path.
+    pub fn contains_dynamic(&self, other: &AppPath) -> bool {
+        self.contains_impl(other, true)
+    }
+
+    fn contains_impl(&self, other: &AppPath, match_dynamic: bool) -> bool {
         // TODO: handle OptionalCatchAll properly.
         for (i, segment) in other.0.iter().enumerate() {
             let Some(self_segment) = self.0.get(i) else {
@@ -465,6 +502,13 @@ impl AppPath {
                 PathSegment::CatchAll(_) | PathSegment::OptionalCatchAll(_)
             ) {
                 return true;
+            }
+
+            // A Dynamic segment matches any single Static segment.
+            // This allows parallel routes with dynamic segments (e.g. @parallel/test/[param])
+            // to match static paths (e.g. /test/static) in other slots.
+            if match_dynamic && matches!(segment, PathSegment::Dynamic(_)) {
+                continue;
             }
 
             return false;

--- a/packages/next/src/build/normalize-catchall-routes.test.ts
+++ b/packages/next/src/build/normalize-catchall-routes.test.ts
@@ -219,4 +219,48 @@ describe('normalizeCatchallRoutes', () => {
     // ensure values are correct after normalizing
     expect(appPaths).toMatchObject(initialAppPaths)
   })
+
+  // Test to verify normalizeDynamicRoutes doesn't break static-siblings parallel route test
+  it('should not propagate dynamic parallel routes when the slot already has a static match', () => {
+    // Mimics the static-siblings dashboard scenario:
+    // /dashboard/@panel/settings/page.tsx (static)
+    // /dashboard/@panel/[id]/page.tsx (dynamic)
+    const appPaths: Record<string, string[]> = {
+      '/dashboard': ['/dashboard/page'],
+      '/dashboard/settings': ['/dashboard/@panel/settings/page'],
+      '/dashboard/[id]': ['/dashboard/@panel/[id]/page'],
+    }
+
+    const initialAppPaths = JSON.parse(JSON.stringify(appPaths))
+
+    normalizeCatchAllRoutes(appPaths)
+
+    // /dashboard/settings should NOT get /dashboard/@panel/[id]/page added
+    // because @panel already has a match (settings)
+    expect(appPaths).toMatchObject(initialAppPaths)
+  })
+
+  // Test for the actual fix: dynamic parallel route should be propagated when no static match exists
+  it('should propagate dynamic parallel routes when the slot has no match', () => {
+    // Mimics the #62656 scenario:
+    // /test/[testParam]/page.tsx (children dynamic)
+    // /test/static/page.tsx (children static)
+    // /@parallel/test/[testParam]/page.tsx (parallel dynamic, no static match)
+    const appPaths: Record<string, string[]> = {
+      '/': ['/page'],
+      '/test/static': ['/test/static/page'],
+      '/test/[testParam]': [
+        '/test/[testParam]/page',
+        '/@parallel/test/[testParam]/page',
+      ],
+    }
+
+    normalizeCatchAllRoutes(appPaths)
+
+    // /test/static SHOULD get /@parallel/test/[testParam]/page added
+    // because @parallel has no match for /test/static
+    expect(appPaths['/test/static']).toContain(
+      '/@parallel/test/[testParam]/page'
+    )
+  })
 })

--- a/packages/next/src/build/normalize-catchall-routes.ts
+++ b/packages/next/src/build/normalize-catchall-routes.ts
@@ -6,6 +6,10 @@ import { AppPathnameNormalizer } from '../server/normalizers/built/app/app-pathn
  * It will traverse the appPaths, looking for catch-all routes and try to find parallel routes that could match
  * the catch-all. If it finds a match, it will add the catch-all to the parallel route's list of possible routes.
  *
+ * It also handles single dynamic segment routes (`[param]`) in parallel slots. When a static path like
+ * `/test/static` exists and a parallel slot has a dynamic route like `/@parallel/test/[param]` but no
+ * `/@parallel/test/static`, the dynamic route is added as a fallback for that slot.
+ *
  * @param appPaths The appPaths to transform
  */
 export function normalizeCatchAllRoutes(
@@ -59,6 +63,108 @@ export function normalizeCatchAllRoutes(
       }
     }
   }
+
+  // Propagate single dynamic segment routes from parallel slots.
+  // When a static path like `/test/static` exists and a parallel slot has
+  // `/@parallel/test/[param]` but no `/@parallel/test/static`, add the
+  // dynamic route as a fallback for that slot.
+  normalizeDynamicRoutes(appPaths, filteredAppPaths, normalizer)
+}
+
+/**
+ * Propagates single dynamic segment parallel routes to static paths that
+ * could be matched by them.
+ *
+ * For example, if `@parallel/test/[testParam]/page` exists but there is no
+ * `@parallel/test/static/page`, and `/test/static` is a valid app path,
+ * then `@parallel/test/[testParam]/page` will be added to the `/test/static`
+ * entry so that the parallel slot resolves to the dynamic page instead of
+ * falling back to `default.tsx`.
+ */
+function normalizeDynamicRoutes(
+  appPaths: Record<string, string[]>,
+  filteredAppPaths: string[],
+  normalizer: AppPathnameNormalizer
+): void {
+  // Collect all dynamic routes that belong to a parallel slot (contain @).
+  const dynamicParallelRoutes = [
+    ...new Set(
+      Object.values(appPaths)
+        .flat()
+        .filter(
+          (route) =>
+            route.includes('@') &&
+            hasDynamicSegment(route) &&
+            !isCatchAllRoute(route)
+        )
+        // Prefer more specific (deeper) routes first.
+        .sort((a, b) => b.split('/').length - a.split('/').length)
+    ),
+  ]
+
+  if (dynamicParallelRoutes.length === 0) return
+
+  for (const appPath of filteredAppPaths) {
+    // Skip default route entries, which are fallback routes and should not
+    // receive dynamic route propagation.
+    if (appPath.endsWith('/default')) continue
+
+    for (const dynamicRoute of dynamicParallelRoutes) {
+      const normalizedDynamic = normalizer.normalize(dynamicRoute)
+
+      // Check if this dynamic route could match the appPath.
+      // A dynamic route like `/test/[param]` can match `/test/static` if:
+      // 1. They have the same number of segments.
+      // 2. All non-dynamic segments in the dynamic route match the appPath.
+      // 3. Dynamic segments in the dynamic route only match static (non-dynamic)
+      //    segments in the appPath.
+      if (
+        dynamicRouteMatchesPath(normalizedDynamic, appPath) &&
+        // Don't add if the slot already has a matching entry for this path.
+        !appPaths[appPath].some((path) => hasMatchedSlots(path, dynamicRoute))
+      ) {
+        appPaths[appPath].push(dynamicRoute)
+      }
+    }
+  }
+}
+
+/**
+ * Checks if a normalized dynamic route pattern could match a given path.
+ * For example, `/test/[param]` matches `/test/static` because they have the same
+ * number of segments and the non-dynamic segments match.
+ *
+ * Dynamic segments in the dynamic route must correspond to static (non-dynamic)
+ * segments in the target path. This prevents matching patterns like
+ * `/nested/[foo]/[bar]/[baz]` against `/nested/[foo]/[bar]/[qux]` where both
+ * sides have dynamic segments at the same position.
+ */
+function dynamicRouteMatchesPath(
+  dynamicRoute: string,
+  targetPath: string
+): boolean {
+  const dynamicSegments = dynamicRoute.split('/').filter(Boolean)
+  const targetSegments = targetPath.split('/').filter(Boolean)
+
+  if (dynamicSegments.length !== targetSegments.length) return false
+
+  // At least one position must have a dynamic-to-static match
+  let hasDynamicToStaticMatch = false
+
+  for (let i = 0; i < dynamicSegments.length; i++) {
+    if (isDynamicSegment(dynamicSegments[i])) {
+      // Only count as a match if the corresponding target segment is static.
+      // If the target also has a dynamic segment at this position, skip it
+      // (both sides are dynamic, so this isn't a meaningful match).
+      if (!isDynamicSegment(targetSegments[i])) {
+        hasDynamicToStaticMatch = true
+      }
+      continue
+    }
+    if (dynamicSegments[i] !== targetSegments[i]) return false
+  }
+
+  return hasDynamicToStaticMatch
 }
 
 function hasMatchedSlots(path1: string, path2: string): boolean {
@@ -98,4 +204,14 @@ function isOptionalCatchAll(pathname: string): boolean {
 
 function isCatchAll(pathname: string): boolean {
   return pathname.includes('[...')
+}
+
+function isDynamicSegment(segment: string): boolean {
+  return (
+    segment.startsWith('[') && segment.endsWith(']') && !segment.includes('...')
+  )
+}
+
+function hasDynamicSegment(pathname: string): boolean {
+  return pathname.split('/').some(isDynamicSegment)
 }

--- a/packages/next/src/build/normalize-catchall-routes.ts
+++ b/packages/next/src/build/normalize-catchall-routes.ts
@@ -95,7 +95,8 @@ function normalizeDynamicRoutes(
           (route) =>
             route.includes('@') &&
             hasDynamicSegment(route) &&
-            !isCatchAllRoute(route)
+            !isCatchAllRoute(route) &&
+            !isInterceptionRouteAppPath(route)
         )
         // Prefer more specific (deeper) routes first.
         .sort((a, b) => b.split('/').length - a.split('/').length)

--- a/test/e2e/app-dir/parallel-routes-dynamic-static-match/app/@parallel/default.tsx
+++ b/test/e2e/app-dir/parallel-routes-dynamic-static-match/app/@parallel/default.tsx
@@ -1,0 +1,3 @@
+export default function ParallelDefault() {
+  return <p>Parallel: Default Fallback</p>
+}

--- a/test/e2e/app-dir/parallel-routes-dynamic-static-match/app/@parallel/test/[testParam]/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-dynamic-static-match/app/@parallel/test/[testParam]/page.tsx
@@ -1,0 +1,8 @@
+export default async function ParallelTestParamPage({
+  params,
+}: {
+  params: Promise<{ testParam: string }>
+}) {
+  const { testParam } = await params
+  return <p>Parallel: {testParam}</p>
+}

--- a/test/e2e/app-dir/parallel-routes-dynamic-static-match/app/default.tsx
+++ b/test/e2e/app-dir/parallel-routes-dynamic-static-match/app/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return null
+}

--- a/test/e2e/app-dir/parallel-routes-dynamic-static-match/app/layout.tsx
+++ b/test/e2e/app-dir/parallel-routes-dynamic-static-match/app/layout.tsx
@@ -1,0 +1,16 @@
+export default function RootLayout({
+  children,
+  parallel,
+}: {
+  children: React.ReactNode
+  parallel: React.ReactNode
+}) {
+  return (
+    <html>
+      <body>
+        <div id="children">{children}</div>
+        <div id="parallel">{parallel}</div>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-dynamic-static-match/app/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-dynamic-static-match/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Home() {
+  return <p>Home</p>
+}

--- a/test/e2e/app-dir/parallel-routes-dynamic-static-match/app/test/[testParam]/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-dynamic-static-match/app/test/[testParam]/page.tsx
@@ -1,0 +1,8 @@
+export default async function TestParamPage({
+  params,
+}: {
+  params: Promise<{ testParam: string }>
+}) {
+  const { testParam } = await params
+  return <p>Children: {testParam}</p>
+}

--- a/test/e2e/app-dir/parallel-routes-dynamic-static-match/app/test/static/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-dynamic-static-match/app/test/static/page.tsx
@@ -1,0 +1,3 @@
+export default function StaticPage() {
+  return <p>Children: Static Page</p>
+}

--- a/test/e2e/app-dir/parallel-routes-dynamic-static-match/next.config.js
+++ b/test/e2e/app-dir/parallel-routes-dynamic-static-match/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/parallel-routes-dynamic-static-match/parallel-routes-dynamic-static-match.test.ts
+++ b/test/e2e/app-dir/parallel-routes-dynamic-static-match/parallel-routes-dynamic-static-match.test.ts
@@ -1,0 +1,37 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('parallel-routes-dynamic-static-match', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should match dynamic parallel route for dynamic path', async () => {
+    const browser = await next.browser('/test/dynamic-val')
+
+    // The children slot should render the dynamic [testParam] page
+    expect(await browser.elementById('children').text()).toContain(
+      'Children: dynamic-val'
+    )
+
+    // The parallel slot should also match via [testParam]
+    expect(await browser.elementById('parallel').text()).toContain(
+      'Parallel: dynamic-val'
+    )
+  })
+
+  it('should match dynamic parallel route for static path', async () => {
+    const browser = await next.browser('/test/static')
+
+    // The children slot should render the static page
+    expect(await browser.elementById('children').text()).toContain(
+      'Children: Static Page'
+    )
+
+    // The parallel slot should match via [testParam] with value "static",
+    // NOT fall back to the default.
+    // Bug #62656: this currently shows "Parallel: Default Fallback" instead.
+    expect(await browser.elementById('parallel').text()).toContain(
+      'Parallel: static'
+    )
+  })
+})


### PR DESCRIPTION
## Problem

Fixes #62656

When a parallel route slot has a dynamic segment page (e.g. `@parallel/test/[testParam]/page.tsx`) and the children slot has a static page at the same level (e.g. `test/static/page.tsx`), navigating to `/test/static` renders the parallel slot's `default.tsx` fallback instead of matching via `[testParam]`.

This is inconsistent with how catch-all routes work: `normalizeCatchAllRoutes` already propagates `[...param]` routes across parallel slots so they match static paths in other slots. But single dynamic segments like `[param]` had no equivalent propagation.

### Reproduction

```
app/
├── layout.tsx              # renders {children} + {parallel}
├── @parallel/
│   ├── default.tsx         # "Parallel: Default Fallback"
│   └── test/
│       └── [testParam]/
│           └── page.tsx    # "Parallel: {testParam}"
└── test/
    ├── [testParam]/
    │   └── page.tsx        # "Children: {testParam}"
    └── static/
        └── page.tsx        # "Children: Static Page"
```

| Path | Children slot | Parallel slot (before) | Parallel slot (after) |
|------|--------------|----------------------|---------------------|
| `/test/dynamic-val` | `Children: dynamic-val` | `Parallel: dynamic-val` | `Parallel: dynamic-val` (no change) |
| `/test/static` | `Children: Static Page` | `Parallel: Default Fallback` (bug) | `Parallel: static` (fixed) |

## Fix

### Webpack (`normalize-catchall-routes.ts`)

Added a new `normalizeDynamicRoutes()` function, modeled after the existing catch-all propagation. It:

1. Collects all dynamic segment routes that belong to a parallel slot (contain `@`, have a `[param]` segment, are not catch-all)
2. For each static app path, checks if a dynamic parallel route could match it (same segment count, non-dynamic segments match, dynamic segments correspond to static segments in the target)
3. If no matching slot entry already exists, adds the dynamic route as a fallback for that path

Helper functions added: `isDynamicSegment()`, `hasDynamicSegment()`, `dynamicRouteMatchesPath()`.

### Turbopack (`next_app/mod.rs` + `app_structure.rs`)

Added two new methods on `AppPath`:

- `contains_dynamic()`: like `contains()` but treats `Dynamic` segments in the pattern as matching any single `Static` segment in the target path
- `matches_dynamic()`: checks if two equal-length paths match with at least one dynamic-to-static correspondence

In `app_structure.rs`, added a `match_dynamic` flag that is set to `true` when entering a parallel route slot subtree. This flag propagates down through the recursive `directory_tree_to_loader_tree_internal` calls, so the entire parallel slot subtree uses dynamic matching against the target path.

## Known CI Issues

Several CI jobs are failing with build crashes (Turbopack production, node streams, cache components). The `static-siblings` parallel routes test may also regress since this change broadens which paths dynamic parallel routes can match. These need investigation before the PR is ready.

## Test Plan

- Added e2e test `parallel-routes-dynamic-static-match` with the exact reproduction from the bug report
- Test verifies both the already-working case (`/test/dynamic-val` matches both slots) and the fixed case (`/test/static` matches the parallel slot via `[testParam]` instead of falling back to `default.tsx`)