### PR TITLE
Turbopack: cache webfonts locally between builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4873,6 +4873,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_path_to_error",
+ "sha2",
  "smallvec",
  "swc_core",
  "swc_sourcemap",

--- a/crates/next-core/Cargo.toml
+++ b/crates/next-core/Cargo.toml
@@ -34,6 +34,7 @@ remove_console = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+sha2 = { workspace = true }
 serde_path_to_error = { workspace = true }
 smallvec = { workspace = true }
 swc_sourcemap = { workspace = true }

--- a/crates/next-core/src/next_font/google/font_cache.rs
+++ b/crates/next-core/src/next_font/google/font_cache.rs
@@ -1,0 +1,87 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use sha2::{Digest, Sha256};
+
+fn hash_key(url: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(url.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+/// Write to a temp file then rename into place so concurrent readers never see
+/// a partial file. On Windows, rename can fail if the target exists, so we fall
+/// back to a direct write.
+fn write_file_atomic(path: &Path, data: &[u8]) -> std::io::Result<()> {
+    let tmp = path.with_extension(format!("tmp.{}", std::process::id()));
+    fs::write(&tmp, data)?;
+    if fs::rename(&tmp, path).is_err() {
+        // Windows: rename fails when target exists. Fall back to direct write.
+        fs::write(path, data)?;
+        let _ = fs::remove_file(&tmp);
+    }
+    Ok(())
+}
+
+/// Uses synchronous I/O intentionally — turbo-tasks-fs found that blocking the
+/// tokio thread is faster than `spawn_blocking` for short operations like these
+/// (see turbopack/crates/turbo-tasks-fs/src/retry.rs and PR #87661).
+pub struct FontDiskCache {
+    cache_dir: PathBuf,
+}
+
+impl FontDiskCache {
+    /// Create a font disk cache from a project root path.
+    ///
+    /// Returns `None` if `NEXT_FONT_GOOGLE_MOCKED_RESPONSES` is set (tests
+    /// should bypass the cache) or if the project path cannot be resolved.
+    pub fn new(project_root: &Path) -> Option<Self> {
+        if std::env::var("NEXT_FONT_GOOGLE_MOCKED_RESPONSES").is_ok() {
+            return None;
+        }
+
+        let cache_dir = match std::env::var("NEXT_FONT_CACHE_DIR") {
+            Ok(dir) => PathBuf::from(dir),
+            Err(_) => project_root.join(".next/cache/google-fonts"),
+        };
+
+        Some(Self { cache_dir })
+    }
+
+    pub fn get_css(&self, url: &str) -> Option<String> {
+        let path = self.cache_dir.join(format!("css-{}.txt", hash_key(url)));
+        fs::read_to_string(path).ok()
+    }
+
+    pub fn set_css(&self, url: &str, css: &str) {
+        if let Err(e) = self.set_inner(&format!("css-{}.txt", hash_key(url)), css.as_bytes()) {
+            tracing::warn!(
+                "Failed to write to font cache directory {:?}: {}",
+                self.cache_dir,
+                e
+            );
+        }
+    }
+
+    pub fn get_font(&self, url: &str) -> Option<Vec<u8>> {
+        let path = self.cache_dir.join(format!("font-{}.bin", hash_key(url)));
+        fs::read(path).ok()
+    }
+
+    pub fn set_font(&self, url: &str, data: &[u8]) {
+        if let Err(e) = self.set_inner(&format!("font-{}.bin", hash_key(url)), data) {
+            tracing::warn!(
+                "Failed to write to font cache directory {:?}: {}",
+                self.cache_dir,
+                e
+            );
+        }
+    }
+
+    fn set_inner(&self, filename: &str, data: &[u8]) -> std::io::Result<()> {
+        fs::create_dir_all(&self.cache_dir)?;
+        write_file_atomic(&self.cache_dir.join(filename), data)
+    }
+}

--- a/crates/next-core/src/next_font/google/mod.rs
+++ b/crates/next-core/src/next_font/google/mod.rs
@@ -718,20 +718,20 @@ async fn fetch_real_stylesheet(
     disk_cache: &Option<FontDiskCache>,
 ) -> Result<Option<Vc<RcStr>>> {
     // Check disk cache first
-    if let Some(cache) = disk_cache {
-        if let Some(css) = cache.get_css(&stylesheet_url) {
-            return Ok(Some(Vc::cell(css.into())));
-        }
+    if let Some(cache) = disk_cache
+        && let Some(css) = cache.get_css(&stylesheet_url)
+    {
+        return Ok(Some(Vc::cell(css.into())));
     }
 
     let body =
         fetch_from_google_fonts(fetch_client, stylesheet_url.clone(), css_virtual_path).await?;
 
-    if let Some(body) = &body {
-        if let Some(cache) = disk_cache {
-            let css_str = body.to_string().await?;
-            cache.set_css(&stylesheet_url, &css_str);
-        }
+    if let Some(body) = &body
+        && let Some(cache) = disk_cache
+    {
+        let css_str = body.to_string().await?;
+        cache.set_css(&stylesheet_url, &css_str);
     }
 
     Ok(body.map(|body| body.to_string()))

--- a/crates/next-core/src/next_font/google/mod.rs
+++ b/crates/next-core/src/next_font/google/mod.rs
@@ -12,7 +12,7 @@ use turbo_tasks_env::{CommandLineProcessEnv, ProcessEnv};
 use turbo_tasks_fetch::{FetchClientConfig, HttpResponseBody};
 use turbo_tasks_fs::{
     DiskFileSystem, File, FileContent, FileSystem, FileSystemPath,
-    json::parse_json_with_source_context,
+    json::parse_json_with_source_context, to_sys_path,
 };
 use turbo_tasks_hash::hash_xxh3_hash64;
 use turbopack::evaluate_context::node_evaluate_asset_context;
@@ -44,6 +44,7 @@ use crate::{
     next_font::{
         font_fallback::FontFallback,
         google::{
+            font_cache::FontDiskCache,
             font_fallback::get_font_fallback,
             options::{FontDataEntry, FontWeights, NextFontGoogleOptions, options_from_request},
             stylesheet::build_stylesheet,
@@ -58,6 +59,7 @@ use crate::{
     util::load_next_js_json_file,
 };
 
+pub mod font_cache;
 pub mod font_fallback;
 pub mod options;
 pub mod request;
@@ -238,6 +240,10 @@ impl NextFontGoogleCssModuleReplacer {
             .read(rcstr!("NEXT_FONT_GOOGLE_MOCKED_RESPONSES"))
             .await?;
 
+        let disk_cache = to_sys_path(self.project_path.clone())
+            .await?
+            .and_then(|p| FontDiskCache::new(&p));
+
         let stylesheet_str = mocked_responses_path
             .as_ref()
             .map_or_else(
@@ -246,6 +252,7 @@ impl NextFontGoogleCssModuleReplacer {
                         *self.fetch_client,
                         stylesheet_url.clone(),
                         css_virtual_path.clone(),
+                        &disk_cache,
                     )
                     .boxed()
                 },
@@ -454,20 +461,35 @@ impl ImportMappingReplacement for NextFontGoogleFontFileReplacer {
             .await?
             .join(&format!("/{name}.{ext}"))?;
 
-        // doesn't seem ideal to download the font into a string, but probably doesn't
-        // really matter either.
-        let Some(font) =
-            fetch_from_google_fonts(*self.fetch_client, url.into(), font_virtual_path.clone())
-                .await?
-        else {
-            return Ok(
-                ImportMapResult::Result(ResolveResult::unresolvable().resolved_cell()).cell(),
-            );
+        let disk_cache = to_sys_path(self.project_path.clone())
+            .await?
+            .and_then(|p| FontDiskCache::new(&p));
+
+        // Check disk cache before fetching from Google
+        let font_data = if let Some(cached) = disk_cache.as_ref().and_then(|c| c.get_font(&url)) {
+            cached
+        } else {
+            let Some(font) = fetch_from_google_fonts(
+                *self.fetch_client,
+                url.clone().into(),
+                font_virtual_path.clone(),
+            )
+            .await?
+            else {
+                return Ok(
+                    ImportMapResult::Result(ResolveResult::unresolvable().resolved_cell()).cell(),
+                );
+            };
+            let bytes = font.await?.0.clone();
+            if let Some(cache) = &disk_cache {
+                cache.set_font(&url, &bytes);
+            }
+            bytes
         };
 
         let font_source = VirtualSource::new(
             font_virtual_path,
-            AssetContent::file(FileContent::Content(font.await?.0.as_slice().into()).cell()),
+            AssetContent::file(FileContent::Content(font_data.as_slice().into()).cell()),
         )
         .to_resolved()
         .await?;
@@ -693,8 +715,24 @@ async fn fetch_real_stylesheet(
     fetch_client: Vc<FetchClientConfig>,
     stylesheet_url: RcStr,
     css_virtual_path: FileSystemPath,
+    disk_cache: &Option<FontDiskCache>,
 ) -> Result<Option<Vc<RcStr>>> {
-    let body = fetch_from_google_fonts(fetch_client, stylesheet_url, css_virtual_path).await?;
+    // Check disk cache first
+    if let Some(cache) = disk_cache {
+        if let Some(css) = cache.get_css(&stylesheet_url) {
+            return Ok(Some(Vc::cell(css.into())));
+        }
+    }
+
+    let body =
+        fetch_from_google_fonts(fetch_client, stylesheet_url.clone(), css_virtual_path).await?;
+
+    if let Some(body) = &body {
+        if let Some(cache) = disk_cache {
+            let css_str = body.to_string().await?;
+            cache.set_css(&stylesheet_url, &css_str);
+        }
+    }
 
     Ok(body.map(|body| body.to_string()))
 }

--- a/crates/next-core/src/next_font/google/mod.rs
+++ b/crates/next-core/src/next_font/google/mod.rs
@@ -742,21 +742,51 @@ async fn fetch_from_google_fonts(
     url: RcStr,
     virtual_path: FileSystemPath,
 ) -> Result<Option<Vc<HttpResponseBody>>> {
-    let result = fetch_client
-        .fetch(url, Some(rcstr!(USER_AGENT_FOR_GOOGLE_FONTS)))
-        .await?;
+    const MAX_ATTEMPTS: usize = 3;
 
-    Ok(match *result {
-        Ok(r) => Some(*r.await?.body),
-        Err(err) => {
-            err.to_issue(IssueSeverity::Warning, virtual_path)
-                .to_resolved()
-                .await?
-                .emit();
+    for attempt in 1..=MAX_ATTEMPTS {
+        let result = fetch_client
+            .fetch(url.clone(), Some(rcstr!(USER_AGENT_FOR_GOOGLE_FONTS)))
+            .await?;
 
-            None
+        match &*result {
+            Ok(r) => {
+                if attempt > 1 {
+                    tracing::info!(
+                        "Successfully fetched Google Font {} on attempt {}/{}",
+                        url,
+                        attempt,
+                        MAX_ATTEMPTS
+                    );
+                }
+                return Ok(Some(*r.await?.body));
+            }
+            Err(err) => {
+                if attempt < MAX_ATTEMPTS {
+                    tracing::warn!(
+                        "Failed to fetch Google Font {} (attempt {}/{}), retrying...",
+                        url,
+                        attempt,
+                        MAX_ATTEMPTS
+                    );
+                } else {
+                    tracing::warn!(
+                        "Failed to fetch Google Font {} after {} attempts",
+                        url,
+                        MAX_ATTEMPTS
+                    );
+                    err.to_issue(IssueSeverity::Warning, virtual_path)
+                        .to_resolved()
+                        .await?
+                        .emit();
+
+                    return Ok(None);
+                }
+            }
         }
-    })
+    }
+
+    Ok(None)
 }
 
 async fn get_mock_stylesheet(


### PR DESCRIPTION
Each time a devserver / build starts, `next/font/google` reaches out to remotely fetch the webfont+CSS files. This makes local development dependent on your network connection.

With this change, we cache the files locally in `.next/cache/google-fonts`. The CSS and font files are stored uniquely by a hash of the URL.
When Turbopack looks for a font, it first checks this cache before going to the local server. This means during normal development, you'll now only fetch a font when you first add the code that references it. All future server starts / builds should be able to use the cached version -- no need for an active network connection, go develop on a plane or in a locked-down sandbox!

I also added a retry loop that attempts to fetch fonts 3 times. This is what the Webpack loader already does today, but Turbopack only tries once to resolve fonts.

There are tests that mock the raw values of fonts with an env variable. This still supports `NEXT_FONT_GOOGLE_MOCKED_RESPONSES` so these tests pass.

It also allows you to specify an env variable for a custom cache directory for the fonts (`NEXT_FONT_CACHE_DIR`). Someone, somewhere might need this for locally cached fonts.