### PR TITLE
fix: add @deprecated annotation to experimental.useCache

### DIFF
--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -939,6 +939,7 @@ export interface ExperimentalConfig {
   authInterrupts?: boolean
 
   /**
+   * Enables the use of the `"use cache"` directive.
    * @deprecated use top-level `cacheComponents` instead
    */
   useCache?: boolean

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -939,7 +939,7 @@ export interface ExperimentalConfig {
   authInterrupts?: boolean
 
   /**
-   * Enables the use of the `"use cache"` directive.
+   * @deprecated use top-level `cacheComponents` instead
    */
   useCache?: boolean
 


### PR DESCRIPTION
### What?

Add a `@deprecated` JSDoc annotation to `experimental.useCache` in `config-shared.ts`, pointing to `cacheComponents: true` as the successor.

### Why?

`experimental.cacheComponents` already has `@deprecated use top-level cacheComponents instead`, but `experimental.useCache` has no deprecation notice despite `cacheComponents: true` being the documented successor. This causes both developers and AI coding agents to use the old flag, since nothing in the type definitions signals it's deprecated. IDEs and agents rely on JSDoc annotations for guidance.

### How?

Replace the existing JSDoc comment on `experimental.useCache` with `@deprecated use top-level cacheComponents instead`, matching the existing pattern on `experimental.cacheComponents`.

## PR checklist (Fixing a bug)

- One-line JSDoc change, no tests needed

Made with [Cursor](https://cursor.com)