### PR TITLE
test: reduce writeToDisk memory test iterations to fix CI timeout

### DIFF
--- a/test/development/basic/next-rs-api.test.ts
+++ b/test/development/basic/next-rs-api.test.ts
@@ -239,7 +239,7 @@ async function main() {
   const entrypointsSubscription = project.entrypointsSubscribe();
   const entrypoints = (await entrypointsSubscription.next()).value;
 
-  const RUNS = 10000;
+  const RUNS = 1000;
   async function compileRoute(route) {
     const endpoint = route.endpoint ?? route.htmlEndpoint ?? route.pages[0].htmlEndpoint;
     if (!endpoint) {


### PR DESCRIPTION
### What?

Reduces `RUNS` from 10,000 to 1,000 in the `next.rs api writeToDisk multiple times` test in `test/development/basic/next-rs-api.test.ts`.

### Why?

The test was frequently timing out on CI. It spawns a child `node --expose-gc` process that calls `writeToDisk()` in a loop (`RUNS` times per batch) for each discovered route (~11 routes), with up to 11 measurement batches per route. At 10,000 runs per batch that is up to ~1.1 million `writeToDisk()` calls total — all under the global 60-second Jest timeout.

Each call, even in the turbo-tasks memoized steady state, has non-trivial overhead: an NAPI crossing, a task-cache lookup, a `read_strongly_consistent()` wait, and an O(N effects) iteration over output assets (each requiring a mutex acquisition). On slow CI hardware this easily exceeds 60 seconds.

### How?

Reduce `RUNS` to 1,000. This gives a 10× speedup without compromising the test's ability to detect memory leaks: a leak of even a single OS page (4 KB) per 1,000 calls is still detectable via the RSS delta check. The warmup + measurement loop structure is unchanged.

<!-- NEXT_JS_LLM_PR -->