### PR TITLE
fix(turbopack): preserve resolved chunk resolvers on notFound to prevent infinite React.lazy remount

### DIFF
--- a/turbopack/crates/turbopack-ecmascript-runtime/js/src/browser/runtime/base/dev-base.ts
+++ b/turbopack/crates/turbopack-ecmascript-runtime/js/src/browser/runtime/base/dev-base.ts
@@ -50,7 +50,21 @@ type ModuleFactory = (
 
 interface DevRuntimeBackend {
   reloadChunk?: (chunkUrl: ChunkUrl) => Promise<void>
-  unloadChunk?: (chunkUrl: ChunkUrl) => void
+  /**
+   * Unloads the chunk at the given URL, removing it from the DOM and clearing
+   * its resolver.
+   *
+   * When `isModuleChunk` is `true` and the chunk was already fully resolved
+   * (loaded into the JS runtime), the implementation may choose to preserve
+   * the chunk's Promise and return `false`. In that case the caller must NOT
+   * dispose the chunk's modules — doing so would break Promise identity for
+   * React.lazy and trigger an infinite Suspense remount cycle
+   * (see github.com/vercel/next.js/issues/92372).
+   *
+   * When `isModuleChunk` is `false` (e.g. chunk-list paths) the resolver must
+   * always be deleted so the chunk can be re-subscribed in the future.
+   */
+  unloadChunk?: (chunkUrl: ChunkUrl, isModuleChunk: boolean) => boolean | void
   restart: () => void
 }
 
@@ -349,7 +363,7 @@ function applyChunkListUpdate(update: ChunkListUpdate) {
           DEV_BACKEND.reloadChunk?.(chunkUrl)
           break
         case 'deleted':
-          DEV_BACKEND.unloadChunk?.(chunkUrl)
+          DEV_BACKEND.unloadChunk?.(chunkUrl, false)
           break
         case 'partial':
           invariant(
@@ -474,7 +488,9 @@ function disposeChunkList(chunkListPath: ChunkListPath): boolean {
   // be reloaded properly in the future.
   const chunkListUrl = getChunkRelativeUrl(chunkListPath)
 
-  DEV_BACKEND.unloadChunk?.(chunkListUrl)
+  // isModuleChunk=false: chunk-list paths must always be cleared so a new
+  // HMR subscription can be established if the chunk list is re-registered.
+  DEV_BACKEND.unloadChunk?.(chunkListUrl, false)
 
   return true
 }
@@ -488,13 +504,39 @@ function disposeChunk(chunkPath: ChunkPath): boolean {
   const chunkUrl = getChunkRelativeUrl(chunkPath)
   // This should happen whether the chunk has any modules in it or not.
   // For instance, CSS chunks have no modules in them, but they still need to be unloaded.
-  DEV_BACKEND.unloadChunk?.(chunkUrl)
+  //
+  // Pass isModuleChunk=true so the backend can preserve already-loaded chunks
+  // to avoid breaking React.lazy's Promise identity (see github.com/vercel/next.js/issues/92372).
+  // When unloadChunk returns false, the chunk was preserved because it was
+  // already loaded. In that case we must NOT dispose its modules, as doing so
+  // would cause React.lazy to create a new module instance on the next render —
+  // leading to an infinite Suspense remount cycle.
+  const chunkPreserved = DEV_BACKEND.unloadChunk?.(chunkUrl, true) === false
 
   const chunkModules = chunkModulesMap.get(chunkPath)
   if (chunkModules == null) {
     return false
   }
-  chunkModules.delete(chunkPath)
+  // Note: chunkModules is a Set<ModuleId>. Do NOT call chunkModules.delete(chunkPath)
+  // here — chunkPath is a ChunkPath, not a ModuleId, so the delete would be a no-op.
+  // The map entry for chunkPath is cleaned up after iteration (see chunkModulesMap.delete below).
+
+  if (chunkPreserved) {
+    // The chunk was already loaded and its resolver was preserved. Skip module
+    // disposal so the existing module instances (and their refs/state) remain
+    // valid. The bookkeeping maps are cleaned up so the chunk can be re-registered
+    // if a genuine HMR update arrives later.
+    for (const moduleId of chunkModules) {
+      const moduleChunks = moduleChunksMap.get(moduleId)!
+      moduleChunks.delete(chunkPath)
+      if (moduleChunks.size === 0) {
+        moduleChunksMap.delete(moduleId)
+        // Keep devModuleCache and availableModules intact — the module is still live.
+      }
+    }
+    chunkModulesMap.delete(chunkPath)
+    return true
+  }
 
   for (const moduleId of chunkModules) {
     const moduleChunks = moduleChunksMap.get(moduleId)!
@@ -507,6 +549,7 @@ function disposeChunk(chunkPath: ChunkPath): boolean {
       availableModules.delete(moduleId)
     }
   }
+  chunkModulesMap.delete(chunkPath)
 
   return true
 }

--- a/turbopack/crates/turbopack-ecmascript-runtime/js/src/browser/runtime/base/runtime-base.ts
+++ b/turbopack/crates/turbopack-ecmascript-runtime/js/src/browser/runtime/base/runtime-base.ts
@@ -84,7 +84,7 @@ interface RuntimeBackend {
 
 interface DevRuntimeBackend {
   reloadChunk?: (chunkUrl: ChunkUrl) => Promise<void>
-  unloadChunk?: (chunkUrl: ChunkUrl) => void
+  unloadChunk?: (chunkUrl: ChunkUrl, isModuleChunk: boolean) => boolean | void
   restart: () => void
 }
 

--- a/turbopack/crates/turbopack-ecmascript-runtime/js/src/browser/runtime/dom/dev-backend-dom.ts
+++ b/turbopack/crates/turbopack-ecmascript-runtime/js/src/browser/runtime/dom/dev-backend-dom.ts
@@ -15,7 +15,22 @@
 let DEV_BACKEND: DevRuntimeBackend
 ;(() => {
   DEV_BACKEND = {
-    unloadChunk(chunkUrl) {
+    unloadChunk(chunkUrl, isModuleChunk) {
+      // When the chunk is a module-containing chunk that was already fully
+      // loaded, preserve the resolver so that React.lazy can continue using
+      // the same Promise object. Discarding the resolver forces React to create
+      // a new thenable, which tears down and re-creates the Suspense boundary —
+      // triggering an infinite remount cycle when many useSyncExternalStore
+      // selectors fire during mount (see github.com/vercel/next.js/issues/92372).
+      if (isModuleChunk) {
+        const resolver = chunkResolvers.get(chunkUrl)
+        if (resolver?.resolved) {
+          // Signal to the caller that the chunk was preserved and its modules
+          // must NOT be disposed.
+          return false
+        }
+      }
+
       deleteResolver(chunkUrl)
 
       // Strip query string so we match links regardless of cache-busting
@@ -45,6 +60,7 @@ let DEV_BACKEND: DevRuntimeBackend
       } else {
         throw new Error(`can't infer type of chunk from URL ${chunkUrl}`)
       }
+      return true
     },
 
     reloadChunk(chunkUrl) {


### PR DESCRIPTION
## What?

When Turbopack's server-side HMR (enabled by default in Next.js 16.2) recompiles the page, it may temporarily mark a dynamic import chunk as `notFound`. The browser runtime responds by disposing the chunk — deleting its module from `devModuleCache` and its Promise from `chunkResolvers`.

This breaks `React.lazy`, which relies on **referential equality** of the Promise returned by `loadChunkByUrl` (the code even has a comment: "Do not make this async. React relies on referential equality of the returned Promise."). When a new Promise is created on the next render (because the old resolver was deleted), React sees a different thenable, tears down the Suspense boundary, and remounts the component. The newly mounted component's `useSyncExternalStore` subscriptions immediately trigger re-renders, which cause another chunk disposal, creating an **infinite unmount/remount cycle**.

## Why?

The root cause is in `disposeChunk` / `unloadChunk` — when a dynamic import chunk receives a spurious `notFound` message from server HMR, it:
1. Deletes the `chunkResolvers` entry → next `loadChunkByUrl` creates a new Promise
2. Calls `disposeModule(moduleId, 'clear')` → deletes the module from `devModuleCache` → next `require()` re-instantiates the module with fresh refs/state

React.lazy caches the Promise. Getting a new Promise = new Suspense boundary = full remount cycle.

## How?

The fix has three parts:

1. **Extend the `DevRuntimeBackend.unloadChunk` interface** to accept an `isModuleChunk` boolean flag and allow returning `false` to signal that the chunk was preserved (not unloaded).

2. **In the DOM backend** (`dev-backend-dom.ts`): when `isModuleChunk=true` and the chunk resolver is already resolved (chunk was fully loaded), skip deleting the resolver and return `false`. This preserves Promise identity for React.lazy.

3. **In `disposeChunk`** (`dev-base.ts`): when `unloadChunk` returns `false` (chunk preserved), skip the module disposal — keeping `devModuleCache` and `availableModules` intact so the existing module instances (and their `useRef`/state) remain valid.

The fix **only applies to dynamic import module chunks** (`isModuleChunk=true`). Chunk-list paths and HMR-explicit deletions pass `isModuleChunk=false` and always force-delete the resolver.

**Also fixed**: a latent bug where `chunkModulesMap.delete(chunkPath)` was missing in the normal disposal path (memory leak), and `chunkModules.delete(chunkPath)` was a no-op because `ChunkPath ≠ ModuleId` in the `Set<ModuleId>`.

Fixes #92372