### PR TITLE
CI: Remove unused dependencies from next-stats-action dockerfile

### DIFF
--- a/.github/actions/next-stats-action/Dockerfile
+++ b/.github/actions/next-stats-action/Dockerfile
@@ -6,11 +6,11 @@ LABEL com.github.actions.name="Next.js PR Stats"
 LABEL com.github.actions.description="Compares stats of a PR with the main branch"
 LABEL repository="https://github.com/vercel/next-stats-action"
 
+ENV DEBIAN_FRONTEND=noninteractive
+
 # use apt-get instead of apt, because apt does not have a stable CLI interface
 RUN apt-get update && apt-get upgrade -y
-RUN apt-get install unzip wget curl nano htop screen build-essential pkg-config libssl-dev git build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libreadline-dev libffi-dev python3 moreutils jq iproute2 openssh-server sudo whois dnsutils apache2-utils -y
-
-RUN ln $(which python3) /usr/bin/python
+RUN apt-get install -y --no-install-recommends curl ca-certificates git
 
 RUN curl -sfLS https://install-node.vercel.app/v20.9.0 | bash -s -- -f
 RUN npm i -g corepack@0.34.6


### PR DESCRIPTION
We don't need nano, htop, and screen inside of a CI dockerfile.