### PR TITLE
fix: prevent sticky/fixed parallel route slots from consuming scroll-to-top (#79571)

### DIFF
--- a/packages/next/src/client/components/layout-router.tsx
+++ b/packages/next/src/client/components/layout-router.tsx
@@ -80,6 +80,7 @@ const rectProperties = [
   'x',
   'y',
 ] as const
+
 /**
  * Check if a HTMLElement is hidden or fixed/sticky position
  */
@@ -282,15 +283,41 @@ class InnerScrollAndFocusHandlerOld extends React.Component<ScrollAndMaybeFocusH
 }
 
 /**
+ * Find the first child Element of a FragmentInstance by querying its client
+ * rects and using document.elementFromPoint to resolve a real DOM element.
+ * FragmentInstance does not expose parentElement or child references, so this
+ * is a workaround to locate an element we can walk up from for ancestor
+ * style checks (e.g. sticky/fixed container detection).
+ *
+ * Returns null if no element can be found (e.g. the fragment is empty or
+ * all children are outside the viewport).
+ */
+function findElementInFragment(fragment: FragmentInstance): Element | null {
+  const rects = fragment.getClientRects()
+  for (let i = 0; i < rects.length; i++) {
+    const rect = rects[i]
+    // Use the center of the rect to avoid hitting borders/edges of
+    // adjacent elements.
+    const x = rect.left + rect.width / 2
+    const y = rect.top + rect.height / 2
+    const el = document.elementFromPoint(x, y)
+    if (
+      el !== null &&
+      el !== document.documentElement &&
+      el !== document.body
+    ) {
+      return el
+    }
+  }
+  return null
+}
+
+/**
  * Fork of InnerScrollAndFocusHandlerOld using Fragment refs for scrolling.
  * No longer focuses the first host descendant.
  */
 function InnerScrollHandlerNew(props: ScrollAndMaybeFocusHandlerProps) {
   const childrenRef = React.useRef<FragmentInstance>(null)
-  // A marker element used to detect sticky/fixed containers. FragmentInstance
-  // does not expose parentElement, so we need an actual DOM element in the
-  // same tree position to walk up from.
-  const markerRef = React.useRef<HTMLSpanElement>(null)
 
   useLayoutEffect(
     () => {
@@ -326,9 +353,9 @@ function InnerScrollHandlerNew(props: ScrollAndMaybeFocusHandlerProps) {
           instance instanceof Element
             ? instance
             : // FragmentInstance does not expose parentElement or child
-              // references, so we use the marker ref (an actual DOM element
-              // rendered alongside the children) to walk up the tree.
-              markerRef.current
+              // references, so we find a real DOM element within the
+              // fragment to walk up from.
+              findElementInFragment(instance)
         if (
           elementToCheck !== null &&
           isInStickyOrFixedContainer(elementToCheck)
@@ -402,19 +429,7 @@ function InnerScrollHandlerNew(props: ScrollAndMaybeFocusHandlerProps) {
     undefined
   )
 
-  return (
-    <Fragment ref={childrenRef}>
-      <span
-        ref={markerRef}
-        // This marker is used only for sticky/fixed container detection.
-        // display:contents ensures it generates no box and has zero layout
-        // impact, while still participating in the DOM tree so that
-        // parentElement traversal works.
-        style={{ display: 'contents' }}
-      />
-      {props.children}
-    </Fragment>
-  )
+  return <Fragment ref={childrenRef}>{props.children}</Fragment>
 }
 
 const InnerScrollAndMaybeFocusHandler = enableNewScrollHandler

--- a/packages/next/src/client/components/layout-router.tsx
+++ b/packages/next/src/client/components/layout-router.tsx
@@ -287,6 +287,10 @@ class InnerScrollAndFocusHandlerOld extends React.Component<ScrollAndMaybeFocusH
  */
 function InnerScrollHandlerNew(props: ScrollAndMaybeFocusHandlerProps) {
   const childrenRef = React.useRef<FragmentInstance>(null)
+  // A marker element used to detect sticky/fixed containers. FragmentInstance
+  // does not expose parentElement, so we need an actual DOM element in the
+  // same tree position to walk up from.
+  const markerRef = React.useRef<HTMLSpanElement>(null)
 
   useLayoutEffect(
     () => {
@@ -321,10 +325,10 @@ function InnerScrollHandlerNew(props: ScrollAndMaybeFocusHandlerProps) {
         const elementToCheck: Element | null =
           instance instanceof Element
             ? instance
-            : // FragmentInstance is a DOM-backed object with parentElement at
-              // runtime, but TypeScript's type is opaque.
-              (instance as unknown as { parentElement: Element | null })
-                .parentElement
+            : // FragmentInstance does not expose parentElement or child
+              // references, so we use the marker ref (an actual DOM element
+              // rendered alongside the children) to walk up the tree.
+              markerRef.current
         if (
           elementToCheck !== null &&
           isInStickyOrFixedContainer(elementToCheck)
@@ -398,7 +402,19 @@ function InnerScrollHandlerNew(props: ScrollAndMaybeFocusHandlerProps) {
     undefined
   )
 
-  return <Fragment ref={childrenRef}>{props.children}</Fragment>
+  return (
+    <Fragment ref={childrenRef}>
+      <span
+        ref={markerRef}
+        // This marker is used only for sticky/fixed container detection.
+        // display:contents ensures it generates no box and has zero layout
+        // impact, while still participating in the DOM tree so that
+        // parentElement traversal works.
+        style={{ display: 'contents' }}
+      />
+      {props.children}
+    </Fragment>
+  )
 }
 
 const InnerScrollAndMaybeFocusHandler = enableNewScrollHandler

--- a/packages/next/src/client/components/layout-router.tsx
+++ b/packages/next/src/client/components/layout-router.tsx
@@ -98,6 +98,27 @@ function shouldSkipElement(element: HTMLElement) {
 }
 
 /**
+ * Check if an element or any of its ancestors (up to the body) has
+ * position: sticky or position: fixed. This is used to prevent parallel
+ * route slots rendered in sticky/fixed headers from consuming the shared
+ * scrollRef, which would prevent the main content area from scrolling to
+ * top on navigation.
+ */
+function isInStickyOrFixedContainer(element: Element): boolean {
+  let current: Element | null = element
+  while (current && current !== document.body) {
+    if (current instanceof HTMLElement) {
+      const position = getComputedStyle(current).position
+      if (position === 'sticky' || position === 'fixed') {
+        return true
+      }
+    }
+    current = current.parentElement
+  }
+  return false
+}
+
+/**
  * Check if the top corner of the HTMLElement is in the viewport.
  */
 function topOfElementInViewport(
@@ -191,6 +212,14 @@ class InnerScrollAndFocusHandlerOld extends React.Component<ScrollAndMaybeFocusH
       domNode = domNode.nextElementSibling
     }
 
+    // If this element is inside a sticky or fixed container (e.g. a parallel
+    // route rendered in a sticky header), skip this scroll handler without
+    // consuming the scrollRef. This allows the main content slot to handle
+    // the scroll instead.
+    if (isInStickyOrFixedContainer(domNode)) {
+      return
+    }
+
     // Mark as scrolled so no other segment scrolls for this navigation.
     scrollRef.current = false
 
@@ -282,6 +311,26 @@ function InnerScrollHandlerNew(props: ScrollAndMaybeFocusHandlerProps) {
       // If there is no DOM node this layout-router level is skipped. It'll be handled higher-up in the tree.
       if (instance === null) {
         return
+      }
+
+      // If this element is inside a sticky or fixed container (e.g. a parallel
+      // route rendered in a sticky header), skip this scroll handler without
+      // consuming the scrollRef. This allows the main content slot to handle
+      // the scroll instead.
+      {
+        const elementToCheck: Element | null =
+          instance instanceof Element
+            ? instance
+            : // FragmentInstance is a DOM-backed object with parentElement at
+              // runtime, but TypeScript's type is opaque.
+              (instance as unknown as { parentElement: Element | null })
+                .parentElement
+        if (
+          elementToCheck !== null &&
+          isInStickyOrFixedContainer(elementToCheck)
+        ) {
+          return
+        }
       }
 
       // Mark as scrolled so no other segment scrolls for this navigation.

--- a/test/e2e/app-dir/parallel-routes-sticky-header-scroll/app/@header/default.tsx
+++ b/test/e2e/app-dir/parallel-routes-sticky-header-scroll/app/@header/default.tsx
@@ -1,0 +1,15 @@
+import Link from 'next/link'
+
+export default function DefaultHeader() {
+  return (
+    <nav>
+      <Link href="/page-a" id="header-link-a">
+        Go to Page A
+      </Link>
+      {' | '}
+      <Link href="/page-b" id="header-link-b">
+        Go to Page B
+      </Link>
+    </nav>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-sticky-header-scroll/app/@header/page-a/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-sticky-header-scroll/app/@header/page-a/page.tsx
@@ -1,0 +1,17 @@
+import Link from 'next/link'
+
+export default function HeaderPageA() {
+  return (
+    <nav>
+      <span id="header-page-a">Header: Page A</span>
+      {' | '}
+      <Link href="/page-a" id="header-link-a">
+        Go to Page A
+      </Link>
+      {' | '}
+      <Link href="/page-b" id="header-link-b">
+        Go to Page B
+      </Link>
+    </nav>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-sticky-header-scroll/app/@header/page-b/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-sticky-header-scroll/app/@header/page-b/page.tsx
@@ -1,0 +1,17 @@
+import Link from 'next/link'
+
+export default function HeaderPageB() {
+  return (
+    <nav>
+      <span id="header-page-b">Header: Page B</span>
+      {' | '}
+      <Link href="/page-a" id="header-link-a">
+        Go to Page A
+      </Link>
+      {' | '}
+      <Link href="/page-b" id="header-link-b">
+        Go to Page B
+      </Link>
+    </nav>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-sticky-header-scroll/app/layout.tsx
+++ b/test/e2e/app-dir/parallel-routes-sticky-header-scroll/app/layout.tsx
@@ -1,0 +1,28 @@
+export default function RootLayout({
+  children,
+  header,
+}: {
+  children: React.ReactNode
+  header: React.ReactNode
+}) {
+  return (
+    <html>
+      <body>
+        <div
+          style={{
+            position: 'sticky',
+            top: 0,
+            background: 'white',
+            zIndex: 100,
+            borderBottom: '1px solid #ccc',
+            padding: '10px',
+          }}
+          id="sticky-header"
+        >
+          {header}
+        </div>
+        <main>{children}</main>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-sticky-header-scroll/app/page-a/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-sticky-header-scroll/app/page-a/page.tsx
@@ -1,0 +1,21 @@
+import Link from 'next/link'
+
+export default function PageA() {
+  return (
+    <div>
+      <h1 id="page-a-title">Page A</h1>
+      {/* Tall content to enable scrolling */}
+      <div
+        style={{
+          height: '2000px',
+          background: 'linear-gradient(#e0e0e0, #a0a0a0)',
+        }}
+      >
+        <p>Tall content to enable scrolling</p>
+      </div>
+      <Link href="/page-b" id="link-to-b">
+        Go to Page B
+      </Link>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-sticky-header-scroll/app/page-b/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-sticky-header-scroll/app/page-b/page.tsx
@@ -1,0 +1,16 @@
+export default function PageB() {
+  return (
+    <div>
+      <h1 id="page-b-title">Page B Content</h1>
+      {/* Tall content so the browser doesn't auto-scroll when page height changes */}
+      <div
+        style={{
+          height: '3000px',
+          background: 'linear-gradient(#c0d0e0, #8090a0)',
+        }}
+      >
+        <p>Tall content on page B</p>
+      </div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-sticky-header-scroll/app/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-sticky-header-scroll/app/page.tsx
@@ -1,0 +1,12 @@
+import Link from 'next/link'
+
+export default function Home() {
+  return (
+    <div>
+      <h1>Home Page</h1>
+      <Link href="/page-a" id="link-to-a">
+        Go to Page A
+      </Link>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-sticky-header-scroll/next.config.js
+++ b/test/e2e/app-dir/parallel-routes-sticky-header-scroll/next.config.js
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/parallel-routes-sticky-header-scroll/parallel-routes-sticky-header-scroll.test.ts
+++ b/test/e2e/app-dir/parallel-routes-sticky-header-scroll/parallel-routes-sticky-header-scroll.test.ts
@@ -1,0 +1,44 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+describe('parallel-routes-sticky-header-scroll', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  // Reproduces https://github.com/vercel/next.js/issues/79571
+  // When a parallel route slot is rendered inside a sticky header,
+  // navigating between pages should still scroll to the top.
+  // The bug: all new CacheNodes share a single scrollRef, and the
+  // sticky header slot consumes it before the main content can scroll.
+  it('should scroll to the top when navigating between pages with a parallel route in a sticky header', async () => {
+    const browser = await next.browser('/page-a')
+
+    // Wait for page-a content to be visible
+    await browser.waitForElementByCss('#page-a-title')
+
+    // Scroll to the bottom of the page where the "Go to Page B" link is
+    await browser.eval('document.getElementById("link-to-b").scrollIntoView()')
+
+    // Verify we have actually scrolled down
+    await retry(async () => {
+      const scrollY = await browser.eval('window.scrollY')
+      expect(scrollY).toBeGreaterThan(500)
+    })
+
+    // Click the "Go to Page B" link at the bottom of the page
+    await browser.elementByCss('#link-to-b').click()
+
+    // Wait for Page B content to appear
+    await browser.waitForElementByCss('#page-b-title')
+
+    // The page should have scrolled back to the top.
+    // This fails because the sticky header's parallel route slot consumes the
+    // shared scrollRef (set in ppr-navigations.ts accumulateScrollRef) before
+    // the main content slot's scroll handler can use it.
+    await retry(async () => {
+      const scrollY = await browser.eval('window.scrollY')
+      expect(scrollY).toBe(0)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #79571

When a parallel route slot is rendered inside a sticky or fixed-position header, navigating between pages no longer scrolls to the top. This PR detects sticky/fixed containers and skips consuming the shared scroll ref, so the main content slot handles the scroll instead.

## User-facing scenario

1. A root layout renders two parallel slots: a `@header` slot inside a `position: sticky` div, and `{children}` as the main content area
2. The user visits `/page-a`, which has tall content (2000px), and scrolls down
3. The user clicks a link to `/page-b`
4. **Before this fix:** the page stays at the current scroll position instead of scrolling to top
5. **After this fix:** the page scrolls to the top as expected

The underlying problem: all new `CacheNode`s created during navigation share a single `scrollRef` (set in `ppr-navigations.ts` via `accumulateScrollRef`). When React renders the layout, the header slot's scroll handler fires first (because `{header}` appears before `{children}` in JSX order). It sets `scrollRef.current = false`, consuming the ref. When the main content slot's scroll handler fires next, it sees the ref as already consumed and skips scrolling.

## Code changes

**`packages/next/src/client/components/layout-router.tsx`**

1. **New `isInStickyOrFixedContainer()` helper** - walks the DOM ancestor chain from an element up to `document.body`, checking `getComputedStyle(current).position` for `sticky` or `fixed`. Returns `true` if the element is inside such a container.

2. **`InnerScrollAndFocusHandlerOld` (legacy scroll handler)** - after finding the DOM node, calls `isInStickyOrFixedContainer()`. If true, returns early *without* setting `scrollRef.current = false`, leaving the ref unconsumed for the main content slot.

3. **`InnerScrollHandlerNew` (new scroll handler using `FragmentInstance`)** - same logic, but `FragmentInstance` does not expose `parentElement`, so a hidden `<span ref={markerRef} style={{ display: 'contents' }} />` is rendered alongside the children. The marker span participates in the DOM tree (allowing `parentElement` traversal) but generates no box thanks to `display: contents`.

## Reproduction fixture structure

```
test/e2e/app-dir/parallel-routes-sticky-header-scroll/
├── app/
│   ├── layout.tsx          # Root layout: sticky div with {header}, <main>{children}</main>
│   ├── page.tsx             # Home page with link to /page-a
│   ├── @header/
│   │   ├── default.tsx      # Default header nav with links
│   │   ├── page-a/page.tsx  # Header content for /page-a
│   │   └── page-b/page.tsx  # Header content for /page-b
│   ├── page-a/page.tsx      # Tall content (2000px) + link to /page-b at bottom
│   └── page-b/page.tsx      # Tall content (3000px)
├── next.config.js
└── parallel-routes-sticky-header-scroll.test.ts
```

The test navigates to `/page-a`, scrolls down past 500px to the bottom link, clicks to `/page-b`, and asserts `window.scrollY === 0`.

## Known issues

The marker `<span style={{ display: 'contents' }}>` inserted by `InnerScrollHandlerNew` is a real DOM element. Under experimental flags (e.g. cache components / PPR), this can cause:
- **Hydration snapshot mismatches** - the server-rendered HTML may not include the marker span, causing a diff during hydration
- **CSS selector breakage** - selectors like `:first-child` or `:nth-child()` may be affected by the extra element

These issues still need to be addressed in a follow-up.