### PR TITLE
Share native binaries via GitHub artifacts

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -71,6 +71,7 @@ jobs:
     with:
       skipInstallBuild: 'yes'
       stepName: 'build-native'
+      uploadNativeArtifact: 'next-swc-linux'
     secrets: inherit
 
   build-native-windows:
@@ -83,6 +84,7 @@ jobs:
       stepName: 'build-native-windows'
       runs_on_labels: '["windows","self-hosted","x64"]'
       buildNativeTarget: 'x86_64-pc-windows-msvc'
+      uploadNativeArtifact: 'next-swc-windows'
 
     secrets: inherit
 
@@ -698,7 +700,7 @@ jobs:
 
   test-unit-windows:
     name: test unit windows
-    needs: ['changes', 'build-native', 'build-native-windows']
+    needs: ['changes', 'build-native-windows', 'build-next']
     if: ${{ needs.changes.outputs.docs-only == 'false' }}
 
     strategy:
@@ -712,7 +714,6 @@ jobs:
       afterBuild: node run-tests.js --type unit
       stepName: 'test-unit-windows-${{ matrix.node }}'
       runs_on_labels: '["windows","self-hosted","x64"]'
-      buildNativeTarget: 'x86_64-pc-windows-msvc'
 
     secrets: inherit
 
@@ -866,14 +867,7 @@ jobs:
 
   test-dev-windows:
     name: test dev windows
-    needs:
-      [
-        'optimize-ci',
-        'changes',
-        'build-native-windows',
-        'build-native',
-        'build-next',
-      ]
+    needs: ['optimize-ci', 'changes', 'build-native-windows', 'build-next']
     if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
 
     uses: ./.github/workflows/build_reusable.yml
@@ -891,19 +885,11 @@ jobs:
           test/development/app-dir/segment-explorer/segment-explorer.test.ts
       stepName: 'test-dev-windows'
       runs_on_labels: '["windows","self-hosted","x64"]'
-      buildNativeTarget: 'x86_64-pc-windows-msvc'
     secrets: inherit
 
   test-integration-windows:
     name: test integration windows
-    needs:
-      [
-        'optimize-ci',
-        'changes',
-        'build-native-windows',
-        'build-native',
-        'build-next',
-      ]
+    needs: ['optimize-ci', 'changes', 'build-native-windows', 'build-next']
     if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
 
     uses: ./.github/workflows/build_reusable.yml
@@ -921,19 +907,11 @@ jobs:
           test/integration/create-next-app/package-manager/pnpm.test.ts
       stepName: 'test-integration-windows'
       runs_on_labels: '["windows","self-hosted","x64"]'
-      buildNativeTarget: 'x86_64-pc-windows-msvc'
     secrets: inherit
 
   test-prod-windows:
     name: test prod windows
-    needs:
-      [
-        'optimize-ci',
-        'changes',
-        'build-native-windows',
-        'build-native',
-        'build-next',
-      ]
+    needs: ['optimize-ci', 'changes', 'build-native-windows', 'build-next']
     if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
 
     uses: ./.github/workflows/build_reusable.yml
@@ -951,7 +929,6 @@ jobs:
           test/e2e/app-dir/proxy-runtime-nodejs/proxy-runtime-nodejs.test.ts
       stepName: 'test-prod-windows'
       runs_on_labels: '["windows","self-hosted","x64"]'
-      buildNativeTarget: 'x86_64-pc-windows-msvc'
     secrets: inherit
 
   test-prod:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -714,6 +714,7 @@ jobs:
       afterBuild: node run-tests.js --type unit
       stepName: 'test-unit-windows-${{ matrix.node }}'
       runs_on_labels: '["windows","self-hosted","x64"]'
+      buildNativeTarget: 'x86_64-pc-windows-msvc'
 
     secrets: inherit
 
@@ -885,6 +886,7 @@ jobs:
           test/development/app-dir/segment-explorer/segment-explorer.test.ts
       stepName: 'test-dev-windows'
       runs_on_labels: '["windows","self-hosted","x64"]'
+      buildNativeTarget: 'x86_64-pc-windows-msvc'
     secrets: inherit
 
   test-integration-windows:
@@ -907,6 +909,7 @@ jobs:
           test/integration/create-next-app/package-manager/pnpm.test.ts
       stepName: 'test-integration-windows'
       runs_on_labels: '["windows","self-hosted","x64"]'
+      buildNativeTarget: 'x86_64-pc-windows-msvc'
     secrets: inherit
 
   test-prod-windows:
@@ -929,6 +932,7 @@ jobs:
           test/e2e/app-dir/proxy-runtime-nodejs/proxy-runtime-nodejs.test.ts
       stepName: 'test-prod-windows'
       runs_on_labels: '["windows","self-hosted","x64"]'
+      buildNativeTarget: 'x86_64-pc-windows-msvc'
     secrets: inherit
 
   test-prod:

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -85,6 +85,12 @@ on:
         type: string
         default: ''
 
+      uploadNativeArtifact:
+        description: 'Artifact name to upload native .node files to after building. When set, this job is the native binary producer.'
+        required: false
+        type: string
+        default: ''
+
       browser:
         description: 'Browser to use for tests'
         required: false
@@ -232,14 +238,14 @@ jobs:
       # local action -> needs to run after checkout
       - name: Install Rust
         uses: ./.github/actions/setup-rust
-        if: ${{ inputs.skipNativeBuild != 'yes' || inputs.needsNextest == 'yes' || inputs.needsRust == 'yes' }}
+        if: ${{ (inputs.uploadNativeArtifact != '') || inputs.needsNextest == 'yes' || inputs.needsRust == 'yes' }}
 
       - name: Install nextest
         if: ${{ inputs.needsNextest == 'yes' }}
         uses: taiki-e/install-action@3a0adc33ab45d7b9b9da91822dd2b3c0151704be # nextest
 
       - run: rustc --version
-        if: ${{ inputs.skipNativeBuild != 'yes' || inputs.needsNextest == 'yes' || inputs.needsRust == 'yes' }}
+        if: ${{ (inputs.uploadNativeArtifact != '') || inputs.needsNextest == 'yes' || inputs.needsRust == 'yes' }}
 
       - run: corepack prepare --activate yarn@1.22.19 && npm i -g "@napi-rs/cli@${NAPI_CLI_VERSION}"
 
@@ -258,12 +264,29 @@ jobs:
 
       - name: Start sccache
         uses: ./.github/actions/sccache
-        if: ${{ inputs.skipNativeBuild != 'yes' || inputs.needsNextest == 'yes' || inputs.needsRust == 'yes' }}
+        if: ${{ (inputs.uploadNativeArtifact != '') || inputs.needsNextest == 'yes' || inputs.needsRust == 'yes' }}
         with:
           turbo-token: ${{ secrets.TURBO_REMOTE_CACHE_TOKEN }}
 
+      - name: Download pre-built native binary
+        if: ${{ inputs.skipNativeBuild != 'yes' && inputs.uploadNativeArtifact == '' }}
+        id: native-download
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ contains(fromJson(inputs.runs_on_labels), 'windows') && 'next-swc-windows' || 'next-swc-linux' }}
+          path: packages/next-swc/native/
+
       - run: pnpm dlx turbo@${TURBO_VERSION} run build-native-${{ inputs.rustBuildProfile }} ${TURBO_ARGS} --summarize -- --target ${{ inputs.buildNativeTarget }}
-        if: ${{ inputs.skipNativeBuild != 'yes' }}
+        if: ${{ inputs.skipNativeBuild != 'yes' && (inputs.uploadNativeArtifact != '' || steps.native-download.outcome != 'success') }}
+
+      - name: Upload native artifact
+        if: ${{ inputs.uploadNativeArtifact != '' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ inputs.uploadNativeArtifact }}
+          path: packages/next-swc/native/next-swc.*.node
+          retention-days: 1
 
       - name: Upload next-swc artifact
         if: ${{ inputs.uploadSwcArtifact == 'yes' }}


### PR DESCRIPTION
## What

Use the GHA cache instead of turborepo cache for intemediate build products.

## Why

turborepo is fast, but GHA is pretty fast too (adds a few seconds), and this takes load off the cache server. As a bonus, we get intermediate artifacts available for download and we work regardless of cache server availability.

## Details

- Add `nativeArtifact`/`uploadNativeArtifact` inputs to `build_reusable.yml`
- Build jobs upload `.node` files as GitHub artifacts
- Test jobs download pre-built artifacts instead of rebuilding via turborepo cache
- Rust installation and sccache are skipped when downloading pre-built artifacts
- Both Linux (`next-swc-linux`) and Windows (`next-swc-windows`) native builds upload artifacts
