### PR TITLE
Fix React18 tests for unstable_io

### DIFF
--- a/test/e2e/app-dir/unstable-io/fixtures/cache-components/pages/pages-use.tsx
+++ b/test/e2e/app-dir/unstable-io/fixtures/cache-components/pages/pages-use.tsx
@@ -2,7 +2,9 @@ import React from 'react'
 import { unstable_io } from 'next/cache'
 
 export default function PagesUse() {
-  React.use(unstable_io())
+  if (typeof React.use === 'function') {
+    React.use(unstable_io())
+  }
   return (
     <>
       <p>This page calls React.use(unstable_io()) in the component body.</p>

--- a/test/e2e/app-dir/unstable-io/fixtures/default/pages/pages-use.tsx
+++ b/test/e2e/app-dir/unstable-io/fixtures/default/pages/pages-use.tsx
@@ -2,7 +2,9 @@ import React from 'react'
 import { unstable_io } from 'next/cache'
 
 export default function PagesUse() {
-  React.use(unstable_io())
+  if (typeof React.use === 'function') {
+    React.use(unstable_io())
+  }
   return (
     <>
       <p>This page calls React.use(unstable_io()) in the component body.</p>

--- a/test/e2e/app-dir/unstable-io/unstable-io.test.ts
+++ b/test/e2e/app-dir/unstable-io/unstable-io.test.ts
@@ -1,7 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
 
-const isReact18 = parseInt(process.env.NEXT_TEST_REACT_VERSION) === 18
-
 describe('unstable_io with cache components', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname + '/fixtures/cache-components',
@@ -53,15 +51,10 @@ describe('unstable_io with cache components', () => {
     expect($('#pages-content').text()).toBe('ok')
   })
 
-  /* eslint-disable jest/no-standalone-expect */
-  ;(isReact18 ? it.skip : it)(
-    'should work in pages router with React.use() (CC)',
-    async () => {
-      const $ = await next.render$('/pages-use')
-      expect($('#pages-content').text()).toBe('ok')
-    }
-  )
-  /* eslint-enable jest/no-standalone-expect */
+  it('should work in pages router with React.use() (CC)', async () => {
+    const $ = await next.render$('/pages-use')
+    expect($('#pages-content').text()).toBe('ok')
+  })
 })
 
 describe('unstable_io without cache components', () => {
@@ -99,13 +92,8 @@ describe('unstable_io without cache components', () => {
     expect($('#pages-content').text()).toBe('ok')
   })
 
-  /* eslint-disable jest/no-standalone-expect */
-  ;(isReact18 ? it.skip : it)(
-    'should work in pages router with React.use()',
-    async () => {
-      const $ = await next.render$('/pages-use')
-      expect($('#pages-content').text()).toBe('ok')
-    }
-  )
-  /* eslint-enable jest/no-standalone-expect */
+  it('should work in pages router with React.use()', async () => {
+    const $ = await next.render$('/pages-use')
+    expect($('#pages-content').text()).toBe('ok')
+  })
 })


### PR DESCRIPTION
The last attempt to skip tests doesn't work because there is a failure to build. This strategy takes the fixture and only conditionally calls `use` if it exists