### PR TITLE
fix: ensure test files are ignored when type checking

### DIFF
--- a/packages/next/src/lib/typescript/runTypeCheck.ts
+++ b/packages/next/src/lib/typescript/runTypeCheck.ts
@@ -106,6 +106,18 @@ export async function runTypeCheck(
     })
   }
 
+  const ignoreRegex = [
+    // matches **/__(tests|mocks)__/**
+    /[\\/]__(?:tests|mocks)__[\\/]/,
+    // matches **/*.(spec|test).*
+    /(?<=[\\/.])(?:spec|test)\.[^\\/]+$/,
+  ]
+  const regexIgnoredFile = new RegExp(
+    ignoreRegex.map((r) => r.source).join('|')
+  )
+
+  fileNames = fileNames.filter((fileName) => !regexIgnoredFile.test(fileName))
+
   if (fileNames.length < 1) {
     return {
       hasWarnings: false,
@@ -150,20 +162,9 @@ export async function runTypeCheck(
 
   const result = program.emit()
 
-  const ignoreRegex = [
-    // matches **/__(tests|mocks)__/**
-    /[\\/]__(?:tests|mocks)__[\\/]/,
-    // matches **/*.(spec|test).*
-    /(?<=[\\/.])(?:spec|test)\.[^\\/]+$/,
-  ]
-  const regexIgnoredFile = new RegExp(
-    ignoreRegex.map((r) => r.source).join('|')
-  )
-
   const allDiagnostics = typescript
     .getPreEmitDiagnostics(program as import('typescript').Program)
     .concat(result.diagnostics)
-    .filter((d) => !(d.file && regexIgnoredFile.test(d.file.fileName)))
 
   const firstError =
     allDiagnostics.find(


### PR DESCRIPTION
Fixes #92408
Move test file exclusion filter to run before the TypeScript program is created, rather than filtering diagnostics after the emit.

Previously, test and mock files (__tests__, __mocks__, *.spec.*, *.test.*) were still compiled as part of the program — their errors were just suppressed. Now they are excluded from rootNames upfront, so they are never type-checked at all.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
