### PR TITLE
fix: return 405 for POST to auto-exported pages in dev (#38863)

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2252,6 +2252,21 @@ export default abstract class Server<
       res.statusCode = parseInt(pathname.slice(1), 10)
     }
 
+    // In development, `isSSG` is not inferred from the prerender manifest the
+    // same way as in production, so auto-exported pages (no data hooks) were
+    // incorrectly accepting non-GET/HEAD document requests. Treat those like
+    // static pages and respond with 405 to match `next start`.
+    const defaultAppGetInitialProps =
+      components.App.getInitialProps ===
+      (components.App as any).origGetInitialProps
+    const hasPageGetInitialProps = !!(components.Component as any)?.getInitialProps
+    const isAutoExport =
+      !isAppPath &&
+      !hasPageGetInitialProps &&
+      defaultAppGetInitialProps &&
+      !isSSG &&
+      !hasServerProps
+
     if (
       // Server actions can use non-GET/HEAD methods.
       !isPossibleServerAction &&
@@ -2262,7 +2277,7 @@ export default abstract class Server<
       pathname !== '/_error' &&
       req.method !== 'HEAD' &&
       req.method !== 'GET' &&
-      (typeof components.Component === 'string' || isSSG)
+      (typeof components.Component === 'string' || isSSG || isAutoExport)
     ) {
       res.statusCode = 405
       res.setHeader('Allow', ['GET', 'HEAD'])

--- a/test/e2e/prerender.test.ts
+++ b/test/e2e/prerender.test.ts
@@ -572,6 +572,17 @@ describe('Prerender', () => {
       }
     })
 
+    it('should respond with 405 for POST to auto-exported page', async () => {
+      const res = await fetchViaHTTP(next.url, '/normal', undefined, {
+        method: 'POST',
+      })
+      expect(res.status).toBe(405)
+
+      if (!isDeploy) {
+        expect(await res.text()).toContain('Method Not Allowed')
+      }
+    })
+
     it('should SSR normal page correctly', async () => {
       const html = await renderViaHTTP(next.url, '/')
       expect(html).toMatch(/hello.*?world/)


### PR DESCRIPTION
## Summary
Fixes **#38863** (good first issue): `next dev` was accepting POST (and other non-GET/HEAD) requests to pages-router **auto-exported** routes and responding with 200, while `next start` correctly returned **405 Method Not Allowed**. That happened because the existing method guard only ran when the page was treated as SSG or served as a static string component; in development the SSG signal from the prerender manifest is not applied the same way, so plain auto-export pages slipped through.

## What changed
- **`base-server.ts`**: Before the existing non-GET/HEAD guard, detect **auto-export** pages (Pages Router, default App `getInitialProps`, no page `getInitialProps`, no `getStaticProps` / `getServerSideProps`) and treat them like static targets for this check.
- **`prerender.test.ts`**: Add an e2e assertion that `POST /normal` returns 405 in the prerender suite (alongside the existing POST `/` case).

## How to verify
```bash
pnpm test-dev-turbo test/e2e/prerender.test.ts -t "405 for POST"
```

## Notes
- **Not UI-related** — no screenshots or video.
- **Files touched**: 2 (`packages/next/src/server/base-server.ts`, `test/e2e/prerender.test.ts`).

Made with [Cursor](https://cursor.com)