### PR TITLE
fix(next/image): suppress false positive dimension warning when aspect ratio is preserved

### DIFF
--- a/packages/next/src/client/image-component.tsx
+++ b/packages/next/src/client/image-component.tsx
@@ -158,9 +158,25 @@ function handleLoading(
         (heightModified && !widthModified) ||
         (!heightModified && widthModified)
       ) {
-        warnOnce(
-          `Image with src "${origSrc}" has either width or height modified, but not the other. If you use CSS to change the size of your image, also include the styles 'width: "auto"' or 'height: "auto"' to maintain the aspect ratio.`
-        )
+        // Skip warning if the aspect ratio is preserved (e.g. global CSS
+        // like Tailwind's preflight sets `height: auto` on all images,
+        // which changes the rendered dimension but maintains aspect ratio).
+        // Use cross-multiplication to avoid floating point division, and
+        // allow for up to 1px rounding error per dimension.
+        const aspectRatioPreserved =
+          img.naturalWidth > 0 &&
+          img.naturalHeight > 0 &&
+          img.height > 0 &&
+          Math.abs(
+            img.width * img.naturalHeight -
+              img.height * img.naturalWidth
+          ) <=
+            img.naturalWidth + img.naturalHeight
+        if (!aspectRatioPreserved) {
+          warnOnce(
+            `Image with src "${origSrc}" has either width or height modified, but not the other. If you use CSS to change the size of your image, also include the styles 'width: "auto"' or 'height: "auto"' to maintain the aspect ratio.`
+          )
+        }
       }
     }
   })

--- a/test/integration/next-image-new/app-dir/app/wrapper-div/page.js
+++ b/test/integration/next-image-new/app-dir/app/wrapper-div/page.js
@@ -47,6 +47,16 @@ const Page = () => {
           style={{ width: '50%', height: 'auto' }}
         />
       </div>
+      <div id="image-container5">
+        <Image
+          id="img5"
+          src="/super-wide.png"
+          width="200"
+          height="200"
+          loading="eager"
+          style={{ height: 'auto' }}
+        />
+      </div>
     </div>
   )
 }

--- a/test/integration/next-image-new/app-dir/test/index.test.ts
+++ b/test/integration/next-image-new/app-dir/test/index.test.ts
@@ -825,6 +825,11 @@ function runTests(mode: 'dev' | 'server') {
         expect(warnings).not.toMatch(
           /Image with src "\/test.png" has either width or height modified, but not the other./gm
         )
+        // Ensure no false positive when CSS preserves the aspect ratio
+        // (e.g. height: auto changes the dimension but keeps the ratio)
+        expect(warnings).not.toMatch(
+          /Image with src "\/super-wide.png" has either width or height modified, but not the other./gm
+        )
       }
     } finally {
       if (browser) {

--- a/test/integration/next-image-new/default/pages/wrapper-div.js
+++ b/test/integration/next-image-new/default/pages/wrapper-div.js
@@ -47,6 +47,16 @@ const Page = () => {
           style={{ width: '50%', height: 'auto' }}
         />
       </div>
+      <div id="image-container5">
+        <Image
+          id="img5"
+          src="/super-wide.png"
+          width="200"
+          height="200"
+          loading="eager"
+          style={{ height: 'auto' }}
+        />
+      </div>
     </div>
   )
 }

--- a/test/integration/next-image-new/default/test/index.test.ts
+++ b/test/integration/next-image-new/default/test/index.test.ts
@@ -825,6 +825,11 @@ function runTests(mode: 'dev' | 'server') {
         expect(warnings).not.toMatch(
           /Image with src "\/test.png" has either width or height modified, but not the other./gm
         )
+        // Ensure no false positive when CSS preserves the aspect ratio
+        // (e.g. height: auto changes the dimension but keeps the ratio)
+        expect(warnings).not.toMatch(
+          /Image with src "\/super-wide.png" has either width or height modified, but not the other./gm
+        )
       }
     } finally {
       if (browser) {


### PR DESCRIPTION
## Summary

- The `next/image` component warns when a rendered dimension differs from the HTML attribute but not the other. This triggers **false positives** when global CSS (e.g. Tailwind's preflight `img { height: auto }`) changes one dimension while preserving the image's natural aspect ratio.
- Before warning, check if the rendered aspect ratio matches the image's natural (intrinsic) aspect ratio using cross-multiplication with a 1px rounding tolerance. If preserved, suppress the warning.
- Added test cases using `super-wide.png` with `height: auto` to verify the false positive is no longer triggered.

### How it was

```
Image with src "/vercel.svg" has either width or height modified, but not the other.
If you use CSS to change the size of your image, also include the styles
'width: "auto"' or 'height: "auto"' to maintain the aspect ratio.
```

This warning fires even when the user sets both `width` and `height` props on `<Image>`, because Tailwind's preflight CSS (`img { height: auto }`) adjusts the rendered height to match the image's natural aspect ratio. The aspect ratio is actually **preserved**, not broken — it's a false positive.

### How it is now

The warning only fires when the rendered aspect ratio **actually differs** from the natural aspect ratio, meaning the image is genuinely distorted. Cases where global CSS preserves the ratio (like `height: auto`) no longer trigger the warning.

## Test plan

- [ ] Existing test: `wide.png` with `width=1200 height=700` in a narrow viewport still triggers the warning (genuine distortion — width constrained but height unchanged)
- [ ] Existing test: `test.png` with matching square dimensions does not trigger
- [ ] New test: `super-wide.png` with `width=200 height=200 style={{ height: 'auto' }}` does **not** trigger (aspect ratio preserved by CSS)

<!-- NEXT_JS_LLM_PR -->