### PR TITLE
Add structured error details for cause-specific blocking-route overlay

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/container/errors.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/container/errors.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useRef, Suspense, useCallback } from 'react'
 import type { DebugInfo } from '../../shared/types'
+import type { DynamicAPIExpressionName } from '../../../server/app-render/dynamic-rendering'
 import { Overlay, OverlayBackdrop } from '../components/overlay'
 import { RuntimeError } from './runtime-error'
 import { getErrorSource } from '../../../shared/lib/error-source'
@@ -166,9 +167,11 @@ function DynamicMetadataErrorDescription({
 function BlockingPageLoadErrorDescription({
   variant,
   refinement,
+  expression,
 }: {
   variant: 'navigation' | 'runtime'
   refinement: '' | 'generateViewport' | 'generateMetadata'
+  expression?: DynamicAPIExpressionName | (string & {})
 }) {
   if (refinement === 'generateViewport') {
     if (variant === 'navigation') {
@@ -355,6 +358,124 @@ function BlockingPageLoadErrorDescription({
     }
   }
 
+  if (refinement === '') {
+    if (expression === 'cookies') {
+      return (
+        <div className="nextjs__blocking_page_load_error_description">
+          <h3 className="nextjs__blocking_page_load_error_description_title">
+            <code>cookies()</code> is blocking{' '}
+            {variant === 'navigation' ? 'navigation' : 'the initial render'}
+          </h3>
+          <p>
+            This route reads request-time cookie data in a part of the tree that
+            Next.js expected to keep prefetchable and renderable without
+            waiting.
+          </p>
+          <h4>To fix this:</h4>
+          <p className="nextjs__blocking_page_load_error_fix_option">
+            <strong>
+              Wrap the part that reads <code>cookies()</code> in{' '}
+              <code>{'<Suspense>'}</code>
+            </strong>
+            . This lets the rest of the route render first while the cookie
+            dependent section waits for request-time data.
+          </p>
+          <h4 className="nextjs__blocking_page_load_error_fix_option_separator">
+            or
+          </h4>
+          <p className="nextjs__blocking_page_load_error_fix_option">
+            <strong>
+              Move the <code>cookies()</code> call deeper in the tree
+            </strong>
+            . This keeps more of the route available for the initial shell.
+          </p>
+          <p>
+            Learn more:{' '}
+            <a href="https://nextjs.org/docs/messages/blocking-route">
+              https://nextjs.org/docs/messages/blocking-route
+            </a>
+          </p>
+        </div>
+      )
+    }
+
+    if (expression === 'headers') {
+      return (
+        <div className="nextjs__blocking_page_load_error_description">
+          <h3 className="nextjs__blocking_page_load_error_description_title">
+            <code>headers()</code> is blocking{' '}
+            {variant === 'navigation' ? 'navigation' : 'the initial render'}
+          </h3>
+          <p>
+            This route reads request-time header data in a part of the tree that
+            Next.js expected to keep prefetchable and renderable without
+            waiting.
+          </p>
+          <h4>To fix this:</h4>
+          <p className="nextjs__blocking_page_load_error_fix_option">
+            <strong>
+              Wrap the part that reads <code>headers()</code> in{' '}
+              <code>{'<Suspense>'}</code>
+            </strong>
+            . This lets the rest of the route render first while the
+            header-dependent section waits for request-time data.
+          </p>
+          <h4 className="nextjs__blocking_page_load_error_fix_option_separator">
+            or
+          </h4>
+          <p className="nextjs__blocking_page_load_error_fix_option">
+            <strong>
+              Move the <code>headers()</code> call deeper in the tree
+            </strong>
+            . This keeps more of the route available for the initial shell.
+          </p>
+          <p>
+            Learn more:{' '}
+            <a href="https://nextjs.org/docs/messages/blocking-route">
+              https://nextjs.org/docs/messages/blocking-route
+            </a>
+          </p>
+        </div>
+      )
+    }
+
+    if (expression === 'connection') {
+      return (
+        <div className="nextjs__blocking_page_load_error_description">
+          <h3 className="nextjs__blocking_page_load_error_description_title">
+            <code>connection()</code> is blocking{' '}
+            {variant === 'navigation' ? 'navigation' : 'the initial render'}
+          </h3>
+          <p>
+            This route explicitly waits for request-time work before Next.js can
+            continue rendering this part of the tree.
+          </p>
+          <h4>To fix this:</h4>
+          <p className="nextjs__blocking_page_load_error_fix_option">
+            <strong>
+              Move <code>connection()</code> behind <code>{'<Suspense>'}</code>
+            </strong>
+            . This allows the rest of the route to render while the request-time
+            section waits.
+          </p>
+          <h4 className="nextjs__blocking_page_load_error_fix_option_separator">
+            or
+          </h4>
+          <p className="nextjs__blocking_page_load_error_fix_option">
+            <strong>Move the request-time work deeper in the tree</strong>. This
+            keeps more of the route available for the initial shell.
+          </p>
+          <p>
+            Learn more:{' '}
+            <a href="https://nextjs.org/docs/messages/blocking-route">
+              https://nextjs.org/docs/messages/blocking-route
+            </a>
+          </p>
+        </div>
+      )
+    }
+  }
+
   if (variant === 'runtime') {
     return (
       <div className="nextjs__blocking_page_load_error_description">
@@ -476,13 +597,19 @@ type HydrationErrorDetails = {
 type BlockingRouteErrorDetails = {
   type: 'blocking-route'
   variant: 'navigation' | 'runtime'
-  refinement: '' | 'generateViewport'
+  refinement: '' | 'generateViewport' | 'generateMetadata'
+  expression?: DynamicAPIExpressionName | (string & {})
 }
 
 type DynamicMetadataErrorDetails = {
   type: 'dynamic-metadata'
   variant: 'navigation' | 'runtime'
+  expression?: string
 }
+
+type NextStructuredErrorDetails =
+  | BlockingRouteErrorDetails
+  | DynamicMetadataErrorDetails
 
 const noErrorDetails: ErrorDetails = {
   type: 'empty',
@@ -546,7 +673,47 @@ function getHydrationErrorDetails(
   }
 }
 
-function getBlockingRouteErrorDetails(error: Error): null | ErrorDetails {
+const KNOWN_EXPRESSIONS: DynamicAPIExpressionName[] = [
+  'cookies',
+  'headers',
+  'connection',
+  'draftMode',
+]
+
+function extractExpressionFromMessage(
+  message: string
+): DynamicAPIExpressionName | undefined {
+  for (const expr of KNOWN_EXPRESSIONS) {
+    if (message.includes(`\`${expr}()\``)) {
+      return expr
+    }
+  }
+  return undefined
+}
+
+export function getBlockingRouteErrorDetails(
+  error: Error
+): null | ErrorDetails {
+  const structuredDetails = (
+    error as Error & {
+      __NEXT_ERROR_DETAILS?: NextStructuredErrorDetails
+    }
+  ).__NEXT_ERROR_DETAILS
+
+  if (structuredDetails) {
+    if (structuredDetails.type === 'dynamic-metadata') {
+      return structuredDetails
+    }
+
+    return {
+      ...structuredDetails,
+      refinement:
+        structuredDetails.refinement === 'generateMetadata'
+          ? ''
+          : structuredDetails.refinement,
+    }
+  }
+
   const isBlockingPageLoadError = error.message.includes('/blocking-route')
 
   if (isBlockingPageLoadError) {
@@ -556,6 +723,7 @@ function getBlockingRouteErrorDetails(error: Error): null | ErrorDetails {
       type: 'blocking-route',
       variant: isRuntimeData ? 'runtime' : 'navigation',
       refinement: '',
+      expression: extractExpressionFromMessage(error.message),
     }
   }
 
@@ -755,6 +923,7 @@ Next.js version: ${props.versionInfo.installed} (${process.env.__NEXT_BUNDLER})\
         <BlockingPageLoadErrorDescription
           variant={errorDetails.variant}
           refinement={errorDetails.refinement}
+          expression={errorDetails.expression}
         />
       )
       break

--- a/packages/next/src/server/app-render/dynamic-rendering.ts
+++ b/packages/next/src/server/app-render/dynamic-rendering.ts
@@ -61,6 +61,19 @@ import type { InstantValidationSampleTracking } from './instant-validation/insta
 
 const hasPostpone = typeof React.unstable_postpone === 'function'
 
+/**
+ * Known API names that produce dynamic access. The overlay has specific
+ * copy for each of these, so keep this union in sync with the
+ * `callingExpression` values in `server/request/*.ts` and the expression
+ * checks in `dev-overlay/container/errors.tsx`.
+ */
+export type DynamicAPIExpressionName =
+  | 'cookies'
+  | 'headers'
+  | 'connection'
+  | 'draftMode'
+  | 'unstable_noStore()'
+
 export type DynamicAccess = {
   /**
    * If debugging, this will contain the stack trace of where the dynamic access
@@ -834,6 +847,25 @@ export enum DynamicHoleKind {
   Dynamic = 2,
 }
 
+type NextBlockingRouteErrorDetails = {
+  type: 'blocking-route' | 'dynamic-metadata'
+  variant: 'navigation' | 'runtime'
+  refinement: '' | 'generateViewport' | 'generateMetadata'
+  expression?: DynamicAPIExpressionName | (string & {})
+}
+
+function attachBlockingRouteErrorDetails(
+  error: Error,
+  details: NextBlockingRouteErrorDetails
+): Error {
+  Object.defineProperty(error, '__NEXT_ERROR_DETAILS', {
+    value: details,
+    enumerable: true,
+    configurable: true,
+  })
+  return error
+}
+
 /** Stores dynamic reasons used during an SSR render in instant validation. */
 export type InstantValidationState = {
   hasDynamicMetadata: boolean
@@ -981,6 +1013,12 @@ export function trackDynamicHoleInNavigation(
     if (effectiveCreateInstantStack !== null && syncError.cause === undefined) {
       syncError.cause = effectiveCreateInstantStack()
     }
+    attachBlockingRouteErrorDetails(syncError, {
+      type: 'blocking-route',
+      variant: kind === DynamicHoleKind.Runtime ? 'runtime' : 'navigation',
+      refinement: '',
+      expression: getFirstDynamicReason(clientDynamic),
+    })
     dynamicValidation.dynamicErrors.push(syncError)
     return
   }
@@ -989,9 +1027,15 @@ export function trackDynamicHoleInNavigation(
     kind === DynamicHoleKind.Runtime
       ? `Runtime data such as \`cookies()\`, \`headers()\`, \`params\`, or \`searchParams\` was accessed outside of \`<Suspense>\`.`
       : `Uncached data, \`params\`, \`searchParams\`, or \`connection()\` was accessed outside of \`<Suspense>\`.`
+  const expression = getFirstDynamicReason(clientDynamic)
   const message = `Route "${workStore.route}": ${usageDescription} This delays the entire page from rendering, resulting in a slow user experience. Learn more: https://nextjs.org/docs/messages/blocking-route`
   const error = addErrorContext(
-    new Error(message),
+    attachBlockingRouteErrorDetails(new Error(message), {
+      type: 'blocking-route',
+      variant: kind === DynamicHoleKind.Runtime ? 'runtime' : 'navigation',
+      refinement: '',
+      expression,
+    }),
     componentStack,
     effectiveCreateInstantStack
   )
@@ -1062,7 +1106,15 @@ export function trackDynamicHoleInRuntimeShell(
     return
   } else if (hasMetadataRegex.test(componentStack)) {
     const message = `Route "${workStore.route}": Uncached data or \`connection()\` was accessed inside \`generateMetadata\`. Except for this instance, the page would have been entirely prerenderable which may have been the intended behavior. See more info here: https://nextjs.org/docs/messages/next-prerender-dynamic-metadata`
-    const error = addErrorContext(new Error(message), componentStack, null)
+    const error = addErrorContext(
+      attachBlockingRouteErrorDetails(new Error(message), {
+        type: 'dynamic-metadata',
+        variant: 'navigation',
+        refinement: 'generateMetadata',
+      }),
+      componentStack,
+      null
+    )
     dynamicValidation.dynamicMetadata = error
     return
   } else if (hasViewportRegex.test(componentStack)) {
@@ -1070,7 +1122,15 @@ export function trackDynamicHoleInRuntimeShell(
     // we won't find out if there's a suspense-above-body and error for dynamic viewport
     // even if there is in fact a suspense-above-body
     const message = `Route "${workStore.route}": Uncached data or \`connection()\` was accessed inside \`generateViewport\`. This delays the entire page from rendering, resulting in a slow user experience. Learn more: https://nextjs.org/docs/messages/next-prerender-dynamic-viewport`
-    const error = addErrorContext(new Error(message), componentStack, null)
+    const error = addErrorContext(
+      attachBlockingRouteErrorDetails(new Error(message), {
+        type: 'blocking-route',
+        variant: 'navigation',
+        refinement: 'generateViewport',
+      }),
+      componentStack,
+      null
+    )
     dynamicValidation.dynamicErrors.push(error)
     return
   } else if (
@@ -1091,6 +1151,12 @@ export function trackDynamicHoleInRuntimeShell(
     return
   } else if (clientDynamic.syncDynamicErrorWithStack) {
     // This task was the task that called the sync error.
+    attachBlockingRouteErrorDetails(clientDynamic.syncDynamicErrorWithStack, {
+      type: 'blocking-route',
+      variant: 'navigation',
+      refinement: '',
+      expression: getFirstDynamicReason(clientDynamic),
+    })
     dynamicValidation.dynamicErrors.push(
       clientDynamic.syncDynamicErrorWithStack
     )
@@ -1098,7 +1164,17 @@ export function trackDynamicHoleInRuntimeShell(
   }
 
   const message = `Route "${workStore.route}": Uncached data, \`params\`, \`searchParams\`, or \`connection()\` was accessed outside of \`<Suspense>\`. This delays the entire page from rendering, resulting in a slow user experience. Learn more: https://nextjs.org/docs/messages/blocking-route`
-  const error = addErrorContext(new Error(message), componentStack, null)
+  const expression = getFirstDynamicReason(clientDynamic)
+  const error = addErrorContext(
+    attachBlockingRouteErrorDetails(new Error(message), {
+      type: 'blocking-route',
+      variant: 'navigation',
+      refinement: '',
+      expression,
+    }),
+    componentStack,
+    null
+  )
   dynamicValidation.dynamicErrors.push(error)
   return
 }
@@ -1114,12 +1190,28 @@ export function trackDynamicHoleInStaticShell(
     return
   } else if (hasMetadataRegex.test(componentStack)) {
     const message = `Route "${workStore.route}": Runtime data such as \`cookies()\`, \`headers()\`, \`params\`, or \`searchParams\` was accessed inside \`generateMetadata\` or you have file-based metadata such as icons that depend on dynamic params segments. Except for this instance, the page would have been entirely prerenderable which may have been the intended behavior. See more info here: https://nextjs.org/docs/messages/next-prerender-dynamic-metadata`
-    const error = addErrorContext(new Error(message), componentStack, null)
+    const error = addErrorContext(
+      attachBlockingRouteErrorDetails(new Error(message), {
+        type: 'dynamic-metadata',
+        variant: 'runtime',
+        refinement: 'generateMetadata',
+      }),
+      componentStack,
+      null
+    )
     dynamicValidation.dynamicMetadata = error
     return
   } else if (hasViewportRegex.test(componentStack)) {
     const message = `Route "${workStore.route}": Runtime data such as \`cookies()\`, \`headers()\`, \`params\`, or \`searchParams\` was accessed inside \`generateViewport\`. This delays the entire page from rendering, resulting in a slow user experience. Learn more: https://nextjs.org/docs/messages/next-prerender-dynamic-viewport`
-    const error = addErrorContext(new Error(message), componentStack, null)
+    const error = addErrorContext(
+      attachBlockingRouteErrorDetails(new Error(message), {
+        type: 'blocking-route',
+        variant: 'runtime',
+        refinement: 'generateViewport',
+      }),
+      componentStack,
+      null
+    )
     dynamicValidation.dynamicErrors.push(error)
     return
   } else if (
@@ -1140,13 +1232,29 @@ export function trackDynamicHoleInStaticShell(
     return
   } else if (clientDynamic.syncDynamicErrorWithStack) {
     // This task was the task that called the sync error.
+    attachBlockingRouteErrorDetails(clientDynamic.syncDynamicErrorWithStack, {
+      type: 'blocking-route',
+      variant: 'runtime',
+      refinement: '',
+      expression: getFirstDynamicReason(clientDynamic),
+    })
     dynamicValidation.dynamicErrors.push(
       clientDynamic.syncDynamicErrorWithStack
     )
     return
   } else {
     const message = `Route "${workStore.route}": Runtime data such as \`cookies()\`, \`headers()\`, \`params\`, or \`searchParams\` was accessed outside of \`<Suspense>\`. This delays the entire page from rendering, resulting in a slow user experience. Learn more: https://nextjs.org/docs/messages/blocking-route`
-    const error = addErrorContext(new Error(message), componentStack, null)
+    const expression = getFirstDynamicReason(clientDynamic)
+    const error = addErrorContext(
+      attachBlockingRouteErrorDetails(new Error(message), {
+        type: 'blocking-route',
+        variant: 'runtime',
+        refinement: '',
+        expression,
+      }),
+      componentStack,
+      null
+    )
     dynamicValidation.dynamicErrors.push(error)
     return
   }

--- a/packages/next/src/server/request/connection.ts
+++ b/packages/next/src/server/request/connection.ts
@@ -7,6 +7,7 @@ import {
   postponeWithTracking,
   throwToInterruptStaticGeneration,
   trackDynamicDataInDynamicRender,
+  type DynamicAPIExpressionName,
 } from '../app-render/dynamic-rendering'
 import { StaticGenBailoutError } from '../../client/components/static-generation-bailout'
 import {
@@ -23,7 +24,7 @@ import { InvariantError } from '../../shared/lib/invariant-error'
  * During prerendering it will never resolve and during rendering it resolves immediately.
  */
 export function connection(): Promise<void> {
-  const callingExpression = 'connection'
+  const callingExpression: DynamicAPIExpressionName = 'connection'
   const workStore = workAsyncStorage.getStore()
   const workUnitStore = workUnitAsyncStorage.getStore()
 

--- a/packages/next/src/server/request/cookies.ts
+++ b/packages/next/src/server/request/cookies.ts
@@ -19,6 +19,7 @@ import {
   postponeWithTracking,
   throwToInterruptStaticGeneration,
   trackDynamicDataInDynamicRender,
+  type DynamicAPIExpressionName,
 } from '../app-render/dynamic-rendering'
 import { StaticGenBailoutError } from '../../client/components/static-generation-bailout'
 import {
@@ -32,7 +33,7 @@ import { InvariantError } from '../../shared/lib/invariant-error'
 import { RenderStage } from '../app-render/staged-rendering'
 
 export function cookies(): Promise<ReadonlyRequestCookies> {
-  const callingExpression = 'cookies'
+  const callingExpression: DynamicAPIExpressionName = 'cookies'
   const workStore = workAsyncStorage.getStore()
   const workUnitStore = workUnitAsyncStorage.getStore()
 

--- a/packages/next/src/server/request/draft-mode.ts
+++ b/packages/next/src/server/request/draft-mode.ts
@@ -14,6 +14,7 @@ import {
   abortAndThrowOnSynchronousRequestDataAccess,
   postponeWithTracking,
   trackDynamicDataInDynamicRender,
+  type DynamicAPIExpressionName,
 } from '../app-render/dynamic-rendering'
 import { createDedupedByCallsiteServerErrorLoggerDev } from '../create-deduped-by-callsite-server-error-logger'
 import { StaticGenBailoutError } from '../../client/components/static-generation-bailout'
@@ -23,7 +24,7 @@ import { delayUntilRuntimeStage } from '../dynamic-rendering-utils'
 import { ReflectAdapter } from '../web/spec-extension/adapters/reflect'
 
 export function draftMode(): Promise<DraftMode> {
-  const callingExpression = 'draftMode'
+  const callingExpression: DynamicAPIExpressionName = 'draftMode'
   const workStore = workAsyncStorage.getStore()
   const workUnitStore = workUnitAsyncStorage.getStore()
 

--- a/packages/next/src/server/request/headers.ts
+++ b/packages/next/src/server/request/headers.ts
@@ -17,6 +17,7 @@ import {
   postponeWithTracking,
   throwToInterruptStaticGeneration,
   trackDynamicDataInDynamicRender,
+  type DynamicAPIExpressionName,
 } from '../app-render/dynamic-rendering'
 import { StaticGenBailoutError } from '../../client/components/static-generation-bailout'
 import {
@@ -39,7 +40,7 @@ import { RenderStage } from '../app-render/staged-rendering'
  * Read more: [Next.js Docs: `headers`](https://nextjs.org/docs/app/api-reference/functions/headers)
  */
 export function headers(): Promise<ReadonlyHeaders> {
-  const callingExpression = 'headers'
+  const callingExpression: DynamicAPIExpressionName = 'headers'
   const workStore = workAsyncStorage.getStore()
   const workUnitStore = workUnitAsyncStorage.getStore()
 

--- a/packages/next/src/server/web/spec-extension/unstable-no-store.ts
+++ b/packages/next/src/server/web/spec-extension/unstable-no-store.ts
@@ -1,6 +1,9 @@
 import { workAsyncStorage } from '../../app-render/work-async-storage.external'
 import { workUnitAsyncStorage } from '../../app-render/work-unit-async-storage.external'
-import { markCurrentScopeAsDynamic } from '../../app-render/dynamic-rendering'
+import {
+  markCurrentScopeAsDynamic,
+  type DynamicAPIExpressionName,
+} from '../../app-render/dynamic-rendering'
 
 /**
  * This function can be used to declaratively opt out of static rendering and indicate a particular component should not be cached.
@@ -18,7 +21,7 @@ import { markCurrentScopeAsDynamic } from '../../app-render/dynamic-rendering'
  * Read more: [Next.js Docs: `unstable_noStore`](https://nextjs.org/docs/app/api-reference/functions/unstable_noStore)
  */
 export function unstable_noStore() {
-  const callingExpression = 'unstable_noStore()'
+  const callingExpression: DynamicAPIExpressionName = 'unstable_noStore()'
   const store = workAsyncStorage.getStore()
   const workUnitStore = workUnitAsyncStorage.getStore()
   if (!store) {


### PR DESCRIPTION
## Summary

- Attach `__NEXT_ERROR_DETAILS` with `expression` to blocking-route errors so the dev overlay can show **cause-specific** titles and remediation instead of generic "Runtime data was accessed outside of `<Suspense>`".
- Add `DynamicAPIExpressionName` shared type for known API expression names, applied to `callingExpression` in each API file for compile-time safety between server and overlay.
- Fix all three `syncDynamicErrorWithStack` branches to also attach structured details (previously these pushed raw errors without `__NEXT_ERROR_DETAILS`).
- Implement cause-specific overlay copy for `cookies()`, `headers()`, and `connection()`, split by initial render vs navigation context.
- Fix expression value mismatch: overlay checked `'cookies()'` but the server stores `'cookies'`.
- Add `extractExpressionFromMessage` fallback so errors without structured details still route to cause-specific copy.

### Before

All blocking-route errors for `cookies()`, `headers()`, `connection()` showed:

> **Runtime data was accessed outside of `<Suspense>`**
> This delays the entire page from rendering...

### After

Each API gets its own title and targeted fix suggestions:

> **`cookies()` is blocking the initial render**
> This route reads request-time cookie data in a part of the tree that Next.js expected to keep prefetchable and renderable without waiting.

## Test plan

- [ ] Verify overlay shows cause-specific copy for `cookies()`, `headers()`, `connection()` routes
- [ ] Verify generic copy still shows for `params`, `searchParams`, `fetch()` routes
- [ ] Update ~25-30 inline test snapshots in `instant-validation-causes.test.ts`, `instant-validation.test.ts`, and `cache-components-errors.test.ts`