### PR TITLE
[test] Harden temporary test fixture installs against supply chain attacks

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -29,10 +29,10 @@ ignoredBuiltDependencies:
   - ssh2
   - unrs-resolver
   - wasm-pack
+# Keep security related settings in sync with pnpm-workspace.yaml written to
+# temporary fixture dirs in file://./test/lib/create-next-install.js
 blockExoticSubdeps: true
 minimumReleaseAge: 2880 # 48 hrs
-# Keep in sync with pnpm-workspace.yaml written to temporary fixture dirs in
-# file://./test/lib/create-next-install.js
 minimumReleaseAgeExclude:
   - '@next/*'
   - '@turbo/*'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,6 +31,8 @@ ignoredBuiltDependencies:
   - wasm-pack
 blockExoticSubdeps: true
 minimumReleaseAge: 2880 # 48 hrs
+# Keep in sync with pnpm-workspace.yaml written to temporary fixture dirs in
+# file://./test/lib/create-next-install.js
 minimumReleaseAgeExclude:
   - '@next/*'
   - '@turbo/*'

--- a/test/lib/create-next-install.js
+++ b/test/lib/create-next-install.js
@@ -191,15 +191,14 @@ async function createNextInstall({
         )
       )
 
-      // pnpm propagates minimumReleaseAge via `npm_config_minimum_release_age`
-      // env variable despite claiming `npm_config` has no effect on pnpm.
-      // Only `pnpm_config_*` should have.
-      // However, it doesn't propagate `minimumReleaseAgeExclude` so we need to
-      // manually propagate those from the minimumReleaseAgeExclude in
-      // file://./../../pnpm-workspace.yaml
+      // Propagate security relate settings from file://./../../pnpm-workspace.yaml
+      // TODO: Ensure tests with custom installCommand also include necessary pnpm
+      // configs for security related settings, and remove this workaround.
       await fs.writeFile(
         path.join(installDir, 'pnpm-workspace.yaml'),
         outdent`
+          blockExoticSubdeps: true
+          minimumReleaseAge: 2880 # 48 hrs
           minimumReleaseAgeExclude:
             - '@next/*'
             - '@turbo/*'

--- a/test/lib/create-next-install.js
+++ b/test/lib/create-next-install.js
@@ -2,6 +2,7 @@ const os = require('os')
 const path = require('path')
 const execa = require('execa')
 const fs = require('fs-extra')
+const outdent = require('outdent')
 const childProcess = require('child_process')
 const { randomBytes } = require('crypto')
 const { linkPackages } =
@@ -188,6 +189,31 @@ async function createNextInstall({
           null,
           2
         )
+      )
+
+      // pnpm propagates minimumReleaseAge via `npm_config_minimum_release_age`
+      // env variable despite claiming `npm_config` has no effect on pnpm.
+      // Only `pnpm_config_*` should have.
+      // However, it doesn't propagate `minimumReleaseAgeExclude` so we need to
+      // manually propagate those from the minimumReleaseAgeExclude in
+      // file://./../../pnpm-workspace.yaml
+      await fs.writeFile(
+        path.join(installDir, 'pnpm-workspace.yaml'),
+        outdent`
+          minimumReleaseAgeExclude:
+            - '@next/*'
+            - '@turbo/*'
+            - '@vercel/*'
+            - '@workflow/*'
+            - babel-plugin-react-compiler
+            - next
+            - react
+            - react-dom
+            - react-is
+            - react-server-dom-*
+            - scheduler
+            - turbo
+        `
       )
 
       if (beforeInstall !== undefined) {


### PR DESCRIPTION
We set `minimumReleaseAge` in our monorepo but that's already secured against unintentional upgrades to compromised packages with a lockfile. However, test fixture installs are open since they don't have a lockfile.

We now propagate `minimumReleaseAge`, `minimumReleaseAgeExclude`, and `blockExoticSubdeps`. This doesn't apply to tests using other package managers with a custom `installCommand`.