### PR TITLE
fix: codemod should wrap unused params type in Promise

### DIFF
--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-41.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-41.input.tsx
@@ -1,0 +1,3 @@
+export default function Page({ params }: { params: { id: string } }) {
+  return <div>Hello</div>
+}

--- a/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-41.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/next-async-request-api-dynamic-props/access-props-41.output.tsx
@@ -1,0 +1,3 @@
+export default async function Page({ params }: { params: Promise<{ id: string }> }) {
+  return <div>Hello</div>
+}

--- a/packages/next-codemod/transforms/lib/async-request-api/next-async-dynamic-prop.ts
+++ b/packages/next-codemod/transforms/lib/async-request-api/next-async-dynamic-prop.ts
@@ -595,6 +595,17 @@ export function transformDynamicProps(
           params[propsArgumentIndex] = propsIdentifier
 
           modified = true
+        } else if (j.ObjectPattern.check(currentParam)) {
+          // Even when params/searchParams aren't used in the body,
+          // we still need to wrap their type annotations in Promise<>
+          // to satisfy Next.js 15's type requirements.
+          const typesModified = modifyTypes(
+            currentParam.typeAnnotation,
+            propsIdentifier,
+            root,
+            j
+          )
+          modified ||= typesModified
         }
       } else {
         // When the prop argument is not destructured, we need to add comments to the spread properties


### PR DESCRIPTION
## Summary
- The `next-async-request-api` codemod skipped transforming `params`/`searchParams` type annotations when they were declared but unused in the function body
- This caused TypeScript build failures after migrating to Next.js 15 because the type must be `Promise<...>` regardless of usage
- Now calls `modifyTypes()` even when `resolveAsyncProp` returns false, wrapping the type in `Promise<>` without adding runtime `await`/`use()`
- Added test fixture (`access-props-41`) for unused params with type annotations

## Test plan
- [x] All 51 codemod dynamic-props tests pass (including the new fixture)
- [x] Pre-existing test `access-props-39` (JS file, no types, unused params) still passes unchanged

Fixes #73296

<!-- NEXT_JS_LLM_PR -->