### PR TITLE
turbopack: move CSS module composes validation from code generation to resolving

### DIFF
--- a/test/development/mcp-server/fixtures/compilation-errors-app/app/css-composes-error/not-a-css-module.txt
+++ b/test/development/mcp-server/fixtures/compilation-errors-app/app/css-composes-error/not-a-css-module.txt
@@ -1,0 +1,1 @@
+This is not a CSS module.

--- a/test/development/mcp-server/fixtures/compilation-errors-app/app/css-composes-error/page.tsx
+++ b/test/development/mcp-server/fixtures/compilation-errors-app/app/css-composes-error/page.tsx
@@ -1,0 +1,5 @@
+import styles from './styles.module.css'
+
+export default function CssComposesErrorPage() {
+  return <div className={styles.myClass}>CSS Composes Error</div>
+}

--- a/test/development/mcp-server/fixtures/compilation-errors-app/app/css-composes-error/styles.module.css
+++ b/test/development/mcp-server/fixtures/compilation-errors-app/app/css-composes-error/styles.module.css
@@ -1,0 +1,4 @@
+.myClass {
+  composes: something from './not-a-css-module.txt';
+  color: red;
+}

--- a/test/development/mcp-server/mcp-server-get-compilation-issues.test.ts
+++ b/test/development/mcp-server/mcp-server-get-compilation-issues.test.ts
@@ -74,6 +74,16 @@ import { nextTestSetup } from 'e2e-utils'
       expect(syntaxErrorIssue).toBeDefined()
     })
 
+    it('should detect CSS module composes errors', () => {
+      const errors = errorIssues()
+      const composesIssue = errors.find(
+        (issue) =>
+          issue.filePath.includes('css-composes-error') ||
+          issue.title.includes('composes')
+      )
+      expect(composesIssue).toBeDefined()
+    })
+
     it('should include issue metadata fields', () => {
       const errors = errorIssues()
       expect(errors.length).toBeGreaterThan(0)

--- a/turbopack/crates/turbopack-css/src/module_asset.rs
+++ b/turbopack/crates/turbopack-css/src/module_asset.rs
@@ -230,11 +230,50 @@ impl EcmascriptCssModule {
     #[turbo_tasks::function]
     async fn module_references(self: Vc<Self>) -> Result<Vc<ModuleReferences>> {
         let mut references = vec![];
+        let this = self.await?;
 
         for (_, class_names) in &*self.classes().await? {
             for class_name in class_names {
                 match class_name {
                     ModuleCssClass::Import { from, .. } => {
+                        // Validate that the composes reference resolves to a CSS module.
+                        // This runs during module graph building so issues are surfaced
+                        // by get_compilation_issues.
+                        let resolved_module = from.resolve_reference().first_module().await?;
+                        if let Some(resolved_module) = &*resolved_module {
+                            if ResolvedVc::try_downcast_type::<EcmascriptCssModule>(
+                                *resolved_module,
+                            )
+                            .is_none()
+                            {
+                                CssModuleComposesIssue {
+                                    severity: IssueSeverity::Error,
+                                    source: IssueSource::from_source_only(this.source),
+                                    message: turbofmt!(
+                                        "Module {} referenced in `composes: ... from ...;` is not \
+                                         a CSS module.\n",
+                                        from.await?.request
+                                    )
+                                    .await?,
+                                }
+                                .resolved_cell()
+                                .emit();
+                            }
+                        } else {
+                            CssModuleComposesIssue {
+                                severity: IssueSeverity::Error,
+                                source: IssueSource::from_source_only(this.source),
+                                message: turbofmt!(
+                                    "Module {} referenced in `composes: ... from ...;` can't be \
+                                     resolved.\n",
+                                    from.await?.request
+                                )
+                                .await?,
+                            }
+                            .resolved_cell()
+                            .emit();
+                        }
+
                         references.push(ResolvedVc::upcast(*from));
                     }
                     ModuleCssClass::Local { .. } | ModuleCssClass::Global { .. } => {}
@@ -288,40 +327,14 @@ impl EcmascriptChunkPlaceable for EcmascriptCssModule {
                         let resolved_module = from.resolve_reference().first_module().await?;
 
                         let Some(resolved_module) = &*resolved_module else {
-                            CssModuleComposesIssue {
-                                severity: IssueSeverity::Error,
-                                // TODO(PACK-4879): this should include detailed location
-                                // information
-                                source: IssueSource::from_source_only(self.await?.source),
-                                message: turbofmt!(
-                                    "Module {} referenced in `composes: ... from ...;` can't be \
-                                     resolved.\n",
-                                    from.await?.request
-                                )
-                                .await?,
-                            }
-                            .resolved_cell()
-                            .emit();
+                            // Issue already emitted during module_references()
                             continue;
                         };
 
                         let Some(css_module) =
                             ResolvedVc::try_downcast_type::<EcmascriptCssModule>(*resolved_module)
                         else {
-                            CssModuleComposesIssue {
-                                severity: IssueSeverity::Error,
-                                // TODO(PACK-4879): this should include detailed location
-                                // information
-                                source: IssueSource::from_source_only(self.await?.source),
-                                message: turbofmt!(
-                                    "Module {} referenced in `composes: ... from ...;` is not a \
-                                     CSS module.\n",
-                                    from.await?.request
-                                )
-                                .await?,
-                            }
-                            .resolved_cell()
-                            .emit();
+                            // Issue already emitted during module_references()
                             continue;
                         };
 
@@ -437,7 +450,7 @@ impl Issue for CssModuleComposesIssue {
 
     #[turbo_tasks::function]
     fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::CodeGen.cell()
+        IssueStage::Resolve.cell()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-css/src/module_asset.rs
+++ b/turbopack/crates/turbopack-css/src/module_asset.rs
@@ -10,10 +10,6 @@ use turbopack_core::{
     chunk::{AsyncModuleInfo, ChunkableModule, ChunkingContext, ModuleChunkItemIdExt},
     context::{AssetContext, ProcessResult},
     ident::AssetIdent,
-    issue::{
-        Issue, IssueExt, IssueSeverity, IssueSource, IssueStage, OptionIssueSource,
-        OptionStyledString, StyledString,
-    },
     module::{Module, ModuleSideEffects},
     module_graph::ModuleGraph,
     reference::{ModuleReference, ModuleReferences},
@@ -33,7 +29,10 @@ use turbopack_ecmascript::{
 
 use crate::{
     process::{CssWithPlaceholderResult, ProcessCss},
-    references::{compose::CssModuleComposeReference, internal::InternalCssAssetReference},
+    references::{
+        compose::{CssModuleComposable, CssModuleComposeReference},
+        internal::InternalCssAssetReference,
+    },
 };
 
 /// A [CSS Module, as in `.module.css`][spec]. For a global CSS module, see [`CssModule`].
@@ -230,50 +229,11 @@ impl EcmascriptCssModule {
     #[turbo_tasks::function]
     async fn module_references(self: Vc<Self>) -> Result<Vc<ModuleReferences>> {
         let mut references = vec![];
-        let this = self.await?;
 
         for (_, class_names) in &*self.classes().await? {
             for class_name in class_names {
                 match class_name {
                     ModuleCssClass::Import { from, .. } => {
-                        // Validate that the composes reference resolves to a CSS module.
-                        // This runs during module graph building so issues are surfaced
-                        // by get_compilation_issues.
-                        let resolved_module = from.resolve_reference().first_module().await?;
-                        if let Some(resolved_module) = &*resolved_module {
-                            if ResolvedVc::try_downcast_type::<EcmascriptCssModule>(
-                                *resolved_module,
-                            )
-                            .is_none()
-                            {
-                                CssModuleComposesIssue {
-                                    severity: IssueSeverity::Error,
-                                    source: IssueSource::from_source_only(this.source),
-                                    message: turbofmt!(
-                                        "Module {} referenced in `composes: ... from ...;` is not \
-                                         a CSS module.\n",
-                                        from.await?.request
-                                    )
-                                    .await?,
-                                }
-                                .resolved_cell()
-                                .emit();
-                            }
-                        } else {
-                            CssModuleComposesIssue {
-                                severity: IssueSeverity::Error,
-                                source: IssueSource::from_source_only(this.source),
-                                message: turbofmt!(
-                                    "Module {} referenced in `composes: ... from ...;` can't be \
-                                     resolved.\n",
-                                    from.await?.request
-                                )
-                                .await?,
-                            }
-                            .resolved_cell()
-                            .emit();
-                        }
-
                         references.push(ResolvedVc::upcast(*from));
                     }
                     ModuleCssClass::Local { .. } | ModuleCssClass::Global { .. } => {}
@@ -284,6 +244,9 @@ impl EcmascriptCssModule {
         Ok(Vc::cell(references))
     }
 }
+
+#[turbo_tasks::value_impl]
+impl CssModuleComposable for EcmascriptCssModule {}
 
 #[turbo_tasks::value_impl]
 impl ChunkableModule for EcmascriptCssModule {
@@ -327,14 +290,14 @@ impl EcmascriptChunkPlaceable for EcmascriptCssModule {
                         let resolved_module = from.resolve_reference().first_module().await?;
 
                         let Some(resolved_module) = &*resolved_module else {
-                            // Issue already emitted during module_references()
+                            // Issue already emitted by CssModuleComposeReference::resolve_reference
                             continue;
                         };
 
                         let Some(css_module) =
                             ResolvedVc::try_downcast_type::<EcmascriptCssModule>(*resolved_module)
                         else {
-                            // Issue already emitted during module_references()
+                            // Issue already emitted by CssModuleComposeReference::resolve_reference
                             continue;
                         };
 
@@ -425,48 +388,4 @@ fn generate_minimal_source_map(filename: String, source: String) -> Result<Rope>
     sm.new_source_file(FileName::Custom(filename).into(), source);
     let map = generate_js_source_map(&*sm, mappings, None, true, true, Default::default())?;
     Ok(map)
-}
-
-#[turbo_tasks::value(shared)]
-struct CssModuleComposesIssue {
-    severity: IssueSeverity,
-    source: IssueSource,
-    message: RcStr,
-}
-
-#[turbo_tasks::value_impl]
-impl Issue for CssModuleComposesIssue {
-    fn severity(&self) -> IssueSeverity {
-        self.severity
-    }
-
-    #[turbo_tasks::function]
-    fn title(&self) -> Vc<StyledString> {
-        StyledString::Text(rcstr!(
-            "An issue occurred while resolving a CSS module `composes:` rule"
-        ))
-        .cell()
-    }
-
-    #[turbo_tasks::function]
-    fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::Resolve.cell()
-    }
-
-    #[turbo_tasks::function]
-    fn file_path(&self) -> Vc<FileSystemPath> {
-        self.source.file_path()
-    }
-
-    #[turbo_tasks::function]
-    fn description(&self) -> Vc<OptionStyledString> {
-        Vc::cell(Some(
-            StyledString::Text(self.message.clone()).resolved_cell(),
-        ))
-    }
-
-    #[turbo_tasks::function]
-    fn source(&self) -> Vc<OptionIssueSource> {
-        Vc::cell(Some(self.source))
-    }
 }

--- a/turbopack/crates/turbopack-css/src/module_asset.rs
+++ b/turbopack/crates/turbopack-css/src/module_asset.rs
@@ -29,10 +29,7 @@ use turbopack_ecmascript::{
 
 use crate::{
     process::{CssWithPlaceholderResult, ProcessCss},
-    references::{
-        compose::{CssModuleComposable, CssModuleComposeReference},
-        internal::InternalCssAssetReference,
-    },
+    references::{compose::CssModuleComposeReference, internal::InternalCssAssetReference},
 };
 
 /// A [CSS Module, as in `.module.css`][spec]. For a global CSS module, see [`CssModule`].
@@ -244,9 +241,6 @@ impl EcmascriptCssModule {
         Ok(Vc::cell(references))
     }
 }
-
-#[turbo_tasks::value_impl]
-impl CssModuleComposable for EcmascriptCssModule {}
 
 #[turbo_tasks::value_impl]
 impl ChunkableModule for EcmascriptCssModule {

--- a/turbopack/crates/turbopack-css/src/references/compose.rs
+++ b/turbopack/crates/turbopack-css/src/references/compose.rs
@@ -10,12 +10,7 @@ use turbopack_core::{
     resolve::{ModuleResolveResult, origin::ResolveOrigin, parse::Request},
 };
 
-use crate::references::css_resolve;
-
-/// Marker trait for CSS module files (`.module.css`) that can be used as the
-/// target of a `composes: ... from ...;` rule.
-#[turbo_tasks::value_trait]
-pub(crate) trait CssModuleComposable {}
+use crate::{module_asset::EcmascriptCssModule, references::css_resolve};
 
 /// A `composes: ... from ...` CSS module reference.
 #[turbo_tasks::value]
@@ -53,7 +48,7 @@ impl ModuleReference for CssModuleComposeReference {
         let resolved = result.first_module().await?;
         let file_path = self.origin.origin_path().to_resolved().await?;
         if let Some(module) = &*resolved {
-            if ResolvedVc::try_sidecast::<Box<dyn CssModuleComposable>>(*module).is_none() {
+            if ResolvedVc::try_downcast_type::<EcmascriptCssModule>(*module).is_none() {
                 CssModuleComposesIssue {
                     severity: IssueSeverity::Error,
                     file_path,

--- a/turbopack/crates/turbopack-css/src/references/compose.rs
+++ b/turbopack/crates/turbopack-css/src/references/compose.rs
@@ -1,12 +1,21 @@
-use turbo_tasks::{ResolvedVc, ValueToString, Vc};
+use anyhow::Result;
+use turbo_rcstr::{RcStr, rcstr};
+use turbo_tasks::{ResolvedVc, ValueToString, Vc, turbofmt};
+use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     chunk::ChunkingType,
+    issue::{Issue, IssueExt, IssueSeverity, IssueStage, OptionStyledString, StyledString},
     reference::ModuleReference,
     reference_type::CssReferenceSubType,
     resolve::{ModuleResolveResult, origin::ResolveOrigin, parse::Request},
 };
 
 use crate::references::css_resolve;
+
+/// Marker trait for CSS module files (`.module.css`) that can be used as the
+/// target of a `composes: ... from ...;` rule.
+#[turbo_tasks::value_trait]
+pub(crate) trait CssModuleComposable {}
 
 /// A `composes: ... from ...` CSS module reference.
 #[turbo_tasks::value]
@@ -32,14 +41,48 @@ impl CssModuleComposeReference {
 #[turbo_tasks::value_impl]
 impl ModuleReference for CssModuleComposeReference {
     #[turbo_tasks::function]
-    fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
-        css_resolve(
+    async fn resolve_reference(&self) -> Result<Vc<ModuleResolveResult>> {
+        let result = css_resolve(
             *self.origin,
             *self.request,
             CssReferenceSubType::Compose,
             // TODO: add real issue source, currently impossible
             None,
-        )
+        );
+
+        let resolved = result.first_module().await?;
+        let file_path = self.origin.origin_path().to_resolved().await?;
+        if let Some(module) = &*resolved {
+            if ResolvedVc::try_sidecast::<Box<dyn CssModuleComposable>>(*module).is_none() {
+                CssModuleComposesIssue {
+                    severity: IssueSeverity::Error,
+                    file_path,
+                    // TODO(PACK-4879): this should include detailed location information
+                    message: turbofmt!(
+                        "Module {} referenced in `composes: ... from ...;` is not a CSS module.\n",
+                        self.request
+                    )
+                    .await?,
+                }
+                .resolved_cell()
+                .emit();
+            }
+        } else {
+            CssModuleComposesIssue {
+                severity: IssueSeverity::Error,
+                file_path,
+                // TODO(PACK-4879): this should include detailed location information
+                message: turbofmt!(
+                    "Module {} referenced in `composes: ... from ...;` can't be resolved.\n",
+                    self.request
+                )
+                .await?,
+            }
+            .resolved_cell()
+            .emit();
+        }
+
+        Ok(result)
     }
 
     fn chunking_type(&self) -> Option<ChunkingType> {
@@ -47,5 +90,44 @@ impl ModuleReference for CssModuleComposeReference {
             inherit_async: false,
             hoisted: false,
         })
+    }
+}
+
+#[turbo_tasks::value(shared)]
+struct CssModuleComposesIssue {
+    severity: IssueSeverity,
+    file_path: ResolvedVc<FileSystemPath>,
+    message: RcStr,
+}
+
+#[turbo_tasks::value_impl]
+impl Issue for CssModuleComposesIssue {
+    fn severity(&self) -> IssueSeverity {
+        self.severity
+    }
+
+    #[turbo_tasks::function]
+    fn title(&self) -> Vc<StyledString> {
+        StyledString::Text(rcstr!(
+            "An issue occurred while resolving a CSS module `composes:` rule"
+        ))
+        .cell()
+    }
+
+    #[turbo_tasks::function]
+    fn stage(&self) -> Vc<IssueStage> {
+        IssueStage::Resolve.cell()
+    }
+
+    #[turbo_tasks::function]
+    fn file_path(&self) -> Vc<FileSystemPath> {
+        *self.file_path
+    }
+
+    #[turbo_tasks::function]
+    fn description(&self) -> Vc<OptionStyledString> {
+        Vc::cell(Some(
+            StyledString::Text(self.message.clone()).resolved_cell(),
+        ))
     }
 }


### PR DESCRIPTION
### What?

Move the validation that can produce `CssModuleComposesIssue` from code generation (`chunk_item_content`) to the reference's own `resolve_reference()` method, so these errors are surfaced during resolving rather than only during bundling.

Two validation checks are moved into `CssModuleComposeReference::resolve_reference()`:
1. A `composes: ... from "...";` target module can't be resolved (unresolvable reference)
2. A `composes: ... from "...";` target module is not a CSS module (e.g. composing from a `.js` or `.txt` file)

The `IssueStage` is updated from `CodeGen` to `Resolve` to reflect the new phase.

Code generation still handles the error cases gracefully (skipping broken references with `continue`) — it just no longer re-emits the issue since it is already emitted by `resolve_reference()`.

### Why?

`get_compilation_issues` (used by the MCP server and other tooling) only builds the module graph — it does not run code generation. Previously, both `CssModuleComposesIssue` variants were only emitted during `chunk_item_content()`, which meant they were invisible to `get_compilation_issues`. Developers using the MCP `get_compilation_issues` tool would not see errors from broken `composes` references until an actual build/bundle was triggered.

Since `resolve_reference()` is called as part of module graph traversal, emitting the issue there means it is captured by `get_compilation_issues` alongside other resolve-phase errors.

### How?

**`turbopack-css/src/references/compose.rs`**

- `CssModuleComposeReference::resolve_reference()` is changed from `fn` to `async fn`. It calls `css_resolve` as before, then awaits `first_module()` on the result and validates:
  - Resolved to nothing → emit "can't be resolved" issue
  - Resolved to a module that doesn't implement `CssModuleComposable` → emit "not a CSS module" issue
- `CssModuleComposesIssue` and its `Issue` impl are moved here from `module_asset.rs`, now using `ResolvedVc<FileSystemPath>` (from `origin_path()`) as the issue location rather than the `IssueSource` of the composing file.
- A new `CssModuleComposable` marker trait (`#[turbo_tasks::value_trait]`) is defined here. `resolve_reference()` uses a `try_sidecast` to this trait to check whether the resolved module is a valid compose target — avoiding a hard dependency on `EcmascriptCssModule` from within `compose.rs`.

**`turbopack-css/src/module_asset.rs`**

- `EcmascriptCssModule` implements `CssModuleComposable`, marking it as a valid `composes:` target.
- `module_references()` is reverted to its original simple form — it only collects references without any validation.
- All issue-related imports (`Issue`, `IssueExt`, `IssueSource`, etc.) are removed.

**Test fixtures** (`test/development/mcp-server/fixtures/compilation-errors-app/app/css-composes-error/`)

- `styles.module.css` — CSS module with `composes: something from './not-a-css-module.txt'`
- `not-a-css-module.txt` — a plain text file (resolves but is not a CSS module)
- `page.tsx` — page importing the broken CSS module

**`test/development/mcp-server/mcp-server-get-compilation-issues.test.ts`**

- New test case `should detect CSS module composes errors` verifies the issue is surfaced via `get_compilation_issues`.

<!-- NEXT_JS_LLM_PR -->