### PR TITLE
Fix swc wasm test on canary

### DIFF
--- a/apps/bundle-analyzer/package.json
+++ b/apps/bundle-analyzer/package.json
@@ -3,7 +3,7 @@
   "version": "16.0.2-canary.16",
   "private": true,
   "scripts": {
-    "build": "cross-env NEXT_TEST_NATIVE_IGNORE_LOCAL_INSTALL=true NEXT_TEST_NATIVE_DIR=no next build --no-mangling",
+    "build": "cross-env NEXT_TEST_NATIVE_IGNORE_LOCAL_INSTALL=true NEXT_TEST_NATIVE_DIR=no NEXT_TEST_WASM= next build --no-mangling",
     "dev": "cross-env NEXT_TEST_NATIVE_IGNORE_LOCAL_INSTALL=true NEXT_TEST_NATIVE_DIR=no next dev",
     "lint": "eslint .",
     "start": "cross-env NEXT_TEST_NATIVE_IGNORE_LOCAL_INSTALL=true NEXT_TEST_NATIVE_DIR=no next start"


### PR DESCRIPTION
## What?

Fixes the failure of "test next-swc wasm" on the canary branch. The env var it sets incorrectly propagated into the build process for the bundle analyzer. 

Example: https://github.com/vercel/next.js/actions/runs/24352454644/job/71117953939

This makes sure that the env var is set to empty so that it is ignored for that step specifically. 

Ideally we'd figure out a more granular way to set this env var where it is needed instead, but this unblocks the CI.