### PR TITLE
Exclude use tests from react18 testing

### DIFF
--- a/test/e2e/app-dir/unstable-io/unstable-io.test.ts
+++ b/test/e2e/app-dir/unstable-io/unstable-io.test.ts
@@ -1,5 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
+const isReact18 = parseInt(process.env.NEXT_TEST_REACT_VERSION) === 18
+
 describe('unstable_io with cache components', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname + '/fixtures/cache-components',
@@ -51,10 +53,15 @@ describe('unstable_io with cache components', () => {
     expect($('#pages-content').text()).toBe('ok')
   })
 
-  it('should work in pages router with React.use() (CC)', async () => {
-    const $ = await next.render$('/pages-use')
-    expect($('#pages-content').text()).toBe('ok')
-  })
+  /* eslint-disable jest/no-standalone-expect */
+  ;(isReact18 ? it.skip : it)(
+    'should work in pages router with React.use() (CC)',
+    async () => {
+      const $ = await next.render$('/pages-use')
+      expect($('#pages-content').text()).toBe('ok')
+    }
+  )
+  /* eslint-enable jest/no-standalone-expect */
 })
 
 describe('unstable_io without cache components', () => {
@@ -92,8 +99,13 @@ describe('unstable_io without cache components', () => {
     expect($('#pages-content').text()).toBe('ok')
   })
 
-  it('should work in pages router with React.use()', async () => {
-    const $ = await next.render$('/pages-use')
-    expect($('#pages-content').text()).toBe('ok')
-  })
+  /* eslint-disable jest/no-standalone-expect */
+  ;(isReact18 ? it.skip : it)(
+    'should work in pages router with React.use()',
+    async () => {
+      const $ = await next.render$('/pages-use')
+      expect($('#pages-content').text()).toBe('ok')
+    }
+  )
+  /* eslint-enable jest/no-standalone-expect */
 })


### PR DESCRIPTION
use is not available in React 18. exlcude these tests from testing when React18 is being used.