### PR TITLE
Wrap instrumentation hook load errors instead of mutating them

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1156,5 +1156,6 @@
   "1155": "Not implemented",
   "1156": "Cannot create a replay stream after the ReplayableNodeStream has been disposed.",
   "1157": "`unstable_io()` requires the `experimental.unstableIO` option to be enabled in your Next.js config.",
-  "1158": "The prerender-ppr work unit type has been removed. This code path should be unreachable."
+  "1158": "The prerender-ppr work unit type has been removed. This code path should be unreachable.",
+  "1159": "An error occurred while loading instrumentation hook: %s"
 }

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -16,6 +16,7 @@ import {
   type NextUrlWithParsedQuery,
 } from '../request-meta'
 import type { DevBundlerService } from '../lib/dev-bundler-service'
+import { wrapInstrumentationLoadError } from '../lib/instrumentation-error'
 import type { IncrementalCache } from '../lib/incremental-cache'
 import type { UnwrapPromise } from '../../lib/coalesced-function'
 import type { NodeNextResponse, NodeNextRequest } from '../base-http/node'
@@ -720,9 +721,8 @@ export default class DevServer extends Server {
           this.dir,
           this.nextConfig.distDir
         )
-      } catch (err: any) {
-        err.message = `An error occurred while loading instrumentation hook: ${err.message}`
-        throw err
+      } catch (err) {
+        throw wrapInstrumentationLoadError(err)
       }
     }
     return instrumentationModule

--- a/packages/next/src/server/lib/instrumentation-error.ts
+++ b/packages/next/src/server/lib/instrumentation-error.ts
@@ -1,0 +1,16 @@
+/**
+ * Wrap an error thrown while loading the instrumentation hook in a new
+ * `Error` with an informative prefix, preserving the original error via
+ * `cause`.
+ *
+ * Avoids mutating the original error's `message` — which fails when the
+ * thrown value is not an `Error` instance, or when `message` is defined
+ * as a getter-only property (as happens with some validator libraries).
+ */
+export function wrapInstrumentationLoadError(err: unknown): Error {
+  const originalMessage = err instanceof Error ? err.message : String(err)
+  return new Error(
+    `An error occurred while loading instrumentation hook: ${originalMessage}`,
+    { cause: err }
+  )
+}

--- a/packages/next/src/server/lib/router-utils/instrumentation-globals.external.ts
+++ b/packages/next/src/server/lib/router-utils/instrumentation-globals.external.ts
@@ -1,5 +1,6 @@
 import path from 'node:path'
 import isError from '../../../lib/is-error'
+import { wrapInstrumentationLoadError } from '../instrumentation-error'
 import { INSTRUMENTATION_HOOK_FILENAME } from '../../../lib/constants'
 import type {
   InstrumentationModule,
@@ -57,9 +58,8 @@ async function registerInstrumentation(projectDir: string, distDir: string) {
     try {
       await instrumentation.register()
       extendInstrumentationAfterRegistration()
-    } catch (err: any) {
-      err.message = `An error occurred while loading instrumentation hook: ${err.message}`
-      throw err
+    } catch (err) {
+      throw wrapInstrumentationLoadError(err)
     }
   }
 }

--- a/packages/next/src/server/web/globals.ts
+++ b/packages/next/src/server/web/globals.ts
@@ -2,6 +2,7 @@ import type {
   InstrumentationModule,
   InstrumentationOnRequestError,
 } from '../instrumentation/types'
+import { wrapInstrumentationLoadError } from '../lib/instrumentation-error'
 
 declare const _ENTRIES: any
 
@@ -27,9 +28,8 @@ async function registerInstrumentation() {
   if (instrumentation?.register) {
     try {
       await instrumentation.register()
-    } catch (err: any) {
-      err.message = `An error occurred while loading instrumentation hook: ${err.message}`
-      throw err
+    } catch (err) {
+      throw wrapInstrumentationLoadError(err)
     }
   }
 }

--- a/test/unit/wrap-instrumentation-load-error.test.ts
+++ b/test/unit/wrap-instrumentation-load-error.test.ts
@@ -1,0 +1,62 @@
+import { wrapInstrumentationLoadError } from 'next/dist/server/lib/instrumentation-error'
+
+describe('wrapInstrumentationLoadError', () => {
+  it('prefixes the message of a plain Error', () => {
+    const original = new Error('boom')
+    const wrapped = wrapInstrumentationLoadError(original)
+
+    expect(wrapped).toBeInstanceOf(Error)
+    expect(wrapped.message).toBe(
+      'An error occurred while loading instrumentation hook: boom'
+    )
+    expect(wrapped.cause).toBe(original)
+  })
+
+  it('does not crash when the original error has a getter-only message', () => {
+    // This mirrors errors thrown by some validator libraries (e.g. Zod)
+    // where `message` is defined as a getter without a setter. Assigning
+    // to it would throw `Cannot set property message of [object] which has
+    // only a getter`.
+    class GetterOnlyError extends Error {
+      get message() {
+        return 'getter-only boom'
+      }
+    }
+
+    const original = new GetterOnlyError()
+    const wrapped = wrapInstrumentationLoadError(original)
+
+    expect(wrapped.message).toBe(
+      'An error occurred while loading instrumentation hook: getter-only boom'
+    )
+    expect(wrapped.cause).toBe(original)
+  })
+
+  it('handles a thrown string', () => {
+    const wrapped = wrapInstrumentationLoadError('not an Error')
+
+    expect(wrapped.message).toBe(
+      'An error occurred while loading instrumentation hook: not an Error'
+    )
+    expect(wrapped.cause).toBe('not an Error')
+  })
+
+  it('handles a thrown undefined', () => {
+    const wrapped = wrapInstrumentationLoadError(undefined)
+
+    expect(wrapped.message).toBe(
+      'An error occurred while loading instrumentation hook: undefined'
+    )
+    expect(wrapped.cause).toBeUndefined()
+  })
+
+  it('handles a thrown plain object', () => {
+    const original = { foo: 'bar' }
+    const wrapped = wrapInstrumentationLoadError(original)
+
+    expect(wrapped.message).toBe(
+      'An error occurred while loading instrumentation hook: [object Object]'
+    )
+    expect(wrapped.cause).toBe(original)
+  })
+})


### PR DESCRIPTION
### What?

When the instrumentation hook fails to load, Next.js should report a clear framework-level error with the original cause preserved, even when the thrown value is not a plain mutable \`Error\`. Today it crashes with \`TypeError: Cannot set property message of [object Error] which has only a getter\` in some cases, or silently drops the underlying error in others.

### Why?

Three sites in Next.js (dev server, Node instrumentation globals, edge runtime globals) wrap instrumentation hook load failures with the same pattern:

\`\`\`ts
} catch (err: any) {
  err.message = \`An error occurred while loading instrumentation hook: \${err.message}\`
  throw err
}
\`\`\`

That breaks in two observed cases:

1. **Non-Error throws** (\`throw 'boom'\`, \`throw null\`, \`throw { foo }\`, etc.) — reassigning \`.message\` on a primitive is dropped, and on a plain object silently mutates an unrelated field, so the user sees a missing or confusing error.
2. **Getter-only \`message\`** — some validator libraries (e.g. Zod) define \`message\` as a getter without a setter. Reassigning it throws \`TypeError: Cannot set property message of [object Error] which has only a getter\`, and that framework-internal crash completely replaces the user's real error. This is the reproduction in #54417: a \`zod.parse()\` at the top of \`instrumentation.ts\` becomes an unreadable stack with no clue what went wrong.

### How?

- Added \`wrapInstrumentationLoadError(err)\` in \`packages/next/src/server/lib/instrumentation-error.ts\` that builds a **new** \`Error\` with the prefixed message and attaches the original value via \`cause\`.
- Replaced the three \`err.message = ...; throw err\` call sites with \`throw wrapInstrumentationLoadError(err)\`.
- No mutation of the original error object — it's preserved intact under \`.cause\` for downstream inspection.
- Non-Error throws are coerced via \`String(err)\` so \`throw null\`, \`throw 'boom'\`, \`throw { ... }\` all surface a readable top-level message.

The \`packages/next/errors.json\` bump (new entry 1159) was produced by \`pnpm update-error-codes\` as required by the repo's error-codes check, since the message now appears in a \`new Error(...)\` site.

### Scope

- \`packages/next/src/build/analysis/get-page-static-info.ts\` uses the same \`error.message = ...; throw\` anti-pattern for file-read errors — left alone in this PR because the context is different (it's wrapping Node's \`readFileSync\` errors, which are always real \`Error\` instances) and I wanted to keep the change focused on the reported regression path. Happy to extend if reviewers prefer.
- \`packages/next/src/build/templates/middleware.ts\` reassigns a message on an error that's already guaranteed to be a Next.js internal \`isNextRouterError\` instance with a writable message, so it isn't at risk of the getter-only / non-Error failure modes and is left alone.

### Test plan

Added \`test/unit/wrap-instrumentation-load-error.test.ts\` with five cases covering the helper:

- Plain \`Error\` with mutable message → prefixed, cause preserved.
- \`Error\` subclass with getter-only \`message\` (the #54417 repro shape) → prefixed, cause preserved, no \`TypeError\`.
- Thrown string → coerced, cause preserved.
- Thrown \`undefined\` → coerced to \`\"undefined\"\`, cause undefined.
- Thrown plain object → coerced to \`\"[object Object]\"\`, cause preserved.

\`pnpm test-unit test/unit/wrap-instrumentation-load-error.test.ts\` → 5 passed.

Fixes #54417