### PR TITLE
docs: note PPR default in cacheComponents reference

### DIFF
--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/cacheComponents.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/cacheComponents.mdx
@@ -29,12 +29,11 @@ When `cacheComponents` is enabled, you can use the following cache functions and
 - The [`cacheLife` function](/docs/app/api-reference/config/next-config-js/cacheLife) with `use cache`
 - The [`cacheTag` function](/docs/app/api-reference/functions/cacheTag)
 
-> **Good to know**:
->
-> With `cacheComponents` enabled, Next.js uses **Partial Prerendering (PPR)** for the App Router. That replaces the older `experimental.ppr` config and `experimental_ppr` route segment. Seeing `◐ (Partial Prerender)` in `next build` output is expected.
->
-> Read [How rendering works](/docs/app/getting-started/caching#how-rendering-works) for how the static shell and streaming fit together. If you used experimental PPR on Next.js 15, follow [Partial Prerendering (PPR)](/docs/app/guides/upgrading/version-16#partial-prerendering-ppr) in the Version 16 upgrade guide when you migrate.
+Additionally, `cacheComponents` implements **Partial Prerendering (PPR)** as the default behavior in the App Router. This means the experimental.ppr configuration flag and the experimental_ppr route segment configuration are no longer necessary and have since been removed.
 
+Read [How rendering works](/docs/app/getting-started/caching#how-rendering-works) for how the static shell and streaming fit together.
+
+> **Good to know**: If you used experimental PPR in Next.js 15, refer to the [Partial Prerendering (PPR)](/docs/app/guides/upgrading/version-16#partial-prerendering-ppr) section of the Version 16 upgrade guide when migrating.
 ## Navigation with Activity
 
 When `cacheComponents` is enabled, Next.js uses React's [`<Activity>`](https://react.dev/reference/react/Activity) component to preserve component state during client-side navigation.

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/cacheComponents.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/cacheComponents.mdx
@@ -29,6 +29,8 @@ When `cacheComponents` is enabled, you can use the following cache functions and
 - The [`cacheLife` function](/docs/app/api-reference/config/next-config-js/cacheLife) with `use cache`
 - The [`cacheTag` function](/docs/app/api-reference/functions/cacheTag)
 
+> **Good to know:** With `cacheComponents` enabled, Next.js uses **Partial Prerendering (PPR)** for the App Router. That replaces the older `experimental.ppr` config and `experimental_ppr` route segment, so `◐ (Partial Prerender)` in `next build` output is expected. Read [How rendering works](/docs/app/getting-started/caching#how-rendering-works) for how the static shell and streaming fit together. If you used experimental PPR on Next.js 15, follow [Partial Prerendering (PPR)](/docs/app/guides/upgrading/version-16#partial-prerendering-ppr) in the Version 16 upgrade guide when you migrate.
+
 ## Navigation with Activity
 
 When `cacheComponents` is enabled, Next.js uses React's [`<Activity>`](https://react.dev/reference/react/Activity) component to preserve component state during client-side navigation.

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/cacheComponents.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/cacheComponents.mdx
@@ -29,7 +29,11 @@ When `cacheComponents` is enabled, you can use the following cache functions and
 - The [`cacheLife` function](/docs/app/api-reference/config/next-config-js/cacheLife) with `use cache`
 - The [`cacheTag` function](/docs/app/api-reference/functions/cacheTag)
 
-> **Good to know:** With `cacheComponents` enabled, Next.js uses **Partial Prerendering (PPR)** for the App Router. That replaces the older `experimental.ppr` config and `experimental_ppr` route segment, so `◐ (Partial Prerender)` in `next build` output is expected. Read [How rendering works](/docs/app/getting-started/caching#how-rendering-works) for how the static shell and streaming fit together. If you used experimental PPR on Next.js 15, follow [Partial Prerendering (PPR)](/docs/app/guides/upgrading/version-16#partial-prerendering-ppr) in the Version 16 upgrade guide when you migrate.
+> **Good to know**:
+>
+> With `cacheComponents` enabled, Next.js uses **Partial Prerendering (PPR)** for the App Router. That replaces the older `experimental.ppr` config and `experimental_ppr` route segment. Seeing `◐ (Partial Prerender)` in `next build` output is expected.
+>
+> Read [How rendering works](/docs/app/getting-started/caching#how-rendering-works) for how the static shell and streaming fit together. If you used experimental PPR on Next.js 15, follow [Partial Prerendering (PPR)](/docs/app/guides/upgrading/version-16#partial-prerendering-ppr) in the Version 16 upgrade guide when you migrate.
 
 ## Navigation with Activity
 

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/cacheComponents.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/cacheComponents.mdx
@@ -29,11 +29,12 @@ When `cacheComponents` is enabled, you can use the following cache functions and
 - The [`cacheLife` function](/docs/app/api-reference/config/next-config-js/cacheLife) with `use cache`
 - The [`cacheTag` function](/docs/app/api-reference/functions/cacheTag)
 
-Additionally, `cacheComponents` implements **Partial Prerendering (PPR)** as the default behavior in the App Router. This means the experimental.ppr configuration flag and the experimental_ppr route segment configuration are no longer necessary and have since been removed.
+Additionally, `cacheComponents` implements **[Partial Prerendering (PPR)](/docs/app/glossary#partial-prerendering-ppr)** as the default behavior in the App Router. This means the `experimental.ppr` configuration flag and the `experimental_ppr` route segment configuration are no longer necessary and have since been removed.
 
 Read [How rendering works](/docs/app/getting-started/caching#how-rendering-works) for how the static shell and streaming fit together.
 
 > **Good to know**: If you used experimental PPR in Next.js 15, refer to the [Partial Prerendering (PPR)](/docs/app/guides/upgrading/version-16#partial-prerendering-ppr) section of the Version 16 upgrade guide when migrating.
+
 ## Navigation with Activity
 
 When `cacheComponents` is enabled, Next.js uses React's [`<Activity>`](https://react.dev/reference/react/Activity) component to preserve component state during client-side navigation.

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/cacheComponents.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/cacheComponents.mdx
@@ -29,7 +29,7 @@ When `cacheComponents` is enabled, you can use the following cache functions and
 - The [`cacheLife` function](/docs/app/api-reference/config/next-config-js/cacheLife) with `use cache`
 - The [`cacheTag` function](/docs/app/api-reference/functions/cacheTag)
 
-Additionally, `cacheComponents` implements **[Partial Prerendering (PPR)](/docs/app/glossary#partial-prerendering-ppr)** as the default behavior in the App Router. This means the `experimental.ppr` configuration flag and the `experimental_ppr` route segment configuration are no longer necessary and have since been removed.
+Additionally, `cacheComponents` implements **[Partial Prerendering (PPR)](/docs/app/glossary#partial-prerendering-ppr)** as the default behavior in the App Router. This means the `experimental.ppr` configuration flag and the `experimental_ppr` route segment configuration are no longer necessary and have been removed.
 
 Read [How rendering works](/docs/app/getting-started/caching#how-rendering-works) for how the static shell and streaming fit together.
 


### PR DESCRIPTION
### What?
Add a **Good to know** callout on the [`cacheComponents`](https://nextjs.org/docs/app/api-reference/config/next-config-js/cacheComponents) API reference, placed after the Usage list and before **Navigation with Activity**.

### Why?
Developers enabling `cacheComponents: true` may see routes built as partial prerenders (`◐ (Partial Prerender)`) without ever turning on a separate PPR flag. The Caching getting-started guide already explains PPR as the default with Cache Components; this surfaces the same idea on the config page people often open first, and points to migration context for Next.js 15 experimental PPR.

### How?
Single callout: PPR is used with the flag, legacy `experimental.ppr` / `experimental_ppr` are superseded, `◐` in `next build` is expected, with links to [How rendering works](https://nextjs.org/docs/app/getting-started/caching#how-rendering-works) and [Partial Prerendering (PPR)](https://nextjs.org/docs/app/guides/upgrading/version-16#partial-prerendering-ppr) in the Version 16 upgrade guide.

## PR checklist (Improving Documentation)
- Ran Prettier via lint-staged on commit; run `pnpm prettier-fix` locally if CI flags anything.
- Follow the docs contribution guide: https://nextjs.org/docs/community/contribution-guide

Made with [Cursor](https://cursor.com)