### PR TITLE
chore(turbopack): upgrade qfiler to v0.3.0-alpha.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2362,6 +2362,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "foldhash-portable"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "631c01cdb9b602a84f0ef5e813d3691936aade6d390dba117f28aa03eb4d0e09"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5663,13 +5669,13 @@ dependencies = [
 
 [[package]]
 name = "qfilter"
-version = "0.3.0-alpha.3"
+version = "0.3.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8c6e59c09e93a6dbc7ff5feff747fc4efc3f5a90c00851e1472ce1bdf2eff"
+checksum = "edd9c903cd64233eb97cf95d96d58645c2b1c0154d30ff835f3bb4be417158b1"
 dependencies = [
+ "foldhash-portable",
  "serde",
  "serde_bytes",
- "xxhash-rust",
 ]
 
 [[package]]

--- a/turbopack/crates/turbo-persistence/Cargo.toml
+++ b/turbopack/crates/turbo-persistence/Cargo.toml
@@ -25,7 +25,7 @@ memmap2 = "0.9.5"
 nohash-hasher = { workspace = true }
 parking_lot = { workspace = true }
 # See https://github.com/vercel/next.js/issues/91708 for why we need the legacy_x86_64_support feature
-qfilter = { version = "0.3.0-alpha.3", features = ["serde", "legacy_x86_64_support"] }
+qfilter = { version = "0.3.0-alpha.4", features = ["serde", "legacy_x86_64_support"] }
 postcard = { workspace = true, features = ["alloc", "use-std"] }
 zerocopy = { version = "0.8", features = ["derive"] }
 quick_cache = { workspace = true }

--- a/turbopack/crates/turbo-persistence/Cargo.toml
+++ b/turbopack/crates/turbo-persistence/Cargo.toml
@@ -25,7 +25,7 @@ memmap2 = "0.9.5"
 nohash-hasher = { workspace = true }
 parking_lot = { workspace = true }
 # See https://github.com/vercel/next.js/issues/91708 for why we need the legacy_x86_64_support feature
-qfilter = { version = "0.3.0-alpha.4", features = ["serde", "legacy_x86_64_support"] }
+qfilter = { version = "=0.3.0-alpha.4", features = ["serde", "legacy_x86_64_support"] }
 postcard = { workspace = true, features = ["alloc", "use-std"] }
 zerocopy = { version = "0.8", features = ["derive"] }
 quick_cache = { workspace = true }

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
@@ -947,8 +947,11 @@ impl<E: Entry> StreamingSstWriter<E> {
         // Hashes are already sorted by key_hash (SST invariant), but fingerprints
         // (truncated hashes) may not be sorted, so we sort by `fingerprint & mask`.
         let actual_count = self.collected_fingerprints.len() as u64;
-        let mut builder = qfilter::Builder::new(actual_count.max(1), AMQF_FALSE_POSITIVE_RATE)
-            .expect("Filter can't be constructed");
+        let mut builder = qfilter::Builder::new(
+            qfilter::Filter::new(actual_count.max(1), AMQF_FALSE_POSITIVE_RATE)
+                .expect("Filter can't be constructed"),
+        );
+
         let fp_size = builder.fingerprint_size();
         assert!(fp_size < 32, "fp_size {fp_size} exceeds u32");
         let fp_mask = (1u32 << fp_size) - 1;


### PR DESCRIPTION
utoopack upgrade to crate dependencies of turbopack, this dependenices will upgrade to `0.3.0-alpha.4` and cause api build error.

it seems we can just upgrade it: https://github.com/arthurprs/qfilter/pull/24/changes#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759