### PR TITLE
Turbopack: add extension alias config option to match alternate file extensions

### DIFF
--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -26,7 +26,10 @@ use turbopack_core::{
     issue::{
         IgnoreIssue, IgnoreIssuePattern, Issue, IssueExt, IssueSeverity, IssueStage, StyledString,
     },
-    resolve::ResolveAliasMap,
+    resolve::{
+        ResolveAliasMap,
+        options::{ImportMap, ImportMapping},
+    },
 };
 use turbopack_ecmascript::{OptionTreeShaking, TreeShakingMode};
 use turbopack_ecmascript_plugins::transform::{
@@ -613,6 +616,8 @@ pub struct TurbopackConfig {
     #[bincode(with = "turbo_bincode::serde_self_describing")]
     pub resolve_alias: Option<FxIndexMap<RcStr, JsonValue>>,
     pub resolve_extensions: Option<Vec<RcStr>>,
+    #[bincode(with = "turbo_bincode::serde_self_describing")]
+    pub resolve_extension_alias: Option<FxIndexMap<RcStr, Vec<RcStr>>>,
     pub debug_ids: Option<bool>,
     /// Issue patterns to ignore (suppress) from Turbopack output.
     #[serde(default)]
@@ -1791,6 +1796,50 @@ impl NextConfig {
         };
         let alias_map: ResolveAliasMap = resolve_alias.try_into()?;
         Ok(alias_map.cell())
+    }
+
+    #[turbo_tasks::function]
+    pub fn resolve_extension_alias_import_map(&self) -> Vc<ImportMap> {
+        let Some(ext_alias) = self
+            .turbopack
+            .as_ref()
+            .and_then(|t| t.resolve_extension_alias.as_ref())
+        else {
+            return ImportMap::empty().cell();
+        };
+
+        let mut import_map = ImportMap::empty();
+        for (ext, alternatives) in ext_alias {
+            // The import map lookup separates requests by prefix type:
+            // - "./" relative paths only match aliases with "./" prefix
+            // - "../" relative paths only match aliases with "../" prefix
+            // - bare specifiers match aliases without a relative prefix
+            //
+            // The wildcard capture strips the prefix, so each template must
+            // re-include the prefix to produce a valid request.
+            for prefix in &["./", "../", ""] {
+                let mappings: Vec<_> = alternatives
+                    .iter()
+                    .map(|alt_ext| {
+                        ImportMapping::PrimaryAlternative(
+                            format!("{prefix}*{alt_ext}").into(),
+                            None,
+                        )
+                        .resolved_cell()
+                    })
+                    .collect();
+
+                let mapping = if mappings.len() == 1 {
+                    mappings.into_iter().next().unwrap()
+                } else {
+                    ImportMapping::Alternatives(mappings).resolved_cell()
+                };
+
+                import_map.insert_wildcard_alias_with_suffix(*prefix, ext.as_str(), mapping);
+            }
+        }
+
+        import_map.cell()
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_import_map.rs
+++ b/crates/next-core/src/next_import_map.rs
@@ -71,6 +71,8 @@ pub async fn get_next_client_import_map(
     )
     .await?;
 
+    insert_extension_alias_option(&mut import_map, next_config).await?;
+
     match &ty {
         ClientContextType::Pages { .. } => {
             // Resolve next/error to the ESM entry point so the bundler can
@@ -295,6 +297,8 @@ pub async fn get_next_server_import_map(
     )
     .await?;
 
+    insert_extension_alias_option(&mut import_map, next_config).await?;
+
     let external = ImportMapping::External(None, ExternalType::CommonJs, ExternalTraced::Traced)
         .resolved_cell();
 
@@ -441,6 +445,8 @@ pub async fn get_next_edge_import_map(
         [],
     )
     .await?;
+
+    insert_extension_alias_option(&mut import_map, next_config).await?;
 
     match &ty {
         ServerContextType::Pages { .. }
@@ -1294,6 +1300,15 @@ pub async fn insert_alias_option<const N: usize>(
             import_map.insert_alias(alias, mapping);
         }
     }
+    Ok(())
+}
+
+pub async fn insert_extension_alias_option(
+    import_map: &mut ImportMap,
+    next_config: Vc<NextConfig>,
+) -> Result<()> {
+    let ext_alias_map = next_config.resolve_extension_alias_import_map().await?;
+    import_map.extend_ref(&ext_alias_map);
     Ok(())
 }
 

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopack.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopack.mdx
@@ -44,13 +44,14 @@ module.exports = nextConfig
 
 The following options are available for the `turbopack` configuration:
 
-| Option              | Description                                                                                                                              |
-| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `root`              | Sets the application root directory. Should be an absolute path.                                                                         |
-| `rules`             | List of supported webpack loaders to apply when running with Turbopack.                                                                  |
-| `resolveAlias`      | Map aliased imports to modules to load in their place.                                                                                   |
-| `resolveExtensions` | List of extensions to resolve when importing files.                                                                                      |
-| `debugIds`          | Enable generation of [debug IDs](https://github.com/tc39/ecma426/blob/main/proposals/debug-id.md) in JavaScript bundles and source maps. |
+| Option                  | Description                                                                                                                              |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `root`                  | Sets the application root directory. Should be an absolute path.                                                                         |
+| `rules`                 | List of supported webpack loaders to apply when running with Turbopack.                                                                  |
+| `resolveAlias`          | Map aliased imports to modules to load in their place.                                                                                   |
+| `resolveExtensions`     | List of extensions to resolve when importing files.                                                                                      |
+| `resolveExtensionAlias` | Map file extensions to alternative extensions to try during module resolution.                                                           |
+| `debugIds`              | Enable generation of [debug IDs](https://github.com/tc39/ecma426/blob/main/proposals/debug-id.md) in JavaScript bundles and source maps. |
 
 ### Supported loaders
 
@@ -365,6 +366,27 @@ module.exports = {
 ```
 
 This overwrites the original resolve extensions with the provided list. Make sure to include the default extensions.
+
+### Resolving extension aliases
+
+Turbopack can be configured to map file extensions to alternative extensions during module resolution, similar to webpack's [`resolve.extensionAlias`](https://webpack.js.org/configuration/resolve/#resolveextensionalias) configuration.
+
+To configure extension aliases, use the `resolveExtensionAlias` field in `next.config.js`:
+
+```js filename="next.config.js"
+module.exports = {
+  turbopack: {
+    resolveExtensionAlias: {
+      '.js': ['.ts', '.tsx', '.js'],
+      '.mjs': ['.mts', '.mjs'],
+    },
+  },
+}
+```
+
+This configures Turbopack to try alternative extensions when resolving imports that end with the specified extension. For example, an import of `./myfile.js` will first try to resolve `./myfile.ts`, then `./myfile.tsx`, and finally `./myfile.js`.
+
+This is useful when writing TypeScript code that uses `.js` extensions in imports, which is required for ESM compatibility with Node.js module resolution.
 
 For more information and guidance for how to migrate your app to Turbopack from webpack, see [Turbopack's documentation on webpack compatibility](https://turbo.build/pack/docs/migrating-from-webpack).
 

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -174,6 +174,7 @@ const zTurbopackConfig: zod.ZodType<TurbopackOptions> = z.strictObject({
     )
     .optional(),
   resolveExtensions: z.array(z.string()).optional(),
+  resolveExtensionAlias: z.record(z.string(), z.array(z.string())).optional(),
   root: z.string().optional(),
   debugIds: z.boolean().optional(),
   ignoreIssue: z

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -210,6 +210,26 @@ export interface TurbopackOptions {
   resolveExtensions?: string[]
 
   /**
+   * (`next --turbopack` only) A mapping of file extensions to alternative
+   * extensions to try during module resolution. Similar to webpack's
+   * `resolve.extensionAlias`.
+   *
+   * @example
+   * ```js
+   * // next.config.js
+   * module.exports = {
+   *   turbopack: {
+   *     resolveExtensionAlias: {
+   *       '.js': ['.ts', '.tsx', '.js'],
+   *       '.mjs': ['.mts', '.mjs'],
+   *     },
+   *   },
+   * }
+   * ```
+   */
+  resolveExtensionAlias?: Record<string, string[]>
+
+  /**
    * (`next --turbopack` only) A list of webpack loaders to apply when running with Turbopack.
    *
    * @see [Turbopack Loaders](https://nextjs.org/docs/app/api-reference/config/next-config-js/turbopack#configuring-webpack-loaders)

--- a/test/e2e/turbopack-resolve-extension-alias/app/layout.tsx
+++ b/test/e2e/turbopack-resolve-extension-alias/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/turbopack-resolve-extension-alias/app/nested/page.tsx
+++ b/test/e2e/turbopack-resolve-extension-alias/app/nested/page.tsx
@@ -1,0 +1,6 @@
+// ../../lib/helper.js exercises the double-parent ("../../") prefix path
+import { add } from '../../lib/helper.js'
+
+export default function NestedPage() {
+  return <p id="nested-sum">{add(10, 20)}</p>
+}

--- a/test/e2e/turbopack-resolve-extension-alias/app/page.tsx
+++ b/test/e2e/turbopack-resolve-extension-alias/app/page.tsx
@@ -1,0 +1,17 @@
+// ../lib/* exercises the single-parent ("../") prefix path
+import { Greeting } from '../lib/greeting.js'
+import { add } from '../lib/helper.js'
+import { PLAIN_VALUE } from '../lib/plain.js'
+// ./same-dir-util.js exercises the same-directory ("./") prefix path
+import { SAME_DIR } from './same-dir-util.js'
+
+export default function Page() {
+  return (
+    <div>
+      <Greeting />
+      <p id="sum">{add(1, 2)}</p>
+      <p id="plain">{PLAIN_VALUE}</p>
+      <p id="same-dir">{SAME_DIR}</p>
+    </div>
+  )
+}

--- a/test/e2e/turbopack-resolve-extension-alias/app/same-dir-util.ts
+++ b/test/e2e/turbopack-resolve-extension-alias/app/same-dir-util.ts
@@ -1,0 +1,1 @@
+export const SAME_DIR = 'same-dir-works'

--- a/test/e2e/turbopack-resolve-extension-alias/lib/greeting.tsx
+++ b/test/e2e/turbopack-resolve-extension-alias/lib/greeting.tsx
@@ -1,0 +1,3 @@
+export function Greeting() {
+  return <p id="greeting">Hello from TSX</p>
+}

--- a/test/e2e/turbopack-resolve-extension-alias/lib/helper.ts
+++ b/test/e2e/turbopack-resolve-extension-alias/lib/helper.ts
@@ -1,0 +1,3 @@
+export function add(a: number, b: number): number {
+  return a + b
+}

--- a/test/e2e/turbopack-resolve-extension-alias/lib/plain.js
+++ b/test/e2e/turbopack-resolve-extension-alias/lib/plain.js
@@ -1,0 +1,1 @@
+export const PLAIN_VALUE = 'from-plain-js'

--- a/test/e2e/turbopack-resolve-extension-alias/next.config.js
+++ b/test/e2e/turbopack-resolve-extension-alias/next.config.js
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+module.exports = {
+  turbopack: {
+    resolveExtensionAlias: {
+      '.js': ['.ts', '.tsx', '.js'],
+    },
+  },
+}

--- a/test/e2e/turbopack-resolve-extension-alias/turbopack-resolve-extension-alias.test.ts
+++ b/test/e2e/turbopack-resolve-extension-alias/turbopack-resolve-extension-alias.test.ts
@@ -1,17 +1,15 @@
 import { nextTestSetup } from 'e2e-utils'
 
-describe('turbopack resolve extension alias', () => {
-  const { next, isTurbopack, skipped } = nextTestSetup({
+// resolveExtensionAlias is a Turbopack-only feature; skip under webpack
+const testFn = process.env.IS_WEBPACK_TEST ? describe.skip : describe
+
+testFn('turbopack resolve extension alias', () => {
+  const { next, skipped } = nextTestSetup({
     files: __dirname,
     skipDeployment: true,
   })
 
   if (skipped) {
-    return
-  }
-
-  if (!isTurbopack) {
-    it('should only run the test in turbopack', () => {})
     return
   }
 

--- a/test/e2e/turbopack-resolve-extension-alias/turbopack-resolve-extension-alias.test.ts
+++ b/test/e2e/turbopack-resolve-extension-alias/turbopack-resolve-extension-alias.test.ts
@@ -1,0 +1,36 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('turbopack resolve extension alias', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should resolve .js import to .tsx file via ../', async () => {
+    const browser = await next.browser('/')
+    expect(await browser.elementByCss('#greeting').text()).toBe(
+      'Hello from TSX'
+    )
+  })
+
+  it('should resolve .js import to .ts file via ../', async () => {
+    const browser = await next.browser('/')
+    expect(await browser.elementByCss('#sum').text()).toBe('3')
+  })
+
+  it('should resolve .js import to actual .js file via ../', async () => {
+    const browser = await next.browser('/')
+    expect(await browser.elementByCss('#plain').text()).toBe('from-plain-js')
+  })
+
+  it('should resolve .js import to .ts file via ./', async () => {
+    const browser = await next.browser('/')
+    expect(await browser.elementByCss('#same-dir').text()).toBe(
+      'same-dir-works'
+    )
+  })
+
+  it('should resolve .js import to .ts file via ../../', async () => {
+    const browser = await next.browser('/nested')
+    expect(await browser.elementByCss('#nested-sum').text()).toBe('30')
+  })
+})

--- a/test/e2e/turbopack-resolve-extension-alias/turbopack-resolve-extension-alias.test.ts
+++ b/test/e2e/turbopack-resolve-extension-alias/turbopack-resolve-extension-alias.test.ts
@@ -1,9 +1,19 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('turbopack resolve extension alias', () => {
-  const { next } = nextTestSetup({
+  const { next, isTurbopack, skipped } = nextTestSetup({
     files: __dirname,
+    skipDeployment: true,
   })
+
+  if (skipped) {
+    return
+  }
+
+  if (!isTurbopack) {
+    it('should only run the test in turbopack', () => {})
+    return
+  }
 
   it('should resolve .js import to .tsx file via ../', async () => {
     const browser = await next.browser('/')


### PR DESCRIPTION
Fixes #82945
Closes PACK-5449

Adds a config option that can resolve extensions with other optional extensions, matching the behavior of Webpack's [`resolve.extensionAlias`](https://webpack.js.org/configuration/resolve/#resolveextensionalias):

```js filename="next.config.js"
module.exports = {
  turbopack: {
    resolveExtensionAlias: {
      // checks for .ts first, then .tsx, and finally .js
      '.js': ['.ts', '.tsx', '.js'],
      // checks for .mts first, then .mjs
      '.mjs': ['.mts', '.mjs'],
    },
  },
}
```

TypeScript with ESM sets the expectation that you don't transform the import, so it wants to import from the compiled `.js` file. This breaks down in Next if you have code that's shared between a Node.js server and your Next app.

Most of the pieces were already in place because of other direct aliasing options for Turbopack (`resolveAlias`). I did have to match 3 different prefixes (`""`, `"./"`, `"../"`) to cover all potential paths. This could be considered leaking internal implementation details from `ImportMap::lookup`...

There's a new E2E test exercising this functionality.

I've looked at this a few different ways for perf concerns. Yes we're adding some wildcard matching, but I think the only new computation is at config/setup time, in a hopefully-cached turbo task.

Finally, I have identified one limitation: When the option is used, some dynamic imports with >4 sections will be too complex to match. This is already an issue with existing alias code. It will trigger a hard error with a "Complex patterns into wildcard exports fields are not implemented" message. Since this doesn't add errors if the option isn't leveraged, we should consider
1) finding a way to surface a better error message in alias-specific code
2) documenting the limitations / error in the alias option docs