### PR TITLE
fix: middleware matcher should match root path with basePath

### DIFF
--- a/packages/next/src/build/analysis/get-page-static-info.ts
+++ b/packages/next/src/build/analysis/get-page-static-info.ts
@@ -472,7 +472,27 @@ export function getMiddlewareMatchers(
     }`
 
     if (nextConfig.basePath) {
-      source = `${nextConfig.basePath}${source}`
+      // When basePath is set and the source pattern can match the root path "/",
+      // we need to make the source optional so that the basePath alone (e.g. "/test")
+      // also matches. Without this, patterns like /((?!api|_next/static|...).*)
+      // would require at least a "/" after the basePath.
+      if (!isRoot) {
+        const parsed = tryToParsePath(originalSource)
+        if (parsed.regexStr && new RegExp(parsed.regexStr).test('/')) {
+          const optionalSource = `/:nextData(_next/data/[^/]{1,})?{${originalSource}}?{(\\.json)}?`
+          const candidateSource = `${nextConfig.basePath}${optionalSource}`
+          const candidateParsed = tryToParsePath(candidateSource)
+          if (!candidateParsed.error) {
+            source = candidateSource
+          } else {
+            source = `${nextConfig.basePath}${source}`
+          }
+        } else {
+          source = `${nextConfig.basePath}${source}`
+        }
+      } else {
+        source = `${nextConfig.basePath}${source}`
+      }
     }
 
     // Validate that the source is still.

--- a/packages/next/src/build/analysis/get-page-static-info.ts
+++ b/packages/next/src/build/analysis/get-page-static-info.ts
@@ -479,7 +479,11 @@ export function getMiddlewareMatchers(
       if (!isRoot) {
         const parsed = tryToParsePath(originalSource)
         if (parsed.regexStr && new RegExp(parsed.regexStr).test('/')) {
-          const optionalSource = `/:nextData(_next/data/[^/]{1,})?{${originalSource}}?{(\\.json)}?`
+          const i18nPrefix =
+            i18n?.locales && matcher.locale !== false
+              ? '/:nextInternalLocale((?!_next/)[^/.]{1,})'
+              : ''
+          const optionalSource = `/:nextData(_next/data/[^/]{1,})?${i18nPrefix}{${originalSource}}?{(\\.json)}?`
           const candidateSource = `${nextConfig.basePath}${optionalSource}`
           const candidateParsed = tryToParsePath(candidateSource)
           if (!candidateParsed.error) {


### PR DESCRIPTION
## Summary
- When `basePath` is set, middleware matchers using negative lookahead patterns like `/((?!api|_next/static|...).*)` failed to match the root basePath URL (e.g. `/test`)
- The root check `source === '/'` only recognized the literal `/`, missing patterns that semantically match root
- Now detects when a source pattern can match `/` and wraps it in an optional group `{...}?` so the basePath alone triggers the middleware
- Falls back to the original behavior if the optional wrapping fails to parse (e.g. for named params like `/:path*`)

## Test plan
- [x] Verified regex matches: `/test` (root), `/test/foo`, `/test/about` all match
- [x] Verified exclusions still work: `/test/api`, `/test/_next/static`, `/test/favicon.ico` don't match
- [x] Verified non-root patterns unaffected: `/hello` with basePath still works correctly
- [x] Verified no basePath case unchanged
- [x] Zod validation passes for the new source pattern

Fixes #73786

<!-- NEXT_JS_LLM_PR -->