### PR TITLE
 Add unstable_prefetch route segment config and decouple runtime prefetching from unstable_instant

### DIFF
--- a/crates/next-core/src/segment_config.rs
+++ b/crates/next-core/src/segment_config.rs
@@ -119,6 +119,9 @@ pub struct NextSegmentConfig {
     #[turbo_tasks(trace_ignore)]
     #[bincode(with_serde)]
     pub unstable_instant: Option<Span>,
+    #[turbo_tasks(trace_ignore)]
+    #[bincode(with_serde)]
+    pub unstable_prefetch: Option<Span>,
 }
 
 #[turbo_tasks::value_impl]
@@ -533,9 +536,25 @@ pub async fn parse_segment_config_from_source(
                 "unstable_instant",
                 span,
                 rcstr!(
-                    "App pages cannot export \"unstable_instant\" from a Client Component module. \
-                     To use this API, convert this module to a Server Component by removing the \
-                     \"use client\" directive."
+                    "\"unstable_instant\" is a route segment config and can only be used when the \
+                     segment is a Server Component module. Remove the \"use client\" directive to \
+                     use this API."
+                ),
+                None,
+                IssueSeverity::Error,
+            )
+            .await?;
+        }
+
+        if let Some(span) = config.unstable_prefetch {
+            invalid_config(
+                source,
+                "unstable_prefetch",
+                span,
+                rcstr!(
+                    "\"unstable_prefetch\" is a route segment config and can only be used when \
+                     the segment is a Server Component module. Remove the \"use client\" \
+                     directive to use this API."
                 ),
                 None,
                 IssueSeverity::Error,
@@ -961,6 +980,9 @@ async fn parse_config_value(
         }
         "unstable_instant" => {
             config.unstable_instant = Some(span);
+        }
+        "unstable_prefetch" => {
+            config.unstable_prefetch = Some(span);
         }
         _ => {}
     }

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1156,5 +1156,9 @@
   "1155": "Not implemented",
   "1156": "Cannot create a replay stream after the ReplayableNodeStream has been disposed.",
   "1157": "`unstable_io()` requires the `experimental.unstableIO` option to be enabled in your Next.js config.",
-  "1158": "The prerender-ppr work unit type has been removed. This code path should be unreachable."
+  "1158": "The prerender-ppr work unit type has been removed. This code path should be unreachable.",
+  "1159": "\"unstable_instant\" is a route segment config and can only be used when the segment is a Server Component module. Remove the \"use client\" directive from \"%s\" to use this API.",
+  "1160": "Route \"%s\" cannot use \\`export const unstable_prefetch = ...\\` without enabling \\`cacheComponents\\`.",
+  "1161": "\"unstable_prefetch\" is a route segment config and can only be used when the segment is a Server Component module. Remove the \"use client\" directive from \"%s\" to use this API.",
+  "1162": "Route \"%s\" cannot use \\`export const unstable_instant = ...\\` without enabling \\`cacheComponents\\`."
 }

--- a/packages/next/src/build/analysis/get-page-static-info.ts
+++ b/packages/next/src/build/analysis/get-page-static-info.ts
@@ -681,13 +681,26 @@ export async function getAppPageStaticInfo({
   // Prevent use client and unstable_instant in the same file.
   if (directives?.has('client') && 'unstable_instant' in config) {
     throw new Error(
-      `Page "${page}" cannot export "unstable_instant" from a Client Component module. To use this API, convert this module to a Server Component by removing the "use client" directive.`
+      `"unstable_instant" is a route segment config and can only be used when the segment is a Server Component module. Remove the "use client" directive from "${pageFilePath}" to use this API.`
     )
   }
 
   if ('unstable_instant' in config && !nextConfig.cacheComponents) {
     throw new Error(
-      `Page "${page}" cannot use \`export const unstable_instant = ...\` without enabling \`cacheComponents\`.`
+      `Route "${page}" cannot use \`export const unstable_instant = ...\` without enabling \`cacheComponents\`.`
+    )
+  }
+
+  // Prevent use client and unstable_prefetch in the same file.
+  if (directives?.has('client') && 'unstable_prefetch' in config) {
+    throw new Error(
+      `"unstable_prefetch" is a route segment config and can only be used when the segment is a Server Component module. Remove the "use client" directive from "${pageFilePath}" to use this API.`
+    )
+  }
+
+  if ('unstable_prefetch' in config && !nextConfig.cacheComponents) {
+    throw new Error(
+      `Route "${page}" cannot use \`export const unstable_prefetch = ...\` without enabling \`cacheComponents\`.`
     )
   }
 

--- a/packages/next/src/build/segment-config/app/app-segment-config.ts
+++ b/packages/next/src/build/segment-config/app/app-segment-config.ts
@@ -49,7 +49,11 @@ const InstantConfigSchema = z.union([
   z.literal(false),
 ])
 
+const PrefetchSchema = z.enum(['static', 'runtime'])
+
 export type Instant = InstantConfigStatic | InstantConfigRuntime | false
+
+export type Prefetch = 'static' | 'runtime'
 
 export type InstantConfigForTypeCheckInternal = __GenericInstantConfig | Instant
 // the __GenericPrefetch type is used to avoid type widening issues with
@@ -146,6 +150,13 @@ const AppSegmentConfigSchema = z.object({
   unstable_instant: InstantConfigSchema.optional(),
 
   /**
+   * Controls runtime prefetching for this segment.
+   * 'static' is a noop (default behavior).
+   * 'runtime' enables runtime prefetching.
+   */
+  unstable_prefetch: PrefetchSchema.optional(),
+
+  /**
    * The stale time for dynamic responses in seconds.
    * Controls how long the client-side router cache retains dynamic page data.
    * Pages only — not allowed in layouts.
@@ -193,6 +204,11 @@ export function parseAppSegmentConfig(
             return {
               // @TODO replace this link with a link to the docs when they are written
               message: `Invalid unstable_instant value ${JSON.stringify(ctx.data)} on "${route}", must be an object with \`prefetch: "static"\` or \`prefetch: "runtime"\`, or \`false\`. Read more at https://nextjs.org/docs/messages/invalid-instant-configuration`,
+            }
+          }
+          case 'unstable_prefetch': {
+            return {
+              message: `Invalid unstable_prefetch value ${JSON.stringify(ctx.data)} on "${route}", must be "static" or "runtime".`,
             }
           }
           case 'unstable_dynamicStaleTime': {
@@ -253,6 +269,13 @@ export type AppSegmentConfig = {
    * How this segment should be prefetched.
    */
   unstable_instant?: Instant
+
+  /**
+   * Controls runtime prefetching for this segment.
+   * 'static' is a noop (default behavior).
+   * 'runtime' enables runtime prefetching.
+   */
+  unstable_prefetch?: Prefetch
 
   /**
    * The stale time for dynamic responses in seconds.

--- a/packages/next/src/build/webpack/plugins/next-types-plugin/index.ts
+++ b/packages/next/src/build/webpack/plugins/next-types-plugin/index.ts
@@ -54,7 +54,7 @@ ${
     : `import type { ResolvingMetadata, ResolvingViewport } from 'next/dist/lib/metadata/types/metadata-interface.js'`
 }
 
-import type { InstantConfigForTypeCheckInternal } from 'next/dist/build/segment-config/app/app-segment-config.js'
+import type { InstantConfigForTypeCheckInternal, Prefetch } from 'next/dist/build/segment-config/app/app-segment-config.js'
 
 type TEntry = typeof import('${relativePath}.js')
 
@@ -72,6 +72,7 @@ checkFields<Diff<{
   config?: {}
   generateStaticParams?: Function
   unstable_instant?: InstantConfigForTypeCheckInternal
+  unstable_prefetch?: Prefetch
   unstable_dynamicStaleTime?: number
   revalidate?: RevalidateRange<TEntry> | false
   dynamic?: 'auto' | 'force-dynamic' | 'error' | 'force-static'

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -243,13 +243,10 @@ async function createComponentTreeInternal(
       })
     : []
 
-  const instantConfig = layoutOrPageMod
-    ? (layoutOrPageMod as AppSegmentConfig).unstable_instant
+  const prefetchConfig = layoutOrPageMod
+    ? (layoutOrPageMod as AppSegmentConfig).unstable_prefetch
     : undefined
-  const hasRuntimePrefetch =
-    instantConfig && typeof instantConfig === 'object'
-      ? instantConfig.prefetch === 'runtime'
-      : false
+  const hasRuntimePrefetch = prefetchConfig === 'runtime'
   const isRuntimePrefetchable = hasRuntimePrefetch || parentRuntimePrefetchable
 
   const [Forbidden, forbiddenStyles] =

--- a/packages/next/src/server/app-render/create-flight-router-state-from-loader-tree.ts
+++ b/packages/next/src/server/app-render/create-flight-router-state-from-loader-tree.ts
@@ -28,10 +28,13 @@ async function createFlightRouterStateFromLoaderTreeImpl(
     {},
   ]
 
-  // Load the layout or page module to check for unstable_instant config
+  // Load the layout or page module to check for unstable_instant/unstable_prefetch config
   const mod = layout ? await layout[0]() : page ? await page[0]() : undefined
   const instantConfig = mod
     ? (mod as AppSegmentConfig).unstable_instant
+    : undefined
+  const prefetchConfig = mod
+    ? (mod as AppSegmentConfig).unstable_prefetch
     : undefined
   let prefetchHints = 0
 
@@ -89,9 +92,10 @@ async function createFlightRouterStateFromLoaderTreeImpl(
     prefetchHints |= PrefetchHint.PrefetchDisabled
   } else if (instantConfig && typeof instantConfig === 'object') {
     prefetchHints |= PrefetchHint.SubtreeHasInstant
-    if (instantConfig.prefetch === 'runtime') {
-      prefetchHints |= PrefetchHint.HasRuntimePrefetch
-    }
+  }
+
+  if (prefetchConfig === 'runtime') {
+    prefetchHints |= PrefetchHint.HasRuntimePrefetch
   }
 
   // Check if this segment has a loading boundary

--- a/packages/next/src/server/app-render/instant-validation/instant-config.tsx
+++ b/packages/next/src/server/app-render/instant-validation/instant-config.tsx
@@ -16,14 +16,10 @@ export async function anySegmentHasRuntimePrefetchEnabled(
   const { mod: layoutOrPageMod } = await getLayoutOrPageModule(tree)
 
   // TODO(restart-on-cache-miss): Does this work correctly for client page/layout modules?
-  const instantConfig = layoutOrPageMod
-    ? (layoutOrPageMod as AppSegmentConfig).unstable_instant
+  const prefetchConfig = layoutOrPageMod
+    ? (layoutOrPageMod as AppSegmentConfig).unstable_prefetch
     : undefined
-  const hasRuntimePrefetch =
-    instantConfig && typeof instantConfig === 'object'
-      ? instantConfig.prefetch === 'runtime'
-      : false
-  if (hasRuntimePrefetch) {
+  if (prefetchConfig === 'runtime') {
     return true
   }
 

--- a/packages/next/src/server/app-render/instant-validation/instant-validation.tsx
+++ b/packages/next/src/server/app-render/instant-validation/instant-validation.tsx
@@ -1146,10 +1146,13 @@ export async function createCombinedPayloadAtDepth(
         : createChildSegmentPath(parentPath, key!, segment)
 
     let instantConfig: Instant | null = null
+    let prefetchConfig: AppSegmentConfig['unstable_prefetch'] | null = null
     let localCreateInstantStack: (() => Error) | null = null
     if (layoutOrPageMod !== undefined) {
       instantConfig =
         (layoutOrPageMod as AppSegmentConfig).unstable_instant ?? null
+      prefetchConfig =
+        (layoutOrPageMod as AppSegmentConfig).unstable_prefetch ?? null
       if (instantConfig && typeof instantConfig === 'object') {
         const rawFactory: unknown = (layoutOrPageMod as any)
           .__debugCreateInstantConfigStack
@@ -1158,14 +1161,12 @@ export async function createCombinedPayloadAtDepth(
       }
     }
 
+    const segmentHasRuntimePrefetch = prefetchConfig === 'runtime'
+
     let childIsInsideRuntimePrefetch = isInsideRuntimePrefetch
     let stage: SegmentStage
     if (!isInsideRuntimePrefetch) {
-      if (
-        instantConfig &&
-        typeof instantConfig === 'object' &&
-        instantConfig.prefetch === 'runtime'
-      ) {
+      if (segmentHasRuntimePrefetch) {
         stage = RenderStage.Runtime
         childIsInsideRuntimePrefetch = true
         hasRuntimeSegments = true

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/apis/[param]/page.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/apis/[param]/page.tsx
@@ -4,6 +4,7 @@ import { connection } from 'next/server'
 import { Suspense } from 'react'
 
 export const unstable_instant = { prefetch: 'runtime', samples: [{}] }
+export const unstable_prefetch = 'runtime'
 
 const CACHE_KEY = __dirname + '/__PAGE__'
 

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/private-cache/layout.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/private-cache/layout.tsx
@@ -3,6 +3,7 @@ import { UncachedFetch, CachedData } from '../data-fetching'
 import { PrivateCachedData } from './data-fetching'
 
 export const unstable_instant = { prefetch: 'runtime', samples: [{}] }
+export const unstable_prefetch = 'runtime'
 
 const CACHE_KEY = '/private-cache/__LAYOUT__'
 

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/short-lived-cache/layout.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/short-lived-cache/layout.tsx
@@ -3,6 +3,7 @@ import { UncachedFetch, CachedData } from '../data-fetching'
 import { ShortLivedCache } from './data-fetching'
 
 export const unstable_instant = { prefetch: 'runtime', samples: [{}] }
+export const unstable_prefetch = 'runtime'
 
 const CACHE_KEY = __dirname + '/__LAYOUT__'
 

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/simple/layout.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/simple/layout.tsx
@@ -2,6 +2,7 @@ import { Suspense } from 'react'
 import { UncachedFetch, CachedFetch, CachedData } from '../data-fetching'
 
 export const unstable_instant = { prefetch: 'runtime', samples: [{}] }
+export const unstable_prefetch = 'runtime'
 
 const CACHE_KEY = __dirname + '/__LAYOUT__'
 

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/successive-caches/page.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/successive-caches/page.tsx
@@ -1,4 +1,5 @@
 export const unstable_instant = { prefetch: 'runtime', samples: [{}] }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page() {
   return (

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/sync-io/runtime/page.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/sync-io/runtime/page.tsx
@@ -3,6 +3,7 @@ import { CachedData, getCachedData } from '../../data-fetching'
 import { cookies } from 'next/headers'
 
 export const unstable_instant = { prefetch: 'runtime', samples: [{}] }
+export const unstable_prefetch = 'runtime'
 
 const CACHE_KEY = __dirname + '/__PAGE__'
 

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/sync-io/static/page.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/sync-io/static/page.tsx
@@ -1,6 +1,7 @@
 import { CachedData, getCachedData } from '../../data-fetching'
 
 export const unstable_instant = { prefetch: 'runtime', samples: [{}] }
+export const unstable_prefetch = 'runtime'
 
 const CACHE_KEY = __dirname + '/__PAGE__'
 

--- a/test/development/app-dir/cache-components-tasks/fixtures/with-prefetch-config/app/simple/layout.tsx
+++ b/test/development/app-dir/cache-components-tasks/fixtures/with-prefetch-config/app/simple/layout.tsx
@@ -2,6 +2,7 @@ import { Suspense } from 'react'
 import { Static, Runtime, Dynamic } from '../shared'
 
 export const unstable_instant = { prefetch: 'runtime', samples: [{}] }
+export const unstable_prefetch = 'runtime'
 
 export default function Root({ children }: { children: React.ReactNode }) {
   return (

--- a/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/app/runtime-prefetch-target/page.tsx
+++ b/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/app/runtime-prefetch-target/page.tsx
@@ -5,6 +5,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ searchParams: { myParam: 'testValue' } }],
 }
+export const unstable_prefetch = 'runtime'
 
 type SearchParams = { [key: string]: string | string[] | undefined }
 

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/invalid-undeclared-cookie-get-caught/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/invalid-undeclared-cookie-get-caught/page.tsx
@@ -6,6 +6,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/invalid-undeclared-cookie-get/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/invalid-undeclared-cookie-get/page.tsx
@@ -6,6 +6,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/invalid-undeclared-cookie-has/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/invalid-undeclared-cookie-has/page.tsx
@@ -6,6 +6,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/valid-cookies-in-samples/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/valid-cookies-in-samples/page.tsx
@@ -15,6 +15,7 @@ export const unstable_instant: Instant = {
     },
   ],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/valid-cookies-passed-to-cache/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/valid-cookies-passed-to-cache/page.tsx
@@ -10,6 +10,7 @@ export const unstable_instant: Instant = {
     },
   ],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/valid-cookies-passed-to-client/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/valid-cookies-passed-to-client/page.tsx
@@ -10,6 +10,7 @@ export const unstable_instant: Instant = {
     },
   ],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/gsp/[slug]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/gsp/[slug]/page.tsx
@@ -16,6 +16,7 @@ export const unstable_instant: Instant = {
     },
   ],
 }
+export const unstable_prefetch = 'runtime'
 
 export function generateStaticParams() {
   return [{ slug: 'foo' }, { slug: 'bar' }]

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/headers/invalid-undeclared-header-get-caught/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/headers/invalid-undeclared-header-get-caught/page.tsx
@@ -6,6 +6,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ headers: [] }],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/headers/invalid-undeclared-header-get/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/headers/invalid-undeclared-header-get/page.tsx
@@ -6,6 +6,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ headers: [] }],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/headers/invalid-undeclared-header-has/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/headers/invalid-undeclared-header-has/page.tsx
@@ -6,6 +6,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ headers: [] }],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/headers/valid-headers-in-samples/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/headers/valid-headers-in-samples/page.tsx
@@ -15,6 +15,7 @@ export const unstable_instant: Instant = {
     },
   ],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/headers/valid-headers-passed-to-cache/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/headers/valid-headers-passed-to-cache/page.tsx
@@ -10,6 +10,7 @@ export const unstable_instant: Instant = {
     },
   ],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/headers/valid-headers-passed-to-client/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/headers/valid-headers-passed-to-client/page.tsx
@@ -10,6 +10,7 @@ export const unstable_instant: Instant = {
     },
   ],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/invalid-missing-suspense-around-runtime/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/invalid-missing-suspense-around-runtime/page.tsx
@@ -5,6 +5,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [{ name: 'auth', value: '1' }] }],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page() {
   const c = await cookies()

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/params/invalid-param-not-provided-caught/[one]/[two]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/params/invalid-param-not-provided-caught/[one]/[two]/page.tsx
@@ -13,6 +13,7 @@ export const unstable_instant: Instant = {
     },
   ],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page({
   params,

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/params/invalid-param-not-provided/[one]/[two]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/params/invalid-param-not-provided/[one]/[two]/page.tsx
@@ -13,6 +13,7 @@ export const unstable_instant: Instant = {
     },
   ],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page({
   params,

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/params/valid-params-in-samples/[one]/[two]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/params/valid-params-in-samples/[one]/[two]/page.tsx
@@ -12,6 +12,7 @@ export const unstable_instant: Instant = {
     },
   ],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page({
   params,

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/params/valid-params-passed-to-cache/[slug]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/params/valid-params-passed-to-cache/[slug]/page.tsx
@@ -5,6 +5,7 @@ export const unstable_instant: Instant = {
   prefetch: 'runtime',
   samples: [{ params: { slug: 'hello' } }],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page({
   params,

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/params/valid-params-passed-to-client/[slug]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/params/valid-params-passed-to-client/[slug]/page.tsx
@@ -5,6 +5,7 @@ export const unstable_instant: Instant = {
   prefetch: 'runtime',
   samples: [{ params: { slug: 'hello' } }],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page({
   params,

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/invalid-undeclared-search-param-caught/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/invalid-undeclared-search-param-caught/page.tsx
@@ -4,6 +4,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ searchParams: { q: 'test' } }],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page({
   searchParams,

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/invalid-undeclared-search-param/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/invalid-undeclared-search-param/page.tsx
@@ -4,6 +4,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ searchParams: { q: 'test' } }],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page({
   searchParams,

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/invalid-undeclared-use-search-params-caught/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/invalid-undeclared-use-search-params-caught/page.tsx
@@ -12,6 +12,7 @@ export const unstable_instant: Instant = {
     },
   ],
 }
+export const unstable_prefetch = 'runtime'
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/invalid-undeclared-use-search-params/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/invalid-undeclared-use-search-params/page.tsx
@@ -11,6 +11,7 @@ export const unstable_instant: Instant = {
     },
   ],
 }
+export const unstable_prefetch = 'runtime'
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/valid-search-params-in-samples/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/valid-search-params-in-samples/page.tsx
@@ -16,6 +16,7 @@ export const unstable_instant: Instant = {
     },
   ],
 }
+export const unstable_prefetch = 'runtime'
 
 type SearchParams = Record<string, string | string[]>
 

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/valid-search-params-passed-to-cache/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/valid-search-params-passed-to-cache/page.tsx
@@ -12,6 +12,7 @@ export const unstable_instant: Instant = {
     },
   ],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page({
   searchParams,

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/valid-search-params-passed-to-client/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/valid-search-params-passed-to-client/page.tsx
@@ -14,6 +14,7 @@ export const unstable_instant: Instant = {
     },
   ],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page({
   searchParams,

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/valid-use-search-params/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/valid-use-search-params/page.tsx
@@ -14,6 +14,7 @@ export const unstable_instant: Instant = {
     },
   ],
 }
+export const unstable_prefetch = 'runtime'
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/server-errors/error-passed-to-client-and-ignored/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/server-errors/error-passed-to-client-and-ignored/page.tsx
@@ -5,6 +5,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
+export const unstable_prefetch = 'runtime'
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/server-errors/page-throws-with-suspense/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/server-errors/page-throws-with-suspense/page.tsx
@@ -4,6 +4,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
+export const unstable_prefetch = 'runtime'
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/server-errors/page-throws/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/server-errors/page-throws/page.tsx
@@ -4,6 +4,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
+export const unstable_prefetch = 'runtime'
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/valid-await-cache-without-suspense/mixed/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/valid-await-cache-without-suspense/mixed/page.tsx
@@ -4,6 +4,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{}],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page() {
   await cachedIO('static')

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/valid-await-cache-without-suspense/private/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/valid-await-cache-without-suspense/private/page.tsx
@@ -2,6 +2,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{}],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page() {
   await privateCachedIO()

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/valid-await-cache-without-suspense/runtime/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/valid-await-cache-without-suspense/runtime/page.tsx
@@ -4,6 +4,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{}],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page() {
   await cookies()

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/valid-suspense-around-runtime/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/valid-suspense-around-runtime/page.tsx
@@ -6,6 +6,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [{ name: 'auth', value: '1' }] }],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/root-params/[lang]/invalid-root-param-not-provided-caught/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/root-params/[lang]/invalid-root-param-not-provided-caught/page.tsx
@@ -8,6 +8,7 @@ export const unstable_instant: Instant = {
   // no samples
   samples: [{}],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page() {
   // Guard behind cookies() so that the rest of this component only runs during validation

--- a/test/e2e/app-dir/instant-validation-build/app/root-params/[lang]/invalid-root-param-not-provided/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/root-params/[lang]/invalid-root-param-not-provided/page.tsx
@@ -8,6 +8,7 @@ export const unstable_instant: Instant = {
   // no samples
   samples: [{}],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page() {
   // Guard behind cookies() so that the rest of this component only runs during validation

--- a/test/e2e/app-dir/instant-validation-build/app/root-params/[lang]/valid-root-param-in-samples/runtime/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/root-params/[lang]/valid-root-param-in-samples/runtime/page.tsx
@@ -7,6 +7,7 @@ export const unstable_instant: Instant = {
   prefetch: 'runtime',
   samples: [{ params: { lang: 'en-from-samples' } }],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page() {
   // Guard behind cookies() so that the rest of this component only runs during validation

--- a/test/e2e/app-dir/instant-validation-build/instant-validation-build.test.ts
+++ b/test/e2e/app-dir/instant-validation-build/instant-validation-build.test.ts
@@ -93,13 +93,13 @@ describe('instant-validation-build', () => {
            at body (<anonymous>)
            at html (<anonymous>) {
          [cause]: Error: Kaboom
-             at a (app/(default)/server-errors/page-throws/page.tsx:24:9)
-           22 | async function Throws(): Promise<never> {
-           23 |   await cookies()
-         > 24 |   throw new Error('Kaboom')
+             at a (app/(default)/server-errors/page-throws/page.tsx:25:9)
+           23 | async function Throws(): Promise<never> {
+           24 |   await cookies()
+         > 25 |   throw new Error('Kaboom')
               |         ^
-           25 | }
-           26 | {
+           26 | }
+           27 | {
            digest: '<error-digest>'
          }
        }
@@ -121,13 +121,13 @@ describe('instant-validation-build', () => {
            at body (<anonymous>)
            at html (<anonymous>) {
          [cause]: Error: Kaboom
-             at b (app/(default)/server-errors/page-throws-with-suspense/page.tsx:24:9)
-           22 | async function Throws(): Promise<never> {
-           23 |   await cookies()
-         > 24 |   throw new Error('Kaboom')
+             at b (app/(default)/server-errors/page-throws-with-suspense/page.tsx:25:9)
+           23 | async function Throws(): Promise<never> {
+           24 |   await cookies()
+         > 25 |   throw new Error('Kaboom')
               |         ^
-           25 | }
-           26 | {
+           26 | }
+           27 | {
            digest: '<error-digest>'
          }
        }
@@ -221,16 +221,16 @@ describe('instant-validation-build', () => {
       expect(extractBuildValidationError(result.cliOutput))
         .toMatchInlineSnapshot(`
        "Error: Route "/search-params/invalid-undeclared-search-param" accessed searchParam "undeclared" which is not defined in the \`samples\` of \`unstable_instant\`. Add it to the sample's \`searchParams\` object, or \`{ "undeclared": null }\` if it should be absent.
-           at <unknown> (app/(default)/search-params/invalid-undeclared-search-param/page.tsx:31:14)
+           at <unknown> (app/(default)/search-params/invalid-undeclared-search-param/page.tsx:32:14)
            at <unknown> (ensure-error.ts:11:5)
-           at a (app/(default)/search-params/invalid-undeclared-search-param/page.tsx:30:3)
-         29 |   const sp = await searchParams
-         30 |   ensureThrows(
-       > 31 |     () => sp.undeclared,
+           at a (app/(default)/search-params/invalid-undeclared-search-param/page.tsx:31:3)
+         30 |   const sp = await searchParams
+         31 |   ensureThrows(
+       > 32 |     () => sp.undeclared,
             |              ^
-         32 |     \`Expected accessing an undeclared search param to throw\`
-         33 |   )
-         34 |   return null {
+         33 |     \`Expected accessing an undeclared search param to throw\`
+         34 |   )
+         35 |   return null {
          digest: 'INSTANT_VALIDATION_ERROR'
        }
        Build-time instant validation failed for route "/search-params/invalid-undeclared-search-param".
@@ -255,16 +255,16 @@ describe('instant-validation-build', () => {
       expect(extractBuildValidationError(result.cliOutput))
         .toMatchInlineSnapshot(`
        "Error: Route "/search-params/invalid-undeclared-search-param-caught" accessed searchParam "undeclared" which is not defined in the \`samples\` of \`unstable_instant\`. Add it to the sample's \`searchParams\` object, or \`{ "undeclared": null }\` if it should be absent.
-           at <unknown> (app/(default)/search-params/invalid-undeclared-search-param-caught/page.tsx:35:16)
+           at <unknown> (app/(default)/search-params/invalid-undeclared-search-param-caught/page.tsx:36:16)
            at <unknown> (ensure-error.ts:11:5)
-           at a (app/(default)/search-params/invalid-undeclared-search-param-caught/page.tsx:34:5)
-         33 |   try {
-         34 |     ensureThrows(
-       > 35 |       () => sp.undeclared,
+           at a (app/(default)/search-params/invalid-undeclared-search-param-caught/page.tsx:35:5)
+         34 |   try {
+         35 |     ensureThrows(
+       > 36 |       () => sp.undeclared,
             |                ^
-         36 |       \`Expected accessing an undeclared search param to throw\`
-         37 |     )
-         38 |   } catch (err) { {
+         37 |       \`Expected accessing an undeclared search param to throw\`
+         38 |     )
+         39 |   } catch (err) { {
          digest: 'INSTANT_VALIDATION_ERROR'
        }
        Build-time instant validation failed for route "/search-params/invalid-undeclared-search-param-caught".
@@ -359,16 +359,16 @@ describe('instant-validation-build', () => {
       expect(extractBuildValidationError(result.cliOutput))
         .toMatchInlineSnapshot(`
        "Error: Route "/headers/invalid-undeclared-header-get" accessed header "undeclaredheader" which is not defined in the \`samples\` of \`unstable_instant\`. Add it to the sample's \`headers\` array, or \`["undeclaredheader", null]\` if it should be absent.
-           at <unknown> (app/(default)/headers/invalid-undeclared-header-get/page.tsx:27:24)
+           at <unknown> (app/(default)/headers/invalid-undeclared-header-get/page.tsx:28:24)
            at <unknown> (ensure-error.ts:11:5)
-           at a (app/(default)/headers/invalid-undeclared-header-get/page.tsx:26:3)
-         25 |   const headersStore = await headers()
-         26 |   ensureThrows(
-       > 27 |     () => headersStore.get('undeclaredHeader'),
+           at a (app/(default)/headers/invalid-undeclared-header-get/page.tsx:27:3)
+         26 |   const headersStore = await headers()
+         27 |   ensureThrows(
+       > 28 |     () => headersStore.get('undeclaredHeader'),
             |                        ^
-         28 |     \`Expected get() to throw for undeclared headers\`
-         29 |   )
-         30 |   return null {
+         29 |     \`Expected get() to throw for undeclared headers\`
+         30 |   )
+         31 |   return null {
          digest: 'INSTANT_VALIDATION_ERROR'
        }
        Build-time instant validation failed for route "/headers/invalid-undeclared-header-get".
@@ -385,16 +385,16 @@ describe('instant-validation-build', () => {
       expect(extractBuildValidationError(result.cliOutput))
         .toMatchInlineSnapshot(`
        "Error: Route "/headers/invalid-undeclared-header-get-caught" accessed header "undeclaredheader" which is not defined in the \`samples\` of \`unstable_instant\`. Add it to the sample's \`headers\` array, or \`["undeclaredheader", null]\` if it should be absent.
-           at <unknown> (app/(default)/headers/invalid-undeclared-header-get-caught/page.tsx:30:25)
+           at <unknown> (app/(default)/headers/invalid-undeclared-header-get-caught/page.tsx:31:25)
            at <unknown> (ensure-error.ts:11:5)
-           at a (app/(default)/headers/invalid-undeclared-header-get-caught/page.tsx:29:5)
-         28 |   try {
-         29 |     ensureThrows(
-       > 30 |       () => headerStore.get('undeclaredHeader'),
+           at a (app/(default)/headers/invalid-undeclared-header-get-caught/page.tsx:30:5)
+         29 |   try {
+         30 |     ensureThrows(
+       > 31 |       () => headerStore.get('undeclaredHeader'),
             |                         ^
-         31 |       \`Expected get() to throw for undeclared headers\`
-         32 |     )
-         33 |   } catch (err) { {
+         32 |       \`Expected get() to throw for undeclared headers\`
+         33 |     )
+         34 |   } catch (err) { {
          digest: 'INSTANT_VALIDATION_ERROR'
        }
        Build-time instant validation failed for route "/headers/invalid-undeclared-header-get-caught".
@@ -410,16 +410,16 @@ describe('instant-validation-build', () => {
       expect(extractBuildValidationError(result.cliOutput))
         .toMatchInlineSnapshot(`
        "Error: Route "/headers/invalid-undeclared-header-has" accessed header "undeclaredheader" which is not defined in the \`samples\` of \`unstable_instant\`. Add it to the sample's \`headers\` array, or \`["undeclaredheader", null]\` if it should be absent.
-           at <unknown> (app/(default)/headers/invalid-undeclared-header-has/page.tsx:27:23)
+           at <unknown> (app/(default)/headers/invalid-undeclared-header-has/page.tsx:28:23)
            at <unknown> (ensure-error.ts:11:5)
-           at a (app/(default)/headers/invalid-undeclared-header-has/page.tsx:26:3)
-         25 |   const headerStore = await headers()
-         26 |   ensureThrows(
-       > 27 |     () => headerStore.has('undeclaredHeader'),
+           at a (app/(default)/headers/invalid-undeclared-header-has/page.tsx:27:3)
+         26 |   const headerStore = await headers()
+         27 |   ensureThrows(
+       > 28 |     () => headerStore.has('undeclaredHeader'),
             |                       ^
-         28 |     \`Expected has() to throw for undeclared headers\`
-         29 |   )
-         30 |   return null {
+         29 |     \`Expected has() to throw for undeclared headers\`
+         30 |   )
+         31 |   return null {
          digest: 'INSTANT_VALIDATION_ERROR'
        }
        Build-time instant validation failed for route "/headers/invalid-undeclared-header-has".
@@ -462,16 +462,16 @@ describe('instant-validation-build', () => {
       expect(extractBuildValidationError(result.cliOutput))
         .toMatchInlineSnapshot(`
        "Error: Route "/cookies/invalid-undeclared-cookie-get" accessed cookie "undeclaredCookie" which is not defined in the \`samples\` of \`unstable_instant\`. Add it to the sample's \`cookies\` array, or \`{ name: "undeclaredCookie", value: null }\` if it should be absent.
-           at <unknown> (app/(default)/cookies/invalid-undeclared-cookie-get/page.tsx:28:23)
+           at <unknown> (app/(default)/cookies/invalid-undeclared-cookie-get/page.tsx:29:23)
            at <unknown> (ensure-error.ts:11:5)
-           at a (app/(default)/cookies/invalid-undeclared-cookie-get/page.tsx:27:3)
-         26 |
-         27 |   ensureThrows(
-       > 28 |     () => cookieStore.get('undeclaredCookie'),
+           at a (app/(default)/cookies/invalid-undeclared-cookie-get/page.tsx:28:3)
+         27 |
+         28 |   ensureThrows(
+       > 29 |     () => cookieStore.get('undeclaredCookie'),
             |                       ^
-         29 |     \`Expected get() to throw for undeclared cookies\`
-         30 |   )
-         31 |   return null {
+         30 |     \`Expected get() to throw for undeclared cookies\`
+         31 |   )
+         32 |   return null {
          digest: 'INSTANT_VALIDATION_ERROR'
        }
        Build-time instant validation failed for route "/cookies/invalid-undeclared-cookie-get".
@@ -488,16 +488,16 @@ describe('instant-validation-build', () => {
       expect(extractBuildValidationError(result.cliOutput))
         .toMatchInlineSnapshot(`
        "Error: Route "/cookies/invalid-undeclared-cookie-get-caught" accessed cookie "undeclaredCookie" which is not defined in the \`samples\` of \`unstable_instant\`. Add it to the sample's \`cookies\` array, or \`{ name: "undeclaredCookie", value: null }\` if it should be absent.
-           at <unknown> (app/(default)/cookies/invalid-undeclared-cookie-get-caught/page.tsx:30:25)
+           at <unknown> (app/(default)/cookies/invalid-undeclared-cookie-get-caught/page.tsx:31:25)
            at <unknown> (ensure-error.ts:11:5)
-           at a (app/(default)/cookies/invalid-undeclared-cookie-get-caught/page.tsx:29:5)
-         28 |   try {
-         29 |     ensureThrows(
-       > 30 |       () => cookieStore.get('undeclaredCookie'),
+           at a (app/(default)/cookies/invalid-undeclared-cookie-get-caught/page.tsx:30:5)
+         29 |   try {
+         30 |     ensureThrows(
+       > 31 |       () => cookieStore.get('undeclaredCookie'),
             |                         ^
-         31 |       \`Expected get() to throw for undeclared cookies\`
-         32 |     )
-         33 |   } catch (err) { {
+         32 |       \`Expected get() to throw for undeclared cookies\`
+         33 |     )
+         34 |   } catch (err) { {
          digest: 'INSTANT_VALIDATION_ERROR'
        }
        Build-time instant validation failed for route "/cookies/invalid-undeclared-cookie-get-caught".
@@ -514,16 +514,16 @@ describe('instant-validation-build', () => {
       expect(extractBuildValidationError(result.cliOutput))
         .toMatchInlineSnapshot(`
        "Error: Route "/cookies/invalid-undeclared-cookie-has" accessed cookie "undeclaredCookie" which is not defined in the \`samples\` of \`unstable_instant\`. Add it to the sample's \`cookies\` array, or \`{ name: "undeclaredCookie", value: null }\` if it should be absent.
-           at <unknown> (app/(default)/cookies/invalid-undeclared-cookie-has/page.tsx:27:23)
+           at <unknown> (app/(default)/cookies/invalid-undeclared-cookie-has/page.tsx:28:23)
            at <unknown> (ensure-error.ts:11:5)
-           at a (app/(default)/cookies/invalid-undeclared-cookie-has/page.tsx:26:3)
-         25 |   const cookieStore = await cookies()
-         26 |   ensureThrows(
-       > 27 |     () => cookieStore.has('undeclaredCookie'),
+           at a (app/(default)/cookies/invalid-undeclared-cookie-has/page.tsx:27:3)
+         26 |   const cookieStore = await cookies()
+         27 |   ensureThrows(
+       > 28 |     () => cookieStore.has('undeclaredCookie'),
             |                       ^
-         28 |     \`Expected has() to throw for undeclared cookies\`
-         29 |   )
-         30 |   return null {
+         29 |     \`Expected has() to throw for undeclared cookies\`
+         30 |   )
+         31 |   return null {
          digest: 'INSTANT_VALIDATION_ERROR'
        }
        Build-time instant validation failed for route "/cookies/invalid-undeclared-cookie-has".
@@ -558,16 +558,16 @@ describe('instant-validation-build', () => {
       expect(extractBuildValidationError(result.cliOutput))
         .toMatchInlineSnapshot(`
        "Error: Route "/params/invalid-param-not-provided/[one]/[two]" accessed param "two" which is not defined in the \`samples\` of \`unstable_instant\`. Add it to the sample's \`params\` object.
-           at <unknown> (app/(default)/params/invalid-param-not-provided/[one]/[two]/page.tsx:47:24)
+           at <unknown> (app/(default)/params/invalid-param-not-provided/[one]/[two]/page.tsx:48:24)
            at <unknown> (ensure-error.ts:11:5)
-           at a (app/(default)/params/invalid-param-not-provided/[one]/[two]/page.tsx:47:3)
-         45 |
-         46 |   // We're not allowed to access params not in the samples.
-       > 47 |   ensureThrows(() => p.two)
+           at a (app/(default)/params/invalid-param-not-provided/[one]/[two]/page.tsx:48:3)
+         46 |
+         47 |   // We're not allowed to access params not in the samples.
+       > 48 |   ensureThrows(() => p.two)
             |                        ^
-         48 |
-         49 |   // TODO: test \`in\` and iteration
-         50 |   // assert.deepStrictEqual( {
+         49 |
+         50 |   // TODO: test \`in\` and iteration
+         51 |   // assert.deepStrictEqual( {
          digest: 'INSTANT_VALIDATION_ERROR'
        }
        Build-time instant validation failed for route "/params/invalid-param-not-provided/[one]/[two]".
@@ -584,16 +584,16 @@ describe('instant-validation-build', () => {
       expect(extractBuildValidationError(result.cliOutput))
         .toMatchInlineSnapshot(`
        "Error: Route "/params/invalid-param-not-provided-caught/[one]/[two]" accessed param "two" which is not defined in the \`samples\` of \`unstable_instant\`. Add it to the sample's \`params\` object.
-           at <unknown> (app/(default)/params/invalid-param-not-provided-caught/[one]/[two]/page.tsx:45:26)
+           at <unknown> (app/(default)/params/invalid-param-not-provided-caught/[one]/[two]/page.tsx:46:26)
            at <unknown> (ensure-error.ts:11:5)
-           at a (app/(default)/params/invalid-param-not-provided-caught/[one]/[two]/page.tsx:45:5)
-         43 |   try {
-         44 |     // We're not allowed to access params not in the samples.
-       > 45 |     ensureThrows(() => p.two, \`Expected accessing an undeclared param to throw\`)
+           at a (app/(default)/params/invalid-param-not-provided-caught/[one]/[two]/page.tsx:46:5)
+         44 |   try {
+         45 |     // We're not allowed to access params not in the samples.
+       > 46 |     ensureThrows(() => p.two, \`Expected accessing an undeclared param to throw\`)
             |                          ^
-         46 |   } catch (err) {
-         47 |     // We swallow the error. It should still be reported and fail the validation.
-         48 |   } {
+         47 |   } catch (err) {
+         48 |     // We swallow the error. It should still be reported and fail the validation.
+         49 |   } {
          digest: 'INSTANT_VALIDATION_ERROR'
        }
        Build-time instant validation failed for route "/params/invalid-param-not-provided-caught/[one]/[two]".
@@ -768,16 +768,16 @@ describe('instant-validation-build', () => {
       expect(extractBuildValidationError(result.cliOutput))
         .toMatchInlineSnapshot(`
        "Error: Route "/root-params/[lang]/invalid-root-param-not-provided" accessed root param "lang" which is not defined in the \`samples\` of \`unstable_instant\`. Add it to the sample's \`params\` object.
-           at <unknown> (app/root-params/[lang]/invalid-root-param-not-provided/page.tsx:17:11)
+           at <unknown> (app/root-params/[lang]/invalid-root-param-not-provided/page.tsx:18:11)
            at a (ensure-error.ts:48:11)
-           at b (app/root-params/[lang]/invalid-root-param-not-provided/page.tsx:16:9)
-         15 |
-         16 |   await ensureRejects(
-       > 17 |     () => lang(),
+           at b (app/root-params/[lang]/invalid-root-param-not-provided/page.tsx:17:9)
+         16 |
+         17 |   await ensureRejects(
+       > 18 |     () => lang(),
             |           ^
-         18 |     \`Expected lang() to error if sample is not provided\`
-         19 |   )
-         20 |   return ( {
+         19 |     \`Expected lang() to error if sample is not provided\`
+         20 |   )
+         21 |   return ( {
          digest: 'INSTANT_VALIDATION_ERROR'
        }
        Build-time instant validation failed for route "/root-params/[lang]/invalid-root-param-not-provided".
@@ -794,16 +794,16 @@ describe('instant-validation-build', () => {
       expect(extractBuildValidationError(result.cliOutput))
         .toMatchInlineSnapshot(`
        "Error: Route "/root-params/[lang]/invalid-root-param-not-provided-caught" accessed root param "lang" which is not defined in the \`samples\` of \`unstable_instant\`. Add it to the sample's \`params\` object.
-           at <unknown> (app/root-params/[lang]/invalid-root-param-not-provided-caught/page.tsx:18:13)
+           at <unknown> (app/root-params/[lang]/invalid-root-param-not-provided-caught/page.tsx:19:13)
            at a (ensure-error.ts:48:11)
-           at b (app/root-params/[lang]/invalid-root-param-not-provided-caught/page.tsx:17:11)
-         16 |   try {
-         17 |     await ensureRejects(
-       > 18 |       () => lang(),
+           at b (app/root-params/[lang]/invalid-root-param-not-provided-caught/page.tsx:18:11)
+         17 |   try {
+         18 |     await ensureRejects(
+       > 19 |       () => lang(),
             |             ^
-         19 |       \`Expected lang() to error if sample is not provided\`
-         20 |     )
-         21 |   } catch { {
+         20 |       \`Expected lang() to error if sample is not provided\`
+         21 |     )
+         22 |   } catch { {
          digest: 'INSTANT_VALIDATION_ERROR'
        }
        Build-time instant validation failed for route "/root-params/[lang]/invalid-root-param-not-provided-caught".

--- a/test/e2e/app-dir/instant-validation-client/instant-validation-client.test.ts
+++ b/test/e2e/app-dir/instant-validation-client/instant-validation-client.test.ts
@@ -13,9 +13,7 @@ describe('app dir - instant-validation-client', () => {
   }
 
   it('should error when a client component exports unstable_instant', async () => {
-    const expectedErrMsg = process.env.IS_TURBOPACK_TEST
-      ? `Next.js can't recognize the exported \`unstable_instant\` field in route. App pages cannot export "unstable_instant" from a Client Component module. To use this API, convert this module to a Server Component by removing the "use client" directive.`
-      : `Page "/page" cannot export "unstable_instant" from a Client Component module. To use this API, convert this module to a Server Component by removing the "use client" directive.`
+    const expectedErrMsg = `"unstable_instant" is a route segment config and can only be used when the segment is a Server Component module. Remove the "use client" directive`
 
     if (isNextDev) {
       await next.start().catch(() => {})

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/disable-validation/in-layout/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/disable-validation/in-layout/layout.tsx
@@ -3,6 +3,7 @@ export const unstable_instant = {
   samples: [{ cookies: [] }],
   unstable_disableValidation: true,
 }
+export const unstable_prefetch = 'runtime'
 
 export default function Layout({ children }) {
   return <>{children}</>

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/disable-validation/in-page-with-outer/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/disable-validation/in-page-with-outer/page.tsx
@@ -5,6 +5,7 @@ export const unstable_instant = {
   samples: [{ cookies: [] }],
   unstable_disableValidation: true,
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page() {
   await connection()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/disable-validation/in-page/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/disable-validation/in-page/page.tsx
@@ -5,6 +5,7 @@ export const unstable_instant = {
   samples: [{ cookies: [] }],
   unstable_disableValidation: true,
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page() {
   await connection()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/invalid-dynamic-viewport-in-runtime/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/invalid-dynamic-viewport-in-runtime/page.tsx
@@ -7,6 +7,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
+export const unstable_prefetch = 'runtime'
 
 // Note that we're inside a root layout with suspense, so we skip the static shell
 export async function generateViewport(): Promise<Viewport> {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/invalid-runtime-viewport-in-static/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/invalid-runtime-viewport-in-static/layout.tsx
@@ -2,6 +2,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Layout({ children }) {
   return <>{children}</>

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/valid-dynamic-metadata-in-runtime/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/valid-dynamic-metadata-in-runtime/page.tsx
@@ -7,6 +7,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
+export const unstable_prefetch = 'runtime'
 
 export async function generateMetadata(): Promise<Metadata> {
   await connection()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/valid-runtime-viewport-in-runtime/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/valid-runtime-viewport-in-runtime/page.tsx
@@ -5,6 +5,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
+export const unstable_prefetch = 'runtime'
 
 export async function generateViewport(): Promise<Viewport> {
   await cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/slot-runtime-config/@slot/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/slot-runtime-config/@slot/page.tsx
@@ -5,6 +5,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{}],
 }
+export const unstable_prefetch = 'runtime'
 
 export default function SlotPage() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-blocking-inside-runtime/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-blocking-inside-runtime/layout.tsx
@@ -4,6 +4,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function RuntimeLayout({ children }) {
   await cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-after-cache-with-cookie-input/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-after-cache-with-cookie-input/layout.tsx
@@ -1,5 +1,6 @@
 // Avoid static shell validation -- we only want to test the validation of `prefetch: 'runtime'` here.
 export const unstable_instant = false
+export const unstable_prefetch = 'runtime'
 
 export default function DisableStaticShell({ children }) {
   return <>{children}</>

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-after-cache-with-cookie-input/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-after-cache-with-cookie-input/page.tsx
@@ -4,6 +4,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
+export const unstable_prefetch = 'runtime'
 
 // This page HAS runtime prefetch enabled. cookies() is passed as a promise
 // input to a public "use cache" function. The cache doesn't read the cookies

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-in-generate-metadata/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-in-generate-metadata/page.tsx
@@ -5,6 +5,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
+export const unstable_prefetch = 'runtime'
 
 export async function generateMetadata() {
   await cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-in-layout-generate-metadata/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-in-layout-generate-metadata/page.tsx
@@ -5,6 +5,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
+export const unstable_prefetch = 'runtime'
 
 async function Runtime() {
   await cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-in-runtime-with-valid-static-parent/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-in-runtime-with-valid-static-parent/page.tsx
@@ -4,6 +4,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
+export const unstable_prefetch = 'runtime'
 
 // This page HAS runtime prefetch enabled. The sync IO (Date.now()) after
 // cookies() is invalid here because during a runtime prefetch, cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io/page.tsx
@@ -4,6 +4,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page() {
   await cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/missing-suspense-around-dynamic-layout/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/missing-suspense-around-dynamic-layout/layout.tsx
@@ -5,6 +5,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Layout({ children }: { children: ReactNode }) {
   await connection()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/missing-suspense-around-dynamic/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/missing-suspense-around-dynamic/page.tsx
@@ -5,6 +5,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page() {
   await cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/static-layout-above-runtime-config/inner/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/static-layout-above-runtime-config/inner/layout.tsx
@@ -7,6 +7,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
+export const unstable_prefetch = 'runtime'
 
 export default function InnerLayout({ children }: { children: ReactNode }) {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/suspense-around-dynamic/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/suspense-around-dynamic/page.tsx
@@ -6,6 +6,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/suspense-too-high/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/suspense-too-high/page.tsx
@@ -5,6 +5,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page() {
   await cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-blocking-inside-runtime/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-blocking-inside-runtime/layout.tsx
@@ -5,6 +5,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function RuntimeLayout({ children }) {
   await cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-no-suspense-around-params/[param]/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-no-suspense-around-params/[param]/page.tsx
@@ -5,6 +5,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [], params: { param: '123' } }],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page({
   params,

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-no-suspense-around-search-params/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-no-suspense-around-search-params/page.tsx
@@ -5,6 +5,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [], searchParams: { foo: 'bar' } }],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page({
   searchParams,

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-sync-io-in-static-parent/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-sync-io-in-static-parent/page.tsx
@@ -5,6 +5,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
+export const unstable_prefetch = 'runtime'
 
 async function Runtime() {
   await cookies()

--- a/test/e2e/app-dir/instant-validation/instant-validation.test.ts
+++ b/test/e2e/app-dir/instant-validation/instant-validation.test.ts
@@ -318,12 +318,12 @@ describe('instant validation', () => {
          Learn more: https://nextjs.org/docs/messages/blocking-route",
            "environmentLabel": "Server",
            "label": "Blocking Route",
-           "source": "app/suspense-in-root/runtime/missing-suspense-around-dynamic/page.tsx (25:19) @ Dynamic
-         > 25 |   await connection()
+           "source": "app/suspense-in-root/runtime/missing-suspense-around-dynamic/page.tsx (26:19) @ Dynamic
+         > 26 |   await connection()
               |                   ^",
            "stack": [
-             "Dynamic app/suspense-in-root/runtime/missing-suspense-around-dynamic/page.tsx (25:19)",
-             "Page app/suspense-in-root/runtime/missing-suspense-around-dynamic/page.tsx (18:9)",
+             "Dynamic app/suspense-in-root/runtime/missing-suspense-around-dynamic/page.tsx (26:19)",
+             "Page app/suspense-in-root/runtime/missing-suspense-around-dynamic/page.tsx (19:9)",
            ],
          }
         `)
@@ -443,11 +443,11 @@ describe('instant validation', () => {
          Learn more: https://nextjs.org/docs/messages/blocking-route",
            "environmentLabel": "Server",
            "label": "Blocking Route",
-           "source": "app/suspense-in-root/runtime/missing-suspense-around-dynamic-layout/layout.tsx (10:19) @ Layout
-         > 10 |   await connection()
+           "source": "app/suspense-in-root/runtime/missing-suspense-around-dynamic-layout/layout.tsx (11:19) @ Layout
+         > 11 |   await connection()
               |                   ^",
            "stack": [
-             "Layout app/suspense-in-root/runtime/missing-suspense-around-dynamic-layout/layout.tsx (10:19)",
+             "Layout app/suspense-in-root/runtime/missing-suspense-around-dynamic-layout/layout.tsx (11:19)",
            ],
          }
         `)
@@ -730,12 +730,12 @@ describe('instant validation', () => {
          Learn more: https://nextjs.org/docs/messages/blocking-route",
            "environmentLabel": "Server",
            "label": "Blocking Route",
-           "source": "app/suspense-in-root/runtime/suspense-too-high/page.tsx (26:19) @ Dynamic
-         > 26 |   await connection()
+           "source": "app/suspense-in-root/runtime/suspense-too-high/page.tsx (27:19) @ Dynamic
+         > 27 |   await connection()
               |                   ^",
            "stack": [
-             "Dynamic app/suspense-in-root/runtime/suspense-too-high/page.tsx (26:19)",
-             "Page app/suspense-in-root/runtime/suspense-too-high/page.tsx (19:9)",
+             "Dynamic app/suspense-in-root/runtime/suspense-too-high/page.tsx (27:19)",
+             "Page app/suspense-in-root/runtime/suspense-too-high/page.tsx (20:9)",
            ],
          }
         `)
@@ -770,11 +770,11 @@ describe('instant validation', () => {
            "description": "Route "/suspense-in-root/runtime/invalid-sync-io" used \`Date.now()\` before accessing either uncached data (e.g. \`fetch()\`) or awaiting \`connection()\`. When configured for Runtime prefetching, accessing the current time in a Server Component requires reading one of these data sources first. Alternatively, consider moving this expression into a Client Component or Cache Component. See more info here: https://nextjs.org/docs/messages/next-prerender-runtime-current-time",
            "environmentLabel": "Server",
            "label": "Console Error",
-           "source": "app/suspense-in-root/runtime/invalid-sync-io/page.tsx (10:20) @ Page
-         > 10 |   const now = Date.now()
+           "source": "app/suspense-in-root/runtime/invalid-sync-io/page.tsx (11:20) @ Page
+         > 11 |   const now = Date.now()
               |                    ^",
            "stack": [
-             "Page app/suspense-in-root/runtime/invalid-sync-io/page.tsx (10:20)",
+             "Page app/suspense-in-root/runtime/invalid-sync-io/page.tsx (11:20)",
              "Page <anonymous>",
            ],
          }
@@ -786,23 +786,23 @@ describe('instant validation', () => {
         expect(extractBuildValidationError(result.cliOutput))
           .toMatchInlineSnapshot(`
          "Error: Route "/suspense-in-root/runtime/invalid-sync-io" used \`Date.now()\` before accessing either uncached data (e.g. \`fetch()\`) or awaiting \`connection()\`. When configured for Runtime prefetching, accessing the current time in a Server Component requires reading one of these data sources first. Alternatively, consider moving this expression into a Client Component or Cache Component. See more info here: https://nextjs.org/docs/messages/next-prerender-runtime-current-time
-             at a (app/suspense-in-root/runtime/invalid-sync-io/page.tsx:10:20)
-            8 | export default async function Page() {
-            9 |   await cookies()
-         > 10 |   const now = Date.now()
+             at a (app/suspense-in-root/runtime/invalid-sync-io/page.tsx:11:20)
+            9 | export default async function Page() {
+           10 |   await cookies()
+         > 11 |   const now = Date.now()
               |                    ^
-           11 |   return (
-           12 |     <main>
-           13 |       <p>This page uses sync IO after awaiting cookies(): {now}</p>
+           12 |   return (
+           13 |     <main>
+           14 |       <p>This page uses sync IO after awaiting cookies(): {now}</p>
          Error: Route "/suspense-in-root/runtime/invalid-sync-io" used \`Date.now()\` before accessing either uncached data (e.g. \`fetch()\`) or awaiting \`connection()\`. When configured for Runtime prefetching, accessing the current time in a Server Component requires reading one of these data sources first. Alternatively, consider moving this expression into a Client Component or Cache Component. See more info here: https://nextjs.org/docs/messages/next-prerender-runtime-current-time
-             at b (app/suspense-in-root/runtime/invalid-sync-io/page.tsx:10:20)
-            8 | export default async function Page() {
-            9 |   await cookies()
-         > 10 |   const now = Date.now()
+             at b (app/suspense-in-root/runtime/invalid-sync-io/page.tsx:11:20)
+            9 | export default async function Page() {
+           10 |   await cookies()
+         > 11 |   const now = Date.now()
               |                    ^
-           11 |   return (
-           12 |     <main>
-           13 |       <p>This page uses sync IO after awaiting cookies(): {now}</p>
+           12 |   return (
+           13 |     <main>
+           14 |       <p>This page uses sync IO after awaiting cookies(): {now}</p>
          Build-time instant validation failed for route "/suspense-in-root/runtime/invalid-sync-io".
          Stopping prerender due to instant validation errors."
         `)
@@ -825,11 +825,11 @@ describe('instant validation', () => {
            "description": "Route "/suspense-in-root/runtime/invalid-sync-io-in-runtime-with-valid-static-parent" used \`Date.now()\` before accessing either uncached data (e.g. \`fetch()\`) or awaiting \`connection()\`. When configured for Runtime prefetching, accessing the current time in a Server Component requires reading one of these data sources first. Alternatively, consider moving this expression into a Client Component or Cache Component. See more info here: https://nextjs.org/docs/messages/next-prerender-runtime-current-time",
            "environmentLabel": "Server",
            "label": "Console Error",
-           "source": "app/suspense-in-root/runtime/invalid-sync-io-in-runtime-with-valid-static-parent/page.tsx (14:20) @ Page
-         > 14 |   const now = Date.now()
+           "source": "app/suspense-in-root/runtime/invalid-sync-io-in-runtime-with-valid-static-parent/page.tsx (15:20) @ Page
+         > 15 |   const now = Date.now()
               |                    ^",
            "stack": [
-             "Page app/suspense-in-root/runtime/invalid-sync-io-in-runtime-with-valid-static-parent/page.tsx (14:20)",
+             "Page app/suspense-in-root/runtime/invalid-sync-io-in-runtime-with-valid-static-parent/page.tsx (15:20)",
              "Page <anonymous>",
            ],
          }
@@ -841,32 +841,32 @@ describe('instant validation', () => {
         expect(extractBuildValidationError(result.cliOutput))
           .toMatchInlineSnapshot(`
          "Error: Route "/suspense-in-root/runtime/invalid-sync-io-in-runtime-with-valid-static-parent" used \`Date.now()\` before accessing either uncached data (e.g. \`fetch()\`) or awaiting \`connection()\`. When configured for Runtime prefetching, accessing the current time in a Server Component requires reading one of these data sources first. Alternatively, consider moving this expression into a Client Component or Cache Component. See more info here: https://nextjs.org/docs/messages/next-prerender-runtime-current-time
-             at a (app/suspense-in-root/runtime/invalid-sync-io-in-runtime-with-valid-static-parent/page.tsx:14:20)
-           12 | export default async function Page() {
-           13 |   await cookies()
-         > 14 |   const now = Date.now()
+             at a (app/suspense-in-root/runtime/invalid-sync-io-in-runtime-with-valid-static-parent/page.tsx:15:20)
+           13 | export default async function Page() {
+           14 |   await cookies()
+         > 15 |   const now = Date.now()
               |                    ^
-           15 |   return (
-           16 |     <main>
-           17 |       <p>Runtime page with sync IO after cookies: {now}</p>
+           16 |   return (
+           17 |     <main>
+           18 |       <p>Runtime page with sync IO after cookies: {now}</p>
          Error: Route "/suspense-in-root/runtime/invalid-sync-io-in-runtime-with-valid-static-parent" used \`Date.now()\` before accessing either uncached data (e.g. \`fetch()\`) or awaiting \`connection()\`. When configured for Runtime prefetching, accessing the current time in a Server Component requires reading one of these data sources first. Alternatively, consider moving this expression into a Client Component or Cache Component. See more info here: https://nextjs.org/docs/messages/next-prerender-runtime-current-time
-             at b (app/suspense-in-root/runtime/invalid-sync-io-in-runtime-with-valid-static-parent/page.tsx:14:20)
-           12 | export default async function Page() {
-           13 |   await cookies()
-         > 14 |   const now = Date.now()
+             at b (app/suspense-in-root/runtime/invalid-sync-io-in-runtime-with-valid-static-parent/page.tsx:15:20)
+           13 | export default async function Page() {
+           14 |   await cookies()
+         > 15 |   const now = Date.now()
               |                    ^
-           15 |   return (
-           16 |     <main>
-           17 |       <p>Runtime page with sync IO after cookies: {now}</p>
+           16 |   return (
+           17 |     <main>
+           18 |       <p>Runtime page with sync IO after cookies: {now}</p>
          Error: Route "/suspense-in-root/runtime/invalid-sync-io-in-runtime-with-valid-static-parent" used \`Date.now()\` before accessing either uncached data (e.g. \`fetch()\`) or awaiting \`connection()\`. When configured for Runtime prefetching, accessing the current time in a Server Component requires reading one of these data sources first. Alternatively, consider moving this expression into a Client Component or Cache Component. See more info here: https://nextjs.org/docs/messages/next-prerender-runtime-current-time
-             at c (app/suspense-in-root/runtime/invalid-sync-io-in-runtime-with-valid-static-parent/page.tsx:14:20)
-           12 | export default async function Page() {
-           13 |   await cookies()
-         > 14 |   const now = Date.now()
+             at c (app/suspense-in-root/runtime/invalid-sync-io-in-runtime-with-valid-static-parent/page.tsx:15:20)
+           13 | export default async function Page() {
+           14 |   await cookies()
+         > 15 |   const now = Date.now()
               |                    ^
-           15 |   return (
-           16 |     <main>
-           17 |       <p>Runtime page with sync IO after cookies: {now}</p>
+           16 |   return (
+           17 |     <main>
+           18 |       <p>Runtime page with sync IO after cookies: {now}</p>
          Build-time instant validation failed for route "/suspense-in-root/runtime/invalid-sync-io-in-runtime-with-valid-static-parent".
          Stopping prerender due to instant validation errors."
         `)
@@ -895,11 +895,11 @@ describe('instant validation', () => {
            "description": "Route "/suspense-in-root/runtime/invalid-sync-io-after-cache-with-cookie-input" used \`Date.now()\` before accessing either uncached data (e.g. \`fetch()\`) or awaiting \`connection()\`. When configured for Runtime prefetching, accessing the current time in a Server Component requires reading one of these data sources first. Alternatively, consider moving this expression into a Client Component or Cache Component. See more info here: https://nextjs.org/docs/messages/next-prerender-runtime-current-time",
            "environmentLabel": "Server",
            "label": "Console Error",
-           "source": "app/suspense-in-root/runtime/invalid-sync-io-after-cache-with-cookie-input/page.tsx (30:20) @ Page
-         > 30 |   const now = Date.now()
+           "source": "app/suspense-in-root/runtime/invalid-sync-io-after-cache-with-cookie-input/page.tsx (31:20) @ Page
+         > 31 |   const now = Date.now()
               |                    ^",
            "stack": [
-             "Page app/suspense-in-root/runtime/invalid-sync-io-after-cache-with-cookie-input/page.tsx (30:20)",
+             "Page app/suspense-in-root/runtime/invalid-sync-io-after-cache-with-cookie-input/page.tsx (31:20)",
              "Page <anonymous>",
            ],
          }
@@ -911,14 +911,14 @@ describe('instant validation', () => {
         expect(extractBuildValidationError(result.cliOutput))
           .toMatchInlineSnapshot(`
          "Error: Route "/suspense-in-root/runtime/invalid-sync-io-after-cache-with-cookie-input" accessed cookie "testCookie" which is not defined in the \`samples\` of \`unstable_instant\`. Add it to the sample's \`cookies\` array, or \`{ name: "testCookie", value: null }\` if it should be absent.
-             at <unknown> (app/suspense-in-root/runtime/invalid-sync-io-after-cache-with-cookie-input/page.tsx:28:49)
-           26 |
-           27 | export default async function Page() {
-         > 28 |   const cookiePromise = cookies().then((c) => c.get('testCookie')?.value ?? '')
+             at <unknown> (app/suspense-in-root/runtime/invalid-sync-io-after-cache-with-cookie-input/page.tsx:29:49)
+           27 |
+           28 | export default async function Page() {
+         > 29 |   const cookiePromise = cookies().then((c) => c.get('testCookie')?.value ?? '')
               |                                                 ^
-           29 |   await cachedFn(cookiePromise)
-           30 |   const now = Date.now()
-           31 |   return ( {
+           30 |   await cachedFn(cookiePromise)
+           31 |   const now = Date.now()
+           32 |   return ( {
            digest: 'INSTANT_VALIDATION_ERROR'
          }
          Build-time instant validation failed for route "/suspense-in-root/runtime/invalid-sync-io-after-cache-with-cookie-input".
@@ -960,11 +960,11 @@ describe('instant validation', () => {
            "description": "Route "/suspense-in-root/runtime/invalid-sync-io-in-generate-metadata" used \`Date.now()\` before accessing either uncached data (e.g. \`fetch()\`) or awaiting \`connection()\`. When configured for Runtime prefetching, accessing the current time in a Server Component requires reading one of these data sources first. Alternatively, consider moving this expression into a Client Component or Cache Component. See more info here: https://nextjs.org/docs/messages/next-prerender-runtime-current-time",
            "environmentLabel": "Server",
            "label": "Console Error",
-           "source": "app/suspense-in-root/runtime/invalid-sync-io-in-generate-metadata/page.tsx (11:20) @ Module.generateMetadata
-         > 11 |   const now = Date.now()
+           "source": "app/suspense-in-root/runtime/invalid-sync-io-in-generate-metadata/page.tsx (12:20) @ Module.generateMetadata
+         > 12 |   const now = Date.now()
               |                    ^",
            "stack": [
-             "Module.generateMetadata app/suspense-in-root/runtime/invalid-sync-io-in-generate-metadata/page.tsx (11:20)",
+             "Module.generateMetadata app/suspense-in-root/runtime/invalid-sync-io-in-generate-metadata/page.tsx (12:20)",
              "Next.MetadataOutlet <anonymous>",
            ],
          }
@@ -976,23 +976,23 @@ describe('instant validation', () => {
         expect(extractBuildValidationError(result.cliOutput))
           .toMatchInlineSnapshot(`
          "Error: Route "/suspense-in-root/runtime/invalid-sync-io-in-generate-metadata" used \`Date.now()\` before accessing either uncached data (e.g. \`fetch()\`) or awaiting \`connection()\`. When configured for Runtime prefetching, accessing the current time in a Server Component requires reading one of these data sources first. Alternatively, consider moving this expression into a Client Component or Cache Component. See more info here: https://nextjs.org/docs/messages/next-prerender-runtime-current-time
-             at Module.e [as generateMetadata] (app/suspense-in-root/runtime/invalid-sync-io-in-generate-metadata/page.tsx:11:20)
-            9 | export async function generateMetadata() {
-           10 |   await cookies()
-         > 11 |   const now = Date.now()
+             at Module.e [as generateMetadata] (app/suspense-in-root/runtime/invalid-sync-io-in-generate-metadata/page.tsx:12:20)
+           10 | export async function generateMetadata() {
+           11 |   await cookies()
+         > 12 |   const now = Date.now()
               |                    ^
-           12 |   return {
-           13 |     title: \`Sync IO in metadata: \${now}\`,
-           14 |   }
+           13 |   return {
+           14 |     title: \`Sync IO in metadata: \${now}\`,
+           15 |   }
          Error: Route "/suspense-in-root/runtime/invalid-sync-io-in-generate-metadata" used \`Date.now()\` before accessing either uncached data (e.g. \`fetch()\`) or awaiting \`connection()\`. When configured for Runtime prefetching, accessing the current time in a Server Component requires reading one of these data sources first. Alternatively, consider moving this expression into a Client Component or Cache Component. See more info here: https://nextjs.org/docs/messages/next-prerender-runtime-current-time
-             at Module.e [as generateMetadata] (app/suspense-in-root/runtime/invalid-sync-io-in-generate-metadata/page.tsx:11:20)
-            9 | export async function generateMetadata() {
-           10 |   await cookies()
-         > 11 |   const now = Date.now()
+             at Module.e [as generateMetadata] (app/suspense-in-root/runtime/invalid-sync-io-in-generate-metadata/page.tsx:12:20)
+           10 | export async function generateMetadata() {
+           11 |   await cookies()
+         > 12 |   const now = Date.now()
               |                    ^
-           12 |   return {
-           13 |     title: \`Sync IO in metadata: \${now}\`,
-           14 |   }
+           13 |   return {
+           14 |     title: \`Sync IO in metadata: \${now}\`,
+           15 |   }
          Build-time instant validation failed for route "/suspense-in-root/runtime/invalid-sync-io-in-generate-metadata".
          Stopping prerender due to instant validation errors."
         `)
@@ -2342,11 +2342,11 @@ describe('instant validation', () => {
            Learn more: https://nextjs.org/docs/messages/next-prerender-dynamic-viewport",
              "environmentLabel": "Server",
              "label": "Blocking Route",
-             "source": "app/suspense-in-root/head/invalid-dynamic-viewport-in-runtime/page.tsx (13:19) @ Module.generateViewport
-           > 13 |   await connection()
+             "source": "app/suspense-in-root/head/invalid-dynamic-viewport-in-runtime/page.tsx (14:19) @ Module.generateViewport
+           > 14 |   await connection()
                 |                   ^",
              "stack": [
-               "Module.generateViewport app/suspense-in-root/head/invalid-dynamic-viewport-in-runtime/page.tsx (13:19)",
+               "Module.generateViewport app/suspense-in-root/head/invalid-dynamic-viewport-in-runtime/page.tsx (14:19)",
              ],
            }
           `)

--- a/test/e2e/app-dir/prefetch-true-instant/app/layout-instant/layout.tsx
+++ b/test/e2e/app-dir/prefetch-true-instant/app/layout-instant/layout.tsx
@@ -4,6 +4,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [{ name: 'test', value: null }] }],
 }
+export const unstable_prefetch = 'runtime'
 
 export default function Layout({ children }: { children: ReactNode }) {
   return <div>{children}</div>

--- a/test/e2e/app-dir/prefetch-true-instant/app/target-page/page.tsx
+++ b/test/e2e/app-dir/prefetch-true-instant/app/target-page/page.tsx
@@ -6,6 +6,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [{ name: 'test', value: null }] }],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/cached-navigations/app/runtime-prefetchable/page.tsx
+++ b/test/e2e/app-dir/segment-cache/cached-navigations/app/runtime-prefetchable/page.tsx
@@ -14,6 +14,7 @@ export const unstable_instant = {
     },
   ],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page({
   searchParams,

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-independent-head/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-independent-head/layout.tsx
@@ -15,6 +15,7 @@ export const unstable_instant = {
     },
   ],
 }
+export const unstable_prefetch = 'runtime'
 
 async function LayoutContent({ children }: { children: ReactNode }) {
   const cookieStore = await cookies()

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-runtime-bailout/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-runtime-bailout/page.tsx
@@ -4,6 +4,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [{ name: 'theme', value: 'default' }] }],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function RuntimeBailoutPage() {
   const cookieStore = await cookies()

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-runtime-parallel/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-runtime-parallel/layout.tsx
@@ -9,6 +9,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [{ name: 'theme', value: 'default' }] }],
 }
+export const unstable_prefetch = 'runtime'
 
 async function DynamicContent() {
   const cookieStore = await cookies()

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-runtime-passthrough/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-runtime-passthrough/layout.tsx
@@ -9,6 +9,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [{ name: 'theme', value: 'default' }] }],
 }
+export const unstable_prefetch = 'runtime'
 
 async function DynamicContent() {
   const cookieStore = await cookies()

--- a/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/segment-config/runtime-prefetchable/configured-as-runtime/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/segment-config/runtime-prefetchable/configured-as-runtime/page.tsx
@@ -5,6 +5,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
+export const unstable_prefetch = 'runtime'
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/segment-config/runtime-prefetchable/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/segment-config/runtime-prefetchable/layout.tsx
@@ -6,6 +6,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
+export const unstable_prefetch = 'runtime'
 export default async function Layout({ children }) {
   return (
     <main>

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/private-seconds/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/private-seconds/page.tsx
@@ -6,6 +6,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/private-short-stale/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/private-short-stale/page.tsx
@@ -6,6 +6,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/public-seconds/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/public-seconds/page.tsx
@@ -6,6 +6,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/public-short-expire-long-stale/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/public-short-expire-long-stale/page.tsx
@@ -6,6 +6,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/public-short-expire-short-stale/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/public-short-expire-short-stale/page.tsx
@@ -6,6 +6,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/error-after-cookies/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/error-after-cookies/page.tsx
@@ -10,6 +10,7 @@ export const unstable_instant = {
   unstable_disableValidation: true,
   samples: [{ cookies: [{ name: 'user-agent', value: null }] }],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/cookies/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/cookies/page.tsx
@@ -9,6 +9,7 @@ export const unstable_instant = {
   unstable_disableValidation: true,
   samples: [{ cookies: [] }],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/dynamic-params/[id]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/dynamic-params/[id]/page.tsx
@@ -10,6 +10,7 @@ export const unstable_instant = {
   unstable_disableValidation: true,
   samples: [{ cookies: [] }],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page({ params }: { params: Promise<Params> }) {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/headers/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/headers/page.tsx
@@ -9,6 +9,7 @@ export const unstable_instant = {
   unstable_disableValidation: true,
   samples: [{ cookies: [] }],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/private-cache/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/private-cache/page.tsx
@@ -8,6 +8,7 @@ export const unstable_instant = {
   unstable_disableValidation: true,
   samples: [{ cookies: [] }],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/quickly-expiring-public-cache/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/quickly-expiring-public-cache/page.tsx
@@ -9,6 +9,7 @@ export const unstable_instant = {
   unstable_disableValidation: true,
   samples: [{ cookies: [] }],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/search-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/search-params/page.tsx
@@ -10,6 +10,7 @@ export const unstable_instant = {
   unstable_disableValidation: true,
   samples: [{ cookies: [] }],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page({
   searchParams,

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/fully-static/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/fully-static/page.tsx
@@ -7,6 +7,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/cookies-only/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/cookies-only/page.tsx
@@ -6,6 +6,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [{ name: 'testCookie', value: 'testValue' }] }],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/cookies/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/cookies/page.tsx
@@ -7,6 +7,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [{ name: 'testCookie', value: 'testValue' }] }],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/dynamic-params/[id]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/dynamic-params/[id]/page.tsx
@@ -6,6 +6,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ params: { id: 'test' } }],
 }
+export const unstable_prefetch = 'runtime'
 
 type Params = { id: string }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/headers/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/headers/page.tsx
@@ -7,6 +7,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ headers: [['host', 'test-host']] }],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/search-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/search-params/page.tsx
@@ -6,6 +6,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ searchParams: { searchParam: 'value' } }],
 }
+export const unstable_prefetch = 'runtime'
 
 type AnySearchParams = { [key: string]: string | string[] | undefined }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/cookies-only/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/cookies-only/page.tsx
@@ -6,6 +6,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [{ name: 'testCookie', value: 'testValue' }] }],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/cookies/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/cookies/page.tsx
@@ -7,6 +7,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [{ name: 'testCookie', value: 'testValue' }] }],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/date-now/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/date-now/page.tsx
@@ -6,6 +6,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/dynamic-params/[id]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/dynamic-params/[id]/page.tsx
@@ -6,6 +6,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ params: { id: 'test' } }],
 }
+export const unstable_prefetch = 'runtime'
 
 type Params = { id: string }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/headers/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/headers/page.tsx
@@ -7,6 +7,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ headers: [['host', 'test-host']] }],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/search-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/search-params/page.tsx
@@ -6,6 +6,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ searchParams: { searchParam: 'value' } }],
 }
+export const unstable_prefetch = 'runtime'
 
 type AnySearchParams = { [key: string]: string | string[] | undefined }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/cookies-only/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/cookies-only/page.tsx
@@ -6,6 +6,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [{ name: 'testCookie', value: 'testValue' }] }],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/cookies/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/cookies/page.tsx
@@ -7,6 +7,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [{ name: 'testCookie', value: 'testValue' }] }],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/dynamic-params/[id]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/dynamic-params/[id]/page.tsx
@@ -7,6 +7,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ params: { id: 'test' } }],
 }
+export const unstable_prefetch = 'runtime'
 
 type Params = { id: string }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/headers/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/headers/page.tsx
@@ -7,6 +7,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ headers: [['host', 'test-host']] }],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/search-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/search-params/page.tsx
@@ -7,6 +7,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ searchParams: { searchParam: 'value' } }],
 }
+export const unstable_prefetch = 'runtime'
 
 type AnySearchParams = { [key: string]: string | string[] | undefined }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/in-page/root-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/in-page/root-params/page.tsx
@@ -8,6 +8,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ params: { lang: 'en' } }],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/in-private-cache/root-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/in-private-cache/root-params/page.tsx
@@ -7,6 +7,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ params: { lang: 'en' } }],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/passed-to-public-cache/root-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/passed-to-public-cache/root-params/page.tsx
@@ -7,6 +7,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ params: { lang: 'en' } }],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/staleness/app/runtime-stale-2-minutes/page.tsx
+++ b/test/e2e/app-dir/segment-cache/staleness/app/runtime-stale-2-minutes/page.tsx
@@ -3,6 +3,7 @@ import { cacheLife } from 'next/cache'
 import { cookies } from 'next/headers'
 
 export const unstable_instant = { prefetch: 'runtime', samples: [{}] }
+export const unstable_prefetch = 'runtime'
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/staleness/app/runtime-stale-4-minutes/page.tsx
+++ b/test/e2e/app-dir/segment-cache/staleness/app/runtime-stale-4-minutes/page.tsx
@@ -3,6 +3,7 @@ import { cacheLife } from 'next/cache'
 import { cookies } from 'next/headers'
 
 export const unstable_instant = { prefetch: 'runtime', samples: [{}] }
+export const unstable_prefetch = 'runtime'
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-all-vary/[category]/[itemId]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-all-vary/[category]/[itemId]/page.tsx
@@ -18,6 +18,7 @@ export const unstable_instant: {
     { params: { category: 'clothing', itemId: 'shirt' } },
   ],
 }
+export const unstable_prefetch = 'runtime'
 
 type Params = { category: string; itemId: string }
 

--- a/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-layout-split/[category]/[itemId]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-layout-split/[category]/[itemId]/page.tsx
@@ -19,6 +19,7 @@ export const unstable_instant: {
     { params: { category: 'clothing', itemId: 'shirt' } },
   ],
 }
+export const unstable_prefetch = 'runtime'
 
 type Params = { category: string; itemId: string }
 

--- a/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-metadata/[slug]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-metadata/[slug]/page.tsx
@@ -17,6 +17,7 @@ export const unstable_instant: {
   prefetch: 'runtime',
   samples: [{ params: { slug: 'aaa' } }, { params: { slug: 'bbb' } }],
 }
+export const unstable_prefetch = 'runtime'
 
 type Params = { slug: string }
 

--- a/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-no-vary/[category]/[itemId]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-no-vary/[category]/[itemId]/page.tsx
@@ -18,6 +18,7 @@ export const unstable_instant: {
     { params: { category: 'clothing', itemId: 'shirt' } },
   ],
 }
+export const unstable_prefetch = 'runtime'
 
 type Params = { category: string; itemId: string }
 

--- a/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-search-params/target-page/page.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-search-params/target-page/page.tsx
@@ -11,6 +11,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ searchParams: { q: '1' } }],
 }
+export const unstable_prefetch = 'runtime'
 
 export default async function RuntimePrefetchSearchParamsTargetPage() {
   // Intentionally NOT accessing searchParams

--- a/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch/[category]/[itemId]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch/[category]/[itemId]/page.tsx
@@ -21,6 +21,7 @@ export const unstable_instant: {
     { params: { category: 'clothing', itemId: 'shirt' } },
   ],
 }
+export const unstable_prefetch = 'runtime'
 
 type Params = { category: string; itemId: string }
 

--- a/test/e2e/app-dir/segment-cache/vary-params/app/(main)/search-params/target-page/page.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params/app/(main)/search-params/target-page/page.tsx
@@ -18,6 +18,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ searchParams: { foo: '1' } }],
 }
+export const unstable_prefetch = 'runtime'
 
 type SearchParams = { foo?: string }
 


### PR DESCRIPTION
Allows you to opt into runtime prefetching without coupling it to the way you configure instant validation. We do not intend to allow shipping runtime prefetching without opting into instant validation unless you specifically disable the validation because the cost of the runtime prefetching is potentially high but the way you configure validation is likely going to be pulling in lots of test code and we want to make it easier to discern that the validation code is not going to be bundled into production builds so separating the config is helpful.

Another reason to separate the config is that we expect that eventually most prefetching is configured globally and you do not need to opt specific segments into a different prefetching strategy.

Improved client component error messages to accurately describe the constraint: these are route segment configs that require a Server Component module, not exports that are forbidden.