### PR TITLE
fix(server-actions): skip type-only ExportNamed in pre-pass to prevent phantom registerServerReference

### DIFF
--- a/crates/next-custom-transforms/src/transforms/server_actions.rs
+++ b/crates/next-custom-transforms/src/transforms/server_actions.rs
@@ -1819,7 +1819,7 @@ impl<C: Comments> VisitMut for ServerActions<C> {
                         }
                     }
                     ModuleItem::ModuleDecl(ModuleDecl::ExportNamed(named_export))
-                        if named_export.src.is_none() =>
+                        if named_export.src.is_none() && !named_export.type_only =>
                     {
                         for spec in &named_export.specifiers {
                             match spec {

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/72/input.ts
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/72/input.ts
@@ -1,5 +1,6 @@
 'use server'
 
+// @ts-ignore -- that file does not exist
 export type { Item } from './types'
 export type { Foo }
 

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/72/input.ts
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/72/input.ts
@@ -1,0 +1,10 @@
+'use server'
+
+export type { Item } from './types'
+export type { Foo }
+
+type Foo = string
+
+export async function actionA(): Promise<string> {
+  return 'hello from actionA'
+}

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/72/output.ts
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/72/output.ts
@@ -1,0 +1,12 @@
+/* __next_internal_action_entry_do_not_use__ {"0095ef8ede0a8a4c822fcbdb018cb264731cb15281":{"name":"actionA"}} */ import { registerServerReference } from "private-next-rsc-server-reference";
+export type { Item } from './types';
+export type { Foo };
+type Foo = string;
+export async function actionA(): Promise<string> {
+    return 'hello from actionA';
+}
+import { ensureServerEntryExports } from "private-next-rsc-action-validate";
+ensureServerEntryExports([
+    actionA
+]);
+registerServerReference(actionA, "0095ef8ede0a8a4c822fcbdb018cb264731cb15281", null);

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/72/output.ts
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/72/output.ts
@@ -1,4 +1,5 @@
 /* __next_internal_action_entry_do_not_use__ {"0095ef8ede0a8a4c822fcbdb018cb264731cb15281":{"name":"actionA"}} */ import { registerServerReference } from "private-next-rsc-server-reference";
+// @ts-ignore -- that file does not exist
 export type { Item } from './types';
 export type { Foo };
 type Foo = string;


### PR DESCRIPTION
## What?

Fixes #92461

`export type { Foo }` inside a `"use server"` file was incorrectly added to `export_name_by_local_id` in the pre-pass of `visit_mut_module_items`, causing it to be registered as a Server Action via `registerServerReference()` and `ensureServerEntryExports()` in the post-pass.

## Why?

The pre-pass guard only checked `named_export.src.is_none()` but did not check `!named_export.type_only`:

```rust
// Before fix — missing !named_export.type_only check
ModuleItem::ModuleDecl(ModuleDecl::ExportNamed(named_export))
    if named_export.src.is_none() => { ... }
```

`export type { Foo }` sets `ExportNamed.type_only = true`, but the individual specifiers inside still have `ExportNamedSpecifier.is_type_only = false` (that field is only `true` for `export { type A }` syntax with a per-specifier type keyword). So the specifier-level pattern match would succeed, incorrectly inserting the TypeScript type identifier as a would-be Server Action.

The main validation pass at line 1958 correctly guards with `if !named.type_only` — this fix applies the same guard to the pre-pass.

## How?

Added `&& !named_export.type_only` to the pre-pass guard:

```rust
// After fix
ModuleItem::ModuleDecl(ModuleDecl::ExportNamed(named_export))
    if named_export.src.is_none() && !named_export.type_only => { ... }
```

Added test fixture 72 covering:
- `export type { Item } from './types'` (already handled by main pass `!named.type_only`)
- `export type { Foo }` (the bug — type-only local re-export without `from`)
- `export async function actionA()` (correctly registered as Server Action)