### PR TITLE
[test] Ensure incomplete minimum release age isn't propagated to fixture installs

### DIFF
--- a/test/lib/create-next-install.js
+++ b/test/lib/create-next-install.js
@@ -27,7 +27,17 @@ async function installDependencies(cwd, tmpDir) {
   await execa('pnpm', args, {
     cwd,
     stdio: ['ignore', 'inherit', 'inherit'],
-    env: process.env,
+    env: {
+      ...process.env,
+      // pnpm reads this despite claims it ignores `npm_config_*` env variables.
+      // This isn't set in CI but some local environments set this from the
+      // pnpm-workspace.yaml for unknown reasons.
+      // minimumReleaseAgeExclude is not propagated with environment variables
+      // so some installs would just fail.
+      // TODO: ideally every test fixture would run with minimumReleaseAgeExclude but
+      // that requires some work in monorepo test suites.
+      npm_config_minimum_release_age: undefined,
+    },
   })
 }
 


### PR DESCRIPTION
Pnpm reads `npm_config_minimum_release_age` despite claims it ignores `npm_config_*` env variables. `npm_config_minimum_release_age`  isn't set in CI but some local environments set this from the `pnpm-workspace.yaml` for unknown reasons.
`minimumReleaseAgeExclude` is not propagated with environment variables so some installs would just fail.



## test plan

Local `p test-dev test/development/tsconfig-path-reloading/index.test.ts` works