### PR TITLE
fix(next/server): mitigate SSRF in Server Actions via Host header fallback injection

### DIFF
--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -226,7 +226,8 @@ async function createForwardedActionResponse(
 
   // For standalone or the serverful mode, use the internal origin directly
   // other than the host headers from the request.
-  const origin = process.env.__NEXT_PRIVATE_ORIGIN || `${proto}://${host.value}`
+  // Prevent SSRF: If __NEXT_PRIVATE_ORIGIN is unset, fallback to localhost to avoid trusting the Host header.
+  const origin = process.env.__NEXT_PRIVATE_ORIGIN || `${proto}://localhost:${process.env.PORT || 3000}`
 
   const fetchUrl = new URL(`${origin}${basePath}${workerPathname}`)
 
@@ -375,8 +376,9 @@ async function createRedirectRenderResult(
 
     // For standalone or the serverful mode, use the internal origin directly
     // other than the host headers from the request.
+    // Prevent SSRF: If __NEXT_PRIVATE_ORIGIN is unset, fallback to localhost to avoid trusting the Host header.
     const origin =
-      process.env.__NEXT_PRIVATE_ORIGIN || `${proto}://${originalHost.value}`
+      process.env.__NEXT_PRIVATE_ORIGIN || `${proto}://localhost:${process.env.PORT || 3000}`
 
     const fetchUrl = new URL(
       `${origin}${appRelativeRedirectUrl.pathname}${appRelativeRedirectUrl.search}`


### PR DESCRIPTION
### BUG FIX

### What?
Hardens Server Actions against Host header injection SSRF. Replaces trusting the client `Host` header dynamically via the `proto` and `host.value` fallback with a secure `localhost:${process.env.PORT || 3000}` fallback when `__NEXT_PRIVATE_ORIGIN` is unset.

### Why?
To prevent a residual Server Side Request Forgery (SSRF) vulnerability. In previous versions, when `__NEXT_PRIVATE_ORIGIN` was unset (e.g. in custom server configurations), the `action-handler.ts` fell back to forwarding Server Actions towards the user-supplied `Host` header. This allowed an attacker to inject arbitrary `Host` headers which could redirect Next.js internal Server Action fetch requests to unintended internal endpoints (like AWS metadata services).

### How?
Modified `packages/next/src/server/app-render/action-handler.ts` within `createForwardedActionResponse` and `createRedirectRenderResult`. It now safely routes requests to `localhost` along with the configured application port ensuring local resolution and neutralizing attacker-driven external routing.