### PR TITLE
feat(turbo-tasks-backend): gate prepare_tasks_with_callback trace span behind feature flag

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-backend/Cargo.toml
@@ -31,6 +31,7 @@ trace_task_modification = []
 trace_task_dirty = ["trace_aggregation_update_queue"]
 trace_task_output_dependencies = []
 trace_task_details = []
+trace_prepare_tasks = []
 
 [dependencies]
 anyhow = { workspace = true }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -14,6 +14,7 @@ use std::{
 
 use anyhow::{Context, Result, bail};
 use bincode::{Decode, Encode};
+#[cfg(feature = "trace_prepare_tasks")]
 use tracing::trace_span;
 use turbo_tasks::{
     CellId, FxIndexMap, TaskExecutionReason, TaskId, TaskPriority, TurboTasksBackendApi,
@@ -295,7 +296,10 @@ impl<'e, B: BackingStorage> ExecuteContextImpl<'e, B> {
             StorageWriteGuard<'e>,
         ),
     ) {
+        #[cfg(feature = "trace_prepare_tasks")]
         let _span = trace_span!("prepare_tasks_with_callback", reason).entered();
+        #[cfg(not(feature = "trace_prepare_tasks"))]
+        let _ = reason;
 
         // Fast path: no backing storage to restore from — all tasks should already
         // have restored flags set at allocation time, so just invoke callbacks directly.


### PR DESCRIPTION
### What?

Gates the `prepare_tasks_with_callback` trace span in `turbo-tasks-backend` behind a new `trace_prepare_tasks` Cargo feature flag.

### Why?

The `prepare_tasks_with_callback` span was emitted unconditionally on every call, which is extremely frequent during task scheduling. This made trace files very verbose with high-volume, low-signal entries. All other trace spans in `turbo-tasks-backend` (e.g. `trace_task_completion`, `trace_task_modification`, `trace_task_dirty`, etc.) are already gated behind `#[cfg(feature = "trace_*")]` flags — this brings `prepare_tasks_with_callback` in line with that convention.

### How?

- Added `trace_prepare_tasks = []` to the `[features]` section of `turbopack/crates/turbo-tasks-backend/Cargo.toml`, alongside the existing `trace_*` flags.
- Gated the `use tracing::trace_span` import and the `trace_span!("prepare_tasks_with_callback", reason)` call in `src/backend/operation/mod.rs` behind `#[cfg(feature = "trace_prepare_tasks")]`.
- Added `#[cfg(not(feature = "trace_prepare_tasks"))] let _ = reason;` to suppress the unused-variable warning when the feature is off (the `reason` parameter has no other use in the function body).

The span is now silent by default. It can be re-enabled for debugging by compiling with `--features trace_prepare_tasks`.

<!-- NEXT_JS_LLM_PR -->