### PR TITLE
fix: return 'npm' from getPkgManager when npm_config_user_agent starts with npm

### DIFF
--- a/packages/next/src/lib/helpers/get-pkg-manager.ts
+++ b/packages/next/src/lib/helpers/get-pkg-manager.ts
@@ -21,6 +21,8 @@ export function getPkgManager(baseDir: string): PackageManager {
         return 'yarn'
       } else if (userAgent.startsWith('pnpm')) {
         return 'pnpm'
+      } else {
+        return 'npm'
       }
     }
     try {


### PR DESCRIPTION
## Why?

`getPkgManager` in `packages/next/src/lib/helpers/get-pkg-manager.ts` checks `npm_config_user_agent` for `yarn` and `pnpm`, but has no branch for `npm`. When the user agent starts with `"npm"` (because the project uses npm), the function falls through to the global detection fallback, which runs `yarn --version`. If yarn is installed globally (common for developers working across multiple projects), it returns `'yarn'` instead of `'npm'`.

This causes `getRegistry()` to execute `yarn config get registry`, which fails when the `packageManager` field in `package.json` is set to `npm@x.x.x` — Corepack intercepts the yarn command and blocks it because the project declares npm as its package manager.

## How to reproduce

1. Have a monorepo with npm workspaces (lockfile at root, not in workspace dirs)
2. Set `"packageManager": "npm@11.6.1"` in root `package.json` (required by Turborepo)
3. Have yarn installed globally (e.g. for other projects)
4. Run `next dev` from a workspace subdirectory

**Error:**
```
Error: Failed to get registry from "yarn".
  [cause]: Error: Command failed: yarn config get registry
  error This project's package.json defines "packageManager": "npm@11.6.1".
  However the current global version of Yarn is 1.22.22.
```

## Fix

Add an `else` branch to return `'npm'` when `npm_config_user_agent` is present but doesn't match yarn or pnpm — since it must be npm at that point.

```diff
     if (userAgent) {
       if (userAgent.startsWith('yarn')) {
         return 'yarn'
       } else if (userAgent.startsWith('pnpm')) {
         return 'pnpm'
+      } else {
+        return 'npm'
       }
     }
```