### PR TITLE
fix: warn when html tag is used in next/head

### DIFF
--- a/packages/next/src/shared/lib/head.tsx
+++ b/packages/next/src/shared/lib/head.tsx
@@ -140,6 +140,10 @@ function reduceComponents(
           warnOnce(
             `Do not add stylesheets using next/head (see <link rel="stylesheet"> tag with href="${c.props['href']}"). Use Document instead. \nSee more info here: https://nextjs.org/docs/messages/no-stylesheets-in-head-component`
           )
+        } else if (c.type === 'html') {
+          warnOnce(
+            `Do not add <html> tags using next/head. This tag is not valid in the head and may cause unexpected behavior. Use the lang attribute on <html> in your _document.js or _app.js instead. \nSee more info here: https://nextjs.org/docs/advanced-features/custom-document`
+          )
         }
       }
       return React.cloneElement(c, { key })


### PR DESCRIPTION
## Description

Adds a warning when users try to add <html> tags inside next/head, which is not valid HTML and causes the misleading 'next-head-count is missing' error.

## Problem

When users mistakenly add an <html> tag inside next/head like this:

```jsx
<Head>
  <html lang="en" />
  <title>Demo Page</title>
</Head>
```

They get an unhelpful 'next-head-count is missing' error and the head content ends up in the body.

## Solution

Add a development warning that:
1. Warns about the invalid tag
2. Directs users to Custom Document documentation for setting html attributes
3. Gracefully continues rendering instead of failing silently

## Related Issue

Fixes #20924

## Changes

- Added warning check for <html> tags in head.tsx reduceComponents function
- Warning message explains the issue and provides link to Custom Document docs
