### PR TITLE
useParams: accept interface types in the generic parameter

### DIFF
--- a/packages/next/src/client/components/navigation.ts
+++ b/packages/next/src/client/components/navigation.ts
@@ -1,4 +1,4 @@
-import type { Params } from '../../server/request/params'
+import type { ParamValue, Params } from '../../server/request/params'
 
 import React, { useContext, useMemo, use } from 'react'
 import {
@@ -200,7 +200,17 @@ export function useRouter(): AppRouterInstance {
  * Read more: [Next.js Docs: `useParams`](https://nextjs.org/docs/app/api-reference/functions/use-params)
  */
 // Client components API
-export function useParams<T extends Params = Params>(): T {
+// The generic constraint is expressed with a mapped type rather than
+// `T extends Params` (which is `Record<string, ParamValue>`). `Record` has
+// an index signature, which TypeScript interfaces do not implicitly
+// satisfy, so the bare `extends Params` form forced users with
+// `interface PageParams { ... }` to either add `[key: string]: ParamValue`
+// manually or switch to a `type` alias (see issue #61951). The mapped-type
+// form accepts both interfaces and type aliases while still rejecting
+// types whose values are not `ParamValue`.
+export function useParams<
+  T extends { [K in keyof T]: ParamValue } = Params,
+>(): T {
   useDynamicRouteParams?.('useParams()')
 
   const params = useContext(PathParamsContext) as T

--- a/test/e2e/app-dir/types/src/app/use-params/page.tsx
+++ b/test/e2e/app-dir/types/src/app/use-params/page.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+// Regression test for #61951: useParams<T>() must accept both `interface`
+// and `type` generic parameters. Previously the constraint was
+// `T extends Params` where `Params` has an index signature, which TypeScript
+// interfaces do not implicitly satisfy.
+interface PageParamsInterface {
+  storefront: string
+  product: string
+}
+
+type PageParamsAlias = {
+  storefront: string
+  product: string
+}
+
+export default function Page() {
+  const a = useParams<PageParamsInterface>()
+  const b = useParams<PageParamsAlias>()
+  return (
+    <div>
+      {a.storefront}/{a.product} - {b.storefront}/{b.product}
+    </div>
+  )
+}


### PR DESCRIPTION
### What?

Make \`useParams<T>()\` accept user-defined \`interface\` types in its generic parameter, the same way it already accepts \`type\` aliases. Today, passing an \`interface\` crashes TypeScript with an index-signature constraint error, forcing users to either rewrite their shape as a \`type\` or manually add \`[key: string]: ParamValue\` to every interface.

### Why?

The current constraint is

\`\`\`ts
export function useParams<T extends Params = Params>(): T { ... }
\`\`\`

where \`Params = Record<string, ParamValue>\`. TypeScript interfaces do **not** implicitly satisfy index-signature constraints — that's a well-known TypeScript behavior — so:

\`\`\`ts
interface PageParams {
  storefront: string
  product: string
}

useParams<PageParams>()
// Type 'PageParams' does not satisfy the constraint 'Params'.
// Index signature for type 'string' is missing in type 'PageParams'. ts(2344)
\`\`\`

while the structurally identical type alias works:

\`\`\`ts
type PageParams = {
  storefront: string
  product: string
}

useParams<PageParams>() // ✓
\`\`\`

Interfaces are the idiomatic way to declare object shapes in TypeScript projects, so users hit this inconsistency frequently and are forced into awkward workarounds.

### How?

Replace \`T extends Params\` with a **mapped-type** constraint:

\`\`\`ts
export function useParams<
  T extends { [K in keyof T]: ParamValue } = Params,
>(): T { ... }
\`\`\`

The mapped form \`{ [K in keyof T]: ParamValue }\` iterates over \`T\`'s own keys and requires each value to be assignable to \`ParamValue\`. That's a safer-but-equivalent check that:

- ✅ Accepts \`interface PageParams { storefront: string }\` (no index signature needed).
- ✅ Accepts \`type PageParams = { storefront: string }\` (unchanged).
- ✅ Still **rejects** types whose values are not \`ParamValue\` (e.g. \`interface Bad { count: number }\` — verified with a \`@ts-expect-error\` during development).

No runtime change; only the type-level constraint.

### Test plan

Added a regression fixture under \`test/e2e/app-dir/types/src/app/use-params/page.tsx\` that calls \`useParams<Interface>()\` and \`useParams<TypeAlias>()\` side-by-side. The existing \`app-dir types\` end-to-end test (\`test/e2e/app-dir/types/types.test.ts\`) runs \`pnpm tsc\` against that project, so if the constraint regresses, the fixture fails to compile and the test fails.

Locally verified that the fix compiles via \`pnpm --filter=next types\` (zero errors) and by ad-hoc \`tsc\`-ing a scratch file with the same \`interface\` / \`type\` / \`interface with wrong value\` cases.

Fixes #61951