### PR TITLE
turbo-persistence: skip BlockCache for uncompressed (mmap-backed) blocks

### DIFF
--- a/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
@@ -1,4 +1,14 @@
-use std::{cmp::Ordering, fs::File, hash::BuildHasherDefault, path::Path, rc::Rc, sync::Arc};
+use std::{
+    cmp::Ordering,
+    fs::File,
+    hash::BuildHasherDefault,
+    path::Path,
+    rc::Rc,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering as AtomicOrdering},
+    },
+};
 
 use anyhow::{Context, Result, bail, ensure};
 use memmap2::Mmap;
@@ -77,9 +87,8 @@ pub struct BlockWeighter;
 impl quick_cache::Weighter<(u32, u16), ArcBytes> for BlockWeighter {
     fn weight(&self, _key: &(u32, u16), val: &ArcBytes) -> u64 {
         if val.is_mmap_backed() {
-            // Mmap-backed blocks are cheap (just a pointer + Arc clone), so we
-            // assign a small fixed weight. Caching them avoids re-parsing block
-            // offsets on every lookup.
+            // Mmap-backed blocks bypass the cache (served directly from mmap),
+            // so this branch is a safety net only. Assign a negligible weight.
             64
         } else {
             val.len() as u64 + 8
@@ -105,15 +114,24 @@ trait ValueBlockCache<B: SharedBytes> {
     ) -> Result<B>;
 }
 
-/// Lookup-path: concurrent `BlockCache`, with uncompressed-bypass optimization.
-impl ValueBlockCache<ArcBytes> for &BlockCache {
+/// Bundles the shared block cache with the per-file CRC-verified bitmap,
+/// used on the lookup path.
+#[derive(Clone, Copy)]
+struct ArcBlockCacheReader<'a> {
+    cache: &'a BlockCache,
+    verified_blocks: &'a [AtomicU64],
+}
+
+/// Lookup-path: concurrent `BlockCache` with uncompressed-bypass and
+/// once-per-block CRC verification via `verified_blocks` bitmap.
+impl ValueBlockCache<ArcBytes> for ArcBlockCacheReader<'_> {
     fn get_or_read(
         self,
         mmap: &Arc<Mmap>,
         meta: &StaticSortedFileMetaData,
         block_index: u16,
     ) -> Result<ArcBytes> {
-        get_or_cache_block(mmap, meta, block_index, self)
+        get_or_cache_block(mmap, meta, block_index, self.cache, self.verified_blocks)
     }
 }
 
@@ -159,6 +177,11 @@ pub struct StaticSortedFile {
     /// We store as an Arc so we can hand out references (via ArcBytes) that can outlive this
     /// struct (not that we expect them to outlive it by very much)
     mmap: Arc<Mmap>,
+    /// One bit per block, set when that block's CRC has been verified at least once.
+    /// Uncompressed (mmap-backed) blocks bypass the `BlockCache`, so without this
+    /// bitmap the CRC would be re-computed on every access. `Relaxed` ordering
+    /// suffices: racing first-time verifications are idempotent.
+    verified_blocks: Box<[AtomicU64]>,
 }
 
 impl StaticSortedFile {
@@ -183,9 +206,14 @@ impl StaticSortedFile {
             let _ = mmap.advise_range(memmap2::Advice::Sequential, offset, mmap.len() - offset);
         }
         advise_mmap_for_persistence(&mmap)?;
+        let bitmap_words = (meta.block_count as usize).div_ceil(64);
+        let verified_blocks = (0..bitmap_words)
+            .map(|_| AtomicU64::new(0))
+            .collect::<Box<[_]>>();
         Ok(Self {
             meta,
             mmap: Arc::new(mmap),
+            verified_blocks,
         })
     }
 
@@ -208,17 +236,15 @@ impl StaticSortedFile {
         let key_block_index = self.lookup_index_block(&index_block, key_hash)?;
 
         let key_block_arc = self.get_key_block(key_block_index, key_block_cache)?;
+        let reader = ArcBlockCacheReader {
+            cache: value_block_cache,
+            verified_blocks: &self.verified_blocks,
+        };
         let block_type = be::read_u8(&key_block_arc);
         match block_type {
             BLOCK_TYPE_KEY_WITH_HASH | BLOCK_TYPE_KEY_NO_HASH => {
                 let has_hash = block_type == BLOCK_TYPE_KEY_WITH_HASH;
-                self.lookup_key_block::<K, FIND_ALL>(
-                    key_block_arc,
-                    key_hash,
-                    key,
-                    has_hash,
-                    value_block_cache,
-                )
+                self.lookup_key_block::<K, FIND_ALL>(key_block_arc, key_hash, key, has_hash, reader)
             }
 
             BLOCK_TYPE_FIXED_KEY_WITH_HASH | BLOCK_TYPE_FIXED_KEY_NO_HASH => {
@@ -228,7 +254,7 @@ impl StaticSortedFile {
                     key_hash,
                     key,
                     has_hash,
-                    value_block_cache,
+                    reader,
                 )
             }
             _ => {
@@ -269,7 +295,7 @@ impl StaticSortedFile {
         key_hash: u64,
         key: &K,
         has_hash: bool,
-        value_block_cache: &BlockCache,
+        reader: ArcBlockCacheReader<'_>,
     ) -> Result<SstLookupResult> {
         let hash_len: u8 = if has_hash { 8 } else { 0 };
         ensure!(block.len() >= 4, "key block too short");
@@ -282,14 +308,9 @@ impl StaticSortedFile {
         let offsets = &data[..entry_count * 4];
         let entries = &data[entry_count * 4..];
 
-        self.lookup_block_inner::<K, FIND_ALL>(
-            &block,
-            entry_count,
-            key_hash,
-            key,
-            value_block_cache,
-            |i| get_key_entry(offsets, entries, entry_count, i, hash_len),
-        )
+        self.lookup_block_inner::<K, FIND_ALL>(&block, entry_count, key_hash, key, reader, |i| {
+            get_key_entry(offsets, entries, entry_count, i, hash_len)
+        })
     }
 
     /// Looks up a key in a fixed-size key block.
@@ -302,7 +323,7 @@ impl StaticSortedFile {
         key_hash: u64,
         key: &K,
         has_hash: bool,
-        value_block_cache: &BlockCache,
+        reader: ArcBlockCacheReader<'_>,
     ) -> Result<SstLookupResult> {
         let hash_len: u8 = if has_hash { 8 } else { 0 };
         ensure!(block.len() >= 6, "fixed key block too short");
@@ -317,18 +338,11 @@ impl StaticSortedFile {
             "fixed key block for {entry_count} entries must is the wrong size"
         );
 
-        self.lookup_block_inner::<K, FIND_ALL>(
-            &block,
-            entry_count,
-            key_hash,
-            key,
-            value_block_cache,
-            |i| {
-                Ok(get_fixed_key_entry(
-                    entries, i, hash_len, key_size, value_type, stride,
-                ))
-            },
-        )
+        self.lookup_block_inner::<K, FIND_ALL>(&block, entry_count, key_hash, key, reader, |i| {
+            Ok(get_fixed_key_entry(
+                entries, i, hash_len, key_size, value_type, stride,
+            ))
+        })
     }
 
     /// Shared binary search + collection logic for both key block variants.
@@ -341,7 +355,7 @@ impl StaticSortedFile {
         entry_count: usize,
         key_hash: u64,
         key: &K,
-        value_block_cache: &BlockCache,
+        reader: ArcBlockCacheReader<'_>,
         get_entry: impl Fn(usize) -> Result<GetKeyEntryResult<'a>>,
     ) -> Result<SstLookupResult> {
         let mut l = 0;
@@ -364,7 +378,7 @@ impl StaticSortedFile {
                     if !FIND_ALL {
                         // SingleValue mode: each key has exactly one entry
                         // this is enforced when writing
-                        let result = self.handle_key_match(ty, val, block, value_block_cache)?;
+                        let result = self.handle_key_match(ty, val, block, reader)?;
                         return Ok(SstLookupResult::Found(SmallVec::from_buf([result])));
                     }
                     // FIND_ALL (MultiValue) mode: collect all values for this key.
@@ -383,7 +397,7 @@ impl StaticSortedFile {
                         if !entry_matches_key(hash, entry_key, key_hash, key) {
                             break;
                         }
-                        results.push(self.handle_key_match(ty, val, block, value_block_cache)?);
+                        results.push(self.handle_key_match(ty, val, block, reader)?);
                     }
                     // Technically we could `.reverse()` the items collected by the backwards
                     // scan, but the only ordering constraint we need to maintain for single
@@ -393,7 +407,7 @@ impl StaticSortedFile {
                     // their order.
 
                     // Add the entry at `m`
-                    results.push(self.handle_key_match(ty, val, block, value_block_cache)?);
+                    results.push(self.handle_key_match(ty, val, block, reader)?);
                     for i in (m + 1)..r {
                         let GetKeyEntryResult {
                             hash,
@@ -404,7 +418,7 @@ impl StaticSortedFile {
                         if !entry_matches_key(hash, entry_key, key_hash, key) {
                             break;
                         }
-                        results.push(self.handle_key_match(ty, val, block, value_block_cache)?);
+                        results.push(self.handle_key_match(ty, val, block, reader)?);
                     }
                     return Ok(SstLookupResult::Found(results));
                 }
@@ -421,16 +435,9 @@ impl StaticSortedFile {
         ty: u8,
         val: &[u8],
         key_block_arc: &ArcBytes,
-        value_block_cache: &BlockCache,
+        reader: ArcBlockCacheReader<'_>,
     ) -> Result<LookupValue> {
-        handle_key_match_generic(
-            &self.mmap,
-            &self.meta,
-            ty,
-            val,
-            key_block_arc,
-            value_block_cache,
-        )
+        handle_key_match_generic(&self.mmap, &self.meta, ty, val, key_block_arc, reader)
     }
 
     /// Gets a key block from the cache or reads it from the file.
@@ -439,42 +446,64 @@ impl StaticSortedFile {
         block: u16,
         key_block_cache: &BlockCache,
     ) -> Result<ArcBytes, anyhow::Error> {
-        get_or_cache_block(&self.mmap, &self.meta, block, key_block_cache)
+        get_or_cache_block(
+            &self.mmap,
+            &self.meta,
+            block,
+            key_block_cache,
+            &self.verified_blocks,
+        )
     }
-}
-
-/// Returns `true` when the block at `block_index` is stored uncompressed
-/// (mmap-backed), i.e. its `uncompressed_length` header is zero.
-/// Cost: 2–3 mmap word-reads (offset table entry + header word).
-fn is_block_uncompressed(mmap: &Mmap, meta: &StaticSortedFileMetaData, block_index: u16) -> bool {
-    let offset = meta.block_offsets_start(mmap.len()) + block_index as usize * 4;
-    let block_start = if block_index == 0 {
-        0
-    } else {
-        be::read_u32(&mmap[offset - 4..]) as usize
-    };
-    be::read_u32(&mmap[block_start..]) == 0
 }
 
 /// Gets a block from the cache, or reads it from the mmap and inserts it.
 ///
-/// Uncompressed blocks bypass the cache entirely — creating an mmap-backed
-/// `ArcBytes` is cheaper than a cache hash + lookup, so we peek at the block
-/// header first and short-circuit when the block is uncompressed.
+/// Reads the block header exactly once via `get_raw_block_slice` (which
+/// includes all `strict_checks` bounds guards). Uncompressed blocks bypass
+/// the cache — an mmap-backed `ArcBytes` is cheaper than a cache lookup.
+/// Their CRC is verified at most once per file open, tracked by
+/// `verified_blocks`. Compressed blocks are looked up in `cache`; on a
+/// miss they are decompressed, CRC-verified, and inserted.
 fn get_or_cache_block(
     mmap: &Arc<Mmap>,
     meta: &StaticSortedFileMetaData,
     block_index: u16,
     cache: &BlockCache,
+    verified_blocks: &[AtomicU64],
 ) -> Result<ArcBytes> {
-    if is_block_uncompressed(mmap, meta, block_index) {
-        return read_block_generic(mmap, meta, block_index);
+    let (uncompressed_length, checksum, block_data) = get_raw_block_slice(mmap, meta, block_index)
+        .with_context(|| {
+            format!(
+                "Failed to read raw block {} from {:08}.sst",
+                block_index, meta.sequence_number
+            )
+        })?;
+
+    if uncompressed_length == 0 {
+        // Uncompressed: serve directly from mmap. Verify CRC only once per file open.
+        let word_idx = block_index as usize / 64;
+        let bit = 1u64 << (block_index as usize % 64);
+        if verified_blocks[word_idx].load(AtomicOrdering::Relaxed) & bit == 0 {
+            verify_checksum(meta, block_data, checksum, block_index)?;
+            verified_blocks[word_idx].fetch_or(bit, AtomicOrdering::Relaxed);
+        }
+        // SAFETY: block_data points into the mmap backing `mmap`.
+        return Ok(unsafe { ArcBytes::from_mmap(mmap, block_data) });
     }
+
+    // Compressed: check cache; decompress and insert on miss.
     Ok(
         match cache.get_value_or_guard(&(meta.sequence_number, block_index), None) {
             GuardResult::Value(block) => block,
             GuardResult::Guard(guard) => {
-                let block: ArcBytes = read_block_generic(mmap, meta, block_index)?;
+                verify_checksum(meta, block_data, checksum, block_index)?;
+                let block = ArcBytes::from_decompressed(uncompressed_length, block_data)
+                    .with_context(|| {
+                        format!(
+                            "Failed to decompress block {} from {:08}.sst ({} bytes uncompressed)",
+                            block_index, meta.sequence_number, uncompressed_length
+                        )
+                    })?;
                 let _ = guard.insert(block.clone());
                 block
             }

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
@@ -105,10 +105,7 @@ trait ValueBlockCache<B: SharedBytes> {
     ) -> Result<B>;
 }
 
-/// Lookup-path: concurrent `BlockCache`.
-///
-/// Uncompressed blocks bypass the cache entirely — creating an mmap-backed
-/// `ArcBytes` is cheaper than a cache hash + lookup.
+/// Lookup-path: concurrent `BlockCache`, with uncompressed-bypass optimization.
 impl ValueBlockCache<ArcBytes> for &BlockCache {
     fn get_or_read(
         self,
@@ -116,22 +113,7 @@ impl ValueBlockCache<ArcBytes> for &BlockCache {
         meta: &StaticSortedFileMetaData,
         block_index: u16,
     ) -> Result<ArcBytes> {
-        // Uncompressed blocks are trivially cheap to construct from the mmap
-        // (just an Arc::clone + pointer), so bypass the cache entirely.
-        if peek_uncompressed_length(mmap, meta, block_index) == 0 {
-            return read_block_generic(mmap, meta, block_index);
-        }
-        Ok(
-            match self.get_value_or_guard(&(meta.sequence_number, block_index), None) {
-                GuardResult::Value(block) => block,
-                GuardResult::Guard(guard) => {
-                    let block: ArcBytes = read_block_generic(mmap, meta, block_index)?;
-                    let _ = guard.insert(block.clone());
-                    block
-                }
-                GuardResult::Timeout => unreachable!(),
-            },
-        )
+        get_or_cache_block(mmap, meta, block_index, self)
     }
 }
 
@@ -452,31 +434,12 @@ impl StaticSortedFile {
     }
 
     /// Gets a key block from the cache or reads it from the file.
-    ///
-    /// Uncompressed blocks are served directly from the mmap (zero-copy) without
-    /// consulting the cache, since creating an mmap-backed `ArcBytes` is cheaper
-    /// than a cache lookup.
     fn get_key_block(
         &self,
         block: u16,
         key_block_cache: &BlockCache,
     ) -> Result<ArcBytes, anyhow::Error> {
-        // Uncompressed blocks are trivially cheap to construct from the mmap
-        // (just an Arc::clone + pointer), so bypass the cache entirely.
-        if peek_uncompressed_length(&self.mmap, &self.meta, block) == 0 {
-            return self.read_block(block);
-        }
-        Ok(
-            match key_block_cache.get_value_or_guard(&(self.meta.sequence_number, block), None) {
-                GuardResult::Value(block) => block,
-                GuardResult::Guard(guard) => {
-                    let block = self.read_block(block)?;
-                    let _ = guard.insert(block.clone());
-                    block
-                }
-                GuardResult::Timeout => unreachable!(),
-            },
-        )
+        get_or_cache_block(&self.mmap, &self.meta, block, key_block_cache)
     }
 
     /// Reads a block from the file, decompressing if needed, and verifies its checksum.
@@ -488,18 +451,44 @@ impl StaticSortedFile {
     }
 }
 
-/// Peeks at the `uncompressed_length` header of a block without reading the
-/// rest. Returns `0` when the block is stored uncompressed (mmap-backed),
-/// `>0` when it is LZ4-compressed. Cost: 2–3 mmap word-reads (offset table
-/// entry + header word).
-fn peek_uncompressed_length(mmap: &Mmap, meta: &StaticSortedFileMetaData, block_index: u16) -> u32 {
+/// Returns `true` when the block at `block_index` is stored uncompressed
+/// (mmap-backed), i.e. its `uncompressed_length` header is zero.
+/// Cost: 2–3 mmap word-reads (offset table entry + header word).
+fn is_block_uncompressed(mmap: &Mmap, meta: &StaticSortedFileMetaData, block_index: u16) -> bool {
     let offset = meta.block_offsets_start(mmap.len()) + block_index as usize * 4;
     let block_start = if block_index == 0 {
         0
     } else {
         be::read_u32(&mmap[offset - 4..]) as usize
     };
-    be::read_u32(&mmap[block_start..])
+    be::read_u32(&mmap[block_start..]) == 0
+}
+
+/// Gets a block from the cache, or reads it from the mmap and inserts it.
+///
+/// Uncompressed blocks bypass the cache entirely — creating an mmap-backed
+/// `ArcBytes` is cheaper than a cache hash + lookup, so we peek at the block
+/// header first and short-circuit when the block is uncompressed.
+fn get_or_cache_block(
+    mmap: &Arc<Mmap>,
+    meta: &StaticSortedFileMetaData,
+    block_index: u16,
+    cache: &BlockCache,
+) -> Result<ArcBytes> {
+    if is_block_uncompressed(mmap, meta, block_index) {
+        return read_block_generic(mmap, meta, block_index);
+    }
+    Ok(
+        match cache.get_value_or_guard(&(meta.sequence_number, block_index), None) {
+            GuardResult::Value(block) => block,
+            GuardResult::Guard(guard) => {
+                let block: ArcBytes = read_block_generic(mmap, meta, block_index)?;
+                let _ = guard.insert(block.clone());
+                block
+            }
+            GuardResult::Timeout => unreachable!(),
+        },
+    )
 }
 
 /// Gets the raw block slice directly from a memory-mapped file.

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
@@ -236,10 +236,22 @@ impl StaticSortedFile {
         // There is exactly one index block per file (always the last block).
         // Read it first, then dispatch directly to the key block it points to.
         let index_block_index = self.meta.block_count - 1;
-        let index_block = self.get_key_block(index_block_index, key_block_cache)?;
+        let index_block = get_or_cache_block(
+            &self.mmap,
+            &self.meta,
+            index_block_index,
+            key_block_cache,
+            &self.verified_blocks,
+        )?;
         let key_block_index = self.lookup_index_block(&index_block, key_hash)?;
 
-        let key_block_arc = self.get_key_block(key_block_index, key_block_cache)?;
+        let key_block_arc = get_or_cache_block(
+            &self.mmap,
+            &self.meta,
+            key_block_index,
+            key_block_cache,
+            &self.verified_blocks,
+        )?;
         let reader = ArcBlockCacheReader {
             cache: value_block_cache,
             verified_blocks: &self.verified_blocks,
@@ -443,21 +455,6 @@ impl StaticSortedFile {
     ) -> Result<LookupValue> {
         handle_key_match_generic(&self.mmap, &self.meta, ty, val, key_block_arc, reader)
     }
-
-    /// Gets a key block from the cache or reads it from the file.
-    fn get_key_block(
-        &self,
-        block: u16,
-        key_block_cache: &BlockCache,
-    ) -> Result<ArcBytes, anyhow::Error> {
-        get_or_cache_block(
-            &self.mmap,
-            &self.meta,
-            block,
-            key_block_cache,
-            &self.verified_blocks,
-        )
-    }
 }
 
 /// Gets a block from the cache, or reads it from the mmap and inserts it.
@@ -594,9 +591,12 @@ fn verify_checksum(
     Ok(())
 }
 
-/// Verifies a block's CRC at most once per file open, using the `verified_blocks`
-/// bitmap to skip redundant checks. Racing first-time verifications are harmless
-/// (CRC check is deterministic and idempotent).
+/// Verifies a block's CRC using the `verified_blocks` bitmap to avoid redundant
+/// work. In practice each block is verified once, but concurrent first-time
+/// accesses may race and verify the same block more than once — this is harmless
+/// since the check is deterministic and idempotent. Verification failures are
+/// *not* recorded in the bitmap, so a corrupted block will be re-checked (and
+/// fail again) on every access.
 fn verify_checksum_once(
     meta: &StaticSortedFileMetaData,
     data: &[u8],

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
@@ -88,7 +88,11 @@ impl quick_cache::Weighter<(u32, u16), ArcBytes> for BlockWeighter {
     fn weight(&self, _key: &(u32, u16), val: &ArcBytes) -> u64 {
         if val.is_mmap_backed() {
             // Mmap-backed blocks bypass the cache (served directly from mmap),
-            // so this branch is a safety net only. Assign a negligible weight.
+            // so this branch should never be reached.
+            debug_assert!(
+                !val.is_mmap_backed(),
+                "mmap-backed block should not be inserted into BlockCache"
+            );
             64
         } else {
             val.len() as u64 + 8
@@ -206,7 +210,7 @@ impl StaticSortedFile {
             let _ = mmap.advise_range(memmap2::Advice::Sequential, offset, mmap.len() - offset);
         }
         advise_mmap_for_persistence(&mmap)?;
-        let bitmap_words = (meta.block_count as usize).div_ceil(64);
+        let bitmap_words = (meta.block_count as usize).div_ceil(u64::BITS as usize);
         let verified_blocks = (0..bitmap_words)
             .map(|_| AtomicU64::new(0))
             .collect::<Box<[_]>>();
@@ -481,12 +485,7 @@ fn get_or_cache_block(
 
     if uncompressed_length == 0 {
         // Uncompressed: serve directly from mmap. Verify CRC only once per file open.
-        let word_idx = block_index as usize / 64;
-        let bit = 1u64 << (block_index as usize % 64);
-        if verified_blocks[word_idx].load(AtomicOrdering::Relaxed) & bit == 0 {
-            verify_checksum(meta, block_data, checksum, block_index)?;
-            verified_blocks[word_idx].fetch_or(bit, AtomicOrdering::Relaxed);
-        }
+        verify_checksum_once(meta, block_data, checksum, block_index, verified_blocks)?;
         // SAFETY: block_data points into the mmap backing `mmap`.
         return Ok(unsafe { ArcBytes::from_mmap(mmap, block_data) });
     }
@@ -496,7 +495,9 @@ fn get_or_cache_block(
         match cache.get_value_or_guard(&(meta.sequence_number, block_index), None) {
             GuardResult::Value(block) => block,
             GuardResult::Guard(guard) => {
-                verify_checksum(meta, block_data, checksum, block_index)?;
+                // A cached block may have been evicted, so re-reading still
+                // benefits from the bitmap to skip redundant CRC verification.
+                verify_checksum_once(meta, block_data, checksum, block_index, verified_blocks)?;
                 let block = ArcBytes::from_decompressed(uncompressed_length, block_data)
                     .with_context(|| {
                         format!(
@@ -590,6 +591,26 @@ fn verify_checksum(
             actual
         );
     }
+    Ok(())
+}
+
+/// Verifies a block's CRC at most once per file open, using the `verified_blocks`
+/// bitmap to skip redundant checks. Racing first-time verifications are harmless
+/// (CRC check is deterministic and idempotent).
+fn verify_checksum_once(
+    meta: &StaticSortedFileMetaData,
+    data: &[u8],
+    expected: u32,
+    block_index: u16,
+    verified_blocks: &[AtomicU64],
+) -> Result<()> {
+    let word_idx = block_index as usize / u64::BITS as usize;
+    let bit = 1u64 << (block_index as usize % u64::BITS as usize);
+    if verified_blocks[word_idx].load(AtomicOrdering::Relaxed) & bit != 0 {
+        return Ok(());
+    }
+    verify_checksum(meta, data, expected, block_index)?;
+    verified_blocks[word_idx].fetch_or(bit, AtomicOrdering::Relaxed);
     Ok(())
 }
 

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
@@ -106,6 +106,9 @@ trait ValueBlockCache<B: SharedBytes> {
 }
 
 /// Lookup-path: concurrent `BlockCache`.
+///
+/// Uncompressed blocks bypass the cache entirely — creating an mmap-backed
+/// `ArcBytes` is cheaper than a cache hash + lookup.
 impl ValueBlockCache<ArcBytes> for &BlockCache {
     fn get_or_read(
         self,
@@ -113,6 +116,11 @@ impl ValueBlockCache<ArcBytes> for &BlockCache {
         meta: &StaticSortedFileMetaData,
         block_index: u16,
     ) -> Result<ArcBytes> {
+        // Uncompressed blocks are trivially cheap to construct from the mmap
+        // (just an Arc::clone + pointer), so bypass the cache entirely.
+        if peek_uncompressed_length(mmap, meta, block_index) == 0 {
+            return read_block_generic(mmap, meta, block_index);
+        }
         Ok(
             match self.get_value_or_guard(&(meta.sequence_number, block_index), None) {
                 GuardResult::Value(block) => block,
@@ -444,11 +452,20 @@ impl StaticSortedFile {
     }
 
     /// Gets a key block from the cache or reads it from the file.
+    ///
+    /// Uncompressed blocks are served directly from the mmap (zero-copy) without
+    /// consulting the cache, since creating an mmap-backed `ArcBytes` is cheaper
+    /// than a cache lookup.
     fn get_key_block(
         &self,
         block: u16,
         key_block_cache: &BlockCache,
     ) -> Result<ArcBytes, anyhow::Error> {
+        // Uncompressed blocks are trivially cheap to construct from the mmap
+        // (just an Arc::clone + pointer), so bypass the cache entirely.
+        if peek_uncompressed_length(&self.mmap, &self.meta, block) == 0 {
+            return self.read_block(block);
+        }
         Ok(
             match key_block_cache.get_value_or_guard(&(self.meta.sequence_number, block), None) {
                 GuardResult::Value(block) => block,
@@ -469,6 +486,20 @@ impl StaticSortedFile {
     fn read_block(&self, block_index: u16) -> Result<ArcBytes> {
         read_block_generic(&self.mmap, &self.meta, block_index)
     }
+}
+
+/// Peeks at the `uncompressed_length` header of a block without reading the
+/// rest. Returns `0` when the block is stored uncompressed (mmap-backed),
+/// `>0` when it is LZ4-compressed. Cost: 2–3 mmap word-reads (offset table
+/// entry + header word).
+fn peek_uncompressed_length(mmap: &Mmap, meta: &StaticSortedFileMetaData, block_index: u16) -> u32 {
+    let offset = meta.block_offsets_start(mmap.len()) + block_index as usize * 4;
+    let block_start = if block_index == 0 {
+        0
+    } else {
+        be::read_u32(&mmap[offset - 4..]) as usize
+    };
+    be::read_u32(&mmap[block_start..])
 }
 
 /// Gets the raw block slice directly from a memory-mapped file.

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
@@ -441,14 +441,6 @@ impl StaticSortedFile {
     ) -> Result<ArcBytes, anyhow::Error> {
         get_or_cache_block(&self.mmap, &self.meta, block, key_block_cache)
     }
-
-    /// Reads a block from the file, decompressing if needed, and verifies its checksum.
-    ///
-    /// The checksum is verified on the raw on-disk data **before** decompression, so
-    /// corruption is caught before passing data to LZ4.
-    fn read_block(&self, block_index: u16) -> Result<ArcBytes> {
-        read_block_generic(&self.mmap, &self.meta, block_index)
-    }
 }
 
 /// Returns `true` when the block at `block_index` is stored uncompressed


### PR DESCRIPTION
### What?

Skip the `BlockCache` entirely for uncompressed (mmap-backed) SST blocks, and add a per-file CRC verification bitmap so checksums are verified at most once per file open for any block.

### Why?

Uncompressed blocks produce an `ArcBytes` with `Backing::Mmap` — just an `Arc::clone` of the mmap handle plus a pointer into it. No heap allocation, no decompression. The cost of constructing one (an atomic refcount increment + pointer copy) is far less than a `BlockCache` hash + concurrent-map lookup + potential insertion.

Bypassing the cache for these blocks:
- Reduces lock contention on the shared `BlockCache`
- Avoids polluting the cache with entries that are essentially free to recreate
- Eliminates redundant mmap reads (the old code peeked at the header, then re-read it inside `read_block_generic`)

Key blocks (index block + all key blocks) tend to be small and are frequently accessed. In practice, small key blocks are often stored uncompressed, so this optimization applies on the hot path.

### How?

**Single mmap read per block access.** `get_or_cache_block` calls `get_raw_block_slice` exactly once to read the block header (with all `#[cfg(feature = "strict_checks")]` bounds guards), then branches on `uncompressed_length`:
- `== 0` (uncompressed): verify CRC via bitmap, return mmap-backed `ArcBytes` directly
- `> 0` (compressed): check `BlockCache`; on miss, verify CRC via bitmap, decompress, insert

**CRC verification bitmap.** `StaticSortedFile` now holds a `Box<[AtomicU64]>` with one bit per block, set once the block's CRC has been verified. This prevents re-computing the checksum on every access for uncompressed blocks (which bypass the cache) and for compressed blocks that were evicted and re-read. `Relaxed` ordering suffices since racing first-time verifications are idempotent.

**`ArcBlockCacheReader` wrapper.** A `Copy` struct bundling `&BlockCache` + `&[AtomicU64]` that implements `ValueBlockCache<ArcBytes>`, threading the bitmap through the existing generic lookup machinery without changing the trait signature.

**`BlockWeighter` safety net.** The mmap-backed branch now has a `debug_assert!(!val.is_mmap_backed())` to catch accidental insertion, with a negligible weight (64) as a defensive fallback in release builds.

<!-- NEXT_JS_LLM_PR -->