### PR TITLE
webpack: fix swcPlugins with relative paths

### DIFF
--- a/packages/next/src/build/jest/jest.ts
+++ b/packages/next/src/build/jest/jest.ts
@@ -134,12 +134,7 @@ export default function nextJest(options: { dir?: string } = {}) {
 
       const jestTransformerConfig: JestTransformerConfig = {
         modularizeImports: nextConfig?.modularizeImports,
-        swcPlugins: (nextConfig?.experimental?.swcPlugins ?? [])
-          .filter(Array.isArray)
-          .map(([name, opts]: any) => [
-            require.resolve(name, { paths: [options.dir!] }),
-            opts,
-          ]),
+        swcPlugins: nextConfig?.experimental?.swcPlugins,
         compilerOptions: nextConfig?.compiler,
         jsConfig,
         resolvedBaseUrl,
@@ -147,6 +142,7 @@ export default function nextJest(options: { dir?: string } = {}) {
         isEsmProject,
         pagesDir,
         imageConfig,
+        configDir: options.dir,
       }
 
       return {

--- a/packages/next/src/build/jest/jest.ts
+++ b/packages/next/src/build/jest/jest.ts
@@ -134,7 +134,12 @@ export default function nextJest(options: { dir?: string } = {}) {
 
       const jestTransformerConfig: JestTransformerConfig = {
         modularizeImports: nextConfig?.modularizeImports,
-        swcPlugins: nextConfig?.experimental?.swcPlugins,
+        swcPlugins: (nextConfig?.experimental?.swcPlugins ?? [])
+          .filter(Array.isArray)
+          .map(([name, opts]: any) => [
+            require.resolve(name, { paths: [options.dir!] }),
+            opts,
+          ]),
         compilerOptions: nextConfig?.compiler,
         jsConfig,
         resolvedBaseUrl,

--- a/packages/next/src/build/swc/jest-transformer.ts
+++ b/packages/next/src/build/swc/jest-transformer.ts
@@ -43,6 +43,7 @@ export interface JestTransformerConfig extends TransformerConfig {
   jsConfig: any
   resolvedBaseUrl?: ResolvedBaseUrl
   pagesDir?: string
+  configDir?: string
   serverComponents?: boolean
   isEsmProject: boolean
   modularizeImports?: NextConfig['modularizeImports']
@@ -90,6 +91,7 @@ const createTransformer: TransformerCreator<
         jestConfig.testEnvironment === 'node' ||
         jestConfig.testEnvironment.includes('jest-environment-node'),
       filename,
+      configDir: inputOptions?.configDir,
       jsConfig: inputOptions?.jsConfig,
       resolvedBaseUrl: inputOptions?.resolvedBaseUrl,
       pagesDir: inputOptions?.pagesDir,

--- a/packages/next/src/build/swc/options.ts
+++ b/packages/next/src/build/swc/options.ts
@@ -60,6 +60,7 @@ function getBaseSWCOptions({
   hasReactRefresh,
   globalWindow,
   esm,
+  configDir,
   modularizeImports,
   swcPlugins,
   compilerOptions,
@@ -83,6 +84,7 @@ function getBaseSWCOptions({
   hasReactRefresh: boolean
   globalWindow: boolean
   esm: boolean
+  configDir?: string
   modularizeImports?: NextConfig['modularizeImports']
   compilerOptions: NextConfig['compiler']
   swcPlugins: ExperimentalConfig['swcPlugins']
@@ -113,6 +115,12 @@ function getBaseSWCOptions({
   const useDefineForClassFields = Boolean(
     jsConfig?.compilerOptions?.useDefineForClassFields
   )
+  const plugins = (swcPlugins ?? [])
+    .filter(Array.isArray)
+    .map(([name, options]: any) => [
+      require.resolve(name, configDir ? { paths: [configDir] } : undefined),
+      options,
+    ])
 
   return {
     jsc: {
@@ -127,7 +135,7 @@ function getBaseSWCOptions({
       experimental: {
         keepImportAttributes: true,
         emitAssertForImportAttributes: true,
-        plugins: swcPlugins,
+        plugins,
         cacheRoot: swcCacheDir,
       },
       transform: {
@@ -308,6 +316,7 @@ export function getJestSWCOptions({
   filename,
   esm,
   modularizeImports,
+  configDir,
   swcPlugins,
   compilerOptions,
   jsConfig,
@@ -319,6 +328,7 @@ export function getJestSWCOptions({
   isServer: boolean
   filename: string
   esm: boolean
+  configDir?: string
   modularizeImports?: NextConfig['modularizeImports']
   swcPlugins: ExperimentalConfig['swcPlugins']
   compilerOptions: NextConfig['compiler']
@@ -334,6 +344,7 @@ export function getJestSWCOptions({
     jest: true,
     development: false,
     hasReactRefresh: false,
+    configDir,
     globalWindow: !isServer,
     modularizeImports,
     swcPlugins,
@@ -390,6 +401,8 @@ export function getLoaderSWCOptions({
   isPageFile,
   isCacheComponents,
   hasReactRefresh,
+  // The folder containing the next.config.js, used for resolving relative config paths.
+  configDir,
   modularizeImports,
   optimizeServerReact,
   optimizePackageImports,
@@ -417,6 +430,7 @@ export function getLoaderSWCOptions({
   appDir?: string
   isPageFile: boolean
   hasReactRefresh: boolean
+  configDir: string
   optimizeServerReact?: boolean
   modularizeImports: NextConfig['modularizeImports']
   isCacheComponents?: boolean
@@ -445,6 +459,7 @@ export function getLoaderSWCOptions({
     development,
     globalWindow: !isServer,
     hasReactRefresh,
+    configDir,
     modularizeImports,
     swcPlugins,
     compilerOptions,

--- a/packages/next/src/build/swc/options.ts
+++ b/packages/next/src/build/swc/options.ts
@@ -113,9 +113,6 @@ function getBaseSWCOptions({
   const useDefineForClassFields = Boolean(
     jsConfig?.compilerOptions?.useDefineForClassFields
   )
-  const plugins = (swcPlugins ?? [])
-    .filter(Array.isArray)
-    .map(([name, options]: any) => [require.resolve(name), options])
 
   return {
     jsc: {
@@ -130,7 +127,7 @@ function getBaseSWCOptions({
       experimental: {
         keepImportAttributes: true,
         emitAssertForImportAttributes: true,
-        plugins,
+        plugins: swcPlugins,
         cacheRoot: swcCacheDir,
       },
       transform: {

--- a/packages/next/src/build/webpack/loaders/next-swc-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-swc-loader.ts
@@ -152,14 +152,10 @@ async function loaderTransform(
       !!nextConfig.experimental?.allowDevelopmentBuild,
     isCacheComponents: nextConfig.cacheComponents,
     hasReactRefresh,
+    configDir: rootDir,
     modularizeImports: nextConfig?.modularizeImports,
     optimizePackageImports: nextConfig?.experimental?.optimizePackageImports,
-    swcPlugins: (nextConfig?.experimental?.swcPlugins ?? [])
-      .filter(Array.isArray)
-      .map(([name, opts]: any) => [
-        require.resolve(name, { paths: [rootDir] }),
-        opts,
-      ]),
+    swcPlugins: nextConfig?.experimental?.swcPlugins,
     swcEnvOptions: nextConfig?.experimental?.swcEnvOptions,
     compilerOptions: nextConfig?.compiler,
     optimizeServerReact: nextConfig?.experimental?.optimizeServerReact,

--- a/packages/next/src/build/webpack/loaders/next-swc-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-swc-loader.ts
@@ -154,7 +154,12 @@ async function loaderTransform(
     hasReactRefresh,
     modularizeImports: nextConfig?.modularizeImports,
     optimizePackageImports: nextConfig?.experimental?.optimizePackageImports,
-    swcPlugins: nextConfig?.experimental?.swcPlugins,
+    swcPlugins: (nextConfig?.experimental?.swcPlugins ?? [])
+      .filter(Array.isArray)
+      .map(([name, opts]: any) => [
+        require.resolve(name, { paths: [rootDir] }),
+        opts,
+      ]),
     swcEnvOptions: nextConfig?.experimental?.swcEnvOptions,
     compilerOptions: nextConfig?.compiler,
     optimizeServerReact: nextConfig?.experimental?.optimizeServerReact,

--- a/test/unit/swc-auto-polyfill-options.test.ts
+++ b/test/unit/swc-auto-polyfill-options.test.ts
@@ -19,6 +19,7 @@ describe('swcEnvOptions', () => {
     serverReferenceHashSalt: 'test-salt',
     bundleLayer: undefined,
     cacheHandlers: undefined,
+    configDir: '/',
   }
 
   it('should not include extra env options when swcEnvOptions is not set', () => {


### PR DESCRIPTION
Webpack didn't correctly load relative paths for `swcPlugins`.

https://github.com/vercel/next.js/pull/92579 will add a test