### PR TITLE
fix(use-cache): remove awaiting revalidation

### DIFF
--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -2627,6 +2627,7 @@ export async function cache(
             // If this is stale, and we're not in a prerender (i.e. this is
             // dynamic render), then we should warm up the cache with a fresh
             // revalidated entry.
+            const revalidateCacheHandlerKey = cacheHandlerKey
             generateCacheEntry(
               workStore,
               // The background revalidation preserves the outer store for
@@ -2642,30 +2643,38 @@ export async function cache(
               encodedCacheKeyParts,
               fn,
               timeoutError
-            ).then((result) => {
-              if (result.type === 'cached') {
-                const { stream: ignoredStream, pendingCacheResult } = result
+            )
+              .then((result) => {
+                if (result.type === 'cached') {
+                  const { stream: ignoredStream, pendingCacheResult } = result
 
-                const savedCacheResult = saveToResumeDataCache(
-                  prerenderResumeDataCache,
-                  serializedCacheKey,
-                  pendingCacheResult
-                )
-
-                if (cacheHandler) {
-                  saveToCacheHandler(
-                    cacheHandler,
-                    workStore,
-                    id,
+                  const savedCacheResult = saveToResumeDataCache(
+                    prerenderResumeDataCache,
                     serializedCacheKey,
-                    savedCacheResult,
-                    rootParams
+                    pendingCacheResult
                   )
-                }
 
-                ignoredStream.cancel()
-              }
-            })
+                  if (cacheHandler) {
+                    saveToCacheHandler(
+                      cacheHandler,
+                      workStore,
+                      id,
+                      serializedCacheKey,
+                      savedCacheResult,
+                      rootParams
+                    )
+                  }
+
+                  ignoredStream.cancel()
+                }
+              })
+              .catch((error) => {
+                debug?.(
+                  'background cache revalidation failed for',
+                  revalidateCacheHandlerKey,
+                  error
+                )
+              })
           }
         }
       }

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -2628,7 +2628,7 @@ export async function cache(
             // dynamic render), then we should warm up the cache with a fresh
             // revalidated entry.
             const revalidateCacheHandlerKey = cacheHandlerKey
-            generateCacheEntry(
+            const revalidatePromise = generateCacheEntry(
               workStore,
               // The background revalidation preserves the outer store for
               // reading (e.g. implicitTags) but skips propagation of cache life
@@ -2675,6 +2675,8 @@ export async function cache(
                   error
                 )
               })
+            workStore.pendingRevalidateWrites ??= []
+            workStore.pendingRevalidateWrites.push(revalidatePromise)
           }
         }
       }

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -2644,7 +2644,7 @@ export async function cache(
               fn,
               timeoutError
             )
-              .then((result) => {
+              .then(async (result) => {
                 if (result.type === 'cached') {
                   const { stream: ignoredStream, pendingCacheResult } = result
 
@@ -2665,7 +2665,7 @@ export async function cache(
                     )
                   }
 
-                  ignoredStream.cancel()
+                  await ignoredStream.cancel()
                 }
               })
               .catch((error) => {

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -2627,7 +2627,7 @@ export async function cache(
             // If this is stale, and we're not in a prerender (i.e. this is
             // dynamic render), then we should warm up the cache with a fresh
             // revalidated entry.
-            const result = await generateCacheEntry(
+            generateCacheEntry(
               workStore,
               // The background revalidation preserves the outer store for
               // reading (e.g. implicitTags) but skips propagation of cache life
@@ -2642,30 +2642,30 @@ export async function cache(
               encodedCacheKeyParts,
               fn,
               timeoutError
-            )
+            ).then((result) => {
+              if (result.type === 'cached') {
+                const { stream: ignoredStream, pendingCacheResult } = result
 
-            if (result.type === 'cached') {
-              const { stream: ignoredStream, pendingCacheResult } = result
-
-              const savedCacheResult = saveToResumeDataCache(
-                prerenderResumeDataCache,
-                serializedCacheKey,
-                pendingCacheResult
-              )
-
-              if (cacheHandler) {
-                saveToCacheHandler(
-                  cacheHandler,
-                  workStore,
-                  id,
+                const savedCacheResult = saveToResumeDataCache(
+                  prerenderResumeDataCache,
                   serializedCacheKey,
-                  savedCacheResult,
-                  rootParams
+                  pendingCacheResult
                 )
-              }
 
-              await ignoredStream.cancel()
-            }
+                if (cacheHandler) {
+                  saveToCacheHandler(
+                    cacheHandler,
+                    workStore,
+                    id,
+                    serializedCacheKey,
+                    savedCacheResult,
+                    rootParams
+                  )
+                }
+
+                ignoredStream.cancel()
+              }
+            })
           }
         }
       }

--- a/test/e2e/app-dir/use-cache-swr/app/delayed/page.tsx
+++ b/test/e2e/app-dir/use-cache-swr/app/delayed/page.tsx
@@ -1,0 +1,24 @@
+import { cacheLife } from 'next/cache'
+import { connection } from 'next/server'
+import { setTimeout } from 'timers/promises'
+
+async function Cached() {
+  'use cache'
+
+  cacheLife('seconds')
+
+  await setTimeout(1000)
+
+  return <p id="cached">{new Date().toISOString()}</p>
+}
+
+export default async function Page() {
+  await connection()
+
+  return (
+    <>
+      <p id="dynamic">{new Date().toISOString()}</p>
+      <Cached />
+    </>
+  )
+}

--- a/test/e2e/app-dir/use-cache-swr/use-cache-swr.test.ts
+++ b/test/e2e/app-dir/use-cache-swr/use-cache-swr.test.ts
@@ -53,6 +53,52 @@ describe('use-cache-swr', () => {
     expect(cliOutput).not.toMatch(/PersistentCacheHandler::set.*"outer"/)
   })
 
+  it('should serve stale data without blocking on the background regeneration', async () => {
+    // Fetch 1: cold cache. The cached component blocks for ~1s.
+    const $1 = await next.render$('/delayed')
+    const cached1 = $1('#cached').text()
+    const dynamic1 = $1('#dynamic').text()
+    expect(cached1).toBeDateString()
+    expect(dynamic1).toBeDateString()
+
+    // Wait past the 1s revalidate window (cacheLife('seconds')).
+    await new Promise((resolve) => setTimeout(resolve, 1200))
+
+    outputIndex = next.cliOutput.length
+
+    // Fetch 2: stale hit. Should return the stale entry immediately and kick
+    // off the regeneration in the background, rather than blocking on the 1s
+    // delay in the cached component.
+    const start2 = Date.now()
+    const $2 = await next.render$('/delayed')
+    const duration2 = Date.now() - start2
+    const cached2 = $2('#cached').text()
+    const dynamic2 = $2('#dynamic').text()
+
+    expect(cached2).toBe(cached1)
+    expect(dynamic2).not.toBe(dynamic1)
+    expect(duration2).toBeLessThan(1000)
+
+    // Wait for the background regen to finish writing the fresh entry.
+    await retry(() => {
+      expect(next.cliOutput.slice(outputIndex)).toMatch(
+        /PersistentCacheHandler::set/
+      )
+    })
+
+    // Fetch 3: should serve the pre-warmed fresh entry from the background
+    // regen, not a new stale value.
+    const start3 = Date.now()
+    const $3 = await next.render$('/delayed')
+    const duration3 = Date.now() - start3
+    const cached3 = $3('#cached').text()
+    const dynamic3 = $3('#dynamic').text()
+
+    expect(cached3).not.toBe(cached1)
+    expect(dynamic3).not.toBe(dynamic2)
+    expect(duration3).toBeLessThan(1000)
+  })
+
   it('should pass implicit tags to cache handler get() for nested caches during SWR', async () => {
     const browser = await next.browser('/')
     await browser.elementById('outer-data').text()

--- a/test/e2e/app-dir/use-cache-swr/use-cache-swr.test.ts
+++ b/test/e2e/app-dir/use-cache-swr/use-cache-swr.test.ts
@@ -23,6 +23,10 @@ describe('use-cache-swr', () => {
     // Wait for the outer cache to go stale (revalidate: 5).
     await new Promise((resolve) => setTimeout(resolve, 6000))
 
+    // Reset output index so the regen set we poll for below can't be satisfied
+    // by the initial cold-fill set from the first fetch.
+    outputIndex = next.cliOutput.length
+
     // This request should trigger SWR: the handler returns the stale entry,
     // the framework serves it to the client, and kicks off a background regen.
     await browser.refresh()


### PR DESCRIPTION
### What?
fixes #74882

The `use cache` directive does not revalidate in the background while serving (not expired) stale data.

For the static pages, the whole page is blocked during revalidation, and fresh data is fetched served. While I don't agree with this, as it is just a duplication of the expire behaviour, this is documented as intended in the comments in the code.

For the dynamic pages, when the data is flagged for revalidation, the stale data is blocked while fresh data is fetched. Once the fresh data is fetched, the function returns the stale data. On refreshing, the fresh data is served. This is the worst of both worlds, as we are still waiting for fresh data, and then seeing the stale data.

In both cases there is no background revalidation of data, leading to slow, unresponsive pages.

I have an example app showing this behaviour here: https://github.com/awo00/nextjs-use-cache-revalidate

### Why?

In the `use-cache-wrapper`, the `generateCacheEntry()` function is awaited during revalidation which is blocking the stale data being returned.

### How?

Removing the await allows the stale data to be returned faster.
