### PR TITLE
docs: document `samples` field for instant navigation cookie/header reads

### DIFF
--- a/docs/01-app/02-guides/instant-navigation.mdx
+++ b/docs/01-app/02-guides/instant-navigation.mdx
@@ -270,6 +270,26 @@ Each entry point is validated independently. A Suspense boundary that covers one
 
 </details>
 
+## Routes that read cookies or headers
+
+If a component behind `<Suspense>` reads a cookie or header, validation needs to know which values to simulate. Add a [`samples`](/docs/app/api-reference/file-conventions/route-segment-config/instant#samples) array to `unstable_instant`:
+
+```tsx filename="app/profile/page.tsx" highlight={3-5}
+export const unstable_instant = {
+  prefetch: 'static',
+  samples: [{ cookies: [{ name: 'username', value: 'demo' }] }],
+}
+```
+
+```jsx filename="app/profile/page.js" highlight={3-5}
+export const unstable_instant = {
+  prefetch: 'static',
+  samples: [{ cookies: [{ name: 'username', value: 'demo' }] }],
+}
+```
+
+Without `samples`, the build fails because validation does not know what value to use for the cookie. See the [`samples` reference](/docs/app/api-reference/file-conventions/route-segment-config/instant#samples) for headers, params, search params, and absent values.
+
 ## Opting out with `instant = false`
 
 Not every layout can be instant. A dashboard layout that reads cookies and fetches user-specific data might be too dynamic for the first entry. You can set `instant = false` on that layout to exempt it from validation:

--- a/docs/01-app/03-api-reference/03-file-conventions/02-route-segment-config/instant.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/02-route-segment-config/instant.mdx
@@ -51,7 +51,37 @@ export const unstable_instant = {
 }
 ```
 
-- **`'static'`**: Enables validation. Prefetching behavior stays the same (static by default). Components that read cookies or headers are treated as dynamic and must be behind Suspense.
+- **`'static'`**: Enables validation. Prefetching behavior stays the same (static by default). Components that read cookies or headers are treated as dynamic and must be behind Suspense. If a component reads a specific cookie or header, you must also declare it in [`samples`](#samples) so validation knows which values to simulate.
+
+### `samples`
+
+Declares the cookies, headers, params, or search params that a route reads at runtime. Validation uses these values to simulate the request during dev and build.
+
+`samples` is optional when `prefetch` is `'static'` and required when `prefetch` is `'runtime'`. If a component reads a cookie or header that is not listed, the build fails with an error telling you which value to add.
+
+```tsx filename="app/profile/page.tsx" highlight={3-5}
+export const unstable_instant = {
+  prefetch: 'static',
+  samples: [{ cookies: [{ name: 'username', value: 'demo' }] }],
+}
+```
+
+```jsx filename="app/profile/page.js" highlight={3-5}
+export const unstable_instant = {
+  prefetch: 'static',
+  samples: [{ cookies: [{ name: 'username', value: 'demo' }] }],
+}
+```
+
+To declare a cookie that may be absent, set `value` to `null`:
+
+```tsx
+{
+  cookies: [{ name: 'username', value: null }]
+}
+```
+
+Each entry in the `samples` array is one simulated request. Validation runs for every sample, so you can test multiple scenarios (for example, logged-in and logged-out).
 
 ### Disabling instant
 
@@ -106,16 +136,17 @@ The DevTools use a `next-instant-navigation-testing` cookie to freeze the UI at 
 
 ```tsx
 type RuntimeSample = {
-  cookies?: Array<{ name: string; value: string }>
-  headers?: Array<[string, string]>
+  cookies?: Array<{ name: string; value: string | null }>
+  headers?: Array<[string, string | null]>
   params?: Record<string, string | string[]>
-  searchParams?: Record<string, string | string[]>
+  searchParams?: Record<string, string | string[] | null>
 }
 
 type InstantConfig =
   | false
   | {
       prefetch: 'static'
+      samples?: RuntimeSample[]
       from?: string[]
       unstable_disableValidation?: boolean
     }


### PR DESCRIPTION
## What?

Document the `samples` field on `unstable_instant` for routes that read cookies or headers.

## Why?

A developer following the instant navigation guide who puts a cookie-reading component behind `<Suspense>` hits a build error:

```
Route "/profile" accessed cookie "username" which is not defined in the `samples`
of `unstable_instant`. Add it to the sample's `cookies` array, or
`{ name: "username", value: null }` if it should be absent.
```

The `samples` field only appeared in the TypeScript type block at the bottom of the API reference with no prose or example. Neither the guide nor the reference explained that cookie/header reads require `samples`.

## How?

- Add a `### samples` section to the `instant` API reference with prose and code examples (TSX/JSX)
- Add a "Routes that read cookies or headers" section to the instant navigation guide with an example and a link to the reference
- Update the `'static'` description to mention `samples` for cookies/headers
- Fix the TypeScript type block to show `samples?` on the `'static'` variant (matching `app-segment-config.ts`)
- Fix `RuntimeSample` type to include `| null` for cookies, headers, and searchParams (matching the source)

### Improving Documentation

- [x] Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- [x] Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines.

<!-- NEXT_JS_LLM_PR -->

Made with [Cursor](https://cursor.com)