### PR TITLE
test: Add tests for client reference side effects

### DIFF
--- a/test/e2e/app-dir/client-reference-side-effects/app/client-sideeffect-only.ts
+++ b/test/e2e/app-dir/client-reference-side-effects/app/client-sideeffect-only.ts
@@ -1,0 +1,4 @@
+'use client'
+
+// @ts-expect-error
+if (typeof window !== 'undefined') window.client_sideeffect_only = true

--- a/test/e2e/app-dir/client-reference-side-effects/app/client-sideeffect-reexport.ts
+++ b/test/e2e/app-dir/client-reference-side-effects/app/client-sideeffect-reexport.ts
@@ -1,0 +1,6 @@
+'use client'
+
+// @ts-expect-error
+if (typeof window !== 'undefined') window.client_sideeffect_reexport = true
+
+export { Component } from './client'

--- a/test/e2e/app-dir/client-reference-side-effects/app/client.tsx
+++ b/test/e2e/app-dir/client-reference-side-effects/app/client.tsx
@@ -1,0 +1,8 @@
+'use client'
+
+// @ts-expect-error
+if (typeof window !== 'undefined') window.client = true
+
+export function Component() {
+  return <div>client component</div>
+}

--- a/test/e2e/app-dir/client-reference-side-effects/app/imported/page.tsx
+++ b/test/e2e/app-dir/client-reference-side-effects/app/imported/page.tsx
@@ -1,0 +1,6 @@
+import '../client-sideeffect-only'
+import '../client-sideeffect-reexport'
+
+export default function Home() {
+  return <div>Server</div>
+}

--- a/test/e2e/app-dir/client-reference-side-effects/app/layout.tsx
+++ b/test/e2e/app-dir/client-reference-side-effects/app/layout.tsx
@@ -1,0 +1,20 @@
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode
+}>) {
+  return (
+    <html lang="en">
+      <body>
+        <header>
+          <nav>
+            <a href="/" className="inline-block border px-4 py-2">
+              Home
+            </a>
+          </nav>
+        </header>
+        <main>{children}</main>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/client-reference-side-effects/app/rendered/page.tsx
+++ b/test/e2e/app-dir/client-reference-side-effects/app/rendered/page.tsx
@@ -1,0 +1,11 @@
+import '../client-sideeffect-only'
+import { Component } from '../client-sideeffect-reexport'
+
+export default function Home() {
+  return (
+    <div>
+      Server
+      <Component />
+    </div>
+  )
+}

--- a/test/e2e/app-dir/client-reference-side-effects/client-reference-side-effects.test.ts
+++ b/test/e2e/app-dir/client-reference-side-effects/client-reference-side-effects.test.ts
@@ -1,0 +1,53 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('client-reference-side-effects', () => {
+  const { next, isTurbopack } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+  })
+
+  it('side effect behavior when only importing', async () => {
+    const browser = await next.browser('/imported')
+
+    expect(await browser.elementByCss('body').text()).toContain('Server')
+
+    let client = await browser.eval('window.client')
+    let client_sideeffect_reexport = await browser.eval(
+      'window.client_sideeffect_reexport'
+    )
+    let client_sideeffect_only = await browser.eval(
+      'window.client_sideeffect_only'
+    )
+
+    // No client references are rendered, so nothing is executed.
+    expect(client).toBeUndefined()
+    expect(client_sideeffect_reexport).toBeUndefined()
+    expect(client_sideeffect_only).toBeUndefined()
+  })
+
+  it('side effect behavior when rendering', async () => {
+    const browser = await next.browser('/rendered')
+
+    const body = await browser.elementByCss('body').text()
+    expect(body).toContain('Server')
+    expect(body).toContain('client component')
+
+    let client = await browser.eval('window.client')
+    let client_sideeffect_reexport = await browser.eval(
+      'window.client_sideeffect_reexport'
+    )
+    let client_sideeffect_only = await browser.eval(
+      'window.client_sideeffect_only'
+    )
+
+    expect(client).toBeTrue()
+    expect(client_sideeffect_reexport).toBeTrue()
+    if (isTurbopack) {
+      expect(client_sideeffect_only).toBeUndefined()
+    } else {
+      // Webpack eagerly initializes all client reference modules once at least one of them is
+      // rendered.
+      expect(client_sideeffect_only).toBeTrue()
+    }
+  })
+})

--- a/test/e2e/app-dir/client-reference-side-effects/next.config.js
+++ b/test/e2e/app-dir/client-reference-side-effects/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig


### PR DESCRIPTION
Just adding some test coverage

- Turbopack: module are only evaluated when the given module is actually rendered
- Webpack: all client component modules are evaluated when at least one client reference renders