### PR TITLE
[tests]: remove unnecessary skipDeployment flags

### DIFF
--- a/test/development/app-dir/css-parse-error-recovery/css-parse-error-recovery.test.ts
+++ b/test/development/app-dir/css-parse-error-recovery/css-parse-error-recovery.test.ts
@@ -9,7 +9,6 @@ import stripAnsi from 'strip-ansi'
     describe('with turbopack.ignoreIssue config', () => {
       const { next, skipped } = nextTestSetup({
         files: __dirname,
-        skipDeployment: true,
         nextConfig: {
           turbopack: {
             ignoreIssue: [
@@ -47,7 +46,6 @@ import stripAnsi from 'strip-ansi'
     describe('without turbopack.ignoreIssue config', () => {
       const { next, skipped } = nextTestSetup({
         files: __dirname,
-        skipDeployment: true,
       })
 
       if (skipped) return

--- a/test/development/app-dir/dynamic-error-trace/index.test.ts
+++ b/test/development/app-dir/dynamic-error-trace/index.test.ts
@@ -3,7 +3,6 @@ import { nextTestSetup } from 'e2e-utils'
 describe('app dir - dynamic error trace', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
   if (skipped) return
 

--- a/test/development/app-dir/turbopack-ignore-issue/turbopack-ignore-issue.test.ts
+++ b/test/development/app-dir/turbopack-ignore-issue/turbopack-ignore-issue.test.ts
@@ -7,7 +7,6 @@ describe('turbopack-ignore-issue', () => {
     const { next, skipped, isTurbopack } = nextTestSetup({
       files: __dirname,
       // turbopack.ignoreIssue is turbopack-only
-      skipDeployment: true,
       nextConfig: {
         turbopack: {
           ignoreIssue: [
@@ -125,7 +124,6 @@ describe('turbopack-ignore-issue', () => {
   describe('without turbopack.ignoreIssue config', () => {
     const { next, skipped, isTurbopack } = nextTestSetup({
       files: __dirname,
-      skipDeployment: true,
     })
 
     if (skipped) return

--- a/test/development/app-dir/turbopack-import-assertions-use/turbopack-import-assertions-use.test.ts
+++ b/test/development/app-dir/turbopack-import-assertions-use/turbopack-import-assertions-use.test.ts
@@ -3,8 +3,6 @@ import { nextTestSetup } from 'e2e-utils'
 describe('turbopack-import-assertions-use', () => {
   const { next, isTurbopack } = nextTestSetup({
     files: __dirname,
-    // This test is Turbopack-only; turbopackUse is not supported in webpack
-    skipDeployment: true,
   })
 
   if (!isTurbopack) {

--- a/test/development/mcp-server/mcp-server-get-compilation-issues.test.ts
+++ b/test/development/mcp-server/mcp-server-get-compilation-issues.test.ts
@@ -7,7 +7,6 @@ import { nextTestSetup } from 'e2e-utils'
   () => {
     const { next, skipped } = nextTestSetup({
       files: path.join(__dirname, 'fixtures', 'compilation-errors-app'),
-      skipDeployment: true,
     })
 
     if (skipped) {

--- a/test/development/mcp-server/mcp-server-get-logs.test.ts
+++ b/test/development/mcp-server/mcp-server-get-logs.test.ts
@@ -5,7 +5,6 @@ import { retry } from 'next-test-utils'
 describe('get-logs MCP tool', () => {
   const { next, skipped } = nextTestSetup({
     files: path.join(__dirname, 'fixtures', 'log-file-app'),
-    skipDeployment: true,
   })
 
   if (skipped) {

--- a/test/development/mcp-server/mcp-server-get-routes.test.ts
+++ b/test/development/mcp-server/mcp-server-get-routes.test.ts
@@ -4,7 +4,6 @@ import { nextTestSetup } from 'e2e-utils'
 describe('get_routes MCP tool', () => {
   const { next, skipped } = nextTestSetup({
     files: path.join(__dirname, 'fixtures', 'dynamic-routes-app'),
-    skipDeployment: true,
   })
 
   if (skipped) {

--- a/test/development/sass-error/index.test.ts
+++ b/test/development/sass-error/index.test.ts
@@ -4,7 +4,6 @@ import { waitForRedbox, getRedboxSource } from 'next-test-utils'
 describe('app dir - css', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     dependencies: {
       sass: 'latest',
     },

--- a/test/production/500-page/mixed-router-no-custom-pages-error/mixed-router-no-error.test.ts
+++ b/test/production/500-page/mixed-router-no-custom-pages-error/mixed-router-no-error.test.ts
@@ -5,7 +5,6 @@ import path from 'path'
 describe('500-page - mixed-router-no-custom-pages-error', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
 
   if (skipped) {

--- a/test/production/500-page/mixed-router-with-custom-pages-error/mixed-router-with-error.test.ts
+++ b/test/production/500-page/mixed-router-with-custom-pages-error/mixed-router-with-error.test.ts
@@ -5,7 +5,6 @@ import path from 'path'
 describe('500-page - mixed-router-with-custom-pages-error', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
 
   if (skipped) {

--- a/test/production/app-dir/actions-tree-shaking/reexport/reexport.test.ts
+++ b/test/production/app-dir/actions-tree-shaking/reexport/reexport.test.ts
@@ -10,7 +10,6 @@ import { retry } from 'next-test-utils'
   () => {
     const { next } = nextTestSetupActionTreeShaking({
       files: __dirname,
-      skipDeployment: true,
     })
 
     it('should not tree-shake namespace exports the manifest', async () => {

--- a/test/production/app-dir/bad-file-structure/bad-file-structure.test.ts
+++ b/test/production/app-dir/bad-file-structure/bad-file-structure.test.ts
@@ -3,7 +3,6 @@ import { nextTestSetup } from 'e2e-utils'
 describe('bad-file-structure', () => {
   const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     skipStart: true,
   })
 

--- a/test/production/app-dir/browser-chunks/browser-chunks.test.ts
+++ b/test/production/app-dir/browser-chunks/browser-chunks.test.ts
@@ -24,7 +24,6 @@ async function readFilesRecursive(
 describe('browser-chunks', () => {
   const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
 
   let sources: string[] = []

--- a/test/production/app-dir/client-components-tree-shaking/index.test.ts
+++ b/test/production/app-dir/client-components-tree-shaking/index.test.ts
@@ -3,7 +3,6 @@ import { nextTestSetup } from 'e2e-utils'
 describe('app-dir client-components-tree-shaking', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
   if (skipped) return
 

--- a/test/production/app-dir/empty-generate-static-params/empty-generate-static-params.test.ts
+++ b/test/production/app-dir/empty-generate-static-params/empty-generate-static-params.test.ts
@@ -5,7 +5,6 @@ describe('empty-generate-static-params', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
 
   if (skipped) return

--- a/test/production/app-dir/empty-shell-route-cache/empty-shell-route-cache.test.ts
+++ b/test/production/app-dir/empty-shell-route-cache/empty-shell-route-cache.test.ts
@@ -6,9 +6,6 @@ describe('empty-shell-route-cache', () => {
   const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    // This regression inspects on-disk .next artifacts, so it only applies to
-    // self-hosted build + start and is not portable to deployment mode.
-    skipDeployment: true,
   })
 
   beforeAll(async () => {

--- a/test/production/app-dir/metadata-streaming-config/metadata-streaming-config-customized.test.ts
+++ b/test/production/app-dir/metadata-streaming-config/metadata-streaming-config-customized.test.ts
@@ -4,7 +4,6 @@ import { nextTestSetup } from 'e2e-utils'
 describe.skip('app-dir - metadata-streaming-config-customized', () => {
   const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     overrideFiles: {
       'next.config.js': `
         module.exports = {

--- a/test/production/app-dir/next-types-plugin/basic/index.test.ts
+++ b/test/production/app-dir/next-types-plugin/basic/index.test.ts
@@ -4,7 +4,6 @@ import { nextTestSetup } from 'e2e-utils'
   () => {
     const { next, skipped } = nextTestSetup({
       files: __dirname,
-      skipDeployment: true,
     })
 
     if (skipped) return

--- a/test/production/app-dir/next-types-plugin/private-folder-convention/index.test.ts
+++ b/test/production/app-dir/next-types-plugin/private-folder-convention/index.test.ts
@@ -4,7 +4,6 @@ import { nextTestSetup } from 'e2e-utils'
   () => {
     const { next, skipped } = nextTestSetup({
       files: __dirname,
-      skipDeployment: true,
     })
 
     if (skipped) return

--- a/test/production/app-dir/next-types-plugin/sync-params-type-check/sync-params-type-check.test.ts
+++ b/test/production/app-dir/next-types-plugin/sync-params-type-check/sync-params-type-check.test.ts
@@ -10,7 +10,6 @@ const strictRouteTypes =
     const { next } = nextTestSetup({
       files: __dirname,
       skipStart: true,
-      skipDeployment: true,
     })
 
     it('should pass build with Promise params', async () => {

--- a/test/production/app-dir/post-build/post-build.test.ts
+++ b/test/production/app-dir/post-build/post-build.test.ts
@@ -12,7 +12,6 @@ describe('post-build', () => {
   const { next, isTurbopack, skipped } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
     env: {
       NEXT_USE_POST_BUILD: '1',
     },

--- a/test/production/app-dir/revalidate/revalidate.test.ts
+++ b/test/production/app-dir/revalidate/revalidate.test.ts
@@ -3,7 +3,6 @@ import { nextTestSetup } from 'e2e-utils'
 describe('app-dir revalidate', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
 
   if (skipped) {

--- a/test/production/app-dir/route-handler-manifest-size/route-handler-manifest-size.test.ts
+++ b/test/production/app-dir/route-handler-manifest-size/route-handler-manifest-size.test.ts
@@ -5,8 +5,6 @@ import type { ClientReferenceManifest } from 'next/dist/build/webpack/plugins/fl
 describe('route-handler-manifest-size', () => {
   const { next, isNextStart, skipped } = nextTestSetup({
     files: __dirname,
-    // This test is specifically for webpack behavior
-    skipDeployment: true,
   })
 
   if (skipped) return

--- a/test/production/app-dir/ssg-single-pass/ssg-single-pass.test.ts
+++ b/test/production/app-dir/ssg-single-pass/ssg-single-pass.test.ts
@@ -3,7 +3,6 @@ import { retry } from 'next-test-utils'
 
 describe('ssg-single-pass', () => {
   const { next, skipped } = nextTestSetup({
-    skipDeployment: true,
     files: __dirname,
   })
 

--- a/test/production/app-dir/types-gen-nounuselocal/types-gen-nounuselocal.test.ts
+++ b/test/production/app-dir/types-gen-nounuselocal/types-gen-nounuselocal.test.ts
@@ -8,7 +8,6 @@ const strictRouteTypes =
 describe('types-gen-nounuselocal', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
 
   if (skipped) {

--- a/test/production/app-dir/unstable-cache-foreground-revalidate/unstable-cache-foreground-revalidate.test.ts
+++ b/test/production/app-dir/unstable-cache-foreground-revalidate/unstable-cache-foreground-revalidate.test.ts
@@ -3,7 +3,6 @@ import { nextTestSetup } from 'e2e-utils'
 describe('unstable-cache-foreground-revalidate', () => {
   const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
 
   if (isNextDev) {

--- a/test/production/build-failed-trace/build-failed-trace.test.ts
+++ b/test/production/build-failed-trace/build-failed-trace.test.ts
@@ -10,7 +10,6 @@ describe('build-failed-trace', () => {
   const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
 
   it('should mark the next-build span as failed when the build fails', async () => {

--- a/test/production/clean-distdir/index.test.ts
+++ b/test/production/clean-distdir/index.test.ts
@@ -5,7 +5,6 @@ import { nextTestSetup } from 'e2e-utils'
 describe('Cleaning distDir', () => {
   const { next, isTurbopack, skipped } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     skipStart: true,
   })
 

--- a/test/production/config-validation-fatal-errors/index.test.ts
+++ b/test/production/config-validation-fatal-errors/index.test.ts
@@ -3,7 +3,6 @@ import { nextTestSetup } from 'e2e-utils'
 describe('config validation - fatal errors', () => {
   const { next } = nextTestSetup({
     skipStart: true,
-    skipDeployment: true,
     files: __dirname,
   })
 

--- a/test/production/config-validation-warnings/index.test.ts
+++ b/test/production/config-validation-warnings/index.test.ts
@@ -3,7 +3,6 @@ import { nextTestSetup } from 'e2e-utils'
 describe('config validation - warnings only', () => {
   const { next } = nextTestSetup({
     skipStart: true,
-    skipDeployment: true,
     files: __dirname,
   })
 

--- a/test/production/css-url-deployment-id/css-url-deployment-id.test.ts
+++ b/test/production/css-url-deployment-id/css-url-deployment-id.test.ts
@@ -3,7 +3,6 @@ import { isNextStart, nextTestSetup } from 'e2e-utils'
 describe('css-url-deployment-id', () => {
   const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     dependencies: { sass: '1.54.0' },
     env: {
       NEXT_DEPLOYMENT_ID: isNextStart ? 'test-deployment-id' : undefined,

--- a/test/production/debug-build-path/debug-build-paths.test.ts
+++ b/test/production/debug-build-path/debug-build-paths.test.ts
@@ -5,7 +5,6 @@ describe('debug-build-paths', () => {
   describe('default fixture', () => {
     const { next, skipped } = nextTestSetup({
       files: path.join(__dirname, 'fixtures/default'),
-      skipDeployment: true,
       skipStart: true,
     })
 
@@ -283,7 +282,6 @@ describe('debug-build-paths', () => {
   describe('with-compile-error fixture', () => {
     const { next, skipped } = nextTestSetup({
       files: path.join(__dirname, 'fixtures/with-compile-error'),
-      skipDeployment: true,
       skipStart: true,
     })
 

--- a/test/production/deterministic-build/deployment-id.test.ts
+++ b/test/production/deterministic-build/deployment-id.test.ts
@@ -216,7 +216,6 @@ const FILES = {
           NOW_BUILDER: '1',
         },
         skipStart: true,
-        skipDeployment: true,
         disableAutoSkewProtection: true,
       })
 
@@ -254,7 +253,6 @@ const FILES = {
               }
             : undefined,
         skipStart: true,
-        skipDeployment: true,
         disableAutoSkewProtection: true,
       })
 

--- a/test/production/edge-config-validations/index.test.ts
+++ b/test/production/edge-config-validations/index.test.ts
@@ -3,7 +3,6 @@ import { nextTestSetup } from 'e2e-utils'
 describe('Edge config validations', () => {
   const { next } = nextTestSetup({
     skipStart: true,
-    skipDeployment: true,
     files: {
       'pages/index.js': `
           export default function Page() { 

--- a/test/production/next-server-nft/next-server-nft.test.ts
+++ b/test/production/next-server-nft/next-server-nft.test.ts
@@ -72,7 +72,6 @@ async function readNormalizedNFT(next, name) {
     describe('with output:standalone', () => {
       const { next, skipped } = nextTestSetup({
         files: __dirname,
-        skipDeployment: true,
         dependencies: {
           typescript: '5.9.2',
         },
@@ -402,7 +401,6 @@ async function readNormalizedNFT(next, name) {
     describe('default mode', () => {
       const { next, skipped } = nextTestSetup({
         files: __dirname,
-        skipDeployment: true,
         dependencies: {
           typescript: '5.9.2',
         },

--- a/test/production/production-browser-sourcemaps/index.test.ts
+++ b/test/production/production-browser-sourcemaps/index.test.ts
@@ -60,7 +60,6 @@ describe('Production browser sourcemaps', () => {
         nextConfig: {
           productionBrowserSourceMaps,
         },
-        skipDeployment: true,
       })
 
       if (skipped) {

--- a/test/production/remove-unused-imports/remove-unused-imports.test.ts
+++ b/test/production/remove-unused-imports/remove-unused-imports.test.ts
@@ -3,7 +3,6 @@ import { nextTestSetup } from 'e2e-utils'
 describe('remove-unused-imports', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
 
   if (skipped) {

--- a/test/production/standalone-mode/tracing-side-effects-false/tracing-side-effects-false.test.ts
+++ b/test/production/standalone-mode/tracing-side-effects-false/tracing-side-effects-false.test.ts
@@ -6,7 +6,6 @@ describe('standalone mode - tracing-side-effects-false', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
     dependencies,
-    skipDeployment: true,
     skipStart: true,
   })
 

--- a/test/production/standalone-mode/tracing-static-files/tracing-static-files.test.ts
+++ b/test/production/standalone-mode/tracing-static-files/tracing-static-files.test.ts
@@ -6,7 +6,6 @@ describe('standalone mode - tracing-static-files', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
     dependencies,
-    skipDeployment: true,
     skipStart: true,
   })
 

--- a/test/production/standalone-mode/tracing-unparsable/tracing-unparsable.test.ts
+++ b/test/production/standalone-mode/tracing-unparsable/tracing-unparsable.test.ts
@@ -6,7 +6,6 @@ describe('standalone mode - tracing-unparsable', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
     dependencies,
-    skipDeployment: true,
     skipStart: true,
   })
 

--- a/test/production/typescript-build-output/typescript-build-output.test.ts
+++ b/test/production/typescript-build-output/typescript-build-output.test.ts
@@ -4,7 +4,6 @@ describe('typescript-build-output', () => {
   const { next, isNextDeploy, skipped } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
 
   if (skipped) {

--- a/test/production/typescript-checked-side-effect-imports/index.test.ts
+++ b/test/production/typescript-checked-side-effect-imports/index.test.ts
@@ -4,7 +4,6 @@ describe('Side-effect imports with noUncheckedSideEffectImports', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
     dependencies: { sass: '1.54.0' },
-    skipDeployment: true, // No need to run this in deployment mode.
     skipStart: true,
   })
   if (skipped) return


### PR DESCRIPTION
These tests won't ever be run in a deployed environment, so this removes `skipDeployment` so it's easier to grok which tests are intentionally disabled because they don't work when deployed. 