### PR TITLE
Add manual compile mode to pause Turbopack scheduling during batched edits

### DIFF
--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -2134,6 +2134,31 @@ pub fn project_update_info_subscribe(
     Ok(())
 }
 
+/// Pause compilation. Task scheduling is deferred — file changes still mark
+/// tasks dirty, but no recomputation happens until `project_compile_and_resume`
+/// is called.
+#[napi]
+pub fn project_pause_compilation(
+    #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: External<ProjectInstance>,
+) -> napi::Result<()> {
+    project.turbopack_ctx.turbo_tasks().pause_compilation();
+    Ok(())
+}
+
+/// Compile all deferred tasks in one batch, wait for the compilation cycle to
+/// finish, then resume normal scheduling.
+#[napi]
+pub async fn project_compile_and_resume(
+    #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: External<ProjectInstance>,
+) -> napi::Result<()> {
+    project
+        .turbopack_ctx
+        .turbo_tasks()
+        .compile_and_resume()
+        .await;
+    Ok(())
+}
+
 /// Subscribes to all compilation events that are not cached like timing and progress information.
 #[napi]
 pub fn project_compilation_events_subscribe(

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -345,6 +345,21 @@ export declare function projectInvalidateFileSystemCache(project: {
   __napiType: 'Project'
 }): Promise<void>
 /**
+ * Pause compilation. Task scheduling is deferred — file changes still mark
+ * tasks dirty, but no recomputation happens until `projectCompileAndResume`
+ * is called.
+ */
+export declare function projectPauseCompilation(project: {
+  __napiType: 'Project'
+}): void
+/**
+ * Compile all deferred tasks in one batch, wait for the compilation cycle to
+ * finish, then resume normal scheduling.
+ */
+export declare function projectCompileAndResume(project: {
+  __napiType: 'Project'
+}): Promise<void>
+/**
  * Runs exit handlers for the project registered using the [`ExitHandler`] API.
  *
  * This is called by `project_shutdown`, so if you're calling that API, you shouldn't call this

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -843,6 +843,14 @@ function bindingToApi(
       return binding.projectInvalidateFileSystemCache(this._nativeProject)
     }
 
+    pauseCompilation(): void {
+      binding.projectPauseCompilation(this._nativeProject)
+    }
+
+    compileAndResume(): Promise<void> {
+      return binding.projectCompileAndResume(this._nativeProject)
+    }
+
     shutdown(): Promise<void> {
       return binding.projectShutdown(this._nativeProject)
     }

--- a/packages/next/src/build/swc/types.ts
+++ b/packages/next/src/build/swc/types.ts
@@ -333,6 +333,10 @@ export interface Project {
 
   invalidateFileSystemCache(): Promise<void>
 
+  pauseCompilation(): void
+
+  compileAndResume(): Promise<void>
+
   shutdown(): Promise<void>
 
   onExit(): Promise<void>

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -1050,6 +1050,12 @@ export async function createHotReloaderTurbopack(
               clientsWithoutHtmlRequestId.size + clientsByHtmlRequestId.size,
             getDevServerUrl: () => process.env.__NEXT_PRIVATE_ORIGIN,
             getTurbopackProject: () => project,
+            pauseCompilation: () => {
+              project.pauseCompilation()
+            },
+            compileAndResume: async () => {
+              await project.compileAndResume()
+            },
           }),
         ]
       : []),

--- a/packages/next/src/server/dev/hot-reloader-webpack.ts
+++ b/packages/next/src/server/dev/hot-reloader-webpack.ts
@@ -1699,6 +1699,8 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
               getActiveConnectionCount: () =>
                 this.webpackHotMiddleware?.getClientCount() ?? 0,
               getDevServerUrl: () => process.env.__NEXT_PRIVATE_ORIGIN,
+              pauseCompilation: () => {},
+              compileAndResume: async () => {},
             }),
           ]
         : [])

--- a/packages/next/src/server/mcp/get-or-create-mcp-server.ts
+++ b/packages/next/src/server/mcp/get-or-create-mcp-server.ts
@@ -6,6 +6,10 @@ import { registerGetLogsTool } from './tools/get-logs'
 import { registerGetActionByIdTool } from './tools/get-server-action-by-id'
 import { registerGetRoutesTool } from './tools/get-routes'
 import { registerGetCompilationIssuesTool } from './tools/get-compilation-issues'
+import {
+  registerPauseCompilationTool,
+  registerCompileAndResumeTool,
+} from './tools/manual-compile'
 import type { HmrMessageSentToBrowser } from '../dev/hot-reloader-types'
 import type { NextConfigComplete } from '../config-shared'
 import type { Project } from '../../build/swc/types'
@@ -20,6 +24,8 @@ export interface McpServerOptions {
   getActiveConnectionCount: () => number
   getDevServerUrl: () => string | undefined
   getTurbopackProject?: () => Project | undefined
+  pauseCompilation: () => void
+  compileAndResume: () => Promise<void>
 }
 
 let mcpServer: McpServer | undefined
@@ -61,6 +67,9 @@ export const getOrCreateMcpServer = (options: McpServerOptions) => {
   if (options.getTurbopackProject) {
     registerGetCompilationIssuesTool(mcpServer, options.getTurbopackProject)
   }
+
+  registerPauseCompilationTool(mcpServer, options.pauseCompilation)
+  registerCompileAndResumeTool(mcpServer, options.compileAndResume)
 
   return mcpServer
 }

--- a/packages/next/src/server/mcp/tools/manual-compile.ts
+++ b/packages/next/src/server/mcp/tools/manual-compile.ts
@@ -1,0 +1,54 @@
+import type { McpServer } from 'next/dist/compiled/@modelcontextprotocol/sdk/server/mcp'
+import { mcpTelemetryTracker } from '../mcp-telemetry-tracker'
+
+export function registerPauseCompilationTool(
+  server: McpServer,
+  pauseCompilation: () => void
+) {
+  server.registerTool(
+    'pause_compilation',
+    {
+      description:
+        'Pause compilation. File watching continues, but compilation is deferred until compile_and_resume is called. Use this at the start of an editing session to prevent wasted intermediate compilations and ephemeral errors.',
+      inputSchema: {},
+    },
+    async () => {
+      mcpTelemetryTracker.recordToolCall('mcp/pause_compilation')
+      pauseCompilation()
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({ status: 'compilation_paused' }),
+          },
+        ],
+      }
+    }
+  )
+}
+
+export function registerCompileAndResumeTool(
+  server: McpServer,
+  compileAndResume: () => Promise<void>
+) {
+  server.registerTool(
+    'compile_and_resume',
+    {
+      description:
+        'Compile all accumulated file changes in a single batch, then resume normal compilation. Waits for compilation to complete before returning. No-op if compilation is not paused.',
+      inputSchema: {},
+    },
+    async () => {
+      mcpTelemetryTracker.recordToolCall('mcp/compile_and_resume')
+      await compileAndResume()
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({ status: 'compiled_and_resumed' }),
+          },
+        ],
+      }
+    }
+  )
+}

--- a/packages/next/src/telemetry/events/build.ts
+++ b/packages/next/src/telemetry/events/build.ts
@@ -260,6 +260,8 @@ export type McpToolName =
   | 'mcp/get_routes'
   | 'mcp/get_server_action_by_id'
   | 'mcp/get_compilation_issues'
+  | 'mcp/pause_compilation'
+  | 'mcp/compile_and_resume'
 
 export type EventMcpToolUsage = {
   toolName: McpToolName

--- a/test/development/mcp-server/fixtures/manual-compile-app/app/layout.tsx
+++ b/test/development/mcp-server/fixtures/manual-compile-app/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/mcp-server/fixtures/manual-compile-app/app/page.tsx
+++ b/test/development/mcp-server/fixtures/manual-compile-app/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>Hello from Manual Compile Test</h1>
+}

--- a/test/development/mcp-server/fixtures/manual-compile-app/next.config.js
+++ b/test/development/mcp-server/fixtures/manual-compile-app/next.config.js
@@ -1,0 +1,1 @@
+module.exports = {}

--- a/test/development/mcp-server/mcp-server-manual-compile.test.ts
+++ b/test/development/mcp-server/mcp-server-manual-compile.test.ts
@@ -1,0 +1,137 @@
+import { FileRef, nextTestSetup } from 'e2e-utils'
+import path from 'path'
+import { retry, waitFor, waitForNoRedbox } from 'next-test-utils'
+
+// pause_compilation/compile_and_resume require Turbopack — they are
+// no-ops in the webpack hot reloader.
+;(process.env.IS_WEBPACK_TEST ? describe.skip : describe)(
+  'mcp-server manual compile tools',
+  () => {
+    const { next, skipped } = nextTestSetup({
+      files: new FileRef(
+        path.join(__dirname, 'fixtures', 'manual-compile-app')
+      ),
+      skipDeployment: true,
+    })
+
+    if (skipped) {
+      return
+    }
+
+    async function callMcpTool(
+      name: string,
+      args: Record<string, unknown> = {}
+    ) {
+      const response = await fetch(`${next.url}/_next/mcp`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json, text/event-stream',
+        },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: `${name}-${Date.now()}`,
+          method: 'tools/call',
+          params: { name, arguments: args },
+        }),
+      })
+
+      const text = await response.text()
+      const match = text.match(/data: ({.*})/s)
+      expect(match).toBeTruthy()
+      const result = JSON.parse(match![1])
+      return JSON.parse(result.result?.content?.[0]?.text)
+    }
+
+    it('should batch edits without leaking errors and flush with a compilation', async () => {
+      const browser = await next.browser('/')
+      expect(await browser.elementByCss('h1').text()).toBe(
+        'Hello from Manual Compile Test'
+      )
+
+      // Pause compilation
+      const pauseResult = await callMcpTool('pause_compilation')
+      expect(pauseResult.status).toBe('compilation_paused')
+
+      // 1. Make an edit that would cause a compilation error:
+      //    import from a module that doesn't exist yet
+      await next.patchFile(
+        'app/page.tsx',
+        `import { greeting } from './utils'
+export default function Page() {
+  return <h1>{greeting}</h1>
+}`
+      )
+
+      // Wait long enough for a normal HMR cycle to have completed
+      await waitFor(3000)
+
+      // Browser should still show old content, no error overlay
+      expect(await browser.elementByCss('h1').text()).toBe(
+        'Hello from Manual Compile Test'
+      )
+      await waitForNoRedbox(browser, { waitInMs: 0 })
+
+      // 2. Fix the error by creating the missing module,
+      //    and update the page to its final state
+      await next.patchFile(
+        'app/utils.ts',
+        `export const greeting = 'Manual Compile Works'`
+      )
+
+      // Wait again — browser should still show old content
+      await waitFor(3000)
+      expect(await browser.elementByCss('h1').text()).toBe(
+        'Hello from Manual Compile Test'
+      )
+      await waitForNoRedbox(browser, { waitInMs: 0 })
+
+      // Record the CLI output length before flushing so we can check
+      // that compilation activity appears after compile_and_resume
+      const outputLengthBeforeFlush = next.cliOutput.length
+
+      // 3. Flush: compile_and_resume triggers one compilation from the
+      //    final file state and waits for it to finish
+      const resumeResult = await callMcpTool('compile_and_resume')
+      expect(resumeResult.status).toBe('compiled_and_resumed')
+
+      // Browser should update to the final state
+      await retry(async () => {
+        expect(await browser.elementByCss('h1').text()).toBe(
+          'Manual Compile Works'
+        )
+      })
+
+      // No error overlay after flush
+      await waitForNoRedbox(browser, { waitInMs: 0 })
+
+      // The flush must have triggered a compilation — verify that the
+      // server handled requests for the updated page
+      await retry(async () => {
+        const outputAfterFlush = next.cliOutput.substring(
+          outputLengthBeforeFlush
+        )
+        expect(outputAfterFlush).toContain('GET / 200')
+      })
+
+      // 4. Normal HMR resumes — edits apply without manual mode
+      await next.patchFile(
+        'app/page.tsx',
+        `export default function Page() {
+  return <h1>Hello from Manual Compile Test</h1>
+}`
+      )
+      await next.deleteFile('app/utils.ts')
+      await retry(async () => {
+        expect(await browser.elementByCss('h1').text()).toBe(
+          'Hello from Manual Compile Test'
+        )
+      })
+    })
+
+    it('should handle compile_and_resume without paused compilation as a no-op', async () => {
+      const result = await callMcpTool('compile_and_resume')
+      expect(result.status).toBe('compiled_and_resumed')
+    })
+  }
+)

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -498,6 +498,11 @@ pub struct TurboTasks<B: Backend + 'static> {
     event_background_done: Event,
     program_start: Instant,
     compilation_events: CompilationEventQueue,
+    /// When true, `schedule()` buffers tasks instead of executing them.
+    /// Calling `compile_and_resume()` drains the buffer and runs one
+    /// compilation cycle from the final file-system state.
+    compilation_paused: AtomicBool,
+    compilation_deferred: Mutex<Vec<(TaskId, TaskPriority)>>,
 }
 
 type LocalTaskTracker = Option<
@@ -664,6 +669,8 @@ impl<B: Backend + 'static> TurboTasks<B> {
             }),
             program_start: Instant::now(),
             compilation_events: CompilationEventQueue::default(),
+            compilation_paused: AtomicBool::new(false),
+            compilation_deferred: Mutex::new(Vec::new()),
         });
         this.backend.startup(&*this);
         this
@@ -863,6 +870,14 @@ impl<B: Backend + 'static> TurboTasks<B> {
 
     #[track_caller]
     pub(crate) fn schedule(&self, task_id: TaskId, priority: TaskPriority) {
+        if self.compilation_paused.load(Ordering::Acquire) {
+            self.compilation_deferred
+                .lock()
+                .unwrap()
+                .push((task_id, priority));
+            return;
+        }
+
         self.begin_foreground_job();
         self.scheduled_tasks.fetch_add(1, Ordering::AcqRel);
 
@@ -1099,6 +1114,53 @@ impl<B: Backend + 'static> TurboTasks<B> {
         {
             listener.await;
         }
+    }
+
+    /// Pause compilation. Task scheduling is deferred — file changes still
+    /// mark tasks dirty, but no recomputation happens until
+    /// [`Self::compile_and_resume`] is called.
+    pub fn pause_compilation(&self) {
+        self.compilation_paused.store(true, Ordering::Release);
+    }
+
+    /// Compile all deferred tasks in one batch, wait for the compilation
+    /// cycle to finish, then resume normal scheduling.
+    pub async fn compile_and_resume(&self) {
+        if !self.compilation_paused.swap(false, Ordering::AcqRel) {
+            return;
+        }
+
+        let deferred: Vec<(TaskId, TaskPriority)> = {
+            let mut buf = self.compilation_deferred.lock().unwrap();
+            take(&mut *buf)
+        };
+
+        if deferred.is_empty() {
+            return;
+        }
+
+        // Listen for the foreground-done event before scheduling, so we
+        // don't miss the signal if tasks complete very quickly.
+        let listener = self
+            .event_foreground_done
+            .listen_with_note(|| || "compile_and_resume".to_string());
+
+        // Schedule all deferred tasks
+        for (task_id, priority) in deferred {
+            self.begin_foreground_job();
+            self.scheduled_tasks.fetch_add(1, Ordering::AcqRel);
+            self.priority_runner.schedule(
+                &self.pin(),
+                ScheduledTask::Task {
+                    task_id,
+                    span: Span::current(),
+                },
+                priority,
+            );
+        }
+
+        // Wait for the compilation cycle to finish
+        listener.await;
     }
 
     pub async fn stop_and_wait(&self) {


### PR DESCRIPTION
When an AI agent edits multiple files in sequence, Turbopack eagerly recompiles after each save. This produces ephemeral compilation errors (e.g. importing a module that hasn't been created yet) and wastes CPU on intermediate states that are immediately invalidated.

This adds two new MCP tools: `pause_compilation` and `compile_and_resume`. Calling `pause_compilation` pauses the turbo-tasks scheduler — file changes still mark tasks dirty via the file watcher, but `schedule()` buffers task IDs instead of dispatching them to the priority runner. No compilation happens, no errors are produced, and no HMR messages reach the browser.

Calling `compile_and_resume` clears the pause flag, drains all buffered tasks into the scheduler, and waits for `event_foreground_done` before returning. This produces exactly one compilation cycle from the final file-system state. The existing HMR pipeline then sends one clean update to the browser with the correct issues and module state. Zero JS-side guards are needed because no intermediate compilation ever occurs.

The pause is implemented as an `AtomicBool` and a `Mutex<Vec<(TaskId, TaskPriority)>>` on the `TurboTasks` struct. The gate in `schedule()` is the only code path that changes behavior — everything else (subscriptions, `handleProjectUpdates`, `sendEnqueuedMessages`, `sendToClient`) runs unmodified.

<!-- NEXT_JS_LLM_PR -->