### PR TITLE
fix: update stale server-actions-and-mutations doc URLs

### DIFF
--- a/packages/next/src/client/app-dir/form.tsx
+++ b/packages/next/src/client/app-dir/form.tsx
@@ -85,7 +85,7 @@ export default function Form({
           `<Form> does not support changing \`${key}\`. ` +
             (isNavigatingForm
               ? `If you'd like to use it to perform a mutation, consider making \`action\` a function instead.\n` +
-                `Learn more: https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions-and-mutations`
+                `Learn more: https://nextjs.org/docs/app/getting-started/updating-data`
               : '')
         )
       }

--- a/packages/next/src/client/components/forbidden.ts
+++ b/packages/next/src/client/components/forbidden.ts
@@ -12,7 +12,7 @@ import {
  * `forbidden()` can be used in
  * [Server Components](https://nextjs.org/docs/app/building-your-application/rendering/server-components),
  * [Route Handlers](https://nextjs.org/docs/app/building-your-application/routing/route-handlers), and
- * [Server Actions](https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions-and-mutations).
+ * [Server Actions](https://nextjs.org/docs/app/getting-started/updating-data).
  *
  * Read more: [Next.js Docs: `forbidden`](https://nextjs.org/docs/app/api-reference/functions/forbidden)
  */

--- a/packages/next/src/client/components/not-found.ts
+++ b/packages/next/src/client/components/not-found.ts
@@ -10,7 +10,7 @@ import {
  * `notFound()` can be used in
  * [Server Components](https://nextjs.org/docs/app/building-your-application/rendering/server-components),
  * [Route Handlers](https://nextjs.org/docs/app/building-your-application/routing/route-handlers), and
- * [Server Actions](https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions-and-mutations).
+ * [Server Actions](https://nextjs.org/docs/app/getting-started/updating-data).
  *
  * - In a Server Component, this will insert a `<meta name="robots" content="noindex" />` meta tag and set the status code to 404.
  * - In a Route Handler or Server Action, it will serve a 404 to the caller.

--- a/packages/next/src/client/components/redirect.ts
+++ b/packages/next/src/client/components/redirect.ts
@@ -27,7 +27,7 @@ export function getRedirectError(
  * This function allows you to redirect the user to another URL. It can be used in
  * [Server Components](https://nextjs.org/docs/app/building-your-application/rendering/server-components),
  * [Route Handlers](https://nextjs.org/docs/app/building-your-application/routing/route-handlers), and
- * [Server Actions](https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions-and-mutations).
+ * [Server Actions](https://nextjs.org/docs/app/getting-started/updating-data).
  *
  * - In a Server Component, this will insert a meta tag to redirect the user to the target page.
  * - In a Route Handler or Server Action, it will serve a 307/303 to the caller.
@@ -49,7 +49,7 @@ export function redirect(
  * This function allows you to redirect the user to another URL. It can be used in
  * [Server Components](https://nextjs.org/docs/app/building-your-application/rendering/server-components),
  * [Route Handlers](https://nextjs.org/docs/app/building-your-application/routing/route-handlers), and
- * [Server Actions](https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions-and-mutations).
+ * [Server Actions](https://nextjs.org/docs/app/getting-started/updating-data).
  *
  * - In a Server Component, this will insert a meta tag to redirect the user to the target page.
  * - In a Route Handler or Server Action, it will serve a 308/303 to the caller.

--- a/packages/next/src/client/components/unauthorized.ts
+++ b/packages/next/src/client/components/unauthorized.ts
@@ -12,7 +12,7 @@ import {
  * `unauthorized()` can be used in
  * [Server Components](https://nextjs.org/docs/app/building-your-application/rendering/server-components),
  * [Route Handlers](https://nextjs.org/docs/app/building-your-application/routing/route-handlers), and
- * [Server Actions](https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions-and-mutations).
+ * [Server Actions](https://nextjs.org/docs/app/getting-started/updating-data).
  *
  *
  * Read more: [Next.js Docs: `unauthorized`](https://nextjs.org/docs/app/api-reference/functions/unauthorized)

--- a/packages/next/src/server/lib/router-utils/typegen.ts
+++ b/packages/next/src/server/lib/router-utils/typegen.ts
@@ -375,7 +375,7 @@ declare module 'next/navigation' {
    * This function allows you to redirect the user to another URL. It can be used in
    * [Server Components](https://nextjs.org/docs/app/building-your-application/rendering/server-components),
    * [Route Handlers](https://nextjs.org/docs/app/building-your-application/routing/route-handlers), and
-   * [Server Actions](https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions-and-mutations).
+   * [Server Actions](https://nextjs.org/docs/app/getting-started/updating-data).
    *
    * - In a Server Component, this will insert a meta tag to redirect the user to the target page.
    * - In a Route Handler or Server Action, it will serve a 307/303 to the caller.
@@ -393,7 +393,7 @@ declare module 'next/navigation' {
    * This function allows you to redirect the user to another URL. It can be used in
    * [Server Components](https://nextjs.org/docs/app/building-your-application/rendering/server-components),
    * [Route Handlers](https://nextjs.org/docs/app/building-your-application/routing/route-handlers), and
-   * [Server Actions](https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions-and-mutations).
+   * [Server Actions](https://nextjs.org/docs/app/getting-started/updating-data).
    *
    * - In a Server Component, this will insert a meta tag to redirect the user to the target page.
    * - In a Route Handler or Server Action, it will serve a 308/303 to the caller.

--- a/packages/next/src/server/request/headers.ts
+++ b/packages/next/src/server/request/headers.ts
@@ -32,7 +32,7 @@ import { RenderStage } from '../app-render/staged-rendering'
 /**
  * This function allows you to read the HTTP incoming request headers in
  * [Server Components](https://nextjs.org/docs/app/building-your-application/rendering/server-components),
- * [Server Actions](https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions-and-mutations),
+ * [Server Actions](https://nextjs.org/docs/app/getting-started/updating-data),
  * [Route Handlers](https://nextjs.org/docs/app/building-your-application/routing/route-handlers) and
  * [Middleware](https://nextjs.org/docs/app/building-your-application/routing/middleware).
  *


### PR DESCRIPTION
## Summary
- Updated 9 references to the old docs URL `docs/app/building-your-application/data-fetching/server-actions-and-mutations` across 7 files
- The docs page has been restructured to `docs/app/getting-started/updating-data`
- Affects JSDoc comments and one error message in `<Form>`

## Test plan
- [x] `grep -r "server-actions-and-mutations" packages/` returns 0 results
- [x] Type checking passes

Fixes #73817

<!-- NEXT_JS_LLM_PR -->