### PR TITLE
fix(csp): Provide nonce in `create-component-styles-and-scripts`

### DIFF
--- a/packages/next/src/server/app-render/create-component-styles-and-scripts.tsx
+++ b/packages/next/src/server/app-render/create-component-styles-and-scripts.tsx
@@ -37,6 +37,7 @@ export async function createComponentStylesAndScripts({
         src: `${ctx.assetPrefix}/_next/${encodeURIPath(href)}${getAssetQueryString(ctx, true)}`,
         async: true,
         key: `script-${scriptIndex}`,
+        nonce: ctx.nonce,
       })
     )
     scriptIndex++


### PR DESCRIPTION
### What?

Add `nonce={ctx.nonce}` to `<script>` and `<link>` tags in `createComponentStylesAndScripts`.

### Why?

`createComponentStylesAndScripts` creates `<script>` and `<link>` tags for boundary components (`loading`, `error`, `not-found`, etc.) without providing the CSP nonce. The sibling function `getLayerAssets`, which seemingly does the same thing for layout/page chunks, already includes it.

In my app, this causes the loading boundary's script tag to be emitted without a nonce attribute, which breaks nonce-based CSP. Of dozens of chunks loaded, the only one without a nonce is the loading chunk (e.g. `loading_tsx_0fhk6ua._.js`).

### How?

Pass `nonce={ctx.nonce}` in the props, matching what `getLayerAssets` already does.

I was unable to create a minimal reproduction in the test suite, but I've confirmed that this patch resolves the CSP violation in my application.

My application is quite large – it uses Next 16.2.0 w/ turbopack. I spent some time trying to create a minimal repro w/ both turbopack and webpack but was unable to. Patching the compiled code in my repo, I was able to verify this fix.

I will happily write tests in order to fix this if someone more familiar might know how to hit this failure mode.