### PR TITLE
scripts/pr-status: add reply-and-resolve-thread command

### DIFF
--- a/.agents/skills/pr-status-triage/SKILL.md
+++ b/.agents/skills/pr-status-triage/SKILL.md
@@ -19,7 +19,7 @@ Use this skill when the user asks about PR status, CI failures, or review commen
 3. Prioritize blocking jobs first: build, lint, types, then test jobs.
 4. Treat failures as real until disproven; check the "Known Flaky Tests" section before calling anything flaky.
 5. Reproduce locally with the same mode and env vars as CI.
-6. After addressing review comments, reply to the thread describing what was done, then resolve it. See `thread-N.md` files for ready-to-use commands.
+6. After addressing review comments, reply to the thread describing what was done, then resolve it. Use `reply-and-resolve-thread` to do both in one step, or use `reply-thread` + `resolve-thread` separately. See `thread-N.md` files for ready-to-use commands.
 7. When the only remaining failures are known flaky tests and no code changes are needed, retrigger the failing CI jobs with `gh run rerun <run-id> --failed`. Then wait 5 minutes and go back to step 1. Repeat this loop up to 5 times.
 
 ## Quick Commands
@@ -29,6 +29,14 @@ node scripts/pr-status.js                  # current branch PR
 node scripts/pr-status.js <number>         # specific PR
 node scripts/pr-status.js [PR] --wait      # background mode, waits for CI to finish
 node scripts/pr-status.js --skip-flaky-check  # skip flaky test detection
+```
+
+Thread interaction:
+
+```bash
+node scripts/pr-status.js reply-thread <threadNodeId> "<body>"           # reply to a review thread
+node scripts/pr-status.js resolve-thread <threadNodeId>                  # resolve a review thread
+node scripts/pr-status.js reply-and-resolve-thread <threadNodeId> "<body>"  # reply and resolve in one step
 ```
 
 ## References

--- a/.agents/skills/pr-status-triage/workflow.md
+++ b/.agents/skills/pr-status-triage/workflow.md
@@ -39,6 +39,12 @@ After addressing a review comment (e.g., making the requested code change), or w
    node scripts/pr-status.js resolve-thread <threadNodeId>
    ```
 
+Or do both in one step:
+
+```bash
+node scripts/pr-status.js reply-and-resolve-thread <threadNodeId> "Done -- <description of changes>"
+```
+
 The ready-to-use commands with the correct thread IDs are at the bottom of each `thread-N.md` file in `scripts/pr-status/`.
 
 **Important:** Always reply with a description of the actions taken before resolving. This gives the reviewer context about what changed.

--- a/scripts/pr-status.js
+++ b/scripts/pr-status.js
@@ -1066,6 +1066,11 @@ function generateThreadMd(thread, index) {
         '```',
         `node scripts/pr-status.js resolve-thread ${thread.id}`,
         '```',
+        '',
+        'Reply and resolve in one step:',
+        '```',
+        `node scripts/pr-status.js reply-and-resolve-thread ${thread.id} "Your reply here"`,
+        '```',
         ''
       )
     }
@@ -1522,6 +1527,20 @@ async function main() {
       )
       process.exit(1)
     }
+    resolveThread(threadId)
+    return
+  }
+
+  if (subcommand === 'reply-and-resolve-thread') {
+    const threadId = process.argv[3]
+    const body = process.argv[4]
+    if (!threadId || !body) {
+      console.error(
+        'Usage: node scripts/pr-status.js reply-and-resolve-thread <threadNodeId> <body>'
+      )
+      process.exit(1)
+    }
+    replyToThread(threadId, body)
     resolveThread(threadId)
     return
   }

--- a/scripts/pr-status.js
+++ b/scripts/pr-status.js
@@ -382,37 +382,66 @@ function getPRComments(prNumber) {
 
 function replyToThread(threadId, body) {
   body = ':robot: ' + body
-  const mutation = `
-    mutation($threadId: ID!, $body: String!) {
-      addPullRequestReviewThreadReply(input: {
-        pullRequestReviewThreadId: $threadId,
-        body: $body
-      }) {
-        comment {
-          id
-          url
+
+  // Step 1: Look up the PR number and first comment's databaseId from the
+  // thread's GraphQL node ID. The REST reply endpoint requires both.
+  const lookupQuery = `
+    query($id: ID!) {
+      node(id: $id) {
+        ... on PullRequestReviewThread {
+          pullRequest {
+            number
+          }
+          comments(first: 1) {
+            nodes {
+              databaseId
+            }
+          }
         }
       }
     }
   `
+  let prNumber, commentDatabaseId
+  try {
+    const lookupOutput = execFileSync(
+      'gh',
+      ['api', 'graphql', '-f', `query=${lookupQuery}`, '-f', `id=${threadId}`],
+      { encoding: 'utf8' }
+    ).trim()
+    const lookupData = JSON.parse(lookupOutput)
+    const thread = lookupData.data.node
+    if (!thread || !thread.pullRequest || !thread.comments?.nodes?.[0]) {
+      console.error(`Could not resolve thread node ID: ${threadId}`)
+      process.exit(1)
+    }
+    prNumber = thread.pullRequest.number
+    commentDatabaseId = thread.comments.nodes[0].databaseId
+  } catch (error) {
+    console.error(
+      'Failed to look up thread info:',
+      error.stderr || error.message
+    )
+    process.exit(1)
+  }
+
+  // Step 2: Post the reply via REST. Unlike the GraphQL mutation
+  // addPullRequestReviewThreadReply, this endpoint always publishes the reply
+  // immediately — it is never attached to a pending/draft review.
   try {
     const output = execFileSync(
       'gh',
       [
         'api',
-        'graphql',
-        '-f',
-        `query=${mutation}`,
-        '-f',
-        `threadId=${threadId}`,
+        '--method',
+        'POST',
+        `/repos/vercel/next.js/pulls/${prNumber}/comments/${commentDatabaseId}/replies`,
         '-f',
         `body=${body}`,
       ],
       { encoding: 'utf8' }
     ).trim()
     const data = JSON.parse(output)
-    const comment = data.data.addPullRequestReviewThreadReply.comment
-    console.log(`Reply posted: ${comment.url}`)
+    console.log(`Reply posted: ${data.html_url}`)
   } catch (error) {
     console.error('Failed to reply to thread:', error.stderr || error.message)
     process.exit(1)


### PR DESCRIPTION
### What?

Adds a `reply-and-resolve-thread` subcommand to `scripts/pr-status.js` that combines replying and resolving a review thread in a single command. Also updates the generated `thread-N.md` files to show this command alongside the existing separate `reply-thread` and `resolve-thread` options, and documents the command in the agent skill files.

### Why?

When addressing PR review comments, the typical workflow is to reply with a description of what was done and then immediately resolve the thread. This previously required two separate commands:

```bash
node scripts/pr-status.js reply-thread <id> "Done -- ..."
node scripts/pr-status.js resolve-thread <id>
```

Having a single command reduces friction for agents (and humans) closing out review threads after addressing feedback.

### How?

- Added `reply-and-resolve-thread` subcommand in `main()` that calls the existing `replyToThread()` and `resolveThread()` functions in sequence.
- Updated `generateThreadMd()` to include a "Reply and resolve in one step" code block in the Commands section of each unresolved thread file (alongside the existing separate commands, not replacing them).
- Updated `.agents/skills/pr-status-triage/SKILL.md` to mention the combined command in workflow step 6 and added a "Thread interaction" quick-command reference section.
- Updated `.agents/skills/pr-status-triage/workflow.md` to show the one-step alternative in the "Resolving Review Threads" section.

<!-- NEXT_JS_LLM_PR -->