### PR TITLE
[Plugin] Add experimental next-dev Claude Code plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,6 +13,15 @@
       "author": {
         "name": "Next.js Team"
       }
+    },
+    {
+      "name": "next-dev",
+      "source": "./plugins/next-dev",
+      "description": "Experimental: real-time Turbopack compilation feedback for agents. Pauses compilation during edits, batches one compile at turn-end, blocks on errors. Requires unreleased MCP tools (pause_compilation/compile_and_resume/get_compilation_issues).",
+      "version": "0.1.0",
+      "author": {
+        "name": "Next.js Team"
+      }
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "cache-components",
-      "source": "./plugins/cache-components",
+      "source": "./.claude-plugin/plugins/cache-components",
       "description": "Expert guidance for Next.js Cache Components and Partial Prerendering (PPR). Proactively activates in projects with cacheComponents enabled.",
       "version": "1.0.0",
       "author": {
@@ -16,7 +16,7 @@
     },
     {
       "name": "next-dev",
-      "source": "./plugins/next-dev",
+      "source": "./.claude-plugin/plugins/next-dev",
       "description": "Experimental: real-time Turbopack compilation feedback for agents. Pauses compilation during edits, batches one compile at turn-end, blocks on errors. Requires unreleased MCP tools (pause_compilation/compile_and_resume/get_compilation_issues).",
       "version": "0.1.0",
       "author": {

--- a/.claude-plugin/plugins/README.md
+++ b/.claude-plugin/plugins/README.md
@@ -24,6 +24,7 @@ The Next.js repository serves as a Claude Code plugin marketplace. Team members 
 | Plugin | Description |
 |--------|-------------|
 | `cache-components` | Expert guidance for Cache Components and PPR |
+| `next-dev` | **Experimental.** Real-time Turbopack compilation feedback for agents (requires unreleased MCP tools) |
 
 ## For Team Members
 

--- a/.claude-plugin/plugins/next-dev/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugins/next-dev/.claude-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "next-dev",
+  "version": "0.1.0",
+  "description": "Experimental: Real-time Turbopack compilation feedback for agents editing Next.js code. Pauses compilation during edits, batches a single compile at turn-end, blocks on errors. Requires a Next.js dev server with the pause_compilation/compile_and_resume/get_compilation_issues MCP tools (Turbopack only).",
+  "author": {
+    "name": "Next.js Team",
+    "url": "https://nextjs.org"
+  },
+  "homepage": "https://github.com/vercel/next.js/tree/canary/.claude-plugin/plugins/next-dev",
+  "repository": "https://github.com/vercel/next.js",
+  "license": "MIT",
+  "keywords": [
+    "nextjs",
+    "turbopack",
+    "dev-server",
+    "mcp",
+    "agents",
+    "compilation",
+    "experimental"
+  ]
+}

--- a/.claude-plugin/plugins/next-dev/README.md
+++ b/.claude-plugin/plugins/next-dev/README.md
@@ -1,0 +1,117 @@
+# Next Dev Plugin for Claude Code
+
+> ⚠️ **Experimental.** This plugin requires a Next.js dev server that exposes the `pause_compilation`, `compile_and_resume`, and `get_compilation_issues` MCP tools (Turbopack only). These tools are still landing in canary — see [Status](#status) below before installing.
+
+Real-time Turbopack compilation feedback for agents editing Next.js code. The agent's edits no longer pile up errors silently across many tool calls — compilation is paused while editing, batched once at turn-end, and the agent is blocked from finishing if there are errors.
+
+## Why
+
+Agents editing Next.js code don't open a browser, so Turbopack's on-demand compilation never kicks in. Errors pile up silently and only surface at the final `pnpm build`. This plugin wires the dev server's MCP endpoint into Claude Code so that:
+
+1. **Edits don't trigger HMR.** While the agent is working, the turbo-tasks scheduler is paused. File watchers still mark tasks dirty, but no compilation runs.
+2. **One batch compile per turn.** When the agent finishes responding, the Stop hook drains buffered tasks in a single compile cycle and runs `get_compilation_issues` against the full module graph.
+3. **The agent is blocked on errors.** If compilation produces errors, the Stop hook returns `decision: block` with the formatted errors, forcing the agent to fix them before stopping.
+4. **Normal HMR resumes between turns.** Your browser still updates live when you're not in an agent turn.
+
+For more architectural detail, see the design notes referenced from the Next.js Dev Agent Plugin Notion doc.
+
+## Status
+
+This plugin depends on MCP tools that are not yet in stable Next.js:
+
+| MCP tool | PR | Status |
+|----------|----|--------|
+| `get_compilation_issues` | [vercel/next.js#92062](https://github.com/vercel/next.js/pull/92062) | Landed |
+| `pause_compilation` / `compile_and_resume` | [vercel/next.js#92410](https://github.com/vercel/next.js/pull/92410) | Open |
+
+The activation script verifies these tools are present and refuses to enable hooks otherwise. **Do not install this plugin against an unsupported Next.js version** — the activation will fail with a clear error.
+
+## Installation
+
+### Step 1: Add the Next.js Marketplace
+
+```
+/plugin marketplace add vercel/next.js
+```
+
+### Step 2: Install the Plugin
+
+```
+/plugin install next-dev@nextjs
+```
+
+## Usage
+
+In your Next.js project, start the dev server with Turbopack (the default):
+
+```bash
+pnpm dev -p 3000
+```
+
+Then in Claude Code, activate the skill:
+
+```
+/next-dev 3000
+```
+
+The skill's activation script will:
+
+1. Write the port to `.claude/port` in your project (state flag)
+2. Connect to `localhost:3000/_next/mcp` and verify `get_compilation_issues` is available
+3. Warm up Turbopack's module graph in the background (the first compile is the slow one)
+4. Clear any stale dismissed-issues file from a previous session
+
+If activation fails, the port file is deleted and the hooks become silent no-ops — normal editing is unaffected.
+
+## Architecture
+
+Two skill-scoped hooks fire while the skill is active:
+
+- **`UserPromptSubmit`** → `hooks/enter-manual-compile.mjs`
+  Pings the dev server, then calls `pause_compilation`. Silent no-op if the port file is missing or the server is unreachable.
+
+- **`Stop`** → `hooks/stop-compile-check.mjs`
+  Calls `compile_and_resume` (drains pending tasks in one batch), then `get_compilation_issues`. If issues are found, returns `decision: block` with the formatted errors. If `stop_hook_active` is `true`, exits 0 unconditionally to avoid infinite loops.
+
+State files are project-local (`$CLAUDE_PROJECT_DIR/.claude/`):
+
+- `.claude/port` — dev server port; existence is the activation flag
+- `.claude/dismissed-issues.json` — issue keys the agent has dismissed as non-actionable
+
+Hook scripts are plugin-local (`${CLAUDE_PLUGIN_ROOT}/hooks/`).
+
+## Files
+
+```
+.claude-plugin/plugins/next-dev/
+├── .claude-plugin/
+│   └── plugin.json
+├── hooks/
+│   ├── enter-manual-compile.mjs    # UserPromptSubmit: ping + pause_compilation
+│   ├── stop-compile-check.mjs      # Stop: compile_and_resume + get_compilation_issues
+│   └── mcp-client.mjs              # Shared MCP/SSE client
+├── skills/
+│   └── next-dev/
+│       ├── SKILL.md                # Skill definition + hook bindings
+│       └── scripts/
+│           ├── activate.mjs        # /next-dev <port> entry point
+│           ├── get-errors.mjs      # On-demand error check
+│           └── dismiss-errors.mjs  # Classify + dismiss non-actionable errors
+└── README.md
+```
+
+## Dismissing non-actionable errors
+
+Large projects often have compilation errors the agent can't fix — `node_modules` resolving server-only builtins (`child_process`, `dns`, `net`, `tls`) in client context, Turbopack empty-module stubs, etc. The agent can dismiss these:
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/skills/next-dev/scripts/dismiss-errors.mjs"
+```
+
+Dismissals are keyed by `severity|filePath|title|startLine:startCol` (matches the server-side dedup key) and persist in `.claude/dismissed-issues.json` for the rest of the session. Activation clears them on the next session.
+
+## Limitations
+
+- **Turbopack only.** The MCP tools rely on the Turbopack hot-reloader; webpack is not supported.
+- **Config file changes are not detected.** `get_compilation_issues` builds the module graph for all endpoints, but changes to `next.config.js`, `tsconfig.json`, etc. require a dev server restart.
+- **Skill must stay active.** The hooks are scoped to the skill's lifetime. If the skill isn't loaded, normal editing works without compilation feedback.

--- a/.claude-plugin/plugins/next-dev/README.md
+++ b/.claude-plugin/plugins/next-dev/README.md
@@ -65,20 +65,20 @@ If activation fails, the port file is deleted and the hooks become silent no-ops
 
 ## Architecture
 
-Two skill-scoped hooks fire while the skill is active:
+Hooks are declared at **plugin level** in `hooks/hooks.json`, not in the SKILL.md frontmatter. Skill-scoped hooks are not currently supported by Claude Code (see [anthropics/claude-code#17688](https://github.com/anthropics/claude-code/issues/17688)). To get the same effect, both hooks gate on `.claude/port` and silently no-op when it's missing — so they only do real work after `/next-dev` activation has written the port file.
 
 - **`UserPromptSubmit`** → `hooks/enter-manual-compile.mjs`
   Pings the dev server, then calls `pause_compilation`. Silent no-op if the port file is missing or the server is unreachable.
 
 - **`Stop`** → `hooks/stop-compile-check.mjs`
-  Calls `compile_and_resume` (drains pending tasks in one batch), then `get_compilation_issues`. If issues are found, returns `decision: block` with the formatted errors. If `stop_hook_active` is `true`, exits 0 unconditionally to avoid infinite loops.
+  Calls `compile_and_resume` (drains pending tasks in one batch), then `get_compilation_issues`. If issues are found, returns `decision: block` with the formatted errors. The hook does not short-circuit on `stop_hook_active`: if the agent can't fix an issue, it can dismiss everything currently reported via `dismiss-errors.mjs` and stop cleanly — the block message itself surfaces that command.
 
 State files are project-local (`$CLAUDE_PROJECT_DIR/.claude/`):
 
-- `.claude/port` — dev server port; existence is the activation flag
-- `.claude/dismissed-issues.json` — issue keys the agent has dismissed as non-actionable
+- `.claude/port` — dev server port; existence is the activation flag and the gate for plugin hooks
+- `.claude/dismissed-issues.json` — issue keys the agent has dismissed
 
-Hook scripts are plugin-local (`${CLAUDE_PLUGIN_ROOT}/hooks/`).
+Hook scripts live under `${CLAUDE_PLUGIN_ROOT}/hooks/` (referenced from `hooks/hooks.json`). Skill scripts live under `${CLAUDE_SKILL_DIR}/scripts/` (referenced from the skill body and from commands the hooks tell the agent to run).
 
 ## Files
 
@@ -105,7 +105,7 @@ Hook scripts are plugin-local (`${CLAUDE_PLUGIN_ROOT}/hooks/`).
 Large projects often have compilation errors the agent can't fix — `node_modules` resolving server-only builtins (`child_process`, `dns`, `net`, `tls`) in client context, Turbopack empty-module stubs, etc. The agent can dismiss these:
 
 ```bash
-node "${CLAUDE_PLUGIN_ROOT}/skills/next-dev/scripts/dismiss-errors.mjs"
+node "${CLAUDE_SKILL_DIR}/scripts/dismiss-errors.mjs"
 ```
 
 Dismissals are keyed by `severity|filePath|title|startLine:startCol` (matches the server-side dedup key) and persist in `.claude/dismissed-issues.json` for the rest of the session. Activation clears them on the next session.

--- a/.claude-plugin/plugins/next-dev/hooks/enter-manual-compile.mjs
+++ b/.claude-plugin/plugins/next-dev/hooks/enter-manual-compile.mjs
@@ -1,32 +1,73 @@
 #!/usr/bin/env node
 /**
- * UserPromptSubmit hook (skill-scoped). At the start of each agent turn:
+ * UserPromptSubmit hook (plugin-level, gated on .claude/port).
+ * At the start of each agent turn:
  *   1. Checks the dev server is reachable (precondition gate)
  *   2. Pauses compilation so intermediate edits don't trigger HMR
  *
- * Silent no-op if the port file is missing or the server is unreachable.
- * If the server goes down mid-session, the agent simply loses compilation
- * feedback for that turn — the Stop hook exits 0 gracefully.
+ * ─────────────────────────────────────────────────────────────────────────
+ * Why we silently skip when the port file is missing
+ * ─────────────────────────────────────────────────────────────────────────
+ * The port file is written by activate.mjs only after it verifies that the
+ * dev server exposes the required MCP tools. If the file is missing, one of
+ * these is true:
+ *
+ *   (a) The user never ran `/next-dev <port>`. Nothing to do.
+ *   (b) Activation ran but failed because the running Next.js version is too
+ *       old to expose the required MCP tools (`get_compilation_issues`,
+ *       `pause_compilation`, `compile_and_resume`). activate.mjs already
+ *       printed a clear error at that point; re-surfacing it on every prompt
+ *       would be noise.
+ *
+ * In either case the correct behaviour is a silent exit — we must not block
+ * the user's turn just because the skill isn't functional.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * The Webpack edge case (port file present, but hooks are no-ops)
+ * ─────────────────────────────────────────────────────────────────────────
+ * The MCP tools are registered unconditionally, but they only do real work
+ * when the dev server is running Turbopack. If the user ran `next dev
+ * --webpack`, activation still succeeds (the tools exist), so this hook
+ * runs. `pause_compilation` becomes a no-op, `get_compilation_issues`
+ * returns nothing, and the whole skill degrades silently to doing nothing.
+ * That's an acceptable failure mode — webpack users just don't get the
+ * compilation-feedback loop, and nothing is broken. We do not try to
+ * detect webpack here; the documentation (README + PR) calls out the
+ * Turbopack requirement explicitly.
+ * ─────────────────────────────────────────────────────────────────────────
  */
 
-import { existsSync } from 'node:fs'
+import { existsSync, unlinkSync } from 'node:fs'
 import { join } from 'node:path'
 import { getPort, ping, pauseCompilation } from './mcp-client.mjs'
 
-const projectDir = process.env.CLAUDE_PROJECT_DIR || process.cwd()
-const portFile = join(projectDir, '.claude', 'port')
+// CLAUDE_PROJECT_DIR is guaranteed to be set in hook subprocesses.
+// https://code.claude.com/docs/en/hooks#reference-scripts-by-path
+const portFile = join(process.env.CLAUDE_PROJECT_DIR, '.claude', 'port')
 
 if (!existsSync(portFile)) {
   process.exit(0)
+}
+
+// Self-disable if the dev server is gone. The port file persists across
+// sessions, but the dev server may not — without this, every turn would
+// burn the hook's full timeout trying to reach a dead port. Deleting the
+// port file makes subsequent turns instant no-ops; the user re-runs
+// `/next-dev <port>` when they bring the server back up.
+function selfDisable() {
+  try {
+    unlinkSync(portFile)
+  } catch {}
 }
 
 try {
   const port = getPort()
   const reachable = await ping(port)
   if (!reachable) {
+    selfDisable()
     process.exit(0)
   }
   await pauseCompilation(port)
 } catch {
-  // Server unreachable — silent no-op. Stop hook handles gracefully.
+  selfDisable()
 }

--- a/.claude-plugin/plugins/next-dev/hooks/enter-manual-compile.mjs
+++ b/.claude-plugin/plugins/next-dev/hooks/enter-manual-compile.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+/**
+ * UserPromptSubmit hook (skill-scoped). At the start of each agent turn:
+ *   1. Checks the dev server is reachable (precondition gate)
+ *   2. Pauses compilation so intermediate edits don't trigger HMR
+ *
+ * Silent no-op if the port file is missing or the server is unreachable.
+ * If the server goes down mid-session, the agent simply loses compilation
+ * feedback for that turn — the Stop hook exits 0 gracefully.
+ */
+
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { getPort, ping, pauseCompilation } from './mcp-client.mjs'
+
+const projectDir = process.env.CLAUDE_PROJECT_DIR || process.cwd()
+const portFile = join(projectDir, '.claude', 'port')
+
+if (!existsSync(portFile)) {
+  process.exit(0)
+}
+
+try {
+  const port = getPort()
+  const reachable = await ping(port)
+  if (!reachable) {
+    process.exit(0)
+  }
+  await pauseCompilation(port)
+} catch {
+  // Server unreachable — silent no-op. Stop hook handles gracefully.
+}

--- a/.claude-plugin/plugins/next-dev/hooks/hooks.json
+++ b/.claude-plugin/plugins/next-dev/hooks/hooks.json
@@ -1,0 +1,26 @@
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/enter-manual-compile.mjs\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/stop-compile-check.mjs\"",
+            "timeout": 120
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude-plugin/plugins/next-dev/hooks/mcp-client.mjs
+++ b/.claude-plugin/plugins/next-dev/hooks/mcp-client.mjs
@@ -1,0 +1,272 @@
+/**
+ * Shared MCP client utilities for hooks.
+ * Handles the SSE-based JSON-RPC protocol used by Next.js MCP endpoint.
+ */
+
+import { readFileSync, writeFileSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+
+const projectDir = process.env.CLAUDE_PROJECT_DIR || process.cwd()
+const dismissedFile = join(projectDir, '.claude', 'dismissed-issues.json')
+
+export function getPort() {
+  return readFileSync(join(projectDir, '.claude', 'port'), 'utf8').trim()
+}
+
+/**
+ * Stable key for deduplicating/matching issues.
+ * Matches the server-side dedup format: severity|filePath|title|startLine:startCol
+ */
+export function issueKey(issue) {
+  const severity = issue.severity || 'error'
+  const file = issue.filePath || 'unknown'
+  const title = issue.title || ''
+  const line = issue.source?.range?.start?.line ?? '?'
+  const col = issue.source?.range?.start?.column ?? '?'
+  return `${severity}|${file}|${title}|${line}:${col}`
+}
+
+/**
+ * Write dismissed issue keys. Called by dismiss-errors.mjs.
+ */
+export function writeDismissed(keys) {
+  writeFileSync(dismissedFile, JSON.stringify({ keys }), 'utf8')
+}
+
+/**
+ * Read dismissed keys. Returns a Set, or null if no dismissals exist.
+ */
+export function readDismissedKeys() {
+  if (!existsSync(dismissedFile)) return null
+  try {
+    const { keys } = JSON.parse(readFileSync(dismissedFile, 'utf8'))
+    return new Set(keys)
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Filter out dismissed issues. Returns { issues, dismissedCount }.
+ * If no dismissals exist, returns all issues with dismissedCount 0.
+ */
+export function filterDismissedIssues(issues) {
+  const dismissed = readDismissedKeys()
+  if (!dismissed) return { issues, dismissedCount: 0 }
+  const kept = issues.filter((i) => !dismissed.has(issueKey(i)))
+  return { issues: kept, dismissedCount: issues.length - kept.length }
+}
+
+export function getMcpUrl(port) {
+  return `http://localhost:${port}/_next/mcp`
+}
+
+const MCP_HEADERS = {
+  'Content-Type': 'application/json',
+  Accept: 'application/json, text/event-stream',
+}
+
+function parseSSE(text) {
+  for (const line of text.split('\n')) {
+    if (line.startsWith('data:')) {
+      return JSON.parse(line.slice(5))
+    }
+  }
+  return null
+}
+
+/**
+ * Ping the MCP endpoint. Returns true if reachable, false otherwise.
+ */
+export async function ping(port) {
+  const url = getMcpUrl(port)
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: MCP_HEADERS,
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2025-03-26',
+          capabilities: {},
+          clientInfo: { name: 'agent-mode-hook', version: '1.0.0' },
+        },
+      }),
+    })
+    return res.ok
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Call pause_compilation via the MCP protocol.
+ * Pauses compilation until compile_and_resume is called.
+ */
+export async function pauseCompilation(port) {
+  const url = getMcpUrl(port)
+
+  await fetch(url, {
+    method: 'POST',
+    headers: MCP_HEADERS,
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2025-03-26',
+        capabilities: {},
+        clientInfo: { name: 'agent-mode-hook', version: '1.0.0' },
+      },
+    }),
+  })
+
+  await fetch(url, {
+    method: 'POST',
+    headers: MCP_HEADERS,
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      method: 'notifications/initialized',
+    }),
+  })
+
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: MCP_HEADERS,
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/call',
+      params: { name: 'pause_compilation', arguments: {} },
+    }),
+  })
+
+  const body = parseSSE(await res.text())
+  if (body?.error) {
+    throw new Error(body.error.message)
+  }
+
+  const text = body?.result?.content?.[0]?.text
+  if (!text) {
+    throw new Error('Unexpected MCP response shape')
+  }
+
+  return JSON.parse(text)
+}
+
+/**
+ * Call compile_and_resume via the MCP protocol.
+ * Compiles all pending changes, then resumes normal compilation.
+ */
+export async function compileAndResume(port) {
+  const url = getMcpUrl(port)
+
+  await fetch(url, {
+    method: 'POST',
+    headers: MCP_HEADERS,
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2025-03-26',
+        capabilities: {},
+        clientInfo: { name: 'agent-mode-hook', version: '1.0.0' },
+      },
+    }),
+  })
+
+  await fetch(url, {
+    method: 'POST',
+    headers: MCP_HEADERS,
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      method: 'notifications/initialized',
+    }),
+  })
+
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: MCP_HEADERS,
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/call',
+      params: { name: 'compile_and_resume', arguments: {} },
+    }),
+  })
+
+  const body = parseSSE(await res.text())
+  if (body?.error) {
+    throw new Error(body.error.message)
+  }
+
+  const text = body?.result?.content?.[0]?.text
+  if (!text) {
+    throw new Error('Unexpected MCP response shape')
+  }
+
+  return JSON.parse(text)
+}
+
+/**
+ * Call get_compilation_issues via the MCP protocol.
+ * Returns the parsed result object { issues: [], diagnostics: [] }.
+ */
+export async function getCompilationIssues(port) {
+  const url = getMcpUrl(port)
+
+  // Initialize
+  await fetch(url, {
+    method: 'POST',
+    headers: MCP_HEADERS,
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2025-03-26',
+        capabilities: {},
+        clientInfo: { name: 'agent-mode-hook', version: '1.0.0' },
+      },
+    }),
+  })
+
+  // Initialized notification
+  await fetch(url, {
+    method: 'POST',
+    headers: MCP_HEADERS,
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      method: 'notifications/initialized',
+    }),
+  })
+
+  // Call tool
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: MCP_HEADERS,
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/call',
+      params: { name: 'get_compilation_issues', arguments: {} },
+    }),
+  })
+
+  const body = parseSSE(await res.text())
+
+  if (body?.error) {
+    throw new Error(body.error.message)
+  }
+
+  // The result is a JSON string inside content[0].text
+  const text = body?.result?.content?.[0]?.text
+  if (!text) {
+    throw new Error('Unexpected MCP response shape')
+  }
+
+  return JSON.parse(text)
+}

--- a/.claude-plugin/plugins/next-dev/hooks/mcp-client.mjs
+++ b/.claude-plugin/plugins/next-dev/hooks/mcp-client.mjs
@@ -6,7 +6,9 @@
 import { readFileSync, writeFileSync, existsSync } from 'node:fs'
 import { join } from 'node:path'
 
-const projectDir = process.env.CLAUDE_PROJECT_DIR || process.cwd()
+// CLAUDE_PROJECT_DIR is guaranteed to be set in hook subprocesses.
+// https://code.claude.com/docs/en/hooks#reference-scripts-by-path
+const projectDir = process.env.CLAUDE_PROJECT_DIR
 const dismissedFile = join(projectDir, '.claude', 'dismissed-issues.json')
 
 export function getPort() {

--- a/.claude-plugin/plugins/next-dev/hooks/stop-compile-check.mjs
+++ b/.claude-plugin/plugins/next-dev/hooks/stop-compile-check.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+/**
+ * Stop hook (skill-scoped). Runs a compilation pass, then blocks if there
+ * are compilation errors. The agent must fix them or dismiss them to proceed.
+ */
+
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import {
+  getPort,
+  getCompilationIssues,
+  compileAndResume,
+  filterDismissedIssues,
+} from './mcp-client.mjs'
+
+const projectDir = process.env.CLAUDE_PROJECT_DIR || process.cwd()
+const portFile = join(projectDir, '.claude', 'port')
+
+// No port file = setup didn't complete or skill not fully active.
+if (!existsSync(portFile)) {
+  process.exit(0)
+}
+
+try {
+  const port = getPort()
+
+  // Run a compilation pass before checking for errors.
+  // This processes all accumulated file changes in one batch.
+  try {
+    await compileAndResume(port)
+  } catch {
+    // If compile fails, continue with error check anyway.
+  }
+
+  const result = await getCompilationIssues(port)
+  const allIssues = result.issues || []
+  const { issues, dismissedCount } = filterDismissedIssues(allIssues)
+
+  if (issues.length === 0) {
+    process.exit(0)
+  }
+
+  const lines =
+    dismissedCount > 0
+      ? [`Compilation errors found (${dismissedCount} dismissed hidden):`, '']
+      : ['Compilation errors found:', '']
+
+  for (const issue of issues) {
+    const severity = issue.severity || 'error'
+    const file = issue.filePath || 'unknown'
+    const title = issue.title || 'Unknown error'
+
+    let line = `[${severity}] ${file}: ${title}`
+
+    if (issue.description) line += ` — ${issue.description}`
+
+    if (issue.source?.range) {
+      const r = issue.source.range
+      line += ` (line ${r.start?.line ?? '?'}:${r.start?.column ?? '?'})`
+    }
+
+    lines.push(line)
+
+    if (issue.detail) {
+      lines.push(issue.detail.trim())
+    }
+
+    if (issue.codeFrame) {
+      lines.push(issue.codeFrame)
+    }
+
+    lines.push('')
+  }
+
+  lines.push(
+    `${issues.length} issue(s). Fix them or dismiss non-actionable ones with: node "./scripts/dismiss-errors.mjs"`
+  )
+
+  const output = {
+    decision: 'block',
+    reason: lines.join('\n'),
+  }
+  process.stdout.write(JSON.stringify(output))
+  process.exit(0)
+} catch (err) {
+  // Server unreachable — don't block the agent from stopping.
+  process.exit(0)
+}

--- a/.claude-plugin/plugins/next-dev/hooks/stop-compile-check.mjs
+++ b/.claude-plugin/plugins/next-dev/hooks/stop-compile-check.mjs
@@ -1,28 +1,86 @@
 #!/usr/bin/env node
 /**
- * Stop hook (skill-scoped). Runs a compilation pass, then blocks if there
- * are compilation errors. The agent must fix them or dismiss them to proceed.
+ * Stop hook (plugin-level, gated on .claude/port).
+ * Runs a compilation pass, then blocks if there are compilation errors.
+ * The agent must fix them or dismiss them to proceed.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * Why we silently skip when the port file is missing
+ * ─────────────────────────────────────────────────────────────────────────
+ * Mirrors enter-manual-compile.mjs. No port file → either the skill was
+ * never activated, or activation failed because the Next.js version is too
+ * old to expose the required MCP tools. Blocking a stop on a non-functional
+ * skill would trap the agent with no way forward, so we exit 0.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * The Webpack edge case (port file present, but hooks are no-ops)
+ * ─────────────────────────────────────────────────────────────────────────
+ * If the dev server is running `next dev --webpack`, the MCP tools exist
+ * but do nothing: `compile_and_resume` is a no-op and `get_compilation_issues`
+ * returns an empty list. This hook will then exit 0 every time, which is
+ * the correct degradation — webpack users just lose the feedback loop.
+ * See enter-manual-compile.mjs for the full rationale.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * Why we do NOT short-circuit on `stop_hook_active`
+ * ─────────────────────────────────────────────────────────────────────────
+ * Repeated blocks are fine: the agent can always dismiss non-actionable
+ * issues via dismiss-errors.mjs and stop cleanly. The block message itself
+ * surfaces that escape hatch.
+ * ─────────────────────────────────────────────────────────────────────────
  */
 
-import { existsSync } from 'node:fs'
-import { join } from 'node:path'
+import { existsSync, unlinkSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import {
   getPort,
+  ping,
   getCompilationIssues,
   compileAndResume,
   filterDismissedIssues,
 } from './mcp-client.mjs'
 
-const projectDir = process.env.CLAUDE_PROJECT_DIR || process.cwd()
-const portFile = join(projectDir, '.claude', 'port')
+// CLAUDE_PROJECT_DIR is guaranteed to be set in hook subprocesses.
+// https://code.claude.com/docs/en/hooks#reference-scripts-by-path
+const portFile = join(process.env.CLAUDE_PROJECT_DIR, '.claude', 'port')
 
-// No port file = setup didn't complete or skill not fully active.
+// Resolve the dismiss-errors script to an absolute path at hook time.
+// We can't print `${CLAUDE_SKILL_DIR}/...` in the block message because
+// that's a skill-load-time template substitution, not a runtime env var —
+// the agent's Bash tool invocation wouldn't expand it. Computing from
+// import.meta.url is also self-contained (no reliance on CLAUDE_PLUGIN_ROOT
+// being set in the agent's Bash subprocess).
+const hookDir = dirname(fileURLToPath(import.meta.url))
+const dismissScript = resolve(
+  hookDir,
+  '..',
+  'skills',
+  'next-dev',
+  'scripts',
+  'dismiss-errors.mjs'
+)
+
 if (!existsSync(portFile)) {
   process.exit(0)
 }
 
+// Self-disable if the dev server is gone. The port file persists across
+// sessions but the dev server may not — see enter-manual-compile.mjs for
+// the full rationale.
+function selfDisable() {
+  try {
+    unlinkSync(portFile)
+  } catch {}
+}
+
 try {
   const port = getPort()
+
+  if (!(await ping(port))) {
+    selfDisable()
+    process.exit(0)
+  }
 
   // Run a compilation pass before checking for errors.
   // This processes all accumulated file changes in one batch.
@@ -73,7 +131,9 @@ try {
   }
 
   lines.push(
-    `${issues.length} issue(s). Fix them or dismiss non-actionable ones with: node "./scripts/dismiss-errors.mjs"`
+    `${issues.length} issue(s). Fix them. If they aren't fixable from your end (third-party code, bundler stubs, false positives), use the escape hatch to dismiss everything currently reported and stop:`,
+    `  node "${dismissScript}"`,
+    `Dismissed issues stay hidden for the rest of the session.`
   )
 
   const output = {
@@ -83,6 +143,7 @@ try {
   process.stdout.write(JSON.stringify(output))
   process.exit(0)
 } catch (err) {
-  // Server unreachable — don't block the agent from stopping.
+  // Server unreachable mid-call — self-disable and don't block the stop.
+  selfDisable()
   process.exit(0)
 }

--- a/.claude-plugin/plugins/next-dev/skills/next-dev/SKILL.md
+++ b/.claude-plugin/plugins/next-dev/skills/next-dev/SKILL.md
@@ -2,17 +2,6 @@
 name: next-dev
 description: "Connect to Next.js dev server for real-time compilation feedback on every edit"
 argument-hint: "[port]"
-hooks:
-  UserPromptSubmit:
-    - hooks:
-        - type: command
-          command: 'node "${CLAUDE_PLUGIN_ROOT}/hooks/enter-manual-compile.mjs"'
-          timeout: 10
-  Stop:
-    - hooks:
-        - type: command
-          command: 'node "${CLAUDE_PLUGIN_ROOT}/hooks/stop-compile-check.mjs"'
-          timeout: 120
 ---
 
 # Next Dev
@@ -24,7 +13,7 @@ Connects to the Next.js dev server MCP endpoint for compilation feedback.
 ## Setup
 
 ```bash
-node "${CLAUDE_PLUGIN_ROOT}/skills/next-dev/scripts/activate.mjs" $ARGUMENTS
+node "${CLAUDE_SKILL_DIR}/scripts/activate.mjs" $ARGUMENTS
 ```
 
 If it fails (non-zero exit), tell the user the error from stderr and offer to retry. Do not edit files until activation succeeds.
@@ -35,23 +24,23 @@ If it fails (non-zero exit), tell the user the error from stderr and offer to re
 
 ## How it works
 
-Two hooks run while this skill is active:
+Activation writes the port number to `.claude/port`. Two plugin-level hooks gate on that file, so they no-op until `/next-dev` runs and silently re-engage on every session afterwards (no `/reload-plugins` needed):
 
 - **UserPromptSubmit**: Checks the dev server is reachable, then pauses compilation for the turn. If the server is down, silently skips — you lose feedback for that turn but aren't blocked.
 - **Stop**: Compiles all pending changes in one batch and exits manual mode (normal HMR resumes). **Blocks you from finishing if there are compilation errors.** Fix them before trying again.
 
-## Noisy / non-actionable errors
+## Escape hatch: dismissing errors
 
-If the stop hook blocks you with errors that aren't yours (node_modules, Turbopack stubs, etc.), dismiss them:
+If the stop hook blocks you with errors you can't fix (third-party code, bundler stubs, false positives) and you'd rather move on, dismiss everything currently reported:
 
 ```bash
-node "${CLAUDE_PLUGIN_ROOT}/skills/next-dev/scripts/dismiss-errors.mjs"
+node "${CLAUDE_SKILL_DIR}/scripts/dismiss-errors.mjs"
 ```
 
-Hides non-actionable errors from all future checks for the rest of the session. Dismissals reset on next activation. To clear manually:
+Hides every currently-reported error from future checks for the rest of the session. New errors from later edits will still surface. To clear manually:
 
 ```bash
-node "${CLAUDE_PLUGIN_ROOT}/skills/next-dev/scripts/dismiss-errors.mjs" --reset
+node "${CLAUDE_SKILL_DIR}/scripts/dismiss-errors.mjs" --reset
 ```
 
 ## On-demand error check
@@ -59,7 +48,7 @@ node "${CLAUDE_PLUGIN_ROOT}/skills/next-dev/scripts/dismiss-errors.mjs" --reset
 Check compilation errors mid-task without waiting for the stop hook:
 
 ```bash
-node "${CLAUDE_PLUGIN_ROOT}/skills/next-dev/scripts/get-errors.mjs"
+node "${CLAUDE_SKILL_DIR}/scripts/get-errors.mjs"
 ```
 
 Compiles pending changes and returns current errors (respects dismissals).

--- a/.claude-plugin/plugins/next-dev/skills/next-dev/SKILL.md
+++ b/.claude-plugin/plugins/next-dev/skills/next-dev/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: next-dev
+description: "Connect to Next.js dev server for real-time compilation feedback on every edit"
+argument-hint: "[port]"
+hooks:
+  UserPromptSubmit:
+    - hooks:
+        - type: command
+          command: 'node "${CLAUDE_PLUGIN_ROOT}/hooks/enter-manual-compile.mjs"'
+          timeout: 10
+  Stop:
+    - hooks:
+        - type: command
+          command: 'node "${CLAUDE_PLUGIN_ROOT}/hooks/stop-compile-check.mjs"'
+          timeout: 120
+---
+
+# Next Dev
+
+> **Experimental.** Requires a Next.js dev server that exposes the `pause_compilation`, `compile_and_resume`, and `get_compilation_issues` MCP tools (Turbopack only). These are not yet available in stable Next.js — see the plugin README for status.
+
+Connects to the Next.js dev server MCP endpoint for compilation feedback.
+
+## Setup
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/skills/next-dev/scripts/activate.mjs" $ARGUMENTS
+```
+
+If it fails (non-zero exit), tell the user the error from stderr and offer to retry. Do not edit files until activation succeeds.
+
+**After activation, tell the user:**
+
+> The dev server is now connected. During each of my turns, automatic recompilation is paused so intermediate edits don't cause errors. When I finish a response, I compile everything in one batch and normal HMR resumes — so between my turns, your browser updates live as usual. To fully disconnect, restart the dev server.
+
+## How it works
+
+Two hooks run while this skill is active:
+
+- **UserPromptSubmit**: Checks the dev server is reachable, then pauses compilation for the turn. If the server is down, silently skips — you lose feedback for that turn but aren't blocked.
+- **Stop**: Compiles all pending changes in one batch and exits manual mode (normal HMR resumes). **Blocks you from finishing if there are compilation errors.** Fix them before trying again.
+
+## Noisy / non-actionable errors
+
+If the stop hook blocks you with errors that aren't yours (node_modules, Turbopack stubs, etc.), dismiss them:
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/skills/next-dev/scripts/dismiss-errors.mjs"
+```
+
+Hides non-actionable errors from all future checks for the rest of the session. Dismissals reset on next activation. To clear manually:
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/skills/next-dev/scripts/dismiss-errors.mjs" --reset
+```
+
+## On-demand error check
+
+Check compilation errors mid-task without waiting for the stop hook:
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/skills/next-dev/scripts/get-errors.mjs"
+```
+
+Compiles pending changes and returns current errors (respects dismissals).

--- a/.claude-plugin/plugins/next-dev/skills/next-dev/scripts/activate.mjs
+++ b/.claude-plugin/plugins/next-dev/skills/next-dev/scripts/activate.mjs
@@ -90,11 +90,20 @@ try {
   const listBody = parseSSE(await listRes.text())
   const tools = listBody?.result?.tools?.map((t) => t.name) || []
 
-  if (!tools.includes('get_compilation_issues')) {
+  const required = [
+    'get_compilation_issues',
+    'pause_compilation',
+    'compile_and_resume',
+  ]
+  const missing = required.filter((t) => !tools.includes(t))
+
+  if (missing.length > 0) {
     fail(
-      `MCP endpoint is reachable but missing "get_compilation_issues" tool.\n` +
+      `MCP endpoint is reachable but missing required tools: ${missing.join(', ')}.\n` +
         `Available tools: ${tools.join(', ')}\n` +
-        `This requires Turbopack. Start the dev server with: pnpm dev --turbopack`
+        `This skill requires a recent Next.js version that exposes these MCP tools, ` +
+        `running with Turbopack (the default in recent Next.js). Upgrade to the ` +
+        `latest Next.js and start the dev server with: pnpm dev`
     )
   }
 
@@ -146,6 +155,6 @@ try {
   }
   fail(
     `Cannot reach MCP endpoint at ${url}: ${err.message}\n` +
-      `Make sure the dev server is running: pnpm dev --turbopack -p ${port}`
+      `Make sure the dev server is running: pnpm dev -p ${port}`
   )
 }

--- a/.claude-plugin/plugins/next-dev/skills/next-dev/scripts/activate.mjs
+++ b/.claude-plugin/plugins/next-dev/skills/next-dev/scripts/activate.mjs
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+/**
+ * Activates agent-mode: writes the port file, then verifies the MCP endpoint
+ * has the get_compilation_issues tool. Cleans up the port file on failure
+ * so hooks know setup didn't complete.
+ */
+
+import { writeFileSync, unlinkSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+
+const port = process.argv[2] || '3000'
+const projectDir = process.env.CLAUDE_PROJECT_DIR || process.cwd()
+const portFile = join(projectDir, '.claude', 'port')
+const dismissedFile = join(projectDir, '.claude', 'dismissed-issues.json')
+const url = `http://localhost:${port}/_next/mcp`
+const headers = {
+  'Content-Type': 'application/json',
+  Accept: 'application/json, text/event-stream',
+}
+
+function parseSSE(text) {
+  for (const line of text.split('\n')) {
+    if (line.startsWith('data:')) {
+      return JSON.parse(line.slice(5))
+    }
+  }
+  return null
+}
+
+function fail(message) {
+  console.error(message)
+  try {
+    unlinkSync(portFile)
+  } catch {}
+  process.exit(1)
+}
+
+// Step 1: Write port, clear stale dismissals from previous session
+writeFileSync(portFile, port, 'utf8')
+try {
+  if (existsSync(dismissedFile)) unlinkSync(dismissedFile)
+} catch {}
+console.log(`Port ${port} written to ${portFile}`)
+
+// Step 2: Verify MCP endpoint
+try {
+  const initRes = await fetch(url, {
+    method: 'POST',
+    headers,
+    signal: AbortSignal.timeout(5000),
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2025-03-26',
+        capabilities: {},
+        clientInfo: { name: 'agent-mode-activate', version: '1.0.0' },
+      },
+    }),
+  })
+
+  if (!initRes.ok) {
+    fail(
+      `MCP endpoint returned ${initRes.status}. Is the dev server running on port ${port}?`
+    )
+  }
+
+  // Send initialized notification
+  await fetch(url, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      method: 'notifications/initialized',
+    }),
+  })
+
+  // List tools
+  const listRes = await fetch(url, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/list',
+    }),
+  })
+
+  const listBody = parseSSE(await listRes.text())
+  const tools = listBody?.result?.tools?.map((t) => t.name) || []
+
+  if (!tools.includes('get_compilation_issues')) {
+    fail(
+      `MCP endpoint is reachable but missing "get_compilation_issues" tool.\n` +
+        `Available tools: ${tools.join(', ')}\n` +
+        `This requires Turbopack. Start the dev server with: pnpm dev --turbopack`
+    )
+  }
+
+  console.log(`Verified. Available tools: ${tools.join(', ')}`)
+
+  // Step 3: Warm up by calling get_compilation_issues in the background.
+  // The first call builds module graphs for all routes and can take minutes
+  // on large projects. Fire-and-forget so the agent can start working
+  // immediately. Turbo-tasks deduplicates — the stop hook's first call
+  // will join the same in-flight computation rather than starting a new one.
+  console.log(
+    'Warming up Turbopack cache in the background (first stop hook may be slow if not ready)...'
+  )
+  fetch(url, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 3,
+      method: 'tools/call',
+      params: { name: 'get_compilation_issues', arguments: {} },
+    }),
+  })
+    .then(async (res) => {
+      const body = parseSSE(await res.text())
+      const issuesText = body?.result?.content?.[0]?.text
+      if (issuesText) {
+        const { issues } = JSON.parse(issuesText)
+        if (issues?.length) {
+          console.log(
+            `Background warm-up done: ${issues.length} issue(s) found.`
+          )
+        } else {
+          console.log('Background warm-up done: no issues found.')
+        }
+      }
+    })
+    .catch(() => {
+      // Warm-up failed silently — stop hook will handle it.
+    })
+
+  // Manual compile mode is entered per-turn by the UserPromptSubmit hook,
+  // not here. This keeps normal HMR active between agent turns.
+} catch (err) {
+  if (err.name === 'TimeoutError') {
+    fail(
+      `MCP endpoint at ${url} timed out. Is the dev server running on port ${port}?`
+    )
+  }
+  fail(
+    `Cannot reach MCP endpoint at ${url}: ${err.message}\n` +
+      `Make sure the dev server is running: pnpm dev --turbopack -p ${port}`
+  )
+}

--- a/.claude-plugin/plugins/next-dev/skills/next-dev/scripts/dismiss-errors.mjs
+++ b/.claude-plugin/plugins/next-dev/skills/next-dev/scripts/dismiss-errors.mjs
@@ -1,12 +1,11 @@
 #!/usr/bin/env node
 /**
- * Classifies compilation errors as actionable or non-actionable and dismisses
- * the non-actionable ones. Dismissed errors are filtered from future checks
+ * Escape hatch: dismisses every currently-reported compilation error so the
+ * stop hook stops blocking. Dismissed errors are filtered from future checks
  * (stop hook + get-errors) for the rest of the session.
  *
- * Heuristics for non-actionable:
- * - File is in node_modules/ (third-party dependency, agent can't fix)
- * - Error references turbopack/empty.js (bundler stub for server-only modules)
+ * Use this when the agent can't fix the reported errors (third-party code,
+ * bundler stubs, false positives) and you'd rather move on than fight them.
  *
  * Usage: node dismiss-errors.mjs [port]
  *   --reset   Clear all dismissals
@@ -47,27 +46,6 @@ function issueKey(issue) {
   const line = issue.source?.range?.start?.line ?? '?'
   const col = issue.source?.range?.start?.column ?? '?'
   return `${severity}|${file}|${title}|${line}:${col}`
-}
-
-/**
- * Classify an issue as non-actionable if the agent can't fix it.
- */
-function isNonActionable(issue) {
-  const file = issue.filePath || ''
-  const description = issue.description || ''
-  const detail = issue.detail || ''
-  const title = issue.title || ''
-  const text = `${title} ${description} ${detail}`
-
-  // Third-party dependency — agent can't edit node_modules
-  if (file.includes('/node_modules/')) return 'node_modules'
-
-  // Turbopack empty module stub — bundler replaces server-only modules with
-  // an empty shim in client bundles, causing "export not found" errors.
-  // Not a real code issue; the source file is correct.
-  if (text.includes('turbopack/empty.js')) return 'turbopack-stub'
-
-  return null
 }
 
 async function mcpCall(port, id, method, params) {
@@ -145,7 +123,7 @@ try {
   const allIssues = result.issues || []
 
   if (allIssues.length === 0) {
-    console.log('No compilation errors to classify.')
+    console.log('No compilation errors to dismiss.')
     process.exit(0)
   }
 
@@ -158,67 +136,19 @@ try {
   }
   const dismissedSet = new Set(existingKeys)
 
-  const actionable = []
-  const dismissed = []
-
   for (const issue of allIssues) {
-    const reason = isNonActionable(issue)
-    if (reason) {
-      dismissed.push({ issue, reason })
-      dismissedSet.add(issueKey(issue))
-    } else {
-      actionable.push(issue)
-    }
+    dismissedSet.add(issueKey(issue))
   }
 
-  // Write merged dismissals
-  if (dismissedSet.size > 0) {
-    writeFileSync(
-      dismissedFile,
-      JSON.stringify({ keys: [...dismissedSet] }),
-      'utf8'
-    )
-  }
+  writeFileSync(
+    dismissedFile,
+    JSON.stringify({ keys: [...dismissedSet] }),
+    'utf8'
+  )
 
-  // Report dismissed
-  if (dismissed.length > 0) {
-    const byReason = {}
-    for (const { reason } of dismissed) {
-      byReason[reason] = (byReason[reason] || 0) + 1
-    }
-    const summary = Object.entries(byReason)
-      .map(([reason, count]) => `${count} ${reason}`)
-      .join(', ')
-    console.log(
-      `Dismissed ${dismissed.length} non-actionable error(s): ${summary}.`
-    )
-  }
-
-  // Report actionable
-  if (actionable.length === 0) {
-    console.log('No actionable errors remain.')
-    process.exit(0)
-  }
-
-  console.log(`\n${actionable.length} actionable error(s):\n`)
-
-  for (const issue of actionable) {
-    const severity = issue.severity || 'error'
-    const file = issue.filePath || 'unknown'
-    const title = issue.title || 'Unknown error'
-
-    let line = `[${severity}] ${file}: ${title}`
-    if (issue.description) line += ` — ${issue.description}`
-    if (issue.source?.range) {
-      const r = issue.source.range
-      line += ` (line ${r.start?.line ?? '?'}:${r.start?.column ?? '?'})`
-    }
-    console.log(line)
-
-    if (issue.detail) console.log(issue.detail.trim())
-    if (issue.codeFrame) console.log(issue.codeFrame)
-    console.log()
-  }
+  console.log(
+    `Dismissed ${allIssues.length} error(s). They will be hidden from future checks this session. Run with --reset to clear.`
+  )
 } catch (err) {
   console.error(`Cannot reach dev server on port ${port}: ${err.message}`)
   process.exit(1)

--- a/.claude-plugin/plugins/next-dev/skills/next-dev/scripts/dismiss-errors.mjs
+++ b/.claude-plugin/plugins/next-dev/skills/next-dev/scripts/dismiss-errors.mjs
@@ -1,0 +1,225 @@
+#!/usr/bin/env node
+/**
+ * Classifies compilation errors as actionable or non-actionable and dismisses
+ * the non-actionable ones. Dismissed errors are filtered from future checks
+ * (stop hook + get-errors) for the rest of the session.
+ *
+ * Heuristics for non-actionable:
+ * - File is in node_modules/ (third-party dependency, agent can't fix)
+ * - Error references turbopack/empty.js (bundler stub for server-only modules)
+ *
+ * Usage: node dismiss-errors.mjs [port]
+ *   --reset   Clear all dismissals
+ */
+
+import { readFileSync, writeFileSync, existsSync, unlinkSync } from 'node:fs'
+import { join } from 'node:path'
+
+const MCP_HEADERS = {
+  'Content-Type': 'application/json',
+  Accept: 'application/json, text/event-stream',
+}
+
+function parseSSE(text) {
+  for (const line of text.split('\n')) {
+    if (line.startsWith('data:')) {
+      return JSON.parse(line.slice(5))
+    }
+  }
+  return null
+}
+
+const projectDir = process.env.CLAUDE_PROJECT_DIR || process.cwd()
+const dismissedFile = join(projectDir, '.claude', 'dismissed-issues.json')
+
+function getPort() {
+  return readFileSync(join(projectDir, '.claude', 'port'), 'utf8').trim()
+}
+
+function getMcpUrl(port) {
+  return `http://localhost:${port}/_next/mcp`
+}
+
+function issueKey(issue) {
+  const severity = issue.severity || 'error'
+  const file = issue.filePath || 'unknown'
+  const title = issue.title || ''
+  const line = issue.source?.range?.start?.line ?? '?'
+  const col = issue.source?.range?.start?.column ?? '?'
+  return `${severity}|${file}|${title}|${line}:${col}`
+}
+
+/**
+ * Classify an issue as non-actionable if the agent can't fix it.
+ */
+function isNonActionable(issue) {
+  const file = issue.filePath || ''
+  const description = issue.description || ''
+  const detail = issue.detail || ''
+  const title = issue.title || ''
+  const text = `${title} ${description} ${detail}`
+
+  // Third-party dependency — agent can't edit node_modules
+  if (file.includes('/node_modules/')) return 'node_modules'
+
+  // Turbopack empty module stub — bundler replaces server-only modules with
+  // an empty shim in client bundles, causing "export not found" errors.
+  // Not a real code issue; the source file is correct.
+  if (text.includes('turbopack/empty.js')) return 'turbopack-stub'
+
+  return null
+}
+
+async function mcpCall(port, id, method, params) {
+  const url = getMcpUrl(port)
+
+  await fetch(url, {
+    method: 'POST',
+    headers: MCP_HEADERS,
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2025-03-26',
+        capabilities: {},
+        clientInfo: { name: 'dismiss-errors', version: '1.0.0' },
+      },
+    }),
+  })
+
+  await fetch(url, {
+    method: 'POST',
+    headers: MCP_HEADERS,
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      method: 'notifications/initialized',
+    }),
+  })
+
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: MCP_HEADERS,
+    body: JSON.stringify({ jsonrpc: '2.0', id, method, params }),
+  })
+
+  const body = parseSSE(await res.text())
+  if (body?.error) throw new Error(body.error.message)
+
+  const text = body?.result?.content?.[0]?.text
+  if (!text) throw new Error('Unexpected MCP response shape')
+  return JSON.parse(text)
+}
+
+// Handle --reset flag
+if (process.argv.includes('--reset')) {
+  try {
+    if (existsSync(dismissedFile)) {
+      unlinkSync(dismissedFile)
+      console.log('Dismissed issues cleared.')
+    } else {
+      console.log('No dismissed issues to clear.')
+    }
+  } catch (err) {
+    console.error(`Failed to clear dismissals: ${err.message}`)
+    process.exit(1)
+  }
+  process.exit(0)
+}
+
+const port = process.argv[2] || getPort()
+
+try {
+  // Compile first to flush pending changes.
+  try {
+    await mcpCall(port, 2, 'tools/call', {
+      name: 'compile_and_resume',
+      arguments: {},
+    })
+  } catch {}
+
+  const result = await mcpCall(port, 3, 'tools/call', {
+    name: 'get_compilation_issues',
+    arguments: {},
+  })
+  const allIssues = result.issues || []
+
+  if (allIssues.length === 0) {
+    console.log('No compilation errors to classify.')
+    process.exit(0)
+  }
+
+  // Load existing dismissals so we can merge
+  let existingKeys = []
+  if (existsSync(dismissedFile)) {
+    try {
+      existingKeys = JSON.parse(readFileSync(dismissedFile, 'utf8')).keys || []
+    } catch {}
+  }
+  const dismissedSet = new Set(existingKeys)
+
+  const actionable = []
+  const dismissed = []
+
+  for (const issue of allIssues) {
+    const reason = isNonActionable(issue)
+    if (reason) {
+      dismissed.push({ issue, reason })
+      dismissedSet.add(issueKey(issue))
+    } else {
+      actionable.push(issue)
+    }
+  }
+
+  // Write merged dismissals
+  if (dismissedSet.size > 0) {
+    writeFileSync(
+      dismissedFile,
+      JSON.stringify({ keys: [...dismissedSet] }),
+      'utf8'
+    )
+  }
+
+  // Report dismissed
+  if (dismissed.length > 0) {
+    const byReason = {}
+    for (const { reason } of dismissed) {
+      byReason[reason] = (byReason[reason] || 0) + 1
+    }
+    const summary = Object.entries(byReason)
+      .map(([reason, count]) => `${count} ${reason}`)
+      .join(', ')
+    console.log(
+      `Dismissed ${dismissed.length} non-actionable error(s): ${summary}.`
+    )
+  }
+
+  // Report actionable
+  if (actionable.length === 0) {
+    console.log('No actionable errors remain.')
+    process.exit(0)
+  }
+
+  console.log(`\n${actionable.length} actionable error(s):\n`)
+
+  for (const issue of actionable) {
+    const severity = issue.severity || 'error'
+    const file = issue.filePath || 'unknown'
+    const title = issue.title || 'Unknown error'
+
+    let line = `[${severity}] ${file}: ${title}`
+    if (issue.description) line += ` — ${issue.description}`
+    if (issue.source?.range) {
+      const r = issue.source.range
+      line += ` (line ${r.start?.line ?? '?'}:${r.start?.column ?? '?'})`
+    }
+    console.log(line)
+
+    if (issue.detail) console.log(issue.detail.trim())
+    if (issue.codeFrame) console.log(issue.codeFrame)
+    console.log()
+  }
+} catch (err) {
+  console.error(`Cannot reach dev server on port ${port}: ${err.message}`)
+  process.exit(1)
+}

--- a/.claude-plugin/plugins/next-dev/skills/next-dev/scripts/get-errors.mjs
+++ b/.claude-plugin/plugins/next-dev/skills/next-dev/scripts/get-errors.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+/**
+ * Returns current compilation errors from the Next.js dev server.
+ *
+ * Usage: node get-errors.mjs [port]
+ */
+
+import { readFileSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+
+const MCP_HEADERS = {
+  'Content-Type': 'application/json',
+  Accept: 'application/json, text/event-stream',
+}
+
+function parseSSE(text) {
+  for (const line of text.split('\n')) {
+    if (line.startsWith('data:')) {
+      return JSON.parse(line.slice(5))
+    }
+  }
+  return null
+}
+
+const projectDir = process.env.CLAUDE_PROJECT_DIR || process.cwd()
+
+function getPort() {
+  return readFileSync(join(projectDir, '.claude', 'port'), 'utf8').trim()
+}
+
+function issueKey(issue) {
+  const severity = issue.severity || 'error'
+  const file = issue.filePath || 'unknown'
+  const title = issue.title || ''
+  const line = issue.source?.range?.start?.line ?? '?'
+  const col = issue.source?.range?.start?.column ?? '?'
+  return `${severity}|${file}|${title}|${line}:${col}`
+}
+
+function filterDismissedIssues(issues) {
+  const dismissedFile = join(projectDir, '.claude', 'dismissed-issues.json')
+  if (!existsSync(dismissedFile)) return { issues, dismissedCount: 0 }
+  try {
+    const { keys } = JSON.parse(readFileSync(dismissedFile, 'utf8'))
+    const dismissed = new Set(keys)
+    const kept = issues.filter((i) => !dismissed.has(issueKey(i)))
+    return { issues: kept, dismissedCount: issues.length - kept.length }
+  } catch {
+    return { issues, dismissedCount: 0 }
+  }
+}
+
+function getMcpUrl(port) {
+  return `http://localhost:${port}/_next/mcp`
+}
+
+async function mcpCall(port, id, method, params) {
+  const url = getMcpUrl(port)
+
+  // Initialize
+  await fetch(url, {
+    method: 'POST',
+    headers: MCP_HEADERS,
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2025-03-26',
+        capabilities: {},
+        clientInfo: { name: 'get-errors', version: '1.0.0' },
+      },
+    }),
+  })
+
+  await fetch(url, {
+    method: 'POST',
+    headers: MCP_HEADERS,
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      method: 'notifications/initialized',
+    }),
+  })
+
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: MCP_HEADERS,
+    body: JSON.stringify({ jsonrpc: '2.0', id, method, params }),
+  })
+
+  const body = parseSSE(await res.text())
+  if (body?.error) throw new Error(body.error.message)
+
+  const text = body?.result?.content?.[0]?.text
+  if (!text) throw new Error('Unexpected MCP response shape')
+  return JSON.parse(text)
+}
+
+const port = process.argv[2] || getPort()
+
+try {
+  // Compile first to flush pending changes.
+  try {
+    await mcpCall(port, 2, 'tools/call', {
+      name: 'compile_and_resume',
+      arguments: {},
+    })
+  } catch {}
+
+  const result = await mcpCall(port, 3, 'tools/call', {
+    name: 'get_compilation_issues',
+    arguments: {},
+  })
+  const allIssues = result.issues || []
+  const { issues, dismissedCount } = filterDismissedIssues(allIssues)
+
+  if (issues.length === 0) {
+    if (dismissedCount > 0) {
+      console.log(`No compilation errors (${dismissedCount} dismissed hidden).`)
+    } else {
+      console.log('No compilation errors.')
+    }
+    process.exit(0)
+  }
+
+  for (const issue of issues) {
+    const severity = issue.severity || 'error'
+    const file = issue.filePath || 'unknown'
+    const title = issue.title || 'Unknown error'
+
+    let line = `[${severity}] ${file}: ${title}`
+    if (issue.description) line += ` — ${issue.description}`
+    if (issue.source?.range) {
+      const r = issue.source.range
+      line += ` (line ${r.start?.line ?? '?'}:${r.start?.column ?? '?'})`
+    }
+    console.log(line)
+
+    if (issue.detail) console.log(issue.detail.trim())
+    if (issue.codeFrame) console.log(issue.codeFrame)
+    console.log()
+  }
+
+  if (dismissedCount > 0) {
+    console.log(
+      `${issues.length} issue(s) found (${dismissedCount} dismissed hidden).`
+    )
+  } else {
+    console.log(`${issues.length} issue(s) found.`)
+  }
+} catch (err) {
+  console.error(`Cannot reach dev server on port ${port}: ${err.message}`)
+  process.exit(1)
+}

--- a/.claude-plugin/plugins/next-dev/test/README.md
+++ b/.claude-plugin/plugins/next-dev/test/README.md
@@ -1,0 +1,105 @@
+# Local end-to-end testing
+
+This directory has a fake MCP server you can use to exercise the plugin's full
+hook flow without spinning up a real Next.js dev server. Useful when iterating
+on the plugin itself.
+
+## Run the fake server
+
+```bash
+node .claude-plugin/plugins/next-dev/test/start-test-server.mjs 4321
+```
+
+It listens on `http://localhost:<port>` and serves the same `/_next/mcp`
+JSON-RPC surface that Next.js's real dev server exposes — just enough of it
+to make `initialize`, `tools/list`, `pause_compilation`, `compile_and_resume`,
+and `get_compilation_issues` work. By default it returns zero compilation
+issues.
+
+## Install the plugin from the local marketplace
+
+In a separate Claude Code session, in any working directory:
+
+```
+/plugin marketplace add /absolute/path/to/next.js/.claude-plugin
+/plugin install next-dev@nextjs
+/next-dev 4321
+```
+
+> **Note:** point `marketplace add` at the `.claude-plugin/` directory (the
+> one that contains `marketplace.json`), not the repo root. Source paths in
+> `marketplace.json` resolve relative to whatever path you pass here, so
+> pointing at the repo root makes `./plugins/next-dev` resolve to a non-existent
+> `<repo>/plugins/next-dev`.
+
+Activation should succeed (the fake server reports the three required tools
+as available) and write `.claude/port`. From that point on the plugin's
+`UserPromptSubmit` and `Stop` hooks fire on every turn and call into the fake
+server.
+
+> **Why plugin-level hooks?** Skill-frontmatter hooks are not currently
+> reliably supported by Claude Code (see
+> [anthropics/claude-code#17688](https://github.com/anthropics/claude-code/issues/17688)),
+> so the hooks live in `hooks/hooks.json` and gate on the existence of
+> `.claude/port` instead. Net result is the same: hooks no-op until
+> `/next-dev` runs.
+
+## Test the Stop-hook block flow
+
+The fake server has a tiny control surface for injecting fake errors:
+
+```bash
+# Make the next Stop hook block
+curl -X POST http://localhost:4321/control/issues \
+  -H 'content-type: application/json' \
+  -d '[{"severity":"error","filePath":"app/page.tsx","title":"Boom","description":"fake error"}]'
+
+# Let the next Stop hook pass again
+curl -X POST http://localhost:4321/control/clear
+
+# Inspect current fake state
+curl http://localhost:4321/control/state
+```
+
+Drive the plugin in Claude Code, toggle errors on, ask the agent to stop —
+you should see the block message with the dismiss instructions.
+
+## Test the dismiss escape hatch
+
+`dismiss-errors.mjs` is an unconditional escape hatch: it dismisses every
+currently-reported error so the Stop hook stops blocking. There's no heuristic.
+
+1. Inject any fake error (see above) and ask the agent to stop — Stop hook
+   blocks.
+2. Run the dismiss command from the block message. It dismisses the injected
+   error and writes `.claude/dismissed-issues.json`.
+3. Ask the agent to stop again — Stop hook now passes.
+4. Inject a *different* error and try again — it blocks again, because the
+   dismissal only covers the keys recorded at dismiss time.
+5. To clear all dismissals: `node <dismiss-script> --reset`. Dismissals also
+   reset automatically on the next `/next-dev` activation.
+
+## Test the dev-server-gone self-disable
+
+The plugin self-disables (deletes `.claude/port`) when a hook can't reach the
+dev server, so a stale port file from a previous session doesn't burn the
+hook timeout on every turn.
+
+1. Activate with `/next-dev 4321`, do a turn — hooks fire.
+2. Kill the fake server (Ctrl-C the `start-test-server.mjs` process).
+3. Do another turn. The next `UserPromptSubmit` hook will fail its ping and
+   delete `.claude/port`. Confirm: `ls /Users/judegao/workspace/empty/.claude/port`
+   should now be gone.
+4. Subsequent turns are instant no-ops until the user re-runs `/next-dev`.
+
+## Reload after editing
+
+Hook scripts (`hooks/*.mjs`) are re-read on each invocation, so edits take
+effect on the next prompt with no restart. Edits to `hooks/hooks.json`,
+`SKILL.md`, or skill scripts require uninstalling and reinstalling the
+plugin (or running `/reload-plugins`):
+
+```
+/plugin uninstall next-dev@nextjs
+/plugin install next-dev@nextjs
+```

--- a/.claude-plugin/plugins/next-dev/test/start-test-server.mjs
+++ b/.claude-plugin/plugins/next-dev/test/start-test-server.mjs
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+/**
+ * Fake Next.js MCP server for end-to-end testing the next-dev plugin
+ * without spinning up a real Next.js dev server.
+ *
+ * Implements just enough of the JSON-RPC over POST /_next/mcp protocol
+ * to satisfy the plugin's hooks:
+ *   - initialize / notifications/initialized
+ *   - tools/list (returns the three required tool names)
+ *   - tools/call: pause_compilation, compile_and_resume, get_compilation_issues
+ *
+ * Also exposes a tiny control surface so you can toggle the fake error
+ * state mid-session without restarting the server:
+ *
+ *   # Inject fake errors (forces the Stop hook to block)
+ *   curl -X POST http://localhost:<port>/control/issues \
+ *     -H 'content-type: application/json' \
+ *     -d '[{"severity":"error","filePath":"app/page.tsx","title":"Boom","description":"fake error"}]'
+ *
+ *   # Clear errors (let the Stop hook pass)
+ *   curl -X POST http://localhost:<port>/control/clear
+ *
+ *   # Inspect current state
+ *   curl http://localhost:<port>/control/state
+ *
+ * Usage:
+ *   node test/start-test-server.mjs [port]
+ */
+
+import { createServer } from 'node:http'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const port = parseInt(process.argv[2] || process.env.PORT || '3000', 10)
+
+// .../next.js/.claude-plugin/plugins/next-dev/test → .../next.js/.claude-plugin
+// `marketplace add` must point at the directory that *contains* marketplace.json
+// (i.e. .claude-plugin/), not the repo root. Source paths in marketplace.json
+// resolve relative to whatever path you pass to `marketplace add`.
+const marketplaceRoot = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+  '..'
+)
+
+let fakeIssues = []
+
+function sse(payload) {
+  return `data: ${JSON.stringify(payload)}\n\n`
+}
+
+function jsonRpcResult(id, result) {
+  return { jsonrpc: '2.0', id, result }
+}
+
+function toolResult(id, value) {
+  return jsonRpcResult(id, {
+    content: [{ type: 'text', text: JSON.stringify(value) }],
+  })
+}
+
+function readBody(req) {
+  return new Promise((resolve, reject) => {
+    let buf = ''
+    req.on('data', (chunk) => {
+      buf += chunk
+    })
+    req.on('end', () => resolve(buf))
+    req.on('error', reject)
+  })
+}
+
+const server = createServer(async (req, res) => {
+  try {
+    // Control surface — not part of the MCP protocol, just for tests.
+    if (req.method === 'POST' && req.url === '/control/issues') {
+      fakeIssues = JSON.parse(await readBody(req))
+      console.log(`[control] set ${fakeIssues.length} fake issue(s)`)
+      res.writeHead(200, { 'content-type': 'application/json' })
+      res.end(JSON.stringify({ ok: true, count: fakeIssues.length }))
+      return
+    }
+
+    if (req.method === 'POST' && req.url === '/control/clear') {
+      fakeIssues = []
+      console.log('[control] cleared fake issues')
+      res.writeHead(200, { 'content-type': 'application/json' })
+      res.end('{"ok":true}')
+      return
+    }
+
+    if (req.method === 'GET' && req.url === '/control/state') {
+      res.writeHead(200, { 'content-type': 'application/json' })
+      res.end(JSON.stringify({ issues: fakeIssues }))
+      return
+    }
+
+    // MCP endpoint
+    if (req.method === 'POST' && req.url === '/_next/mcp') {
+      const raw = await readBody(req)
+      const msg = JSON.parse(raw)
+
+      console.log(
+        `[mcp] ${msg.method}${msg.params?.name ? ` (${msg.params.name})` : ''}`
+      )
+
+      // Notifications have no id and no response body.
+      if (msg.method === 'notifications/initialized') {
+        res.writeHead(202)
+        res.end()
+        return
+      }
+
+      let payload
+      if (msg.method === 'initialize') {
+        payload = jsonRpcResult(msg.id, {
+          protocolVersion: '2025-03-26',
+          capabilities: { tools: {} },
+          serverInfo: { name: 'fake-next-mcp', version: '0.0.0' },
+        })
+      } else if (msg.method === 'tools/list') {
+        payload = jsonRpcResult(msg.id, {
+          tools: [
+            { name: 'get_compilation_issues', description: 'fake' },
+            { name: 'pause_compilation', description: 'fake' },
+            { name: 'compile_and_resume', description: 'fake' },
+          ],
+        })
+      } else if (msg.method === 'tools/call') {
+        const name = msg.params?.name
+        if (name === 'pause_compilation') {
+          payload = toolResult(msg.id, { paused: true })
+        } else if (name === 'compile_and_resume') {
+          payload = toolResult(msg.id, { compiled: true })
+        } else if (name === 'get_compilation_issues') {
+          payload = toolResult(msg.id, { issues: fakeIssues })
+        } else {
+          payload = {
+            jsonrpc: '2.0',
+            id: msg.id,
+            error: { code: -32601, message: `unknown tool: ${name}` },
+          }
+        }
+      } else {
+        payload = {
+          jsonrpc: '2.0',
+          id: msg.id,
+          error: { code: -32601, message: `unknown method: ${msg.method}` },
+        }
+      }
+
+      res.writeHead(200, {
+        'content-type': 'text/event-stream',
+        'cache-control': 'no-cache',
+      })
+      res.end(sse(payload))
+      return
+    }
+
+    res.writeHead(404)
+    res.end('not found')
+  } catch (err) {
+    console.error('[error]', err)
+    res.writeHead(500)
+    res.end(err.message)
+  }
+})
+
+server.listen(port, () => {
+  console.log(`fake next-dev MCP server listening on http://localhost:${port}`)
+  console.log('')
+  console.log('In a Claude Code session:')
+  console.log(`  /plugin marketplace add ${marketplaceRoot}`)
+  console.log(`  /plugin install next-dev@nextjs`)
+  console.log(`  /next-dev ${port}`)
+  console.log('')
+  console.log('Inject a fake error to test the Stop-hook block flow:')
+  console.log(
+    `  curl -X POST http://localhost:${port}/control/issues -H 'content-type: application/json' \\`
+  )
+  console.log(
+    `    -d '[{"severity":"error","filePath":"app/page.tsx","title":"Boom","description":"fake error"}]'`
+  )
+  console.log('')
+  console.log('Clear errors:')
+  console.log(`  curl -X POST http://localhost:${port}/control/clear`)
+})


### PR DESCRIPTION
## Summary

Adds an experimental `next-dev` Claude Code plugin to the Next.js marketplace.

Today, an agent editing Next.js code usually only discovers compilation errors at the very end, when it runs `pnpm build`. By then it may have layered many edits on top of a broken state, and fixing things means unwinding work instead of correcting it in place. The feedback loop that a human developer gets from a running dev server — "you just broke this, fix it now" — isn't available to the agent.

This plugin closes that gap. While the `/next-dev <port>` skill is active, the agent is wired into a running Next.js dev server's MCP endpoint and gets Turbopack compilation feedback between turns:

- At the start of each turn, compilation is paused so intermediate edits don't thrash HMR.
- When the agent tries to stop, compilation is resumed and run in one batch. If there are errors, the agent is blocked from stopping and must fix them — or explicitly dismiss non-actionable ones (e.g. `node_modules` resolution noise, Turbopack empty-module stubs) via a dismiss script.

The result is that the agent is forced to converge on a compiling state turn by turn, instead of accumulating breakage until the final build.

## Status: experimental

This plugin depends on MCP tools that are not yet in stable Next.js:

- `get_compilation_issues` — #92062
- `pause_compilation` / `compile_and_resume` — #92410

**Requirements:** the latest Next.js (with the PRs above), running with Turbopack. Webpack is not supported — the MCP tools exist but are no-ops under webpack, so the skill silently degrades to doing nothing. The activation script verifies the tools are present and bails out with a clear error otherwise.

## Drive-by fix: marketplace `source` paths

Both plugins in `.claude-plugin/marketplace.json` had `source: "./plugins/<name>"`, which the marketplace docs say resolves relative to the directory containing `.claude-plugin/` (i.e. the repo root). That points at a non-existent `<repo>/plugins/<name>` instead of the actual `<repo>/.claude-plugin/plugins/<name>`, so neither plugin was actually installable. Updated both `cache-components` and `next-dev` source paths to `./.claude-plugin/plugins/<name>`. Verified locally with `/plugin install next-dev@nextjs`.

## Test plan

- [ ] Install via `/plugin marketplace add vercel/next.js` + `/plugin install next-dev@nextjs` against a Next.js dev server with the dependency PRs applied
- [ ] `/next-dev 3000` activates cleanly; activation fails with a clear message when tools are missing
- [ ] Stop hook blocks on errors; dismissing via `dismiss-errors.mjs` lets the agent stop cleanly

<!-- NEXT_JS_LLM_PR -->
