### PR TITLE
CI: Download and run self-contained datadog-ci instead of using pnpm dlx or npx

### DIFF
--- a/.github/actions/setup-datadog-ci/action.yml
+++ b/.github/actions/setup-datadog-ci/action.yml
@@ -1,0 +1,26 @@
+name: 'Setup Datadog CI'
+description: 'Installs the datadog-ci binary and sets $DATADOG_CI_PATH'
+runs:
+  using: 'composite'
+  steps:
+    - name: 'Install datadog-ci'
+      shell: bash
+      run: |
+        echo "DATADOG_CI_PATH=/bin/false" >> $GITHUB_ENV
+
+        DATADOG_CI_VERSION=v5.12.1
+        DATADOG_CI_PATH="/tmp/nextjs-ci-bin-datadog-ci-$DATADOG_CI_VERSION"
+        DATADOG_CI_SHA256=86fcf24d5211f5ae714e947354ccb621e74e2bba4162247890454c6461e74ca5
+
+        if [[ ! -x "$DATADOG_CI_PATH" ]]; then
+          echo "Downloading $DATADOG_CI_PATH"
+          curl -L --fail --retry 2 -o "$DATADOG_CI_PATH" "https://github.com/DataDog/datadog-ci/releases/download/$DATADOG_CI_VERSION/datadog-ci_linux-x64"
+          if ! echo "$DATADOG_CI_SHA256  $DATADOG_CI_PATH" | sha256sum --check --status; then
+            echo "Checksum mismatch of $DATADOG_CI_PATH"
+            rm -f "$DATADOG_CI_PATH"
+            exit 1
+          fi
+          chmod +x "$DATADOG_CI_PATH"
+        fi
+
+        echo "DATADOG_CI_PATH=$DATADOG_CI_PATH" >> $GITHUB_ENV

--- a/.github/actions/setup-datadog-ci/action.yml
+++ b/.github/actions/setup-datadog-ci/action.yml
@@ -10,11 +10,22 @@ runs:
 
         DATADOG_CI_VERSION=v5.12.1
         DATADOG_CI_PATH="/tmp/nextjs-ci-bin-datadog-ci-$DATADOG_CI_VERSION"
-        DATADOG_CI_SHA256=86fcf24d5211f5ae714e947354ccb621e74e2bba4162247890454c6461e74ca5
+        case "$RUNNER_OS" in
+          Windows)
+            DATADOG_CI_PATH="$DATADOG_CI_PATH.exe"
+            DATADOG_CI_SHA256=4b8320d0b5644c9370e01fd9e38e6f0306c709757c45238416b8eae679c41f75
+            DATADOG_CI_ASSET=datadog-ci_win-x64
+            ;;
+          *)
+            DATADOG_CI_SHA256=86fcf24d5211f5ae714e947354ccb621e74e2bba4162247890454c6461e74ca5
+            DATADOG_CI_ASSET=datadog-ci_linux-x64
+            ;;
+        esac
 
         if [[ ! -x "$DATADOG_CI_PATH" ]]; then
           echo "Downloading $DATADOG_CI_PATH"
-          curl -L --fail --retry 2 -o "$DATADOG_CI_PATH" "https://github.com/DataDog/datadog-ci/releases/download/$DATADOG_CI_VERSION/datadog-ci_linux-x64"
+          curl -L --fail --retry 2 -o "$DATADOG_CI_PATH" \
+            "https://github.com/DataDog/datadog-ci/releases/download/$DATADOG_CI_VERSION/$DATADOG_CI_ASSET"
           if ! echo "$DATADOG_CI_SHA256  $DATADOG_CI_PATH" | sha256sum --check --status; then
             echo "Checksum mismatch of $DATADOG_CI_PATH"
             rm -f "$DATADOG_CI_PATH"

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -588,14 +588,17 @@ jobs:
           merge-multiple: true
           path: turbopack-bin-size
 
+      - name: Install datadog-ci
+        uses: ./.github/actions/setup-datadog-ci
+
       - name: Upload to Datadog
         run: |
           ls -al turbopack-bin-size
 
           for filename in turbopack-bin-size/*; do
-            export BYTESIZE+=" --metrics $(cat $filename)"
+            export BYTESIZE+=" --measures $(cat $filename)"
           done
 
           echo "Reporting $BYTESIZE"
 
-          npx @datadog/datadog-ci@2.23.1 metric --no-fail --level pipeline $BYTESIZE
+          "$DATADOG_CI_PATH" measure --no-fail --level pipeline $BYTESIZE

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -581,6 +581,11 @@ jobs:
     env:
       DATADOG_API_KEY: ${{ secrets.DATA_DOG_API_KEY }}
     steps:
+      - uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            .github
+
       - name: Collect bytesize metrics
         uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -353,13 +353,17 @@ jobs:
           name: webpack bundle analysis stats-${{ steps.var.outputs.input_step_key }}
           path: packages/next/dist/compiled/next-server/report.*.html
 
+      - name: Install datadog-ci
+        if: ${{ inputs.afterBuild && always() && !github.event.pull_request.head.repo.fork }}
+        uses: ./.github/actions/setup-datadog-ci
+
       - name: Upload test report to datadog
         if: ${{ inputs.afterBuild && always() && !github.event.pull_request.head.repo.fork }}
         run: |
           # Add a `test.type` tag to distinguish between turbopack and next.js runs
           # Add a `nextjs.test_session.name` tag to help identify the job
           if [ -d ./test/test-junit-report ]; then
-            pnpm dlx @datadog/datadog-ci@2.45.1 junit upload \
+            "$DATADOG_CI_PATH" junit upload \
               --service nextjs \
               --tags test.type:nextjs \
               --tags test_session.name:"${{ inputs.stepName }}" \
@@ -367,7 +371,7 @@ jobs:
               ./test/test-junit-report
           fi
           if [ -d ./test/turbopack-test-junit-report ]; then
-            pnpm dlx @datadog/datadog-ci@2.45.1 junit upload \
+            "$DATADOG_CI_PATH" junit upload \
               --service nextjs \
               --tags test.type:turbopack \
               --tags test_session.name:"${{ inputs.stepName }}" \

--- a/.github/workflows/test_e2e_deploy_release.yml
+++ b/.github/workflows/test_e2e_deploy_release.yml
@@ -232,6 +232,11 @@ jobs:
     runs-on: ubuntu-latest
     name: Report test results to datadog
     steps:
+      - uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            .github
+
       - name: Download test report artifacts
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/test_e2e_deploy_release.yml
+++ b/.github/workflows/test_e2e_deploy_release.yml
@@ -233,17 +233,19 @@ jobs:
     name: Report test results to datadog
     steps:
       - name: Download test report artifacts
-        id: download-test-reports
         uses: actions/download-artifact@v4
         with:
           pattern: test-reports-*
           path: test
           merge-multiple: true
 
+      - name: Install datadog-ci
+        uses: ./.github/actions/setup-datadog-ci
+
       - name: Upload test report to datadog
         run: |
           if [ -d ./test/test-junit-report ]; then
-            DD_ENV=ci npx @datadog/datadog-ci@2.23.1 junit upload --tags test.type:deploy --service nextjs ./test/test-junit-report
+            DD_ENV=ci "$DATADOG_CI_PATH" junit upload --tags test.type:deploy --service nextjs ./test/test-junit-report
           fi
 
   upload-adapter-test-results:


### PR DESCRIPTION
`pnpm dlx` isn't using a lockfile. Using the self-contained binary from GitHub and validate the checksum lets us effectively pin `datadog-ci` and all of its possible transitive dependencies.

This is a follow-up for https://vercel.slack.com/archives/C0APPN2LC83/p1775073127894859