### PR TITLE
Handle edge runtime in places that import node:stream

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1146,5 +1146,7 @@
   "1145": "Internal Next.js Error: Prefetch inlining is enabled but no hints were found for route \"%s\". prefetch-hints.json should contain an entry for every route that produces segment data. This is a bug in Next.js.",
   "1146": "Internal Next.js Error: Prefetch inlining is enabled but no hint tree was provided during incremental static revalidation. The prefetch-hints.json manifest should contain an entry for this route. This is a bug in Next.js.",
   "1147": "Turbopack database compaction is not supported on this platform",
-  "1148": "webToReadable cannot be used in the edge runtime"
+  "1148": "webToReadable cannot be used in the edge runtime",
+  "1149": "Node.js Readable cannot be teed in the edge runtime",
+  "1150": "Node.js Readable cannot be converted to a web stream in the edge runtime"
 }

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1145,5 +1145,6 @@
   "1144": "Prefetch inlining is enabled but no hints were found for route \"%s\". This is a bug in the Next.js build pipeline — prefetch-hints.json should contain an entry for every route that produces segment data.",
   "1145": "Internal Next.js Error: Prefetch inlining is enabled but no hints were found for route \"%s\". prefetch-hints.json should contain an entry for every route that produces segment data. This is a bug in Next.js.",
   "1146": "Internal Next.js Error: Prefetch inlining is enabled but no hint tree was provided during incremental static revalidation. The prefetch-hints.json manifest should contain an entry for this route. This is a bug in Next.js.",
-  "1147": "Turbopack database compaction is not supported on this platform"
+  "1147": "Turbopack database compaction is not supported on this platform",
+  "1148": "webToReadable cannot be used in the edge runtime"
 }

--- a/packages/next/src/server/app-render/app-render-prerender-utils.ts
+++ b/packages/next/src/server/app-render/app-render-prerender-utils.ts
@@ -30,21 +30,29 @@ export class ReactServerResult {
       return tee[1]
     }
 
-    let Readable: typeof import('node:stream').Readable
-    if (process.env.TURBOPACK) {
-      Readable = (require('node:stream') as typeof import('node:stream'))
-        .Readable
+    if (process.env.NEXT_RUNTIME === 'edge') {
+      throw new InvariantError(
+        'Node.js Readable cannot be teed in the edge runtime'
+      )
     } else {
-      Readable = (
-        __non_webpack_require__('node:stream') as typeof import('node:stream')
-      ).Readable
+      let Readable: typeof import('node:stream').Readable
+      if (process.env.TURBOPACK) {
+        Readable = (require('node:stream') as typeof import('node:stream'))
+          .Readable
+      } else {
+        Readable = (
+          __non_webpack_require__('node:stream') as typeof import('node:stream')
+        ).Readable
+      }
+      const webStream = Readable.toWeb(
+        this._stream
+      ) as ReadableStream<Uint8Array>
+      const tee = webStream.tee()
+      this._stream = Readable.fromWeb(
+        tee[0] as import('stream/web').ReadableStream
+      )
+      return Readable.fromWeb(tee[1] as import('stream/web').ReadableStream)
     }
-    const webStream = Readable.toWeb(this._stream) as ReadableStream<Uint8Array>
-    const tee = webStream.tee()
-    this._stream = Readable.fromWeb(
-      tee[0] as import('stream/web').ReadableStream
-    )
-    return Readable.fromWeb(tee[1] as import('stream/web').ReadableStream)
   }
 
   consume(): AnyStream {

--- a/packages/next/src/server/render-result.ts
+++ b/packages/next/src/server/render-result.ts
@@ -248,16 +248,24 @@ export default class RenderResult<
     }
 
     if (isNodeReadable(this.response)) {
-      let Readable: typeof import('node:stream').Readable
-      if (process.env.TURBOPACK) {
-        Readable = (require('node:stream') as typeof import('node:stream'))
-          .Readable
+      if (process.env.NEXT_RUNTIME === 'edge') {
+        throw new InvariantError(
+          'Node.js Readable cannot be converted to a web stream in the edge runtime'
+        )
       } else {
-        Readable = (
-          __non_webpack_require__('node:stream') as typeof import('node:stream')
-        ).Readable
+        let Readable: typeof import('node:stream').Readable
+        if (process.env.TURBOPACK) {
+          Readable = (require('node:stream') as typeof import('node:stream'))
+            .Readable
+        } else {
+          Readable = (
+            __non_webpack_require__(
+              'node:stream'
+            ) as typeof import('node:stream')
+          ).Readable
+        }
+        return Readable.toWeb(this.response) as ReadableStream<Uint8Array>
       }
-      return Readable.toWeb(this.response) as ReadableStream<Uint8Array>
     }
 
     return this.response
@@ -283,16 +291,24 @@ export default class RenderResult<
     } else if (Buffer.isBuffer(this.response)) {
       return [streamFromBuffer(this.response)]
     } else if (isNodeReadable(this.response)) {
-      let Readable: typeof import('node:stream').Readable
-      if (process.env.TURBOPACK) {
-        Readable = (require('node:stream') as typeof import('node:stream'))
-          .Readable
+      if (process.env.NEXT_RUNTIME === 'edge') {
+        throw new InvariantError(
+          'Node.js Readable cannot be converted to a web stream in the edge runtime'
+        )
       } else {
-        Readable = (
-          __non_webpack_require__('node:stream') as typeof import('node:stream')
-        ).Readable
+        let Readable: typeof import('node:stream').Readable
+        if (process.env.TURBOPACK) {
+          Readable = (require('node:stream') as typeof import('node:stream'))
+            .Readable
+        } else {
+          Readable = (
+            __non_webpack_require__(
+              'node:stream'
+            ) as typeof import('node:stream')
+          ).Readable
+        }
+        return [Readable.toWeb(this.response) as ReadableStream<Uint8Array>]
       }
-      return [Readable.toWeb(this.response) as ReadableStream<Uint8Array>]
     } else {
       return [this.response]
     }

--- a/packages/next/src/server/stream-utils/node-web-streams-helper.ts
+++ b/packages/next/src/server/stream-utils/node-web-streams-helper.ts
@@ -135,20 +135,26 @@ export async function webstreamToUint8Array(
 function webToReadable(
   stream: ReadableStream<Uint8Array> | import('node:stream').Readable
 ): import('node:stream').Readable {
-  let Readable: typeof import('node:stream').Readable
-  if (process.env.TURBOPACK) {
-    Readable = (require('node:stream') as typeof import('node:stream')).Readable
-  } else if (process.env.__NEXT_BUNDLER === 'Webpack') {
-    Readable = (
-      __non_webpack_require__('node:stream') as typeof import('node:stream')
-    ).Readable
+  if (process.env.NEXT_RUNTIME === 'edge') {
+    throw new Error('webToReadable cannot be used in the edge runtime')
   } else {
-    Readable = (require('node:stream') as typeof import('node:stream')).Readable
+    let Readable: typeof import('node:stream').Readable
+    if (process.env.TURBOPACK) {
+      Readable = (require('node:stream') as typeof import('node:stream'))
+        .Readable
+    } else if (process.env.__NEXT_BUNDLER === 'Webpack') {
+      Readable = (
+        __non_webpack_require__('node:stream') as typeof import('node:stream')
+      ).Readable
+    } else {
+      Readable = (require('node:stream') as typeof import('node:stream'))
+        .Readable
+    }
+    if (stream instanceof Readable) {
+      return stream
+    }
+    return Readable.fromWeb(stream as import('stream/web').ReadableStream)
   }
-  if (stream instanceof Readable) {
-    return stream
-  }
-  return Readable.fromWeb(stream as import('stream/web').ReadableStream)
 }
 
 export async function nodestreamToUint8Array(
@@ -162,20 +168,29 @@ export async function nodestreamToUint8Array(
 }
 
 export async function streamToUint8Array(stream: AnyStream) {
-  let Readable: typeof import('node:stream').Readable
-  if (process.env.TURBOPACK) {
-    Readable = (require('node:stream') as typeof import('node:stream')).Readable
-  } else if (process.env.__NEXT_BUNDLER === 'Webpack') {
-    Readable = (
-      __non_webpack_require__('node:stream') as typeof import('node:stream')
-    ).Readable
+  if (process.env.NEXT_RUNTIME === 'edge') {
+    // Edge runtime always uses web streams
+    return webstreamToUint8Array(stream as ReadableStream<Uint8Array>)
   } else {
-    Readable = (require('node:stream') as typeof import('node:stream')).Readable
+    let Readable: typeof import('node:stream').Readable
+    if (process.env.TURBOPACK) {
+      Readable = (require('node:stream') as typeof import('node:stream'))
+        .Readable
+    } else if (process.env.__NEXT_BUNDLER === 'Webpack') {
+      Readable = (
+        __non_webpack_require__('node:stream') as typeof import('node:stream')
+      ).Readable
+    } else {
+      Readable = (require('node:stream') as typeof import('node:stream'))
+        .Readable
+    }
+
+    if (stream instanceof Readable) {
+      return nodestreamToUint8Array(stream)
+    }
+
+    return webstreamToUint8Array(stream)
   }
-  if (stream instanceof Readable) {
-    return nodestreamToUint8Array(stream)
-  }
-  return webstreamToUint8Array(stream)
 }
 
 export async function streamToBuffer(

--- a/test/e2e/app-dir/actions-unrecognized/actions-unrecognized.test.ts
+++ b/test/e2e/app-dir/actions-unrecognized/actions-unrecognized.test.ts
@@ -11,6 +11,7 @@ describe('unrecognized server actions', () => {
   let cliOutputPosition: number = 0
   beforeEach(() => {
     console.log('update file 2')
+    console.log('update file 3')
     cliOutputPosition = next.cliOutput.length
   })
   const getLogs = () => {

--- a/test/e2e/app-dir/actions-unrecognized/actions-unrecognized.test.ts
+++ b/test/e2e/app-dir/actions-unrecognized/actions-unrecognized.test.ts
@@ -10,7 +10,7 @@ describe('unrecognized server actions', () => {
 
   let cliOutputPosition: number = 0
   beforeEach(() => {
-    console.log('update file 1')
+    console.log('update file 2')
     cliOutputPosition = next.cliOutput.length
   })
   const getLogs = () => {

--- a/test/e2e/app-dir/actions-unrecognized/actions-unrecognized.test.ts
+++ b/test/e2e/app-dir/actions-unrecognized/actions-unrecognized.test.ts
@@ -10,6 +10,7 @@ describe('unrecognized server actions', () => {
 
   let cliOutputPosition: number = 0
   beforeEach(() => {
+    console.log('update file')
     cliOutputPosition = next.cliOutput.length
   })
   const getLogs = () => {

--- a/test/e2e/app-dir/actions-unrecognized/actions-unrecognized.test.ts
+++ b/test/e2e/app-dir/actions-unrecognized/actions-unrecognized.test.ts
@@ -10,8 +10,6 @@ describe('unrecognized server actions', () => {
 
   let cliOutputPosition: number = 0
   beforeEach(() => {
-    console.log('update file 2')
-    console.log('update file 3')
     cliOutputPosition = next.cliOutput.length
   })
   const getLogs = () => {

--- a/test/e2e/app-dir/actions-unrecognized/actions-unrecognized.test.ts
+++ b/test/e2e/app-dir/actions-unrecognized/actions-unrecognized.test.ts
@@ -10,7 +10,7 @@ describe('unrecognized server actions', () => {
 
   let cliOutputPosition: number = 0
   beforeEach(() => {
-    console.log('update file')
+    console.log('update file 1')
     cliOutputPosition = next.cliOutput.length
   })
   const getLogs = () => {


### PR DESCRIPTION
## What?

The codepath would cause checks to fail during deployment because it tries to import `node:stream` even when not used. This adds a specific path for edge runtime to avoid that.