### PR TITLE
docs: fix reuse wording in app icons metadata example

### DIFF
--- a/docs/01-app/03-api-reference/03-file-conventions/01-metadata/app-icons.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/01-metadata/app-icons.mdx
@@ -112,7 +112,7 @@ export default function Icon() {
     ),
     // ImageResponse options
     {
-      // For convenience, we can re-use the exported icons size metadata
+      // For convenience, we can reuse the exported icons size metadata
       // config to also set the ImageResponse's width and height.
       ...size,
     }


### PR DESCRIPTION
### What?
- fix `re-use` -> `reuse` in the app icons metadata example comment

### Why?
- keep the docs example wording consistent

### How?
- update one comment in `docs/01-app/03-api-reference/03-file-conventions/01-metadata/app-icons.mdx`
- no behavior changes

Related issue: N/A (trivial docs fix)

<!-- NEXT_JS_LLM_PR -->
