### PR TITLE
fix: deterministic metadata resolution order for parallel routes

### DIFF
--- a/packages/next/src/lib/metadata/resolve-metadata.ts
+++ b/packages/next/src/lib/metadata/resolve-metadata.ts
@@ -788,7 +788,14 @@ async function resolveMetadataItemsImpl(
       .join('/'),
   })
 
-  for (const key in parallelRoutes) {
+  // Process children first, then other parallel routes, for consistent ordering
+  const metadataParallelRouteKeys = Object.keys(parallelRoutes)
+  metadataParallelRouteKeys.sort((a, b) => {
+    if (a === 'children') return -1
+    if (b === 'children') return 1
+    return a.localeCompare(b)
+  })
+  for (const key of metadataParallelRouteKeys) {
     const childTree = parallelRoutes[key]
     await resolveMetadataItemsImpl(
       metadataItems,
@@ -911,7 +918,14 @@ async function resolveViewportItemsImpl(
       .join('/'),
   })
 
-  for (const key in parallelRoutes) {
+  // Process children first, then other parallel routes, for consistent ordering
+  const viewportParallelRouteKeys = Object.keys(parallelRoutes)
+  viewportParallelRouteKeys.sort((a, b) => {
+    if (a === 'children') return -1
+    if (b === 'children') return 1
+    return a.localeCompare(b)
+  })
+  for (const key of viewportParallelRouteKeys) {
     const childTree = parallelRoutes[key]
     await resolveViewportItemsImpl(
       viewportItems,

--- a/packages/next/src/lib/metadata/resolve-metadata.ts
+++ b/packages/next/src/lib/metadata/resolve-metadata.ts
@@ -788,7 +788,11 @@ async function resolveMetadataItemsImpl(
       .join('/'),
   })
 
-  // Process children first, then other parallel routes, for consistent ordering
+  // Process children first so named parallel route slots are pushed to
+  // metadataItems last. Since accumulateMetadata applies last-write-wins,
+  // named slots take precedence over children when both define metadata.
+  // This ensures deterministic behavior across webpack and Turbopack,
+  // which may construct loader trees with different key orderings.
   const metadataParallelRouteKeys = Object.keys(parallelRoutes)
   metadataParallelRouteKeys.sort((a, b) => {
     if (a === 'children') return -1
@@ -918,7 +922,11 @@ async function resolveViewportItemsImpl(
       .join('/'),
   })
 
-  // Process children first, then other parallel routes, for consistent ordering
+  // Process children first so named parallel route slots are pushed to
+  // viewportItems last. Since accumulateViewport applies last-write-wins,
+  // named slots take precedence over children when both define viewport.
+  // This ensures deterministic behavior across webpack and Turbopack,
+  // which may construct loader trees with different key orderings.
   const viewportParallelRouteKeys = Object.keys(parallelRoutes)
   viewportParallelRouteKeys.sort((a, b) => {
     if (a === 'children') return -1

--- a/test/e2e/app-dir/metadata-streaming-parallel-routes/app/parallel-routes/@bar/metadata-conflict/page.tsx
+++ b/test/e2e/app-dir/metadata-streaming-parallel-routes/app/parallel-routes/@bar/metadata-conflict/page.tsx
@@ -1,0 +1,7 @@
+export default function Page() {
+  return <div id="bar-conflict-page">bar slot page</div>
+}
+
+export const metadata = {
+  title: 'bar slot title',
+}

--- a/test/e2e/app-dir/metadata-streaming-parallel-routes/app/parallel-routes/@foo/metadata-conflict/page.tsx
+++ b/test/e2e/app-dir/metadata-streaming-parallel-routes/app/parallel-routes/@foo/metadata-conflict/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div id="foo-conflict-page">foo slot page</div>
+}

--- a/test/e2e/app-dir/metadata-streaming-parallel-routes/app/parallel-routes/metadata-conflict/page.tsx
+++ b/test/e2e/app-dir/metadata-streaming-parallel-routes/app/parallel-routes/metadata-conflict/page.tsx
@@ -1,0 +1,7 @@
+export default function Page() {
+  return <div id="children-page">children page</div>
+}
+
+export const metadata = {
+  title: 'children title',
+}

--- a/test/e2e/app-dir/metadata-streaming-parallel-routes/metadata-streaming-parallel-routes.test.ts
+++ b/test/e2e/app-dir/metadata-streaming-parallel-routes/metadata-streaming-parallel-routes.test.ts
@@ -59,6 +59,15 @@ describe('app-dir - metadata-streaming', () => {
     expect($('body title').text()).toBe('parallel-routes-default layout title')
   })
 
+  it('should use named slot metadata over children when both define conflicting metadata', async () => {
+    const $ = await next.render$('/parallel-routes/metadata-conflict')
+    expect($('title').text()).toBe('bar slot title')
+
+    const browser = await next.browser('/parallel-routes/metadata-conflict')
+    expect(await browser.elementByCss('title').text()).toBe('bar slot title')
+    expect((await browser.elementsByCss('title')).length).toBe(1)
+  })
+
   it('should change metadata when navigating between two pages under a slot when children is not rendered', async () => {
     // first page is /parallel-routes-no-children/first,
     // second page is /parallel-routes-no-children/second


### PR DESCRIPTION
## Summary
- Ensures consistent metadata resolution when multiple parallel slots define metadata at the same route
- Previously, the winner depended on `for...in` iteration order of loader tree keys, which differs between webpack and Turbopack
- Now `children` is always processed first, so named parallel slots take precedence consistently

## Root Cause
- `resolveMetadataItemsImpl` in `resolve-metadata.ts` iterates `for (const key in parallelRoutes)`
- `for...in` order depends on property insertion order, which differs by bundler
- Webpack: `parallel` first, then `children` (children wins as "last write")
- Turbopack: `children` first, then `parallel` (parallel wins)

## Fix
- Sort parallel route keys so `children` is always first, then alphabetical
- Named parallel slots are processed after `children`, so their metadata takes precedence
- This matches the convention that named slots are more specific than the default `children` slot

## Test Plan
- Existing metadata tests pass in both webpack and Turbopack modes
- Related: discovered while fixing #77888 (PR #92311)

Fixes the non-deterministic behavior found during #77888 investigation.