### PR TITLE
Drop turbo_tasks::function from ValueDebug trait items

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/tests/debug.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/debug.rs
@@ -4,17 +4,17 @@
 
 use std::sync::Mutex;
 
-use turbo_tasks::{
-    ResolvedVc, Vc,
-    debug::{ValueDebug, ValueDebugString},
-};
+use turbo_rcstr::RcStr;
+use turbo_tasks::{ResolvedVc, Vc, debug::ValueDebug};
 use turbo_tasks_testing::{Registration, register, run_once};
 
 static REGISTRATION: Registration = register!();
 
 #[turbo_tasks::function(operation)]
-fn dbg_operation(value: ResolvedVc<Box<dyn ValueDebug>>) -> Vc<ValueDebugString> {
-    value.dbg()
+async fn dbg_operation(value: ResolvedVc<Box<dyn ValueDebug>>) -> anyhow::Result<Vc<RcStr>> {
+    let trait_ref = value.into_trait_ref().await?;
+    let s = trait_ref.dbg().await?;
+    Ok(Vc::cell(s.into()))
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -23,7 +23,7 @@ async fn test_primitive_debug() {
         let a = ResolvedVc::<u32>::cell(42);
         assert_eq!(
             format!(
-                "{:?}",
+                "{}",
                 dbg_operation(ResolvedVc::upcast(a))
                     .read_strongly_consistent()
                     .await?,
@@ -42,7 +42,7 @@ async fn test_transparent_debug() {
         let a = Transparent(42).resolved_cell();
         assert_eq!(
             format!(
-                "{:?}",
+                "{}",
                 dbg_operation(ResolvedVc::upcast(a))
                     .read_strongly_consistent()
                     .await?,
@@ -61,7 +61,7 @@ async fn test_enum_none_debug() {
         let a = Enum::None.resolved_cell();
         assert_eq!(
             format!(
-                "{:?}",
+                "{}",
                 dbg_operation(ResolvedVc::upcast(a))
                     .read_strongly_consistent()
                     .await?,
@@ -80,7 +80,7 @@ async fn test_enum_transparent_debug() {
         let a = Enum::Transparent(Transparent(42).resolved_cell()).resolved_cell();
         assert_eq!(
             format!(
-                "{:?}",
+                "{}",
                 dbg_operation(ResolvedVc::upcast(a))
                     .read_strongly_consistent()
                     .await?,
@@ -99,7 +99,7 @@ async fn test_enum_inner_vc_debug() {
         let a = Enum::Enum(Enum::None.resolved_cell()).resolved_cell();
         assert_eq!(
             format!(
-                "{:?}",
+                "{}",
                 dbg_operation(ResolvedVc::upcast(a))
                     .read_strongly_consistent()
                     .await?,
@@ -118,7 +118,7 @@ async fn test_struct_unit_debug() {
         let a = StructUnit.resolved_cell();
         assert_eq!(
             format!(
-                "{:?}",
+                "{}",
                 dbg_operation(ResolvedVc::upcast(a))
                     .read_strongly_consistent()
                     .await?,
@@ -140,7 +140,7 @@ async fn test_struct_transparent_debug() {
         .resolved_cell();
         assert_eq!(
             format!(
-                "{:?}",
+                "{}",
                 dbg_operation(ResolvedVc::upcast(a))
                     .read_strongly_consistent()
                     .await?,
@@ -159,7 +159,7 @@ async fn test_struct_option_debug() {
         let a = StructWithOption { option: None }.resolved_cell();
         assert_eq!(
             format!(
-                "{:?}",
+                "{}",
                 dbg_operation(ResolvedVc::upcast(a))
                     .read_strongly_consistent()
                     .await?,
@@ -173,7 +173,7 @@ async fn test_struct_option_debug() {
         .resolved_cell();
         assert_eq!(
             format!(
-                "{:?}",
+                "{}",
                 dbg_operation(ResolvedVc::upcast(b))
                     .read_strongly_consistent()
                     .await?,
@@ -193,7 +193,7 @@ async fn test_struct_vec_debug() {
         let a = StructWithVec { vec: Vec::new() }.resolved_cell();
         assert_eq!(
             format!(
-                "{:?}",
+                "{}",
                 dbg_operation(ResolvedVc::upcast(a))
                     .read_strongly_consistent()
                     .await?,
@@ -207,7 +207,7 @@ async fn test_struct_vec_debug() {
         .resolved_cell();
         assert_eq!(
             format!(
-                "{:?}",
+                "{}",
                 dbg_operation(ResolvedVc::upcast(b))
                     .read_strongly_consistent()
                     .await?,
@@ -231,7 +231,7 @@ async fn test_struct_ignore_debug() {
         .resolved_cell();
         assert_eq!(
             format!(
-                "{:?}",
+                "{}",
                 dbg_operation(ResolvedVc::upcast(a))
                     .read_strongly_consistent()
                     .await?,

--- a/turbopack/crates/turbo-tasks-macros/src/derive/value_debug_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/derive/value_debug_macro.rs
@@ -12,14 +12,21 @@ pub fn derive_value_debug(input: TokenStream) -> TokenStream {
     quote! {
         #[turbo_tasks::value_impl]
         impl turbo_tasks::debug::ValueDebug for #ident {
-            #[turbo_tasks::function]
-            async fn dbg(&self) -> anyhow::Result<turbo_tasks::Vc<turbo_tasks::debug::ValueDebugString>> {
-                turbo_tasks::debug::ValueDebugFormat::value_debug_format(self, usize::MAX).try_to_value_debug_string().await
-            }
-
-            #[turbo_tasks::function]
-            async fn dbg_depth(&self, depth: usize) -> anyhow::Result<turbo_tasks::Vc<turbo_tasks::debug::ValueDebugString>> {
-                turbo_tasks::debug::ValueDebugFormat::value_debug_format(self, depth).try_to_value_debug_string().await
+            fn dbg_depth<'a>(
+                &'a self,
+                depth: usize,
+            ) -> ::std::pin::Pin<
+                ::std::boxed::Box<
+                    dyn ::std::future::Future<Output = ::anyhow::Result<::std::string::String>>
+                        + ::std::marker::Send
+                        + 'a,
+                >,
+            > {
+                ::std::boxed::Box::pin(async move {
+                    turbo_tasks::debug::ValueDebugFormat::value_debug_format(self, depth)
+                        .try_to_string()
+                        .await
+                })
             }
         }
     }

--- a/turbopack/crates/turbo-tasks-macros/src/primitive_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/primitive_macro.rs
@@ -25,16 +25,21 @@ pub fn primitive(input: TokenStream) -> TokenStream {
     let value_debug_impl = quote! {
         #[turbo_tasks::value_impl]
         impl turbo_tasks::debug::ValueDebug for #ty {
-            #[turbo_tasks::function]
-            async fn dbg(&self) -> anyhow::Result<turbo_tasks::Vc<turbo_tasks::debug::ValueDebugString>> {
-                use turbo_tasks::debug::ValueDebugFormat;
-                self.value_debug_format(usize::MAX).try_to_value_debug_string().await
-            }
-
-            #[turbo_tasks::function]
-            async fn dbg_depth(&self, depth: usize) -> anyhow::Result<turbo_tasks::Vc<turbo_tasks::debug::ValueDebugString>> {
-                use turbo_tasks::debug::ValueDebugFormat;
-                self.value_debug_format(depth).try_to_value_debug_string().await
+            fn dbg_depth<'a>(
+                &'a self,
+                depth: usize,
+            ) -> ::std::pin::Pin<
+                ::std::boxed::Box<
+                    dyn ::std::future::Future<
+                            Output = ::anyhow::Result<::std::string::String>,
+                        > + ::std::marker::Send
+                        + 'a,
+                >,
+            > {
+                ::std::boxed::Box::pin(async move {
+                    use turbo_tasks::debug::ValueDebugFormat;
+                    self.value_debug_format(depth).try_to_string().await
+                })
             }
         }
     };

--- a/turbopack/crates/turbo-tasks-macros/src/value_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/value_macro.rs
@@ -417,16 +417,21 @@ pub fn value(args: TokenStream, input: TokenStream) -> TokenStream {
         quote! {
             #[turbo_tasks::value_impl]
             impl turbo_tasks::debug::ValueDebug for #ident {
-                #[turbo_tasks::function]
-                async fn dbg(&self) -> anyhow::Result<turbo_tasks::Vc<turbo_tasks::debug::ValueDebugString>> {
-                    use turbo_tasks::debug::ValueDebugFormat;
-                    (&self.0).value_debug_format(usize::MAX).try_to_value_debug_string().await
-                }
-
-                #[turbo_tasks::function]
-                async fn dbg_depth(&self, depth: usize) -> anyhow::Result<turbo_tasks::Vc<turbo_tasks::debug::ValueDebugString>> {
-                    use turbo_tasks::debug::ValueDebugFormat;
-                    (&self.0).value_debug_format(depth).try_to_value_debug_string().await
+                fn dbg_depth<'a>(
+                    &'a self,
+                    depth: usize,
+                ) -> ::std::pin::Pin<
+                    ::std::boxed::Box<
+                        dyn ::std::future::Future<
+                                Output = ::anyhow::Result<::std::string::String>,
+                            > + ::std::marker::Send
+                            + 'a,
+                    >,
+                > {
+                    ::std::boxed::Box::pin(async move {
+                        use turbo_tasks::debug::ValueDebugFormat;
+                        (&self.0).value_debug_format(depth).try_to_string().await
+                    })
                 }
             }
         }

--- a/turbopack/crates/turbo-tasks/src/debug/mod.rs
+++ b/turbopack/crates/turbo-tasks/src/debug/mod.rs
@@ -1,9 +1,9 @@
-use std::fmt::{Debug, Display};
+use std::{fmt::Debug, future::Future, pin::Pin};
 
 use auto_hash_map::{AutoMap, AutoSet};
 use smallvec::SmallVec;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{FxIndexMap, FxIndexSet, Vc};
+use turbo_tasks::{FxIndexMap, FxIndexSet};
 pub use turbo_tasks_macros::ValueDebugFormat;
 
 use crate::{self as turbo_tasks};
@@ -14,55 +14,26 @@ mod vdbg;
 
 use internal::PassthroughDebug;
 
-/// The return type of [`ValueDebug::dbg`].
-///
-/// We don't use [`Vc<RcStr>`][turbo_rcstr::RcStr] or [`String`] directly because we
-/// don't want the [`Debug`]/[`Display`] representations to be escaped.
-#[turbo_tasks::value]
-pub struct ValueDebugString(String);
-
-impl Debug for ValueDebugString {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.0)
-    }
-}
-
-impl Display for ValueDebugString {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.0)
-    }
-}
-
-impl ValueDebugString {
-    /// Returns the underlying string.
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-}
-
-impl ValueDebugString {
-    /// Create a new `ValueDebugString` from a string.
-    pub fn new(s: String) -> Vc<Self> {
-        ValueDebugString::cell(ValueDebugString(s))
-    }
-}
-
 /// [`Debug`]-like trait for [`Vc`] types, automatically derived when using
 /// [`macro@turbo_tasks::value`] and [`turbo_tasks::value_trait`].
 ///
 /// # Usage
 ///
 /// ```ignore
-/// dbg!(any_vc.dbg().await?);
+/// let trait_ref = any_vc.into_trait_ref().await?;
+/// println!("{}", trait_ref.dbg().await?);
 /// ```
 #[turbo_tasks::value_trait(no_debug)]
 pub trait ValueDebug {
-    #[turbo_tasks::function]
-    fn dbg(self: Vc<Self>) -> Vc<ValueDebugString>;
+    fn dbg(&self) -> Pin<Box<dyn Future<Output = anyhow::Result<String>> + Send + '_>> {
+        self.dbg_depth(usize::MAX)
+    }
 
     /// Like `dbg`, but with a depth limit.
-    #[turbo_tasks::function]
-    fn dbg_depth(self: Vc<Self>, depth: usize) -> Vc<ValueDebugString>;
+    fn dbg_depth(
+        &self,
+        depth: usize,
+    ) -> Pin<Box<dyn Future<Output = anyhow::Result<String>> + Send + '_>>;
 }
 
 /// Use [autoref specialization] to implement [`ValueDebug`] for `T: Debug`.
@@ -422,12 +393,5 @@ impl ValueDebugFormatString<'_> {
             ValueDebugFormatString::Sync(value) => value,
             ValueDebugFormatString::Async(future) => future.await?,
         })
-    }
-
-    /// Convert the `ValueDebugFormatString` into a `Vc<ValueDebugString>`.
-    ///
-    /// This can fail when resolving `Vc` types.
-    pub async fn try_to_value_debug_string(self) -> anyhow::Result<Vc<ValueDebugString>> {
-        Ok(ValueDebugString::new(self.try_to_string().await?))
     }
 }

--- a/turbopack/crates/turbo-tasks/src/macro_helpers.rs
+++ b/turbopack/crates/turbo-tasks/src/macro_helpers.rs
@@ -29,11 +29,8 @@ pub use crate::{
 
 #[inline(never)]
 pub async fn value_debug_format_field(value: ValueDebugFormatString<'_>) -> String {
-    match value.try_to_value_debug_string().await {
-        Ok(result) => match result.await {
-            Ok(result) => result.to_string(),
-            Err(err) => format!("{err:?}"),
-        },
+    match value.try_to_string().await {
+        Ok(result) => result,
         Err(err) => format!("{err:?}"),
     }
 }

--- a/turbopack/crates/turbo-tasks/src/vc/mod.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/mod.rs
@@ -482,10 +482,9 @@ where
 {
     fn value_debug_format(&self, depth: usize) -> ValueDebugFormatString<'_> {
         ValueDebugFormatString::Async(Box::pin(async move {
-            Ok({
-                let vc_value_debug = Vc::upcast::<Box<dyn ValueDebug>>(*self);
-                vc_value_debug.dbg_depth(depth).await?.to_string()
-            })
+            let vc_value_debug = Vc::upcast::<Box<dyn ValueDebug>>(*self);
+            let trait_ref = vc_value_debug.into_trait_ref().await?;
+            trait_ref.dbg_depth(depth).await
         }))
     }
 }


### PR DESCRIPTION
## What?

Simplify the `ValueDebug` trait in turbo-tasks by removing turbo-tasks function overhead from `dbg` and `dbg_depth`.

## Why?

Every `#[turbo_tasks::value]` and `#[turbo_tasks::value_trait]` type previously generated two `#[turbo_tasks::function]` implementations of `dbg` and `dbg_depth`. These are debugging utilities that are almost never called in production, but the turbo-tasks function machinery (task registration, vtable entries, `NativeFunction` statics, inline extension traits) was emitted for every type regardless — contributing to binary bloat.

## How?

- Change `dbg` and `dbg_depth` on the `ValueDebug` trait from `#[turbo_tasks::function]` methods to plain methods returning `Pin<Box<dyn Future<...>>>` (required for object safety without `async_trait`)
- Add a default `dbg` implementation on the trait itself that delegates to `dbg_depth(usize::MAX)`, so derived impls only need to implement `dbg_depth`
- Remove `ValueDebugString` wrapper type — callers now get a plain `String` back
- Callers use `vc.into_trait_ref().await?` then call `.dbg()` / `.dbg_depth()` directly on the trait ref
- Update the four macro locations that generate `ValueDebug` impls: `value_debug_macro.rs`, `value_macro.rs`, `primitive_macro.rs`, and the call site in `vc/mod.rs`
- `#[turbo_tasks::value_impl]` is kept on the generated `impl ValueDebug for T` blocks so that `Upcast`/`UpcastStrict` and `CollectableTraitCastFunctions` (needed for `into_trait_ref`) are still registered

## Binary size impact (darwin-arm64, compared against canary)

| Metric | Canary | This PR | Delta |
|---|---|---|---|
| Unstripped dylib | 128.6 MB | 124.6 MB | **-4.0 MB (-3.1%)** |
| Stripped | 87.2 MB | 84.7 MB | **-2.5 MB (-2.9%)** |
| Stripped + gzip (npm) | 29.6 MB | 29.2 MB | **-0.4 MB (-1.4%)** |

<!-- NEXT_JS_LLM_PR -->