### PR TITLE
docs: clarify that proxy/middleware matches static assets by default

### DIFF
--- a/docs/01-app/03-api-reference/03-file-conventions/proxy.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/proxy.mdx
@@ -70,7 +70,9 @@ Optionally, a config object can be exported alongside the Proxy function. This o
 
 ### Matcher
 
-The `matcher` option allows you to target specific paths for the Proxy to run on. You can specify these paths in several ways:
+The `matcher` option allows you to target specific paths for the Proxy to run on. Without a `matcher`, Proxy runs on **every request**, including requests for static files (`_next/static`), image optimizations (`_next/image`), and assets in the `public/` folder. This means auth logic or redirects can unintentionally block CSS, JS, or images from loading. Use `matcher` to specify which paths the Proxy should run on, or use a [negative match pattern](#negative-matching) to exclude these paths.
+
+You can specify paths in several ways:
 
 - For a single path: Directly use a string to define the path, like `'/about'`.
 - For multiple paths: Use an array to list multiple paths, such as `matcher: ['/about', '/contact']`, which applies the Proxy to both `/about` and `/contact`.

--- a/docs/01-app/03-api-reference/03-file-conventions/proxy.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/proxy.mdx
@@ -70,7 +70,9 @@ Optionally, a config object can be exported alongside the Proxy function. This o
 
 ### Matcher
 
-The `matcher` option allows you to target specific paths for the Proxy to run on. Without a `matcher`, Proxy runs on **every request**, including requests for static files (`_next/static`), image optimizations (`_next/image`), and assets in the `public/` folder. This means auth logic or redirects can unintentionally block CSS, JS, or images from loading. Use `matcher` to specify which paths the Proxy should run on, or use a [negative match pattern](#negative-matching) to exclude these paths.
+The `matcher` option allows you to target specific paths for the Proxy to run on.
+
+Without a `matcher`, Proxy runs on **every request** — including static files (`_next/static`), image optimizations (`_next/image`), and assets in the `public/` folder. Consider using a [negative match pattern](#negative-matching) to exclude these paths, otherwise auth logic or redirects can unintentionally block CSS, JS, or images from loading.
 
 You can specify paths in several ways:
 

--- a/docs/01-app/03-api-reference/03-file-conventions/proxy.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/proxy.mdx
@@ -201,11 +201,7 @@ To produce a response from Proxy, you can:
 
 ## Execution order
 
-Proxy will be invoked for **every route in your project**. Given this, it's crucial to use [matchers](#matcher) to precisely target or exclude specific routes.
-
-> **Good to know**: Without a configured `matcher`, Proxy runs on **every request**, including `_next/static` (CSS/JS bundles), `_next/image` (image optimizations), and files served from the `public/` folder (like `favicon.ico`). If your Proxy performs redirects or access control without excluding these paths, static assets may fail to load. See [Negative matching](#negative-matching) for an example of how to exclude them.
-
-The following is the execution order:
+Proxy will be invoked for **every route in your project**. Given this, it's crucial to use [matchers](#matcher) to precisely target or exclude specific routes. The following is the execution order:
 
 1. `headers` from `next.config.js`
 2. `redirects` from `next.config.js`

--- a/docs/01-app/03-api-reference/03-file-conventions/proxy.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/proxy.mdx
@@ -199,7 +199,11 @@ To produce a response from Proxy, you can:
 
 ## Execution order
 
-Proxy will be invoked for **every route in your project**. Given this, it's crucial to use [matchers](#matcher) to precisely target or exclude specific routes. The following is the execution order:
+Proxy will be invoked for **every route in your project**. Given this, it's crucial to use [matchers](#matcher) to precisely target or exclude specific routes.
+
+> **Good to know**: Without a configured `matcher`, Proxy runs on **every request**, including `_next/static` (CSS/JS bundles), `_next/image` (image optimizations), and files served from the `public/` folder (like `favicon.ico`). If your Proxy performs redirects or access control without excluding these paths, static assets may fail to load. See [Negative matching](#negative-matching) for an example of how to exclude them.
+
+The following is the execution order:
 
 1. `headers` from `next.config.js`
 2. `redirects` from `next.config.js`

--- a/docs/01-app/03-api-reference/03-file-conventions/proxy.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/proxy.mdx
@@ -72,7 +72,7 @@ Optionally, a config object can be exported alongside the Proxy function. This o
 
 The `matcher` option allows you to target specific paths for the Proxy to run on.
 
-Without a `matcher`, Proxy runs on **every request** — including static files (`_next/static`), image optimizations (`_next/image`), and assets in the `public/` folder. Consider using a [negative match pattern](#negative-matching) to exclude these paths, otherwise auth logic or redirects can unintentionally block CSS, JS, or images from loading.
+Without a `matcher`, Proxy runs on **every request**, including static files (`_next/static`), image optimizations (`_next/image`), and assets in the `public/` folder. Consider using a [negative match pattern](#negative-matching) to exclude these paths, otherwise auth logic or redirects can unintentionally block CSS, JS, or images from loading.
 
 You can specify paths in several ways:
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What?

Adds an explicit note about Proxy's default matching behavior at the top of the **Matcher** section in the Proxy API reference — the first place users look when configuring which paths Proxy runs on.

### Why?

Users have reported issues where Tailwind styles and other static assets fail to load because their Proxy auth logic intercepts `_next/static` requests and redirects them (see #92435). The existing docs mention that Proxy runs on "every route" but don't explicitly call out static assets, image optimizations, or public folder files — making this a common pitfall that gets misdiagnosed as a CSS/PostCSS problem.

### How?

Added an inline paragraph at the top of the **Matcher** subsection explaining that without a `matcher`, Proxy matches every request — including `_next/static`, `_next/image`, and `public/` files — and that this can break asset loading. Links to the existing Negative matching section.

Fixes #92435

<!-- NEXT_JS_LLM_PR -->
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://vercel.slack.com/archives/C0AA1U29GQ0/p1775539745696779?thread_ts=1775539745.696779&cid=C0AA1U29GQ0)

<div><a href="https://cursor.com/agents/bc-263e5d8f-e356-5e3a-a247-856d00a78af4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-263e5d8f-e356-5e3a-a247-856d00a78af4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

