### PR TITLE
Flag dev static indicator as Dynamic when route reads searchParams

### DIFF
--- a/packages/next/src/server/request/search-params.ts
+++ b/packages/next/src/server/request/search-params.ts
@@ -13,6 +13,7 @@ import {
   throwToInterruptStaticGeneration,
   postponeWithTracking,
   annotateDynamicAccess,
+  trackDynamicDataInDynamicRender,
 } from '../app-render/dynamic-rendering'
 
 import {
@@ -517,6 +518,7 @@ function makeUntrackedSearchParamsWithDevWarningsImpl(
   const proxiedUnderlying = instrumentSearchParamsObjectWithDevWarnings(
     underlyingSearchParams,
     workStore,
+    requestStore,
     promiseInitialized
   )
 
@@ -558,7 +560,8 @@ function makeUntrackedSearchParamsWithDevWarningsImpl(
   return instrumentSearchParamsPromiseWithDevWarnings(
     underlyingSearchParams,
     promise,
-    workStore
+    workStore,
+    requestStore
   )
 }
 
@@ -567,6 +570,7 @@ function ignoreReject() {}
 function instrumentSearchParamsObjectWithDevWarnings(
   underlyingSearchParams: SearchParams,
   workStore: WorkStore,
+  requestStore: RequestStore,
   promiseInitialized: { current: boolean }
 ) {
   // We have an unfortunate sequence of events that requires this initialization logic. We want to instrument the underlying
@@ -578,6 +582,11 @@ function instrumentSearchParamsObjectWithDevWarnings(
   return new Proxy(underlyingSearchParams, {
     get(target, prop, receiver) {
       if (typeof prop === 'string' && promiseInitialized.current) {
+        // Reading a property off the resolved searchParams object means the
+        // route is consuming dynamic data. Flag the request so the dev
+        // static indicator reports "Dynamic".
+        trackDynamicDataInDynamicRender(requestStore)
+
         if (workStore.dynamicShouldError) {
           const expression = describeStringPropertyAccess('searchParams', prop)
           throwWithStaticGenerationBailoutErrorWithDynamicError(
@@ -590,6 +599,9 @@ function instrumentSearchParamsObjectWithDevWarnings(
     },
     has(target, prop) {
       if (typeof prop === 'string') {
+        if (promiseInitialized.current) {
+          trackDynamicDataInDynamicRender(requestStore)
+        }
         if (workStore.dynamicShouldError) {
           const expression = describeHasCheckingStringProperty(
             'searchParams',
@@ -604,6 +616,9 @@ function instrumentSearchParamsObjectWithDevWarnings(
       return Reflect.has(target, prop)
     },
     ownKeys(target) {
+      if (promiseInitialized.current) {
+        trackDynamicDataInDynamicRender(requestStore)
+      }
       if (workStore.dynamicShouldError) {
         const expression =
           '`{...searchParams}`, `Object.keys(searchParams)`, or similar'
@@ -620,7 +635,8 @@ function instrumentSearchParamsObjectWithDevWarnings(
 function instrumentSearchParamsPromiseWithDevWarnings(
   underlyingSearchParams: SearchParams,
   promise: Promise<SearchParams>,
-  workStore: WorkStore
+  workStore: WorkStore,
+  requestStore: RequestStore
 ) {
   // Track which properties we should warn for.
   const proxiedProperties = new Set<string>()
@@ -651,6 +667,11 @@ function instrumentSearchParamsPromiseWithDevWarnings(
             // the underlying searchParams.
             Reflect.has(target, prop) === false)
         ) {
+          // Synchronous access is a usage bug, but it still indicates the
+          // route is consuming dynamic data — track it so the static
+          // indicator reports correctly.
+          trackDynamicDataInDynamicRender(requestStore)
+
           const expression = describeStringPropertyAccess('searchParams', prop)
           warnForSyncAccess(workStore.route, expression)
         }
@@ -672,6 +693,8 @@ function instrumentSearchParamsPromiseWithDevWarnings(
             // the underlying searchParams.
             Reflect.has(target, prop) === false)
         ) {
+          trackDynamicDataInDynamicRender(requestStore)
+
           const expression = describeHasCheckingStringProperty(
             'searchParams',
             prop
@@ -682,6 +705,8 @@ function instrumentSearchParamsPromiseWithDevWarnings(
       return Reflect.has(target, prop)
     },
     ownKeys(target) {
+      trackDynamicDataInDynamicRender(requestStore)
+
       const expression = '`Object.keys(searchParams)` or similar'
       warnForSyncAccess(workStore.route, expression)
       return Reflect.ownKeys(target)

--- a/test/development/app-dir/dev-indicator/app/search-params/page.tsx
+++ b/test/development/app-dir/dev-indicator/app/search-params/page.tsx
@@ -1,0 +1,8 @@
+export default async function Page({
+  searchParams,
+}: {
+  searchParams: Promise<{ a?: string }>
+}) {
+  const sp = await searchParams
+  return <p>sp: {sp.a ?? 'none'}</p>
+}

--- a/test/development/app-dir/dev-indicator/route-type.test.ts
+++ b/test/development/app-dir/dev-indicator/route-type.test.ts
@@ -52,4 +52,10 @@ describe('app dir dev indicator - route type', () => {
 
     await waitForStaticIndicator(browser, 'Dynamic')
   })
+
+  it('should have route type as dynamic when page awaits searchParams', async () => {
+    const browser = await next.browser('/search-params')
+
+    await waitForStaticIndicator(browser, 'Dynamic')
+  })
 })


### PR DESCRIPTION
### What?

Fixes the dev static indicator reporting a route as **Static** when the page reads `searchParams`. It now correctly reports **Dynamic**, matching how the same route is treated at build time.

### Why?

`searchParams` is a dynamic API in the app router — awaiting it (or accessing a property on the resolved value) forces the route to render dynamically. However, `createRenderSearchParams` in dev did not update `requestStore.usedDynamic`, so the dev indicator — which derives its state from `isStatic = !usedDynamic && !forceDynamic` in `app-render.tsx` — showed **Static** even though `next build` correctly marked the same route dynamic. This caused confusing dev/build drift for users of `searchParams`.

### How?

`cookies()` and `headers()` already flip `usedDynamic` via `trackDynamicDataInDynamicRender()` at their call site. `searchParams` can't do the same at its creation site because `createServerSearchParamsForServerPage` runs for *every* server component page, whether the page uses searchParams or not — tracking there would over-report every page as dynamic.

Instead, the dev proxy traps in `makeUntrackedSearchParamsWithDevWarnings` now call `trackDynamicDataInDynamicRender(requestStore)`:

- On the **resolved-object proxy** (`instrumentSearchParamsObjectWithDevWarnings`): any `get` / `has` / `ownKeys` access that occurs *after* `promiseInitialized.current === true`. This is the path that fires only when user code does `const sp = await searchParams; sp.a` (or similar), so framework probes are excluded.
- On the **promise proxy** (`instrumentSearchParamsPromiseWithDevWarnings`): sync misuse paths (property / `in` / `Object.keys` on the promise itself without awaiting). Left the `.then` trap alone to avoid counting framework internals as dynamic access.

`trackDynamicDataInDynamicRender` is already a no-op in production, so the change is dev-indicator-only at runtime.

### Test plan

Added a new `search-params/page.tsx` fixture plus a test case to `test/development/app-dir/dev-indicator/route-type.test.ts` that reproduces the original bug (reported as Static on canary without the fix). The existing static / force-dynamic / headers cases in the same suite still pass, confirming no over-reporting.

Also ran the adjacent suites that exercise searchParams behavior to catch regressions:

- `test/development/app-dir/async-request-warnings/async-request-warnings.test.ts` — 7/7 pass (includes sync searchParams access warning).
- `test/e2e/app-dir/searchparams-static-bailout/searchparams-static-bailout.test.ts` — 5/5 pass (covers both server and client component searchParams).

Fixes #72133