### PR TITLE
fix: prevent crash "Cannot redefine property: default" when loading next.config

### DIFF
--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1779,6 +1779,15 @@ export default async function loadConfig(
 
     const configModule = interopDefault(userConfigModule)
 
+    if (
+      configModule == null ||
+      (typeof configModule !== 'object' && typeof configModule !== 'function')
+    ) {
+      throw new Error(
+        `Invalid next.config export. Expected an object or function, but received ${configModule}.`
+      )
+    }
+
     const normalized = await normalizeConfig(phase, configModule)
 
     // Spread into a plain object so Object.freeze works even if

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1781,13 +1781,10 @@ export default async function loadConfig(
 
     const normalized = await normalizeConfig(phase, configModule)
 
-    // unwrap default if present
-    const finalNormalized =
-      normalized && typeof normalized === 'object' && 'default' in normalized
-        ? (normalized as any).default
-        : normalized
-
-    const loadedConfig = Object.freeze({ ...finalNormalized })
+    // Spread into a plain object so Object.freeze works even if
+    // `normalized` is an exotic object (e.g. ESM module namespace)
+    // whose properties are already non-configurable.
+    const loadedConfig = Object.freeze({ ...normalized } as NextConfig)
 
     if (loadedConfig.experimental) {
       for (const name of Object.keys(

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1777,12 +1777,17 @@ export default async function loadConfig(
       throw err
     }
 
-    const loadedConfig = Object.freeze(
-      (await normalizeConfig(
-        phase,
-        interopDefault(userConfigModule)
-      )) as NextConfig
-    )
+    const configModule = interopDefault(userConfigModule)
+
+    const normalized = await normalizeConfig(phase, configModule)
+
+    // unwrap default if present
+    const finalNormalized =
+      normalized && typeof normalized === 'object' && 'default' in normalized
+        ? (normalized as any).default
+        : normalized
+
+    const loadedConfig = Object.freeze({ ...finalNormalized })
 
     if (loadedConfig.experimental) {
       for (const name of Object.keys(


### PR DESCRIPTION
## What?

Fixes a crash when running `next dev` on a fresh app using canary + pnpm:

```
TypeError: Cannot redefine property: default
```

## Why?

When loading `next.config`, the result of `normalizeConfig` may include a `default` property due to ESM interop.

Applying `Object.freeze` directly on this object can cause property redefinition errors, especially in environments like pnpm with file-based dependencies.

## How?

* Normalize config using `interopDefault`
* Safely unwrap `default` if present
* Clone the normalized config before freezing to avoid descriptor conflicts

## Reproduction

https://github.com/Akash504-ai/nextjs-cannot-redefine-property-default-repro

## Notes

This fix has been validated using a fresh Next.js app with:

* pnpm
* canary version
* empty `next.config.js`

The dev server now starts successfully without crashing.

Fixes #92497
