### PR TITLE
[turbopack] add family name to many spans

### DIFF
--- a/turbopack/crates/turbo-persistence/benches/mod.rs
+++ b/turbopack/crates/turbo-persistence/benches/mod.rs
@@ -576,6 +576,7 @@ fn prefill_multi_value_database(
 ) -> Result<Vec<Box<[u8]>>> {
     let db_config = TpDbConfig {
         family_configs: [FamilyConfig {
+            name: "test",
             kind: FamilyKind::MultiValue,
         }],
     };
@@ -648,6 +649,7 @@ fn setup_prefilled_multi_value_db(
 fn open_multi_value_db(path: &Path) -> TurboPersistence<SerialScheduler, 1> {
     let db_config = TpDbConfig {
         family_configs: [FamilyConfig {
+            name: "test",
             kind: FamilyKind::MultiValue,
         }],
     };
@@ -914,6 +916,7 @@ fn bench_write_multi_value(c: &mut Criterion) {
                     |(tempdir, keys, random_data)| {
                         let db_config = TpDbConfig {
                             family_configs: [FamilyConfig {
+                                name: "test",
                                 kind: FamilyKind::MultiValue,
                             }],
                         };

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -1072,7 +1072,10 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                         .collect::<Vec<_>>();
 
                     // Merge SST files
-                    let span = tracing::trace_span!("merge files");
+                    let span = tracing::trace_span!(
+                        "merge files",
+                        family = self.config.family_configs[family as usize].name
+                    );
                     enum PartialMergeResult<'l> {
                         Merged {
                             new_sst_files: Vec<(u32, File, StaticSortedFileBuilderMeta<'static>)>,
@@ -1445,7 +1448,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
         }
         let span = tracing::trace_span!(
             "database read",
-            name = family,
+            name = self.config.family_configs[family].name,
             result_size = tracing::field::Empty
         )
         .entered();
@@ -1475,7 +1478,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
         }
         let span = tracing::trace_span!(
             "database read multiple",
-            name = family,
+            name = self.config.family_configs[family].name,
             result_count = tracing::field::Empty,
             result_size = tracing::field::Empty
         )
@@ -1612,7 +1615,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
         }
         let span = tracing::trace_span!(
             "database batch read",
-            name = family,
+            name = self.config.family_configs[family].name,
             keys = keys.len(),
             not_found = tracing::field::Empty,
             deleted = tracing::field::Empty,

--- a/turbopack/crates/turbo-persistence/src/lib.rs
+++ b/turbopack/crates/turbo-persistence/src/lib.rs
@@ -49,6 +49,7 @@ pub enum FamilyKind {
 /// Configuration for a single family to describe how the data is stored.
 #[derive(Clone, Copy, Debug)]
 pub struct FamilyConfig {
+    pub name: &'static str,
     pub kind: FamilyKind,
 }
 
@@ -65,6 +66,7 @@ impl<const FAMILIES: usize> Default for DbConfig<FAMILIES> {
     fn default() -> Self {
         Self {
             family_configs: [FamilyConfig {
+                name: "unknown",
                 kind: FamilyKind::SingleValue,
             }; FAMILIES],
         }

--- a/turbopack/crates/turbo-persistence/src/tests.rs
+++ b/turbopack/crates/turbo-persistence/src/tests.rs
@@ -1521,6 +1521,7 @@ fn compaction_multi_value_preserves_different_values() -> Result<()> {
 fn multi_value_config() -> DbConfig<1> {
     let mut config = DbConfig::<1>::default();
     config.family_configs[0] = FamilyConfig {
+        name: "test",
         kind: FamilyKind::MultiValue,
     };
     config
@@ -2097,6 +2098,7 @@ fn compaction_deletes_blob_multi_value_tombstone() -> Result<()> {
 
     let config = DbConfig {
         family_configs: [FamilyConfig {
+            name: "test",
             kind: FamilyKind::MultiValue,
         }],
     };

--- a/turbopack/crates/turbo-persistence/src/write_batch.rs
+++ b/turbopack/crates/turbo-persistence/src/write_batch.rs
@@ -141,7 +141,7 @@ impl<K: StoreKey + Send + Sync, S: ParallelScheduler, const FAMILIES: usize>
         Ok(collector)
     }
 
-    #[tracing::instrument(level = "trace", skip(self, collector))]
+    #[tracing::instrument(level = "trace", skip(self, collector), fields(family_name = self.family_configs[usize_from_u32(family)].name))]
     fn flush_thread_local_collector(
         &self,
         family: u32,
@@ -243,7 +243,7 @@ impl<K: StoreKey + Send + Sync, S: ParallelScheduler, const FAMILIES: usize>
     ///
     /// Caller must ensure that no concurrent put or delete operation is happening on the flushed
     /// family.
-    #[tracing::instrument(level = "trace", skip(self))]
+    #[tracing::instrument(level = "trace", skip(self), fields(family_name = self.family_configs[usize_from_u32(family)].name))]
     pub unsafe fn flush(&self, family: u32) -> Result<()> {
         // Flush the thread local collectors to the global collector.
         let mut collectors = Vec::new();
@@ -452,7 +452,7 @@ impl<K: StoreKey + Send + Sync, S: ParallelScheduler, const FAMILIES: usize>
 
     /// Creates a new SST file with the given collector data.
     /// Returns a tuple of (sequence number, file).
-    #[tracing::instrument(level = "trace", skip(self, collector_data))]
+    #[tracing::instrument(level = "trace", skip(self, collector_data), fields(family_name = self.family_configs[usize_from_u32(family)].name))]
     fn create_sst_file(
         &self,
         family: u32,

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1912,7 +1912,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
             let once_task = matches!(task_type, TaskType::Transient(ref tt) if matches!(&**tt, TransientTask::Once(_)));
             if let Some(tasks) = task.prefetch() {
                 drop(task);
-                ctx.prepare_tasks(tasks);
+                ctx.prepare_tasks(tasks, "prefetch");
                 task = ctx.task(task_id, TaskDataCategory::All);
             }
             let in_progress = task.take_in_progress()?;
@@ -2399,6 +2399,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                 output_dependent_tasks
                     .iter()
                     .map(|&id| (id, TaskDataCategory::All)),
+                "invalidate output dependents",
             );
         }
 
@@ -2491,20 +2492,24 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         debug_assert!(!new_children.is_empty());
 
         let mut queue = AggregationUpdateQueue::new();
-        ctx.for_each_task_all(new_children.iter().copied(), |child_task, ctx| {
-            if !child_task.has_output() {
-                let child_id = child_task.id();
-                make_task_dirty_internal(
-                    child_task,
-                    child_id,
-                    false,
-                    #[cfg(feature = "trace_task_dirty")]
-                    TaskDirtyCause::InitialDirty,
-                    &mut queue,
-                    ctx,
-                );
-            }
-        });
+        ctx.for_each_task_all(
+            new_children.iter().copied(),
+            "unfinished children dirty",
+            |child_task, ctx| {
+                if !child_task.has_output() {
+                    let child_id = child_task.id();
+                    make_task_dirty_internal(
+                        child_task,
+                        child_id,
+                        false,
+                        #[cfg(feature = "trace_task_dirty")]
+                        TaskDirtyCause::InitialDirty,
+                        &mut queue,
+                        ctx,
+                    );
+                }
+            },
+        );
 
         queue.execute(ctx);
     }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
@@ -1256,10 +1256,14 @@ impl AggregationUpdateQueue {
             self.find_and_schedule_dirty(jobs, ctx);
             false
         } else if !self.scheduled_tasks.is_empty() {
-            ctx.for_each_task_all(self.scheduled_tasks.keys().copied(), |task, ctx| {
-                let parent_priority = self.scheduled_tasks[&task.id()];
-                ctx.schedule_task(task, parent_priority);
-            });
+            ctx.for_each_task_all(
+                self.scheduled_tasks.keys().copied(),
+                "schedule tasks",
+                |task, ctx| {
+                    let parent_priority = self.scheduled_tasks[&task.id()];
+                    ctx.schedule_task(task, parent_priority);
+                },
+            );
             self.scheduled_tasks.clear();
             false
         } else {
@@ -1444,18 +1448,22 @@ impl AggregationUpdateQueue {
             .map(|job| (job.task_id, job.span.clone()))
             .collect();
         // For performance reasons this should stay `Meta` and not `All`
-        ctx.for_each_task_meta(jobs.into_iter().map(|job| job.task_id), |task, ctx| {
-            let task_id = task.id();
-            // Enter the enqueue-time span and create a per-task child span with the
-            // task description. Both guards must live until the end of the closure.
-            #[cfg(feature = "trace_find_and_schedule")]
-            let _trace = (
-                spans.remove(&task_id).flatten().map(|s| s.entered()),
-                trace_span!("find and schedule", %task_id, name = task.get_task_description())
-                    .entered(),
-            );
-            self.find_and_schedule_dirty_internal(task_id, task, ctx);
-        });
+        ctx.for_each_task_meta(
+            jobs.into_iter().map(|job| job.task_id),
+            "find and schedule dirty",
+            |task, ctx| {
+                let task_id = task.id();
+                // Enter the enqueue-time span and create a per-task child span with the
+                // task description. Both guards must live until the end of the closure.
+                #[cfg(feature = "trace_find_and_schedule")]
+                let _trace = (
+                    spans.remove(&task_id).flatten().map(|s| s.entered()),
+                    trace_span!("find and schedule", %task_id, name = task.get_task_description())
+                        .entered(),
+                );
+                self.find_and_schedule_dirty_internal(task_id, task, ctx);
+            },
+        );
     }
 
     fn find_and_schedule_dirty_internal(
@@ -1507,21 +1515,25 @@ impl AggregationUpdateQueue {
         update: AggregatedDataUpdate,
     ) {
         // For performance reasons this should stay `Meta` and not `All`
-        ctx.for_each_task_meta(upper_ids.iter().copied(), |mut upper, ctx| {
-            let diff = update.apply(&mut upper, ctx.should_track_activeness(), self);
-            if !diff.is_empty() {
-                let upper_ids = get_uppers(&upper);
-                if !upper_ids.is_empty() {
-                    self.push(
-                        AggregatedDataUpdateJob {
-                            upper_ids,
-                            update: diff,
-                        }
-                        .into(),
-                    );
+        ctx.for_each_task_meta(
+            upper_ids.iter().copied(),
+            "aggregated data update",
+            |mut upper, ctx| {
+                let diff = update.apply(&mut upper, ctx.should_track_activeness(), self);
+                if !diff.is_empty() {
+                    let upper_ids = get_uppers(&upper);
+                    if !upper_ids.is_empty() {
+                        self.push(
+                            AggregatedDataUpdateJob {
+                                upper_ids,
+                                update: diff,
+                            }
+                            .into(),
+                        );
+                    }
                 }
-            }
-        });
+            },
+        );
     }
 
     fn inner_of_uppers_lost_follower(
@@ -1574,20 +1586,24 @@ impl AggregationUpdateQueue {
                 if !data.is_empty() {
                     // remove data from upper
                     // For performance reasons this should stay `Meta` and not `All`
-                    ctx.for_each_task_meta(removed_uppers.iter().copied(), |mut upper, ctx| {
-                        // STEP 6
-                        let diff = data.apply(&mut upper, ctx.should_track_activeness(), self);
-                        if !diff.is_empty() {
-                            let upper_ids = get_uppers(&upper);
-                            self.push(
-                                AggregatedDataUpdateJob {
-                                    upper_ids,
-                                    update: diff,
-                                }
-                                .into(),
-                            )
-                        }
-                    });
+                    ctx.for_each_task_meta(
+                        removed_uppers.iter().copied(),
+                        "remove data from uppers",
+                        |mut upper, ctx| {
+                            // STEP 6
+                            let diff = data.apply(&mut upper, ctx.should_track_activeness(), self);
+                            if !diff.is_empty() {
+                                let upper_ids = get_uppers(&upper);
+                                self.push(
+                                    AggregatedDataUpdateJob {
+                                        upper_ids,
+                                        update: diff,
+                                    }
+                                    .into(),
+                                )
+                            }
+                        },
+                    );
                 }
                 // STEP 7
                 if !followers.is_empty() {
@@ -2061,6 +2077,7 @@ impl AggregationUpdateQueue {
                         upper_ids_with_min_aggregation_number
                             .iter()
                             .map(|(entry, _)| entry.task_id()),
+                        "add data to uppers",
                         |mut upper, ctx| {
                             // STEP 6d
                             if has_data {

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -13,6 +13,7 @@ use std::{
 };
 
 use bincode::{Decode, Encode};
+use tracing::trace_span;
 use turbo_tasks::{
     CellId, FxIndexMap, TaskExecutionReason, TaskId, TaskPriority, TurboTasksBackendApi,
     TurboTasksCallApi, TypedSharedReference, backend::CachedTaskType,
@@ -44,30 +45,36 @@ pub trait ExecuteContext<'e>: Sized {
     /// The iterator should not have duplicates, as this would cause over-fetching.
     fn prepare_tasks(
         &mut self,
-        task_ids: impl IntoIterator<Item = (TaskId, TaskDataCategory)> + Clone,
+        task_ids: impl IntoIterator<Item = (TaskId, TaskDataCategory)>,
+        reason: &'static str,
     );
     fn for_each_task(
         &mut self,
         task_ids: impl IntoIterator<Item = (TaskId, TaskDataCategory)>,
+        reason: &'static str,
         func: impl FnMut(Self::TaskGuardImpl, &mut Self),
     );
     fn for_each_task_meta(
         &mut self,
         task_ids: impl IntoIterator<Item = TaskId>,
+        reason: &'static str,
         func: impl FnMut(Self::TaskGuardImpl, &mut Self),
     ) {
         self.for_each_task(
             task_ids.into_iter().map(|id| (id, TaskDataCategory::Meta)),
+            reason,
             func,
         )
     }
     fn for_each_task_all(
         &mut self,
         task_ids: impl IntoIterator<Item = TaskId>,
+        reason: &'static str,
         func: impl FnMut(Self::TaskGuardImpl, &mut Self),
     ) {
         self.for_each_task(
             task_ids.into_iter().map(|id| (id, TaskDataCategory::All)),
+            reason,
             func,
         )
     }
@@ -230,6 +237,7 @@ impl<'e, B: BackingStorage> ExecuteContextImpl<'e, B> {
         &mut self,
         task_ids: impl IntoIterator<Item = (TaskId, TaskDataCategory)>,
         call_prepared_task_callback_for_transient_tasks: bool,
+        reason: &'static str,
         mut prepared_task_callback: impl FnMut(
             &mut Self,
             TaskId,
@@ -237,6 +245,13 @@ impl<'e, B: BackingStorage> ExecuteContextImpl<'e, B> {
             StorageWriteGuard<'e>,
         ),
     ) {
+        let span = trace_span!(
+            "prepare_tasks_with_callback",
+            reason,
+            requested_data = tracing::field::Empty,
+            requested_meta = tracing::field::Empty,
+        );
+        let _guard = span.enter();
         let mut data_count = 0;
         let mut meta_count = 0;
         let mut all_count = 0;
@@ -267,6 +282,8 @@ impl<'e, B: BackingStorage> ExecuteContextImpl<'e, B> {
             .collect::<Vec<_>>();
         data_count += all_count;
         meta_count += all_count;
+        span.record("requested_data", data_count);
+        span.record("requested_meta", meta_count);
 
         let mut tasks_to_restore_for_data = Vec::with_capacity(data_count);
         let mut tasks_to_restore_for_data_indicies = Vec::with_capacity(data_count);
@@ -446,30 +463,41 @@ impl<'e, B: BackingStorage> ExecuteContext<'e> for ExecuteContextImpl<'e, B> {
         }
     }
 
-    fn prepare_tasks(&mut self, task_ids: impl IntoIterator<Item = (TaskId, TaskDataCategory)>) {
-        self.prepare_tasks_with_callback(task_ids, false, |_, _, _, _| {});
+    fn prepare_tasks(
+        &mut self,
+        task_ids: impl IntoIterator<Item = (TaskId, TaskDataCategory)>,
+        reason: &'static str,
+    ) {
+        self.prepare_tasks_with_callback(task_ids, false, reason, |_, _, _, _| {});
     }
 
     fn for_each_task(
         &mut self,
         task_ids: impl IntoIterator<Item = (TaskId, TaskDataCategory)>,
+        reason: &'static str,
         mut func: impl FnMut(Self::TaskGuardImpl, &mut Self),
     ) {
         let task_lock_counter = self.task_lock_counter.clone();
-        self.prepare_tasks_with_callback(task_ids, true, |this, task_id, _category, task| {
-            // prepare_tasks_with_callback releases the counter before calling this callback,
-            // so the counter is 0 here. Acquire for the TaskGuardImpl that will release on Drop.
-            task_lock_counter.acquire();
+        self.prepare_tasks_with_callback(
+            task_ids,
+            true,
+            reason,
+            |this, task_id, _category, task| {
+                // prepare_tasks_with_callback releases the counter before calling this callback,
+                // so the counter is 0 here. Acquire for the TaskGuardImpl that will release on
+                // Drop.
+                task_lock_counter.acquire();
 
-            let guard = TaskGuardImpl {
-                task,
-                task_id,
-                #[cfg(debug_assertions)]
-                category: _category,
-                task_lock_counter: task_lock_counter.clone(),
-            };
-            func(guard, this);
-        });
+                let guard = TaskGuardImpl {
+                    task,
+                    task_id,
+                    #[cfg(debug_assertions)]
+                    category: _category,
+                    task_lock_counter: task_lock_counter.clone(),
+                };
+                func(guard, this);
+            },
+        );
     }
 
     fn task_pair(

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_cell.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_cell.rs
@@ -182,6 +182,7 @@ impl UpdateCellOperation {
                     dependent_tasks
                         .keys()
                         .map(|&id| (id, TaskDataCategory::All)),
+                    "invalidate cell dependents",
                 );
 
                 UpdateCellOperation::InvalidateWhenCellDependency {

--- a/turbopack/crates/turbo-tasks-backend/src/database/key_value_database.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/key_value_database.rs
@@ -27,13 +27,24 @@ impl KeySpace {
         }
     }
 
+    const fn name(&self) -> &'static str {
+        match self {
+            KeySpace::Infra => "Infra",
+            KeySpace::TaskMeta => "TaskMeta",
+            KeySpace::TaskData => "TaskData",
+            KeySpace::TaskCache => "TaskCache",
+        }
+    }
+
     /// Returns the persistence configuration for this keyspace.
     pub const fn family_config(&self) -> FamilyConfig {
         match self {
             KeySpace::Infra | KeySpace::TaskMeta | KeySpace::TaskData => FamilyConfig {
+                name: self.name(),
                 kind: FamilyKind::SingleValue,
             },
             KeySpace::TaskCache => FamilyConfig {
+                name: self.name(),
                 // TaskCache uses hash-based lookups with potential collisions.
                 kind: FamilyKind::MultiValue,
             },


### PR DESCRIPTION
Add the 'family name' to spans produced by the turbo-persistence backend.

Record a `reason` for the batch fetch.  this might be overkill but i found it useful to know that certain spans were related to prefetching vs data updates