### PR TITLE
fix: scope "Pages Router only" comment to default export in next/error

### DIFF
--- a/packages/next/error.d.ts
+++ b/packages/next/error.d.ts
@@ -1,4 +1,4 @@
-// Pages Router only
+// Default export is Pages Router only
 import Error from './dist/api/error'
 export * from './dist/api/error'
 export default Error

--- a/packages/next/src/api/error.ts
+++ b/packages/next/src/api/error.ts
@@ -1,4 +1,4 @@
-// Pages Router only
+// Default export is Pages Router only
 export { default } from '../pages/_error'
 export * from '../pages/_error'
 


### PR DESCRIPTION
### What?

Clarifies the misleading `// Pages Router only` comment at the top of `packages/next/error.d.ts` and `packages/next/src/api/error.ts`.

### Why?

The blanket comment implies the entire `next/error` module is Pages Router only. However, `unstable_catchError` is a named export from the same module that works in App Router Client Components (it's loaded from `client/components/catch-error`). Developers and AI agents reading the file would distrust or skip the import based on the top-level comment.

### How?

Changed the comment from `// Pages Router only` to `// Default export is Pages Router only` in both files, scoping it accurately to just the `Error` default export.