### PR TITLE
fix(next-dev): return 405 for non-GET/HEAD requests to pages in dev mode

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2262,7 +2262,13 @@ export default abstract class Server<
       pathname !== '/_error' &&
       req.method !== 'HEAD' &&
       req.method !== 'GET' &&
-      (typeof components.Component === 'string' || isSSG)
+      (typeof components.Component === 'string' ||
+        isSSG ||
+        // In development mode, pages are not pre-rendered to strings, so we
+        // need to also check for pages that don't have server-side rendering
+        // capabilities. These pages should reject non-GET/HEAD methods with
+        // 405, matching production (`next start`) behavior. See #38863.
+        (!hasServerProps && !isAppPath))
     ) {
       res.statusCode = 405
       res.setHeader('Allow', ['GET', 'HEAD'])

--- a/test/e2e/page-respond-with-405-on-post/index.test.ts
+++ b/test/e2e/page-respond-with-405-on-post/index.test.ts
@@ -1,0 +1,124 @@
+import { createNext } from 'e2e-utils'
+import { NextInstance } from 'test/lib/next-modes/base'
+import { fetchViaHTTP } from 'next-test-utils'
+
+/**
+ * Verifies that `next dev` returns 405 Method Not Allowed for non-GET/HEAD
+ * requests to pages, matching `next start` behavior.
+ *
+ * Regression test for: https://github.com/vercel/next.js/issues/38863
+ */
+describe('Page responds with 405 on POST in dev mode', () => {
+  let next: NextInstance
+
+  beforeAll(async () => {
+    next = await createNext({
+      files: {
+        // Plain page — no getStaticProps, no getServerSideProps
+        'pages/index.js': `
+          export default function Page() {
+            return <h1>Home</h1>
+          }
+        `,
+        // SSG page — has getStaticProps
+        'pages/ssg.js': `
+          export default function SSGPage() {
+            return <h1>SSG Page</h1>
+          }
+          export async function getStaticProps() {
+            return { props: {} }
+          }
+        `,
+        // SSR page — has getServerSideProps (should NOT return 405)
+        'pages/ssr.js': `
+          export default function SSRPage() {
+            return <h1>SSR Page</h1>
+          }
+          export async function getServerSideProps() {
+            return { props: {} }
+          }
+        `,
+        // API route — should NOT be affected by page-level 405 logic
+        'pages/api/hello.js': `
+          export default function handler(req, res) {
+            res.status(200).json({ name: 'hello' })
+          }
+        `,
+      },
+      dependencies: {},
+    })
+  })
+  afterAll(() => next.destroy())
+
+  describe('plain page (no data fetching)', () => {
+    it('should return 405 for POST requests', async () => {
+      const res = await fetchViaHTTP(next.url, '/', undefined, {
+        method: 'POST',
+      })
+      expect(res.status).toBe(405)
+      expect(res.headers.get('allow')).toBe('GET, HEAD')
+    })
+
+    it('should return 405 for PUT requests', async () => {
+      const res = await fetchViaHTTP(next.url, '/', undefined, {
+        method: 'PUT',
+      })
+      expect(res.status).toBe(405)
+    })
+
+    it('should return 200 for GET requests', async () => {
+      const res = await fetchViaHTTP(next.url, '/')
+      expect(res.status).toBe(200)
+    })
+
+    it('should return 200 for HEAD requests', async () => {
+      const res = await fetchViaHTTP(next.url, '/', undefined, {
+        method: 'HEAD',
+      })
+      expect(res.status).toBe(200)
+    })
+  })
+
+  describe('SSG page (with getStaticProps)', () => {
+    it('should return 405 for POST requests', async () => {
+      const res = await fetchViaHTTP(next.url, '/ssg', undefined, {
+        method: 'POST',
+      })
+      expect(res.status).toBe(405)
+    })
+
+    it('should return 200 for GET requests', async () => {
+      const res = await fetchViaHTTP(next.url, '/ssg')
+      expect(res.status).toBe(200)
+    })
+  })
+
+  describe('SSR page (with getServerSideProps)', () => {
+    // SSR pages may need to handle POST for form submissions or server
+    // actions, so they should NOT return 405. This test documents that
+    // behavior is preserved.
+    it('should return 200 for POST requests', async () => {
+      const res = await fetchViaHTTP(next.url, '/ssr', undefined, {
+        method: 'POST',
+      })
+      expect(res.status).toBe(200)
+    })
+
+    it('should return 200 for GET requests', async () => {
+      const res = await fetchViaHTTP(next.url, '/ssr')
+      expect(res.status).toBe(200)
+    })
+  })
+
+  describe('API routes are not affected', () => {
+    it('should return 200 for POST to API route', async () => {
+      const res = await fetchViaHTTP(
+        next.url,
+        '/api/hello',
+        undefined,
+        { method: 'POST' }
+      )
+      expect(res.status).toBe(200)
+    })
+  })
+})


### PR DESCRIPTION
## Problem

**Issue: #38863**

When sending a `POST` (or any non-GET/HEAD) request to a page in `next dev`, the server responds with **200 OK** instead of **405 Method Not Allowed**. This is inconsistent with production behavior (`next start`), which correctly returns 405.

### Reproduction

\```bash
# Terminal 1: start dev server
next dev

# Terminal 2: send POST request
curl http://localhost:3000 -X POST -v
# Expected: 405 Method Not Allowed (what next start returns)
# Actual (before fix):   200 OK
\```

## Root Cause

In [`base-server.ts`](packages/next/src/server/base-server.ts), the HTTP method validation check that returns 405 only triggers under these conditions:

\`\`\`typescript
(typeof components.Component === string || isSSG)
\`\`\`

- **`typeof Component === string`** — true only when the page has been pre-rendered to static HTML (production build output)
- **`isSSG`** — true only when the page exports `getStaticProps`

In **development mode**, pages are **never** pre-rendered to strings — they are always loaded as React component functions. This means a plain page (no data fetching methods) fails **both** conditions and skips the 405 check entirely, allowing any HTTP method through.

## Solution

Extended the 405 condition to also cover pages without server-side rendering capabilities:

\`\`\`typescript
(typeof components.Component === string ||
  isSSG ||
  (!hasServerProps && !isAppPath))  // ← new condition
\`\`\`

The added condition `!hasServerProps && !isAppPath` catches plain pages in development mode:
- **`!hasServerProps`** — the page does not export `getServerSideProps` (so it does not need to handle form POSTs)
- **`!isAppPath`** — this is a Pages Router page, not an App Router route (which has its own method handling)

### Why this is safe

| Page type | `Component === string` | `isSSG` | `hasServerProps` | **405 for POST?** |
|---|---|---|---|---|
| Plain page (prod) | ✅ | ❌ | ❌ | ✅ (was) |
| Plain page (dev) | ❌ | ❌ | ❌ | ✅ (**now fixed**) |
| SSG page | ❌ | ✅ | ❌ | ✅ (was) |
| SSR page | ❌ | ❌ | ✅ | ❌ (intentional — forms/actions) |
| App Router page | N/A | N/A | N/A | ❌ (separate handling) |
| API routes | N/A | N/A | N/A | ❌ (separate handling) |

## Test Coverage

Added e2e test suite (`test/e2e/page-respond-with-405-on-post/index.test.ts`) covering:

1. **Plain page**: POST → 405, PUT → 405, GET → 200, HEAD → 200 ✅
2. **SSG page** (`getStaticProps`): POST → 405, GET → 200 ✅
3. **SSR page** (`getServerSideProps`): POST → 200, GET → 200 ✅ (preserved)
4. **API route**: POST → 200 ✅ (not affected)

## Verification Steps

\`\`\`bash
# Clone this PR, then:
pnpm install
pnpm next-dev
# In another terminal:
curl http://localhost:3000 -X POST -v   # Should return 405
curl http://localhost:3000 -X GET -v     # Should return 200
\`\`\`

## Edge Cases Handled

- **SSR pages with `getServerSideProps`**: Explicitly excluded (they may handle form POSTs)
- **App Router routes**: Excluded via `isAppPath` check (separate method handling)
- **API routes**: Not affected (handled by different code path)
- **Error pages** (`/_error`, `/404`, `/500`): Already excluded by existing conditions
- **Server actions**: Already excluded by `isPossibleServerAction` check
- **PPR resume requests**: Already excluded by `minimalPostponed` check