### PR TITLE
fix(security): mitigate SSRF vulnerability in Server Action handler (enforce __NEXT_PRIVATE_ORIGIN)

### DIFF
--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -226,7 +226,13 @@ async function createForwardedActionResponse(
 
   // For standalone or the serverful mode, use the internal origin directly
   // other than the host headers from the request.
-  const origin = process.env.__NEXT_PRIVATE_ORIGIN || `${proto}://${host.value}`
+  const privateOrigin = process.env.__NEXT_PRIVATE_ORIGIN
+
+  if (!privateOrigin) {
+    return RenderResult.fromStatic('{}', JSON_CONTENT_TYPE_HEADER)
+  }
+
+  const origin = privateOrigin
 
   const fetchUrl = new URL(`${origin}${basePath}${workerPathname}`)
 
@@ -375,8 +381,13 @@ async function createRedirectRenderResult(
 
     // For standalone or the serverful mode, use the internal origin directly
     // other than the host headers from the request.
-    const origin =
-      process.env.__NEXT_PRIVATE_ORIGIN || `${proto}://${originalHost.value}`
+    const privateOrigin = process.env.__NEXT_PRIVATE_ORIGIN
+
+    if (!privateOrigin) {
+      return RenderResult.EMPTY
+    }
+
+    const origin = privateOrigin
 
     const fetchUrl = new URL(
       `${origin}${appRelativeRedirectUrl.pathname}${appRelativeRedirectUrl.search}`

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -221,9 +221,6 @@ async function createForwardedActionResponse(
   // with the response from the forwarded worker
   forwardedHeaders.set('x-action-forwarded', '1')
 
-  const proto =
-    getRequestMeta(req, 'initProtocol')?.replace(/:+$/, '') || 'https'
-
   // For standalone or the serverful mode, use the internal origin directly
   // other than the host headers from the request.
   const privateOrigin = process.env.__NEXT_PRIVATE_ORIGIN
@@ -375,9 +372,6 @@ async function createRedirectRenderResult(
 
     const forwardedHeaders = getForwardedHeaders(req, res)
     forwardedHeaders.set(RSC_HEADER, '1')
-
-    const proto =
-      getRequestMeta(req, 'initProtocol')?.replace(/:+$/, '') || 'https'
 
     // For standalone or the serverful mode, use the internal origin directly
     // other than the host headers from the request.


### PR DESCRIPTION
## Overview
This pull request mitigates a critical Server-Side Request Forgery (SSRF) and credential leakage vulnerability within Next.js Server Actions request handling.

## Vulnerability Details
During internal forwarding of server actions (in `createForwardedActionResponse`) and "streaming redirect" optimizations (in `createRedirectRenderResult`), the internal `fetch` destination defaulted to the incoming request's `Host` or `X-Forwarded-Host` header whenever `process.env.__NEXT_PRIVATE_ORIGIN` was missing or undefined. 

In custom server deployments lacking the `__NEXT_PRIVATE_ORIGIN` variable, an attacker could supply a specially crafted request (e.g., omitting the `Origin` header to bypass CSRF checks and spoofing the `X-Forwarded-Host`). Consequently, Next.js forcefully sent an internal proxy `fetch()` request directly to an attacker-controlled domain. Due to request header inheritance, this caused Next.js to leak sensitive session cookies and `Authorization` headers to the attacker payload.

## Remediation
This patch enforces strict, secure-by-default degradation:
- Disables fallback to the user-supplied `host.value` when formulating an internal origin.
- If `process.env.__NEXT_PRIVATE_ORIGIN` is absent, the system now safely degrades by escaping the internal optimization (e.g. failing gracefully or issuing a standard client-side 303/307 redirect) rather than relying on untrusted data.
- Ensures cross-validation is not circumvented.

This surgically addresses the SSRF without disrupting safely configured deployments.