### PR TITLE
Fix prefetch hints not being loaded during revalidation

### DIFF
--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -246,6 +246,7 @@ export async function handler(
     clientReferenceManifest,
     subresourceIntegrityManifest,
     prerenderManifest,
+    prefetchHintsManifest,
     isDraftMode,
     resolvedPathname,
     revalidateOnlyGenerated,
@@ -856,6 +857,7 @@ export async function handler(
           reactMaxHeadersLength: nextConfig.reactMaxHeadersLength,
 
           multiZoneDraftMode,
+          prefetchHints: prefetchHintsManifest,
           incrementalCache,
           cacheLifeProfiles: nextConfig.cacheLife,
           basePath: nextConfig.basePath,

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1901,6 +1901,7 @@ async function getRSCPayload(
     tree,
     hints,
     prefetchInliningEnabled,
+    ctx.renderOpts.cacheComponents,
     workStore.isStaticGeneration,
     ctx.renderOpts.isBuildTimePrerendering ?? false,
     getDynamicParamFromSegment,
@@ -2099,6 +2100,7 @@ async function getErrorRSCPayload(
     tree,
     errorHints,
     errorPrefetchInliningEnabled,
+    ctx.renderOpts.cacheComponents,
     workStore.isStaticGeneration,
     ctx.renderOpts.isBuildTimePrerendering ?? false,
     getDynamicParamFromSegment,
@@ -8442,21 +8444,26 @@ async function collectSegmentData(
     // during ISR/revalidation.
     const manifestHints = renderOpts.prefetchHints?.[pagePath]
     if (manifestHints === undefined) {
-      // TODO(#91407): No hints found for this route. This currently
-      // happens for routes with `instant = false` at the root segment,
-      // which causes the prerender to run per-request and the hints
-      // manifest to be unavailable at runtime.
-      //
-      // Fall back to a hint tree that marks everything as unprefetchable.
-      // The root gets PrefetchDisabled, and children inherit null hints
-      // which triggers PrefetchDisabled in createFlightRouterStateFromLoaderTree.
-      //
-      // Once the instant:false bug is fixed, this should become an error —
-      // the manifest should always have an entry for every route that
-      // reaches collectSegmentData.
-      hints = {
-        hints: PrefetchHint.PrefetchDisabled,
-        slots: null,
+      if (!renderOpts.cacheComponents) {
+        // Without cacheComponents, dynamic pages have no static shell
+        // and therefore no prerender pass to compute hints. This is
+        // expected — just skip the hint system for this route and let
+        // prefetching proceed normally without inlining decisions.
+        hints = null
+      } else {
+        // TODO(#91407): No hints found for this route. This currently
+        // happens for routes with `instant = false` at the root segment,
+        // which causes the prerender to run per-request and the hints
+        // manifest to be unavailable at runtime.
+        //
+        // Fall back to a hint tree that marks everything as
+        // unprefetchable. Once the instant:false bug is fixed, this
+        // should become an error — the manifest should always have an
+        // entry for every route that reaches collectSegmentData.
+        hints = {
+          hints: PrefetchHint.PrefetchDisabled,
+          slots: null,
+        }
       }
     } else {
       hints = manifestHints

--- a/packages/next/src/server/app-render/create-flight-router-state-from-loader-tree.ts
+++ b/packages/next/src/server/app-render/create-flight-router-state-from-loader-tree.ts
@@ -12,6 +12,7 @@ async function createFlightRouterStateFromLoaderTreeImpl(
   loaderTree: LoaderTree,
   hintTree: PrefetchHints | null,
   prefetchInliningEnabled: boolean,
+  cacheComponents: boolean,
   isStaticGeneration: boolean,
   isBuildTimePrerendering: boolean,
   getDynamicParamFromSegment: GetDynamicParamFromSegment,
@@ -65,12 +66,16 @@ async function createFlightRouterStateFromLoaderTreeImpl(
       // Once that bug is fixed, this branch should become an error again —
       // hints should always be available from the manifest during ISR.
       prefetchHints |= PrefetchHint.PrefetchDisabled
-    } else {
+    } else if (cacheComponents) {
       // At runtime with no hint tree, this is a fully dynamic route with no
       // manifest entry. Treat every segment as unprefetchable. Do NOT set
       // InliningHintsStale — that would cause the client to enter an
       // infinite re-fetch loop trying to get hints that will never exist.
       prefetchHints |= PrefetchHint.PrefetchDisabled
+    } else {
+      // Without cacheComponents, dynamic pages have no static shell so
+      // hints are never computed. Don't disable prefetching — just skip
+      // the inlining hint system and let prefetching proceed normally.
     }
   }
 
@@ -104,6 +109,7 @@ async function createFlightRouterStateFromLoaderTreeImpl(
       parallelRoutes[parallelRouteKey],
       childHintNode,
       prefetchInliningEnabled,
+      cacheComponents,
       isStaticGeneration,
       isBuildTimePrerendering,
       getDynamicParamFromSegment,
@@ -151,6 +157,7 @@ export async function createFlightRouterStateFromLoaderTree(
   loaderTree: LoaderTree,
   hintTree: PrefetchHints | null,
   prefetchInliningEnabled: boolean,
+  cacheComponents: boolean,
   isStaticGeneration: boolean,
   isBuildTimePrerendering: boolean,
   getDynamicParamFromSegment: GetDynamicParamFromSegment,
@@ -161,6 +168,7 @@ export async function createFlightRouterStateFromLoaderTree(
     loaderTree,
     hintTree,
     prefetchInliningEnabled,
+    cacheComponents,
     isStaticGeneration,
     isBuildTimePrerendering,
     getDynamicParamFromSegment,
@@ -173,6 +181,7 @@ export async function createRouteTreePrefetch(
   loaderTree: LoaderTree,
   hintTree: PrefetchHints | null,
   prefetchInliningEnabled: boolean,
+  cacheComponents: boolean,
   isStaticGeneration: boolean,
   isBuildTimePrerendering: boolean,
   getDynamicParamFromSegment: GetDynamicParamFromSegment
@@ -186,6 +195,7 @@ export async function createRouteTreePrefetch(
     loaderTree,
     hintTree,
     prefetchInliningEnabled,
+    cacheComponents,
     isStaticGeneration,
     isBuildTimePrerendering,
     getDynamicParamFromSegment,

--- a/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
+++ b/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
@@ -63,6 +63,7 @@ export async function walkTreeWithFlightRouterState({
     workStore,
   } = ctx
   const prefetchInliningEnabled = Boolean(experimental.prefetchInlining)
+  const cacheComponents = ctx.renderOpts.cacheComponents
   const isStaticGeneration = workStore.isStaticGeneration
   const isBuildTimePrerendering =
     ctx.renderOpts.isBuildTimePrerendering ?? false
@@ -161,6 +162,7 @@ export async function walkTreeWithFlightRouterState({
           loaderTreeToFilter,
           hintTree,
           prefetchInliningEnabled,
+          cacheComponents,
           isStaticGeneration,
           isBuildTimePrerendering,
           getDynamicParamFromSegment
@@ -169,6 +171,7 @@ export async function walkTreeWithFlightRouterState({
           loaderTreeToFilter,
           hintTree,
           prefetchInliningEnabled,
+          cacheComponents,
           isStaticGeneration,
           isBuildTimePrerendering,
           getDynamicParamFromSegment,
@@ -199,6 +202,7 @@ export async function walkTreeWithFlightRouterState({
           loaderTreeToFilter,
           hintTree,
           prefetchInliningEnabled,
+          cacheComponents,
           isStaticGeneration,
           isBuildTimePrerendering,
           getDynamicParamFromSegment
@@ -207,6 +211,7 @@ export async function walkTreeWithFlightRouterState({
           loaderTreeToFilter,
           hintTree,
           prefetchInliningEnabled,
+          cacheComponents,
           isStaticGeneration,
           isBuildTimePrerendering,
           getDynamicParamFromSegment,
@@ -238,6 +243,7 @@ export async function walkTreeWithFlightRouterState({
       loaderTreeToFilter,
       hintTree,
       prefetchInliningEnabled,
+      cacheComponents,
       isStaticGeneration,
       isBuildTimePrerendering,
       getDynamicParamFromSegment,
@@ -369,6 +375,7 @@ export async function createFullTreeFlightDataForNavigation({
     loaderTree,
     hintTreeForInitialRender,
     Boolean(experimental.prefetchInlining),
+    ctx.renderOpts.cacheComponents,
     workStoreForInitialRender.isStaticGeneration,
     ctx.renderOpts.isBuildTimePrerendering ?? false,
     getDynamicParamFromSegment,

--- a/packages/next/src/server/route-modules/route-module.ts
+++ b/packages/next/src/server/route-modules/route-module.ts
@@ -19,6 +19,7 @@ import {
   CLIENT_REFERENCE_MANIFEST,
   DYNAMIC_CSS_MANIFEST,
   NEXT_FONT_MANIFEST,
+  PREFETCH_HINTS,
   PRERENDER_MANIFEST,
   REACT_LOADABLE_MANIFEST,
   ROUTES_MANIFEST,
@@ -216,6 +217,7 @@ export abstract class RouteModule<
     clientReferenceManifest: any
     serverActionsManifest: any
     dynamicCssManifest: any
+    prefetchHintsManifest: Record<string, any> | undefined
     interceptionRoutePatterns: RegExp[]
   } {
     let result
@@ -264,6 +266,9 @@ export abstract class RouteModule<
           self.__SUBRESOURCE_INTEGRITY_MANIFEST
         ),
         dynamicCssManifest: maybeJSONParse(self.__DYNAMIC_CSS_MANIFEST),
+        // Edge pages are always dynamic so prefetch inlining hints
+        // don't apply. The runtime handles missing hints gracefully.
+        prefetchHintsManifest: undefined,
         interceptionRoutePatterns: (
           maybeJSONParse(self.__INTERCEPTION_ROUTE_REWRITE_MANIFEST) ?? []
         ).map((rewrite: any) => new RegExp(rewrite.regex)),
@@ -295,6 +300,7 @@ export abstract class RouteModule<
         serverFilesManifest,
         buildId,
         dynamicCssManifest,
+        prefetchHintsManifest,
       ] = [
         loadManifestFromRelativePath<DevRoutesManifest>({
           projectDir,
@@ -388,6 +394,15 @@ export abstract class RouteModule<
           shouldCache: !this.isDev,
           handleMissing: true,
         }),
+        router === 'app'
+          ? loadManifestFromRelativePath<Record<string, any>>({
+              projectDir,
+              distDir: this.distDir,
+              manifest: `server/${PREFETCH_HINTS}`,
+              shouldCache: !this.isDev,
+              handleMissing: true,
+            })
+          : undefined,
       ]
 
       result = {
@@ -404,6 +419,7 @@ export abstract class RouteModule<
         serverActionsManifest,
         subresourceIntegrityManifest,
         dynamicCssManifest,
+        prefetchHintsManifest,
         interceptionRoutePatterns: routesManifest.rewrites.beforeFiles
           .filter(isInterceptionRouteRewrite)
           .map((rewrite) => new RegExp(rewrite.regex)),
@@ -617,6 +633,7 @@ export abstract class RouteModule<
         clientReferenceManifest?: any
         serverActionsManifest?: any
         dynamicCssManifest?: any
+        prefetchHintsManifest?: Record<string, any>
         subresourceIntegrityManifest?: DeepReadonly<Record<string, string>>
         isOnDemandRevalidate: boolean
         revalidateOnlyGenerated: boolean

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining-no-cache-components/app/dynamic-edge/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining-no-cache-components/app/dynamic-edge/page.tsx
@@ -1,0 +1,10 @@
+export const runtime = 'edge'
+
+export default function DynamicEdgePage() {
+  return (
+    <>
+      <p id="page-dynamic-edge">Dynamic edge page</p>
+      <p id="page-dynamic-edge-value">{Math.random()}</p>
+    </>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining-no-cache-components/app/dynamic-page/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining-no-cache-components/app/dynamic-page/page.tsx
@@ -1,0 +1,12 @@
+import { cookies } from 'next/headers'
+
+export default async function DynamicPage() {
+  // Force dynamic rendering by reading cookies
+  await cookies()
+  return (
+    <>
+      <p id="page-dynamic">Dynamic page</p>
+      <p id="page-dynamic-value">{Math.random()}</p>
+    </>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining-no-cache-components/app/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining-no-cache-components/app/layout.tsx
@@ -1,0 +1,30 @@
+import { LinkAccordion } from '../components/link-accordion'
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html>
+      <body>
+        <ul>
+          <li>
+            <LinkAccordion href="/static-page">Static page</LinkAccordion>
+          </li>
+          <li>
+            <LinkAccordion href="/dynamic-page" prefetch={true}>
+              Dynamic page
+            </LinkAccordion>
+          </li>
+          <li>
+            <LinkAccordion href="/dynamic-edge" prefetch={true}>
+              Dynamic edge
+            </LinkAccordion>
+          </li>
+        </ul>
+        {children}
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining-no-cache-components/app/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining-no-cache-components/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p id="home">Home</p>
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining-no-cache-components/app/static-page/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining-no-cache-components/app/static-page/page.tsx
@@ -1,0 +1,3 @@
+export default function StaticPage() {
+  return <p id="page-static">Static page</p>
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining-no-cache-components/components/link-accordion.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining-no-cache-components/components/link-accordion.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import Link, { type LinkProps } from 'next/link'
+import { useState } from 'react'
+
+export function LinkAccordion({
+  href,
+  prefetch,
+  children,
+}: {
+  href: LinkProps['href']
+  prefetch?: boolean
+  children: React.ReactNode
+}) {
+  const [isVisible, setIsVisible] = useState(false)
+  return (
+    <>
+      <input
+        type="checkbox"
+        checked={isVisible}
+        onChange={() => setIsVisible(!isVisible)}
+        data-link-accordion={href}
+      />
+      {isVisible ? (
+        <Link href={href} prefetch={prefetch}>
+          {children}
+        </Link>
+      ) : (
+        `${children} (link is hidden)`
+      )}
+    </>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining-no-cache-components/next.config.js
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining-no-cache-components/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: false,
+  experimental: {
+    prefetchInlining: true,
+    cachedNavigations: false,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining-no-cache-components/prefetch-inlining-no-cache-components.test.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining-no-cache-components/prefetch-inlining-no-cache-components.test.ts
@@ -1,0 +1,104 @@
+import type * as Playwright from 'playwright'
+import { nextTestSetup } from 'e2e-utils'
+import { createRouterAct } from 'router-act'
+
+describe('prefetch inlining without cacheComponents', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: __dirname,
+  })
+
+  if (isNextDev) {
+    it('prefetch hints are only computed during build', () => {})
+    return
+  }
+
+  it('static page is prefetched with inlining', async () => {
+    // Static pages always have hints computed during the build, regardless
+    // of cacheComponents. Inlining should work normally.
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page!)
+
+    await act(
+      async () => {
+        await browser
+          .elementByCss('input[data-link-accordion="/static-page"]')
+          .click()
+      },
+      { includes: 'Static page' }
+    )
+
+    await act(async () => {
+      await browser.elementByCss('a[href="/static-page"]').click()
+    }, 'no-requests')
+
+    expect(await browser.elementByCss('#page-static').text()).toBe(
+      'Static page'
+    )
+  })
+
+  it('dynamic page is fully prefetched with prefetch={true}', async () => {
+    // Without cacheComponents, dynamic pages have no static shell and
+    // therefore no prerender pass to compute inlining hints. With
+    // prefetch={true} on the Link, the client should still fully prefetch
+    // the dynamic page content.
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page!)
+
+    await act(
+      async () => {
+        await browser
+          .elementByCss('input[data-link-accordion="/dynamic-page"]')
+          .click()
+      },
+      { includes: 'Dynamic page' }
+    )
+
+    await act(async () => {
+      await browser.elementByCss('a[href="/dynamic-page"]').click()
+    }, 'no-requests')
+
+    expect(await browser.elementByCss('#page-dynamic').text()).toBe(
+      'Dynamic page'
+    )
+  })
+
+  it('dynamic edge page is fully prefetched with prefetch={true}', async () => {
+    // Edge runtime forces pages to be dynamic. Same as the non-edge
+    // dynamic case: with prefetch={true}, the page content should be
+    // fully prefetched before navigation.
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page!)
+
+    await act(
+      async () => {
+        await browser
+          .elementByCss('input[data-link-accordion="/dynamic-edge"]')
+          .click()
+      },
+      { includes: 'Dynamic edge page' }
+    )
+
+    await act(async () => {
+      await browser.elementByCss('a[href="/dynamic-edge"]').click()
+    }, 'no-requests')
+
+    expect(await browser.elementByCss('#page-dynamic-edge').text()).toBe(
+      'Dynamic edge page'
+    )
+  })
+})

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/api/revalidate-path/route.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/api/revalidate-path/route.ts
@@ -1,0 +1,13 @@
+import { revalidatePath } from 'next/cache'
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function GET(req: NextRequest) {
+  const path = req.nextUrl.searchParams.get('path') || '/'
+
+  try {
+    revalidatePath(path)
+    return NextResponse.json({ revalidated: true, path })
+  } catch {
+    return NextResponse.json({ revalidated: false, path }, { status: 500 })
+  }
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-on-demand-revalidate/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-on-demand-revalidate/layout.tsx
@@ -1,0 +1,9 @@
+import { ReactNode } from 'react'
+
+export default function OnDemandRevalidateLayout({
+  children,
+}: {
+  children: ReactNode
+}) {
+  return <div>{children}</div>
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-on-demand-revalidate/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-on-demand-revalidate/page.tsx
@@ -1,0 +1,17 @@
+import { cacheLife } from 'next/cache'
+
+async function CachedValue() {
+  'use cache'
+  cacheLife({ stale: 120 })
+
+  return <p id="page-on-demand-revalidate-value">{Math.random()}</p>
+}
+
+export default function OnDemandRevalidatePage() {
+  return (
+    <>
+      <p id="page-on-demand-revalidate">On-demand revalidate page</p>
+      <CachedValue />
+    </>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/prefetch-inlining.test.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/prefetch-inlining.test.ts
@@ -234,14 +234,12 @@ describe('prefetch inlining', () => {
     )
   })
 
-  it.failing(
-    'preserves prefetch hints after on-demand revalidation',
-    async () => {
-      const beforeTree = await fetchRouteTreePrefetch(
-        next,
-        '/test-on-demand-revalidate'
-      )
-      expect(renderInliningTree(beforeTree.tree)).toMatchInlineSnapshot(`
+  it('preserves prefetch hints after on-demand revalidation', async () => {
+    const beforeTree = await fetchRouteTreePrefetch(
+      next,
+      '/test-on-demand-revalidate'
+    )
+    expect(renderInliningTree(beforeTree.tree)).toMatchInlineSnapshot(`
      "
               ⇣  root
               ⇣  └── "test-on-demand-revalidate"
@@ -249,39 +247,38 @@ describe('prefetch inlining', () => {
      "
     `)
 
-      const before$ = await next.render$('/test-on-demand-revalidate')
-      const beforeValue = before$('#page-on-demand-revalidate-value').text()
-      expect(beforeValue).toMatch(/^0\.\d+$/)
+    const before$ = await next.render$('/test-on-demand-revalidate')
+    const beforeValue = before$('#page-on-demand-revalidate-value').text()
+    expect(beforeValue).toMatch(/^0\.\d+$/)
 
-      const revalidateRes = await next.fetch(
-        '/api/revalidate-path?path=/test-on-demand-revalidate'
-      )
-      expect(revalidateRes.status).toBe(200)
-      expect(await revalidateRes.json()).toEqual({
-        revalidated: true,
-        path: '/test-on-demand-revalidate',
-      })
+    const revalidateRes = await next.fetch(
+      '/api/revalidate-path?path=/test-on-demand-revalidate'
+    )
+    expect(revalidateRes.status).toBe(200)
+    expect(await revalidateRes.json()).toEqual({
+      revalidated: true,
+      path: '/test-on-demand-revalidate',
+    })
 
-      await retry(
-        async () => {
-          const $ = await next.render$('/test-on-demand-revalidate')
-          const afterValue = $('#page-on-demand-revalidate-value').text()
-          expect(afterValue).toMatch(/^0\.\d+$/)
-          expect(afterValue).not.toBe(beforeValue)
-        },
-        15000,
-        1000
-      )
+    await retry(
+      async () => {
+        const $ = await next.render$('/test-on-demand-revalidate')
+        const afterValue = $('#page-on-demand-revalidate-value').text()
+        expect(afterValue).toMatch(/^0\.\d+$/)
+        expect(afterValue).not.toBe(beforeValue)
+      },
+      15000,
+      1000
+    )
 
-      const afterTree = await fetchRouteTreePrefetch(
-        next,
-        '/test-on-demand-revalidate'
-      )
-      expect(renderInliningTree(afterTree.tree)).toBe(
-        renderInliningTree(beforeTree.tree)
-      )
-    }
-  )
+    const afterTree = await fetchRouteTreePrefetch(
+      next,
+      '/test-on-demand-revalidate'
+    )
+    expect(renderInliningTree(afterTree.tree)).toBe(
+      renderInliningTree(beforeTree.tree)
+    )
+  })
 
   it('parallel routes: parent inlines into one slot only', async () => {
     // Layout with two parallel slots (children + @sidebar), all small. The

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/prefetch-inlining.test.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/prefetch-inlining.test.ts
@@ -1,5 +1,6 @@
 import type * as Playwright from 'playwright'
 import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
 import { createRouterAct } from 'router-act'
 
 // Bit values from PrefetchHint enum (const enum, so we duplicate values here)
@@ -232,6 +233,55 @@ describe('prefetch inlining', () => {
       'Outlined test page'
     )
   })
+
+  it.failing(
+    'preserves prefetch hints after on-demand revalidation',
+    async () => {
+      const beforeTree = await fetchRouteTreePrefetch(
+        next,
+        '/test-on-demand-revalidate'
+      )
+      expect(renderInliningTree(beforeTree.tree)).toMatchInlineSnapshot(`
+     "
+              ⇣  root
+              ⇣  └── "test-on-demand-revalidate"
+     outlined ■      └── "__PAGE__" (+metadata)
+     "
+    `)
+
+      const before$ = await next.render$('/test-on-demand-revalidate')
+      const beforeValue = before$('#page-on-demand-revalidate-value').text()
+      expect(beforeValue).toMatch(/^0\.\d+$/)
+
+      const revalidateRes = await next.fetch(
+        '/api/revalidate-path?path=/test-on-demand-revalidate'
+      )
+      expect(revalidateRes.status).toBe(200)
+      expect(await revalidateRes.json()).toEqual({
+        revalidated: true,
+        path: '/test-on-demand-revalidate',
+      })
+
+      await retry(
+        async () => {
+          const $ = await next.render$('/test-on-demand-revalidate')
+          const afterValue = $('#page-on-demand-revalidate-value').text()
+          expect(afterValue).toMatch(/^0\.\d+$/)
+          expect(afterValue).not.toBe(beforeValue)
+        },
+        15000,
+        1000
+      )
+
+      const afterTree = await fetchRouteTreePrefetch(
+        next,
+        '/test-on-demand-revalidate'
+      )
+      expect(renderInliningTree(afterTree.tree)).toBe(
+        renderInliningTree(beforeTree.tree)
+      )
+    }
+  )
 
   it('parallel routes: parent inlines into one slot only', async () => {
     // Layout with two parallel slots (children + @sidebar), all small. The


### PR DESCRIPTION
The prefetch hints manifest was not loaded during revalidation renders, causing all segments to fall back to PrefetchDisabled — effectively disabling prefetching for that route until the next full build.

The app-page template handler constructs its own renderOpts from scratch without including prefetch-hints.json. Normal requests go through the server's renderOpts (which loads the manifest at startup), but background revalidation renders go through the template handler, so the hints were always empty.

Load the manifest in the route module's loadManifests() and pass it through to renderOpts.

Closes #92255