### PR TITLE
[build info]: omit symbol from top level gSP route

### DIFF
--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -376,6 +376,7 @@ export async function printTreeView(
         (pageInfo?.ssgPageDurations?.reduce((a, b) => a + (b || 0), 0) || 0)
 
       const symbol = getTreeViewSymbol(item, pageInfo)
+      const hasChildRoutes = Boolean(pageInfo?.ssgPageRoutes?.length)
 
       const displayPath = getTreeViewDisplayPath(item)
 
@@ -396,10 +397,14 @@ export async function printTreeView(
         ])
       }
 
-      usedSymbols.add(symbol)
+      // Grouped rows act as headers for the generated outputs below them. The
+      // child rows carry the concrete route symbols instead.
+      if (!hasChildRoutes) {
+        usedSymbols.add(symbol)
+      }
 
       messages.push([
-        `${border} ${symbol} ${displayPath}${
+        `${border} ${hasChildRoutes ? ' ' : symbol} ${displayPath}${
           totalDuration > MIN_DURATION
             ? ` (${getPrettyDuration(totalDuration)})`
             : ''
@@ -465,6 +470,7 @@ export async function printTreeView(
             // parent route pattern, so prefer the child entry when present.
             const routePageInfo = pageInfos.get(route) ?? pageInfo
             const routeSymbol = getTreeViewSymbol(route, routePageInfo)
+            usedSymbols.add(routeSymbol)
 
             const initialCacheControl =
               pageInfos.get(route)?.initialCacheControl

--- a/test/e2e/app-dir/ppr/ppr.test.ts
+++ b/test/e2e/app-dir/ppr/ppr.test.ts
@@ -22,8 +22,8 @@ describe.skip('ppr', () => {
       it('correctly marks pages as being partially prerendered in the build output', () => {
         expect(next.cliOutput).toContain('◐ /loading/nested/[slug]')
         expect(next.cliOutput).toContain('◐ /suspense/node')
-        expect(next.cliOutput).toContain('◐ /suspense/node/gsp/[slug]')
-        expect(next.cliOutput).toContain('◐ /suspense/node/nested/[slug]')
+        expect(next.cliOutput).toContain(' /suspense/node/gsp/[slug]')
+        expect(next.cliOutput).toContain(' /suspense/node/nested/[slug]')
       })
     })
 

--- a/test/e2e/prerender.test.ts
+++ b/test/e2e/prerender.test.ts
@@ -2218,7 +2218,7 @@ describe('Prerender', () => {
     if ((global as any).isNextStart) {
       it('should of formatted build output correctly', () => {
         expect(next.cliOutput).toMatch(/○ \/normal/)
-        expect(next.cliOutput).toMatch(/● \/blog\/\[post\]/)
+        expect(next.cliOutput).toMatch(/[├└] {3}\/blog\/\[post\]/)
         expect(next.cliOutput).toMatch(/\+2 more paths/)
       })
 

--- a/test/production/app-dir/build-output-ssg-bailout/build-output-ssg-bailout.test.ts
+++ b/test/production/app-dir/build-output-ssg-bailout/build-output-ssg-bailout.test.ts
@@ -43,11 +43,11 @@ describe('build-output-ssg-bailout', () => {
      "Route (app)
      ┌ ○ /_not-found
      ├ ƒ /ssg-bailout-partial/[id]
-     ├ ● /ssg-bailout-partial/[id]
+     ├   /ssg-bailout-partial/[id]
      │ ├ ● /ssg-bailout-partial/2
      │ └ ● /ssg-bailout-partial/3
      ├ ƒ /ssg-bailout/[id]
-     └ ● /ssg/[id]
+     └   /ssg/[id]
        ├ ● /ssg/1
        ├ ● /ssg/2
        └ ● /ssg/3

--- a/test/production/app-dir/build-output-tree-view/build-output-tree-view.test.ts
+++ b/test/production/app-dir/build-output-tree-view/build-output-tree-view.test.ts
@@ -24,10 +24,10 @@ describe('build-output-tree-view', () => {
        ├ ○ /cache-life-custom         ≈7m     ≈2h
        ├ ○ /cache-life-hours           1h      1d
        ├ ƒ /dynamic
-       ├ ◐ /ppr/[slug]                 1w     30d
-       │ ├ /ppr/[slug]                 1w     30d
-       │ ├ /ppr/days                   1d      1w
-       │ └ /ppr/weeks                  1w     30d
+       ├   /ppr/[slug]                 1w     30d
+       │ ├ ◐ /ppr/[slug]               1w     30d
+       │ ├ ◐ /ppr/days                 1d      1w
+       │ └ ◐ /ppr/weeks                1w     30d
        └ ○ /revalidate                15m      1y
 
        Route (pages)           Revalidate  Expire
@@ -82,7 +82,7 @@ describe('build-output-tree-view', () => {
 
     it('should show child route symbols for generated app paths', async () => {
       expect(getTreeView(next.cliOutput)).toContain(
-        `├ ◐ /params/semantics/[lowcard]/[highcard]/layout-has/server
+        `├   /params/semantics/[lowcard]/[highcard]/layout-has/server
 │ ├ ◐ /params/semantics/[lowcard]/[highcard]/layout-has/server
 │ ├ ◐ /params/semantics/one/[highcard]/layout-has/server
 │ └ ○ /params/semantics/one/build/layout-has/server`


### PR DESCRIPTION
When a route with params specifies `generateStaticParams`, the meaningful outputs are the sub-paths contained within. The top level route just corresponds with the file path, which isn't representative of a static or partially prerendered output. Previously it'd just inherit one of the sub-path values (ie if one path was PPRed, it'd show PPR, even if some were fully static).

This removes the symbol from those types of outputs, since #92518 moved those symbols to be within the subpaths. 

For truly dynamic param cases (ie, no subpaths), the rendering symbol will still appear. 