### PR TITLE
Stop using deprecated `baseUrl`

### DIFF
--- a/crates/next-core/js/tsconfig.json
+++ b/crates/next-core/js/tsconfig.json
@@ -14,9 +14,7 @@
     "jsx": "react-jsx",
     "lib": ["ESNext", "DOM"],
     "target": "esnext",
-    "ignoreDeprecations": "6.0",
     // modules
-    "baseUrl": ".",
     "module": "node16",
     "moduleResolution": "node16",
     "resolveJsonModule": true,

--- a/turbopack/crates/turbopack-cli/js/tsconfig.json
+++ b/turbopack/crates/turbopack-cli/js/tsconfig.json
@@ -9,10 +9,8 @@
     "jsx": "react-jsx",
     "lib": ["ESNext", "DOM"],
     "target": "esnext",
-    "ignoreDeprecations": "6.0",
 
     // modules
-    "baseUrl": ".",
     "module": "nodenext",
     "moduleResolution": "nodenext",
     "types": [],

--- a/turbopack/crates/turbopack-ecmascript-runtime/js/src/tsconfig.base.json
+++ b/turbopack/crates/turbopack-ecmascript-runtime/js/src/tsconfig.base.json
@@ -12,7 +12,6 @@
     "target": "ESNext",
 
     // modules
-    "baseUrl": ".",
     "module": "CommonJS",
     "types": [], // disable implicit types.
 

--- a/turbopack/crates/turbopack-node/js/tsconfig.json
+++ b/turbopack/crates/turbopack-node/js/tsconfig.json
@@ -19,7 +19,6 @@
     "ignoreDeprecations": "6.0",
 
     // modules
-    "baseUrl": ".",
     "module": "esnext",
     "moduleResolution": "node",
 

--- a/turbopack/tsconfig.json
+++ b/turbopack/tsconfig.json
@@ -9,9 +9,8 @@
     "noEmitHelpers": false,
     "skipLibCheck": true,
     "outDir": "./dist",
-    "baseUrl": "./packages",
     "paths": {
-      "@vercel/webpack-nft": ["webpack-nmt/src/index.ts"]
+      "@vercel/webpack-nft": ["./packages/webpack-nmt/src/index.ts"]
     }
   },
   "exclude": ["node_modules", "target"]


### PR DESCRIPTION
[`baseUrl`](https://www.typescriptlang.org/tsconfig/#baseUrl) only has an effect on type resolution. Should be safe to remove.