### PR TITLE
Exclude trace files from directory deletion in builds

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1121,7 +1121,10 @@ export default async function build(
         await nextBuildSpan
           .traceChild('clean')
           .traceAsyncFn(() =>
-            recursiveDeleteSyncWithAsyncRetries(distDir, /^(cache|dev|lock)/)
+            recursiveDeleteSyncWithAsyncRetries(
+              distDir,
+              /^(cache|dev|lock|trace)/
+            )
           )
       }
 

--- a/packages/next/src/trace/report/to-json.ts
+++ b/packages/next/src/trace/report/to-json.ts
@@ -50,7 +50,13 @@ class RotatingWriteStream {
     this.createWriteStream()
   }
   private createWriteStream() {
-    this.writeStream = fs.createWriteStream(this.file, writeStreamOptions)
+    const phase = traceGlobals.get('phase')
+    this.writeStream = fs.createWriteStream(this.file, {
+      ...writeStreamOptions,
+      // In dev, append so traces accumulate across hot reloads. In production,
+      // truncate so each build starts with a fresh trace file.
+      flags: phase === PHASE_DEVELOPMENT_SERVER ? 'a' : 'w',
+    })
   }
   // Recreate the file
   private async rotate() {

--- a/packages/next/src/trace/report/to-json.ts
+++ b/packages/next/src/trace/report/to-json.ts
@@ -53,7 +53,7 @@ class RotatingWriteStream {
     const phase = traceGlobals.get('phase')
     this.writeStream = fs.createWriteStream(this.file, {
       ...writeStreamOptions,
-      // In dev, append so traces accumulate across hot reloads. In production,
+      // In dev, append so traces accumulate across sessions. In production,
       // truncate so each build starts with a fresh trace file.
       flags: phase === PHASE_DEVELOPMENT_SERVER ? 'a' : 'w',
     })


### PR DESCRIPTION
On Windows, open file handles lock files — if the trace write stream happened to be open during `cleanDistDir`, deleting `{distDir}/trace` would fail with `EPERM`/`EBUSY`. 

TBH: because we batch writes to the file this basically shouldn't happen, but this approach is much clearer.

Two changes:

- Exclude `trace*` files from the `cleanDistDir` deletion (alongside `cache`, `dev`, `lock`), so the clean step never races with an open write stream.
- Open the trace file with `flags: 'w'` (truncate) for production builds so each build gets a fresh trace file, and `'a'` (append) for dev so traces accumulate across hot reloads.

Fixes #92298.

<!-- NEXT_JS_LLM_PR -->