### PR TITLE
Switch segment prefetch cache miss response from 204 to 404

### DIFF
--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -1606,7 +1606,7 @@ export async function handler(
       ) {
         // This is a prefetch request issued by the client Segment Cache. These
         // should never reach the application layer (lambda). We should either
-        // respond from the cache (HIT) or respond with 204 No Content (MISS).
+        // respond from the cache (HIT) or respond with 404 (MISS).
 
         // Set a header to indicate that PPR is enabled for this route. This
         // lets the client distinguish between a regular cache miss and a cache
@@ -1642,10 +1642,8 @@ export async function handler(
         // Cache miss. Either a cache entry for this route has not been generated
         // (which technically should not be possible when PPR is enabled, because
         // at a minimum there should always be a fallback entry) or there's no
-        // match for the requested segment. Respond with a 204 No Content. We
-        // don't bother to respond with 404, because these requests are only
-        // issued as part of a prefetch.
-        res.statusCode = 204
+        // match for the requested segment. Respond with a 404.
+        res.statusCode = 404
         return sendRenderResult({
           req,
           res,

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -1672,15 +1672,7 @@ export async function fetchRouteOnCacheMiss(
         response !== null && response.redirected ? new URL(response.url) : url
     }
 
-    if (
-      !response ||
-      !response.ok ||
-      // 204 is a Cache miss. Though theoretically this shouldn't happen when
-      // PPR is enabled, because we always respond to route tree requests, even
-      // if it needs to be blockingly generated on demand.
-      response.status === 204 ||
-      !response.body
-    ) {
+    if (!response || !response.ok || !response.body) {
       // Server responded with an error, or with a miss. We should still cache
       // the response, but we can try again after 10 seconds.
       rejectRouteCacheEntry(entry, Date.now() + 10 * 1000)
@@ -1950,7 +1942,6 @@ export async function fetchSegmentsOnCacheMiss(
     if (
       !response ||
       !response.ok ||
-      response.status === 204 || // Cache miss
       // This checks whether the response was served from the per-segment cache,
       // rather than the old prefetching flow. If it fails, it implies that PPR
       // is disabled on this route. Theoretically this should never happen


### PR DESCRIPTION
The original reason for using 204 was to prevent segment cache misses from appearing as errors in the browser network panel, e.g. if you prefetch a same-origin link that happens to route to a different app on the same domain. However, in output: export mode, we can't use custom status codes — responses are served as static files, so we're limited to standard HTTP semantics. Using 404 lets the server-driven and static deployment strategies converge on the same client-server protocol. The network panel noise is a minor, non-essential compromise.

<!-- NEXT_JS_LLM_PR -->