### PR TITLE
Turbopack: fix filesystem watcher config not applying follow_symlinks(false)

### DIFF
--- a/turbopack/crates/turbo-tasks-fs/src/watcher.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/watcher.rs
@@ -380,13 +380,13 @@ impl DiskWatcher {
         let config = Config::default();
         // we should track and invalidate each part of a symlink chain ourselves in
         // turbo-tasks-fs
-        config.with_follow_symlinks(false);
+        let config = config.with_follow_symlinks(false);
 
         let mut notify_watcher = if let Some(poll_interval) = poll_interval {
             let config = config.with_poll_interval(poll_interval);
             NotifyWatcher::Polling(PollWatcher::new(tx, config)?)
         } else {
-            NotifyWatcher::Recommended(RecommendedWatcher::new(tx, Config::default())?)
+            NotifyWatcher::Recommended(RecommendedWatcher::new(tx, config)?)
         };
 
         // TOCTOU: we must watch `root_path` before calling any invalidators and setting up the


### PR DESCRIPTION
## Summary

- The notify `Config` uses a builder pattern where `with_follow_symlinks()` consumes `self` and returns a new `Config`, but the return value was being discarded — so `follow_symlinks` remained at its default (`true`).
- The `RecommendedWatcher` branch was also passing `Config::default()` instead of the configured `config` object, ignoring the config entirely.

## Test plan

- [x] `cargo check -p turbo-tasks-fs` passes
- Behavioral: symlinks under the watched root will now trigger events for the symlink itself rather than the target, matching the intent of the existing comment.

<!-- NEXT_JS_LLM_PR -->