### PR TITLE
CI: Use minimumReleaseAge in pnpm workspace files

### DIFF
--- a/.github/pnpm-workspace.yaml
+++ b/.github/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
   - 'actions/*'
 injectWorkspacePackages: true
+blockExoticSubdeps: true
 minimumReleaseAge: 2880 # 48 hrs
 minimumReleaseAgeExclude:
   - '@next/*'

--- a/.github/pnpm-workspace.yaml
+++ b/.github/pnpm-workspace.yaml
@@ -1,3 +1,11 @@
 packages:
   - 'actions/*'
 injectWorkspacePackages: true
+minimumReleaseAge: 2880 # 48 hrs
+minimumReleaseAgeExclude:
+  - '@next/*'
+  - 'next'
+  - '@turbo/*'
+  - 'turbo'
+  - '@vercel/*'
+  - '@workflow/*'

--- a/.github/pnpm-workspace.yaml
+++ b/.github/pnpm-workspace.yaml
@@ -3,6 +3,8 @@ packages:
 injectWorkspacePackages: true
 minimumReleaseAge: 2880 # 48 hrs
 minimumReleaseAgeExclude:
+  - react
+  - react-dom
   - '@next/*'
   - 'next'
   - '@turbo/*'

--- a/.github/pnpm-workspace.yaml
+++ b/.github/pnpm-workspace.yaml
@@ -3,11 +3,18 @@ packages:
 injectWorkspacePackages: true
 minimumReleaseAge: 2880 # 48 hrs
 minimumReleaseAgeExclude:
-  - react
-  - react-dom
   - '@next/*'
-  - 'next'
   - '@turbo/*'
-  - 'turbo'
   - '@vercel/*'
   - '@workflow/*'
+  - babel-plugin-react-compiler
+  - next
+  - react
+  - react-dom
+  - react-dom-*
+  - react-experimental-builtin
+  - react-is
+  - react-is-builtin
+  - react-server-dom-*
+  - scheduler-*
+  - turbo

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,11 +31,18 @@ ignoredBuiltDependencies:
   - wasm-pack
 minimumReleaseAge: 2880 # 48 hrs
 minimumReleaseAgeExclude:
-  - react
-  - react-dom
   - '@next/*'
-  - 'next'
   - '@turbo/*'
-  - 'turbo'
   - '@vercel/*'
   - '@workflow/*'
+  - babel-plugin-react-compiler
+  - next
+  - react
+  - react-dom
+  - react-dom-*
+  - react-experimental-builtin
+  - react-is
+  - react-is-builtin
+  - react-server-dom-*
+  - scheduler-*
+  - turbo

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -29,6 +29,7 @@ ignoredBuiltDependencies:
   - ssh2
   - unrs-resolver
   - wasm-pack
+blockExoticSubdeps: true
 minimumReleaseAge: 2880 # 48 hrs
 minimumReleaseAgeExclude:
   - '@next/*'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,6 +31,8 @@ ignoredBuiltDependencies:
   - wasm-pack
 minimumReleaseAge: 2880 # 48 hrs
 minimumReleaseAgeExclude:
+  - react
+  - react-dom
   - '@next/*'
   - 'next'
   - '@turbo/*'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -29,3 +29,11 @@ ignoredBuiltDependencies:
   - ssh2
   - unrs-resolver
   - wasm-pack
+minimumReleaseAge: 2880 # 48 hrs
+minimumReleaseAgeExclude:
+  - '@next/*'
+  - 'next'
+  - '@turbo/*'
+  - 'turbo'
+  - '@vercel/*'
+  - '@workflow/*'

--- a/rspack/package.json
+++ b/rspack/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "git+https://github.com/vercel/next.js.git"
   },
-  "packageManager": "pnpm@10.13.1",
+  "packageManager": "pnpm@10.33.0",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "exports": {

--- a/rspack/pnpm-workspace.yaml
+++ b/rspack/pnpm-workspace.yaml
@@ -1,3 +1,9 @@
 packages:
   - 'crates/binding'
   - '.'
+
+minimumReleaseAge: 2880 # 48 hrs
+minimumReleaseAgeExclude:
+  - '@next/*'
+  - 'next'
+  - '@rspack/*'

--- a/rspack/pnpm-workspace.yaml
+++ b/rspack/pnpm-workspace.yaml
@@ -2,6 +2,7 @@ packages:
   - 'crates/binding'
   - '.'
 
+blockExoticSubdeps: true
 minimumReleaseAge: 2880 # 48 hrs
 minimumReleaseAgeExclude:
   - '@next/*'


### PR DESCRIPTION
Depends on pnpm 10.x: https://github.com/vercel/next.js/pull/92283

Enables https://pnpm.io/settings#minimumreleaseage to protect against supply-chain attacks.

The `minimumReleaseAgeExclude` list is copied from https://github.com/vercel/front/blob/1c3a9458d970265e1fb5ec14ddfed9a0eab2abef/pnpm-workspace.yaml#L13, with `react` and `react-dom` added.