### PR TITLE
CI: Another attempt to fix pnpm versions for next-stats-action on canary

### DIFF
--- a/.github/actions/next-stats-action/src/index.js
+++ b/.github/actions/next-stats-action/src/index.js
@@ -111,18 +111,15 @@ if (!allowedActions.has(actionInfo.actionName) && !actionInfo.isRelease) {
       if (!actionInfo.skipClone) {
         const usePnpm = existsSync(path.join(dir, 'pnpm-lock.yaml'))
         if (usePnpm) {
-          // TODO: we can remove this explicit `corepack use` once Next.js
+          // TODO: we can remove this `packageManager` modification once Next.js
           // 16.3 is released, but we must override it for now because 16.2 uses
           // pnpm 9.6.0, which supports different arguments. `diffRepoDir`
           // points to the most recent stable tag.
-          //
-          // First, remove `engines.pnpm`. `corepack use` will update
-          // `packageManager`, but not `engines`. `pnpm install` can then fail
-          // because it checks `engines.pnpm`.
           const packageJson = path.join(dir, 'package.json')
           const packageJsonContents = JSON.parse(
             await fs.readFile(packageJson, { encoding: 'utf8' })
           )
+          packageJsonContents.packageManager = 'pnpm@10.33.0'
           if (packageJsonContents.engines != null) {
             delete packageJsonContents.engines.pnpm
           }
@@ -130,9 +127,6 @@ if (!allowedActions.has(actionInfo.actionName) && !actionInfo.isRelease) {
             packageJson,
             JSON.stringify(packageJsonContents, null, '  ')
           )
-          await exec.spawnPromise('corepack use pnpm@10.33.0', {
-            cwd: dir,
-          })
         }
 
         if (!statsConfig.skipInitialInstall) {

--- a/package.json
+++ b/package.json
@@ -314,8 +314,7 @@
     "yargs": "16.2.0"
   },
   "engines": {
-    "node": ">=20.9.0",
-    "pnpm": "10.33.0"
+    "node": ">=20.9.0"
   },
   "packageManager": "pnpm@10.33.0",
   "pnpm": {


### PR DESCRIPTION
It looks like https://github.com/vercel/next.js/pull/92533 didn't fully solve our issue here: https://github.com/vercel/next.js/actions/runs/24162886733/job/70518191406#step:7:163

`corepack use pnpm@10.33.0` runs `pnpm install`, but we want to run `pnpm install` with specific flags including `--no-frozen-lockfile`.

What I really want is some way to get corepack to update the `packageManager` field, but not run `pnpm install`.

We already have to modify the `package.json` ourselves to fix `engines.pnpm`, so let's just not call `corepack use`. It seems that the changes to `packageManager` are picked up the next time that `pnpm` is run with no other interaction needed:

![Screenshot 2026-04-08 at 5.03.24 PM.png](https://app.graphite.com/user-attachments/assets/0cc50764-3a9e-4dec-980c-7389e39cef07.png)