### PR TITLE
docs: clarify that content outside Suspense must be cacheable or static

### DIFF
--- a/errors/next-prerender-crypto.mdx
+++ b/errors/next-prerender-crypto.mdx
@@ -12,7 +12,7 @@ If the random crypto value is appropriate to be prerendered and prefetched consi
 
 If the random crypto value is intended to be generated on every user request consider whether an async API exists that achieves the same result. If not consider whether you can move the random crypto value generation later, behind other existing uncached data or Request data access. If there is no way to do this you can always precede the random crypto value generation with Request data access by using `await connection()`.
 
-> **Note**: Suspense fallbacks and skeleton components are part of the prerendered static shell. If a skeleton component uses `crypto.randomUUID()` or similar (e.g., for generating placeholder keys), it will trigger this error. Use deterministic values for loading placeholders instead.
+> **Note**: Any content that is not wrapped in a `<Suspense>` boundary must be cacheable or static. This includes Suspense fallbacks themselves — a fallback that calls `crypto.randomUUID()` will trigger this error unless there is another `<Suspense>` boundary above it. Use cached values or wrap the component in `<Suspense>` to fix it.
 
 ### Cache the token value
 

--- a/errors/next-prerender-crypto.mdx
+++ b/errors/next-prerender-crypto.mdx
@@ -27,7 +27,7 @@ async function getCachedData(token: string) {
 }
 
 export default async function Page() {
-  const token = crypto.getRandomUUID()
+  const token = crypto.randomUUID()
   const data = await getCachedData(token);
   return ...
 }
@@ -38,7 +38,7 @@ After:
 ```jsx filename="app/page.js"
 async function getCachedData() {
   "use cache"
-  const token = crypto.getRandomUUID()
+  const token = crypto.randomUUID()
   return db.query(token, ...)
 }
 

--- a/errors/next-prerender-crypto.mdx
+++ b/errors/next-prerender-crypto.mdx
@@ -12,6 +12,8 @@ If the random crypto value is appropriate to be prerendered and prefetched consi
 
 If the random crypto value is intended to be generated on every user request consider whether an async API exists that achieves the same result. If not consider whether you can move the random crypto value generation later, behind other existing uncached data or Request data access. If there is no way to do this you can always precede the random crypto value generation with Request data access by using `await connection()`.
 
+> **Note**: Suspense fallbacks and skeleton components are part of the prerendered static shell. If a skeleton component uses `crypto.randomUUID()` or similar (e.g., for generating placeholder keys), it will trigger this error. Use deterministic values for loading placeholders instead.
+
 ### Cache the token value
 
 If you are generating a token to talk to a database that itself should be cached move the token generation inside the `"use cache"`.

--- a/errors/next-prerender-current-time.mdx
+++ b/errors/next-prerender-current-time.mdx
@@ -14,7 +14,7 @@ If the current time is appropriate to be prerendered and prefetched consider mov
 
 If the current time is intended to be accessed dynamically on every user request first consider whether it is more appropriate to access it in a Client Component, which can often be the case when reading the time for display purposes. If a Client Component isn't the right choice then consider whether you can move the current time access later, behind other existing uncached data or Request data access. If there is no way to do this you can always precede the current time access with Request data access by using `await connection()`.
 
-> **Note**: Suspense fallbacks and skeleton components are part of the prerendered static shell. If a skeleton component uses `Date.now()` or `new Date()` (e.g., for a "last updated" placeholder), it will trigger this error. Use static placeholder text or CSS animations instead.
+> **Note**: Suspense fallbacks and skeleton components are part of the prerendered static shell. If a skeleton component uses `Date.now()`, `Date()`, or `new Date()` (e.g., for a "last updated" placeholder), it will trigger this error. Use static placeholder text or CSS animations instead.
 
 > **Note**: Sometimes the place that accesses the current time is inside 3rd party code. While you can't easily convert the time access to `performance.now()` the other strategies can be applied in your own project code regardless of how deeply the time is read.
 

--- a/errors/next-prerender-current-time.mdx
+++ b/errors/next-prerender-current-time.mdx
@@ -14,6 +14,8 @@ If the current time is appropriate to be prerendered and prefetched consider mov
 
 If the current time is intended to be accessed dynamically on every user request first consider whether it is more appropriate to access it in a Client Component, which can often be the case when reading the time for display purposes. If a Client Component isn't the right choice then consider whether you can move the current time access later, behind other existing uncached data or Request data access. If there is no way to do this you can always precede the current time access with Request data access by using `await connection()`.
 
+> **Note**: Suspense fallbacks and skeleton components are part of the prerendered static shell. If a skeleton component uses `Date.now()` or `new Date()` (e.g., for a "last updated" placeholder), it will trigger this error. Use static placeholder text or CSS animations instead.
+
 > **Note**: Sometimes the place that accesses the current time is inside 3rd party code. While you can't easily convert the time access to `performance.now()` the other strategies can be applied in your own project code regardless of how deeply the time is read.
 
 ### Performance use case

--- a/errors/next-prerender-current-time.mdx
+++ b/errors/next-prerender-current-time.mdx
@@ -14,7 +14,7 @@ If the current time is appropriate to be prerendered and prefetched consider mov
 
 If the current time is intended to be accessed dynamically on every user request first consider whether it is more appropriate to access it in a Client Component, which can often be the case when reading the time for display purposes. If a Client Component isn't the right choice then consider whether you can move the current time access later, behind other existing uncached data or Request data access. If there is no way to do this you can always precede the current time access with Request data access by using `await connection()`.
 
-> **Note**: Suspense fallbacks and skeleton components are part of the prerendered static shell. If a skeleton component uses `Date.now()`, `Date()`, or `new Date()` (e.g., for a "last updated" placeholder), it will trigger this error. Use static placeholder text or CSS animations instead.
+> **Note**: Any content that is not wrapped in a `<Suspense>` boundary must be cacheable or static. This includes Suspense fallbacks themselves — a fallback that calls `Date.now()`, `Date()`, or `new Date()` will trigger this error unless there is another `<Suspense>` boundary above it. Use cached values, static placeholders, or wrap the component in `<Suspense>` to fix it.
 
 > **Note**: Sometimes the place that accesses the current time is inside 3rd party code. While you can't easily convert the time access to `performance.now()` the other strategies can be applied in your own project code regardless of how deeply the time is read.
 

--- a/errors/next-prerender-random.mdx
+++ b/errors/next-prerender-random.mdx
@@ -14,7 +14,7 @@ If the random value is intended to be generated on every user request consider w
 
 If the random value is being used as a unique identifier for diagnostic purposes such as logging or tracking consider using an alternate method of id generation that does not rely on random number generation such as incrementing an integer.
 
-> **Note**: Suspense fallbacks and skeleton components are part of the prerendered static shell. If a skeleton component uses `Math.random()` (e.g., for randomized placeholder widths), it will trigger this error. Use fixed values or CSS animations for loading placeholders instead.
+> **Note**: Any content that is not wrapped in a `<Suspense>` boundary must be cacheable or static. This includes Suspense fallbacks themselves — a fallback that calls `Math.random()` will trigger this error unless there is another `<Suspense>` boundary above it. Use cached values or wrap the component in `<Suspense>` to fix it.
 
 > **Note**: Sometimes the place that generates a random value synchronously is inside 3rd party code. While you can't easily replace the `Math.random()` call directly, the other strategies can be applied in your own project code regardless of how deep random generation is.
 

--- a/errors/next-prerender-random.mdx
+++ b/errors/next-prerender-random.mdx
@@ -14,6 +14,8 @@ If the random value is intended to be generated on every user request consider w
 
 If the random value is being used as a unique identifier for diagnostic purposes such as logging or tracking consider using an alternate method of id generation that does not rely on random number generation such as incrementing an integer.
 
+> **Note**: Suspense fallbacks and skeleton components are part of the prerendered static shell. If a skeleton component uses `Math.random()` (e.g., for randomized placeholder widths), it will trigger this error. Use fixed values or CSS animations for loading placeholders instead.
+
 > **Note**: Sometimes the place that generates a random value synchronously is inside 3rd party code. While you can't easily replace the `Math.random()` call directly, the other strategies can be applied in your own project code regardless of how deep random generation is.
 
 ### Cache the random value


### PR DESCRIPTION
### What?

Adds a callout to the `next-prerender-random`, `next-prerender-current-time`, and `next-prerender-crypto` error pages noting that Suspense fallback/skeleton components are part of the prerendered static shell and must not use non-deterministic expressions like `Math.random()`, `Date.now()`, or `crypto.randomUUID()`.

### Why?

Developers using `Math.random()` inside skeleton components (e.g., for randomized placeholder widths) get a correct but confusing build error. The conceptual connection — "skeletons are part of the static shell and must be deterministic" — is missing from the docs. This leads to wasted debugging time, especially for AI coding agents that rely on error page guidance to fix issues.

### How?

Added a `> **Note**:` block to each of the three error pages, matching the existing note style used throughout these pages.