### PR TITLE
Add experimental unstable_io() API behind experimental.unstableIO flag

### DIFF
--- a/packages/next/cache.d.ts
+++ b/packages/next/cache.d.ts
@@ -9,6 +9,8 @@ export {
 
 export { unstable_noStore } from 'next/dist/server/web/spec-extension/unstable-no-store'
 
+export { unstable_io } from 'next/dist/server/request/io'
+
 import { cacheTag } from 'next/dist/server/use-cache/cache-tag'
 
 export { cacheTag }

--- a/packages/next/cache.js
+++ b/packages/next/cache.js
@@ -17,6 +17,7 @@ if (process.env.NEXT_RUNTIME === '') {
       }
     },
     unstable_noStore: function unstable_noStore() {},
+    unstable_io: require('next/dist/client/request/io.browser').unstable_io,
 
     updateTag: notAvailableInClient('updateTag'),
     revalidateTag: notAvailableInClient('revalidateTag'),
@@ -45,6 +46,7 @@ if (process.env.NEXT_RUNTIME === '') {
     unstable_noStore:
       require('next/dist/server/web/spec-extension/unstable-no-store')
         .unstable_noStore,
+    unstable_io: require('next/dist/server/request/io').unstable_io,
     cacheLife: require('next/dist/server/use-cache/cache-life').cacheLife,
     cacheTag: require('next/dist/server/use-cache/cache-tag').cacheTag,
   }
@@ -92,3 +94,4 @@ exports.unstable_cacheLife = cacheExports.unstable_cacheLife
 exports.cacheTag = cacheExports.cacheTag
 exports.unstable_cacheTag = cacheExports.unstable_cacheTag
 exports.refresh = cacheExports.refresh
+exports.unstable_io = cacheExports.unstable_io

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1154,5 +1154,7 @@
   "1153": "renderToPipeableStream is not implemented",
   "1154": "not implemented",
   "1155": "Not implemented",
-  "1156": "Cannot create a replay stream after the ReplayableNodeStream has been disposed."
+  "1156": "Cannot create a replay stream after the ReplayableNodeStream has been disposed.",
+  "1157": "`unstable_io()` requires the `experimental.unstableIO` option to be enabled in your Next.js config.",
+  "1158": "The prerender-ppr work unit type has been removed. This code path should be unreachable."
 }

--- a/packages/next/src/build/define-env.ts
+++ b/packages/next/src/build/define-env.ts
@@ -246,6 +246,7 @@ export function getDefineEnv({
       config.experimental.dynamicOnHover
     ),
     'process.env.__NEXT_USE_OFFLINE': Boolean(config.experimental.useOffline),
+    'process.env.__NEXT_UNSTABLE_IO': Boolean(config.experimental.unstableIO),
     'process.env.__NEXT_PREFETCH_INLINING': Boolean(
       config.experimental.prefetchInlining
     ),

--- a/packages/next/src/client/request/io.browser.ts
+++ b/packages/next/src/client/request/io.browser.ts
@@ -1,0 +1,19 @@
+// A fulfilled thenable that React can unwrap synchronously via `use()` without
+// ever suspending. Reusing a single instance avoids allocating on every call.
+const resolvedIOPromise: Promise<void> = Promise.resolve(undefined)
+;(resolvedIOPromise as any).status = 'fulfilled'
+;(resolvedIOPromise as any).value = undefined
+
+/**
+ * Browser implementation of unstable_io(). On the client there is no
+ * prerender context so we always resolve immediately.
+ */
+export function unstable_io(): Promise<void> {
+  if (!process.env.__NEXT_UNSTABLE_IO) {
+    throw new Error(
+      '`unstable_io()` requires the `experimental.unstableIO` option to be enabled in your Next.js config.'
+    )
+  }
+
+  return resolvedIOPromise
+}

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -4392,6 +4392,7 @@ function createAsyncApiPromises(
       'connection',
       undefined
     ),
+    io: stagedRendering.delayUntilStage(RenderStage.Dynamic, 'io', undefined),
   }
 }
 

--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -114,6 +114,10 @@ export type AsyncApiPromises = {
   // Connection is not a runtime promise and doesn't
   // need to distinguish between early and late
   connection: Promise<undefined>
+
+  // IO is not a runtime promise and doesn't
+  // need to distinguish between early and late
+  io: Promise<undefined>
 }
 
 /**

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -223,6 +223,7 @@ export const experimentalSchema = {
   partialFallbacks: z.boolean().optional(),
   dynamicOnHover: z.boolean().optional(),
   useOffline: z.boolean().optional(),
+  unstableIO: z.boolean().optional(),
   optimisticRouting: z.boolean().optional(),
   varyParams: z.boolean().optional(),
   prefetchInlining: z

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -430,6 +430,7 @@ export interface ExperimentalConfig {
   partialFallbacks?: boolean
   dynamicOnHover?: boolean
   useOffline?: boolean
+  unstableIO?: boolean
   optimisticRouting?: boolean
   varyParams?: boolean
   prefetchInlining?:
@@ -1833,6 +1834,7 @@ export const defaultConfig = Object.freeze({
     partialFallbacks: false,
     dynamicOnHover: false,
     useOffline: false,
+    unstableIO: false,
     varyParams: false,
     prefetchInlining: false,
     preloadEntriesOnStart: true,
@@ -1979,6 +1981,7 @@ export interface NextConfigRuntime {
     | 'staleTimes'
     | 'dynamicOnHover'
     | 'useOffline'
+    | 'unstableIO'
     | 'optimisticRouting'
     | 'inlineCss'
     | 'prefetchInlining'
@@ -2046,6 +2049,7 @@ export function getNextConfigRuntime(
         staleTimes: ex.staleTimes,
         dynamicOnHover: ex.dynamicOnHover,
         useOffline: ex.useOffline,
+        unstableIO: ex.unstableIO,
         optimisticRouting: ex.optimisticRouting,
         inlineCss: ex.inlineCss,
         prefetchInlining: ex.prefetchInlining,

--- a/packages/next/src/server/lib/router-utils/cache-life-type-utils.test.ts
+++ b/packages/next/src/server/lib/router-utils/cache-life-type-utils.test.ts
@@ -29,6 +29,7 @@ describe('cache-life-type-utils', () => {
          refresh,
        } from 'next/dist/server/web/spec-extension/revalidate'
        export { unstable_noStore } from 'next/dist/server/web/spec-extension/unstable-no-store'
+       export { unstable_io } from 'next/dist/server/request/io'
 
        
          /**
@@ -186,6 +187,7 @@ describe('cache-life-type-utils', () => {
          refresh,
        } from 'next/dist/server/web/spec-extension/revalidate'
        export { unstable_noStore } from 'next/dist/server/web/spec-extension/unstable-no-store'
+       export { unstable_io } from 'next/dist/server/request/io'
 
        
          /**
@@ -263,6 +265,7 @@ describe('cache-life-type-utils', () => {
          refresh,
        } from 'next/dist/server/web/spec-extension/revalidate'
        export { unstable_noStore } from 'next/dist/server/web/spec-extension/unstable-no-store'
+       export { unstable_io } from 'next/dist/server/request/io'
 
        
          /**
@@ -339,6 +342,7 @@ describe('cache-life-type-utils', () => {
          refresh,
        } from 'next/dist/server/web/spec-extension/revalidate'
        export { unstable_noStore } from 'next/dist/server/web/spec-extension/unstable-no-store'
+       export { unstable_io } from 'next/dist/server/request/io'
 
        
          /**
@@ -416,6 +420,7 @@ describe('cache-life-type-utils', () => {
          refresh,
        } from 'next/dist/server/web/spec-extension/revalidate'
        export { unstable_noStore } from 'next/dist/server/web/spec-extension/unstable-no-store'
+       export { unstable_io } from 'next/dist/server/request/io'
 
        
          /**
@@ -497,6 +502,7 @@ describe('cache-life-type-utils', () => {
          refresh,
        } from 'next/dist/server/web/spec-extension/revalidate'
        export { unstable_noStore } from 'next/dist/server/web/spec-extension/unstable-no-store'
+       export { unstable_io } from 'next/dist/server/request/io'
 
        
          /**

--- a/packages/next/src/server/lib/router-utils/cache-life-type-utils.ts
+++ b/packages/next/src/server/lib/router-utils/cache-life-type-utils.ts
@@ -177,6 +177,7 @@ declare module 'next/cache' {
     refresh,
   } from 'next/dist/server/web/spec-extension/revalidate'
   export { unstable_noStore } from 'next/dist/server/web/spec-extension/unstable-no-store'
+  export { unstable_io } from 'next/dist/server/request/io'
 
   ${overloads}
 

--- a/packages/next/src/server/request/io.ts
+++ b/packages/next/src/server/request/io.ts
@@ -1,0 +1,108 @@
+import { workAsyncStorage } from '../app-render/work-async-storage.external'
+import { workUnitAsyncStorage } from '../app-render/work-unit-async-storage.external'
+import {
+  makeHangingPromise,
+  makeDevtoolsIOAwarePromise,
+} from '../dynamic-rendering-utils'
+import { RenderStage } from '../app-render/staged-rendering'
+import { throwPrerenderPPRRemovedError } from '../../shared/lib/ppr-removed-error'
+
+// A fulfilled thenable that React can unwrap synchronously via `use()` without
+// ever suspending. Reusing a single instance avoids allocating on every call.
+const resolvedIOPromise: Promise<void> = Promise.resolve(undefined)
+;(resolvedIOPromise as any).status = 'fulfilled'
+;(resolvedIOPromise as any).value = undefined
+
+/**
+ * This function allows you to indicate that the code following it performs
+ * I/O or accesses dynamic data sources such as `new Date()` or `Math.random()`.
+ *
+ * During prerendering it will prevent the prerender from continuing past this
+ * point, creating a dynamic boundary. Inside `"use cache"` scopes or during
+ * a real request it resolves immediately.
+ *
+ * Unlike `connection()`, `unstable_io()` does not require an actual HTTP
+ * request and can be used freely inside cache scopes and client components.
+ */
+export function unstable_io(): Promise<void> {
+  if (!process.env.__NEXT_UNSTABLE_IO) {
+    throw new Error(
+      '`unstable_io()` requires the `experimental.unstableIO` option to be enabled in your Next.js config.'
+    )
+  }
+
+  const workStore = workAsyncStorage.getStore()
+  const workUnitStore = workUnitAsyncStorage.getStore()
+
+  if (workStore && workUnitStore) {
+    switch (workUnitStore.type) {
+      case 'request':
+        // For dev renders we instrument the promise so it will show up in
+        // React Suspense Devtools and, if also doing `instant` validation,
+        // ensure it resolves in the right stage for staged rendering
+        // In production we just let it resolve immediately because we're doing
+        // a dynamic SSR or resume render and have no need to delay anything
+        // after this call
+        if (process.env.NODE_ENV === 'development') {
+          if (workUnitStore.asyncApiPromises) {
+            return workUnitStore.asyncApiPromises.io
+          }
+          return makeDevtoolsIOAwarePromise(
+            undefined,
+            workUnitStore,
+            RenderStage.Dynamic
+          )
+        } else if (workUnitStore.asyncApiPromises) {
+          return workUnitStore.asyncApiPromises.io
+        }
+        return resolvedIOPromise
+      case 'prerender':
+      case 'prerender-client':
+      case 'prerender-runtime':
+        // When prerendering with Cache Components we consider `io()` to be
+        // actual IO if not in a cache scope and we can avoid actually executing
+        // anything after it by making it return a hanging promise.
+        return makeHangingPromise(
+          workUnitStore.renderSignal,
+          workStore.route,
+          '`unstable_io()`'
+        )
+      case 'prerender-ppr':
+        // Dead code to be removed when we eliminate legacy ppr code
+        throwPrerenderPPRRemovedError()
+        break
+      case 'cache':
+      case 'private-cache':
+      case 'unstable-cache':
+      // Inside cache scopes, unstable_io() resolves immediately.
+      // Caches can contain IO-dependent code like new Date() — it will
+      // simply return the value at cache-fill time.
+      // ...
+      // intentional fallthrough
+      case 'generate-static-params':
+      // generateStaticParams runs at build time. There is no prerender
+      // to stall so we resolve immediately.
+      // ...
+      // intentional fallthrough
+      case 'validation-client':
+      // unstable_io() is usable in client components, resolve immediately.
+      // The reason we take this position is most io shielding you would do
+      // in a browser is for sync IO as there aren't many non-fetch based IO
+      // operations you can do in the browser that have meaningful latency.
+      // So while you might use
+      // ...
+      // intentional fallthrough
+      case 'prerender-legacy':
+        // Without cache components, IO is not inherently dynamic.
+        // Resolve immediately rather than interrupting static generation.
+        return resolvedIOPromise
+      default:
+        workUnitStore satisfies never
+    }
+  }
+
+  // No work store — we're outside the Next.js rendering context (e.g. in
+  // a client component on the browser or in a standalone script). Resolve
+  // immediately.
+  return resolvedIOPromise
+}

--- a/packages/next/src/shared/lib/ppr-removed-error.ts
+++ b/packages/next/src/shared/lib/ppr-removed-error.ts
@@ -1,0 +1,13 @@
+import { InvariantError } from './invariant-error'
+
+/**
+ * Throws an InvariantError indicating that a prerender-ppr code path was
+ * reached. The prerender-ppr work unit type has been removed and all code
+ * handling it is dead. Use this in exhaustive switch cases while the
+ * prerender-ppr type is being cleaned up.
+ */
+export function throwPrerenderPPRRemovedError(): never {
+  throw new InvariantError(
+    'The prerender-ppr work unit type has been removed. This code path should be unreachable.'
+  )
+}

--- a/test/cache-components-tests-manifest.json
+++ b/test/cache-components-tests-manifest.json
@@ -370,7 +370,8 @@
       "test/production/app-dir/worker-restart/worker-restart.test.ts",
       "test/production/app-dir/resume-data-cache/resume-data-cache.test.ts",
       "test/production/app-dir/unstable-cache-foreground-revalidate/unstable-cache-foreground-revalidate.test.ts",
-      "test/e2e/app-dir/parallel-routes-root-param-dynamic-child/parallel-routes-root-param-dynamic-child.test.ts"
+      "test/e2e/app-dir/parallel-routes-root-param-dynamic-child/parallel-routes-root-param-dynamic-child.test.ts",
+      "test/e2e/app-dir/unstable-io/unstable-io.test.ts"
     ]
   }
 }

--- a/test/e2e/app-dir/unstable-io/fixtures/cache-components/app/getSentinelValue.tsx
+++ b/test/e2e/app-dir/unstable-io/fixtures/cache-components/app/getSentinelValue.tsx
@@ -1,0 +1,7 @@
+const { PHASE_PRODUCTION_BUILD } = require('next/constants')
+
+export function getSentinelValue() {
+  return process.env.NEXT_PHASE === PHASE_PRODUCTION_BUILD
+    ? 'at buildtime'
+    : 'at runtime'
+}

--- a/test/e2e/app-dir/unstable-io/fixtures/cache-components/app/io-boundary/page.tsx
+++ b/test/e2e/app-dir/unstable-io/fixtures/cache-components/app/io-boundary/page.tsx
@@ -1,0 +1,25 @@
+import { Suspense } from 'react'
+import { unstable_io } from 'next/cache'
+import { getSentinelValue } from '../getSentinelValue'
+
+export default function Page() {
+  return (
+    <>
+      <p>
+        This page uses unstable_io() inside a Suspense boundary. With cache
+        components the content after unstable_io() should be dynamic and
+        rendered at request time, not during the build prerender.
+      </p>
+      <div id="before">{getSentinelValue()}</div>
+      <Suspense fallback={<div id="fallback">loading...</div>}>
+        <DynamicComponent />
+      </Suspense>
+      <div id="page">{getSentinelValue()}</div>
+    </>
+  )
+}
+
+async function DynamicComponent() {
+  await unstable_io()
+  return <div id="after-io">{getSentinelValue()}</div>
+}

--- a/test/e2e/app-dir/unstable-io/fixtures/cache-components/app/io-in-cache/page.tsx
+++ b/test/e2e/app-dir/unstable-io/fixtures/cache-components/app/io-in-cache/page.tsx
@@ -1,0 +1,30 @@
+import { Suspense } from 'react'
+import { unstable_io } from 'next/cache'
+import { getSentinelValue } from '../getSentinelValue'
+
+export default function Page() {
+  return (
+    <>
+      <p>
+        This page uses unstable_io() inside a "use cache" function. Inside cache
+        scopes unstable_io() resolves immediately so the cached value should be
+        computed at cache-fill time during the build.
+      </p>
+      <Suspense fallback="loading...">
+        <CachedComponent />
+      </Suspense>
+      <div id="page">{getSentinelValue()}</div>
+    </>
+  )
+}
+
+async function CachedComponent() {
+  const value = await getCachedValue()
+  return <div id="cached-value">{value}</div>
+}
+
+async function getCachedValue() {
+  'use cache'
+  await unstable_io()
+  return getSentinelValue()
+}

--- a/test/e2e/app-dir/unstable-io/fixtures/cache-components/app/layout.tsx
+++ b/test/e2e/app-dir/unstable-io/fixtures/cache-components/app/layout.tsx
@@ -1,0 +1,12 @@
+import { getSentinelValue } from './getSentinelValue'
+
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>
+        <main>{children}</main>
+        <div id="layout">{getSentinelValue()}</div>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/unstable-io/fixtures/cache-components/next.config.js
+++ b/test/e2e/app-dir/unstable-io/fixtures/cache-components/next.config.js
@@ -1,0 +1,11 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+  experimental: {
+    unstableIO: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/unstable-io/fixtures/cache-components/pages/pages-gsp.tsx
+++ b/test/e2e/app-dir/unstable-io/fixtures/cache-components/pages/pages-gsp.tsx
@@ -1,0 +1,15 @@
+import { unstable_io } from 'next/cache'
+
+export default function PagesGSP({ rendered }: { rendered: string }) {
+  return (
+    <>
+      <p>This page uses unstable_io() in getStaticProps.</p>
+      <div id="pages-content">{rendered}</div>
+    </>
+  )
+}
+
+export async function getStaticProps() {
+  await unstable_io()
+  return { props: { rendered: 'ok' } }
+}

--- a/test/e2e/app-dir/unstable-io/fixtures/cache-components/pages/pages-gssp.tsx
+++ b/test/e2e/app-dir/unstable-io/fixtures/cache-components/pages/pages-gssp.tsx
@@ -1,0 +1,15 @@
+import { unstable_io } from 'next/cache'
+
+export default function PagesGSSP({ rendered }: { rendered: string }) {
+  return (
+    <>
+      <p>This page uses unstable_io() in getServerSideProps.</p>
+      <div id="pages-content">{rendered}</div>
+    </>
+  )
+}
+
+export async function getServerSideProps() {
+  await unstable_io()
+  return { props: { rendered: 'ok' } }
+}

--- a/test/e2e/app-dir/unstable-io/fixtures/cache-components/pages/pages-use.tsx
+++ b/test/e2e/app-dir/unstable-io/fixtures/cache-components/pages/pages-use.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import { unstable_io } from 'next/cache'
+
+export default function PagesUse() {
+  React.use(unstable_io())
+  return (
+    <>
+      <p>This page calls React.use(unstable_io()) in the component body.</p>
+      <div id="pages-content">ok</div>
+    </>
+  )
+}

--- a/test/e2e/app-dir/unstable-io/fixtures/default/app/getSentinelValue.tsx
+++ b/test/e2e/app-dir/unstable-io/fixtures/default/app/getSentinelValue.tsx
@@ -1,0 +1,7 @@
+const { PHASE_PRODUCTION_BUILD } = require('next/constants')
+
+export function getSentinelValue() {
+  return process.env.NEXT_PHASE === PHASE_PRODUCTION_BUILD
+    ? 'at buildtime'
+    : 'at runtime'
+}

--- a/test/e2e/app-dir/unstable-io/fixtures/default/app/io-boundary/page.tsx
+++ b/test/e2e/app-dir/unstable-io/fixtures/default/app/io-boundary/page.tsx
@@ -1,0 +1,25 @@
+import { Suspense } from 'react'
+import { unstable_io } from 'next/cache'
+import { getSentinelValue } from '../getSentinelValue'
+
+export default function Page() {
+  return (
+    <>
+      <p>
+        This page uses unstable_io() inside a Suspense boundary. Without cache
+        components unstable_io() is a no-op during prerendering so the entire
+        page should be fully static.
+      </p>
+      <div id="before">{getSentinelValue()}</div>
+      <Suspense fallback={<div id="fallback">loading...</div>}>
+        <DynamicComponent />
+      </Suspense>
+      <div id="page">{getSentinelValue()}</div>
+    </>
+  )
+}
+
+async function DynamicComponent() {
+  await unstable_io()
+  return <div id="after-io">{getSentinelValue()}</div>
+}

--- a/test/e2e/app-dir/unstable-io/fixtures/default/app/layout.tsx
+++ b/test/e2e/app-dir/unstable-io/fixtures/default/app/layout.tsx
@@ -1,0 +1,12 @@
+import { getSentinelValue } from './getSentinelValue'
+
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>
+        <main>{children}</main>
+        <div id="layout">{getSentinelValue()}</div>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/unstable-io/fixtures/default/next.config.js
+++ b/test/e2e/app-dir/unstable-io/fixtures/default/next.config.js
@@ -1,0 +1,10 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    unstableIO: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/unstable-io/fixtures/default/pages/pages-gsp.tsx
+++ b/test/e2e/app-dir/unstable-io/fixtures/default/pages/pages-gsp.tsx
@@ -1,0 +1,15 @@
+import { unstable_io } from 'next/cache'
+
+export default function PagesGSP({ rendered }: { rendered: string }) {
+  return (
+    <>
+      <p>This page uses unstable_io() in getStaticProps.</p>
+      <div id="pages-content">{rendered}</div>
+    </>
+  )
+}
+
+export async function getStaticProps() {
+  await unstable_io()
+  return { props: { rendered: 'ok' } }
+}

--- a/test/e2e/app-dir/unstable-io/fixtures/default/pages/pages-gssp.tsx
+++ b/test/e2e/app-dir/unstable-io/fixtures/default/pages/pages-gssp.tsx
@@ -1,0 +1,15 @@
+import { unstable_io } from 'next/cache'
+
+export default function PagesGSSP({ rendered }: { rendered: string }) {
+  return (
+    <>
+      <p>This page uses unstable_io() in getServerSideProps.</p>
+      <div id="pages-content">{rendered}</div>
+    </>
+  )
+}
+
+export async function getServerSideProps() {
+  await unstable_io()
+  return { props: { rendered: 'ok' } }
+}

--- a/test/e2e/app-dir/unstable-io/fixtures/default/pages/pages-use.tsx
+++ b/test/e2e/app-dir/unstable-io/fixtures/default/pages/pages-use.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import { unstable_io } from 'next/cache'
+
+export default function PagesUse() {
+  React.use(unstable_io())
+  return (
+    <>
+      <p>This page calls React.use(unstable_io()) in the component body.</p>
+      <div id="pages-content">ok</div>
+    </>
+  )
+}

--- a/test/e2e/app-dir/unstable-io/unstable-io.test.ts
+++ b/test/e2e/app-dir/unstable-io/unstable-io.test.ts
@@ -1,0 +1,99 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('unstable_io with cache components', () => {
+  const { next, isNextDev, skipped } = nextTestSetup({
+    files: __dirname + '/fixtures/cache-components',
+    skipDeployment: true,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  it('should make content after unstable_io() dynamic during prerender', async () => {
+    const $ = await next.render$('/io-boundary')
+    if (isNextDev) {
+      // In dev mode everything renders at runtime
+      expect($('#before').text()).toBe('at runtime')
+      expect($('#after-io').text()).toBe('at runtime')
+      expect($('#page').text()).toBe('at runtime')
+    } else {
+      // In production with cache components, unstable_io() creates a dynamic
+      // boundary. Content in the static shell is rendered at buildtime.
+      // Content after unstable_io() is rendered at request time because the
+      // hanging promise prevented it from executing during the build prerender.
+      expect($('#before').text()).toBe('at buildtime')
+      expect($('#page').text()).toBe('at buildtime')
+      expect($('#after-io').text()).toBe('at runtime')
+    }
+  })
+
+  it('should resolve immediately inside a "use cache" scope', async () => {
+    const $ = await next.render$('/io-in-cache')
+    if (isNextDev) {
+      expect($('#cached-value').text()).toBe('at runtime')
+      expect($('#page').text()).toBe('at runtime')
+    } else {
+      // unstable_io() inside "use cache" is a no-op so the cached value is
+      // computed at cache-fill time during the build
+      expect($('#cached-value').text()).toBe('at buildtime')
+      expect($('#page').text()).toBe('at buildtime')
+    }
+  })
+
+  it('should work in pages router with getServerSideProps (CC)', async () => {
+    const $ = await next.render$('/pages-gssp')
+    expect($('#pages-content').text()).toBe('ok')
+  })
+
+  it('should work in pages router with getStaticProps (CC)', async () => {
+    const $ = await next.render$('/pages-gsp')
+    expect($('#pages-content').text()).toBe('ok')
+  })
+
+  it('should work in pages router with React.use() (CC)', async () => {
+    const $ = await next.render$('/pages-use')
+    expect($('#pages-content').text()).toBe('ok')
+  })
+})
+
+describe('unstable_io without cache components', () => {
+  const { next, isNextDev, skipped } = nextTestSetup({
+    files: __dirname + '/fixtures/default',
+    skipDeployment: true,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  it('should be a no-op during prerender without cache components', async () => {
+    const $ = await next.render$('/io-boundary')
+    if (isNextDev) {
+      expect($('#before').text()).toBe('at runtime')
+      expect($('#after-io').text()).toBe('at runtime')
+      expect($('#page').text()).toBe('at runtime')
+    } else {
+      // Without cache components, unstable_io() resolves immediately during
+      // prerendering so the entire page is fully static
+      expect($('#before').text()).toBe('at buildtime')
+      expect($('#after-io').text()).toBe('at buildtime')
+      expect($('#page').text()).toBe('at buildtime')
+    }
+  })
+
+  it('should work in pages router with getServerSideProps', async () => {
+    const $ = await next.render$('/pages-gssp')
+    expect($('#pages-content').text()).toBe('ok')
+  })
+
+  it('should work in pages router with getStaticProps', async () => {
+    const $ = await next.render$('/pages-gsp')
+    expect($('#pages-content').text()).toBe('ok')
+  })
+
+  it('should work in pages router with React.use()', async () => {
+    const $ = await next.render$('/pages-use')
+    expect($('#pages-content').text()).toBe('ok')
+  })
+})


### PR DESCRIPTION
Adds a new export from next/cache that acts as a metasyntactic IO boundary. During prerendering with cache components it returns a hanging promise to prevent execution of code that follows it. In all other contexts it resolves as a fulfilled thenable that React can unwrap synchronously. This is gated behind experimental.unstableIO and not ready for general use.