### PR TITLE
Add TurboMalloc::thread_park() to flush and collect on thread park

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10133,6 +10133,7 @@ dependencies = [
 name = "turbo-tasks-malloc"
 version = "0.1.0"
 dependencies = [
+ "libmimalloc-sys",
  "mimalloc",
 ]
 

--- a/crates/next-build-test/src/main.rs
+++ b/crates/next-build-test/src/main.rs
@@ -86,6 +86,7 @@ fn main() {
                     tracing::debug!("threads stopped");
                 })
                 .on_thread_park(|| {
+                    TurboMalloc::thread_park();
                     LAST_SWC_ATOM_GC_TIME.with_borrow_mut(|cell| {
                         if cell.is_none_or(|t| t.elapsed() > Duration::from_secs(2)) {
                             swc_core::ecma::atoms::hstr::global_atom_store_gc();

--- a/crates/next-build-test/src/main.rs
+++ b/crates/next-build-test/src/main.rs
@@ -86,13 +86,13 @@ fn main() {
                     tracing::debug!("threads stopped");
                 })
                 .on_thread_park(|| {
-                    TurboMalloc::thread_park();
                     LAST_SWC_ATOM_GC_TIME.with_borrow_mut(|cell| {
                         if cell.is_none_or(|t| t.elapsed() > Duration::from_secs(2)) {
                             swc_core::ecma::atoms::hstr::global_atom_store_gc();
                             *cell = Some(Instant::now());
                         }
                     });
+                    TurboMalloc::thread_park();
                 })
                 .build()
                 .unwrap()

--- a/crates/next-napi-bindings/src/lib.rs
+++ b/crates/next-napi-bindings/src/lib.rs
@@ -100,6 +100,7 @@ fn init() {
             TurboMalloc::thread_stop();
         })
         .on_thread_park(|| {
+            TurboMalloc::thread_park();
             LAST_SWC_ATOM_GC_TIME.with_borrow_mut(|cell| {
                 if cell.is_none_or(|t| t.elapsed() > Duration::from_secs(2)) {
                     swc_core::ecma::atoms::hstr::global_atom_store_gc();

--- a/crates/next-napi-bindings/src/lib.rs
+++ b/crates/next-napi-bindings/src/lib.rs
@@ -100,13 +100,13 @@ fn init() {
             TurboMalloc::thread_stop();
         })
         .on_thread_park(|| {
-            TurboMalloc::thread_park();
             LAST_SWC_ATOM_GC_TIME.with_borrow_mut(|cell| {
                 if cell.is_none_or(|t| t.elapsed() > Duration::from_secs(2)) {
                     swc_core::ecma::atoms::hstr::global_atom_store_gc();
                     *cell = Some(Instant::now());
                 }
             });
+            TurboMalloc::thread_park();
         })
         .worker_threads(worker_threads)
         // Avoid a limit on threads to avoid deadlocks due to usage of block_in_place

--- a/turbopack/crates/turbo-tasks-backend/fuzz/src/graph.rs
+++ b/turbopack/crates/turbo-tasks-backend/fuzz/src/graph.rs
@@ -87,6 +87,9 @@ static RUNTIME: Lazy<tokio::runtime::Runtime> = Lazy::new(|| {
         .on_thread_stop(|| {
             TurboMalloc::thread_stop();
         })
+        .on_thread_park(|| {
+            TurboMalloc::thread_park();
+        })
         .build()
         .unwrap()
 });

--- a/turbopack/crates/turbo-tasks-malloc/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-malloc/Cargo.toml
@@ -10,6 +10,8 @@ autobenches = false
 bench = false
 
 [dependencies]
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
 libmimalloc-sys = { version = "0.1.44", features = [
   "extended",
 ], optional = true }

--- a/turbopack/crates/turbo-tasks-malloc/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-malloc/Cargo.toml
@@ -17,6 +17,9 @@ mimalloc = { version = "0.1.48", features = [
   "v3",
   "extended",
 ], optional = true }
+libmimalloc-sys = { version = "0.1.44", features = [
+  "extended",
+], optional = true }
 
 [target.'cfg(all(target_os = "linux", not(target_family = "wasm")))'.dependencies]
 mimalloc = { version = "0.1.48", features = [
@@ -24,7 +27,10 @@ mimalloc = { version = "0.1.48", features = [
   "extended",
   "local_dynamic_tls",
 ], optional = true }
+libmimalloc-sys = { version = "0.1.44", features = [
+  "extended",
+], optional = true }
 
 [features]
-custom_allocator = ["dep:mimalloc"]
+custom_allocator = ["dep:mimalloc", "dep:libmimalloc-sys"]
 default = ["custom_allocator"]

--- a/turbopack/crates/turbo-tasks-malloc/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-malloc/Cargo.toml
@@ -10,14 +10,13 @@ autobenches = false
 bench = false
 
 [dependencies]
-
+libmimalloc-sys = { version = "0.1.44", features = [
+  "extended",
+], optional = true }
 
 [target.'cfg(not(any(target_os = "linux", target_family = "wasm")))'.dependencies]
 mimalloc = { version = "0.1.48", features = [
   "v3",
-  "extended",
-], optional = true }
-libmimalloc-sys = { version = "0.1.44", features = [
   "extended",
 ], optional = true }
 
@@ -26,9 +25,6 @@ mimalloc = { version = "0.1.48", features = [
   "v3",
   "extended",
   "local_dynamic_tls",
-], optional = true }
-libmimalloc-sys = { version = "0.1.44", features = [
-  "extended",
 ], optional = true }
 
 [features]

--- a/turbopack/crates/turbo-tasks-malloc/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-malloc/src/lib.rs
@@ -97,7 +97,7 @@ impl TurboMalloc {
         flush();
         #[cfg(all(feature = "custom_allocator", not(target_family = "wasm")))]
         unsafe {
-            libmimalloc_sys::mi_collect(true);
+            libmimalloc_sys::mi_collect(false);
         }
     }
 

--- a/turbopack/crates/turbo-tasks-malloc/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-malloc/src/lib.rs
@@ -93,6 +93,14 @@ impl TurboMalloc {
         flush();
     }
 
+    pub fn thread_park() {
+        flush();
+        #[cfg(all(feature = "custom_allocator", not(target_family = "wasm")))]
+        unsafe {
+            libmimalloc_sys::mi_collect(true);
+        }
+    }
+
     pub fn allocation_counters() -> AllocationCounters {
         self::counter::allocation_counters()
     }

--- a/turbopack/crates/turbo-tasks-malloc/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-malloc/src/lib.rs
@@ -94,7 +94,6 @@ impl TurboMalloc {
     }
 
     pub fn thread_park() {
-        flush();
         #[cfg(all(feature = "custom_allocator", not(target_family = "wasm")))]
         unsafe {
             libmimalloc_sys::mi_collect(false);

--- a/turbopack/crates/turbopack-cli/benches/small_apps.rs
+++ b/turbopack/crates/turbopack-cli/benches/small_apps.rs
@@ -50,9 +50,13 @@ fn bench_small_apps(c: &mut Criterion) {
 
                 b.iter(move || {
                     let mut rt = tokio::runtime::Builder::new_multi_thread();
-                    rt.enable_all().on_thread_stop(|| {
-                        TurboMalloc::thread_stop();
-                    });
+                    rt.enable_all()
+                        .on_thread_stop(|| {
+                            TurboMalloc::thread_stop();
+                        })
+                        .on_thread_park(|| {
+                            TurboMalloc::thread_park();
+                        });
                     let rt = rt.build().unwrap();
 
                     let apps_dir = apps_dir.clone();

--- a/turbopack/crates/turbopack-cli/src/main.rs
+++ b/turbopack/crates/turbopack-cli/src/main.rs
@@ -29,7 +29,6 @@ fn main() {
             TurboMalloc::thread_stop();
         })
         .on_thread_park(|| {
-            TurboMalloc::thread_park();
             LAST_SWC_ATOM_GC_TIME.with_borrow_mut(|cell| {
                 use std::time::Duration;
 
@@ -38,6 +37,7 @@ fn main() {
                     *cell = Some(Instant::now());
                 }
             });
+            TurboMalloc::thread_park();
         });
 
     let args = Arguments::parse();

--- a/turbopack/crates/turbopack-cli/src/main.rs
+++ b/turbopack/crates/turbopack-cli/src/main.rs
@@ -29,6 +29,7 @@ fn main() {
             TurboMalloc::thread_stop();
         })
         .on_thread_park(|| {
+            TurboMalloc::thread_park();
             LAST_SWC_ATOM_GC_TIME.with_borrow_mut(|cell| {
                 use std::time::Duration;
 


### PR DESCRIPTION
### What?

Adds `TurboMalloc::thread_park()` — a new method on `TurboMalloc` that calls `libmimalloc_sys::mi_collect(false)` to process mimalloc's lazy free lists when a Tokio worker thread parks.

Registers it as an `on_thread_park` callback in every Tokio runtime that already registers `on_thread_stop`:
- `turbopack-cli/src/main.rs`
- `turbopack-cli/benches/small_apps.rs`
- `next-napi-bindings/src/lib.rs`
- `next-build-test/src/main.rs`
- `turbo-tasks-backend/fuzz/src/graph.rs`

### Why?

mimalloc uses deferred freeing: memory freed by one thread is not reclaimed immediately but is queued until that thread performs N more allocations. Tokio worker threads that are parked (waiting for work) don't allocate, so deferred frees accumulate indefinitely — memory is never returned to the OS until the thread wakes up and does real work.

Calling `mi_collect(false)` on park processes the lazy free lists, allowing mimalloc to reclaim that memory, while avoiding the syscalls and globally synchronized operations that `mi_collect(true)` would trigger.

### How?

- `thread_park()` only calls `mi_collect(false)` — it intentionally does **not** call `flush()`. `flush()` transfers the thread-local allocation counter to the global atomic and resets it to zero, which would violate the trace server's assumption that per-thread counters are monotonically increasing. Counter sync remains exclusively in `thread_stop()`.
- `thread_park()` is feature-gated behind `cfg(all(feature = "custom_allocator", not(target_family = "wasm")))` and is a no-op otherwise.
- `libmimalloc-sys` is added as a direct optional dependency under `[target.'cfg(not(target_family = "wasm"))'.dependencies]` (it was already a transitive dep via `mimalloc`) to access `mi_collect` directly, since `mimalloc`'s `use ffi::*` is not a public re-export.
- In each `on_thread_park` callback, `TurboMalloc::thread_park()` is called **after** the existing SWC atom store GC, so atoms freed by that GC pass are also eligible for reclamation in the same collection.

<!-- NEXT_JS_LLM_PR -->