### PR TITLE
Improve error stacks for dynamic API usage in `"use cache"`

### DIFF
--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -346,6 +346,7 @@ export interface CommonUseCacheStore extends CommonCacheStore, RevalidateStore {
   readonly isHmrRefresh: boolean
   readonly serverComponentsHmrCache: ServerComponentsHmrCache | undefined
   readonly forceRevalidate: boolean
+  readonly outerOwnerStack: string | undefined
 }
 
 export interface PublicUseCacheStore extends CommonUseCacheStore {

--- a/packages/next/src/server/dynamic-rendering-utils.ts
+++ b/packages/next/src/server/dynamic-rendering-utils.ts
@@ -7,6 +7,8 @@ import type {
   PrerenderStoreModernRuntime,
   RequestStore,
 } from './app-render/work-unit-async-storage.external'
+import { workUnitAsyncStorage } from './app-render/work-unit-async-storage.external'
+import { getServerReact, getClientReact } from './runtime-reacts.external'
 
 export function isHangingPromiseRejectionError(
   err: unknown
@@ -147,4 +149,65 @@ export function delayUntilRuntimeStage<T>(
   return stagedRendering
     .waitForStage(getRuntimeStage(stagedRendering))
     .then(() => result)
+}
+
+export function applyOwnerStack(error: Error): Error {
+  if (process.env.NODE_ENV !== 'production') {
+    let ownerStack: string | undefined | null
+    const workUnitStore = workUnitAsyncStorage.getStore()
+
+    // captureOwnerStack() returns the owner stack for the current React
+    // rendering context. Inside a cache scope this only includes the inner
+    // component tree. The outer owner stack (captured before entering the
+    // cache boundary in use-cache-wrapper.ts) is stored on the cache store.
+    // We concatenate both to get the full component tree.
+    const innerOwnerStack =
+      getClientReact()?.captureOwnerStack?.() ??
+      getServerReact()?.captureOwnerStack?.()
+
+    switch (workUnitStore?.type) {
+      case 'cache':
+      case 'private-cache':
+        ownerStack =
+          (innerOwnerStack || '') + (workUnitStore.outerOwnerStack || '') ||
+          undefined
+        break
+      case 'unstable-cache':
+      case 'request':
+      case 'prerender':
+      case 'prerender-ppr':
+      case 'prerender-legacy':
+      case 'prerender-runtime':
+      case 'prerender-client':
+      case 'validation-client':
+      case 'generate-static-params':
+      case undefined:
+        ownerStack = innerOwnerStack
+        break
+      default:
+        workUnitStore satisfies never
+    }
+
+    if (ownerStack) {
+      let stack = ownerStack
+
+      if (error.stack) {
+        const frames: string[] = []
+
+        for (const frame of error.stack.split('\n').slice(1)) {
+          if (frame.includes('react_stack_bottom_frame')) {
+            break
+          }
+
+          frames.push(frame)
+        }
+
+        stack = '\n' + frames.join('\n') + stack
+      }
+
+      error.stack = error.name + ': ' + error.message + stack
+    }
+  }
+
+  return error
 }

--- a/packages/next/src/server/node-environment-extensions/io-utils.tsx
+++ b/packages/next/src/server/node-environment-extensions/io-utils.tsx
@@ -3,8 +3,7 @@ import { workUnitAsyncStorage } from '../app-render/work-unit-async-storage.exte
 import { abortOnSynchronousPlatformIOAccess } from '../app-render/dynamic-rendering'
 import { InvariantError } from '../../shared/lib/invariant-error'
 import { RenderStage } from '../app-render/staged-rendering'
-
-import { getServerReact, getClientReact } from '../runtime-reacts.external'
+import { applyOwnerStack } from '../dynamic-rendering-utils'
 
 type ApiType = 'time' | 'random' | 'crypto'
 
@@ -166,38 +165,4 @@ export function io(expression: string, type: ApiType) {
     default:
       workUnitStore satisfies never
   }
-}
-
-function applyOwnerStack(error: Error) {
-  // TODO: Instead of stitching the stacks here, we should log the original
-  // error as-is when it occurs, and let `patchErrorInspect` handle adding the
-  // owner stack, instead of logging it deferred in the `LogSafely` component
-  // via `throwIfDisallowedDynamic`.
-  if (process.env.NODE_ENV !== 'production') {
-    const ownerStack =
-      getClientReact()?.captureOwnerStack?.() ??
-      getServerReact()?.captureOwnerStack?.()
-
-    if (ownerStack) {
-      let stack = ownerStack
-
-      if (error.stack) {
-        const frames: string[] = []
-
-        for (const frame of error.stack.split('\n').slice(1)) {
-          if (frame.includes('react_stack_bottom_frame')) {
-            break
-          }
-
-          frames.push(frame)
-        }
-
-        stack = '\n' + frames.join('\n') + stack
-      }
-
-      error.stack = error.name + ': ' + error.message + stack
-    }
-  }
-
-  return error
 }

--- a/packages/next/src/server/request/connection.ts
+++ b/packages/next/src/server/request/connection.ts
@@ -14,6 +14,7 @@ import {
   makeDevtoolsIOAwarePromise,
 } from '../dynamic-rendering-utils'
 import { isRequestAPICallableInsideAfter } from './utils'
+import { applyOwnerStack } from '../dynamic-rendering-utils'
 import { RenderStage } from '../app-render/staged-rendering'
 import { InvariantError } from '../../shared/lib/invariant-error'
 
@@ -57,6 +58,7 @@ export function connection(): Promise<void> {
             `Route ${workStore.route} used \`connection()\` inside "use cache". The \`connection()\` function is used to indicate the subsequent code must only run when there is an actual request, but caches must be able to be produced before a request, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache`
           )
           Error.captureStackTrace(error, connection)
+          applyOwnerStack(error)
           workStore.invalidDynamicUsageError ??= error
           throw error
         }
@@ -68,6 +70,7 @@ export function connection(): Promise<void> {
             `Route ${workStore.route} used \`connection()\` inside "use cache: private". The \`connection()\` function is used to indicate the subsequent code must only run when there is an actual navigation request, but caches must be able to be produced before a navigation request, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache`
           )
           Error.captureStackTrace(error, connection)
+          applyOwnerStack(error)
           workStore.invalidDynamicUsageError ??= error
           throw error
         }

--- a/packages/next/src/server/request/cookies.ts
+++ b/packages/next/src/server/request/cookies.ts
@@ -28,6 +28,7 @@ import {
 } from '../dynamic-rendering-utils'
 import { createDedupedByCallsiteServerErrorLoggerDev } from '../create-deduped-by-callsite-server-error-logger'
 import { isRequestAPICallableInsideAfter } from './utils'
+import { applyOwnerStack } from '../dynamic-rendering-utils'
 import { InvariantError } from '../../shared/lib/invariant-error'
 import { RenderStage } from '../app-render/staged-rendering'
 
@@ -68,6 +69,7 @@ export function cookies(): Promise<ReadonlyRequestCookies> {
             `Route ${workStore.route} used \`cookies()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`cookies()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache`
           )
           Error.captureStackTrace(error, cookies)
+          applyOwnerStack(error)
           workStore.invalidDynamicUsageError ??= error
           throw error
         case 'unstable-cache':

--- a/packages/next/src/server/request/draft-mode.ts
+++ b/packages/next/src/server/request/draft-mode.ts
@@ -21,6 +21,7 @@ import { DynamicServerError } from '../../client/components/hooks-server-context
 import { InvariantError } from '../../shared/lib/invariant-error'
 import { delayUntilRuntimeStage } from '../dynamic-rendering-utils'
 import { ReflectAdapter } from '../web/spec-extension/adapters/reflect'
+import { applyOwnerStack } from '../dynamic-rendering-utils'
 
 export function draftMode(): Promise<DraftMode> {
   const callingExpression = 'draftMode'
@@ -206,6 +207,7 @@ function trackDynamicDraftMode(expression: string, constructorOpt: Function) {
             `Route ${workStore.route} used "${expression}" inside "use cache". The enabled status of \`draftMode()\` can be read in caches but you must not enable or disable \`draftMode()\` inside a cache. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache`
           )
           Error.captureStackTrace(error, constructorOpt)
+          applyOwnerStack(error)
           workStore.invalidDynamicUsageError ??= error
           throw error
         }

--- a/packages/next/src/server/request/headers.ts
+++ b/packages/next/src/server/request/headers.ts
@@ -26,6 +26,7 @@ import {
 } from '../dynamic-rendering-utils'
 import { createDedupedByCallsiteServerErrorLoggerDev } from '../create-deduped-by-callsite-server-error-logger'
 import { isRequestAPICallableInsideAfter } from './utils'
+import { applyOwnerStack } from '../dynamic-rendering-utils'
 import { InvariantError } from '../../shared/lib/invariant-error'
 import { RenderStage } from '../app-render/staged-rendering'
 
@@ -68,6 +69,7 @@ export function headers(): Promise<ReadonlyHeaders> {
             `Route ${workStore.route} used \`headers()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`headers()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache`
           )
           Error.captureStackTrace(error, headers)
+          applyOwnerStack(error)
           workStore.invalidDynamicUsageError ??= error
           throw error
         }

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -75,6 +75,7 @@ import { dynamicAccessAsyncStorage } from '../app-render/dynamic-access-async-st
 import type { CacheLife } from './cache-life'
 import { RenderStage } from '../app-render/staged-rendering'
 import * as Log from '../../build/output/log'
+import { getServerReact, getClientReact } from '../runtime-reacts.external'
 
 interface PrivateCacheContext {
   readonly kind: 'private'
@@ -83,6 +84,7 @@ interface PrivateCacheContext {
     | PrivateUseCacheStore
     | PrerenderStoreModernRuntime
   readonly skipPropagation: boolean
+  readonly outerOwnerStack: string | undefined
 }
 
 interface PublicCacheContext {
@@ -93,6 +95,7 @@ interface PublicCacheContext {
     PrerenderStoreModernClient | ValidationStoreClient
   >
   readonly skipPropagation: boolean
+  readonly outerOwnerStack: string | undefined
 }
 
 type CacheContext = PrivateCacheContext | PublicCacheContext
@@ -360,6 +363,7 @@ function createUseCacheStore(
       rootParams: outerWorkUnitStore.rootParams,
       headers: outerWorkUnitStore.headers,
       cookies: outerWorkUnitStore.cookies,
+      outerOwnerStack: cacheContext.outerOwnerStack,
     }
   } else {
     let useCacheOrRequestStore: RequestStore | UseCacheStore | undefined
@@ -404,8 +408,46 @@ function createUseCacheStore(
       ),
       rootParams: outerWorkUnitStore.rootParams,
       readRootParamNames: new Set<string>(),
+      outerOwnerStack: cacheContext.outerOwnerStack,
     }
   }
+}
+
+/**
+ * Captures the owner stack from the outer component tree before entering a
+ * cache boundary. When nested inside another cache scope, the parent's
+ * outerOwnerStack is concatenated so that the full component tree is preserved
+ * across multiple cache boundaries.
+ */
+function captureOuterOwnerStack(
+  workUnitStore: WorkUnitStore
+): string | undefined {
+  const capturedOwnerStack =
+    (getClientReact()?.captureOwnerStack?.() ??
+      getServerReact()?.captureOwnerStack?.()) ||
+    ''
+
+  let parentOuterOwnerStack: string | undefined
+  switch (workUnitStore.type) {
+    case 'cache':
+    case 'private-cache':
+      parentOuterOwnerStack = workUnitStore.outerOwnerStack
+      break
+    case 'unstable-cache':
+    case 'request':
+    case 'prerender':
+    case 'prerender-ppr':
+    case 'prerender-legacy':
+    case 'prerender-runtime':
+    case 'prerender-client':
+    case 'validation-client':
+    case 'generate-static-params':
+      break
+    default:
+      workUnitStore satisfies never
+  }
+
+  return capturedOwnerStack + (parentOuterOwnerStack || '') || undefined
 }
 
 function assertDefaultCacheLife(
@@ -1125,6 +1167,11 @@ export async function cache(
     )
   }
 
+  const outerOwnerStack =
+    process.env.NODE_ENV !== 'production'
+      ? captureOuterOwnerStack(workUnitStore)
+      : undefined
+
   const name = originalFn.name
   let fn = originalFn
   let cacheContext: CacheContext
@@ -1182,6 +1229,7 @@ export async function cache(
           kind: 'private',
           outerWorkUnitStore: workUnitStore,
           skipPropagation: false,
+          outerOwnerStack,
         }
         break
       case 'generate-static-params':
@@ -1221,6 +1269,7 @@ export async function cache(
           kind: 'public',
           outerWorkUnitStore: workUnitStore,
           skipPropagation: false,
+          outerOwnerStack,
         }
         break
       default:
@@ -2048,6 +2097,7 @@ export async function cache(
             kind: cacheContext.kind,
             outerWorkUnitStore: cacheContext.outerWorkUnitStore,
             skipPropagation: true,
+            outerOwnerStack: cacheContext.outerOwnerStack,
           },
           clientReferenceManifest,
           encodedCacheKeyParts,

--- a/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
@@ -2205,6 +2205,7 @@ describe('Cache Components Errors', () => {
                   |                  ^",
                "stack": [
                  "CookiesReadingComponent app/use-cache-cookies/page.tsx (22:18)",
+                 "Page app/use-cache-cookies/page.tsx (10:7)",
                ],
              }
             `)
@@ -2227,6 +2228,7 @@ describe('Cache Components Errors', () => {
                 expect(output).toMatchInlineSnapshot(`
                  "Error: Route /use-cache-cookies used \`cookies()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`cookies()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
                      at CookiesReadingComponent (app/use-cache-cookies/page.tsx:22:18)
+                     at Page (app/use-cache-cookies/page.tsx:10:7)
                    20 |   // in userland.
                    21 |   try {
                  > 22 |     await cookies()
@@ -2263,6 +2265,7 @@ describe('Cache Components Errors', () => {
                 expect(output).toMatchInlineSnapshot(`
                  "Error: Route /use-cache-cookies used \`cookies()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`cookies()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
                      at CookiesReadingComponent (webpack:///app/use-cache-cookies/page.tsx:22:18)
+                     at Page (webpack:///app/use-cache-cookies/page.tsx:10:7)
                    20 |   // in userland.
                    21 |   try {
                  > 22 |     await cookies()
@@ -2311,6 +2314,7 @@ describe('Cache Components Errors', () => {
                   |                          ^",
                "stack": [
                  "DraftModeEnablingComponent app/use-cache-draft-mode/page.tsx (20:26)",
+                 "Page app/use-cache-draft-mode/page.tsx (9:7)",
                ],
              }
             `)
@@ -2333,6 +2337,7 @@ describe('Cache Components Errors', () => {
                 expect(output).toMatchInlineSnapshot(`
                  "Error: Route /use-cache-draft-mode used "draftMode().enable()" inside "use cache". The enabled status of \`draftMode()\` can be read in caches but you must not enable or disable \`draftMode()\` inside a cache. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
                      at DraftModeEnablingComponent (app/use-cache-draft-mode/page.tsx:20:26)
+                     at Page (app/use-cache-draft-mode/page.tsx:9:7)
                    18 |   // here to ensure that this error is shown even when it's caught in userland.
                    19 |   try {
                  > 20 |     ;(await draftMode()).enable()
@@ -2350,6 +2355,7 @@ describe('Cache Components Errors', () => {
                 expect(output).toMatchInlineSnapshot(`
                  "Error: Route /use-cache-draft-mode used "draftMode().enable()" inside "use cache". The enabled status of \`draftMode()\` can be read in caches but you must not enable or disable \`draftMode()\` inside a cache. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
                      at DraftModeEnablingComponent (webpack:///app/use-cache-draft-mode/page.tsx:20:26)
+                     at Page (webpack:///app/use-cache-draft-mode/page.tsx:9:7)
                    18 |   // here to ensure that this error is shown even when it's caught in userland.
                    19 |   try {
                  > 20 |     ;(await draftMode()).enable()
@@ -2416,6 +2422,7 @@ describe('Cache Components Errors', () => {
                   |                  ^",
                "stack": [
                  "HeadersReadingComponent app/use-cache-headers/page.tsx (21:18)",
+                 "Page app/use-cache-headers/page.tsx (10:7)",
                ],
              }
             `)
@@ -2438,6 +2445,7 @@ describe('Cache Components Errors', () => {
                 expect(output).toMatchInlineSnapshot(`
                  "Error: Route /use-cache-headers used \`headers()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`headers()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
                      at HeadersReadingComponent (app/use-cache-headers/page.tsx:21:18)
+                     at Page (app/use-cache-headers/page.tsx:10:7)
                    19 |   // to ensure that this error is shown even when it's caught in userland.
                    20 |   try {
                  > 21 |     await headers()
@@ -2474,6 +2482,7 @@ describe('Cache Components Errors', () => {
                 expect(output).toMatchInlineSnapshot(`
                  "Error: Route /use-cache-headers used \`headers()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`headers()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
                      at HeadersReadingComponent (webpack:///app/use-cache-headers/page.tsx:21:18)
+                     at Page (webpack:///app/use-cache-headers/page.tsx:10:7)
                    19 |   // to ensure that this error is shown even when it's caught in userland.
                    20 |   try {
                  > 21 |     await headers()
@@ -2520,6 +2529,7 @@ describe('Cache Components Errors', () => {
                   |                     ^",
                "stack": [
                  "ConnectionCallingComponent app/use-cache-connection/page.tsx (21:21)",
+                 "Page app/use-cache-connection/page.tsx (10:7)",
                ],
              }
             `)
@@ -2542,6 +2552,7 @@ describe('Cache Components Errors', () => {
                 expect(output).toMatchInlineSnapshot(`
                  "Error: Route /use-cache-connection used \`connection()\` inside "use cache". The \`connection()\` function is used to indicate the subsequent code must only run when there is an actual request, but caches must be able to be produced before a request, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
                      at ConnectionCallingComponent (app/use-cache-connection/page.tsx:21:21)
+                     at Page (app/use-cache-connection/page.tsx:10:7)
                    19 |   // here to ensure that this error is shown even when it's caught in userland.
                    20 |   try {
                  > 21 |     await connection()
@@ -2578,6 +2589,7 @@ describe('Cache Components Errors', () => {
                 expect(output).toMatchInlineSnapshot(`
                  "Error: Route /use-cache-connection used \`connection()\` inside "use cache". The \`connection()\` function is used to indicate the subsequent code must only run when there is an actual request, but caches must be able to be produced before a request, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
                      at ConnectionCallingComponent (webpack:///app/use-cache-connection/page.tsx:21:21)
+                     at Page (webpack:///app/use-cache-connection/page.tsx:10:7)
                    19 |   // here to ensure that this error is shown even when it's caught in userland.
                    20 |   try {
                  > 21 |     await connection()
@@ -3649,8 +3661,12 @@ describe('Cache Components Errors', () => {
                  "description": "Route /use-cache-cookies-third-party used \`cookies()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`cookies()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache",
                  "environmentLabel": null,
                  "label": "Runtime Error",
-                 "source": null,
-                 "stack": [],
+                 "source": "app/use-cache-cookies-third-party/page.tsx (10:7) @ Page
+               > 10 |       <CachedCookiesReader />
+                    |       ^",
+                 "stack": [
+                   "Page app/use-cache-cookies-third-party/page.tsx (10:7)",
+                 ],
                }
               `)
             })
@@ -3671,7 +3687,14 @@ describe('Cache Components Errors', () => {
                 if (isDebugPrerender) {
                   expect(output).toMatchInlineSnapshot(`
                    "Error: Route /use-cache-cookies-third-party used \`cookies()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`cookies()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
-                       at ignore-listed frames
+                       at Page (app/use-cache-cookies-third-party/page.tsx:10:7)
+                      8 |         which triggers an error.
+                      9 |       </p>
+                   > 10 |       <CachedCookiesReader />
+                        |       ^
+                     11 |     </>
+                     12 |   )
+                     13 | }
                    To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-cookies-third-party" in your browser to investigate the error.
                    Error occurred prerendering page "/use-cache-cookies-third-party". Read more: https://nextjs.org/docs/messages/prerender-error
 
@@ -3693,7 +3716,14 @@ describe('Cache Components Errors', () => {
                 if (isDebugPrerender) {
                   expect(output).toMatchInlineSnapshot(`
                    "Error: Route /use-cache-cookies-third-party used \`cookies()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`cookies()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
-                       at ignore-listed frames
+                       at Page (webpack:///app/use-cache-cookies-third-party/page.tsx:10:7)
+                      8 |         which triggers an error.
+                      9 |       </p>
+                   > 10 |       <CachedCookiesReader />
+                        |       ^
+                     11 |     </>
+                     12 |   )
+                     13 | }
                    To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-cookies-third-party" in your browser to investigate the error.
                    Error occurred prerendering page "/use-cache-cookies-third-party". Read more: https://nextjs.org/docs/messages/prerender-error
 
@@ -3730,8 +3760,12 @@ describe('Cache Components Errors', () => {
                  "description": "Route /use-cache-draft-mode-third-party used "draftMode().enable()" inside "use cache". The enabled status of \`draftMode()\` can be read in caches but you must not enable or disable \`draftMode()\` inside a cache. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache",
                  "environmentLabel": null,
                  "label": "Runtime Error",
-                 "source": null,
-                 "stack": [],
+                 "source": "app/use-cache-draft-mode-third-party/page.tsx (10:7) @ Page
+               > 10 |       <CachedDraftModeEnabler />
+                    |       ^",
+                 "stack": [
+                   "Page app/use-cache-draft-mode-third-party/page.tsx (10:7)",
+                 ],
                }
               `)
             })
@@ -3752,7 +3786,14 @@ describe('Cache Components Errors', () => {
                 if (isTurbopack) {
                   expect(output).toMatchInlineSnapshot(`
                    "Error: Route /use-cache-draft-mode-third-party used "draftMode().enable()" inside "use cache". The enabled status of \`draftMode()\` can be read in caches but you must not enable or disable \`draftMode()\` inside a cache. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
-                       at ignore-listed frames
+                       at Page (app/use-cache-draft-mode-third-party/page.tsx:10:7)
+                      8 |         which triggers an error.
+                      9 |       </p>
+                   > 10 |       <CachedDraftModeEnabler />
+                        |       ^
+                     11 |     </>
+                     12 |   )
+                     13 | }
                    To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-draft-mode-third-party" in your browser to investigate the error.
                    Error occurred prerendering page "/use-cache-draft-mode-third-party". Read more: https://nextjs.org/docs/messages/prerender-error
 
@@ -3762,7 +3803,14 @@ describe('Cache Components Errors', () => {
                 } else {
                   expect(output).toMatchInlineSnapshot(`
                    "Error: Route /use-cache-draft-mode-third-party used "draftMode().enable()" inside "use cache". The enabled status of \`draftMode()\` can be read in caches but you must not enable or disable \`draftMode()\` inside a cache. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
-                       at ignore-listed frames
+                       at Page (webpack:///app/use-cache-draft-mode-third-party/page.tsx:10:7)
+                      8 |         which triggers an error.
+                      9 |       </p>
+                   > 10 |       <CachedDraftModeEnabler />
+                        |       ^
+                     11 |     </>
+                     12 |   )
+                     13 | }
                    To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-draft-mode-third-party" in your browser to investigate the error.
                    Error occurred prerendering page "/use-cache-draft-mode-third-party". Read more: https://nextjs.org/docs/messages/prerender-error
 
@@ -3810,8 +3858,12 @@ describe('Cache Components Errors', () => {
                  "description": "Route /use-cache-headers-third-party used \`headers()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`headers()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache",
                  "environmentLabel": null,
                  "label": "Runtime Error",
-                 "source": null,
-                 "stack": [],
+                 "source": "app/use-cache-headers-third-party/page.tsx (10:7) @ Page
+               > 10 |       <CachedHeadersReader />
+                    |       ^",
+                 "stack": [
+                   "Page app/use-cache-headers-third-party/page.tsx (10:7)",
+                 ],
                }
               `)
             })
@@ -3832,7 +3884,14 @@ describe('Cache Components Errors', () => {
                 if (isDebugPrerender) {
                   expect(output).toMatchInlineSnapshot(`
                    "Error: Route /use-cache-headers-third-party used \`headers()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`headers()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
-                       at ignore-listed frames
+                       at Page (app/use-cache-headers-third-party/page.tsx:10:7)
+                      8 |         which triggers an error.
+                      9 |       </p>
+                   > 10 |       <CachedHeadersReader />
+                        |       ^
+                     11 |     </>
+                     12 |   )
+                     13 | }
                    To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-headers-third-party" in your browser to investigate the error.
                    Error occurred prerendering page "/use-cache-headers-third-party". Read more: https://nextjs.org/docs/messages/prerender-error
 
@@ -3854,7 +3913,14 @@ describe('Cache Components Errors', () => {
                 if (isDebugPrerender) {
                   expect(output).toMatchInlineSnapshot(`
                    "Error: Route /use-cache-headers-third-party used \`headers()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`headers()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
-                       at ignore-listed frames
+                       at Page (webpack:///app/use-cache-headers-third-party/page.tsx:10:7)
+                      8 |         which triggers an error.
+                      9 |       </p>
+                   > 10 |       <CachedHeadersReader />
+                        |       ^
+                     11 |     </>
+                     12 |   )
+                     13 | }
                    To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-headers-third-party" in your browser to investigate the error.
                    Error occurred prerendering page "/use-cache-headers-third-party". Read more: https://nextjs.org/docs/messages/prerender-error
 
@@ -3891,8 +3957,12 @@ describe('Cache Components Errors', () => {
                  "description": "Route /use-cache-connection-third-party used \`connection()\` inside "use cache". The \`connection()\` function is used to indicate the subsequent code must only run when there is an actual request, but caches must be able to be produced before a request, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache",
                  "environmentLabel": null,
                  "label": "Runtime Error",
-                 "source": null,
-                 "stack": [],
+                 "source": "app/use-cache-connection-third-party/page.tsx (10:7) @ Page
+               > 10 |       <CachedConnectionCaller />
+                    |       ^",
+                 "stack": [
+                   "Page app/use-cache-connection-third-party/page.tsx (10:7)",
+                 ],
                }
               `)
             })
@@ -3913,7 +3983,14 @@ describe('Cache Components Errors', () => {
                 if (isDebugPrerender) {
                   expect(output).toMatchInlineSnapshot(`
                    "Error: Route /use-cache-connection-third-party used \`connection()\` inside "use cache". The \`connection()\` function is used to indicate the subsequent code must only run when there is an actual request, but caches must be able to be produced before a request, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
-                       at ignore-listed frames
+                       at Page (app/use-cache-connection-third-party/page.tsx:10:7)
+                      8 |         which triggers an error.
+                      9 |       </p>
+                   > 10 |       <CachedConnectionCaller />
+                        |       ^
+                     11 |     </>
+                     12 |   )
+                     13 | }
                    To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-connection-third-party" in your browser to investigate the error.
                    Error occurred prerendering page "/use-cache-connection-third-party". Read more: https://nextjs.org/docs/messages/prerender-error
 
@@ -3935,7 +4012,14 @@ describe('Cache Components Errors', () => {
                 if (isDebugPrerender) {
                   expect(output).toMatchInlineSnapshot(`
                    "Error: Route /use-cache-connection-third-party used \`connection()\` inside "use cache". The \`connection()\` function is used to indicate the subsequent code must only run when there is an actual request, but caches must be able to be produced before a request, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
-                       at ignore-listed frames
+                       at Page (webpack:///app/use-cache-connection-third-party/page.tsx:10:7)
+                      8 |         which triggers an error.
+                      9 |       </p>
+                   > 10 |       <CachedConnectionCaller />
+                        |       ^
+                     11 |     </>
+                     12 |   )
+                     13 | }
                    To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-connection-third-party" in your browser to investigate the error.
                    Error occurred prerendering page "/use-cache-connection-third-party". Read more: https://nextjs.org/docs/messages/prerender-error
 

--- a/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
@@ -2504,6 +2504,110 @@ describe('Cache Components Errors', () => {
         }
       })
 
+      describe('connection', () => {
+        if (isNextDev) {
+          it('should show a redbox error', async () => {
+            const browser = await next.browser('/use-cache-connection')
+
+            await expect(browser).toDisplayRedbox(`
+             {
+               "code": "E394",
+               "description": "Route /use-cache-connection used \`connection()\` inside "use cache". The \`connection()\` function is used to indicate the subsequent code must only run when there is an actual request, but caches must be able to be produced before a request, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache",
+               "environmentLabel": null,
+               "label": "Runtime Error",
+               "source": "app/use-cache-connection/page.tsx (21:21) @ ConnectionCallingComponent
+             > 21 |     await connection()
+                  |                     ^",
+               "stack": [
+                 "ConnectionCallingComponent app/use-cache-connection/page.tsx (21:21)",
+               ],
+             }
+            `)
+          })
+        } else {
+          it('should error the build', async () => {
+            try {
+              await prerender('/use-cache-connection')
+            } catch {
+              // we expect the build to fail
+            }
+
+            const output = getPrerenderOutput(
+              next.cliOutput.slice(cliOutputLength),
+              { isMinified: !isDebugPrerender }
+            )
+
+            if (isTurbopack) {
+              if (isDebugPrerender) {
+                expect(output).toMatchInlineSnapshot(`
+                 "Error: Route /use-cache-connection used \`connection()\` inside "use cache". The \`connection()\` function is used to indicate the subsequent code must only run when there is an actual request, but caches must be able to be produced before a request, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+                     at ConnectionCallingComponent (app/use-cache-connection/page.tsx:21:21)
+                   19 |   // here to ensure that this error is shown even when it's caught in userland.
+                   20 |   try {
+                 > 21 |     await connection()
+                      |                     ^
+                   22 |   } catch {}
+                   23 |
+                   24 |   return null
+                 To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-connection" in your browser to investigate the error.
+                 Error occurred prerendering page "/use-cache-connection". Read more: https://nextjs.org/docs/messages/prerender-error
+
+                 > Export encountered errors on 1 path:
+                 	/use-cache-connection/page: /use-cache-connection"
+                `)
+              } else {
+                expect(output).toMatchInlineSnapshot(`
+                 "Error: Route /use-cache-connection used \`connection()\` inside "use cache". The \`connection()\` function is used to indicate the subsequent code must only run when there is an actual request, but caches must be able to be produced before a request, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+                     at a (app/use-cache-connection/page.tsx:21:11)
+                   19 |   // here to ensure that this error is shown even when it's caught in userland.
+                   20 |   try {
+                 > 21 |     await connection()
+                      |           ^
+                   22 |   } catch {}
+                   23 |
+                   24 |   return null
+                 To get a more detailed stack trace and pinpoint the issue, try one of the following:
+                   - Start the app in development mode by running \`next dev\`, then open "/use-cache-connection" in your browser to investigate the error.
+                   - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+                 Error occurred prerendering page "/use-cache-connection". Read more: https://nextjs.org/docs/messages/prerender-error
+                 Export encountered an error on /use-cache-connection/page: /use-cache-connection, exiting the build."
+                `)
+              }
+            } else {
+              if (isDebugPrerender) {
+                expect(output).toMatchInlineSnapshot(`
+                 "Error: Route /use-cache-connection used \`connection()\` inside "use cache". The \`connection()\` function is used to indicate the subsequent code must only run when there is an actual request, but caches must be able to be produced before a request, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+                     at ConnectionCallingComponent (webpack:///app/use-cache-connection/page.tsx:21:21)
+                   19 |   // here to ensure that this error is shown even when it's caught in userland.
+                   20 |   try {
+                 > 21 |     await connection()
+                      |                     ^
+                   22 |   } catch {}
+                   23 |
+                   24 |   return null
+                 To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-connection" in your browser to investigate the error.
+                 Error occurred prerendering page "/use-cache-connection". Read more: https://nextjs.org/docs/messages/prerender-error
+
+                 > Export encountered errors on 1 path:
+                 	/use-cache-connection/page: /use-cache-connection"
+                `)
+              } else {
+                expect(output).toMatchInlineSnapshot(`
+                 "Error: Route /use-cache-connection used \`connection()\` inside "use cache". The \`connection()\` function is used to indicate the subsequent code must only run when there is an actual request, but caches must be able to be produced before a request, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+                     at a (<next-dist-dir>)
+                     at b (<next-dist-dir>)
+                 To get a more detailed stack trace and pinpoint the issue, try one of the following:
+                   - Start the app in development mode by running \`next dev\`, then open "/use-cache-connection" in your browser to investigate the error.
+                   - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+                 Error occurred prerendering page "/use-cache-connection". Read more: https://nextjs.org/docs/messages/prerender-error
+                 Export encountered an error on /use-cache-connection/page: /use-cache-connection, exiting the build."
+                `)
+              }
+            }
+          })
+        }
+      })
+
       describe('cacheLife with expire < 5 minutes', () => {
         describe('microtasky cache', () => {
           if (isNextDev) {
@@ -3529,6 +3633,331 @@ describe('Cache Components Errors', () => {
             }
           })
         }
+      })
+
+      describe('in ignore-listed code', () => {
+        describe('cookies', () => {
+          if (isNextDev) {
+            it('should show a redbox error', async () => {
+              const browser = await next.browser(
+                '/use-cache-cookies-third-party'
+              )
+
+              await expect(browser).toDisplayRedbox(`
+               {
+                 "code": "E394",
+                 "description": "Route /use-cache-cookies-third-party used \`cookies()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`cookies()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache",
+                 "environmentLabel": null,
+                 "label": "Runtime Error",
+                 "source": null,
+                 "stack": [],
+               }
+              `)
+            })
+          } else {
+            it('should error the build', async () => {
+              try {
+                await prerender('/use-cache-cookies-third-party')
+              } catch {
+                // we expect the build to fail
+              }
+
+              const output = getPrerenderOutput(
+                next.cliOutput.slice(cliOutputLength),
+                { isMinified: !isDebugPrerender }
+              )
+
+              if (isTurbopack) {
+                if (isDebugPrerender) {
+                  expect(output).toMatchInlineSnapshot(`
+                   "Error: Route /use-cache-cookies-third-party used \`cookies()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`cookies()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+                       at ignore-listed frames
+                   To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-cookies-third-party" in your browser to investigate the error.
+                   Error occurred prerendering page "/use-cache-cookies-third-party". Read more: https://nextjs.org/docs/messages/prerender-error
+
+                   > Export encountered errors on 1 path:
+                   	/use-cache-cookies-third-party/page: /use-cache-cookies-third-party"
+                  `)
+                } else {
+                  expect(output).toMatchInlineSnapshot(`
+                   "Error: Route /use-cache-cookies-third-party used \`cookies()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`cookies()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+                       at ignore-listed frames
+                   To get a more detailed stack trace and pinpoint the issue, try one of the following:
+                     - Start the app in development mode by running \`next dev\`, then open "/use-cache-cookies-third-party" in your browser to investigate the error.
+                     - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+                   Error occurred prerendering page "/use-cache-cookies-third-party". Read more: https://nextjs.org/docs/messages/prerender-error
+                   Export encountered an error on /use-cache-cookies-third-party/page: /use-cache-cookies-third-party, exiting the build."
+                  `)
+                }
+              } else {
+                if (isDebugPrerender) {
+                  expect(output).toMatchInlineSnapshot(`
+                   "Error: Route /use-cache-cookies-third-party used \`cookies()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`cookies()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+                       at ignore-listed frames
+                   To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-cookies-third-party" in your browser to investigate the error.
+                   Error occurred prerendering page "/use-cache-cookies-third-party". Read more: https://nextjs.org/docs/messages/prerender-error
+
+                   > Export encountered errors on 1 path:
+                   	/use-cache-cookies-third-party/page: /use-cache-cookies-third-party"
+                  `)
+                } else {
+                  expect(output).toMatchInlineSnapshot(`
+                   "Error: Route /use-cache-cookies-third-party used \`cookies()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`cookies()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+                       at a (<next-dist-dir>)
+                       at b (<next-dist-dir>)
+                   To get a more detailed stack trace and pinpoint the issue, try one of the following:
+                     - Start the app in development mode by running \`next dev\`, then open "/use-cache-cookies-third-party" in your browser to investigate the error.
+                     - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+                   Error occurred prerendering page "/use-cache-cookies-third-party". Read more: https://nextjs.org/docs/messages/prerender-error
+                   Export encountered an error on /use-cache-cookies-third-party/page: /use-cache-cookies-third-party, exiting the build."
+                  `)
+                }
+              }
+            })
+          }
+        })
+
+        describe('draftMode', () => {
+          if (isNextDev) {
+            it('should show a redbox error', async () => {
+              const browser = await next.browser(
+                '/use-cache-draft-mode-third-party'
+              )
+
+              await expect(browser).toDisplayRedbox(`
+               {
+                 "code": "E394",
+                 "description": "Route /use-cache-draft-mode-third-party used "draftMode().enable()" inside "use cache". The enabled status of \`draftMode()\` can be read in caches but you must not enable or disable \`draftMode()\` inside a cache. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache",
+                 "environmentLabel": null,
+                 "label": "Runtime Error",
+                 "source": null,
+                 "stack": [],
+               }
+              `)
+            })
+          } else {
+            it('should error the build', async () => {
+              try {
+                await prerender('/use-cache-draft-mode-third-party')
+              } catch {
+                // we expect the build to fail
+              }
+
+              const output = getPrerenderOutput(
+                next.cliOutput.slice(cliOutputLength),
+                { isMinified: !isDebugPrerender }
+              )
+
+              if (isDebugPrerender) {
+                if (isTurbopack) {
+                  expect(output).toMatchInlineSnapshot(`
+                   "Error: Route /use-cache-draft-mode-third-party used "draftMode().enable()" inside "use cache". The enabled status of \`draftMode()\` can be read in caches but you must not enable or disable \`draftMode()\` inside a cache. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+                       at ignore-listed frames
+                   To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-draft-mode-third-party" in your browser to investigate the error.
+                   Error occurred prerendering page "/use-cache-draft-mode-third-party". Read more: https://nextjs.org/docs/messages/prerender-error
+
+                   > Export encountered errors on 1 path:
+                   	/use-cache-draft-mode-third-party/page: /use-cache-draft-mode-third-party"
+                  `)
+                } else {
+                  expect(output).toMatchInlineSnapshot(`
+                   "Error: Route /use-cache-draft-mode-third-party used "draftMode().enable()" inside "use cache". The enabled status of \`draftMode()\` can be read in caches but you must not enable or disable \`draftMode()\` inside a cache. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+                       at ignore-listed frames
+                   To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-draft-mode-third-party" in your browser to investigate the error.
+                   Error occurred prerendering page "/use-cache-draft-mode-third-party". Read more: https://nextjs.org/docs/messages/prerender-error
+
+                   > Export encountered errors on 1 path:
+                   	/use-cache-draft-mode-third-party/page: /use-cache-draft-mode-third-party"
+                  `)
+                }
+              } else {
+                if (isTurbopack) {
+                  expect(output).toMatchInlineSnapshot(`
+                   "Error: Route /use-cache-draft-mode-third-party used "draftMode().enable()" inside "use cache". The enabled status of \`draftMode()\` can be read in caches but you must not enable or disable \`draftMode()\` inside a cache. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+                       at ignore-listed frames
+                   To get a more detailed stack trace and pinpoint the issue, try one of the following:
+                     - Start the app in development mode by running \`next dev\`, then open "/use-cache-draft-mode-third-party" in your browser to investigate the error.
+                     - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+                   Error occurred prerendering page "/use-cache-draft-mode-third-party". Read more: https://nextjs.org/docs/messages/prerender-error
+                   Export encountered an error on /use-cache-draft-mode-third-party/page: /use-cache-draft-mode-third-party, exiting the build."
+                  `)
+                } else {
+                  expect(output).toMatchInlineSnapshot(`
+                   "Error: Route /use-cache-draft-mode-third-party used "draftMode().enable()" inside "use cache". The enabled status of \`draftMode()\` can be read in caches but you must not enable or disable \`draftMode()\` inside a cache. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+                       at a (<next-dist-dir>)
+                   To get a more detailed stack trace and pinpoint the issue, try one of the following:
+                     - Start the app in development mode by running \`next dev\`, then open "/use-cache-draft-mode-third-party" in your browser to investigate the error.
+                     - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+                   Error occurred prerendering page "/use-cache-draft-mode-third-party". Read more: https://nextjs.org/docs/messages/prerender-error
+                   Export encountered an error on /use-cache-draft-mode-third-party/page: /use-cache-draft-mode-third-party, exiting the build."
+                  `)
+                }
+              }
+            })
+          }
+        })
+
+        describe('headers', () => {
+          if (isNextDev) {
+            it('should show a redbox error', async () => {
+              const browser = await next.browser(
+                '/use-cache-headers-third-party'
+              )
+
+              await expect(browser).toDisplayRedbox(`
+               {
+                 "code": "E394",
+                 "description": "Route /use-cache-headers-third-party used \`headers()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`headers()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache",
+                 "environmentLabel": null,
+                 "label": "Runtime Error",
+                 "source": null,
+                 "stack": [],
+               }
+              `)
+            })
+          } else {
+            it('should error the build', async () => {
+              try {
+                await prerender('/use-cache-headers-third-party')
+              } catch {
+                // we expect the build to fail
+              }
+
+              const output = getPrerenderOutput(
+                next.cliOutput.slice(cliOutputLength),
+                { isMinified: !isDebugPrerender }
+              )
+
+              if (isTurbopack) {
+                if (isDebugPrerender) {
+                  expect(output).toMatchInlineSnapshot(`
+                   "Error: Route /use-cache-headers-third-party used \`headers()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`headers()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+                       at ignore-listed frames
+                   To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-headers-third-party" in your browser to investigate the error.
+                   Error occurred prerendering page "/use-cache-headers-third-party". Read more: https://nextjs.org/docs/messages/prerender-error
+
+                   > Export encountered errors on 1 path:
+                   	/use-cache-headers-third-party/page: /use-cache-headers-third-party"
+                  `)
+                } else {
+                  expect(output).toMatchInlineSnapshot(`
+                   "Error: Route /use-cache-headers-third-party used \`headers()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`headers()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+                       at ignore-listed frames
+                   To get a more detailed stack trace and pinpoint the issue, try one of the following:
+                     - Start the app in development mode by running \`next dev\`, then open "/use-cache-headers-third-party" in your browser to investigate the error.
+                     - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+                   Error occurred prerendering page "/use-cache-headers-third-party". Read more: https://nextjs.org/docs/messages/prerender-error
+                   Export encountered an error on /use-cache-headers-third-party/page: /use-cache-headers-third-party, exiting the build."
+                  `)
+                }
+              } else {
+                if (isDebugPrerender) {
+                  expect(output).toMatchInlineSnapshot(`
+                   "Error: Route /use-cache-headers-third-party used \`headers()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`headers()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+                       at ignore-listed frames
+                   To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-headers-third-party" in your browser to investigate the error.
+                   Error occurred prerendering page "/use-cache-headers-third-party". Read more: https://nextjs.org/docs/messages/prerender-error
+
+                   > Export encountered errors on 1 path:
+                   	/use-cache-headers-third-party/page: /use-cache-headers-third-party"
+                  `)
+                } else {
+                  expect(output).toMatchInlineSnapshot(`
+                   "Error: Route /use-cache-headers-third-party used \`headers()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`headers()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+                       at a (<next-dist-dir>)
+                       at b (<next-dist-dir>)
+                   To get a more detailed stack trace and pinpoint the issue, try one of the following:
+                     - Start the app in development mode by running \`next dev\`, then open "/use-cache-headers-third-party" in your browser to investigate the error.
+                     - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+                   Error occurred prerendering page "/use-cache-headers-third-party". Read more: https://nextjs.org/docs/messages/prerender-error
+                   Export encountered an error on /use-cache-headers-third-party/page: /use-cache-headers-third-party, exiting the build."
+                  `)
+                }
+              }
+            })
+          }
+        })
+
+        describe('connection', () => {
+          if (isNextDev) {
+            it('should show a redbox error', async () => {
+              const browser = await next.browser(
+                '/use-cache-connection-third-party'
+              )
+
+              await expect(browser).toDisplayRedbox(`
+               {
+                 "code": "E394",
+                 "description": "Route /use-cache-connection-third-party used \`connection()\` inside "use cache". The \`connection()\` function is used to indicate the subsequent code must only run when there is an actual request, but caches must be able to be produced before a request, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache",
+                 "environmentLabel": null,
+                 "label": "Runtime Error",
+                 "source": null,
+                 "stack": [],
+               }
+              `)
+            })
+          } else {
+            it('should error the build', async () => {
+              try {
+                await prerender('/use-cache-connection-third-party')
+              } catch {
+                // we expect the build to fail
+              }
+
+              const output = getPrerenderOutput(
+                next.cliOutput.slice(cliOutputLength),
+                { isMinified: !isDebugPrerender }
+              )
+
+              if (isTurbopack) {
+                if (isDebugPrerender) {
+                  expect(output).toMatchInlineSnapshot(`
+                   "Error: Route /use-cache-connection-third-party used \`connection()\` inside "use cache". The \`connection()\` function is used to indicate the subsequent code must only run when there is an actual request, but caches must be able to be produced before a request, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+                       at ignore-listed frames
+                   To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-connection-third-party" in your browser to investigate the error.
+                   Error occurred prerendering page "/use-cache-connection-third-party". Read more: https://nextjs.org/docs/messages/prerender-error
+
+                   > Export encountered errors on 1 path:
+                   	/use-cache-connection-third-party/page: /use-cache-connection-third-party"
+                  `)
+                } else {
+                  expect(output).toMatchInlineSnapshot(`
+                   "Error: Route /use-cache-connection-third-party used \`connection()\` inside "use cache". The \`connection()\` function is used to indicate the subsequent code must only run when there is an actual request, but caches must be able to be produced before a request, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+                       at ignore-listed frames
+                   To get a more detailed stack trace and pinpoint the issue, try one of the following:
+                     - Start the app in development mode by running \`next dev\`, then open "/use-cache-connection-third-party" in your browser to investigate the error.
+                     - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+                   Error occurred prerendering page "/use-cache-connection-third-party". Read more: https://nextjs.org/docs/messages/prerender-error
+                   Export encountered an error on /use-cache-connection-third-party/page: /use-cache-connection-third-party, exiting the build."
+                  `)
+                }
+              } else {
+                if (isDebugPrerender) {
+                  expect(output).toMatchInlineSnapshot(`
+                   "Error: Route /use-cache-connection-third-party used \`connection()\` inside "use cache". The \`connection()\` function is used to indicate the subsequent code must only run when there is an actual request, but caches must be able to be produced before a request, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+                       at ignore-listed frames
+                   To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-connection-third-party" in your browser to investigate the error.
+                   Error occurred prerendering page "/use-cache-connection-third-party". Read more: https://nextjs.org/docs/messages/prerender-error
+
+                   > Export encountered errors on 1 path:
+                   	/use-cache-connection-third-party/page: /use-cache-connection-third-party"
+                  `)
+                } else {
+                  expect(output).toMatchInlineSnapshot(`
+                   "Error: Route /use-cache-connection-third-party used \`connection()\` inside "use cache". The \`connection()\` function is used to indicate the subsequent code must only run when there is an actual request, but caches must be able to be produced before a request, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache
+                       at a (<next-dist-dir>)
+                       at b (<next-dist-dir>)
+                   To get a more detailed stack trace and pinpoint the issue, try one of the following:
+                     - Start the app in development mode by running \`next dev\`, then open "/use-cache-connection-third-party" in your browser to investigate the error.
+                     - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+                   Error occurred prerendering page "/use-cache-connection-third-party". Read more: https://nextjs.org/docs/messages/prerender-error
+                   Export encountered an error on /use-cache-connection-third-party/page: /use-cache-connection-third-party, exiting the build."
+                  `)
+                }
+              }
+            })
+          }
+        })
       })
     })
 

--- a/test/e2e/app-dir/cache-components-errors/fixtures/default/app/use-cache-connection-third-party/layout.tsx
+++ b/test/e2e/app-dir/cache-components-errors/fixtures/default/app/use-cache-connection-third-party/layout.tsx
@@ -1,0 +1,9 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>
+        <main>{children}</main>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/cache-components-errors/fixtures/default/app/use-cache-connection-third-party/page.tsx
+++ b/test/e2e/app-dir/cache-components-errors/fixtures/default/app/use-cache-connection-third-party/page.tsx
@@ -1,0 +1,13 @@
+import { CachedConnectionCaller } from 'third-party-pkg'
+
+export default async function Page() {
+  return (
+    <>
+      <p>
+        This page calls `connection()` in `'use cache'` from third-party code,
+        which triggers an error.
+      </p>
+      <CachedConnectionCaller />
+    </>
+  )
+}

--- a/test/e2e/app-dir/cache-components-errors/fixtures/default/app/use-cache-connection/layout.tsx
+++ b/test/e2e/app-dir/cache-components-errors/fixtures/default/app/use-cache-connection/layout.tsx
@@ -1,0 +1,9 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>
+        <main>{children}</main>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/cache-components-errors/fixtures/default/app/use-cache-connection/page.tsx
+++ b/test/e2e/app-dir/cache-components-errors/fixtures/default/app/use-cache-connection/page.tsx
@@ -1,0 +1,25 @@
+import { connection } from 'next/server'
+
+export default async function Page() {
+  return (
+    <>
+      <p>
+        This page calls `connection()` in `'use cache'`, which triggers an
+        error.
+      </p>
+      <ConnectionCallingComponent />
+    </>
+  )
+}
+
+async function ConnectionCallingComponent() {
+  'use cache'
+
+  // Calling connection() in a cache context is not allowed. We're try/catching
+  // here to ensure that this error is shown even when it's caught in userland.
+  try {
+    await connection()
+  } catch {}
+
+  return null
+}

--- a/test/e2e/app-dir/cache-components-errors/fixtures/default/app/use-cache-cookies-third-party/layout.tsx
+++ b/test/e2e/app-dir/cache-components-errors/fixtures/default/app/use-cache-cookies-third-party/layout.tsx
@@ -1,0 +1,9 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>
+        <main>{children}</main>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/cache-components-errors/fixtures/default/app/use-cache-cookies-third-party/page.tsx
+++ b/test/e2e/app-dir/cache-components-errors/fixtures/default/app/use-cache-cookies-third-party/page.tsx
@@ -1,0 +1,13 @@
+import { CachedCookiesReader } from 'third-party-pkg'
+
+export default async function Page() {
+  return (
+    <>
+      <p>
+        This page accesses `cookies()` in `'use cache'` from third-party code,
+        which triggers an error.
+      </p>
+      <CachedCookiesReader />
+    </>
+  )
+}

--- a/test/e2e/app-dir/cache-components-errors/fixtures/default/app/use-cache-draft-mode-third-party/layout.tsx
+++ b/test/e2e/app-dir/cache-components-errors/fixtures/default/app/use-cache-draft-mode-third-party/layout.tsx
@@ -1,0 +1,9 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>
+        <main>{children}</main>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/cache-components-errors/fixtures/default/app/use-cache-draft-mode-third-party/page.tsx
+++ b/test/e2e/app-dir/cache-components-errors/fixtures/default/app/use-cache-draft-mode-third-party/page.tsx
@@ -1,0 +1,13 @@
+import { CachedDraftModeEnabler } from 'third-party-pkg'
+
+export default async function Page() {
+  return (
+    <>
+      <p>
+        This page enables draft mode in `'use cache'` from third-party code,
+        which triggers an error.
+      </p>
+      <CachedDraftModeEnabler />
+    </>
+  )
+}

--- a/test/e2e/app-dir/cache-components-errors/fixtures/default/app/use-cache-headers-third-party/layout.tsx
+++ b/test/e2e/app-dir/cache-components-errors/fixtures/default/app/use-cache-headers-third-party/layout.tsx
@@ -1,0 +1,9 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>
+        <main>{children}</main>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/cache-components-errors/fixtures/default/app/use-cache-headers-third-party/page.tsx
+++ b/test/e2e/app-dir/cache-components-errors/fixtures/default/app/use-cache-headers-third-party/page.tsx
@@ -1,0 +1,13 @@
+import { CachedHeadersReader } from 'third-party-pkg'
+
+export default async function Page() {
+  return (
+    <>
+      <p>
+        This page accesses `headers()` in `'use cache'` from third-party code,
+        which triggers an error.
+      </p>
+      <CachedHeadersReader />
+    </>
+  )
+}

--- a/test/e2e/app-dir/cache-components-errors/fixtures/default/node_modules/third-party-pkg/index.js
+++ b/test/e2e/app-dir/cache-components-errors/fixtures/default/node_modules/third-party-pkg/index.js
@@ -1,0 +1,42 @@
+import { cookies, headers, draftMode } from 'next/headers'
+import { connection } from 'next/server'
+
+export async function CachedCookiesReader() {
+  'use cache'
+
+  try {
+    await cookies()
+  } catch {}
+
+  return null
+}
+
+export async function CachedHeadersReader() {
+  'use cache'
+
+  try {
+    await headers()
+  } catch {}
+
+  return null
+}
+
+export async function CachedDraftModeEnabler() {
+  'use cache'
+
+  try {
+    ;(await draftMode()).enable()
+  } catch {}
+
+  return null
+}
+
+export async function CachedConnectionCaller() {
+  'use cache'
+
+  try {
+    await connection()
+  } catch {}
+
+  return null
+}

--- a/test/e2e/app-dir/cache-components-errors/fixtures/default/node_modules/third-party-pkg/package.json
+++ b/test/e2e/app-dir/cache-components-errors/fixtures/default/node_modules/third-party-pkg/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "third-party-pkg",
+  "type": "module",
+  "exports": {
+    ".": "./index.js"
+  }
+}


### PR DESCRIPTION
When `cookies()`, `headers()`, `draftMode()`, or `connection()` are called inside `"use cache"` from third-party (ignore-listed) code, the error stacks previously had no usable frames. The redbox showed no source location and an empty call stack, and the build output only showed `at ignore-listed frames`. This made it difficult to trace which component was responsible for the invalid API usage.

This PR fixes the issue by calling React's `captureOwnerStack()` at the `"use cache"` boundary (in `use-cache-wrapper.ts`) before entering the cache scope, and storing the result on the cache work unit store as `outerOwnerStack`. When an error is later thrown inside the cache scope (e.g. from `cookies()`), `applyOwnerStack()` concatenates the inner owner stack (from within the cache scope) with the stored outer owner stack to reconstruct the full component tree across cache boundaries. This also correctly handles nested `"use cache"` scopes by chaining the outer owner stacks.

The `applyOwnerStack` function was extracted from `io-utils.tsx` into `dynamic-rendering-utils.ts` so it can be reused by both the request API files (`cookies.ts`, `headers.ts`, `draft-mode.ts`, `connection.ts`) and the sync IO error handling in `io-utils.tsx`.

New test cases cover both first-party and third-party usage of all four APIs, including a previously missing `connection()` in `"use cache"` test case.

> [!TIP]
> This PR is best reviewed commit by commit to see how the error stacks changed.