### PR TITLE
chore: Bump reqwest to 0.13.2 (Fixes Google Fonts with Turbopack for Windows on ARM64)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6477,9 +6477,9 @@ checksum = "e3a8614ee435691de62bcffcf4a66d91b3594bf1428a5722e79103249a095690"
 
 [[package]]
 name = "reqwest"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04e9018c9d814e5f30cc16a0f03271aeab3571e609612d9fe78c1aa8d11c2f62"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
  "base64 0.22.1",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -320,7 +320,7 @@ rand = "0.10.0"
 rayon = "1.10.0"
 regex = "1.10.6"
 regress = "0.10.4"
-reqwest = { version = "0.13.1", default-features = false }
+reqwest = { version = "0.13.2", default-features = false }
 ringmap = "0.2.3"
 roaring = "0.10.10"
 rstest = "0.16.0"


### PR DESCRIPTION
Fixes #91653

Running `next dev` with the latest Turbopack fails to fetch fonts on Windows ARM machines, resulting in an `http2 feature is not enabled` error. This issue was fixed in `reqwest` v0.13.2: https://github.com/seanmonstar/reqwest/pull/2927