### PR TITLE
fix(eslint-plugin-next): respect pageExtensions in no-html-link-for-pages rule

### DIFF
--- a/errors/no-html-link-for-pages.mdx
+++ b/errors/no-html-link-for-pages.mdx
@@ -60,6 +60,22 @@ In some cases, you may also need to configure this rule directly by providing a 
 }
 ```
 
+#### `pageExtensions`
+
+By default, this rule considers files with `.js`, `.jsx`, `.ts`, and `.tsx` extensions as pages. If you have customized [`pageExtensions`](/docs/pages/api-reference/config/next-config-js/pageExtensions) in `next.config.js` (for example, to support `.md` or `.mdx` pages), you can pass the same list to the rule so that it recognizes those files as pages.
+
+```json filename="eslint.config.json"
+{
+  "rules": {
+    "@next/next/no-html-link-for-pages": [
+      "error",
+      "packages/my-app/pages/",
+      { "pageExtensions": ["ts", "tsx", "md", "mdx"] }
+    ]
+  }
+}
+```
+
 ## Useful Links
 
 - [next/link API Reference](/docs/pages/api-reference/components/link)

--- a/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
+++ b/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
@@ -62,6 +62,19 @@ export default defineRule({
           },
         ],
       },
+      {
+        type: 'object',
+        properties: {
+          pageExtensions: {
+            type: 'array',
+            uniqueItems: true,
+            items: {
+              type: 'string',
+            },
+          },
+        },
+        additionalProperties: false,
+      },
     ],
   },
 
@@ -69,8 +82,16 @@ export default defineRule({
    * Creates an ESLint rule listener.
    */
   create(context) {
-    const ruleOptions: (string | string[])[] = context.options
-    const [customPagesDirectory] = ruleOptions
+    const ruleOptions: (string | string[] | { pageExtensions?: string[] })[] =
+      context.options
+    const [customPagesDirectory, secondOption] = ruleOptions
+
+    const pageExtensions =
+      (secondOption &&
+        typeof secondOption === 'object' &&
+        !Array.isArray(secondOption) &&
+        secondOption.pageExtensions) ||
+      undefined
 
     const rootDirs = getRootDirs(context)
 
@@ -107,8 +128,16 @@ export default defineRule({
       return {}
     }
 
-    const pageUrls = cachedGetUrlFromPagesDirectories('/', foundPagesDirs)
-    const appDirUrls = cachedGetUrlFromAppDirectory('/', foundAppDirs)
+    const pageUrls = cachedGetUrlFromPagesDirectories(
+      '/',
+      foundPagesDirs,
+      pageExtensions
+    )
+    const appDirUrls = cachedGetUrlFromAppDirectory(
+      '/',
+      foundAppDirs,
+      pageExtensions
+    )
     const allUrlRegex = [...pageUrls, ...appDirUrls]
 
     return {

--- a/packages/eslint-plugin-next/src/utils/url.ts
+++ b/packages/eslint-plugin-next/src/utils/url.ts
@@ -5,28 +5,56 @@ import * as fs from 'fs'
 // Prevent multiple blocking IO requests that have already been calculated.
 const fsReadDirSyncCache = {}
 
+// Default page extensions used by Next.js when `pageExtensions` is not
+// configured in next.config.js. Kept in sync with the default
+// `pageExtensions` value in the Next.js core.
+const DEFAULT_PAGE_EXTENSIONS = ['tsx', 'ts', 'jsx', 'js']
+
+function escapeRegex(str: string) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+/**
+ * Build a RegExp that matches any file name ending with one of the provided
+ * page extensions, e.g. for `['tsx','ts','jsx','js']` => `/\.(tsx|ts|jsx|js)$/`.
+ */
+function buildExtensionRegex(pageExtensions: string[]) {
+  const exts = (pageExtensions.length ? pageExtensions : DEFAULT_PAGE_EXTENSIONS)
+    .map((ext) => escapeRegex(ext.replace(/^\./, '')))
+    .join('|')
+  return new RegExp(`\\.(${exts})$`)
+}
+
 /**
  * Recursively parse directory for page URLs.
  */
-function parseUrlForPages(urlprefix: string, directory: string) {
+function parseUrlForPages(
+  urlprefix: string,
+  directory: string,
+  pageExtensions: string[] = DEFAULT_PAGE_EXTENSIONS
+) {
   fsReadDirSyncCache[directory] ??= fs.readdirSync(directory, {
     withFileTypes: true,
   })
+  const extensionRegex = buildExtensionRegex(pageExtensions)
+  const indexRegex = new RegExp(`^index${extensionRegex.source}`)
   const res = []
   fsReadDirSyncCache[directory].forEach((dirent) => {
-    // TODO: this should account for all page extensions
-    // not just js(x) and ts(x)
-    if (/(\.(j|t)sx?)$/.test(dirent.name)) {
-      if (/^index(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(
-          `${urlprefix}${dirent.name.replace(/^index(\.(j|t)sx?)$/, '')}`
-        )
+    if (extensionRegex.test(dirent.name)) {
+      if (indexRegex.test(dirent.name)) {
+        res.push(`${urlprefix}${dirent.name.replace(indexRegex, '')}`)
       }
-      res.push(`${urlprefix}${dirent.name.replace(/(\.(j|t)sx?)$/, '')}`)
+      res.push(`${urlprefix}${dirent.name.replace(extensionRegex, '')}`)
     } else {
       const dirPath = path.join(directory, dirent.name)
       if (dirent.isDirectory() && !dirent.isSymbolicLink()) {
-        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath))
+        res.push(
+          ...parseUrlForPages(
+            urlprefix + dirent.name + '/',
+            dirPath,
+            pageExtensions
+          )
+        )
       }
     }
   })
@@ -36,24 +64,35 @@ function parseUrlForPages(urlprefix: string, directory: string) {
 /**
  * Recursively parse app directory for URLs.
  */
-function parseUrlForAppDir(urlprefix: string, directory: string) {
+function parseUrlForAppDir(
+  urlprefix: string,
+  directory: string,
+  pageExtensions: string[] = DEFAULT_PAGE_EXTENSIONS
+) {
   fsReadDirSyncCache[directory] ??= fs.readdirSync(directory, {
     withFileTypes: true,
   })
+  const extensionRegex = buildExtensionRegex(pageExtensions)
+  const pageRegex = new RegExp(`^page${extensionRegex.source}`)
+  const layoutRegex = new RegExp(`^layout${extensionRegex.source}`)
   const res = []
   fsReadDirSyncCache[directory].forEach((dirent) => {
-    // TODO: this should account for all page extensions
-    // not just js(x) and ts(x)
-    if (/(\.(j|t)sx?)$/.test(dirent.name)) {
-      if (/^page(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(`${urlprefix}${dirent.name.replace(/^page(\.(j|t)sx?)$/, '')}`)
-      } else if (!/^layout(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(`${urlprefix}${dirent.name.replace(/(\.(j|t)sx?)$/, '')}`)
+    if (extensionRegex.test(dirent.name)) {
+      if (pageRegex.test(dirent.name)) {
+        res.push(`${urlprefix}${dirent.name.replace(pageRegex, '')}`)
+      } else if (!layoutRegex.test(dirent.name)) {
+        res.push(`${urlprefix}${dirent.name.replace(extensionRegex, '')}`)
       }
     } else {
       const dirPath = path.join(directory, dirent.name)
       if (dirent.isDirectory(dirPath) && !dirent.isSymbolicLink()) {
-        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath))
+        res.push(
+          ...parseUrlForPages(
+            urlprefix + dirent.name + '/',
+            dirPath,
+            pageExtensions
+          )
+        )
       }
     }
   })
@@ -136,13 +175,16 @@ export function normalizeAppPath(route: string) {
  */
 export function getUrlFromPagesDirectories(
   urlPrefix: string,
-  directories: string[]
+  directories: string[],
+  pageExtensions: string[] = DEFAULT_PAGE_EXTENSIONS
 ) {
   return Array.from(
     // De-duplicate similar pages across multiple directories.
     new Set(
       directories
-        .flatMap((directory) => parseUrlForPages(urlPrefix, directory))
+        .flatMap((directory) =>
+          parseUrlForPages(urlPrefix, directory, pageExtensions)
+        )
         .map(
           // Since the URLs are normalized we add `^` and `$` to the RegExp to make sure they match exactly.
           (url) => `^${normalizeURL(url)}$`
@@ -156,13 +198,16 @@ export function getUrlFromPagesDirectories(
 
 export function getUrlFromAppDirectory(
   urlPrefix: string,
-  directories: string[]
+  directories: string[],
+  pageExtensions: string[] = DEFAULT_PAGE_EXTENSIONS
 ) {
   return Array.from(
     // De-duplicate similar pages across multiple directories.
     new Set(
       directories
-        .map((directory) => parseUrlForAppDir(urlPrefix, directory))
+        .map((directory) =>
+          parseUrlForAppDir(urlPrefix, directory, pageExtensions)
+        )
         .flat()
         .map(
           // Since the URLs are normalized we add `^` and `$` to the RegExp to make sure they match exactly.


### PR DESCRIPTION
### What?

Makes the `no-html-link-for-pages` ESLint rule respect a custom `pageExtensions` configuration.

### Why?

Fixes #53473.

Previously, the rule hardcoded `.js`, `.jsx`, `.ts`, and `.tsx` as the recognized page extensions when scanning the `pages` and `app` directories. Projects that customize [`pageExtensions`](https://nextjs.org/docs/pages/api-reference/config/next-config-js/pageExtensions) in `next.config.js` (for example, to use `.md`/`.mdx` or to narrow the set of extensions) would get false negatives — valid internal pages were not detected, so `<a>` links pointing to them were not flagged.

The two `TODO` comments in `packages/eslint-plugin-next/src/utils/url.ts` called this out explicitly:

```ts
// TODO: this should account for all page extensions
// not just js(x) and ts(x)
```

### How?

- Added an optional second argument (`pageExtensions`) to `getUrlFromPagesDirectories` and `getUrlFromAppDirectory`, defaulting to `['tsx','ts','jsx','js']` to preserve existing behavior.
- `parseUrlForPages` and `parseUrlForAppDir` now build their match regex from that list instead of a hardcoded pattern.
- Extended the `no-html-link-for-pages` rule schema to accept a second options object with a `pageExtensions` array, and threaded it through to the URL helpers.
- Updated `errors/no-html-link-for-pages.mdx` with a short `pageExtensions` section and example config.

### Usage

```json
{
  "rules": {
    "@next/next/no-html-link-for-pages": [
      "error",
      "packages/my-app/pages/",
      { "pageExtensions": ["ts", "tsx", "md", "mdx"] }
    ]
  }
}
```

The change is fully backwards compatible — projects not passing `pageExtensions` get the same default behavior as before.

Fixes #53473