### PR TITLE
CI: Use pnpm lockfile for next-stats-action

### DIFF
--- a/.github/actions/next-stats-action/action.yml
+++ b/.github/actions/next-stats-action/action.yml
@@ -7,4 +7,6 @@ inputs:
     required: false
 runs:
   using: 'docker'
-  image: 'Dockerfile'
+  # this dockerfile must be located in the parent directory, otherwise
+  # `pnpm deploy` can't read the pnpm-lock.yaml
+  image: '../../next-stats-action.Dockerfile'

--- a/.github/actions/next-stats-action/package.json
+++ b/.github/actions/next-stats-action/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "next-stats-action",
   "private": true,
   "main": "src/index.js",
   "dependencies": {

--- a/.github/next-stats-action.Dockerfile
+++ b/.github/next-stats-action.Dockerfile
@@ -16,8 +16,9 @@ RUN corepack enable
 FROM base AS pnpm-deploy
 
 WORKDIR /dot-github
-COPY --exclude=node_modules --exclude=actions/*/node_modules . .
-RUN ls -l
+COPY pnpm-lock.yaml pnpm-workspace.yaml .
+COPY --exclude=actions/*/node_modules \
+  actions/next-stats-action actions/next-stats-action
 RUN pnpm deploy --filter=next-stats-action --production /next-stats
 
 
@@ -34,7 +35,6 @@ RUN git config --global user.email 'stats@localhost' && \
 WORKDIR /next-stats
 
 COPY --from=pnpm-deploy /next-stats .
-RUN pnpm install --production
 
-COPY entrypoint.sh /entrypoint.sh
+COPY actions/next-stats-action/entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/pnpm-workspace.yaml
+++ b/.github/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 packages:
   - 'actions/*'
+injectWorkspacePackages: true


### PR DESCRIPTION
Previously, we were just copying the `package.json` into the container and `pnpm install`ing it.

This wouldn't respect the lockfile or `minimumReleaseAge`. This uses `pnpm deploy` based on the documentation here: https://pnpm.io/docker