### PR TITLE
output export fallback: recover unmatched routes with _not-found

### DIFF
--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -29,9 +29,10 @@ import { createInitialRSCPayloadFromFallbackPrerender } from './flight-data-help
 import { getDeploymentId } from '../shared/lib/deployment-id'
 import { setNavigationBuildId } from './navigation-build-id'
 import {
-  addOutputExportDataSuffix,
+  getConfiguredOutputExportNotFoundCandidate,
   fetchOutputExportFallbackResponse,
   fetchOutputExportNotFoundDataResponse,
+  fetchOutputExportNotFoundResponse,
 } from './output-export-fallback'
 
 /// <reference types="react-dom/experimental" />
@@ -306,12 +307,11 @@ if (instantTestStaticFetch) {
       (await fetchOutputExportNotFoundDataResponse(renderedUrl, {
         credentials: 'same-origin',
       })) ??
-      (await fetch(
-        addOutputExportDataSuffix(new URL('/_not-found', renderedUrl)),
-        {
-          credentials: 'same-origin',
-        }
-      ))
+      (await fetchOutputExportNotFoundResponse(renderedUrl, {
+        credentials: 'same-origin',
+      }))
+    initialOutputExportFallbackBasePath =
+      getConfiguredOutputExportNotFoundCandidate(renderedUrl.pathname)
 
     return decodeFallbackPrerenderPayload(
       Promise.resolve(response),

--- a/packages/next/src/client/output-export-fallback.test.ts
+++ b/packages/next/src/client/output-export-fallback.test.ts
@@ -4,6 +4,7 @@ import {
   fetchOutputExportDataResponse,
   fetchOutputExportFallbackResponse,
   fetchOutputExportNotFoundDataResponse,
+  fetchOutputExportNotFoundResponse,
   getCachedOutputExportFallbackDataUrl,
   getCachedOutputExportFallbackRequestUrl,
   getOutputExportFallbackCandidates,
@@ -13,10 +14,12 @@ import {
 
 describe('output export fallback helpers', () => {
   const originalFetch = global.fetch
+  const originalBasePath = process.env.__NEXT_ROUTER_BASEPATH
   const originalTrailingSlash = process.env.__NEXT_TRAILING_SLASH
 
   afterEach(() => {
     global.fetch = originalFetch
+    process.env.__NEXT_ROUTER_BASEPATH = originalBasePath
     process.env.__NEXT_TRAILING_SLASH = originalTrailingSlash
     clearOutputExportFallbackManifestCache()
     jest.restoreAllMocks()
@@ -410,12 +413,45 @@ describe('output export fallback helpers', () => {
     )
 
     expect(response).not.toBeNull()
+    expect(
+      getCachedOutputExportFallbackDataUrl(
+        new URL('https://example.com/docs/missing/route.txt')
+      )?.href
+    ).toBe('https://example.com/docs/_not-found.txt')
     expect(fetchMock.mock.calls.map(([url]) => String(url))).toEqual([
       'https://example.com/docs/missing/route/_not-found.txt',
       'https://example.com/docs/missing/route/_not-found/index.txt',
       'https://example.com/docs/missing/_not-found.txt',
       'https://example.com/docs/missing/_not-found/index.txt',
       'https://example.com/docs/_not-found.txt',
+    ])
+  })
+
+  it('uses the configured app-root not-found artifact as the raw fallback', async () => {
+    process.env.__NEXT_ROUTER_BASEPATH = '/docs'
+    process.env.__NEXT_TRAILING_SLASH = 'true'
+
+    const fetchMock = jest.fn(async () => {
+      return new Response('payload', {
+        status: 200,
+        headers: { 'content-type': 'application/octet-stream' },
+      })
+    })
+
+    global.fetch = fetchMock as typeof fetch
+
+    const response = await fetchOutputExportNotFoundResponse(
+      new URL('https://example.com/docs/missing/route/')
+    )
+
+    expect(response.ok).toBe(true)
+    expect(
+      getCachedOutputExportFallbackDataUrl(
+        new URL('https://example.com/docs/missing/route/index.txt')
+      )?.href
+    ).toBe('https://example.com/docs/_not-found/index.txt')
+    expect(fetchMock.mock.calls.map(([url]) => String(url))).toEqual([
+      'https://example.com/docs/_not-found/index.txt',
     ])
   })
 })

--- a/packages/next/src/client/output-export-fallback.ts
+++ b/packages/next/src/client/output-export-fallback.ts
@@ -3,9 +3,11 @@ import {
   getOutputExportFallbackPath,
   type OutputExportFallbackManifestEntry,
 } from '../lib/output-export-dynamic-fallback'
+import { addPathPrefix } from '../shared/lib/router/utils/add-path-prefix'
 import { RSC_CONTENT_TYPE_HEADER } from './components/app-router-headers'
 import { getRouteMatcher } from '../shared/lib/router/utils/route-matcher'
 import { getRouteRegex } from '../shared/lib/router/utils/route-regex'
+import { normalizePathTrailingSlash } from './normalize-trailing-slash'
 
 type OutputExportFallbackManifest = {
   version: 1
@@ -74,6 +76,23 @@ function getOutputExportNotFoundPath(prefix: string): string {
 export function getOutputExportNotFoundCandidates(pathname: string): string[] {
   return getOutputExportCandidatePrefixes(pathname).map((prefix) =>
     getOutputExportNotFoundPath(prefix)
+  )
+}
+
+export function getConfiguredOutputExportNotFoundCandidate(
+  pathname: string
+): string {
+  const configuredPath = normalizeOutputExportRouteDirectory(
+    normalizePathTrailingSlash(
+      addPathPrefix('/_not-found', process.env.__NEXT_ROUTER_BASEPATH || '')
+    )
+  )
+
+  return (
+    getOutputExportNotFoundCandidates(pathname).find(
+      (candidate) =>
+        normalizeOutputExportRouteDirectory(candidate) === configuredPath
+    ) ?? getOutputExportNotFoundPath('')
   )
 }
 
@@ -348,13 +367,39 @@ export async function fetchOutputExportNotFoundDataResponse(
     const candidateUrl = new URL(renderedUrl)
     candidateUrl.pathname = candidate
 
-    const response = await fetchOutputExportDataResponse(candidateUrl, init)
-    if (response !== null) {
-      return response
+    const result = await fetchOutputExportDataResult(candidateUrl, init)
+    if (result !== null) {
+      cacheOutputExportFallbackDataUrl(
+        renderedUrl,
+        candidateUrl,
+        result.dataUrl
+      )
+      return result.response
     }
   }
 
   return null
+}
+
+export async function fetchOutputExportNotFoundResponse(
+  renderedUrl: URL,
+  init?: RequestInit
+): Promise<Response> {
+  // The raw fallback should preserve the configured app root (for example a
+  // basePath) without probing deeper missing prefixes that may be served by an
+  // HTML fallback document instead of the RSC not-found payload.
+  const candidateUrl = new URL(renderedUrl)
+  candidateUrl.pathname = getConfiguredOutputExportNotFoundCandidate(
+    renderedUrl.pathname
+  )
+  const configuredDataUrl = getConfiguredOutputExportDataUrl(
+    candidateUrl,
+    renderedUrl.pathname.endsWith('/')
+  )
+
+  cacheOutputExportFallbackDataUrl(renderedUrl, candidateUrl, configuredDataUrl)
+
+  return fetch(configuredDataUrl, init)
 }
 
 export async function fetchOutputExportFallbackResponse(

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/docs/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/docs/page.js
@@ -6,6 +6,9 @@ export default function DocsIndex() {
       <h1>Docs</h1>
       <ul>
         <li>
+          <Link href="/docs/reference/export">docs reference page</Link>
+        </li>
+        <li>
           <Link href="/docs/guides/export/fallback">
             docs export fallback page
           </Link>

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/docs/reference/[topic]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/docs/reference/[topic]/page.js
@@ -1,0 +1,18 @@
+import Link from 'next/link'
+import { Suspense } from 'react'
+import ReferenceTopicClient from './topic-client'
+
+export default function DocsReferenceTopicPage() {
+  return (
+    <main>
+      <Suspense fallback={<h1>Loading reference...</h1>}>
+        <ReferenceTopicClient />
+      </Suspense>
+      <ul>
+        <li>
+          <Link href="/docs">Visit docs index</Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/docs/reference/[topic]/topic-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/docs/reference/[topic]/topic-client.js
@@ -1,0 +1,9 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function ReferenceTopicClient() {
+  const params = useParams()
+
+  return <h1>{`reference:${params.topic ?? 'missing'}`}</h1>
+}

--- a/test/e2e/app-dir-export/test/dynamic-fallback-cache-components-basepath.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-fallback-cache-components-basepath.test.ts
@@ -1,0 +1,75 @@
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+import webdriver from 'next-webdriver'
+import { buildAndStartOutputExportServer } from './utils'
+
+const { next, skipped, isNextDev } = nextTestSetup({
+  files: join(__dirname, '..', 'fixtures', 'dynamic-fallback-cache-components'),
+  skipDeployment: true,
+  skipStart: true,
+  disableAutoSkewProtection: true,
+})
+
+if (skipped) {
+  describe.skip('app dir - output export dynamic routes with Cache Components and basePath', () => {})
+} else {
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  describeProduction(
+    'app dir - output export dynamic routes with Cache Components and basePath',
+    () => {
+      let port: number
+      let stopOrKill: (() => Promise<void>) | undefined
+      let getRequests: () => string[]
+      let clearRequests: () => void
+
+      beforeAll(async () => {
+        await next.patchFile('next.config.js', (content) =>
+          content.replace(
+            'cacheComponents: true,',
+            "cacheComponents: true,\n  basePath: '/base',"
+          )
+        )
+        ;({ port, stopOrKill, getRequests, clearRequests } =
+          await buildAndStartOutputExportServer(next, {
+            basePath: '/base',
+            trailingSlash: true,
+            useFallbackDocument: true,
+          }))
+      })
+
+      afterAll(async () => {
+        await stopOrKill?.()
+        await next.destroy()
+      })
+
+      it('keeps unmatched fallback not-found fetches under the basePath', async () => {
+        clearRequests()
+        const browser = await webdriver(port, '/base/missing/route/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'My custom not found page'
+            )
+          })
+
+          const requests = getRequests()
+          expect(
+            requests.some((requestPath) =>
+              requestPath.startsWith('/base/_not-found/index.txt')
+            )
+          ).toBe(true)
+          expect(
+            requests.some((requestPath) =>
+              requestPath.startsWith('/_not-found.txt')
+            )
+          ).toBe(false)
+        } finally {
+          await browser.close()
+        }
+      })
+    }
+  )
+}

--- a/test/e2e/app-dir-export/test/dynamic-fallback-cache-components.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-fallback-cache-components.test.ts
@@ -249,6 +249,47 @@ if (skipped) {
         }
       })
 
+      it('prefers deeper static-prefix fallback routes over shallower overlaps', async () => {
+        clearRequests()
+        const browser = await webdriver(port, '/docs/reference/export/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'reference:export'
+            )
+          })
+
+          const requests = getRequests()
+          expect(
+            requests.some((requestPath) =>
+              requestPath.startsWith('/docs/__fallback')
+            )
+          ).toBe(false)
+          expect(
+            requests.filter((requestPath) =>
+              requestPath.startsWith('/docs/reference/__fallback/index.txt')
+            )
+          ).toHaveLength(1)
+
+          await browser.elementByCss('a[href="/docs/"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('Docs')
+          })
+
+          await browser
+            .elementByCss('a[href="/docs/reference/export/"]')
+            .click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'reference:export'
+            )
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+
       it('renders optional catch-all fallback routes for empty and nested params', async () => {
         const browser = await webdriver(port, '/optional/')
 

--- a/test/e2e/app-dir-export/test/utils.ts
+++ b/test/e2e/app-dir-export/test/utils.ts
@@ -27,9 +27,11 @@ const glob = promisify(globOrig)
 export async function buildAndStartOutputExportServer(
   next: Pick<NextInstance, 'build' | 'testDir'>,
   {
+    basePath,
     trailingSlash,
     useFallbackDocument,
   }: {
+    basePath?: string
     trailingSlash: boolean
     useFallbackDocument: boolean
   }
@@ -63,6 +65,17 @@ export async function buildAndStartOutputExportServer(
     requests.push(req.url || '/')
     nextHandler()
   })
+
+  if (basePath) {
+    app.use((req, _res, nextHandler) => {
+      if (req.url === basePath) {
+        req.url = '/'
+      } else if (req.url?.startsWith(`${basePath}/`)) {
+        req.url = req.url.slice(basePath.length)
+      }
+      nextHandler()
+    })
+  }
 
   app.use(
     express.static(outDir, {


### PR DESCRIPTION
## Summary
- Recover unmatched fallback routes with the app `_not-found` payload instead of falling back to the wrong document path.
- Preserve configured app roots such as `basePath` during unmatched not-found probing and fetches.

## Why
- Unmatched fallback recovery was dropping configured subpaths and could fetch the wrong `_not-found` artifact in static-export deployments.

## Validation
- `pnpm --filter=next build`
- `pnpm testonly packages/next/src/client/output-export-fallback.test.ts`
- `NEXT_SKIP_ISOLATE=1 NEXT_TEST_MODE=start pnpm testheadless test/e2e/app-dir-export/test/dynamic-fallback-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-cache-components-basepath.test.ts`

## Stack
- Previous: [#93022](https://github.com/vercel/next.js/pull/93022)
- Next: None

Full stack:
1. [#93013](https://github.com/vercel/next.js/pull/93013) output export fallback: cover flat fallbacks and fix resume path
2. [#93014](https://github.com/vercel/next.js/pull/93014) output export fallback: move fallback e2e suites onto fixtures
3. [#93015](https://github.com/vercel/next.js/pull/93015) output export fallback: support conflicting routes
4. [#93016](https://github.com/vercel/next.js/pull/93016) output export fallback: hide the bootstrap shell
5. [#93017](https://github.com/vercel/next.js/pull/93017) output export fallback: guard server-only APIs
6. [#93018](https://github.com/vercel/next.js/pull/93018) output export fallback: cover server IO boundaries
7. [#93019](https://github.com/vercel/next.js/pull/93019) output export fallback: avoid fallback document URL swaps
8. [#93020](https://github.com/vercel/next.js/pull/93020) output export fallback: prefetch and dedupe fallback payloads
9. [#93021](https://github.com/vercel/next.js/pull/93021) output export fallback: carry fallback bases through hydration
10. [#93022](https://github.com/vercel/next.js/pull/93022) output export fallback: prefer deeper static prefixes
11. [#92555](https://github.com/vercel/next.js/pull/92555) output export fallback: recover unmatched routes with _not-found <- current

<!-- NEXT_JS_LLM_PR -->
