### PR TITLE
[test] Regenerate checked-in tsconfig.json files

### DIFF
--- a/test/development/app-dir/dev-fetch-hmr/tsconfig.json
+++ b/test/development/app-dir/dev-fetch-hmr/tsconfig.json
@@ -9,7 +9,7 @@
     "incremental": true,
     "module": "esnext",
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",

--- a/test/development/app-dir/experimental-lightningcss/tsconfig.json
+++ b/test/development/app-dir/experimental-lightningcss/tsconfig.json
@@ -8,7 +8,7 @@
     "incremental": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",

--- a/test/development/app-dir/instant-navs-devtools/tsconfig.json
+++ b/test/development/app-dir/instant-navs-devtools/tsconfig.json
@@ -9,7 +9,7 @@
     "incremental": true,
     "module": "esnext",
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",

--- a/test/development/app-dir/server-components-hmr-cache/tsconfig.json
+++ b/test/development/app-dir/server-components-hmr-cache/tsconfig.json
@@ -9,7 +9,7 @@
     "incremental": true,
     "module": "esnext",
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",

--- a/test/development/typescript-plugin/client-boundary/tsconfig.json
+++ b/test/development/typescript-plugin/client-boundary/tsconfig.json
@@ -9,7 +9,7 @@
     "incremental": true,
     "module": "esnext",
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",

--- a/test/development/typescript-plugin/metadata/tsconfig.json
+++ b/test/development/typescript-plugin/metadata/tsconfig.json
@@ -9,7 +9,7 @@
     "incremental": true,
     "module": "esnext",
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",

--- a/test/development/typescript-plugin/tsconfig.json
+++ b/test/development/typescript-plugin/tsconfig.json
@@ -9,7 +9,7 @@
     "incremental": true,
     "module": "esnext",
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",

--- a/test/e2e/app-dir/metadata-suspense/tsconfig.json
+++ b/test/e2e/app-dir/metadata-suspense/tsconfig.json
@@ -9,7 +9,7 @@
     "incremental": true,
     "module": "esnext",
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",

--- a/test/e2e/app-dir/modularizeimports/tsconfig.json
+++ b/test/e2e/app-dir/modularizeimports/tsconfig.json
@@ -9,7 +9,7 @@
     "incremental": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",

--- a/test/e2e/app-dir/typed-routes-validator/tsconfig.json
+++ b/test/e2e/app-dir/typed-routes-validator/tsconfig.json
@@ -9,7 +9,7 @@
     "incremental": true,
     "module": "esnext",
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",

--- a/test/e2e/app-dir/typed-routes/tsconfig.json
+++ b/test/e2e/app-dir/typed-routes/tsconfig.json
@@ -9,7 +9,7 @@
     "incremental": true,
     "module": "esnext",
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",

--- a/test/integration/cpu-profiling/fixtures/basic-app/tsconfig.json
+++ b/test/integration/cpu-profiling/fixtures/basic-app/tsconfig.json
@@ -9,7 +9,7 @@
     "incremental": true,
     "module": "esnext",
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",
@@ -27,5 +27,5 @@
     "**/*.ts",
     "**/*.tsx"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "**/*.test.ts", "**/*.test.tsx"]
 }

--- a/test/integration/css-fixtures/cssmodules-pure-no-check/tsconfig.json
+++ b/test/integration/css-fixtures/cssmodules-pure-no-check/tsconfig.json
@@ -9,7 +9,7 @@
     "incremental": true,
     "module": "esnext",
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",

--- a/test/integration/next-dynamic-css/tsconfig.json
+++ b/test/integration/next-dynamic-css/tsconfig.json
@@ -9,7 +9,7 @@
     "incremental": true,
     "module": "esnext",
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",

--- a/test/integration/react-current-version/tsconfig.json
+++ b/test/integration/react-current-version/tsconfig.json
@@ -9,7 +9,7 @@
     "incremental": true,
     "module": "esnext",
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",

--- a/test/production/app-dir/actions-tree-shaking/use-effect-actions/tsconfig.json
+++ b/test/production/app-dir/actions-tree-shaking/use-effect-actions/tsconfig.json
@@ -9,7 +9,7 @@
     "incremental": true,
     "module": "esnext",
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",

--- a/test/production/graceful-shutdown/src/tsconfig.json
+++ b/test/production/graceful-shutdown/src/tsconfig.json
@@ -8,7 +8,7 @@
     "incremental": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",

--- a/test/production/terser-class-static-blocks/tsconfig.json
+++ b/test/production/terser-class-static-blocks/tsconfig.json
@@ -8,7 +8,7 @@
     "incremental": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",

--- a/test/production/typescript-checked-side-effect-imports/tsconfig.json
+++ b/test/production/typescript-checked-side-effect-imports/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "module": "esnext",
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",


### PR DESCRIPTION
This is slowing down tests and produces noise in CI logs. Also gets rid of 6.0 deprecated `moduleResolution` to allow landing https://github.com/vercel/next.js/pull/91257 with less changes.

Same approach as in https://github.com/vercel/next.js/pull/85515