### PR TITLE
fix(testing): resolve async function configs in unstable_getResponseFromNextConfig

### DIFF
--- a/packages/next/src/experimental/testing/server/config-testing-utils.test.ts
+++ b/packages/next/src/experimental/testing/server/config-testing-utils.test.ts
@@ -283,3 +283,35 @@ describe('config-testing-utils', () => {
     expect(response.headers.get('x-using-base-path')).toBeNull()
   })
 })
+
+describe('function configs', () => {
+  it('resolves a synchronous function config', async () => {
+    const response = await unstable_getResponseFromNextConfig({
+      url: 'https://nextjs.org/old',
+      nextConfig: (_phase, _ctx) => ({
+        async rewrites() {
+          return [{ source: '/old', destination: '/new' }]
+        },
+      }),
+    })
+    expect(response.status).toEqual(200)
+    expect(getRewrittenUrl(response)).toEqual('https://nextjs.org/new')
+  })
+
+  it('resolves an async function config (plugin wrapper pattern)', async () => {
+    function withPlugin(config: object) {
+      return async (_phase: string, _ctx: object) => ({
+        ...config,
+      })
+    }
+    const response = await unstable_getResponseFromNextConfig({
+      url: 'https://nextjs.org/old',
+      nextConfig: withPlugin({
+        async rewrites() {
+          return [{ source: '/old', destination: '/new' }]
+        },
+      }) as any,
+    })
+    expect(response.status).toEqual(200)
+  })
+})

--- a/packages/next/src/experimental/testing/server/config-testing-utils.ts
+++ b/packages/next/src/experimental/testing/server/config-testing-utils.ts
@@ -7,7 +7,9 @@ import {
 } from '../../../shared/lib/router/utils/prepare-destination'
 import { buildCustomRoute } from '../../../lib/build-custom-route'
 import loadCustomRoutes from '../../../lib/load-custom-routes'
+import { normalizeConfig } from '../../../server/config-shared'
 import type { NextConfig } from '../../../server/config-shared'
+import { PHASE_PRODUCTION_BUILD } from '../../../shared/lib/constants'
 import { NextResponse } from '../../../server/web/exports'
 import { getRedirectStatus } from '../../../lib/redirect-status'
 import type {
@@ -81,13 +83,22 @@ export async function unstable_getResponseFromNextConfig({
   cookies = {},
 }: {
   url: string
-  nextConfig: NextConfig
+  nextConfig:
+    | NextConfig
+    | ((
+        phase: string,
+        ctx: { defaultConfig: any }
+      ) => NextConfig | Promise<NextConfig>)
   headers?: IncomingHttpHeaders
   cookies?: Record<string, string>
 }): Promise<NextResponse> {
   const parsedUrl = parse(url, true)
   const request = constructRequest({ url, headers, cookies })
-  const routes = await loadCustomRoutes(nextConfig)
+  const resolvedConfig = (await normalizeConfig(
+    PHASE_PRODUCTION_BUILD,
+    nextConfig
+  )) as NextConfig
+  const routes = await loadCustomRoutes(resolvedConfig)
 
   const headerRoutes = routes.headers.map((route) =>
     buildCustomRoute('header', route)


### PR DESCRIPTION
## What?

Plugin wrappers like `@sentry/nextjs`, `@vercel/workflow` wrap the user config in an async function:

```js
// next.config.mjs
function withPlugin(config) {
  return async (phase, { defaultConfig }) => ({ ...config })
}
export default withPlugin({ rewrites() { ... } })
```

When such a config is passed to `unstable_getResponseFromNextConfig`, the config is passed directly to `loadCustomRoutes`, which immediately accesses `config.rewrites`, `config.redirects`, etc. Since the value is still a function, all those properties are `undefined` and every route matcher returns `null`.

## Why?

`loadCustomRoutes` expects a plain config object. The main Next.js config loader already calls `normalizeConfig(phase, rawExport)` which properly resolves both function and Promise exports before use.

## How?

Call `normalizeConfig(PHASE_PRODUCTION_BUILD, nextConfig)` before passing to `loadCustomRoutes`. This is the same helper used by the Next.js config loading pipeline to unwrap function/async function configs.

Also broadened the TypeScript parameter type to accept function-wrapped configs without needing an `as any` cast in user code.

## Test

Added two test cases in `config-testing-utils.test.ts`:
1. Synchronous function config `(phase, ctx) => config`
2. Async function config (plugin wrapper pattern) `(phase, ctx) => Promise<config>`

Closes #92500