### PR TITLE
Allow for parsing app route strings with and without slot names.

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1148,5 +1148,7 @@
   "1147": "Turbopack database compaction is not supported on this platform",
   "1148": "webToReadable cannot be used in the edge runtime",
   "1149": "Node.js Readable cannot be teed in the edge runtime",
-  "1150": "Node.js Readable cannot be converted to a web stream in the edge runtime"
+  "1150": "Node.js Readable cannot be converted to a web stream in the edge runtime",
+  "1151": "%s is being parsed as a normalized route, but it has a route group segment.",
+  "1152": "%s is being parsed as a normalized route, but it has a parallel route segment."
 }

--- a/packages/next/src/build/static-paths/app/extract-pathname-route-param-segments-from-loader-tree.test.ts
+++ b/packages/next/src/build/static-paths/app/extract-pathname-route-param-segments-from-loader-tree.test.ts
@@ -1,4 +1,4 @@
-import { parseAppRoute } from '../../../shared/lib/router/routes/app'
+import { parseNormalizedAppRoute } from '../../../shared/lib/router/routes/app'
 import { extractPathnameRouteParamSegmentsFromLoaderTree } from './extract-pathname-route-param-segments-from-loader-tree'
 
 // Helper to create LoaderTree structures for testing
@@ -23,7 +23,7 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
     it('should extract single dynamic segment from children route', () => {
       // Tree: /[slug]
       const loaderTree = createLoaderTree('', {}, createLoaderTree('[slug]'))
-      const route = parseAppRoute('/[slug]', true)
+      const route = parseNormalizedAppRoute('/[slug]')
       const { pathnameRouteParamSegments: result } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
 
@@ -39,7 +39,7 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
         {},
         createLoaderTree('[category]', {}, createLoaderTree('[slug]'))
       )
-      const route = parseAppRoute('/[category]/[slug]', true)
+      const route = parseNormalizedAppRoute('/[category]/[slug]')
       const { pathnameRouteParamSegments: result } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
 
@@ -52,7 +52,7 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
     it('should extract catchall segment', () => {
       // Tree: /[...slug]
       const loaderTree = createLoaderTree('', {}, createLoaderTree('[...slug]'))
-      const route = parseAppRoute('/[...slug]', true)
+      const route = parseNormalizedAppRoute('/[...slug]')
       const { pathnameRouteParamSegments: result } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
 
@@ -68,7 +68,7 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
         {},
         createLoaderTree('[[...slug]]')
       )
-      const route = parseAppRoute('/[[...slug]]', true)
+      const route = parseNormalizedAppRoute('/[[...slug]]')
       const { pathnameRouteParamSegments: result } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
 
@@ -96,7 +96,7 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
           )
         )
       )
-      const route = parseAppRoute('/blog/[category]/posts/[slug]', true)
+      const route = parseNormalizedAppRoute('/blog/[category]/posts/[slug]')
       const { pathnameRouteParamSegments: result } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
 
@@ -113,7 +113,7 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
         {},
         createLoaderTree('blog', {}, createLoaderTree('posts'))
       )
-      const route = parseAppRoute('/blog/posts', true)
+      const route = parseNormalizedAppRoute('/blog/posts')
       const { pathnameRouteParamSegments: result } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
 
@@ -127,7 +127,7 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
         {},
         createLoaderTree('blog', {}, createLoaderTree('[category]'))
       )
-      const route = parseAppRoute('/[category]', true)
+      const route = parseNormalizedAppRoute('/[category]')
       const { pathnameRouteParamSegments: result } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
 
@@ -148,7 +148,7 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
           createLoaderTree('blog', {}, createLoaderTree('[slug]'))
         )
       )
-      const route = parseAppRoute('/blog/[slug]', true)
+      const route = parseNormalizedAppRoute('/blog/[slug]')
       const { pathnameRouteParamSegments: result } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
 
@@ -168,7 +168,7 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
           createLoaderTree('(group2)', {}, createLoaderTree('[id]'))
         )
       )
-      const route = parseAppRoute('/[id]', true)
+      const route = parseNormalizedAppRoute('/[id]')
       const { pathnameRouteParamSegments: result } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
 
@@ -192,7 +192,7 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
           )
         )
       )
-      const route = parseAppRoute('/dashboard/[userId]', true)
+      const route = parseNormalizedAppRoute('/dashboard/[userId]')
       const { pathnameRouteParamSegments: result } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
 
@@ -208,7 +208,7 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
       const loaderTree = createLoaderTree('', {
         modal: createLoaderTree('[id]'),
       })
-      const route = parseAppRoute('/[id]', true)
+      const route = parseNormalizedAppRoute('/[id]')
       const { pathnameRouteParamSegments: result } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
 
@@ -223,7 +223,7 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
         modal: createLoaderTree('[id]'),
         sidebar: createLoaderTree('[category]'),
       })
-      const route = parseAppRoute('/[id]', true)
+      const route = parseNormalizedAppRoute('/[id]')
       const { pathnameRouteParamSegments: result } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
 
@@ -242,7 +242,7 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
           modal: createLoaderTree('[photoId]'),
         })
       )
-      const route = parseAppRoute('/[lang]/[photoId]', true)
+      const route = parseNormalizedAppRoute('/[lang]/[photoId]')
       const { pathnameRouteParamSegments: result } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
 
@@ -257,7 +257,7 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
       const loaderTree = createLoaderTree('', {
         sidebar: createLoaderTree('[...path]'),
       })
-      const route = parseAppRoute('/[...path]', true)
+      const route = parseNormalizedAppRoute('/[...path]')
       const { pathnameRouteParamSegments: result } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
 
@@ -276,7 +276,7 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
           sidebar: createLoaderTree('[category]'),
         })
       )
-      const route = parseAppRoute('/[id]', true)
+      const route = parseNormalizedAppRoute('/[id]')
       const { pathnameRouteParamSegments: result } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
 
@@ -295,7 +295,7 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
         {},
         createLoaderTree('(.)photo', {}, createLoaderTree('[photoId]'))
       )
-      const route = parseAppRoute('/(.)photo/[photoId]', true)
+      const route = parseNormalizedAppRoute('/(.)photo/[photoId]')
       const { pathnameRouteParamSegments: result } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
 
@@ -319,7 +319,7 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
           createLoaderTree('(..)photo', {}, createLoaderTree('[photoId]'))
         )
       )
-      const route = parseAppRoute('/gallery/(..)photo/[photoId]', true)
+      const route = parseNormalizedAppRoute('/gallery/(..)photo/[photoId]')
       const { pathnameRouteParamSegments: result } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
 
@@ -347,7 +347,7 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
           )
         )
       )
-      const route = parseAppRoute('/app/gallery/(...)photo/[photoId]', true)
+      const route = parseNormalizedAppRoute('/app/gallery/(...)photo/[photoId]')
       const { pathnameRouteParamSegments: result } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
 
@@ -375,7 +375,7 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
           )
         )
       )
-      const route = parseAppRoute('/a/b/(..)(..)photo/[photoId]', true)
+      const route = parseNormalizedAppRoute('/a/b/(..)(..)photo/[photoId]')
       const { pathnameRouteParamSegments: result } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
 
@@ -401,8 +401,8 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
         createLoaderTree('(.)photo', {}, createLoaderTree('[photoId]'))
       )
 
-      const routeGroupRoute = parseAppRoute('/[slug]', true)
-      const interceptionRoute = parseAppRoute('/(.)photo/[photoId]', true)
+      const routeGroupRoute = parseNormalizedAppRoute('/[slug]')
+      const interceptionRoute = parseNormalizedAppRoute('/(.)photo/[photoId]')
 
       const { pathnameRouteParamSegments: routeGroupResult } =
         extractPathnameRouteParamSegmentsFromLoaderTree(
@@ -437,7 +437,7 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
         {},
         createLoaderTree('(.)photo', {}, createLoaderTree('[...segments]'))
       )
-      const route = parseAppRoute('/(.)photo/[...segments]', true)
+      const route = parseNormalizedAppRoute('/(.)photo/[...segments]')
       const { pathnameRouteParamSegments: result } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
 
@@ -458,7 +458,7 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
         {},
         createLoaderTree('(.)[photoId]')
       )
-      const route = parseAppRoute('/[photoId]', true)
+      const route = parseNormalizedAppRoute('/[photoId]')
       const { pathnameRouteParamSegments: result } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
 
@@ -478,7 +478,7 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
       const loaderTree = createLoaderTree('', {
         modal: createLoaderTree('(.)photo', {}, createLoaderTree('[photoId]')),
       })
-      const route = parseAppRoute('/(.)photo/[photoId]', true)
+      const route = parseNormalizedAppRoute('/(.)photo/[photoId]')
       const { pathnameRouteParamSegments: result } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
 
@@ -504,7 +504,7 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
           ),
         })
       )
-      const route = parseAppRoute('/[id]/(.)photo/[photoId]', true)
+      const route = parseNormalizedAppRoute('/[id]/(.)photo/[photoId]')
       const { pathnameRouteParamSegments: result } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
 
@@ -536,7 +536,7 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
           ),
         })
       )
-      const route = parseAppRoute('/[category]/(.)photo/[photoId]', true)
+      const route = parseNormalizedAppRoute('/[category]/(.)photo/[photoId]')
       const { pathnameRouteParamSegments: result } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
 
@@ -567,7 +567,7 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
           })
         )
       )
-      const route = parseAppRoute('/gallery/[id]/(..)photo/[photoId]', true)
+      const route = parseNormalizedAppRoute('/gallery/[id]/(..)photo/[photoId]')
       const { pathnameRouteParamSegments: result } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
 
@@ -602,9 +602,8 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
           )
         )
       )
-      const route = parseAppRoute(
-        '/app/gallery/[id]/(...)photo/[photoId]',
-        true
+      const route = parseNormalizedAppRoute(
+        '/app/gallery/[id]/(...)photo/[photoId]'
       )
       const { pathnameRouteParamSegments: result } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
@@ -632,7 +631,7 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
           ),
         })
       )
-      const route = parseAppRoute('/[id]/(.)details/[...segments]', true)
+      const route = parseNormalizedAppRoute('/[id]/(.)details/[...segments]')
       const { pathnameRouteParamSegments: result } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
 
@@ -665,7 +664,7 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
           })
         )
       )
-      const route = parseAppRoute('/[lang]/(.)photo/[photoId]', true)
+      const route = parseNormalizedAppRoute('/[lang]/(.)photo/[photoId]')
       const { pathnameRouteParamSegments: result } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
 
@@ -700,9 +699,8 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
           )
         )
       )
-      const route = parseAppRoute(
-        '/[lang]/blog/[category]/(.)post/[slug]',
-        true
+      const route = parseNormalizedAppRoute(
+        '/[lang]/blog/[category]/(.)post/[slug]'
       )
       const { pathnameRouteParamSegments: result } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
@@ -728,7 +726,7 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
           modal2: createLoaderTree('(..)b', {}, createLoaderTree('[b]')),
         })
       )
-      const route = parseAppRoute('/[id]/(.)a/[a]', true)
+      const route = parseNormalizedAppRoute('/[id]/(.)a/[a]')
       const { pathnameRouteParamSegments: result } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
 
@@ -759,7 +757,7 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
           })
         )
       )
-      const route = parseAppRoute('/photos/[id]/(.)photo/[photoId]', true)
+      const route = parseNormalizedAppRoute('/photos/[id]/(.)photo/[photoId]')
       const { pathnameRouteParamSegments: result } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
 
@@ -794,9 +792,8 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
           )
         )
       )
-      const route = parseAppRoute(
-        '/[locale]/products/[category]/(.)product/[productId]',
-        true
+      const route = parseNormalizedAppRoute(
+        '/[locale]/products/[category]/(.)product/[productId]'
       )
       const { pathnameRouteParamSegments: result } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
@@ -820,7 +817,7 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
         {},
         createLoaderTree('blog', {}, createLoaderTree('posts'))
       )
-      const route = parseAppRoute('/blog/posts', true)
+      const route = parseNormalizedAppRoute('/blog/posts')
       const { pathnameRouteParamSegments: result } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
 
@@ -834,7 +831,7 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
         {},
         createLoaderTree('api', {}, createLoaderTree('[version]'))
       )
-      const route = parseAppRoute('/different/path', true)
+      const route = parseNormalizedAppRoute('/different/path')
       const { pathnameRouteParamSegments: result } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
 
@@ -844,7 +841,7 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
     it('should handle empty segment in tree', () => {
       // Tree: '' -> [id]
       const loaderTree = createLoaderTree('', {}, createLoaderTree('[id]'))
-      const route = parseAppRoute('/[id]', true)
+      const route = parseNormalizedAppRoute('/[id]')
       const { pathnameRouteParamSegments: result } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
 
@@ -864,7 +861,7 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
           createLoaderTree('blog', {}, createLoaderTree('[slug]'))
         )
       )
-      const route = parseAppRoute('/[lang]/[slug]', true)
+      const route = parseNormalizedAppRoute('/[lang]/[slug]')
       const { pathnameRouteParamSegments: result } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
 
@@ -879,7 +876,7 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
       const loaderTree = createLoaderTree('', {
         sidebar: createLoaderTree('[[...optional]]'),
       })
-      const route = parseAppRoute('/[[...optional]]', true)
+      const route = parseNormalizedAppRoute('/[[...optional]]')
       const { pathnameRouteParamSegments: result } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
 
@@ -907,7 +904,7 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
           )
         )
       )
-      const route = parseAppRoute('/[id]', true)
+      const route = parseNormalizedAppRoute('/[id]')
       const { pathnameRouteParamSegments: result } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
 
@@ -925,7 +922,7 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
         {},
         createLoaderTree('blog', {}, createLoaderTree('[slug]'))
       )
-      const route = parseAppRoute('/news/[slug]', true)
+      const route = parseNormalizedAppRoute('/news/[slug]')
       const { pathnameRouteParamSegments: result } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
 
@@ -943,7 +940,7 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
           createLoaderTree('v1', {}, createLoaderTree('[endpoint]'))
         )
       )
-      const route = parseAppRoute('/api/v1/[endpoint]', true)
+      const route = parseNormalizedAppRoute('/api/v1/[endpoint]')
       const { pathnameRouteParamSegments: result } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
 
@@ -961,7 +958,7 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
         },
         createLoaderTree('blog', {}, createLoaderTree('[slug]'))
       )
-      const route = parseAppRoute('/blog/my-slug', true)
+      const route = parseNormalizedAppRoute('/blog/my-slug')
       const { pathnameRouteParamSegments: result } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
 
@@ -988,7 +985,7 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
           modal: createLoaderTree('[id]'),
         })
       )
-      const route = parseAppRoute('/[category]/[id]', true)
+      const route = parseNormalizedAppRoute('/[category]/[id]')
       const { pathnameRouteParamSegments: result } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
 
@@ -1016,7 +1013,7 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
           modal: createLoaderTree('[id]'),
         })
       )
-      const route = parseAppRoute('/photo/[id]', true)
+      const route = parseNormalizedAppRoute('/photo/[id]')
       const { pathnameRouteParamSegments: result } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
 
@@ -1041,7 +1038,7 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
           modal: createLoaderTree('(.)photo', {}, createLoaderTree('[id]')),
         })
       )
-      const route = parseAppRoute('/blog/(.)photo/[id]', true)
+      const route = parseNormalizedAppRoute('/blog/(.)photo/[id]')
       const { pathnameRouteParamSegments: result } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
 
@@ -1061,7 +1058,7 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
       // Tree: /[id]
       // Route: /123 (static value)
       const loaderTree = createLoaderTree('', {}, createLoaderTree('[id]'))
-      const route = parseAppRoute('/123', true)
+      const route = parseNormalizedAppRoute('/123')
       const { pathnameRouteParamSegments, params } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
 
@@ -1077,7 +1074,7 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
         {},
         createLoaderTree('[category]', {}, createLoaderTree('[id]'))
       )
-      const route = parseAppRoute('/electronics/123', true)
+      const route = parseNormalizedAppRoute('/electronics/123')
       const { pathnameRouteParamSegments, params } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
 
@@ -1098,7 +1095,7 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
           modal: createLoaderTree('(.)photo', {}, createLoaderTree('[id]')),
         })
       )
-      const route = parseAppRoute('/blog/(.)photo/123', true)
+      const route = parseNormalizedAppRoute('/blog/(.)photo/123')
       const { pathnameRouteParamSegments, params } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
 
@@ -1114,7 +1111,9 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
         {},
         createLoaderTree('docs', {}, createLoaderTree('[...slug]'))
       )
-      const route = parseAppRoute('/docs/getting-started/installation', true)
+      const route = parseNormalizedAppRoute(
+        '/docs/getting-started/installation'
+      )
       const { pathnameRouteParamSegments, params } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
 
@@ -1132,7 +1131,7 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
         {},
         createLoaderTree('docs', {}, createLoaderTree('[[...slug]]'))
       )
-      const route = parseAppRoute('/docs/api/reference', true)
+      const route = parseNormalizedAppRoute('/docs/api/reference')
       const { pathnameRouteParamSegments, params } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
 
@@ -1150,7 +1149,7 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
         {},
         createLoaderTree('docs', {}, createLoaderTree('[[...slug]]'))
       )
-      const route = parseAppRoute('/docs', true)
+      const route = parseNormalizedAppRoute('/docs')
       const { pathnameRouteParamSegments, params } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
 
@@ -1170,7 +1169,7 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
           createLoaderTree('[lang]', {}, createLoaderTree('[slug]'))
         )
       )
-      const route = parseAppRoute('/blog/en/[slug]', true)
+      const route = parseNormalizedAppRoute('/blog/en/[slug]')
       const { pathnameRouteParamSegments, params } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
 
@@ -1191,7 +1190,7 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
         {},
         createLoaderTree('[category]', {}, createLoaderTree('[id]'))
       )
-      const route = parseAppRoute('/[category]/[id]', true)
+      const route = parseNormalizedAppRoute('/[category]/[id]')
       const { pathnameRouteParamSegments, params } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
 
@@ -1214,7 +1213,7 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
           createLoaderTree('[category]', {}, createLoaderTree('[id]'))
         )
       )
-      const route = parseAppRoute('/electronics/123', true)
+      const route = parseNormalizedAppRoute('/electronics/123')
       const { pathnameRouteParamSegments, params } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
 
@@ -1235,7 +1234,7 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
           modal: createLoaderTree('[id]'),
         })
       )
-      const route = parseAppRoute('/blog/123', true)
+      const route = parseNormalizedAppRoute('/blog/123')
       const { pathnameRouteParamSegments, params } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
 
@@ -1247,7 +1246,7 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
       // Tree: /(.)[id]
       // Route: /(.)123
       const loaderTree = createLoaderTree('', {}, createLoaderTree('(.)[id]'))
-      const route = parseAppRoute('/(.)123', true)
+      const route = parseNormalizedAppRoute('/(.)123')
       const { pathnameRouteParamSegments, params } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
 
@@ -1260,7 +1259,7 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
       // Tree: /[...slug]
       // Route: /api/[version]/users (version is dynamic, api and users are static)
       const loaderTree = createLoaderTree('', {}, createLoaderTree('[...slug]'))
-      const route = parseAppRoute('/api/[version]/users', true)
+      const route = parseNormalizedAppRoute('/api/[version]/users')
       const { pathnameRouteParamSegments, params } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
 
@@ -1275,7 +1274,7 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
       const loaderTree = createLoaderTree('', {
         modal: createLoaderTree('(.)photo', {}, createLoaderTree('[id]')),
       })
-      const route = parseAppRoute('/(.)photo/abc123', true)
+      const route = parseNormalizedAppRoute('/(.)photo/abc123')
       const { pathnameRouteParamSegments, params } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
 
@@ -1293,7 +1292,7 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
           modal: createLoaderTree('(..)[id]'),
         })
       )
-      const route = parseAppRoute('/blog/(..)456', true)
+      const route = parseNormalizedAppRoute('/blog/(..)456')
       const { pathnameRouteParamSegments, params } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
 
@@ -1311,7 +1310,7 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
           modal: createLoaderTree('(..)[...catchAll]'),
         })
       )
-      const route = parseAppRoute('/blog/(..)some/path/here', true)
+      const route = parseNormalizedAppRoute('/blog/(..)some/path/here')
       const { pathnameRouteParamSegments, params } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
 
@@ -1339,7 +1338,9 @@ describe('extractPathnameRouteParamSegmentsFromLoaderTree', () => {
           )
         )
       )
-      const route = parseAppRoute('/en/us/shop/electronics/laptop-123', true)
+      const route = parseNormalizedAppRoute(
+        '/en/us/shop/electronics/laptop-123'
+      )
       const { pathnameRouteParamSegments, params } =
         extractPathnameRouteParamSegmentsFromLoaderTree(loaderTree, route)
 

--- a/packages/next/src/build/static-paths/utils.test.ts
+++ b/packages/next/src/build/static-paths/utils.test.ts
@@ -1,5 +1,5 @@
 import type { Params } from '../../server/request/params'
-import { parseAppRoute } from '../../shared/lib/router/routes/app'
+import { parseNormalizedAppRoute } from '../../shared/lib/router/routes/app'
 import type { FallbackRouteParam } from './types'
 import { resolveRouteParamsFromTree } from './utils'
 
@@ -28,7 +28,7 @@ describe('resolveRouteParamsFromTree', () => {
         sidebar: createLoaderTree('[existingParam]'),
       })
       const params: Params = { existingParam: 'value' }
-      const route = parseAppRoute('/some/path', true)
+      const route = parseNormalizedAppRoute('/some/path')
       const fallbackRouteParams: FallbackRouteParam[] = []
 
       resolveRouteParamsFromTree(loaderTree, params, route, fallbackRouteParams)
@@ -44,7 +44,7 @@ describe('resolveRouteParamsFromTree', () => {
         modal: createLoaderTree('[...param2]'),
       })
       const params: Params = { param1: 'value1', param2: ['a', 'b'] }
-      const route = parseAppRoute('/some/path', true)
+      const route = parseNormalizedAppRoute('/some/path')
       const fallbackRouteParams: FallbackRouteParam[] = []
 
       resolveRouteParamsFromTree(loaderTree, params, route, fallbackRouteParams)
@@ -63,7 +63,7 @@ describe('resolveRouteParamsFromTree', () => {
         sidebar: createLoaderTree('[dynamicParam]'),
       })
       const params: Params = {}
-      const route = parseAppRoute('/some/path', true)
+      const route = parseNormalizedAppRoute('/some/path')
       const fallbackRouteParams: FallbackRouteParam[] = []
 
       resolveRouteParamsFromTree(loaderTree, params, route, fallbackRouteParams)
@@ -80,7 +80,7 @@ describe('resolveRouteParamsFromTree', () => {
         sidebar: createLoaderTree('[category]'),
       })
       const params: Params = {}
-      const route = parseAppRoute('/photo/123', true)
+      const route = parseNormalizedAppRoute('/photo/123')
       const fallbackRouteParams: FallbackRouteParam[] = []
 
       resolveRouteParamsFromTree(loaderTree, params, route, fallbackRouteParams)
@@ -97,7 +97,7 @@ describe('resolveRouteParamsFromTree', () => {
         sidebar: createLoaderTree('[category]'),
       })
       const params: Params = {}
-      const route = parseAppRoute('/tech', true)
+      const route = parseNormalizedAppRoute('/tech')
       const fallbackRouteParams: FallbackRouteParam[] = []
 
       resolveRouteParamsFromTree(loaderTree, params, route, fallbackRouteParams)
@@ -116,7 +116,7 @@ describe('resolveRouteParamsFromTree', () => {
         })
       )
       const params: Params = {}
-      const route = parseAppRoute('/blog/tech', true)
+      const route = parseNormalizedAppRoute('/blog/tech')
       const fallbackRouteParams: FallbackRouteParam[] = []
 
       resolveRouteParamsFromTree(loaderTree, params, route, fallbackRouteParams)
@@ -133,7 +133,7 @@ describe('resolveRouteParamsFromTree', () => {
         sidebar: createLoaderTree('[category]'),
       })
       const params: Params = {}
-      const route = parseAppRoute('/tech', true)
+      const route = parseNormalizedAppRoute('/tech')
       const fallbackRouteParams: FallbackRouteParam[] = [
         { paramName: 'slug', paramType: 'dynamic' },
       ]
@@ -159,7 +159,7 @@ describe('resolveRouteParamsFromTree', () => {
         )
       )
       const params: Params = {}
-      const route = parseAppRoute('/blog', true)
+      const route = parseNormalizedAppRoute('/blog')
       const fallbackRouteParams: FallbackRouteParam[] = []
 
       resolveRouteParamsFromTree(loaderTree, params, route, fallbackRouteParams)
@@ -182,7 +182,7 @@ describe('resolveRouteParamsFromTree', () => {
         })
       )
       const params: Params = { lang: 'en' }
-      const route = parseAppRoute('/en/tech', true)
+      const route = parseNormalizedAppRoute('/en/tech')
       const fallbackRouteParams: FallbackRouteParam[] = []
 
       resolveRouteParamsFromTree(loaderTree, params, route, fallbackRouteParams)
@@ -208,7 +208,7 @@ describe('resolveRouteParamsFromTree', () => {
         )
       )
       const params: Params = { lang: 'en' }
-      const route = parseAppRoute('/en/products/[category]', true)
+      const route = parseNormalizedAppRoute('/en/products/[category]')
       const fallbackRouteParams: FallbackRouteParam[] = [
         { paramName: 'category', paramType: 'dynamic' },
       ]
@@ -240,7 +240,7 @@ describe('resolveRouteParamsFromTree', () => {
         )
       )
       const params: Params = { lang: 'en' }
-      const route = parseAppRoute('/en/products/[category]', true)
+      const route = parseNormalizedAppRoute('/en/products/[category]')
       const fallbackRouteParams: FallbackRouteParam[] = [
         { paramName: 'category', paramType: 'dynamic' },
       ]
@@ -269,7 +269,7 @@ describe('resolveRouteParamsFromTree', () => {
         })
       )
       const params: Params = {}
-      const route = parseAppRoute('/blog/2023/posts/my-article', true)
+      const route = parseNormalizedAppRoute('/blog/2023/posts/my-article')
       const fallbackRouteParams: FallbackRouteParam[] = []
 
       resolveRouteParamsFromTree(loaderTree, params, route, fallbackRouteParams)
@@ -285,7 +285,7 @@ describe('resolveRouteParamsFromTree', () => {
         sidebar: createLoaderTree('[...catchallParam]'),
       })
       const params: Params = {}
-      const route = parseAppRoute('/blog/2023/posts', true)
+      const route = parseNormalizedAppRoute('/blog/2023/posts')
       const fallbackRouteParams: FallbackRouteParam[] = []
 
       resolveRouteParamsFromTree(loaderTree, params, route, fallbackRouteParams)
@@ -309,7 +309,9 @@ describe('resolveRouteParamsFromTree', () => {
         )
       )
       const params: Params = { category: 'electronics' }
-      const route = parseAppRoute('/products/electronics/phones/iphone', true)
+      const route = parseNormalizedAppRoute(
+        '/products/electronics/phones/iphone'
+      )
       const fallbackRouteParams: FallbackRouteParam[] = []
 
       resolveRouteParamsFromTree(loaderTree, params, route, fallbackRouteParams)
@@ -325,7 +327,7 @@ describe('resolveRouteParamsFromTree', () => {
         sidebar: createLoaderTree('[...catchallParam]'),
       })
       const params: Params = {}
-      const route = parseAppRoute('/single', true)
+      const route = parseNormalizedAppRoute('/single')
       const fallbackRouteParams: FallbackRouteParam[] = []
 
       resolveRouteParamsFromTree(loaderTree, params, route, fallbackRouteParams)
@@ -347,7 +349,7 @@ describe('resolveRouteParamsFromTree', () => {
         })
       )
       const params: Params = {}
-      const route = parseAppRoute('/blog/post', true)
+      const route = parseNormalizedAppRoute('/blog/post')
       const fallbackRouteParams: FallbackRouteParam[] = []
 
       resolveRouteParamsFromTree(loaderTree, params, route, fallbackRouteParams)
@@ -375,7 +377,7 @@ describe('resolveRouteParamsFromTree', () => {
         )
       )
       const params: Params = {}
-      const route = parseAppRoute('/blog/2023/posts', true)
+      const route = parseNormalizedAppRoute('/blog/2023/posts')
       const fallbackRouteParams: FallbackRouteParam[] = []
 
       resolveRouteParamsFromTree(loaderTree, params, route, fallbackRouteParams)
@@ -393,7 +395,7 @@ describe('resolveRouteParamsFromTree', () => {
         sidebar: createLoaderTree('[[...optionalCatchall]]'),
       })
       const params: Params = {}
-      const route = parseAppRoute('/', true)
+      const route = parseNormalizedAppRoute('/')
       const fallbackRouteParams: FallbackRouteParam[] = []
 
       resolveRouteParamsFromTree(loaderTree, params, route, fallbackRouteParams)
@@ -412,7 +414,7 @@ describe('resolveRouteParamsFromTree', () => {
         })
       )
       const params: Params = {}
-      const route = parseAppRoute('/blog', true)
+      const route = parseNormalizedAppRoute('/blog')
       const fallbackRouteParams: FallbackRouteParam[] = []
 
       resolveRouteParamsFromTree(loaderTree, params, route, fallbackRouteParams)
@@ -429,7 +431,7 @@ describe('resolveRouteParamsFromTree', () => {
         sidebar: createLoaderTree('[[...optionalCatchall]]'),
       })
       const params: Params = {}
-      const route = parseAppRoute('/api/v1/users', true)
+      const route = parseNormalizedAppRoute('/api/v1/users')
       const fallbackRouteParams: FallbackRouteParam[] = []
 
       resolveRouteParamsFromTree(loaderTree, params, route, fallbackRouteParams)
@@ -447,7 +449,7 @@ describe('resolveRouteParamsFromTree', () => {
         modal: createLoaderTree('[...path]'),
       })
       const params: Params = {}
-      const route = parseAppRoute('/photos/album/2023', true)
+      const route = parseNormalizedAppRoute('/photos/album/2023')
       const fallbackRouteParams: FallbackRouteParam[] = []
 
       resolveRouteParamsFromTree(loaderTree, params, route, fallbackRouteParams)
@@ -465,7 +467,7 @@ describe('resolveRouteParamsFromTree', () => {
         sidebar: createLoaderTree('[...catchallParam]'),
       })
       const params: Params = {}
-      const route = parseAppRoute('/', true)
+      const route = parseNormalizedAppRoute('/')
       const fallbackRouteParams: FallbackRouteParam[] = []
 
       expect(() =>
@@ -493,7 +495,7 @@ describe('resolveRouteParamsFromTree', () => {
         )
       )
       const params: Params = {}
-      const route = parseAppRoute('/blog', true)
+      const route = parseNormalizedAppRoute('/blog')
       const fallbackRouteParams: FallbackRouteParam[] = []
 
       expect(() =>
@@ -515,7 +517,7 @@ describe('resolveRouteParamsFromTree', () => {
         modal: createLoaderTree('[[...modalPath]]'),
       })
       const params: Params = {}
-      const route = parseAppRoute('/products/electronics', true)
+      const route = parseNormalizedAppRoute('/products/electronics')
       const fallbackRouteParams: FallbackRouteParam[] = []
 
       resolveRouteParamsFromTree(loaderTree, params, route, fallbackRouteParams)
@@ -535,7 +537,7 @@ describe('resolveRouteParamsFromTree', () => {
         })
       )
       const params: Params = { lang: 'en' }
-      const route = parseAppRoute('/en/blog/post', true)
+      const route = parseNormalizedAppRoute('/en/blog/post')
       const fallbackRouteParams: FallbackRouteParam[] = []
 
       resolveRouteParamsFromTree(loaderTree, params, route, fallbackRouteParams)
@@ -555,7 +557,7 @@ describe('resolveRouteParamsFromTree', () => {
         createLoaderTree('blog')
       )
       const params: Params = {}
-      const route = parseAppRoute('/blog/post', true)
+      const route = parseNormalizedAppRoute('/blog/post')
       const fallbackRouteParams: FallbackRouteParam[] = []
 
       resolveRouteParamsFromTree(loaderTree, params, route, fallbackRouteParams)
@@ -578,7 +580,7 @@ describe('resolveRouteParamsFromTree', () => {
         })
       )
       const params: Params = {}
-      const route = parseAppRoute('/photo/123/details', true)
+      const route = parseNormalizedAppRoute('/photo/123/details')
       const fallbackRouteParams: FallbackRouteParam[] = []
 
       resolveRouteParamsFromTree(loaderTree, params, route, fallbackRouteParams)
@@ -602,7 +604,7 @@ describe('resolveRouteParamsFromTree', () => {
         )
       )
       const params: Params = {}
-      const route = parseAppRoute('/gallery/photo/123', true)
+      const route = parseNormalizedAppRoute('/gallery/photo/123')
       const fallbackRouteParams: FallbackRouteParam[] = []
 
       resolveRouteParamsFromTree(loaderTree, params, route, fallbackRouteParams)
@@ -630,7 +632,7 @@ describe('resolveRouteParamsFromTree', () => {
         )
       )
       const params: Params = {}
-      const route = parseAppRoute('/app/gallery/photo/2023/album', true)
+      const route = parseNormalizedAppRoute('/app/gallery/photo/2023/album')
       const fallbackRouteParams: FallbackRouteParam[] = []
 
       resolveRouteParamsFromTree(loaderTree, params, route, fallbackRouteParams)
@@ -658,7 +660,7 @@ describe('resolveRouteParamsFromTree', () => {
         )
       )
       const params: Params = {}
-      const route = parseAppRoute('/a/b/photo/nature', true)
+      const route = parseNormalizedAppRoute('/a/b/photo/nature')
       const fallbackRouteParams: FallbackRouteParam[] = []
 
       resolveRouteParamsFromTree(loaderTree, params, route, fallbackRouteParams)
@@ -687,7 +689,7 @@ describe('resolveRouteParamsFromTree', () => {
         })
       )
 
-      const route = parseAppRoute('/photo/123', true)
+      const route = parseNormalizedAppRoute('/photo/123')
 
       // Route group - should NOT increment depth
       const routeGroupParams: Params = {}
@@ -722,7 +724,7 @@ describe('resolveRouteParamsFromTree', () => {
         modal: createLoaderTree('[id]'),
       })
       const params: Params = {}
-      const route = parseAppRoute('/', true)
+      const route = parseNormalizedAppRoute('/')
       const fallbackRouteParams: FallbackRouteParam[] = []
 
       resolveRouteParamsFromTree(loaderTree, params, route, fallbackRouteParams)
@@ -742,7 +744,7 @@ describe('resolveRouteParamsFromTree', () => {
         sidebar: createLoaderTree('[filter]'),
       })
       const params: Params = {}
-      const route = parseAppRoute('/', true)
+      const route = parseNormalizedAppRoute('/')
       const fallbackRouteParams: FallbackRouteParam[] = []
 
       resolveRouteParamsFromTree(loaderTree, params, route, fallbackRouteParams)
@@ -770,7 +772,7 @@ describe('resolveRouteParamsFromTree', () => {
         })
       )
       const params: Params = {}
-      const route = parseAppRoute('/blog', true)
+      const route = parseNormalizedAppRoute('/blog')
       const fallbackRouteParams: FallbackRouteParam[] = []
 
       resolveRouteParamsFromTree(loaderTree, params, route, fallbackRouteParams)
@@ -793,7 +795,7 @@ describe('resolveRouteParamsFromTree', () => {
         sidebar: createLoaderTree('[...path]'),
       })
       const params: Params = {}
-      const route = parseAppRoute('/blog/[category]/tech', true)
+      const route = parseNormalizedAppRoute('/blog/[category]/tech')
       const fallbackRouteParams: FallbackRouteParam[] = [
         { paramName: 'category', paramType: 'dynamic' },
       ]
@@ -820,7 +822,7 @@ describe('resolveRouteParamsFromTree', () => {
         })
       )
       const params: Params = { lang: 'en' }
-      const route = parseAppRoute('/en/blog/[category]', true)
+      const route = parseNormalizedAppRoute('/en/blog/[category]')
       const fallbackRouteParams: FallbackRouteParam[] = []
 
       resolveRouteParamsFromTree(loaderTree, params, route, fallbackRouteParams)
@@ -848,9 +850,8 @@ describe('resolveRouteParamsFromTree', () => {
         )
       )
       const params: Params = { category: 'electronics' }
-      const route = parseAppRoute(
-        '/products/electronics/brand/apple/price/high',
-        true
+      const route = parseNormalizedAppRoute(
+        '/products/electronics/brand/apple/price/high'
       )
       const fallbackRouteParams: FallbackRouteParam[] = []
 
@@ -878,7 +879,7 @@ describe('resolveRouteParamsFromTree', () => {
         )
       )
       const params: Params = {}
-      const route = parseAppRoute('/gallery/photo/123', true)
+      const route = parseNormalizedAppRoute('/gallery/photo/123')
       const fallbackRouteParams: FallbackRouteParam[] = []
 
       resolveRouteParamsFromTree(loaderTree, params, route, fallbackRouteParams)
@@ -907,7 +908,7 @@ describe('resolveRouteParamsFromTree', () => {
         )
       )
       const params: Params = {}
-      const route = parseAppRoute('/gallery/photo/2023/album', true)
+      const route = parseNormalizedAppRoute('/gallery/photo/2023/album')
       const fallbackRouteParams: FallbackRouteParam[] = []
 
       resolveRouteParamsFromTree(loaderTree, params, route, fallbackRouteParams)
@@ -930,7 +931,7 @@ describe('resolveRouteParamsFromTree', () => {
         })
       )
       const params: Params = { lang: 'en' }
-      const route = parseAppRoute('/en/tech/react/nextjs', true)
+      const route = parseNormalizedAppRoute('/en/tech/react/nextjs')
       const fallbackRouteParams: FallbackRouteParam[] = []
 
       resolveRouteParamsFromTree(loaderTree, params, route, fallbackRouteParams)
@@ -960,7 +961,7 @@ describe('resolveRouteParamsFromTree', () => {
         )
       )
       const params: Params = {}
-      const route = parseAppRoute('/app/modal/photo/image-123', true)
+      const route = parseNormalizedAppRoute('/app/modal/photo/image-123')
       const fallbackRouteParams: FallbackRouteParam[] = []
 
       resolveRouteParamsFromTree(loaderTree, params, route, fallbackRouteParams)

--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -80,7 +80,7 @@ import type {
 } from '../server/route-modules/app-route/module'
 import type { FunctionsConfigManifest, ManifestRoute } from './index'
 import { getNamedRouteRegex } from '../shared/lib/router/utils/route-regex'
-import { parseAppRoute } from '../shared/lib/router/routes/app'
+import { parseNormalizedAppRoute } from '../shared/lib/router/routes/app'
 import { fillMetadataSegment } from '../lib/metadata/get-metadata-route'
 import { STATIC_METADATA_IMAGES } from '../lib/metadata/is-metadata-route'
 
@@ -836,7 +836,7 @@ export async function isPageStatic({
           appConfig.revalidate = 0
         }
 
-        const route = parseAppRoute(page, true)
+        const route = parseNormalizedAppRoute(page)
 
         // If the page is dynamic and we're not in edge runtime, then we need to
         // build the static paths. The edge runtime doesn't support static

--- a/packages/next/src/build/validate-app-paths.ts
+++ b/packages/next/src/build/validate-app-paths.ts
@@ -4,7 +4,7 @@ import {
 } from '../shared/lib/router/utils/get-segment-param'
 import {
   isInterceptionAppRoute,
-  parseAppRoute,
+  parseNormalizedAppRoute,
   type NormalizedAppRoute,
   type NormalizedAppRouteSegment,
 } from '../shared/lib/router/routes/app'
@@ -143,8 +143,8 @@ function validateAppRoute(route: NormalizedAppRoute): void {
  */
 function parseAndValidateAppPath(path: string): NormalizedAppRoute {
   // Fast parse the route information. We're expecting this to be a normalized
-  // route, so we pass `true` to the `parseAppRoute` function.
-  const route = parseAppRoute(path, true)
+  // route.
+  const route = parseNormalizedAppRoute(path)
 
   // Slow walk the data from the route in order to validate it.
   validateAppRoute(route)

--- a/packages/next/src/server/dev/static-paths-worker.ts
+++ b/packages/next/src/server/dev/static-paths-worker.ts
@@ -26,7 +26,7 @@ import { collectRootParamKeys } from '../../build/segment-config/app/collect-roo
 import { buildAppStaticPaths } from '../../build/static-paths/app'
 import { buildPagesStaticPaths } from '../../build/static-paths/pages'
 import { createIncrementalCache } from '../../export/helpers/create-incremental-cache'
-import { parseAppRoute } from '../../shared/lib/router/routes/app'
+import { parseNormalizedAppRoute } from '../../shared/lib/router/routes/app'
 
 type RuntimeConfig = {
   pprConfig: ExperimentalPPRConfig | undefined
@@ -119,7 +119,7 @@ export async function loadStaticPaths({
       routeModule as AppPageRouteModule | AppRouteRouteModule
     )
 
-    const route = parseAppRoute(pathname, true)
+    const route = parseNormalizedAppRoute(pathname)
     if (route.dynamicSegments.length === 0) {
       throw new InvariantError(
         `Expected a dynamic route, but got a static route: ${pathname}`

--- a/packages/next/src/server/request/fallback-params.ts
+++ b/packages/next/src/server/request/fallback-params.ts
@@ -3,7 +3,7 @@ import type { FallbackRouteParam } from '../../build/static-paths/types'
 import type { DynamicParamTypesShort } from '../../shared/lib/app-router-types'
 import { dynamicParamTypes } from '../app-render/get-short-dynamic-param-type'
 import type AppPageRouteModule from '../route-modules/app-page/module'
-import { parseAppRoute } from '../../shared/lib/router/routes/app'
+import { parseNormalizedAppRoute } from '../../shared/lib/router/routes/app'
 import { extractPathnameRouteParamSegmentsFromLoaderTree } from '../../build/static-paths/app/extract-pathname-route-param-segments-from-loader-tree'
 import { getParamProperties } from '../../shared/lib/router/utils/get-segment-param'
 
@@ -119,7 +119,7 @@ export function getFallbackRouteParams(
   page: string,
   routeModule: AppPageRouteModule
 ) {
-  const route = parseAppRoute(page, true)
+  const route = parseNormalizedAppRoute(page)
 
   // Extract the pathname-contributing segments from the loader tree. This
   // mirrors the logic in buildAppStaticPaths where we determine which segments

--- a/packages/next/src/shared/lib/router/routes/app.ts
+++ b/packages/next/src/shared/lib/router/routes/app.ts
@@ -173,14 +173,17 @@ export function isInterceptionAppRoute(
   )
 }
 
-export function parseAppRoute(
+// Bitmask for which non-URL segment types to allow during parsing.
+// By default, route groups and parallel routes are rejected because
+// they should have been stripped by normalizeAppPath. These flags
+// let callers opt in to allowing specific types.
+const OnlyRoutableSegments = /*   */ 0b00
+const AllowParallelSegments = /*  */ 0b01
+const AllowGroupSegments = /*     */ 0b10
+
+function parseAppRouteImpl(
   pathname: string,
-  normalized: true
-): NormalizedAppRoute
-export function parseAppRoute(pathname: string, normalized: false): AppRoute
-export function parseAppRoute(
-  pathname: string,
-  normalized: boolean
+  allowedTypes: number
 ): AppRoute | NormalizedAppRoute {
   const pathnameSegments = pathname.split('/').filter(Boolean)
 
@@ -202,12 +205,20 @@ export function parseAppRoute(
     }
 
     if (
-      normalized &&
-      (appSegment.type === 'route-group' ||
-        appSegment.type === 'parallel-route')
+      appSegment.type === 'route-group' &&
+      !(allowedTypes & AllowGroupSegments)
     ) {
       throw new InvariantError(
-        `${pathname} is being parsed as a normalized route, but it has a route group or parallel route segment.`
+        `${pathname} is being parsed as a normalized route, but it has a route group segment.`
+      )
+    }
+
+    if (
+      appSegment.type === 'parallel-route' &&
+      !(allowedTypes & AllowParallelSegments)
+    ) {
+      throw new InvariantError(
+        `${pathname} is being parsed as a normalized route, but it has a parallel route segment.`
       )
     }
 
@@ -219,12 +230,8 @@ export function parseAppRoute(
         throw new Error(`Invalid interception route: ${pathname}`)
       }
 
-      interceptingRoute = normalized
-        ? parseAppRoute(parts[0], true)
-        : parseAppRoute(parts[0], false)
-      interceptedRoute = normalized
-        ? parseAppRoute(parts[1], true)
-        : parseAppRoute(parts[1], false)
+      interceptingRoute = parseAppRouteImpl(parts[0], allowedTypes)
+      interceptedRoute = parseAppRouteImpl(parts[1], allowedTypes)
       interceptionMarker = appSegment.interceptionMarker
     }
   }
@@ -234,7 +241,7 @@ export function parseAppRoute(
   )
 
   return {
-    normalized,
+    normalized: allowedTypes === OnlyRoutableSegments,
     pathname,
     segments,
     dynamicSegments,
@@ -242,4 +249,22 @@ export function parseAppRoute(
     interceptingRoute,
     interceptedRoute,
   }
+}
+
+/**
+ * Parse an app route that has been fully normalized (no @slot or ()
+ * group segments). Throws if either is present.
+ */
+export function parseNormalizedAppRoute(pathname: string): NormalizedAppRoute {
+  return parseAppRouteImpl(pathname, OnlyRoutableSegments) as NormalizedAppRoute
+}
+
+/**
+ * Parse an app route that may contain @slot segments but not ()
+ * group segments. Slot segments are preserved as parallel-route
+ * type segments so callers can distinguish routes in different
+ * parallel slots.
+ */
+export function parseAppRouteWithSlots(pathname: string): AppRoute {
+  return parseAppRouteImpl(pathname, AllowParallelSegments) as AppRoute
 }

--- a/packages/next/src/shared/lib/router/utils/get-dynamic-param.ts
+++ b/packages/next/src/shared/lib/router/utils/get-dynamic-param.ts
@@ -5,7 +5,7 @@ import type { Params } from '../../../../server/request/params'
 import type { DynamicParamTypesShort } from '../../app-router-types'
 import { InvariantError } from '../../invariant-error'
 import { parseLoaderTree } from './parse-loader-tree'
-import { parseAppRoute, parseAppRouteSegment } from '../routes/app'
+import { parseNormalizedAppRoute, parseAppRouteSegment } from '../routes/app'
 import { resolveParamValue } from './resolve-param-value'
 
 /**
@@ -53,7 +53,7 @@ export function interpolateParallelRouteParams(
   ]
 
   // Parse the route from the provided page path.
-  const route = parseAppRoute(pagePath, true)
+  const route = parseNormalizedAppRoute(pagePath)
 
   while (stack.length > 0) {
     const { tree, depth } = stack.pop()!


### PR DESCRIPTION
The old impl has a boolean arg that was always true. To support some fixes to routing I need to make the parser sometimes allow for slots but still not things like route groups. I am generalizing the function implementation to have a filter type that decides whether the input string is allowed to have certain types such as route groups and slot names. All the existing uses still disallow any non-url path segments.