### PR TITLE
Fix `minimumReleaseAgeExclude` for React and friends

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -40,10 +40,7 @@ minimumReleaseAgeExclude:
   - next
   - react
   - react-dom
-  - react-dom-*
-  - react-experimental-builtin
   - react-is
-  - react-is-builtin
   - react-server-dom-*
-  - scheduler-*
+  - scheduler
   - turbo


### PR DESCRIPTION
Fixes 

> ERR_PNPM_NO_MATURE_MATCHING_VERSION  Version 0.28.0-canary-404b38c7-20260408 (released 4 minutes ago) of scheduler-builtin does not meet the minimumReleaseAge constraint

-- https://github.com/vercel/next.js/actions/runs/24153975697/job/70488293803#step:7:41

Tested with `p sync-react --commit`.

The resolved packages are used not aliases: [pnpm.io/settings#minimumreleaseageexclude](https://pnpm.io/settings#minimumreleaseageexclude)