### PR TITLE
config: migrate moved experimental options before validation to avoid duplicate warnings

### DIFF
--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -213,6 +213,8 @@ function checkDeprecations(
       silent
     )
   }
+
+  moveConfigOptionsOutOfExperimental(userConfig, configFileName, silent)
 }
 
 export function warnOptionHasBeenMovedOutOfExperimental(
@@ -223,6 +225,8 @@ export function warnOptionHasBeenMovedOutOfExperimental(
   silent: boolean
 ) {
   if (config.experimental && oldExperimentalKey in config.experimental) {
+    const movedValue = (config.experimental as any)[oldExperimentalKey]
+
     if (!silent) {
       Log.warn(
         `\`experimental.${oldExperimentalKey}\` has been moved to \`${newKey}\`. ` +
@@ -237,12 +241,56 @@ export function warnOptionHasBeenMovedOutOfExperimental(
       ;(current as any)[key] = (current as any)[key] || {}
       current = (current as any)[key]
     }
-    ;(current as any)[newKeys.shift()!] = (config.experimental as any)[
-      oldExperimentalKey
-    ]
+    ;(current as any)[newKeys.shift()!] = movedValue
+
+    delete (config.experimental as any)[oldExperimentalKey]
+
+    if (Object.keys(config.experimental).length === 0) {
+      delete config.experimental
+    }
   }
 
   return config
+}
+
+const MOVED_EXPERIMENTAL_OPTIONS = [
+  ['bundlePagesExternals', 'bundlePagesRouterDependencies'],
+  ['serverComponentsExternalPackages', 'serverExternalPackages'],
+  ['relay', 'compiler.relay'],
+  ['styledComponents', 'compiler.styledComponents'],
+  ['emotion', 'compiler.emotion'],
+  ['reactRemoveProperties', 'compiler.reactRemoveProperties'],
+  ['removeConsole', 'compiler.removeConsole'],
+  ['swrDelta', 'expireTime'],
+  ['typedRoutes', 'typedRoutes'],
+  ['outputFileTracingRoot', 'outputFileTracingRoot'],
+  ['outputFileTracingIncludes', 'outputFileTracingIncludes'],
+  ['outputFileTracingExcludes', 'outputFileTracingExcludes'],
+  ['reactCompiler', 'reactCompiler'],
+  ['enablePrerenderSourceMaps', 'enablePrerenderSourceMaps'],
+  ['cacheComponents', 'cacheComponents'],
+  ['cacheLife', 'cacheLife'],
+  ['cacheHandlers', 'cacheHandlers'],
+  ['adapterPath', 'adapterPath'],
+  ['transpilePackages', 'transpilePackages'],
+  ['skipMiddlewareUrlNormalize', 'skipMiddlewareUrlNormalize'],
+  ['skipTrailingSlashRedirect', 'skipTrailingSlashRedirect'],
+] as const
+
+function moveConfigOptionsOutOfExperimental(
+  config: NextConfig,
+  configFileName: string,
+  silent: boolean
+) {
+  for (const [oldExperimentalKey, newKey] of MOVED_EXPERIMENTAL_OPTIONS) {
+    warnOptionHasBeenMovedOutOfExperimental(
+      config,
+      oldExperimentalKey,
+      newKey,
+      configFileName,
+      silent
+    )
+  }
 }
 
 function warnCustomizedOption(
@@ -686,132 +734,7 @@ function assignDefaultsAndValidate(
     silent
   )
 
-  warnOptionHasBeenMovedOutOfExperimental(
-    result,
-    'bundlePagesExternals',
-    'bundlePagesRouterDependencies',
-    configFileName,
-    silent
-  )
-  warnOptionHasBeenMovedOutOfExperimental(
-    result,
-    'serverComponentsExternalPackages',
-    'serverExternalPackages',
-    configFileName,
-    silent
-  )
-  warnOptionHasBeenMovedOutOfExperimental(
-    result,
-    'relay',
-    'compiler.relay',
-    configFileName,
-    silent
-  )
-  warnOptionHasBeenMovedOutOfExperimental(
-    result,
-    'styledComponents',
-    'compiler.styledComponents',
-    configFileName,
-    silent
-  )
-  warnOptionHasBeenMovedOutOfExperimental(
-    result,
-    'emotion',
-    'compiler.emotion',
-    configFileName,
-    silent
-  )
-  warnOptionHasBeenMovedOutOfExperimental(
-    result,
-    'reactRemoveProperties',
-    'compiler.reactRemoveProperties',
-    configFileName,
-    silent
-  )
-  warnOptionHasBeenMovedOutOfExperimental(
-    result,
-    'removeConsole',
-    'compiler.removeConsole',
-    configFileName,
-    silent
-  )
-  warnOptionHasBeenMovedOutOfExperimental(
-    result,
-    'swrDelta',
-    'expireTime',
-    configFileName,
-    silent
-  )
-  warnOptionHasBeenMovedOutOfExperimental(
-    result,
-    'typedRoutes',
-    'typedRoutes',
-    configFileName,
-    silent
-  )
-  warnOptionHasBeenMovedOutOfExperimental(
-    result,
-    'outputFileTracingRoot',
-    'outputFileTracingRoot',
-    configFileName,
-    silent
-  )
-  warnOptionHasBeenMovedOutOfExperimental(
-    result,
-    'outputFileTracingIncludes',
-    'outputFileTracingIncludes',
-    configFileName,
-    silent
-  )
-  warnOptionHasBeenMovedOutOfExperimental(
-    result,
-    'outputFileTracingExcludes',
-    'outputFileTracingExcludes',
-    configFileName,
-    silent
-  )
-  warnOptionHasBeenMovedOutOfExperimental(
-    result,
-    'reactCompiler',
-    'reactCompiler',
-    configFileName,
-    silent
-  )
-  warnOptionHasBeenMovedOutOfExperimental(
-    result,
-    'enablePrerenderSourceMaps',
-    'enablePrerenderSourceMaps',
-    configFileName,
-    silent
-  )
-  warnOptionHasBeenMovedOutOfExperimental(
-    result,
-    'cacheComponents',
-    'cacheComponents',
-    configFileName,
-    silent
-  )
-  warnOptionHasBeenMovedOutOfExperimental(
-    result,
-    'cacheLife',
-    'cacheLife',
-    configFileName,
-    silent
-  )
-  warnOptionHasBeenMovedOutOfExperimental(
-    result,
-    'cacheHandlers',
-    'cacheHandlers',
-    configFileName,
-    silent
-  )
-  warnOptionHasBeenMovedOutOfExperimental(
-    result,
-    'adapterPath',
-    'adapterPath',
-    configFileName,
-    silent
-  )
+  moveConfigOptionsOutOfExperimental(result, configFileName, silent)
 
   if ((result.experimental as any).outputStandalone) {
     if (!silent) {
@@ -952,28 +875,6 @@ function assignDefaultsAndValidate(
     // Store the normalized value as a number
     result.experimental.proxyClientMaxBodySize = normalizedValue
   }
-
-  warnOptionHasBeenMovedOutOfExperimental(
-    result,
-    'transpilePackages',
-    'transpilePackages',
-    configFileName,
-    silent
-  )
-  warnOptionHasBeenMovedOutOfExperimental(
-    result,
-    'skipMiddlewareUrlNormalize',
-    'skipMiddlewareUrlNormalize',
-    configFileName,
-    silent
-  )
-  warnOptionHasBeenMovedOutOfExperimental(
-    result,
-    'skipTrailingSlashRedirect',
-    'skipTrailingSlashRedirect',
-    configFileName,
-    silent
-  )
 
   if (
     result?.outputFileTracingRoot &&

--- a/test/integration/config-validation/test/index.test.ts
+++ b/test/integration/config-validation/test/index.test.ts
@@ -70,6 +70,32 @@ describe('next.config.js validation', () => {
         }
       )
 
+      it('should avoid duplicate unknown-key warnings for moved experimental options', async () => {
+        const configContent = `
+        module.exports = {
+          experimental: {
+            bundlePagesExternals: true,
+          },
+        }
+      `
+
+        await fs.writeFile(nextConfigPath, configContent)
+        const result = await nextBuild(path.join(__dirname, '../'), undefined, {
+          stderr: true,
+          stdout: true,
+        })
+        await fs.remove(nextConfigPath)
+
+        const cliOutput = result.stdout + result.stderr
+
+        expect(cliOutput).toContain(
+          '`experimental.bundlePagesExternals` has been moved to `bundlePagesRouterDependencies`'
+        )
+        expect(cliOutput).not.toContain(
+          `Unrecognized key(s) in object: 'bundlePagesExternals' at "experimental"`
+        )
+      })
+
       it('should allow undefined environment variables', async () => {
         const configContent = `
         module.exports = {

--- a/test/unit/warn-removed-experimental-config.test.ts
+++ b/test/unit/warn-removed-experimental-config.test.ts
@@ -92,7 +92,7 @@ describe('warnOptionHasBeenMovedOutOfExperimental', () => {
       false
     )
 
-    expect(config.experimental.skipTrailingSlashRedirect).toBe(true)
+    expect(config.experimental).toBeUndefined()
     expect(config.skipTrailingSlashRedirect).toBe(true)
   })
 
@@ -110,7 +110,7 @@ describe('warnOptionHasBeenMovedOutOfExperimental', () => {
       false
     )
 
-    expect(config.experimental.foo).toBe('bar')
+    expect(config.experimental).toBeUndefined()
     expect(config.deep.prop.baz).toBe('bar')
   })
 


### PR DESCRIPTION
## Summary
This PR improves Next.js config UX by preventing duplicate warnings for options that were moved out of experimental.

Previously, users could see both:
- an unrecognized key warning under experimental
- a moved-option warning for the same key

Now, moved experimental options are migrated before schema validation, so users see one clear migration warning.

## What Changed
- Added a centralized moved-option mapping and migration helper in the config loader.
- Applied moved-option migration in the pre-validation path.
- Reused the same migration helper in defaults normalization to keep behavior consistent.
- Updated unit test expectations for migrated config shape cleanup.
- Added integration regression coverage to ensure duplicate warning noise does not reappear.

## Validation
- pnpm.cmd exec jest test/unit/warn-removed-experimental-config.test.ts --runInBand --silent
- pnpm.cmd testheadless test/integration/config-validation/test/index.test.ts

<!-- NEXT_JS_LLM_PR -->