### PR TITLE
CI: Fix issue with conflicting 'engines.pnpm' field in next-stats-action

### DIFF
--- a/.github/actions/next-stats-action/src/index.js
+++ b/.github/actions/next-stats-action/src/index.js
@@ -115,6 +115,21 @@ if (!allowedActions.has(actionInfo.actionName) && !actionInfo.isRelease) {
           // 16.3 is released, but we must override it for now because 16.2 uses
           // pnpm 9.6.0, which supports different arguments. `diffRepoDir`
           // points to the most recent stable tag.
+          //
+          // First, remove `engines.pnpm`. `corepack use` will update
+          // `packageManager`, but not `engines`. `pnpm install` can then fail
+          // because it checks `engines.pnpm`.
+          const packageJson = path.join(dir, 'package.json')
+          const packageJsonContents = JSON.parse(
+            await fs.readFile(packageJson, { encoding: 'utf8' })
+          )
+          if (packageJsonContents.engines != null) {
+            delete packageJsonContents.engines.pnpm
+          }
+          await fs.writeFile(
+            packageJson,
+            JSON.stringify(packageJsonContents, null, '  ')
+          )
           await exec.spawnPromise('corepack use pnpm@10.33.0', {
             cwd: dir,
           })


### PR DESCRIPTION
This job has been failing on canary pushes, but not on PRs. I'm not sure why it's only happening in canary pushes, but hopefully this should fix the specific error we're seeing when it does fail.

Discussion: https://vercel.slack.com/archives/C04KC8A53T7/p1775571376147179