### PR TITLE
[test] Stop using deprecated `target: "es5"` TypeScript compiler option

### DIFF
--- a/test/development/acceptance-app/fixtures/app-hmr-changes/tsconfig.json
+++ b/test/development/acceptance-app/fixtures/app-hmr-changes/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2017",
     "module": "esnext",
     "jsx": "react-jsx",
     "strict": false,

--- a/test/development/app-dir/dev-fetch-hmr/tsconfig.json
+++ b/test/development/app-dir/dev-fetch-hmr/tsconfig.json
@@ -9,7 +9,7 @@
     "incremental": true,
     "module": "esnext",
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",

--- a/test/development/app-dir/experimental-lightningcss/tsconfig.json
+++ b/test/development/app-dir/experimental-lightningcss/tsconfig.json
@@ -8,7 +8,7 @@
     "incremental": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",

--- a/test/development/app-dir/instant-navs-devtools/tsconfig.json
+++ b/test/development/app-dir/instant-navs-devtools/tsconfig.json
@@ -9,7 +9,7 @@
     "incremental": true,
     "module": "esnext",
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",

--- a/test/development/app-dir/server-components-hmr-cache/tsconfig.json
+++ b/test/development/app-dir/server-components-hmr-cache/tsconfig.json
@@ -9,7 +9,7 @@
     "incremental": true,
     "module": "esnext",
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",

--- a/test/development/basic/define-class-fields/fixture/tsconfig.json
+++ b/test/development/basic/define-class-fields/fixture/tsconfig.json
@@ -4,7 +4,7 @@
     "esModuleInterop": true,
     "module": "esnext",
     "jsx": "react-jsx",
-    "target": "es5",
+    "target": "es2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": false,

--- a/test/development/jsconfig-path-reloading/app/jsconfig.json
+++ b/test/development/jsconfig-path-reloading/app/jsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/test/development/tsconfig-path-reloading/app/tsconfig.json
+++ b/test/development/tsconfig-path-reloading/app/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/test/development/typescript-plugin/client-boundary/tsconfig.json
+++ b/test/development/typescript-plugin/client-boundary/tsconfig.json
@@ -9,7 +9,7 @@
     "incremental": true,
     "module": "esnext",
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",

--- a/test/development/typescript-plugin/metadata/tsconfig.json
+++ b/test/development/typescript-plugin/metadata/tsconfig.json
@@ -9,7 +9,7 @@
     "incremental": true,
     "module": "esnext",
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",

--- a/test/development/typescript-plugin/tsconfig.json
+++ b/test/development/typescript-plugin/tsconfig.json
@@ -9,7 +9,7 @@
     "incremental": true,
     "module": "esnext",
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",

--- a/test/e2e/app-dir/metadata-suspense/tsconfig.json
+++ b/test/e2e/app-dir/metadata-suspense/tsconfig.json
@@ -9,7 +9,7 @@
     "incremental": true,
     "module": "esnext",
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",

--- a/test/e2e/app-dir/modularizeimports/tsconfig.json
+++ b/test/e2e/app-dir/modularizeimports/tsconfig.json
@@ -9,7 +9,7 @@
     "incremental": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",

--- a/test/e2e/app-dir/typed-routes-validator/tsconfig.json
+++ b/test/e2e/app-dir/typed-routes-validator/tsconfig.json
@@ -9,7 +9,7 @@
     "incremental": true,
     "module": "esnext",
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",

--- a/test/e2e/app-dir/typed-routes/tsconfig.json
+++ b/test/e2e/app-dir/typed-routes/tsconfig.json
@@ -9,7 +9,7 @@
     "incremental": true,
     "module": "esnext",
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",

--- a/test/integration/app-tree/tsconfig.json
+++ b/test/integration/app-tree/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/test/integration/cpu-profiling/fixtures/basic-app/tsconfig.json
+++ b/test/integration/cpu-profiling/fixtures/basic-app/tsconfig.json
@@ -9,7 +9,7 @@
     "incremental": true,
     "module": "esnext",
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",
@@ -27,5 +27,5 @@
     "**/*.ts",
     "**/*.tsx"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "**/*.test.ts", "**/*.test.tsx"]
 }

--- a/test/integration/css-fixtures/cssmodules-pure-no-check/tsconfig.json
+++ b/test/integration/css-fixtures/cssmodules-pure-no-check/tsconfig.json
@@ -9,7 +9,7 @@
     "incremental": true,
     "module": "esnext",
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",

--- a/test/integration/custom-server-types/tsconfig.json
+++ b/test/integration/custom-server-types/tsconfig.json
@@ -3,7 +3,7 @@
     "esModuleInterop": true,
     "module": "esnext",
     "jsx": "react-jsx",
-    "target": "es5",
+    "target": "es2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/test/integration/import-assertion/tsconfig.json
+++ b/test/integration/import-assertion/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/test/integration/import-attributes/tsconfig.json
+++ b/test/integration/import-attributes/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/test/integration/next-dynamic-css/tsconfig.json
+++ b/test/integration/next-dynamic-css/tsconfig.json
@@ -9,7 +9,7 @@
     "incremental": true,
     "module": "esnext",
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",

--- a/test/integration/next-image-legacy/typescript/tsconfig.json
+++ b/test/integration/next-image-legacy/typescript/tsconfig.json
@@ -3,7 +3,7 @@
     "esModuleInterop": true,
     "module": "esnext",
     "jsx": "react-jsx",
-    "target": "es5",
+    "target": "es2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/test/integration/next-image-new/typescript/tsconfig.json
+++ b/test/integration/next-image-new/typescript/tsconfig.json
@@ -3,7 +3,7 @@
     "esModuleInterop": true,
     "module": "esnext",
     "jsx": "react-jsx",
-    "target": "es5",
+    "target": "es2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/test/integration/react-current-version/app/tsconfig.json
+++ b/test/integration/react-current-version/app/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/test/integration/react-current-version/tsconfig.json
+++ b/test/integration/react-current-version/tsconfig.json
@@ -9,7 +9,7 @@
     "incremental": true,
     "module": "esnext",
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",

--- a/test/integration/relay-graphql-swc-multi-project/project-a/tsconfig.json
+++ b/test/integration/relay-graphql-swc-multi-project/project-a/tsconfig.json
@@ -4,7 +4,7 @@
     "esModuleInterop": true,
     "module": "esnext",
     "jsx": "react-jsx",
-    "target": "es5",
+    "target": "es2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/test/integration/relay-graphql-swc-multi-project/project-b/tsconfig.json
+++ b/test/integration/relay-graphql-swc-multi-project/project-b/tsconfig.json
@@ -4,7 +4,7 @@
     "esModuleInterop": true,
     "module": "esnext",
     "jsx": "react-jsx",
-    "target": "es5",
+    "target": "es2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/test/integration/relay-graphql-swc-single-project/tsconfig.json
+++ b/test/integration/relay-graphql-swc-single-project/tsconfig.json
@@ -4,7 +4,7 @@
     "esModuleInterop": true,
     "module": "esnext",
     "jsx": "react-jsx",
-    "target": "es5",
+    "target": "es2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/test/integration/typescript-app-type-declarations/tsconfig.json
+++ b/test/integration/typescript-app-type-declarations/tsconfig.json
@@ -4,7 +4,7 @@
     "esModuleInterop": true,
     "module": "esnext",
     "jsx": "react-jsx",
-    "target": "es5",
+    "target": "es2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/test/integration/typescript-baseurl/tsconfig.json
+++ b/test/integration/typescript-baseurl/tsconfig.json
@@ -4,7 +4,7 @@
     "esModuleInterop": true,
     "module": "esnext",
     "jsx": "react-jsx",
-    "target": "es5",
+    "target": "es2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/test/integration/typescript-custom-tsconfig/web.tsconfig.json
+++ b/test/integration/typescript-custom-tsconfig/web.tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/test/integration/typescript-external-dir/project/tsconfig.json
+++ b/test/integration/typescript-external-dir/project/tsconfig.json
@@ -4,7 +4,7 @@
     "esModuleInterop": true,
     "module": "esnext",
     "jsx": "react-jsx",
-    "target": "es5",
+    "target": "es2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/test/integration/typescript-external-dir/shared/tsconfig.json
+++ b/test/integration/typescript-external-dir/shared/tsconfig.json
@@ -3,7 +3,7 @@
     "esModuleInterop": true,
     "module": "esnext",
     "jsx": "react-jsx",
-    "target": "es5",
+    "target": "es2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/test/integration/typescript-filtered-files/tsconfig.json
+++ b/test/integration/typescript-filtered-files/tsconfig.json
@@ -3,7 +3,7 @@
     "esModuleInterop": true,
     "module": "esnext",
     "jsx": "react-jsx",
-    "target": "es5",
+    "target": "es2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/test/integration/typescript-hmr/tsconfig.json
+++ b/test/integration/typescript-hmr/tsconfig.json
@@ -3,7 +3,7 @@
     "esModuleInterop": true,
     "module": "esnext",
     "jsx": "react-jsx",
-    "target": "es5",
+    "target": "es2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/test/integration/typescript-ignore-errors/tsconfig.json
+++ b/test/integration/typescript-ignore-errors/tsconfig.json
@@ -3,7 +3,7 @@
     "esModuleInterop": true,
     "module": "esnext",
     "jsx": "react-jsx",
-    "target": "es5",
+    "target": "es2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/test/integration/typescript-only-remove-type-imports/tsconfig.json
+++ b/test/integration/typescript-only-remove-type-imports/tsconfig.json
@@ -3,7 +3,7 @@
     "esModuleInterop": true,
     "module": "esnext",
     "jsx": "react-jsx",
-    "target": "es5",
+    "target": "es2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/test/integration/typescript-paths/tsconfig.json
+++ b/test/integration/typescript-paths/tsconfig.json
@@ -15,7 +15,7 @@
     "esModuleInterop": true,
     "module": "esnext",
     "jsx": "react-jsx",
-    "target": "es5",
+    "target": "es2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/test/integration/typescript-workspaces-paths/tsconfig.json
+++ b/test/integration/typescript-workspaces-paths/tsconfig.json
@@ -16,7 +16,7 @@
     "esModuleInterop": true,
     "module": "esnext",
     "jsx": "react-jsx",
-    "target": "es5",
+    "target": "es2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/test/integration/typescript/tsconfig.json
+++ b/test/integration/typescript/tsconfig.json
@@ -3,7 +3,7 @@
     "esModuleInterop": true,
     "module": "esnext",
     "jsx": "react-jsx",
-    "target": "es5",
+    "target": "es2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/test/production/app-dir/actions-tree-shaking/use-effect-actions/tsconfig.json
+++ b/test/production/app-dir/actions-tree-shaking/use-effect-actions/tsconfig.json
@@ -9,7 +9,7 @@
     "incremental": true,
     "module": "esnext",
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",

--- a/test/production/graceful-shutdown/src/tsconfig.json
+++ b/test/production/graceful-shutdown/src/tsconfig.json
@@ -8,7 +8,7 @@
     "incremental": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",

--- a/test/production/jest/relay/app/tsconfig.json
+++ b/test/production/jest/relay/app/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/test/production/jest/remove-react-properties/app/tsconfig.json
+++ b/test/production/jest/remove-react-properties/app/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/test/production/middleware-typescript/app/tsconfig.json
+++ b/test/production/middleware-typescript/app/tsconfig.json
@@ -3,7 +3,7 @@
     "esModuleInterop": true,
     "module": "esnext",
     "jsx": "react-jsx",
-    "target": "es5",
+    "target": "es2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": false,

--- a/test/production/supports-module-resolution-nodenext/tsconfig.json
+++ b/test/production/supports-module-resolution-nodenext/tsconfig.json
@@ -3,7 +3,7 @@
     "esModuleInterop": true,
     "module": "NodeNext",
     "jsx": "react-jsx",
-    "target": "es5",
+    "target": "es2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/test/production/terser-class-static-blocks/tsconfig.json
+++ b/test/production/terser-class-static-blocks/tsconfig.json
@@ -8,7 +8,7 @@
     "incremental": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",

--- a/test/production/typescript-checked-side-effect-imports/tsconfig.json
+++ b/test/production/typescript-checked-side-effect-imports/tsconfig.json
@@ -12,7 +12,7 @@
     "incremental": true,
     "module": "esnext",
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",


### PR DESCRIPTION
Tests specifying a `target` use the default Next.js would generate if `target` is not specified (`es2017`).