### PR TITLE
Node.js streams: Add forkpoint for generateDynamicFlightRenderResult

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -846,42 +846,77 @@ async function generateDynamicFlightRenderResult(
     onFlightDataRenderError
   )
 
-  const debugChannel = setReactDebugChannel && createWebDebugChannel()
+  if (process.env.__NEXT_USE_NODE_STREAMS) {
+    const debugChannel = setReactDebugChannel && createNodeDebugChannel()
 
-  if (debugChannel) {
-    setReactDebugChannel(debugChannel.clientSide, htmlRequestId, requestId)
-  }
-
-  const { clientModules } = getClientReferenceManifest()
-
-  // For app dir, use the bundled version of Flight server renderer (renderToReadableStream)
-  // which contains the subset React.
-  const rscPayload = await workUnitAsyncStorage.run(
-    requestStore,
-    generateDynamicRSCPayload,
-    ctx,
-    options
-  )
-
-  const flightStream = workUnitAsyncStorage.run(
-    requestStore,
-    renderToWebFlightStream,
-    ctx.componentMod,
-    rscPayload,
-    clientModules,
-    {
-      onError,
-      temporaryReferences: options?.temporaryReferences,
-      filterStackFrame,
-      debugChannel: debugChannel?.serverSide,
+    if (debugChannel) {
+      setReactDebugChannel(debugChannel.clientSide, htmlRequestId, requestId)
     }
-  )
 
-  return new FlightRenderResult(
-    flightStream,
-    { fetchMetrics: workStore.fetchMetrics },
-    options?.waitUntil
-  )
+    const { clientModules } = getClientReferenceManifest()
+
+    const rscPayload = await workUnitAsyncStorage.run(
+      requestStore,
+      generateDynamicRSCPayload,
+      ctx,
+      options
+    )
+
+    const flightStream = workUnitAsyncStorage.run(
+      requestStore,
+      renderToNodeFlightStream,
+      ctx.componentMod,
+      rscPayload,
+      clientModules,
+      {
+        onError,
+        temporaryReferences: options?.temporaryReferences,
+        filterStackFrame,
+        debugChannel: debugChannel?.serverSide,
+      }
+    )
+
+    return new FlightRenderResult(
+      flightStream,
+      { fetchMetrics: workStore.fetchMetrics },
+      options?.waitUntil
+    )
+  } else {
+    const debugChannel = setReactDebugChannel && createWebDebugChannel()
+
+    if (debugChannel) {
+      setReactDebugChannel(debugChannel.clientSide, htmlRequestId, requestId)
+    }
+
+    const { clientModules } = getClientReferenceManifest()
+
+    const rscPayload = await workUnitAsyncStorage.run(
+      requestStore,
+      generateDynamicRSCPayload,
+      ctx,
+      options
+    )
+
+    const flightStream = workUnitAsyncStorage.run(
+      requestStore,
+      renderToWebFlightStream,
+      ctx.componentMod,
+      rscPayload,
+      clientModules,
+      {
+        onError,
+        temporaryReferences: options?.temporaryReferences,
+        filterStackFrame,
+        debugChannel: debugChannel?.serverSide,
+      }
+    )
+
+    return new FlightRenderResult(
+      flightStream,
+      { fetchMetrics: workStore.fetchMetrics },
+      options?.waitUntil
+    )
+  }
 }
 
 /**

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -42,7 +42,8 @@ import {
   continueFizzStream,
   continueDynamicPrerender,
   continueStaticPrerender,
-  continueDynamicHTMLResume,
+  continueDynamicHTMLResumeNode,
+  continueDynamicHTMLResumeWeb,
   continueStaticFallbackPrerender,
   streamToBuffer,
   streamToString,
@@ -3783,7 +3784,7 @@ async function renderToStream(
             // We have a complete HTML Document in the prerender but we need to
             // still include the new server component render because it was not included
             // in the static prelude.
-            const inlinedDataStream = createWebInlinedDataStream(
+            const inlinedDataStream = createNodeInlinedDataStream(
               reactServerResult.tee(),
               nonce,
               formState
@@ -3834,10 +3835,10 @@ async function renderToStream(
               if (renderSpan.isRecording()) renderSpan.end()
             })
 
-            return await continueDynamicHTMLResume(htmlStream, {
+            return await continueDynamicHTMLResumeNode(htmlStream, {
               delayDataUntilFirstHtmlChunk:
                 preludeState === DynamicHTMLPreludeState.Empty,
-              inlinedDataStream: createWebInlinedDataStream(
+              inlinedDataStream: createNodeInlinedDataStream(
                 reactServerResult.consume(),
                 nonce,
                 formState
@@ -3973,7 +3974,7 @@ async function renderToStream(
               if (renderSpan.isRecording()) renderSpan.end()
             })
 
-            return await continueDynamicHTMLResume(htmlStream, {
+            return await continueDynamicHTMLResumeWeb(htmlStream, {
               delayDataUntilFirstHtmlChunk:
                 preludeState === DynamicHTMLPreludeState.Empty,
               inlinedDataStream: createWebInlinedDataStream(

--- a/packages/next/src/server/app-render/stream-ops.node.ts
+++ b/packages/next/src/server/app-render/stream-ops.node.ts
@@ -812,7 +812,52 @@ export async function continueStaticFallbackPrerender(
   return webToReadable(webResult)
 }
 
-export async function continueDynamicHTMLResume(
+export async function continueDynamicHTMLResumeNode(
+  renderStream: AnyStream,
+  {
+    delayDataUntilFirstHtmlChunk,
+    inlinedDataStream,
+    getServerInsertedHTML,
+    getServerInsertedMetadata,
+    deploymentId,
+  }: import('./stream-ops.web').ContinueDynamicHTMLResumeOptions
+): Promise<AnyStream> {
+  await waitAtLeastOneReactRenderTask()
+
+  const buffered = createBufferedTransformStream()
+  webToReadable(renderStream).pipe(buffered)
+
+  let source: Readable = buffered
+
+  if (deploymentId) {
+    const dplId = createHtmlDataDplIdTransform(deploymentId)
+    source.pipe(dplId)
+    source = dplId
+  }
+
+  const headInsertion = createHeadInsertionTransform(getServerInsertedHTML)
+  source.pipe(headInsertion)
+  source = headInsertion
+
+  const metadata = createMetadataTransform(getServerInsertedMetadata)
+  source.pipe(metadata)
+  source = metadata
+
+  const flightInjection = createFlightDataInjectionTransform(
+    webToReadable(inlinedDataStream),
+    delayDataUntilFirstHtmlChunk
+  )
+  source.pipe(flightInjection)
+  source = flightInjection
+
+  const moveSuffix = createMoveSuffixTransform()
+  source.pipe(moveSuffix)
+  source = moveSuffix
+
+  return source
+}
+
+export async function continueDynamicHTMLResumeWeb(
   renderStream: AnyStream,
   opts: import('./stream-ops.web').ContinueDynamicHTMLResumeOptions
 ): Promise<AnyStream> {

--- a/packages/next/src/server/app-render/stream-ops.ts
+++ b/packages/next/src/server/app-render/stream-ops.ts
@@ -35,7 +35,8 @@ export const continueStaticPrerender = _m.continueStaticPrerender
 export const continueDynamicPrerender = _m.continueDynamicPrerender
 export const continueStaticFallbackPrerender =
   _m.continueStaticFallbackPrerender
-export const continueDynamicHTMLResume = _m.continueDynamicHTMLResume
+export const continueDynamicHTMLResumeNode = _m.continueDynamicHTMLResumeNode
+export const continueDynamicHTMLResumeWeb = _m.continueDynamicHTMLResumeWeb
 export const streamToBuffer = _m.streamToBuffer
 export const chainStreams = _m.chainStreams
 export const createDocumentClosingStream = _m.createDocumentClosingStream

--- a/packages/next/src/server/app-render/stream-ops.web.ts
+++ b/packages/next/src/server/app-render/stream-ops.web.ts
@@ -141,7 +141,7 @@ export async function continueStaticFallbackPrerender(
   )
 }
 
-export async function continueDynamicHTMLResume(
+export async function continueDynamicHTMLResumeWeb(
   renderStream: AnyStream,
   opts: ContinueDynamicHTMLResumeOptions
 ): Promise<AnyStream> {
@@ -152,6 +152,13 @@ export async function continueDynamicHTMLResume(
       inlinedDataStream: opts.inlinedDataStream as ReadableStream<Uint8Array>,
     }
   )
+}
+
+export function continueDynamicHTMLResumeNode(
+  _renderStream: AnyStream,
+  _opts: ContinueDynamicHTMLResumeOptions
+): Promise<AnyStream> {
+  throw new Error('not implemented')
 }
 
 export async function streamToBuffer(stream: AnyStream): Promise<Buffer> {


### PR DESCRIPTION
## What?

Building on top of the changes in #92252. This PR implements similar fork points for generateDynamicFlightRenderResult