### PR TITLE
Turbopack: Use FrozenSet for collectibles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9958,6 +9958,7 @@ dependencies = [
  "tokio",
  "tracing",
  "turbo-bincode",
+ "turbo-frozenmap",
  "turbo-persistence",
  "turbo-rcstr",
  "turbo-tasks",
@@ -10414,7 +10415,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "auto-hash-map",
  "bincode 2.0.1",
  "flate2",
  "futures",
@@ -10434,6 +10434,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "turbo-bincode",
+ "turbo-frozenmap",
  "turbo-rcstr",
  "turbo-tasks",
  "turbo-tasks-backend",

--- a/turbopack/crates/turbo-tasks-backend/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-backend/Cargo.toml
@@ -66,6 +66,7 @@ futures = { workspace = true }
 indoc = { workspace = true }
 regex = { workspace = true }
 tempfile = { workspace = true }
+turbo-frozenmap = { workspace = true }
 turbo-tasks-malloc = { workspace = true }
 rstest = { workspace = true }
 turbo-tasks-testing = { workspace = true }

--- a/turbopack/crates/turbo-tasks-backend/tests/collectibles.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/collectibles.rs
@@ -5,9 +5,9 @@
 use std::time::Duration;
 
 use anyhow::Result;
-use auto_hash_map::AutoSet;
 use rustc_hash::FxHashSet;
 use tokio::time::sleep;
+use turbo_frozenmap::FrozenSet;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     CollectiblesSource, ResolvedVc, ValueToString, Vc, emit,
@@ -163,7 +163,7 @@ async fn taking_collectibles_with_resolve() {
 }
 
 #[turbo_tasks::value(transparent)]
-struct Collectibles(AutoSet<ResolvedVc<Box<dyn ValueToString>>>);
+struct Collectibles(FrozenSet<ResolvedVc<Box<dyn ValueToString>>>);
 
 #[turbo_tasks::function(operation)]
 async fn my_collecting_function() -> Result<Vc<Thing>> {

--- a/turbopack/crates/turbo-tasks/src/collectibles.rs
+++ b/turbopack/crates/turbo-tasks/src/collectibles.rs
@@ -1,10 +1,10 @@
-use auto_hash_map::AutoSet;
+use turbo_frozenmap::FrozenSet;
 
 use crate::{ResolvedVc, VcValueTrait};
 
 /// Implemented on `OperationVc` and `RawVc`.
 pub trait CollectiblesSource {
     fn drop_collectibles<T: VcValueTrait>(self);
-    fn take_collectibles<T: VcValueTrait>(self) -> AutoSet<ResolvedVc<T>>;
-    fn peek_collectibles<T: VcValueTrait>(self) -> AutoSet<ResolvedVc<T>>;
+    fn take_collectibles<T: VcValueTrait>(self) -> FrozenSet<ResolvedVc<T>>;
+    fn peek_collectibles<T: VcValueTrait>(self) -> FrozenSet<ResolvedVc<T>>;
 }

--- a/turbopack/crates/turbo-tasks/src/raw_vc.rs
+++ b/turbopack/crates/turbo-tasks/src/raw_vc.rs
@@ -7,9 +7,9 @@ use std::{
 };
 
 use anyhow::Result;
-use auto_hash_map::AutoSet;
 use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
+use turbo_frozenmap::FrozenSet;
 
 use crate::{
     CollectiblesSource, ReadCellOptions, ReadConsistency, ReadOutputOptions, ResolvedVc, TaskId,
@@ -218,7 +218,7 @@ impl RawVc {
 
 /// This implementation of `CollectiblesSource` assumes that `self` is a `RawVc::TaskOutput`.
 impl CollectiblesSource for RawVc {
-    fn peek_collectibles<T: VcValueTrait + ?Sized>(self) -> AutoSet<ResolvedVc<T>> {
+    fn peek_collectibles<T: VcValueTrait + ?Sized>(self) -> FrozenSet<ResolvedVc<T>> {
         let RawVc::TaskOutput(task_id) = self else {
             panic!(
                 "<RawVc as CollectiblesSource>::peek_collectibles() must only be called on a \
@@ -232,7 +232,7 @@ impl CollectiblesSource for RawVc {
             .collect()
     }
 
-    fn take_collectibles<T: VcValueTrait + ?Sized>(self) -> AutoSet<ResolvedVc<T>> {
+    fn take_collectibles<T: VcValueTrait + ?Sized>(self) -> FrozenSet<ResolvedVc<T>> {
         let RawVc::TaskOutput(task_id) = self else {
             panic!(
                 "<RawVc as CollectiblesSource>::take_collectibles() must only be called on a \

--- a/turbopack/crates/turbo-tasks/src/vc/operation.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/operation.rs
@@ -8,9 +8,9 @@ use std::{
 };
 
 use anyhow::Result;
-use auto_hash_map::AutoSet;
 use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
+use turbo_frozenmap::FrozenSet;
 pub use turbo_tasks_macros::OperationValue;
 
 use crate::{
@@ -295,11 +295,11 @@ where
         self.node.node.drop_collectibles::<Vt>();
     }
 
-    fn take_collectibles<Vt: VcValueTrait>(self) -> AutoSet<ResolvedVc<Vt>> {
+    fn take_collectibles<Vt: VcValueTrait>(self) -> FrozenSet<ResolvedVc<Vt>> {
         self.node.node.take_collectibles()
     }
 
-    fn peek_collectibles<Vt: VcValueTrait>(self) -> AutoSet<ResolvedVc<Vt>> {
+    fn peek_collectibles<Vt: VcValueTrait>(self) -> FrozenSet<ResolvedVc<Vt>> {
         self.node.node.peek_collectibles()
     }
 }

--- a/turbopack/crates/turbopack-core/src/diagnostics/mod.rs
+++ b/turbopack/crates/turbopack-core/src/diagnostics/mod.rs
@@ -2,7 +2,7 @@ use std::cmp::Ordering;
 
 use anyhow::Result;
 use async_trait::async_trait;
-use auto_hash_map::AutoSet;
+use turbo_frozenmap::FrozenSet;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{CollectiblesSource, FxIndexMap, ResolvedVc, Upcast, Vc, emit};
 
@@ -114,5 +114,5 @@ where
 #[derive(Debug)]
 #[turbo_tasks::value]
 pub struct CapturedDiagnostics {
-    pub diagnostics: AutoSet<ResolvedVc<Box<dyn Diagnostic>>>,
+    pub diagnostics: FrozenSet<ResolvedVc<Box<dyn Diagnostic>>>,
 }

--- a/turbopack/crates/turbopack-core/src/issue/mod.rs
+++ b/turbopack/crates/turbopack-core/src/issue/mod.rs
@@ -10,10 +10,10 @@ use std::{
 
 use anyhow::{Result, bail};
 use async_trait::async_trait;
-use auto_hash_map::AutoSet;
 use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use turbo_esregex::EsRegex;
+use turbo_frozenmap::FrozenSet;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     CollectiblesSource, NonLocalValue, OperationVc, RawVc, ReadRef, ResolvedVc, TaskInput,
@@ -195,7 +195,7 @@ pub trait ImportTracer {
 #[turbo_tasks::value]
 #[derive(Debug)]
 pub struct DelegatingImportTracer {
-    delegates: AutoSet<ResolvedVc<Box<dyn ImportTracer>>>,
+    delegates: FrozenSet<ResolvedVc<Box<dyn ImportTracer>>>,
 }
 
 impl DelegatingImportTracer {
@@ -404,7 +404,7 @@ impl IssueFilter {
 #[turbo_tasks::value(shared)]
 #[derive(Debug)]
 pub struct CapturedIssues {
-    issues: AutoSet<ResolvedVc<Box<dyn Issue>>>,
+    issues: FrozenSet<ResolvedVc<Box<dyn Issue>>>,
     tracer: ResolvedVc<DelegatingImportTracer>,
 }
 

--- a/turbopack/crates/turbopack-dev-server/Cargo.toml
+++ b/turbopack/crates/turbopack-dev-server/Cargo.toml
@@ -18,7 +18,6 @@ workspace = true
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
-auto-hash-map = { workspace = true }
 bincode = { workspace = true }
 flate2 = { workspace = true }
 futures = { workspace = true }
@@ -38,6 +37,7 @@ tokio-stream = "0.1.9"
 tokio-util = { workspace = true }
 tracing = { workspace = true }
 turbo-bincode = { workspace = true }
+turbo-frozenmap = { workspace = true }
 turbo-rcstr = { workspace = true }
 turbo-tasks = { workspace = true }
 turbo-tasks-bytes = { workspace = true }

--- a/turbopack/crates/turbopack-dev-server/src/http.rs
+++ b/turbopack/crates/turbopack-dev-server/src/http.rs
@@ -1,7 +1,6 @@
 use std::{io::Read, iter};
 
 use anyhow::{Result, anyhow};
-use auto_hash_map::AutoSet;
 use flate2::{Compression, bufread::GzEncoder};
 use futures::{StreamExt, TryStreamExt, stream};
 use hyper::{
@@ -10,6 +9,7 @@ use hyper::{
     http::HeaderValue,
 };
 use mime::Mime;
+use turbo_frozenmap::FrozenSet;
 use turbo_tasks::{
     CollectiblesSource, Effects, OperationVc, ReadRef, ResolvedVc, TransientInstance, Vc,
     take_effects, util::SharedError,
@@ -75,7 +75,7 @@ async fn get_from_source_operation(
 struct GetFromSourceResultWithCollectibles {
     result: ReadRef<GetFromSourceResult>,
     effects: Effects,
-    content_source_side_effects: AutoSet<ResolvedVc<Box<dyn ContentSourceSideEffect>>>,
+    content_source_side_effects: FrozenSet<ResolvedVc<Box<dyn ContentSourceSideEffect>>>,
 }
 
 #[turbo_tasks::function(operation)]
@@ -100,7 +100,7 @@ pub async fn process_request_with_content_source(
     issue_reporter: Vc<Box<dyn IssueReporter>>,
 ) -> Result<(
     Response<hyper::Body>,
-    AutoSet<ResolvedVc<Box<dyn ContentSourceSideEffect>>>,
+    FrozenSet<ResolvedVc<Box<dyn ContentSourceSideEffect>>>,
 )> {
     let original_path = request.uri().path().to_string();
     let request = http_request_to_source_request(request).await?;


### PR DESCRIPTION
Gathered collectibles are often stored inside of a turbo-task value, so FrozenSet seems like a better fit than AutoSet. It potentially uses less memory than an `AutoSet` when `AutoMap` is using the boxed-`FxHashMap` backing implementation.

PR is entirely LLM-generated.