### PR TITLE
fix(eslint-plugin-next): respect pageExtensions in no-html-link-for-pages rule

### DIFF
--- a/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
+++ b/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
@@ -10,6 +10,44 @@ import {
   getUrlFromAppDirectory,
 } from '../utils/url'
 
+const defaultPageExtensions = ['tsx', 'ts', 'jsx', 'js']
+
+/**
+ * Reads `pageExtensions` from `next.config.js` (or `.mjs`/`.cjs`).
+ * Returns `undefined` if the config doesn't exist or doesn't define `pageExtensions`.
+ */
+function getPageExtensionsFromConfig(rootDir: string): string[] | undefined {
+  const configFiles = [
+    'next.config.js',
+    'next.config.mjs',
+    'next.config.cjs',
+    'next.config.ts',
+  ]
+
+  for (const file of configFiles) {
+    const configPath = path.join(rootDir, file)
+    if (!fs.existsSync(configPath)) {
+      continue
+    }
+
+    try {
+      // Clear require cache to pick up fresh config
+      const resolvedPath = require.resolve(configPath)
+      delete require.cache[resolvedPath]
+
+      const config = require(resolvedPath)
+      const pageExtensions = config?.default?.pageExtensions ?? config?.pageExtensions
+      if (Array.isArray(pageExtensions) && pageExtensions.length > 0) {
+        return pageExtensions
+      }
+    } catch {
+      // If we can't load the config, fall back to defaults
+    }
+  }
+
+  return undefined
+}
+
 const pagesDirWarning = execOnce((pagesDirs) => {
   console.warn(
     `Pages directory cannot be found at ${pagesDirs.join(' or ')}. ` +
@@ -74,6 +112,13 @@ export default defineRule({
 
     const rootDirs = getRootDirs(context)
 
+    // Resolve pageExtensions: from next.config.js or fall back to defaults
+    const pageExtensions =
+      rootDirs
+        .map((dir) => getPageExtensionsFromConfig(dir))
+        .find((exts): exts is string[] => exts !== undefined) ??
+      defaultPageExtensions
+
     const pagesDirs = (
       customPagesDirectory
         ? [customPagesDirectory]
@@ -107,8 +152,16 @@ export default defineRule({
       return {}
     }
 
-    const pageUrls = cachedGetUrlFromPagesDirectories('/', foundPagesDirs)
-    const appDirUrls = cachedGetUrlFromAppDirectory('/', foundAppDirs)
+    const pageUrls = cachedGetUrlFromPagesDirectories(
+      '/',
+      foundPagesDirs,
+      pageExtensions
+    )
+    const appDirUrls = cachedGetUrlFromAppDirectory(
+      '/',
+      foundAppDirs,
+      pageExtensions
+    )
     const allUrlRegex = [...pageUrls, ...appDirUrls]
 
     return {

--- a/packages/eslint-plugin-next/src/utils/url.ts
+++ b/packages/eslint-plugin-next/src/utils/url.ts
@@ -5,28 +5,49 @@ import * as fs from 'fs'
 // Prevent multiple blocking IO requests that have already been calculated.
 const fsReadDirSyncCache = {}
 
+const defaultPageExtensions = ['tsx', 'ts', 'jsx', 'js']
+
+/**
+ * Builds a regex pattern that matches any of the given page extensions.
+ */
+function buildPageExtensionsPattern(pageExtensions: string[]): string {
+  return `\\.(${pageExtensions.map((ext) => ext.replace(/^\./, '')).join('|')})$`
+}
+
 /**
  * Recursively parse directory for page URLs.
  */
-function parseUrlForPages(urlprefix: string, directory: string) {
+function parseUrlForPages(
+  urlprefix: string,
+  directory: string,
+  pageExtensions: string[] = defaultPageExtensions
+) {
   fsReadDirSyncCache[directory] ??= fs.readdirSync(directory, {
     withFileTypes: true,
   })
+  const extPattern = buildPageExtensionsPattern(pageExtensions)
   const res = []
   fsReadDirSyncCache[directory].forEach((dirent) => {
-    // TODO: this should account for all page extensions
-    // not just js(x) and ts(x)
-    if (/(\.(j|t)sx?)$/.test(dirent.name)) {
-      if (/^index(\.(j|t)sx?)$/.test(dirent.name)) {
+    if (new RegExp(extPattern).test(dirent.name)) {
+      const indexPattern = new RegExp(
+        `^index(${buildPageExtensionsPattern(pageExtensions)})$`
+      )
+      if (indexPattern.test(dirent.name)) {
         res.push(
-          `${urlprefix}${dirent.name.replace(/^index(\.(j|t)sx?)$/, '')}`
+          `${urlprefix}${dirent.name.replace(new RegExp(extPattern), '')}`
         )
       }
-      res.push(`${urlprefix}${dirent.name.replace(/(\.(j|t)sx?)$/, '')}`)
+      res.push(`${urlprefix}${dirent.name.replace(new RegExp(extPattern), '')}`)
     } else {
       const dirPath = path.join(directory, dirent.name)
       if (dirent.isDirectory() && !dirent.isSymbolicLink()) {
-        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath))
+        res.push(
+          ...parseUrlForPages(
+            urlprefix + dirent.name + '/',
+            dirPath,
+            pageExtensions
+          )
+        )
       }
     }
   })
@@ -36,24 +57,39 @@ function parseUrlForPages(urlprefix: string, directory: string) {
 /**
  * Recursively parse app directory for URLs.
  */
-function parseUrlForAppDir(urlprefix: string, directory: string) {
+function parseUrlForAppDir(
+  urlprefix: string,
+  directory: string,
+  pageExtensions: string[] = defaultPageExtensions
+) {
   fsReadDirSyncCache[directory] ??= fs.readdirSync(directory, {
     withFileTypes: true,
   })
+  const extPattern = buildPageExtensionsPattern(pageExtensions)
   const res = []
   fsReadDirSyncCache[directory].forEach((dirent) => {
-    // TODO: this should account for all page extensions
-    // not just js(x) and ts(x)
-    if (/(\.(j|t)sx?)$/.test(dirent.name)) {
-      if (/^page(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(`${urlprefix}${dirent.name.replace(/^page(\.(j|t)sx?)$/, '')}`)
-      } else if (!/^layout(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(`${urlprefix}${dirent.name.replace(/(\.(j|t)sx?)$/, '')}`)
+    if (new RegExp(extPattern).test(dirent.name)) {
+      const pagePattern = new RegExp(
+        `^page(${buildPageExtensionsPattern(pageExtensions)})$`
+      )
+      const layoutPattern = new RegExp(
+        `^layout(${buildPageExtensionsPattern(pageExtensions)})$`
+      )
+      if (pagePattern.test(dirent.name)) {
+        res.push(`${urlprefix}${dirent.name.replace(new RegExp(extPattern), '')}`)
+      } else if (!layoutPattern.test(dirent.name)) {
+        res.push(`${urlprefix}${dirent.name.replace(new RegExp(extPattern), '')}`)
       }
     } else {
       const dirPath = path.join(directory, dirent.name)
       if (dirent.isDirectory(dirPath) && !dirent.isSymbolicLink()) {
-        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath))
+        res.push(
+          ...parseUrlForPages(
+            urlprefix + dirent.name + '/',
+            dirPath,
+            pageExtensions
+          )
+        )
       }
     }
   })
@@ -136,13 +172,16 @@ export function normalizeAppPath(route: string) {
  */
 export function getUrlFromPagesDirectories(
   urlPrefix: string,
-  directories: string[]
+  directories: string[],
+  pageExtensions?: string[]
 ) {
   return Array.from(
     // De-duplicate similar pages across multiple directories.
     new Set(
       directories
-        .flatMap((directory) => parseUrlForPages(urlPrefix, directory))
+        .flatMap((directory) =>
+          parseUrlForPages(urlPrefix, directory, pageExtensions)
+        )
         .map(
           // Since the URLs are normalized we add `^` and `$` to the RegExp to make sure they match exactly.
           (url) => `^${normalizeURL(url)}$`
@@ -156,13 +195,16 @@ export function getUrlFromPagesDirectories(
 
 export function getUrlFromAppDirectory(
   urlPrefix: string,
-  directories: string[]
+  directories: string[],
+  pageExtensions?: string[]
 ) {
   return Array.from(
     // De-duplicate similar pages across multiple directories.
     new Set(
       directories
-        .map((directory) => parseUrlForAppDir(urlPrefix, directory))
+        .map((directory) =>
+          parseUrlForAppDir(urlPrefix, directory, pageExtensions)
+        )
         .flat()
         .map(
           // Since the URLs are normalized we add `^` and `$` to the RegExp to make sure they match exactly.

--- a/packages/eslint-plugin-next/src/utils/url.ts
+++ b/packages/eslint-plugin-next/src/utils/url.ts
@@ -34,7 +34,7 @@ function parseUrlForPages(
       )
       if (indexPattern.test(dirent.name)) {
         res.push(
-          `${urlprefix}${dirent.name.replace(new RegExp(extPattern), '')}`
+          `${urlprefix}${dirent.name.replace(new RegExp(indexPattern), '')}`
         )
       }
       res.push(`${urlprefix}${dirent.name.replace(new RegExp(extPattern), '')}`)

--- a/test/unit/eslint-plugin-next/no-html-link-for-pages.test.ts
+++ b/test/unit/eslint-plugin-next/no-html-link-for-pages.test.ts
@@ -10,6 +10,7 @@ const withCustomPagesDir = path.join(__dirname, 'with-custom-pages-dir')
 const withNestedPagesDir = path.join(__dirname, 'with-nested-pages-dir')
 const withoutPagesDir = path.join(__dirname, 'without-pages-dir')
 const withAppDir = path.join(__dirname, 'with-app-dir')
+const withPageExtensions = path.join(__dirname, 'with-page-extensions')
 
 const linters = {
   withoutPages: new Linter({
@@ -26,6 +27,10 @@ const linters = {
   }),
   withCustomPages: new Linter({
     cwd: withCustomPagesDir,
+    configType: 'eslintrc',
+  }),
+  withPageExtensions: new Linter({
+    cwd: withPageExtensions,
     configType: 'eslintrc',
   }),
 }
@@ -494,5 +499,31 @@ describe('no-html-link-for-pages', function () {
       report.message,
       'Do not use an `<a>` element to navigate to `/photo/1/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages'
     )
+  })
+  it('detects pages with custom pageExtensions from next.config.js', function () {
+    // With custom pageExtensions: ['page.tsx', 'page.ts'],
+    // regular .js/.tsx files should NOT be treated as pages
+    const report = linters.withPageExtensions.verify(
+      invalidStaticCode,
+      linterConfig,
+      { filename: 'foo.js' }
+    )
+    // index.page.tsx is a page, so / should be flagged
+    assert.notEqual(report, undefined, 'No lint errors found.')
+  })
+  it('detects about page with custom pageExtensions', function () {
+    const [report] = linters.withPageExtensions.verify(
+      `
+export class Blah {
+  render() {
+    return <a href='/about/'>About</a>
+  }
+}
+`,
+      linterConfig,
+      { filename: 'foo.js' }
+    )
+    assert.notEqual(report, undefined, 'No lint errors found.')
+    assert.ok(report.message.includes('/about/'))
   })
 })

--- a/test/unit/eslint-plugin-next/with-page-extensions/next.config.js
+++ b/test/unit/eslint-plugin-next/with-page-extensions/next.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  pageExtensions: ['page.tsx', 'page.ts'],
+}

--- a/test/unit/eslint-plugin-next/with-page-extensions/pages/about/index.page.tsx
+++ b/test/unit/eslint-plugin-next/with-page-extensions/pages/about/index.page.tsx
@@ -1,0 +1,1 @@
+// about page with custom extension

--- a/test/unit/eslint-plugin-next/with-page-extensions/pages/index.page.tsx
+++ b/test/unit/eslint-plugin-next/with-page-extensions/pages/index.page.tsx
@@ -1,0 +1,1 @@
+// page with custom extension


### PR DESCRIPTION
## Summary

Fixes #53473

The `@next/next/no-html-link-for-pages` ESLint rule hardcoded the regex to detect page files, ignoring custom `pageExtensions` configured in `next.config.js`.

## Changes

- `url.ts`: Added `pageExtensions` parameter to `parseUrlForPages()` and `parseUrlForAppDir()`, with a `buildPageExtensionsPattern()` helper
- `no-html-link-for-pages.ts`: Added `getPageExtensionsFromConfig()` to read `pageExtensions` from `next.config.js`, falls back to defaults
- Tests: Added test fixture and cases for custom pageExtensions