### PR TITLE
docs: `experimental.partialFallbacks`

### DIFF
--- a/docs/01-app/02-guides/incremental-static-regeneration-cache-components.mdx
+++ b/docs/01-app/02-guides/incremental-static-regeneration-cache-components.mdx
@@ -14,17 +14,14 @@ related:
 
 [Incremental Static Regeneration (ISR)](/docs/app/glossary#incremental-static-regeneration-isr) with [`cacheComponents`](/docs/app/api-reference/config/next-config-js/cacheComponents) lets you:
 
-- Prerender a subset of your dynamic routes at build time
-- Serve the most specific prerendered shell available for routes that were not prerendered, instead of blocking until the server finishes rendering
+- Prerender a subset of your dynamic routes at build time with [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params)
+- For routes not included in that subset, prerender a static shell treating unknown params as runtime data
+- Serve something instantly for every route: either the prerendered page or the static shell
 - Progressively improve what visitors see for a given route as param values become known from real traffic
 
 If you have used [ISR](/docs/app/guides/incremental-static-regeneration) or [`fallback: true`](https://nextjs.org/docs/pages/api-reference/functions/get-static-paths#fallback-true) in the Pages Router, this is the Cache Components equivalent.
 
-## Example
-
-We'll build a product catalog with category layouts and product detail pages using the [Recipe API](https://next-recipe-api.vercel.dev/).
-
-### Step 1: Enable Cache Components
+Make sure [`cacheComponents`](/docs/app/api-reference/config/next-config-js/cacheComponents) is enabled in your project:
 
 ```ts filename="next.config.ts" highlight={4}
 import type { NextConfig } from 'next'
@@ -36,62 +33,19 @@ const nextConfig: NextConfig = {
 export default nextConfig
 ```
 
-### Step 2: Prerender a subset with generateStaticParams
+## Example
 
-Start with a data layer. The `'use cache'` directive on each function ensures that fetched data is cached after the first request. `getTopCategories` and `getPopularProducts` fetch from the API and return a subset to prerender at build time.
+We'll build a product catalog with category layouts and product detail pages using the [Recipe API](https://next-recipe-api.vercel.dev/).
 
-```ts filename="app/lib/data.ts" highlight={5,11,17,23,30-33,36-39}
-const API = 'https://next-recipe-api.vercel.dev'
+### Prepare your routes
 
-// ... type definitions ...
+Use [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params) to define which param values to prerender. When rendering these routes, the param values are known at build time. The prerender process builds a static shell until it hits runtime APIs or uncached data. See [how rendering works](/docs/app/getting-started/caching#how-rendering-works) for more details.
 
-export async function getCategories(): Promise<Category[]> {
-  'use cache'
-  const res = await fetch(`${API}/categories`)
-  return res.json()
-}
+The category layout prerenders two categories:
 
-export async function getCategory(
-  slug: string
-): Promise<CategoryWithProducts | null> {
-  'use cache'
-  const res = await fetch(`${API}/categories/${slug}`)
-  if (!res.ok) return null
-  return res.json()
-}
-
-export async function getProduct(slug: string): Promise<Product | null> {
-  'use cache'
-  const res = await fetch(`${API}/products/${slug}`)
-  if (!res.ok) return null
-  return res.json()
-}
-
-export async function getProducts(category?: string): Promise<Product[]> {
-  'use cache'
-  const url = category
-    ? `${API}/products?category=${category}`
-    : `${API}/products`
-  const res = await fetch(url)
-  return res.json()
-}
-
-export async function getTopCategories() {
-  const categories = await getCategories()
-  return categories.slice(0, 2)
-}
-
-export async function getPopularProducts(category: string) {
-  const products = await getProducts(category)
-  return products.slice(0, 1)
-}
-```
-
-The category layout reads `params` and wraps the header in a `<Suspense>` boundary. `generateStaticParams` fetches the subset of categories to prerender:
-
-```tsx filename="app/[category]/layout.tsx" highlight={4-7}
+```tsx filename="app/[category]/layout.tsx" highlight={5-8}
 import Link from 'next/link'
-import { type ReactNode, Suspense } from 'react'
+import { Suspense } from 'react'
 import { getCategory, getTopCategories } from '../lib/data'
 
 export async function generateStaticParams() {
@@ -99,41 +53,39 @@ export async function generateStaticParams() {
   return categories.map((c) => ({ category: c.slug }))
 }
 
-async function CategoryHeader({ slug }: { slug: string }) {
-  const category = await getCategory(slug)
+async function CategoryHeader({
+  params,
+}: Pick<LayoutProps<'/[category]'>, 'params'>) {
+  const { category } = await params
+  const data = await getCategory(category)
 
   return (
     <div>
       <Link href="/">&larr; All categories</Link>
-      <h1>{category?.name ?? 'Category'}</h1>
-      {category?.description && <p>{category.description}</p>}
+      <h1>{data?.name ?? 'Category'}</h1>
+      {data?.description && <p>{data.description}</p>}
     </div>
   )
 }
 
-export default async function CategoryLayout({
-  children,
-  params,
-}: {
-  children: ReactNode
-  params: Promise<{ category: string }>
-}) {
-  const { category } = await params
-
+export default function CategoryLayout(props: LayoutProps<'/[category]'>) {
   return (
     <div>
       <Suspense fallback={<div>Loading...</div>}>
-        <CategoryHeader slug={category} />
+        <CategoryHeader params={props.params} />
       </Suspense>
-      <div>{children}</div>
+      {props.children}
     </div>
   )
 }
 ```
 
-The product page receives the parent `category` param and fetches the most popular products for that category:
+Notice that `CategoryLayout` does not `await props.params` itself. Instead, it passes the `params` promise to `CategoryHeader` inside `<Suspense>`. The `await` happens inside the boundary, so for unknown categories Next.js can still generate a static shell with the fallback UI.
 
-```tsx filename="app/[category]/[product]/page.tsx" highlight={4-11}
+The product page prerenders one product per category. `generateStaticParams` receives the parent `category` param:
+
+```tsx filename="app/[category]/[product]/page.tsx" highlight={5-12}
+import { Suspense } from 'react'
 import Link from 'next/link'
 import { getProduct, getPopularProducts } from '../../lib/data'
 
@@ -146,74 +98,104 @@ export async function generateStaticParams({
   return products.map((p) => ({ product: p.slug }))
 }
 
-export default async function ProductPage({
-  params,
-}: {
-  params: Promise<{ category: string; product: string }>
-}) {
-  const { category, product } = await params
-  const data = await getProduct(product)
+async function ProductDetails(props: PageProps<'/[category]/[product]'>) {
+  const { category, product } = await props.params
+  const data = await getProduct(category, product)
 
   if (!data) {
     return <p>Product not found.</p>
   }
 
   return (
-    <div>
+    <>
       <Link href={`/${category}`}>&larr; Back to products</Link>
       <h2>{data.name}</h2>
       <p>${data.price}</p>
       <p>{data.description}</p>
+    </>
+  )
+}
+
+export default function ProductPage(props: PageProps<'/[category]/[product]'>) {
+  return (
+    <div>
+      <Suspense fallback={<div>Loading product...</div>}>
+        <ProductDetails {...props} />
+      </Suspense>
     </div>
   )
 }
 ```
 
-For a fallback shell to be generated, there must be a `<Suspense>` fallback above any dynamic access (params, uncached data, runtime APIs). Next.js renders as far down the tree as it can statically. A [`loading.tsx`](/docs/app/api-reference/file-conventions/loading) file is the simplest way to provide a fallback, but a `<Suspense>` boundary in the page itself also works:
+> **Good to know:** You can also use [`loading.tsx`](/docs/app/api-reference/file-conventions/loading) files instead of `<Suspense>` in JSX. They are equivalent, but `<Suspense>` gives you more control over where the boundary sits in the component tree.
 
-```tsx filename="app/[category]/loading.tsx"
-export default function Loading() {
-  return <p>Loading products...</p>
+The data helpers use `'use cache'` at the module level so all exported functions are cached. This lets their results be included in the static shell:
+
+```ts filename="app/lib/data.ts" highlight={1}
+'use cache'
+
+const API = 'https://next-recipe-api.vercel.dev'
+
+export async function getCategory(slug: string) {
+  const res = await fetch(`${API}/categories/${slug}`)
+  if (!res.ok) return null
+  return res.json()
+}
+
+export async function getProduct(category: string, slug: string) {
+  const res = await fetch(`${API}/products/${category}/${slug}`)
+  if (!res.ok) return null
+  return res.json()
+}
+
+export async function getTopCategories() {
+  const res = await fetch(`${API}/categories`)
+  const categories = await res.json()
+  return categories.slice(0, 2)
+}
+
+export async function getPopularProducts(category: string) {
+  const res = await fetch(`${API}/products?category=${category}`)
+  const products = await res.json()
+  return products.slice(0, 1)
 }
 ```
 
-```tsx filename="app/[category]/[product]/loading.tsx"
-export default function Loading() {
-  return <p>Loading product...</p>
-}
-```
+If your components access runtime APIs like `cookies` or `headers`, wrap them in `<Suspense>`. Their fallback UI is included in the static shell instead.
 
-At build time, this produces three tiers of output:
+### At build time
 
-1. **Fully static pages** for known combos (one product per prerendered category): `/tops/tee`, `/shorts/joggers`
-2. **Intermediate shells** for known categories with an unknown product: `/tops/[product]`, `/shorts/[product]`
-3. **Generic shell** for everything else: `/[category]/[product]`
+When you run `next build`, Next.js prerenders the layout for each known category (`tops`, `shorts`), plus one render where `await params` suspends, producing the `[category]` shell.
 
-### Step 3: What visitors see for uncached routes
+It also prerenders the page for each known product under each category (`tee` under `tops`, `joggers` under `shorts`), plus one render where `await params` suspends, producing the `[product]` shell.
 
-**Known category, unknown product** (`/tops/overshirt`)
+These are combined into:
 
-The category `tops` was prerendered, so the intermediate shell `/tops/[product]` exists. The visitor immediately sees the category header ("Tops") fully rendered. The product area shows the `loading.tsx` skeleton. Product data streams in as it resolves.
+- `/tops/tee`, `/shorts/joggers`: fully static pages, both params known
+- `/tops/[product]`, `/shorts/[product]`: category header rendered, product shows fallback
+- `/[category]/[product]`: both show fallback
 
-**Unknown category, any product** (`/shoes/basketball-shoes` if `shoes` was not prerendered)
+### At runtime
 
-No intermediate shell exists for this category. Next.js falls back to the generic `/[category]/[product]` shell. Both the category header and the product area show skeleton UI. Both stream in as they resolve.
+A visitor navigates to `/tops/tee`. Both params were prerendered. They get a fully static page.
 
-**After the first visit**
+The first visit to `/tops/overshirt`. The product is unknown, but the category `tops` was prerendered. Next.js serves the `/tops/[product]` shell with the category header already rendered. The product streams in.
 
-Next.js tries to push the static boundary further down the component tree in the background. Because the data functions in this example use `'use cache'`, the upgrade produces a fully static page. The next visitor gets it without any streaming.
+The first visit to `/shoes/basketball-shoes`. The category `shoes` was not prerendered. Next.js serves the generic `/[category]/[product]` shell. Both the category and the product stream in.
 
-### Step 4: What determines the upgrade result
+After the first visit, Next.js renders these routes in the background with the now-known params. The next visitor to the same URLs gets a more specific result.
 
-How far Next.js can push the static boundary determines the result:
+### What the upgrade produces
+
+After the first visit, Next.js renders the page in the background with the known params and tries to push the static boundary as far down the component tree as possible:
 
 - If every data access is cached and all params are resolved, the upgrade produces a **fully static page**.
 - If some data is uncached or runtime APIs (`cookies`, `headers`) are accessed behind `<Suspense>` fallbacks, the upgrade produces a **more specific shell** with the params resolved but the dynamic parts still streaming.
-- If a param does not have `generateStaticParams`, it cannot trigger an upgrade. Params are resolved in route order, so a param without `generateStaticParams` also blocks all subsequent params from upgrading.
+- Params are resolved in route order. A param without `generateStaticParams` blocks all subsequent params from upgrading.
 
-> **Good to know**: Client-side prefetches (via [`<Link>`](/docs/app/api-reference/components/link) or [`router.prefetch`](/docs/app/api-reference/functions/use-router)) do not trigger upgrades. Only a full page visit does.
+> **Good to know**: Client-side prefetches (via [`<Link>`](/docs/app/api-reference/components/link) or [`router.prefetch`](/docs/app/api-reference/functions/use-router)) do not trigger upgrades. Only a navigation into the page visit does.
 
-To disable fallback shells and revert to blocking behavior for uncached routes, set [`experimental.partialFallbacks`](/docs/app/api-reference/config/next-config-js/partialFallbacks) to `false`. The page is still cached after the first visit, but visitors wait for the full render instead of seeing a loading state.
+To disable fallback shells and revert to blocking behavior for routes not in `generateStaticParams`, set [`experimental.partialFallbacks`](/docs/app/api-reference/config/next-config-js/partialFallbacks) to `false`. The page is still generated after the first visit, but visitors wait for the full render instead of seeing a loading state.
 
 ## Coming from the Pages Router
 

--- a/docs/01-app/02-guides/incremental-static-regeneration-cache-components.mdx
+++ b/docs/01-app/02-guides/incremental-static-regeneration-cache-components.mdx
@@ -35,7 +35,10 @@ export default nextConfig
 
 ## Example
 
-We'll build a product catalog with category layouts and product detail pages using the [Recipe API](https://next-recipe-api.vercel.dev/).
+We'll build a product catalog with category layouts and product detail pages using the [Recipe API](https://next-recipe-api.vercel.dev/). You can find the resources used in this example here:
+
+- [Demo](https://partial-fallbacks.labs.vercel.dev/)
+- [Code](https://github.com/vercel-labs/partial-fallbacks)
 
 ### Prepare your routes
 

--- a/docs/01-app/02-guides/incremental-static-regeneration-cache-components.mdx
+++ b/docs/01-app/02-guides/incremental-static-regeneration-cache-components.mdx
@@ -15,8 +15,8 @@ related:
 [Incremental Static Regeneration (ISR)](/docs/app/glossary#incremental-static-regeneration-isr) with [`cacheComponents`](/docs/app/api-reference/config/next-config-js/cacheComponents) lets you:
 
 - Prerender a subset of your dynamic routes at build time with [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params)
-- For routes not included in that subset, prerender a static shell treating unknown params as runtime data
-- Serve something instantly for every route: either the prerendered page or the static shell
+- For routes not included in that subset, prerender a [**fallback shell**](/docs/app/api-reference/config/next-config-js/partialFallbacks) treating unknown params as runtime data
+- Serve something instantly for every route: either the prerendered page or the fallback shell
 - Progressively improve what visitors see for a given route as param values become known from real traffic
 
 If you have used [ISR](/docs/app/guides/incremental-static-regeneration) or [`fallback: true`](https://nextjs.org/docs/pages/api-reference/functions/get-static-paths#fallback-true) in the Pages Router, this is the Cache Components equivalent.

--- a/docs/01-app/02-guides/incremental-static-regeneration-cache-components.mdx
+++ b/docs/01-app/02-guides/incremental-static-regeneration-cache-components.mdx
@@ -1,0 +1,264 @@
+---
+title: Incremental Static Regeneration with Cache Components
+description: Learn how to use partialFallbacks to serve instant fallback shells for uncached dynamic routes and upgrade them after the first visit.
+nav_title: ISR with Cache Components
+version: experimental
+related:
+  links:
+    - app/api-reference/config/next-config-js/partialFallbacks
+    - app/api-reference/config/next-config-js/cacheComponents
+    - app/api-reference/functions/generate-static-params
+    - app/api-reference/file-conventions/loading
+    - app/getting-started/caching
+---
+
+[Incremental Static Regeneration (ISR)](/docs/app/glossary#incremental-static-regeneration-isr) with [`cacheComponents`](/docs/app/api-reference/config/next-config-js/cacheComponents) and [`partialFallbacks`](/docs/app/api-reference/config/next-config-js/partialFallbacks) lets you:
+
+- Prerender a subset of your dynamic routes at build time and serve fallback shells for the rest
+- Upgrade fallback shells to fully static pages after the first visit, without rebuilding
+- Serve partial shells at multiple route levels, so visitors see prerendered layouts instantly while only the unknown parts stream in
+- Cache data with [`'use cache'`](/docs/app/api-reference/directives/use-cache) and control revalidation with [`cacheLife`](/docs/app/api-reference/functions/cacheLife)
+
+If you have used [ISR](/docs/app/guides/incremental-static-regeneration) or [`fallback: true`](https://nextjs.org/docs/pages/api-reference/functions/get-static-paths#fallback-true) in the Pages Router, this is the Cache Components equivalent.
+
+## Example
+
+We'll build a product catalog with category layouts and product detail pages using the [Recipe API](https://next-recipe-api.vercel.dev/).
+
+### Step 1: Enable partialFallbacks
+
+Enable `partialFallbacks` alongside `cacheComponents` in your `next.config.ts`:
+
+```ts filename="next.config.ts" highlight={4-6}
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  cacheComponents: true,
+  experimental: {
+    partialFallbacks: true,
+  },
+}
+
+export default nextConfig
+```
+
+> **Good to know**: `partialFallbacks` has no effect unless `cacheComponents` is also enabled.
+
+### Step 2: Prerender a subset with generateStaticParams
+
+Start with a data layer. The `'use cache'` directive on each function ensures that fetched data is cached after the first request. `getTopCategories` and `getPopularProducts` fetch from the API and return a subset to prerender at build time.
+
+```ts filename="app/lib/data.ts" highlight={5,11,17,23,30-33,36-39}
+const API = 'https://next-recipe-api.vercel.dev'
+
+// ... type definitions ...
+
+export async function getCategories(): Promise<Category[]> {
+  'use cache'
+  const res = await fetch(`${API}/categories`)
+  return res.json()
+}
+
+export async function getCategory(
+  slug: string
+): Promise<CategoryWithProducts | null> {
+  'use cache'
+  const res = await fetch(`${API}/categories/${slug}`)
+  if (!res.ok) return null
+  return res.json()
+}
+
+export async function getProduct(slug: string): Promise<Product | null> {
+  'use cache'
+  const res = await fetch(`${API}/products/${slug}`)
+  if (!res.ok) return null
+  return res.json()
+}
+
+export async function getProducts(category?: string): Promise<Product[]> {
+  'use cache'
+  const url = category
+    ? `${API}/products?category=${category}`
+    : `${API}/products`
+  const res = await fetch(url)
+  return res.json()
+}
+
+// Prerender the top categories.
+export async function getTopCategories() {
+  const categories = await getCategories()
+  return categories.slice(0, 2)
+}
+
+// Prerender the most popular products for a given category.
+export async function getPopularProducts(category: string) {
+  const products = await getProducts(category)
+  return products.slice(0, 1)
+}
+```
+
+The category layout reads `params` and wraps the header in a `<Suspense>` boundary. `generateStaticParams` fetches the subset of categories to prerender:
+
+```tsx filename="app/[category]/layout.tsx" highlight={28-30,37-40}
+import Link from 'next/link'
+import { type ReactNode, Suspense } from 'react'
+import { getCategory, getTopCategories } from '../lib/data'
+
+async function CategoryHeader({ slug }: { slug: string }) {
+  const category = await getCategory(slug)
+
+  return (
+    <div>
+      <Link href="/">&larr; All categories</Link>
+      <h1>{category?.name ?? 'Category'}</h1>
+      {category?.description && <p>{category.description}</p>}
+    </div>
+  )
+}
+
+export default async function CategoryLayout({
+  children,
+  params,
+}: {
+  children: ReactNode
+  params: Promise<{ category: string }>
+}) {
+  const { category } = await params
+
+  return (
+    <div>
+      <Suspense fallback={<div>Loading...</div>}>
+        <CategoryHeader slug={category} />
+      </Suspense>
+      <div>{children}</div>
+    </div>
+  )
+}
+
+// Prerender the top categories. The rest use fallback shells.
+export async function generateStaticParams() {
+  const categories = await getTopCategories()
+  return categories.map((c) => ({ category: c.slug }))
+}
+```
+
+The product page receives the parent `category` param and fetches the most popular products for that category:
+
+```tsx filename="app/[category]/[product]/page.tsx" highlight={27-34}
+import Link from 'next/link'
+import { getProduct, getPopularProducts } from '../../lib/data'
+
+export default async function ProductPage({
+  params,
+}: {
+  params: Promise<{ category: string; product: string }>
+}) {
+  const { category, product } = await params
+  const data = await getProduct(product)
+
+  if (!data) {
+    return <p>Product not found.</p>
+  }
+
+  return (
+    <div>
+      <Link href={`/${category}`}>&larr; Back to products</Link>
+      <h2>{data.name}</h2>
+      <p>${data.price}</p>
+      <p>{data.description}</p>
+    </div>
+  )
+}
+
+// Prerender the most popular products for this category.
+export async function generateStaticParams({
+  params,
+}: {
+  params: { category: string }
+}) {
+  const products = await getPopularProducts(params.category)
+  return products.map((p) => ({ product: p.slug }))
+}
+```
+
+For a fallback shell to be generated, there must be a `<Suspense>` fallback above any dynamic access (params, uncached data, runtime APIs). Next.js renders as far down the tree as it can statically. A [`loading.tsx`](/docs/app/api-reference/file-conventions/loading) file is the simplest way to provide a fallback, but a `<Suspense>` boundary in the page itself also works:
+
+```tsx filename="app/[category]/loading.tsx"
+export default function Loading() {
+  return (
+    <ul className="grid gap-4">
+      {Array.from({ length: 4 }).map((_, i) => (
+        <li key={i}>
+          <div className="h-5 w-40 animate-pulse rounded bg-zinc-100" />
+          <div className="mt-1 h-4 w-12 animate-pulse rounded bg-zinc-100" />
+        </li>
+      ))}
+    </ul>
+  )
+}
+```
+
+```tsx filename="app/[category]/[product]/loading.tsx"
+export default function Loading() {
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="h-4 w-36 animate-pulse rounded bg-zinc-100" />
+      <div className="rounded-lg border p-6">
+        <div className="h-7 w-48 animate-pulse rounded bg-zinc-100" />
+        <div className="mt-1 h-5 w-16 animate-pulse rounded bg-zinc-100" />
+        <div className="mt-4 h-4 w-full animate-pulse rounded bg-zinc-100" />
+      </div>
+    </div>
+  )
+}
+```
+
+At build time, this produces three tiers of output:
+
+1. **Fully static pages** for known combos (one product per prerendered category): `/tops/tee`, `/shorts/joggers`
+2. **Intermediate shells** for known categories with an unknown product: `/tops/[product]`, `/shorts/[product]`
+3. **Generic shell** for everything else: `/[category]/[product]`
+
+### Step 3: What visitors see for uncached routes
+
+**Scenario A: `/tops/overshirt`** (known category, unknown product)
+
+The category `tops` was prerendered, so the intermediate shell `/tops/[product]` exists. The visitor immediately sees the category header ("Tops") fully rendered. The product area shows the `loading.tsx` skeleton from `app/[category]/[product]/loading.tsx`. In the background, Next.js fetches product data for "overshirt" and streams it in, replacing the skeleton.
+
+**Scenario B: `/shorts/joggers`** (unknown category, any product)
+
+Neither `shorts` nor `joggers` was prerendered. Next.js falls back to the generic `/[category]/[product]` shell. Both the category header and the product area show skeleton UI. The category data and product data stream in as they resolve.
+
+**Scenario C: After the first visit (upgrades)**
+
+After scenario A, `/tops/overshirt` gets upgraded. The next visitor gets a fully static page because `getProduct` uses `'use cache'`, so the fetched data is now cached.
+
+After scenario B, `/shorts/joggers` also gets upgraded to a fully static page since all data functions use `'use cache'` and both params are now known.
+
+### Step 4: When upgrades produce partial vs full results
+
+When an upgrade happens, Next.js tries to push the static boundary further down the component tree. How far it gets determines the result:
+
+- If every data access in the page is cached (with [`'use cache'`](/docs/app/api-reference/directives/use-cache)) and all params are resolved, the upgrade produces a **fully static page**. No server work needed for subsequent visitors.
+- If some data is uncached or runtime APIs (`cookies`, `headers`) are accessed behind `<Suspense>` fallbacks, the upgrade produces a **more specific shell**. The params are resolved, but the dynamic parts still stream at request time.
+- If a param does not have `generateStaticParams`, it cannot trigger an upgrade. Params are resolved in route order, so a param without `generateStaticParams` also blocks all subsequent params from upgrading.
+
+> **Good to know**: Client-side prefetches (via [`<Link>`](/docs/app/api-reference/components/link) or [`router.prefetch`](/docs/app/api-reference/functions/use-router#routerprefetch)) do not trigger upgrades. Only a full page visit does.
+
+### Step 5: Coming from the Pages Router
+
+If you are migrating from the Pages Router, here is how the concepts map:
+
+- `fallback: true` in `getStaticPaths` → `partialFallbacks: true` with a `<Suspense>` fallback (skeleton shows instantly, content streams in)
+- `fallback: 'blocking'` in `getStaticPaths` → the default behavior without `partialFallbacks` (server blocks until render completes)
+- `router.isFallback` → not needed; `<Suspense>` boundaries handle the loading state automatically
+- `getStaticProps` with `revalidate` → `'use cache'` with [`cacheLife`](/docs/app/api-reference/functions/cacheLife)
+- `getStaticPaths` → [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params)
+
+## Next steps
+
+- [`partialFallbacks` API reference](/docs/app/api-reference/config/next-config-js/partialFallbacks) for configuration details and the full upgrade algorithm
+- [`cacheComponents`](/docs/app/api-reference/config/next-config-js/cacheComponents) to understand the caching layer that powers fallback shells
+- [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params) for controlling which param combinations are prerendered
+- [`loading.tsx`](/docs/app/api-reference/file-conventions/loading) for providing skeleton UI in fallback shells
+- [Streaming](/docs/app/guides/streaming) for a deeper look at how `<Suspense>` boundaries and progressive rendering work

--- a/docs/01-app/02-guides/incremental-static-regeneration-cache-components.mdx
+++ b/docs/01-app/02-guides/incremental-static-regeneration-cache-components.mdx
@@ -1,23 +1,22 @@
 ---
 title: Incremental Static Regeneration with Cache Components
-description: Learn how to use partialFallbacks to serve instant fallback shells for uncached dynamic routes and upgrade them after the first visit.
+description: Learn how to prerender a subset of dynamic routes, serve fallback shells for the rest, and upgrade them after the first visit.
 nav_title: ISR with Cache Components
 version: experimental
 related:
   links:
-    - app/api-reference/config/next-config-js/partialFallbacks
     - app/api-reference/config/next-config-js/cacheComponents
     - app/api-reference/functions/generate-static-params
     - app/api-reference/file-conventions/loading
     - app/getting-started/caching
+    - app/api-reference/config/next-config-js/partialFallbacks
 ---
 
-[Incremental Static Regeneration (ISR)](/docs/app/glossary#incremental-static-regeneration-isr) with [`cacheComponents`](/docs/app/api-reference/config/next-config-js/cacheComponents) and [`partialFallbacks`](/docs/app/api-reference/config/next-config-js/partialFallbacks) lets you:
+[Incremental Static Regeneration (ISR)](/docs/app/glossary#incremental-static-regeneration-isr) with [`cacheComponents`](/docs/app/api-reference/config/next-config-js/cacheComponents) lets you:
 
-- Prerender a subset of your dynamic routes at build time and serve fallback shells for the rest
-- Upgrade fallback shells to fully static pages after the first visit, without rebuilding
-- Serve partial shells at multiple route levels, so visitors see prerendered layouts instantly while only the unknown parts stream in
-- Cache data with [`'use cache'`](/docs/app/api-reference/directives/use-cache) and control revalidation with [`cacheLife`](/docs/app/api-reference/functions/cacheLife)
+- Prerender a subset of your dynamic routes at build time
+- Serve the most specific prerendered shell available for routes that were not prerendered, instead of blocking until the server finishes rendering
+- Progressively improve what visitors see for a given route as param values become known from real traffic
 
 If you have used [ISR](/docs/app/guides/incremental-static-regeneration) or [`fallback: true`](https://nextjs.org/docs/pages/api-reference/functions/get-static-paths#fallback-true) in the Pages Router, this is the Cache Components equivalent.
 
@@ -25,24 +24,17 @@ If you have used [ISR](/docs/app/guides/incremental-static-regeneration) or [`fa
 
 We'll build a product catalog with category layouts and product detail pages using the [Recipe API](https://next-recipe-api.vercel.dev/).
 
-### Step 1: Enable partialFallbacks
+### Step 1: Enable Cache Components
 
-Enable `partialFallbacks` alongside `cacheComponents` in your `next.config.ts`:
-
-```ts filename="next.config.ts" highlight={4-6}
+```ts filename="next.config.ts" highlight={4}
 import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
   cacheComponents: true,
-  experimental: {
-    partialFallbacks: true,
-  },
 }
 
 export default nextConfig
 ```
-
-> **Good to know**: `partialFallbacks` has no effect unless `cacheComponents` is also enabled.
 
 ### Step 2: Prerender a subset with generateStaticParams
 
@@ -99,7 +91,7 @@ export async function getPopularProducts(category: string) {
 
 The category layout reads `params` and wraps the header in a `<Suspense>` boundary. `generateStaticParams` fetches the subset of categories to prerender:
 
-```tsx filename="app/[category]/layout.tsx" highlight={28-30,37-40}
+```tsx filename="app/[category]/layout.tsx" highlight={25-27,34-37}
 import Link from 'next/link'
 import { type ReactNode, Suspense } from 'react'
 import { getCategory, getTopCategories } from '../lib/data'
@@ -135,7 +127,6 @@ export default async function CategoryLayout({
   )
 }
 
-// Prerender the top categories. The rest use fallback shells.
 export async function generateStaticParams() {
   const categories = await getTopCategories()
   return categories.map((c) => ({ category: c.slug }))
@@ -185,31 +176,13 @@ For a fallback shell to be generated, there must be a `<Suspense>` fallback abov
 
 ```tsx filename="app/[category]/loading.tsx"
 export default function Loading() {
-  return (
-    <ul className="grid gap-4">
-      {Array.from({ length: 4 }).map((_, i) => (
-        <li key={i}>
-          <div className="h-5 w-40 animate-pulse rounded bg-zinc-100" />
-          <div className="mt-1 h-4 w-12 animate-pulse rounded bg-zinc-100" />
-        </li>
-      ))}
-    </ul>
-  )
+  return <p>Loading products...</p>
 }
 ```
 
 ```tsx filename="app/[category]/[product]/loading.tsx"
 export default function Loading() {
-  return (
-    <div className="flex flex-col gap-4">
-      <div className="h-4 w-36 animate-pulse rounded bg-zinc-100" />
-      <div className="rounded-lg border p-6">
-        <div className="h-7 w-48 animate-pulse rounded bg-zinc-100" />
-        <div className="mt-1 h-5 w-16 animate-pulse rounded bg-zinc-100" />
-        <div className="mt-4 h-4 w-full animate-pulse rounded bg-zinc-100" />
-      </div>
-    </div>
-  )
+  return <p>Loading product...</p>
 }
 ```
 
@@ -221,44 +194,44 @@ At build time, this produces three tiers of output:
 
 ### Step 3: What visitors see for uncached routes
 
-**Scenario A: `/tops/overshirt`** (known category, unknown product)
+**Known category, unknown product** (`/tops/overshirt`)
 
-The category `tops` was prerendered, so the intermediate shell `/tops/[product]` exists. The visitor immediately sees the category header ("Tops") fully rendered. The product area shows the `loading.tsx` skeleton from `app/[category]/[product]/loading.tsx`. In the background, Next.js fetches product data for "overshirt" and streams it in, replacing the skeleton.
+The category `tops` was prerendered, so the intermediate shell `/tops/[product]` exists. The visitor immediately sees the category header ("Tops") fully rendered. The product area shows the `loading.tsx` skeleton. Product data streams in as it resolves.
 
-**Scenario B: `/shorts/joggers`** (unknown category, any product)
+**Unknown category, any product** (`/shoes/basketball-shoes` if `shoes` was not prerendered)
 
-Neither `shorts` nor `joggers` was prerendered. Next.js falls back to the generic `/[category]/[product]` shell. Both the category header and the product area show skeleton UI. The category data and product data stream in as they resolve.
+No intermediate shell exists for this category. Next.js falls back to the generic `/[category]/[product]` shell. Both the category header and the product area show skeleton UI. Both stream in as they resolve.
 
-**Scenario C: After the first visit (upgrades)**
+**After the first visit**
 
-After scenario A, `/tops/overshirt` gets upgraded. The next visitor gets a fully static page because `getProduct` uses `'use cache'`, so the fetched data is now cached.
+Next.js tries to push the static boundary further down the component tree in the background. Because the data functions in this example use `'use cache'`, the upgrade produces a fully static page. The next visitor gets it without any streaming.
 
-After scenario B, `/shorts/joggers` also gets upgraded to a fully static page since all data functions use `'use cache'` and both params are now known.
+### Step 4: What determines the upgrade result
 
-### Step 4: When upgrades produce partial vs full results
+How far Next.js can push the static boundary determines the result:
 
-When an upgrade happens, Next.js tries to push the static boundary further down the component tree. How far it gets determines the result:
-
-- If every data access in the page is cached (with [`'use cache'`](/docs/app/api-reference/directives/use-cache)) and all params are resolved, the upgrade produces a **fully static page**. No server work needed for subsequent visitors.
-- If some data is uncached or runtime APIs (`cookies`, `headers`) are accessed behind `<Suspense>` fallbacks, the upgrade produces a **more specific shell**. The params are resolved, but the dynamic parts still stream at request time.
+- If every data access is cached and all params are resolved, the upgrade produces a **fully static page**.
+- If some data is uncached or runtime APIs (`cookies`, `headers`) are accessed behind `<Suspense>` fallbacks, the upgrade produces a **more specific shell** with the params resolved but the dynamic parts still streaming.
 - If a param does not have `generateStaticParams`, it cannot trigger an upgrade. Params are resolved in route order, so a param without `generateStaticParams` also blocks all subsequent params from upgrading.
 
-> **Good to know**: Client-side prefetches (via [`<Link>`](/docs/app/api-reference/components/link) or [`router.prefetch`](/docs/app/api-reference/functions/use-router#routerprefetch)) do not trigger upgrades. Only a full page visit does.
+> **Good to know**: Client-side prefetches (via [`<Link>`](/docs/app/api-reference/components/link) or [`router.prefetch`](/docs/app/api-reference/functions/use-router)) do not trigger upgrades. Only a full page visit does.
+
+To disable fallback shells and upgrades entirely (reverting to blocking behavior for uncached routes), set [`experimental.partialFallbacks`](/docs/app/api-reference/config/next-config-js/partialFallbacks) to `false`.
 
 ### Step 5: Coming from the Pages Router
 
-If you are migrating from the Pages Router, here is how the concepts map:
+If you are migrating from the Pages Router:
 
-- `fallback: true` in `getStaticPaths` → `partialFallbacks: true` with a `<Suspense>` fallback (skeleton shows instantly, content streams in)
-- `fallback: 'blocking'` in `getStaticPaths` → the default behavior without `partialFallbacks` (server blocks until render completes)
-- `router.isFallback` → not needed; `<Suspense>` boundaries handle the loading state automatically
-- `getStaticProps` with `revalidate` → `'use cache'` with [`cacheLife`](/docs/app/api-reference/functions/cacheLife)
-- `getStaticPaths` → [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params)
+- `fallback: true` in `getStaticPaths` is now the default behavior with `cacheComponents`. Visitors get a `<Suspense>` fallback instantly and content streams in.
+- `fallback: 'blocking'` in `getStaticPaths` can be restored by setting `experimental.partialFallbacks: false`.
+- `router.isFallback` is not needed. The prerendering step generates a static shell, and you can grow it further with `'use cache'`.
+- `getStaticProps` with `revalidate` maps to `'use cache'` with [`cacheLife`](/docs/app/api-reference/functions/cacheLife).
+- `getStaticPaths` maps to [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params).
 
 ## Next steps
 
-- [`partialFallbacks` API reference](/docs/app/api-reference/config/next-config-js/partialFallbacks) for configuration details and the full upgrade algorithm
-- [`cacheComponents`](/docs/app/api-reference/config/next-config-js/cacheComponents) to understand the caching layer that powers fallback shells
+- [Caching with Cache Components](/docs/app/getting-started/caching) for the full caching model
 - [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params) for controlling which param combinations are prerendered
 - [`loading.tsx`](/docs/app/api-reference/file-conventions/loading) for providing skeleton UI in fallback shells
-- [Streaming](/docs/app/guides/streaming) for a deeper look at how `<Suspense>` boundaries and progressive rendering work
+- [Streaming](/docs/app/guides/streaming) to learn how to progressively render UI as data becomes available
+- [`partialFallbacks`](/docs/app/api-reference/config/next-config-js/partialFallbacks) API reference for opt-out and implementation details

--- a/docs/01-app/02-guides/incremental-static-regeneration-cache-components.mdx
+++ b/docs/01-app/02-guides/incremental-static-regeneration-cache-components.mdx
@@ -76,13 +76,11 @@ export async function getProducts(category?: string): Promise<Product[]> {
   return res.json()
 }
 
-// Prerender the top categories.
 export async function getTopCategories() {
   const categories = await getCategories()
   return categories.slice(0, 2)
 }
 
-// Prerender the most popular products for a given category.
 export async function getPopularProducts(category: string) {
   const products = await getProducts(category)
   return products.slice(0, 1)
@@ -91,10 +89,15 @@ export async function getPopularProducts(category: string) {
 
 The category layout reads `params` and wraps the header in a `<Suspense>` boundary. `generateStaticParams` fetches the subset of categories to prerender:
 
-```tsx filename="app/[category]/layout.tsx" highlight={25-27,34-37}
+```tsx filename="app/[category]/layout.tsx" highlight={4-7}
 import Link from 'next/link'
 import { type ReactNode, Suspense } from 'react'
 import { getCategory, getTopCategories } from '../lib/data'
+
+export async function generateStaticParams() {
+  const categories = await getTopCategories()
+  return categories.map((c) => ({ category: c.slug }))
+}
 
 async function CategoryHeader({ slug }: { slug: string }) {
   const category = await getCategory(slug)
@@ -126,18 +129,22 @@ export default async function CategoryLayout({
     </div>
   )
 }
-
-export async function generateStaticParams() {
-  const categories = await getTopCategories()
-  return categories.map((c) => ({ category: c.slug }))
-}
 ```
 
 The product page receives the parent `category` param and fetches the most popular products for that category:
 
-```tsx filename="app/[category]/[product]/page.tsx" highlight={27-34}
+```tsx filename="app/[category]/[product]/page.tsx" highlight={4-11}
 import Link from 'next/link'
 import { getProduct, getPopularProducts } from '../../lib/data'
+
+export async function generateStaticParams({
+  params,
+}: {
+  params: { category: string }
+}) {
+  const products = await getPopularProducts(params.category)
+  return products.map((p) => ({ product: p.slug }))
+}
 
 export default async function ProductPage({
   params,
@@ -159,16 +166,6 @@ export default async function ProductPage({
       <p>{data.description}</p>
     </div>
   )
-}
-
-// Prerender the most popular products for this category.
-export async function generateStaticParams({
-  params,
-}: {
-  params: { category: string }
-}) {
-  const products = await getPopularProducts(params.category)
-  return products.map((p) => ({ product: p.slug }))
 }
 ```
 
@@ -216,9 +213,9 @@ How far Next.js can push the static boundary determines the result:
 
 > **Good to know**: Client-side prefetches (via [`<Link>`](/docs/app/api-reference/components/link) or [`router.prefetch`](/docs/app/api-reference/functions/use-router)) do not trigger upgrades. Only a full page visit does.
 
-To disable fallback shells and upgrades entirely (reverting to blocking behavior for uncached routes), set [`experimental.partialFallbacks`](/docs/app/api-reference/config/next-config-js/partialFallbacks) to `false`.
+To disable fallback shells and revert to blocking behavior for uncached routes, set [`experimental.partialFallbacks`](/docs/app/api-reference/config/next-config-js/partialFallbacks) to `false`. The page is still cached after the first visit, but visitors wait for the full render instead of seeing a loading state.
 
-### Step 5: Coming from the Pages Router
+## Coming from the Pages Router
 
 If you are migrating from the Pages Router:
 

--- a/docs/01-app/02-guides/incremental-static-regeneration.mdx
+++ b/docs/01-app/02-guides/incremental-static-regeneration.mdx
@@ -13,6 +13,8 @@ description: Learn how to create or update static pages at runtime with Incremen
 
 </details>
 
+> **Good to know**: This guide covers ISR without Cache Components. If you are using [`cacheComponents`](/docs/app/api-reference/config/next-config-js/cacheComponents), see [ISR with Cache Components](/docs/app/guides/incremental-static-regeneration-cache-components) instead.
+
 Incremental Static Regeneration (ISR) enables you to:
 
 - Update static content without rebuilding the entire site

--- a/docs/01-app/02-guides/public-static-pages.mdx
+++ b/docs/01-app/02-guides/public-static-pages.mdx
@@ -2,6 +2,9 @@
 title: Building public pages
 description: Learn how to build public, "static" pages that share data across users, such as landing pages, list pages (products, blogs, etc.), marketing and news sites.
 nav_title: Public pages
+related:
+  links:
+    - app/guides/incremental-static-regeneration-cache-components
 ---
 
 Public pages show the same content to every user. Common examples include landing pages, marketing pages, and product pages.

--- a/docs/01-app/03-api-reference/04-functions/generate-static-params.mdx
+++ b/docs/01-app/03-api-reference/04-functions/generate-static-params.mdx
@@ -311,7 +311,7 @@ When using [Cache Components](/docs/app/getting-started/caching) with dynamic ro
 
 > **Good to know**: If you don't know the actual param values at build time, you can return a placeholder param (e.g., `[{ slug: '__placeholder__' }]`) for validation, then handle it in your page with `notFound()`. However, this prevents build time validation from working effectively and may cause runtime errors.
 
-See the [dynamic routes section](/docs/app/api-reference/file-conventions/dynamic-routes#with-cache-components) for detailed walkthroughs.
+See the [dynamic routes section](/docs/app/api-reference/file-conventions/dynamic-routes#with-cache-components) for detailed walkthroughs, or [ISR with Cache Components](/docs/app/guides/incremental-static-regeneration-cache-components) for prerendering a subset of routes and serving fallback shells for the rest.
 
 ### With Route Handlers
 

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/cacheComponents.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/cacheComponents.mdx
@@ -1,6 +1,12 @@
 ---
 title: cacheComponents
 description: Learn how to enable the cacheComponents flag in Next.js.
+related:
+  links:
+    - app/getting-started/caching
+    - app/guides/incremental-static-regeneration-cache-components
+    - app/api-reference/directives/use-cache
+    - app/api-reference/directives/use-cache-remote
 ---
 
 Cache Components enables component and function-level caching using the [`use cache`](/docs/app/api-reference/directives/use-cache) directive. Data fetching is dynamic by default, and you choose what to cache at the page, component, or function level. Next.js prerenders a static HTML shell that is served immediately while dynamic content streams in when ready, letting you mix static and dynamic content within a single route.

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/partialFallbacks.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/partialFallbacks.mdx
@@ -108,7 +108,7 @@ The result becomes the new shell for that URL, upgrading the fallback. If the pa
 
 Upgrades require [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params). If `[slug]` had no `generateStaticParams`, the `/electronics/[slug]` shell would be served for every slug under `electronics` and never upgraded further. Params are resolved in route order. A param without `generateStaticParams` is always resolved at request time, and any params that come after it in the route are too, even if they have `generateStaticParams`.
 
-`partialFallbacks` also applies to [catch-all segments](/docs/app/building-your-application/routing/dynamic-routes#catch-all-segments) (`[...slug]`) and [optional catch-all segments](/docs/app/building-your-application/routing/dynamic-routes#optional-catch-all-segments) (`[[...slug]]`).
+`partialFallbacks` also applies to [catch-all segments](/docs/app/api-reference/file-conventions/dynamic-routes#catch-all-segments) (`[...slug]`) and [optional catch-all segments](/docs/app/api-reference/file-conventions/dynamic-routes#optional-catch-all-segments) (`[[...slug]]`).
 
 > **Good to know:** If you used [`fallback: true`](https://nextjs.org/docs/pages/api-reference/functions/get-static-paths#fallback-true) with `getStaticPaths` in the Pages Router: this is the App Router equivalent, built on `<Suspense>` instead of `router.isFallback`.
 

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/partialFallbacks.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/partialFallbacks.mdx
@@ -17,7 +17,7 @@ related:
 - **Prerender every combination** with `generateStaticParams`: this can lead to longer build times and increased cache write costs.
 - **Skip `generateStaticParams`**: the server blocks until the full page is rendered before sending any content to the visitor.
 
-[Cache Components](/docs/app/api-reference/config/next-config-js/cacheComponents) with the `partialFallbacks` enabled change this. Instead of blocking until the page is rendered, the visitor gets a **fallback shell** instantly. A fallback shell is prerendered static content where one or more params are unknown at build time.
+[Cache Components](/docs/app/api-reference/config/next-config-js/cacheComponents) with `partialFallbacks` enabled changes this. Instead of blocking until the page is rendered, the visitor gets a **fallback shell** instantly. A fallback shell is prerendered static content where one or more params are unknown at build time.
 
 In the background, Next.js uses the param values from the incoming request to try to generate a more specific shell, or a fully static page if possible. Subsequent visitors to that URL then get this **upgraded** version instead of the fallback.
 

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/partialFallbacks.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/partialFallbacks.mdx
@@ -10,7 +10,7 @@ related:
     - app/getting-started/caching
 ---
 
-> **Good to know**: `partialFallbacks` has no effect unless [`cacheComponents`](/docs/app/api-reference/config/next-config-js/cacheComponents) is also enabled.
+> **Good to know**: `partialFallbacks` is enabled by default when [`cacheComponents`](/docs/app/api-reference/config/next-config-js/cacheComponents) is enabled. It has no effect without `cacheComponents`.
 
 [Dynamic routes](/docs/app/api-reference/file-conventions/dynamic-routes) that use [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params) are prerendered at build time for each combination returned. Without `partialFallbacks`, you face a tradeoff:
 
@@ -23,16 +23,13 @@ In the background, Next.js uses the param values from the incoming request to tr
 
 ## Usage
 
-Enable `partialFallbacks` alongside [`cacheComponents`](/docs/app/api-reference/config/next-config-js/cacheComponents):
+`partialFallbacks` is enabled by default with [`cacheComponents`](/docs/app/api-reference/config/next-config-js/cacheComponents). No additional configuration is needed:
 
 ```ts filename="next.config.ts" switcher
 import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
   cacheComponents: true,
-  experimental: {
-    partialFallbacks: true,
-  },
 }
 
 export default nextConfig
@@ -42,15 +39,21 @@ export default nextConfig
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   cacheComponents: true,
-  experimental: {
-    partialFallbacks: true,
-  },
 }
 
 module.exports = nextConfig
 ```
 
-The default value is `false`.
+To opt out, set `experimental.partialFallbacks` to `false`:
+
+```ts filename="next.config.ts"
+const nextConfig: NextConfig = {
+  cacheComponents: true,
+  experimental: {
+    partialFallbacks: false,
+  },
+}
+```
 
 ## How it works
 

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/partialFallbacks.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/partialFallbacks.mdx
@@ -201,4 +201,4 @@ At runtime:
 
 | Version   | Changes                                     |
 | --------- | ------------------------------------------- |
-| `v16.x.x` | Experimental `partialFallbacks` introduced. |
+| `v16.3.0` | Experimental `partialFallbacks` introduced. |

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/partialFallbacks.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/partialFallbacks.mdx
@@ -76,12 +76,8 @@ export function generateStaticParams() {
   return [{ slug: 'headphones' }]
 }
 
-export default async function Page({
-  params,
-}: {
-  params: Promise<{ category: string; slug: string }>
-}) {
-  const { category, slug } = await params
+export default async function Page(props: PageProps<'/[category]/[slug]'>) {
+  const { category, slug } = await props.params
 }
 ```
 
@@ -121,30 +117,30 @@ Upgrades require [`generateStaticParams`](/docs/app/api-reference/functions/gene
 
 A page provides `generateStaticParams` for a subset of product slugs. Products not in the list are served as fallback shells and upgraded after the first visit:
 
-```tsx filename="app/products/[slug]/page.tsx" highlight={20-24}
+```tsx filename="app/products/[slug]/page.tsx" highlight={4-7}
 import { Suspense } from 'react'
+import { getProduct, getProductsByTraffic } from '../lib/data'
 
-export default async function ProductPage({
-  params,
-}: {
-  params: Promise<{ slug: string }>
-}) {
-  const { slug } = await params
+export async function generateStaticParams() {
+  const topProducts = await getProductsByTraffic({ limit: 100 })
+  return topProducts.map((product) => ({ slug: product.slug }))
+}
 
+async function ProductDetails(props: PageProps<'/products/[slug]'>) {
+  const { slug } = await props.params
+  const product = await getProduct(slug)
+  return <div>{product.name}</div>
+}
+
+export default function ProductPage(props: PageProps<'/products/[slug]'>) {
   return (
     <div>
       <h1>Product</h1>
       <Suspense fallback={<p>Loading product details...</p>}>
-        <ProductDetails slug={slug} />
+        <ProductDetails {...props} />
       </Suspense>
     </div>
   )
-}
-
-export function generateStaticParams() {
-  // Only prerender the top 100 products at build time.
-  // All other slugs are served as fallback shells.
-  return topProducts.map((product) => ({ slug: product.slug }))
 }
 ```
 
@@ -158,22 +154,18 @@ With this setup:
 
 A layout provides `generateStaticParams` for `[category]`:
 
-```tsx filename="app/[category]/layout.tsx" highlight={20-22}
-import { Suspense, type ReactNode } from 'react'
+```tsx filename="app/[category]/layout.tsx" highlight={16-18}
+import { Suspense } from 'react'
 
-export default async function CategoryLayout({
-  children,
-  params,
-}: {
-  children: ReactNode
-  params: Promise<{ category: string }>
-}) {
-  const { category } = await params
+export default async function CategoryLayout(
+  props: LayoutProps<'/[category]'>
+) {
+  const { category } = await props.params
 
   return (
     <section>
       <h1>{category}</h1>
-      <Suspense fallback={<p>Loading product...</p>}>{children}</Suspense>
+      <Suspense fallback={<p>Loading product...</p>}>{props.children}</Suspense>
     </section>
   )
 }
@@ -185,13 +177,11 @@ export function generateStaticParams() {
 
 The page provides `generateStaticParams` for `[slug]` with a subset of values:
 
-```tsx filename="app/[category]/[slug]/page.tsx" highlight={10-12}
-export default async function ProductPage({
-  params,
-}: {
-  params: Promise<{ category: string; slug: string }>
-}) {
-  const { slug } = await params
+```tsx filename="app/[category]/[slug]/page.tsx" highlight={8-10}
+export default async function ProductPage(
+  props: PageProps<'/[category]/[slug]'>
+) {
+  const { slug } = await props.params
   return <p>{slug}</p>
 }
 

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/partialFallbacks.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/partialFallbacks.mdx
@@ -12,9 +12,9 @@ related:
 
 > **Good to know**: `partialFallbacks` has no effect unless [`cacheComponents`](/docs/app/api-reference/config/next-config-js/cacheComponents) is also enabled.
 
-Routes that use [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params) are prerendered at build time for each value returned. For routes with many possible values (e.g. an e-commerce catalog with millions of products), you face a tradeoff:
+[Dynamic routes](/docs/app/api-reference/file-conventions/dynamic-routes) that use [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params) are prerendered at build time for each combination returned. Without `partialFallbacks`, you face a tradeoff:
 
-- **Prerender every value** with `generateStaticParams`: longer build times and increased cache write costs.
+- **Prerender every combination** with `generateStaticParams`: this can lead to longer build times and increased cache write costs.
 - **Skip `generateStaticParams`**: the server blocks until the full page is rendered before sending any content to the visitor.
 
 [Cache Components](/docs/app/api-reference/config/next-config-js/cacheComponents) with the `partialFallbacks` enabled change this. Instead of blocking until the page is rendered, the visitor gets a **fallback shell** instantly. A fallback shell is prerendered static content where one or more params are unknown at build time.
@@ -106,7 +106,7 @@ When a visitor requests a param combination that wasn't prerendered (e.g. `/elec
 
 The result becomes the new shell for that URL, upgrading the fallback. If the page also has uncached data or runtime APIs behind `<Suspense>` fallbacks, the upgraded shell will still be partial, but with more params resolved.
 
-Upgrades require [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params). If `[slug]` had no `generateStaticParams`, the `/electronics/[slug]` shell would be served for every slug under `electronics` and never upgraded further. Params without `generateStaticParams` are always resolved at request time, and once one is encountered in the route, all params after it are too.
+Upgrades require [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params). If `[slug]` had no `generateStaticParams`, the `/electronics/[slug]` shell would be served for every slug under `electronics` and never upgraded further. Params are resolved in route order. A param without `generateStaticParams` is always resolved at request time, and any params that come after it in the route are too, even if they have `generateStaticParams`.
 
 `partialFallbacks` also applies to [catch-all segments](/docs/app/building-your-application/routing/dynamic-routes#catch-all-segments) (`[...slug]`) and [optional catch-all segments](/docs/app/building-your-application/routing/dynamic-routes#optional-catch-all-segments) (`[[...slug]]`).
 

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/partialFallbacks.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/partialFallbacks.mdx
@@ -6,20 +6,26 @@ related:
   links:
     - app/api-reference/config/next-config-js/cacheComponents
     - app/api-reference/functions/generate-static-params
+    - app/api-reference/file-conventions/loading
     - app/getting-started/caching
 ---
 
-> **Good to know**: `partialFallbacks` requires [`cacheComponents: true`](/docs/app/api-reference/config/next-config-js/cacheComponents). You must enable both flags together.
+> **Good to know**: `partialFallbacks` has no effect unless [`cacheComponents`](/docs/app/api-reference/config/next-config-js/cacheComponents) is also enabled.
 
-With [Cache Components](/docs/app/api-reference/config/next-config-js/cacheComponents), routes that use [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params) are prerendered at build time for each value returned.
+Routes that use [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params) are prerendered at build time for each value returned. For routes with many possible values (e.g. an e-commerce catalog with millions of products), you face a tradeoff:
 
-However for routes with many possible values (e.g. an e-commerce catalog with millions of products), prerendering every page means longer build times and increased cache write costs. Skipping `generateStaticParams` entirely means every visitor gets a generic static shell (a loading screen) with no param-specific content prerendered.
+- **Prerender every value** with `generateStaticParams`: longer build times and increased cache write costs.
+- **Skip `generateStaticParams`**: the server blocks until the full page is rendered before sending any content to the visitor.
 
-With `partialFallbacks` enable, Next.js still prerenders a subset of pages with `generateStaticParams`, and any page not included in that subset is served instantly as a **fallback shell**, with the dynamic content streaming in through `<Suspense>`.
+[Cache Components](/docs/app/api-reference/config/next-config-js/cacheComponents) with the `partialFallbacks` enabled change this. Instead of blocking until the page is rendered, the visitor gets a **fallback shell** instantly. A fallback shell is prerendered static content where one or more params are unknown at build time.
 
-After that, the page is automatically upgraded to a fully prerendered version in the background. Subsequent visitors get it instantly without any streaming delay.
+In the background, Next.js uses the param values from the incoming request to try to generate a more specific shell, or a fully static page if possible. Subsequent visitors to that URL then get this **upgraded** version instead of the fallback.
 
-```ts filename="next.config.ts"
+## Usage
+
+Enable `partialFallbacks` alongside [`cacheComponents`](/docs/app/api-reference/config/next-config-js/cacheComponents):
+
+```ts filename="next.config.ts" switcher
 import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
@@ -32,7 +38,7 @@ const nextConfig: NextConfig = {
 export default nextConfig
 ```
 
-```js filename="next.config.js"
+```js filename="next.config.js" switcher
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   cacheComponents: true,
@@ -44,35 +50,67 @@ const nextConfig = {
 module.exports = nextConfig
 ```
 
+The default value is `false`.
+
 ## How it works
 
-Consider a route `/[slug]` where `generateStaticParams` returns a subset of values (e.g. `[{ slug: 'popular-post' }]`).
+Consider a route `/[category]/[slug]`.
 
-Without `partialFallbacks`, a request for `/new-post` (a slug not in `generateStaticParams`) serves a generic static shell with no param-specific content. The visitor sees a loading screen while the page renders on the server.
+The layout prerenders two categories, `electronics` and `books`:
 
-With `partialFallbacks`, `/new-post` is served instantly as a fallback shell. The static parts of the page (root layout, any cached components) are already prerendered, and the dynamic content streams in through `<Suspense>`. After this first visit, the deployment platform upgrades the fallback shell to a fully prerendered page in the background, so the next visitor gets `/new-post` instantly.
+```tsx filename="app/[category]/layout.tsx"
+export function generateStaticParams() {
+  return [{ category: 'electronics' }, { category: 'books' }]
+}
 
-To serve a fallback shell, the param must be accessed inside a `<Suspense>` boundary (for example, via a [`loading.tsx`](/docs/app/api-reference/file-conventions/loading) file) so Next.js can prerender the static parts above it.
+// Layout implementation
+```
 
-### Multiple params
+The page prerenders one slug, `headphones`:
 
-With Cache Components, Next.js already generates intermediate shells for routes with multiple params (e.g. `/electronics/[slug]` when `category` has `generateStaticParams`). Without `partialFallbacks`, those shells are the final result. With `partialFallbacks`, those shells become upgradeable: the skeleton is served first, and the deployment platform can progressively upgrade through the chain in the background.
+```tsx filename="app/[category]/[slug]/page.tsx"
+export function generateStaticParams() {
+  return [{ slug: 'headphones' }]
+}
 
-Consider `/[category]/[slug]` where the layout provides `generateStaticParams` for `category` (returning `electronics` and `books`) but no `generateStaticParams` exists for `slug`:
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ category: string; slug: string }>
+}) {
+  const { category, slug } = await params
+}
+```
 
-| Shell                 | Type     | Resolved params           |
-| --------------------- | -------- | ------------------------- |
-| `/electronics/[slug]` | Fallback | `category: "electronics"` |
-| `/books/[slug]`       | Fallback | `category: "books"`       |
-| `/[category]/[slug]`  | Fallback | none                      |
+### Shell generation
 
-A request to `/electronics/headphones` serves the `/electronics/[slug]` fallback shell. The category layout is already prerendered, and only the `[slug]` page content streams in. The platform can then upgrade this to a complete shell for `/electronics/headphones` in the background. A request to `/clothing/shirts` (a category not in `generateStaticParams`) falls back to the generic `/[category]/[slug]` shell.
+At build time, Next.js renders the route treating `await params` as runtime API access. Everything above the nearest `<Suspense>` fallback becomes the shell. The fallback UI fills in for the part that depends on the param. A [`loading.tsx`](/docs/app/api-reference/file-conventions/loading) file is the simplest way to provide one.
 
-> **Good to know:**
->
-> - Once a dynamic param is encountered in the route, all subsequent params are also treated as unresolved. The order of params in the route matters.
-> - Shell upgrades depend on deployment platform support. The `partialFallback` flag in the build adapter output signals to the platform which shells are eligible for upgrade.
-> - If you used [`fallback: true`](https://nextjs.org/docs/pages/api-reference/functions/get-static-paths#fallback-true) with `getStaticPaths` in the Pages Router: this is the App Router equivalent, built on `<Suspense>` instead of `router.isFallback`.
+```tsx filename="app/[category]/[slug]/loading.tsx"
+export default function Loading() {
+  return <p>Loading...</p>
+}
+```
+
+For the route above, this produces:
+
+- `/electronics/headphones`: fully static, all params known
+- `/electronics/[slug]`: category resolved, slug shows fallback UI
+- `/[category]/[slug]`: both params show fallback UI
+
+> **Good to know**: If there is no `Suspense` fallback above the param access, no shell can be generated and the page blocks at request time.
+
+### Upgrades
+
+When a visitor requests a param combination that wasn't prerendered (e.g. `/electronics/speakers`), Next.js serves the most specific fallback shell available (`/electronics/[slug]`) and uses the param values from the request to render the page in the background.
+
+The result becomes the new shell for that URL, upgrading the fallback. If the page also has uncached data or runtime APIs behind `<Suspense>` fallbacks, the upgraded shell will still be partial, but with more params resolved.
+
+Upgrades require [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params). If `[slug]` had no `generateStaticParams`, the `/electronics/[slug]` shell would be served for every slug under `electronics` and never upgraded further. Params without `generateStaticParams` are always resolved at request time, and once one is encountered in the route, all params after it are too.
+
+`partialFallbacks` also applies to [catch-all segments](/docs/app/building-your-application/routing/dynamic-routes#catch-all-segments) (`[...slug]`) and [optional catch-all segments](/docs/app/building-your-application/routing/dynamic-routes#optional-catch-all-segments) (`[[...slug]]`).
+
+> **Good to know:** If you used [`fallback: true`](https://nextjs.org/docs/pages/api-reference/functions/get-static-paths#fallback-true) with `getStaticPaths` in the Pages Router: this is the App Router equivalent, built on `<Suspense>` instead of `router.isFallback`.
 
 ## Examples
 
@@ -107,9 +145,15 @@ export function generateStaticParams() {
 }
 ```
 
-### Category and slug
+With this setup:
 
-A layout provides `generateStaticParams` for `[category]`. The page does not provide `generateStaticParams` for `[slug]`:
+1. A visitor navigates to `/products/popular-item` (a prerendered slug). The page is served instantly as a fully static page.
+2. A visitor navigates to `/products/new-item` (not prerendered). They get the fallback shell immediately, seeing "Loading product details..." while the product data streams in.
+3. The next visitor to `/products/new-item` gets a fully static page. The slug was upgraded in the background after the first visit.
+
+### Nested params
+
+A layout provides `generateStaticParams` for `[category]`:
 
 ```tsx filename="app/[category]/layout.tsx" highlight={20-22}
 import { Suspense, type ReactNode } from 'react'
@@ -136,7 +180,9 @@ export function generateStaticParams() {
 }
 ```
 
-```tsx filename="app/[category]/[slug]/page.tsx"
+The page provides `generateStaticParams` for `[slug]` with a subset of values:
+
+```tsx filename="app/[category]/[slug]/page.tsx" highlight={10-12}
 export default async function ProductPage({
   params,
 }: {
@@ -145,9 +191,18 @@ export default async function ProductPage({
   const { slug } = await params
   return <p>{slug}</p>
 }
+
+export function generateStaticParams() {
+  return [{ slug: 'headphones' }, { slug: 'fiction' }]
+}
 ```
 
-At build time, Next.js generates fallback shells for `/electronics/[slug]`, `/books/[slug]`, and `/[category]/[slug]`. A request to `/electronics/headphones` receives the `/electronics/[slug]` shell with the category layout already prerendered.
+With this setup:
+
+1. `/electronics/headphones` (both params prerendered): served as a fully static page.
+2. `/electronics/speakers` (known category, unknown slug): the `/electronics/[slug]` fallback shell is served with the category layout already prerendered. The slug content streams in through `<Suspense>`.
+3. `/clothing/shirts` (unknown category): falls back to the generic `/[category]/[slug]` shell. Both params stream in.
+4. On subsequent visits, any fallback shell that was served is upgraded to a fully static page.
 
 ### Version History
 

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/partialFallbacks.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/partialFallbacks.mdx
@@ -1,0 +1,156 @@
+---
+title: partialFallbacks
+description: API Reference for the partialFallbacks experimental config option.
+version: experimental
+related:
+  links:
+    - app/api-reference/config/next-config-js/cacheComponents
+    - app/api-reference/functions/generate-static-params
+    - app/getting-started/caching
+---
+
+> **Good to know**: `partialFallbacks` requires [`cacheComponents: true`](/docs/app/api-reference/config/next-config-js/cacheComponents). You must enable both flags together.
+
+With [Cache Components](/docs/app/api-reference/config/next-config-js/cacheComponents), routes that use [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params) are prerendered at build time for each value returned.
+
+However for routes with many possible values (e.g. an e-commerce catalog with millions of products), prerendering every page means longer build times and increased cache write costs. Skipping `generateStaticParams` entirely means every visitor gets a generic static shell (a loading screen) with no param-specific content prerendered.
+
+With `partialFallbacks` enable, Next.js still prerenders a subset of pages with `generateStaticParams`, and any page not included in that subset is served instantly as a **fallback shell**, with the dynamic content streaming in through `<Suspense>`.
+
+After that, the page is automatically upgraded to a fully prerendered version in the background. Subsequent visitors get it instantly without any streaming delay.
+
+```ts filename="next.config.ts"
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  cacheComponents: true,
+  experimental: {
+    partialFallbacks: true,
+  },
+}
+
+export default nextConfig
+```
+
+```js filename="next.config.js"
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  cacheComponents: true,
+  experimental: {
+    partialFallbacks: true,
+  },
+}
+
+module.exports = nextConfig
+```
+
+## How it works
+
+Consider a route `/[slug]` where `generateStaticParams` returns a subset of values (e.g. `[{ slug: 'popular-post' }]`).
+
+Without `partialFallbacks`, a request for `/new-post` (a slug not in `generateStaticParams`) serves a generic static shell with no param-specific content. The visitor sees a loading screen while the page renders on the server.
+
+With `partialFallbacks`, `/new-post` is served instantly as a fallback shell. The static parts of the page (root layout, any cached components) are already prerendered, and the dynamic content streams in through `<Suspense>`. After this first visit, the deployment platform upgrades the fallback shell to a fully prerendered page in the background, so the next visitor gets `/new-post` instantly.
+
+To serve a fallback shell, the param must be accessed inside a `<Suspense>` boundary (for example, via a [`loading.tsx`](/docs/app/api-reference/file-conventions/loading) file) so Next.js can prerender the static parts above it.
+
+### Multiple params
+
+With Cache Components, Next.js already generates intermediate shells for routes with multiple params (e.g. `/electronics/[slug]` when `category` has `generateStaticParams`). Without `partialFallbacks`, those shells are the final result. With `partialFallbacks`, those shells become upgradeable: the skeleton is served first, and the deployment platform can progressively upgrade through the chain in the background.
+
+Consider `/[category]/[slug]` where the layout provides `generateStaticParams` for `category` (returning `electronics` and `books`) but no `generateStaticParams` exists for `slug`:
+
+| Shell                 | Type     | Resolved params           |
+| --------------------- | -------- | ------------------------- |
+| `/electronics/[slug]` | Fallback | `category: "electronics"` |
+| `/books/[slug]`       | Fallback | `category: "books"`       |
+| `/[category]/[slug]`  | Fallback | none                      |
+
+A request to `/electronics/headphones` serves the `/electronics/[slug]` fallback shell. The category layout is already prerendered, and only the `[slug]` page content streams in. The platform can then upgrade this to a complete shell for `/electronics/headphones` in the background. A request to `/clothing/shirts` (a category not in `generateStaticParams`) falls back to the generic `/[category]/[slug]` shell.
+
+> **Good to know:**
+>
+> - Once a dynamic param is encountered in the route, all subsequent params are also treated as unresolved. The order of params in the route matters.
+> - Shell upgrades depend on deployment platform support. The `partialFallback` flag in the build adapter output signals to the platform which shells are eligible for upgrade.
+> - If you used [`fallback: true`](https://nextjs.org/docs/pages/api-reference/functions/get-static-paths#fallback-true) with `getStaticPaths` in the Pages Router: this is the App Router equivalent, built on `<Suspense>` instead of `router.isFallback`.
+
+## Examples
+
+### Product catalog
+
+A page provides `generateStaticParams` for a subset of product slugs. Products not in the list are served as fallback shells and upgraded after the first visit:
+
+```tsx filename="app/products/[slug]/page.tsx" highlight={20-24}
+import { Suspense } from 'react'
+
+export default async function ProductPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+
+  return (
+    <div>
+      <h1>Product</h1>
+      <Suspense fallback={<p>Loading product details...</p>}>
+        <ProductDetails slug={slug} />
+      </Suspense>
+    </div>
+  )
+}
+
+export function generateStaticParams() {
+  // Only prerender the top 100 products at build time.
+  // All other slugs are served as fallback shells.
+  return topProducts.map((product) => ({ slug: product.slug }))
+}
+```
+
+### Category and slug
+
+A layout provides `generateStaticParams` for `[category]`. The page does not provide `generateStaticParams` for `[slug]`:
+
+```tsx filename="app/[category]/layout.tsx" highlight={20-22}
+import { Suspense, type ReactNode } from 'react'
+
+export default async function CategoryLayout({
+  children,
+  params,
+}: {
+  children: ReactNode
+  params: Promise<{ category: string }>
+}) {
+  const { category } = await params
+
+  return (
+    <section>
+      <h1>{category}</h1>
+      <Suspense fallback={<p>Loading product...</p>}>{children}</Suspense>
+    </section>
+  )
+}
+
+export function generateStaticParams() {
+  return [{ category: 'electronics' }, { category: 'books' }]
+}
+```
+
+```tsx filename="app/[category]/[slug]/page.tsx"
+export default async function ProductPage({
+  params,
+}: {
+  params: Promise<{ category: string; slug: string }>
+}) {
+  const { slug } = await params
+  return <p>{slug}</p>
+}
+```
+
+At build time, Next.js generates fallback shells for `/electronics/[slug]`, `/books/[slug]`, and `/[category]/[slug]`. A request to `/electronics/headphones` receives the `/electronics/[slug]` shell with the category layout already prerendered.
+
+### Version History
+
+| Version   | Changes                                     |
+| --------- | ------------------------------------------- |
+| `v16.x.x` | Experimental `partialFallbacks` introduced. |

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/partialFallbacks.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/partialFallbacks.mdx
@@ -15,7 +15,7 @@ related:
 [Dynamic routes](/docs/app/api-reference/file-conventions/dynamic-routes) that use [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params) are prerendered at build time for each combination returned. Without `partialFallbacks`, you face a tradeoff:
 
 - **Prerender every combination** with `generateStaticParams`: this can lead to longer build times and increased cache write costs.
-- **Skip `generateStaticParams`**: the server blocks until the full page is rendered before sending any content to the visitor.
+- **Skip `generateStaticParams`**: every visitor gets a generic fallback shell with no param-specific content prerendered.
 
 [Cache Components](/docs/app/api-reference/config/next-config-js/cacheComponents) with `partialFallbacks` enabled changes this. Instead of blocking until the page is rendered, the visitor gets a **fallback shell** instantly. A fallback shell is prerendered static content where one or more params are unknown at build time.
 
@@ -101,7 +101,7 @@ For the route above, this produces:
 - `/electronics/[slug]`: category resolved, slug shows fallback UI
 - `/[category]/[slug]`: both params show fallback UI
 
-> **Good to know**: If there is no `Suspense` fallback above the param access, no shell can be generated and the page blocks at request time.
+> **Good to know**: If there is no `<Suspense>` fallback above the param access, no shell can be generated and the page blocks at request time, just like it does without `partialFallbacks`.
 
 ### Upgrades
 
@@ -200,7 +200,7 @@ export function generateStaticParams() {
 }
 ```
 
-With this setup:
+At runtime:
 
 1. `/electronics/headphones` (both params prerendered): served as a fully static page.
 2. `/electronics/speakers` (known category, unknown slug): the `/electronics/[slug]` fallback shell is served with the category layout already prerendered. The slug content streams in through `<Suspense>`.

--- a/docs/01-app/04-glossary.mdx
+++ b/docs/01-app/04-glossary.mdx
@@ -94,7 +94,7 @@ Custom path mappings that provide shorthand references for frequently used direc
 
 ## Incremental Static Regeneration (ISR)
 
-A technique that allows you to update static content without rebuilding the entire site. ISR enables you to use static generation on a per-page basis while revalidating pages in the background as traffic comes in. Learn more in the [ISR guide](/docs/app/guides/incremental-static-regeneration).
+A technique that allows you to update static content without rebuilding the entire site. ISR enables you to use static generation on a per-page basis while revalidating pages in the background as traffic comes in. Learn more in the [ISR guide](/docs/app/guides/incremental-static-regeneration) or, when using Cache Components, [ISR with Cache Components](/docs/app/guides/incremental-static-regeneration-cache-components).
 
 > **Good to know**: In Next.js, ISR is also known as [Revalidation](#revalidation).
 


### PR DESCRIPTION
Completing the ISR with Cache Components story.

- [ ] mention to cacheHandler and cacheHandlers - these work fine together (aka with cacheComponents activated)
- [ ] prefetch behavior - background revalidation
- [x] link to demo app
- [x] update version history in partialFallbacks config

Closes: https://github.com/vercel/next.js/issues/91951