### PR TITLE
fix: correct source path in .claude-plugin/marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "cache-components",
-      "source": "./plugins/cache-components",
+      "source": "./.claude-plugin/plugins/cache-components",
       "description": "Expert guidance for Next.js Cache Components and Partial Prerendering (PPR). Proactively activates in projects with cacheComponents enabled.",
       "version": "1.0.0",
       "author": {


### PR DESCRIPTION
## What

Fixes the `source` path for the `cache-components` plugin in `.claude-plugin/marketplace.json`.

## Why

Source paths in `marketplace.json` are resolved **relative to the repository root**. The current path:

```json
"source": "./plugins/cache-components"
```

resolves to `plugins/cache-components/` at the repo root — which does not exist.

The plugin files actually live at `.claude-plugin/plugins/cache-components/`, so the correct path is:

```json
"source": "./.claude-plugin/plugins/cache-components"
```

## Result

Installing the plugin via the Claude Code plugin system now works correctly:

```sh
claude plugin marketplace add vercel/next.js
claude plugin install cache-components@nextjs
```