### PR TITLE
prefetchInlining: fix build crash on notFound() pages

### DIFF
--- a/packages/next/src/server/app-render/collect-segment-data.tsx
+++ b/packages/next/src/server/app-render/collect-segment-data.tsx
@@ -487,7 +487,9 @@ async function collectPrefetchHintsImpl(
     const childRoute = children[parallelRouteKey]
     const childSegment = childRoute[0]
     const childSeedData =
-      seedDataChildren !== null ? seedDataChildren[parallelRouteKey] : null
+      seedDataChildren !== null
+        ? (seedDataChildren[parallelRouteKey] ?? null)
+        : null
 
     const childRequestKey = appendSegmentRequestKeyPart(
       requestKey,
@@ -870,7 +872,9 @@ function collectSegmentDataImpl(
     const childRoute = children[parallelRouteKey]
     const childSegment = childRoute[0]
     const childSeedData =
-      seedDataChildren !== null ? seedDataChildren[parallelRouteKey] : null
+      seedDataChildren !== null
+        ? (seedDataChildren[parallelRouteKey] ?? null)
+        : null
 
     const childRequestKey = appendSegmentRequestKeyPart(
       requestKey,

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/page.tsx
@@ -66,9 +66,7 @@ export default function Page() {
           </LinkAccordion>
         </li>
         <li>
-          <LinkAccordion href="/test-not-found/exists">
-            Not found
-          </LinkAccordion>
+          <LinkAccordion href="/test-not-found/exists">Not found</LinkAccordion>
         </li>
       </ul>
     </div>

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/page.tsx
@@ -65,6 +65,11 @@ export default function Page() {
             Independent head B
           </LinkAccordion>
         </li>
+        <li>
+          <LinkAccordion href="/test-not-found/exists">
+            Not found
+          </LinkAccordion>
+        </li>
       </ul>
     </div>
   )

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-not-found/[slug]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-not-found/[slug]/page.tsx
@@ -1,0 +1,20 @@
+import { notFound } from 'next/navigation'
+
+// Some slugs trigger notFound() during prerendering. This produces a
+// different RSC payload shape. collectPrefetchHints must handle this
+// without crashing the build.
+export default async function NotFoundPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+  if (slug === 'missing') {
+    notFound()
+  }
+  return <p id="page-not-found">Found: {slug}</p>
+}
+
+export function generateStaticParams() {
+  return [{ slug: 'exists' }, { slug: 'missing' }]
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/prefetch-inlining.test.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/prefetch-inlining.test.ts
@@ -758,4 +758,15 @@ describe('prefetch inlining', () => {
       'Independent head page'
     )
   })
+
+  it('notFound() during prerender does not crash build', async () => {
+    // Regression test: a page that calls notFound() during prerendering
+    // produces a flight data tree where some child seed data entries are
+    // undefined. collectPrefetchHints must handle this without crashing.
+    // The build succeeding is the primary assertion.
+    const browser = await next.browser('/test-not-found/exists')
+    expect(await browser.elementByCss('#page-not-found').text()).toBe(
+      'Found: exists'
+    )
+  })
 })


### PR DESCRIPTION
When traversing the route tree in collectPrefetchHints, we use keys from the FlightRouterState to look up corresponding entries in the seed data object. Usually these two structures agree, but there are subtle cases like notFound() where the router state contains keys that don't exist in the seed data. TypeScript doesn't catch this because the `in` operator narrows the key to `string`, which is assignable to the seed data object's index signature — but the lookup returns `undefined` rather than `null`.

Eventually the plan is to converge these into a single data structure so this kind of mismatch can't happen structurally. For now, coalesce undefined to null with `?? null`, matching the pattern already used in ppr-navigations.ts and segment-cache/cache.ts on the client.

## Test plan

- Added regression test: page with `notFound()` + `generateStaticParams` under `prefetchInlining`
- Verified the build crashes without the fix and passes with it
- All existing prefetch-inlining tests continue to pass

<!-- NEXT_JS_LLM_PR -->