### PR TITLE
Fix segment explorer file pill accessibility

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.css
+++ b/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.css
@@ -91,6 +91,13 @@
   font-weight: 500;
   background-color: var(--color-gray-300);
   color: var(--color-gray-1000);
+  cursor: pointer;
+  text-align: center;
+}
+
+.segment-explorer-file-label:focus-visible {
+  outline: var(--focus-ring);
+  outline-offset: 2px;
 }
 .segment-explorer-file-label-text {
   display: inline-flex;
@@ -123,7 +130,6 @@
   color: var(--color-gray-900);
   border: 1px dashed var(--color-gray-500);
   height: 24px;
-  cursor: default;
 }
 .segment-explorer-file-label--builtin svg {
   margin-left: 4px;

--- a/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/overview/segment-explorer.tsx
@@ -113,20 +113,26 @@ function FilePill({
   fileName: string
 }) {
   return (
-    <span
+    <button
+      type="button"
       className={cx(
         'segment-explorer-file-label',
         `segment-explorer-file-label--${type}`,
         isBuiltin && 'segment-explorer-file-label--builtin',
         isOverridden && 'segment-explorer-file-label--overridden'
       )}
+      aria-label={`Open ${fileName} in editor`}
       onClick={() => {
         openInEditor({ filePath })
       }}
     >
       <span className="segment-explorer-file-label-text">{fileName}</span>
-      {isBuiltin ? <InfoIcon /> : <CodeIcon className="code-icon" />}
-    </span>
+      {isBuiltin ? (
+        <InfoIcon aria-hidden />
+      ) : (
+        <CodeIcon className="code-icon" aria-hidden />
+      )}
+    </button>
   )
 }
 


### PR DESCRIPTION
### What?

Make the segment explorer file pills keyboard-accessible by rendering them as buttons and preserving their pill styling.

### Why?

The pills launch files in the editor, but they were rendered as clickable spans, so they were not exposed as interactive controls for keyboard and assistive technology users.

### How?

- replace the clickable span with a button element
- add an accessible label and hide decorative icons from assistive technology
- add pointer and focus-visible styles so the control remains recognizable and keyboard accessible

Closes NEXT-
Fixes #

<!-- NEXT_JS_LLM_PR -->