### PR TITLE
test: skip .next and other build artifacts in writeFiles filter

### DIFF
--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -139,6 +139,12 @@ export class NextInstance {
         )
       }
 
+      const skippedRelativePaths = new Set([
+        'package.json',
+        '.next',
+        '.next-profiles',
+        '.DS_Store',
+      ])
       await fs.cp(files.fsPath, testDir, {
         recursive: true,
         // By default Node.js turns relative symlinks into absolute symlinks.
@@ -148,12 +154,10 @@ export class NextInstance {
         // See https://nodejs.org/api/fs.html#fscpsrc-dest-options-callback
         verbatimSymlinks: true,
         filter(source) {
-          // we don't copy a package.json as it's manually written
-          // via the createNextInstall process
-          if (path.relative(files.fsPath, source) === 'package.json') {
-            return false
-          }
-          return true
+          const topLevel = path
+            .relative(files.fsPath, source)
+            .split(path.sep)[0]
+          return !skippedRelativePaths.has(topLevel)
         },
       })
     } else {


### PR DESCRIPTION
### What?

Skip `.next`, `.next-profiles`, and `.DS_Store` directories in the `writeFiles` filter when copying test fixture directories.

### Why?

`writeInitialFiles` was taking ~500ms because the `fs.cp` filter only skipped `package.json`. When a test uses `files: __dirname`, local build artifacts like `.next` (117MB / 411 files) and `.next-profiles` (147MB) were being copied into the test directory unnecessarily if a dev/build run had previously happened on the test app.

This really only applies to working on the repository locally, but it's a nice win for that case.

### How?

Expanded the `fs.cp` filter to also skip `.next`, `.next-profiles`, and `.DS_Store`. These are local artifacts never tracked in git. `node_modules` is intentionally not skipped since some tests include tracked `node_modules` as fixtures.

<!-- NEXT_JS_LLM_PR -->