### PR TITLE
fix(types): correct AppType<P> so P applies to App props, not pageProps

### DIFF
--- a/packages/next/src/shared/lib/utils.ts
+++ b/packages/next/src/shared/lib/utils.ts
@@ -30,8 +30,8 @@ export type DocumentType = NextComponentType<
 
 export type AppType<P = {}> = NextComponentType<
   AppContextType,
-  P,
-  AppPropsType<any, P>
+  AppInitialProps & P,
+  AppPropsType<any, any> & P
 >
 
 export type AppTreeType = ComponentType<

--- a/test/integration/typescript/pages/_app.tsx
+++ b/test/integration/typescript/pages/_app.tsx
@@ -1,9 +1,16 @@
 import type { AppType } from 'next/app'
 
-const MyApp: AppType<{ foo: string }> = ({ Component, pageProps }) => {
-  return <Component {...pageProps} />
+const MyApp: AppType<{ foo: string }> = ({ Component, pageProps, foo }) => {
+  return (
+    <>
+      <span id="app-foo" hidden>
+        {foo}
+      </span>
+      <Component {...pageProps} />
+    </>
+  )
 }
 
-MyApp.getInitialProps = () => ({ foo: 'bar' })
+MyApp.getInitialProps = () => ({ foo: 'bar', pageProps: {} })
 
 export default MyApp


### PR DESCRIPTION
## Summary

Fixes #42846.

The `AppType<P>` alias passed the generic `P` into both the second and third type parameters of `NextComponentType` as if `P` described `getInitialProps` return data *and* the page’s `pageProps` type. In practice, `P` is meant to represent **extra top-level keys** (for example from a custom `App.getInitialProps` alongside `pageProps`), matching how `_app` receives props at runtime.

## Changes

- `packages/next/src/shared/lib/utils.ts`: define `AppType<P>` as `NextComponentType<AppContextType, AppInitialProps & P, AppPropsType<any, any> & P>`.
- `test/integration/typescript/pages/_app.tsx`: update the fixture so `getInitialProps` returns a valid shape (`foo` plus `pageProps`) and the component destructures `foo` from props so the types are exercised.

## Verification

- `pnpm exec tsc --noEmit -p test/integration/typescript/tsconfig.json`
- `pnpm exec jest test/unit/write-app-declarations.test.ts --runInBand`

## Notes

This is a typing change only; no UI behavior change. Consumers who relied on `AppType<SomePageProps>` to type `pageProps` should use `AppProps<SomePageProps>` (or `AppPropsType<...>`) for page props instead.

Made with [Cursor](https://cursor.com)