### PR TITLE
fix: safely parse Origin header to prevent DoS vulnerability in Server Actions

### DIFF
--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -77,6 +77,33 @@ import {
 const INLINE_ACTION_PREFIX = '$$RSC_SERVER_ACTION_'
 
 /**
+ * Safely parses Origin header to extract host.
+ * Returns a sentinel value for malformed origins to prevent CSRF bypass.
+ *
+ * This fixes a DoS vulnerability where malformed Origin headers
+ * (e.g., "http://", "ftp://", "not-a-url") cause unhandled TypeError.
+ *
+ * @see https://github.com/vercel/next.js/issues/92703
+ */
+function parseOriginHostSafely(originHeader: string): string | undefined {
+  // Browsers send "null" from sandboxed iframes, data: URLs, file: origins
+  if (originHeader === 'null') {
+    return 'null';
+  }
+
+  try {
+    // Valid URL - extract host
+    return new URL(originHeader).host;
+  } catch {
+    // Malformed URL - return sentinel value that will never match a valid host
+    // IMPORTANT: Must NOT return undefined/null - that would skip CSRF validation
+    // and introduce a CSRF bypass (CVE-2026-27977/CVE-2026-27978)
+    // This sentinel value is guaranteed to fail the host comparison later
+    return '\x00INVALID_ORIGIN';
+  }
+}
+
+/**
  * Checks if the app has any server actions defined in any runtime.
  */
 function hasServerActions() {
@@ -619,13 +646,9 @@ export async function handleAction({
   const originHeader = req.headers['origin']
   const originHost =
     typeof originHeader === 'string'
-      ? // 'null' is a valid origin e.g. from privacy-sensitive contexts like sandboxed iframes.
-        // However, these contexts can still send along credentials like cookies,
-        // so we need to check if they're allowed cross-origin requests.
-        originHeader === 'null'
-        ? 'null'
-        : new URL(originHeader).host
+      ? parseOriginHostSafely(originHeader)
       : undefined
+
   const host = parseHostHeader(req.headers)
 
   let warning: string | undefined = undefined


### PR DESCRIPTION
## 🔒 Security Fix: DoS Vulnerability in Server Actions

### Problem
When a request with a malformed Origin header (e.g., `Origin: http://`, `Origin: ftp://`, `Origin: not-a-url`) is sent to any page with a Server Action, the following happens:

1. `new URL(originHeader).host` throws `TypeError: Invalid URL`
2. The exception is **uncaught** - no try-catch around it
3. Propagates through `handleAction()` → `renderToHTMLOrFlightImpl` → base-server error handler
4. Server responds with **HTTP 500 Internal Server Error**
5. The Server Action is never executed
6. **An attacker can cause continuous 500 errors (Denial of Service)**

### Root Cause
```typescript
// Before (VULNERABLE):
const originHost = new URL(originHeader).host  // ❌ No try-catch!
```

### Solution
Added `parseOriginHostSafely()` helper function:

```typescript
function parseOriginHostSafely(originHeader: string): string | undefined {
  if (originHeader === 'null') return 'null';
  try {
    return new URL(originHeader).host;
  } catch {
    // IMPORTANT: Must NOT return undefined/null - that would skip CSRF validation!
    return '\x00INVALID_ORIGIN';
  }
}
```

### Why This Matters
| Return Value | CSRF Validation | Result |
|--------------|-----------------|--------|
| `undefined` / `null` | ❌ Bypassed | **CSRF Vulnerability** |
| `'\x00INVALID_ORIGIN'` | ✅ Still checked | **Safe** |

### Testing Performed
Using the provided PoC (https://github.com/FJRG2007/nextjs-sa-dos-poc-20260413):

| Test Case | Before | After |
|-----------|--------|-------|
| `Origin: http://` | ❌ HTTP 500 (crash) | ✅ No crash, proper error |
| `Origin: ftp://` | ❌ HTTP 500 (crash) | ✅ No crash, proper error |
| `Origin: not-a-url` | ❌ HTTP 500 (crash) | ✅ No crash, proper error |
| `Origin: null` | ✅ Works (sandboxed iframes) | ✅ Works (preserved) |
| Valid Origin | ✅ Works | ✅ Works |

### Impact
- ✅ **DoS vulnerability fixed** - malformed headers no longer crash the server
- ✅ **CSRF protection intact** - sentinel value doesn't bypass validation
- ✅ **Backward compatible** - valid origins work exactly as before
- ✅ **Sandboxed iframes preserved** - `Origin: null` handling unchanged

### Files Changed
- `packages/next/src/server/app-render/action-handler.ts` (+29, -6)

### Related Issue
Fixes #92703

### Type of Change
- [x] 🔒 Security fix
- [x] 🐛 Bug fix

### Checklist
- [x] My code follows the code style
- [x] I have tested my changes
- [x] I have added comments explaining my changes
- [x] I have fixed a real security vulnerability