### PR TITLE
Turbopack: refactor ESM codegen generation

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/benches/analyzer.rs
+++ b/turbopack/crates/turbopack-ecmascript/benches/analyzer.rs
@@ -72,6 +72,7 @@ pub fn benchmark(c: &mut Criterion) {
                     &program,
                     &eval_context,
                     AnalyzeMode::CodeGenerationAndTracing,
+                    true,
                 );
 
                 let input = BenchInput {
@@ -103,6 +104,7 @@ fn bench_create_graph(b: &mut Bencher, input: &BenchInput) {
             &input.program,
             &input.eval_context,
             AnalyzeMode::CodeGenerationAndTracing,
+            true,
         )
     });
 }

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/graph.rs
@@ -31,7 +31,10 @@ use super::{
 use crate::{
     AnalyzeMode, SpecifiedModuleType,
     analyzer::{WellKnownObjectKind, is_unresolved},
-    references::{constant_value::parse_single_expr_lit, for_each_ident_in_pat},
+    code_gen::CodeGen,
+    references::{
+        constant_value::parse_single_expr_lit, esm::EsmModuleItem, for_each_ident_in_pat,
+    },
     utils::{AstPathRange, unparen},
 };
 
@@ -364,6 +367,8 @@ pub struct VarGraph {
     pub free_var_ids: FxHashMap<Atom, Id>,
 
     pub effects: Vec<Effect>,
+    // Some unconditional codegens, usually for ESM items.
+    pub code_gens: Vec<CodeGen>,
 
     // ident -> immediate usage (top level decl)
     pub decl_usages: FxHashMap<Id, DeclUsage>,
@@ -388,11 +393,13 @@ pub fn create_graph(
     m: &Program,
     eval_context: &EvalContext,
     analyze_mode: AnalyzeMode,
+    supports_block_scoping: bool,
 ) -> VarGraph {
     let mut graph = VarGraph {
         values: Default::default(),
         free_var_ids: Default::default(),
         effects: Default::default(),
+        code_gens: Default::default(),
         decl_usages: Default::default(),
         import_usages: Default::default(),
         exports: Default::default(),
@@ -406,6 +413,8 @@ pub fn create_graph(
             state: Default::default(),
             effects: Default::default(),
             hoisted_effects: Default::default(),
+            code_gens: Default::default(),
+            supports_block_scoping,
         },
         &mut Default::default(),
     );
@@ -940,6 +949,13 @@ struct Analyzer<'a> {
     /// Tracked separately so we can preserve effects from hoisted declarations even when we don't
     /// collect effects from the declaring context.
     hoisted_effects: Vec<Effect>,
+
+    // Some unconditional codegens, usually for ESM items.
+    code_gens: Vec<CodeGen>,
+
+    /// Whether we may codegen `let` and `const` or if we should fallback to var (at the cost of
+    /// slightly less correct circular import errors) for EsmModuleItem
+    supports_block_scoping: bool,
 
     eval_context: &'a EvalContext,
 }
@@ -1940,6 +1956,23 @@ impl Analyzer<'_> {
 }
 
 impl VisitAstPath for Analyzer<'_> {
+    fn visit_import_decl<'ast: 'r, 'r>(
+        &mut self,
+        import: &'ast ImportDecl,
+        ast_path: &mut AstNodePath<AstParentNodeRef<'r>>,
+    ) {
+        import.visit_children_with_ast_path(self, ast_path);
+        if import.type_only {
+            return;
+        }
+        if self.analyze_mode.is_code_gen() {
+            self.code_gens.push(
+                EsmModuleItem::new(as_parent_path(ast_path).into(), self.supports_block_scoping)
+                    .into(),
+            );
+        }
+    }
+
     fn visit_import_specifier<'ast: 'r, 'r>(
         &mut self,
         _import_specifier: &'ast ImportSpecifier,
@@ -2727,6 +2760,7 @@ impl VisitAstPath for Analyzer<'_> {
         });
         self.effects.append(&mut self.hoisted_effects);
         self.data.effects = take(&mut self.effects);
+        self.data.code_gens = take(&mut self.code_gens);
     }
 
     fn visit_cond_expr<'ast: 'r, 'r>(
@@ -2981,6 +3015,23 @@ impl VisitAstPath for Analyzer<'_> {
         self.effects = prev_effects;
     }
 
+    fn visit_export_all<'ast: 'r, 'r>(
+        &mut self,
+        export: &'ast ExportAll,
+        ast_path: &mut AstNodePath<AstParentNodeRef<'r>>,
+    ) {
+        if export.type_only {
+            return;
+        }
+        if self.analyze_mode.is_code_gen() {
+            self.code_gens.push(
+                EsmModuleItem::new(as_parent_path(ast_path).into(), self.supports_block_scoping)
+                    .into(),
+            );
+        }
+        export.visit_children_with_ast_path(self, ast_path);
+    }
+
     fn visit_export_decl<'ast: 'r, 'r>(
         &mut self,
         node: &'ast ExportDecl,
@@ -3004,8 +3055,20 @@ impl VisitAstPath for Analyzer<'_> {
                     });
                 }
             }
-            _ => {}
+            Decl::Using(_) => {
+                // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export#:~:text=You%20cannot%20use%20export%20on%20a%20using%20or%20await%20using%20declaration
+                unreachable!("using declarations can not be exported");
+            }
+            Decl::TsInterface(_) | Decl::TsTypeAlias(_) | Decl::TsEnum(_) | Decl::TsModule(_) => {
+                // ignore typescript for code generation
+            }
         };
+        if self.analyze_mode.is_code_gen() {
+            self.code_gens.push(
+                EsmModuleItem::new(as_parent_path(ast_path).into(), self.supports_block_scoping)
+                    .into(),
+            );
+        }
         node.visit_children_with_ast_path(self, ast_path);
     }
 
@@ -3014,6 +3077,9 @@ impl VisitAstPath for Analyzer<'_> {
         node: &'ast ExportNamedSpecifier,
         ast_path: &mut swc_core::ecma::visit::AstNodePath<'r>,
     ) {
+        if node.is_type_only {
+            return;
+        }
         let export_name = node
             .exported
             .as_ref()
@@ -3028,6 +3094,51 @@ impl VisitAstPath for Analyzer<'_> {
             },
         );
         node.visit_children_with_ast_path(self, ast_path);
+    }
+
+    fn visit_export_default_expr<'ast: 'r, 'r>(
+        &mut self,
+        export: &'ast ExportDefaultExpr,
+        ast_path: &mut AstNodePath<AstParentNodeRef<'r>>,
+    ) {
+        if self.analyze_mode.is_code_gen() {
+            self.code_gens.push(
+                EsmModuleItem::new(as_parent_path(ast_path).into(), self.supports_block_scoping)
+                    .into(),
+            );
+        }
+        export.visit_children_with_ast_path(self, ast_path);
+    }
+
+    fn visit_export_default_decl<'ast: 'r, 'r>(
+        &mut self,
+        export: &'ast ExportDefaultDecl,
+        ast_path: &mut AstNodePath<AstParentNodeRef<'r>>,
+    ) {
+        if self.analyze_mode.is_code_gen() {
+            self.code_gens.push(
+                EsmModuleItem::new(as_parent_path(ast_path).into(), self.supports_block_scoping)
+                    .into(),
+            );
+        }
+        export.visit_children_with_ast_path(self, ast_path);
+    }
+
+    fn visit_named_export<'ast: 'r, 'r>(
+        &mut self,
+        export: &'ast NamedExport,
+        ast_path: &mut AstNodePath<AstParentNodeRef<'r>>,
+    ) {
+        if export.type_only {
+            return;
+        }
+        if self.analyze_mode.is_code_gen() {
+            self.code_gens.push(
+                EsmModuleItem::new(as_parent_path(ast_path).into(), self.supports_block_scoping)
+                    .into(),
+            );
+        }
+        export.visit_children_with_ast_path(self, ast_path);
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/graph.rs
@@ -1953,6 +1953,15 @@ impl Analyzer<'_> {
             span: member_expr.span(),
         });
     }
+
+    fn add_esm_module_item(&mut self, ast_path: &AstNodePath<AstParentNodeRef<'_>>) {
+        if self.analyze_mode.is_code_gen() {
+            self.code_gens.push(
+                EsmModuleItem::new(as_parent_path(ast_path).into(), self.supports_block_scoping)
+                    .into(),
+            );
+        }
+    }
 }
 
 impl VisitAstPath for Analyzer<'_> {
@@ -1965,12 +1974,7 @@ impl VisitAstPath for Analyzer<'_> {
         if import.type_only {
             return;
         }
-        if self.analyze_mode.is_code_gen() {
-            self.code_gens.push(
-                EsmModuleItem::new(as_parent_path(ast_path).into(), self.supports_block_scoping)
-                    .into(),
-            );
-        }
+        self.add_esm_module_item(ast_path);
     }
 
     fn visit_import_specifier<'ast: 'r, 'r>(
@@ -3023,12 +3027,7 @@ impl VisitAstPath for Analyzer<'_> {
         if export.type_only {
             return;
         }
-        if self.analyze_mode.is_code_gen() {
-            self.code_gens.push(
-                EsmModuleItem::new(as_parent_path(ast_path).into(), self.supports_block_scoping)
-                    .into(),
-            );
-        }
+        self.add_esm_module_item(ast_path);
         export.visit_children_with_ast_path(self, ast_path);
     }
 
@@ -3063,12 +3062,7 @@ impl VisitAstPath for Analyzer<'_> {
                 // ignore typescript for code generation
             }
         };
-        if self.analyze_mode.is_code_gen() {
-            self.code_gens.push(
-                EsmModuleItem::new(as_parent_path(ast_path).into(), self.supports_block_scoping)
-                    .into(),
-            );
-        }
+        self.add_esm_module_item(ast_path);
         node.visit_children_with_ast_path(self, ast_path);
     }
 
@@ -3101,12 +3095,7 @@ impl VisitAstPath for Analyzer<'_> {
         export: &'ast ExportDefaultExpr,
         ast_path: &mut AstNodePath<AstParentNodeRef<'r>>,
     ) {
-        if self.analyze_mode.is_code_gen() {
-            self.code_gens.push(
-                EsmModuleItem::new(as_parent_path(ast_path).into(), self.supports_block_scoping)
-                    .into(),
-            );
-        }
+        self.add_esm_module_item(ast_path);
         export.visit_children_with_ast_path(self, ast_path);
     }
 
@@ -3115,12 +3104,7 @@ impl VisitAstPath for Analyzer<'_> {
         export: &'ast ExportDefaultDecl,
         ast_path: &mut AstNodePath<AstParentNodeRef<'r>>,
     ) {
-        if self.analyze_mode.is_code_gen() {
-            self.code_gens.push(
-                EsmModuleItem::new(as_parent_path(ast_path).into(), self.supports_block_scoping)
-                    .into(),
-            );
-        }
+        self.add_esm_module_item(ast_path);
         export.visit_children_with_ast_path(self, ast_path);
     }
 
@@ -3132,12 +3116,7 @@ impl VisitAstPath for Analyzer<'_> {
         if export.type_only {
             return;
         }
-        if self.analyze_mode.is_code_gen() {
-            self.code_gens.push(
-                EsmModuleItem::new(as_parent_path(ast_path).into(), self.supports_block_scoping)
-                    .into(),
-            );
-        }
+        self.add_esm_module_item(ast_path);
         export.visit_children_with_ast_path(self, ast_path);
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -3801,8 +3801,12 @@ mod tests {
                     None,
                 );
 
-                let mut var_graph =
-                    create_graph(&m, &eval_context, AnalyzeMode::CodeGenerationAndTracing);
+                let mut var_graph = create_graph(
+                    &m,
+                    &eval_context,
+                    AnalyzeMode::CodeGenerationAndTracing,
+                    true,
+                );
                 let var_cache = Default::default();
 
                 let mut named_values = var_graph

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -130,9 +130,9 @@ use crate::{
         },
         dynamic_expression::DynamicExpression,
         esm::{
-            EsmAssetReference, EsmAsyncAssetReference, EsmBinding, EsmExports, EsmModuleItem,
-            ImportMetaBinding, ImportMetaRef, UrlAssetReference, UrlRewriteBehavior,
-            base::EsmAssetReferences, export::EsmExport, module_id::EsmModuleIdAssetReference,
+            EsmAssetReference, EsmAsyncAssetReference, EsmBinding, EsmExports, ImportMetaBinding,
+            ImportMetaRef, UrlAssetReference, UrlRewriteBehavior, base::EsmAssetReferences,
+            export::EsmExport, module_id::EsmModuleIdAssetReference,
         },
         exports_info::{ExportsInfoBinding, ExportsInfoRef},
         hot_module::{ModuleHotReferenceAssetReference, ModuleHotReferenceCodeGen},
@@ -750,10 +750,16 @@ async fn analyze_ecmascript_module_internal(
     let (emitter, collector) = IssueEmitter::new(source, source_map.clone(), None);
     let handler = Handler::with_emitter(true, false, Box::new(emitter));
 
+    let supports_block_scoping = *compile_time_info
+        .environment()
+        .runtime_versions()
+        .supports_block_scoping()
+        .await?;
+
     let mut var_graph = {
         let _span = tracing::trace_span!("analyze variable values").entered();
         set_handler_and_globals(&handler, globals, || {
-            create_graph(program, eval_context, analyze_mode)
+            create_graph(program, eval_context, analyze_mode, supports_block_scoping)
         })
     };
 
@@ -861,21 +867,13 @@ async fn analyze_ecmascript_module_internal(
 
     let span = tracing::trace_span!("exports");
     async {
-        let supports_block_scoping = *compile_time_info
-            .environment()
-            .runtime_versions()
-            .supports_block_scoping()
-            .await?;
-
         let mut esm_exports = set_handler_and_globals(&handler, globals, || {
             // TODO migrate to effects
             let mut visitor = ModuleReferencesVisitor::new(
                 eval_context,
                 &import_references,
                 &mut analysis,
-                analyze_mode,
                 &var_graph,
-                supports_block_scoping,
             );
             // ModuleReferencesVisitor has already called analysis.add_esm_reexport_reference
             // for any references in esm_exports
@@ -1019,6 +1017,7 @@ async fn analyze_ecmascript_module_internal(
 
     let span = tracing::trace_span!("effects processing");
     async {
+        analysis.code_gens.extend(take(&mut var_graph.code_gens));
         let effects = take(&mut var_graph.effects);
         let compile_time_info_ref = compile_time_info.await?;
 
@@ -3854,14 +3853,12 @@ async fn require_context_visitor(
 /// A visitor that walks the AST and collects information about the various
 /// references a module makes to other parts of the code.
 struct ModuleReferencesVisitor<'a> {
-    analyze_mode: AnalyzeMode,
     eval_context: &'a EvalContext,
     imports: FxHashMap<String, (String, Vec<String>)>,
     import_references: &'a [ResolvedVc<EsmAssetReference>],
     analysis: &'a mut AnalyzeEcmascriptModuleResultBuilder,
     esm_exports: Vec<(RcStr, EsmExport)>,
     var_graph: &'a VarGraph,
-    supports_block_scoping: bool,
 }
 
 impl<'a> ModuleReferencesVisitor<'a> {
@@ -3869,24 +3866,18 @@ impl<'a> ModuleReferencesVisitor<'a> {
         eval_context: &'a EvalContext,
         import_references: &'a [ResolvedVc<EsmAssetReference>],
         analysis: &'a mut AnalyzeEcmascriptModuleResultBuilder,
-        analyze_mode: AnalyzeMode,
         var_graph: &'a VarGraph,
-        supports_block_scoping: bool,
     ) -> Self {
         Self {
-            analyze_mode,
             eval_context,
             imports: FxHashMap::default(),
             import_references,
             analysis,
             esm_exports: Vec::new(),
             var_graph,
-            supports_block_scoping,
         }
     }
-}
 
-impl<'a> ModuleReferencesVisitor<'a> {
     /// Returns the liveness of a given export identifier.  An export is live if it might
     /// change values after module evaluation.
     fn get_export_ident_liveness(&self, id: Id) -> Liveness {
@@ -3909,10 +3900,6 @@ impl<'a> ModuleReferencesVisitor<'a> {
             Liveness::Live
         }
     }
-}
-
-fn as_parent_path(ast_path: &AstNodePath<AstParentNodeRef<'_>>) -> Vec<AstParentKind> {
-    ast_path.iter().map(|n| n.kind()).collect()
 }
 
 pub(crate) fn for_each_ident_in_pat(pat: &Pat, f: &mut impl FnMut(&Atom, SyntaxContext)) {
@@ -3951,25 +3938,14 @@ pub(crate) fn for_each_ident_in_pat(pat: &Pat, f: &mut impl FnMut(&Atom, SyntaxC
 }
 
 impl VisitAstPath for ModuleReferencesVisitor<'_> {
-    fn visit_export_all<'ast: 'r, 'r>(
-        &mut self,
-        export: &'ast ExportAll,
-        ast_path: &mut AstNodePath<AstParentNodeRef<'r>>,
-    ) {
-        if self.analyze_mode.is_code_gen() {
-            self.analysis.add_code_gen(EsmModuleItem::new(
-                as_parent_path(ast_path).into(),
-                self.supports_block_scoping,
-            ));
-        }
-        export.visit_children_with_ast_path(self, ast_path);
-    }
-
     fn visit_named_export<'ast: 'r, 'r>(
         &mut self,
         export: &'ast NamedExport,
         ast_path: &mut AstNodePath<AstParentNodeRef<'r>>,
     ) {
+        if export.type_only {
+            return;
+        }
         // We create mutable exports for fake ESMs generated by module splitting
         let is_fake_esm = export
             .with
@@ -4041,13 +4017,6 @@ impl VisitAstPath for ModuleReferencesVisitor<'_> {
                 }
             }
         }
-
-        if self.analyze_mode.is_code_gen() {
-            self.analysis.add_code_gen(EsmModuleItem::new(
-                as_parent_path(ast_path).into(),
-                self.supports_block_scoping,
-            ));
-        }
         export.visit_children_with_ast_path(self, ast_path);
     }
 
@@ -4088,12 +4057,6 @@ impl VisitAstPath for ModuleReferencesVisitor<'_> {
                 }
             }
         };
-        if self.analyze_mode.is_code_gen() {
-            self.analysis.add_code_gen(EsmModuleItem::new(
-                as_parent_path(ast_path).into(),
-                self.supports_block_scoping,
-            ));
-        }
         export.visit_children_with_ast_path(self, ast_path);
     }
 
@@ -4110,12 +4073,6 @@ impl VisitAstPath for ModuleReferencesVisitor<'_> {
                 Liveness::Constant,
             ),
         ));
-        if self.analyze_mode.is_code_gen() {
-            self.analysis.add_code_gen(EsmModuleItem::new(
-                as_parent_path(ast_path).into(),
-                self.supports_block_scoping,
-            ));
-        }
         export.visit_children_with_ast_path(self, ast_path);
     }
 
@@ -4143,12 +4100,6 @@ impl VisitAstPath for ModuleReferencesVisitor<'_> {
                 // ignore
             }
         }
-        if self.analyze_mode.is_code_gen() {
-            self.analysis.add_code_gen(EsmModuleItem::new(
-                as_parent_path(ast_path).into(),
-                self.supports_block_scoping,
-            ));
-        }
         export.visit_children_with_ast_path(self, ast_path);
     }
 
@@ -4157,7 +4108,6 @@ impl VisitAstPath for ModuleReferencesVisitor<'_> {
         import: &'ast ImportDecl,
         ast_path: &mut AstNodePath<AstParentNodeRef<'r>>,
     ) {
-        let path = as_parent_path(ast_path).into();
         let src = import.src.value.to_string_lossy().into_owned();
         import.visit_children_with_ast_path(self, ast_path);
         if import.type_only {
@@ -4194,26 +4144,6 @@ impl VisitAstPath for ModuleReferencesVisitor<'_> {
                 }
             }
         }
-        if self.analyze_mode.is_code_gen() {
-            self.analysis
-                .add_code_gen(EsmModuleItem::new(path, self.supports_block_scoping));
-        }
-    }
-
-    fn visit_var_declarator<'ast: 'r, 'r>(
-        &mut self,
-        decl: &'ast VarDeclarator,
-        ast_path: &mut AstNodePath<AstParentNodeRef<'r>>,
-    ) {
-        decl.visit_children_with_ast_path(self, ast_path);
-    }
-
-    fn visit_call_expr<'ast: 'r, 'r>(
-        &mut self,
-        call: &'ast CallExpr,
-        ast_path: &mut AstNodePath<AstParentNodeRef<'r>>,
-    ) {
-        call.visit_children_with_ast_path(self, ast_path);
     }
 }
 


### PR DESCRIPTION
Move more logic out of the `ModuleReferencesVisitor`, so that we can remove it at some point.