### PR TITLE
change the process name of builds

### DIFF
--- a/packages/next/src/cli/next-build.ts
+++ b/packages/next/src/cli/next-build.ts
@@ -36,6 +36,7 @@ export type NextBuildOptions = {
 }
 
 const nextBuild = async (options: NextBuildOptions, directory?: string) => {
+  process.title = `next-build (v${process.env.__NEXT_VERSION})`
   process.on('SIGTERM', () => {
     saveCpuProfile()
     process.exit(143)


### PR DESCRIPTION
When `next dev` is running we change the process name, we should do the same thing for builds.

This is a small performance hit on MacOs, about 10ms, (See node issue: https://github.com/nodejs/node/issues/59678), but not on other platforms.  `process.title` is also apparently not implemented on `Bun` or `Deno` 🤦 

