### PR TITLE
fix: server action with external redirect returns undefined to client

### DIFF
--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -1183,12 +1183,26 @@ export async function handleAction({
       const redirectUrl = getURLFromRedirectError(err)
       const redirectType = getRedirectTypeFromError(err)
 
-      // if it's a fetch action, we'll set the status code for logging/debugging purposes
-      // but we won't set a Location header, as the redirect will be handled by the client router
-      res.statusCode = RedirectStatusCode.SeeOther
-      metadata.statusCode = RedirectStatusCode.SeeOther
-
       if (isFetchAction) {
+        const appRelativeRedirectUrl = getAppRelativeRedirectUrl(
+          ctx.renderOpts.basePath,
+          host,
+          redirectUrl,
+          requestStore.url.pathname
+        )
+
+        // For internal redirects, set 303 for logging/debugging purposes.
+        // For external redirects, we must NOT set a 303 status code because
+        // the browser's fetch() API may interpret it as a redirect response
+        // and interfere with the custom x-action-redirect header mechanism,
+        // causing the action to resolve with `undefined` instead of properly
+        // rejecting with a redirect error on the client.
+        // See: https://github.com/vercel/next.js/issues/73536
+        if (appRelativeRedirectUrl) {
+          res.statusCode = RedirectStatusCode.SeeOther
+          metadata.statusCode = RedirectStatusCode.SeeOther
+        }
+
         return {
           type: 'done',
           result: await createRedirectRenderResult(
@@ -1204,7 +1218,9 @@ export async function handleAction({
         }
       }
 
-      // For an MPA action, the redirect doesn't need a body, just a Location header.
+      // For an MPA action, use a standard HTTP redirect with a Location header.
+      res.statusCode = RedirectStatusCode.SeeOther
+      metadata.statusCode = RedirectStatusCode.SeeOther
       res.setHeader('Location', redirectUrl)
       return {
         type: 'done',

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -1201,6 +1201,22 @@ describe('app-dir action handling', () => {
       })
     })
 
+    it('should not return undefined when server action redirects to external URL', async () => {
+      // Regression test for https://github.com/vercel/next.js/issues/73536
+      // Server actions that redirect to external URLs should throw a redirect
+      // error, not resolve with `undefined`.
+      const browser = await next.browser('/client/redirect-external-return')
+
+      await browser.elementByCss('#redirect-external-check').click()
+
+      await retry(async () => {
+        const result = await browser.elementByCss('#action-result').text()
+        // The action should throw (caught by try/catch), not resolve with undefined.
+        // If it resolves, result would be "resolved:undefined".
+        expect(result).toBe('thrown')
+      })
+    })
+
     it('should allow cookie and header async storages', async () => {
       const browser = await next.browser('/client/edge')
 

--- a/test/e2e/app-dir/actions/app/client/redirect-external-return/page.js
+++ b/test/e2e/app-dir/actions/app/client/redirect-external-return/page.js
@@ -1,0 +1,32 @@
+'use client'
+
+import { useState } from 'react'
+import { redirectAction } from '../actions'
+
+export default function Page() {
+  const [result, setResult] = useState('pending')
+
+  return (
+    <div>
+      <p id="action-result">{result}</p>
+      <button
+        id="redirect-external-check"
+        onClick={async () => {
+          try {
+            const value = await redirectAction(
+              'https://next-data-api-endpoint.vercel.app/api/random?page'
+            )
+            // If we get here, the action resolved instead of throwing.
+            // This is the bug — external redirects should throw, not resolve.
+            setResult('resolved:' + String(value))
+          } catch (e) {
+            // This is the expected behavior — redirect should throw.
+            setResult('thrown')
+          }
+        }}
+      >
+        redirect external and check return
+      </button>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Fixes #73536

When a server action calls `redirect()` with an external URL, the action promise incorrectly resolves with `undefined` on the client instead of rejecting with a redirect error (like internal redirects do). This causes client code to briefly see `undefined` as the "result" before the browser navigates away, which can flash error UI.

### Root Cause

The server responds with HTTP **303** status for all fetch-based server action redirects. For external redirects, the response body is empty (no RSC Flight data) and `RenderResult.EMPTY` has `contentType: null`. The 303 status code can cause the browser's `fetch()` API to interfere with the response, preventing the client from reading the custom `x-action-redirect` header that signals the redirect.

### Fix

- **Only set 303 status for internal redirects** in fetch actions (where `getAppRelativeRedirectUrl()` returns a URL)
- **Skip 303 for external redirects** in fetch actions — the client handles them via the `x-action-redirect` header, which needs to be preserved
- MPA (non-fetch) actions continue to use 303 + `Location` header as before

The client already has correct logic to detect external redirects via `x-action-redirect` and reject the action promise — it just needs the header to be preserved in the response.

### Files Changed

- `packages/next/src/server/app-render/action-handler.ts` — conditionally set 303 status only for internal redirects in fetch actions
- `test/e2e/app-dir/actions/app-action.test.ts` — regression test verifying external redirect throws instead of resolving
- `test/e2e/app-dir/actions/app/client/redirect-external-return/page.js` — test fixture

## Test plan

- [ ] Existing test `should handle calls to redirect() with external URLs` still passes (navigation works)
- [ ] Existing test `should handle calls to redirect() with a relative/absolute URL in a single pass` still passes (303 status preserved for internal redirects)
- [ ] New test `should not return undefined when server action redirects to external URL` passes (action throws instead of resolving with `undefined`)