### PR TITLE
turbopack: fix incremental build when module factories are restored from persistent cache

### DIFF
--- a/turbopack/crates/turbopack-core/src/code_builder.rs
+++ b/turbopack/crates/turbopack-core/src/code_builder.rs
@@ -42,7 +42,7 @@ pub struct PersistedCode(Code);
 #[turbo_tasks::value_impl]
 impl PersistedCode {
     #[turbo_tasks::function]
-    async fn to_code(self: Vc<Self>) -> Result<Vc<Code>> {
+    pub async fn to_code(self: Vc<Self>) -> Result<Vc<Code>> {
         // PersistedCode is transparent over Code; owned() yields Code directly.
         Ok(self.owned().await?.cell())
     }
@@ -69,8 +69,8 @@ impl Code {
 
     /// Stores this `Code` as a [`PersistedCode`] (fully serialized) and returns a `Vc<Code>`
     /// backed by the persisted version, avoiding an intermediate hash-mode `Code` cell.
-    pub fn cell_persisted(self) -> Vc<Code> {
-        PersistedCode::to_code(PersistedCode(self).cell())
+    pub fn cell_persisted(self) -> ResolvedVc<PersistedCode> {
+        PersistedCode(self).resolved_cell()
     }
 
     // Formats the code with the source map and debug id comments as

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
@@ -14,7 +14,7 @@ use turbopack_core::{
         AsyncModuleInfo, ChunkItem, ChunkItemWithAsyncModuleInfo, ChunkType, ChunkingContext,
         ChunkingContextExt, ModuleId, SourceMapSourceType,
     },
-    code_builder::{Code, CodeBuilder},
+    code_builder::{Code, CodeBuilder, PersistedCode},
     ident::AssetIdent,
     issue::{IssueExt, IssueSeverity, StyledString, code_gen::CodeGenerationIssue},
     module::Module,
@@ -132,7 +132,7 @@ impl EcmascriptChunkItemContent {
 }
 
 impl EcmascriptChunkItemContent {
-    async fn module_factory(&self) -> Result<ResolvedVc<Code>> {
+    async fn module_factory(&self) -> Result<ResolvedVc<PersistedCode>> {
         let mut code = CodeBuilder::default();
         for additional_id in self.additional_ids.iter() {
             writeln!(code, "{}, ", StringifyJs(&additional_id))?;
@@ -204,7 +204,7 @@ impl EcmascriptChunkItemContent {
 
         code += "})";
 
-        Ok(code.build().resolved_cell())
+        Ok(code.build().cell_persisted())
     }
 }
 
@@ -286,6 +286,7 @@ where
     /// Generates the module factory for this chunk item.
     fn code(self: Vc<Self>, async_module_info: Option<Vc<AsyncModuleInfo>>) -> Vc<Code> {
         module_factory_with_code_generation_issue(Vc::upcast_non_strict(self), async_module_info)
+            .to_code()
     }
 }
 
@@ -293,7 +294,7 @@ where
 async fn module_factory_with_code_generation_issue(
     chunk_item: Vc<Box<dyn EcmascriptChunkItem>>,
     async_module_info: Option<Vc<AsyncModuleInfo>>,
-) -> Result<Vc<Code>> {
+) -> Result<Vc<PersistedCode>> {
     let content = match chunk_item
         .content_with_async_module_info(async_module_info, false)
         .await
@@ -327,7 +328,7 @@ async fn module_factory_with_code_generation_issue(
             code += "(() => {{\n\n";
             writeln!(code, "throw new Error({error});", error = &js_error_message)?;
             code += "\n}})";
-            code.build().cell_persisted()
+            *code.build().cell_persisted()
         }
     })
 }


### PR DESCRIPTION
### What?

Fix an incremental build bug in Turbopack where module factories restored from the persistent cache would skip a necessary code conversion step, producing incorrect output.

### Why?

`cell_persisted()` previously returned `Vc<Code>` by immediately calling `to_code()` on the newly created `PersistedCode` cell. This meant the returned `Vc<Code>` was a local, non-persisted cell — so it triggered a recomputation of the task that produces the `Vc<Code>`, which recomputes the actual code and doesn't restore it from the PersistentCode.

### How?

- Changed `cell_persisted()` to return `ResolvedVc<PersistedCode>` instead of `Vc<Code>`, so callers explicitly hold a handle to the persisted cell rather than a pre-converted `Code`.
- Made `PersistedCode::to_code()` `pub` so callers can invoke the conversion when they actually need a `Vc<Code>`.
- Updated `module_factory()` and `module_factory_with_code_generation_issue()` to return `ResolvedVc<PersistedCode>` all the way up the call chain, deferring the `to_code()` call to the final `code()` method that produces a `Vc<Code>` for the chunk pipeline.

This ensures that on a cache-warm incremental build, turbo-tasks sees the `PersistedCode` task as a dependency and correctly re-runs the `to_code()` conversion when needed, rather than serving a stale or missing `Code` value.

<!-- NEXT_JS_LLM_PR -->