### PR TITLE
feat(dev-overlay): add Fix in Cursor action next to copy button

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/copy-button/index.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/copy-button/index.tsx
@@ -131,28 +131,45 @@ export function CopyButton(
     )
 
   return (
-    <button
-      {...rest}
-      type="button"
-      title={label}
-      aria-label={label}
-      aria-disabled={isDisabled}
-      data-nextjs-copy-button
-      data-pending={isPending}
-      className={cx(
-        props.className,
-        'nextjs-data-copy-button',
-        `nextjs-data-copy-button--${copyState.state}`
-      )}
-      onClick={() => {
-        if (!isDisabled) {
-          copy()
-        }
-      }}
-    >
-      {renderedIcon}
-      {copyState.state === 'error' ? ` ${copyState.error}` : null}
-    </button>
+    <>
+      <button
+        {...rest}
+        type="button"
+        title={label}
+        aria-label={label}
+        aria-disabled={isDisabled}
+        data-nextjs-copy-button
+        data-pending={isPending}
+        className={cx(
+          props.className,
+          'nextjs-data-copy-button',
+          `nextjs-data-copy-button--${copyState.state}`
+        )}
+        onClick={() => {
+          if (!isDisabled) {
+            copy()
+          }
+        }}
+      >
+        {renderedIcon}
+        {copyState.state === 'error' ? ` ${copyState.error}` : null}
+      </button>
+      <button
+        type="button"
+        className="cursor-fix-button"
+        title="Fix in Cursor"
+        aria-label="Fix in Cursor"
+        onClick={() => {
+          getContentString().then((text) => {
+            window.location.href =
+              'cursor://anysphere.cursor-deeplink/prompt?text=' +
+              encodeURIComponent('Fix this Next.js error. Look at the relevant source files and fix the root cause:\n\n' + text)
+          })
+        }}
+      >
+        <CursorIcon />
+      </button>
+    </>
   )
 }
 
@@ -172,6 +189,25 @@ function CopyIcon(props: React.SVGProps<SVGSVGElement>) {
         d="M2.406.438c-.845 0-1.531.685-1.531 1.53v6.563c0 .846.686 1.531 1.531 1.531H3.937V8.75H2.406a.219.219 0 0 1-.219-.219V1.97c0-.121.098-.219.22-.219h4.812c.12 0 .218.098.218.219v.656H8.75v-.656c0-.846-.686-1.532-1.531-1.532H2.406zm4.375 3.5c-.845 0-1.531.685-1.531 1.53v6.563c0 .846.686 1.531 1.531 1.531h4.813c.845 0 1.531-.685 1.531-1.53V5.468c0-.846-.686-1.532-1.531-1.532H6.78zm-.218 1.53c0-.12.097-.218.218-.218h4.813c.12 0 .219.098.219.219v6.562c0 .121-.098.219-.22.219H6.782a.219.219 0 0 1-.218-.219V5.47z"
         fill="currentColor"
       />
+    </svg>
+  )
+}
+
+function CursorIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 466.73 533.32"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <path fill="#72716d" d="M233.37,266.66l231.16,133.46c-1.42,2.46-3.48,4.56-6.03,6.03l-216.06,124.74c-5.61,3.24-12.53,3.24-18.14,0L8.24,406.15c-2.55-1.47-4.61-3.57-6.03-6.03l231.16-133.46h0Z" />
+      <path fill="#55544f" d="M233.37,0v266.66L2.21,400.12c-1.42-2.46-2.21-5.3-2.21-8.24v-250.44c0-5.89,3.14-11.32,8.24-14.27L224.29,2.43c2.81-1.62,5.94-2.43,9.07-2.43h.01Z" />
+      <path fill="#43413c" d="M464.52,133.2c-1.42-2.46-3.48-4.56-6.03-6.03L242.43,2.43c-2.8-1.62-5.93-2.43-9.06-2.43v266.66l231.16,133.46c1.42-2.46,2.21-5.3,2.21-8.24v-250.44c0-2.95-.78-5.77-2.21-8.24h-.01Z" />
+      <path fill="#d6d5d2" d="M448.35,142.54c1.31,2.26,1.49,5.16,0,7.74l-209.83,363.42c-1.41,2.46-5.16,1.45-5.16-1.38v-239.48c0-1.91-.51-3.75-1.44-5.36l216.42-124.95h.01Z" />
+      <path fill="#ffffff" d="M448.35,142.54l-216.42,124.95c-.92-1.6-2.26-2.96-3.92-3.92L20.62,143.83c-2.46-1.41-1.45-5.16,1.38-5.16h419.65c2.98,0,5.4,1.61,6.7,3.87Z" />
     </svg>
   )
 }
@@ -216,5 +252,38 @@ export const COPY_BUTTON_STYLES = `
   }
   .nextjs-data-copy-button--success:not([aria-disabled="true"]) {
     color: var(--color-ansi-green);
+  }
+`
+
+export const CURSOR_FIX_BUTTON_STYLES = `
+  .cursor-fix-button {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: var(--size-28);
+    height: var(--size-28);
+    background: var(--color-background-100);
+    background-clip: padding-box;
+    border: 1px solid var(--color-gray-alpha-400);
+    box-shadow: var(--shadow-small);
+    border-radius: var(--rounded-full);
+
+    svg {
+      width: var(--size-14);
+      height: var(--size-14);
+    }
+
+    &:focus {
+      outline: var(--focus-ring);
+    }
+
+    &:hover {
+      background: var(--color-gray-alpha-100);
+      cursor: pointer;
+    }
+
+    &:active {
+      background: var(--color-gray-alpha-200);
+    }
   }
 `


### PR DESCRIPTION
Adds a secondary control next to the dev overlay copy button that opens Cursor with a prefilled prompt containing the error content, for quicker iteration when fixing issues.

## For maintainers

### What?

The dev error overlay’s copy control is paired with a **Fix in Cursor** button. It uses the same payload as copy (stack / error text via the existing `getContentString()` path), then navigates to Cursor’s prompt deeplink with a short instruction prefix plus that content.

### Why?

Reduces friction for developers who use Cursor: they can jump from a Next.js overlay error straight into an AI-assisted fix flow without manually copying and pasting.

### How?

- `CopyButton` renders a fragment: the existing copy button unchanged, plus a second button with `CursorIcon`.
- On click, the handler resolves content asynchronously and sets `window.location.href` to `cursor://anysphere.cursor-deeplink/prompt?text=` with URL-encoded text (fixed prefix + error body).
- Adds `CURSOR_FIX_BUTTON_STYLES` for the new control (ensure these styles are included in `ComponentStyles` alongside `COPY_BUTTON_STYLES` if not already wired).

## Checklist

- [ ] Related issue / discussion linked if applicable (`Fixes #…` / `Closes NEXT-…`)
- [ ] Tests added or gap justified per [testing guide](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- [ ] `CURSOR_FIX_BUTTON_STYLES` registered in dev overlay global styles if needed for correct appearance


<img width="1045" height="785" alt="image" src="https://github.com/user-attachments/assets/8d1b272e-6300-4ac3-a3ad-3cd2c673adf8" />

<img width="712" height="825" alt="image" src="https://github.com/user-attachments/assets/045bae31-f350-4aa8-8e25-0146ea783497" />


<!-- NEXT_JS_LLM_PR -->
