### PR TITLE
fix: clearer errors for non-string catch-all segments in static path generation

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1156,5 +1156,8 @@
   "1155": "Not implemented",
   "1156": "Cannot create a replay stream after the ReplayableNodeStream has been disposed.",
   "1157": "`unstable_io()` requires the `experimental.unstableIO` option to be enabled in your Next.js config.",
-  "1158": "The prerender-ppr work unit type has been removed. This code path should be unreachable."
+  "1158": "The prerender-ppr work unit type has been removed. This code path should be unreachable.",
+  "1159": "A required parameter (%s) was not provided as an array received %s in getStaticPaths for %s",
+  "1160": "A required parameter (%s) was provided as an array, but each segment must be a string. Received %s at index %s in %s for %s",
+  "1161": "A required parameter (%s) was not provided as a string received %s in getStaticPaths for %s"
 }

--- a/packages/next/src/build/static-paths/app.ts
+++ b/packages/next/src/build/static-paths/app.ts
@@ -13,6 +13,7 @@ import { createWorkStore } from '../../server/async-storage/work-store'
 import { FallbackMode } from '../../lib/fallback'
 import type { IncrementalCache } from '../../server/lib/incremental-cache'
 import {
+  assertRepeatParamSegmentsAreStrings,
   normalizePathname,
   encodeParam,
   extractPathnameRouteParamSegments,
@@ -383,6 +384,12 @@ function validateParams(
             `A required parameter (${key}) was not provided as an array received ${typeof paramValue} in generateStaticParams for ${page}`
           )
         }
+        assertRepeatParamSegmentsAreStrings(
+          key,
+          paramValue,
+          page,
+          'generateStaticParams'
+        )
       } else {
         if (typeof paramValue !== 'string') {
           throw new Error(

--- a/packages/next/src/build/static-paths/pages.ts
+++ b/packages/next/src/build/static-paths/pages.ts
@@ -7,7 +7,11 @@ import escapePathDelimiters from '../../shared/lib/router/utils/escape-path-deli
 import { removeTrailingSlash } from '../../shared/lib/router/utils/remove-trailing-slash'
 import { getRouteMatcher } from '../../shared/lib/router/utils/route-matcher'
 import { getRouteRegex } from '../../shared/lib/router/utils/route-regex'
-import { encodeParam, normalizePathname } from './utils'
+import {
+  assertRepeatParamSegmentsAreStrings,
+  encodeParam,
+  normalizePathname,
+} from './utils'
 
 export async function buildPagesStaticPaths({
   page,
@@ -162,15 +166,21 @@ export async function buildPagesStaticPaths({
           paramValue = []
         }
 
-        if (
-          (repeat && !Array.isArray(paramValue)) ||
-          (!repeat && typeof paramValue !== 'string') ||
-          typeof paramValue === 'undefined'
-        ) {
+        if (repeat) {
+          if (!Array.isArray(paramValue)) {
+            throw new Error(
+              `A required parameter (${validParamKey}) was not provided as an array received ${typeof paramValue} in getStaticPaths for ${page}`
+            )
+          }
+          assertRepeatParamSegmentsAreStrings(
+            validParamKey,
+            paramValue,
+            page,
+            'getStaticPaths'
+          )
+        } else if (typeof paramValue !== 'string') {
           throw new Error(
-            `A required parameter (${validParamKey}) was not provided as ${
-              repeat ? 'an array' : 'a string'
-            } received ${typeof paramValue} in getStaticPaths for ${page}`
+            `A required parameter (${validParamKey}) was not provided as a string received ${typeof paramValue} in getStaticPaths for ${page}`
           )
         }
 

--- a/packages/next/src/build/static-paths/utils.ts
+++ b/packages/next/src/build/static-paths/utils.ts
@@ -36,6 +36,27 @@ export function encodeParam(
 }
 
 /**
+ * Ensures catch-all / optional-catch-all param arrays only contain strings.
+ * Non-string values otherwise fail deep in path encoding with a confusing error
+ * (e.g. `segment.replace is not a function`).
+ */
+export function assertRepeatParamSegmentsAreStrings(
+  paramKey: string,
+  segments: ReadonlyArray<unknown>,
+  page: string,
+  source: 'getStaticPaths' | 'generateStaticParams'
+): void {
+  for (let i = 0; i < segments.length; i++) {
+    const segment = segments[i]
+    if (typeof segment !== 'string') {
+      throw new Error(
+        `A required parameter (${paramKey}) was provided as an array, but each segment must be a string. Received ${typeof segment} at index ${i} in ${source} for ${page}`
+      )
+    }
+  }
+}
+
+/**
  * Normalizes a pathname to a consistent format.
  *
  * @param pathname - The pathname to normalize.

--- a/test/unit/build-static-paths-repeat-params.test.ts
+++ b/test/unit/build-static-paths-repeat-params.test.ts
@@ -1,0 +1,47 @@
+/* eslint-env jest */
+
+import { buildPagesStaticPaths } from 'next/dist/build/static-paths/pages'
+import { assertRepeatParamSegmentsAreStrings } from 'next/dist/build/static-paths/utils'
+
+describe('assertRepeatParamSegmentsAreStrings', () => {
+  it('does not throw for string[]', () => {
+    expect(() =>
+      assertRepeatParamSegmentsAreStrings(
+        'slug',
+        ['a', 'b'],
+        '/x',
+        'getStaticPaths'
+      )
+    ).not.toThrow()
+  })
+
+  it('throws a descriptive error when a segment is not a string', () => {
+    expect(() =>
+      assertRepeatParamSegmentsAreStrings(
+        'slug',
+        ['a', 2 as any],
+        '/[...slug]',
+        'getStaticPaths'
+      )
+    ).toThrow(
+      'A required parameter (slug) was provided as an array, but each segment must be a string. Received number at index 1 in getStaticPaths for /[...slug]'
+    )
+  })
+})
+
+describe('buildPagesStaticPaths (repeat params)', () => {
+  it('rejects non-string segments in catch-all params from getStaticPaths', async () => {
+    await expect(
+      buildPagesStaticPaths({
+        page: '/[...slug]',
+        configFileName: 'next.config.js',
+        getStaticPaths: async () => ({
+          paths: [{ params: { slug: [1, 2] as any } }],
+          fallback: false,
+        }),
+      })
+    ).rejects.toThrow(
+      'A required parameter (slug) was provided as an array, but each segment must be a string. Received number at index 0 in getStaticPaths for /[...slug]'
+    )
+  })
+})


### PR DESCRIPTION
## Summary

Improves developer-facing errors when dynamic route parameters for **catch-all** (`[...slug]`) and **optional catch-all** segments are returned as arrays containing non-strings (e.g. numbers from pagination). Previously this could fail later during path encoding with a low-level error (e.g. `segment.replace is not a function`), which is hard to connect to the root mistake.

This adds the same validation for both **Pages** (`getStaticPaths` → `buildPagesStaticPaths`) and **App** (`generateStaticParams` → `validateParams`), and registers structured error codes.

Fixes #41281.

## Test plan

- [x] `npx jest test/unit/build-static-paths-repeat-params.test.ts --config jest.config.js`
- [x] Confirmed `next build` on a minimal pages catch-all app with `[1, 2]` segments surfaces the new message:

```
Error: A required parameter (slug) was provided as an array, but each segment must be a string. Received number at index 0 in getStaticPaths for /[...slug]
```

<!-- NEXT_JS_LLM_PR -->

Made with [Cursor](https://cursor.com)