### PR TITLE
Include more context in macOS Rosetta 2 warning message

### DIFF
--- a/packages/next/src/bin/next.ts
+++ b/packages/next/src/bin/next.ts
@@ -96,7 +96,9 @@ class NextRootCommand extends Command {
         os.cpus().some((cpu) => cpu.model.includes('Apple'))
       ) {
         warn(
-          'You are running Next.js on an Apple Silicon Mac with Rosetta 2 translation, which may cause degraded performance.'
+          'You are running Next.js on an Apple Silicon Mac with Rosetta 2 ' +
+            'translation, which may cause degraded performance. You may have ' +
+            'accidentally installed an x86-64 version of Node.js.'
         )
       }
 


### PR DESCRIPTION
Addresses this missed review comment: https://github.com/vercel/next.js/pull/92220#discussion_r3024004242

There's only so much context we can provide because there's a ton of different ways users could've installed node incorrectly.