### PR TITLE
Ensure x-nextjs-data header is only set during resolve

### DIFF
--- a/packages/next/src/server/lib/router-utils/resolve-routes.ts
+++ b/packages/next/src/server/lib/router-utils/resolve-routes.ts
@@ -200,6 +200,11 @@ export function getResolveRoutes(
       return pathname
     }
 
+    const setIsNextDataRequest = () => {
+      addRequestMeta(req, 'isNextDataReq', true)
+      req.headers['x-nextjs-data'] = '1'
+    }
+
     let domainLocale: ReturnType<typeof detectDomainLocale> | undefined
     let defaultLocale: string | undefined
     let initialLocaleResult:
@@ -328,7 +333,7 @@ export function getResolveRoutes(
           }
 
           if (pageOutput && curPathname?.startsWith('/_next/data')) {
-            addRequestMeta(req, 'isNextDataReq', true)
+            setIsNextDataRequest()
           }
 
           if (config.useFileSystemPublicRoutes || didRewrite) {
@@ -424,11 +429,18 @@ export function getResolveRoutes(
               normalized = normalizers.basePath.normalize(normalized, true)
             }
 
+            const isNextDataPath =
+              pathHasPrefix(normalized, '/_next/data') &&
+              normalized.endsWith('.json')
+            const hasCurrentBuildIdDataPath = normalizers.data.match(normalized)
+
             let updated = false
-            if (normalizers.data.match(normalized)) {
+            if (hasCurrentBuildIdDataPath) {
               updated = true
-              addRequestMeta(req, 'isNextDataReq', true)
               normalized = normalizers.data.normalize(normalized, true)
+            }
+            if (isNextDataPath) {
+              setIsNextDataRequest()
             }
 
             if (config.i18n) {

--- a/packages/next/src/server/lib/server-ipc/utils.ts
+++ b/packages/next/src/server/lib/server-ipc/utils.ts
@@ -48,6 +48,7 @@ const INTERNAL_HEADERS = [
   'x-middleware-next',
   'x-now-route-matches',
   'x-matched-path',
+  'x-nextjs-data',
   'x-next-resume-state-length',
 ]
 

--- a/test/e2e/middleware-general/test/index.test.ts
+++ b/test/e2e/middleware-general/test/index.test.ts
@@ -108,6 +108,19 @@ describe('Middleware Runtime', () => {
   }
 
   function runTests({ i18n }: { i18n?: boolean }) {
+    it('should not treat as _next/data request with just header', async () => {
+      const res = await next.fetch('/redirect-to-somewhere', {
+        redirect: 'manual',
+        headers: {
+          'x-nextjs-data': '1',
+        },
+      })
+
+      expect(res.status).toBe(307)
+      expect(res.headers.get('Location')).toContain('/somewhere')
+      expect(res.headers.get('x-nextjs-redirect')).toBe(null)
+    })
+
     if (isNodeMiddleware) {
       it('should be able to use node builtins with node runtime', async () => {
         const res = await next.fetch('/test-node-fs')


### PR DESCRIPTION
Makes sure we set this header during route resolving so user request doesn't need to. 