### PR TITLE
Don't swallow strings thrown in Server Components

### DIFF
--- a/packages/next/src/server/app-render/create-error-handler.tsx
+++ b/packages/next/src/server/app-render/create-error-handler.tsx
@@ -60,11 +60,6 @@ export function createReactServerErrorHandler(
   spanToRecordOn?: any
 ): RSCErrorHandler {
   return (thrownValue: unknown) => {
-    if (typeof thrownValue === 'string') {
-      // TODO-APP: look at using webcrypto instead. Requires a promise to be awaited.
-      return stringHash(thrownValue).toString()
-    }
-
     // If the response was closed, we don't need to log the error.
     if (isAbortError(thrownValue)) return
 
@@ -103,11 +98,14 @@ export function createReactServerErrorHandler(
         // but has a digest from other means. Keep the error as-is.
       }
     } else {
-      err.digest = createDigestWithErrorCode(
-        err,
-        // TODO-APP: look at using webcrypto instead. Requires a promise to be awaited.
-        stringHash(err.message + (err.stack || '')).toString()
-      )
+      // TODO-APP: look at using webcrypto instead of string-hash. Requires a promise to be awaited.
+      err.digest =
+        typeof thrownValue === 'string'
+          ? stringHash(thrownValue).toString()
+          : createDigestWithErrorCode(
+              err,
+              stringHash(err.message + (err.stack || '')).toString()
+            )
     }
 
     // @TODO by putting this here and not at the top it is possible that

--- a/test/e2e/app-dir/errors/index.test.ts
+++ b/test/e2e/app-dir/errors/index.test.ts
@@ -187,7 +187,8 @@ describe('app-dir - errors', () => {
         )
       } else {
         expect(cleanCliOutput).toMatchInlineSnapshot(`
-         "⨯ [Error: An error occurred in the Server Components render. The specific message is omitted in production builds to avoid leaking sensitive details. A digest property is included on this error instance which may provide additional details about the nature of the error.] {
+         "⨯ Error: this is a test
+             at stringify (<anonymous>) {
            digest: '<digest>'
          }
          "

--- a/test/e2e/app-dir/errors/index.test.ts
+++ b/test/e2e/app-dir/errors/index.test.ts
@@ -94,6 +94,7 @@ describe('app-dir - errors', () => {
     })
 
     it('should trigger error component when undefined is thrown during server components rendering', async () => {
+      const outputIndex = next.cliOutput.length
       const browser = await next.browser('/server-component/throw-undefined')
 
       expect(
@@ -107,16 +108,28 @@ describe('app-dir - errors', () => {
         await browser.waitForElementByCss('#error-boundary-digest').text()
         // Digest of the error message should be stable.
       ).not.toBe('')
-      expect(stripAnsi(next.cliOutput)).toEqual(
-        expect.stringMatching(
-          isNextDev
-            ? /Error: An undefined error was thrown.*digest: '\d+@E\d+'/s
-            : /Error: undefined.*digest: '\d+@E\d+'/s
+      const cleanCliOutput = stripAnsi(
+        next.cliOutput.slice(outputIndex)
+      ).replaceAll(/digest: '\d+(@E\d+)'/g, "digest: '<digest>$1'")
+      if (isNextDev) {
+        expect(cleanCliOutput).toEqual(
+          expect.stringMatching(
+            /Error: An undefined error was thrown.*digest: '<digest>@E98'/s
+          )
         )
-      )
+      } else {
+        expect(cleanCliOutput).toMatchInlineSnapshot(`
+         "⨯ Error: undefined
+             at stringify (<anonymous>) {
+           digest: '<digest>@E394'
+         }
+         "
+        `)
+      }
     })
 
     it('should trigger error component when null is thrown during server components rendering', async () => {
+      const outputIndex = next.cliOutput.length
       const browser = await next.browser('/server-component/throw-null')
 
       expect(
@@ -130,16 +143,28 @@ describe('app-dir - errors', () => {
         await browser.waitForElementByCss('#error-boundary-digest').text()
         // Digest of the error message should be stable.
       ).not.toBe('')
-      expect(stripAnsi(next.cliOutput)).toEqual(
-        expect.stringMatching(
-          isNextDev
-            ? /Error: A null error was thrown.*digest: '\d+@E\d+'/s
-            : /Error: null.*digest: '\d+@E\d+'/s
+      const cleanCliOutput = stripAnsi(
+        next.cliOutput.slice(outputIndex)
+      ).replaceAll(/digest: '\d+(@E\d+)'/g, "digest: '<digest>$1'")
+      if (isNextDev) {
+        expect(cleanCliOutput).toEqual(
+          expect.stringMatching(
+            /Error: A null error was thrown.*digest: '<digest>@E336'/s
+          )
         )
-      )
+      } else {
+        expect(cleanCliOutput).toMatchInlineSnapshot(`
+         "⨯ Error: null
+             at stringify (<anonymous>) {
+           digest: '<digest>@E394'
+         }
+         "
+        `)
+      }
     })
 
     it('should trigger error component when a string is thrown during server components rendering', async () => {
+      const outputIndex = next.cliOutput.length
       const browser = await next.browser('/server-component/throw-string')
 
       expect(
@@ -153,13 +178,21 @@ describe('app-dir - errors', () => {
         await browser.waitForElementByCss('#error-boundary-digest').text()
         // Digest of the error message should be stable.
       ).not.toBe('')
-      expect(stripAnsi(next.cliOutput)).toEqual(
-        expect.stringMatching(
-          isNextDev
-            ? /Error: this is a test.*digest: '\d+'/s
-            : /Error: An error occurred in the Server Components render.*digest: '\d+'/s
+      const cleanCliOutput = stripAnsi(
+        next.cliOutput.slice(outputIndex)
+      ).replaceAll(/digest: '\d+'/g, "digest: '<digest>'")
+      if (isNextDev) {
+        expect(cleanCliOutput).toEqual(
+          expect.stringMatching(/Error: this is a test.*digest: '<digest>'/s)
         )
-      )
+      } else {
+        expect(cleanCliOutput).toMatchInlineSnapshot(`
+         "⨯ [Error: An error occurred in the Server Components render. The specific message is omitted in production builds to avoid leaking sensitive details. A digest property is included on this error instance which may provide additional details about the nature of the error.] {
+           digest: '<digest>'
+         }
+         "
+        `)
+      }
     })
 
     it('should use default error boundary for prod and overlay for dev when no error component specified', async () => {


### PR DESCRIPTION
Better than omitting them entirely especially since we previously included a digest that could not be matched since we never logged the string on the server the digest belonged to.

First commit shows a clearer picture of the current behavior. Second commit shows that we no longer swallow the string.

Throwing strings is still discouraged since they're missing the location from where they were thrown. But if you throw them accidentally we should at least do our best to make them grep-able. 