### PR TITLE
Fix devlow-bench: tsconfig rootDir mismatch with package.json bin

### DIFF
--- a/turbopack/packages/devlow-bench/tsconfig.json
+++ b/turbopack/packages/devlow-bench/tsconfig.json
@@ -3,7 +3,7 @@
     "strict": true,
     "target": "ES2022",
     "module": "NodeNext",
-    "rootDir": ".",
+    "rootDir": "src",
     "types": ["node"],
     "outDir": "dist",
     "declaration": true,


### PR DESCRIPTION
## What

Change `rootDir` from `"."` to `"src"` in `turbopack/packages/devlow-bench/tsconfig.json`.

## Why

The `bin` entry in `package.json` points to `dist/cli.js`. With `rootDir: "."`, `tsc` outputs `src/cli.ts` → `dist/src/cli.js` — the bin path is never produced by the build.

The `pnpm:devPreinstall` hook (from #91016) creates a placeholder stub at `dist/cli.js`. Since the build never overwrites it, turbo caches the placeholder as part of `dist/**`. On subsequent runs, turbo restores the cached placeholder, and devlow-bench fails with "Local workspace has not been built yet."

## How

One-line change: `rootDir: "."` → `rootDir: "src"`. Now `tsc` outputs `src/cli.ts` → `dist/cli.js`, matching the `bin` entry. The placeholder gets properly overwritten by the build.

<!-- NEXT_JS_LLM_PR -->