### PR TITLE
Delete some dead turbo task functions

### DIFF
--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -1707,7 +1707,7 @@ impl Project {
     /// Emit a telemetry event corresponding to [webpack configuration telemetry](https://github.com/vercel/next.js/blob/9da305fe320b89ee2f8c3cfb7ecbf48856368913/packages/next/src/build/webpack-config.ts#L2516)
     /// to detect which feature is enabled.
     #[turbo_tasks::function]
-    async fn collect_project_feature_telemetry(self: Vc<Self>) -> Result<Vc<()>> {
+    async fn collect_project_feature_telemetry(self: Vc<Self>) -> Result<()> {
         let emit_event = |feature_name: &str, enabled: bool| {
             NextFeatureTelemetry::new(feature_name.into(), enabled)
                 .resolved_cell()
@@ -1778,7 +1778,7 @@ impl Project {
         emit_event("swcRemoveConsole", remove_console_enabled);
         emit_event("swcEmotion", emotion_enabled);
 
-        Ok(Default::default())
+        Ok(())
     }
 
     /// Scans the app/pages directories for entry points files (matching the

--- a/crates/next-api/src/versioned_content_map.rs
+++ b/crates/next-api/src/versioned_content_map.rs
@@ -5,7 +5,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
     FxIndexSet, NonLocalValue, OperationValue, OperationVc, ResolvedVc, State, TryFlatJoinIterExt,
-    TryJoinIterExt, ValueDefault, Vc, debug::ValueDebugFormat, trace::TraceRawVcs, turbobail,
+    TryJoinIterExt, Vc, debug::ValueDebugFormat, trace::TraceRawVcs, turbobail,
 };
 use turbo_tasks_fs::{FileContent, FileSystemPath};
 use turbopack_core::{
@@ -72,12 +72,6 @@ pub struct VersionedContentMap {
     // FxIndexSet<FileSystemPath>
     map_path_to_op: State<PathToOutputOperation>,
     map_op_to_compute_entry: State<OutputOperationToComputeEntry>,
-}
-
-impl ValueDefault for VersionedContentMap {
-    fn value_default() -> Vc<Self> {
-        *VersionedContentMap::new()
-    }
 }
 
 impl VersionedContentMap {

--- a/crates/next-core/src/next_app/metadata/image.rs
+++ b/crates/next-core/src/next_app/metadata/image.rs
@@ -228,5 +228,5 @@ async fn collect_direct_exports(module: Vc<Box<dyn Module>>) -> Result<Vc<Vec<Rc
         return Ok(Vc::cell(exports.exports.keys().cloned().collect()));
     }
 
-    Ok(Vc::cell(Vec::new()))
+    Ok(Default::default())
 }

--- a/turbopack/crates/turbo-tasks-fs/examples/hash_directory.rs
+++ b/turbopack/crates/turbo-tasks-fs/examples/hash_directory.rs
@@ -55,9 +55,9 @@ async fn main() -> Result<()> {
 }
 
 #[turbo_tasks::function]
-async fn print_hash(dir_hash: Vc<RcStr>) -> Result<Vc<()>> {
+async fn print_hash(dir_hash: Vc<RcStr>) -> Result<()> {
     println!("DIR HASH: {}", dir_hash.await?.as_str());
-    Ok(Default::default())
+    Ok(())
 }
 
 async fn filename(path: FileSystemPath) -> Result<String> {

--- a/turbopack/crates/turbo-tasks-fs/examples/hash_glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/examples/hash_glob.rs
@@ -63,9 +63,9 @@ pub fn empty_string() -> Vc<RcStr> {
 }
 
 #[turbo_tasks::function]
-async fn print_hash(dir_hash: Vc<RcStr>) -> Result<Vc<()>> {
+async fn print_hash(dir_hash: Vc<RcStr>) -> Result<()> {
     println!("DIR HASH: {}", dir_hash.await?.as_str());
-    Ok(Default::default())
+    Ok(())
 }
 
 #[turbo_tasks::function]

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -2724,14 +2724,10 @@ impl FileSystem for NullFileSystem {
     }
 
     #[turbo_tasks::function]
-    fn write(&self, _fs_path: FileSystemPath, _content: Vc<FileContent>) -> Vc<()> {
-        Vc::default()
-    }
+    fn write(&self, _fs_path: FileSystemPath, _content: Vc<FileContent>) {}
 
     #[turbo_tasks::function]
-    fn write_link(&self, _fs_path: FileSystemPath, _target: Vc<LinkContent>) -> Vc<()> {
-        Vc::default()
-    }
+    fn write_link(&self, _fs_path: FileSystemPath, _target: Vc<LinkContent>) {}
 
     #[turbo_tasks::function]
     fn metadata(&self, _fs_path: FileSystemPath) -> Vc<FileMeta> {

--- a/turbopack/crates/turbo-tasks-fs/src/virtual_fs.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/virtual_fs.rs
@@ -1,6 +1,6 @@
 use anyhow::{Result, bail};
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{ValueDefault, ValueToString, Vc};
+use turbo_tasks::{ValueToString, Vc};
 
 use crate::{FileContent, FileMeta, FileSystem, FileSystemPath, LinkContent, RawDirectoryContent};
 
@@ -36,12 +36,6 @@ impl VirtualFileSystem {
     /// [`Vc<VirtualFileSystem>`].
     pub fn new_with_name(name: RcStr) -> Vc<Self> {
         Self::cell(VirtualFileSystem { name })
-    }
-}
-
-impl ValueDefault for VirtualFileSystem {
-    fn value_default() -> Vc<Self> {
-        Self::new()
     }
 }
 

--- a/turbopack/crates/turbopack-browser/src/ecmascript/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/chunk.rs
@@ -128,11 +128,6 @@ impl OutputAsset for EcmascriptBrowserChunk {
             .chunking_context
             .chunk_path(Some(Vc::upcast(self)), ident, None, rcstr!(".js")))
     }
-
-    #[turbo_tasks::function]
-    fn size_bytes(self: Vc<Self>) -> Vc<Option<u64>> {
-        self.own_content().content().len()
-    }
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -196,7 +196,7 @@ async fn build_internal(
     minify_type: MinifyType,
     target: Target,
     scope_hoist: bool,
-) -> Result<Vc<()>> {
+) -> Result<()> {
     let output_fs = output_fs(project_dir.clone());
     const OUTPUT_DIR: &str = "dist";
     let project_relative = project_dir.strip_prefix(&*root_dir).unwrap();
@@ -518,7 +518,7 @@ async fn build_internal(
         .try_join()
         .await?;
 
-    Ok(Default::default())
+    Ok(())
 }
 
 pub async fn build(args: &BuildArguments) -> Result<()> {

--- a/turbopack/crates/turbopack-core/src/environment.rs
+++ b/turbopack/crates/turbopack-core/src/environment.rs
@@ -113,7 +113,7 @@ impl Environment {
             // browserslist correctly because CSS Modules in client components is double-processed,
             // once for server once for browser.
             {
-                Vc::cell(rcstr!(""))
+                Vc::default()
             }
             ExecutionEnvironment::Browser(browser_env) => {
                 Vc::cell(browser_env.await?.browserslist_query.clone())

--- a/turbopack/crates/turbopack-core/src/output.rs
+++ b/turbopack/crates/turbopack-core/src/output.rs
@@ -43,11 +43,6 @@ pub trait OutputAsset: Asset + OutputAssetsReference {
     fn path_string(self: Vc<Self>) -> Vc<RcStr> {
         self.path().to_string()
     }
-
-    #[turbo_tasks::function]
-    fn size_bytes(self: Vc<Self>) -> Vc<Option<u64>> {
-        Vc::cell(None)
-    }
 }
 
 #[turbo_tasks::value(transparent)]

--- a/turbopack/crates/turbopack-dev-server/src/source/mod.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/mod.rs
@@ -18,8 +18,8 @@ use bincode::{Decode, Encode};
 use futures::{TryStreamExt, stream::Stream as StreamTrait};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    Completion, NonLocalValue, OperationVc, ResolvedVc, TaskInput, Upcast, ValueDefault, Vc,
-    trace::TraceRawVcs, util::SharedError,
+    Completion, NonLocalValue, OperationVc, ResolvedVc, TaskInput, Upcast, Vc, trace::TraceRawVcs,
+    util::SharedError,
 };
 use turbo_tasks_bytes::{Bytes, Stream, StreamRead};
 use turbo_tasks_fs::FileSystemPath;
@@ -230,12 +230,6 @@ impl Body {
 impl<T: Into<Bytes>> From<T> for Body {
     fn from(value: T) -> Self {
         Body::new(vec![Ok(value.into())])
-    }
-}
-
-impl ValueDefault for Body {
-    fn value_default() -> Vc<Self> {
-        Body::default().cell()
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript-plugins/src/transform/emotion.rs
+++ b/turbopack/crates/turbopack-ecmascript-plugins/src/transform/emotion.rs
@@ -84,20 +84,6 @@ pub struct EmotionTransformConfig {
     pub import_map: Option<IndexMap<RcStr, EmotionImportMapValue, FxBuildHasher>>,
 }
 
-#[turbo_tasks::value_impl]
-impl EmotionTransformConfig {
-    #[turbo_tasks::function]
-    pub fn default_private() -> Vc<Self> {
-        Self::cell(Default::default())
-    }
-}
-
-impl ValueDefault for EmotionTransformConfig {
-    fn value_default() -> Vc<Self> {
-        EmotionTransformConfig::default_private()
-    }
-}
-
 #[derive(Debug)]
 pub struct EmotionTransformer {
     #[cfg(feature = "transform_emotion")]

--- a/turbopack/crates/turbopack-ecmascript-plugins/src/transform/styled_components.rs
+++ b/turbopack/crates/turbopack-ecmascript-plugins/src/transform/styled_components.rs
@@ -2,7 +2,6 @@ use anyhow::Result;
 use async_trait::async_trait;
 use serde::Deserialize;
 use swc_core::{atoms::Wtf8Atom, common::comments::NoopComments, ecma::ast::Program};
-use turbo_tasks::{ValueDefault, Vc};
 use turbopack_ecmascript::{CustomTransformer, TransformContext};
 
 #[turbo_tasks::value(shared, operation)]
@@ -29,20 +28,6 @@ impl Default for StyledComponentsTransformConfig {
             css_prop: true,
             namespace: None,
         }
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl StyledComponentsTransformConfig {
-    #[turbo_tasks::function]
-    fn default_private() -> Vc<Self> {
-        Self::cell(Default::default())
-    }
-}
-
-impl ValueDefault for StyledComponentsTransformConfig {
-    fn value_default() -> Vc<Self> {
-        StyledComponentsTransformConfig::default_private()
     }
 }
 

--- a/turbopack/crates/turbopack-mdx/src/lib.rs
+++ b/turbopack/crates/turbopack-mdx/src/lib.rs
@@ -7,7 +7,7 @@ use async_trait::async_trait;
 use mdxjs::{MdxParseOptions, Options, compile};
 use serde::Deserialize;
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{ResolvedVc, ValueDefault, Vc};
+use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::{File, FileContent, FileSystemPath, rope::Rope};
 use turbopack_core::{
     asset::{Asset, AssetContent},
@@ -56,20 +56,6 @@ impl Default for MdxTransformOptions {
             provider_import_source: None,
             mdx_type: Some(MdxParseConstructs::Commonmark),
         }
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl MdxTransformOptions {
-    #[turbo_tasks::function]
-    fn default_private() -> Vc<Self> {
-        Self::cell(Default::default())
-    }
-}
-
-impl ValueDefault for MdxTransformOptions {
-    fn value_default() -> Vc<Self> {
-        Self::default_private()
     }
 }
 

--- a/turbopack/crates/turbopack-node/src/evaluate.rs
+++ b/turbopack/crates/turbopack-node/src/evaluate.rs
@@ -9,9 +9,9 @@ use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use serde_json::Value as JsonValue;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
-    Completion, FxIndexMap, NonLocalValue, OperationVc, PrettyPrintError, ReadRef, ResolvedVc,
-    TaskInput, TryJoinIterExt, ValueToString, Vc, duration_span, fxindexmap,
-    mark_session_dependent, mark_top_level_task, take_effects, trace::TraceRawVcs,
+    Completion, FxIndexMap, NonLocalValue, OperationVc, PrettyPrintError, ResolvedVc, TaskInput,
+    TryJoinIterExt, ValueToString, Vc, duration_span, fxindexmap, mark_session_dependent,
+    mark_top_level_task, take_effects, trace::TraceRawVcs,
 };
 use turbo_tasks_env::{EnvMap, ProcessEnv};
 use turbo_tasks_fs::{File, FileContent, FileSystemPath, to_sys_path};
@@ -176,11 +176,6 @@ async fn emit_evaluate_pool_assets_operation(
         entrypoint: entrypoint.clone(),
     }
     .cell())
-}
-
-#[turbo_tasks::value(serialization = "none")]
-struct EmittedEvaluatePoolAssetsWithEffects {
-    assets: ReadRef<EmittedEvaluatePoolAssets>,
 }
 
 #[turbo_tasks::function(operation)]

--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -633,7 +633,7 @@ async fn run_test_operation(prepared_test: ResolvedVc<PreparedTest>) -> Result<V
 async fn snapshot_issues(
     prepared_test: Vc<PreparedTest>,
     run_result_op: OperationVc<RunTestResult>,
-) -> Result<Vc<()>> {
+) -> Result<()> {
     let PreparedTest { path, .. } = &*prepared_test.await?;
     let _ = run_result_op.resolve().strongly_consistent().await;
 
@@ -646,5 +646,5 @@ async fn snapshot_issues(
         .await
         .context("Unable to handle issues")?;
 
-    Ok(Default::default())
+    Ok(())
 }

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -1225,11 +1225,11 @@ pub async fn emit_assets_into_dir(
 pub async fn emit_assets_into_dir_operation(
     assets: ResolvedVc<ExpandedOutputAssets>,
     output_dir: FileSystemPath,
-) -> Result<Vc<()>> {
+) -> Result<()> {
     emit_assets_into_dir(*assets, output_dir)
         .as_side_effect()
         .await?;
-    Ok(Vc::cell(()))
+    Ok(())
 }
 
 /// Replaces the externals in the result with `ExternalModuleAsset` instances.

--- a/turbopack/crates/turbopack/src/module_options/module_options_context.rs
+++ b/turbopack/crates/turbopack/src/module_options/module_options_context.rs
@@ -174,14 +174,6 @@ pub struct DecoratorsOptions {
     pub use_define_for_class_fields: bool,
 }
 
-#[turbo_tasks::value_impl]
-impl ValueDefault for DecoratorsOptions {
-    #[turbo_tasks::function]
-    fn value_default() -> Vc<Self> {
-        Self::default().cell()
-    }
-}
-
 /// Subset of Typescript options configured via tsconfig.json or jsconfig.json,
 /// which affects the runtime transform output.
 #[turbo_tasks::value(shared)]
@@ -189,14 +181,6 @@ impl ValueDefault for DecoratorsOptions {
 pub struct TypescriptTransformOptions {
     pub use_define_for_class_fields: bool,
     pub verbatim_module_syntax: bool,
-}
-
-#[turbo_tasks::value_impl]
-impl ValueDefault for TypescriptTransformOptions {
-    #[turbo_tasks::function]
-    fn value_default() -> Vc<Self> {
-        Self::default().cell()
-    }
 }
 
 #[turbo_tasks::value(shared)]


### PR DESCRIPTION
Removes a handful of dead code discovered while exploring deletion of the `ValueDefault` trait. That larger change turned out not to be worth it from a binary size perspective, so it was backed out — but the dead code found along the way is worth keeping.

**Removed:**
- `impl ValueDefault for VersionedContentMap` (not tagged with `#[turbo_tasks::value_impl]`, never a turbo-tasks singleton)
- `impl ValueDefault for Body` in `turbopack-dev-server` (same — plain Rust impl, no callers via `Vc::default()`)
- `EmotionTransformConfig::default_private()` and `impl ValueDefault for EmotionTransformConfig` (unused)
- `StyledComponentsTransformConfig::default_private()` and `impl ValueDefault for StyledComponentsTransformConfig` (unused)
- `EmittedEvaluatePoolAssetsWithEffects` struct in `evaluate.rs` (defined but never referenced)
- `OutputAsset::size_bytes()` default trait method (no call sites)

<!-- NEXT_JS_LLM_PR -->