### PR TITLE
fix(eslint): support pageExtensions in no-html-link-for-pages rule

### DIFF
--- a/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
+++ b/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
@@ -107,8 +107,12 @@ export default defineRule({
       return {}
     }
 
-    const pageUrls = cachedGetUrlFromPagesDirectories('/', foundPagesDirs)
-    const appDirUrls = cachedGetUrlFromAppDirectory('/', foundAppDirs)
+    const nextSettings: { pageExtensions?: string[] } =
+      context.settings?.next || {}
+    const pageExtensions = nextSettings.pageExtensions || undefined
+
+    const pageUrls = cachedGetUrlFromPagesDirectories('/', foundPagesDirs, pageExtensions)
+    const appDirUrls = cachedGetUrlFromAppDirectory('/', foundAppDirs, pageExtensions)
     const allUrlRegex = [...pageUrls, ...appDirUrls]
 
     return {

--- a/packages/eslint-plugin-next/src/utils/url.ts
+++ b/packages/eslint-plugin-next/src/utils/url.ts
@@ -13,6 +13,21 @@ function buildExtensionsRegex(extensions: string[]) {
 }
 
 /**
+ * Strip only the matched file extension from a filename.
+ * Unlike /\..+$/ which is greedy, this only removes the actual extension
+ * (e.g., 'my.component.tsx' → 'my.component', not 'my').
+ */
+function stripExtension(filename: string, extensions: string[]): string {
+  for (const ext of extensions) {
+    if (filename.endsWith('.' + ext)) {
+      return filename.slice(0, -(ext.length + 1))
+    }
+  }
+  // Fallback: strip last extension
+  return filename.replace(/\.[^.]+$/, '')
+}
+
+/**
  * Recursively parse directory for page URLs.
  */
 function parseUrlForPages(urlprefix: string, directory: string, extensions: string[] = DEFAULT_EXTENSIONS) {
@@ -23,12 +38,11 @@ function parseUrlForPages(urlprefix: string, directory: string, extensions: stri
   const res = []
   fsReadDirSyncCache[directory].forEach((dirent) => {
     if (extRegex.test(dirent.name)) {
-      if (/^index\./.test(dirent.name)) {
-        res.push(
-          `${urlprefix}${dirent.name.replace(/^index\..+$/, '')}`
-        )
+      const stripped = stripExtension(dirent.name, extensions)
+      if (stripped === 'index') {
+        res.push(`${urlprefix}`)
       }
-      res.push(`${urlprefix}${dirent.name.replace(/\..+$/, '')}`)
+      res.push(`${urlprefix}${stripped}`)
     } else {
       const dirPath = path.join(directory, dirent.name)
       if (dirent.isDirectory() && !dirent.isSymbolicLink()) {
@@ -50,10 +64,11 @@ function parseUrlForAppDir(urlprefix: string, directory: string, extensions: str
   const res = []
   fsReadDirSyncCache[directory].forEach((dirent) => {
     if (extRegex.test(dirent.name)) {
-      if (/^page\./.test(dirent.name)) {
-        res.push(`${urlprefix}${dirent.name.replace(/^page\..+$/, '')}`)
-      } else if (!/^layout\./.test(dirent.name)) {
-        res.push(`${urlprefix}${dirent.name.replace(/\..+$/, '')}`)
+      const stripped = stripExtension(dirent.name, extensions)
+      if (stripped === 'page') {
+        res.push(`${urlprefix}`)
+      } else if (stripped !== 'layout') {
+        res.push(`${urlprefix}${stripped}`)
       }
     } else {
       const dirPath = path.join(directory, dirent.name)

--- a/packages/eslint-plugin-next/src/utils/url.ts
+++ b/packages/eslint-plugin-next/src/utils/url.ts
@@ -5,28 +5,34 @@ import * as fs from 'fs'
 // Prevent multiple blocking IO requests that have already been calculated.
 const fsReadDirSyncCache = {}
 
+const DEFAULT_EXTENSIONS = ['tsx', 'ts', 'jsx', 'js']
+
+function buildExtensionsRegex(extensions: string[]) {
+  const escaped = extensions.map((ext) => ext.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+  return new RegExp(`\\.(${escaped.join('|')})$`)
+}
+
 /**
  * Recursively parse directory for page URLs.
  */
-function parseUrlForPages(urlprefix: string, directory: string) {
+function parseUrlForPages(urlprefix: string, directory: string, extensions: string[] = DEFAULT_EXTENSIONS) {
+  const extRegex = buildExtensionsRegex(extensions)
   fsReadDirSyncCache[directory] ??= fs.readdirSync(directory, {
     withFileTypes: true,
   })
   const res = []
   fsReadDirSyncCache[directory].forEach((dirent) => {
-    // TODO: this should account for all page extensions
-    // not just js(x) and ts(x)
-    if (/(\.(j|t)sx?)$/.test(dirent.name)) {
-      if (/^index(\.(j|t)sx?)$/.test(dirent.name)) {
+    if (extRegex.test(dirent.name)) {
+      if (/^index\./.test(dirent.name)) {
         res.push(
-          `${urlprefix}${dirent.name.replace(/^index(\.(j|t)sx?)$/, '')}`
+          `${urlprefix}${dirent.name.replace(/^index\..+$/, '')}`
         )
       }
-      res.push(`${urlprefix}${dirent.name.replace(/(\.(j|t)sx?)$/, '')}`)
+      res.push(`${urlprefix}${dirent.name.replace(/\..+$/, '')}`)
     } else {
       const dirPath = path.join(directory, dirent.name)
       if (dirent.isDirectory() && !dirent.isSymbolicLink()) {
-        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath))
+        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath, extensions))
       }
     }
   })
@@ -36,24 +42,23 @@ function parseUrlForPages(urlprefix: string, directory: string) {
 /**
  * Recursively parse app directory for URLs.
  */
-function parseUrlForAppDir(urlprefix: string, directory: string) {
+function parseUrlForAppDir(urlprefix: string, directory: string, extensions: string[] = DEFAULT_EXTENSIONS) {
+  const extRegex = buildExtensionsRegex(extensions)
   fsReadDirSyncCache[directory] ??= fs.readdirSync(directory, {
     withFileTypes: true,
   })
   const res = []
   fsReadDirSyncCache[directory].forEach((dirent) => {
-    // TODO: this should account for all page extensions
-    // not just js(x) and ts(x)
-    if (/(\.(j|t)sx?)$/.test(dirent.name)) {
-      if (/^page(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(`${urlprefix}${dirent.name.replace(/^page(\.(j|t)sx?)$/, '')}`)
-      } else if (!/^layout(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(`${urlprefix}${dirent.name.replace(/(\.(j|t)sx?)$/, '')}`)
+    if (extRegex.test(dirent.name)) {
+      if (/^page\./.test(dirent.name)) {
+        res.push(`${urlprefix}${dirent.name.replace(/^page\..+$/, '')}`)
+      } else if (!/^layout\./.test(dirent.name)) {
+        res.push(`${urlprefix}${dirent.name.replace(/\..+$/, '')}`)
       }
     } else {
       const dirPath = path.join(directory, dirent.name)
       if (dirent.isDirectory(dirPath) && !dirent.isSymbolicLink()) {
-        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath))
+        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath, extensions))
       }
     }
   })
@@ -136,13 +141,14 @@ export function normalizeAppPath(route: string) {
  */
 export function getUrlFromPagesDirectories(
   urlPrefix: string,
-  directories: string[]
+  directories: string[],
+  extensions: string[] = DEFAULT_EXTENSIONS
 ) {
   return Array.from(
     // De-duplicate similar pages across multiple directories.
     new Set(
       directories
-        .flatMap((directory) => parseUrlForPages(urlPrefix, directory))
+        .flatMap((directory) => parseUrlForPages(urlPrefix, directory, extensions))
         .map(
           // Since the URLs are normalized we add `^` and `$` to the RegExp to make sure they match exactly.
           (url) => `^${normalizeURL(url)}$`
@@ -156,13 +162,14 @@ export function getUrlFromPagesDirectories(
 
 export function getUrlFromAppDirectory(
   urlPrefix: string,
-  directories: string[]
+  directories: string[],
+  extensions: string[] = DEFAULT_EXTENSIONS
 ) {
   return Array.from(
     // De-duplicate similar pages across multiple directories.
     new Set(
       directories
-        .map((directory) => parseUrlForAppDir(urlPrefix, directory))
+        .map((directory) => parseUrlForAppDir(urlPrefix, directory, extensions))
         .flat()
         .map(
           // Since the URLs are normalized we add `^` and `$` to the RegExp to make sure they match exactly.


### PR DESCRIPTION
The `no-html-link-for-pages` ESLint rule hardcodes `.js(x)`/`.ts(x)` when scanning for page files, so pages using custom `pageExtensions` (like `.page.tsx`) are invisible to the rule.

This reads `pageExtensions` from `context.settings.next` and builds the file-matching regex from it. Also replaced the greedy `/\..+$/` strip (which turned `my.component.tsx` into `my`) with a `stripExtension()` helper that only removes the matched extension.

Fixes #53473
<!-- NEXT_JS_LLM_PR -->