### PR TITLE
turbo-tasks: Drop output_dependent on immutable task completion

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
@@ -74,7 +74,13 @@ struct TaskStorageSchema {
 
     /// Tasks that depend on this task's output.
 
-    #[field(storage = "auto_set", category = "data", inline, filter_transient)]
+    #[field(
+        storage = "auto_set",
+        category = "data",
+        inline,
+        filter_transient,
+        drop_on_completion_if_immutable
+    )]
     output_dependent: AutoSet<TaskId>,
 
     /// The task's output value.

--- a/turbopack/crates/turbo-tasks-macros/src/derive/task_storage_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/derive/task_storage_macro.rs
@@ -537,6 +537,38 @@ fn parse_field_storage_attributes(field: &syn::Field) -> FieldInfo {
         }
     };
 
+    // Validate that shrink_on_completion and drop_on_completion_if_immutable are only used on
+    // collection types (auto_set, auto_map, counter_map) for inline fields.
+    // Lazy non-collection fields can still use drop_on_completion_if_immutable (removes from the
+    // lazy vec), but shrink_on_completion is meaningless for non-collection types.
+    let is_collection = matches!(
+        storage_type,
+        StorageType::AutoSet | StorageType::AutoMap | StorageType::CounterMap
+    );
+    if !is_collection {
+        if shrink_on_completion {
+            field_name
+                .span()
+                .unwrap()
+                .error(format!(
+                    "`shrink_on_completion` on field `{field_name}` has no effect: only \
+                     collection types (auto_set, auto_map, counter_map) support shrinking"
+                ))
+                .emit();
+        }
+        if inline && drop_on_completion_if_immutable {
+            field_name
+                .span()
+                .unwrap()
+                .error(format!(
+                    "`drop_on_completion_if_immutable` on inline field `{field_name}` has no \
+                     effect: only inline collection types (auto_set, auto_map, counter_map) \
+                     support dropping"
+                ))
+                .emit();
+        }
+    }
+
     FieldInfo {
         is_pub,
         field_name,

--- a/turbopack/crates/turbo-tasks-macros/src/derive/task_storage_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/derive/task_storage_macro.rs
@@ -2474,46 +2474,36 @@ fn generate_automap_ops(field: &FieldInfo) -> TokenStream {
 /// 4. For fields with `shrink_on_completion`: shrink or remove if empty
 /// 5. For fields with `drop_on_completion_if_immutable` when task is immutable: remove
 fn generate_cleanup_after_execution(grouped_fields: &GroupedFields) -> TokenStream {
-    // Generate cleanup calls for inline collection fields
+    // Generate cleanup calls for inline collection fields.
+    // Invalid attribute combinations (e.g. shrink/drop on non-collection fields) are rejected
+    // during parsing, so we can generate code unconditionally here.
     let mut inline_cleanups = Vec::new();
     for field in grouped_fields.all_inline() {
         if field.is_flag() {
             continue;
         }
-        let shrink = field.shrink_on_completion;
-        let drop_if_immutable = field.drop_on_completion_if_immutable;
-        if !shrink && !drop_if_immutable {
-            continue;
-        }
-        // Only collection types can be shrunk/dropped
-        let is_collection = matches!(
-            field.storage_type,
-            StorageType::AutoSet | StorageType::AutoMap | StorageType::CounterMap
-        );
-        if is_collection {
-            let field_name = &field.field_name;
-            let cleanup = match (shrink, drop_if_immutable) {
-                (_, true) => quote! {
-                    if is_immutable {
-                        typed.#field_name = Default::default();
-                    } else {
-                        typed.#field_name.shrink_to_fit();
-                    }
-                },
-                (true, false) => quote! {
+        let field_name = &field.field_name;
+        if field.drop_on_completion_if_immutable {
+            inline_cleanups.push(quote! {
+                if is_immutable {
+                    typed.#field_name = Default::default();
+                } else {
                     typed.#field_name.shrink_to_fit();
-                },
-                (false, false) => unreachable!(),
-            };
-            inline_cleanups.push(cleanup);
+                }
+            });
+        } else if field.shrink_on_completion {
+            inline_cleanups.push(quote! {
+                typed.#field_name.shrink_to_fit();
+            });
         }
     }
 
     // Generate match arms for lazy fields that have cleanup attributes
     let mut match_arms = Vec::new();
 
+    // Invalid attribute combinations (e.g. shrink on non-collection fields) are rejected
+    // during parsing, so we can simplify the match here.
     for field in grouped_fields.all_lazy() {
-        // Skip flags - they're in the bitfield, not the lazy vec
         if field.is_flag() {
             continue;
         }
@@ -2522,57 +2512,45 @@ fn generate_cleanup_after_execution(grouped_fields: &GroupedFields) -> TokenStre
         let shrink = field.shrink_on_completion;
         let drop_if_immutable = field.drop_on_completion_if_immutable;
 
-        // Skip fields with no cleanup attributes
         if !shrink && !drop_if_immutable {
             continue;
         }
 
-        // Determine whether this is a collection type that can be shrunk
         let is_collection = matches!(
             field.storage_type,
             StorageType::AutoSet | StorageType::AutoMap | StorageType::CounterMap
         );
 
         // Each arm returns bool: true = keep, false = remove
-        let arm_body = match (shrink, drop_if_immutable, is_collection) {
-            // shrink_on_completion + drop_on_completion_if_immutable + collection
-            (true, true, true) => quote! {
+        let arm_body = if drop_if_immutable && shrink && is_collection {
+            // Drop for immutable, shrink or remove-if-empty for mutable
+            quote! {
                 if is_immutable {
-                    false // drop for immutable tasks
+                    false
                 } else if c.is_empty() {
-                    false // remove empty
+                    false
                 } else {
                     c.shrink_to_fit();
-                    true // keep
+                    true
                 }
-            },
-            // shrink_on_completion only + collection
-            (true, false, true) => quote! {
+            }
+        } else if shrink && is_collection {
+            // Shrink or remove-if-empty
+            quote! {
                 if c.is_empty() {
-                    false // remove empty
+                    false
                 } else {
                     c.shrink_to_fit();
-                    true // keep
+                    true
                 }
-            },
-            // drop_on_completion_if_immutable only + collection
-            (false, true, true) => quote! {
-                !is_immutable // keep if mutable, drop if immutable
-            },
-            // shrink_on_completion + drop_on_completion_if_immutable + direct value
-            (true, true, false) => quote! {
-                !is_immutable // keep if mutable, drop if immutable
-            },
-            // shrink_on_completion only + direct value (unusual but handle it)
-            (true, false, false) => quote! {
-                true // keep (direct values don't need shrinking)
-            },
-            // drop_on_completion_if_immutable only + direct value
-            (false, true, false) => quote! {
-                !is_immutable // keep if mutable, drop if immutable
-            },
-            // No attributes (shouldn't reach here due to continue above)
-            (false, false, _) => unreachable!(),
+            }
+        } else if drop_if_immutable {
+            // Drop for immutable (works for both collection and direct values)
+            quote! {
+                !is_immutable
+            }
+        } else {
+            continue;
         };
 
         match_arms.push(quote! {

--- a/turbopack/crates/turbo-tasks-macros/src/derive/task_storage_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/derive/task_storage_macro.rs
@@ -2442,25 +2442,38 @@ fn generate_automap_ops(field: &FieldInfo) -> TokenStream {
 /// 4. For fields with `shrink_on_completion`: shrink or remove if empty
 /// 5. For fields with `drop_on_completion_if_immutable` when task is immutable: remove
 fn generate_cleanup_after_execution(grouped_fields: &GroupedFields) -> TokenStream {
-    // Generate shrink calls for inline collection fields with shrink_on_completion
-    let mut inline_shrinks = Vec::new();
+    // Generate cleanup calls for inline collection fields
+    let mut inline_cleanups = Vec::new();
     for field in grouped_fields.all_inline() {
         if field.is_flag() {
             continue;
         }
-        if !field.shrink_on_completion {
+        let shrink = field.shrink_on_completion;
+        let drop_if_immutable = field.drop_on_completion_if_immutable;
+        if !shrink && !drop_if_immutable {
             continue;
         }
-        // Only collection types can be shrunk
+        // Only collection types can be shrunk/dropped
         let is_collection = matches!(
             field.storage_type,
             StorageType::AutoSet | StorageType::AutoMap | StorageType::CounterMap
         );
         if is_collection {
             let field_name = &field.field_name;
-            inline_shrinks.push(quote! {
-                typed.#field_name.shrink_to_fit();
-            });
+            let cleanup = match (shrink, drop_if_immutable) {
+                (_, true) => quote! {
+                    if is_immutable {
+                        typed.#field_name = Default::default();
+                    } else {
+                        typed.#field_name.shrink_to_fit();
+                    }
+                },
+                (true, false) => quote! {
+                    typed.#field_name.shrink_to_fit();
+                },
+                (false, false) => unreachable!(),
+            };
+            inline_cleanups.push(cleanup);
         }
     }
 
@@ -2551,8 +2564,8 @@ fn generate_cleanup_after_execution(grouped_fields: &GroupedFields) -> TokenStre
             let typed = self.typed_mut();
             let is_immutable = typed.flags.immutable();
 
-            // Shrink inline collection fields (always present, not in lazy vec)
-            #(#inline_shrinks)*
+            // Clean up inline collection fields (always present, not in lazy vec)
+            #(#inline_cleanups)*
 
             // swap_retain pattern: iterate with manual index, swap_remove to delete
             let mut i = 0;


### PR DESCRIPTION
### What?

Extend the `cleanup_after_execution` macro codegen to support `drop_on_completion_if_immutable` on **inline** collection fields (previously only lazy fields were supported), and apply it to `output_dependent` in the task storage schema.

### Why?

`output_dependent` tracks which tasks depend on a given task's output, used for invalidation and leaf distance propagation. For immutable tasks:

- **No invalidation needed** — the output never changes, so dependents never need to be dirtied via this edge.
- **No new readers added** — `try_read_task_output` already guards with `!task.immutable()` at `mod.rs:742`, so the set is frozen after completion.
- **Leaf distance propagation** — immutable tasks can be treated as non-participants in the leaf distance graph; propagation simply stops at immutable nodes.

This matches the existing treatment of `cell_dependents`, which already has `drop_on_completion_if_immutable` for the same reasons (immutable tasks' cells don't change).

### How?

**Macro change** (`turbo-tasks-macros/src/derive/task_storage_macro.rs`):

The `generate_cleanup_after_execution` function previously only handled `shrink_on_completion` for inline fields. Now it also handles `drop_on_completion_if_immutable`: when the task is immutable, it emits `typed.field_name = Default::default()` which replaces the `AutoSet` with an empty one, releasing any heap allocation (`Box<HashMap>` or spilled `SmallVec` buffer). When mutable, it falls back to `shrink_to_fit()`.

Note: unlike lazy fields which are physically removed from `Vec<LazyField>`, inline fields always occupy their struct slot — but `Default::default()` ensures zero heap overhead (the `SmallVec<[_; 1]>` reverts to inline storage).

**Schema change** (`turbo-tasks-backend/src/backend/storage_schema.rs`):

Added `drop_on_completion_if_immutable` to the `#[field(...)]` attribute on `output_dependent`.

<!-- NEXT_JS_LLM_PR -->