### PR TITLE
Stop using deprecated `downlevelIteration`

### DIFF
--- a/packages/next-codemod/tsconfig.json
+++ b/packages/next-codemod/tsconfig.json
@@ -5,8 +5,6 @@
     "esModuleInterop": true,
     "noImplicitAny": false,
     "target": "ES2022",
-    "downlevelIteration": true,
-    "ignoreDeprecations": "6.0",
     "preserveWatchOutput": true,
     "strictFunctionTypes": false,
     "strictNullChecks": false,

--- a/packages/react-refresh-utils/tsconfig.json
+++ b/packages/react-refresh-utils/tsconfig.json
@@ -6,8 +6,6 @@
     "esModuleInterop": true,
     "target": "es2015",
     "lib": ["dom", "es2020"],
-    "downlevelIteration": true,
-    "ignoreDeprecations": "6.0",
     "preserveWatchOutput": true,
     "skipLibCheck": true,
     "outDir": "dist",


### PR DESCRIPTION
TypeScript transpiled ES6 iterators with [`downLevelIteration`](https://www.typescriptlang.org/tsconfig/#downlevelIteration) which was still used by `@next/codemod` and `@next/refresh-utils`. Currently supported Node.js versions and targets of Next.js support ES6 iterators so we should be able to safely get rid of `downLevelIteration`.