### PR TITLE
docs: add /_not-found caveat to next-prerender-dynamic-viewport error page

### DIFF
--- a/errors/next-prerender-dynamic-viewport.mdx
+++ b/errors/next-prerender-dynamic-viewport.mdx
@@ -106,7 +106,7 @@ export default function RootLayout({ children }) {
 }
 ```
 
-> **Note:** The built-in `/_not-found` route must be statically prerendered. If your root layout has a `generateViewport` that depends on request data, the `<Suspense>` fix above will not resolve the error for `/_not-found`. For that route, use static values or cached data in `generateViewport()` instead.
+> **Note:** The built-in `/_not-found` route must be statically prerendered. If your root layout has a `generateViewport` that depends on request data, the `<Suspense>` fix above will not resolve the error for `/_not-found`. For that route, use static values or cached data in `generateViewport()` instead. Alternatively, you can use [`global-not-found.js`](/docs/app/api-reference/file-conventions/not-found#global-not-foundjs-experimental) (experimental), which bypasses the root layout entirely and avoids inheriting its `generateViewport`.
 
 ## Useful Links
 

--- a/errors/next-prerender-dynamic-viewport.mdx
+++ b/errors/next-prerender-dynamic-viewport.mdx
@@ -106,6 +106,8 @@ export default function RootLayout({ children }) {
 }
 ```
 
+> **Note:** The built-in `/_not-found` route must be statically prerendered. If your root layout has a `generateViewport` that depends on request data, the `<Suspense>` fix above will not resolve the error for `/_not-found`. For that route, use static values or cached data in `generateViewport()` instead.
+
 ## Useful Links
 
 - [`generateViewport()`](/docs/app/api-reference/functions/generate-viewport)


### PR DESCRIPTION
## What

Add a note to the `next-prerender-dynamic-viewport` error page warning that the `<Suspense>` fix does not resolve the error for the built-in `/_not-found` route.

## Why

When `generateViewport` in the root layout uses request-time data (e.g., `cookies()`), the documented fix is to wrap `<body>` in `<Suspense>`. However, `/_not-found` must be statically prerendered, so this fix does not work for that route. Users hit a second wave of build failures after applying the documented fix, with no guidance about why `/_not-found` behaves differently.

## How

Added a `> **Note:**` block after the `<Suspense>` fix code example, directing users to use static values or cached data in `generateViewport()` for the `/_not-found` route.