### PR TITLE
Turbopack: Implement Ord for ResolvedVc and OperationVc

### DIFF
--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -281,7 +281,9 @@ pub struct UpdateInfo {
     placeholder_for_future_fields: (),
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize, Encode, Decode)]
+#[derive(
+    Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord, Hash, Serialize, Deserialize, Encode, Decode,
+)]
 pub enum TaskPersistence {
     /// Tasks that may be persisted across sessions using serialization.
     Persistent,

--- a/turbopack/crates/turbo-tasks/src/raw_vc.rs
+++ b/turbopack/crates/turbo-tasks/src/raw_vc.rs
@@ -25,7 +25,9 @@ use crate::{
     turbo_tasks,
 };
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Encode, Decode)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Encode, Decode,
+)]
 pub struct CellId {
     pub type_id: ValueTypeId,
     pub index: u32,
@@ -47,7 +49,9 @@ impl Display for CellId {
 ///
 /// [`Vc`]: crate::Vc
 /// [monomorphization]: https://doc.rust-lang.org/book/ch10-01-syntax.html#performance-of-code-using-generics
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Encode, Decode)]
+#[derive(
+    Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Encode, Decode,
+)]
 pub enum RawVc {
     /// The synchronous return value of a task (after argument resolution). This is the
     /// representation used by [`OperationVc`][crate::OperationVc].

--- a/turbopack/crates/turbo-tasks/src/vc/operation.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/operation.rs
@@ -1,4 +1,5 @@
 use std::{
+    cmp::Ordering,
     fmt::Debug,
     future::Future,
     hash::Hash,
@@ -220,6 +221,24 @@ where
 }
 
 impl<T> Eq for OperationVc<T> where T: ?Sized {}
+
+impl<T> PartialOrd<OperationVc<T>> for OperationVc<T>
+where
+    T: ?Sized,
+{
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<T> Ord for OperationVc<T>
+where
+    T: ?Sized,
+{
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.node.node.cmp(&other.node.node)
+    }
+}
 
 impl<T> Debug for OperationVc<T>
 where

--- a/turbopack/crates/turbo-tasks/src/vc/resolved.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/resolved.rs
@@ -1,5 +1,6 @@
 use std::{
     any::Any,
+    cmp::Ordering,
     fmt::Debug,
     future::IntoFuture,
     hash::{Hash, Hasher},
@@ -131,6 +132,24 @@ where
 }
 
 impl<T> Eq for ResolvedVc<T> where T: ?Sized {}
+
+impl<T> PartialOrd<ResolvedVc<T>> for ResolvedVc<T>
+where
+    T: ?Sized,
+{
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<T> Ord for ResolvedVc<T>
+where
+    T: ?Sized,
+{
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.node.node.cmp(&other.node.node)
+    }
+}
 
 impl<T> Hash for ResolvedVc<T>
 where


### PR DESCRIPTION
This is potentially contentious, but I want to us `ResolvedVc`s and `OperationVc`s inside `FrozenSet`/`FrozenMap` as keys.

Obviously this could be abused, but I don't think it's any more likely to be abused than `Hash`+`Eq` are.

We don't need to implement this for `Vc` because `Vc` is never stored inside of a value type.

PR is entirely LLM-generated.