### PR TITLE
turbopack: mark injected chunk scripts as async for React DOM dedupe

### DIFF
--- a/turbopack/crates/turbopack-ecmascript-runtime/js/src/browser/runtime/dom/runtime-backend-dom.ts
+++ b/turbopack/crates/turbopack-ecmascript-runtime/js/src/browser/runtime/dom/runtime-backend-dom.ts
@@ -210,6 +210,14 @@ const chunkResolvers: Map<ChunkUrl, ChunkResolver> = new Map()
         } else {
           const script = document.createElement('script')
           script.src = chunkUrl
+          // React DOM reuses hoistable scripts by:
+          // 1. keying them by `src`, and
+          // 2. looking them up in the DOM via `script[async][src="..."]`.
+          // Set `async` explicitly so Turbopack-inserted chunk scripts participate in
+          // that dedupe path and do not trigger a second request for the same URL.
+          // Dynamically inserted scripts already load asynchronously, so this only
+          // makes the DOM representation explicit without changing load behavior.
+          script.async = true
           // We'll only mark the chunk as loaded once the script has been executed,
           // which happens in `registerChunk`. Hence the absence of `resolve()` in
           // this branch.


### PR DESCRIPTION
### What?

Set `script.async = true` on JS chunk scripts created by Turbopack's DOM runtime backend.

### Why?

Client-side App Router navigations request the same route chunk twice when Turbopack and React DOM both try to load it.

The reproducer and investigation are here:

- Reproducer: https://github.com/gurkerl83/next-app-router-duplicate-chunk-nav-repro
- Repro README: https://github.com/gurkerl83/next-app-router-duplicate-chunk-nav-repro/blob/main/README.md
- Investigation notes: https://github.com/gurkerl83/next-app-router-duplicate-chunk-nav-repro/blob/main/RESOLUTION.md

In particular, the investigation notes describe 
"Option A: Add `async` Attribute to Turbopack's Script Tags", which is what this PR implements.

React DOM reuses hoistable scripts by `src` and looks them up in the DOM via `script[async][src="..."]`. Turbopack's DOM chunk loader inserted matching chunk scripts without explicitly setting `async`, so React DOM misses an already-present script and appends a second one for the same URL.

### How?

Set `async` explicitly on Turbopack-inserted chunk scripts so they participate in the same DOM dedupe path that React DOM uses for hoistable scripts.

Dynamically inserted scripts already load asynchronously, so this only makes the DOM representation explicit without changing load behavior.

This change is in Turbopack's DOM runtime backend, which is used for both development and production DOM chunk loading.

### Verification

Validating this change against the reproducer requires:

1. In the local `next.js` checkout, run a full rebuild so the Turbopack native
   binary is rebuilt with the updated embedded DOM runtime sources:

```bash
pnpm build-all
```

2. In the reproducer app, build it against that local native binding:

```bash
NEXT_TEST_NATIVE_DIR=<path-to-local-nextjs-checkout>/packages/next-swc/native pnpm next build
```

Without NEXT_TEST_NATIVE_DIR, the reproducer may resolve a different native binding and not include the patched runtime.

Fixes #92689 