### PR TITLE
Fix styled-jsx styles lost when _document.getInitialProps bypasses defaultGetInitialProps

### DIFF
--- a/packages/next/src/server/render.tsx
+++ b/packages/next/src/server/render.tsx
@@ -1413,8 +1413,15 @@ export async function renderToHTMLImpl(
 
     let styles
     if (hasDocumentGetInitialProps) {
-      styles = docProps.styles
-      head = docProps.head
+      styles = docProps?.styles
+      head = docProps?.head
+      if (!styles && documentInitialPropsRes !== null) {
+        // Custom _document.getInitialProps called ctx.renderPage() directly
+        // without Document.getInitialProps, so styled-jsx styles were not
+        // collected. Collect them from the registry populated during renderPage.
+        styles = jsxStyleRegistry.styles()
+        jsxStyleRegistry.flush()
+      }
     } else {
       styles = jsxStyleRegistry.styles()
       jsxStyleRegistry.flush()

--- a/test/e2e/styled-jsx-render-page/index.test.ts
+++ b/test/e2e/styled-jsx-render-page/index.test.ts
@@ -1,0 +1,18 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('styled-jsx with custom _document renderPage', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+  })
+
+  // When _document.getInitialProps calls ctx.renderPage() directly instead of
+  // Document.getInitialProps(ctx), styled-jsx styles are lost because
+  // defaultGetInitialProps is never called to collect them.
+  it('should contain styled-jsx styles in <head> during SSR', async () => {
+    const html = await next.render('/')
+    // Styles must appear in <head>, not just anywhere in the HTML
+    const headContent = html.match(/<head[^>]*>([\s\S]*?)<\/head>/i)?.[1] ?? ''
+    expect(headContent).toMatch(/color:.*?red/)
+  })
+})

--- a/test/e2e/styled-jsx-render-page/pages/_document.js
+++ b/test/e2e/styled-jsx-render-page/pages/_document.js
@@ -1,0 +1,24 @@
+import Document, { Html, Head, Main, NextScript } from 'next/document'
+
+class MyDocument extends Document {
+  static async getInitialProps(ctx) {
+    // This pattern bypasses defaultGetInitialProps which collects styled-jsx styles.
+    // It calls ctx.renderPage() directly and returns { html, head } without styles.
+    const { html, head } = await ctx.renderPage()
+    return { html, head }
+  }
+
+  render() {
+    return (
+      <Html>
+        <Head />
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    )
+  }
+}
+
+export default MyDocument

--- a/test/e2e/styled-jsx-render-page/pages/index.js
+++ b/test/e2e/styled-jsx-render-page/pages/index.js
@@ -1,0 +1,8 @@
+export default function Page() {
+  return (
+    <div>
+      <style jsx>{'p { color: red; }'}</style>
+      <p>hello world</p>
+    </div>
+  )
+}


### PR DESCRIPTION
## What?

Fix styled-jsx styles missing from SSR output when a custom `_document.getInitialProps` calls `ctx.renderPage()` directly instead of delegating to `Document.getInitialProps(ctx)`.

## Why?

`Document.getInitialProps` (the default implementation) is responsible for collecting styled-jsx styles from the registry after rendering. When a custom `_document.js` overrides `getInitialProps` and calls `ctx.renderPage()` directly, it typically returns `{ html, head }` without a `styles` property:

```js
// _document.js — bypasses styled-jsx style collection
class MyDocument extends Document {
  static async getInitialProps(ctx) {
    const { html, head } = await ctx.renderPage()
    return { html, head } // no styles key → styles were silently dropped
  }
}
```

The server-side render path in `render.tsx` had `styles = docProps.styles` with no fallback, so when `docProps.styles` is `undefined` the `<Head>` component receives no styles — causing a FOUC or missing styles entirely in production.

## How?

In `packages/next/src/server/render.tsx`, when `hasDocumentGetInitialProps` is true and `docProps.styles` is absent, fall back to collecting styles directly from the `jsxStyleRegistry` (which was already populated during `renderPage`):

```ts
if (!styles && documentInitialPropsRes !== null) {
  styles = jsxStyleRegistry.styles()
  jsxStyleRegistry.flush()
}
```

This covers the case where the custom `_document.getInitialProps` did not call `Document.getInitialProps` and so never collected the styled-jsx registry into `docProps.styles`.

## Tests

- `test/e2e/styled-jsx-render-page/` — reproduces the affected pattern: a custom `_document.getInitialProps` that calls `ctx.renderPage()` directly. Asserts that styled-jsx styles are present in `<head>` (not just anywhere in the HTML) during SSR.

<!-- NEXT_JS_LLM_PR -->