### PR TITLE
[turbopack] Make RequestKey collection optional in resolve results

### DIFF
--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -442,7 +442,7 @@ impl ModuleResolveResultBuilder {
                         .drain(..)
                         .map(|v| (RequestKey::default(), v))
                         .collect();
-                    let mut keyed_map = ModuleResolveResultPrimary::Keyed(keyed);
+                    let keyed_map = ModuleResolveResultPrimary::Keyed(keyed);
                     let mut tmp = ModuleResolveResultBuilder {
                         primary: keyed_map,
                         affecting_sources: Vec::new(),

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -371,73 +371,89 @@ impl ModuleResolveResult {
     }
 }
 
+/// Primary storage for a [`ModuleResolveResultBuilder`], encoded as an enum so
+/// that keyed and key-free results are never mixed in the same map (which would
+/// collapse key-free entries onto a shared default key).
+pub enum ModuleResolveResultPrimary {
+    /// All results carry explicit [`RequestKey`]s; deduplication is by key.
+    Keyed(FxIndexMap<RequestKey, ModuleResolveResultItem>),
+    /// No keys were collected; values are kept in insertion order without
+    /// key-based deduplication.
+    KeyFree(Vec<ModuleResolveResultItem>),
+}
+
 pub struct ModuleResolveResultBuilder {
-    pub primary: FxIndexMap<RequestKey, ModuleResolveResultItem>,
-    /// Values from key-free results (where `primary_keys` was empty). Kept
-    /// separate so that key-based deduplication in `primary` does not
-    /// incorrectly collapse multiple key-free entries onto the same default
-    /// key.
-    pub key_free_values: Vec<ModuleResolveResultItem>,
+    pub primary: ModuleResolveResultPrimary,
     pub affecting_sources: Vec<ResolvedVc<Box<dyn Source>>>,
 }
 
 impl From<ModuleResolveResultBuilder> for ModuleResolveResult {
     fn from(v: ModuleResolveResultBuilder) -> Self {
-        if v.primary.is_empty() {
-            // All values came from key-free results — preserve the "no keys" invariant.
-            ModuleResolveResult {
-                primary_keys: Box::default(),
-                primary_values: v.key_free_values.into_boxed_slice(),
-                affecting_sources: v.affecting_sources.into_boxed_slice(),
+        let (primary_keys, primary_values) = match v.primary {
+            ModuleResolveResultPrimary::Keyed(map) => {
+                let (keys, values): (Vec<_>, Vec<_>) = map.into_iter().unzip();
+                (keys.into_boxed_slice(), values.into_boxed_slice())
             }
-        } else {
-            let (mut keys, mut values): (Vec<_>, Vec<_>) = v.primary.into_iter().unzip();
-            // Append any key-free values with a default key so they are not
-            // silently dropped when mixing keyed and key-free results.
-            for value in v.key_free_values {
-                keys.push(RequestKey::default());
-                values.push(value);
+            ModuleResolveResultPrimary::KeyFree(values) => {
+                (Box::default(), values.into_boxed_slice())
             }
-            ModuleResolveResult {
-                primary_keys: keys.into_boxed_slice(),
-                primary_values: values.into_boxed_slice(),
-                affecting_sources: v.affecting_sources.into_boxed_slice(),
-            }
+        };
+        ModuleResolveResult {
+            primary_keys,
+            primary_values,
+            affecting_sources: v.affecting_sources.into_boxed_slice(),
         }
     }
 }
 impl From<ModuleResolveResult> for ModuleResolveResultBuilder {
     fn from(v: ModuleResolveResult) -> Self {
-        if v.primary_keys.is_empty() {
-            // Key-free result: put values into key_free_values to avoid
-            // collapsing them under a shared default key.
-            ModuleResolveResultBuilder {
-                primary: FxIndexMap::default(),
-                key_free_values: v.primary_values.into_vec(),
-                affecting_sources: v.affecting_sources.into_vec(),
-            }
+        let primary = if v.primary_keys.is_empty() {
+            ModuleResolveResultPrimary::KeyFree(v.primary_values.into_vec())
         } else {
-            ModuleResolveResultBuilder {
-                primary: v.primary_keys.into_iter().zip(v.primary_values).collect(),
-                key_free_values: Vec::new(),
-                affecting_sources: v.affecting_sources.into_vec(),
-            }
+            ModuleResolveResultPrimary::Keyed(
+                v.primary_keys.into_iter().zip(v.primary_values).collect(),
+            )
+        };
+        ModuleResolveResultBuilder {
+            primary,
+            affecting_sources: v.affecting_sources.into_vec(),
         }
     }
 }
 impl ModuleResolveResultBuilder {
     pub fn merge_alternatives(&mut self, other: &ModuleResolveResult) {
-        if other.has_keys() {
-            for (key, value) in other.iter_primary() {
-                let key = key.cloned().unwrap_or_default();
-                if !self.primary.contains_key(&key) {
-                    self.primary.insert(key, value.clone());
+        match &mut self.primary {
+            ModuleResolveResultPrimary::Keyed(map) => {
+                // `other` is either keyed (deduplicate by key) or key-free
+                // (promote to keyed with default key, no dedup within the
+                // key-free batch since each default key overwrites the last —
+                // promote instead by inserting only when the key is absent).
+                for (key, value) in other.iter_primary() {
+                    let key = key.cloned().unwrap_or_default();
+                    if !map.contains_key(&key) {
+                        map.insert(key, value.clone());
+                    }
                 }
             }
-        } else {
-            // Key-free result: append all values without key-based deduplication.
-            self.key_free_values
-                .extend(other.primary_values.iter().cloned());
+            ModuleResolveResultPrimary::KeyFree(values) => {
+                if other.has_keys() {
+                    // Promote self to keyed, then re-merge `other` keyed.
+                    let keyed: FxIndexMap<_, _> = values
+                        .drain(..)
+                        .map(|v| (RequestKey::default(), v))
+                        .collect();
+                    let mut keyed_map = ModuleResolveResultPrimary::Keyed(keyed);
+                    let mut tmp = ModuleResolveResultBuilder {
+                        primary: keyed_map,
+                        affecting_sources: Vec::new(),
+                    };
+                    tmp.merge_alternatives(other);
+                    self.primary = tmp.primary;
+                } else {
+                    // Both key-free: just append, no deduplication.
+                    values.extend(other.primary_values.iter().cloned());
+                }
+            }
         }
         let set = self
             .affecting_sources
@@ -973,73 +989,84 @@ impl ResolveResult {
     }
 }
 
+/// Primary storage for a [`ResolveResultBuilder`], encoded as an enum so that
+/// keyed and key-free results are never mixed in the same map (which would
+/// collapse key-free entries onto a shared default key).
+enum ResolveResultPrimary {
+    /// All results carry explicit [`RequestKey`]s; deduplication is by key.
+    Keyed(FxIndexMap<RequestKey, ResolveResultItem>),
+    /// No keys were collected; values are kept in insertion order without
+    /// key-based deduplication.
+    KeyFree(Vec<ResolveResultItem>),
+}
+
 struct ResolveResultBuilder {
-    primary: FxIndexMap<RequestKey, ResolveResultItem>,
-    /// Values from key-free results (where `primary_keys` was empty). Kept
-    /// separate so that key-based deduplication in `primary` does not
-    /// incorrectly collapse multiple key-free entries onto the same default
-    /// key.
-    key_free_values: Vec<ResolveResultItem>,
+    primary: ResolveResultPrimary,
     affecting_sources: Vec<ResolvedVc<Box<dyn Source>>>,
 }
 
 impl From<ResolveResultBuilder> for ResolveResult {
     fn from(v: ResolveResultBuilder) -> Self {
-        if v.primary.is_empty() {
-            // All values came from key-free results — preserve the "no keys" invariant.
-            ResolveResult {
-                primary_keys: Box::default(),
-                primary_values: v.key_free_values.into_boxed_slice(),
-                affecting_sources: v.affecting_sources.into_boxed_slice(),
+        let (primary_keys, primary_values) = match v.primary {
+            ResolveResultPrimary::Keyed(map) => {
+                let (keys, values): (Vec<_>, Vec<_>) = map.into_iter().unzip();
+                (keys.into_boxed_slice(), values.into_boxed_slice())
             }
-        } else {
-            let (mut keys, mut values): (Vec<_>, Vec<_>) = v.primary.into_iter().unzip();
-            // Append any key-free values with a default key so they are not
-            // silently dropped when mixing keyed and key-free results.
-            for value in v.key_free_values {
-                keys.push(RequestKey::default());
-                values.push(value);
-            }
-            ResolveResult {
-                primary_keys: keys.into_boxed_slice(),
-                primary_values: values.into_boxed_slice(),
-                affecting_sources: v.affecting_sources.into_boxed_slice(),
-            }
+            ResolveResultPrimary::KeyFree(values) => (Box::default(), values.into_boxed_slice()),
+        };
+        ResolveResult {
+            primary_keys,
+            primary_values,
+            affecting_sources: v.affecting_sources.into_boxed_slice(),
         }
     }
 }
 impl From<ResolveResult> for ResolveResultBuilder {
     fn from(v: ResolveResult) -> Self {
-        if v.primary_keys.is_empty() {
-            // Key-free result: put values into key_free_values to avoid
-            // collapsing them under a shared default key.
-            ResolveResultBuilder {
-                primary: FxIndexMap::default(),
-                key_free_values: v.primary_values.into_vec(),
-                affecting_sources: v.affecting_sources.into_vec(),
-            }
+        let primary = if v.primary_keys.is_empty() {
+            ResolveResultPrimary::KeyFree(v.primary_values.into_vec())
         } else {
-            ResolveResultBuilder {
-                primary: v.primary_keys.into_iter().zip(v.primary_values).collect(),
-                key_free_values: Vec::new(),
-                affecting_sources: v.affecting_sources.into_vec(),
-            }
+            ResolveResultPrimary::Keyed(v.primary_keys.into_iter().zip(v.primary_values).collect())
+        };
+        ResolveResultBuilder {
+            primary,
+            affecting_sources: v.affecting_sources.into_vec(),
         }
     }
 }
 impl ResolveResultBuilder {
     pub fn merge_alternatives(&mut self, other: &ResolveResult) {
-        if other.has_keys() {
-            for (key, value) in other.iter_primary() {
-                let key = key.cloned().unwrap_or_default();
-                if !self.primary.contains_key(&key) {
-                    self.primary.insert(key, value.clone());
+        match &mut self.primary {
+            ResolveResultPrimary::Keyed(map) => {
+                // `other` is either keyed (deduplicate by key) or key-free
+                // (promote to keyed with default key, no dedup within the
+                // key-free batch since each default key overwrites the last —
+                // promote instead by inserting only when the key is absent).
+                for (key, value) in other.iter_primary() {
+                    let key = key.cloned().unwrap_or_default();
+                    if !map.contains_key(&key) {
+                        map.insert(key, value.clone());
+                    }
                 }
             }
-        } else {
-            // Key-free result: append all values without key-based deduplication.
-            self.key_free_values
-                .extend(other.primary_values.iter().cloned());
+            ResolveResultPrimary::KeyFree(values) => {
+                if other.has_keys() {
+                    // Promote self to keyed, then re-merge `other` keyed.
+                    let keyed: FxIndexMap<_, _> = values
+                        .drain(..)
+                        .map(|v| (RequestKey::default(), v))
+                        .collect();
+                    let mut tmp = ResolveResultBuilder {
+                        primary: ResolveResultPrimary::Keyed(keyed),
+                        affecting_sources: Vec::new(),
+                    };
+                    tmp.merge_alternatives(other);
+                    self.primary = tmp.primary;
+                } else {
+                    // Both key-free: just append, no deduplication.
+                    values.extend(other.primary_values.iter().cloned());
+                }
+            }
         }
         let set = self
             .affecting_sources

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -211,16 +211,33 @@ impl ExportUsage {
 #[turbo_tasks::value(shared)]
 #[derive(Clone, Debug)]
 pub struct ModuleResolveResult {
-    pub primary: Box<[(RequestKey, ModuleResolveResultItem)]>,
+    /// The request keys for each primary result. Either empty (keys not collected) or the same
+    /// length as `primary_values`. When empty, the keys are not tracked — callers that only need
+    /// the resolved modules/assets can opt out of key allocation.
+    pub primary_keys: Box<[RequestKey]>,
+    pub primary_values: Box<[ModuleResolveResultItem]>,
     /// Affecting sources are other files that influence the resolve result.  For example,
     /// traversed symlinks
     pub affecting_sources: Box<[ResolvedVc<Box<dyn Source>>]>,
 }
 
 impl ModuleResolveResult {
+    pub fn from_keyed(
+        keyed: impl IntoIterator<Item = (RequestKey, ModuleResolveResultItem)>,
+        affecting_sources: Box<[ResolvedVc<Box<dyn Source>>]>,
+    ) -> Self {
+        let (keys, values): (Vec<_>, Vec<_>) = keyed.into_iter().unzip();
+        ModuleResolveResult {
+            primary_keys: keys.into_boxed_slice(),
+            primary_values: values.into_boxed_slice(),
+            affecting_sources,
+        }
+    }
+
     pub fn unresolvable() -> ResolvedVc<Self> {
         ModuleResolveResult {
-            primary: Default::default(),
+            primary_keys: Default::default(),
+            primary_values: Default::default(),
             affecting_sources: Default::default(),
         }
         .resolved_cell()
@@ -235,8 +252,8 @@ impl ModuleResolveResult {
         module: ResolvedVc<Box<dyn Module>>,
     ) -> ResolvedVc<Self> {
         ModuleResolveResult {
-            primary: vec![(request_key, ModuleResolveResultItem::Module(module))]
-                .into_boxed_slice(),
+            primary_keys: Box::new([request_key]),
+            primary_values: Box::new([ModuleResolveResultItem::Module(module)]),
             affecting_sources: Default::default(),
         }
         .resolved_cell()
@@ -247,11 +264,8 @@ impl ModuleResolveResult {
         output_asset: ResolvedVc<Box<dyn OutputAsset>>,
     ) -> ResolvedVc<Self> {
         ModuleResolveResult {
-            primary: vec![(
-                request_key,
-                ModuleResolveResultItem::OutputAsset(output_asset),
-            )]
-            .into_boxed_slice(),
+            primary_keys: Box::new([request_key]),
+            primary_values: Box::new([ModuleResolveResultItem::OutputAsset(output_asset)]),
             affecting_sources: Default::default(),
         }
         .resolved_cell()
@@ -260,13 +274,12 @@ impl ModuleResolveResult {
     pub fn modules(
         modules: impl IntoIterator<Item = (RequestKey, ResolvedVc<Box<dyn Module>>)>,
     ) -> ResolvedVc<Self> {
-        ModuleResolveResult {
-            primary: modules
+        Self::from_keyed(
+            modules
                 .into_iter()
-                .map(|(k, v)| (k, ModuleResolveResultItem::Module(v)))
-                .collect(),
-            affecting_sources: Default::default(),
-        }
+                .map(|(k, v)| (k, ModuleResolveResultItem::Module(v))),
+            Default::default(),
+        )
         .resolved_cell()
     }
 
@@ -274,23 +287,58 @@ impl ModuleResolveResult {
         modules: impl IntoIterator<Item = (RequestKey, ResolvedVc<Box<dyn Module>>)>,
         affecting_sources: Vec<ResolvedVc<Box<dyn Source>>>,
     ) -> ResolvedVc<Self> {
-        ModuleResolveResult {
-            primary: modules
+        Self::from_keyed(
+            modules
                 .into_iter()
-                .map(|(k, v)| (k, ModuleResolveResultItem::Module(v)))
-                .collect(),
-            affecting_sources: affecting_sources.into_boxed_slice(),
-        }
+                .map(|(k, v)| (k, ModuleResolveResultItem::Module(v))),
+            affecting_sources.into_boxed_slice(),
+        )
         .resolved_cell()
     }
 }
 
 impl ModuleResolveResult {
+    /// Returns true if request keys were collected alongside primary values.
+    /// When false, `primary_keys` is empty even though `primary_values` may be non-empty.
+    pub fn has_keys(&self) -> bool {
+        !self.primary_keys.is_empty() || self.primary_values.is_empty()
+    }
+
+    /// Returns the number of primary items.
+    pub fn primary_len(&self) -> usize {
+        self.primary_values.len()
+    }
+
+    /// Iterates `(key, value)` pairs. `key` is `None` when keys were not collected.
+    pub fn iter_primary(
+        &self,
+    ) -> impl Iterator<Item = (Option<&RequestKey>, &ModuleResolveResultItem)> {
+        debug_assert!(
+            self.primary_keys.is_empty() || self.primary_keys.len() == self.primary_values.len(),
+            "primary_keys and primary_values length mismatch"
+        );
+        if self.has_keys() {
+            Either::Left(
+                self.primary_keys
+                    .iter()
+                    .map(Some)
+                    .zip(self.primary_values.iter()),
+            )
+        } else {
+            Either::Right(self.primary_values.iter().map(|v| (None, v)))
+        }
+    }
+
+    /// Iterates primary values only (always available, even when keys are not collected).
+    pub fn iter_primary_values(&self) -> impl Iterator<Item = &ModuleResolveResultItem> {
+        self.primary_values.iter()
+    }
+
     /// Returns all module results (but ignoring any errors).
     pub fn primary_modules_raw_iter(
         &self,
     ) -> impl Iterator<Item = ResolvedVc<Box<dyn Module>>> + '_ {
-        self.primary.iter().filter_map(|(_, item)| match *item {
+        self.primary_values.iter().filter_map(|item| match *item {
             ModuleResolveResultItem::Module(a) => Some(a),
             _ => None,
         })
@@ -299,7 +347,7 @@ impl ModuleResolveResult {
     /// Returns a set (no duplicates) of primary modules in the result.
     pub async fn primary_modules_ref(&self) -> Result<Vec<ResolvedVc<Box<dyn Module>>>> {
         let mut set = FxIndexSet::default();
-        for (_, item) in self.primary.iter() {
+        for item in self.primary_values.iter() {
             if let Some(module) = item.as_module().await? {
                 set.insert(module);
             }
@@ -312,11 +360,11 @@ impl ModuleResolveResult {
     }
 
     pub fn is_unresolvable_ref(&self) -> bool {
-        self.primary.is_empty()
+        self.primary_values.is_empty()
     }
 
     pub fn errors(&self) -> impl Iterator<Item = ResolvedVc<Box<dyn Issue>>> + '_ {
-        self.primary.iter().filter_map(|i| match &i.1 {
+        self.primary_values.iter().filter_map(|item| match item {
             ModuleResolveResultItem::Error(e) => Some(*e),
             _ => None,
         })
@@ -330,8 +378,10 @@ pub struct ModuleResolveResultBuilder {
 
 impl From<ModuleResolveResultBuilder> for ModuleResolveResult {
     fn from(v: ModuleResolveResultBuilder) -> Self {
+        let (keys, values): (Vec<_>, Vec<_>) = v.primary.into_iter().unzip();
         ModuleResolveResult {
-            primary: v.primary.into_iter().collect(),
+            primary_keys: keys.into_boxed_slice(),
+            primary_values: values.into_boxed_slice(),
             affecting_sources: v.affecting_sources.into_boxed_slice(),
         }
     }
@@ -339,16 +389,21 @@ impl From<ModuleResolveResultBuilder> for ModuleResolveResult {
 impl From<ModuleResolveResult> for ModuleResolveResultBuilder {
     fn from(v: ModuleResolveResult) -> Self {
         ModuleResolveResultBuilder {
-            primary: IntoIterator::into_iter(v.primary).collect(),
+            primary: v
+                .primary_keys
+                .into_iter()
+                .zip(v.primary_values.into_iter())
+                .collect(),
             affecting_sources: v.affecting_sources.into_vec(),
         }
     }
 }
 impl ModuleResolveResultBuilder {
     pub fn merge_alternatives(&mut self, other: &ModuleResolveResult) {
-        for (k, v) in other.primary.iter() {
-            if !self.primary.contains_key(k) {
-                self.primary.insert(k.clone(), v.clone());
+        for (key, value) in other.iter_primary() {
+            let key = key.cloned().unwrap_or_default();
+            if !self.primary.contains_key(&key) {
+                self.primary.insert(key, value.clone());
             }
         }
         let set = self
@@ -394,7 +449,7 @@ impl ModuleResolveResult {
 
     #[turbo_tasks::function]
     pub async fn first_module(&self) -> Result<Vc<OptionModule>> {
-        for (_, item) in self.primary.iter() {
+        for item in self.primary_values.iter() {
             if let Some(module) = item.as_module().await? {
                 return Ok(Vc::cell(Some(module)));
             }
@@ -407,7 +462,7 @@ impl ModuleResolveResult {
     #[turbo_tasks::function]
     pub async fn primary_modules(&self) -> Result<Vc<Modules>> {
         let mut set = FxIndexSet::default();
-        for (_, item) in self.primary.iter() {
+        for item in self.primary_values.iter() {
             if let Some(module) = item.as_module().await? {
                 set.insert(module);
             }
@@ -418,9 +473,9 @@ impl ModuleResolveResult {
     #[turbo_tasks::function]
     pub fn primary_output_assets(&self) -> Vc<OutputAssets> {
         Vc::cell(
-            self.primary
+            self.primary_values
                 .iter()
-                .filter_map(|(_, item)| match item {
+                .filter_map(|item| match item {
                     &ModuleResolveResultItem::OutputAsset(a) => Some(a),
                     _ => None,
                 })
@@ -561,7 +616,11 @@ impl RequestKey {
 #[turbo_tasks::value(shared)]
 #[derive(Clone)]
 pub struct ResolveResult {
-    pub primary: Box<[(RequestKey, ResolveResultItem)]>,
+    /// The request keys for each primary result. Either empty (keys not collected) or the same
+    /// length as `primary_values`. When empty, the keys are not tracked — callers that only need
+    /// the resolved sources can opt out of key allocation.
+    pub primary_keys: Box<[RequestKey]>,
+    pub primary_values: Box<[ResolveResultItem]>,
     /// Affecting sources are other files that influence the resolve result.  For example,
     /// traversed symlinks
     pub affecting_sources: Box<[ResolvedVc<Box<dyn Source>>]>,
@@ -575,11 +634,15 @@ impl ValueToString for ResolveResult {
         if self.is_unresolvable_ref() {
             result.push_str("unresolvable");
         }
-        for (i, (request, item)) in self.primary.iter().enumerate() {
+        for (i, (request, item)) in self.iter_primary().enumerate() {
             if i > 0 {
                 result.push_str(", ");
             }
-            write!(result, "{request} -> ").unwrap();
+            if let Some(request) = request {
+                write!(result, "{request} -> ").unwrap();
+            } else {
+                result.push_str("<no-key> -> ");
+            }
             match item {
                 ResolveResultItem::Source(a) => {
                     result.push_str(&a.ident().to_string().await?);
@@ -632,9 +695,22 @@ impl ValueToString for ResolveResult {
 }
 
 impl ResolveResult {
+    fn from_keyed(
+        keyed: impl IntoIterator<Item = (RequestKey, ResolveResultItem)>,
+        affecting_sources: Box<[ResolvedVc<Box<dyn Source>>]>,
+    ) -> Self {
+        let (keys, values): (Vec<_>, Vec<_>) = keyed.into_iter().unzip();
+        ResolveResult {
+            primary_keys: keys.into_boxed_slice(),
+            primary_values: values.into_boxed_slice(),
+            affecting_sources,
+        }
+    }
+
     pub fn unresolvable() -> Self {
         ResolveResult {
-            primary: Default::default(),
+            primary_keys: Default::default(),
+            primary_values: Default::default(),
             affecting_sources: Default::default(),
         }
     }
@@ -643,7 +719,8 @@ impl ResolveResult {
         affecting_sources: Vec<ResolvedVc<Box<dyn Source>>>,
     ) -> Self {
         ResolveResult {
-            primary: Default::default(),
+            primary_keys: Default::default(),
+            primary_values: Default::default(),
             affecting_sources: affecting_sources.into_boxed_slice(),
         }
     }
@@ -654,7 +731,8 @@ impl ResolveResult {
 
     pub fn primary_with_key(request_key: RequestKey, result: ResolveResultItem) -> Self {
         ResolveResult {
-            primary: vec![(request_key, result)].into_boxed_slice(),
+            primary_keys: Box::new([request_key]),
+            primary_values: Box::new([result]),
             affecting_sources: Default::default(),
         }
     }
@@ -665,7 +743,8 @@ impl ResolveResult {
         affecting_sources: Vec<ResolvedVc<Box<dyn Source>>>,
     ) -> Self {
         ResolveResult {
-            primary: vec![(request_key, result)].into_boxed_slice(),
+            primary_keys: Box::new([request_key]),
+            primary_values: Box::new([result]),
             affecting_sources: affecting_sources.into_boxed_slice(),
         }
     }
@@ -676,7 +755,16 @@ impl ResolveResult {
 
     fn source_with_key(request_key: RequestKey, source: ResolvedVc<Box<dyn Source>>) -> Self {
         ResolveResult {
-            primary: vec![(request_key, ResolveResultItem::Source(source))].into_boxed_slice(),
+            primary_keys: Box::new([request_key]),
+            primary_values: Box::new([ResolveResultItem::Source(source)]),
+            affecting_sources: Default::default(),
+        }
+    }
+
+    fn source_without_key(source: ResolvedVc<Box<dyn Source>>) -> Self {
+        ResolveResult {
+            primary_keys: Default::default(),
+            primary_values: Box::new([ResolveResultItem::Source(source)]),
             affecting_sources: Default::default(),
         }
     }
@@ -687,13 +775,25 @@ impl ResolveResult {
         affecting_sources: Vec<ResolvedVc<Box<dyn Source>>>,
     ) -> Self {
         ResolveResult {
-            primary: vec![(request_key, ResolveResultItem::Source(source))].into_boxed_slice(),
+            primary_keys: Box::new([request_key]),
+            primary_values: Box::new([ResolveResultItem::Source(source)]),
+            affecting_sources: affecting_sources.into_boxed_slice(),
+        }
+    }
+
+    fn source_without_key_with_affecting_sources(
+        source: ResolvedVc<Box<dyn Source>>,
+        affecting_sources: Vec<ResolvedVc<Box<dyn Source>>>,
+    ) -> Self {
+        ResolveResult {
+            primary_keys: Default::default(),
+            primary_values: Box::new([ResolveResultItem::Source(source)]),
             affecting_sources: affecting_sources.into_boxed_slice(),
         }
     }
 
     pub fn errors(&self) -> impl Iterator<Item = ResolvedVc<Box<dyn Issue>>> + '_ {
-        self.primary.iter().filter_map(|i| match &i.1 {
+        self.primary_values.iter().filter_map(|item| match item {
             ResolveResultItem::Error(e) => Some(*e),
             _ => None,
         })
@@ -701,6 +801,42 @@ impl ResolveResult {
 }
 
 impl ResolveResult {
+    /// Returns true if request keys were collected alongside primary values.
+    /// When false, `primary_keys` is empty even though `primary_values` may be non-empty.
+    pub fn has_keys(&self) -> bool {
+        !self.primary_keys.is_empty() || self.primary_values.is_empty()
+    }
+
+    /// Returns the number of primary items.
+    pub fn primary_len(&self) -> usize {
+        self.primary_values.len()
+    }
+
+    /// Iterates `(key, value)` pairs. `key` is `None` when keys were not collected.
+    pub fn iter_primary(
+        &self,
+    ) -> impl Iterator<Item = (Option<&RequestKey>, &ResolveResultItem)> {
+        debug_assert!(
+            self.primary_keys.is_empty() || self.primary_keys.len() == self.primary_values.len(),
+            "primary_keys and primary_values length mismatch"
+        );
+        if self.has_keys() {
+            Either::Left(
+                self.primary_keys
+                    .iter()
+                    .map(Some)
+                    .zip(self.primary_values.iter()),
+            )
+        } else {
+            Either::Right(self.primary_values.iter().map(|v| (None, v)))
+        }
+    }
+
+    /// Iterates primary values only (always available, even when keys are not collected).
+    pub fn iter_primary_values(&self) -> impl Iterator<Item = &ResolveResultItem> {
+        self.primary_values.iter()
+    }
+
     /// Returns the affecting sources for this result. Will be empty if affecting sources are
     /// disabled for this result.
     pub fn get_affecting_sources(&self) -> impl Iterator<Item = ResolvedVc<Box<dyn Source>>> + '_ {
@@ -708,7 +844,7 @@ impl ResolveResult {
     }
 
     pub fn is_unresolvable_ref(&self) -> bool {
-        self.primary.is_empty()
+        self.primary_values.is_empty()
     }
 
     pub async fn map_module<A, AF>(&self, source_fn: A) -> Result<ModuleResolveResult>
@@ -716,45 +852,39 @@ impl ResolveResult {
         A: Fn(ResolvedVc<Box<dyn Source>>) -> AF,
         AF: Future<Output = Result<ModuleResolveResultItem>>,
     {
+        let new_values = self
+            .primary_values
+            .iter()
+            .map(|item| {
+                let asset_fn = &source_fn;
+                let item = item.clone();
+                async move {
+                    Ok(match item {
+                        ResolveResultItem::Source(source) => asset_fn(source).await?,
+                        ResolveResultItem::External {
+                            name,
+                            ty,
+                            traced,
+                            target,
+                        } => {
+                            if traced == ExternalTraced::Traced || target.is_some() {
+                                // Should use map_primary_items instead
+                                bail!("map_module doesn't handle traced externals");
+                            }
+                            ModuleResolveResultItem::External { name, ty }
+                        }
+                        ResolveResultItem::Ignore => ModuleResolveResultItem::Ignore,
+                        ResolveResultItem::Empty => ModuleResolveResultItem::Empty,
+                        ResolveResultItem::Error(e) => ModuleResolveResultItem::Error(e),
+                        ResolveResultItem::Custom(u8) => ModuleResolveResultItem::Custom(u8),
+                    })
+                }
+            })
+            .try_join()
+            .await?;
         Ok(ModuleResolveResult {
-            primary: self
-                .primary
-                .iter()
-                .map(|(request, item)| {
-                    let asset_fn = &source_fn;
-                    let request = request.clone();
-                    let item = item.clone();
-                    async move {
-                        Ok((
-                            request,
-                            match item {
-                                ResolveResultItem::Source(source) => asset_fn(source).await?,
-                                ResolveResultItem::External {
-                                    name,
-                                    ty,
-                                    traced,
-                                    target,
-                                } => {
-                                    if traced == ExternalTraced::Traced || target.is_some() {
-                                        // Should use map_primary_items instead
-                                        bail!("map_module doesn't handle traced externals");
-                                    }
-                                    ModuleResolveResultItem::External { name, ty }
-                                }
-                                ResolveResultItem::Ignore => ModuleResolveResultItem::Ignore,
-                                ResolveResultItem::Empty => ModuleResolveResultItem::Empty,
-                                ResolveResultItem::Error(e) => ModuleResolveResultItem::Error(e),
-                                ResolveResultItem::Custom(u8) => {
-                                    ModuleResolveResultItem::Custom(u8)
-                                }
-                            },
-                        ))
-                    }
-                })
-                .try_join()
-                .await?
-                .into_iter()
-                .collect(),
+            primary_keys: self.primary_keys.clone(),
+            primary_values: new_values.into_boxed_slice(),
             affecting_sources: self.affecting_sources.clone(),
         })
     }
@@ -764,20 +894,19 @@ impl ResolveResult {
         A: Fn(ResolveResultItem) -> AF,
         AF: Future<Output = Result<ModuleResolveResultItem>>,
     {
+        let new_values = self
+            .primary_values
+            .iter()
+            .map(|item| {
+                let asset_fn = &item_fn;
+                let item = item.clone();
+                async move { asset_fn(item).await }
+            })
+            .try_join()
+            .await?;
         Ok(ModuleResolveResult {
-            primary: self
-                .primary
-                .iter()
-                .map(|(request, item)| {
-                    let asset_fn = &item_fn;
-                    let request = request.clone();
-                    let item = item.clone();
-                    async move { Ok((request, asset_fn(item).await?)) }
-                })
-                .try_join()
-                .await?
-                .into_iter()
-                .collect(),
+            primary_keys: self.primary_keys.clone(),
+            primary_values: new_values.into_boxed_slice(),
             affecting_sources: self.affecting_sources.clone(),
         })
     }
@@ -785,43 +914,41 @@ impl ResolveResult {
     /// Returns a new [ResolveResult] where all [RequestKey]s are set to the
     /// passed `request`.
     fn with_request_ref(&self, request: RcStr) -> Self {
-        let new_primary = self
-            .primary
+        if !self.has_keys() {
+            return self.clone();
+        }
+        let new_keys = self
+            .primary_keys
             .iter()
-            .map(|(k, v)| {
-                (
-                    RequestKey {
-                        request: Some(request.clone()),
-                        conditions: k.conditions.clone(),
-                    },
-                    v.clone(),
-                )
+            .map(|k| RequestKey {
+                request: Some(request.clone()),
+                conditions: k.conditions.clone(),
             })
             .collect();
         ResolveResult {
-            primary: new_primary,
+            primary_keys: new_keys,
+            primary_values: self.primary_values.clone(),
             affecting_sources: self.affecting_sources.clone(),
         }
     }
 
     pub fn with_conditions(&self, new_conditions: &[(RcStr, bool)]) -> Self {
-        let primary = self
-            .primary
+        if !self.has_keys() {
+            return self.clone();
+        }
+        let deduped = self
+            .primary_keys
             .iter()
-            .map(|(k, v)| {
-                (
-                    RequestKey {
-                        request: k.request.clone(),
-                        conditions: k.conditions.extend(new_conditions.iter().cloned()),
-                    },
-                    v.clone(),
-                )
+            .map(|k| RequestKey {
+                request: k.request.clone(),
+                conditions: k.conditions.extend(new_conditions.iter().cloned()),
             })
-            .collect::<FxIndexMap<_, _>>() // Deduplicate
-            .into_iter()
-            .collect();
+            .zip(self.primary_values.iter().cloned())
+            .collect::<FxIndexMap<_, _>>(); // Deduplicate
+        let (keys, values): (Vec<_>, Vec<_>) = deduped.into_iter().unzip();
         ResolveResult {
-            primary,
+            primary_keys: keys.into_boxed_slice(),
+            primary_values: values.into_boxed_slice(),
             affecting_sources: self.affecting_sources.clone(),
         }
     }
@@ -834,8 +961,10 @@ struct ResolveResultBuilder {
 
 impl From<ResolveResultBuilder> for ResolveResult {
     fn from(v: ResolveResultBuilder) -> Self {
+        let (keys, values): (Vec<_>, Vec<_>) = v.primary.into_iter().unzip();
         ResolveResult {
-            primary: v.primary.into_iter().collect(),
+            primary_keys: keys.into_boxed_slice(),
+            primary_values: values.into_boxed_slice(),
             affecting_sources: v.affecting_sources.into_boxed_slice(),
         }
     }
@@ -843,16 +972,21 @@ impl From<ResolveResultBuilder> for ResolveResult {
 impl From<ResolveResult> for ResolveResultBuilder {
     fn from(v: ResolveResult) -> Self {
         ResolveResultBuilder {
-            primary: IntoIterator::into_iter(v.primary).collect(),
+            primary: v
+                .primary_keys
+                .into_iter()
+                .zip(v.primary_values.into_iter())
+                .collect(),
             affecting_sources: v.affecting_sources.into_vec(),
         }
     }
 }
 impl ResolveResultBuilder {
     pub fn merge_alternatives(&mut self, other: &ResolveResult) {
-        for (k, v) in other.primary.iter() {
-            if !self.primary.contains_key(k) {
-                self.primary.insert(k.clone(), v.clone());
+        for (key, value) in other.iter_primary() {
+            let key = key.cloned().unwrap_or_default();
+            if !self.primary.contains_key(&key) {
+                self.primary.insert(key, value.clone());
             }
         }
         let set = self
@@ -890,7 +1024,8 @@ impl ResolveResult {
         sources: Vec<ResolvedVc<Box<dyn Source>>>,
     ) -> Result<Vc<Self>> {
         Ok(Self {
-            primary: self.primary.clone(),
+            primary_keys: self.primary_keys.clone(),
+            primary_values: self.primary_values.clone(),
             affecting_sources: self
                 .affecting_sources
                 .iter()
@@ -958,7 +1093,7 @@ impl ResolveResult {
 
     #[turbo_tasks::function]
     pub fn first_source(&self) -> Vc<OptionSource> {
-        Vc::cell(self.primary.iter().find_map(|(_, item)| {
+        Vc::cell(self.primary_values.iter().find_map(|item| {
             if let &ResolveResultItem::Source(a) = item {
                 Some(a)
             } else {
@@ -970,9 +1105,9 @@ impl ResolveResult {
     #[turbo_tasks::function]
     pub fn primary_sources(&self) -> Vc<Sources> {
         Vc::cell(
-            self.primary
+            self.primary_values
                 .iter()
-                .filter_map(|(_, item)| {
+                .filter_map(|item| {
                     if let &ResolveResultItem::Source(a) = item {
                         Some(a)
                     } else {
@@ -993,9 +1128,13 @@ impl ResolveResult {
         old_request_key: RcStr,
         request_key: RequestKey,
     ) -> Result<Vc<Self>> {
-        let new_primary = self
-            .primary
+        if !self.has_keys() {
+            return Ok(self.clone().cell());
+        }
+        let (new_keys, new_values): (Vec<_>, Vec<_>) = self
+            .primary_keys
             .iter()
+            .zip(self.primary_values.iter())
             .filter_map(|(k, v)| {
                 let remaining = k.request.as_ref()?.strip_prefix(&*old_request_key)?;
                 Some((
@@ -1009,9 +1148,10 @@ impl ResolveResult {
                     v.clone(),
                 ))
             })
-            .collect();
+            .unzip();
         Ok(ResolveResult {
-            primary: new_primary,
+            primary_keys: new_keys.into_boxed_slice(),
+            primary_values: new_values.into_boxed_slice(),
             affecting_sources: self.affecting_sources.clone(),
         }
         .cell())
@@ -1022,9 +1162,13 @@ impl ResolveResult {
     /// without the prefix, but if there are still some, they are discarded.
     #[turbo_tasks::function]
     fn with_stripped_request_key_prefix(&self, prefix: RcStr) -> Result<Vc<Self>> {
-        let new_primary = self
-            .primary
+        if !self.has_keys() {
+            return Ok(self.clone().cell());
+        }
+        let (new_keys, new_values): (Vec<_>, Vec<_>) = self
+            .primary_keys
             .iter()
+            .zip(self.primary_values.iter())
             .filter_map(|(k, v)| {
                 let remaining = k.request.as_ref()?.strip_prefix(&*prefix)?;
                 Some((
@@ -1035,9 +1179,10 @@ impl ResolveResult {
                     v.clone(),
                 ))
             })
-            .collect();
+            .unzip();
         Ok(ResolveResult {
-            primary: new_primary,
+            primary_keys: new_keys.into_boxed_slice(),
+            primary_values: new_values.into_boxed_slice(),
             affecting_sources: self.affecting_sources.clone(),
         }
         .cell())
@@ -1053,12 +1198,16 @@ impl ResolveResult {
         old_request_key: Vc<Pattern>,
         request_key: Vc<Pattern>,
     ) -> Result<Vc<Self>> {
+        if !self.has_keys() {
+            return Ok(self.clone().cell());
+        }
         let old_request_key = &*old_request_key.await?;
         let request_key = &*request_key.await?;
 
-        let new_primary = self
-            .primary
+        let (new_keys, new_values): (Vec<_>, Vec<_>) = self
+            .primary_keys
             .iter()
+            .zip(self.primary_values.iter())
             .map(|(k, v)| {
                 (
                     RequestKey {
@@ -1072,9 +1221,10 @@ impl ResolveResult {
                     v.clone(),
                 )
             })
-            .collect();
+            .unzip();
         Ok(ResolveResult {
-            primary: new_primary,
+            primary_keys: new_keys.into_boxed_slice(),
+            primary_values: new_values.into_boxed_slice(),
             affecting_sources: self.affecting_sources.clone(),
         }
         .cell())
@@ -1084,21 +1234,20 @@ impl ResolveResult {
     /// passed `request`.
     #[turbo_tasks::function]
     fn with_request(&self, request: RcStr) -> Vc<Self> {
-        let new_primary = self
-            .primary
+        if !self.has_keys() {
+            return self.clone().cell();
+        }
+        let new_keys: Box<[_]> = self
+            .primary_keys
             .iter()
-            .map(|(k, v)| {
-                (
-                    RequestKey {
-                        request: Some(request.clone()),
-                        conditions: k.conditions.clone(),
-                    },
-                    v.clone(),
-                )
+            .map(|k| RequestKey {
+                request: Some(request.clone()),
+                conditions: k.conditions.clone(),
             })
             .collect();
         ResolveResult {
-            primary: new_primary,
+            primary_keys: new_keys,
+            primary_values: self.primary_values.clone(),
             affecting_sources: self.affecting_sources.clone(),
         }
         .cell()
@@ -1523,46 +1672,79 @@ pub async fn resolve_raw(
     collect_affecting_sources: bool,
     force_in_lookup_dir: bool,
 ) -> Result<Vc<ResolveResult>> {
+    resolve_raw_inner(
+        lookup_dir,
+        path,
+        collect_affecting_sources,
+        true,
+        force_in_lookup_dir,
+    )
+    .await
+}
+
+async fn resolve_raw_inner(
+    lookup_dir: FileSystemPath,
+    path: Vc<Pattern>,
+    collect_affecting_sources: bool,
+    collect_request_keys: bool,
+    force_in_lookup_dir: bool,
+) -> Result<Vc<ResolveResult>> {
     async fn to_result(
         request: RcStr,
         path: &FileSystemPath,
         collect_affecting_sources: bool,
+        collect_request_keys: bool,
     ) -> Result<ResolveResult> {
         let result = &*path.realpath_with_links().await?;
         let path = match &result.path_result {
             Ok(path) => path,
             Err(e) => bail!(e.as_error_message(path, result).await?),
         };
-        let request_key = RequestKey::new(request);
         let source = ResolvedVc::upcast(FileSource::new(path.clone()).to_resolved().await?);
-        Ok(if collect_affecting_sources {
-            ResolveResult::source_with_affecting_sources(
-                request_key,
-                source,
-                result
-                    .symlinks
-                    .iter()
-                    .map(|symlink| {
-                        Vc::upcast::<Box<dyn Source>>(FileSource::new(symlink.clone()))
-                            .to_resolved()
-                    })
-                    .try_join()
-                    .await?,
-            )
+        let symlinks = if collect_affecting_sources {
+            result
+                .symlinks
+                .iter()
+                .map(|symlink| {
+                    Vc::upcast::<Box<dyn Source>>(FileSource::new(symlink.clone())).to_resolved()
+                })
+                .try_join()
+                .await?
         } else {
-            ResolveResult::source_with_key(request_key, source)
+            vec![]
+        };
+        Ok(if collect_request_keys {
+            let request_key = RequestKey::new(request);
+            if collect_affecting_sources {
+                ResolveResult::source_with_affecting_sources(request_key, source, symlinks)
+            } else {
+                ResolveResult::source_with_key(request_key, source)
+            }
+        } else if collect_affecting_sources {
+            ResolveResult::source_without_key_with_affecting_sources(source, symlinks)
+        } else {
+            ResolveResult::source_without_key(source)
         })
     }
 
     async fn collect_matches(
         matches: &[PatternMatch],
         collect_affecting_sources: bool,
+        collect_request_keys: bool,
     ) -> Result<Vec<Vc<ResolveResult>>> {
         Ok(matches
             .iter()
             .map(|m| async move {
                 Ok(if let PatternMatch::File(request, path) = m {
-                    Some(to_result(request.clone(), path, collect_affecting_sources).await?)
+                    Some(
+                        to_result(
+                            request.clone(),
+                            path,
+                            collect_affecting_sources,
+                            collect_request_keys,
+                        )
+                        .await?,
+                    )
                 } else {
                     None
                 })
@@ -1593,17 +1775,39 @@ pub async fn resolve_raw(
             path,
         )
         .await?;
-        results.extend(collect_matches(&matches, collect_affecting_sources).await?);
+        results.extend(
+            collect_matches(&matches, collect_affecting_sources, collect_request_keys)
+                .await?
+        );
     }
 
     {
         let matches =
             read_matches(lookup_dir.clone(), rcstr!(""), force_in_lookup_dir, path).await?;
 
-        results.extend(collect_matches(&matches, collect_affecting_sources).await?);
+        results.extend(collect_matches(&matches, collect_affecting_sources, collect_request_keys).await?);
     }
 
     Ok(merge_results(results))
+}
+
+/// Like [`resolve_raw`] but skips allocating [`RequestKey`]s for each result. Use this when the
+/// caller only needs the resolved sources and never inspects or transforms the keys.
+#[turbo_tasks::function]
+pub async fn resolve_raw_without_keys(
+    lookup_dir: FileSystemPath,
+    path: Vc<Pattern>,
+    collect_affecting_sources: bool,
+    force_in_lookup_dir: bool,
+) -> Result<Vc<ResolveResult>> {
+    resolve_raw_inner(
+        lookup_dir,
+        path,
+        collect_affecting_sources,
+        false,
+        force_in_lookup_dir,
+    )
+    .await
 }
 
 #[turbo_tasks::function]
@@ -1811,50 +2015,95 @@ async fn handle_after_resolve_plugins(
     let mut changed = false;
     let result_value = result.await?;
 
-    let mut new_primary = FxIndexMap::default();
     let mut new_affecting_sources = Vec::new();
 
-    for (key, primary) in result_value.primary.iter() {
-        if let &ResolveResultItem::Source(source) = primary {
-            let path = source.ident().path().owned().await?;
-            if let Some(new_result) = apply_plugins_to_path(
-                path.clone(),
-                lookup_path.clone(),
-                reference_type.clone(),
-                request,
-                &resolved_conditions,
-            )
-            .await?
-            {
-                let new_result = new_result.await?;
-                changed = true;
-                new_primary.extend(
-                    new_result
-                        .primary
-                        .iter()
-                        .map(|(_, item)| (key.clone(), item.clone())),
-                );
-                new_affecting_sources.extend(new_result.affecting_sources.iter().copied());
+    if result_value.has_keys() {
+        let mut new_primary: FxIndexMap<RequestKey, ResolveResultItem> = FxIndexMap::default();
+        for (key, primary) in result_value
+            .primary_keys
+            .iter()
+            .zip(result_value.primary_values.iter())
+        {
+            if let &ResolveResultItem::Source(source) = primary {
+                let path = source.ident().path().owned().await?;
+                if let Some(new_result) = apply_plugins_to_path(
+                    path.clone(),
+                    lookup_path.clone(),
+                    reference_type.clone(),
+                    request,
+                    &resolved_conditions,
+                )
+                .await?
+                {
+                    let new_result = new_result.await?;
+                    changed = true;
+                    new_primary.extend(
+                        new_result
+                            .primary_values
+                            .iter()
+                            .map(|item| (key.clone(), item.clone())),
+                    );
+                    new_affecting_sources.extend(new_result.affecting_sources.iter().copied());
+                } else {
+                    new_primary.insert(key.clone(), primary.clone());
+                }
             } else {
                 new_primary.insert(key.clone(), primary.clone());
             }
-        } else {
-            new_primary.insert(key.clone(), primary.clone());
         }
-    }
 
-    if !changed {
-        return Ok(result);
-    }
+        if !changed {
+            return Ok(result);
+        }
 
-    let mut affecting_sources = result_value.affecting_sources.to_vec();
-    affecting_sources.append(&mut new_affecting_sources);
+        let mut affecting_sources = result_value.affecting_sources.to_vec();
+        affecting_sources.append(&mut new_affecting_sources);
+        let (keys, values): (Vec<_>, Vec<_>) = new_primary.into_iter().unzip();
+        Ok(ResolveResult {
+            primary_keys: keys.into_boxed_slice(),
+            primary_values: values.into_boxed_slice(),
+            affecting_sources: affecting_sources.into_boxed_slice(),
+        }
+        .cell())
+    } else {
+        let mut new_values: Vec<ResolveResultItem> = Vec::new();
+        for primary in result_value.primary_values.iter() {
+            if let &ResolveResultItem::Source(source) = primary {
+                let path = source.ident().path().owned().await?;
+                if let Some(new_result) = apply_plugins_to_path(
+                    path.clone(),
+                    lookup_path.clone(),
+                    reference_type.clone(),
+                    request,
+                    &resolved_conditions,
+                )
+                .await?
+                {
+                    let new_result = new_result.await?;
+                    changed = true;
+                    new_values.extend(new_result.primary_values.iter().cloned());
+                    new_affecting_sources.extend(new_result.affecting_sources.iter().copied());
+                } else {
+                    new_values.push(primary.clone());
+                }
+            } else {
+                new_values.push(primary.clone());
+            }
+        }
 
-    Ok(ResolveResult {
-        primary: new_primary.into_iter().collect(),
-        affecting_sources: affecting_sources.into_boxed_slice(),
+        if !changed {
+            return Ok(result);
+        }
+
+        let mut affecting_sources = result_value.affecting_sources.to_vec();
+        affecting_sources.append(&mut new_affecting_sources);
+        Ok(ResolveResult {
+            primary_keys: Default::default(),
+            primary_values: new_values.into_boxed_slice(),
+            affecting_sources: affecting_sources.into_boxed_slice(),
+        }
+        .cell())
     }
-    .cell())
 }
 
 #[turbo_tasks::function]
@@ -3161,22 +3410,29 @@ async fn resolved(
             .to_resolved()
             .await?,
     );
+    let symlinks = if options_value.collect_affecting_sources {
+        result
+            .symlinks
+            .iter()
+            .map(|symlink| async move {
+                anyhow::Ok(ResolvedVc::upcast(
+                    FileSource::new(symlink.clone()).to_resolved().await?,
+                ))
+            })
+            .try_join()
+            .await?
+    } else {
+        vec![]
+    };
     Ok(ResolveResultOrCell::Value(
-        if options_value.collect_affecting_sources {
-            ResolveResult::source_with_affecting_sources(
-                request_key,
-                source,
-                result
-                    .symlinks
-                    .iter()
-                    .map(|symlink| async move {
-                        anyhow::Ok(ResolvedVc::upcast(
-                            FileSource::new(symlink.clone()).to_resolved().await?,
-                        ))
-                    })
-                    .try_join()
-                    .await?,
-            )
+        if options_value.skip_request_keys {
+            if options_value.collect_affecting_sources {
+                ResolveResult::source_without_key_with_affecting_sources(source, symlinks)
+            } else {
+                ResolveResult::source_without_key(source)
+            }
+        } else if options_value.collect_affecting_sources {
+            ResolveResult::source_with_affecting_sources(request_key, source, symlinks)
         } else {
             ResolveResult::source_with_key(request_key, source)
         },
@@ -3753,11 +4009,10 @@ mod tests {
                 .await?;
 
                 let results: Vec<(String, String)> = result
-                    .primary
-                    .iter()
+                    .iter_primary()
                     .map(async |(k, v)| {
                         Ok((
-                            k.to_string(),
+                            k.map(|k| k.to_string()).unwrap_or_default(),
                             if let ResolveResultItem::Source(source) = v {
                                 source.ident().await?.path.path.to_string()
                             } else {

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -373,38 +373,71 @@ impl ModuleResolveResult {
 
 pub struct ModuleResolveResultBuilder {
     pub primary: FxIndexMap<RequestKey, ModuleResolveResultItem>,
+    /// Values from key-free results (where `primary_keys` was empty). Kept
+    /// separate so that key-based deduplication in `primary` does not
+    /// incorrectly collapse multiple key-free entries onto the same default
+    /// key.
+    pub key_free_values: Vec<ModuleResolveResultItem>,
     pub affecting_sources: Vec<ResolvedVc<Box<dyn Source>>>,
 }
 
 impl From<ModuleResolveResultBuilder> for ModuleResolveResult {
     fn from(v: ModuleResolveResultBuilder) -> Self {
-        let (keys, values): (Vec<_>, Vec<_>) = v.primary.into_iter().unzip();
-        ModuleResolveResult {
-            primary_keys: keys.into_boxed_slice(),
-            primary_values: values.into_boxed_slice(),
-            affecting_sources: v.affecting_sources.into_boxed_slice(),
+        if v.primary.is_empty() {
+            // All values came from key-free results — preserve the "no keys" invariant.
+            ModuleResolveResult {
+                primary_keys: Box::default(),
+                primary_values: v.key_free_values.into_boxed_slice(),
+                affecting_sources: v.affecting_sources.into_boxed_slice(),
+            }
+        } else {
+            let (mut keys, mut values): (Vec<_>, Vec<_>) = v.primary.into_iter().unzip();
+            // Append any key-free values with a default key so they are not
+            // silently dropped when mixing keyed and key-free results.
+            for value in v.key_free_values {
+                keys.push(RequestKey::default());
+                values.push(value);
+            }
+            ModuleResolveResult {
+                primary_keys: keys.into_boxed_slice(),
+                primary_values: values.into_boxed_slice(),
+                affecting_sources: v.affecting_sources.into_boxed_slice(),
+            }
         }
     }
 }
 impl From<ModuleResolveResult> for ModuleResolveResultBuilder {
     fn from(v: ModuleResolveResult) -> Self {
-        ModuleResolveResultBuilder {
-            primary: v
-                .primary_keys
-                .into_iter()
-                .zip(v.primary_values.into_iter())
-                .collect(),
-            affecting_sources: v.affecting_sources.into_vec(),
+        if v.primary_keys.is_empty() {
+            // Key-free result: put values into key_free_values to avoid
+            // collapsing them under a shared default key.
+            ModuleResolveResultBuilder {
+                primary: FxIndexMap::default(),
+                key_free_values: v.primary_values.into_vec(),
+                affecting_sources: v.affecting_sources.into_vec(),
+            }
+        } else {
+            ModuleResolveResultBuilder {
+                primary: v.primary_keys.into_iter().zip(v.primary_values).collect(),
+                key_free_values: Vec::new(),
+                affecting_sources: v.affecting_sources.into_vec(),
+            }
         }
     }
 }
 impl ModuleResolveResultBuilder {
     pub fn merge_alternatives(&mut self, other: &ModuleResolveResult) {
-        for (key, value) in other.iter_primary() {
-            let key = key.cloned().unwrap_or_default();
-            if !self.primary.contains_key(&key) {
-                self.primary.insert(key, value.clone());
+        if other.has_keys() {
+            for (key, value) in other.iter_primary() {
+                let key = key.cloned().unwrap_or_default();
+                if !self.primary.contains_key(&key) {
+                    self.primary.insert(key, value.clone());
+                }
             }
+        } else {
+            // Key-free result: append all values without key-based deduplication.
+            self.key_free_values
+                .extend(other.primary_values.iter().cloned());
         }
         let set = self
             .affecting_sources
@@ -695,18 +728,6 @@ impl ValueToString for ResolveResult {
 }
 
 impl ResolveResult {
-    fn from_keyed(
-        keyed: impl IntoIterator<Item = (RequestKey, ResolveResultItem)>,
-        affecting_sources: Box<[ResolvedVc<Box<dyn Source>>]>,
-    ) -> Self {
-        let (keys, values): (Vec<_>, Vec<_>) = keyed.into_iter().unzip();
-        ResolveResult {
-            primary_keys: keys.into_boxed_slice(),
-            primary_values: values.into_boxed_slice(),
-            affecting_sources,
-        }
-    }
-
     pub fn unresolvable() -> Self {
         ResolveResult {
             primary_keys: Default::default(),
@@ -954,38 +975,71 @@ impl ResolveResult {
 
 struct ResolveResultBuilder {
     primary: FxIndexMap<RequestKey, ResolveResultItem>,
+    /// Values from key-free results (where `primary_keys` was empty). Kept
+    /// separate so that key-based deduplication in `primary` does not
+    /// incorrectly collapse multiple key-free entries onto the same default
+    /// key.
+    key_free_values: Vec<ResolveResultItem>,
     affecting_sources: Vec<ResolvedVc<Box<dyn Source>>>,
 }
 
 impl From<ResolveResultBuilder> for ResolveResult {
     fn from(v: ResolveResultBuilder) -> Self {
-        let (keys, values): (Vec<_>, Vec<_>) = v.primary.into_iter().unzip();
-        ResolveResult {
-            primary_keys: keys.into_boxed_slice(),
-            primary_values: values.into_boxed_slice(),
-            affecting_sources: v.affecting_sources.into_boxed_slice(),
+        if v.primary.is_empty() {
+            // All values came from key-free results — preserve the "no keys" invariant.
+            ResolveResult {
+                primary_keys: Box::default(),
+                primary_values: v.key_free_values.into_boxed_slice(),
+                affecting_sources: v.affecting_sources.into_boxed_slice(),
+            }
+        } else {
+            let (mut keys, mut values): (Vec<_>, Vec<_>) = v.primary.into_iter().unzip();
+            // Append any key-free values with a default key so they are not
+            // silently dropped when mixing keyed and key-free results.
+            for value in v.key_free_values {
+                keys.push(RequestKey::default());
+                values.push(value);
+            }
+            ResolveResult {
+                primary_keys: keys.into_boxed_slice(),
+                primary_values: values.into_boxed_slice(),
+                affecting_sources: v.affecting_sources.into_boxed_slice(),
+            }
         }
     }
 }
 impl From<ResolveResult> for ResolveResultBuilder {
     fn from(v: ResolveResult) -> Self {
-        ResolveResultBuilder {
-            primary: v
-                .primary_keys
-                .into_iter()
-                .zip(v.primary_values.into_iter())
-                .collect(),
-            affecting_sources: v.affecting_sources.into_vec(),
+        if v.primary_keys.is_empty() {
+            // Key-free result: put values into key_free_values to avoid
+            // collapsing them under a shared default key.
+            ResolveResultBuilder {
+                primary: FxIndexMap::default(),
+                key_free_values: v.primary_values.into_vec(),
+                affecting_sources: v.affecting_sources.into_vec(),
+            }
+        } else {
+            ResolveResultBuilder {
+                primary: v.primary_keys.into_iter().zip(v.primary_values).collect(),
+                key_free_values: Vec::new(),
+                affecting_sources: v.affecting_sources.into_vec(),
+            }
         }
     }
 }
 impl ResolveResultBuilder {
     pub fn merge_alternatives(&mut self, other: &ResolveResult) {
-        for (key, value) in other.iter_primary() {
-            let key = key.cloned().unwrap_or_default();
-            if !self.primary.contains_key(&key) {
-                self.primary.insert(key, value.clone());
+        if other.has_keys() {
+            for (key, value) in other.iter_primary() {
+                let key = key.cloned().unwrap_or_default();
+                if !self.primary.contains_key(&key) {
+                    self.primary.insert(key, value.clone());
+                }
             }
+        } else {
+            // Key-free result: append all values without key-based deduplication.
+            self.key_free_values
+                .extend(other.primary_values.iter().cloned());
         }
         let set = self
             .affecting_sources

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -813,9 +813,7 @@ impl ResolveResult {
     }
 
     /// Iterates `(key, value)` pairs. `key` is `None` when keys were not collected.
-    pub fn iter_primary(
-        &self,
-    ) -> impl Iterator<Item = (Option<&RequestKey>, &ResolveResultItem)> {
+    pub fn iter_primary(&self) -> impl Iterator<Item = (Option<&RequestKey>, &ResolveResultItem)> {
         debug_assert!(
             self.primary_keys.is_empty() || self.primary_keys.len() == self.primary_values.len(),
             "primary_keys and primary_values length mismatch"
@@ -1776,8 +1774,7 @@ async fn resolve_raw_inner(
         )
         .await?;
         results.extend(
-            collect_matches(&matches, collect_affecting_sources, collect_request_keys)
-                .await?
+            collect_matches(&matches, collect_affecting_sources, collect_request_keys).await?,
         );
     }
 
@@ -1785,7 +1782,9 @@ async fn resolve_raw_inner(
         let matches =
             read_matches(lookup_dir.clone(), rcstr!(""), force_in_lookup_dir, path).await?;
 
-        results.extend(collect_matches(&matches, collect_affecting_sources, collect_request_keys).await?);
+        results.extend(
+            collect_matches(&matches, collect_affecting_sources, collect_request_keys).await?,
+        );
     }
 
     Ok(merge_results(results))

--- a/turbopack/crates/turbopack-core/src/resolve/options.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/options.rs
@@ -650,6 +650,10 @@ pub struct ResolveOptions {
     pub loose_errors: bool,
     /// Collect affecting sources for each resolve result.  Useful for tracing.
     pub collect_affecting_sources: bool,
+    /// When true, skip collecting request keys in resolve results. Request keys are needed for
+    /// dynamic pattern mapping and key-rewriting transforms; callers that only need the resolved
+    /// sources/modules (e.g. raw file references) can set this to true to avoid the allocation.
+    pub skip_request_keys: bool,
     /// Whether to parse data URIs into modules (as opposed to keeping them as externals)
     pub parse_data_uris: bool,
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -287,8 +287,8 @@ impl ReferencedAsset {
         if result.is_unresolvable_ref() {
             return Ok(ReferencedAsset::Unresolvable.cell());
         }
-        for (_, result) in result.primary.iter() {
-            match result {
+        for item in result.iter_primary_values() {
+            match item {
                 ModuleResolveResultItem::External {
                     name: request, ty, ..
                 } => {
@@ -457,7 +457,8 @@ impl ModuleReference for EsmAssetReference {
                 && *self.module.side_effects().await? == ModuleSideEffects::SideEffectFree
             {
                 return Ok(ModuleResolveResult {
-                    primary: Box::new([(RequestKey::default(), ModuleResolveResultItem::Ignore)]),
+                    primary_keys: Box::new([RequestKey::default()]),
+                    primary_values: Box::new([ModuleResolveResultItem::Ignore]),
                     affecting_sources: Default::default(),
                 }
                 .cell());

--- a/turbopack/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
@@ -401,25 +401,28 @@ impl PatternMapping {
         resolve_type: ResolveType,
     ) -> Result<Vc<PatternMapping>> {
         let result = resolve_result.await?;
-        match result.primary.len() {
+        match result.primary_len() {
             0 => Ok(PatternMapping::Single(SinglePatternMapping::Unresolvable(
                 request_to_string(request).await?.to_string(),
             ))
             .cell()),
             1 if !request.request_pattern().await?.has_dynamic_parts() => {
-                let resolve_item = &result.primary.first().unwrap().1;
+                let resolve_item = result.primary_values.first().unwrap();
                 let single_pattern_mapping =
                     to_single_pattern_mapping(origin, chunking_context, resolve_item, resolve_type)
                         .await?;
                 Ok(PatternMapping::Single(single_pattern_mapping).cell())
             }
             _ => {
+                debug_assert!(
+                    result.has_keys(),
+                    "PatternMapping::Map requires request keys to be collected"
+                );
                 let mut set = HashSet::new();
                 let map = result
-                    .primary
-                    .iter()
+                    .iter_primary()
                     .filter_map(|(k, v)| {
-                        let request = k.request.as_ref()?;
+                        let request = k?.request.as_ref()?;
                         set.insert(request).then(|| (request.to_string(), v))
                     })
                     .map(|(k, v)| async move {

--- a/turbopack/crates/turbopack-ecmascript/src/references/raw.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/raw.rs
@@ -12,7 +12,7 @@ use turbopack_core::{
     resolve::{
         ModuleResolveResult, RequestKey,
         pattern::{Pattern, PatternMatch, read_matches},
-        resolve_raw,
+        resolve_raw_without_keys,
     },
 };
 
@@ -55,7 +55,7 @@ impl ModuleReference for FileSourceReference {
             pattern = display(self.path.to_string().await?)
         );
         async {
-            let result = resolve_raw(
+            let result = resolve_raw_without_keys(
                 self.context_dir.clone(),
                 *self.path,
                 self.collect_affecting_sources,

--- a/turbopack/crates/turbopack-ecmascript/src/references/util.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/util.rs
@@ -76,7 +76,7 @@ pub async fn check_and_emit_too_many_matches_warning(
     context_dir: FileSystemPath,
     pattern: ResolvedVc<Pattern>,
 ) -> Result<()> {
-    let num_matches = result.await?.primary.len();
+    let num_matches = result.await?.primary_len();
     if num_matches > TOO_MANY_MATCHES_LIMIT {
         TooManyMatchesWarning {
             source: issue_source,

--- a/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
@@ -19,7 +19,7 @@ use turbopack_core::{
     reference::ModuleReference,
     reference_type::{ReferenceType, WorkerReferenceSubType},
     resolve::{
-        ModuleResolveResult, ModuleResolveResultItem, ResolveErrorMode,
+        ModuleResolveResult, ModuleResolveResultItem, RequestKey, ResolveErrorMode,
         error::handle_resolve_error, origin::ResolveOrigin, parse::Request, pattern::Pattern,
         resolve_raw, url_resolve,
     },
@@ -173,9 +173,11 @@ impl ModuleReference for WorkerAssetReference {
 
         // Wrap each resolved module in a WorkerLoaderModule
         let result_ref = result.await?;
-        let mut primary = Vec::with_capacity(result_ref.primary.len());
+        let mut primary: Vec<(RequestKey, ModuleResolveResultItem)> =
+            Vec::with_capacity(result_ref.primary_len());
 
-        for (request_key, resolve_item) in result_ref.primary.iter() {
+        for (request_key, resolve_item) in result_ref.iter_primary() {
+            let request_key = request_key.cloned().unwrap_or_default();
             match resolve_item {
                 ModuleResolveResultItem::Module(module) => {
                     let Some(chunkable) =
@@ -238,22 +240,18 @@ impl ModuleReference for WorkerAssetReference {
                             .await?;
 
                     primary.push((
-                        request_key.clone(),
+                        request_key,
                         ModuleResolveResultItem::Module(ResolvedVc::upcast(loader)),
                     ));
                 }
                 // Pass through other result types (External, Ignore, etc.)
                 _ => {
-                    primary.push((request_key.clone(), resolve_item.clone()));
+                    primary.push((request_key, resolve_item.clone()));
                 }
             }
         }
 
-        Ok(ModuleResolveResult {
-            primary: primary.into_boxed_slice(),
-            affecting_sources: result_ref.affecting_sources.clone(),
-        }
-        .cell())
+        Ok(ModuleResolveResult::from_keyed(primary, result_ref.affecting_sources.clone()).cell())
     }
 
     fn chunking_type(&self) -> Option<ChunkingType> {

--- a/turbopack/crates/turbopack-resolve/src/node_native_binding.rs
+++ b/turbopack/crates/turbopack-resolve/src/node_native_binding.rs
@@ -294,8 +294,8 @@ async fn resolve_node_gyp_build_files(
                     true,
                 )
                 .await?;
-                if let Some((_, ResolveResultItem::Source(source))) =
-                    resolved_prebuilt_file.primary.first()
+                if let Some(ResolveResultItem::Source(source)) =
+                    resolved_prebuilt_file.primary_values.first()
                 {
                     resolved.insert(format!("build/Release/{name}.node").into(), *source);
                     if collect_affecting_sources {

--- a/turbopack/crates/turbopack-resolve/src/typescript.rs
+++ b/turbopack/crates/turbopack-resolve/src/typescript.rs
@@ -465,17 +465,14 @@ pub async fn type_resolve(
 #[turbo_tasks::function]
 pub async fn as_typings_result(result: Vc<ModuleResolveResult>) -> Result<Vc<ModuleResolveResult>> {
     let mut result = result.owned().await?;
-    result.primary = IntoIterator::into_iter(take(&mut result.primary))
-        .map(|(k, v)| {
-            (
-                RequestKey {
-                    request: k.request.clone(),
-                    conditions: k.conditions.extend([(rcstr!("types"), true)]),
-                },
-                v,
-            )
-        })
-        .collect();
+    if result.has_keys() {
+        result.primary_keys = IntoIterator::into_iter(take(&mut result.primary_keys))
+            .map(|k| RequestKey {
+                request: k.request.clone(),
+                conditions: k.conditions.extend([(rcstr!("types"), true)]),
+            })
+            .collect();
+    }
     Ok(result.cell())
 }
 


### PR DESCRIPTION
## What?

Split `ResolveResult` and `ModuleResolveResult`'s `primary` field from `Box<[(RequestKey, Item)]>` into two parallel slices:

```rust
pub primary_keys: Box<[RequestKey]>,   // empty = "keys not collected"
pub primary_values: Box<[Item]>,
```

**Invariant:** `primary_keys` is either empty (opt-out) or the same length as `primary_values`.

New accessor API:
- `has_keys()` — true when keys were collected
- `iter_primary()` — yields `(Option<&RequestKey>, &Item)`
- `iter_primary_values()` — values only, always available

## Why?

Keys were always allocated even when callers only need the resolved sources or modules. `RequestKey` is only required in a few places: dynamic pattern mapping, TypeScript condition rewriting (`"types"` condition), and key-prefix transforms during exports field resolution.

This mirrors the existing `collect_affecting_sources` pattern already in the codebase.

## How?

- Key-manipulating methods (`with_conditions`, `with_replaced_request_key`, etc.) are no-ops when keys are absent.
- `resolve_raw_without_keys()` is a new entry point that skips key allocation entirely — used by `FileSourceReference` for raw filesystem lookups where keys are immediately discarded.
- `ResolveOptions::skip_request_keys: bool` (default `false`) allows the main resolve pipeline to opt out as well.
- Builders (`ResolveResultBuilder`, `ModuleResolveResultBuilder`) convert to/from the parallel slice representation via `unzip()`/`zip()`.