### PR TITLE
Bump @datadog/datadog-ci to 5.12.1

### DIFF
--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -354,7 +354,7 @@ jobs:
           # Add a `test.type` tag to distinguish between turbopack and next.js runs
           # Add a `nextjs.test_session.name` tag to help identify the job
           if [ -d ./test/test-junit-report ]; then
-            pnpm dlx @datadog/datadog-ci@2.45.1 junit upload \
+            pnpm dlx @datadog/datadog-ci@5.12.1 junit upload \
               --service nextjs \
               --tags test.type:nextjs \
               --tags test_session.name:"${{ inputs.stepName }}" \
@@ -362,7 +362,7 @@ jobs:
               ./test/test-junit-report
           fi
           if [ -d ./test/turbopack-test-junit-report ]; then
-            pnpm dlx @datadog/datadog-ci@2.45.1 junit upload \
+            pnpm dlx @datadog/datadog-ci@5.12.1 junit upload \
               --service nextjs \
               --tags test.type:turbopack \
               --tags test_session.name:"${{ inputs.stepName }}" \

--- a/.github/workflows/test_e2e_deploy_release.yml
+++ b/.github/workflows/test_e2e_deploy_release.yml
@@ -243,7 +243,7 @@ jobs:
       - name: Upload test report to datadog
         run: |
           if [ -d ./test/test-junit-report ]; then
-            DD_ENV=ci npx @datadog/datadog-ci@2.23.1 junit upload --tags test.type:deploy --service nextjs ./test/test-junit-report
+            DD_ENV=ci npx @datadog/datadog-ci@5.12.1 junit upload --tags test.type:deploy --service nextjs ./test/test-junit-report
           fi
 
   upload-adapter-test-results:


### PR DESCRIPTION
## Summary

- Bumps `@datadog/datadog-ci` from `2.45.1`/`2.23.1` to `5.12.1` in CI workflows
- Fixes `Entity expansion limit exceeded: 1440 > 1000` error during jUnit XML upload to Datadog

### Root cause

`@datadog/datadog-ci@2.45.1` depends on `fast-xml-parser@^4.4.1`. This semver range previously resolved to versions without an entity expansion limit, but starting from `4.5.3`, `fast-xml-parser` introduced a default limit of 1000 as a security fix for XML entity expansion attacks (CVE-2024-41818). Since CI runs `pnpm dlx` (which resolves the latest matching version each time), the transitive dependency silently upgraded to `4.5.6`, activating the new limit.

When `jest-junit` captures test failure output containing many XML-encodable characters (`&`, `<`, `>` in HTML, URLs, stack traces, etc.), the resulting jUnit XML can exceed this limit — in our case, 1440 entity references vs the 1000 cap — causing the Datadog upload to fail.

### Fix

`@datadog/datadog-ci@5.10.0` includes [DataDog/datadog-ci#2184](https://github.com/DataDog/datadog-ci/pull/2184), which disables entity processing entirely during XML validation. This is the correct fix: jUnit XML is trusted CI output, not untrusted web content, so entity expansion protection is unnecessary.

### Why the v2 → v5 major version bump is safe

We only use the `junit upload` subcommand, which is **unaffected** by every breaking change across v3, v4, and v5:

| Version | Breaking changes | Affects `junit upload`? |
|---------|-----------------|------------------------|
| [v3.0.0](https://github.com/DataDog/datadog-ci/releases/tag/v3.0.0) | Drop Node 14/16; remove deprecated synthetics features | No |
| [v4.0.0](https://github.com/DataDog/datadog-ci/releases/tag/v4.0.0) | Drop `aas`, `cloud-run`, `lambda`, `stepfunctions`, `synthetics` plugins | No |
| [v5.0.0](https://github.com/DataDog/datadog-ci/releases/tag/v5.0.0) | Drop Node 18; serverless default layer change; SBOM upload change | No |

CI runs Node 20, so the Node version drops are also a non-issue.

Generated with [Claude Code](https://claude.ai/code)

<!-- NEXT_JS_LLM_PR -->