### PR TITLE
chore: Pin actions-rust-lang/setup-rust-toolchain to SHA digest

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -9,7 +9,7 @@ runs:
   using: 'composite'
   steps:
     - name: 'Setup Rust toolchain'
-      uses: actions-rust-lang/setup-rust-toolchain@v1
+      uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1
       with:
         target: ${{ inputs.targets }}
         # needed to not make it override the defaults


### PR DESCRIPTION
Pin `actions-rust-lang/setup-rust-toolchain` from mutable tag `@v1` to immutable SHA `@150fca883cd4034361b621bd4e6a9d34e5143606` in `.github/actions/setup-rust/action.yml`, preventing supply chain attacks via tag hijacking. This was missed by #92016 which pinned 19 other actions.

## Recommendations

> These items require manual follow-up and are NOT included as code changes in this PR.

- [ ] **[MEDIUM] wasm-pack curl|sh** — `.github/workflows/build_and_deploy.yml:385` uses `curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh`. Consider replacing with a pinned install method when one becomes available.
- [ ] **[MEDIUM] npm install without lockfile** — `.github/workflows/pull_request_stats.yml:122` runs `npm install` in `.github/actions/next-stats-action/` which has no `package-lock.json`. Consider committing a lockfile and switching to `npm ci`.

<!-- NEXT_JS_LLM_PR -->