### PR TITLE
Remove prefetch from instant config

### DIFF
--- a/packages/next/src/build/segment-config/app/app-segment-config.ts
+++ b/packages/next/src/build/segment-config/app/app-segment-config.ts
@@ -19,9 +19,8 @@ const RuntimeSampleSchema = z
   })
   .strict()
 
-const InstantConfigStaticSchema = z
+const InstantConfigObjectSchema = z
   .object({
-    prefetch: z.literal('static'),
     samples: z.array(RuntimeSampleSchema).min(1).optional(),
     from: z.array(z.string()).optional(),
     unstable_disableValidation: z.literal(true).optional(),
@@ -30,22 +29,9 @@ const InstantConfigStaticSchema = z
   })
   .strict()
 
-const InstantConfigRuntimeSchema = z
-  .object({
-    prefetch: z.literal('runtime'),
-    samples: z.array(RuntimeSampleSchema).min(1),
-    from: z.array(z.string()).optional(),
-    unstable_disableValidation: z.literal(true).optional(),
-    unstable_disableDevValidation: z.literal(true).optional(),
-    unstable_disableBuildValidation: z.literal(true).optional(),
-  })
-  .strict()
-
 const InstantConfigSchema = z.union([
-  z.discriminatedUnion('prefetch', [
-    InstantConfigStaticSchema,
-    InstantConfigRuntimeSchema,
-  ]),
+  InstantConfigObjectSchema,
+  z.literal(true),
   z.literal(false),
 ])
 
@@ -56,7 +42,7 @@ const PrefetchSchema = z.enum([
   'force-runtime',
 ])
 
-export type Instant = InstantConfigStatic | InstantConfigRuntime | false
+export type Instant = InstantConfig | true | false
 
 export type Prefetch =
   | 'auto'
@@ -65,14 +51,13 @@ export type Prefetch =
   | 'force-runtime'
 
 export type InstantConfigForTypeCheckInternal = __GenericInstantConfig | Instant
-// the __GenericPrefetch type is used to avoid type widening issues with
+// the __GenericInstantConfig type is used to avoid type widening issues with
 // our choice to make exports the medium for programming a Next.js application
 // With exports the type is controlled by the module and all we can do is assert on it
 // from a consumer. However with string literals in objects these are by default typed widely
 // and thus cannot match the discriminated union type. If we figure out a better way we should
-// delete the __GenericPrefetch member.
+// delete the __GenericInstantConfig member.
 interface __GenericInstantConfig {
-  prefetch: string
   samples?: Array<WideInstantSample>
   from?: string[]
   unstable_disableValidation?: boolean
@@ -80,29 +65,19 @@ interface __GenericInstantConfig {
   unstable_disableBuildValidation?: boolean
 }
 
-interface InstantConfigStatic {
-  prefetch: 'static'
-  samples?: Array<InstantSample>
-  from?: string[]
-  unstable_disableValidation?: true
-  unstable_disableDevValidation?: true
-  unstable_disableBuildValidation?: true
-}
-
-interface InstantConfigRuntime {
-  prefetch: 'runtime'
-  samples: Array<InstantSample>
-  from?: string[]
-  unstable_disableValidation?: true
-  unstable_disableDevValidation?: true
-  unstable_disableBuildValidation?: true
-}
-
 type WideInstantSample = {
   cookies?: InstantSample['cookies']
   headers?: Array<string[]>
   params?: InstantSample['params']
   searchParams?: InstantSample['searchParams']
+}
+
+export interface InstantConfig {
+  samples?: Array<InstantSample>
+  from?: string[]
+  unstable_disableValidation?: true
+  unstable_disableDevValidation?: true
+  unstable_disableBuildValidation?: true
 }
 
 export type InstantSample = {
@@ -212,7 +187,7 @@ export function parseAppSegmentConfig(
           case 'unstable_instant': {
             return {
               // @TODO replace this link with a link to the docs when they are written
-              message: `Invalid unstable_instant value ${JSON.stringify(ctx.data)} on "${route}", must be an object with \`prefetch: "static"\` or \`prefetch: "runtime"\`, or \`false\`. Read more at https://nextjs.org/docs/messages/invalid-instant-configuration`,
+              message: `Invalid unstable_instant value ${JSON.stringify(ctx.data)} on "${route}", must be \`true\`, \`false\`, or an object. Read more at https://nextjs.org/docs/messages/invalid-instant-configuration`,
             }
           }
           case 'unstable_prefetch': {

--- a/packages/next/src/server/app-render/create-flight-router-state-from-loader-tree.ts
+++ b/packages/next/src/server/app-render/create-flight-router-state-from-loader-tree.ts
@@ -88,7 +88,10 @@ async function createFlightRouterStateFromLoaderTreeImpl(
     prefetchHints |= PrefetchHint.IsRootLayout
   }
 
-  if (instantConfig && typeof instantConfig === 'object') {
+  if (
+    instantConfig === true ||
+    (typeof instantConfig === 'object' && instantConfig !== null)
+  ) {
     prefetchHints |= PrefetchHint.SubtreeHasInstant
   }
 

--- a/packages/next/src/server/app-render/instant-validation/instant-config.tsx
+++ b/packages/next/src/server/app-render/instant-validation/instant-config.tsx
@@ -49,10 +49,10 @@ export async function isPageAllowedToBlock(tree: LoaderTree): Promise<boolean> {
   // instant UI, so we should make sure that a static shell exists.
   // (even if it'd use runtime prefetching for client navs)
   if (instantConfig !== undefined) {
-    if (typeof instantConfig === 'object') {
-      return false
-    } else if (instantConfig === false) {
+    if (instantConfig === false) {
       return true
+    } else {
+      return false
     }
   }
 
@@ -84,12 +84,14 @@ async function anySegmentNeedsInstantValidation(
 ): Promise<boolean> {
   const segments = await findSegmentsWithInstantConfig(rootTree)
 
-  // Check if there's any configs with `prefetch: 'static'` or `mode: 'instant'`.
+  // Check if there's any non-false configs that need validation.
   // (If there's only `false`, there's no need to run validation).
   // If any segment has `unstable_disableValidation`, we skip validation for the whole tree.
   let needsValidation = false
   for (const { config } of segments) {
-    if (typeof config === 'object') {
+    if (config === true) {
+      needsValidation = true
+    } else if (typeof config === 'object') {
       if (
         config.unstable_disableValidation === true ||
         (mode === 'dev' && config.unstable_disableDevValidation === true) ||

--- a/packages/next/src/server/app-render/instant-validation/instant-validation.tsx
+++ b/packages/next/src/server/app-render/instant-validation/instant-validation.tsx
@@ -1155,7 +1155,10 @@ export async function createCombinedPayloadAtDepth(
         (layoutOrPageMod as AppSegmentConfig).unstable_instant ?? null
       prefetchConfig =
         (layoutOrPageMod as AppSegmentConfig).unstable_prefetch ?? null
-      if (instantConfig && typeof instantConfig === 'object') {
+      if (
+        instantConfig === true ||
+        (typeof instantConfig === 'object' && instantConfig !== null)
+      ) {
         const rawFactory: unknown = (layoutOrPageMod as any)
           .__debugCreateInstantConfigStack
         localCreateInstantStack =
@@ -1243,7 +1246,10 @@ export async function createCombinedPayloadAtDepth(
       requiresInstantUI = false
       createInstantStack = null
       configDepth = -1
-    } else if (instantConfig && typeof instantConfig === 'object') {
+    } else if (
+      instantConfig === true ||
+      (typeof instantConfig === 'object' && instantConfig !== null)
+    ) {
       requiresInstantUI = true
       createInstantStack = localCreateInstantStack
       configDepth = segmentDepth

--- a/packages/next/src/server/typescript/rules/config.ts
+++ b/packages/next/src/server/typescript/rules/config.ts
@@ -147,14 +147,14 @@ const API_DOCS: Record<
     link: 'https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#maxduration',
   },
   unstable_instant: {
-    description: `Specifies the default prefetching behavior for this segment. This configuration is currently under development and will change.`,
+    description: `Enables instant navigation validation for this segment. This configuration is currently under development and will change.`,
     link: '(docs coming soon)',
-    type: 'object | false',
+    type: 'true | object | false',
     // TODO: ideally, we'd validate the config object somehow, but this is difficult to do
     // with the way this plugin is currently structured.
     // For now, since we don't provide an `options` here, we won't do any validation in
     // `getSemanticDiagnosticsForExportVariableStatement` below, and only provide hover a tooltip + autocomplete.
-    insertText: 'unstable_instant = { prefetch: "static" };',
+    insertText: 'unstable_instant = true;',
   },
   unstable_prefetch: {
     description: `Controls prefetching behavior for this segment. This configuration is currently under development and will change.`,

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/apis/[param]/page.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/apis/[param]/page.tsx
@@ -3,7 +3,7 @@ import { CachedData } from '../../data-fetching'
 import { connection } from 'next/server'
 import { Suspense } from 'react'
 
-export const unstable_instant = { prefetch: 'runtime', samples: [{}] }
+export const unstable_instant = true
 export const unstable_prefetch = 'force-runtime'
 
 const CACHE_KEY = __dirname + '/__PAGE__'

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/private-cache/layout.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/private-cache/layout.tsx
@@ -2,7 +2,7 @@ import { Suspense } from 'react'
 import { UncachedFetch, CachedData } from '../data-fetching'
 import { PrivateCachedData } from './data-fetching'
 
-export const unstable_instant = { prefetch: 'runtime', samples: [{}] }
+export const unstable_instant = true
 export const unstable_prefetch = 'force-runtime'
 
 const CACHE_KEY = '/private-cache/__LAYOUT__'

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/short-lived-cache/layout.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/short-lived-cache/layout.tsx
@@ -2,7 +2,7 @@ import { Suspense } from 'react'
 import { UncachedFetch, CachedData } from '../data-fetching'
 import { ShortLivedCache } from './data-fetching'
 
-export const unstable_instant = { prefetch: 'runtime', samples: [{}] }
+export const unstable_instant = true
 export const unstable_prefetch = 'force-runtime'
 
 const CACHE_KEY = __dirname + '/__LAYOUT__'

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/simple/layout.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/simple/layout.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from 'react'
 import { UncachedFetch, CachedFetch, CachedData } from '../data-fetching'
 
-export const unstable_instant = { prefetch: 'runtime', samples: [{}] }
+export const unstable_instant = true
 export const unstable_prefetch = 'force-runtime'
 
 const CACHE_KEY = __dirname + '/__LAYOUT__'

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/successive-caches/page.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/successive-caches/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = { prefetch: 'runtime', samples: [{}] }
+export const unstable_instant = true
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/sync-io/runtime/page.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/sync-io/runtime/page.tsx
@@ -2,7 +2,7 @@ import { Suspense } from 'react'
 import { CachedData, getCachedData } from '../../data-fetching'
 import { cookies } from 'next/headers'
 
-export const unstable_instant = { prefetch: 'runtime', samples: [{}] }
+export const unstable_instant = true
 export const unstable_prefetch = 'force-runtime'
 
 const CACHE_KEY = __dirname + '/__PAGE__'

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/sync-io/static/page.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/sync-io/static/page.tsx
@@ -1,6 +1,6 @@
 import { CachedData, getCachedData } from '../../data-fetching'
 
-export const unstable_instant = { prefetch: 'runtime', samples: [{}] }
+export const unstable_instant = true
 export const unstable_prefetch = 'force-runtime'
 
 const CACHE_KEY = __dirname + '/__PAGE__'

--- a/test/development/app-dir/cache-components-tasks/fixtures/with-prefetch-config/app/simple/layout.tsx
+++ b/test/development/app-dir/cache-components-tasks/fixtures/with-prefetch-config/app/simple/layout.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from 'react'
 import { Static, Runtime, Dynamic } from '../shared'
 
-export const unstable_instant = { prefetch: 'runtime', samples: [{}] }
+export const unstable_instant = true
 export const unstable_prefetch = 'force-runtime'
 
 export default function Root({ children }: { children: React.ReactNode }) {

--- a/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/app/runtime-prefetch-target/page.tsx
+++ b/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/app/runtime-prefetch-target/page.tsx
@@ -2,7 +2,6 @@ import { Suspense } from 'react'
 import { connection } from 'next/server'
 
 export const unstable_instant = {
-  prefetch: 'runtime',
   samples: [{ searchParams: { myParam: 'testValue' } }],
 }
 export const unstable_prefetch = 'force-runtime'

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/client-errors/page-throws-with-suspense/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/client-errors/page-throws-with-suspense/page.tsx
@@ -2,7 +2,6 @@ import { Instant } from 'next'
 import { ThrowsInClient } from './client'
 
 export const unstable_instant: Instant = {
-  prefetch: 'static',
   samples: [{ searchParams: {} }],
 }
 

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/client-errors/page-throws/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/client-errors/page-throws/page.tsx
@@ -2,7 +2,6 @@ import { Instant } from 'next'
 import { ThrowsInClient } from './client'
 
 export const unstable_instant: Instant = {
-  prefetch: 'static',
   samples: [{ searchParams: {} }],
 }
 

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/invalid-undeclared-cookie-get-caught/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/invalid-undeclared-cookie-get-caught/page.tsx
@@ -2,10 +2,7 @@ import { cookies } from 'next/headers'
 import { Suspense } from 'react'
 import { ensureThrows } from '../../../../ensure-error'
 
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [{ cookies: [] }],
-}
+export const unstable_instant = true
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/invalid-undeclared-cookie-get/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/invalid-undeclared-cookie-get/page.tsx
@@ -2,10 +2,7 @@ import { cookies } from 'next/headers'
 import { Suspense } from 'react'
 import { ensureThrows } from '../../../../ensure-error'
 
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [{ cookies: [] }],
-}
+export const unstable_instant = true
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/invalid-undeclared-cookie-has/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/invalid-undeclared-cookie-has/page.tsx
@@ -2,10 +2,7 @@ import { cookies } from 'next/headers'
 import { Suspense } from 'react'
 import { ensureThrows } from '../../../../ensure-error'
 
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [{ cookies: [] }],
-}
+export const unstable_instant = true
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/valid-cookies-in-samples/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/valid-cookies-in-samples/page.tsx
@@ -5,7 +5,6 @@ import assert from 'node:assert'
 import { Suspense } from 'react'
 
 export const unstable_instant: Instant = {
-  prefetch: 'runtime',
   samples: [
     {
       cookies: [

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/valid-cookies-passed-to-cache/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/valid-cookies-passed-to-cache/page.tsx
@@ -3,7 +3,6 @@ import { cookies } from 'next/headers'
 import assert from 'node:assert/strict'
 
 export const unstable_instant: Instant = {
-  prefetch: 'runtime',
   samples: [
     {
       cookies: [{ name: 'testCookie', value: 'testValue' }],

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/valid-cookies-passed-to-client/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/valid-cookies-passed-to-client/page.tsx
@@ -3,7 +3,6 @@ import { cookies } from 'next/headers'
 import { ClientChild } from './client'
 
 export const unstable_instant: Instant = {
-  prefetch: 'runtime',
   samples: [
     {
       cookies: [{ name: 'testCookie', value: 'testValue' }],

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/gsp/[slug]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/gsp/[slug]/page.tsx
@@ -7,7 +7,6 @@ import { AssertParamsClient } from './client'
 // samples use 'hello', but generateStaticParams uses 'foo'/'bar'.
 // During validation, the sample params should be used, not the GSP values.
 export const unstable_instant: Instant = {
-  prefetch: 'runtime',
   samples: [
     {
       params: {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/headers/invalid-undeclared-header-get-caught/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/headers/invalid-undeclared-header-get-caught/page.tsx
@@ -2,10 +2,7 @@ import { headers } from 'next/headers'
 import { Suspense } from 'react'
 import { ensureThrows } from '../../../../ensure-error'
 
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [{ headers: [] }],
-}
+export const unstable_instant = { samples: [{ headers: [] }] }
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/headers/invalid-undeclared-header-get/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/headers/invalid-undeclared-header-get/page.tsx
@@ -2,10 +2,7 @@ import { headers } from 'next/headers'
 import { Suspense } from 'react'
 import { ensureThrows } from '../../../../ensure-error'
 
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [{ headers: [] }],
-}
+export const unstable_instant = { samples: [{ headers: [] }] }
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/headers/invalid-undeclared-header-has/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/headers/invalid-undeclared-header-has/page.tsx
@@ -2,10 +2,7 @@ import { headers } from 'next/headers'
 import { Suspense } from 'react'
 import { ensureThrows } from '../../../../ensure-error'
 
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [{ headers: [] }],
-}
+export const unstable_instant = { samples: [{ headers: [] }] }
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/headers/valid-headers-in-samples/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/headers/valid-headers-in-samples/page.tsx
@@ -5,7 +5,6 @@ import assert from 'node:assert'
 import { Suspense } from 'react'
 
 export const unstable_instant: Instant = {
-  prefetch: 'runtime',
   samples: [
     {
       headers: [

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/headers/valid-headers-passed-to-cache/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/headers/valid-headers-passed-to-cache/page.tsx
@@ -3,7 +3,6 @@ import { headers } from 'next/headers'
 import assert from 'node:assert/strict'
 
 export const unstable_instant: Instant = {
-  prefetch: 'runtime',
   samples: [
     {
       headers: [['x-test-header', 'testValue']],

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/headers/valid-headers-passed-to-client/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/headers/valid-headers-passed-to-client/page.tsx
@@ -3,7 +3,6 @@ import { headers } from 'next/headers'
 import { ClientChild } from './client'
 
 export const unstable_instant: Instant = {
-  prefetch: 'runtime',
   samples: [
     {
       headers: [['x-test-header', 'testValue']],

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/invalid-missing-suspense-around-runtime/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/invalid-missing-suspense-around-runtime/page.tsx
@@ -2,7 +2,6 @@ import { cookies } from 'next/headers'
 import { connection } from 'next/server'
 
 export const unstable_instant = {
-  prefetch: 'runtime',
   samples: [{ cookies: [{ name: 'auth', value: '1' }] }],
 }
 export const unstable_prefetch = 'force-runtime'

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/params/invalid-param-not-provided-caught/[one]/[two]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/params/invalid-param-not-provided-caught/[one]/[two]/page.tsx
@@ -3,7 +3,6 @@ import assert from 'node:assert/strict'
 import { ensureThrows } from '../../../../../../ensure-error'
 
 export const unstable_instant: Instant = {
-  prefetch: 'runtime',
   samples: [
     {
       params: {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/params/invalid-param-not-provided/[one]/[two]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/params/invalid-param-not-provided/[one]/[two]/page.tsx
@@ -3,7 +3,6 @@ import assert from 'node:assert/strict'
 import { ensureThrows } from '../../../../../../ensure-error'
 
 export const unstable_instant: Instant = {
-  prefetch: 'runtime',
   samples: [
     {
       params: {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/params/invalid-undeclared-use-params-caught/[one]/[two]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/params/invalid-undeclared-use-params-caught/[one]/[two]/page.tsx
@@ -2,7 +2,6 @@ import type { Instant } from 'next'
 import { ParamsReader } from './params-reader'
 
 export const unstable_instant: Instant = {
-  prefetch: 'static',
   samples: [
     {
       params: {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/params/invalid-undeclared-use-params/[one]/[two]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/params/invalid-undeclared-use-params/[one]/[two]/page.tsx
@@ -2,7 +2,6 @@ import type { Instant } from 'next'
 import { ParamsReader } from './params-reader'
 
 export const unstable_instant: Instant = {
-  prefetch: 'static',
   samples: [
     {
       params: {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/params/valid-params-in-samples/[one]/[two]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/params/valid-params-in-samples/[one]/[two]/page.tsx
@@ -2,7 +2,6 @@ import type { Instant } from 'next'
 import assert from 'node:assert/strict'
 
 export const unstable_instant: Instant = {
-  prefetch: 'runtime',
   samples: [
     {
       params: {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/params/valid-params-passed-to-cache/[slug]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/params/valid-params-passed-to-cache/[slug]/page.tsx
@@ -2,7 +2,6 @@ import type { Instant } from 'next'
 import assert from 'node:assert/strict'
 
 export const unstable_instant: Instant = {
-  prefetch: 'runtime',
   samples: [{ params: { slug: 'hello' } }],
 }
 export const unstable_prefetch = 'force-runtime'

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/params/valid-params-passed-to-client/[slug]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/params/valid-params-passed-to-client/[slug]/page.tsx
@@ -2,7 +2,6 @@ import type { Instant } from 'next'
 import { ClientChild } from './client'
 
 export const unstable_instant: Instant = {
-  prefetch: 'runtime',
   samples: [{ params: { slug: 'hello' } }],
 }
 export const unstable_prefetch = 'force-runtime'

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/params/valid-use-params/[one]/[two]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/params/valid-use-params/[one]/[two]/page.tsx
@@ -2,7 +2,6 @@ import type { Instant } from 'next'
 import { ParamsReader } from './params-reader'
 
 export const unstable_instant: Instant = {
-  prefetch: 'static',
   samples: [
     {
       params: {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/pathname/invalid-use-pathname-missing-params/[one]/[two]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/pathname/invalid-use-pathname-missing-params/[one]/[two]/page.tsx
@@ -2,7 +2,6 @@ import type { Instant } from 'next'
 import { PathnameReader } from './pathname-reader'
 
 export const unstable_instant: Instant = {
-  prefetch: 'static',
   samples: [
     {
       params: {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/pathname/valid-use-pathname-catch-all/[...catchAll]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/pathname/valid-use-pathname-catch-all/[...catchAll]/page.tsx
@@ -3,7 +3,6 @@ import { Suspense } from 'react'
 import { PathnameReader } from './pathname-reader'
 
 export const unstable_instant: Instant = {
-  prefetch: 'static',
   samples: [
     {
       params: {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/pathname/valid-use-pathname-no-params/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/pathname/valid-use-pathname-no-params/page.tsx
@@ -1,11 +1,7 @@
-import type { Instant } from 'next'
 import { Suspense } from 'react'
 import { PathnameReader } from './pathname-reader'
 
-export const unstable_instant: Instant = {
-  prefetch: 'static',
-  samples: [{}],
-}
+export const unstable_instant = true
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/pathname/valid-use-pathname-optional-catch-all/[[...optionalCatchAll]]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/pathname/valid-use-pathname-optional-catch-all/[[...optionalCatchAll]]/page.tsx
@@ -3,7 +3,6 @@ import { Suspense } from 'react'
 import { PathnameReader } from './pathname-reader'
 
 export const unstable_instant: Instant = {
-  prefetch: 'static',
   samples: [
     {
       params: {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/pathname/valid-use-pathname-route-group/(route-group)/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/pathname/valid-use-pathname-route-group/(route-group)/page.tsx
@@ -1,11 +1,7 @@
-import type { Instant } from 'next'
 import { Suspense } from 'react'
 import { PathnameReader } from './pathname-reader'
 
-export const unstable_instant: Instant = {
-  prefetch: 'static',
-  samples: [{}],
-}
+export const unstable_instant = true
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/pathname/valid-use-pathname-with-params/[one]/[two]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/pathname/valid-use-pathname-with-params/[one]/[two]/page.tsx
@@ -3,7 +3,6 @@ import { Suspense } from 'react'
 import { PathnameReader } from './pathname-reader'
 
 export const unstable_instant: Instant = {
-  prefetch: 'static',
   samples: [
     {
       params: {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/samples-precedence/[slug]/layout.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/samples-precedence/[slug]/layout.tsx
@@ -1,7 +1,6 @@
 import type { Instant } from 'next'
 
 export const unstable_instant: Instant = {
-  prefetch: 'static',
   samples: [
     {
       params: {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/samples-precedence/[slug]/page-overrides/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/samples-precedence/[slug]/page-overrides/page.tsx
@@ -3,7 +3,6 @@ import assert from 'node:assert/strict'
 import { Suspense } from 'react'
 
 export const unstable_instant: Instant = {
-  prefetch: 'static',
   samples: [
     {
       params: {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/invalid-undeclared-search-param-caught/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/invalid-undeclared-search-param-caught/page.tsx
@@ -1,9 +1,6 @@
 import { ensureThrows } from '../../../../ensure-error'
 
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [{ searchParams: { q: 'test' } }],
-}
+export const unstable_instant = { samples: [{ searchParams: { q: 'test' } }] }
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Page({

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/invalid-undeclared-search-param/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/invalid-undeclared-search-param/page.tsx
@@ -1,9 +1,6 @@
 import { ensureThrows } from '../../../../ensure-error'
 
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [{ searchParams: { q: 'test' } }],
-}
+export const unstable_instant = { samples: [{ searchParams: { q: 'test' } }] }
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Page({

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/invalid-undeclared-use-search-params-caught/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/invalid-undeclared-use-search-params-caught/page.tsx
@@ -3,7 +3,6 @@ import { Suspense } from 'react'
 import { SearchParamsReader } from './search-params-reader'
 
 export const unstable_instant: Instant = {
-  prefetch: 'runtime',
   samples: [
     {
       searchParams: {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/invalid-undeclared-use-search-params/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/invalid-undeclared-use-search-params/page.tsx
@@ -2,7 +2,6 @@ import type { Instant } from 'next'
 import { SearchParamsReader } from './search-params-reader'
 
 export const unstable_instant: Instant = {
-  prefetch: 'runtime',
   samples: [
     {
       searchParams: {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/valid-search-params-in-samples/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/valid-search-params-in-samples/page.tsx
@@ -4,7 +4,6 @@ import assert from 'node:assert/strict'
 import { Suspense } from 'react'
 
 export const unstable_instant: Instant = {
-  prefetch: 'runtime',
   samples: [
     {
       searchParams: {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/valid-search-params-passed-to-cache/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/valid-search-params-passed-to-cache/page.tsx
@@ -2,7 +2,6 @@ import type { Instant } from 'next'
 import assert from 'node:assert/strict'
 
 export const unstable_instant: Instant = {
-  prefetch: 'runtime',
   samples: [
     {
       searchParams: {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/valid-search-params-passed-to-client/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/valid-search-params-passed-to-client/page.tsx
@@ -4,7 +4,6 @@ import assert from 'node:assert/strict'
 import { ClientChild } from './client'
 
 export const unstable_instant: Instant = {
-  prefetch: 'runtime',
   samples: [
     {
       searchParams: {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/valid-use-search-params/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/valid-use-search-params/page.tsx
@@ -3,7 +3,6 @@ import { Suspense } from 'react'
 import { SearchParamsReader } from './search-params-reader'
 
 export const unstable_instant: Instant = {
-  prefetch: 'runtime',
   samples: [
     {
       searchParams: {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/server-errors/error-passed-to-client-and-ignored/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/server-errors/error-passed-to-client-and-ignored/page.tsx
@@ -1,10 +1,7 @@
 import { cookies } from 'next/headers'
 import { IgnoreServerContent } from './client'
 
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [{ cookies: [] }],
-}
+export const unstable_instant = true
 export const unstable_prefetch = 'force-runtime'
 
 export default function Page() {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/server-errors/page-throws-with-suspense/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/server-errors/page-throws-with-suspense/page.tsx
@@ -1,9 +1,6 @@
 import { cookies } from 'next/headers'
 
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [{ cookies: [] }],
-}
+export const unstable_instant = true
 export const unstable_prefetch = 'force-runtime'
 
 export default function Page() {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/server-errors/page-throws/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/server-errors/page-throws/page.tsx
@@ -1,9 +1,6 @@
 import { cookies } from 'next/headers'
 
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [{ cookies: [] }],
-}
+export const unstable_instant = true
 export const unstable_prefetch = 'force-runtime'
 
 export default function Page() {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/valid-await-cache-without-suspense/mixed/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/valid-await-cache-without-suspense/mixed/page.tsx
@@ -1,9 +1,6 @@
 import { cookies } from 'next/headers'
 
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [{}],
-}
+export const unstable_instant = true
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/valid-await-cache-without-suspense/private/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/valid-await-cache-without-suspense/private/page.tsx
@@ -1,7 +1,4 @@
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [{}],
-}
+export const unstable_instant = true
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/valid-await-cache-without-suspense/runtime/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/valid-await-cache-without-suspense/runtime/page.tsx
@@ -1,9 +1,6 @@
 import { cookies } from 'next/headers'
 
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [{}],
-}
+export const unstable_instant = true
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/valid-await-cache-without-suspense/static/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/valid-await-cache-without-suspense/static/page.tsx
@@ -1,6 +1,4 @@
-export const unstable_instant = {
-  prefetch: 'static',
-}
+export const unstable_instant = true
 
 export default async function Page() {
   await cachedIO()

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/valid-suspense-around-runtime/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/valid-suspense-around-runtime/page.tsx
@@ -3,7 +3,6 @@ import { connection } from 'next/server'
 import { Suspense } from 'react'
 
 export const unstable_instant = {
-  prefetch: 'runtime',
   samples: [{ cookies: [{ name: 'auth', value: '1' }] }],
 }
 export const unstable_prefetch = 'force-runtime'

--- a/test/e2e/app-dir/instant-validation-build/app/root-params/[lang]/invalid-root-param-not-provided-caught/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/root-params/[lang]/invalid-root-param-not-provided-caught/page.tsx
@@ -4,7 +4,6 @@ import { lang } from 'next/root-params'
 import { ensureRejects } from '../../../../ensure-error'
 
 export const unstable_instant: Instant = {
-  prefetch: 'runtime',
   // no samples
   samples: [{}],
 }

--- a/test/e2e/app-dir/instant-validation-build/app/root-params/[lang]/invalid-root-param-not-provided/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/root-params/[lang]/invalid-root-param-not-provided/page.tsx
@@ -4,7 +4,6 @@ import { lang } from 'next/root-params'
 import { ensureRejects } from '../../../../ensure-error'
 
 export const unstable_instant: Instant = {
-  prefetch: 'runtime',
   // no samples
   samples: [{}],
 }

--- a/test/e2e/app-dir/instant-validation-build/app/root-params/[lang]/valid-root-param-in-samples/runtime/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/root-params/[lang]/valid-root-param-in-samples/runtime/page.tsx
@@ -4,7 +4,6 @@ import { lang } from 'next/root-params'
 import assert from 'node:assert/strict'
 
 export const unstable_instant: Instant = {
-  prefetch: 'runtime',
   samples: [{ params: { lang: 'en-from-samples' } }],
 }
 export const unstable_prefetch = 'force-runtime'

--- a/test/e2e/app-dir/instant-validation-build/app/root-params/[lang]/valid-root-param-in-samples/static/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/root-params/[lang]/valid-root-param-in-samples/static/page.tsx
@@ -3,7 +3,6 @@ import { lang } from 'next/root-params'
 import assert from 'node:assert/strict'
 
 export const unstable_instant: Instant = {
-  prefetch: 'static',
   samples: [{ params: { lang: 'en' } }],
 }
 

--- a/test/e2e/app-dir/instant-validation-build/instant-validation-build.test.ts
+++ b/test/e2e/app-dir/instant-validation-build/instant-validation-build.test.ts
@@ -105,13 +105,13 @@ describe('instant-validation-build', () => {
            at body (<anonymous>)
            at html (<anonymous>) {
          [cause]: Error: Kaboom
-             at a (app/(default)/server-errors/page-throws/page.tsx:25:9)
-           23 | async function Throws(): Promise<never> {
-           24 |   await cookies()
-         > 25 |   throw new Error('Kaboom')
+             at a (app/(default)/server-errors/page-throws/page.tsx:22:9)
+           20 | async function Throws(): Promise<never> {
+           21 |   await cookies()
+         > 22 |   throw new Error('Kaboom')
               |         ^
-           26 | }
-           27 | {
+           23 | }
+           24 | {
            digest: '<error-digest>'
          }
        }
@@ -136,13 +136,13 @@ describe('instant-validation-build', () => {
            at body (<anonymous>)
            at html (<anonymous>) {
          [cause]: Error: Kaboom
-             at b (app/(default)/server-errors/page-throws-with-suspense/page.tsx:25:9)
-           23 | async function Throws(): Promise<never> {
-           24 |   await cookies()
-         > 25 |   throw new Error('Kaboom')
+             at b (app/(default)/server-errors/page-throws-with-suspense/page.tsx:22:9)
+           20 | async function Throws(): Promise<never> {
+           21 |   await cookies()
+         > 22 |   throw new Error('Kaboom')
               |         ^
-           26 | }
-           27 | {
+           23 | }
+           24 | {
            digest: '<error-digest>'
          }
        }
@@ -245,16 +245,16 @@ describe('instant-validation-build', () => {
       expect(extractBuildValidationError(result.cliOutput))
         .toMatchInlineSnapshot(`
        "Error: Route "/search-params/invalid-undeclared-search-param" accessed searchParam "undeclared" which is not defined in the \`samples\` of \`unstable_instant\`. Add it to the sample's \`searchParams\` object, or \`{ "undeclared": null }\` if it should be absent.
-           at <unknown> (app/(default)/search-params/invalid-undeclared-search-param/page.tsx:32:14)
+           at <unknown> (app/(default)/search-params/invalid-undeclared-search-param/page.tsx:29:14)
            at <unknown> (ensure-error.ts:11:5)
-           at a (app/(default)/search-params/invalid-undeclared-search-param/page.tsx:31:3)
-         30 |   const sp = await searchParams
-         31 |   ensureThrows(
-       > 32 |     () => sp.undeclared,
+           at a (app/(default)/search-params/invalid-undeclared-search-param/page.tsx:28:3)
+         27 |   const sp = await searchParams
+         28 |   ensureThrows(
+       > 29 |     () => sp.undeclared,
             |              ^
-         33 |     \`Expected accessing an undeclared search param to throw\`
-         34 |   )
-         35 |   return null {
+         30 |     \`Expected accessing an undeclared search param to throw\`
+         31 |   )
+         32 |   return null {
          digest: 'INSTANT_VALIDATION_ERROR'
        }
        Build-time instant validation failed for route "/search-params/invalid-undeclared-search-param".
@@ -282,16 +282,16 @@ describe('instant-validation-build', () => {
       expect(extractBuildValidationError(result.cliOutput))
         .toMatchInlineSnapshot(`
        "Error: Route "/search-params/invalid-undeclared-search-param-caught" accessed searchParam "undeclared" which is not defined in the \`samples\` of \`unstable_instant\`. Add it to the sample's \`searchParams\` object, or \`{ "undeclared": null }\` if it should be absent.
-           at <unknown> (app/(default)/search-params/invalid-undeclared-search-param-caught/page.tsx:36:16)
+           at <unknown> (app/(default)/search-params/invalid-undeclared-search-param-caught/page.tsx:33:16)
            at <unknown> (ensure-error.ts:11:5)
-           at a (app/(default)/search-params/invalid-undeclared-search-param-caught/page.tsx:35:5)
-         34 |   try {
-         35 |     ensureThrows(
-       > 36 |       () => sp.undeclared,
+           at a (app/(default)/search-params/invalid-undeclared-search-param-caught/page.tsx:32:5)
+         31 |   try {
+         32 |     ensureThrows(
+       > 33 |       () => sp.undeclared,
             |                ^
-         37 |       \`Expected accessing an undeclared search param to throw\`
-         38 |     )
-         39 |   } catch (err) { {
+         34 |       \`Expected accessing an undeclared search param to throw\`
+         35 |     )
+         36 |   } catch (err) { {
          digest: 'INSTANT_VALIDATION_ERROR'
        }
        Build-time instant validation failed for route "/search-params/invalid-undeclared-search-param-caught".
@@ -395,16 +395,16 @@ describe('instant-validation-build', () => {
       expect(extractBuildValidationError(result.cliOutput))
         .toMatchInlineSnapshot(`
        "Error: Route "/headers/invalid-undeclared-header-get" accessed header "undeclaredheader" which is not defined in the \`samples\` of \`unstable_instant\`. Add it to the sample's \`headers\` array, or \`["undeclaredheader", null]\` if it should be absent.
-           at <unknown> (app/(default)/headers/invalid-undeclared-header-get/page.tsx:28:24)
+           at <unknown> (app/(default)/headers/invalid-undeclared-header-get/page.tsx:25:24)
            at <unknown> (ensure-error.ts:11:5)
-           at a (app/(default)/headers/invalid-undeclared-header-get/page.tsx:27:3)
-         26 |   const headersStore = await headers()
-         27 |   ensureThrows(
-       > 28 |     () => headersStore.get('undeclaredHeader'),
+           at a (app/(default)/headers/invalid-undeclared-header-get/page.tsx:24:3)
+         23 |   const headersStore = await headers()
+         24 |   ensureThrows(
+       > 25 |     () => headersStore.get('undeclaredHeader'),
             |                        ^
-         29 |     \`Expected get() to throw for undeclared headers\`
-         30 |   )
-         31 |   return null {
+         26 |     \`Expected get() to throw for undeclared headers\`
+         27 |   )
+         28 |   return null {
          digest: 'INSTANT_VALIDATION_ERROR'
        }
        Build-time instant validation failed for route "/headers/invalid-undeclared-header-get".
@@ -424,16 +424,16 @@ describe('instant-validation-build', () => {
       expect(extractBuildValidationError(result.cliOutput))
         .toMatchInlineSnapshot(`
        "Error: Route "/headers/invalid-undeclared-header-get-caught" accessed header "undeclaredheader" which is not defined in the \`samples\` of \`unstable_instant\`. Add it to the sample's \`headers\` array, or \`["undeclaredheader", null]\` if it should be absent.
-           at <unknown> (app/(default)/headers/invalid-undeclared-header-get-caught/page.tsx:31:25)
+           at <unknown> (app/(default)/headers/invalid-undeclared-header-get-caught/page.tsx:28:25)
            at <unknown> (ensure-error.ts:11:5)
-           at a (app/(default)/headers/invalid-undeclared-header-get-caught/page.tsx:30:5)
-         29 |   try {
-         30 |     ensureThrows(
-       > 31 |       () => headerStore.get('undeclaredHeader'),
+           at a (app/(default)/headers/invalid-undeclared-header-get-caught/page.tsx:27:5)
+         26 |   try {
+         27 |     ensureThrows(
+       > 28 |       () => headerStore.get('undeclaredHeader'),
             |                         ^
-         32 |       \`Expected get() to throw for undeclared headers\`
-         33 |     )
-         34 |   } catch (err) { {
+         29 |       \`Expected get() to throw for undeclared headers\`
+         30 |     )
+         31 |   } catch (err) { {
          digest: 'INSTANT_VALIDATION_ERROR'
        }
        Build-time instant validation failed for route "/headers/invalid-undeclared-header-get-caught".
@@ -452,16 +452,16 @@ describe('instant-validation-build', () => {
       expect(extractBuildValidationError(result.cliOutput))
         .toMatchInlineSnapshot(`
        "Error: Route "/headers/invalid-undeclared-header-has" accessed header "undeclaredheader" which is not defined in the \`samples\` of \`unstable_instant\`. Add it to the sample's \`headers\` array, or \`["undeclaredheader", null]\` if it should be absent.
-           at <unknown> (app/(default)/headers/invalid-undeclared-header-has/page.tsx:28:23)
+           at <unknown> (app/(default)/headers/invalid-undeclared-header-has/page.tsx:25:23)
            at <unknown> (ensure-error.ts:11:5)
-           at a (app/(default)/headers/invalid-undeclared-header-has/page.tsx:27:3)
-         26 |   const headerStore = await headers()
-         27 |   ensureThrows(
-       > 28 |     () => headerStore.has('undeclaredHeader'),
+           at a (app/(default)/headers/invalid-undeclared-header-has/page.tsx:24:3)
+         23 |   const headerStore = await headers()
+         24 |   ensureThrows(
+       > 25 |     () => headerStore.has('undeclaredHeader'),
             |                       ^
-         29 |     \`Expected has() to throw for undeclared headers\`
-         30 |   )
-         31 |   return null {
+         26 |     \`Expected has() to throw for undeclared headers\`
+         27 |   )
+         28 |   return null {
          digest: 'INSTANT_VALIDATION_ERROR'
        }
        Build-time instant validation failed for route "/headers/invalid-undeclared-header-has".
@@ -507,16 +507,16 @@ describe('instant-validation-build', () => {
       expect(extractBuildValidationError(result.cliOutput))
         .toMatchInlineSnapshot(`
        "Error: Route "/cookies/invalid-undeclared-cookie-get" accessed cookie "undeclaredCookie" which is not defined in the \`samples\` of \`unstable_instant\`. Add it to the sample's \`cookies\` array, or \`{ name: "undeclaredCookie", value: null }\` if it should be absent.
-           at <unknown> (app/(default)/cookies/invalid-undeclared-cookie-get/page.tsx:29:23)
+           at <unknown> (app/(default)/cookies/invalid-undeclared-cookie-get/page.tsx:26:23)
            at <unknown> (ensure-error.ts:11:5)
-           at a (app/(default)/cookies/invalid-undeclared-cookie-get/page.tsx:28:3)
-         27 |
-         28 |   ensureThrows(
-       > 29 |     () => cookieStore.get('undeclaredCookie'),
+           at a (app/(default)/cookies/invalid-undeclared-cookie-get/page.tsx:25:3)
+         24 |
+         25 |   ensureThrows(
+       > 26 |     () => cookieStore.get('undeclaredCookie'),
             |                       ^
-         30 |     \`Expected get() to throw for undeclared cookies\`
-         31 |   )
-         32 |   return null {
+         27 |     \`Expected get() to throw for undeclared cookies\`
+         28 |   )
+         29 |   return null {
          digest: 'INSTANT_VALIDATION_ERROR'
        }
        Build-time instant validation failed for route "/cookies/invalid-undeclared-cookie-get".
@@ -536,16 +536,16 @@ describe('instant-validation-build', () => {
       expect(extractBuildValidationError(result.cliOutput))
         .toMatchInlineSnapshot(`
        "Error: Route "/cookies/invalid-undeclared-cookie-get-caught" accessed cookie "undeclaredCookie" which is not defined in the \`samples\` of \`unstable_instant\`. Add it to the sample's \`cookies\` array, or \`{ name: "undeclaredCookie", value: null }\` if it should be absent.
-           at <unknown> (app/(default)/cookies/invalid-undeclared-cookie-get-caught/page.tsx:31:25)
+           at <unknown> (app/(default)/cookies/invalid-undeclared-cookie-get-caught/page.tsx:28:25)
            at <unknown> (ensure-error.ts:11:5)
-           at a (app/(default)/cookies/invalid-undeclared-cookie-get-caught/page.tsx:30:5)
-         29 |   try {
-         30 |     ensureThrows(
-       > 31 |       () => cookieStore.get('undeclaredCookie'),
+           at a (app/(default)/cookies/invalid-undeclared-cookie-get-caught/page.tsx:27:5)
+         26 |   try {
+         27 |     ensureThrows(
+       > 28 |       () => cookieStore.get('undeclaredCookie'),
             |                         ^
-         32 |       \`Expected get() to throw for undeclared cookies\`
-         33 |     )
-         34 |   } catch (err) { {
+         29 |       \`Expected get() to throw for undeclared cookies\`
+         30 |     )
+         31 |   } catch (err) { {
          digest: 'INSTANT_VALIDATION_ERROR'
        }
        Build-time instant validation failed for route "/cookies/invalid-undeclared-cookie-get-caught".
@@ -565,16 +565,16 @@ describe('instant-validation-build', () => {
       expect(extractBuildValidationError(result.cliOutput))
         .toMatchInlineSnapshot(`
        "Error: Route "/cookies/invalid-undeclared-cookie-has" accessed cookie "undeclaredCookie" which is not defined in the \`samples\` of \`unstable_instant\`. Add it to the sample's \`cookies\` array, or \`{ name: "undeclaredCookie", value: null }\` if it should be absent.
-           at <unknown> (app/(default)/cookies/invalid-undeclared-cookie-has/page.tsx:28:23)
+           at <unknown> (app/(default)/cookies/invalid-undeclared-cookie-has/page.tsx:25:23)
            at <unknown> (ensure-error.ts:11:5)
-           at a (app/(default)/cookies/invalid-undeclared-cookie-has/page.tsx:27:3)
-         26 |   const cookieStore = await cookies()
-         27 |   ensureThrows(
-       > 28 |     () => cookieStore.has('undeclaredCookie'),
+           at a (app/(default)/cookies/invalid-undeclared-cookie-has/page.tsx:24:3)
+         23 |   const cookieStore = await cookies()
+         24 |   ensureThrows(
+       > 25 |     () => cookieStore.has('undeclaredCookie'),
             |                       ^
-         29 |     \`Expected has() to throw for undeclared cookies\`
-         30 |   )
-         31 |   return null {
+         26 |     \`Expected has() to throw for undeclared cookies\`
+         27 |   )
+         28 |   return null {
          digest: 'INSTANT_VALIDATION_ERROR'
        }
        Build-time instant validation failed for route "/cookies/invalid-undeclared-cookie-has".
@@ -612,16 +612,16 @@ describe('instant-validation-build', () => {
       expect(extractBuildValidationError(result.cliOutput))
         .toMatchInlineSnapshot(`
        "Error: Route "/params/invalid-param-not-provided/[one]/[two]" accessed param "two" which is not defined in the \`samples\` of \`unstable_instant\`. Add it to the sample's \`params\` object.
-           at <unknown> (app/(default)/params/invalid-param-not-provided/[one]/[two]/page.tsx:48:24)
+           at <unknown> (app/(default)/params/invalid-param-not-provided/[one]/[two]/page.tsx:47:24)
            at <unknown> (ensure-error.ts:11:5)
-           at a (app/(default)/params/invalid-param-not-provided/[one]/[two]/page.tsx:48:3)
-         46 |
-         47 |   // We're not allowed to access params not in the samples.
-       > 48 |   ensureThrows(() => p.two)
+           at a (app/(default)/params/invalid-param-not-provided/[one]/[two]/page.tsx:47:3)
+         45 |
+         46 |   // We're not allowed to access params not in the samples.
+       > 47 |   ensureThrows(() => p.two)
             |                        ^
-         49 |
-         50 |   // TODO: test \`in\` and iteration
-         51 |   // assert.deepStrictEqual( {
+         48 |
+         49 |   // TODO: test \`in\` and iteration
+         50 |   // assert.deepStrictEqual( {
          digest: 'INSTANT_VALIDATION_ERROR'
        }
        Build-time instant validation failed for route "/params/invalid-param-not-provided/[one]/[two]".
@@ -641,16 +641,16 @@ describe('instant-validation-build', () => {
       expect(extractBuildValidationError(result.cliOutput))
         .toMatchInlineSnapshot(`
        "Error: Route "/params/invalid-param-not-provided-caught/[one]/[two]" accessed param "two" which is not defined in the \`samples\` of \`unstable_instant\`. Add it to the sample's \`params\` object.
-           at <unknown> (app/(default)/params/invalid-param-not-provided-caught/[one]/[two]/page.tsx:46:26)
+           at <unknown> (app/(default)/params/invalid-param-not-provided-caught/[one]/[two]/page.tsx:45:26)
            at <unknown> (ensure-error.ts:11:5)
-           at a (app/(default)/params/invalid-param-not-provided-caught/[one]/[two]/page.tsx:46:5)
-         44 |   try {
-         45 |     // We're not allowed to access params not in the samples.
-       > 46 |     ensureThrows(() => p.two, \`Expected accessing an undeclared param to throw\`)
+           at a (app/(default)/params/invalid-param-not-provided-caught/[one]/[two]/page.tsx:45:5)
+         43 |   try {
+         44 |     // We're not allowed to access params not in the samples.
+       > 45 |     ensureThrows(() => p.two, \`Expected accessing an undeclared param to throw\`)
             |                          ^
-         47 |   } catch (err) {
-         48 |     // We swallow the error. It should still be reported and fail the validation.
-         49 |   } {
+         46 |   } catch (err) {
+         47 |     // We swallow the error. It should still be reported and fail the validation.
+         48 |   } {
          digest: 'INSTANT_VALIDATION_ERROR'
        }
        Build-time instant validation failed for route "/params/invalid-param-not-provided-caught/[one]/[two]".
@@ -837,16 +837,16 @@ describe('instant-validation-build', () => {
       expect(extractBuildValidationError(result.cliOutput))
         .toMatchInlineSnapshot(`
        "Error: Route "/root-params/[lang]/invalid-root-param-not-provided" accessed root param "lang" which is not defined in the \`samples\` of \`unstable_instant\`. Add it to the sample's \`params\` object.
-           at <unknown> (app/root-params/[lang]/invalid-root-param-not-provided/page.tsx:18:11)
+           at <unknown> (app/root-params/[lang]/invalid-root-param-not-provided/page.tsx:17:11)
            at a (ensure-error.ts:48:11)
-           at b (app/root-params/[lang]/invalid-root-param-not-provided/page.tsx:17:9)
-         16 |
-         17 |   await ensureRejects(
-       > 18 |     () => lang(),
+           at b (app/root-params/[lang]/invalid-root-param-not-provided/page.tsx:16:9)
+         15 |
+         16 |   await ensureRejects(
+       > 17 |     () => lang(),
             |           ^
-         19 |     \`Expected lang() to error if sample is not provided\`
-         20 |   )
-         21 |   return ( {
+         18 |     \`Expected lang() to error if sample is not provided\`
+         19 |   )
+         20 |   return ( {
          digest: 'INSTANT_VALIDATION_ERROR'
        }
        Build-time instant validation failed for route "/root-params/[lang]/invalid-root-param-not-provided".
@@ -866,16 +866,16 @@ describe('instant-validation-build', () => {
       expect(extractBuildValidationError(result.cliOutput))
         .toMatchInlineSnapshot(`
        "Error: Route "/root-params/[lang]/invalid-root-param-not-provided-caught" accessed root param "lang" which is not defined in the \`samples\` of \`unstable_instant\`. Add it to the sample's \`params\` object.
-           at <unknown> (app/root-params/[lang]/invalid-root-param-not-provided-caught/page.tsx:19:13)
+           at <unknown> (app/root-params/[lang]/invalid-root-param-not-provided-caught/page.tsx:18:13)
            at a (ensure-error.ts:48:11)
-           at b (app/root-params/[lang]/invalid-root-param-not-provided-caught/page.tsx:18:11)
-         17 |   try {
-         18 |     await ensureRejects(
-       > 19 |       () => lang(),
+           at b (app/root-params/[lang]/invalid-root-param-not-provided-caught/page.tsx:17:11)
+         16 |   try {
+         17 |     await ensureRejects(
+       > 18 |       () => lang(),
             |             ^
-         20 |       \`Expected lang() to error if sample is not provided\`
-         21 |     )
-         22 |   } catch { {
+         19 |       \`Expected lang() to error if sample is not provided\`
+         20 |     )
+         21 |   } catch { {
          digest: 'INSTANT_VALIDATION_ERROR'
        }
        Build-time instant validation failed for route "/root-params/[lang]/invalid-root-param-not-provided-caught".

--- a/test/e2e/app-dir/instant-validation-causes/app/aliased-export/page.tsx
+++ b/test/e2e/app-dir/instant-validation-causes/app/aliased-export/page.tsx
@@ -1,6 +1,6 @@
 import { cookies } from 'next/headers'
 
-const instant = { prefetch: 'static' }
+const instant = true
 export { instant as unstable_instant }
 
 export default async function Page() {

--- a/test/e2e/app-dir/instant-validation-causes/app/indirect-export/page.tsx
+++ b/test/e2e/app-dir/instant-validation-causes/app/indirect-export/page.tsx
@@ -1,6 +1,6 @@
 import { cookies } from 'next/headers'
 
-const _instant = { prefetch: 'static' }
+const _instant = true
 const instant = _instant
 export { instant as unstable_instant }
 

--- a/test/e2e/app-dir/instant-validation-causes/app/named-export/page.tsx
+++ b/test/e2e/app-dir/instant-validation-causes/app/named-export/page.tsx
@@ -1,6 +1,6 @@
 import { cookies } from 'next/headers'
 
-const unstable_instant = { prefetch: 'static' }
+const unstable_instant = true
 export { unstable_instant }
 
 export default async function Page() {

--- a/test/e2e/app-dir/instant-validation-causes/app/reexport/config.ts
+++ b/test/e2e/app-dir/instant-validation-causes/app/reexport/config.ts
@@ -1,1 +1,1 @@
-export const unstable_instant = { prefetch: 'static' }
+export const unstable_instant = true

--- a/test/e2e/app-dir/instant-validation-causes/instant-validation-causes.test.ts
+++ b/test/e2e/app-dir/instant-validation-causes/instant-validation-causes.test.ts
@@ -97,7 +97,7 @@ describe('instant validation causes', () => {
          {
            "label": "Caused by: Instant Validation",
            "source": "app/named-export/page.tsx (3:26) @ unstable_instant
-     > 3 | const unstable_instant = { prefetch: 'static' }
+     > 3 | const unstable_instant = true
          |                          ^",
            "stack": [
              "unstable_instant app/named-export/page.tsx (3:26)",
@@ -128,7 +128,7 @@ describe('instant validation causes', () => {
          {
            "label": "Caused by: Instant Validation",
            "source": "app/aliased-export/page.tsx (3:17) @ unstable_instant
-     > 3 | const instant = { prefetch: 'static' }
+     > 3 | const instant = true
          |                 ^",
            "stack": [
              "unstable_instant app/aliased-export/page.tsx (3:17)",

--- a/test/e2e/app-dir/instant-validation-client/app/page.tsx
+++ b/test/e2e/app-dir/instant-validation-client/app/page.tsx
@@ -4,6 +4,4 @@ export default function Page() {
   return <p>hello world</p>
 }
 
-export const unstable_instant = {
-  prefetch: 'static',
-}
+export const unstable_instant = true

--- a/test/e2e/app-dir/instant-validation-static-shells/fixtures/invalid-blocking-page-below-static/app/blocking-page-below-static/layout.tsx
+++ b/test/e2e/app-dir/instant-validation-static-shells/fixtures/invalid-blocking-page-below-static/app/blocking-page-below-static/layout.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = { prefetch: 'static' }
+export const unstable_instant = true
 
 export default async function Layout({ children }) {
   return (

--- a/test/e2e/app-dir/instant-validation/app/default/static/valid-blocked-children/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/default/static/valid-blocked-children/page.tsx
@@ -1,7 +1,7 @@
 import { connection } from 'next/server'
 import { Suspense } from 'react'
 
-export const unstable_instant = { prefetch: 'static' }
+export const unstable_instant = true
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/default/static/valid-blocking-inside-static/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/default/static/valid-blocking-inside-static/layout.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from 'react'
 
-export const unstable_instant = { prefetch: 'static' }
+export const unstable_instant = true
 
 export default function StaticLayout({ children }) {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/disable-validation/disable-build/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/disable-validation/disable-build/page.tsx
@@ -1,9 +1,6 @@
 import { connection } from 'next/server'
 
-export const unstable_instant = {
-  prefetch: 'static',
-  unstable_disableBuildValidation: true,
-}
+export const unstable_instant = { unstable_disableBuildValidation: true }
 
 export default async function Page() {
   await connection()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/disable-validation/disable-dev/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/disable-validation/disable-dev/page.tsx
@@ -1,9 +1,6 @@
 import { connection } from 'next/server'
 
-export const unstable_instant = {
-  prefetch: 'static',
-  unstable_disableDevValidation: true,
-}
+export const unstable_instant = { unstable_disableDevValidation: true }
 
 export default async function Page() {
   await connection()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/disable-validation/in-layout/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/disable-validation/in-layout/layout.tsx
@@ -1,5 +1,4 @@
 export const unstable_instant = {
-  prefetch: 'runtime',
   samples: [{ cookies: [] }],
   unstable_disableValidation: true,
 }

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/disable-validation/in-page-with-outer/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/disable-validation/in-page-with-outer/layout.tsx
@@ -1,6 +1,4 @@
-export const unstable_instant = {
-  prefetch: 'static',
-}
+export const unstable_instant = true
 
 export default function Layout({ children }) {
   return <>{children}</>

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/disable-validation/in-page-with-outer/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/disable-validation/in-page-with-outer/page.tsx
@@ -1,7 +1,6 @@
 import { connection } from 'next/server'
 
 export const unstable_instant = {
-  prefetch: 'runtime',
   samples: [{ cookies: [] }],
   unstable_disableValidation: true,
 }

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/disable-validation/in-page/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/disable-validation/in-page/page.tsx
@@ -1,7 +1,6 @@
 import { connection } from 'next/server'
 
 export const unstable_instant = {
-  prefetch: 'runtime',
   samples: [{ cookies: [] }],
   unstable_disableValidation: true,
 }

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/invalid-dynamic-viewport-in-blocking-inside-static/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/invalid-dynamic-viewport-in-blocking-inside-static/layout.tsx
@@ -1,6 +1,6 @@
 import { ReactNode, Suspense } from 'react'
 
-export const unstable_instant = { prefetch: 'static' }
+export const unstable_instant = true
 
 export default function Layout({ children }: { children: ReactNode }) {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/invalid-dynamic-viewport-in-runtime/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/invalid-dynamic-viewport-in-runtime/page.tsx
@@ -3,10 +3,7 @@ import { cookies } from 'next/headers'
 import { connection } from 'next/server'
 import { Suspense } from 'react'
 
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [{ cookies: [] }],
-}
+export const unstable_instant = true
 export const unstable_prefetch = 'force-runtime'
 
 // Note that we're inside a root layout with suspense, so we skip the static shell

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/invalid-runtime-viewport-in-static/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/invalid-runtime-viewport-in-static/layout.tsx
@@ -1,7 +1,4 @@
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [{ cookies: [] }],
-}
+export const unstable_instant = true
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Layout({ children }) {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/invalid-runtime-viewport-in-static/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/invalid-runtime-viewport-in-static/page.tsx
@@ -5,10 +5,7 @@ import { cookies } from 'next/headers'
 // This would be valid if it used a runtime prefetch (because then it wouldn't block navigation),
 // but it's static, so it's invalid. As an extra sanity check, we put a runtime prefetch on the
 // layout above, and that should not make this error go away.
-export const unstable_instant = {
-  prefetch: 'static',
-  samples: [{ cookies: [] }],
-}
+export const unstable_instant = true
 
 export async function generateViewport(): Promise<Viewport> {
   await cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/valid-dynamic-metadata-in-runtime/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/valid-dynamic-metadata-in-runtime/page.tsx
@@ -3,10 +3,7 @@ import { cookies } from 'next/headers'
 import { connection } from 'next/server'
 import { Suspense } from 'react'
 
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [{ cookies: [] }],
-}
+export const unstable_instant = true
 export const unstable_prefetch = 'force-runtime'
 
 export async function generateMetadata(): Promise<Metadata> {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/valid-runtime-metadata-in-static/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/valid-runtime-metadata-in-static/page.tsx
@@ -2,10 +2,7 @@ import { Metadata } from 'next'
 import { cookies } from 'next/headers'
 import { Suspense } from 'react'
 
-export const unstable_instant = {
-  prefetch: 'static',
-  samples: [{ cookies: [] }],
-}
+export const unstable_instant = true
 
 export async function generateMetadata(): Promise<Metadata> {
   await cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/valid-runtime-viewport-in-runtime/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/valid-runtime-viewport-in-runtime/page.tsx
@@ -1,10 +1,7 @@
 import type { Viewport } from 'next'
 import { cookies } from 'next/headers'
 
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [{ cookies: [] }],
-}
+export const unstable_instant = true
 export const unstable_prefetch = 'force-runtime'
 
 export async function generateViewport(): Promise<Viewport> {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/both-configs/@slot/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/both-configs/@slot/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = { prefetch: 'static' }
+export const unstable_instant = true
 
 export default function SlotPage() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/both-configs/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/both-configs/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = { prefetch: 'static' }
+export const unstable_instant = true
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/children-config-with-slot/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/children-config-with-slot/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = { prefetch: 'static' }
+export const unstable_instant = true
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/conditional-breadcrumbs/show-both/blocked/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/conditional-breadcrumbs/show-both/blocked/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = { prefetch: 'static' }
+export const unstable_instant = true
 export default function Page() {
   return <p>show-both/blocked — children page with instant config</p>
 }

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/conditional-breadcrumbs/show-both/unblocked/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/conditional-breadcrumbs/show-both/unblocked/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = { prefetch: 'static' }
+export const unstable_instant = true
 export default function Page() {
   return <p>show-both/unblocked — children page with instant config</p>
 }

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/conditional-breadcrumbs/show-only-breadcrumbs/blocked/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/conditional-breadcrumbs/show-only-breadcrumbs/blocked/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = { prefetch: 'static' }
+export const unstable_instant = true
 export default function Page() {
   return (
     <p>show-only-breadcrumbs/blocked — children page with instant config</p>

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/conditional-breadcrumbs/show-only-breadcrumbs/unblocked/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/conditional-breadcrumbs/show-only-breadcrumbs/unblocked/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = { prefetch: 'static' }
+export const unstable_instant = true
 export default function Page() {
   return (
     <p>show-only-breadcrumbs/unblocked — children page with instant config</p>

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/conditional-breadcrumbs/show-only-children/blocked/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/conditional-breadcrumbs/show-only-children/blocked/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = { prefetch: 'static' }
+export const unstable_instant = true
 export default function Page() {
   return <p>show-only-children/blocked — children page with instant config</p>
 }

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/conditional-breadcrumbs/show-only-children/unblocked/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/conditional-breadcrumbs/show-only-children/unblocked/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = { prefetch: 'static' }
+export const unstable_instant = true
 export default function Page() {
   return <p>show-only-children/unblocked — children page with instant config</p>
 }

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/fork-layout-config-with-slot/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/fork-layout-config-with-slot/layout.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react'
 
-export const unstable_instant = { prefetch: 'static' }
+export const unstable_instant = true
 
 export default function Layout({
   children,

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/slot-config-children-suspended/@slot/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/slot-config-children-suspended/@slot/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = { prefetch: 'static' }
+export const unstable_instant = true
 
 export default function SlotPage() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/slot-config-only/@slot/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/slot-config-only/@slot/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = { prefetch: 'static' }
+export const unstable_instant = true
 
 export default function SlotPage() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/slot-layout-config/@slot/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/slot-layout-config/@slot/layout.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react'
 
-export const unstable_instant = { prefetch: 'static' }
+export const unstable_instant = true
 
 export default function SlotLayout({ children }: { children: ReactNode }) {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/slot-runtime-config/@slot/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/slot-runtime-config/@slot/page.tsx
@@ -1,10 +1,7 @@
 import { Suspense } from 'react'
 import { connection } from 'next/server'
 
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [{}],
-}
+export const unstable_instant = true
 export const unstable_prefetch = 'force-runtime'
 
 export default function SlotPage() {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-blocking-inside-runtime/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-blocking-inside-runtime/layout.tsx
@@ -1,9 +1,6 @@
 import { cookies } from 'next/headers'
 
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [{ cookies: [] }],
-}
+export const unstable_instant = true
 export const unstable_prefetch = 'force-runtime'
 
 export default async function RuntimeLayout({ children }) {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-after-cache-with-cookie-input/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-after-cache-with-cookie-input/page.tsx
@@ -1,9 +1,6 @@
 import { cookies } from 'next/headers'
 
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [{ cookies: [] }],
-}
+export const unstable_instant = true
 export const unstable_prefetch = 'force-runtime'
 
 // This page HAS runtime prefetch enabled. cookies() is passed as a promise

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-in-generate-metadata/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-in-generate-metadata/page.tsx
@@ -1,10 +1,7 @@
 import { cookies } from 'next/headers'
 import { Suspense } from 'react'
 
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [{ cookies: [] }],
-}
+export const unstable_instant = true
 export const unstable_prefetch = 'force-runtime'
 
 export async function generateMetadata() {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-in-layout-generate-metadata/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-in-layout-generate-metadata/page.tsx
@@ -1,10 +1,7 @@
 import { cookies } from 'next/headers'
 import { Suspense } from 'react'
 
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [{ cookies: [] }],
-}
+export const unstable_instant = true
 export const unstable_prefetch = 'force-runtime'
 
 async function Runtime() {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-in-runtime-with-valid-static-parent/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-in-runtime-with-valid-static-parent/page.tsx
@@ -1,9 +1,6 @@
 import { cookies } from 'next/headers'
 
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [{ cookies: [] }],
-}
+export const unstable_instant = true
 export const unstable_prefetch = 'force-runtime'
 
 // This page HAS runtime prefetch enabled. The sync IO (Date.now()) after

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io/page.tsx
@@ -1,9 +1,6 @@
 import { cookies } from 'next/headers'
 
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [{ cookies: [] }],
-}
+export const unstable_instant = true
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/missing-suspense-around-dynamic-layout/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/missing-suspense-around-dynamic-layout/layout.tsx
@@ -1,10 +1,7 @@
 import { connection } from 'next/server'
 import { ReactNode } from 'react'
 
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [{ cookies: [] }],
-}
+export const unstable_instant = true
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Layout({ children }: { children: ReactNode }) {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/missing-suspense-around-dynamic/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/missing-suspense-around-dynamic/page.tsx
@@ -1,10 +1,7 @@
 import { cookies } from 'next/headers'
 import { connection } from 'next/server'
 
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [{ cookies: [] }],
-}
+export const unstable_instant = true
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/static-layout-above-runtime-config/inner/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/static-layout-above-runtime-config/inner/layout.tsx
@@ -3,10 +3,7 @@ import { ReactNode } from 'react'
 // This layout has the runtime prefetch config. The developer expects
 // runtime prefetching to handle dynamic data, but the parent layout
 // above this one gets static prefetching by default and blocks.
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [{ cookies: [] }],
-}
+export const unstable_instant = true
 export const unstable_prefetch = 'force-runtime'
 
 export default function InnerLayout({ children }: { children: ReactNode }) {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/suspense-around-dynamic/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/suspense-around-dynamic/page.tsx
@@ -2,10 +2,7 @@ import { cookies } from 'next/headers'
 import { connection } from 'next/server'
 import { Suspense } from 'react'
 
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [{ cookies: [] }],
-}
+export const unstable_instant = true
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/suspense-too-high/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/suspense-too-high/page.tsx
@@ -1,10 +1,7 @@
 import { cookies } from 'next/headers'
 import { connection } from 'next/server'
 
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [{ cookies: [] }],
-}
+export const unstable_instant = true
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-blocking-inside-runtime/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-blocking-inside-runtime/layout.tsx
@@ -1,10 +1,7 @@
 import { cookies } from 'next/headers'
 import { Suspense } from 'react'
 
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [{ cookies: [] }],
-}
+export const unstable_instant = true
 export const unstable_prefetch = 'force-runtime'
 
 export default async function RuntimeLayout({ children }) {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-no-suspense-around-params/[param]/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-no-suspense-around-params/[param]/page.tsx
@@ -2,7 +2,6 @@ import { connection } from 'next/server'
 import { Suspense } from 'react'
 
 export const unstable_instant = {
-  prefetch: 'runtime',
   samples: [{ cookies: [], params: { param: '123' } }],
 }
 export const unstable_prefetch = 'force-runtime'

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-no-suspense-around-search-params/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-no-suspense-around-search-params/page.tsx
@@ -2,7 +2,6 @@ import { connection } from 'next/server'
 import { Suspense } from 'react'
 
 export const unstable_instant = {
-  prefetch: 'runtime',
   samples: [{ cookies: [], searchParams: { foo: 'bar' } }],
 }
 export const unstable_prefetch = 'force-runtime'

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-sync-io-in-generate-metadata-static-page/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-sync-io-in-generate-metadata-static-page/page.tsx
@@ -3,7 +3,7 @@ import { Suspense } from 'react'
 
 // this page is NOT runtime-prefetchable,
 // so Sync IO in generateMetadata should be allowed.
-export const unstable_instant = { prefetch: 'static' }
+export const unstable_instant = true
 
 export async function generateMetadata() {
   await cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-sync-io-in-layout-generate-metadata-static-page/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-sync-io-in-layout-generate-metadata-static-page/layout.tsx
@@ -3,7 +3,7 @@ import { cookies } from 'next/headers'
 // This layout does NOT have runtime prefetch and neither does the child
 // page. Since no segment has runtime prefetch enabled, sync IO in
 // generateMetadata should be allowed.
-export const unstable_instant = { prefetch: 'static' }
+export const unstable_instant = true
 
 export async function generateMetadata() {
   await cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-sync-io-in-static-parent/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-sync-io-in-static-parent/page.tsx
@@ -1,10 +1,7 @@
 import { cookies } from 'next/headers'
 import { Suspense } from 'react'
 
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [{ cookies: [] }],
-}
+export const unstable_instant = true
 export const unstable_prefetch = 'force-runtime'
 
 async function Runtime() {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/blocking-layout/missing-suspense-around-dynamic/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/blocking-layout/missing-suspense-around-dynamic/page.tsx
@@ -1,9 +1,6 @@
 import { cookies } from 'next/headers'
 
-export const unstable_instant = {
-  prefetch: 'static',
-  samples: [{ cookies: [] }],
-}
+export const unstable_instant = true
 
 export default async function Page() {
   await cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/blocking-layout/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/blocking-layout/page.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link'
 
-export const unstable_instant = { prefetch: 'static' }
+export const unstable_instant = true
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/config-children-preferred/@other/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/config-children-preferred/@other/page.tsx
@@ -1,7 +1,7 @@
 // @other has config at the same depth as children's page.
 // Children's config should be preferred for the root cause
 // because children wins at equal depth.
-export const unstable_instant = { prefetch: 'static' }
+export const unstable_instant = true
 
 export default function OtherPage() {
   return <p>Other slot page — same-depth config, no blocking</p>

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/config-children-preferred/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/config-children-preferred/page.tsx
@@ -1,7 +1,7 @@
 // Children and @other both have config at the same depth (page level).
 // Children's config should be preferred as the root cause when the
 // error is in @slot (which has no config).
-export const unstable_instant = { prefetch: 'static' }
+export const unstable_instant = true
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/config-depth-preference-slot-wins/deeper/@anotherSlot/still/deep/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/config-depth-preference-slot-wins/deeper/@anotherSlot/still/deep/page.tsx
@@ -1,6 +1,6 @@
 // Deepest config — in @anotherSlot, deeper than children's catchall.
 // Should be preferred as the root cause because depth wins.
-export const unstable_instant = { prefetch: 'static' }
+export const unstable_instant = true
 
 export default function AnotherSlotDeepPage() {
   return <p>Another slot deep page — deepest config, no blocking</p>

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/config-depth-preference-slot-wins/deeper/[...rest]/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/config-depth-preference-slot-wins/deeper/[...rest]/page.tsx
@@ -1,6 +1,6 @@
 // Children's config via catchall — shallower than @anotherSlot's
 // deep config. Should NOT be preferred as root cause.
-export const unstable_instant = { prefetch: 'static' }
+export const unstable_instant = true
 
 export default function ChildrenCatchallPage() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/config-depth-preference/deeper/@anotherSlot/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/config-depth-preference/deeper/@anotherSlot/page.tsx
@@ -1,6 +1,6 @@
 // Shallow config in a named slot. The deeper config in
 // still/deep/page.tsx should be preferred over this one.
-export const unstable_instant = { prefetch: 'static' }
+export const unstable_instant = true
 
 export default function AnotherSlotPage() {
   return <p>Another slot page — shallow config, no blocking</p>

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/config-depth-preference/deeper/still/deep/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/config-depth-preference/deeper/still/deep/page.tsx
@@ -1,6 +1,6 @@
 // Deepest config — should be preferred as the root cause when
 // the error is in @slot (which has no config).
-export const unstable_instant = { prefetch: 'static' }
+export const unstable_instant = true
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/cross-slot-blocking/inner/deep/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/cross-slot-blocking/inner/deep/page.tsx
@@ -2,7 +2,7 @@
 // second fork point (inner/layout.tsx has @panel). The blocking
 // code is in @slot at the outer fork. The slot marker for @slot
 // has no config, so the cause must fall back to the root config.
-export const unstable_instant = { prefetch: 'static' }
+export const unstable_instant = true
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/false-below-static/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/false-below-static/layout.tsx
@@ -4,7 +4,7 @@ import { ReactNode } from 'react'
 // Even though the page below opts out with `false`, this layout's
 // config still triggers validation at depths where both the layout
 // and the page are in the new tree.
-export const unstable_instant = { prefetch: 'static' }
+export const unstable_instant = true
 
 export default function Layout({ children }: { children: ReactNode }) {
   return <div>{children}</div>

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-blocking-inside-static/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-blocking-inside-static/layout.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = { prefetch: 'static' }
+export const unstable_instant = true
 
 export default function StaticLayout({ children }) {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-client-data-blocks-validation/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-client-data-blocks-validation/page.tsx
@@ -1,6 +1,4 @@
-export const unstable_instant = {
-  prefetch: 'static',
-}
+export const unstable_instant = true
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-client-error-in-parent-blocks-children/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-client-error-in-parent-blocks-children/page.tsx
@@ -1,6 +1,4 @@
-export const unstable_instant = {
-  prefetch: 'static',
-}
+export const unstable_instant = true
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-client-error-in-parent-sibling/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-client-error-in-parent-sibling/page.tsx
@@ -1,6 +1,4 @@
-export const unstable_instant = {
-  prefetch: 'static',
-}
+export const unstable_instant = true
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-csr-bailout-blocks-children/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-csr-bailout-blocks-children/page.tsx
@@ -1,6 +1,4 @@
-export const unstable_instant = {
-  prefetch: 'static',
-}
+export const unstable_instant = true
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-dynamic-layout-with-loading/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-dynamic-layout-with-loading/layout.tsx
@@ -1,7 +1,7 @@
 import { connection } from 'next/server'
 import { ReactNode } from 'react'
 
-export const unstable_instant = { prefetch: 'static' }
+export const unstable_instant = true
 
 export default async function Layout({ children }: { children: ReactNode }) {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-error-in-node-modules-blocks-children/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-error-in-node-modules-blocks-children/page.tsx
@@ -1,6 +1,4 @@
-export const unstable_instant = {
-  prefetch: 'static',
-}
+export const unstable_instant = true
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-loading-above-route-group/(group)/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-loading-above-route-group/(group)/page.tsx
@@ -1,10 +1,7 @@
 import { cookies } from 'next/headers'
 import { connection } from 'next/server'
 
-export const unstable_instant = {
-  prefetch: 'static',
-  samples: [{ cookies: [] }],
-}
+export const unstable_instant = true
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/missing-suspense-around-dynamic-layout/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/missing-suspense-around-dynamic-layout/layout.tsx
@@ -1,10 +1,7 @@
 import { cookies } from 'next/headers'
 import { ReactNode } from 'react'
 
-export const unstable_instant = {
-  prefetch: 'static',
-  samples: [{ cookies: [] }],
-}
+export const unstable_instant = true
 
 export default async function Layout({ children }: { children: ReactNode }) {
   await cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/missing-suspense-around-dynamic/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/missing-suspense-around-dynamic/page.tsx
@@ -1,6 +1,6 @@
 import { connection } from 'next/server'
 
-export const unstable_instant = { prefetch: 'static' }
+export const unstable_instant = true
 
 export default async function Page() {
   await connection()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/missing-suspense-around-params/[param]/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/missing-suspense-around-params/[param]/page.tsx
@@ -1,7 +1,4 @@
-export const unstable_instant = {
-  prefetch: 'static',
-  samples: [{ params: { param: '123' } }],
-}
+export const unstable_instant = { samples: [{ params: { param: '123' } }] }
 
 export default async function Page({
   params,

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/missing-suspense-around-runtime/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/missing-suspense-around-runtime/page.tsx
@@ -1,9 +1,6 @@
 import { cookies } from 'next/headers'
 
-export const unstable_instant = {
-  prefetch: 'static',
-  samples: [{ cookies: [] }],
-}
+export const unstable_instant = true
 
 export default async function Page() {
   await cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/missing-suspense-around-search-params/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/missing-suspense-around-search-params/page.tsx
@@ -1,7 +1,4 @@
-export const unstable_instant = {
-  prefetch: 'static',
-  samples: [{ searchParams: { foo: 'bar' } }],
-}
+export const unstable_instant = { samples: [{ searchParams: { foo: 'bar' } }] }
 
 export default async function Page({ searchParams }) {
   const search = await searchParams

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/missing-suspense-in-parallel-route/@slot/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/missing-suspense-in-parallel-route/@slot/layout.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = { prefetch: 'static' }
+export const unstable_instant = true
 export default function SlotLayout({ children }) {
   return (
     <div>

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/missing-suspense-in-parallel-route/bar/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/missing-suspense-in-parallel-route/bar/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = { prefetch: 'static' }
+export const unstable_instant = true
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/missing-suspense-in-parallel-route/foo/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/missing-suspense-in-parallel-route/foo/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = { prefetch: 'static' }
+export const unstable_instant = true
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/missing-suspense-in-parallel-route/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/missing-suspense-in-parallel-route/page.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link'
 
-export const unstable_instant = { prefetch: 'static' }
+export const unstable_instant = true
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/parallel-group-depths-deep-slot-hole/(b1)/(b2)/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/parallel-group-depths-deep-slot-hole/(b1)/(b2)/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = { prefetch: 'static' }
+export const unstable_instant = true
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/parallel-group-depths-deep-slot-hole/@slot/(g1)/(g2)/(g3)/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/parallel-group-depths-deep-slot-hole/@slot/(g1)/(g2)/(g3)/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = { prefetch: 'static' }
+export const unstable_instant = true
 
 export default function SlotPage() {
   return <p>Slot A page inside 3 nested route groups</p>

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/parallel-group-depths-shallow-slot-hole/(b1)/(b2)/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/parallel-group-depths-shallow-slot-hole/(b1)/(b2)/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = { prefetch: 'static' }
+export const unstable_instant = true
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/parallel-group-depths-shallow-slot-hole/@slot/(g1)/(g2)/(g3)/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/parallel-group-depths-shallow-slot-hole/@slot/(g1)/(g2)/(g3)/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = { prefetch: 'static' }
+export const unstable_instant = true
 
 export default function SlotPage() {
   return <p>Slot A page inside 3 nested route groups</p>

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/parallel-nested-forks/@slot1/@slot2a/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/parallel-nested-forks/@slot1/@slot2a/page.tsx
@@ -1,6 +1,6 @@
 import { cookies } from 'next/headers'
 
-export const unstable_instant = { prefetch: 'static' }
+export const unstable_instant = true
 
 export default async function Slot2aPage() {
   await cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/parallel-nested-forks/@slot1/@slot2b/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/parallel-nested-forks/@slot1/@slot2b/page.tsx
@@ -1,6 +1,6 @@
 import { cookies } from 'next/headers'
 
-export const unstable_instant = { prefetch: 'static' }
+export const unstable_instant = true
 
 export default async function Slot2bPage() {
   await cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/parallel-nested-forks/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/parallel-nested-forks/page.tsx
@@ -1,6 +1,6 @@
 import { cookies } from 'next/headers'
 
-export const unstable_instant = { prefetch: 'static' }
+export const unstable_instant = true
 
 export default async function Page() {
   await cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-config-and-segment-config/(group)/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-config-and-segment-config/(group)/layout.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react'
 
-export const unstable_instant = { prefetch: 'static' }
+export const unstable_instant = true
 
 export default function GroupLayout({ children }: { children: ReactNode }) {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-config-and-segment-config/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-config-and-segment-config/layout.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react'
 
-export const unstable_instant = { prefetch: 'static' }
+export const unstable_instant = true
 
 export default function Layout({ children }: { children: ReactNode }) {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-config-only/(group)/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-config-only/(group)/layout.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react'
 
-export const unstable_instant = { prefetch: 'static' }
+export const unstable_instant = true
 
 export default function GroupLayout({ children }: { children: ReactNode }) {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-config-with-deeper-segment/(group)/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-config-with-deeper-segment/(group)/layout.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react'
 
-export const unstable_instant = { prefetch: 'static' }
+export const unstable_instant = true
 
 export default function GroupLayout({ children }: { children: ReactNode }) {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-deeper-segment-config/(group)/inner/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-deeper-segment-config/(group)/inner/layout.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react'
 
-export const unstable_instant = { prefetch: 'static' }
+export const unstable_instant = true
 
 export default function InnerLayout({ children }: { children: ReactNode }) {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-segment-config-only/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-segment-config-only/layout.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react'
 
-export const unstable_instant = { prefetch: 'static' }
+export const unstable_instant = true
 
 export default function Layout({ children }: { children: ReactNode }) {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-shared-boundary/(outer)/(inner)/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-shared-boundary/(outer)/(inner)/page.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link'
 // The instant config is on the page. When (outer) is shared and
 // (inner) is the boundary, this page is in the new tree where
 // buildNewTreeSeedData finds the config and triggers validation.
-export const unstable_instant = { prefetch: 'static' }
+export const unstable_instant = true
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/suspense-around-dynamic/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/suspense-around-dynamic/page.tsx
@@ -2,10 +2,7 @@ import { cookies } from 'next/headers'
 import { connection } from 'next/server'
 import { Suspense } from 'react'
 
-export const unstable_instant = {
-  prefetch: 'static',
-  samples: [{ cookies: [] }],
-}
+export const unstable_instant = true
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/suspense-too-high/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/suspense-too-high/page.tsx
@@ -1,9 +1,6 @@
 import { cookies } from 'next/headers'
 
-export const unstable_instant = {
-  prefetch: 'static',
-  samples: [{ cookies: [] }],
-}
+export const unstable_instant = true
 
 export default async function Page() {
   await cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/valid-client-api-in-parent/dynamic-params/[id]/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/valid-client-api-in-parent/dynamic-params/[id]/page.tsx
@@ -1,5 +1,4 @@
 export const unstable_instant = {
-  prefetch: 'static',
   // `usePathname` will error if we don't have a sample for `[id]`.
   samples: [{ params: { id: '123' } }],
 }

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/valid-client-api-in-parent/search-params/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/valid-client-api-in-parent/search-params/page.tsx
@@ -1,6 +1,4 @@
-export const unstable_instant = {
-  prefetch: 'static',
-}
+export const unstable_instant = true
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/valid-client-api-in-parent/sync-io/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/valid-client-api-in-parent/sync-io/page.tsx
@@ -1,6 +1,4 @@
-export const unstable_instant = {
-  prefetch: 'static',
-}
+export const unstable_instant = true
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/valid-client-data-does-not-block-validation/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/valid-client-data-does-not-block-validation/page.tsx
@@ -1,6 +1,4 @@
-export const unstable_instant = {
-  prefetch: 'static',
-}
+export const unstable_instant = true
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/valid-client-error-in-parent-does-not-block-validation/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/valid-client-error-in-parent-does-not-block-validation/page.tsx
@@ -1,6 +1,4 @@
-export const unstable_instant = {
-  prefetch: 'static',
-}
+export const unstable_instant = true
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/valid-only-loading-around-dynamic/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/valid-only-loading-around-dynamic/page.tsx
@@ -1,10 +1,7 @@
 import { cookies } from 'next/headers'
 import { connection } from 'next/server'
 
-export const unstable_instant = {
-  prefetch: 'static',
-  samples: [{ cookies: [] }],
-}
+export const unstable_instant = true
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/instant-validation-parallel-slots.test.ts
+++ b/test/e2e/app-dir/instant-validation/instant-validation-parallel-slots.test.ts
@@ -116,7 +116,7 @@ describe('instant validation - parallel slot configs', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/parallel/slot-config-only/@slot/page.tsx (1:33) @ unstable_instant
-           > 1 | export const unstable_instant = { prefetch: 'static' }
+           > 1 | export const unstable_instant = true
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/parallel/slot-config-only/@slot/page.tsx (1:33)",
@@ -176,7 +176,7 @@ describe('instant validation - parallel slot configs', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/parallel/slot-layout-config/@slot/layout.tsx (3:33) @ unstable_instant
-           > 3 | export const unstable_instant = { prefetch: 'static' }
+           > 3 | export const unstable_instant = true
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/parallel/slot-layout-config/@slot/layout.tsx (3:33)",
@@ -236,7 +236,7 @@ describe('instant validation - parallel slot configs', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/parallel/slot-runtime-config/@slot/page.tsx (4:33) @ unstable_instant
-           > 4 | export const unstable_instant = {
+           > 4 | export const unstable_instant = true
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/parallel/slot-runtime-config/@slot/page.tsx (4:33)",
@@ -298,7 +298,7 @@ describe('instant validation - parallel slot configs', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/parallel/children-config-with-slot/page.tsx (1:33) @ unstable_instant
-           > 1 | export const unstable_instant = { prefetch: 'static' }
+           > 1 | export const unstable_instant = true
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/parallel/children-config-with-slot/page.tsx (1:33)",
@@ -360,7 +360,7 @@ describe('instant validation - parallel slot configs', () => {
                  {
                    "label": "Caused by: Instant Validation",
                    "source": "app/suspense-in-root/parallel/fork-layout-config-with-slot/layout.tsx (3:33) @ unstable_instant
-           > 3 | export const unstable_instant = { prefetch: 'static' }
+           > 3 | export const unstable_instant = true
                |                                 ^",
                    "stack": [
                      "unstable_instant app/suspense-in-root/parallel/fork-layout-config-with-slot/layout.tsx (3:33)",
@@ -384,7 +384,7 @@ describe('instant validation - parallel slot configs', () => {
                  {
                    "label": "Caused by: Instant Validation",
                    "source": "app/suspense-in-root/parallel/fork-layout-config-with-slot/layout.tsx (3:33) @ unstable_instant
-           > 3 | export const unstable_instant = { prefetch: 'static' }
+           > 3 | export const unstable_instant = true
                |                                 ^",
                    "stack": [
                      "unstable_instant app/suspense-in-root/parallel/fork-layout-config-with-slot/layout.tsx (3:33)",
@@ -527,7 +527,7 @@ describe('instant validation - parallel slot configs', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/parallel/conditional-breadcrumbs/show-both/blocked/page.tsx (1:33) @ unstable_instant
-           > 1 | export const unstable_instant = { prefetch: 'static' }
+           > 1 | export const unstable_instant = true
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/parallel/conditional-breadcrumbs/show-both/blocked/page.tsx (1:33)",
@@ -587,7 +587,7 @@ describe('instant validation - parallel slot configs', () => {
              "environmentLabel": "Server",
              "label": "Console Error",
              "source": "app/suspense-in-root/parallel/conditional-breadcrumbs/show-only-breadcrumbs/unblocked/page.tsx (1:33) @ unstable_instant
-           > 1 | export const unstable_instant = { prefetch: 'static' }
+           > 1 | export const unstable_instant = true
                |                                 ^",
              "stack": [
                "unstable_instant app/suspense-in-root/parallel/conditional-breadcrumbs/show-only-breadcrumbs/unblocked/page.tsx (1:33)",
@@ -621,7 +621,7 @@ describe('instant validation - parallel slot configs', () => {
              "environmentLabel": "Server",
              "label": "Console Error",
              "source": "app/suspense-in-root/parallel/conditional-breadcrumbs/show-only-breadcrumbs/blocked/page.tsx (1:33) @ unstable_instant
-           > 1 | export const unstable_instant = { prefetch: 'static' }
+           > 1 | export const unstable_instant = true
                |                                 ^",
              "stack": [
                "unstable_instant app/suspense-in-root/parallel/conditional-breadcrumbs/show-only-breadcrumbs/blocked/page.tsx (1:33)",

--- a/test/e2e/app-dir/instant-validation/instant-validation.test.ts
+++ b/test/e2e/app-dir/instant-validation/instant-validation.test.ts
@@ -172,7 +172,7 @@ describe('instant validation', () => {
              {
                "label": "Caused by: Instant Validation",
                "source": "app/suspense-in-root/static/missing-suspense-around-runtime/page.tsx (3:33) @ unstable_instant
-         > 3 | export const unstable_instant = {
+         > 3 | export const unstable_instant = true
              |                                 ^",
                "stack": [
                  "unstable_instant app/suspense-in-root/static/missing-suspense-around-runtime/page.tsx (3:33)",
@@ -184,11 +184,11 @@ describe('instant validation', () => {
            "description": "Next.js encountered runtime data during the initial render.",
            "environmentLabel": "Server",
            "label": "Instant",
-           "source": "app/suspense-in-root/static/missing-suspense-around-runtime/page.tsx (9:16) @ Page
-         >  9 |   await cookies()
-              |                ^",
+           "source": "app/suspense-in-root/static/missing-suspense-around-runtime/page.tsx (6:16) @ Page
+         > 6 |   await cookies()
+             |                ^",
            "stack": [
-             "Page app/suspense-in-root/static/missing-suspense-around-runtime/page.tsx (9:16)",
+             "Page app/suspense-in-root/static/missing-suspense-around-runtime/page.tsx (6:16)",
            ],
          }
         `)
@@ -232,7 +232,7 @@ describe('instant validation', () => {
              {
                "label": "Caused by: Instant Validation",
                "source": "app/suspense-in-root/static/missing-suspense-around-dynamic/page.tsx (3:33) @ unstable_instant
-         > 3 | export const unstable_instant = { prefetch: 'static' }
+         > 3 | export const unstable_instant = true
              |                                 ^",
                "stack": [
                  "unstable_instant app/suspense-in-root/static/missing-suspense-around-dynamic/page.tsx (3:33)",
@@ -292,7 +292,7 @@ describe('instant validation', () => {
              {
                "label": "Caused by: Instant Validation",
                "source": "app/suspense-in-root/runtime/missing-suspense-around-dynamic/page.tsx (4:33) @ unstable_instant
-         > 4 | export const unstable_instant = {
+         > 4 | export const unstable_instant = true
              |                                 ^",
                "stack": [
                  "unstable_instant app/suspense-in-root/runtime/missing-suspense-around-dynamic/page.tsx (4:33)",
@@ -304,12 +304,12 @@ describe('instant validation', () => {
            "description": "Next.js encountered uncached data during the initial render.",
            "environmentLabel": "Server",
            "label": "Instant",
-           "source": "app/suspense-in-root/runtime/missing-suspense-around-dynamic/page.tsx (26:19) @ Dynamic
-         > 26 |   await connection()
+           "source": "app/suspense-in-root/runtime/missing-suspense-around-dynamic/page.tsx (23:19) @ Dynamic
+         > 23 |   await connection()
               |                   ^",
            "stack": [
-             "Dynamic app/suspense-in-root/runtime/missing-suspense-around-dynamic/page.tsx (26:19)",
-             "Page app/suspense-in-root/runtime/missing-suspense-around-dynamic/page.tsx (19:9)",
+             "Dynamic app/suspense-in-root/runtime/missing-suspense-around-dynamic/page.tsx (23:19)",
+             "Page app/suspense-in-root/runtime/missing-suspense-around-dynamic/page.tsx (16:9)",
            ],
          }
         `)
@@ -355,7 +355,7 @@ describe('instant validation', () => {
              {
                "label": "Caused by: Instant Validation",
                "source": "app/suspense-in-root/static/missing-suspense-around-dynamic-layout/layout.tsx (4:33) @ unstable_instant
-         > 4 | export const unstable_instant = {
+         > 4 | export const unstable_instant = true
              |                                 ^",
                "stack": [
                  "unstable_instant app/suspense-in-root/static/missing-suspense-around-dynamic-layout/layout.tsx (4:33)",
@@ -367,11 +367,11 @@ describe('instant validation', () => {
            "description": "Next.js encountered runtime data during the initial render.",
            "environmentLabel": "Server",
            "label": "Instant",
-           "source": "app/suspense-in-root/static/missing-suspense-around-dynamic-layout/layout.tsx (10:16) @ Layout
-         > 10 |   await cookies()
+           "source": "app/suspense-in-root/static/missing-suspense-around-dynamic-layout/layout.tsx (7:16) @ Layout
+         >  7 |   await cookies()
               |                ^",
            "stack": [
-             "Layout app/suspense-in-root/static/missing-suspense-around-dynamic-layout/layout.tsx (10:16)",
+             "Layout app/suspense-in-root/static/missing-suspense-around-dynamic-layout/layout.tsx (7:16)",
            ],
          }
         `)
@@ -415,7 +415,7 @@ describe('instant validation', () => {
              {
                "label": "Caused by: Instant Validation",
                "source": "app/suspense-in-root/runtime/missing-suspense-around-dynamic-layout/layout.tsx (4:33) @ unstable_instant
-         > 4 | export const unstable_instant = {
+         > 4 | export const unstable_instant = true
              |                                 ^",
                "stack": [
                  "unstable_instant app/suspense-in-root/runtime/missing-suspense-around-dynamic-layout/layout.tsx (4:33)",
@@ -427,11 +427,11 @@ describe('instant validation', () => {
            "description": "Next.js encountered uncached data during the initial render.",
            "environmentLabel": "Server",
            "label": "Instant",
-           "source": "app/suspense-in-root/runtime/missing-suspense-around-dynamic-layout/layout.tsx (11:19) @ Layout
-         > 11 |   await connection()
+           "source": "app/suspense-in-root/runtime/missing-suspense-around-dynamic-layout/layout.tsx (8:19) @ Layout
+         >  8 |   await connection()
               |                   ^",
            "stack": [
-             "Layout app/suspense-in-root/runtime/missing-suspense-around-dynamic-layout/layout.tsx (11:19)",
+             "Layout app/suspense-in-root/runtime/missing-suspense-around-dynamic-layout/layout.tsx (8:19)",
            ],
          }
         `)
@@ -478,7 +478,7 @@ describe('instant validation', () => {
            {
              "label": "Caused by: Instant Validation",
              "source": "app/suspense-in-root/static/missing-suspense-around-params/[param]/page.tsx (1:33) @ unstable_instant
-       > 1 | export const unstable_instant = {
+       > 1 | export const unstable_instant = { samples: [{ params: { param: '123' } }] }
            |                                 ^",
              "stack": [
                "unstable_instant app/suspense-in-root/static/missing-suspense-around-params/[param]/page.tsx (1:33)",
@@ -490,12 +490,12 @@ describe('instant validation', () => {
          "description": "Next.js encountered runtime data during the initial render.",
          "environmentLabel": "Server",
          "label": "Instant",
-         "source": "app/suspense-in-root/static/missing-suspense-around-params/[param]/page.tsx (20:21) @ Runtime
-       > 20 |   const { param } = await params
+         "source": "app/suspense-in-root/static/missing-suspense-around-params/[param]/page.tsx (17:21) @ Runtime
+       > 17 |   const { param } = await params
             |                     ^",
          "stack": [
-           "Runtime app/suspense-in-root/static/missing-suspense-around-params/[param]/page.tsx (20:21)",
-           "Page app/suspense-in-root/static/missing-suspense-around-params/[param]/page.tsx (14:7)",
+           "Runtime app/suspense-in-root/static/missing-suspense-around-params/[param]/page.tsx (17:21)",
+           "Page app/suspense-in-root/static/missing-suspense-around-params/[param]/page.tsx (11:7)",
          ],
        }
       `)
@@ -526,7 +526,7 @@ describe('instant validation', () => {
              {
                "label": "Caused by: Instant Validation",
                "source": "app/suspense-in-root/static/missing-suspense-around-search-params/page.tsx (1:33) @ unstable_instant
-         > 1 | export const unstable_instant = {
+         > 1 | export const unstable_instant = { samples: [{ searchParams: { foo: 'bar' } }] }
              |                                 ^",
                "stack": [
                  "unstable_instant app/suspense-in-root/static/missing-suspense-around-search-params/page.tsx (1:33)",
@@ -538,11 +538,11 @@ describe('instant validation', () => {
            "description": "Next.js encountered runtime data during the initial render.",
            "environmentLabel": "Server",
            "label": "Instant",
-           "source": "app/suspense-in-root/static/missing-suspense-around-search-params/page.tsx (7:18) @ Page
-         >  7 |   const search = await searchParams
-              |                  ^",
+           "source": "app/suspense-in-root/static/missing-suspense-around-search-params/page.tsx (4:18) @ Page
+         > 4 |   const search = await searchParams
+             |                  ^",
            "stack": [
-             "Page app/suspense-in-root/static/missing-suspense-around-search-params/page.tsx (7:18)",
+             "Page app/suspense-in-root/static/missing-suspense-around-search-params/page.tsx (4:18)",
            ],
          }
         `)
@@ -621,7 +621,7 @@ describe('instant validation', () => {
              {
                "label": "Caused by: Instant Validation",
                "source": "app/suspense-in-root/static/suspense-too-high/page.tsx (3:33) @ unstable_instant
-         > 3 | export const unstable_instant = {
+         > 3 | export const unstable_instant = true
              |                                 ^",
                "stack": [
                  "unstable_instant app/suspense-in-root/static/suspense-too-high/page.tsx (3:33)",
@@ -633,11 +633,11 @@ describe('instant validation', () => {
            "description": "Next.js encountered runtime data during the initial render.",
            "environmentLabel": "Server",
            "label": "Instant",
-           "source": "app/suspense-in-root/static/suspense-too-high/page.tsx (9:16) @ Page
-         >  9 |   await cookies()
-              |                ^",
+           "source": "app/suspense-in-root/static/suspense-too-high/page.tsx (6:16) @ Page
+         > 6 |   await cookies()
+             |                ^",
            "stack": [
-             "Page app/suspense-in-root/static/suspense-too-high/page.tsx (9:16)",
+             "Page app/suspense-in-root/static/suspense-too-high/page.tsx (6:16)",
            ],
          }
         `)
@@ -684,7 +684,7 @@ describe('instant validation', () => {
              {
                "label": "Caused by: Instant Validation",
                "source": "app/suspense-in-root/runtime/suspense-too-high/page.tsx (4:33) @ unstable_instant
-         > 4 | export const unstable_instant = {
+         > 4 | export const unstable_instant = true
              |                                 ^",
                "stack": [
                  "unstable_instant app/suspense-in-root/runtime/suspense-too-high/page.tsx (4:33)",
@@ -696,12 +696,12 @@ describe('instant validation', () => {
            "description": "Next.js encountered uncached data during the initial render.",
            "environmentLabel": "Server",
            "label": "Instant",
-           "source": "app/suspense-in-root/runtime/suspense-too-high/page.tsx (27:19) @ Dynamic
-         > 27 |   await connection()
+           "source": "app/suspense-in-root/runtime/suspense-too-high/page.tsx (24:19) @ Dynamic
+         > 24 |   await connection()
               |                   ^",
            "stack": [
-             "Dynamic app/suspense-in-root/runtime/suspense-too-high/page.tsx (27:19)",
-             "Page app/suspense-in-root/runtime/suspense-too-high/page.tsx (20:9)",
+             "Dynamic app/suspense-in-root/runtime/suspense-too-high/page.tsx (24:19)",
+             "Page app/suspense-in-root/runtime/suspense-too-high/page.tsx (17:9)",
            ],
          }
         `)
@@ -748,11 +748,11 @@ describe('instant validation', () => {
            "description": "Route "/suspense-in-root/runtime/invalid-sync-io" used \`Date.now()\` before accessing either uncached data (e.g. \`fetch()\`) or awaiting \`connection()\`. When configured for Runtime prefetching, accessing the current time in a Server Component requires reading one of these data sources first. Alternatively, consider moving this expression into a Client Component or Cache Component. See more info here: https://nextjs.org/docs/messages/next-prerender-runtime-current-time",
            "environmentLabel": "Server",
            "label": "Console Error",
-           "source": "app/suspense-in-root/runtime/invalid-sync-io/page.tsx (11:20) @ Page
-         > 11 |   const now = Date.now()
+           "source": "app/suspense-in-root/runtime/invalid-sync-io/page.tsx (8:20) @ Page
+         >  8 |   const now = Date.now()
               |                    ^",
            "stack": [
-             "Page app/suspense-in-root/runtime/invalid-sync-io/page.tsx (11:20)",
+             "Page app/suspense-in-root/runtime/invalid-sync-io/page.tsx (8:20)",
              "Page <anonymous>",
            ],
          }
@@ -764,23 +764,23 @@ describe('instant validation', () => {
         expect(extractBuildValidationError(result.cliOutput))
           .toMatchInlineSnapshot(`
          "Error: Route "/suspense-in-root/runtime/invalid-sync-io" used \`Date.now()\` before accessing either uncached data (e.g. \`fetch()\`) or awaiting \`connection()\`. When configured for Runtime prefetching, accessing the current time in a Server Component requires reading one of these data sources first. Alternatively, consider moving this expression into a Client Component or Cache Component. See more info here: https://nextjs.org/docs/messages/next-prerender-runtime-current-time
-             at a (app/suspense-in-root/runtime/invalid-sync-io/page.tsx:11:20)
-            9 | export default async function Page() {
-           10 |   await cookies()
-         > 11 |   const now = Date.now()
+             at a (app/suspense-in-root/runtime/invalid-sync-io/page.tsx:8:20)
+            6 | export default async function Page() {
+            7 |   await cookies()
+         >  8 |   const now = Date.now()
               |                    ^
-           12 |   return (
-           13 |     <main>
-           14 |       <p>This page uses sync IO after awaiting cookies(): {now}</p>
+            9 |   return (
+           10 |     <main>
+           11 |       <p>This page uses sync IO after awaiting cookies(): {now}</p>
          Error: Route "/suspense-in-root/runtime/invalid-sync-io" used \`Date.now()\` before accessing either uncached data (e.g. \`fetch()\`) or awaiting \`connection()\`. When configured for Runtime prefetching, accessing the current time in a Server Component requires reading one of these data sources first. Alternatively, consider moving this expression into a Client Component or Cache Component. See more info here: https://nextjs.org/docs/messages/next-prerender-runtime-current-time
-             at b (app/suspense-in-root/runtime/invalid-sync-io/page.tsx:11:20)
-            9 | export default async function Page() {
-           10 |   await cookies()
-         > 11 |   const now = Date.now()
+             at b (app/suspense-in-root/runtime/invalid-sync-io/page.tsx:8:20)
+            6 | export default async function Page() {
+            7 |   await cookies()
+         >  8 |   const now = Date.now()
               |                    ^
-           12 |   return (
-           13 |     <main>
-           14 |       <p>This page uses sync IO after awaiting cookies(): {now}</p>
+            9 |   return (
+           10 |     <main>
+           11 |       <p>This page uses sync IO after awaiting cookies(): {now}</p>
          Build-time instant validation failed for route "/suspense-in-root/runtime/invalid-sync-io".
          To get a more detailed stack trace and pinpoint the issue, try one of the following:
            - Start the app in development mode by running \`next dev\`, then open "/suspense-in-root/runtime/invalid-sync-io" in your browser to investigate the error.
@@ -806,11 +806,11 @@ describe('instant validation', () => {
            "description": "Route "/suspense-in-root/runtime/invalid-sync-io-in-runtime-with-valid-static-parent" used \`Date.now()\` before accessing either uncached data (e.g. \`fetch()\`) or awaiting \`connection()\`. When configured for Runtime prefetching, accessing the current time in a Server Component requires reading one of these data sources first. Alternatively, consider moving this expression into a Client Component or Cache Component. See more info here: https://nextjs.org/docs/messages/next-prerender-runtime-current-time",
            "environmentLabel": "Server",
            "label": "Console Error",
-           "source": "app/suspense-in-root/runtime/invalid-sync-io-in-runtime-with-valid-static-parent/page.tsx (15:20) @ Page
-         > 15 |   const now = Date.now()
+           "source": "app/suspense-in-root/runtime/invalid-sync-io-in-runtime-with-valid-static-parent/page.tsx (12:20) @ Page
+         > 12 |   const now = Date.now()
               |                    ^",
            "stack": [
-             "Page app/suspense-in-root/runtime/invalid-sync-io-in-runtime-with-valid-static-parent/page.tsx (15:20)",
+             "Page app/suspense-in-root/runtime/invalid-sync-io-in-runtime-with-valid-static-parent/page.tsx (12:20)",
              "Page <anonymous>",
            ],
          }
@@ -822,32 +822,32 @@ describe('instant validation', () => {
         expect(extractBuildValidationError(result.cliOutput))
           .toMatchInlineSnapshot(`
          "Error: Route "/suspense-in-root/runtime/invalid-sync-io-in-runtime-with-valid-static-parent" used \`Date.now()\` before accessing either uncached data (e.g. \`fetch()\`) or awaiting \`connection()\`. When configured for Runtime prefetching, accessing the current time in a Server Component requires reading one of these data sources first. Alternatively, consider moving this expression into a Client Component or Cache Component. See more info here: https://nextjs.org/docs/messages/next-prerender-runtime-current-time
-             at a (app/suspense-in-root/runtime/invalid-sync-io-in-runtime-with-valid-static-parent/page.tsx:15:20)
-           13 | export default async function Page() {
-           14 |   await cookies()
-         > 15 |   const now = Date.now()
+             at a (app/suspense-in-root/runtime/invalid-sync-io-in-runtime-with-valid-static-parent/page.tsx:12:20)
+           10 | export default async function Page() {
+           11 |   await cookies()
+         > 12 |   const now = Date.now()
               |                    ^
-           16 |   return (
-           17 |     <main>
-           18 |       <p>Runtime page with sync IO after cookies: {now}</p>
+           13 |   return (
+           14 |     <main>
+           15 |       <p>Runtime page with sync IO after cookies: {now}</p>
          Error: Route "/suspense-in-root/runtime/invalid-sync-io-in-runtime-with-valid-static-parent" used \`Date.now()\` before accessing either uncached data (e.g. \`fetch()\`) or awaiting \`connection()\`. When configured for Runtime prefetching, accessing the current time in a Server Component requires reading one of these data sources first. Alternatively, consider moving this expression into a Client Component or Cache Component. See more info here: https://nextjs.org/docs/messages/next-prerender-runtime-current-time
-             at b (app/suspense-in-root/runtime/invalid-sync-io-in-runtime-with-valid-static-parent/page.tsx:15:20)
-           13 | export default async function Page() {
-           14 |   await cookies()
-         > 15 |   const now = Date.now()
+             at b (app/suspense-in-root/runtime/invalid-sync-io-in-runtime-with-valid-static-parent/page.tsx:12:20)
+           10 | export default async function Page() {
+           11 |   await cookies()
+         > 12 |   const now = Date.now()
               |                    ^
-           16 |   return (
-           17 |     <main>
-           18 |       <p>Runtime page with sync IO after cookies: {now}</p>
+           13 |   return (
+           14 |     <main>
+           15 |       <p>Runtime page with sync IO after cookies: {now}</p>
          Error: Route "/suspense-in-root/runtime/invalid-sync-io-in-runtime-with-valid-static-parent" used \`Date.now()\` before accessing either uncached data (e.g. \`fetch()\`) or awaiting \`connection()\`. When configured for Runtime prefetching, accessing the current time in a Server Component requires reading one of these data sources first. Alternatively, consider moving this expression into a Client Component or Cache Component. See more info here: https://nextjs.org/docs/messages/next-prerender-runtime-current-time
-             at c (app/suspense-in-root/runtime/invalid-sync-io-in-runtime-with-valid-static-parent/page.tsx:15:20)
-           13 | export default async function Page() {
-           14 |   await cookies()
-         > 15 |   const now = Date.now()
+             at c (app/suspense-in-root/runtime/invalid-sync-io-in-runtime-with-valid-static-parent/page.tsx:12:20)
+           10 | export default async function Page() {
+           11 |   await cookies()
+         > 12 |   const now = Date.now()
               |                    ^
-           16 |   return (
-           17 |     <main>
-           18 |       <p>Runtime page with sync IO after cookies: {now}</p>
+           13 |   return (
+           14 |     <main>
+           15 |       <p>Runtime page with sync IO after cookies: {now}</p>
          Build-time instant validation failed for route "/suspense-in-root/runtime/invalid-sync-io-in-runtime-with-valid-static-parent".
          To get a more detailed stack trace and pinpoint the issue, try one of the following:
            - Start the app in development mode by running \`next dev\`, then open "/suspense-in-root/runtime/invalid-sync-io-in-runtime-with-valid-static-parent" in your browser to investigate the error.
@@ -879,11 +879,11 @@ describe('instant validation', () => {
            "description": "Route "/suspense-in-root/runtime/invalid-sync-io-after-cache-with-cookie-input" used \`Date.now()\` before accessing either uncached data (e.g. \`fetch()\`) or awaiting \`connection()\`. When configured for Runtime prefetching, accessing the current time in a Server Component requires reading one of these data sources first. Alternatively, consider moving this expression into a Client Component or Cache Component. See more info here: https://nextjs.org/docs/messages/next-prerender-runtime-current-time",
            "environmentLabel": "Server",
            "label": "Console Error",
-           "source": "app/suspense-in-root/runtime/invalid-sync-io-after-cache-with-cookie-input/page.tsx (31:20) @ Page
-         > 31 |   const now = Date.now()
+           "source": "app/suspense-in-root/runtime/invalid-sync-io-after-cache-with-cookie-input/page.tsx (28:20) @ Page
+         > 28 |   const now = Date.now()
               |                    ^",
            "stack": [
-             "Page app/suspense-in-root/runtime/invalid-sync-io-after-cache-with-cookie-input/page.tsx (31:20)",
+             "Page app/suspense-in-root/runtime/invalid-sync-io-after-cache-with-cookie-input/page.tsx (28:20)",
              "Page <anonymous>",
            ],
          }
@@ -895,14 +895,14 @@ describe('instant validation', () => {
         expect(extractBuildValidationError(result.cliOutput))
           .toMatchInlineSnapshot(`
          "Error: Route "/suspense-in-root/runtime/invalid-sync-io-after-cache-with-cookie-input" accessed cookie "testCookie" which is not defined in the \`samples\` of \`unstable_instant\`. Add it to the sample's \`cookies\` array, or \`{ name: "testCookie", value: null }\` if it should be absent.
-             at <unknown> (app/suspense-in-root/runtime/invalid-sync-io-after-cache-with-cookie-input/page.tsx:29:49)
-           27 |
-           28 | export default async function Page() {
-         > 29 |   const cookiePromise = cookies().then((c) => c.get('testCookie')?.value ?? '')
+             at <unknown> (app/suspense-in-root/runtime/invalid-sync-io-after-cache-with-cookie-input/page.tsx:26:49)
+           24 |
+           25 | export default async function Page() {
+         > 26 |   const cookiePromise = cookies().then((c) => c.get('testCookie')?.value ?? '')
               |                                                 ^
-           30 |   await cachedFn(cookiePromise)
-           31 |   const now = Date.now()
-           32 |   return ( {
+           27 |   await cachedFn(cookiePromise)
+           28 |   const now = Date.now()
+           29 |   return ( {
            digest: 'INSTANT_VALIDATION_ERROR'
          }
          Build-time instant validation failed for route "/suspense-in-root/runtime/invalid-sync-io-after-cache-with-cookie-input".
@@ -947,11 +947,11 @@ describe('instant validation', () => {
            "description": "Route "/suspense-in-root/runtime/invalid-sync-io-in-generate-metadata" used \`Date.now()\` before accessing either uncached data (e.g. \`fetch()\`) or awaiting \`connection()\`. When configured for Runtime prefetching, accessing the current time in a Server Component requires reading one of these data sources first. Alternatively, consider moving this expression into a Client Component or Cache Component. See more info here: https://nextjs.org/docs/messages/next-prerender-runtime-current-time",
            "environmentLabel": "Server",
            "label": "Console Error",
-           "source": "app/suspense-in-root/runtime/invalid-sync-io-in-generate-metadata/page.tsx (12:20) @ Module.generateMetadata
-         > 12 |   const now = Date.now()
+           "source": "app/suspense-in-root/runtime/invalid-sync-io-in-generate-metadata/page.tsx (9:20) @ Module.generateMetadata
+         >  9 |   const now = Date.now()
               |                    ^",
            "stack": [
-             "Module.generateMetadata app/suspense-in-root/runtime/invalid-sync-io-in-generate-metadata/page.tsx (12:20)",
+             "Module.generateMetadata app/suspense-in-root/runtime/invalid-sync-io-in-generate-metadata/page.tsx (9:20)",
              "Next.MetadataOutlet <anonymous>",
            ],
          }
@@ -963,23 +963,23 @@ describe('instant validation', () => {
         expect(extractBuildValidationError(result.cliOutput))
           .toMatchInlineSnapshot(`
          "Error: Route "/suspense-in-root/runtime/invalid-sync-io-in-generate-metadata" used \`Date.now()\` before accessing either uncached data (e.g. \`fetch()\`) or awaiting \`connection()\`. When configured for Runtime prefetching, accessing the current time in a Server Component requires reading one of these data sources first. Alternatively, consider moving this expression into a Client Component or Cache Component. See more info here: https://nextjs.org/docs/messages/next-prerender-runtime-current-time
-             at Module.e [as generateMetadata] (app/suspense-in-root/runtime/invalid-sync-io-in-generate-metadata/page.tsx:12:20)
-           10 | export async function generateMetadata() {
-           11 |   await cookies()
-         > 12 |   const now = Date.now()
+             at Module.e [as generateMetadata] (app/suspense-in-root/runtime/invalid-sync-io-in-generate-metadata/page.tsx:9:20)
+            7 | export async function generateMetadata() {
+            8 |   await cookies()
+         >  9 |   const now = Date.now()
               |                    ^
-           13 |   return {
-           14 |     title: \`Sync IO in metadata: \${now}\`,
-           15 |   }
+           10 |   return {
+           11 |     title: \`Sync IO in metadata: \${now}\`,
+           12 |   }
          Error: Route "/suspense-in-root/runtime/invalid-sync-io-in-generate-metadata" used \`Date.now()\` before accessing either uncached data (e.g. \`fetch()\`) or awaiting \`connection()\`. When configured for Runtime prefetching, accessing the current time in a Server Component requires reading one of these data sources first. Alternatively, consider moving this expression into a Client Component or Cache Component. See more info here: https://nextjs.org/docs/messages/next-prerender-runtime-current-time
-             at Module.e [as generateMetadata] (app/suspense-in-root/runtime/invalid-sync-io-in-generate-metadata/page.tsx:12:20)
-           10 | export async function generateMetadata() {
-           11 |   await cookies()
-         > 12 |   const now = Date.now()
+             at Module.e [as generateMetadata] (app/suspense-in-root/runtime/invalid-sync-io-in-generate-metadata/page.tsx:9:20)
+            7 | export async function generateMetadata() {
+            8 |   await cookies()
+         >  9 |   const now = Date.now()
               |                    ^
-           13 |   return {
-           14 |     title: \`Sync IO in metadata: \${now}\`,
-           15 |   }
+           10 |   return {
+           11 |     title: \`Sync IO in metadata: \${now}\`,
+           12 |   }
          Build-time instant validation failed for route "/suspense-in-root/runtime/invalid-sync-io-in-generate-metadata".
          To get a more detailed stack trace and pinpoint the issue, try one of the following:
            - Start the app in development mode by running \`next dev\`, then open "/suspense-in-root/runtime/invalid-sync-io-in-generate-metadata" in your browser to investigate the error.
@@ -1123,7 +1123,7 @@ describe('instant validation', () => {
              {
                "label": "Caused by: Instant Validation",
                "source": "app/suspense-in-root/static/invalid-loading-above-route-group/(group)/page.tsx (4:33) @ unstable_instant
-         > 4 | export const unstable_instant = {
+         > 4 | export const unstable_instant = true
              |                                 ^",
                "stack": [
                  "unstable_instant app/suspense-in-root/static/invalid-loading-above-route-group/(group)/page.tsx (4:33)",
@@ -1135,12 +1135,12 @@ describe('instant validation', () => {
            "description": "Next.js encountered uncached data during the initial render.",
            "environmentLabel": "Server",
            "label": "Instant",
-           "source": "app/suspense-in-root/static/invalid-loading-above-route-group/(group)/page.tsx (37:19) @ Dynamic
-         > 37 |   await connection()
+           "source": "app/suspense-in-root/static/invalid-loading-above-route-group/(group)/page.tsx (34:19) @ Dynamic
+         > 34 |   await connection()
               |                   ^",
            "stack": [
-             "Dynamic app/suspense-in-root/static/invalid-loading-above-route-group/(group)/page.tsx (37:19)",
-             "Page app/suspense-in-root/static/invalid-loading-above-route-group/(group)/page.tsx (25:9)",
+             "Dynamic app/suspense-in-root/static/invalid-loading-above-route-group/(group)/page.tsx (34:19)",
+             "Page app/suspense-in-root/static/invalid-loading-above-route-group/(group)/page.tsx (22:9)",
            ],
          }
         `)
@@ -1187,7 +1187,7 @@ describe('instant validation', () => {
              {
                "label": "Caused by: Instant Validation",
                "source": "app/suspense-in-root/static/invalid-dynamic-layout-with-loading/layout.tsx (4:33) @ unstable_instant
-         > 4 | export const unstable_instant = { prefetch: 'static' }
+         > 4 | export const unstable_instant = true
              |                                 ^",
                "stack": [
                  "unstable_instant app/suspense-in-root/static/invalid-dynamic-layout-with-loading/layout.tsx (4:33)",
@@ -1264,7 +1264,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/static/blocking-layout/missing-suspense-around-dynamic/page.tsx (3:33) @ unstable_instant
-           > 3 | export const unstable_instant = {
+           > 3 | export const unstable_instant = true
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/static/blocking-layout/missing-suspense-around-dynamic/page.tsx (3:33)",
@@ -1276,11 +1276,11 @@ describe('instant validation', () => {
              "description": "Next.js encountered runtime data during the initial render.",
              "environmentLabel": "Server",
              "label": "Instant",
-             "source": "app/suspense-in-root/static/blocking-layout/missing-suspense-around-dynamic/page.tsx (9:16) @ Page
-           >  9 |   await cookies()
-                |                ^",
+             "source": "app/suspense-in-root/static/blocking-layout/missing-suspense-around-dynamic/page.tsx (6:16) @ Page
+           > 6 |   await cookies()
+               |                ^",
              "stack": [
-               "Page app/suspense-in-root/static/blocking-layout/missing-suspense-around-dynamic/page.tsx (9:16)",
+               "Page app/suspense-in-root/static/blocking-layout/missing-suspense-around-dynamic/page.tsx (6:16)",
              ],
            }
           `)
@@ -1352,7 +1352,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/static/invalid-blocking-inside-static/layout.tsx (1:33) @ unstable_instant
-           > 1 | export const unstable_instant = { prefetch: 'static' }
+           > 1 | export const unstable_instant = true
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/static/invalid-blocking-inside-static/layout.tsx (1:33)",
@@ -1413,7 +1413,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/runtime/invalid-blocking-inside-runtime/layout.tsx (3:33) @ unstable_instant
-           > 3 | export const unstable_instant = {
+           > 3 | export const unstable_instant = true
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/runtime/invalid-blocking-inside-runtime/layout.tsx (3:33)",
@@ -1477,7 +1477,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/static/missing-suspense-in-parallel-route/@slot/layout.tsx (1:33) @ unstable_instant
-           > 1 | export const unstable_instant = { prefetch: 'static' }
+           > 1 | export const unstable_instant = true
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/static/missing-suspense-in-parallel-route/@slot/layout.tsx (1:33)",
@@ -1539,7 +1539,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/static/missing-suspense-in-parallel-route/foo/page.tsx (1:33) @ unstable_instant
-           > 1 | export const unstable_instant = { prefetch: 'static' }
+           > 1 | export const unstable_instant = true
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/static/missing-suspense-in-parallel-route/foo/page.tsx (1:33)",
@@ -1601,7 +1601,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/static/missing-suspense-in-parallel-route/bar/page.tsx (1:33) @ unstable_instant
-           > 1 | export const unstable_instant = { prefetch: 'static' }
+           > 1 | export const unstable_instant = true
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/static/missing-suspense-in-parallel-route/bar/page.tsx (1:33)",
@@ -1659,32 +1659,32 @@ describe('instant validation', () => {
             '/suspense-in-root/static/invalid-client-data-blocks-validation'
           )
           await expect(browser).toDisplayCollapsedRedbox(`
-             {
-               "cause": [
-                 {
-                   "label": "Caused by: Instant Validation",
-                   "source": "app/suspense-in-root/static/invalid-client-data-blocks-validation/page.tsx (1:33) @ unstable_instant
-             > 1 | export const unstable_instant = {
-                 |                                 ^",
-                   "stack": [
-                     "unstable_instant app/suspense-in-root/static/invalid-client-data-blocks-validation/page.tsx (1:33)",
-                     "Set.forEach <anonymous>",
-                   ],
-                 },
-               ],
-               "code": "E1082",
-               "description": "Route "/suspense-in-root/static/invalid-client-data-blocks-validation": Could not validate \`unstable_instant\` because a Client Component in a parent segment prevented the page from rendering.",
-               "environmentLabel": "Server",
-               "label": "Console Error",
-               "source": "app/suspense-in-root/static/invalid-client-data-blocks-validation/client.tsx (12:19) @ FetchesClientData
-             > 12 |   const data = use(promise)
-                  |                   ^",
-               "stack": [
-                 "FetchesClientData app/suspense-in-root/static/invalid-client-data-blocks-validation/client.tsx (12:19)",
-                 "Layout app/suspense-in-root/static/invalid-client-data-blocks-validation/layout.tsx (17:9)",
-               ],
-             }
-            `)
+           {
+             "cause": [
+               {
+                 "label": "Caused by: Instant Validation",
+                 "source": "app/suspense-in-root/static/invalid-client-data-blocks-validation/page.tsx (1:33) @ unstable_instant
+           > 1 | export const unstable_instant = true
+               |                                 ^",
+                 "stack": [
+                   "unstable_instant app/suspense-in-root/static/invalid-client-data-blocks-validation/page.tsx (1:33)",
+                   "Set.forEach <anonymous>",
+                 ],
+               },
+             ],
+             "code": "E1082",
+             "description": "Route "/suspense-in-root/static/invalid-client-data-blocks-validation": Could not validate \`unstable_instant\` because a Client Component in a parent segment prevented the page from rendering.",
+             "environmentLabel": "Server",
+             "label": "Console Error",
+             "source": "app/suspense-in-root/static/invalid-client-data-blocks-validation/client.tsx (12:19) @ FetchesClientData
+           > 12 |   const data = use(promise)
+                |                   ^",
+             "stack": [
+               "FetchesClientData app/suspense-in-root/static/invalid-client-data-blocks-validation/client.tsx (12:19)",
+               "Layout app/suspense-in-root/static/invalid-client-data-blocks-validation/layout.tsx (17:9)",
+             ],
+           }
+          `)
         } else {
           const result = await prerender(
             '/suspense-in-root/static/invalid-client-data-blocks-validation'
@@ -1831,7 +1831,7 @@ describe('instant validation', () => {
                "environmentLabel": "Server",
                "label": "Console Error",
                "source": "app/suspense-in-root/static/invalid-client-error-in-parent-blocks-children/page.tsx (1:33) @ unstable_instant
-           > 1 | export const unstable_instant = {
+           > 1 | export const unstable_instant = true
                |                                 ^",
                "stack": [
                  "unstable_instant app/suspense-in-root/static/invalid-client-error-in-parent-blocks-children/page.tsx (1:33)",
@@ -1937,7 +1937,7 @@ describe('instant validation', () => {
                "environmentLabel": "Server",
                "label": "Console Error",
                "source": "app/suspense-in-root/static/invalid-error-in-node-modules-blocks-children/page.tsx (1:33) @ unstable_instant
-           > 1 | export const unstable_instant = {
+           > 1 | export const unstable_instant = true
                |                                 ^",
                "stack": [
                  "unstable_instant app/suspense-in-root/static/invalid-error-in-node-modules-blocks-children/page.tsx (1:33)",
@@ -2004,7 +2004,7 @@ describe('instant validation', () => {
                "environmentLabel": "Server",
                "label": "Console Error",
                "source": "app/suspense-in-root/static/invalid-csr-bailout-blocks-children/page.tsx (1:33) @ unstable_instant
-           > 1 | export const unstable_instant = {
+           > 1 | export const unstable_instant = true
                |                                 ^",
                "stack": [
                  "unstable_instant app/suspense-in-root/static/invalid-csr-bailout-blocks-children/page.tsx (1:33)",
@@ -2100,7 +2100,7 @@ describe('instant validation', () => {
                "environmentLabel": "Server",
                "label": "Console Error",
                "source": "app/suspense-in-root/static/invalid-client-error-in-parent-sibling/page.tsx (1:33) @ unstable_instant
-           > 1 | export const unstable_instant = {
+           > 1 | export const unstable_instant = true
                |                                 ^",
                "stack": [
                  "unstable_instant app/suspense-in-root/static/invalid-client-error-in-parent-sibling/page.tsx (1:33)",
@@ -2254,7 +2254,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/head/invalid-runtime-viewport-in-static/page.tsx (8:33) @ unstable_instant
-           >  8 | export const unstable_instant = {
+           >  8 | export const unstable_instant = true
                 |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/head/invalid-runtime-viewport-in-static/page.tsx (8:33)",
@@ -2280,11 +2280,11 @@ describe('instant validation', () => {
            Learn more: https://nextjs.org/docs/messages/next-prerender-dynamic-viewport",
              "environmentLabel": "Server",
              "label": "Blocking Route",
-             "source": "app/suspense-in-root/head/invalid-runtime-viewport-in-static/page.tsx (14:16) @ Module.generateViewport
-           > 14 |   await cookies()
+             "source": "app/suspense-in-root/head/invalid-runtime-viewport-in-static/page.tsx (11:16) @ Module.generateViewport
+           > 11 |   await cookies()
                 |                ^",
              "stack": [
-               "Module.generateViewport app/suspense-in-root/head/invalid-runtime-viewport-in-static/page.tsx (14:16)",
+               "Module.generateViewport app/suspense-in-root/head/invalid-runtime-viewport-in-static/page.tsx (11:16)",
              ],
            }
           `)
@@ -2319,7 +2319,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/head/invalid-dynamic-viewport-in-runtime/page.tsx (6:33) @ unstable_instant
-           > 6 | export const unstable_instant = {
+           > 6 | export const unstable_instant = true
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/head/invalid-dynamic-viewport-in-runtime/page.tsx (6:33)",
@@ -2343,11 +2343,11 @@ describe('instant validation', () => {
            Learn more: https://nextjs.org/docs/messages/next-prerender-dynamic-viewport",
              "environmentLabel": "Server",
              "label": "Blocking Route",
-             "source": "app/suspense-in-root/head/invalid-dynamic-viewport-in-runtime/page.tsx (14:19) @ Module.generateViewport
-           > 14 |   await connection()
+             "source": "app/suspense-in-root/head/invalid-dynamic-viewport-in-runtime/page.tsx (11:19) @ Module.generateViewport
+           > 11 |   await connection()
                 |                   ^",
              "stack": [
-               "Module.generateViewport app/suspense-in-root/head/invalid-dynamic-viewport-in-runtime/page.tsx (14:19)",
+               "Module.generateViewport app/suspense-in-root/head/invalid-dynamic-viewport-in-runtime/page.tsx (11:19)",
              ],
            }
           `)
@@ -2420,7 +2420,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/head/invalid-dynamic-viewport-in-blocking-inside-static/layout.tsx (3:33) @ unstable_instant
-           > 3 | export const unstable_instant = { prefetch: 'static' }
+           > 3 | export const unstable_instant = true
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/head/invalid-dynamic-viewport-in-blocking-inside-static/layout.tsx (3:33)",
@@ -2483,7 +2483,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/static/route-group-config-only/(group)/layout.tsx (3:33) @ unstable_instant
-           > 3 | export const unstable_instant = { prefetch: 'static' }
+           > 3 | export const unstable_instant = true
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/static/route-group-config-only/(group)/layout.tsx (3:33)",
@@ -2544,7 +2544,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/static/route-group-config-and-segment-config/(group)/layout.tsx (3:33) @ unstable_instant
-           > 3 | export const unstable_instant = { prefetch: 'static' }
+           > 3 | export const unstable_instant = true
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/static/route-group-config-and-segment-config/(group)/layout.tsx (3:33)",
@@ -2606,7 +2606,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/static/route-group-segment-config-only/layout.tsx (3:33) @ unstable_instant
-           > 3 | export const unstable_instant = { prefetch: 'static' }
+           > 3 | export const unstable_instant = true
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/static/route-group-segment-config-only/layout.tsx (3:33)",
@@ -2668,7 +2668,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/static/route-group-config-with-deeper-segment/(group)/layout.tsx (3:33) @ unstable_instant
-           > 3 | export const unstable_instant = { prefetch: 'static' }
+           > 3 | export const unstable_instant = true
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/static/route-group-config-with-deeper-segment/(group)/layout.tsx (3:33)",
@@ -2730,7 +2730,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/static/route-group-deeper-segment-config/(group)/inner/layout.tsx (3:33) @ unstable_instant
-           > 3 | export const unstable_instant = { prefetch: 'static' }
+           > 3 | export const unstable_instant = true
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/static/route-group-deeper-segment-config/(group)/inner/layout.tsx (3:33)",
@@ -2799,7 +2799,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/static/route-group-shared-boundary/(outer)/(inner)/page.tsx (6:33) @ unstable_instant
-           > 6 | export const unstable_instant = { prefetch: 'static' }
+           > 6 | export const unstable_instant = true
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/static/route-group-shared-boundary/(outer)/(inner)/page.tsx (6:33)",
@@ -2870,31 +2870,31 @@ describe('instant validation', () => {
             '/suspense-in-root/static/parallel-group-depths-deep-slot-hole'
           )
           await expect(browser).toDisplayCollapsedRedbox(`
-             {
-               "cause": [
-                 {
-                   "label": "Caused by: Instant Validation",
-                   "source": "app/suspense-in-root/static/parallel-group-depths-deep-slot-hole/@slot/(g1)/(g2)/(g3)/page.tsx (1:33) @ unstable_instant
-             > 1 | export const unstable_instant = { prefetch: 'static' }
-                 |                                 ^",
-                   "stack": [
-                     "unstable_instant app/suspense-in-root/static/parallel-group-depths-deep-slot-hole/@slot/(g1)/(g2)/(g3)/page.tsx (1:33)",
-                     "Set.forEach <anonymous>",
-                   ],
-                 },
-               ],
-               "code": "E1166",
-               "description": "Next.js encountered runtime data during the initial render.",
-               "environmentLabel": "Server",
-               "label": "Instant",
-               "source": "app/suspense-in-root/static/parallel-group-depths-deep-slot-hole/@slot/(g1)/(g2)/(g3)/layout.tsx (7:16) @ G3Layout
-             >  7 |   await cookies()
-                  |                ^",
-               "stack": [
-                 "G3Layout app/suspense-in-root/static/parallel-group-depths-deep-slot-hole/@slot/(g1)/(g2)/(g3)/layout.tsx (7:16)",
-               ],
-             }
-            `)
+           {
+             "cause": [
+               {
+                 "label": "Caused by: Instant Validation",
+                 "source": "app/suspense-in-root/static/parallel-group-depths-deep-slot-hole/@slot/(g1)/(g2)/(g3)/page.tsx (1:33) @ unstable_instant
+           > 1 | export const unstable_instant = true
+               |                                 ^",
+                 "stack": [
+                   "unstable_instant app/suspense-in-root/static/parallel-group-depths-deep-slot-hole/@slot/(g1)/(g2)/(g3)/page.tsx (1:33)",
+                   "Set.forEach <anonymous>",
+                 ],
+               },
+             ],
+             "code": "E1166",
+             "description": "Next.js encountered runtime data during the initial render.",
+             "environmentLabel": "Server",
+             "label": "Instant",
+             "source": "app/suspense-in-root/static/parallel-group-depths-deep-slot-hole/@slot/(g1)/(g2)/(g3)/layout.tsx (7:16) @ G3Layout
+           >  7 |   await cookies()
+                |                ^",
+             "stack": [
+               "G3Layout app/suspense-in-root/static/parallel-group-depths-deep-slot-hole/@slot/(g1)/(g2)/(g3)/layout.tsx (7:16)",
+             ],
+           }
+          `)
         } else {
           const result = await prerender(
             '/suspense-in-root/static/parallel-group-depths-deep-slot-hole/(b1)/(b2)'
@@ -2945,7 +2945,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/static/parallel-group-depths-shallow-slot-hole/(b1)/(b2)/page.tsx (1:33) @ unstable_instant
-           > 1 | export const unstable_instant = { prefetch: 'static' }
+           > 1 | export const unstable_instant = true
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/static/parallel-group-depths-shallow-slot-hole/(b1)/(b2)/page.tsx (1:33)",
@@ -3016,7 +3016,7 @@ describe('instant validation', () => {
              {
                "label": "Caused by: Instant Validation",
                "source": "app/suspense-in-root/runtime/static-layout-above-runtime-config/inner/layout.tsx (6:33) @ unstable_instant
-         > 6 | export const unstable_instant = {
+         > 6 | export const unstable_instant = true
              |                                 ^",
                "stack": [
                  "unstable_instant app/suspense-in-root/runtime/static-layout-above-runtime-config/inner/layout.tsx (6:33)",
@@ -3084,7 +3084,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/static/config-depth-preference/deeper/still/deep/page.tsx (3:33) @ unstable_instant
-           > 3 | export const unstable_instant = { prefetch: 'static' }
+           > 3 | export const unstable_instant = true
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/static/config-depth-preference/deeper/still/deep/page.tsx (3:33)",
@@ -3135,7 +3135,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/static/config-depth-preference-slot-wins/deeper/@anotherSlot/still/deep/page.tsx (3:33) @ unstable_instant
-           > 3 | export const unstable_instant = { prefetch: 'static' }
+           > 3 | export const unstable_instant = true
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/static/config-depth-preference-slot-wins/deeper/@anotherSlot/still/deep/page.tsx (3:33)",
@@ -3199,7 +3199,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/static/config-children-preferred/page.tsx (4:33) @ unstable_instant
-           > 4 | export const unstable_instant = { prefetch: 'static' }
+           > 4 | export const unstable_instant = true
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/static/config-children-preferred/page.tsx (4:33)",
@@ -3264,7 +3264,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/static/cross-slot-blocking/inner/deep/page.tsx (5:33) @ unstable_instant
-           > 5 | export const unstable_instant = { prefetch: 'static' }
+           > 5 | export const unstable_instant = true
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/static/cross-slot-blocking/inner/deep/page.tsx (5:33)",
@@ -3391,7 +3391,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/disable-validation/disable-build/page.tsx (3:33) @ unstable_instant
-           > 3 | export const unstable_instant = {
+           > 3 | export const unstable_instant = { unstable_disableBuildValidation: true }
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/disable-validation/disable-build/page.tsx (3:33)",
@@ -3403,11 +3403,11 @@ describe('instant validation', () => {
              "description": "Next.js encountered uncached data during the initial render.",
              "environmentLabel": "Server",
              "label": "Instant",
-             "source": "app/suspense-in-root/disable-validation/disable-build/page.tsx (9:19) @ Page
-           >  9 |   await connection()
-                |                   ^",
+             "source": "app/suspense-in-root/disable-validation/disable-build/page.tsx (6:19) @ Page
+           > 6 |   await connection()
+               |                   ^",
              "stack": [
-               "Page app/suspense-in-root/disable-validation/disable-build/page.tsx (9:19)",
+               "Page app/suspense-in-root/disable-validation/disable-build/page.tsx (6:19)",
              ],
            }
           `)

--- a/test/e2e/app-dir/prefetch-true-instant/app/layout-instant/layout.tsx
+++ b/test/e2e/app-dir/prefetch-true-instant/app/layout-instant/layout.tsx
@@ -1,7 +1,6 @@
 import { ReactNode } from 'react'
 
 export const unstable_instant = {
-  prefetch: 'runtime',
   samples: [{ cookies: [{ name: 'test', value: null }] }],
 }
 export const unstable_prefetch = 'force-runtime'

--- a/test/e2e/app-dir/prefetch-true-instant/app/target-page/page.tsx
+++ b/test/e2e/app-dir/prefetch-true-instant/app/target-page/page.tsx
@@ -3,7 +3,6 @@ import { cookies } from 'next/headers'
 import { connection } from 'next/server'
 
 export const unstable_instant = {
-  prefetch: 'runtime',
   samples: [{ cookies: [{ name: 'test', value: null }] }],
 }
 export const unstable_prefetch = 'force-runtime'

--- a/test/e2e/app-dir/segment-cache/cached-navigations/app/runtime-prefetchable/page.tsx
+++ b/test/e2e/app-dir/segment-cache/cached-navigations/app/runtime-prefetchable/page.tsx
@@ -5,7 +5,6 @@ import { setTimeout } from 'timers/promises'
 import { Suspense } from 'react'
 
 export const unstable_instant = {
-  prefetch: 'runtime',
   samples: [
     {
       cookies: [{ name: 'testCookie', value: 'testValue' }],

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-independent-head/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-independent-head/layout.tsx
@@ -6,7 +6,6 @@ import { cookies } from 'next/headers'
 // Once cached from the first prefetch, a subsequent prefetch to a sibling
 // page won't need a runtime request for this layout — it's already cached.
 export const unstable_instant = {
-  prefetch: 'runtime',
   samples: [
     {
       cookies: [{ name: 'theme', value: 'default' }],

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-runtime-bailout/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-runtime-bailout/page.tsx
@@ -1,7 +1,6 @@
 import { cookies } from 'next/headers'
 
 export const unstable_instant = {
-  prefetch: 'runtime',
   samples: [{ cookies: [{ name: 'theme', value: 'default' }] }],
 }
 export const unstable_prefetch = 'force-runtime'

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-runtime-parallel/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-runtime-parallel/layout.tsx
@@ -6,7 +6,6 @@ import { ReactNode, Suspense } from 'react'
 import { cookies } from 'next/headers'
 
 export const unstable_instant = {
-  prefetch: 'runtime',
   samples: [{ cookies: [{ name: 'theme', value: 'default' }] }],
 }
 export const unstable_prefetch = 'force-runtime'

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-runtime-passthrough/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-runtime-passthrough/layout.tsx
@@ -6,7 +6,6 @@ import { ReactNode, Suspense } from 'react'
 import { cookies } from 'next/headers'
 
 export const unstable_instant = {
-  prefetch: 'runtime',
   samples: [{ cookies: [{ name: 'theme', value: 'default' }] }],
 }
 export const unstable_prefetch = 'force-runtime'

--- a/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/segment-config/runtime-prefetchable/configured-as-runtime/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/segment-config/runtime-prefetchable/configured-as-runtime/page.tsx
@@ -1,10 +1,7 @@
 import { cookies } from 'next/headers'
 import { Suspense } from 'react'
 
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [{ cookies: [] }],
-}
+export const unstable_instant = true
 export const unstable_prefetch = 'force-runtime'
 
 export default function Page() {

--- a/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/segment-config/runtime-prefetchable/configured-as-static/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/segment-config/runtime-prefetchable/configured-as-static/page.tsx
@@ -4,9 +4,7 @@ import { Suspense } from 'react'
 
 // Technically, no `export const unstable_instant = ...` is needed, because we default to static,
 // this is just to make sure that we excercise the codepaths for it
-export const unstable_instant = {
-  prefetch: 'static',
-}
+export const unstable_instant = true
 export default function Page() {
   return (
     <main>

--- a/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/segment-config/runtime-prefetchable/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/segment-config/runtime-prefetchable/layout.tsx
@@ -2,10 +2,7 @@ import { cookies } from 'next/headers'
 import { Suspense } from 'react'
 import { DebugRenderKind } from '../../shared'
 
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [{ cookies: [] }],
-}
+export const unstable_instant = true
 export const unstable_prefetch = 'force-runtime'
 export default async function Layout({ children }) {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/private-seconds/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/private-seconds/page.tsx
@@ -2,10 +2,7 @@ import { Suspense } from 'react'
 import { cachedDelay, DebugRenderKind } from '../../../shared'
 import { cacheLife } from 'next/cache'
 
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [{ cookies: [] }],
-}
+export const unstable_instant = true
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/private-short-stale/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/private-short-stale/page.tsx
@@ -2,10 +2,7 @@ import { Suspense } from 'react'
 import { cachedDelay, DebugRenderKind } from '../../../shared'
 import { cacheLife } from 'next/cache'
 
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [{ cookies: [] }],
-}
+export const unstable_instant = true
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/public-seconds/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/public-seconds/page.tsx
@@ -2,10 +2,7 @@ import { Suspense } from 'react'
 import { cachedDelay, DebugRenderKind } from '../../../shared'
 import { cacheLife } from 'next/cache'
 
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [{ cookies: [] }],
-}
+export const unstable_instant = true
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/public-short-expire-long-stale/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/public-short-expire-long-stale/page.tsx
@@ -2,10 +2,7 @@ import { Suspense } from 'react'
 import { cachedDelay, DebugRenderKind } from '../../../shared'
 import { cacheLife } from 'next/cache'
 
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [{ cookies: [] }],
-}
+export const unstable_instant = true
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/public-short-expire-short-stale/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/public-short-expire-short-stale/page.tsx
@@ -2,10 +2,7 @@ import { Suspense } from 'react'
 import { cachedDelay, DebugRenderKind } from '../../../shared'
 import { cacheLife } from 'next/cache'
 
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [{ cookies: [] }],
-}
+export const unstable_instant = true
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/error-after-cookies/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/error-after-cookies/page.tsx
@@ -4,7 +4,6 @@ import { cachedDelay, DebugRenderKind } from '../../../shared'
 import { ErrorBoundary } from '../../../../components/error-boundary'
 
 export const unstable_instant = {
-  prefetch: 'runtime',
   // We're intentionally testing error behavior at runtime.
   // Build-time validation catches it and prevents that.
   unstable_disableValidation: true,

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/cookies/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/cookies/page.tsx
@@ -3,7 +3,6 @@ import { Suspense } from 'react'
 import { DebugRenderKind } from '../../../../shared'
 
 export const unstable_instant = {
-  prefetch: 'runtime',
   // We're intentionally testing error behavior at runtime.
   // Build-time validation catches it and prevents that.
   unstable_disableValidation: true,

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/dynamic-params/[id]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/dynamic-params/[id]/page.tsx
@@ -4,7 +4,6 @@ import { DebugRenderKind } from '../../../../../shared'
 type Params = { id: string }
 
 export const unstable_instant = {
-  prefetch: 'runtime',
   // We're intentionally testing error behavior at runtime.
   // Build-time validation catches it and prevents that.
   unstable_disableValidation: true,

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/headers/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/headers/page.tsx
@@ -3,7 +3,6 @@ import { Suspense } from 'react'
 import { DebugRenderKind } from '../../../../shared'
 
 export const unstable_instant = {
-  prefetch: 'runtime',
   // We're intentionally testing error behavior at runtime.
   // Build-time validation catches it and prevents that.
   unstable_disableValidation: true,

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/private-cache/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/private-cache/page.tsx
@@ -2,7 +2,6 @@ import { Suspense } from 'react'
 import { cachedDelay, DebugRenderKind } from '../../../../shared'
 
 export const unstable_instant = {
-  prefetch: 'runtime',
   // We're intentionally testing error behavior at runtime.
   // Build-time validation catches it and prevents that.
   unstable_disableValidation: true,

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/quickly-expiring-public-cache/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/quickly-expiring-public-cache/page.tsx
@@ -3,7 +3,6 @@ import { cachedDelay, DebugRenderKind } from '../../../../shared'
 import { cacheLife } from 'next/cache'
 
 export const unstable_instant = {
-  prefetch: 'runtime',
   // We're intentionally testing error behavior at runtime.
   // Build-time validation catches it and prevents that.
   unstable_disableValidation: true,

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/search-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/search-params/page.tsx
@@ -4,7 +4,6 @@ import { DebugRenderKind } from '../../../../shared'
 type AnySearchParams = { [key: string]: string | string[] | undefined }
 
 export const unstable_instant = {
-  prefetch: 'runtime',
   // We're intentionally testing error behavior at runtime.
   // Build-time validation catches it and prevents that.
   unstable_disableValidation: true,

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/fully-static/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/fully-static/page.tsx
@@ -3,10 +3,7 @@
 // but it's useful to exercise this codepath.
 // In the future, this test can be used to check whether we correctly
 // *skip* a runtime prefetch if a page was prerendered as static.
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [{ cookies: [] }],
-}
+export const unstable_instant = true
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/cookies-only/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/cookies-only/page.tsx
@@ -3,7 +3,6 @@ import { Suspense } from 'react'
 import { cachedDelay, DebugRenderKind } from '../../../shared'
 
 export const unstable_instant = {
-  prefetch: 'runtime',
   samples: [{ cookies: [{ name: 'testCookie', value: 'testValue' }] }],
 }
 export const unstable_prefetch = 'force-runtime'

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/cookies/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/cookies/page.tsx
@@ -4,7 +4,6 @@ import { cachedDelay, DebugRenderKind, uncachedIO } from '../../../shared'
 import { connection } from 'next/server'
 
 export const unstable_instant = {
-  prefetch: 'runtime',
   samples: [{ cookies: [{ name: 'testCookie', value: 'testValue' }] }],
 }
 export const unstable_prefetch = 'force-runtime'

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/dynamic-params/[id]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/dynamic-params/[id]/page.tsx
@@ -2,10 +2,7 @@ import { Suspense } from 'react'
 import { cachedDelay, DebugRenderKind, uncachedIO } from '../../../../shared'
 import { connection } from 'next/server'
 
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [{ params: { id: 'test' } }],
-}
+export const unstable_instant = { samples: [{ params: { id: 'test' } }] }
 export const unstable_prefetch = 'force-runtime'
 
 type Params = { id: string }

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/headers/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/headers/page.tsx
@@ -4,7 +4,6 @@ import { cachedDelay, DebugRenderKind, uncachedIO } from '../../../shared'
 import { connection } from 'next/server'
 
 export const unstable_instant = {
-  prefetch: 'runtime',
   samples: [{ headers: [['host', 'test-host']] }],
 }
 export const unstable_prefetch = 'force-runtime'

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/search-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/search-params/page.tsx
@@ -3,7 +3,6 @@ import { cachedDelay, DebugRenderKind, uncachedIO } from '../../../shared'
 import { connection } from 'next/server'
 
 export const unstable_instant = {
-  prefetch: 'runtime',
   samples: [{ searchParams: { searchParam: 'value' } }],
 }
 export const unstable_prefetch = 'force-runtime'

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/cookies-only/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/cookies-only/page.tsx
@@ -3,7 +3,6 @@ import { Suspense } from 'react'
 import { cachedDelay, DebugRenderKind } from '../../../shared'
 
 export const unstable_instant = {
-  prefetch: 'runtime',
   samples: [{ cookies: [{ name: 'testCookie', value: 'testValue' }] }],
 }
 export const unstable_prefetch = 'force-runtime'

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/cookies/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/cookies/page.tsx
@@ -4,7 +4,6 @@ import { cachedDelay, DebugRenderKind, uncachedIO } from '../../../shared'
 import { connection } from 'next/server'
 
 export const unstable_instant = {
-  prefetch: 'runtime',
   samples: [{ cookies: [{ name: 'testCookie', value: 'testValue' }] }],
 }
 export const unstable_prefetch = 'force-runtime'

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/date-now/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/date-now/page.tsx
@@ -2,10 +2,7 @@ import { Suspense } from 'react'
 import { cachedDelay, DebugRenderKind, uncachedIO } from '../../../shared'
 import { connection } from 'next/server'
 
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [{ cookies: [] }],
-}
+export const unstable_instant = true
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/dynamic-params/[id]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/dynamic-params/[id]/page.tsx
@@ -2,10 +2,7 @@ import { Suspense } from 'react'
 import { cachedDelay, DebugRenderKind, uncachedIO } from '../../../../shared'
 import { connection } from 'next/server'
 
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [{ params: { id: 'test' } }],
-}
+export const unstable_instant = { samples: [{ params: { id: 'test' } }] }
 export const unstable_prefetch = 'force-runtime'
 
 type Params = { id: string }

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/headers/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/headers/page.tsx
@@ -4,7 +4,6 @@ import { cachedDelay, DebugRenderKind, uncachedIO } from '../../../shared'
 import { connection } from 'next/server'
 
 export const unstable_instant = {
-  prefetch: 'runtime',
   samples: [{ headers: [['host', 'test-host']] }],
 }
 export const unstable_prefetch = 'force-runtime'

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/search-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/search-params/page.tsx
@@ -3,7 +3,6 @@ import { cachedDelay, DebugRenderKind, uncachedIO } from '../../../shared'
 import { connection } from 'next/server'
 
 export const unstable_instant = {
-  prefetch: 'runtime',
   samples: [{ searchParams: { searchParam: 'value' } }],
 }
 export const unstable_prefetch = 'force-runtime'

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/cookies-only/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/cookies-only/page.tsx
@@ -3,7 +3,6 @@ import { Suspense } from 'react'
 import { cachedDelay, DebugRenderKind } from '../../../shared'
 
 export const unstable_instant = {
-  prefetch: 'runtime',
   samples: [{ cookies: [{ name: 'testCookie', value: 'testValue' }] }],
 }
 export const unstable_prefetch = 'force-runtime'

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/cookies/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/cookies/page.tsx
@@ -4,7 +4,6 @@ import { cachedDelay, DebugRenderKind } from '../../../shared'
 import { connection } from 'next/server'
 
 export const unstable_instant = {
-  prefetch: 'runtime',
   samples: [{ cookies: [{ name: 'testCookie', value: 'testValue' }] }],
 }
 export const unstable_prefetch = 'force-runtime'

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/dynamic-params/[id]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/dynamic-params/[id]/page.tsx
@@ -3,10 +3,7 @@ import { cachedDelay, DebugRenderKind } from '../../../../shared'
 import { connection } from 'next/server'
 import { cookies } from 'next/headers'
 
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [{ params: { id: 'test' } }],
-}
+export const unstable_instant = { samples: [{ params: { id: 'test' } }] }
 export const unstable_prefetch = 'force-runtime'
 
 type Params = { id: string }

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/headers/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/headers/page.tsx
@@ -4,7 +4,6 @@ import { cachedDelay, DebugRenderKind } from '../../../shared'
 import { connection } from 'next/server'
 
 export const unstable_instant = {
-  prefetch: 'runtime',
   samples: [{ headers: [['host', 'test-host']] }],
 }
 export const unstable_prefetch = 'force-runtime'

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/search-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/search-params/page.tsx
@@ -4,7 +4,6 @@ import { connection } from 'next/server'
 import { cookies } from 'next/headers'
 
 export const unstable_instant = {
-  prefetch: 'runtime',
   samples: [{ searchParams: { searchParam: 'value' } }],
 }
 export const unstable_prefetch = 'force-runtime'

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/in-page/root-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/in-page/root-params/page.tsx
@@ -4,10 +4,7 @@ import { connection } from 'next/server'
 import { lang } from 'next/root-params'
 import { cookies } from 'next/headers'
 
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [{ params: { lang: 'en' } }],
-}
+export const unstable_instant = { samples: [{ params: { lang: 'en' } }] }
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/in-private-cache/root-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/in-private-cache/root-params/page.tsx
@@ -3,10 +3,7 @@ import { cachedDelay, DebugRenderKind, uncachedIO } from '../../../../shared'
 import { connection } from 'next/server'
 import { lang } from 'next/root-params'
 
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [{ params: { lang: 'en' } }],
-}
+export const unstable_instant = { samples: [{ params: { lang: 'en' } }] }
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/passed-to-public-cache/root-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/passed-to-public-cache/root-params/page.tsx
@@ -3,10 +3,7 @@ import { cachedDelay, DebugRenderKind, uncachedIO } from '../../../../shared'
 import { connection } from 'next/server'
 import { lang } from 'next/root-params'
 
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [{ params: { lang: 'en' } }],
-}
+export const unstable_instant = { samples: [{ params: { lang: 'en' } }] }
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {

--- a/test/e2e/app-dir/segment-cache/staleness/app/runtime-stale-2-minutes/page.tsx
+++ b/test/e2e/app-dir/segment-cache/staleness/app/runtime-stale-2-minutes/page.tsx
@@ -2,7 +2,7 @@ import { Suspense } from 'react'
 import { cacheLife } from 'next/cache'
 import { cookies } from 'next/headers'
 
-export const unstable_instant = { prefetch: 'runtime', samples: [{}] }
+export const unstable_instant = true
 export const unstable_prefetch = 'force-runtime'
 
 export default function Page() {

--- a/test/e2e/app-dir/segment-cache/staleness/app/runtime-stale-4-minutes/page.tsx
+++ b/test/e2e/app-dir/segment-cache/staleness/app/runtime-stale-4-minutes/page.tsx
@@ -2,7 +2,7 @@ import { Suspense } from 'react'
 import { cacheLife } from 'next/cache'
 import { cookies } from 'next/headers'
 
-export const unstable_instant = { prefetch: 'runtime', samples: [{}] }
+export const unstable_instant = true
 export const unstable_prefetch = 'force-runtime'
 
 export default function Page() {

--- a/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-all-vary/[category]/[itemId]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-all-vary/[category]/[itemId]/page.tsx
@@ -9,10 +9,8 @@ import { connection } from 'next/server'
  * requires its own prefetch — no cache sharing.
  */
 export const unstable_instant: {
-  prefetch: 'runtime'
   samples: Array<{ params: { category: string; itemId: string } }>
 } = {
-  prefetch: 'runtime',
   samples: [
     { params: { category: 'electronics', itemId: 'phone' } },
     { params: { category: 'clothing', itemId: 'shirt' } },

--- a/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-layout-split/[category]/[itemId]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-layout-split/[category]/[itemId]/page.tsx
@@ -10,10 +10,8 @@ import { connection } from 'next/server'
  * - Page varies only on category → cached when only itemId changes
  */
 export const unstable_instant: {
-  prefetch: 'runtime'
   samples: Array<{ params: { category: string; itemId: string } }>
 } = {
-  prefetch: 'runtime',
   samples: [
     { params: { category: 'electronics', itemId: 'phone' } },
     { params: { category: 'clothing', itemId: 'shirt' } },

--- a/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-metadata/[slug]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-metadata/[slug]/page.tsx
@@ -11,10 +11,8 @@ import { connection } from 'next/server'
  * - Body segment should be cached (body does NOT access slug)
  */
 export const unstable_instant: {
-  prefetch: 'runtime'
   samples: Array<{ params: { slug: string } }>
 } = {
-  prefetch: 'runtime',
   samples: [{ params: { slug: 'aaa' } }, { params: { slug: 'bbb' } }],
 }
 export const unstable_prefetch = 'force-runtime'

--- a/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-no-vary/[category]/[itemId]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-no-vary/[category]/[itemId]/page.tsx
@@ -9,10 +9,8 @@ import { connection } from 'next/server'
  * share the same cached loading shell (empty vary params set = max sharing).
  */
 export const unstable_instant: {
-  prefetch: 'runtime'
   samples: Array<{ params: { category: string; itemId: string } }>
 } = {
-  prefetch: 'runtime',
   samples: [
     { params: { category: 'electronics', itemId: 'phone' } },
     { params: { category: 'clothing', itemId: 'shirt' } },

--- a/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-search-params/target-page/page.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-search-params/target-page/page.tsx
@@ -7,10 +7,7 @@ import { connection } from 'next/server'
  * Since searchParams are not accessed, the '?' sentinel is not added to
  * varyParams, and different search param values share the cached segment.
  */
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [{ searchParams: { q: '1' } }],
-}
+export const unstable_instant = { samples: [{ searchParams: { q: '1' } }] }
 export const unstable_prefetch = 'force-runtime'
 
 export default async function RuntimePrefetchSearchParamsTargetPage() {

--- a/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch/[category]/[itemId]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch/[category]/[itemId]/page.tsx
@@ -12,10 +12,8 @@ import { connection } from 'next/server'
  * providing instant loading feedback when navigating.
  */
 export const unstable_instant: {
-  prefetch: 'runtime'
   samples: Array<{ params: { category: string; itemId: string } }>
 } = {
-  prefetch: 'runtime',
   samples: [
     { params: { category: 'electronics', itemId: 'phone' } },
     { params: { category: 'clothing', itemId: 'shirt' } },

--- a/test/e2e/app-dir/segment-cache/vary-params/app/(main)/search-params/target-page/page.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params/app/(main)/search-params/target-page/page.tsx
@@ -14,10 +14,7 @@ import { Suspense } from 'react'
  * - Prefetching /target?foo=1 fetches the segment with foo=1 content
  * - Prefetching /target?foo=2 fetches the segment AGAIN (no cache hit)
  */
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [{ searchParams: { foo: '1' } }],
-}
+export const unstable_instant = { samples: [{ searchParams: { foo: '1' } }] }
 export const unstable_prefetch = 'force-runtime'
 
 type SearchParams = { foo?: string }


### PR DESCRIPTION
prefetching is now controlled with the prefetch export and this option is inert on the instant export. this removes the prefetch option as a valid property on the instant config type.

also updates the ts plugin for this export and adds the definition for the previously landed prefetch export