### PR TITLE
build trace: treat EISDIR as "not a symlink" for Windows non-C: drives

### DIFF
--- a/packages/next/src/build/collect-build-traces.ts
+++ b/packages/next/src/build/collect-build-traces.ts
@@ -13,6 +13,7 @@ import path from 'path'
 import { resolveCacheHandlerPathToFilesystem } from '../lib/format-dynamic-import-path'
 import fs from 'fs/promises'
 import { nonNullable } from '../lib/non-nullable'
+import { isNonSymlinkReadlinkError } from './lib/is-non-symlink-error'
 import * as ciEnvironment from '../server/ci-info'
 import debugOriginal from 'next/dist/compiled/debug'
 import picomatch from 'next/dist/compiled/picomatch'
@@ -322,12 +323,7 @@ export async function collectBuildTraces({
             try {
               return await fs.readlink(p)
             } catch (e) {
-              if (
-                isError(e) &&
-                (e.code === 'EINVAL' ||
-                  e.code === 'ENOENT' ||
-                  e.code === 'UNKNOWN')
-              ) {
+              if (isNonSymlinkReadlinkError(e)) {
                 return null
               }
               throw e

--- a/packages/next/src/build/lib/is-non-symlink-error.ts
+++ b/packages/next/src/build/lib/is-non-symlink-error.ts
@@ -1,0 +1,31 @@
+import isError from '../../lib/is-error'
+
+/**
+ * Predicate used by the file-trace `readlink` wrappers. Returns `true`
+ * when a `readlink` failure should be treated as "this path is not a
+ * symlink" (so the caller returns `null`), and `false` when it should
+ * bubble as a real I/O error.
+ *
+ * Node returns different error codes for the "not a symlink" case
+ * depending on the platform and the target's real type:
+ *
+ * - **EINVAL** — Linux/macOS: the target exists but is not a symlink.
+ * - **ENOENT** — the path does not exist.
+ * - **UNKNOWN** — a catch-all for platform-specific codes we can't
+ *   map cleanly.
+ * - **EISDIR** — Windows: returned for certain non-symlink entries,
+ *   notably when building projects on drives other than C:/. Without
+ *   this catch, `next build` fails with
+ *   `EISDIR: illegal operation on a directory, readlink <file>.tsx`
+ *   for every traced file on such drives (issue #45067).
+ */
+export function isNonSymlinkReadlinkError(e: unknown): boolean {
+  if (!isError(e)) return false
+  const code = (e as NodeJS.ErrnoException).code
+  return (
+    code === 'EINVAL' ||
+    code === 'ENOENT' ||
+    code === 'UNKNOWN' ||
+    code === 'EISDIR'
+  )
+}

--- a/packages/next/src/build/webpack/plugins/next-trace-entrypoints-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/next-trace-entrypoints-plugin.ts
@@ -1,6 +1,7 @@
 import nodePath from 'path'
 import type { Span } from '../../../trace'
 import isError from '../../../lib/is-error'
+import { isNonSymlinkReadlinkError } from '../../lib/is-non-symlink-error'
 import { nodeFileTrace } from 'next/dist/compiled/@vercel/nft'
 import type { NodeFileTraceReasons } from 'next/dist/compiled/@vercel/nft'
 import {
@@ -594,10 +595,7 @@ export class TraceEntryPointsPlugin implements webpack.WebpackPluginInstance {
             })
           })
         } catch (e) {
-          if (
-            isError(e) &&
-            (e.code === 'EINVAL' || e.code === 'ENOENT' || e.code === 'UNKNOWN')
-          ) {
+          if (isNonSymlinkReadlinkError(e)) {
             return null
           }
           throw e

--- a/test/unit/is-non-symlink-error.test.ts
+++ b/test/unit/is-non-symlink-error.test.ts
@@ -1,0 +1,43 @@
+import { isNonSymlinkReadlinkError } from 'next/dist/build/lib/is-non-symlink-error'
+
+function errWithCode(code: string): Error {
+  const err = new Error(`simulated ${code}`) as NodeJS.ErrnoException
+  err.code = code
+  return err
+}
+
+describe('isNonSymlinkReadlinkError', () => {
+  it('treats EINVAL as "not a symlink" (Linux/macOS non-symlink)', () => {
+    expect(isNonSymlinkReadlinkError(errWithCode('EINVAL'))).toBe(true)
+  })
+
+  it('treats ENOENT as "not a symlink" (path does not exist)', () => {
+    expect(isNonSymlinkReadlinkError(errWithCode('ENOENT'))).toBe(true)
+  })
+
+  it('treats UNKNOWN as "not a symlink" (platform-specific catch-all)', () => {
+    expect(isNonSymlinkReadlinkError(errWithCode('UNKNOWN'))).toBe(true)
+  })
+
+  it('treats EISDIR as "not a symlink" (Windows non-C: drive regression)', () => {
+    // Regression test for #45067: on Windows, `next build` on a drive
+    // other than C:/ raised
+    //   EISDIR: illegal operation on a directory, readlink <file>.tsx
+    // for every traced file. The wrapper must return null instead of
+    // bubbling the error.
+    expect(isNonSymlinkReadlinkError(errWithCode('EISDIR'))).toBe(true)
+  })
+
+  it('does not swallow unrelated I/O errors', () => {
+    expect(isNonSymlinkReadlinkError(errWithCode('EACCES'))).toBe(false)
+    expect(isNonSymlinkReadlinkError(errWithCode('EMFILE'))).toBe(false)
+    expect(isNonSymlinkReadlinkError(errWithCode('EIO'))).toBe(false)
+  })
+
+  it('returns false for non-Error values', () => {
+    expect(isNonSymlinkReadlinkError(undefined)).toBe(false)
+    expect(isNonSymlinkReadlinkError(null)).toBe(false)
+    expect(isNonSymlinkReadlinkError('EISDIR')).toBe(false)
+    expect(isNonSymlinkReadlinkError({ code: 'EISDIR' })).toBe(false)
+  })
+})


### PR DESCRIPTION
### What?

Let \`next build\` succeed on Windows when the project lives on a drive other than \`C:/\`. Today it fails for every traced source file with

\`\`\`
Error: EISDIR: illegal operation on a directory, readlink <file>.tsx
\`\`\`

which is how issue #45067 presents.

### Why?

The build trace has two \`readlink\` wrappers — one passed to \`@vercel/nft\` from \`collect-build-traces.ts\` and one inside the webpack \`next-trace-entrypoints-plugin\`. When \`fs.readlink\` throws on a path that isn't a symlink, both wrappers are supposed to swallow the error and return \`null\` (meaning "not a symlink"). They did that for \`EINVAL\` (Linux/macOS non-symlink), \`ENOENT\` (path missing), and \`UNKNOWN\` (platform-specific catch-all), but not for \`EISDIR\`.

On Windows — and specifically on drives other than \`C:/\` — Node.js raises \`EISDIR\` for certain non-symlink entries during the trace. Because neither wrapper caught it, every traced source file bubbled up a hard error and the build aborted. Users hit this the moment they clone a Next.js project onto a secondary drive (\`A:/\`, \`D:/\`, a networked workspace, etc.) and run \`next build\`.

### How?

- Extracted the \`readlink\` error-code predicate into a shared helper \`isNonSymlinkReadlinkError\` at \`packages/next/src/build/lib/is-non-symlink-error.ts\`. Keeping this in one place avoids the two existing copies drifting from each other (they already disagreed on comments) and gives us a single place to document *why* each code is treated as "not a symlink".
- Added \`EISDIR\` to the allowed codes alongside the existing \`EINVAL\` / \`ENOENT\` / \`UNKNOWN\`. Semantically, if \`readlink\` fails for any of these reasons the correct behavior is "return \`null\`, it's not a symlink", which is exactly what both wrappers already did for the other three codes.
- Switched both wrappers — \`collect-build-traces.ts\` and \`next-trace-entrypoints-plugin.ts\` — to use the helper.

No behavioral change on Linux/macOS. On Windows, the \`EISDIR\` case is now handled the same way the other non-symlink cases already were.

### Scope

Deliberately narrow — only \`EISDIR\` is added. Other Windows-ish codes like \`EACCES\` / \`EPERM\` (symlink read privilege errors) are intentionally *not* added to the allow-list, because those aren't "this isn't a symlink", they're "I couldn't check", and silently treating them as "not a symlink" would mask real permission problems.

### Test plan

Added \`test/unit/is-non-symlink-error.test.ts\` with six cases:

- All four allowed codes map to \`true\` (\`EINVAL\`, \`ENOENT\`, \`UNKNOWN\`, \`EISDIR\`), with the \`EISDIR\` case explicitly annotated as the #45067 regression.
- Unrelated I/O errors (\`EACCES\`, \`EMFILE\`, \`EIO\`) map to \`false\` — we don't want the fix to accidentally swallow real failures.
- Non-\`Error\` values (\`undefined\`, \`null\`, bare strings, plain objects with a \`code\` field) map to \`false\`.

\`npx jest test/unit/is-non-symlink-error.test.ts\` → 6 passed.

I also verified \`pnpm --filter=next types\` stays clean with the refactor and that the existing \`isError\` import is still needed elsewhere in \`collect-build-traces.ts\` so I didn't orphan any imports.

Fixes #45067