### PR TITLE
Add S3 Compatible Storage Options

### DIFF
--- a/docs/01-app/01-getting-started/12-images.mdx
+++ b/docs/01-app/01-getting-started/12-images.mdx
@@ -234,3 +234,37 @@ module.exports = {
   },
 }
 ```
+
+This also works with S3-compatible storage providers. For example, with [Tigris](https://www.tigrisdata.com/):
+
+```ts filename="next.config.ts" switcher
+import type { NextConfig } from 'next'
+
+const config: NextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 't3.storage.dev',
+        pathname: '/my-bucket/**',
+      },
+    ],
+  },
+}
+
+export default config
+```
+
+```js filename="next.config.js" switcher
+module.exports = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 't3.storage.dev',
+        pathname: '/my-bucket/**',
+      },
+    ],
+  },
+}
+```

--- a/docs/01-app/02-guides/self-hosting.mdx
+++ b/docs/01-app/02-guides/self-hosting.mdx
@@ -163,7 +163,7 @@ module.exports = class CacheHandler {
 }
 ```
 
-Using a custom cache handler will allow you to ensure consistency across all pods hosting your Next.js application. For instance, you can save the cached values anywhere, like [Redis](https://github.com/vercel/next.js/tree/canary/examples/cache-handler-redis) or AWS S3.
+Using a custom cache handler will allow you to ensure consistency across all pods hosting your Next.js application. For instance, you can save the cached values anywhere, like [Redis](https://github.com/vercel/next.js/tree/canary/examples/cache-handler-redis), AWS S3, or other S3-compatible providers like [Tigris](https://www.tigrisdata.com/).
 
 > **Good to know:**
 >

--- a/docs/01-app/02-guides/videos.mdx
+++ b/docs/01-app/02-guides/videos.mdx
@@ -243,7 +243,7 @@ Explore these video streaming platforms for integrating video into your Next.js 
 
 ### Open source `next-video` component
 
-- Provides a `<Video>` component for Next.js, compatible with various hosting services including [Vercel Blob](https://vercel.com/docs/storage/vercel-blob?utm_source=next-site&utm_medium=docs&utm_campaign=next-website), S3, Backblaze, and Mux.
+- Provides a `<Video>` component for Next.js, compatible with various hosting services including [Vercel Blob](https://vercel.com/docs/storage/vercel-blob?utm_source=next-site&utm_medium=docs&utm_campaign=next-website), S3, Backblaze, [Tigris](https://www.tigrisdata.com/), and Mux.
 - [Detailed documentation](https://next-video.dev/docs) for using `next-video.dev` with different hosting services.
 
 ### Cloudinary Integration

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/cacheHandlers.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/cacheHandlers.mdx
@@ -482,7 +482,7 @@ In the cache handler API, soft tags are passed to the [`get()`](#get) method as 
 The `CacheEntry.value` is a [`ReadableStream<Uint8Array>`](https://developer.mozilla.org/docs/Web/API/ReadableStream). When implementing a cache handler that stores entries externally, keep in mind:
 
 - **Use `.tee()`** if you need to both store and return the stream. One branch goes to storage, the other is returned to the caller.
-- **Memory implications**: large pages produce large cache entries. For S3-like storage backends, consider streaming directly to storage without buffering the entire entry in memory.
+- **Memory implications**: large pages produce large cache entries. For S3-compatible storage backends (AWS S3, [Tigris](https://www.tigrisdata.com/), etc.), consider streaming directly to storage without buffering the entire entry in memory.
 - **Partial writes**: the stream may error partway through rendering. Your handler should decide whether to keep partial entries or discard them. Discarding is safer, as partial entries can produce incomplete pages.
 
 ## Error Handling


### PR DESCRIPTION
### What?

Add Tigris (https://www.tigrisdata.com/) as an S3-compatible storage option in existing documentation where other providers (AWS S3, Backblaze, etc.) are already listed.

### Why?

The docs reference AWS S3 in several places but don't mention S3-compatible alternatives beyond the occasional Backblaze reference. Tigris is S3-compatible and works as a drop-in with `next/image` remote patterns, cache handlers, and `next-video`. Adding it alongside existing providers gives users more options without requiring a dedicated page.

### How?

Minimal additions to 4 existing doc files — no new files created:

- **`docs/01-app/01-getting-started/12-images.mdx`** — Added a `remotePatterns` config example for Tigris after the existing AWS S3 example (TS/JS switcher)
- **`docs/01-app/02-guides/self-hosting.mdx`** — Appended Tigris to the list of cache handler backends (alongside Redis and AWS S3)
- **`docs/01-app/02-guides/videos.mdx`** — Added Tigris to the `next-video` compatible hosting services list
- **`docs/01-app/03-api-reference/05-config/01-next-config-js/cacheHandlers.mdx`** — Added Tigris as an example S3-compatible backend in the streaming section
