### PR TITLE
fix(next/head): warn on invalid intrinsic elements in dev (#20924)

### DIFF
--- a/errors/next-head-count-missing.mdx
+++ b/errors/next-head-count-missing.mdx
@@ -4,10 +4,28 @@ title: '`next-head-count` is missing'
 
 ## Why This Error Occurred
 
+This message usually means Next.js could not reconcile updates to the document `<head>` during hydration or client navigation.
+
+### Missing components in `pages/_document`
+
 You have a custom `pages/_document.js` that doesn't have the components required for Next.js to render correctly.
+
+### Invalid elements in `next/head`
+
+Another common cause is **invalid HTML inside [`next/head`](/docs/pages/api-reference/components/head)**.
+
+Only [metadata elements](https://html.spec.whatwg.org/multipage/semantics.html#the-head-element) such as `<title>`, `<meta>`, `<link>`, `<script>`, and `<noscript>` belong in `<head>`. Tags like `<html>`, `<body>`, or `<div>` are not valid there: browsers often move them into `<body>`, which prevents Next.js from managing head updates correctly and can produce this error.
+
+Use a [custom Document](/docs/pages/building-your-application/routing/custom-document) (`pages/_document`) for document-level tags (for example `<Html lang="en">`).
 
 ## Possible Ways to Fix It
 
+### `pages/_document` setup
+
 Ensure that your `_document.js` is importing and rendering all of the [required components](/docs/pages/building-your-application/routing/custom-document).
 
-In this case you are most likely not rendering the `<Head>` component imported from `next/document`.
+In many cases the issue is not rendering the `<Head>` component imported from `next/document`.
+
+### `next/head` content
+
+Remove non-metadata tags from `next/head` and use a custom Document when you need to change `<Html>`, `<Head>`, or `<Main>` from `next/document`.

--- a/packages/next/src/shared/lib/head.tsx
+++ b/packages/next/src/shared/lib/head.tsx
@@ -48,6 +48,20 @@ function onlyReactElement(
 
 const METATYPES = ['name', 'httpEquiv', 'charSet', 'itemProp']
 
+// Metadata elements allowed inside HTML <head> (WHATWG). Intrinsic elements outside
+// this set are usually moved to <body> by the browser, which breaks head updates.
+// Custom elements contain a hyphen and are skipped — they may be intentional.
+export const HEAD_METADATA_CONTENT_TYPES = new Set([
+  'base',
+  'link',
+  'meta',
+  'noscript',
+  'script',
+  'style',
+  'template',
+  'title',
+])
+
 /*
  returns a function for filtering head child elements
  which shouldn't be duplicated, like <title/>
@@ -128,6 +142,16 @@ function reduceComponents(
     .map((c: React.ReactElement<any>, i: number) => {
       const key = c.key || i
       if (process.env.NODE_ENV === 'development') {
+        const intrinsicTag = c.type
+        if (
+          typeof intrinsicTag === 'string' &&
+          !HEAD_METADATA_CONTENT_TYPES.has(intrinsicTag) &&
+          !intrinsicTag.includes('-')
+        ) {
+          warnOnce(
+            `Do not put <${intrinsicTag}> in next/head. Only metadata elements (e.g. <title>, <meta>, <link>) belong in <head>; other tags are often relocated to <body> by the browser, which breaks Next.js head handling and may surface confusing errors (for example about next-head-count). For document-level attributes such as lang on <html>, use a custom pages/_document. See https://nextjs.org/docs/messages/next-head-count-missing`
+          )
+        }
         // omit JSON-LD structured data snippets from the warning
         if (c.type === 'script' && c.props['type'] !== 'application/ld+json') {
           const srcMessage = c.props['src']

--- a/test/unit/next-head-metadata-allowlist.test.ts
+++ b/test/unit/next-head-metadata-allowlist.test.ts
@@ -1,0 +1,26 @@
+/* eslint-env jest */
+// Import source so the test does not depend on dist/ being rebuilt (next/head resolves to dist).
+import { HEAD_METADATA_CONTENT_TYPES } from '../../packages/next/src/shared/lib/head'
+
+describe('next/head metadata allowlist', () => {
+  it('includes WHATWG metadata content elements for document head', () => {
+    for (const tag of [
+      'title',
+      'meta',
+      'link',
+      'script',
+      'noscript',
+      'style',
+      'base',
+      'template',
+    ]) {
+      expect(HEAD_METADATA_CONTENT_TYPES.has(tag)).toBe(true)
+    }
+  })
+
+  it('excludes document/body tags that commonly break head management', () => {
+    for (const tag of ['html', 'body', 'div']) {
+      expect(HEAD_METADATA_CONTENT_TYPES.has(tag)).toBe(false)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Addresses [vercel/next.js#20924](https://github.com/vercel/next.js/issues/20924) (labeled **good first issue**): misleading / hard-to-diagnose behavior when **invalid HTML** (for example `<html lang="en" />` or `<div>`) is placed inside [`next/head`](https://nextjs.org/docs/pages/api-reference/components/head). Browsers often move those nodes out of `<head>`, which breaks head reconciliation and surfaces confusing symptoms (historically tied to “next-head-count” messaging).

## What changed

1. **`next/head` (development only)** — When a child is an **intrinsic element** whose tag is **not** WHATWG [metadata content](https://html.spec.whatwg.org/multipage/semantics.html#metadata-content) (`title`, `meta`, `link`, `script`, `style`, `noscript`, `base`, `template`) and is not a **custom element** (name contains `-`), we now emit a **one-time `console.warn`** that names the offending tag, explains why it is unsafe, points to [Custom Document](https://nextjs.org/docs/pages/building-your-application/routing/custom-document) for `lang` / document-level attributes, and links to the docs message below.

2. **`errors/next-head-count-missing.mdx`** — Documents **invalid `next/head` children** as a frequent cause, not only a missing `next/document` `<Head>`.

3. **Unit tests** — `HEAD_METADATA_CONTENT_TYPES` is exported (alongside existing `defaultHead`) so the allowlist stays covered by `test/unit/next-head-metadata-allowlist.test.ts`.

## Why this fixes the issue

Developers get a **direct, actionable warning at the source** (invalid children in `next/head`) instead of only hitting secondary failures or reading a doc that previously focused on `_document` configuration.

## Edge cases / limitations

- **Custom elements** (`<my-widget />`) are **not** warned: names contain `-` and may be intentional; false positives would be noisy.
- **Warnings only run when `NODE_ENV === 'development'`**, consistent with existing `next/head` script/stylesheet warnings.
- **Valid metadata tags** with **wrong usage** (e.g. stylesheet `<link>`) still use the existing dedicated warnings.

## Tests

- `pnpm exec jest test/unit/next-head-metadata-allowlist.test.ts --runInBand`

## Proof (before / after)

**Before:** No targeted feedback for invalid intrinsics in `next/head`; [next-head-count-missing](https://nextjs.org/docs/messages/next-head-count-missing) emphasized custom `_document` setup, which is easy to misread when the real mistake is invalid tags inside `next/head`.

**After (dev console):** A single warning that starts with  
`Do not put <html> in next/head. Only metadata elements …`  
and ends with `See https://nextjs.org/docs/messages/next-head-count-missing`.

Screenshots or a short screen recording can be attached in a follow-up comment—the behavior is the new `console.warn` text above when rendering `<Head><html lang="en" /><title>…` in **`next dev`**.

---

<!-- NEXT_JS_LLM_PR -->
