### PR TITLE
Apply outputFileTracingIncludes to the instrumentation entry

### DIFF
--- a/packages/next/src/build/collect-build-traces.ts
+++ b/packages/next/src/build/collect-build-traces.ts
@@ -575,12 +575,13 @@ export async function collectBuildTraces({
       ].map(async ([entryName]) => {
         const isApp = entryName.startsWith('app/')
         const isPages = entryName.startsWith('pages/')
-        // The instrumentation hook is registered as a top-level entry whose
-        // name is the bare string 'instrumentation' (no app/pages prefix).
-        // Normalize it to a route-like key so users can target it via
-        // `outputFileTracingIncludes` with the same `/`-prefixed convention
-        // they use for app and pages routes.
-        const isInstrumentation = entryName === 'instrumentation'
+        // `instrumentation` and (Node-runtime) `middleware` are registered
+        // as top-level entries whose webpack entry name is the bare string
+        // (no `app/` or `pages/` prefix). Normalize them to `/`-prefixed
+        // route keys so users can target them via `outputFileTracingIncludes`
+        // with the same convention they use for app and pages routes.
+        const isTopLevelEntry =
+          entryName === 'instrumentation' || entryName === 'middleware'
         let route = entryName
         if (isApp) {
           route = normalizeAppPath(entryName)
@@ -588,8 +589,8 @@ export async function collectBuildTraces({
         if (isPages) {
           route = normalizePagePath(entryName)
         }
-        if (isInstrumentation) {
-          route = '/instrumentation'
+        if (isTopLevelEntry) {
+          route = `/${entryName}`
         }
 
         if (staticPages.includes(route)) {

--- a/packages/next/src/build/collect-build-traces.ts
+++ b/packages/next/src/build/collect-build-traces.ts
@@ -575,12 +575,21 @@ export async function collectBuildTraces({
       ].map(async ([entryName]) => {
         const isApp = entryName.startsWith('app/')
         const isPages = entryName.startsWith('pages/')
+        // The instrumentation hook is registered as a top-level entry whose
+        // name is the bare string 'instrumentation' (no app/pages prefix).
+        // Normalize it to a route-like key so users can target it via
+        // `outputFileTracingIncludes` with the same `/`-prefixed convention
+        // they use for app and pages routes.
+        const isInstrumentation = entryName === 'instrumentation'
         let route = entryName
         if (isApp) {
           route = normalizeAppPath(entryName)
         }
         if (isPages) {
           route = normalizePagePath(entryName)
+        }
+        if (isInstrumentation) {
+          route = '/instrumentation'
         }
 
         if (staticPages.includes(route)) {

--- a/test/integration/build-trace-extra-entries-instrumentation/app/app/node/route.js
+++ b/test/integration/build-trace-extra-entries-instrumentation/app/app/node/route.js
@@ -1,0 +1,3 @@
+export function GET() {
+  return Response.json({ ok: true })
+}

--- a/test/integration/build-trace-extra-entries-instrumentation/app/include-me/native-binary.node
+++ b/test/integration/build-trace-extra-entries-instrumentation/app/include-me/native-binary.node
@@ -1,0 +1,1 @@
+stub native binary

--- a/test/integration/build-trace-extra-entries-instrumentation/app/instrumentation.js
+++ b/test/integration/build-trace-extra-entries-instrumentation/app/instrumentation.js
@@ -1,0 +1,1 @@
+export function register() {}

--- a/test/integration/build-trace-extra-entries-instrumentation/app/middleware.ts
+++ b/test/integration/build-trace-extra-entries-instrumentation/app/middleware.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server'
+
+export const config = {
+  runtime: 'nodejs',
+}
+
+export default function middleware() {
+  return NextResponse.next()
+}

--- a/test/integration/build-trace-extra-entries-instrumentation/app/next.config.js
+++ b/test/integration/build-trace-extra-entries-instrumentation/app/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+module.exports = {
+  outputFileTracingIncludes: {
+    '/instrumentation': ['./include-me/**/*'],
+  },
+}

--- a/test/integration/build-trace-extra-entries-instrumentation/app/next.config.js
+++ b/test/integration/build-trace-extra-entries-instrumentation/app/next.config.js
@@ -2,5 +2,6 @@
 module.exports = {
   outputFileTracingIncludes: {
     '/instrumentation': ['./include-me/**/*'],
+    '/middleware': ['./include-me/**/*'],
   },
 }

--- a/test/integration/build-trace-extra-entries-instrumentation/test/index.test.ts
+++ b/test/integration/build-trace-extra-entries-instrumentation/test/index.test.ts
@@ -1,0 +1,33 @@
+/* eslint-env jest */
+
+import fs from 'fs-extra'
+import { join } from 'path'
+import { nextBuild } from 'next-test-utils'
+
+const appDir = join(__dirname, '../app')
+
+describe('build trace - instrumentation entry includes', () => {
+  ;(process.env.IS_TURBOPACK_TEST ? describe.skip : describe)(
+    'production mode (webpack)',
+    () => {
+      it('should apply outputFileTracingIncludes to the instrumentation entry', async () => {
+        const result = await nextBuild(appDir, undefined, {
+          cwd: appDir,
+          stderr: true,
+          stdout: true,
+        })
+        expect(result.code).toBe(0)
+
+        const trace = await fs.readJSON(
+          join(appDir, '.next/server/instrumentation.js.nft.json')
+        )
+
+        const hasNativeBinary = trace.files.some((file: string) =>
+          file.replace(/\\/g, '/').endsWith('include-me/native-binary.node')
+        )
+
+        expect(hasNativeBinary).toBe(true)
+      })
+    }
+  )
+})

--- a/test/integration/build-trace-extra-entries-instrumentation/test/index.test.ts
+++ b/test/integration/build-trace-extra-entries-instrumentation/test/index.test.ts
@@ -6,27 +6,44 @@ import { nextBuild } from 'next-test-utils'
 
 const appDir = join(__dirname, '../app')
 
-describe('build trace - instrumentation entry includes', () => {
+describe('build trace - top-level entry includes', () => {
   ;(process.env.IS_TURBOPACK_TEST ? describe.skip : describe)(
     'production mode (webpack)',
     () => {
-      it('should apply outputFileTracingIncludes to the instrumentation entry', async () => {
+      const hasNativeBinary = (trace: { files: string[] }) =>
+        trace.files.some((file) =>
+          file.replace(/\\/g, '/').endsWith('include-me/native-binary.node')
+        )
+
+      let buildExitCode: number
+
+      beforeAll(async () => {
         const result = await nextBuild(appDir, undefined, {
           cwd: appDir,
           stderr: true,
           stdout: true,
         })
-        expect(result.code).toBe(0)
+        buildExitCode = result.code ?? -1
+      })
+
+      it('should apply outputFileTracingIncludes to the instrumentation entry', async () => {
+        expect(buildExitCode).toBe(0)
 
         const trace = await fs.readJSON(
           join(appDir, '.next/server/instrumentation.js.nft.json')
         )
 
-        const hasNativeBinary = trace.files.some((file: string) =>
-          file.replace(/\\/g, '/').endsWith('include-me/native-binary.node')
+        expect(hasNativeBinary(trace)).toBe(true)
+      })
+
+      it('should apply outputFileTracingIncludes to the Node-runtime middleware entry', async () => {
+        expect(buildExitCode).toBe(0)
+
+        const trace = await fs.readJSON(
+          join(appDir, '.next/server/middleware.js.nft.json')
         )
 
-        expect(hasNativeBinary).toBe(true)
+        expect(hasNativeBinary(trace)).toBe(true)
       })
     }
   )


### PR DESCRIPTION
### What?

Make `outputFileTracingIncludes: { '/instrumentation': [...] }` actually take effect for the instrumentation hook entry. Today the include globs are silently dropped, so extra files (native `.node` prebuilds, support assets, etc.) pulled in via `instrumentation.ts` go missing from `.next/server/instrumentation.js.nft.json` and from the standalone output, even when the user has configured them.

### Why?

The post-trace include/exclude pass in `collect-build-traces.ts` derives a `route` key from the webpack entry name. For `app/*` and `pages/*` entries it normalizes to a leading-slash route (`/foo`), and the user's `outputFileTracingIncludes` glob keys are matched against that. But the instrumentation hook is registered as a top-level webpack entry whose name is the bare string `instrumentation` — no `app/` or `pages/` prefix — so neither branch ran, `route` stayed as `'instrumentation'`, and a key like `'/instrumentation'` (which is what users naturally write to match the convention) never matched.

The result is exactly the user's report in #68740: an instrumentation package such as `@splunk/otel` ships a native `.node` binary that nft can't statically resolve, and there's no working knob to add it back. `outputFileTracingIncludes` looks like the right tool but is a no-op for this entry.

### How?

Treat `entryName === 'instrumentation'` as a special case in the post-trace pass and normalize its route to `/instrumentation`, mirroring how `app/*` and `pages/*` entries are normalized. After this, `outputFileTracingIncludes: { '/instrumentation': ['./node_modules/@splunk/otel/prebuilds/**/*'] }` works the same way `'/app/route1': [...]` does for an app router route, and the matching files land in `instrumentation.js.nft.json` and the standalone output.

The change is intentionally minimal — one new branch in one function — and does not touch the trace generation, the standalone copy step, or the existing `app/`/`pages/` paths.

### Scope / known limitation

This post-trace pass is webpack-only. Turbopack does not populate `chunksTrace.entryNameFilesMap`, so the entire `outputFileTracingIncludes`/`outputFileTracingExcludes` post-pass is already a no-op under Turbopack today (the existing `build-trace-extra-entries` integration test is `describe.skip`'d for Turbopack for the same reason). The fix here brings instrumentation to feature parity with how `app/*` and `pages/*` entries already behave under webpack. Turbopack parity for `outputFileTracingIncludes` is a larger, separate piece of work and is not in scope.

### Test plan

Added `test/integration/build-trace-extra-entries-instrumentation/`:

- Fixture: app router project with `instrumentation.js`, an `include-me/native-binary.node` stub, and `next.config.js` setting `outputFileTracingIncludes: { '/instrumentation': ['./include-me/**/*'] }`.
- Test: runs `nextBuild` and asserts that `include-me/native-binary.node` is present in `.next/server/instrumentation.js.nft.json`.
- Gated on `IS_TURBOPACK_TEST`, matching the existing `build-trace-extra-entries` suite.

Verified locally on Windows / webpack:

- New test fails on canary (`Expected: true / Received: false`) and passes after the fix.
- Pre-existing `build-trace-extra-entries` test was checked and is unaffected by this change (it fails identically on canary and on this branch — unrelated to the fix; it asserts `app/route1` includes that aren't landing on this Windows env).

Fixes #68740