### PR TITLE
pr-status: Show all participants in review thread overview

### DIFF
--- a/scripts/pr-status.js
+++ b/scripts/pr-status.js
@@ -819,18 +819,26 @@ function generateIndexMd(
         '',
         `## Inline Review Comments (${reviewThreads.length} threads)`,
         '',
-        '| File | Line | Author | Replies | Status | Details |',
-        '|------|------|--------|---------|--------|---------|'
+        '| File | Line | Participants | Replies | Status | Details |',
+        '|------|------|--------------|---------|--------|---------|'
       )
 
       for (let i = 0; i < reviewThreads.length; i++) {
         const thread = reviewThreads[i]
         const line = thread.line || thread.startLine || 'N/A'
-        const author = thread.comments.nodes[0]?.author?.login || 'Unknown'
+        const participants = []
+        for (const comment of thread.comments.nodes) {
+          const login = comment.author?.login
+          if (login && !participants.includes(login)) {
+            participants.push(login)
+          }
+        }
+        const participantsStr =
+          participants.length > 0 ? participants.join(', ') : 'Unknown'
         const replyCount = Math.max(0, thread.comments.nodes.length - 1)
         const status = thread.isResolved ? 'Resolved' : 'Open'
         lines.push(
-          `| ${escapeMarkdownTableCell(thread.path)} | ${line} | ${author} | ${replyCount} | ${status} | [View](thread-${i + 1}.md) |`
+          `| ${escapeMarkdownTableCell(thread.path)} | ${line} | ${participantsStr} | ${replyCount} | ${status} | [View](thread-${i + 1}.md) |`
         )
       }
     }

--- a/scripts/pr-status.js
+++ b/scripts/pr-status.js
@@ -826,15 +826,12 @@ function generateIndexMd(
       for (let i = 0; i < reviewThreads.length; i++) {
         const thread = reviewThreads[i]
         const line = thread.line || thread.startLine || 'N/A'
-        const participants = []
+        const participants = new Set()
         for (const comment of thread.comments.nodes) {
-          const login = comment.author?.login
-          if (login && !participants.includes(login)) {
-            participants.push(login)
-          }
+          if (comment.author?.login) participants.add(comment.author.login)
         }
         const participantsStr =
-          participants.length > 0 ? participants.join(', ') : 'Unknown'
+          participants.size > 0 ? [...participants].join(', ') : 'Unknown'
         const replyCount = Math.max(0, thread.comments.nodes.length - 1)
         const status = thread.isResolved ? 'Resolved' : 'Open'
         lines.push(


### PR DESCRIPTION
### What?

In `scripts/pr-status.js`, the "Inline Review Comments" table in `index.md` now shows all participants of each review thread instead of only the first comment's author. The **Author** column has been renamed to **Participants** and lists every unique commenter in the thread (in order of first appearance), as a comma-separated list.

### Why?

When an agent is asked to "address all comments from sokra" (or any specific reviewer), it needs to quickly identify which threads involve that person — including threads where they replied but didn't open the thread. Showing only the first author made it impossible to find reply-only participants from the overview.

### How?

Collect all `author.login` values from every comment node in the thread into a `Set` (for deduplication), then join them into a comma-separated string for the table cell.

<!-- NEXT_JS_LLM_PR -->