### PR TITLE
Remove a ton of turbo task functions from Issue trait items

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4749,6 +4749,7 @@ name = "next-api"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "bincode 2.0.1",
  "byteorder",
  "either",
@@ -10005,6 +10006,7 @@ name = "turbo-tasks-fetch"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "mockito",
  "quick_cache",
  "reqwest",
@@ -10230,6 +10232,7 @@ name = "turbopack-browser"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "bincode 2.0.1",
  "either",
  "indoc",
@@ -10378,6 +10381,7 @@ name = "turbopack-css"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "bincode 2.0.1",
  "indoc",
  "lightningcss",
@@ -10403,6 +10407,7 @@ name = "turbopack-dev-server"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "auto-hash-map",
  "bincode 2.0.1",
  "flate2",
@@ -10540,6 +10545,7 @@ name = "turbopack-env"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "turbo-rcstr",
  "turbo-tasks",
  "turbo-tasks-env",
@@ -10553,6 +10559,7 @@ name = "turbopack-image"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "base64 0.21.4",
  "bincode 2.0.1",
  "image",
@@ -10573,6 +10580,7 @@ name = "turbopack-mdx"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "markdown",
  "mdxjs",
  "serde",
@@ -10680,6 +10688,7 @@ name = "turbopack-resolve"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "bincode 2.0.1",
  "next-taskless",
  "regex",

--- a/crates/next-api/Cargo.toml
+++ b/crates/next-api/Cargo.toml
@@ -19,6 +19,7 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+async-trait = { workspace = true }
 bincode = { workspace = true }
 byteorder = { workspace = true }
 either = { workspace = true }

--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 
 use anyhow::{Ok, Result};
+use async_trait::async_trait;
 use either::Either;
 use futures::join;
 use next_core::{
@@ -21,7 +22,7 @@ use turbo_tasks::{
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     context::AssetContext,
-    issue::{Issue, IssueExt, IssueSeverity, IssueStage, OptionStyledString, StyledString},
+    issue::{Issue, IssueExt, IssueSeverity, IssueStage, StyledString},
     module::Module,
     module_graph::{GraphTraversalAction, ModuleGraph, ModuleGraphLayer},
 };
@@ -704,11 +705,11 @@ impl CssGlobalImportIssue {
     }
 }
 
+#[async_trait]
 #[turbo_tasks::value_impl]
 impl Issue for CssGlobalImportIssue {
-    #[turbo_tasks::function]
-    async fn title(&self) -> Vc<StyledString> {
-        StyledString::Stack(vec![
+    async fn title(&self) -> Result<StyledString> {
+        Ok(StyledString::Stack(vec![
             StyledString::Text(rcstr!("Failed to compile")),
             StyledString::Text(rcstr!(
                 "Global CSS cannot be imported from files other than your Custom <App>. Due to \
@@ -719,12 +720,10 @@ impl Issue for CssGlobalImportIssue {
             StyledString::Text(rcstr!(
                 "Read more: https://nextjs.org/docs/messages/css-global"
             )),
-        ])
-        .cell()
+        ]))
     }
 
-    #[turbo_tasks::function]
-    async fn description(&self) -> Result<Vc<OptionStyledString>> {
+    async fn description(&self) -> Result<Option<StyledString>> {
         let parent_path = self.parent_module.ident().path().owned().await?;
         let module_path = self.module.ident().path().owned().await?;
         let relative_import_location = parent_path.parent();
@@ -740,27 +739,22 @@ impl Issue for CssGlobalImportIssue {
                 import_path
             };
 
-        Ok(Vc::cell(Some(
-            StyledString::Stack(vec![
-                StyledString::Text(format!("Location: {}", parent_path.path).into()),
-                StyledString::Text(format!("Import path: {cleaned_import_path}",).into()),
-            ])
-            .resolved_cell(),
-        )))
+        Ok(Some(StyledString::Stack(vec![
+            StyledString::Text(format!("Location: {}", parent_path.path).into()),
+            StyledString::Text(format!("Import path: {cleaned_import_path}",).into()),
+        ])))
     }
 
     fn severity(&self) -> IssueSeverity {
         IssueSeverity::Error
     }
 
-    #[turbo_tasks::function]
-    fn file_path(&self) -> Vc<FileSystemPath> {
-        self.parent_module.ident().path()
+    async fn file_path(&self) -> Result<FileSystemPath> {
+        self.parent_module.ident().path().owned().await
     }
 
-    #[turbo_tasks::function]
-    fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::ProcessModule.cell()
+    fn stage(&self) -> IssueStage {
+        IssueStage::ProcessModule
     }
 
     // TODO(PACK-4879): compute the source information by following the module references

--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -709,18 +709,13 @@ impl CssGlobalImportIssue {
 #[turbo_tasks::value_impl]
 impl Issue for CssGlobalImportIssue {
     async fn title(&self) -> Result<StyledString> {
-        Ok(StyledString::Stack(vec![
-            StyledString::Text(rcstr!("Failed to compile")),
-            StyledString::Text(rcstr!(
-                "Global CSS cannot be imported from files other than your Custom <App>. Due to \
-                 the Global nature of stylesheets, and to avoid conflicts, Please move all \
-                 first-party global CSS imports to pages/_app.js. Or convert the import to \
-                 Component-Level CSS (CSS Modules)."
-            )),
-            StyledString::Text(rcstr!(
-                "Read more: https://nextjs.org/docs/messages/css-global"
-            )),
-        ]))
+        Ok(StyledString::Text(rcstr!(
+            "Global CSS cannot be imported from files other than your Custom <App>."
+        )))
+    }
+
+    fn documentation_link(&self) -> RcStr {
+        rcstr!("https://nextjs.org/docs/messages/css-global")
     }
 
     async fn description(&self) -> Result<Option<StyledString>> {
@@ -740,8 +735,19 @@ impl Issue for CssGlobalImportIssue {
             };
 
         Ok(Some(StyledString::Stack(vec![
-            StyledString::Text(format!("Location: {}", parent_path.path).into()),
-            StyledString::Text(format!("Import path: {cleaned_import_path}",).into()),
+            StyledString::Text(rcstr!(
+                "Due to the Global nature of stylesheets, and to avoid conflicts, Please move all \
+                 first-party global CSS imports to pages/_app.js. Or convert the import to \
+                 Component-Level CSS (CSS Modules)."
+            )),
+            StyledString::Line(vec![
+                StyledString::Text(rcstr!("Location: ")),
+                StyledString::Code(parent_path.path.clone()),
+            ]),
+            StyledString::Line(vec![
+                StyledString::Text(rcstr!("Import path: ")),
+                StyledString::Code(cleaned_import_path),
+            ]),
         ])))
     }
 

--- a/crates/next-api/src/nft_json.rs
+++ b/crates/next-api/src/nft_json.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeSet, HashSet, VecDeque};
 
 use anyhow::{Result, bail};
+use async_trait::async_trait;
 use serde_json::json;
 use tracing::{Instrument, Level, Span};
 use turbo_rcstr::{RcStr, rcstr};
@@ -15,7 +16,7 @@ use turbo_tasks_fs::{
 };
 use turbopack_core::{
     asset::{Asset, AssetContent},
-    issue::{Issue, IssueExt, IssueSeverity, IssueStage, OptionStyledString, StyledString},
+    issue::{Issue, IssueExt, IssueSeverity, IssueStage, StyledString},
     output::{OutputAsset, OutputAssets, OutputAssetsReference},
 };
 
@@ -544,6 +545,7 @@ struct ForbiddenTracedFileIssue {
     path: Vec<ResolvedVc<Box<dyn OutputAsset>>>,
 }
 
+#[async_trait]
 #[turbo_tasks::value_impl]
 impl Issue for ForbiddenTracedFileIssue {
     fn severity(&self) -> IssueSeverity {
@@ -552,23 +554,21 @@ impl Issue for ForbiddenTracedFileIssue {
         IssueSeverity::Warning
     }
 
-    #[turbo_tasks::function]
-    fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::Misc.cell()
+    fn stage(&self) -> IssueStage {
+        IssueStage::Misc
     }
 
-    #[turbo_tasks::function]
-    fn file_path(&self) -> Vc<FileSystemPath> {
-        self.file.path()
+    async fn file_path(&self) -> Result<FileSystemPath> {
+        self.file.path().owned().await
     }
 
-    #[turbo_tasks::function]
-    fn title(&self) -> Vc<StyledString> {
-        StyledString::Text(rcstr!("Encountered unexpected file in NFT list")).cell()
+    async fn title(&self) -> Result<StyledString> {
+        Ok(StyledString::Text(rcstr!(
+            "Encountered unexpected file in NFT list"
+        )))
     }
 
-    #[turbo_tasks::function]
-    async fn description(&self) -> Result<Vc<OptionStyledString>> {
+    async fn description(&self) -> Result<Option<StyledString>> {
         let mut stack = vec![
             StyledString::Text(rcstr!(
                 "A file was traced that indicates that the whole project was traced \
@@ -625,7 +625,7 @@ impl Issue for ForbiddenTracedFileIssue {
             ])
         }
 
-        Ok(Vc::cell(Some(StyledString::Stack(stack).resolved_cell())))
+        Ok(Some(StyledString::Stack(stack)))
     }
 }
 

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
+use async_trait::async_trait;
 use bincode::{Decode, Encode};
 use indexmap::map::Entry;
 use next_core::{
@@ -60,8 +61,7 @@ use turbopack_core::{
     file_source::FileSource,
     ident::Layer,
     issue::{
-        CollectibleIssuesExt, Issue, IssueExt, IssueFilter, IssueSeverity, IssueStage,
-        OptionStyledString, StyledString,
+        CollectibleIssuesExt, Issue, IssueExt, IssueFilter, IssueSeverity, IssueStage, StyledString,
     },
     module::Module,
     module_graph::{
@@ -1026,30 +1026,27 @@ struct ConflictIssue {
     severity: IssueSeverity,
 }
 
+#[async_trait]
 #[turbo_tasks::value_impl]
 impl Issue for ConflictIssue {
-    #[turbo_tasks::function]
-    fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::AppStructure.cell()
+    fn stage(&self) -> IssueStage {
+        IssueStage::AppStructure
     }
 
     fn severity(&self) -> IssueSeverity {
         self.severity
     }
 
-    #[turbo_tasks::function]
-    fn file_path(&self) -> Vc<FileSystemPath> {
-        self.path.clone().cell()
+    async fn file_path(&self) -> Result<FileSystemPath> {
+        Ok(self.path.clone())
     }
 
-    #[turbo_tasks::function]
-    fn title(&self) -> Vc<StyledString> {
-        *self.title
+    async fn title(&self) -> Result<StyledString> {
+        self.title.owned().await
     }
 
-    #[turbo_tasks::function]
-    fn description(&self) -> Vc<OptionStyledString> {
-        Vc::cell(Some(self.description))
+    async fn description(&self) -> Result<Option<StyledString>> {
+        Ok(Some(self.description.owned().await?))
     }
 }
 

--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 
 use anyhow::{Context, Result, bail};
+use async_trait::async_trait;
 use bincode::{Decode, Encode};
 use indexmap::map::{Entry, OccupiedEntry};
 use rustc_hash::FxHashMap;
@@ -11,9 +12,7 @@ use turbo_tasks::{
     ValueToStringRef, Vc, debug::ValueDebugFormat, fxindexmap, trace::TraceRawVcs, turbobail,
 };
 use turbo_tasks_fs::{DirectoryContent, DirectoryEntry, FileSystemEntryType, FileSystemPath};
-use turbopack_core::issue::{
-    Issue, IssueExt, IssueSeverity, IssueStage, OptionStyledString, StyledString,
-};
+use turbopack_core::issue::{Issue, IssueExt, IssueSeverity, IssueStage, StyledString};
 
 use crate::{
     mode::NextMode,
@@ -884,30 +883,26 @@ struct DuplicateParallelRouteIssue {
     page: AppPage,
 }
 
+#[async_trait]
 #[turbo_tasks::value_impl]
 impl Issue for DuplicateParallelRouteIssue {
-    #[turbo_tasks::function]
-    fn file_path(&self) -> Result<Vc<FileSystemPath>> {
-        Ok(self.app_dir.join(&self.page.to_string())?.cell())
+    async fn file_path(&self) -> Result<FileSystemPath> {
+        self.app_dir.join(&self.page.to_string())
     }
 
-    #[turbo_tasks::function]
-    fn stage(self: Vc<Self>) -> Vc<IssueStage> {
-        IssueStage::ProcessModule.cell()
+    fn stage(&self) -> IssueStage {
+        IssueStage::ProcessModule
     }
 
-    #[turbo_tasks::function]
-    async fn title(self: Vc<Self>) -> Result<Vc<StyledString>> {
-        let this = self.await?;
+    async fn title(&self) -> Result<StyledString> {
         Ok(StyledString::Text(
             format!(
                 "You cannot have two parallel pages that resolve to the same path. Please check \
                  {} and {}.",
-                this.previously_inserted_page, this.page
+                self.previously_inserted_page, self.page
             )
             .into(),
-        )
-        .cell())
+        ))
     }
 }
 
@@ -932,68 +927,56 @@ fn missing_default_parallel_route_issue(
     .cell()
 }
 
+#[async_trait]
 #[turbo_tasks::value_impl]
 impl Issue for MissingDefaultParallelRouteIssue {
-    #[turbo_tasks::function]
-    fn file_path(&self) -> Result<Vc<FileSystemPath>> {
-        Ok(self
-            .app_dir
+    async fn file_path(&self) -> Result<FileSystemPath> {
+        self.app_dir
             .join(&self.app_page.to_string())?
-            .join(&format!("@{}", self.slot_name))?
-            .cell())
+            .join(&format!("@{}", self.slot_name))
     }
 
-    #[turbo_tasks::function]
-    fn stage(self: Vc<Self>) -> Vc<IssueStage> {
-        IssueStage::AppStructure.cell()
+    fn stage(&self) -> IssueStage {
+        IssueStage::AppStructure
     }
 
     fn severity(&self) -> IssueSeverity {
         IssueSeverity::Error
     }
 
-    #[turbo_tasks::function]
-    async fn title(&self) -> Vc<StyledString> {
-        StyledString::Text(
+    async fn title(&self) -> Result<StyledString> {
+        Ok(StyledString::Text(
             format!(
                 "Missing required default.js file for parallel route at {}/@{}",
                 self.app_page, self.slot_name
             )
             .into(),
-        )
-        .cell()
-    }
-
-    #[turbo_tasks::function]
-    async fn description(&self) -> Vc<OptionStyledString> {
-        Vc::cell(Some(
-            StyledString::Stack(vec![
-                StyledString::Text(
-                    format!(
-                        "The parallel route slot \"@{}\" is missing a default.js file. When using \
-                         parallel routes, each slot must have a default.js file to serve as a \
-                         fallback.",
-                        self.slot_name
-                    )
-                    .into(),
-                ),
-                StyledString::Text(
-                    format!(
-                        "Create a default.js file at: {}/@{}/default.js",
-                        self.app_page, self.slot_name
-                    )
-                    .into(),
-                ),
-            ])
-            .resolved_cell(),
         ))
     }
 
-    #[turbo_tasks::function]
-    fn documentation_link(&self) -> Vc<RcStr> {
-        Vc::cell(rcstr!(
-            "https://nextjs.org/docs/messages/slot-missing-default"
-        ))
+    async fn description(&self) -> Result<Option<StyledString>> {
+        Ok(Some(StyledString::Stack(vec![
+            StyledString::Text(
+                format!(
+                    "The parallel route slot \"@{}\" is missing a default.js file. When using \
+                     parallel routes, each slot must have a default.js file to serve as a \
+                     fallback.",
+                    self.slot_name
+                )
+                .into(),
+            ),
+            StyledString::Text(
+                format!(
+                    "Create a default.js file at: {}/@{}/default.js",
+                    self.app_page, self.slot_name
+                )
+                .into(),
+            ),
+        ])))
+    }
+
+    fn documentation_link(&self) -> RcStr {
+        rcstr!("https://nextjs.org/docs/messages/slot-missing-default")
     }
 }
 
@@ -2058,29 +2041,28 @@ struct DirectoryTreeIssue {
     pub message: ResolvedVc<StyledString>,
 }
 
+#[async_trait]
 #[turbo_tasks::value_impl]
 impl Issue for DirectoryTreeIssue {
     fn severity(&self) -> IssueSeverity {
         self.severity
     }
 
-    #[turbo_tasks::function]
-    fn title(&self) -> Vc<StyledString> {
-        StyledString::Text(rcstr!("An issue occurred while preparing your Next.js app")).cell()
+    async fn title(&self) -> Result<StyledString> {
+        Ok(StyledString::Text(rcstr!(
+            "An issue occurred while preparing your Next.js app"
+        )))
     }
 
-    #[turbo_tasks::function]
-    fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::AppStructure.cell()
+    fn stage(&self) -> IssueStage {
+        IssueStage::AppStructure
     }
 
-    #[turbo_tasks::function]
-    fn file_path(&self) -> Vc<FileSystemPath> {
-        self.app_dir.clone().cell()
+    async fn file_path(&self) -> Result<FileSystemPath> {
+        Ok(self.app_dir.clone())
     }
 
-    #[turbo_tasks::function]
-    fn description(&self) -> Vc<OptionStyledString> {
-        Vc::cell(Some(self.message))
+    async fn description(&self) -> Result<Option<StyledString>> {
+        Ok(Some((*self.message.await?).clone()))
     }
 }

--- a/crates/next-core/src/emit.rs
+++ b/crates/next-core/src/emit.rs
@@ -1,4 +1,5 @@
 use anyhow::{Ok, Result};
+use async_trait::async_trait;
 use futures::join;
 use smallvec::{SmallVec, smallvec};
 use tracing::Instrument;
@@ -10,7 +11,7 @@ use turbo_tasks_fs::{FileContent, FileSystemPath, rebase};
 use turbo_tasks_hash::{encode_hex, hash_xxh3_hash64};
 use turbopack_core::{
     asset::{Asset, AssetContent},
-    issue::{Issue, IssueExt, IssueSeverity, IssueStage, OptionStyledString, StyledString},
+    issue::{Issue, IssueExt, IssueSeverity, IssueStage, StyledString},
     output::{ExpandedOutputAssets, OutputAsset, OutputAssets},
     reference::all_assets_from_entries,
 };
@@ -300,34 +301,28 @@ struct EmitConflictIssue {
     detail: RcStr,
 }
 
+#[async_trait]
 #[turbo_tasks::value_impl]
 impl Issue for EmitConflictIssue {
-    #[turbo_tasks::function]
-    fn file_path(&self) -> Vc<FileSystemPath> {
-        self.asset_path.clone().cell()
+    async fn file_path(&self) -> Result<FileSystemPath> {
+        Ok(self.asset_path.clone())
     }
 
-    #[turbo_tasks::function]
-    fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::Emit.cell()
+    fn stage(&self) -> IssueStage {
+        IssueStage::Emit
     }
 
     fn severity(&self) -> IssueSeverity {
         IssueSeverity::Error
     }
 
-    #[turbo_tasks::function]
-    fn title(&self) -> Vc<StyledString> {
-        StyledString::Text(
+    async fn title(&self) -> Result<StyledString> {
+        Ok(StyledString::Text(
             "Two or more assets with different content were emitted to the same output path".into(),
-        )
-        .cell()
+        ))
     }
 
-    #[turbo_tasks::function]
-    fn description(&self) -> Vc<OptionStyledString> {
-        Vc::cell(Some(
-            StyledString::Text(self.detail.clone()).resolved_cell(),
-        ))
+    async fn description(&self) -> Result<Option<StyledString>> {
+        Ok(Some(StyledString::Text(self.detail.clone())))
     }
 }

--- a/crates/next-core/src/middleware.rs
+++ b/crates/next-core/src/middleware.rs
@@ -1,11 +1,12 @@
 use anyhow::Result;
+use async_trait::async_trait;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, Vc, fxindexmap};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     context::AssetContext,
     file_source::FileSource,
-    issue::{Issue, IssueExt, IssueSeverity, IssueStage, OptionStyledString, StyledString},
+    issue::{Issue, IssueExt, IssueSeverity, IssueStage, StyledString},
     module::Module,
     reference_type::ReferenceType,
 };
@@ -144,34 +145,30 @@ struct MiddlewareMissingExportIssue {
     file_path: FileSystemPath,
 }
 
+#[async_trait]
 #[turbo_tasks::value_impl]
 impl Issue for MiddlewareMissingExportIssue {
-    #[turbo_tasks::function]
-    fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::Transform.cell()
+    fn stage(&self) -> IssueStage {
+        IssueStage::Transform
     }
 
     fn severity(&self) -> IssueSeverity {
         IssueSeverity::Error
     }
 
-    #[turbo_tasks::function]
-    fn file_path(&self) -> Vc<FileSystemPath> {
-        self.file_path.clone().cell()
+    async fn file_path(&self) -> Result<FileSystemPath> {
+        Ok(self.file_path.clone())
     }
 
-    #[turbo_tasks::function]
-    async fn title(&self) -> Result<Vc<StyledString>> {
+    async fn title(&self) -> Result<StyledString> {
         let title_text = format!(
             "{} is missing expected function export name",
             self.file_type
         );
-
-        Ok(StyledString::Text(title_text.into()).cell())
+        Ok(StyledString::Text(title_text.into()))
     }
 
-    #[turbo_tasks::function]
-    async fn description(&self) -> Result<Vc<OptionStyledString>> {
+    async fn description(&self) -> Result<Option<StyledString>> {
         let type_description = if self.file_type == "Proxy" {
             "proxy (previously called middleware)"
         } else {
@@ -201,8 +198,6 @@ impl Issue for MiddlewareMissingExportIssue {
             self.function_name
         );
 
-        Ok(Vc::cell(Some(
-            StyledString::Text(description_text.into()).resolved_cell(),
-        )))
+        Ok(Some(StyledString::Text(description_text.into())))
     }
 }

--- a/crates/next-core/src/next_app/metadata/route.rs
+++ b/crates/next-core/src/next_app/metadata/route.rs
@@ -3,6 +3,7 @@
 //! See `next/src/build/webpack/loaders/next-metadata-route-loader`
 
 use anyhow::{Ok, Result};
+use async_trait::async_trait;
 use base64::{display::Base64Display, engine::general_purpose::STANDARD};
 use indoc::formatdoc;
 use turbo_rcstr::{RcStr, rcstr};
@@ -12,7 +13,7 @@ use turbopack::ModuleAssetContext;
 use turbopack_core::{
     asset::AssetContent,
     file_source::FileSource,
-    issue::{Issue, IssueExt, IssueSeverity, IssueStage, OptionStyledString, StyledString},
+    issue::{Issue, IssueExt, IssueSeverity, IssueStage, StyledString},
     source::Source,
     virtual_source::VirtualSource,
 };
@@ -539,48 +540,41 @@ struct StaticMetadataFileSizeIssue {
     file_size_limit_mb: usize,
 }
 
+#[async_trait]
 #[turbo_tasks::value_impl]
 impl Issue for StaticMetadataFileSizeIssue {
     fn severity(&self) -> IssueSeverity {
         IssueSeverity::Error
     }
 
-    #[turbo_tasks::function]
-    fn title(&self) -> Vc<StyledString> {
-        StyledString::Text(rcstr!("Static metadata file size exceeded")).cell()
-    }
-
-    #[turbo_tasks::function]
-    fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::ProcessModule.cell()
-    }
-
-    #[turbo_tasks::function]
-    fn file_path(&self) -> Vc<FileSystemPath> {
-        self.path.clone().cell()
-    }
-
-    #[turbo_tasks::function]
-    async fn description(&self) -> Result<Vc<OptionStyledString>> {
-        let current_size = (self.file_size as f32) / 1024.0 / 1024.0;
-        Ok(Vc::cell(Some(
-            StyledString::Text(
-                turbofmt!(
-                    "File size for {} image \"{}\" exceeds {}MB. (Current: {current_size:.1}MB)",
-                    self.img_name,
-                    self.path,
-                    self.file_size_limit_mb,
-                )
-                .await?,
-            )
-            .resolved_cell(),
+    async fn title(&self) -> Result<StyledString> {
+        Ok(StyledString::Text(rcstr!(
+            "Static metadata file size exceeded"
         )))
     }
 
-    #[turbo_tasks::function]
-    fn documentation_link(&self) -> Vc<RcStr> {
-        Vc::cell(rcstr!(
-            "https://nextjs.org/docs/app/api-reference/file-conventions/metadata/opengraph-image#image-files-jpg-png-gif"
-        ))
+    fn stage(&self) -> IssueStage {
+        IssueStage::ProcessModule
+    }
+
+    async fn file_path(&self) -> Result<FileSystemPath> {
+        Ok(self.path.clone())
+    }
+
+    async fn description(&self) -> Result<Option<StyledString>> {
+        let current_size = (self.file_size as f32) / 1024.0 / 1024.0;
+        Ok(Some(StyledString::Text(
+            turbofmt!(
+                "File size for {} image \"{}\" exceeds {}MB. (Current: {current_size:.1}MB)",
+                self.img_name,
+                self.path,
+                self.file_size_limit_mb,
+            )
+            .await?,
+        )))
+    }
+
+    fn documentation_link(&self) -> RcStr {
+        rcstr!("https://nextjs.org/docs/app/api-reference/file-conventions/metadata/opengraph-image#image-files-jpg-png-gif")
     }
 }

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result, bail};
+use async_trait::async_trait;
 use bincode::{Decode, Encode};
 use either::Either;
 use rustc_hash::FxHashSet;
@@ -23,8 +24,7 @@ use turbopack::module_options::{
 use turbopack_core::{
     chunk::SourceMapsType,
     issue::{
-        IgnoreIssue, IgnoreIssuePattern, Issue, IssueExt, IssueSeverity, IssueStage,
-        OptionStyledString, StyledString,
+        IgnoreIssue, IgnoreIssuePattern, Issue, IssueExt, IssueSeverity, IssueStage, StyledString,
     },
     resolve::ResolveAliasMap,
 };
@@ -1489,40 +1489,32 @@ struct InvalidLoaderRuleRenameAsIssue {
     config_file_path: FileSystemPath,
 }
 
+#[async_trait]
 #[turbo_tasks::value_impl]
 impl Issue for InvalidLoaderRuleRenameAsIssue {
-    #[turbo_tasks::function]
-    async fn file_path(&self) -> Result<Vc<FileSystemPath>> {
-        Ok(self.config_file_path.clone().cell())
+    async fn file_path(&self) -> Result<FileSystemPath> {
+        Ok(self.config_file_path.clone())
     }
 
-    #[turbo_tasks::function]
-    fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::Config.cell()
+    fn stage(&self) -> IssueStage {
+        IssueStage::Config
     }
 
-    #[turbo_tasks::function]
-    async fn title(&self) -> Result<Vc<StyledString>> {
-        Ok(
-            StyledString::Text(format!("Invalid loader rule for extension: {}", self.glob).into())
-                .cell(),
-        )
+    async fn title(&self) -> Result<StyledString> {
+        Ok(StyledString::Text(
+            format!("Invalid loader rule for extension: {}", self.glob).into(),
+        ))
     }
 
-    #[turbo_tasks::function]
-    async fn description(&self) -> Result<Vc<OptionStyledString>> {
-        Ok(Vc::cell(Some(
-            StyledString::Text(RcStr::from(format!(
-                "The extension {} contains a wildcard, but the `as` option does not: {}",
-                self.glob, self.rename_as,
-            )))
-            .resolved_cell(),
-        )))
+    async fn description(&self) -> Result<Option<StyledString>> {
+        Ok(Some(StyledString::Text(RcStr::from(format!(
+            "The extension {} contains a wildcard, but the `as` option does not: {}",
+            self.glob, self.rename_as,
+        )))))
     }
 
-    #[turbo_tasks::function]
-    fn documentation_link(&self) -> Vc<RcStr> {
-        Vc::cell(turbopack_config_documentation_link())
+    fn documentation_link(&self) -> RcStr {
+        turbopack_config_documentation_link()
     }
 }
 
@@ -1533,41 +1525,36 @@ struct InvalidLoaderRuleConditionIssue {
     config_file_path: FileSystemPath,
 }
 
+#[async_trait]
 #[turbo_tasks::value_impl]
 impl Issue for InvalidLoaderRuleConditionIssue {
-    #[turbo_tasks::function]
-    async fn file_path(self: Vc<Self>) -> Result<Vc<FileSystemPath>> {
-        Ok(self.await?.config_file_path.clone().cell())
+    async fn file_path(&self) -> Result<FileSystemPath> {
+        Ok(self.config_file_path.clone())
     }
 
-    #[turbo_tasks::function]
-    fn stage(self: Vc<Self>) -> Vc<IssueStage> {
-        IssueStage::Config.cell()
+    fn stage(&self) -> IssueStage {
+        IssueStage::Config
     }
 
-    #[turbo_tasks::function]
-    async fn title(&self) -> Result<Vc<StyledString>> {
-        Ok(StyledString::Text(rcstr!("Invalid condition for Turbopack loader rule")).cell())
-    }
-
-    #[turbo_tasks::function]
-    async fn description(&self) -> Result<Vc<OptionStyledString>> {
-        Ok(Vc::cell(Some(
-            StyledString::Stack(vec![
-                StyledString::Line(vec![
-                    StyledString::Text(rcstr!("Encountered the following error: ")),
-                    StyledString::Code(self.error_string.clone()),
-                ]),
-                StyledString::Text(rcstr!("While processing the condition:")),
-                StyledString::Code(RcStr::from(format!("{:#?}", self.condition))),
-            ])
-            .resolved_cell(),
+    async fn title(&self) -> Result<StyledString> {
+        Ok(StyledString::Text(rcstr!(
+            "Invalid condition for Turbopack loader rule"
         )))
     }
 
-    #[turbo_tasks::function]
-    fn documentation_link(&self) -> Vc<RcStr> {
-        Vc::cell(turbopack_config_documentation_link())
+    async fn description(&self) -> Result<Option<StyledString>> {
+        Ok(Some(StyledString::Stack(vec![
+            StyledString::Line(vec![
+                StyledString::Text(rcstr!("Encountered the following error: ")),
+                StyledString::Code(self.error_string.clone()),
+            ]),
+            StyledString::Text(rcstr!("While processing the condition:")),
+            StyledString::Code(RcStr::from(format!("{:#?}", self.condition))),
+        ])))
+    }
+
+    fn documentation_link(&self) -> RcStr {
+        turbopack_config_documentation_link()
     }
 }
 

--- a/crates/next-core/src/next_font/issue.rs
+++ b/crates/next-core/src/next_font/issue.rs
@@ -1,6 +1,8 @@
-use turbo_tasks::{ResolvedVc, Vc};
+use anyhow::Result;
+use async_trait::async_trait;
+use turbo_tasks::ResolvedVc;
 use turbo_tasks_fs::FileSystemPath;
-use turbopack_core::issue::{Issue, IssueSeverity, IssueStage, OptionStyledString, StyledString};
+use turbopack_core::issue::{Issue, IssueSeverity, IssueStage, StyledString};
 
 #[turbo_tasks::value(shared)]
 pub(crate) struct NextFontIssue {
@@ -10,29 +12,26 @@ pub(crate) struct NextFontIssue {
     pub(crate) severity: IssueSeverity,
 }
 
+#[async_trait]
 #[turbo_tasks::value_impl]
 impl Issue for NextFontIssue {
-    #[turbo_tasks::function]
-    fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::Resolve.cell()
+    fn stage(&self) -> IssueStage {
+        IssueStage::Resolve
     }
 
     fn severity(&self) -> IssueSeverity {
         self.severity
     }
 
-    #[turbo_tasks::function]
-    fn file_path(&self) -> Vc<FileSystemPath> {
-        self.path.clone().cell()
+    async fn file_path(&self) -> Result<FileSystemPath> {
+        Ok(self.path.clone())
     }
 
-    #[turbo_tasks::function]
-    fn title(&self) -> Vc<StyledString> {
-        *self.title
+    async fn title(&self) -> Result<StyledString> {
+        self.title.owned().await
     }
 
-    #[turbo_tasks::function]
-    fn description(&self) -> Vc<OptionStyledString> {
-        Vc::cell(Some(self.description))
+    async fn description(&self) -> Result<Option<StyledString>> {
+        Ok(Some(self.description.owned().await?))
     }
 }

--- a/crates/next-core/src/next_font/local/mod.rs
+++ b/crates/next-core/src/next_font/local/mod.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result, bail};
+use async_trait::async_trait;
 use indoc::formatdoc;
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::{RcStr, rcstr};
@@ -314,30 +315,26 @@ struct FontResolvingIssue {
     font_path: ResolvedVc<RcStr>,
 }
 
+#[async_trait]
 #[turbo_tasks::value_impl]
 impl Issue for FontResolvingIssue {
     fn severity(&self) -> IssueSeverity {
         IssueSeverity::Error
     }
 
-    #[turbo_tasks::function]
-    fn file_path(&self) -> Vc<FileSystemPath> {
+    async fn file_path(&self) -> Result<FileSystemPath> {
         panic!("FontResolvingIssue::file_path should not be called");
     }
 
-    #[turbo_tasks::function]
-    fn stage(self: Vc<Self>) -> Vc<IssueStage> {
-        IssueStage::Resolve.cell()
+    fn stage(&self) -> IssueStage {
+        IssueStage::Resolve
     }
 
-    #[turbo_tasks::function]
-    async fn title(self: Vc<Self>) -> Result<Vc<StyledString>> {
-        let this = self.await?;
+    async fn title(&self) -> Result<StyledString> {
         Ok(StyledString::Line(vec![
             StyledString::Text(rcstr!("Font file not found: Can't resolve '")),
-            StyledString::Code(this.font_path.owned().await?),
+            StyledString::Code(self.font_path.owned().await?),
             StyledString::Text(rcstr!("'")),
-        ])
-        .cell())
+        ]))
     }
 }

--- a/crates/next-core/src/next_import_map.rs
+++ b/crates/next-core/src/next_import_map.rs
@@ -1,6 +1,7 @@
 use std::{collections::BTreeMap, sync::LazyLock};
 
 use anyhow::{Context, Result};
+use async_trait::async_trait;
 use either::Either;
 use next_taskless::{EDGE_NODE_EXTERNALS, NODE_EXTERNALS};
 use rustc_hash::FxHashMap;
@@ -8,7 +9,7 @@ use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{FxIndexMap, ResolvedVc, Vc, fxindexmap};
 use turbo_tasks_fs::{FileSystem, FileSystemPath, to_sys_path};
 use turbopack_core::{
-    issue::{Issue, IssueExt, IssueSeverity, IssueStage, OptionStyledString, StyledString},
+    issue::{Issue, IssueExt, IssueSeverity, IssueStage, StyledString},
     reference_type::{CommonJsReferenceSubType, ReferenceType},
     resolve::{
         AliasPattern, ExternalTraced, ExternalType, ResolveAliasMap, SubpathValue,
@@ -203,12 +204,10 @@ pub async fn get_next_client_import_map(
     insert_exact_alias_map(
         &mut import_map,
         project_path.clone(),
-        fxindexmap! {
-            rcstr!("server-only") => rcstr!("next/dist/compiled/server-only/index"),
-            rcstr!("client-only") => rcstr!("next/dist/compiled/client-only/index"),
-            rcstr!("next/dist/compiled/server-only") => rcstr!("next/dist/compiled/server-only/index"),
-            rcstr!("next/dist/compiled/client-only") => rcstr!("next/dist/compiled/client-only/index"),
-        },
+        fxindexmap! {rcstr!("server-only") => rcstr!("next/dist/compiled/server-only/index"),
+        rcstr!("client-only") => rcstr!("next/dist/compiled/client-only/index"),
+        rcstr!("next/dist/compiled/server-only") => rcstr!("next/dist/compiled/server-only/index"),
+        rcstr!("next/dist/compiled/client-only") => rcstr!("next/dist/compiled/client-only/index"),},
     );
     insert_next_root_params_mapping(
         &mut import_map,
@@ -391,40 +390,36 @@ pub async fn get_next_edge_import_map(
     insert_wildcard_alias_map(
         &mut import_map,
         project_path.clone(),
-        fxindexmap! {
-            rcstr!("next/dist/build/") => rcstr!("next/dist/esm/build/*"),
-            rcstr!("next/dist/client/") => rcstr!("next/dist/esm/client/*"),
-            rcstr!("next/dist/shared/") => rcstr!("next/dist/esm/shared/*"),
-            rcstr!("next/dist/pages/") => rcstr!("next/dist/esm/pages/*"),
-            rcstr!("next/dist/lib/") => rcstr!("next/dist/esm/lib/*"),
-            rcstr!("next/dist/server/") => rcstr!("next/dist/esm/server/*"),
-            rcstr!("next/dist/api/") => rcstr!("next/dist/esm/api/*"),
-        },
+        fxindexmap! {rcstr!("next/dist/build/") => rcstr!("next/dist/esm/build/*"),
+        rcstr!("next/dist/client/") => rcstr!("next/dist/esm/client/*"),
+        rcstr!("next/dist/shared/") => rcstr!("next/dist/esm/shared/*"),
+        rcstr!("next/dist/pages/") => rcstr!("next/dist/esm/pages/*"),
+        rcstr!("next/dist/lib/") => rcstr!("next/dist/esm/lib/*"),
+        rcstr!("next/dist/server/") => rcstr!("next/dist/esm/server/*"),
+        rcstr!("next/dist/api/") => rcstr!("next/dist/esm/api/*"),},
     );
 
     // Alias the usage of next public APIs
     insert_exact_alias_map(
         &mut import_map,
         project_path.clone(),
-        fxindexmap! {
-            rcstr!("next/app") => rcstr!("next/dist/api/app"),
-            rcstr!("next/document") => rcstr!("next/dist/api/document"),
-            rcstr!("next/dynamic") => rcstr!("next/dist/api/dynamic"),
-            rcstr!("next/error") => rcstr!("next/dist/api/error"),
-            rcstr!("next/form") => rcstr!("next/dist/api/form"),
-            rcstr!("next/head") => rcstr!("next/dist/api/head"),
-            rcstr!("next/headers") => rcstr!("next/dist/api/headers"),
-            rcstr!("next/image") => rcstr!("next/dist/api/image"),
-            rcstr!("next/link") => rcstr!("next/dist/api/link"),
-            rcstr!("next/navigation") => rcstr!("next/dist/api/navigation"),
-            rcstr!("next/router") => rcstr!("next/dist/api/router"),
-            rcstr!("next/script") => rcstr!("next/dist/api/script"),
-            rcstr!("next/server") => rcstr!("next/dist/api/server"),
-            rcstr!("next/og") => rcstr!("next/dist/api/og"),
+        fxindexmap! {rcstr!("next/app") => rcstr!("next/dist/api/app"),
+        rcstr!("next/document") => rcstr!("next/dist/api/document"),
+        rcstr!("next/dynamic") => rcstr!("next/dist/api/dynamic"),
+        rcstr!("next/error") => rcstr!("next/dist/api/error"),
+        rcstr!("next/form") => rcstr!("next/dist/api/form"),
+        rcstr!("next/head") => rcstr!("next/dist/api/head"),
+        rcstr!("next/headers") => rcstr!("next/dist/api/headers"),
+        rcstr!("next/image") => rcstr!("next/dist/api/image"),
+        rcstr!("next/link") => rcstr!("next/dist/api/link"),
+        rcstr!("next/navigation") => rcstr!("next/dist/api/navigation"),
+        rcstr!("next/router") => rcstr!("next/dist/api/router"),
+        rcstr!("next/script") => rcstr!("next/dist/api/script"),
+        rcstr!("next/server") => rcstr!("next/dist/api/server"),
+        rcstr!("next/og") => rcstr!("next/dist/api/og"),
 
-            // Alias built-in @vercel/og to edge bundle for edge runtime
-            rcstr!("next/dist/compiled/@vercel/og/index.node.js") => rcstr!("next/dist/compiled/@vercel/og/index.edge.js"),
-        },
+        // Alias built-in @vercel/og to edge bundle for edge runtime
+        rcstr!("next/dist/compiled/@vercel/og/index.node.js") => rcstr!("next/dist/compiled/@vercel/og/index.edge.js"),},
     );
 
     insert_next_shared_aliases(
@@ -718,12 +713,10 @@ async fn insert_next_server_special_aliases(
             insert_exact_alias_map(
                 import_map,
                 project_path.clone(),
-                fxindexmap! {
-                    rcstr!("server-only") => rcstr!("next/dist/compiled/server-only/empty"),
-                    rcstr!("client-only") => rcstr!("next/dist/compiled/client-only/index"),
-                    rcstr!("next/dist/compiled/server-only") => rcstr!("next/dist/compiled/server-only/empty"),
-                    rcstr!("next/dist/compiled/client-only") => rcstr!("next/dist/compiled/client-only/index"),
-                },
+                fxindexmap! {rcstr!("server-only") => rcstr!("next/dist/compiled/server-only/empty"),
+                rcstr!("client-only") => rcstr!("next/dist/compiled/client-only/index"),
+                rcstr!("next/dist/compiled/server-only") => rcstr!("next/dist/compiled/server-only/empty"),
+                rcstr!("next/dist/compiled/client-only") => rcstr!("next/dist/compiled/client-only/index"),},
             );
         }
         ServerContextType::PagesApi { .. }
@@ -734,11 +727,9 @@ async fn insert_next_server_special_aliases(
             insert_exact_alias_map(
                 import_map,
                 project_path.clone(),
-                fxindexmap! {
-                    rcstr!("server-only") => rcstr!("next/dist/compiled/server-only/empty"),
-                    rcstr!("next/dist/compiled/server-only") => rcstr!("next/dist/compiled/server-only/empty"),
-                    rcstr!("next/dist/compiled/client-only") => rcstr!("next/dist/compiled/client-only/error"),
-                },
+                fxindexmap! {rcstr!("server-only") => rcstr!("next/dist/compiled/server-only/empty"),
+                rcstr!("next/dist/compiled/server-only") => rcstr!("next/dist/compiled/server-only/empty"),
+                rcstr!("next/dist/compiled/client-only") => rcstr!("next/dist/compiled/client-only/error"),},
             );
             insert_client_only_error_alias(import_map);
         }
@@ -746,12 +737,10 @@ async fn insert_next_server_special_aliases(
             insert_exact_alias_map(
                 import_map,
                 project_path.clone(),
-                fxindexmap! {
-                    rcstr!("server-only") => rcstr!("next/dist/compiled/server-only/index"),
-                    rcstr!("client-only") => rcstr!("next/dist/compiled/client-only/index"),
-                    rcstr!("next/dist/compiled/server-only") => rcstr!("next/dist/compiled/server-only/index"),
-                    rcstr!("next/dist/compiled/client-only") => rcstr!("next/dist/compiled/client-only/index"),
-                },
+                fxindexmap! {rcstr!("server-only") => rcstr!("next/dist/compiled/server-only/index"),
+                rcstr!("client-only") => rcstr!("next/dist/compiled/client-only/index"),
+                rcstr!("next/dist/compiled/server-only") => rcstr!("next/dist/compiled/server-only/index"),
+                rcstr!("next/dist/compiled/client-only") => rcstr!("next/dist/compiled/client-only/index"),},
             );
         }
     }
@@ -824,8 +813,7 @@ async fn apply_vendored_react_aliases_server(
 
     let mut react_alias = FxIndexMap::default();
     if runtime == NextRuntime::NodeJs && react_condition == "client" {
-        react_alias.extend(fxindexmap! {
-            // file:///./../../../packages/next/src/compiled/react/package.json
+        react_alias.extend(fxindexmap! {// file:///./../../../packages/next/src/compiled/react/package.json
             rcstr!("react") =>                                  /* ✅ */ rcstr!("next/dist/server/route-modules/app-page/vendored/ssr/react"),
             rcstr!("react/compiler-runtime") =>                 /* ✅ */ rcstr!("next/dist/server/route-modules/app-page/vendored/ssr/react-compiler-runtime"),
             rcstr!("react/jsx-dev-runtime") =>                  /* ✅ */ rcstr!("next/dist/server/route-modules/app-page/vendored/ssr/react-jsx-dev-runtime"),
@@ -848,11 +836,9 @@ async fn apply_vendored_react_aliases_server(
             rcstr!("react-server-dom-turbopack/client") =>      /* ✅ */ rcstr!("next/dist/server/route-modules/app-page/vendored/ssr/react-server-dom-turbopack-client"),
             rcstr!("react-server-dom-turbopack/server") =>      /* ❌ */ format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/server.node").into(),
             rcstr!("react-server-dom-turbopack/server.node") => /* ❌ */ format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/server.node").into(),
-            rcstr!("react-server-dom-turbopack/static.edge") => /* ❌ */ format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/static.edge").into(),
-        })
+            rcstr!("react-server-dom-turbopack/static.edge") => /* ❌ */ format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/static.edge").into(),})
     } else if runtime == NextRuntime::NodeJs && react_condition == "server" {
-        react_alias.extend(fxindexmap! {
-            // file:///./../../../packages/next/src/compiled/react/package.json
+        react_alias.extend(fxindexmap! {// file:///./../../../packages/next/src/compiled/react/package.json
             rcstr!("react") =>                                  /* ✅ */ rcstr!("next/dist/server/route-modules/app-page/vendored/rsc/react"),
             rcstr!("react/compiler-runtime") =>                 /* ✅ */ rcstr!("next/dist/server/route-modules/app-page/vendored/rsc/react-compiler-runtime"),
             rcstr!("react/jsx-dev-runtime") =>                  /* ✅ */ rcstr!("next/dist/server/route-modules/app-page/vendored/rsc/react-jsx-dev-runtime"),
@@ -879,11 +865,9 @@ async fn apply_vendored_react_aliases_server(
 
             // Needed to make `react-dom/server` work.
             // TODO: really?
-                rcstr!("next/dist/compiled/react") => rcstr!("next/dist/compiled/react/index.js"),
-        })
+                rcstr!("next/dist/compiled/react") => rcstr!("next/dist/compiled/react/index.js"),})
     } else if runtime == NextRuntime::Edge && react_condition == "client" {
-        react_alias.extend(fxindexmap! {
-            // file:///./../../../packages/next/src/compiled/react/package.json
+        react_alias.extend(fxindexmap! {// file:///./../../../packages/next/src/compiled/react/package.json
             rcstr!("react") =>                                  /* ✅ */ format!("next/dist/compiled/react{react_channel}").into(),
             rcstr!("react/compiler-runtime") =>                 /* ✅ */ format!("next/dist/compiled/react{react_channel}/compiler-runtime").into(),
             rcstr!("react/jsx-dev-runtime") =>                  /* ✅ */ format!("next/dist/compiled/react{react_channel}/jsx-dev-runtime").into(),
@@ -906,11 +890,9 @@ async fn apply_vendored_react_aliases_server(
             rcstr!("react-server-dom-turbopack/client") =>      /* ✅ */ format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/client.edge").into(),
             rcstr!("react-server-dom-turbopack/server") =>      /* ❌ */ format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/server.edge").into(),
             rcstr!("react-server-dom-turbopack/server.node") => /* ❌ */ format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/server.node").into(),
-            rcstr!("react-server-dom-turbopack/static") =>      /* ❌ */ format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/static.edge").into(),
-        })
+            rcstr!("react-server-dom-turbopack/static") =>      /* ❌ */ format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/static.edge").into(),})
     } else if runtime == NextRuntime::Edge && react_condition == "server" {
-        react_alias.extend(fxindexmap! {
-            // file:///./../../../packages/next/src/compiled/react/package.json
+        react_alias.extend(fxindexmap! {// file:///./../../../packages/next/src/compiled/react/package.json
             rcstr!("react") =>                                  /* ✅ */ format!("next/dist/compiled/react{react_channel}/react.react-server").into(),
             rcstr!("react/compiler-runtime") =>                 /* ❌ */ format!("next/dist/compiled/react{react_channel}/compiler-runtime").into(),
             rcstr!("react/jsx-dev-runtime") =>                  /* ✅ */ format!("next/dist/compiled/react{react_channel}/jsx-dev-runtime.react-server").into(),
@@ -933,11 +915,9 @@ async fn apply_vendored_react_aliases_server(
             rcstr!("react-server-dom-turbopack/client") =>      /* ❔ */ format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/client.edge").into(),
             rcstr!("react-server-dom-turbopack/server") =>      /* ✅ */ format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/server.edge").into(),
             rcstr!("react-server-dom-turbopack/server.node") => /* ✅ */ format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/server.node").into(),
-            rcstr!("react-server-dom-turbopack/static") =>      /* ✅ */ format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/static.edge").into(),
-        });
+            rcstr!("react-server-dom-turbopack/static") =>      /* ✅ */ format!("next/dist/compiled/react-server-dom-turbopack{react_channel}/static.edge").into(),});
 
-        react_alias.extend(fxindexmap! {
-            // This should just be `next/dist/compiled/react${react_channel}` but how to Rust.
+        react_alias.extend(fxindexmap! {// This should just be `next/dist/compiled/react${react_channel}` but how to Rust.
             rcstr!("next/dist/compiled/react")                               => react_alias["react"].clone(),
             rcstr!("next/dist/compiled/react-experimental")                  => react_alias["react"].clone(),
             rcstr!("next/dist/compiled/react/compiler-runtime")              => react_alias["react/compiler-runtime"].clone(),
@@ -947,23 +927,20 @@ async fn apply_vendored_react_aliases_server(
             rcstr!("next/dist/compiled/react/jsx-runtime")                   => react_alias["react/jsx-runtime"].clone(),
             rcstr!("next/dist/compiled/react-experimental/jsx-runtime")      => react_alias["react/jsx-runtime"].clone(),
             rcstr!("next/dist/compiled/react-dom")                           => react_alias["react-dom"].clone(),
-            rcstr!("next/dist/compiled/react-dom-experimental")              => react_alias["react-dom"].clone(),
-        });
+            rcstr!("next/dist/compiled/react-dom-experimental")              => react_alias["react-dom"].clone(),});
     }
 
     let react_client_package = get_react_client_package(next_config).await?;
-    react_alias.extend(fxindexmap! {
-        rcstr!("react-dom/client") => RcStr::from(format!("next/dist/compiled/react-dom{react_channel}/{react_client_package}")),
-    });
+    react_alias.extend(fxindexmap! {rcstr!("react-dom/client") => RcStr::from(format!("next/dist/compiled/react-dom{react_channel}/{react_client_package}")),});
 
     let mut alias = react_alias;
     if react_condition == "server" {
         // This is used in the server runtime to import React Server Components.
-        alias.extend(fxindexmap! {
-            rcstr!("next/error") => rcstr!("next/dist/api/error.react-server"),
+        alias.extend(
+            fxindexmap! {rcstr!("next/error") => rcstr!("next/dist/api/error.react-server"),
             rcstr!("next/navigation") => rcstr!("next/dist/api/navigation.react-server"),
-            rcstr!("next/link") => rcstr!("next/dist/client/app-dir/link.react-server"),
-        });
+            rcstr!("next/link") => rcstr!("next/dist/client/app-dir/link.react-server"),},
+        );
     }
 
     insert_exact_alias_map(import_map, project_path, alias);
@@ -990,11 +967,11 @@ async fn rsc_aliases(
     let mut alias = FxIndexMap::default();
     if ty.should_use_react_server_condition() {
         // This is used in the server runtime to import React Server Components.
-        alias.extend(fxindexmap! {
-            rcstr!("next/error") => rcstr!("next/dist/api/error.react-server"),
+        alias.extend(
+            fxindexmap! {rcstr!("next/error") => rcstr!("next/dist/api/error.react-server"),
             rcstr!("next/navigation") => rcstr!("next/dist/api/navigation.react-server"),
-            rcstr!("next/link") => rcstr!("next/dist/client/app-dir/link.react-server"),
-        });
+            rcstr!("next/link") => rcstr!("next/dist/client/app-dir/link.react-server"),},
+        );
     }
 
     insert_exact_alias_map(import_map, project_path.clone(), alias);
@@ -1015,18 +992,16 @@ async fn insert_optimized_module_aliases(
     insert_exact_alias_map(
         import_map,
         project_path,
-        fxindexmap! {
-            rcstr!("unfetch") => rcstr!("next/dist/build/polyfills/fetch/index.js"),
-            rcstr!("isomorphic-unfetch") => rcstr!("next/dist/build/polyfills/fetch/index.js"),
-            rcstr!("whatwg-fetch") => rcstr!("next/dist/build/polyfills/fetch/whatwg-fetch.js"),
-            rcstr!("object-assign") => rcstr!("next/dist/build/polyfills/object-assign.js"),
-            rcstr!("object.assign/auto") => rcstr!("next/dist/build/polyfills/object.assign/auto.js"),
-            rcstr!("object.assign/implementation") => rcstr!("next/dist/build/polyfills/object.assign/implementation.js"),
-            rcstr!("object.assign/polyfill") => rcstr!("next/dist/build/polyfills/object.assign/polyfill.js"),
-            rcstr!("object.assign/shim") => rcstr!("next/dist/build/polyfills/object.assign/shim.js"),
-            rcstr!("url") => rcstr!("next/dist/compiled/native-url"),
-            rcstr!("node:url") => rcstr!("next/dist/compiled/native-url"),
-        },
+        fxindexmap! {rcstr!("unfetch") => rcstr!("next/dist/build/polyfills/fetch/index.js"),
+        rcstr!("isomorphic-unfetch") => rcstr!("next/dist/build/polyfills/fetch/index.js"),
+        rcstr!("whatwg-fetch") => rcstr!("next/dist/build/polyfills/fetch/whatwg-fetch.js"),
+        rcstr!("object-assign") => rcstr!("next/dist/build/polyfills/object-assign.js"),
+        rcstr!("object.assign/auto") => rcstr!("next/dist/build/polyfills/object.assign/auto.js"),
+        rcstr!("object.assign/implementation") => rcstr!("next/dist/build/polyfills/object.assign/implementation.js"),
+        rcstr!("object.assign/polyfill") => rcstr!("next/dist/build/polyfills/object.assign/polyfill.js"),
+        rcstr!("object.assign/shim") => rcstr!("next/dist/build/polyfills/object.assign/shim.js"),
+        rcstr!("url") => rcstr!("next/dist/compiled/native-url"),
+        rcstr!("node:url") => rcstr!("next/dist/compiled/native-url"),},
     );
     Ok(())
 }
@@ -1222,24 +1197,22 @@ struct MissingNextFolderIssue {
     root: FileSystemPath,
 }
 
+#[async_trait]
 #[turbo_tasks::value_impl]
 impl Issue for MissingNextFolderIssue {
-    #[turbo_tasks::function]
-    fn file_path(&self) -> Vc<FileSystemPath> {
-        self.path.clone().cell()
+    async fn file_path(&self) -> Result<FileSystemPath> {
+        Ok(self.path.clone())
     }
 
     fn severity(&self) -> IssueSeverity {
         IssueSeverity::Fatal
     }
 
-    #[turbo_tasks::function]
-    fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::Resolve.cell()
+    fn stage(&self) -> IssueStage {
+        IssueStage::Resolve
     }
 
-    #[turbo_tasks::function]
-    async fn title(&self) -> Result<Vc<StyledString>> {
+    async fn title(&self) -> Result<StyledString> {
         let system_path = match to_sys_path(self.path.clone()).await? {
             Some(path) => path.to_str().unwrap_or("{unknown}").to_string(),
             _ => "{unknown}".to_string(),
@@ -1252,7 +1225,8 @@ impl Issue for MissingNextFolderIssue {
         Ok(StyledString::Stack(vec![
             StyledString::Line(vec![
                 StyledString::Text(
-                    "Error: Next.js inferred your workspace root, but it may not be correct.".into(),
+                    "Error: Next.js inferred your workspace root, but it may not be correct."
+                        .into(),
                 ),
             ]),
             StyledString::Line(vec![
@@ -1278,10 +1252,9 @@ impl Issue for MissingNextFolderIssue {
             StyledString::Line(vec![
                 StyledString::Text("See ".into()),
                 StyledString::Strong("https://nextjs.org/docs/app/api-reference/config/next-config-js/turbopack#root-directory".into()),
-                StyledString::Text(" for more information.".into())
+                StyledString::Text(" for more information.".into()),
             ]),
-        ])
-            .cell())
+        ]))
     }
 }
 
@@ -1438,12 +1411,12 @@ fn insert_client_only_error_alias(import_map: &mut ImportMap) {
                     )),
                 ])
                 .resolved_cell(),
-                description: ResolvedVc::cell(Some(
+                description: Some(
                     StyledString::Line(vec![StyledString::Text(
                         "It should only be used from a Client Component.".into(),
                     )])
                     .resolved_cell(),
-                )),
+                ),
             }
             .resolved_cell(),
         ))
@@ -1459,14 +1432,14 @@ fn insert_client_only_error_alias(import_map: &mut ImportMap) {
                 StyledString::Text(rcstr!(" cannot be imported from a Server Component module")),
             ])
             .resolved_cell(),
-            description: ResolvedVc::cell(Some(
+            description: Some(
                 StyledString::Line(vec![StyledString::Text(
                     "It only works in a Client Component but none of its parents are marked with \
                      'use client', so they're Server Components by default."
                         .into(),
                 )])
                 .resolved_cell(),
-            )),
+            ),
         }
         .resolved_cell(),
     ))
@@ -1487,12 +1460,12 @@ fn insert_server_only_error_alias(import_map: &mut ImportMap) {
                     )),
                 ])
                 .resolved_cell(),
-                description: ResolvedVc::cell(Some(
+                description: Some(
                     StyledString::Line(vec![StyledString::Text(
                         "It should only be used from a Server Component.".into(),
                     )])
                     .resolved_cell(),
-                )),
+                ),
             }
             .resolved_cell(),
         ))
@@ -1503,33 +1476,33 @@ fn insert_server_only_error_alias(import_map: &mut ImportMap) {
 #[turbo_tasks::value(shared)]
 struct InvalidImportIssue {
     title: ResolvedVc<StyledString>,
-    description: ResolvedVc<OptionStyledString>,
+    description: Option<ResolvedVc<StyledString>>,
 }
 
+#[async_trait]
 #[turbo_tasks::value_impl]
 impl Issue for InvalidImportIssue {
     fn severity(&self) -> IssueSeverity {
         IssueSeverity::Error
     }
 
-    #[turbo_tasks::function]
-    fn file_path(&self) -> Vc<FileSystemPath> {
+    async fn file_path(&self) -> Result<FileSystemPath> {
         panic!("InvalidImportIssue::file_path should not be called");
     }
 
-    #[turbo_tasks::function]
-    fn stage(self: Vc<Self>) -> Vc<IssueStage> {
-        IssueStage::Resolve.cell()
+    fn stage(&self) -> IssueStage {
+        IssueStage::Resolve
     }
 
-    #[turbo_tasks::function]
-    fn title(&self) -> Vc<StyledString> {
-        *self.title
+    async fn title(&self) -> Result<StyledString> {
+        Ok((*self.title.await?).clone())
     }
 
-    #[turbo_tasks::function]
-    fn description(&self) -> Vc<OptionStyledString> {
-        *self.description
+    async fn description(&self) -> Result<Option<StyledString>> {
+        match self.description {
+            Some(inner) => Ok(Some((*inner.await?).clone())),
+            None => Ok(None),
+        }
     }
 }
 

--- a/crates/next-core/src/next_server/resolve.rs
+++ b/crates/next-core/src/next_server/resolve.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use async_trait::async_trait;
 use bincode::{Decode, Encode};
 use next_taskless::NEVER_EXTERNAL_RE;
 use turbo_rcstr::{RcStr, rcstr};
@@ -8,7 +9,7 @@ use turbo_tasks_fs::{
     glob::{Glob, GlobOptions},
 };
 use turbopack_core::{
-    issue::{Issue, IssueExt, IssueSeverity, IssueStage, OptionStyledString, StyledString},
+    issue::{Issue, IssueExt, IssueSeverity, IssueStage, StyledString},
     reference_type::{ReferenceType, ReferenceTypeCondition},
     resolve::{
         ExternalTraced, ExternalType, FindContextFileResult, ResolveResult, ResolveResultItem,
@@ -372,46 +373,39 @@ struct ExternalizeIssue {
     reason: Vec<StyledString>,
 }
 
+#[async_trait]
 #[turbo_tasks::value_impl]
 impl Issue for ExternalizeIssue {
     fn severity(&self) -> IssueSeverity {
         IssueSeverity::Warning
     }
 
-    #[turbo_tasks::function]
-    fn title(&self) -> Vc<StyledString> {
-        StyledString::Line(vec![
+    async fn title(&self) -> Result<StyledString> {
+        Ok(StyledString::Line(vec![
             StyledString::Text(rcstr!("Package ")),
             StyledString::Code(self.package.clone()),
             StyledString::Text(rcstr!(" can't be external")),
-        ])
-        .cell()
+        ]))
     }
 
-    #[turbo_tasks::function]
-    fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::Config.cell()
+    fn stage(&self) -> IssueStage {
+        IssueStage::Config
     }
 
-    #[turbo_tasks::function]
-    fn file_path(&self) -> Vc<FileSystemPath> {
-        self.file_path.clone().cell()
+    async fn file_path(&self) -> Result<FileSystemPath> {
+        Ok(self.file_path.clone())
     }
 
-    #[turbo_tasks::function]
-    fn description(&self) -> Result<Vc<OptionStyledString>> {
-        Ok(Vc::cell(Some(
-            StyledString::Stack(vec![
-                StyledString::Line(vec![
-                    StyledString::Text(rcstr!("The request ")),
-                    StyledString::Code(self.request_str.clone()),
-                    StyledString::Text(rcstr!(" matches ")),
-                    StyledString::Code(rcstr!("serverExternalPackages")),
-                    StyledString::Text(rcstr!(" (or the default list).")),
-                ]),
-                StyledString::Line(self.reason.clone()),
-            ])
-            .resolved_cell(),
-        )))
+    async fn description(&self) -> Result<Option<StyledString>> {
+        Ok(Some(StyledString::Stack(vec![
+            StyledString::Line(vec![
+                StyledString::Text(rcstr!("The request ")),
+                StyledString::Code(self.request_str.clone()),
+                StyledString::Text(rcstr!(" matches ")),
+                StyledString::Code(rcstr!("serverExternalPackages")),
+                StyledString::Text(rcstr!(" (or the default list).")),
+            ]),
+            StyledString::Line(self.reason.clone()),
+        ])))
     }
 }

--- a/crates/next-core/src/next_shared/resolve.rs
+++ b/crates/next-core/src/next_shared/resolve.rs
@@ -1,6 +1,7 @@
 use std::sync::LazyLock;
 
 use anyhow::Result;
+use async_trait::async_trait;
 use rustc_hash::FxHashMap;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, Vc};
@@ -11,7 +12,7 @@ use turbo_tasks_fs::{
 use turbopack_core::{
     diagnostics::DiagnosticExt,
     file_source::FileSource,
-    issue::{Issue, IssueSeverity, IssueStage, OptionStyledString, StyledString},
+    issue::{Issue, IssueSeverity, IssueStage, StyledString},
     reference_type::ReferenceType,
     resolve::{
         ExternalTraced, ExternalType, ResolveResult, ResolveResultItem, ResolveResultOption,
@@ -56,47 +57,43 @@ pub struct InvalidImportModuleIssue {
     pub skip_context_message: bool,
 }
 
+#[async_trait]
 #[turbo_tasks::value_impl]
 impl Issue for InvalidImportModuleIssue {
     fn severity(&self) -> IssueSeverity {
         IssueSeverity::Error
     }
 
-    #[turbo_tasks::function]
-    fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::Resolve.cell()
+    fn stage(&self) -> IssueStage {
+        IssueStage::Resolve
     }
 
-    #[turbo_tasks::function]
-    fn title(&self) -> Vc<StyledString> {
-        StyledString::Text(rcstr!("Invalid import")).cell()
+    async fn title(&self) -> Result<StyledString> {
+        Ok(StyledString::Text(rcstr!("Invalid import")))
     }
 
-    #[turbo_tasks::function]
-    fn file_path(&self) -> Vc<FileSystemPath> {
-        self.file_path.clone().cell()
+    async fn file_path(&self) -> Result<FileSystemPath> {
+        Ok(self.file_path.clone())
     }
 
-    #[turbo_tasks::function]
-    async fn description(&self) -> Result<Vc<OptionStyledString>> {
-        let raw_context = self.file_path.clone();
-
+    async fn description(&self) -> Result<Option<StyledString>> {
         let mut messages = self.messages.clone();
-
         if !self.skip_context_message {
             //[TODO]: how do we get the import trace?
-            messages
-                .push(format!("The error was caused by importing '{}'", raw_context.path).into());
+            messages.push(
+                format!(
+                    "The error was caused by importing '{}'",
+                    self.file_path.path
+                )
+                .into(),
+            );
         }
 
-        Ok(Vc::cell(Some(
-            StyledString::Line(
-                messages
-                    .iter()
-                    .map(|v| StyledString::Text(format!("{v}\n").into()))
-                    .collect::<Vec<StyledString>>(),
-            )
-            .resolved_cell(),
+        Ok(Some(StyledString::Line(
+            messages
+                .iter()
+                .map(|v| StyledString::Text(format!("{v}\n").into()))
+                .collect::<Vec<StyledString>>(),
         )))
     }
 }

--- a/crates/next-core/src/next_shared/webpack_rules/babel.rs
+++ b/crates/next-core/src/next_shared/webpack_rules/babel.rs
@@ -1,6 +1,7 @@
 use std::{collections::BTreeSet, sync::LazyLock};
 
 use anyhow::{Context, Result};
+use async_trait::async_trait;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use turbo_esregex::EsRegex;
@@ -9,7 +10,7 @@ use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::{self, FileContent, FileSystemEntryType, FileSystemPath, to_sys_path};
 use turbopack::module_options::{ConditionItem, LoaderRuleItem};
 use turbopack_core::{
-    issue::{Issue, IssueExt, IssueSeverity, IssueStage, OptionStyledString, StyledString},
+    issue::{Issue, IssueExt, IssueSeverity, IssueStage, StyledString},
     reference_type::{CommonJsReferenceSubType, ReferenceType},
     resolve::{node::node_cjs_resolve_options, parse::Request, pattern::Pattern, resolve},
     source::Source,
@@ -362,50 +363,43 @@ struct BabelPluginReactCompilerResolutionIssue {
     config_file_path: FileSystemPath,
 }
 
+#[async_trait]
 #[turbo_tasks::value_impl]
 impl Issue for BabelPluginReactCompilerResolutionIssue {
-    #[turbo_tasks::function]
-    fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::Transform.cell()
+    fn stage(&self) -> IssueStage {
+        IssueStage::Transform
     }
 
     fn severity(&self) -> IssueSeverity {
         IssueSeverity::Error
     }
 
-    #[turbo_tasks::function]
-    fn file_path(&self) -> Vc<FileSystemPath> {
-        self.config_file_path.clone().cell()
+    async fn file_path(&self) -> Result<FileSystemPath> {
+        Ok(self.config_file_path.clone())
     }
 
-    #[turbo_tasks::function]
-    fn title(&self) -> Vc<StyledString> {
-        StyledString::Line(vec![
+    async fn title(&self) -> Result<StyledString> {
+        Ok(StyledString::Line(vec![
             StyledString::Text(rcstr!("Failed to resolve package ")),
             StyledString::Code(self.failed_resolution.clone()),
             StyledString::Text(rcstr!(" while attempting to resolve React Compiler")),
-        ])
-        .cell()
+        ]))
     }
 
-    #[turbo_tasks::function]
-    fn description(&self) -> Vc<OptionStyledString> {
-        Vc::cell(Some(
-            StyledString::Line(vec![
-                StyledString::Text(rcstr!("React compiler is enabled in ")),
-                StyledString::Code(self.config_file_path.path.clone()),
-                StyledString::Text(rcstr!(
-                    ". We attempted to resolve React Compiler relative to the "
-                )),
-                StyledString::Code(rcstr!("next")),
-                StyledString::Text(rcstr!(" package. Is ")),
-                StyledString::Code(rcstr!(BABEL_PLUGIN_REACT_COMPILER)),
-                StyledString::Text(rcstr!(" installed in your ")),
-                StyledString::Code(rcstr!("node_modules")),
-                StyledString::Text(rcstr!(" directory?")),
-            ])
-            .resolved_cell(),
-        ))
+    async fn description(&self) -> Result<Option<StyledString>> {
+        Ok(Some(StyledString::Line(vec![
+            StyledString::Text(rcstr!("React compiler is enabled in ")),
+            StyledString::Code(self.config_file_path.path.clone()),
+            StyledString::Text(rcstr!(
+                ". We attempted to resolve React Compiler relative to the "
+            )),
+            StyledString::Code(rcstr!("next")),
+            StyledString::Text(rcstr!(" package. Is ")),
+            StyledString::Code(rcstr!(BABEL_PLUGIN_REACT_COMPILER)),
+            StyledString::Text(rcstr!(" installed in your ")),
+            StyledString::Code(rcstr!("node_modules")),
+            StyledString::Text(rcstr!(" directory?")),
+        ])))
     }
 }
 
@@ -415,41 +409,34 @@ struct ReactPackageJsonParseIssue {
     error: RcStr,
 }
 
+#[async_trait]
 #[turbo_tasks::value_impl]
 impl Issue for ReactPackageJsonParseIssue {
-    #[turbo_tasks::function]
-    fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::Transform.cell()
+    fn stage(&self) -> IssueStage {
+        IssueStage::Transform
     }
 
     fn severity(&self) -> IssueSeverity {
         IssueSeverity::Warning
     }
 
-    #[turbo_tasks::function]
-    fn file_path(&self) -> Vc<FileSystemPath> {
-        self.file_path.clone().cell()
+    async fn file_path(&self) -> Result<FileSystemPath> {
+        Ok(self.file_path.clone())
     }
 
-    #[turbo_tasks::function]
-    fn title(&self) -> Vc<StyledString> {
-        StyledString::Line(vec![
+    async fn title(&self) -> Result<StyledString> {
+        Ok(StyledString::Line(vec![
             StyledString::Text(rcstr!("Failed to parse ")),
             StyledString::Code(rcstr!("react/package.json")),
-        ])
-        .cell()
+        ]))
     }
 
-    #[turbo_tasks::function]
-    fn description(&self) -> Vc<OptionStyledString> {
-        Vc::cell(Some(
-            StyledString::Line(vec![
-                StyledString::Text(rcstr!(
-                    "Could not determine the React version for React Compiler target detection: "
-                )),
-                StyledString::Text(self.error.clone()),
-            ])
-            .resolved_cell(),
-        ))
+    async fn description(&self) -> Result<Option<StyledString>> {
+        Ok(Some(StyledString::Line(vec![
+            StyledString::Text(rcstr!(
+                "Could not determine the React version for React Compiler target detection: "
+            )),
+            StyledString::Text(self.error.clone()),
+        ])))
     }
 }

--- a/crates/next-core/src/next_shared/webpack_rules/mod.rs
+++ b/crates/next-core/src/next_shared/webpack_rules/mod.rs
@@ -1,6 +1,7 @@
 use std::{collections::BTreeSet, str::FromStr};
 
 use anyhow::Result;
+use async_trait::async_trait;
 use bincode::{Decode, Encode};
 use serde::Deserialize;
 use turbo_rcstr::{RcStr, rcstr};
@@ -10,7 +11,7 @@ use turbopack::module_options::{
     WebpackLoaderBuiltinConditionSet, WebpackLoaderBuiltinConditionSetMatch, WebpackLoadersOptions,
 };
 use turbopack_core::{
-    issue::{Issue, IssueSeverity, IssueStage, OptionStyledString, StyledString},
+    issue::{Issue, IssueSeverity, IssueStage, StyledString},
     resolve::{ExternalTraced, ExternalType, options::ImportMapping},
 };
 
@@ -184,54 +185,47 @@ pub struct ManuallyConfiguredBuiltinLoaderIssue {
     config_file_path: FileSystemPath,
 }
 
+#[async_trait]
 #[turbo_tasks::value_impl]
 impl Issue for ManuallyConfiguredBuiltinLoaderIssue {
     fn severity(&self) -> IssueSeverity {
         IssueSeverity::Warning
     }
 
-    #[turbo_tasks::function]
-    fn file_path(&self) -> Vc<FileSystemPath> {
-        self.config_file_path.clone().cell()
+    async fn file_path(&self) -> Result<FileSystemPath> {
+        Ok(self.config_file_path.clone())
     }
 
-    #[turbo_tasks::function]
-    fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::Config.cell()
+    fn stage(&self) -> IssueStage {
+        IssueStage::Config
     }
 
-    #[turbo_tasks::function]
-    fn title(&self) -> Vc<StyledString> {
-        StyledString::Line(vec![
+    async fn title(&self) -> Result<StyledString> {
+        Ok(StyledString::Line(vec![
             StyledString::Text(rcstr!("Identified a likely manual configuration of ")),
             StyledString::Code(self.loader.clone()),
             StyledString::Text(rcstr!(" for paths matching ")),
             StyledString::Code(self.glob.clone()),
-        ])
-        .cell()
+        ]))
     }
 
-    #[turbo_tasks::function]
-    fn description(&self) -> Vc<OptionStyledString> {
-        Vc::cell(Some(
-            StyledString::Stack(vec![
-                StyledString::Text(rcstr!(
-                    "Next.js includes a built-in version of this loader that is configured \
-                     automatically. You may not need to configure this."
-                )),
-                StyledString::Line(vec![
-                    StyledString::Text(rcstr!("You can silence this warning by setting ")),
-                    StyledString::Code(self.config_key.clone()),
-                    StyledString::Text(rcstr!(" in ")),
-                    StyledString::Text(self.config_file_path.path.clone()),
-                    StyledString::Text(rcstr!(" to ")),
-                    StyledString::Code(rcstr!("true")),
-                    StyledString::Text(rcstr!(" (to silence this warning) or ")),
-                    StyledString::Code(rcstr!("false")),
-                    StyledString::Text(rcstr!(" (to disable the default built-in loader)")),
-                ]),
-            ])
-            .resolved_cell(),
-        ))
+    async fn description(&self) -> Result<Option<StyledString>> {
+        Ok(Some(StyledString::Stack(vec![
+            StyledString::Text(rcstr!(
+                "Next.js includes a built-in version of this loader that is configured \
+                 automatically. You may not need to configure this."
+            )),
+            StyledString::Line(vec![
+                StyledString::Text(rcstr!("You can silence this warning by setting ")),
+                StyledString::Code(self.config_key.clone()),
+                StyledString::Text(rcstr!(" in ")),
+                StyledString::Text(self.config_file_path.path.clone()),
+                StyledString::Text(rcstr!(" to ")),
+                StyledString::Code(rcstr!("true")),
+                StyledString::Text(rcstr!(" (to silence this warning) or ")),
+                StyledString::Code(rcstr!("false")),
+                StyledString::Text(rcstr!(" (to disable the default built-in loader)")),
+            ]),
+        ])))
     }
 }

--- a/crates/next-core/src/segment_config.rs
+++ b/crates/next-core/src/segment_config.rs
@@ -1,6 +1,7 @@
-use std::{borrow::Cow, future::Future};
+use std::borrow::Cow;
 
 use anyhow::{Result, bail};
+use async_trait::async_trait;
 use bincode::{Decode, Encode};
 use serde::Deserialize;
 use serde_json::Value;
@@ -23,10 +24,7 @@ use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     file_source::FileSource,
     ident::AssetIdent,
-    issue::{
-        Issue, IssueExt, IssueSeverity, IssueSource, IssueStage, OptionIssueSource,
-        OptionStyledString, StyledString,
-    },
+    issue::{Issue, IssueExt, IssueSeverity, IssueSource, IssueStage, StyledString},
     source::Source,
 };
 use turbopack_ecmascript::{
@@ -235,14 +233,14 @@ impl NextSegmentConfigParsingIssue {
     }
 }
 
+#[async_trait]
 #[turbo_tasks::value_impl]
 impl Issue for NextSegmentConfigParsingIssue {
     fn severity(&self) -> IssueSeverity {
         self.severity
     }
 
-    #[turbo_tasks::function]
-    async fn title(&self) -> Result<Vc<StyledString>> {
+    async fn title(&self) -> Result<StyledString> {
         Ok(StyledString::Line(vec![
             StyledString::Text(
                 format!(
@@ -252,46 +250,37 @@ impl Issue for NextSegmentConfigParsingIssue {
                 .into(),
             ),
             StyledString::Text(self.error.clone()),
-        ])
-        .cell())
+        ]))
     }
 
-    #[turbo_tasks::function]
-    fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::Parse.cell()
+    fn stage(&self) -> IssueStage {
+        IssueStage::Parse
     }
 
-    #[turbo_tasks::function]
-    fn file_path(&self) -> Vc<FileSystemPath> {
-        self.ident.path()
+    async fn file_path(&self) -> Result<FileSystemPath> {
+        self.ident.path().owned().await
     }
 
-    #[turbo_tasks::function]
-    fn description(&self) -> Vc<OptionStyledString> {
-        Vc::cell(Some(
-            StyledString::Text(rcstr!(
-                "The exported configuration object in a source file needs to have a very specific \
-                 format from which some properties can be statically parsed at compiled-time."
-            ))
-            .resolved_cell(),
-        ))
+    async fn description(&self) -> Result<Option<StyledString>> {
+        Ok(Some(StyledString::Text(rcstr!(
+            "The exported configuration object in a source file needs to have a very specific \
+             format from which some properties can be statically parsed at compiled-time."
+        ))))
     }
 
-    #[turbo_tasks::function]
-    fn detail(&self) -> Vc<OptionStyledString> {
-        Vc::cell(self.detail)
+    async fn detail(&self) -> Result<Option<StyledString>> {
+        match self.detail {
+            Some(d) => Ok(Some((*d.await?).clone())),
+            None => Ok(None),
+        }
     }
 
-    #[turbo_tasks::function]
-    fn documentation_link(&self) -> Vc<RcStr> {
-        Vc::cell(rcstr!(
-            "https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config"
-        ))
+    fn documentation_link(&self) -> RcStr {
+        rcstr!("https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config")
     }
 
-    #[turbo_tasks::function]
-    fn source(&self) -> Vc<OptionIssueSource> {
-        Vc::cell(Some(self.source))
+    fn source(&self) -> Option<IssueSource> {
+        Some(self.source)
     }
 }
 

--- a/test/e2e/app-dir/scss/invalid-global-with-app/invalid-global-with-app.test.ts
+++ b/test/e2e/app-dir/scss/invalid-global-with-app/invalid-global-with-app.test.ts
@@ -39,11 +39,12 @@ describe('Invalid Global CSS with Custom App', () => {
       if (isTurbopack) {
         expect(errorSource).toMatchInlineSnapshot(`
          "./pages/index.js
-         Failed to compile
-             Global CSS cannot be imported from files other than your Custom <App>. Due to the Global nature of stylesheets, and to avoid conflicts, Please move all first-party global CSS imports to pages/_app.js. Or convert the import to Component-Level CSS (CSS Modules).
-             Read more: https://nextjs.org/docs/messages/css-global
+         Global CSS cannot be imported from files other than your Custom <App>.
+         Due to the Global nature of stylesheets, and to avoid conflicts, Please move all first-party global CSS imports to pages/_app.js. Or convert the import to Component-Level CSS (CSS Modules).
          Location: pages/index.js
-         Import path: ../styles/global.scss"
+         Import path: ../styles/global.scss
+
+         https://nextjs.org/docs/messages/css-global"
         `)
       } else if (isRspack) {
         expect(errorSource).toMatchInlineSnapshot(`

--- a/test/e2e/app-dir/scss/invalid-global-with-app/invalid-global-with-app.test.ts
+++ b/test/e2e/app-dir/scss/invalid-global-with-app/invalid-global-with-app.test.ts
@@ -19,7 +19,9 @@ describe('Invalid Global CSS with Custom App', () => {
     it('should fail to build', async () => {
       const { exitCode, cliOutput } = await next.build()
       expect(exitCode).not.toBe(0)
-      expect(cliOutput).toContain('Failed to compile')
+      if (!isTurbopack) {
+        expect(cliOutput).toContain('Failed to compile')
+      }
       expect(cliOutput).toContain('styles/global.scss')
       expect(cliOutput).toMatch(
         /Please move all first-party global CSS imports.*?pages(\/|\\)_app/

--- a/test/e2e/app-dir/scss/invalid-global/invalid-global.test.ts
+++ b/test/e2e/app-dir/scss/invalid-global/invalid-global.test.ts
@@ -39,11 +39,12 @@ describe('Invalid Global CSS', () => {
       if (isTurbopack) {
         expect(errorSource).toMatchInlineSnapshot(`
          "./pages/index.js
-         Failed to compile
-             Global CSS cannot be imported from files other than your Custom <App>. Due to the Global nature of stylesheets, and to avoid conflicts, Please move all first-party global CSS imports to pages/_app.js. Or convert the import to Component-Level CSS (CSS Modules).
-             Read more: https://nextjs.org/docs/messages/css-global
+         Global CSS cannot be imported from files other than your Custom <App>.
+         Due to the Global nature of stylesheets, and to avoid conflicts, Please move all first-party global CSS imports to pages/_app.js. Or convert the import to Component-Level CSS (CSS Modules).
          Location: pages/index.js
-         Import path: ../styles/global.scss"
+         Import path: ../styles/global.scss
+
+         https://nextjs.org/docs/messages/css-global"
         `)
       } else if (isRspack) {
         expect(errorSource).toMatchInlineSnapshot(`

--- a/test/e2e/app-dir/scss/invalid-global/invalid-global.test.ts
+++ b/test/e2e/app-dir/scss/invalid-global/invalid-global.test.ts
@@ -19,7 +19,9 @@ describe('Invalid Global CSS', () => {
     it('should fail to build', async () => {
       const { exitCode, cliOutput } = await next.build()
       expect(exitCode).not.toBe(0)
-      expect(cliOutput).toContain('Failed to compile')
+      if (!isTurbopack) {
+        expect(cliOutput).toContain('Failed to compile')
+      }
       expect(cliOutput).toContain('styles/global.scss')
       expect(cliOutput).toMatch(
         /Please move all first-party global CSS imports.*?pages(\/|\\)_app/

--- a/test/e2e/app-dir/scss/valid-and-invalid-global/valid-and-invalid-global.test.ts
+++ b/test/e2e/app-dir/scss/valid-and-invalid-global/valid-and-invalid-global.test.ts
@@ -39,11 +39,12 @@ describe('Valid and Invalid Global CSS with Custom App', () => {
       if (isTurbopack) {
         expect(errorSource).toMatchInlineSnapshot(`
          "./pages/index.js
-         Failed to compile
-             Global CSS cannot be imported from files other than your Custom <App>. Due to the Global nature of stylesheets, and to avoid conflicts, Please move all first-party global CSS imports to pages/_app.js. Or convert the import to Component-Level CSS (CSS Modules).
-             Read more: https://nextjs.org/docs/messages/css-global
+         Global CSS cannot be imported from files other than your Custom <App>.
+         Due to the Global nature of stylesheets, and to avoid conflicts, Please move all first-party global CSS imports to pages/_app.js. Or convert the import to Component-Level CSS (CSS Modules).
          Location: pages/index.js
-         Import path: ../styles/global.scss"
+         Import path: ../styles/global.scss
+
+         https://nextjs.org/docs/messages/css-global"
         `)
       } else if (isRspack) {
         expect(errorSource).toMatchInlineSnapshot(`

--- a/test/e2e/app-dir/scss/valid-and-invalid-global/valid-and-invalid-global.test.ts
+++ b/test/e2e/app-dir/scss/valid-and-invalid-global/valid-and-invalid-global.test.ts
@@ -19,7 +19,9 @@ describe('Valid and Invalid Global CSS with Custom App', () => {
     it('should fail to build', async () => {
       const { exitCode, cliOutput } = await next.build()
       expect(exitCode).not.toBe(0)
-      expect(cliOutput).toContain('Failed to compile')
+      if (!isTurbopack) {
+        expect(cliOutput).toContain('Failed to compile')
+      }
       expect(cliOutput).toContain('styles/global.scss')
       expect(cliOutput).toContain(
         'Please move all first-party global CSS imports'

--- a/test/integration/css/test/valid-invalid-css.test.ts
+++ b/test/integration/css/test/valid-invalid-css.test.ts
@@ -61,7 +61,9 @@ describe('Invalid Global CSS', () => {
           stderr: true,
         })
         expect(code).not.toBe(0)
-        expect(stderr).toContain('Failed to compile')
+        if (!process.env.IS_TURBOPACK_TEST) {
+          expect(stderr).toContain('Failed to compile')
+        }
         expect(stderr).toContain('styles/global.css')
         expect(stderr).toMatch(
           /Please move all first-party global CSS imports.*?pages(\/|\\)_app/
@@ -132,7 +134,9 @@ describe('Invalid Global CSS with Custom App', () => {
           stderr: true,
         })
         expect(code).not.toBe(0)
-        expect(stderr).toContain('Failed to compile')
+        if (!process.env.IS_TURBOPACK_TEST) {
+          expect(stderr).toContain('Failed to compile')
+        }
         expect(stderr).toContain('styles/global.css')
         expect(stderr).toMatch(
           /Please move all first-party global CSS imports.*?pages(\/|\\)_app/
@@ -161,7 +165,9 @@ describe('Valid and Invalid Global CSS with Custom App', () => {
           stderr: true,
         })
         expect(code).not.toBe(0)
-        expect(stderr).toContain('Failed to compile')
+        if (!process.env.IS_TURBOPACK_TEST) {
+          expect(stderr).toContain('Failed to compile')
+        }
         expect(stderr).toContain('styles/global.css')
         expect(stderr).toContain(
           'Please move all first-party global CSS imports'

--- a/turbopack/crates/turbo-tasks-fetch/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-fetch/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+async-trait = { workspace = true }
 quick_cache = { workspace = true }
 serde = { workspace = true }
 tokio = { workspace = true }

--- a/turbopack/crates/turbo-tasks-fetch/src/error.rs
+++ b/turbopack/crates/turbo-tasks-fetch/src/error.rs
@@ -1,8 +1,9 @@
 use anyhow::Result;
+use async_trait::async_trait;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
-use turbopack_core::issue::{Issue, IssueSeverity, IssueStage, OptionStyledString, StyledString};
+use turbopack_core::issue::{Issue, IssueSeverity, IssueStage, StyledString};
 
 #[derive(Debug)]
 #[turbo_tasks::value(shared)]
@@ -68,61 +69,56 @@ pub struct FetchIssue {
     pub detail: ResolvedVc<StyledString>,
 }
 
+#[async_trait]
 #[turbo_tasks::value_impl]
 impl Issue for FetchIssue {
-    #[turbo_tasks::function]
-    fn file_path(&self) -> Vc<FileSystemPath> {
-        self.issue_context.clone().cell()
+    async fn file_path(&self) -> Result<FileSystemPath> {
+        Ok(self.issue_context.clone())
     }
 
     fn severity(&self) -> IssueSeverity {
         self.severity
     }
 
-    #[turbo_tasks::function]
-    fn title(&self) -> Vc<StyledString> {
-        StyledString::Text(rcstr!("Error while requesting resource")).cell()
-    }
-
-    #[turbo_tasks::function]
-    fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::Load.cell()
-    }
-
-    #[turbo_tasks::function]
-    async fn description(&self) -> Result<Vc<OptionStyledString>> {
-        let url = &*self.url.await?;
-        let kind = &*self.kind.await?;
-
-        Ok(Vc::cell(Some(
-            match kind {
-                FetchErrorKind::Connect => StyledString::Line(vec![
-                    StyledString::Text(rcstr!(
-                        "There was an issue establishing a connection while requesting "
-                    )),
-                    StyledString::Code(url.clone()),
-                ]),
-                FetchErrorKind::Status(status) => StyledString::Line(vec![
-                    StyledString::Text(rcstr!("Received response with status ")),
-                    StyledString::Code(RcStr::from(status.to_string())),
-                    StyledString::Text(rcstr!(" when requesting ")),
-                    StyledString::Code(url.clone()),
-                ]),
-                FetchErrorKind::Timeout => StyledString::Line(vec![
-                    StyledString::Text(rcstr!("Connection timed out when requesting ")),
-                    StyledString::Code(url.clone()),
-                ]),
-                FetchErrorKind::Other => StyledString::Line(vec![
-                    StyledString::Text(rcstr!("There was an issue requesting ")),
-                    StyledString::Code(url.clone()),
-                ]),
-            }
-            .resolved_cell(),
+    async fn title(&self) -> Result<StyledString> {
+        Ok(StyledString::Text(rcstr!(
+            "Error while requesting resource"
         )))
     }
 
-    #[turbo_tasks::function]
-    fn detail(&self) -> Vc<OptionStyledString> {
-        Vc::cell(Some(self.detail))
+    fn stage(&self) -> IssueStage {
+        IssueStage::Load
+    }
+
+    async fn description(&self) -> Result<Option<StyledString>> {
+        let url = &*self.url.await?;
+        let kind = &*self.kind.await?;
+
+        Ok(Some(match kind {
+            FetchErrorKind::Connect => StyledString::Line(vec![
+                StyledString::Text(rcstr!(
+                    "There was an issue establishing a connection while requesting "
+                )),
+                StyledString::Code(url.clone()),
+            ]),
+            FetchErrorKind::Status(status) => StyledString::Line(vec![
+                StyledString::Text(rcstr!("Received response with status ")),
+                StyledString::Code(RcStr::from(status.to_string())),
+                StyledString::Text(rcstr!(" when requesting ")),
+                StyledString::Code(url.clone()),
+            ]),
+            FetchErrorKind::Timeout => StyledString::Line(vec![
+                StyledString::Text(rcstr!("Connection timed out when requesting ")),
+                StyledString::Code(url.clone()),
+            ]),
+            FetchErrorKind::Other => StyledString::Line(vec![
+                StyledString::Text(rcstr!("There was an issue requesting ")),
+                StyledString::Code(url.clone()),
+            ]),
+        }))
+    }
+
+    async fn detail(&self) -> Result<Option<StyledString>> {
+        Ok(Some((*self.detail.await?).clone()))
     }
 }

--- a/turbopack/crates/turbo-tasks-fetch/tests/fetch.rs
+++ b/turbopack/crates/turbo-tasks-fetch/tests/fetch.rs
@@ -192,7 +192,7 @@ async fn errors_on_failed_connection() {
             ReadRef<FetchErrorKind>,
             RcStr,
             ReadRef<FetchIssue>,
-            ReadRef<StyledString>,
+            StyledString,
         );
 
         #[turbo_tasks::function(operation)]
@@ -206,11 +206,10 @@ async fn errors_on_failed_connection() {
 
             let issue_vc = err_vc.to_issue(IssueSeverity::Error, get_issue_context().owned().await?);
             let issue = issue_vc.await?;
-            let issue_description = issue_vc
+            let issue_description = issue
                 .description()
                 .await?
-                .expect("description is not None")
-                .await?;
+                .expect("description is not None");
 
             Ok(FetchOutput(err_kind, err_url, issue, issue_description).cell())
         }
@@ -257,7 +256,7 @@ async fn errors_on_404() {
                 ReadRef<FetchErrorKind>,
                 RcStr,
                 ReadRef<FetchIssue>,
-                ReadRef<StyledString>,
+                StyledString,
             );
 
             #[turbo_tasks::function(operation)]
@@ -273,11 +272,8 @@ async fn errors_on_404() {
                 let issue_vc =
                     err_vc.to_issue(IssueSeverity::Error, get_issue_context().owned().await?);
                 let issue = issue_vc.await?;
-                let issue_description = issue_vc
-                    .description()
-                    .await?
-                    .expect("description is not None")
-                    .await?;
+                let issue_description =
+                    issue.description().await?.expect("description is not None");
 
                 Ok(FetchOutput(err_kind, err_url, issue, issue_description).cell())
             }

--- a/turbopack/crates/turbo-tasks-fs/src/watcher.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/watcher.rs
@@ -386,7 +386,7 @@ impl DiskWatcher {
             let config = config.with_poll_interval(poll_interval);
             NotifyWatcher::Polling(PollWatcher::new(tx, config)?)
         } else {
-            NotifyWatcher::Recommended(RecommendedWatcher::new(tx, Config::default())?)
+            NotifyWatcher::Recommended(RecommendedWatcher::new(tx, config)?)
         };
 
         // TOCTOU: we must watch `root_path` before calling any invalidators and setting up the

--- a/turbopack/crates/turbopack-browser/Cargo.toml
+++ b/turbopack/crates/turbopack-browser/Cargo.toml
@@ -20,6 +20,7 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+async-trait = { workspace = true }
 bincode = { workspace = true }
 either = { workspace = true }
 indoc = { workspace = true }

--- a/turbopack/crates/turbopack-browser/src/react_refresh.rs
+++ b/turbopack/crates/turbopack-browser/src/react_refresh.rs
@@ -1,9 +1,10 @@
 use anyhow::Result;
+use async_trait::async_trait;
 use turbo_rcstr::rcstr;
 use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
-    issue::{Issue, IssueExt, IssueSeverity, IssueStage, OptionStyledString, StyledString},
+    issue::{Issue, IssueExt, IssueSeverity, IssueStage, StyledString},
     reference_type::{CommonJsReferenceSubType, ReferenceType},
     resolve::parse::Request,
 };
@@ -78,40 +79,36 @@ pub struct ReactRefreshResolvingIssue {
     path: FileSystemPath,
 }
 
+#[async_trait]
 #[turbo_tasks::value_impl]
 impl Issue for ReactRefreshResolvingIssue {
     fn severity(&self) -> IssueSeverity {
         IssueSeverity::Warning
     }
 
-    #[turbo_tasks::function]
-    fn title(&self) -> Vc<StyledString> {
-        StyledString::Text(rcstr!("Could not resolve React Refresh runtime")).cell()
+    async fn title(&self) -> Result<StyledString> {
+        Ok(StyledString::Text(rcstr!(
+            "Could not resolve React Refresh runtime"
+        )))
     }
 
-    #[turbo_tasks::function]
-    fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::Resolve.cell()
+    fn stage(&self) -> IssueStage {
+        IssueStage::Resolve
     }
 
-    #[turbo_tasks::function]
-    fn file_path(&self) -> Vc<FileSystemPath> {
-        self.path.clone().cell()
+    async fn file_path(&self) -> Result<FileSystemPath> {
+        Ok(self.path.clone())
     }
 
-    #[turbo_tasks::function]
-    fn description(&self) -> Vc<OptionStyledString> {
-        Vc::cell(Some(
-            StyledString::Line(vec![
-                StyledString::Text(rcstr!(
-                    "React Refresh will be disabled.\nTo enable React Refresh, install the "
-                )),
-                StyledString::Code(rcstr!("react-refresh")),
-                StyledString::Text(rcstr!(" and ")),
-                StyledString::Code(rcstr!("@next/react-refresh-utils")),
-                StyledString::Text(rcstr!(" modules.")),
-            ])
-            .resolved_cell(),
-        ))
+    async fn description(&self) -> Result<Option<StyledString>> {
+        Ok(Some(StyledString::Line(vec![
+            StyledString::Text(rcstr!(
+                "React Refresh will be disabled.\nTo enable React Refresh, install the "
+            )),
+            StyledString::Code(rcstr!("react-refresh")),
+            StyledString::Text(rcstr!(" and ")),
+            StyledString::Code(rcstr!("@next/react-refresh-utils")),
+            StyledString::Text(rcstr!(" modules.")),
+        ])))
     }
 }

--- a/turbopack/crates/turbopack-core/src/issue/analyze.rs
+++ b/turbopack/crates/turbopack-core/src/issue/analyze.rs
@@ -1,13 +1,11 @@
 use anyhow::Result;
+use async_trait::async_trait;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
 
-use super::{
-    AdditionalIssueSources, Issue, IssueSeverity, IssueSource, IssueStage, OptionStyledString,
-    StyledString,
-};
-use crate::{ident::AssetIdent, issue::OptionIssueSource};
+use super::{AdditionalIssueSource, Issue, IssueSeverity, IssueSource, IssueStage, StyledString};
+use crate::ident::AssetIdent;
 
 #[turbo_tasks::value(shared)]
 pub struct AnalyzeIssue {
@@ -42,14 +40,14 @@ impl AnalyzeIssue {
     }
 }
 
+#[async_trait]
 #[turbo_tasks::value_impl]
 impl Issue for AnalyzeIssue {
     fn severity(&self) -> IssueSeverity {
         self.severity
     }
 
-    #[turbo_tasks::function]
-    async fn title(&self) -> Result<Vc<StyledString>> {
+    async fn title(&self) -> Result<StyledString> {
         let title = &*self.title.await?;
         Ok(if let Some(code) = self.code.as_ref() {
             StyledString::Line(vec![
@@ -59,37 +57,31 @@ impl Issue for AnalyzeIssue {
             ])
         } else {
             StyledString::Text(title.clone())
-        }
-        .cell())
+        })
     }
 
-    #[turbo_tasks::function]
-    fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::Analysis.cell()
+    fn stage(&self) -> IssueStage {
+        IssueStage::Analysis
     }
 
-    #[turbo_tasks::function]
-    fn file_path(&self) -> Vc<FileSystemPath> {
-        self.source_ident.path()
+    async fn file_path(&self) -> Result<FileSystemPath> {
+        self.source_ident.path().owned().await
     }
 
-    #[turbo_tasks::function]
-    fn description(&self) -> Vc<OptionStyledString> {
-        Vc::cell(Some(self.message))
+    async fn description(&self) -> Result<Option<StyledString>> {
+        Ok(Some((*self.message.await?).clone()))
     }
 
-    #[turbo_tasks::function]
-    async fn source(&self) -> Vc<OptionIssueSource> {
-        Vc::cell(self.source)
+    fn source(&self) -> Option<IssueSource> {
+        self.source
     }
 
-    #[turbo_tasks::function]
-    async fn additional_sources(&self) -> Result<Vc<AdditionalIssueSources>> {
-        if let Some(issue_source) = &self.source
-            && let Some(source) = issue_source.to_generated_code_source().await?
+    async fn additional_sources(&self) -> Result<Vec<AdditionalIssueSource>> {
+        if let Some(issue_source) = self.source
+            && let Some(additional) = issue_source.to_generated_code_source().await?
         {
-            return Ok(Vc::cell(vec![source]));
+            return Ok(vec![additional]);
         }
-        Ok(AdditionalIssueSources::empty())
+        Ok(vec![])
     }
 }

--- a/turbopack/crates/turbopack-core/src/issue/code_gen.rs
+++ b/turbopack/crates/turbopack-core/src/issue/code_gen.rs
@@ -1,10 +1,9 @@
-use turbo_tasks::{ResolvedVc, Vc};
+use anyhow::Result;
+use async_trait::async_trait;
+use turbo_tasks::ResolvedVc;
 use turbo_tasks_fs::FileSystemPath;
 
-use super::{
-    Issue, IssueSeverity, IssueSource, IssueStage, OptionIssueSource, OptionStyledString,
-    StyledString,
-};
+use super::{Issue, IssueSeverity, IssueSource, IssueStage, StyledString};
 
 #[turbo_tasks::value(shared)]
 pub struct CodeGenerationIssue {
@@ -16,34 +15,30 @@ pub struct CodeGenerationIssue {
     pub source: Option<IssueSource>,
 }
 
+#[async_trait]
 #[turbo_tasks::value_impl]
 impl Issue for CodeGenerationIssue {
     fn severity(&self) -> IssueSeverity {
         self.severity
     }
 
-    #[turbo_tasks::function]
-    fn title(&self) -> Vc<StyledString> {
-        *self.title
+    async fn file_path(&self) -> Result<FileSystemPath> {
+        Ok(self.path.clone())
     }
 
-    #[turbo_tasks::function]
-    fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::CodeGen.cell()
+    fn stage(&self) -> IssueStage {
+        IssueStage::CodeGen
     }
 
-    #[turbo_tasks::function]
-    fn file_path(&self) -> Vc<FileSystemPath> {
-        self.path.clone().cell()
+    async fn title(&self) -> Result<StyledString> {
+        Ok((*self.title.await?).clone())
     }
 
-    #[turbo_tasks::function]
-    fn description(&self) -> Vc<OptionStyledString> {
-        Vc::cell(Some(self.message))
+    async fn description(&self) -> Result<Option<StyledString>> {
+        Ok(Some((*self.message.await?).clone()))
     }
 
-    #[turbo_tasks::function]
-    fn source(&self) -> Vc<OptionIssueSource> {
-        Vc::cell(self.source)
+    fn source(&self) -> Option<IssueSource> {
+        self.source
     }
 }

--- a/turbopack/crates/turbopack-core/src/issue/mod.rs
+++ b/turbopack/crates/turbopack-core/src/issue/mod.rs
@@ -9,15 +9,16 @@ use std::{
 };
 
 use anyhow::{Result, bail};
+use async_trait::async_trait;
 use auto_hash_map::AutoSet;
 use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use turbo_esregex::EsRegex;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     CollectiblesSource, NonLocalValue, OperationVc, RawVc, ReadRef, ResolvedVc, TaskInput,
-    TransientValue, TryFlatJoinIterExt, TryJoinIterExt, Upcast, ValueDefault, ValueToString, Vc,
-    emit, trace::TraceRawVcs,
+    TransientValue, TryFlatJoinIterExt, TryJoinIterExt, Upcast, ValueDefault, ValueToString,
+    ValueToStringRef, Vc, emit, trace::TraceRawVcs,
 };
 use turbo_tasks_fs::{
     FileContent, FileLine, FileLinesContent, FileSystem, FileSystemPath, glob::Glob,
@@ -127,6 +128,7 @@ impl StyledString {
     }
 }
 
+#[async_trait]
 #[turbo_tasks::value_trait]
 pub trait Issue {
     /// Severity allows the user to filter out unimportant issues, with Bug
@@ -137,59 +139,49 @@ pub trait Issue {
 
     /// The file path that generated the issue, displayed to the user as message
     /// header.
-    #[turbo_tasks::function]
-    fn file_path(self: Vc<Self>) -> Vc<FileSystemPath>;
+    async fn file_path(&self) -> Result<FileSystemPath>;
 
     /// The stage of the compilation process at which the issue occurred. This
     /// is used to sort issues.
-    #[turbo_tasks::function]
-    fn stage(self: Vc<Self>) -> Vc<IssueStage>;
+    fn stage(&self) -> IssueStage;
 
     /// The issue title should be descriptive of the issue, but should be a
     /// single line. This is displayed to the user directly under the issue
     /// header.
-    // TODO add Vc<StyledString>
-    #[turbo_tasks::function]
-    fn title(self: Vc<Self>) -> Vc<StyledString>;
+    async fn title(&self) -> Result<StyledString>;
 
     /// A more verbose message of the issue, appropriate for providing multiline
     /// information of the issue.
-    // TODO add Vc<StyledString>
-    #[turbo_tasks::function]
-    fn description(self: Vc<Self>) -> Vc<OptionStyledString> {
-        Vc::cell(None)
+    async fn description(&self) -> Result<Option<StyledString>> {
+        Ok(None)
     }
 
     /// Full details of the issue, appropriate for providing debug level
     /// information. Only displayed if the user explicitly asks for detailed
     /// messages (not to be confused with severity).
-    #[turbo_tasks::function]
-    fn detail(self: Vc<Self>) -> Vc<OptionStyledString> {
-        Vc::cell(None)
+    async fn detail(&self) -> Result<Option<StyledString>> {
+        Ok(None)
     }
 
     /// A link to relevant documentation of the issue. Only displayed in console
     /// if the user explicitly asks for detailed messages.
-    #[turbo_tasks::function]
-    fn documentation_link(self: Vc<Self>) -> Vc<RcStr> {
-        Vc::<RcStr>::default()
+    fn documentation_link(&self) -> RcStr {
+        rcstr!("")
     }
 
     /// The source location that caused the issue. Eg, for a parsing error it
     /// should point at the offending character. Displayed to the user alongside
     /// the title/description.
-    #[turbo_tasks::function]
-    fn source(self: Vc<Self>) -> Vc<OptionIssueSource> {
-        Vc::cell(None)
+    fn source(&self) -> Option<IssueSource> {
+        None
     }
 
     /// Additional source locations related to this issue (e.g., generated code
     /// from a loader). Each source includes a description and location.
     /// These are displayed alongside the primary source to give users full
     /// context about the error.
-    #[turbo_tasks::function]
-    fn additional_sources(self: Vc<Self>) -> Vc<AdditionalIssueSources> {
-        AdditionalIssueSources::empty()
+    async fn additional_sources(&self) -> Result<Vec<AdditionalIssueSource>> {
+        Ok(vec![])
     }
 }
 
@@ -318,13 +310,15 @@ impl IssueFilter {
             return Ok(Vc::cell(true));
         }
 
+        let trait_ref = issue.into_trait_ref().await?;
+
         // Fetch the file path once — it's used by both severity and ignore-rule
         // checks.
-        let file_path = issue.file_path().await?;
+        let file_path = trait_ref.file_path().await?;
 
         // Check severity first — this is cheap and avoids fetching
         // title/description for issues that would be filtered out anyway.
-        let severity = issue.into_trait_ref().await?.severity();
+        let severity = trait_ref.severity();
         // NOTE: Lower severities are _more_ severe
         let severity_allowed = if severity <= self.severity || severity <= self.foreign_severity {
             // we need to check the path to see if it is foreign or not.  Only await the
@@ -360,7 +354,7 @@ impl IssueFilter {
                 }
                 if let Some(ref title_pat) = rule.title {
                     if title_str.is_none() {
-                        title_str = Some(issue.title().await?.to_unstyled_string());
+                        title_str = Some(trait_ref.title().await?.to_unstyled_string());
                     }
                     if !title_pat.matches(title_str.as_deref().unwrap()) {
                         continue;
@@ -368,11 +362,12 @@ impl IssueFilter {
                 }
                 if let Some(ref desc_pat) = rule.description {
                     if description_text.is_none() {
-                        let desc_opt = issue.description().await?;
-                        description_text = Some(match desc_opt.as_ref() {
-                            Some(desc_vc) => Some(desc_vc.await?.to_unstyled_string()),
-                            None => None,
-                        });
+                        description_text = Some(
+                            trait_ref
+                                .description()
+                                .await?
+                                .map(|s| s.to_unstyled_string()),
+                        );
                     }
                     match description_text.as_ref().unwrap().as_deref() {
                         Some(desc) if desc_pat.matches(desc) => {}
@@ -710,12 +705,6 @@ async fn source_pos(
     Ok(Some((content_1, start, end)))
 }
 
-#[turbo_tasks::value(transparent)]
-pub struct OptionIssueSource(Option<IssueSource>);
-
-#[turbo_tasks::value(transparent)]
-pub struct OptionStyledString(Option<ResolvedVc<StyledString>>);
-
 /// A labeled issue source used to provide additional context in error messages.
 /// For example, when a webpack loader produces broken code, the primary source
 /// shows the original file, while an additional source shows the generated code.
@@ -981,53 +970,43 @@ impl PlainIssue {
         issue: ResolvedVc<Box<dyn Issue>>,
         import_tracer: Option<ResolvedVc<DelegatingImportTracer>>,
     ) -> Result<Vc<Self>> {
-        let description: Option<StyledString> = match *issue.description().await? {
-            Some(description) => Some(description.owned().await?),
-            None => None,
-        };
-        let detail = match *issue.detail().await? {
-            Some(detail) => Some(detail.owned().await?),
-            None => None,
-        };
         let trait_ref = issue.into_trait_ref().await?;
-
         let severity = trait_ref.severity();
+        let file_path = trait_ref.file_path().await?;
+        let file_path_str = file_path.to_string_ref().await?;
 
         Ok(Self::cell(Self {
             severity,
-            file_path: issue.file_path().to_string().owned().await?,
-            stage: issue.stage().owned().await?,
-            title: issue.title().owned().await?,
-            description,
-            detail,
-            documentation_link: issue.documentation_link().owned().await?,
+            file_path: file_path_str,
+            stage: trait_ref.stage(),
+            title: trait_ref.title().await?,
+            description: trait_ref.description().await?,
+            detail: trait_ref.detail().await?,
+            documentation_link: trait_ref.documentation_link(),
             source: {
-                if let Some(s) = &*issue.source().await? {
+                if let Some(s) = trait_ref.source() {
                     Some(s.into_plain().await?)
                 } else {
                     None
                 }
             },
             additional_sources: {
-                let sources = issue.additional_sources().await?;
-                let mut result = Vec::new();
-                for s in sources.iter() {
-                    result.push(PlainAdditionalIssueSource {
-                        description: s.description.clone(),
-                        source: s.source.into_plain().await?,
-                    });
-                }
-                result
+                trait_ref
+                    .additional_sources()
+                    .await?
+                    .into_iter()
+                    .map(async |s| {
+                        Ok(PlainAdditionalIssueSource {
+                            source: s.source.into_plain().await?,
+                            description: s.description,
+                        })
+                    })
+                    .try_join()
+                    .await?
             },
             import_traces: match import_tracer {
                 Some(tracer) => {
-                    into_plain_trace(
-                        tracer
-                            .await?
-                            .get_traces(issue.file_path().owned().await?)
-                            .await?,
-                    )
-                    .await?
+                    into_plain_trace(tracer.await?.get_traces(file_path).await?).await?
                 }
                 None => vec![],
             },

--- a/turbopack/crates/turbopack-core/src/issue/module.rs
+++ b/turbopack/crates/turbopack-core/src/issue/module.rs
@@ -1,14 +1,11 @@
 use anyhow::Result;
+use async_trait::async_trait;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
 
-use super::{Issue, IssueStage, OptionStyledString, StyledString};
-use crate::{
-    ident::AssetIdent,
-    issue::{IssueExt, IssueSource, OptionIssueSource},
-    source::Source,
-};
+use super::{Issue, IssueSource, IssueStage, StyledString};
+use crate::{ident::AssetIdent, issue::IssueExt, source::Source};
 
 #[turbo_tasks::value]
 pub struct ModuleIssue {
@@ -37,38 +34,33 @@ impl ModuleIssue {
     }
 }
 
+#[async_trait]
 #[turbo_tasks::value_impl]
 impl Issue for ModuleIssue {
-    #[turbo_tasks::function]
-    fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::ProcessModule.cell()
+    fn stage(&self) -> IssueStage {
+        IssueStage::ProcessModule
     }
 
-    #[turbo_tasks::function]
-    fn file_path(&self) -> Vc<FileSystemPath> {
-        self.ident.path()
+    async fn file_path(&self) -> Result<FileSystemPath> {
+        self.ident.path().owned().await
     }
 
-    #[turbo_tasks::function]
-    fn title(&self) -> Vc<StyledString> {
-        *self.title
+    async fn title(&self) -> Result<StyledString> {
+        Ok((*self.title.await?).clone())
     }
 
-    #[turbo_tasks::function]
-    fn description(&self) -> Vc<OptionStyledString> {
-        Vc::cell(Some(self.description))
+    async fn description(&self) -> Result<Option<StyledString>> {
+        Ok(Some((*self.description.await?).clone()))
     }
 
-    #[turbo_tasks::function]
-    fn source(&self) -> Vc<OptionIssueSource> {
-        Vc::cell(self.source)
+    fn source(&self) -> Option<IssueSource> {
+        self.source
     }
 }
 
 #[turbo_tasks::function]
 pub async fn emit_unknown_module_type_error(source: Vc<Box<dyn Source>>) -> Result<()> {
-    ModuleIssue {
-        ident: source.ident().to_resolved().await?,
+    ModuleIssue {ident: source.ident().to_resolved().await?,
         title: StyledString::Text(rcstr!("Unknown module type")).resolved_cell(),
         description: StyledString::Text(
             r"This module doesn't have an associated type. Use a known file extension, or register a loader for it.
@@ -76,8 +68,7 @@ pub async fn emit_unknown_module_type_error(source: Vc<Box<dyn Source>>) -> Resu
 Read more: https://nextjs.org/docs/app/api-reference/next-config-js/turbo#webpack-loaders".into(),
         )
         .resolved_cell(),
-        source: Some(IssueSource::from_source_only(source.to_resolved().await?)),
-    }
+        source: Some(IssueSource::from_source_only(source.to_resolved().await?)),}
     .resolved_cell()
     .emit();
 

--- a/turbopack/crates/turbopack-core/src/issue/resolve.rs
+++ b/turbopack/crates/turbopack-core/src/issue/resolve.rs
@@ -1,13 +1,14 @@
 use std::fmt::Write;
 
 use anyhow::Result;
+use async_trait::async_trait;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{PrettyPrintError, ReadRef, ResolvedVc, ValueToString, ValueToStringRef, Vc};
 use turbo_tasks_fs::FileSystemPath;
 
-use super::{Issue, IssueSource, IssueStage, OptionStyledString, StyledString};
+use super::{Issue, IssueSource, IssueStage, StyledString};
 use crate::{
-    issue::{IssueSeverity, OptionIssueSource},
+    issue::IssueSeverity,
     resolve::{
         options::{ImportMap, ImportMapResult, ResolveOptions},
         parse::Request,
@@ -25,35 +26,31 @@ pub struct ResolvingIssue {
     pub source: Option<IssueSource>,
 }
 
+#[async_trait]
 #[turbo_tasks::value_impl]
 impl Issue for ResolvingIssue {
     fn severity(&self) -> IssueSeverity {
         self.severity
     }
 
-    #[turbo_tasks::function]
-    async fn title(&self) -> Result<Vc<StyledString>> {
+    async fn title(&self) -> Result<StyledString> {
         let request = self.request.request_pattern().to_string().owned().await?;
         Ok(StyledString::Line(vec![
             StyledString::Strong(rcstr!("Module not found")),
             StyledString::Text(rcstr!(": Can't resolve ")),
             StyledString::Code(request),
-        ])
-        .cell())
+        ]))
     }
 
-    #[turbo_tasks::function]
-    fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::Resolve.cell()
+    fn stage(&self) -> IssueStage {
+        IssueStage::Resolve
     }
 
-    #[turbo_tasks::function]
-    fn file_path(&self) -> Vc<FileSystemPath> {
-        self.file_path.clone().cell()
+    async fn file_path(&self) -> Result<FileSystemPath> {
+        Ok(self.file_path.clone())
     }
 
-    #[turbo_tasks::function]
-    async fn description(&self) -> Result<Vc<OptionStyledString>> {
+    async fn description(&self) -> Result<Option<StyledString>> {
         let mut description = String::new();
         if let Some(error_message) = &self.error_message {
             writeln!(description, "{error_message}")?;
@@ -65,8 +62,8 @@ impl Issue for ResolvingIssue {
         };
 
         if let Some(import_map) = &self.resolve_options.await?.import_map {
-            for request in request_parts {
-                match lookup_import_map(**import_map, self.file_path.clone(), **request).await {
+            for req in request_parts {
+                match lookup_import_map(**import_map, self.file_path.clone(), **req).await {
                     Ok(None) => {}
                     Ok(Some(str)) => writeln!(description, "Import map: {str}")?,
                     Err(err) => {
@@ -79,13 +76,10 @@ impl Issue for ResolvingIssue {
                 }
             }
         }
-        Ok(Vc::cell(Some(
-            StyledString::Text(description.into()).resolved_cell(),
-        )))
+        Ok(Some(StyledString::Text(description.into())))
     }
 
-    #[turbo_tasks::function]
-    async fn detail(&self) -> Result<Vc<OptionStyledString>> {
+    async fn detail(&self) -> Result<Option<StyledString>> {
         let mut detail = String::new();
 
         if self.error_message.is_some() {
@@ -108,14 +102,11 @@ impl Issue for ResolvingIssue {
             "Type of request: {request_type}",
             request_type = self.request_type,
         )?;
-        Ok(Vc::cell(Some(
-            StyledString::Text(detail.into()).resolved_cell(),
-        )))
+        Ok(Some(StyledString::Text(detail.into())))
     }
 
-    #[turbo_tasks::function]
-    fn source(&self) -> Vc<OptionIssueSource> {
-        Vc::cell(self.source)
+    fn source(&self) -> Option<IssueSource> {
+        self.source
     }
 
     // TODO add sub_issue for a description of resolve_options

--- a/turbopack/crates/turbopack-core/src/package_json.rs
+++ b/turbopack/crates/turbopack-core/src/package_json.rs
@@ -1,6 +1,7 @@
 use std::ops::Deref;
 
 use anyhow::Result;
+use async_trait::async_trait;
 use serde_json::Value as JsonValue;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
@@ -11,9 +12,7 @@ use turbo_tasks_fs::{FileJsonContent, FileSystemPath};
 use super::issue::Issue;
 use crate::{
     asset::Asset,
-    issue::{
-        IssueExt, IssueSource, IssueStage, OptionIssueSource, OptionStyledString, StyledString,
-    },
+    issue::{IssueExt, IssueSource, IssueStage, StyledString},
     source::Source,
 };
 
@@ -69,32 +68,28 @@ pub struct PackageJsonIssue {
     pub source: IssueSource,
 }
 
+#[async_trait]
 #[turbo_tasks::value_impl]
 impl Issue for PackageJsonIssue {
-    #[turbo_tasks::function]
-    fn title(&self) -> Vc<StyledString> {
-        StyledString::Text(rcstr!("Error parsing package.json file")).cell()
+    async fn title(&self) -> Result<StyledString> {
+        Ok(StyledString::Text(rcstr!(
+            "Error parsing package.json file"
+        )))
     }
 
-    #[turbo_tasks::function]
-    fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::Parse.cell()
+    fn stage(&self) -> IssueStage {
+        IssueStage::Parse
     }
 
-    #[turbo_tasks::function]
-    fn file_path(&self) -> Vc<FileSystemPath> {
-        self.source.file_path()
+    async fn file_path(&self) -> Result<FileSystemPath> {
+        self.source.file_path().owned().await
     }
 
-    #[turbo_tasks::function]
-    fn description(&self) -> Vc<OptionStyledString> {
-        Vc::cell(Some(
-            StyledString::Text(self.error_message.clone()).resolved_cell(),
-        ))
+    async fn description(&self) -> Result<Option<StyledString>> {
+        Ok(Some(StyledString::Text(self.error_message.clone())))
     }
 
-    #[turbo_tasks::function]
-    fn source(&self) -> Vc<OptionIssueSource> {
-        Vc::cell(Some(self.source))
+    fn source(&self) -> Option<IssueSource> {
+        Some(self.source)
     }
 }

--- a/turbopack/crates/turbopack-core/src/resolve/error.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/error.rs
@@ -1,12 +1,13 @@
 use anyhow::Result;
+use async_trait::async_trait;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{PrettyPrintError, ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
 
 use crate::{
     issue::{
-        Issue, IssueExt, IssueSeverity, IssueSource, IssueStage, OptionIssueSource,
-        OptionStyledString, StyledString, resolve::ResolvingIssue,
+        Issue, IssueExt, IssueSeverity, IssueSource, IssueStage, StyledString,
+        resolve::ResolvingIssue,
     },
     reference_type::ReferenceType,
     resolve::{
@@ -111,9 +112,12 @@ async fn handle_item_issues(
     if items.peek().is_some() {
         let file_path = origin.origin_path().owned().await?;
         for item in items {
+            let trait_ref = item.into_trait_ref().await?;
             ResolvingIssueWithLocation {
                 inner: item,
-                severity: item.into_trait_ref().await?.severity(),
+                severity: trait_ref.severity(),
+                stage: trait_ref.stage(),
+                documentation_link: trait_ref.documentation_link(),
                 file_path: file_path.clone(),
                 source,
             }
@@ -199,48 +203,44 @@ pub async fn resolve_error_severity(resolve_options: Vc<ResolveOptions>) -> Resu
 pub struct ResolvingIssueWithLocation {
     pub inner: ResolvedVc<Box<dyn Issue>>,
     pub severity: IssueSeverity,
+    pub stage: IssueStage,
+    pub documentation_link: RcStr,
     pub file_path: FileSystemPath,
     pub source: Option<IssueSource>,
 }
 
+#[async_trait]
 #[turbo_tasks::value_impl]
 impl Issue for ResolvingIssueWithLocation {
     fn severity(&self) -> IssueSeverity {
         self.severity
     }
 
-    #[turbo_tasks::function]
-    fn file_path(&self) -> Vc<FileSystemPath> {
-        self.file_path.clone().cell()
+    async fn file_path(&self) -> Result<FileSystemPath> {
+        Ok(self.file_path.clone())
     }
 
-    #[turbo_tasks::function]
-    fn stage(&self) -> Vc<IssueStage> {
-        self.inner.stage()
+    fn stage(&self) -> IssueStage {
+        self.stage.clone()
     }
 
-    #[turbo_tasks::function]
-    fn title(&self) -> Vc<StyledString> {
-        self.inner.title()
+    async fn title(&self) -> Result<StyledString> {
+        self.inner.into_trait_ref().await?.title().await
     }
 
-    #[turbo_tasks::function]
-    fn description(&self) -> Vc<OptionStyledString> {
-        self.inner.description()
+    async fn description(&self) -> Result<Option<StyledString>> {
+        self.inner.into_trait_ref().await?.description().await
     }
 
-    #[turbo_tasks::function]
-    fn detail(&self) -> Vc<OptionStyledString> {
-        self.inner.detail()
+    async fn detail(&self) -> Result<Option<StyledString>> {
+        self.inner.into_trait_ref().await?.detail().await
     }
 
-    #[turbo_tasks::function]
-    fn documentation_link(&self) -> Vc<RcStr> {
-        self.inner.documentation_link()
+    fn documentation_link(&self) -> RcStr {
+        self.documentation_link.clone()
     }
 
-    #[turbo_tasks::function]
-    fn source(&self) -> Vc<OptionIssueSource> {
-        Vc::cell(self.source)
+    fn source(&self) -> Option<IssueSource> {
+        self.source
     }
 }

--- a/turbopack/crates/turbopack-core/src/resolve/options.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/options.rs
@@ -533,7 +533,16 @@ impl ValueToString for ImportMapResult {
             }
             ImportMapResult::NoEntry => Ok(Vc::cell(rcstr!("No import map entry"))),
             ImportMapResult::Error(issue) => Ok(Vc::cell(
-                format!("error: {}", issue.title().await?.to_unstyled_string()).into(),
+                format!(
+                    "error: {}",
+                    issue
+                        .into_trait_ref()
+                        .await?
+                        .title()
+                        .await?
+                        .to_unstyled_string()
+                )
+                .into(),
             )),
         }
     }

--- a/turbopack/crates/turbopack-css/Cargo.toml
+++ b/turbopack/crates/turbopack-css/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+async-trait = { workspace = true }
 bincode = { workspace = true }
 indoc = { workspace = true }
 lightningcss = { workspace = true }

--- a/turbopack/crates/turbopack-css/src/process.rs
+++ b/turbopack/crates/turbopack-css/src/process.rs
@@ -1,6 +1,7 @@
 use std::sync::{Arc, RwLock};
 
 use anyhow::{Result, bail};
+use async_trait::async_trait;
 use lightningcss::{
     css_modules::{CssModuleExport, Pattern, Segment},
     stylesheet::{MinifyOptions, ParserOptions, PrinterOptions, StyleSheet, ToCssResult},
@@ -23,8 +24,8 @@ use turbopack_core::{
     chunk::{ChunkingContext, MinifyType},
     environment::Environment,
     issue::{
-        AdditionalIssueSources, Issue, IssueExt, IssueSeverity, IssueSource, IssueStage,
-        OptionIssueSource, OptionStyledString, StyledString,
+        AdditionalIssueSource, Issue, IssueExt, IssueSeverity, IssueSource, IssueStage,
+        StyledString,
     },
     reference::ModuleReferences,
     reference_type::ImportContext,
@@ -756,50 +757,42 @@ struct ParsingIssue {
     source: IssueSource,
 }
 
+#[async_trait]
 #[turbo_tasks::value_impl]
 impl Issue for ParsingIssue {
     fn severity(&self) -> IssueSeverity {
         self.severity
     }
 
-    #[turbo_tasks::function]
-    fn file_path(&self) -> Vc<FileSystemPath> {
-        self.source.file_path()
+    async fn file_path(&self) -> Result<FileSystemPath> {
+        self.source.file_path().owned().await
     }
 
-    #[turbo_tasks::function]
-    fn stage(&self) -> Vc<IssueStage> {
-        self.stage.clone().cell()
+    fn stage(&self) -> IssueStage {
+        self.stage.clone()
     }
 
-    #[turbo_tasks::function]
-    fn title(&self) -> Vc<StyledString> {
-        StyledString::Text(match self.stage {
+    async fn title(&self) -> Result<StyledString> {
+        Ok(StyledString::Text(match self.stage {
             IssueStage::Parse => rcstr!("Parsing CSS source code failed"),
             IssueStage::Transform => rcstr!("Transforming CSS failed"),
             _ => rcstr!("CSS processing failed"),
-        })
-        .cell()
+        }))
     }
 
-    #[turbo_tasks::function]
-    fn source(&self) -> Vc<OptionIssueSource> {
-        Vc::cell(Some(self.source))
+    fn source(&self) -> Option<IssueSource> {
+        Some(self.source)
     }
 
-    #[turbo_tasks::function]
-    fn description(&self) -> Result<Vc<OptionStyledString>> {
-        Ok(Vc::cell(Some(
-            StyledString::Text(self.msg.clone()).resolved_cell(),
-        )))
+    async fn description(&self) -> Result<Option<StyledString>> {
+        Ok(Some(StyledString::Text(self.msg.clone())))
     }
 
-    #[turbo_tasks::function]
-    async fn additional_sources(&self) -> Result<Vc<AdditionalIssueSources>> {
-        if let Some(source) = self.source.to_generated_code_source().await? {
-            return Ok(Vc::cell(vec![source]));
+    async fn additional_sources(&self) -> Result<Vec<AdditionalIssueSource>> {
+        if let Some(additional) = self.source.to_generated_code_source().await? {
+            return Ok(vec![additional]);
         }
-        Ok(AdditionalIssueSources::empty())
+        Ok(vec![])
     }
 }
 

--- a/turbopack/crates/turbopack-css/src/references/compose.rs
+++ b/turbopack/crates/turbopack-css/src/references/compose.rs
@@ -1,10 +1,11 @@
 use anyhow::Result;
+use async_trait::async_trait;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, ValueToString, Vc, turbofmt};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     chunk::ChunkingType,
-    issue::{Issue, IssueExt, IssueSeverity, IssueStage, OptionStyledString, StyledString},
+    issue::{Issue, IssueExt, IssueSeverity, IssueStage, StyledString},
     reference::ModuleReference,
     reference_type::CssReferenceSubType,
     resolve::{ModuleResolveResult, origin::ResolveOrigin, parse::Request},
@@ -95,34 +96,28 @@ struct CssModuleComposesIssue {
     message: RcStr,
 }
 
+#[async_trait]
 #[turbo_tasks::value_impl]
 impl Issue for CssModuleComposesIssue {
     fn severity(&self) -> IssueSeverity {
         self.severity
     }
 
-    #[turbo_tasks::function]
-    fn title(&self) -> Vc<StyledString> {
-        StyledString::Text(rcstr!(
+    async fn title(&self) -> Result<StyledString> {
+        Ok(StyledString::Text(rcstr!(
             "An issue occurred while resolving a CSS module `composes:` rule"
-        ))
-        .cell()
+        )))
     }
 
-    #[turbo_tasks::function]
-    fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::Resolve.cell()
+    fn stage(&self) -> IssueStage {
+        IssueStage::Resolve
     }
 
-    #[turbo_tasks::function]
-    fn file_path(&self) -> Vc<FileSystemPath> {
-        *self.file_path
+    async fn file_path(&self) -> Result<FileSystemPath> {
+        self.file_path.owned().await
     }
 
-    #[turbo_tasks::function]
-    fn description(&self) -> Vc<OptionStyledString> {
-        Vc::cell(Some(
-            StyledString::Text(self.message.clone()).resolved_cell(),
-        ))
+    async fn description(&self) -> Result<Option<StyledString>> {
+        Ok(Some(StyledString::Text(self.message.clone())))
     }
 }

--- a/turbopack/crates/turbopack-dev-server/Cargo.toml
+++ b/turbopack/crates/turbopack-dev-server/Cargo.toml
@@ -17,6 +17,7 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+async-trait = { workspace = true }
 auto-hash-map = { workspace = true }
 bincode = { workspace = true }
 flate2 = { workspace = true }

--- a/turbopack/crates/turbopack-dev-server/src/update/stream.rs
+++ b/turbopack/crates/turbopack-dev-server/src/update/stream.rs
@@ -1,6 +1,7 @@
 use std::pin::Pin;
 
 use anyhow::Result;
+use async_trait::async_trait;
 use futures::prelude::*;
 use tokio::sync::mpsc::Sender;
 use tokio_stream::wrappers::ReceiverStream;
@@ -13,8 +14,8 @@ use turbo_tasks::{
 use turbo_tasks_fs::{FileSystem, FileSystemPath};
 use turbopack_core::{
     issue::{
-        CollectibleIssuesExt, Issue, IssueFilter, IssueSeverity, IssueStage, OptionStyledString,
-        PlainIssue, StyledString,
+        CollectibleIssuesExt, Issue, IssueFilter, IssueSeverity, IssueStage, PlainIssue,
+        StyledString,
     },
     server_fs::ServerFileSystem,
     version::{
@@ -253,15 +254,13 @@ async fn compute_update_stream(
     from: ResolvedVc<VersionState>,
     get_content: TransientInstance<GetContentFn>,
     sender: TransientInstance<ComputeUpdateStreamSender>,
-) -> Vc<()> {
+) -> () {
     let item = get_update_stream_item_operation(resource, from, get_content)
         .read_strongly_consistent()
         .await;
 
     // Send update. Ignore channel closed error.
     let _ = sender.0.send(item).await;
-
-    Default::default()
 }
 
 pub(super) struct UpdateStream(
@@ -376,34 +375,29 @@ struct FatalStreamIssue {
     resource: RcStr,
 }
 
+#[async_trait]
 #[turbo_tasks::value_impl]
 impl Issue for FatalStreamIssue {
     fn severity(&self) -> IssueSeverity {
         IssueSeverity::Fatal
     }
 
-    #[turbo_tasks::function]
-    fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::Other(rcstr!("websocket")).cell()
+    fn stage(&self) -> IssueStage {
+        IssueStage::Other(rcstr!("websocket"))
     }
 
-    #[turbo_tasks::function]
-    async fn file_path(&self) -> Result<Vc<FileSystemPath>> {
-        Ok(ServerFileSystem::new()
-            .root()
-            .await?
-            .join(&self.resource)?
-            .cell())
+    async fn file_path(&self) -> Result<FileSystemPath> {
+        ServerFileSystem::new().root().await?.join(&self.resource)
     }
 
-    #[turbo_tasks::function]
-    fn title(&self) -> Vc<StyledString> {
-        StyledString::Text(rcstr!("Fatal error while getting content to stream")).cell()
+    async fn title(&self) -> Result<StyledString> {
+        Ok(StyledString::Text(rcstr!(
+            "Fatal error while getting content to stream"
+        )))
     }
 
-    #[turbo_tasks::function]
-    fn description(&self) -> Vc<OptionStyledString> {
-        Vc::cell(Some(self.description))
+    async fn description(&self) -> Result<Option<StyledString>> {
+        Ok(Some((*self.description.await?).clone()))
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript-plugins/src/transform/swc_ecma_transform_plugins.rs
+++ b/turbopack/crates/turbopack-ecmascript-plugins/src/transform/swc_ecma_transform_plugins.rs
@@ -2,9 +2,8 @@ use anyhow::Result;
 use async_trait::async_trait;
 use swc_core::ecma::ast::Program;
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::Vc;
 use turbo_tasks_fs::FileSystemPath;
-use turbopack_core::issue::{Issue, IssueSeverity, IssueStage, OptionStyledString, StyledString};
+use turbopack_core::issue::{Issue, IssueSeverity, IssueStage, StyledString};
 use turbopack_ecmascript::{CustomTransformer, TransformContext};
 
 /// A wrapper around an SWC's ecma transform wasm plugin module bytes, allowing
@@ -52,39 +51,32 @@ struct UnsupportedSwcEcmaTransformPluginsIssue {
     pub file_path: FileSystemPath,
 }
 
+#[async_trait]
 #[turbo_tasks::value_impl]
 impl Issue for UnsupportedSwcEcmaTransformPluginsIssue {
     fn severity(&self) -> IssueSeverity {
         IssueSeverity::Warning
     }
 
-    #[turbo_tasks::function]
-    fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::Transform.cell()
+    fn stage(&self) -> IssueStage {
+        IssueStage::Transform
     }
 
-    #[turbo_tasks::function]
-    fn title(&self) -> Vc<StyledString> {
-        StyledString::Text(rcstr!(
+    async fn title(&self) -> Result<StyledString> {
+        Ok(StyledString::Text(rcstr!(
             "Unsupported SWC EcmaScript transform plugins on this platform."
-        ))
-        .cell()
+        )))
     }
 
-    #[turbo_tasks::function]
-    fn file_path(&self) -> Vc<FileSystemPath> {
-        self.file_path.clone().cell()
+    async fn file_path(&self) -> Result<FileSystemPath> {
+        Ok(self.file_path.clone())
     }
 
-    #[turbo_tasks::function]
-    fn description(&self) -> Vc<OptionStyledString> {
-        Vc::cell(Some(
-            StyledString::Text(rcstr!(
-                "Turbopack does not yet support running SWC EcmaScript transform plugins on this \
-                 platform."
-            ))
-            .resolved_cell(),
-        ))
+    async fn description(&self) -> Result<Option<StyledString>> {
+        Ok(Some(StyledString::Text(rcstr!(
+            "Turbopack does not yet support running SWC EcmaScript transform plugins on this \
+             platform."
+        ))))
     }
 }
 
@@ -94,44 +86,37 @@ struct SwcEcmaTransformFailureIssue {
     pub description: StyledString,
 }
 
+#[async_trait]
 #[turbo_tasks::value_impl]
 impl Issue for SwcEcmaTransformFailureIssue {
     fn severity(&self) -> IssueSeverity {
         IssueSeverity::Error
     }
 
-    #[turbo_tasks::function]
-    fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::Transform.cell()
+    fn stage(&self) -> IssueStage {
+        IssueStage::Transform
     }
 
-    #[turbo_tasks::function]
-    fn title(&self) -> Vc<StyledString> {
-        StyledString::Text(rcstr!("Failed to execute SWC plugin")).cell()
+    async fn title(&self) -> Result<StyledString> {
+        Ok(StyledString::Text(rcstr!("Failed to execute SWC plugin")))
     }
 
-    #[turbo_tasks::function]
-    fn file_path(&self) -> Vc<FileSystemPath> {
-        self.file_path.clone().cell()
+    async fn file_path(&self) -> Result<FileSystemPath> {
+        Ok(self.file_path.clone())
     }
 
-    #[turbo_tasks::function]
-    fn description(&self) -> Vc<OptionStyledString> {
-        Vc::cell(Some(
-            StyledString::Stack(vec![
-                StyledString::Text(rcstr!(
-                    "An unexpected error occurred when executing an SWC EcmaScript transform \
-                     plugin."
-                )),
-                StyledString::Text(rcstr!(
-                    "This might be due to a version mismatch between the plugin and Next.js. \
-                    https://plugins.swc.rs/ can help you find the correct plugin version to use."
-                )),
-                StyledString::Text(Default::default()),
-                self.description.clone(),
-            ])
-            .resolved_cell(),
-        ))
+    async fn description(&self) -> Result<Option<StyledString>> {
+        Ok(Some(StyledString::Stack(vec![
+            StyledString::Text(rcstr!(
+                "An unexpected error occurred when executing an SWC EcmaScript transform plugin."
+            )),
+            StyledString::Text(rcstr!(
+                "This might be due to a version mismatch between the plugin and Next.js. \
+                https://plugins.swc.rs/ can help you find the correct plugin version to use."
+            )),
+            StyledString::Text(Default::default()),
+            self.description.clone(),
+        ])))
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use async_trait::async_trait;
 use either::Either;
 use itertools::Itertools;
 use turbo_rcstr::rcstr;
@@ -12,10 +13,7 @@ use turbopack_core::{
     chunk::{AsyncModuleInfo, ChunkableModule, ChunkingContext},
     file_source::FileSource,
     ident::AssetIdent,
-    issue::{
-        Issue, IssueExt, IssueSeverity, IssueSource, IssueStage, OptionIssueSource,
-        OptionStyledString, StyledString,
-    },
+    issue::{Issue, IssueExt, IssueSeverity, IssueSource, IssueStage, StyledString},
     module::Module,
     module_graph::ModuleGraph,
     output::{OutputAssets, OutputAssetsWithReferenced},
@@ -187,40 +185,33 @@ struct SideEffectsInPackageJsonIssue {
     description: Option<StyledString>,
 }
 
+#[async_trait]
 #[turbo_tasks::value_impl]
 impl Issue for SideEffectsInPackageJsonIssue {
-    #[turbo_tasks::function]
-    fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::Parse.cell()
+    fn stage(&self) -> IssueStage {
+        IssueStage::Parse
     }
 
     fn severity(&self) -> IssueSeverity {
         IssueSeverity::Warning
     }
 
-    #[turbo_tasks::function]
-    fn file_path(&self) -> Vc<FileSystemPath> {
-        self.source.file_path()
+    async fn file_path(&self) -> Result<FileSystemPath> {
+        self.source.file_path().owned().await
     }
 
-    #[turbo_tasks::function]
-    fn title(&self) -> Vc<StyledString> {
-        StyledString::Text(rcstr!("Invalid value for sideEffects in package.json")).cell()
+    async fn title(&self) -> Result<StyledString> {
+        Ok(StyledString::Text(rcstr!(
+            "Invalid value for sideEffects in package.json"
+        )))
     }
 
-    #[turbo_tasks::function]
-    fn description(&self) -> Vc<OptionStyledString> {
-        Vc::cell(
-            self.description
-                .as_ref()
-                .cloned()
-                .map(|s| s.resolved_cell()),
-        )
+    async fn description(&self) -> Result<Option<StyledString>> {
+        Ok(self.description.clone())
     }
 
-    #[turbo_tasks::function]
-    fn source(&self) -> Vc<OptionIssueSource> {
-        Vc::cell(Some(self.source))
+    fn source(&self) -> Option<IssueSource> {
+        Some(self.source)
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/parse.rs
@@ -1,6 +1,7 @@
-use std::{future::Future, sync::Arc};
+use std::sync::Arc;
 
 use anyhow::{Context, Result};
+use async_trait::async_trait;
 use bytes_str::BytesStr;
 use rustc_hash::{FxHashMap, FxHashSet};
 use swc_core::{
@@ -37,10 +38,7 @@ use turbo_tasks_hash::hash_xxh3_hash64;
 use turbopack_core::{
     SOURCE_URL_PROTOCOL,
     asset::{Asset, AssetContent},
-    issue::{
-        Issue, IssueExt, IssueSeverity, IssueSource, IssueStage, OptionIssueSource,
-        OptionStyledString, StyledString,
-    },
+    issue::{Issue, IssueExt, IssueSeverity, IssueSource, IssueStage, StyledString},
     source::Source,
     source_map::utils::add_default_ignore_list,
 };
@@ -634,45 +632,39 @@ struct ReadSourceIssue {
     severity: IssueSeverity,
 }
 
+#[async_trait]
 #[turbo_tasks::value_impl]
 impl Issue for ReadSourceIssue {
-    #[turbo_tasks::function]
-    fn file_path(&self) -> Vc<FileSystemPath> {
-        self.source.file_path()
+    async fn file_path(&self) -> Result<FileSystemPath> {
+        self.source.file_path().owned().await
     }
 
-    #[turbo_tasks::function]
-    fn title(&self) -> Vc<StyledString> {
-        StyledString::Text(rcstr!("Reading source code for parsing failed")).cell()
+    async fn title(&self) -> Result<StyledString> {
+        Ok(StyledString::Text(rcstr!(
+            "Reading source code for parsing failed"
+        )))
     }
 
-    #[turbo_tasks::function]
-    fn description(&self) -> Vc<OptionStyledString> {
-        Vc::cell(Some(
-            StyledString::Text(
-                format!(
-                    "An unexpected error happened while trying to read the source code to parse: \
-                     {}",
-                    self.error
-                )
-                .into(),
+    async fn description(&self) -> Result<Option<StyledString>> {
+        Ok(Some(StyledString::Text(
+            format!(
+                "An unexpected error happened while trying to read the source code to parse: {}",
+                self.error
             )
-            .resolved_cell(),
-        ))
+            .into(),
+        )))
     }
 
     fn severity(&self) -> IssueSeverity {
         self.severity
     }
 
-    #[turbo_tasks::function]
-    fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::Load.cell()
+    fn stage(&self) -> IssueStage {
+        IssueStage::Load
     }
 
-    #[turbo_tasks::function]
-    fn source(&self) -> Vc<OptionIssueSource> {
-        Vc::cell(Some(self.source))
+    fn source(&self) -> Option<IssueSource> {
+        Some(self.source)
     }
 }
 
@@ -800,11 +792,7 @@ mod tests {
     fn test_collect_declare_global_with_content() {
         let ids = parse_and_collect(
             r#"
-            declare global {
-                interface Window {
-                    foo: string;
-                }
-            }
+            declare global {interface Window {foo: string;}}
             "#,
         );
         assert_eq!(ids, vec!["global"]);

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -1,4 +1,5 @@
 use anyhow::{Result, bail};
+use async_trait::async_trait;
 use either::Either;
 use strsim::jaro;
 use swc_core::{
@@ -14,10 +15,7 @@ use turbo_tasks::{ResolvedVc, ValueToString, Vc, turbobail};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     chunk::{ChunkingContext, ChunkingType, ModuleChunkItemIdExt},
-    issue::{
-        Issue, IssueExt, IssueSeverity, IssueSource, IssueStage, OptionIssueSource,
-        OptionStyledString, StyledString,
-    },
+    issue::{Issue, IssueExt, IssueSeverity, IssueSource, IssueStage, StyledString},
     loader::ResolvedWebpackLoaderItem,
     module::{Module, ModuleSideEffects},
     module_graph::binding_usage_info::ModuleExportUsageInfo,
@@ -790,90 +788,78 @@ pub struct InvalidExport {
     source: IssueSource,
 }
 
+#[async_trait]
 #[turbo_tasks::value_impl]
 impl Issue for InvalidExport {
     fn severity(&self) -> IssueSeverity {
         IssueSeverity::Error
     }
 
-    #[turbo_tasks::function]
-    fn title(&self) -> Result<Vc<StyledString>> {
+    async fn title(&self) -> Result<StyledString> {
         Ok(StyledString::Line(vec![
             StyledString::Text(rcstr!("Export ")),
             StyledString::Code(self.export.clone()),
             StyledString::Text(rcstr!(" doesn't exist in target module")),
-        ])
-        .cell())
+        ]))
     }
 
-    #[turbo_tasks::function]
-    fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::Bindings.cell()
+    fn stage(&self) -> IssueStage {
+        IssueStage::Bindings
     }
 
-    #[turbo_tasks::function]
-    fn file_path(&self) -> Vc<FileSystemPath> {
-        self.source.file_path()
+    async fn file_path(&self) -> Result<FileSystemPath> {
+        self.source.file_path().owned().await
     }
 
-    #[turbo_tasks::function]
-    async fn description(&self) -> Result<Vc<OptionStyledString>> {
+    async fn description(&self) -> Result<Option<StyledString>> {
         let export_names = all_known_export_names(*self.module).await?;
         let did_you_mean = export_names
             .iter()
             .map(|s| (s, jaro(self.export.as_str(), s.as_str())))
             .max_by(|a, b| a.1.partial_cmp(&b.1).unwrap())
             .map(|(s, _)| s);
-        Ok(Vc::cell(Some(
-            StyledString::Stack(vec![
-                StyledString::Line(vec![
-                    StyledString::Text(rcstr!("The export ")),
-                    StyledString::Code(self.export.clone()),
-                    StyledString::Text(rcstr!(" was not found in module ")),
-                    StyledString::Strong(self.module.ident().to_string().owned().await?),
-                    StyledString::Text(rcstr!(".")),
-                ]),
-                if let Some(did_you_mean) = did_you_mean {
-                    StyledString::Line(vec![
-                        StyledString::Text(rcstr!("Did you mean to import ")),
-                        StyledString::Code(did_you_mean.clone()),
-                        StyledString::Text(rcstr!("?")),
-                    ])
-                } else {
-                    StyledString::Strong(rcstr!("The module has no exports at all."))
-                },
-                StyledString::Text(
-                    "All exports of the module are statically known (It doesn't have dynamic \
-                     exports). So it's known statically that the requested export doesn't exist."
-                        .into(),
-                ),
-            ])
-            .resolved_cell(),
-        )))
-    }
-
-    #[turbo_tasks::function]
-    async fn detail(&self) -> Result<Vc<OptionStyledString>> {
-        let export_names = all_known_export_names(*self.module).await?;
-        Ok(Vc::cell(Some(
+        Ok(Some(StyledString::Stack(vec![
             StyledString::Line(vec![
-                StyledString::Text(rcstr!("These are the exports of the module:\n")),
-                StyledString::Code(
-                    export_names
-                        .iter()
-                        .map(|s| s.as_str())
-                        .intersperse(", ")
-                        .collect::<String>()
-                        .into(),
-                ),
-            ])
-            .resolved_cell(),
-        )))
+                StyledString::Text(rcstr!("The export ")),
+                StyledString::Code(self.export.clone()),
+                StyledString::Text(rcstr!(" was not found in module ")),
+                StyledString::Strong(self.module.ident().to_string().owned().await?),
+                StyledString::Text(rcstr!(".")),
+            ]),
+            if let Some(did_you_mean) = did_you_mean {
+                StyledString::Line(vec![
+                    StyledString::Text(rcstr!("Did you mean to import ")),
+                    StyledString::Code(did_you_mean.clone()),
+                    StyledString::Text(rcstr!("?")),
+                ])
+            } else {
+                StyledString::Strong(rcstr!("The module has no exports at all."))
+            },
+            StyledString::Text(
+                "All exports of the module are statically known (It doesn't have dynamic \
+                 exports). So it's known statically that the requested export doesn't exist."
+                    .into(),
+            ),
+        ])))
     }
 
-    #[turbo_tasks::function]
-    fn source(&self) -> Vc<OptionIssueSource> {
-        Vc::cell(Some(self.source))
+    async fn detail(&self) -> Result<Option<StyledString>> {
+        let export_names = all_known_export_names(*self.module).await?;
+        Ok(Some(StyledString::Line(vec![
+            StyledString::Text(rcstr!("These are the exports of the module:\n")),
+            StyledString::Code(
+                export_names
+                    .iter()
+                    .map(|s| s.as_str())
+                    .intersperse(", ")
+                    .collect::<String>()
+                    .into(),
+            ),
+        ])))
+    }
+
+    fn source(&self) -> Option<IssueSource> {
+        Some(self.source)
     }
 }
 
@@ -885,60 +871,52 @@ pub struct CircularReExport {
     module_cycle: ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>,
 }
 
+#[async_trait]
 #[turbo_tasks::value_impl]
 impl Issue for CircularReExport {
     fn severity(&self) -> IssueSeverity {
         IssueSeverity::Error
     }
 
-    #[turbo_tasks::function]
-    async fn title(&self) -> Result<Vc<StyledString>> {
+    async fn title(&self) -> Result<StyledString> {
         Ok(StyledString::Line(vec![
             StyledString::Text(rcstr!("Export ")),
             StyledString::Code(self.export.clone()),
             StyledString::Text(rcstr!(" is a circular re-export")),
-        ])
-        .cell())
+        ]))
     }
 
-    #[turbo_tasks::function]
-    fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::Bindings.cell()
+    fn stage(&self) -> IssueStage {
+        IssueStage::Bindings
     }
 
-    #[turbo_tasks::function]
-    fn file_path(&self) -> Vc<FileSystemPath> {
-        self.module.ident().path()
+    async fn file_path(&self) -> Result<FileSystemPath> {
+        self.module.ident().path().owned().await
     }
 
-    #[turbo_tasks::function]
-    async fn description(&self) -> Result<Vc<OptionStyledString>> {
-        Ok(Vc::cell(Some(
-            StyledString::Stack(vec![
-                StyledString::Line(vec![StyledString::Text(rcstr!("The export"))]),
-                StyledString::Line(vec![
-                    StyledString::Code(self.export.clone()),
-                    StyledString::Text(rcstr!(" of module ")),
-                    StyledString::Strong(self.module.ident().to_string().owned().await?),
-                ]),
-                StyledString::Line(vec![StyledString::Text(rcstr!(
-                    "is a re-export of the export"
-                ))]),
-                StyledString::Line(vec![
-                    StyledString::Code(self.import.clone().unwrap_or_else(|| rcstr!("*"))),
-                    StyledString::Text(rcstr!(" of module ")),
-                    StyledString::Strong(self.module_cycle.ident().to_string().owned().await?),
-                    StyledString::Text(rcstr!(".")),
-                ]),
-            ])
-            .resolved_cell(),
-        )))
+    async fn description(&self) -> Result<Option<StyledString>> {
+        Ok(Some(StyledString::Stack(vec![
+            StyledString::Line(vec![StyledString::Text(rcstr!("The export"))]),
+            StyledString::Line(vec![
+                StyledString::Code(self.export.clone()),
+                StyledString::Text(rcstr!(" of module ")),
+                StyledString::Strong(self.module.ident().to_string().owned().await?),
+            ]),
+            StyledString::Line(vec![StyledString::Text(rcstr!(
+                "is a re-export of the export"
+            ))]),
+            StyledString::Line(vec![
+                StyledString::Code(self.import.clone().unwrap_or_else(|| rcstr!("*"))),
+                StyledString::Text(rcstr!(" of module ")),
+                StyledString::Strong(self.module_cycle.ident().to_string().owned().await?),
+                StyledString::Text(rcstr!(".")),
+            ]),
+        ])))
     }
 
-    #[turbo_tasks::function]
-    fn source(&self) -> Vc<OptionIssueSource> {
+    fn source(&self) -> Option<IssueSource> {
         // TODO(PACK-4879): This should point at the buggy export by querying for the source
         // location
-        Vc::cell(None)
+        None
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
@@ -18,7 +18,7 @@ use turbo_tasks::{
 use turbopack_core::{
     chunk::{ChunkableModule, ChunkingContext, ModuleChunkItemIdExt, ModuleId},
     issue::{
-        Issue, IssueExt, IssueSeverity, StyledString, code_gen::CodeGenerationIssue,
+        IssueExt, IssueSeverity, StyledString, code_gen::CodeGenerationIssue,
         module::emit_unknown_module_type_error,
     },
     resolve::{
@@ -101,7 +101,7 @@ impl SinglePatternMapping {
         match self {
             Self::Invalid => {
                 quote!(
-                    "(() => { throw new Error('could not resolve \"' + $arg + '\" into a module'); })()" as Expr,
+                    "(() => {throw new Error('could not resolve \"' + $arg + '\" into a module');})()" as Expr,
                     arg: Expr = key_expr.into_owned()
                 )
             }
@@ -140,7 +140,7 @@ impl SinglePatternMapping {
         match self {
             Self::Invalid => {
                 let error = quote_expr!(
-                    "() => { throw new Error('could not resolve \"' + $arg + '\" into a module'); }",
+                    "() => {throw new Error('could not resolve \"' + $arg + '\" into a module');}",
                     arg: Expr = key_expr.into_owned()
                 );
                 Expr::Call(CallExpr {
@@ -237,19 +237,13 @@ fn create_context_map(
 ) -> Expr {
     let props = map
         .iter()
-        .map(|(k, v)| {
-            PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {
-                key: PropName::Str(k.as_str().into()),
+        .map(|(k, v)| {PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {key: PropName::Str(k.as_str().into()),
                 value: quote_expr!(
-                        "{ id: () => $id, module: () => $module }",
+                        "{id: () => $id, module: () => $module}",
                         id: Expr = v.create_id(Cow::Borrowed(key_expr)),
-                        module: Expr = match import_mode {
-                            ImportMode::Require => v.create_require(Cow::Borrowed(key_expr)),
-                            ImportMode::Import { import_externals } => v.create_import(Cow::Borrowed(key_expr), import_externals),
-                        },
-                    ),
-            })))
-        })
+                        module: Expr = match import_mode {ImportMode::Require => v.create_require(Cow::Borrowed(key_expr)),
+                            ImportMode::Import {import_externals} => v.create_import(Cow::Borrowed(key_expr), import_externals),},
+                    ),})))})
         .collect();
 
     Expr::Object(ObjectLit {
@@ -326,7 +320,12 @@ async fn to_single_pattern_mapping(
         }
         ModuleResolveResultItem::Error(issue) => {
             return Ok(SinglePatternMapping::Unresolvable(
-                issue.title().await?.to_unstyled_string(),
+                issue
+                    .into_trait_ref()
+                    .await?
+                    .title()
+                    .await?
+                    .to_unstyled_string(),
             ));
         }
         ModuleResolveResultItem::OutputAsset(_)

--- a/turbopack/crates/turbopack-ecmascript/src/references/type_issue.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/type_issue.rs
@@ -1,9 +1,7 @@
-use turbo_tasks::Vc;
+use anyhow::Result;
+use async_trait::async_trait;
 use turbo_tasks_fs::FileSystemPath;
-use turbopack_core::issue::{
-    Issue, IssueSeverity, IssueSource, IssueStage, OptionIssueSource, OptionStyledString,
-    StyledString,
-};
+use turbopack_core::issue::{Issue, IssueSeverity, IssueSource, IssueStage, StyledString};
 
 use crate::SpecifiedModuleType;
 
@@ -13,16 +11,15 @@ pub struct SpecifiedModuleTypeIssue {
     pub specified_type: SpecifiedModuleType,
 }
 
+#[async_trait]
 #[turbo_tasks::value_impl]
 impl Issue for SpecifiedModuleTypeIssue {
-    #[turbo_tasks::function]
-    fn file_path(&self) -> Vc<FileSystemPath> {
-        self.source.file_path()
+    async fn file_path(&self) -> Result<FileSystemPath> {
+        self.source.file_path().owned().await
     }
 
-    #[turbo_tasks::function]
-    fn title(&self) -> Vc<StyledString> {
-        StyledString::Text(match self.specified_type {
+    async fn title(&self) -> Result<StyledString> {
+        Ok(StyledString::Text(match self.specified_type {
             SpecifiedModuleType::CommonJs => "Specified module format (CommonJs) is not matching \
                                               the module format of the source code (EcmaScript \
                                               Modules)"
@@ -34,43 +31,37 @@ impl Issue for SpecifiedModuleTypeIssue {
             SpecifiedModuleType::Automatic => "Specified module format is not matching the module \
                                                format of the source code"
                 .into(),
-        })
-        .cell()
+        }))
     }
 
-    #[turbo_tasks::function]
-    fn description(&self) -> Vc<OptionStyledString> {
-        Vc::cell(Some(
-            StyledString::Text(match self.specified_type {
-                SpecifiedModuleType::CommonJs => {
-                    "The CommonJs module format was specified in the package.json that is \
-                     affecting this source file or by using an special extension, but Ecmascript \
-                     import/export syntax is used in the source code.\nThe module was \
-                     automatically converted to an EcmaScript module, but that is in conflict with \
-                     the specified module format. Either change the \"type\" field in the \
-                     package.json or replace EcmaScript import/export syntax with CommonJs syntas \
-                     in the source file.\nIn some cases EcmaScript import/export syntax is added \
-                     by an transform and isn't actually part of the source code. In these cases \
-                     revisit transformation options to inject the correct syntax."
-                        .into()
-                }
-                SpecifiedModuleType::EcmaScript => {
-                    "The EcmaScript module format was specified in the package.json that is \
-                     affecting this source file or by using an special extension, but it looks \
-                     like that CommonJs syntax is used in the source code.\nExports made by \
-                     CommonJs syntax will lead to a runtime error, since the module is in \
-                     EcmaScript mode. Either change the \"type\" field in the package.json or \
-                     replace CommonJs syntax with EcmaScript import/export syntax in the source \
-                     file."
-                        .into()
-                }
-                SpecifiedModuleType::Automatic => "The module format specified in the \
-                                                   package.json file is not matching the module \
-                                                   format of the source code."
-                    .into(),
-            })
-            .resolved_cell(),
-        ))
+    async fn description(&self) -> Result<Option<StyledString>> {
+        Ok(Some(StyledString::Text(match self.specified_type {
+            SpecifiedModuleType::CommonJs => {
+                "The CommonJs module format was specified in the package.json that is affecting \
+                 this source file or by using an special extension, but Ecmascript import/export \
+                 syntax is used in the source code.\nThe module was automatically converted to an \
+                 EcmaScript module, but that is in conflict with the specified module format. \
+                 Either change the \"type\" field in the package.json or replace EcmaScript \
+                 import/export syntax with CommonJs syntas in the source file.\nIn some cases \
+                 EcmaScript import/export syntax is added by an transform and isn't actually part \
+                 of the source code. In these cases revisit transformation options to inject the \
+                 correct syntax."
+                    .into()
+            }
+            SpecifiedModuleType::EcmaScript => {
+                "The EcmaScript module format was specified in the package.json that is affecting \
+                 this source file or by using an special extension, but it looks like that \
+                 CommonJs syntax is used in the source code.\nExports made by CommonJs syntax will \
+                 lead to a runtime error, since the module is in EcmaScript mode. Either change \
+                 the \"type\" field in the package.json or replace CommonJs syntax with EcmaScript \
+                 import/export syntax in the source file."
+                    .into()
+            }
+            SpecifiedModuleType::Automatic => "The module format specified in the package.json \
+                                               file is not matching the module format of the \
+                                               source code."
+                .into(),
+        })))
     }
 
     fn severity(&self) -> IssueSeverity {
@@ -81,13 +72,11 @@ impl Issue for SpecifiedModuleTypeIssue {
         }
     }
 
-    #[turbo_tasks::function]
-    fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::Analysis.cell()
+    fn stage(&self) -> IssueStage {
+        IssueStage::Analysis
     }
 
-    #[turbo_tasks::function]
-    fn source(&self) -> Vc<OptionIssueSource> {
-        Vc::cell(Some(self.source))
+    fn source(&self) -> Option<IssueSource> {
+        Some(self.source)
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/references/util.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/util.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use async_trait::async_trait;
 use bincode::{Decode, Encode};
 use swc_core::{
     common::{
@@ -14,10 +15,7 @@ use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     self,
     chunk::ChunkingType,
-    issue::{
-        Issue, IssueExt, IssueSeverity, IssueSource, IssueStage, OptionIssueSource,
-        OptionStyledString, StyledString,
-    },
+    issue::{Issue, IssueExt, IssueSeverity, IssueSource, IssueStage, StyledString},
     resolve::{ModuleResolveResult, parse::Request, pattern::Pattern},
 };
 
@@ -98,10 +96,10 @@ struct TooManyMatchesWarning {
     pattern: ResolvedVc<Pattern>,
 }
 
+#[async_trait]
 #[turbo_tasks::value_impl]
 impl Issue for TooManyMatchesWarning {
-    #[turbo_tasks::function]
-    async fn title(&self) -> Result<Vc<StyledString>> {
+    async fn title(&self) -> Result<StyledString> {
         Ok(StyledString::Text(
             turbofmt!(
                 "The file pattern {} matches {} files in {}",
@@ -110,37 +108,29 @@ impl Issue for TooManyMatchesWarning {
                 self.context_dir
             )
             .await?,
-        )
-        .cell())
-    }
-
-    #[turbo_tasks::function]
-    fn description(&self) -> Vc<OptionStyledString> {
-        Vc::cell(Some(
-            StyledString::Text(rcstr!(
-                "Overly broad patterns can lead to build performance issues and over bundling."
-            ))
-            .resolved_cell(),
         ))
     }
 
-    #[turbo_tasks::function]
-    async fn file_path(&self) -> Vc<FileSystemPath> {
-        self.source.file_path()
+    async fn description(&self) -> Result<Option<StyledString>> {
+        Ok(Some(StyledString::Text(rcstr!(
+            "Overly broad patterns can lead to build performance issues and over bundling."
+        ))))
     }
 
-    #[turbo_tasks::function]
-    fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::Resolve.cell()
+    async fn file_path(&self) -> Result<FileSystemPath> {
+        self.source.file_path().owned().await
+    }
+
+    fn stage(&self) -> IssueStage {
+        IssueStage::Resolve
     }
 
     fn severity(&self) -> IssueSeverity {
         IssueSeverity::Warning
     }
 
-    #[turbo_tasks::function]
-    fn source(&self) -> Vc<OptionIssueSource> {
-        Vc::cell(Some(self.source))
+    fn source(&self) -> Option<IssueSource> {
+        Some(self.source)
     }
 }
 

--- a/turbopack/crates/turbopack-env/Cargo.toml
+++ b/turbopack/crates/turbopack-env/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+async-trait = { workspace = true }
 turbo-rcstr = { workspace = true }
 turbo-tasks = { workspace = true }
 turbo-tasks-env = { workspace = true }

--- a/turbopack/crates/turbopack-env/src/issue.rs
+++ b/turbopack/crates/turbopack-env/src/issue.rs
@@ -1,7 +1,8 @@
+use async_trait::async_trait;
 use turbo_rcstr::rcstr;
-use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks::ResolvedVc;
 use turbo_tasks_fs::FileSystemPath;
-use turbopack_core::issue::{Issue, IssueStage, OptionStyledString, StyledString};
+use turbopack_core::issue::{Issue, IssueStage, StyledString};
 
 /// An issue that occurred while resolving the parsing or evaluating the .env.
 #[turbo_tasks::value(shared)]
@@ -10,25 +11,22 @@ pub struct ProcessEnvIssue {
     pub description: ResolvedVc<StyledString>,
 }
 
+#[async_trait]
 #[turbo_tasks::value_impl]
 impl Issue for ProcessEnvIssue {
-    #[turbo_tasks::function]
-    fn title(&self) -> Vc<StyledString> {
-        StyledString::Text(rcstr!("Error loading dotenv file")).cell()
+    async fn title(&self) -> anyhow::Result<StyledString> {
+        Ok(StyledString::Text(rcstr!("Error loading dotenv file")))
     }
 
-    #[turbo_tasks::function]
-    fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::Load.cell()
+    fn stage(&self) -> IssueStage {
+        IssueStage::Load
     }
 
-    #[turbo_tasks::function]
-    fn file_path(&self) -> Vc<FileSystemPath> {
-        self.path.clone().cell()
+    async fn file_path(&self) -> anyhow::Result<FileSystemPath> {
+        Ok(self.path.clone())
     }
 
-    #[turbo_tasks::function]
-    fn description(&self) -> Vc<OptionStyledString> {
-        Vc::cell(Some(self.description))
+    async fn description(&self) -> anyhow::Result<Option<StyledString>> {
+        Ok(Some((*self.description.await?).clone()))
     }
 }

--- a/turbopack/crates/turbopack-image/Cargo.toml
+++ b/turbopack/crates/turbopack-image/Cargo.toml
@@ -20,6 +20,7 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+async-trait = { workspace = true }
 base64 = "0.21.0"
 bincode = { workspace = true }
 image = { workspace = true, default-features = false, features = [

--- a/turbopack/crates/turbopack-image/src/process/mod.rs
+++ b/turbopack/crates/turbopack-image/src/process/mod.rs
@@ -3,6 +3,7 @@ pub mod svg;
 use std::{io::Cursor, str::FromStr};
 
 use anyhow::{Context, Result, bail};
+use async_trait::async_trait;
 use base64::{display::Base64Display, engine::general_purpose::STANDARD};
 use bincode::{Decode, Encode};
 use image::{
@@ -22,10 +23,7 @@ use turbo_tasks::{
 };
 use turbo_tasks_fs::{File, FileContent, FileSystemPath};
 use turbopack_core::{
-    issue::{
-        Issue, IssueExt, IssueSeverity, IssueSource, IssueStage, OptionIssueSource,
-        OptionStyledString, StyledString,
-    },
+    issue::{Issue, IssueExt, IssueSeverity, IssueSource, IssueStage, StyledString},
     source::Source,
 };
 
@@ -492,36 +490,33 @@ struct ImageProcessingIssue {
     source: IssueSource,
 }
 
+#[async_trait]
 #[turbo_tasks::value_impl]
 impl Issue for ImageProcessingIssue {
     fn severity(&self) -> IssueSeverity {
         self.issue_severity.unwrap_or(IssueSeverity::Error)
     }
 
-    #[turbo_tasks::function]
-    fn file_path(&self) -> Vc<FileSystemPath> {
-        self.source.file_path()
+    async fn file_path(&self) -> anyhow::Result<FileSystemPath> {
+        self.source.file_path().owned().await
     }
 
-    #[turbo_tasks::function]
-    fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::Transform.cell()
+    fn stage(&self) -> IssueStage {
+        IssueStage::Transform
     }
 
-    #[turbo_tasks::function]
-    fn title(&self) -> Vc<StyledString> {
-        *self
-            .title
-            .unwrap_or(StyledString::Text(rcstr!("Processing image failed")).resolved_cell())
+    async fn title(&self) -> anyhow::Result<StyledString> {
+        Ok(match self.title {
+            Some(t) => (*t.await?).clone(),
+            None => StyledString::Text(rcstr!("Processing image failed")),
+        })
     }
 
-    #[turbo_tasks::function]
-    fn description(&self) -> Vc<OptionStyledString> {
-        Vc::cell(Some(self.message))
+    async fn description(&self) -> anyhow::Result<Option<StyledString>> {
+        Ok(Some((*self.message.await?).clone()))
     }
 
-    #[turbo_tasks::function]
-    fn source(&self) -> Vc<OptionIssueSource> {
-        Vc::cell(Some(self.source))
+    fn source(&self) -> Option<IssueSource> {
+        Some(self.source)
     }
 }

--- a/turbopack/crates/turbopack-mdx/Cargo.toml
+++ b/turbopack/crates/turbopack-mdx/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+async-trait = { workspace = true }
 markdown = { workspace = true }
 mdxjs = { workspace = true }
 serde = { workspace = true }

--- a/turbopack/crates/turbopack-mdx/src/lib.rs
+++ b/turbopack/crates/turbopack-mdx/src/lib.rs
@@ -3,6 +3,7 @@
 #![feature(arbitrary_self_types_pointers)]
 
 use anyhow::Result;
+use async_trait::async_trait;
 use mdxjs::{MdxParseOptions, Options, compile};
 use serde::Deserialize;
 use turbo_rcstr::{RcStr, rcstr};
@@ -12,10 +13,7 @@ use turbopack_core::{
     asset::{Asset, AssetContent},
     context::AssetContext,
     ident::AssetIdent,
-    issue::{
-        Issue, IssueExt, IssueSource, IssueStage, OptionIssueSource, OptionStyledString,
-        StyledString,
-    },
+    issue::{Issue, IssueExt, IssueSource, IssueStage, StyledString},
     source::Source,
     source_pos::SourcePos,
     source_transform::SourceTransform,
@@ -258,32 +256,26 @@ struct MdxIssue {
     mdx_source: RcStr,
 }
 
+#[async_trait]
 #[turbo_tasks::value_impl]
 impl Issue for MdxIssue {
-    #[turbo_tasks::function]
-    fn file_path(&self) -> Vc<FileSystemPath> {
-        self.source.file_path()
+    async fn file_path(&self) -> anyhow::Result<FileSystemPath> {
+        self.source.file_path().owned().await
     }
 
-    #[turbo_tasks::function]
-    fn source(&self) -> Vc<OptionIssueSource> {
-        Vc::cell(Some(self.source))
+    fn source(&self) -> Option<IssueSource> {
+        Some(self.source)
     }
 
-    #[turbo_tasks::function]
-    fn stage(self: Vc<Self>) -> Vc<IssueStage> {
-        IssueStage::Parse.cell()
+    fn stage(&self) -> IssueStage {
+        IssueStage::Parse
     }
 
-    #[turbo_tasks::function]
-    fn title(self: Vc<Self>) -> Vc<StyledString> {
-        StyledString::Text(rcstr!("MDX Parse Error")).cell()
+    async fn title(&self) -> anyhow::Result<StyledString> {
+        Ok(StyledString::Text(rcstr!("MDX Parse Error")))
     }
 
-    #[turbo_tasks::function]
-    fn description(&self) -> Vc<OptionStyledString> {
-        Vc::cell(Some(
-            StyledString::Text(self.reason.clone()).resolved_cell(),
-        ))
+    async fn description(&self) -> anyhow::Result<Option<StyledString>> {
+        Ok(Some(StyledString::Text(self.reason.clone())))
     }
 }

--- a/turbopack/crates/turbopack-node/src/evaluate.rs
+++ b/turbopack/crates/turbopack-node/src/evaluate.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use anyhow::{Result, bail};
+use async_trait::async_trait;
 use bincode::{Decode, Encode};
 use bytes::Bytes;
 use futures_retry::{FutureRetry, RetryPolicy};
@@ -24,10 +25,7 @@ use turbopack_core::{
     context::AssetContext,
     file_source::FileSource,
     ident::AssetIdent,
-    issue::{
-        Issue, IssueExt, IssueSource, IssueStage, OptionIssueSource, OptionStyledString,
-        StyledString,
-    },
+    issue::{Issue, IssueExt, IssueSource, IssueStage, StyledString},
     module::Module,
     module_graph::{
         GraphEntries, ModuleGraph,
@@ -457,15 +455,15 @@ pub async fn get_evaluate_entries(
                 runtime_asset.ident().path().await?.join("evaluate.js")?,
                 AssetContent::file(
                     FileContent::Content(File::from(
-                        "import { run } from 'RUNTIME'; run(() => import('INNER'))",
+                        "import {run} from 'RUNTIME'; run(() => import('INNER'))",
                     ))
                     .cell(),
                 ),
             )),
-            ReferenceType::Internal(ResolvedVc::cell(fxindexmap! {
-                rcstr!("INNER") => module_asset,
-                rcstr!("RUNTIME") => runtime_asset
-            })),
+            ReferenceType::Internal(ResolvedVc::cell(
+                fxindexmap! {rcstr!("INNER") => module_asset,
+                rcstr!("RUNTIME") => runtime_asset},
+            )),
         )
         .module()
         .to_resolved()
@@ -692,43 +690,36 @@ pub struct EvaluationIssue {
     pub root_path: FileSystemPath,
 }
 
+#[async_trait]
 #[turbo_tasks::value_impl]
 impl Issue for EvaluationIssue {
-    #[turbo_tasks::function]
-    fn title(&self) -> Vc<StyledString> {
-        StyledString::Text(rcstr!("Error evaluating Node.js code")).cell()
+    async fn title(&self) -> Result<StyledString> {
+        Ok(StyledString::Text(rcstr!("Error evaluating Node.js code")))
     }
 
-    #[turbo_tasks::function]
-    fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::Transform.cell()
+    fn stage(&self) -> IssueStage {
+        IssueStage::Transform
     }
 
-    #[turbo_tasks::function]
-    fn file_path(&self) -> Vc<FileSystemPath> {
-        self.source.file_path()
+    async fn file_path(&self) -> Result<FileSystemPath> {
+        self.source.file_path().owned().await
     }
 
-    #[turbo_tasks::function]
-    async fn description(&self) -> Result<Vc<OptionStyledString>> {
-        Ok(Vc::cell(Some(
-            StyledString::Text(
-                self.error
-                    .print(
-                        *self.assets_for_source_mapping,
-                        self.assets_root.clone(),
-                        self.root_path.clone(),
-                        FormattingMode::Plain,
-                    )
-                    .await?
-                    .into(),
-            )
-            .resolved_cell(),
+    async fn description(&self) -> Result<Option<StyledString>> {
+        Ok(Some(StyledString::Text(
+            self.error
+                .print(
+                    *self.assets_for_source_mapping,
+                    self.assets_root.clone(),
+                    self.root_path.clone(),
+                    FormattingMode::Plain,
+                )
+                .await?
+                .into(),
         )))
     }
 
-    #[turbo_tasks::function]
-    fn source(&self) -> Vc<OptionIssueSource> {
-        Vc::cell(Some(self.source))
+    fn source(&self) -> Option<IssueSource> {
+        Some(self.source)
     }
 }

--- a/turbopack/crates/turbopack-node/src/transforms/webpack.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/webpack.rs
@@ -1,6 +1,7 @@
 use std::mem::take;
 
 use anyhow::{Context, Result, bail};
+use async_trait::async_trait;
 use base64::Engine;
 use bincode::{Decode, Encode};
 use either::Either;
@@ -27,10 +28,7 @@ use turbopack_core::{
     context::{AssetContext, ProcessResult},
     file_source::FileSource,
     ident::AssetIdent,
-    issue::{
-        Issue, IssueExt, IssueSeverity, IssueSource, IssueStage, OptionIssueSource,
-        OptionStyledString, StyledString,
-    },
+    issue::{Issue, IssueExt, IssueSeverity, IssueSource, IssueStage, StyledString},
     module_graph::{
         ModuleGraph, SingleModuleGraph,
         chunk_group_info::{ChunkGroup, ChunkGroupEntry},
@@ -925,47 +923,42 @@ pub struct BuildDependencyIssue {
     pub source: IssueSource,
 }
 
+#[async_trait]
 #[turbo_tasks::value_impl]
 impl Issue for BuildDependencyIssue {
     fn severity(&self) -> IssueSeverity {
         IssueSeverity::Warning
     }
 
-    #[turbo_tasks::function]
-    fn title(&self) -> Vc<StyledString> {
-        StyledString::Text(rcstr!("Build dependencies are not yet supported")).cell()
-    }
-
-    #[turbo_tasks::function]
-    fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::Unsupported.cell()
-    }
-
-    #[turbo_tasks::function]
-    fn file_path(&self) -> Vc<FileSystemPath> {
-        self.source.file_path()
-    }
-
-    #[turbo_tasks::function]
-    async fn description(&self) -> Result<Vc<OptionStyledString>> {
-        Ok(Vc::cell(Some(
-            StyledString::Line(vec![
-                StyledString::Text(rcstr!("The file at ")),
-                StyledString::Code(self.path.to_string().into()),
-                StyledString::Text(
-                    " is a build dependency, which is not yet implemented.
-    Changing this file or any dependency will not be recognized and might require restarting the \
-                     server"
-                        .into(),
-                ),
-            ])
-            .resolved_cell(),
+    async fn title(&self) -> Result<StyledString> {
+        Ok(StyledString::Text(rcstr!(
+            "Build dependencies are not yet supported"
         )))
     }
 
-    #[turbo_tasks::function]
-    fn source(&self) -> Vc<OptionIssueSource> {
-        Vc::cell(Some(self.source))
+    fn stage(&self) -> IssueStage {
+        IssueStage::Unsupported
+    }
+
+    async fn file_path(&self) -> Result<FileSystemPath> {
+        self.source.file_path().owned().await
+    }
+
+    async fn description(&self) -> Result<Option<StyledString>> {
+        Ok(Some(StyledString::Line(vec![
+            StyledString::Text(rcstr!("The file at ")),
+            StyledString::Code(self.path.to_string().into()),
+            StyledString::Text(
+                " is a build dependency, which is not yet implemented.
+    Changing this file or any dependency will not be recognized and might require restarting the \
+                 server"
+                    .into(),
+            ),
+        ])))
+    }
+
+    fn source(&self) -> Option<IssueSource> {
+        Some(self.source)
     }
 }
 
@@ -979,48 +972,41 @@ pub struct EvaluateEmittedErrorIssue {
     pub project_dir: FileSystemPath,
 }
 
+#[async_trait]
 #[turbo_tasks::value_impl]
 impl Issue for EvaluateEmittedErrorIssue {
-    #[turbo_tasks::function]
-    fn file_path(&self) -> Vc<FileSystemPath> {
-        self.source.file_path()
+    async fn file_path(&self) -> Result<FileSystemPath> {
+        self.source.file_path().owned().await
     }
 
-    #[turbo_tasks::function]
-    fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::Transform.cell()
+    fn stage(&self) -> IssueStage {
+        IssueStage::Transform
     }
 
     fn severity(&self) -> IssueSeverity {
         self.severity
     }
 
-    #[turbo_tasks::function]
-    fn title(&self) -> Vc<StyledString> {
-        StyledString::Text(rcstr!("Issue while running loader")).cell()
+    async fn title(&self) -> Result<StyledString> {
+        Ok(StyledString::Text(rcstr!("Issue while running loader")))
     }
 
-    #[turbo_tasks::function]
-    async fn description(&self) -> Result<Vc<OptionStyledString>> {
-        Ok(Vc::cell(Some(
-            StyledString::Text(
-                self.error
-                    .print(
-                        *self.assets_for_source_mapping,
-                        self.assets_root.clone(),
-                        self.project_dir.clone(),
-                        FormattingMode::Plain,
-                    )
-                    .await?
-                    .into(),
-            )
-            .resolved_cell(),
+    async fn description(&self) -> Result<Option<StyledString>> {
+        Ok(Some(StyledString::Text(
+            self.error
+                .print(
+                    *self.assets_for_source_mapping,
+                    self.assets_root.clone(),
+                    self.project_dir.clone(),
+                    FormattingMode::Plain,
+                )
+                .await?
+                .into(),
         )))
     }
 
-    #[turbo_tasks::function]
-    fn source(&self) -> Vc<OptionIssueSource> {
-        Vc::cell(Some(self.source))
+    fn source(&self) -> Option<IssueSource> {
+        Some(self.source)
     }
 }
 
@@ -1035,29 +1021,28 @@ pub struct EvaluateErrorLoggingIssue {
     pub project_dir: FileSystemPath,
 }
 
+#[async_trait]
 #[turbo_tasks::value_impl]
 impl Issue for EvaluateErrorLoggingIssue {
-    #[turbo_tasks::function]
-    fn file_path(&self) -> Vc<FileSystemPath> {
-        self.source.file_path()
+    async fn file_path(&self) -> Result<FileSystemPath> {
+        self.source.file_path().owned().await
     }
 
-    #[turbo_tasks::function]
-    fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::Transform.cell()
+    fn stage(&self) -> IssueStage {
+        IssueStage::Transform
     }
 
     fn severity(&self) -> IssueSeverity {
         self.severity
     }
 
-    #[turbo_tasks::function]
-    fn title(&self) -> Vc<StyledString> {
-        StyledString::Text(rcstr!("Error logging while running loader")).cell()
+    async fn title(&self) -> Result<StyledString> {
+        Ok(StyledString::Text(rcstr!(
+            "Error logging while running loader"
+        )))
     }
 
-    #[turbo_tasks::function]
-    fn description(&self) -> Vc<OptionStyledString> {
+    async fn description(&self) -> Result<Option<StyledString>> {
         fn fmt_args(prefix: String, args: &[JsonValue]) -> String {
             let mut iter = args.iter();
             let Some(first) = iter.next() else {
@@ -1091,11 +1076,10 @@ impl Issue for EvaluateErrorLoggingIssue {
                 }
             })
             .collect::<Vec<_>>();
-        Vc::cell(Some(StyledString::Stack(lines).resolved_cell()))
+        Ok(Some(StyledString::Stack(lines)))
     }
 
-    #[turbo_tasks::function]
-    fn source(&self) -> Vc<OptionIssueSource> {
-        Vc::cell(Some(self.source))
+    fn source(&self) -> Option<IssueSource> {
+        Some(self.source)
     }
 }

--- a/turbopack/crates/turbopack-resolve/Cargo.toml
+++ b/turbopack/crates/turbopack-resolve/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+async-trait = { workspace = true }
 bincode = { workspace = true }
 regex = { workspace = true }
 serde = { workspace = true }

--- a/turbopack/crates/turbopack-resolve/src/typescript.rs
+++ b/turbopack/crates/turbopack-resolve/src/typescript.rs
@@ -1,6 +1,7 @@
 use std::mem::take;
 
 use anyhow::Result;
+use async_trait::async_trait;
 use serde_json::Value as JsonValue;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{FxIndexMap, ResolvedVc, ValueDefault, Vc, fxindexset};
@@ -9,10 +10,7 @@ use turbopack_core::{
     asset::Asset,
     context::AssetContext,
     file_source::FileSource,
-    issue::{
-        Issue, IssueExt, IssueSeverity, IssueSource, IssueStage, OptionIssueSource,
-        OptionStyledString, StyledString,
-    },
+    issue::{Issue, IssueExt, IssueSeverity, IssueSource, IssueStage, StyledString},
     reference_type::{ReferenceType, TypeScriptReferenceSubType},
     resolve::{
         AliasPattern, ModuleResolveResult, RequestKey, ResolveErrorMode,
@@ -515,39 +513,32 @@ async fn apply_typescript_types_options(
     Ok(resolve_options.cell())
 }
 
+#[async_trait]
 #[turbo_tasks::value_impl]
 impl Issue for TsConfigIssue {
     fn severity(&self) -> IssueSeverity {
         self.severity
     }
 
-    #[turbo_tasks::function]
-    fn title(&self) -> Vc<StyledString> {
-        StyledString::Text(rcstr!(
+    async fn title(&self) -> anyhow::Result<StyledString> {
+        Ok(StyledString::Text(rcstr!(
             "An issue occurred while parsing a tsconfig.json file."
-        ))
-        .cell()
+        )))
     }
 
-    #[turbo_tasks::function]
-    fn file_path(&self) -> Vc<FileSystemPath> {
-        self.source.file_path()
+    async fn file_path(&self) -> anyhow::Result<FileSystemPath> {
+        self.source.file_path().owned().await
     }
 
-    #[turbo_tasks::function]
-    fn description(&self) -> Vc<OptionStyledString> {
-        Vc::cell(Some(
-            StyledString::Text(self.message.clone()).resolved_cell(),
-        ))
+    async fn description(&self) -> anyhow::Result<Option<StyledString>> {
+        Ok(Some(StyledString::Text(self.message.clone())))
     }
 
-    #[turbo_tasks::function]
-    fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::Analysis.cell()
+    fn stage(&self) -> IssueStage {
+        IssueStage::Analysis
     }
 
-    #[turbo_tasks::function]
-    fn source(&self) -> Vc<OptionIssueSource> {
-        Vc::cell(Some(self.source))
+    fn source(&self) -> Option<IssueSource> {
+        Some(self.source)
     }
 }


### PR DESCRIPTION
## What?

Remove `#[turbo_tasks::function]` from all methods on the `Issue` value_trait, following the same pattern as #92593 which did the same for `ValueDebug`.

The `Issue` trait previously had 8 methods decorated with `#[turbo_tasks::function]`, which caused the turbo-tasks machinery to generate `NativeFunction` statics, task registration, vtable entries, and scheduling/caching infrastructure for each method on each of the ~48 `impl Issue for` types in the codebase — most of which are trivially synchronous (returning a constant string, enum variant, or stored struct field).

## How?

- Change all 8 `Issue` trait methods to plain methods. Methods that are always synchronous become direct return-type methods (`severity`, `stage`, `source`, `documentation_link`). Methods that are genuinely async on at least one impl use `Pin<Box<dyn Future<Output = Result<T>> + Send + '_>>` for object safety.
- Callers that need to invoke trait methods on a `Vc<Box<dyn Issue>>` use `issue.into_trait_ref().await?` to get a `TraitRef<Box<dyn Issue>>` and call methods directly on that.
- `PlainIssue::from_issue` (the sole hot caller that materializes all fields) resolves one `trait_ref` and calls all methods on it, similar to the `ValueDebug` pattern.
- `ResolvingIssueWithLocation` (which wraps an inner `ResolvedVc<Box<dyn Issue>>`) eagerly copies `severity`, `stage`, `documentation_link`, and `source` at construction time rather than delegating async calls to the inner issue.
- Delete `OptionIssueSource` and `OptionStyledString` wrapper types, which existed solely as `Vc<T>` return type wrappers for the old turbo-tasks methods.

## Tradeoffs

**Lost per-call caching:** Previously each `Issue` method was a turbo-tasks task, so results were cached per `(Vc<Issue>, method)`. In practice this caching was useless — issues are emitted once and their fields read once by `PlainIssue::from_issue`, so there was never a second call to hit the cache. The only real cost is that `IssueFilter::matches` previously cached per `(filter, issue)` pair; that caching is preserved because `matches` itself remains a `#[turbo_tasks::function]` and now calls `into_trait_ref().await?` once at the top.

**`ResolvingIssueWithLocation` eagerly reads inner fields:** Instead of lazily delegating to the inner issue, `stage` and `documentation_link` are copied at construction. This is a minor semantic change (the values are snapshotted rather than live), but in practice these fields are always constant values so it makes no difference.

## Binary size impact (darwin-arm64, compared against #92593)

| Metric | #92593 baseline | This PR | Delta |
|---|---|---|---|
| Unstripped dylib | 124.6 MB | 124.0 MB | **-0.6 MB (-0.5%)** |
| Stripped | 84.7 MB | 84.4 MB | **-0.3 MB (-0.4%)** |
| Stripped + gzip (npm) | 29.2 MB | 29.1 MB | **-0.1 MB (-0.3%)** |

Smaller savings than `ValueDebug` (~2.5 MB stripped) because there are ~48 `Issue` impls vs. one `ValueDebug` impl per every `#[turbo_tasks::value]` type. But real and cumulative.

<!-- NEXT_JS_LLM_PR -->