### PR TITLE
Turbopack: cut number of client references in half

### DIFF
--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
@@ -241,11 +241,13 @@ impl Module for EcmascriptClientReferenceModule {
 
         Ok(Vc::cell(references))
     }
+
     #[turbo_tasks::function]
     fn side_effects(self: Vc<Self>) -> Vc<ModuleSideEffects> {
-        // These just re-export some specially tagged functions, however we do assume that client
-        // references are executed client side so we need to preserve these in the graph.
-        ModuleSideEffects::SideEffectful.cell()
+        // These just re-export some specially tagged functions. The module itself doesn't have any
+        // side effects, and the functions it re-exports will be marked as having side effects on
+        // the client if needed.
+        ModuleSideEffects::SideEffectFree.cell()
     }
 }
 


### PR DESCRIPTION
Currently, every client reference exists twice, but one of them is always dead code.

This shouldn't have an impact on the responses sent to the browser, but the server code is smaller. Doesn't have a measureable impact on cold build time.

For one page, this shrank page_client-reference-manifest.js from 979k to 742k

```js
"[project]/app/[slug]/counter-2.js [app-rsc] (client reference proxy) <module evaluation>", ((__turbopack_context__) => {
"use strict";

// UNUSED
__turbopack_context__.s(["default",()=>__TURBOPACK__default__export__]);
var reactDom = __turbopack_context__.i("react-server-dom-turbopack-server.js [app-rsc] (ecmascript)");
const __TURBOPACK__default__export__ = (0, reactDom["registerClientReference"])(function() {
    throw new Error("Attempted to call the default export of [project]/app/[slug]/counter-2.js <module evaluation> from the server, but it's on the client. It's not possible to invoke a client function from the server, it can only be rendered as a Component or passed to props of a Client Component.");
}, "[project]/app/[slug]/counter-2.js <module evaluation>", "default");

}),
"[project]/app/[slug]/counter-2.js [app-rsc] (client reference proxy)", ((__turbopack_context__) => {
"use strict";

__turbopack_context__.s(["default",()=>__TURBOPACK__default__export__]);
var reactDom = __turbopack_context__.i("react-server-dom-turbopack-server.js [app-rsc] (ecmascript)");
const __TURBOPACK__default__export__ = (0, reactDom["registerClientReference"])(function() {
    throw new Error("Attempted to call the default export of [project]/app/[slug]/counter-2.js from the server, but it's on the client. It's not possible to invoke a client function from the server, it can only be rendered as a Component or passed to props of a Client Component.");
}, "[project]/app/[slug]/counter-2.js", "default");

}),
"[project]/app/[slug]/counter-2.js [app-rsc] (ecmascript)", ((__turbopack_context__) => {
"use strict";


// UNUSED:
var client__reference__proxy$29$__$3c$module__evaluation$3e$__ = __turbopack_context__.i("[project]/app/[slug]/counter-2.js [app-rsc] (client reference proxy) <module evaluation>");
// Only this is exported
var client__reference__proxy$29$__ = __turbopack_context__.i("[project]/app/[slug]/counter-2.js [app-rsc] (client reference proxy)");
;
__turbopack_context__.n(client__reference__proxy$29$__);
}),

"[project]/app/[slug]/page.js [app-rsc] (ecmascript)", ((__turbopack_context__) => {

var counter = __turbopack_context__.i("[project]/app/[slug]/counter-1.js [app-rsc] (ecmascript)");

```
and also twice in the manifest
```js
    '[project]/bench/client-refs/app/[slug]/counter-1.js <module evaluation>': {
      id: '[project]/bench/client-refs/app/[slug]/counter-1.js [app-client] (ecmascript)',
      name: '*',
      chunks: [
        '/_next/static/chunks/2li6a5uw43ak2.js',
        '/_next/static/chunks/08svqy8591o8a.js',
      ],
      async: false,
    },
    '[project]/bench/client-refs/app/[slug]/counter-1.js': {
      id: '[project]/bench/client-refs/app/[slug]/counter-1.js [app-client] (ecmascript)',
      name: '*',
      chunks: [
        '/_next/static/chunks/2li6a5uw43ak2.js',
        '/_next/static/chunks/08svqy8591o8a.js',
      ],
      async: false,
    },
```