### PR TITLE
fix: show 404 on client-side nav when children slot uses built-in default (#79352)

### DIFF
--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -459,7 +459,16 @@ function updateCacheNodeOnNavigation(
         // was stashed in the history entry as-is.
         freshness !== FreshnessPolicy.HistoryTraversal &&
         newSegmentChild === DEFAULT_SEGMENT_KEY &&
-        oldSegmentChild !== DEFAULT_SEGMENT_KEY
+        oldSegmentChild !== DEFAULT_SEGMENT_KEY &&
+        // Do not reuse the previously active segment if this __DEFAULT__
+        // segment uses the built-in default component that calls notFound().
+        // The built-in default means there is no matching page or
+        // user-provided default.tsx for this slot. Reusing old content would
+        // hide the 404 that should be triggered by the built-in default.
+        !(
+          newRouteTreeChild.prefetchHints &
+          PrefetchHint.IsBuiltinNotFoundDefault
+        )
       ) {
         // This is a "default" segment. These are never sent by the server during
         // a soft navigation; instead, the client reuses whatever segment was

--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -461,14 +461,17 @@ function updateCacheNodeOnNavigation(
         newSegmentChild === DEFAULT_SEGMENT_KEY &&
         oldSegmentChild !== DEFAULT_SEGMENT_KEY &&
         // Do not reuse the previously active segment if this __DEFAULT__
-        // segment uses the built-in default component that calls notFound().
-        // The built-in default means there is no matching page or
-        // user-provided default.tsx for this slot. Reusing old content would
-        // hide the 404 that should be triggered by the built-in default.
-        !(
+        // segment uses the built-in default component that calls notFound(),
+        // UNLESS a sibling parallel slot has a specific (non-catch-all) page
+        // match. A specific sibling match means the URL is intentional (e.g.,
+        // a modal route) and the children slot should keep its previous
+        // content. Only skip reuse when all sibling matches are catch-all or
+        // default segments, which indicates a truly nonexistent route.
+        (!(
           newRouteTreeChild.prefetchHints &
           PrefetchHint.IsBuiltinNotFoundDefault
-        )
+        ) ||
+          hasSiblingWithSpecificPage(newSlots, parallelRouteKey))
       ) {
         // This is a "default" segment. These are never sent by the server during
         // a soft navigation; instead, the client reuses whatever segment was
@@ -836,6 +839,120 @@ function accumulateRefreshUrl(
   } else {
     separateRefreshUrls.add(refreshUrl)
   }
+}
+
+/**
+ * Check if any sibling parallel slot has a specific (non-default, non-catch-all)
+ * page match. This is used to distinguish between two scenarios where the
+ * children slot uses the built-in default:
+ *
+ * 1. A truly nonexistent route where the only sibling matches are catch-all
+ *    routes (e.g., navigating to /does-not-exist with a @breadcrumb catch-all).
+ *    In this case, the children slot should NOT reuse old content, allowing the
+ *    built-in default's notFound() to trigger a 404.
+ *
+ * 2. A legitimate parallel route navigation where a named slot has a specific
+ *    page (e.g., navigating to /modal/show where @modal has a page at /show).
+ *    In this case, the children slot SHOULD reuse old content so the modal
+ *    appears on top of the existing page.
+ */
+function hasSiblingWithSpecificPage(
+  slots: { [parallelRouteKey: string]: RouteTree },
+  currentKey: string
+): boolean {
+  for (const key in slots) {
+    if (key === currentKey) continue
+
+    const sibling = slots[key]
+    const siblingSegment = sibling.segment
+    // Skip __DEFAULT__ segments (they're not real page matches)
+    if (siblingSegment === DEFAULT_SEGMENT_KEY) continue
+
+    if (typeof siblingSegment === 'string') {
+      // Skip group segments like '(__SLOT__)' - these are synthetic wrappers
+      // for parallel route slots and not real page matches. We need to look
+      // deeper into their children to determine if there's a real match.
+      if (siblingSegment[0] === '(' && siblingSegment.endsWith(')')) {
+        // Recurse into the group's children to check for specific pages
+        if (sibling.slots !== null) {
+          if (hasSiblingWithSpecificPageInSubtree(sibling)) {
+            return true
+          }
+        }
+        continue
+      }
+      // A non-default, non-group string segment is a specific page match
+      return true
+    }
+
+    // Dynamic segment tuples have the form [paramName, paramCacheKey, type, staticSiblings].
+    // Catch-all types: 'c' (catchall), 'oc' (optional-catchall), and their
+    // intercepted variants 'ci(...)' etc.
+    if (Array.isArray(siblingSegment)) {
+      const dynamicType = siblingSegment[2]
+      if (
+        dynamicType === 'c' ||
+        dynamicType === 'oc' ||
+        dynamicType === 'ci(..)(..)' ||
+        dynamicType === 'ci(.)' ||
+        dynamicType === 'ci(..)' ||
+        dynamicType === 'ci(...)'
+      ) {
+        // This sibling matched via a catch-all, which matches any URL.
+        // Don't count it as a specific page match.
+        continue
+      }
+      // A non-catch-all dynamic segment (e.g., [slug]) is a specific match
+      return true
+    }
+
+    // Any other segment type is a specific page match
+    return true
+  }
+  return false
+}
+
+/**
+ * Check if a subtree rooted at a group segment (like `(__SLOT__)`) contains
+ * a specific page match. Traverses the children tree looking for non-default,
+ * non-catch-all segments that indicate a real page match.
+ */
+function hasSiblingWithSpecificPageInSubtree(tree: RouteTree): boolean {
+  const segment = tree.segment
+
+  if (typeof segment === 'string') {
+    if (segment === DEFAULT_SEGMENT_KEY) return false
+    // Group segments need recursive checking
+    if (segment[0] === '(' && segment.endsWith(')')) {
+      if (tree.slots !== null) {
+        for (const key in tree.slots) {
+          if (hasSiblingWithSpecificPageInSubtree(tree.slots[key])) {
+            return true
+          }
+        }
+      }
+      return false
+    }
+    // Non-default, non-group string segment: this is a specific page match
+    return true
+  }
+
+  if (Array.isArray(segment)) {
+    const dynamicType = segment[2]
+    if (
+      dynamicType === 'c' ||
+      dynamicType === 'oc' ||
+      dynamicType === 'ci(..)(..)' ||
+      dynamicType === 'ci(.)' ||
+      dynamicType === 'ci(..)' ||
+      dynamicType === 'ci(...)'
+    ) {
+      return false
+    }
+    return true
+  }
+
+  return true
 }
 
 function reuseActiveSegmentInDefaultSlot(

--- a/packages/next/src/server/app-render/create-flight-router-state-from-loader-tree.ts
+++ b/packages/next/src/server/app-render/create-flight-router-state-from-loader-tree.ts
@@ -102,17 +102,14 @@ async function createFlightRouterStateFromLoaderTreeImpl(
   // that calls notFound(). This tells the client router not to reuse the
   // previous page content when navigating to a URL with no matching page.
   // The path comparison uses endsWith because the loader tree stores
-  // absolute filesystem paths while PARALLEL_ROUTE_DEFAULT_PATH is a
-  // package-relative path (e.g., "next/dist/client/components/builtin/default.js").
+  // paths that may include a prefix before the package-relative portion
+  // (e.g., "next/dist/client/components/builtin/default.js").
   if (segment === DEFAULT_SEGMENT_KEY) {
     const { defaultPage } = loaderTree[2]
     if (
       defaultPage !== undefined &&
       typeof defaultPage[1] === 'string' &&
-      defaultPage[1].endsWith(
-        // Strip the leading "next/" from the constant to match absolute paths.
-        PARALLEL_ROUTE_DEFAULT_PATH.slice('next/'.length)
-      )
+      defaultPage[1].endsWith(PARALLEL_ROUTE_DEFAULT_PATH)
     ) {
       prefetchHints |= PrefetchHint.IsBuiltinNotFoundDefault
     }

--- a/packages/next/src/server/app-render/create-flight-router-state-from-loader-tree.ts
+++ b/packages/next/src/server/app-render/create-flight-router-state-from-loader-tree.ts
@@ -5,8 +5,12 @@ import {
   type PrefetchHints,
 } from '../../shared/lib/app-router-types'
 import type { GetDynamicParamFromSegment } from './app-render'
-import { addSearchParamsIfPageSegment } from '../../shared/lib/segment'
+import {
+  DEFAULT_SEGMENT_KEY,
+  addSearchParamsIfPageSegment,
+} from '../../shared/lib/segment'
 import type { AppSegmentConfig } from '../../build/segment-config/app/app-segment-config'
+import { PARALLEL_ROUTE_DEFAULT_PATH } from '../../client/components/builtin/default'
 
 async function createFlightRouterStateFromLoaderTreeImpl(
   loaderTree: LoaderTree,
@@ -92,6 +96,26 @@ async function createFlightRouterStateFromLoaderTreeImpl(
   // Check if this segment has a loading boundary
   if (loading) {
     prefetchHints |= PrefetchHint.SegmentHasLoadingBoundary
+  }
+
+  // Check if this __DEFAULT__ segment uses the built-in default component
+  // that calls notFound(). This tells the client router not to reuse the
+  // previous page content when navigating to a URL with no matching page.
+  // The path comparison uses endsWith because the loader tree stores
+  // absolute filesystem paths while PARALLEL_ROUTE_DEFAULT_PATH is a
+  // package-relative path (e.g., "next/dist/client/components/builtin/default.js").
+  if (segment === DEFAULT_SEGMENT_KEY) {
+    const { defaultPage } = loaderTree[2]
+    if (
+      defaultPage !== undefined &&
+      typeof defaultPage[1] === 'string' &&
+      defaultPage[1].endsWith(
+        // Strip the leading "next/" from the constant to match absolute paths.
+        PARALLEL_ROUTE_DEFAULT_PATH.slice('next/'.length)
+      )
+    ) {
+      prefetchHints |= PrefetchHint.IsBuiltinNotFoundDefault
+    }
   }
 
   const children: FlightRouterState[1] = {}

--- a/packages/next/src/shared/lib/app-router-types.ts
+++ b/packages/next/src/shared/lib/app-router-types.ts
@@ -209,6 +209,12 @@ export const enum PrefetchHint {
   // (HasRuntimePrefetch). Propagates upward so the root reflects the
   // entire subtree.
   SubtreeHasRuntimePrefetch = 0b100000000000,
+  // This __DEFAULT__ segment uses the built-in default component that
+  // calls notFound(). Set so the client can distinguish between a
+  // user-provided default.tsx (where old content should be reused during
+  // navigation) and the built-in not-found default (where a 404 should
+  // be shown).
+  IsBuiltinNotFoundDefault = 0b1000000000000,
 }
 
 /**

--- a/test/e2e/app-dir/parallel-routes-404-consistency/app/@breadcrumb/[...catchAll]/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-404-consistency/app/@breadcrumb/[...catchAll]/page.tsx
@@ -1,8 +1,3 @@
-export default async function BreadcrumbCatchAll({
-  params,
-}: {
-  params: Promise<{ catchAll: string[] }>
-}) {
-  const { catchAll } = await params
-  return <p>Breadcrumb: {catchAll.join('/')}</p>
+export default function BreadcrumbCatchAll() {
+  return <p>Breadcrumb: Catch-All</p>
 }

--- a/test/e2e/app-dir/parallel-routes-404-consistency/app/@breadcrumb/[...catchAll]/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-404-consistency/app/@breadcrumb/[...catchAll]/page.tsx
@@ -1,0 +1,8 @@
+export default async function BreadcrumbCatchAll({
+  params,
+}: {
+  params: Promise<{ catchAll: string[] }>
+}) {
+  const { catchAll } = await params
+  return <p>Breadcrumb: {catchAll.join('/')}</p>
+}

--- a/test/e2e/app-dir/parallel-routes-404-consistency/app/@breadcrumb/default.tsx
+++ b/test/e2e/app-dir/parallel-routes-404-consistency/app/@breadcrumb/default.tsx
@@ -1,0 +1,3 @@
+export default function BreadcrumbDefault() {
+  return <p>Breadcrumb: Home</p>
+}

--- a/test/e2e/app-dir/parallel-routes-404-consistency/app/@breadcrumb/page-a/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-404-consistency/app/@breadcrumb/page-a/page.tsx
@@ -1,0 +1,3 @@
+export default function BreadcrumbPageA() {
+  return <p>Breadcrumb: Page A</p>
+}

--- a/test/e2e/app-dir/parallel-routes-404-consistency/app/layout.tsx
+++ b/test/e2e/app-dir/parallel-routes-404-consistency/app/layout.tsx
@@ -1,0 +1,16 @@
+export default function RootLayout({
+  children,
+  breadcrumb,
+}: {
+  children: React.ReactNode
+  breadcrumb: React.ReactNode
+}) {
+  return (
+    <html>
+      <body>
+        <div id="breadcrumb">{breadcrumb}</div>
+        <div id="children">{children}</div>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-404-consistency/app/not-found.tsx
+++ b/test/e2e/app-dir/parallel-routes-404-consistency/app/not-found.tsx
@@ -1,0 +1,3 @@
+export default function NotFound() {
+  return <p>404 Not Found</p>
+}

--- a/test/e2e/app-dir/parallel-routes-404-consistency/app/page-a/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-404-consistency/app/page-a/page.tsx
@@ -1,0 +1,12 @@
+import Link from 'next/link'
+
+export default function PageA() {
+  return (
+    <div>
+      <p>Page A Content</p>
+      <Link href="/does-not-exist" id="link-to-nonexistent">
+        Go to nonexistent page
+      </Link>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-404-consistency/app/page-b/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-404-consistency/app/page-b/page.tsx
@@ -1,0 +1,3 @@
+export default function PageB() {
+  return <p>Page B Content</p>
+}

--- a/test/e2e/app-dir/parallel-routes-404-consistency/app/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-404-consistency/app/page.tsx
@@ -1,0 +1,3 @@
+export default function HomePage() {
+  return <p>Home Page</p>
+}

--- a/test/e2e/app-dir/parallel-routes-404-consistency/next.config.js
+++ b/test/e2e/app-dir/parallel-routes-404-consistency/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/parallel-routes-404-consistency/parallel-routes-404-consistency.test.ts
+++ b/test/e2e/app-dir/parallel-routes-404-consistency/parallel-routes-404-consistency.test.ts
@@ -1,0 +1,48 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+describe('parallel-routes-404-consistency', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should show 404 on direct navigation to nonexistent route', async () => {
+    const browser = await next.browser('/does-not-exist')
+
+    await retry(async () => {
+      const text = await browser.elementByCss('body').text()
+      expect(text).toContain('404 Not Found')
+    })
+  })
+
+  it('should show 404 on client-side navigation to nonexistent route', async () => {
+    const browser = await next.browser('/page-a')
+
+    // Verify we are on page-a
+    await retry(async () => {
+      const text = await browser.elementById('children').text()
+      expect(text).toContain('Page A Content')
+    })
+
+    // Verify breadcrumb shows Page A
+    await retry(async () => {
+      const text = await browser.elementById('breadcrumb').text()
+      expect(text).toContain('Breadcrumb: Page A')
+    })
+
+    // Click the link to a nonexistent page
+    await browser.elementByCss('#link-to-nonexistent').click()
+
+    // After client-side navigation to a nonexistent route, we should see
+    // the 404 page, not stale content from Page A.
+    // BUG #79352: The catch-all @breadcrumb slot matches /does-not-exist,
+    // so the response is 200 and the children slot falls back to
+    // __DEFAULT__, causing reuseActiveSegmentInDefaultSlot() to reuse
+    // the stale Page A content instead of showing a 404.
+    await retry(async () => {
+      const bodyText = await browser.elementByCss('body').text()
+      expect(bodyText).toContain('404 Not Found')
+      expect(bodyText).not.toContain('Page A Content')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #79352

When an app uses a parallel route with a catch-all slot (e.g., `@breadcrumb/[...catchAll]/page.tsx`), client-side navigation to a nonexistent route shows stale content from the previous page instead of the expected 404 page. Direct navigation (full page load) to the same URL correctly renders the 404.

### The scenario

```
app/
  layout.tsx              # renders {children} + {breadcrumb}
  not-found.tsx           # custom 404 page
  page.tsx                # home
  page-a/page.tsx         # has a <Link> to /does-not-exist
  @breadcrumb/
    default.tsx           # user-provided default for the slot
    [..catchAll]/page.tsx # matches any path, renders breadcrumb text
    page-a/page.tsx       # breadcrumb for page-a
```

1. Navigate to `/page-a` (both `children` and `@breadcrumb` slots render their matched pages).
2. Click a link to `/does-not-exist`.
3. The `@breadcrumb` slot matches via `[...catchAll]`, so the server responds with 200.
4. The `children` slot has no matching page, so the server uses the **built-in default** component (which calls `notFound()`).

**Before this fix:** The client-side router sees the `children` slot resolved to `__DEFAULT__` and calls `reuseActiveSegmentInDefaultSlot()`, which reuses the stale Page A content. The user sees Page A instead of a 404.

**After this fix:** The client detects that the `__DEFAULT__` segment uses the built-in not-found default and skips reuse, allowing the `notFound()` boundary to trigger correctly. Both direct and client-side navigation now show 404.

### Root cause

`reuseActiveSegmentInDefaultSlot()` in `ppr-navigations.ts` unconditionally reused old segment content for any `__DEFAULT__` segment during client-side navigation. This is correct for user-provided `default.tsx` files (which are meant to preserve parallel slot content across navigations), but wrong for the framework's built-in default component (`packages/next/src/client/components/builtin/default.tsx`) that calls `notFound()`. The client had no way to distinguish between the two cases.

### The fix

1. **New flag:** Added `IsBuiltinNotFoundDefault` (`0b1000000000000`) to the `PrefetchHint` enum in `app-router-types.ts`.
2. **Server-side marking:** In `create-flight-router-state-from-loader-tree.ts`, when building the `FlightRouterState` for a `__DEFAULT__` segment, the server checks whether the segment's module path ends with the built-in default path (`dist/client/components/builtin/default.js`). If so, it sets the `IsBuiltinNotFoundDefault` flag in the segment's prefetch hints.
3. **Client-side check:** In `ppr-navigations.ts`, the `reuseActiveSegmentInDefaultSlot` code path now checks for this flag. When `IsBuiltinNotFoundDefault` is set, it skips reusing the previously active segment and instead processes the `__DEFAULT__` segment normally, which triggers the not-found boundary.

## Test plan

- Added e2e test at `test/e2e/app-dir/parallel-routes-404-consistency/` with two cases:
  - Direct navigation to `/does-not-exist` shows 404 (was already working)
  - Client-side navigation from `/page-a` to `/does-not-exist` shows 404 (was broken, now fixed)

### Known CI regressions

Some existing parallel routes tests (`parallel-routes-and-interception`, `parallel-routes-revalidation`) show failures that need investigation to determine whether they are pre-existing flakes or regressions introduced by this change.