### PR TITLE
Print number of page templates for compiler

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1616,7 +1616,10 @@ export default async function build(
 
       // #region Compile
 
-      Log.info('Creating an optimized production build ...')
+      const totalPageCount = pageKeys.pages.length + (pageKeys.app?.length ?? 0)
+      Log.info(
+        `Creating an optimized production build (${totalPageCount} page template${totalPageCount === 1 ? '' : 's'}) ...`
+      )
       traceMemoryUsage('Starting build', nextBuildSpan)
 
       await updateBuildDiagnostics({
@@ -1989,7 +1992,6 @@ export default async function build(
       // #endregion
       // #region Collect data
 
-      const totalPageCount = pageKeys.pages.length + (pageKeys.app?.length || 0)
       const numberOfWorkers = getNumberOfWorkers(config, totalPageCount)
       const collectingPageDataStart = process.hrtime()
       const postCompileSpinner = createSpinner(


### PR DESCRIPTION
Otherwise you have no idea how many page templates are getting compiled. You might have a single page.ts but 1000 instances of that via `generateStaticParams`

```
▲ Next.js 16.2.1-canary.29 (Turbopack)

  Creating an optimized production build (6 page templates) ...
✓ Compiled successfully in 4.1s
✓ Finished TypeScript in 48ms    
✓ Collecting page data using 7 workers in 197ms    
✓ Generating static pages using 7 workers (33/33) in 273ms
✓ Finalizing page optimization in 8ms    

Route (app)
┌ ○ /_not-found
└   /[foo]
  ├ ● /0
  ├ ● /1
  ├ ● /2
  └ ● [+27 more paths]

Route (pages)
─ ƒ /

○  (Static)   prerendered as static content
●  (SSG)      prerendered as static HTML (uses generateStaticParams)
ƒ  (Dynamic)  server-rendered on demand
```