### PR TITLE
Fix NextFontIssue IssueStage: CodeGen → Resolve

### DIFF
--- a/crates/next-core/src/next_font/issue.rs
+++ b/crates/next-core/src/next_font/issue.rs
@@ -14,7 +14,7 @@ pub(crate) struct NextFontIssue {
 impl Issue for NextFontIssue {
     #[turbo_tasks::function]
     fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::CodeGen.cell()
+        IssueStage::Resolve.cell()
     }
 
     fn severity(&self) -> IssueSeverity {


### PR DESCRIPTION
### What?

Changes `NextFontIssue`'s `IssueStage` from `CodeGen` to `Resolve`.

### Why?

`NextFontIssue` is emitted during font resolution — when validating font configuration options (`util.rs`) and when fetching/resolving Google Font metadata (`google/mod.rs`, `google/font_fallback.rs`). None of these occur during code generation; they all happen at the resolve stage of the build pipeline.

Using `IssueStage::CodeGen` was incorrect and caused these font issues to be grouped/sorted with code generation errors rather than resolution errors. The local-font counterpart (`FontResolvingIssue` in `next_font/local/mod.rs`) already correctly uses `IssueStage::Resolve`.

### How?

Single-line fix: change `IssueStage::CodeGen.cell()` to `IssueStage::Resolve.cell()` in the `stage()` method of `impl Issue for NextFontIssue`.

<!-- NEXT_JS_LLM_PR -->