### PR TITLE
ci: fix stats action

### DIFF
--- a/.github/actions/next-stats-action/src/constants.js
+++ b/.github/actions/next-stats-action/src/constants.js
@@ -3,7 +3,20 @@ const os = require('os')
 const fs = require('fs')
 
 const benchTitle = 'Page Load Tests'
-const workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'next-stats'))
+
+function getTempRoot() {
+  const tempRoot = process.env.RUNNER_TEMP || os.tmpdir()
+
+  try {
+    fs.mkdirSync(tempRoot, { recursive: true })
+    return tempRoot
+  } catch {
+    return os.tmpdir()
+  }
+}
+
+const workDir = fs.mkdtempSync(path.join(getTempRoot(), 'next-stats-'))
+const pnpmStoreDir = path.join(workDir, '.pnpm-store')
 const mainRepoDir = path.join(workDir, 'main-repo')
 const diffRepoDir = path.join(workDir, 'diff-repo')
 const statsAppDir = path.join(workDir, 'stats-app')
@@ -18,6 +31,7 @@ const allowedConfigLocations = [
 module.exports = {
   benchTitle,
   workDir,
+  pnpmStoreDir,
   diffingDir,
   mainRepoDir,
   diffRepoDir,

--- a/.github/actions/next-stats-action/src/index.js
+++ b/.github/actions/next-stats-action/src/index.js
@@ -6,7 +6,7 @@ const logger = require('./util/logger')
 const runConfigs = require('./run')
 const addComment = require('./add-comment')
 const actionInfo = require('./prepare/action-info')()
-const { mainRepoDir, diffRepoDir } = require('./constants')
+const { mainRepoDir, diffRepoDir, pnpmStoreDir } = require('./constants')
 const loadStatsConfig = require('./prepare/load-stats-config')
 const { cloneRepo, mergeBranch, getCommitId, linkPackages, getLastStable } =
   require('./prepare/repo-setup')(actionInfo)
@@ -117,9 +117,10 @@ if (!allowedActions.has(actionInfo.actionName) && !actionInfo.isRelease) {
               usePnpm
                 ? // --no-frozen-lockfile is used here to tolerate lockfile
                   // changes from merging latest changes
-                  // --package-import-method=copy avoids EXDEV hardlink failures
-                  // on self-hosted runners where pnpm store/workdirs cross devices.
-                  ` && pnpm install --no-frozen-lockfile --package-import-method=copy`
+                  // --package-import-method=copy avoids hardlink issues on
+                  // self-hosted runners, and the store is colocated with the
+                  // workdir to avoid EXDEV copy failures on overlayfs runners.
+                  ` && pnpm install --no-frozen-lockfile --package-import-method=copy --store-dir=${pnpmStoreDir}`
                 : ' && yarn install --network-timeout 1000000'
             }`,
             { env: { PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1' } }


### PR DESCRIPTION
We recently re-imaged the self-hosted Linux runners and it now hits `ERR_PNPM_EXDEV` when pnpm copies packages between its default store and the temp stats workspace. Keeping both under the same temp root avoids the cross-filesystem copy failure.