### PR TITLE
docs: clarify instance-local revalidation behavior in multi-instance …

### DIFF
--- a/docs/01-app/02-guides/how-revalidation-works.mdx
+++ b/docs/01-app/02-guides/how-revalidation-works.mdx
@@ -54,6 +54,12 @@ In the [cache handler API](/docs/app/api-reference/config/next-config-js/cacheHa
 
 ## Multi-Instance Considerations
 
+> ⚠️ **Important:** In multi-instance or serverless environments (such as deployments on Vercel), revalidation is instance-local by default.
+>
+> Calling `revalidateTag()` or `revalidatePath()` only invalidates the cache on the instance handling the request. Other instances may continue serving stale content until they receive the invalidation event through a shared cache or coordination mechanism.
+>
+> To ensure consistent revalidation across instances, you should configure a shared cache handler (for example, using Redis or another external store).
+
 When running multiple Next.js instances behind a load balancer, revalidation events are local by default. Calling `revalidateTag()` on instance A only invalidates the cache on that instance. Other instances continue serving the stale content until they learn about the invalidation.
 
 The cache handler API provides two hooks for distributed coordination:

--- a/docs/01-app/02-guides/how-revalidation-works.mdx
+++ b/docs/01-app/02-guides/how-revalidation-works.mdx
@@ -54,11 +54,7 @@ In the [cache handler API](/docs/app/api-reference/config/next-config-js/cacheHa
 
 ## Multi-Instance Considerations
 
-> ⚠️ **Important:** In multi-instance or serverless environments (such as deployments on Vercel), revalidation is instance-local by default.
->
-> Calling `revalidateTag()` or `revalidatePath()` only invalidates the cache on the instance handling the request. Other instances may continue serving stale content until they receive the invalidation event through a shared cache or coordination mechanism.
->
-> To ensure consistent revalidation across instances, you should configure a shared cache handler (for example, using Redis or another external store).
+> **Note:** Revalidation is instance-local by default.
 
 When running multiple Next.js instances behind a load balancer, revalidation events are local by default. Calling `revalidateTag()` on instance A only invalidates the cache on that instance. Other instances continue serving the stale content until they learn about the invalidation.
 


### PR DESCRIPTION
### What?

Adds a clear warning in the "Multi-Instance Considerations" section to highlight that revalidation is instance-local by default in multi-instance or serverless environments.

### Why?

While the behavior is already explained later in the section, it is not immediately obvious to most users—especially those deploying on serverless platforms like Vercel.

This can lead to confusion, as developers may assume that `revalidateTag()` or `revalidatePath()` invalidates cache globally across all instances, when in reality it only affects the instance handling the request.

### How?

- Added a short ⚠️ Important note at the beginning of the section
- Did not modify existing content or behavior explanations
- Improves visibility of a critical limitation without changing meaning

Fixes #92402