### PR TITLE
feat(turbopack): Add EmitOption trait for extensible chunking context configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10389,6 +10389,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bincode 2.0.1",
+ "either",
  "indoc",
  "lightningcss",
  "parcel_selectors",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10765,6 +10765,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "serde_json",
+ "smallvec",
  "testing",
  "tokio",
  "tracing-subscriber",

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -26,10 +26,10 @@ use turbopack_core::{
     module_graph::binding_usage_info::OptionBindingUsageInfo,
     resolve::{parse::Request, pattern::Pattern},
 };
-use turbopack_css::chunk::CssChunkType;
+use turbopack_css::{chunk::CssChunkType, emit_options::CssEmitOptions};
 use turbopack_ecmascript::{
-    AnalyzeMode, TypeofWindow, chunk::EcmascriptChunkType, references::esm::UrlRewriteBehavior,
-    transform::PresetEnvConfig,
+    AnalyzeMode, TypeofWindow, chunk::EcmascriptChunkType, emit_options::EcmascriptEmitOptions,
+    references::esm::UrlRewriteBehavior, transform::PresetEnvConfig,
 };
 use turbopack_node::{
     execution_context::ExecutionContext,
@@ -536,22 +536,40 @@ pub async fn get_client_chunking_context(
     } else {
         MinifyType::NoMinify
     })
-    .source_maps(*source_maps.await?)
-    .asset_base_path(Some(asset_prefix))
-    .current_chunk_method(CurrentChunkMethod::DocumentCurrentScript)
-    .cross_origin(cross_origin_loading)
-    .export_usage(*export_usage.await?)
-    .unused_references(unused_references.to_resolved().await?)
-    .module_id_strategy(module_id_strategy.to_resolved().await?)
-    .debug_ids(*debug_ids.await?)
-    .should_use_absolute_url_references(*should_use_absolute_url_references.await?)
-    .nested_async_availability(*nested_async_chunking.await?)
-    .worker_forwarded_globals(worker_forwarded_globals())
-    .hash_salt(hash_salt)
-    .default_url_behavior(UrlBehavior {
-        suffix: AssetSuffix::Inferred,
-        static_suffix: css_url_suffix.to_resolved().await?,
-    });
+    .source_maps(*source_maps.await?);
+
+    if *minify.await? {
+        let ecma_opts = if *no_mangling.await? {
+            EcmascriptEmitOptions::builder().no_mangle().build()
+        } else {
+            EcmascriptEmitOptions::builder()
+                .mangle_optimal_size()
+                .build()
+        };
+        builder = builder.emit_option(ResolvedVc::upcast(ecma_opts.resolved_cell()));
+        let css_opts = CssEmitOptions::builder()
+            .minify(true)
+            .chunk_item_comments(false)
+            .build();
+        builder = builder.emit_option(ResolvedVc::upcast(css_opts.resolved_cell()));
+    }
+
+    builder = builder
+        .asset_base_path(Some(asset_prefix))
+        .current_chunk_method(CurrentChunkMethod::DocumentCurrentScript)
+        .cross_origin(cross_origin_loading)
+        .export_usage(*export_usage.await?)
+        .unused_references(unused_references.to_resolved().await?)
+        .module_id_strategy(module_id_strategy.to_resolved().await?)
+        .debug_ids(*debug_ids.await?)
+        .should_use_absolute_url_references(*should_use_absolute_url_references.await?)
+        .nested_async_availability(*nested_async_chunking.await?)
+        .worker_forwarded_globals(worker_forwarded_globals())
+        .hash_salt(hash_salt)
+        .default_url_behavior(UrlBehavior {
+            suffix: AssetSuffix::Inferred,
+            static_suffix: css_url_suffix.to_resolved().await?,
+        });
 
     if next_mode.is_development() {
         builder = builder

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -540,17 +540,16 @@ pub async fn get_client_chunking_context(
 
     if *minify.await? {
         let ecma_opts = if *no_mangling.await? {
-            EcmascriptEmitOptions::builder().no_mangle().build()
+            EcmascriptEmitOptions::builder()
+                .preset_minify_no_mangle()
+                .build()
         } else {
             EcmascriptEmitOptions::builder()
-                .mangle_optimal_size()
+                .preset_minify_optimal_size()
                 .build()
         };
         builder = builder.emit_option(ResolvedVc::upcast(ecma_opts.resolved_cell()));
-        let css_opts = CssEmitOptions::builder()
-            .minify(true)
-            .chunk_item_comments(false)
-            .build();
+        let css_opts = CssEmitOptions::builder().preset_minify().build();
         builder = builder.emit_option(ResolvedVc::upcast(css_opts.resolved_cell()));
     }
 

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -529,26 +529,23 @@ pub async fn get_client_chunking_context(
     )
     .chunk_base_path(Some(asset_prefix.clone()))
     .asset_suffix(AssetSuffix::Inferred.resolved_cell())
-    .source_maps(*source_maps.await?);
-
-    builder = builder.emit_options(minify_emit_options(minify, no_mangling, false).await?);
-
-    builder = builder
-        .asset_base_path(Some(asset_prefix))
-        .current_chunk_method(CurrentChunkMethod::DocumentCurrentScript)
-        .cross_origin(cross_origin_loading)
-        .export_usage(*export_usage.await?)
-        .unused_references(unused_references.to_resolved().await?)
-        .module_id_strategy(module_id_strategy.to_resolved().await?)
-        .debug_ids(*debug_ids.await?)
-        .should_use_absolute_url_references(*should_use_absolute_url_references.await?)
-        .nested_async_availability(*nested_async_chunking.await?)
-        .worker_forwarded_globals(worker_forwarded_globals())
-        .hash_salt(hash_salt)
-        .default_url_behavior(UrlBehavior {
-            suffix: AssetSuffix::Inferred,
-            static_suffix: css_url_suffix.to_resolved().await?,
-        });
+    .source_maps(*source_maps.await?)
+    .emit_options(minify_emit_options(minify, no_mangling, false).await?)
+    .asset_base_path(Some(asset_prefix))
+    .current_chunk_method(CurrentChunkMethod::DocumentCurrentScript)
+    .cross_origin(cross_origin_loading)
+    .export_usage(*export_usage.await?)
+    .unused_references(unused_references.to_resolved().await?)
+    .module_id_strategy(module_id_strategy.to_resolved().await?)
+    .debug_ids(*debug_ids.await?)
+    .should_use_absolute_url_references(*should_use_absolute_url_references.await?)
+    .nested_async_availability(*nested_async_chunking.await?)
+    .worker_forwarded_globals(worker_forwarded_globals())
+    .hash_salt(hash_salt)
+    .default_url_behavior(UrlBehavior {
+        suffix: AssetSuffix::Inferred,
+        static_suffix: css_url_suffix.to_resolved().await?,
+    });
 
     if next_mode.is_development() {
         builder = builder

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -531,9 +531,7 @@ pub async fn get_client_chunking_context(
     .asset_suffix(AssetSuffix::Inferred.resolved_cell())
     .source_maps(*source_maps.await?);
 
-    for opt in minify_emit_options(minify, no_mangling, false).await? {
-        builder = builder.emit_option(opt);
-    }
+    builder = builder.emit_options(minify_emit_options(minify, no_mangling, false).await?);
 
     builder = builder
         .asset_base_path(Some(asset_prefix))

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -26,10 +26,10 @@ use turbopack_core::{
     module_graph::binding_usage_info::OptionBindingUsageInfo,
     resolve::{parse::Request, pattern::Pattern},
 };
-use turbopack_css::{chunk::CssChunkType, emit_options::CssEmitOptions};
+use turbopack_css::chunk::CssChunkType;
 use turbopack_ecmascript::{
-    AnalyzeMode, TypeofWindow, chunk::EcmascriptChunkType, emit_options::EcmascriptEmitOptions,
-    references::esm::UrlRewriteBehavior, transform::PresetEnvConfig,
+    AnalyzeMode, TypeofWindow, chunk::EcmascriptChunkType, references::esm::UrlRewriteBehavior,
+    transform::PresetEnvConfig,
 };
 use turbopack_node::{
     execution_context::ExecutionContext,
@@ -69,7 +69,7 @@ use crate::{
     util::{
         OptionEnvMap, defines, foreign_code_context_condition,
         free_var_references_with_vercel_system_env_warnings, internal_assets_conditions,
-        module_styles_rule_condition, worker_forwarded_globals,
+        minify_emit_options, module_styles_rule_condition, worker_forwarded_globals,
     },
 };
 
@@ -531,19 +531,8 @@ pub async fn get_client_chunking_context(
     .asset_suffix(AssetSuffix::Inferred.resolved_cell())
     .source_maps(*source_maps.await?);
 
-    if *minify.await? {
-        let ecma_opts = if *no_mangling.await? {
-            EcmascriptEmitOptions::builder()
-                .preset_minify_no_mangle()
-                .build()
-        } else {
-            EcmascriptEmitOptions::builder()
-                .preset_minify_optimal_size()
-                .build()
-        };
-        builder = builder.emit_option(ResolvedVc::upcast(ecma_opts.resolved_cell()));
-        let css_opts = CssEmitOptions::builder().preset_minify().build();
-        builder = builder.emit_option(ResolvedVc::upcast(css_opts.resolved_cell()));
+    for opt in minify_emit_options(minify, no_mangling, false).await? {
+        builder = builder.emit_option(opt);
     }
 
     builder = builder

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -15,8 +15,8 @@ use turbopack_browser::{
 };
 use turbopack_core::{
     chunk::{
-        AssetSuffix, ChunkingConfig, ChunkingContext, ContentHashing, CrossOrigin, MangleType,
-        MinifyType, SourceMapSourceType, SourceMapsType, UnusedReferences, UrlBehavior,
+        AssetSuffix, ChunkingConfig, ChunkingContext, ContentHashing, CrossOrigin,
+        SourceMapSourceType, SourceMapsType, UnusedReferences, UrlBehavior,
         chunk_id_strategy::ModuleIdStrategy,
     },
     compile_time_info::{CompileTimeDefines, CompileTimeInfo, FreeVarReference, FreeVarReferences},
@@ -529,13 +529,6 @@ pub async fn get_client_chunking_context(
     )
     .chunk_base_path(Some(asset_prefix.clone()))
     .asset_suffix(AssetSuffix::Inferred.resolved_cell())
-    .minify_type(if *minify.await? {
-        MinifyType::Minify {
-            mangle: (!*no_mangling.await?).then_some(MangleType::OptimalSize),
-        }
-    } else {
-        MinifyType::NoMinify
-    })
     .source_maps(*source_maps.await?);
 
     if *minify.await? {

--- a/crates/next-core/src/next_edge/context.rs
+++ b/crates/next-core/src/next_edge/context.rs
@@ -263,9 +263,7 @@ pub async fn get_edge_chunking_context_with_client_assets(
     .nested_async_availability(*nested_async_chunking.await?)
     .worker_forwarded_globals(worker_forwarded_globals());
 
-    for opt in minify_emit_options(turbo_minify, no_mangling, true).await? {
-        builder = builder.emit_option(opt);
-    }
+    builder = builder.emit_options(minify_emit_options(turbo_minify, no_mangling, true).await?);
 
     if !next_mode.is_development() {
         builder = builder
@@ -362,9 +360,7 @@ pub async fn get_edge_chunking_context(
     .nested_async_availability(*nested_async_chunking.await?)
     .worker_forwarded_globals(worker_forwarded_globals());
 
-    for opt in minify_emit_options(turbo_minify, no_mangling, false).await? {
-        builder = builder.emit_option(opt);
-    }
+    builder = builder.emit_options(minify_emit_options(turbo_minify, no_mangling, false).await?);
 
     if !next_mode.is_development() {
         builder = builder

--- a/crates/next-core/src/next_edge/context.rs
+++ b/crates/next-core/src/next_edge/context.rs
@@ -6,8 +6,8 @@ use turbo_tasks_fs::FileSystemPath;
 use turbopack_browser::BrowserChunkingContext;
 use turbopack_core::{
     chunk::{
-        AssetSuffix, ChunkingConfig, ChunkingContext, CrossOrigin, MangleType, MinifyType,
-        SourceMapsType, UnusedReferences, UrlBehavior, chunk_id_strategy::ModuleIdStrategy,
+        AssetSuffix, ChunkingConfig, ChunkingContext, CrossOrigin, SourceMapsType,
+        UnusedReferences, UrlBehavior, chunk_id_strategy::ModuleIdStrategy,
     },
     compile_time_info::{CompileTimeDefines, CompileTimeInfo, FreeVarReference, FreeVarReferences},
     environment::{EdgeWorkerEnvironment, Environment, ExecutionEnvironment, NodeJsVersion},
@@ -253,14 +253,6 @@ pub async fn get_edge_chunking_context_with_client_assets(
         suffix: AssetSuffix::FromGlobal(rcstr!("NEXT_CLIENT_ASSET_SUFFIX")),
         static_suffix: css_url_suffix.to_resolved().await?,
     })
-    .minify_type(if *turbo_minify.await? {
-        MinifyType::Minify {
-            // React needs deterministic function names to work correctly.
-            mangle: (!*no_mangling.await?).then_some(MangleType::Deterministic),
-        }
-    } else {
-        MinifyType::NoMinify
-    })
     .source_maps(*turbo_source_maps.await?)
     .cross_origin(cross_origin_loading)
     .module_id_strategy(module_id_strategy.to_resolved().await?)
@@ -371,13 +363,6 @@ pub async fn get_edge_chunking_context(
     // implementation in the edge sandbox. It will respond with the
     // asset from the output directory.
     .asset_base_path(Some(rcstr!("blob:server/edge/")))
-    .minify_type(if *turbo_minify.await? {
-        MinifyType::Minify {
-            mangle: (!*no_mangling.await?).then_some(MangleType::OptimalSize),
-        }
-    } else {
-        MinifyType::NoMinify
-    })
     .source_maps(*turbo_source_maps.await?)
     .cross_origin(cross_origin)
     .module_id_strategy(module_id_strategy.to_resolved().await?)

--- a/crates/next-core/src/next_edge/context.rs
+++ b/crates/next-core/src/next_edge/context.rs
@@ -261,9 +261,8 @@ pub async fn get_edge_chunking_context_with_client_assets(
     .unused_references(unused_references.to_resolved().await?)
     .hash_salt(hash_salt)
     .nested_async_availability(*nested_async_chunking.await?)
-    .worker_forwarded_globals(worker_forwarded_globals());
-
-    builder = builder.emit_options(minify_emit_options(turbo_minify, no_mangling, true).await?);
+    .worker_forwarded_globals(worker_forwarded_globals())
+    .emit_options(minify_emit_options(turbo_minify, no_mangling, true).await?);
 
     if !next_mode.is_development() {
         builder = builder
@@ -358,9 +357,8 @@ pub async fn get_edge_chunking_context(
     .unused_references(unused_references.to_resolved().await?)
     .hash_salt(hash_salt)
     .nested_async_availability(*nested_async_chunking.await?)
-    .worker_forwarded_globals(worker_forwarded_globals());
-
-    builder = builder.emit_options(minify_emit_options(turbo_minify, no_mangling, false).await?);
+    .worker_forwarded_globals(worker_forwarded_globals())
+    .emit_options(minify_emit_options(turbo_minify, no_mangling, false).await?);
 
     if !next_mode.is_development() {
         builder = builder

--- a/crates/next-core/src/next_edge/context.rs
+++ b/crates/next-core/src/next_edge/context.rs
@@ -15,8 +15,8 @@ use turbopack_core::{
     issue::IssueSeverity,
     module_graph::binding_usage_info::OptionBindingUsageInfo,
 };
-use turbopack_css::{chunk::CssChunkType, emit_options::CssEmitOptions};
-use turbopack_ecmascript::{chunk::EcmascriptChunkType, emit_options::EcmascriptEmitOptions};
+use turbopack_css::chunk::CssChunkType;
+use turbopack_ecmascript::chunk::EcmascriptChunkType;
 use turbopack_node::execution_context::ExecutionContext;
 use turbopack_resolve::resolve_options_context::{ResolveOptionsContext, TsConfigHandling};
 
@@ -30,7 +30,8 @@ use crate::{
     next_shared::resolve::{ModuleFeatureReportResolvePlugin, NextSharedRuntimeResolvePlugin},
     util::{
         NextRuntime, OptionEnvMap, defines, foreign_code_context_condition,
-        free_var_references_with_vercel_system_env_warnings, worker_forwarded_globals,
+        free_var_references_with_vercel_system_env_warnings, minify_emit_options,
+        worker_forwarded_globals,
     },
 };
 
@@ -262,19 +263,8 @@ pub async fn get_edge_chunking_context_with_client_assets(
     .nested_async_availability(*nested_async_chunking.await?)
     .worker_forwarded_globals(worker_forwarded_globals());
 
-    if *turbo_minify.await? {
-        let ecma_opts = if *no_mangling.await? {
-            EcmascriptEmitOptions::builder()
-                .preset_minify_no_mangle()
-                .build()
-        } else {
-            EcmascriptEmitOptions::builder()
-                .preset_minify_deterministic()
-                .build()
-        };
-        builder = builder.emit_option(ResolvedVc::upcast(ecma_opts.resolved_cell()));
-        let css_opts = CssEmitOptions::builder().preset_minify().build();
-        builder = builder.emit_option(ResolvedVc::upcast(css_opts.resolved_cell()));
+    for opt in minify_emit_options(turbo_minify, no_mangling, true).await? {
+        builder = builder.emit_option(opt);
     }
 
     if !next_mode.is_development() {
@@ -372,19 +362,8 @@ pub async fn get_edge_chunking_context(
     .nested_async_availability(*nested_async_chunking.await?)
     .worker_forwarded_globals(worker_forwarded_globals());
 
-    if *turbo_minify.await? {
-        let ecma_opts = if *no_mangling.await? {
-            EcmascriptEmitOptions::builder()
-                .preset_minify_no_mangle()
-                .build()
-        } else {
-            EcmascriptEmitOptions::builder()
-                .preset_minify_optimal_size()
-                .build()
-        };
-        builder = builder.emit_option(ResolvedVc::upcast(ecma_opts.resolved_cell()));
-        let css_opts = CssEmitOptions::builder().preset_minify().build();
-        builder = builder.emit_option(ResolvedVc::upcast(css_opts.resolved_cell()));
+    for opt in minify_emit_options(turbo_minify, no_mangling, false).await? {
+        builder = builder.emit_option(opt);
     }
 
     if !next_mode.is_development() {

--- a/crates/next-core/src/next_edge/context.rs
+++ b/crates/next-core/src/next_edge/context.rs
@@ -272,17 +272,16 @@ pub async fn get_edge_chunking_context_with_client_assets(
 
     if *turbo_minify.await? {
         let ecma_opts = if *no_mangling.await? {
-            EcmascriptEmitOptions::builder().no_mangle().build()
+            EcmascriptEmitOptions::builder()
+                .preset_minify_no_mangle()
+                .build()
         } else {
             EcmascriptEmitOptions::builder()
-                .mangle_deterministic()
+                .preset_minify_deterministic()
                 .build()
         };
         builder = builder.emit_option(ResolvedVc::upcast(ecma_opts.resolved_cell()));
-        let css_opts = CssEmitOptions::builder()
-            .minify(true)
-            .chunk_item_comments(false)
-            .build();
+        let css_opts = CssEmitOptions::builder().preset_minify().build();
         builder = builder.emit_option(ResolvedVc::upcast(css_opts.resolved_cell()));
     }
 
@@ -390,17 +389,16 @@ pub async fn get_edge_chunking_context(
 
     if *turbo_minify.await? {
         let ecma_opts = if *no_mangling.await? {
-            EcmascriptEmitOptions::builder().no_mangle().build()
+            EcmascriptEmitOptions::builder()
+                .preset_minify_no_mangle()
+                .build()
         } else {
             EcmascriptEmitOptions::builder()
-                .mangle_optimal_size()
+                .preset_minify_optimal_size()
                 .build()
         };
         builder = builder.emit_option(ResolvedVc::upcast(ecma_opts.resolved_cell()));
-        let css_opts = CssEmitOptions::builder()
-            .minify(true)
-            .chunk_item_comments(false)
-            .build();
+        let css_opts = CssEmitOptions::builder().preset_minify().build();
         builder = builder.emit_option(ResolvedVc::upcast(css_opts.resolved_cell()));
     }
 

--- a/crates/next-core/src/next_edge/context.rs
+++ b/crates/next-core/src/next_edge/context.rs
@@ -15,8 +15,8 @@ use turbopack_core::{
     issue::IssueSeverity,
     module_graph::binding_usage_info::OptionBindingUsageInfo,
 };
-use turbopack_css::chunk::CssChunkType;
-use turbopack_ecmascript::chunk::EcmascriptChunkType;
+use turbopack_css::{chunk::CssChunkType, emit_options::CssEmitOptions};
+use turbopack_ecmascript::{chunk::EcmascriptChunkType, emit_options::EcmascriptEmitOptions};
 use turbopack_node::execution_context::ExecutionContext;
 use turbopack_resolve::resolve_options_context::{ResolveOptionsContext, TsConfigHandling};
 
@@ -270,6 +270,22 @@ pub async fn get_edge_chunking_context_with_client_assets(
     .nested_async_availability(*nested_async_chunking.await?)
     .worker_forwarded_globals(worker_forwarded_globals());
 
+    if *turbo_minify.await? {
+        let ecma_opts = if *no_mangling.await? {
+            EcmascriptEmitOptions::builder().no_mangle().build()
+        } else {
+            EcmascriptEmitOptions::builder()
+                .mangle_deterministic()
+                .build()
+        };
+        builder = builder.emit_option(ResolvedVc::upcast(ecma_opts.resolved_cell()));
+        let css_opts = CssEmitOptions::builder()
+            .minify(true)
+            .chunk_item_comments(false)
+            .build();
+        builder = builder.emit_option(ResolvedVc::upcast(css_opts.resolved_cell()));
+    }
+
     if !next_mode.is_development() {
         builder = builder
             .chunking_config(
@@ -371,6 +387,22 @@ pub async fn get_edge_chunking_context(
     .hash_salt(hash_salt)
     .nested_async_availability(*nested_async_chunking.await?)
     .worker_forwarded_globals(worker_forwarded_globals());
+
+    if *turbo_minify.await? {
+        let ecma_opts = if *no_mangling.await? {
+            EcmascriptEmitOptions::builder().no_mangle().build()
+        } else {
+            EcmascriptEmitOptions::builder()
+                .mangle_optimal_size()
+                .build()
+        };
+        builder = builder.emit_option(ResolvedVc::upcast(ecma_opts.resolved_cell()));
+        let css_opts = CssEmitOptions::builder()
+            .minify(true)
+            .chunk_item_comments(false)
+            .build();
+        builder = builder.emit_option(ResolvedVc::upcast(css_opts.resolved_cell()));
+    }
 
     if !next_mode.is_development() {
         builder = builder

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -25,10 +25,17 @@ use turbopack_core::{
     module_graph::binding_usage_info::OptionBindingUsageInfo,
     target::CompileTarget,
 };
-use turbopack_css::{chunk::CssChunkType, emit_options::CssEmitOptions};
+use turbopack_css::chunk::CssChunkType;
 use turbopack_ecmascript::{
+<<<<<<< HEAD
     AnalyzeMode, CustomTransformer, TransformPlugin, TypeofWindow, chunk::EcmascriptChunkType,
     emit_options::EcmascriptEmitOptions, references::esm::UrlRewriteBehavior,
+||||||| parent of 020235e3 (Clean up EmitOption usage: extract helpers, reduce duplication)
+    AnalyzeMode, TypeofWindow, chunk::EcmascriptChunkType, emit_options::EcmascriptEmitOptions,
+    references::esm::UrlRewriteBehavior,
+=======
+    AnalyzeMode, TypeofWindow, chunk::EcmascriptChunkType, references::esm::UrlRewriteBehavior,
+>>>>>>> 020235e3 (Clean up EmitOption usage: extract helpers, reduce duplication)
 };
 use turbopack_ecmascript_plugins::transform::directives::{
     client::ClientDirectiveTransformer, client_disallowed::ClientDisallowedDirectiveTransformer,
@@ -74,8 +81,8 @@ use crate::{
     util::{
         NextRuntime, OptionEnvMap, defines, foreign_code_context_condition,
         free_var_references_with_vercel_system_env_warnings, get_transpiled_packages,
-        internal_assets_conditions, load_next_js_jsonc_file, module_styles_rule_condition,
-        worker_forwarded_globals,
+        internal_assets_conditions, load_next_js_jsonc_file, minify_emit_options,
+        module_styles_rule_condition, worker_forwarded_globals,
     },
 };
 
@@ -1099,19 +1106,8 @@ pub async fn get_server_chunking_context_with_client_assets(
     .nested_async_availability(*nested_async_chunking.await?)
     .worker_forwarded_globals(worker_forwarded_globals());
 
-    if *minify.await? {
-        let ecma_opts = if *no_mangling.await? {
-            EcmascriptEmitOptions::builder()
-                .preset_minify_no_mangle()
-                .build()
-        } else {
-            EcmascriptEmitOptions::builder()
-                .preset_minify_deterministic()
-                .build()
-        };
-        builder = builder.emit_option(ResolvedVc::upcast(ecma_opts.resolved_cell()));
-        let css_opts = CssEmitOptions::builder().preset_minify().build();
-        builder = builder.emit_option(ResolvedVc::upcast(css_opts.resolved_cell()));
+    for opt in minify_emit_options(minify, no_mangling, true).await? {
+        builder = builder.emit_option(opt);
     }
 
     builder = builder.source_map_source_type(if next_mode.is_development() {
@@ -1213,19 +1209,8 @@ pub async fn get_server_chunking_context(
     .nested_async_availability(*nested_async_chunking.await?)
     .worker_forwarded_globals(worker_forwarded_globals());
 
-    if *minify.await? {
-        let ecma_opts = if *no_mangling.await? {
-            EcmascriptEmitOptions::builder()
-                .preset_minify_no_mangle()
-                .build()
-        } else {
-            EcmascriptEmitOptions::builder()
-                .preset_minify_optimal_size()
-                .build()
-        };
-        builder = builder.emit_option(ResolvedVc::upcast(ecma_opts.resolved_cell()));
-        let css_opts = CssEmitOptions::builder().preset_minify().build();
-        builder = builder.emit_option(ResolvedVc::upcast(css_opts.resolved_cell()));
+    for opt in minify_emit_options(minify, no_mangling, false).await? {
+        builder = builder.emit_option(opt);
     }
 
     if next_mode.is_development() {

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -1109,17 +1109,16 @@ pub async fn get_server_chunking_context_with_client_assets(
 
     if *minify.await? {
         let ecma_opts = if *no_mangling.await? {
-            EcmascriptEmitOptions::builder().no_mangle().build()
+            EcmascriptEmitOptions::builder()
+                .preset_minify_no_mangle()
+                .build()
         } else {
             EcmascriptEmitOptions::builder()
-                .mangle_deterministic()
+                .preset_minify_deterministic()
                 .build()
         };
         builder = builder.emit_option(ResolvedVc::upcast(ecma_opts.resolved_cell()));
-        let css_opts = CssEmitOptions::builder()
-            .minify(true)
-            .chunk_item_comments(false)
-            .build();
+        let css_opts = CssEmitOptions::builder().preset_minify().build();
         builder = builder.emit_option(ResolvedVc::upcast(css_opts.resolved_cell()));
     }
 
@@ -1231,17 +1230,16 @@ pub async fn get_server_chunking_context(
 
     if *minify.await? {
         let ecma_opts = if *no_mangling.await? {
-            EcmascriptEmitOptions::builder().no_mangle().build()
+            EcmascriptEmitOptions::builder()
+                .preset_minify_no_mangle()
+                .build()
         } else {
             EcmascriptEmitOptions::builder()
-                .mangle_optimal_size()
+                .preset_minify_optimal_size()
                 .build()
         };
         builder = builder.emit_option(ResolvedVc::upcast(ecma_opts.resolved_cell()));
-        let css_opts = CssEmitOptions::builder()
-            .minify(true)
-            .chunk_item_comments(false)
-            .build();
+        let css_opts = CssEmitOptions::builder().preset_minify().build();
         builder = builder.emit_option(ResolvedVc::upcast(css_opts.resolved_cell()));
     }
 

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -1106,9 +1106,7 @@ pub async fn get_server_chunking_context_with_client_assets(
     .nested_async_availability(*nested_async_chunking.await?)
     .worker_forwarded_globals(worker_forwarded_globals());
 
-    for opt in minify_emit_options(minify, no_mangling, true).await? {
-        builder = builder.emit_option(opt);
-    }
+    builder = builder.emit_options(minify_emit_options(minify, no_mangling, true).await?);
 
     builder = builder.source_map_source_type(if next_mode.is_development() {
         SourceMapSourceType::AbsoluteFileUri
@@ -1209,9 +1207,7 @@ pub async fn get_server_chunking_context(
     .nested_async_availability(*nested_async_chunking.await?)
     .worker_forwarded_globals(worker_forwarded_globals());
 
-    for opt in minify_emit_options(minify, no_mangling, false).await? {
-        builder = builder.emit_option(opt);
-    }
+    builder = builder.emit_options(minify_emit_options(minify, no_mangling, false).await?);
 
     if next_mode.is_development() {
         builder = builder.source_map_source_type(SourceMapSourceType::AbsoluteFileUri);

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -27,15 +27,8 @@ use turbopack_core::{
 };
 use turbopack_css::chunk::CssChunkType;
 use turbopack_ecmascript::{
-<<<<<<< HEAD
     AnalyzeMode, CustomTransformer, TransformPlugin, TypeofWindow, chunk::EcmascriptChunkType,
-    emit_options::EcmascriptEmitOptions, references::esm::UrlRewriteBehavior,
-||||||| parent of 020235e3 (Clean up EmitOption usage: extract helpers, reduce duplication)
-    AnalyzeMode, TypeofWindow, chunk::EcmascriptChunkType, emit_options::EcmascriptEmitOptions,
     references::esm::UrlRewriteBehavior,
-=======
-    AnalyzeMode, TypeofWindow, chunk::EcmascriptChunkType, references::esm::UrlRewriteBehavior,
->>>>>>> 020235e3 (Clean up EmitOption usage: extract helpers, reduce duplication)
 };
 use turbopack_ecmascript_plugins::transform::directives::{
     client::ClientDirectiveTransformer, client_disallowed::ClientDisallowedDirectiveTransformer,

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -25,10 +25,10 @@ use turbopack_core::{
     module_graph::binding_usage_info::OptionBindingUsageInfo,
     target::CompileTarget,
 };
-use turbopack_css::chunk::CssChunkType;
+use turbopack_css::{chunk::CssChunkType, emit_options::CssEmitOptions};
 use turbopack_ecmascript::{
     AnalyzeMode, CustomTransformer, TransformPlugin, TypeofWindow, chunk::EcmascriptChunkType,
-    references::esm::UrlRewriteBehavior,
+    emit_options::EcmascriptEmitOptions, references::esm::UrlRewriteBehavior,
 };
 use turbopack_ecmascript_plugins::transform::directives::{
     client::ClientDirectiveTransformer, client_disallowed::ClientDisallowedDirectiveTransformer,
@@ -1107,6 +1107,22 @@ pub async fn get_server_chunking_context_with_client_assets(
     .nested_async_availability(*nested_async_chunking.await?)
     .worker_forwarded_globals(worker_forwarded_globals());
 
+    if *minify.await? {
+        let ecma_opts = if *no_mangling.await? {
+            EcmascriptEmitOptions::builder().no_mangle().build()
+        } else {
+            EcmascriptEmitOptions::builder()
+                .mangle_deterministic()
+                .build()
+        };
+        builder = builder.emit_option(ResolvedVc::upcast(ecma_opts.resolved_cell()));
+        let css_opts = CssEmitOptions::builder()
+            .minify(true)
+            .chunk_item_comments(false)
+            .build();
+        builder = builder.emit_option(ResolvedVc::upcast(css_opts.resolved_cell()));
+    }
+
     builder = builder.source_map_source_type(if next_mode.is_development() {
         SourceMapSourceType::AbsoluteFileUri
     } else {
@@ -1212,6 +1228,22 @@ pub async fn get_server_chunking_context(
     .hash_salt(hash_salt)
     .nested_async_availability(*nested_async_chunking.await?)
     .worker_forwarded_globals(worker_forwarded_globals());
+
+    if *minify.await? {
+        let ecma_opts = if *no_mangling.await? {
+            EcmascriptEmitOptions::builder().no_mangle().build()
+        } else {
+            EcmascriptEmitOptions::builder()
+                .mangle_optimal_size()
+                .build()
+        };
+        builder = builder.emit_option(ResolvedVc::upcast(ecma_opts.resolved_cell()));
+        let css_opts = CssEmitOptions::builder()
+            .minify(true)
+            .chunk_item_comments(false)
+            .build();
+        builder = builder.emit_option(ResolvedVc::upcast(css_opts.resolved_cell()));
+    }
 
     if next_mode.is_development() {
         builder = builder.source_map_source_type(SourceMapSourceType::AbsoluteFileUri);

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -1104,9 +1104,8 @@ pub async fn get_server_chunking_context_with_client_assets(
     .debug_ids(*debug_ids.await?)
     .hash_salt(hash_salt)
     .nested_async_availability(*nested_async_chunking.await?)
-    .worker_forwarded_globals(worker_forwarded_globals());
-
-    builder = builder.emit_options(minify_emit_options(minify, no_mangling, true).await?);
+    .worker_forwarded_globals(worker_forwarded_globals())
+    .emit_options(minify_emit_options(minify, no_mangling, true).await?);
 
     builder = builder.source_map_source_type(if next_mode.is_development() {
         SourceMapSourceType::AbsoluteFileUri
@@ -1205,9 +1204,8 @@ pub async fn get_server_chunking_context(
     .debug_ids(*debug_ids.await?)
     .hash_salt(hash_salt)
     .nested_async_availability(*nested_async_chunking.await?)
-    .worker_forwarded_globals(worker_forwarded_globals());
-
-    builder = builder.emit_options(minify_emit_options(minify, no_mangling, false).await?);
+    .worker_forwarded_globals(worker_forwarded_globals())
+    .emit_options(minify_emit_options(minify, no_mangling, false).await?);
 
     if next_mode.is_development() {
         builder = builder.source_map_source_type(SourceMapSourceType::AbsoluteFileUri);

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -15,8 +15,8 @@ use turbopack::{
 };
 use turbopack_core::{
     chunk::{
-        AssetSuffix, ChunkingConfig, MangleType, MinifyType, SourceMapSourceType, SourceMapsType,
-        UnusedReferences, UrlBehavior, chunk_id_strategy::ModuleIdStrategy,
+        AssetSuffix, ChunkingConfig, SourceMapSourceType, SourceMapsType, UnusedReferences,
+        UrlBehavior, chunk_id_strategy::ModuleIdStrategy,
     },
     compile_time_defines,
     compile_time_info::{CompileTimeDefines, CompileTimeInfo, FreeVarReferences},
@@ -1089,14 +1089,6 @@ pub async fn get_server_chunking_context_with_client_assets(
         suffix: AssetSuffix::Inferred,
         static_suffix: ResolvedVc::cell(None),
     })
-    .minify_type(if *minify.await? {
-        MinifyType::Minify {
-            // React needs deterministic function names to work correctly.
-            mangle: (!*no_mangling.await?).then_some(MangleType::Deterministic),
-        }
-    } else {
-        MinifyType::NoMinify
-    })
     .source_maps(*source_maps.await?)
     .module_id_strategy(module_id_strategy.to_resolved().await?)
     .export_usage(*export_usage.await?)
@@ -1210,13 +1202,6 @@ pub async fn get_server_chunking_context(
     .default_url_behavior(UrlBehavior {
         suffix: AssetSuffix::Inferred,
         static_suffix: ResolvedVc::cell(None),
-    })
-    .minify_type(if *minify.await? {
-        MinifyType::Minify {
-            mangle: (!*no_mangling.await?).then_some(MangleType::OptimalSize),
-        }
-    } else {
-        MinifyType::NoMinify
     })
     .source_maps(*source_maps.await?)
     .module_id_strategy(module_id_strategy.to_resolved().await?)

--- a/crates/next-core/src/util.rs
+++ b/crates/next-core/src/util.rs
@@ -4,6 +4,7 @@ use anyhow::{Result, bail};
 use bincode::{Decode, Encode};
 use next_taskless::{expand_next_js_template, expand_next_js_template_no_imports};
 use serde::{Deserialize, de::DeserializeOwned};
+use smallvec::{SmallVec, smallvec};
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     FxIndexMap, NonLocalValue, ResolvedVc, TaskInput, Vc, fxindexset, trace::TraceRawVcs, turbobail,
@@ -572,9 +573,9 @@ pub async fn minify_emit_options(
     minify: Vc<bool>,
     no_mangling: Vc<bool>,
     deterministic_mangle: bool,
-) -> Result<Vec<ResolvedVc<Box<dyn EmitOption>>>> {
+) -> Result<SmallVec<[ResolvedVc<Box<dyn EmitOption>>; 2]>> {
     if !*minify.await? {
-        return Ok(vec![]);
+        return Ok(SmallVec::new());
     }
 
     let ecma_opts = if *no_mangling.await? {
@@ -592,7 +593,7 @@ pub async fn minify_emit_options(
     };
     let css_opts = CssEmitOptions::builder().preset_minify().build();
 
-    Ok(vec![
+    Ok(smallvec![
         ResolvedVc::upcast(ecma_opts.resolved_cell()),
         ResolvedVc::upcast(css_opts.resolved_cell()),
     ])

--- a/crates/next-core/src/util.rs
+++ b/crates/next-core/src/util.rs
@@ -6,12 +6,13 @@ use next_taskless::{expand_next_js_template, expand_next_js_template_no_imports}
 use serde::{Deserialize, de::DeserializeOwned};
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
-    FxIndexMap, NonLocalValue, TaskInput, Vc, fxindexset, trace::TraceRawVcs, turbobail,
+    FxIndexMap, NonLocalValue, ResolvedVc, TaskInput, Vc, fxindexset, trace::TraceRawVcs, turbobail,
 };
 use turbo_tasks_fs::{File, FileContent, FileJsonContent, FileSystem, FileSystemPath, rope::Rope};
 use turbopack::module_options::RuleCondition;
 use turbopack_core::{
     asset::AssetContent,
+    chunk::EmitOption,
     compile_time_info::{
         CompileTimeDefineValue, CompileTimeDefines, DefinableNameSegment, FreeVarReference,
         FreeVarReferences,
@@ -21,6 +22,8 @@ use turbopack_core::{
     source::Source,
     virtual_source::VirtualSource,
 };
+use turbopack_css::emit_options::CssEmitOptions;
+use turbopack_ecmascript::emit_options::EcmascriptEmitOptions;
 
 use crate::{
     embed_js::next_js_fs, next_config::NextConfig, next_import_map::get_next_package,
@@ -556,4 +559,41 @@ pub fn worker_forwarded_globals() -> Vec<RcStr> {
         rcstr!("NEXT_DEPLOYMENT_ID"),
         rcstr!("NEXT_CLIENT_ASSET_SUFFIX"),
     ]
+}
+
+/// Returns JS and CSS minification emit options to add to a chunking context
+/// builder. Returns an empty `Vec` when minification is disabled.
+///
+/// `deterministic_mangle` selects the mangling strategy used when mangling IS
+/// enabled (i.e. `no_mangling` is `false`):
+/// - `true`  → `preset_minify_deterministic` (stable names, used for SSR)
+/// - `false` → `preset_minify_optimal_size`  (smallest output, used for client)
+pub async fn minify_emit_options(
+    minify: Vc<bool>,
+    no_mangling: Vc<bool>,
+    deterministic_mangle: bool,
+) -> Result<Vec<ResolvedVc<Box<dyn EmitOption>>>> {
+    if !*minify.await? {
+        return Ok(vec![]);
+    }
+
+    let ecma_opts = if *no_mangling.await? {
+        EcmascriptEmitOptions::builder()
+            .preset_minify_no_mangle()
+            .build()
+    } else if deterministic_mangle {
+        EcmascriptEmitOptions::builder()
+            .preset_minify_deterministic()
+            .build()
+    } else {
+        EcmascriptEmitOptions::builder()
+            .preset_minify_optimal_size()
+            .build()
+    };
+    let css_opts = CssEmitOptions::builder().preset_minify().build();
+
+    Ok(vec![
+        ResolvedVc::upcast(ecma_opts.resolved_cell()),
+        ResolvedVc::upcast(css_opts.resolved_cell()),
+    ])
 }

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -9,7 +9,7 @@ use turbopack_core::{
     chunk::{
         AssetSuffix, Chunk, ChunkGroupResult, ChunkItem, ChunkType, ChunkableModule,
         ChunkingConfig, ChunkingConfigs, ChunkingContext, ContentHashing, CrossOrigin, EmitOption,
-        EmitOptions, EntryChunkGroupResult, EvaluatableAsset, EvaluatableAssets, MinifyType,
+        EmitOptions, EntryChunkGroupResult, EvaluatableAsset, EvaluatableAssets,
         SourceMapSourceType, SourceMapsType, UnusedReferences, UrlBehavior,
         availability_info::AvailabilityInfo,
         chunk_group::{MakeChunkGroupResult, make_chunk_group},
@@ -115,11 +115,6 @@ impl BrowserChunkingContextBuilder {
 
     pub fn manifest_chunks(mut self, manifest_chunks: bool) -> Self {
         self.chunking_context.manifest_chunks = manifest_chunks;
-        self
-    }
-
-    pub fn minify_type(mut self, minify_type: MinifyType) -> Self {
-        self.chunking_context.minify_type = minify_type;
         self
     }
 
@@ -303,8 +298,6 @@ pub struct BrowserChunkingContext {
     environment: ResolvedVc<Environment>,
     /// The kind of runtime to include in the output.
     runtime_type: RuntimeType,
-    /// Whether to minify resulting chunks
-    minify_type: MinifyType,
     /// Emit options
     emit_options: Vec<ResolvedVc<Box<dyn EmitOption>>>,
     /// Whether content hashing is enabled for chunk filenames.
@@ -375,7 +368,6 @@ impl BrowserChunkingContext {
                 debug_ids: false,
                 environment,
                 runtime_type,
-                minify_type: MinifyType::NoMinify,
                 emit_options: vec![],
                 chunk_content_hashing: None,
                 asset_content_hashing: ContentHashing::Direct { length: 13 },
@@ -491,12 +483,6 @@ impl BrowserChunkingContext {
     #[turbo_tasks::function]
     pub fn source_maps_type(&self) -> Vc<SourceMapsType> {
         self.source_maps_type.cell()
-    }
-
-    /// Returns the minify type.
-    #[turbo_tasks::function]
-    pub fn minify_type(&self) -> Vc<MinifyType> {
-        self.minify_type.cell()
     }
 
     /// Returns the chunk path information.
@@ -731,11 +717,6 @@ impl ChunkingContext for BrowserChunkingContext {
     #[turbo_tasks::function]
     fn is_dynamic_chunk_content_loading_enabled(&self) -> Vc<bool> {
         Vc::cell(self.enable_dynamic_chunk_content_loading)
-    }
-
-    #[turbo_tasks::function]
-    pub fn minify_type(&self) -> Vc<MinifyType> {
-        self.minify_type.cell()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -123,6 +123,14 @@ impl BrowserChunkingContextBuilder {
         self
     }
 
+    pub fn emit_options(
+        mut self,
+        opts: impl IntoIterator<Item = ResolvedVc<Box<dyn EmitOption>>>,
+    ) -> Self {
+        self.chunking_context.emit_options.extend(opts);
+        self
+    }
+
     pub fn source_maps(mut self, source_maps: SourceMapsType) -> Self {
         self.chunking_context.source_maps_type = source_maps;
         self

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -8,8 +8,8 @@ use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{
         AssetSuffix, Chunk, ChunkGroupResult, ChunkItem, ChunkType, ChunkableModule,
-        ChunkingConfig, ChunkingConfigs, ChunkingContext, ContentHashing, CrossOrigin,
-        EntryChunkGroupResult, EvaluatableAsset, EvaluatableAssets, MinifyType,
+        ChunkingConfig, ChunkingConfigs, ChunkingContext, ContentHashing, CrossOrigin, EmitOption,
+        EmitOptions, EntryChunkGroupResult, EvaluatableAsset, EvaluatableAssets, MinifyType,
         SourceMapSourceType, SourceMapsType, UnusedReferences, UrlBehavior,
         availability_info::AvailabilityInfo,
         chunk_group::{MakeChunkGroupResult, make_chunk_group},
@@ -120,6 +120,11 @@ impl BrowserChunkingContextBuilder {
 
     pub fn minify_type(mut self, minify_type: MinifyType) -> Self {
         self.chunking_context.minify_type = minify_type;
+        self
+    }
+
+    pub fn emit_option(mut self, opt: ResolvedVc<Box<dyn EmitOption>>) -> Self {
+        self.chunking_context.emit_options.push(opt);
         self
     }
 
@@ -300,6 +305,8 @@ pub struct BrowserChunkingContext {
     runtime_type: RuntimeType,
     /// Whether to minify resulting chunks
     minify_type: MinifyType,
+    /// Emit options
+    emit_options: Vec<ResolvedVc<Box<dyn EmitOption>>>,
     /// Whether content hashing is enabled for chunk filenames.
     chunk_content_hashing: Option<ContentHashing>,
     /// Content hashing for asset filenames.
@@ -369,6 +376,7 @@ impl BrowserChunkingContext {
                 environment,
                 runtime_type,
                 minify_type: MinifyType::NoMinify,
+                emit_options: vec![],
                 chunk_content_hashing: None,
                 asset_content_hashing: ContentHashing::Direct { length: 13 },
                 source_maps_type: SourceMapsType::Full,
@@ -728,6 +736,11 @@ impl ChunkingContext for BrowserChunkingContext {
     #[turbo_tasks::function]
     pub fn minify_type(&self) -> Vc<MinifyType> {
         self.minify_type.cell()
+    }
+
+    #[turbo_tasks::function]
+    fn emit_options(&self) -> Vc<EmitOptions> {
+        Vc::cell(self.emit_options.clone())
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-browser/src/ecmascript/content.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/content.rs
@@ -7,7 +7,7 @@ use turbo_tasks::{ResolvedVc, Vc, turbobail};
 use turbo_tasks_fs::{File, FileContent};
 use turbopack_core::{
     asset::AssetContent,
-    chunk::{ChunkingContext, ModuleId, find_emit_option},
+    chunk::{ChunkingContext, ModuleId},
     code_builder::{Code, CodeBuilder},
     output::OutputAsset,
     source_map::{GenerateSourceMap, SourceMapAsset},
@@ -130,13 +130,10 @@ impl EcmascriptBrowserChunkContent {
 
         let mut code = code.build();
 
-        if let Some(ecma_opts) =
-            find_emit_option::<EcmascriptEmitOptions>(this.chunking_context.emit_options()).await?
-        {
-            let ecma_opts = ecma_opts.await?;
-            if let Some(ref swc_opts) = ecma_opts.swc_minify_options {
-                code = minify(code, source_maps, swc_opts)?;
-            }
+        let ecma_opts =
+            EcmascriptEmitOptions::get_or_default(Vc::upcast(*this.chunking_context)).await?;
+        if let Some(ref swc_opts) = ecma_opts.swc_minify_options {
+            code = minify(code, source_maps, swc_opts)?;
         }
 
         Ok(code.cell())

--- a/turbopack/crates/turbopack-browser/src/ecmascript/content.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/content.rs
@@ -7,13 +7,16 @@ use turbo_tasks::{ResolvedVc, Vc, turbobail};
 use turbo_tasks_fs::{File, FileContent};
 use turbopack_core::{
     asset::AssetContent,
-    chunk::{ChunkingContext, MinifyType, ModuleId},
+    chunk::{ChunkingContext, ModuleId, find_emit_option},
     code_builder::{Code, CodeBuilder},
     output::OutputAsset,
     source_map::{GenerateSourceMap, SourceMapAsset},
     version::{MergeableVersionedContent, Version, VersionedContent, VersionedContentMerger},
 };
-use turbopack_ecmascript::{chunk::EcmascriptChunkContent, minify::minify, utils::StringifyJs};
+use turbopack_ecmascript::{
+    chunk::EcmascriptChunkContent, emit_options::EcmascriptEmitOptions, minify::minify,
+    utils::StringifyJs,
+};
 
 use super::{
     chunk::EcmascriptBrowserChunk, content_entry::EcmascriptBrowserChunkContentEntries,
@@ -127,8 +130,13 @@ impl EcmascriptBrowserChunkContent {
 
         let mut code = code.build();
 
-        if let MinifyType::Minify { mangle } = *this.chunking_context.minify_type().await? {
-            code = minify(code, source_maps, mangle)?;
+        if let Some(ecma_opts) =
+            find_emit_option::<EcmascriptEmitOptions>(this.chunking_context.emit_options()).await?
+        {
+            let ecma_opts = ecma_opts.await?;
+            if let Some(ref swc_opts) = ecma_opts.swc_minify_options {
+                code = minify(code, source_maps, swc_opts)?;
+            }
         }
 
         Ok(code.cell())

--- a/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
@@ -11,7 +11,6 @@ use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{
         ChunkData, ChunkingContext, ChunksData, EvaluatableAssets, ModuleChunkItemIdExt, ModuleId,
-        find_emit_option,
     },
     code_builder::{Code, CodeBuilder},
     ident::AssetIdent,
@@ -199,13 +198,10 @@ impl EcmascriptBrowserEvaluateChunk {
 
         let mut code = code.build();
 
-        if let Some(ecma_opts) =
-            find_emit_option::<EcmascriptEmitOptions>(this.chunking_context.emit_options()).await?
-        {
-            let ecma_opts = ecma_opts.await?;
-            if let Some(ref swc_opts) = ecma_opts.swc_minify_options {
-                code = minify(code, source_maps, swc_opts)?;
-            }
+        let ecma_opts =
+            EcmascriptEmitOptions::get_or_default(Vc::upcast(*this.chunking_context)).await?;
+        if let Some(ref swc_opts) = ecma_opts.swc_minify_options {
+            code = minify(code, source_maps, swc_opts)?;
         }
 
         Ok(code.cell())

--- a/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
@@ -10,8 +10,8 @@ use turbo_tasks_fs::{File, FileContent, FileSystemPath};
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{
-        ChunkData, ChunkingContext, ChunksData, EvaluatableAssets, MinifyType,
-        ModuleChunkItemIdExt, ModuleId,
+        ChunkData, ChunkingContext, ChunksData, EvaluatableAssets, ModuleChunkItemIdExt, ModuleId,
+        find_emit_option,
     },
     code_builder::{Code, CodeBuilder},
     ident::AssetIdent,
@@ -22,6 +22,7 @@ use turbopack_core::{
 };
 use turbopack_ecmascript::{
     chunk::{EcmascriptChunkData, EcmascriptChunkPlaceable},
+    emit_options::EcmascriptEmitOptions,
     minify::minify,
     utils::StringifyJs,
 };
@@ -198,8 +199,13 @@ impl EcmascriptBrowserEvaluateChunk {
 
         let mut code = code.build();
 
-        if let MinifyType::Minify { mangle } = *this.chunking_context.minify_type().await? {
-            code = minify(code, source_maps, mangle)?;
+        if let Some(ecma_opts) =
+            find_emit_option::<EcmascriptEmitOptions>(this.chunking_context.emit_options()).await?
+        {
+            let ecma_opts = ecma_opts.await?;
+            if let Some(ref swc_opts) = ecma_opts.swc_minify_options {
+                code = minify(code, source_maps, swc_opts)?;
+            }
         }
 
         Ok(code.cell())

--- a/turbopack/crates/turbopack-browser/src/ecmascript/worker.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/worker.rs
@@ -8,7 +8,7 @@ use turbo_tasks_fs::{File, FileContent, FileSystemPath};
 use turbo_tasks_hash::hash_xxh3_hash64;
 use turbopack_core::{
     asset::{Asset, AssetContent},
-    chunk::{ChunkingContext, find_emit_option},
+    chunk::ChunkingContext,
     code_builder::{Code, CodeBuilder},
     ident::AssetIdent,
     output::{OutputAsset, OutputAssetsReference, OutputAssetsWithReferenced},
@@ -57,13 +57,9 @@ impl EcmascriptBrowserWorkerEntrypoint {
         let forwarded_globals = this.forwarded_globals.await?;
         let mut code = generate_worker_bootstrap_code(&forwarded_globals)?;
 
-        if let Some(ecma_opts) =
-            find_emit_option::<EcmascriptEmitOptions>(this.chunking_context.emit_options()).await?
-        {
-            let ecma_opts = ecma_opts.await?;
-            if let Some(ref swc_opts) = ecma_opts.swc_minify_options {
-                code = minify(code, source_maps, swc_opts)?;
-            }
+        let ecma_opts = EcmascriptEmitOptions::get_or_default(*this.chunking_context).await?;
+        if let Some(ref swc_opts) = ecma_opts.swc_minify_options {
+            code = minify(code, source_maps, swc_opts)?;
         }
 
         Ok(code.cell())

--- a/turbopack/crates/turbopack-browser/src/ecmascript/worker.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/worker.rs
@@ -8,13 +8,13 @@ use turbo_tasks_fs::{File, FileContent, FileSystemPath};
 use turbo_tasks_hash::hash_xxh3_hash64;
 use turbopack_core::{
     asset::{Asset, AssetContent},
-    chunk::{ChunkingContext, MinifyType},
+    chunk::{ChunkingContext, find_emit_option},
     code_builder::{Code, CodeBuilder},
     ident::AssetIdent,
     output::{OutputAsset, OutputAssetsReference, OutputAssetsWithReferenced},
     source_map::{GenerateSourceMap, SourceMapAsset},
 };
-use turbopack_ecmascript::minify::minify;
+use turbopack_ecmascript::{emit_options::EcmascriptEmitOptions, minify::minify};
 
 /// A pre-compiled worker entrypoint that bootstraps workers by reading config from URL params.
 ///
@@ -57,8 +57,13 @@ impl EcmascriptBrowserWorkerEntrypoint {
         let forwarded_globals = this.forwarded_globals.await?;
         let mut code = generate_worker_bootstrap_code(&forwarded_globals)?;
 
-        if let MinifyType::Minify { mangle } = *this.chunking_context.minify_type().await? {
-            code = minify(code, source_maps, mangle)?;
+        if let Some(ecma_opts) =
+            find_emit_option::<EcmascriptEmitOptions>(this.chunking_context.emit_options()).await?
+        {
+            let ecma_opts = ecma_opts.await?;
+            if let Some(ref swc_opts) = ecma_opts.swc_minify_options {
+                code = minify(code, source_maps, swc_opts)?;
+            }
         }
 
         Ok(code.cell())

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -27,7 +27,7 @@ use turbopack_core::{
     asset::Asset,
     chunk::{
         ChunkingConfig, ChunkingContext, ChunkingContextExt, ContentHashing, EvaluatableAsset,
-        MangleType, MinifyType, SourceMapsType, availability_info::AvailabilityInfo,
+        SourceMapsType, availability_info::AvailabilityInfo,
     },
     environment::{BrowserEnvironment, Environment, ExecutionEnvironment, NodeJsEnvironment},
     ident::AssetIdent,
@@ -72,7 +72,7 @@ pub struct TurbopackBuildBuilder {
     show_all: bool,
     log_detail: bool,
     source_maps_type: SourceMapsType,
-    minify_type: MinifyType,
+    minify: bool,
     target: Target,
     scope_hoist: bool,
 }
@@ -91,9 +91,7 @@ impl TurbopackBuildBuilder {
             show_all: false,
             log_detail: false,
             source_maps_type: SourceMapsType::Full,
-            minify_type: MinifyType::Minify {
-                mangle: Some(MangleType::OptimalSize),
-            },
+            minify: true,
             target: Target::Node,
             scope_hoist: true,
         }
@@ -129,8 +127,8 @@ impl TurbopackBuildBuilder {
         self
     }
 
-    pub fn minify_type(mut self, minify_type: MinifyType) -> Self {
-        self.minify_type = minify_type;
+    pub fn minify(mut self, minify: bool) -> Self {
+        self.minify = minify;
         self
     }
 
@@ -153,7 +151,7 @@ impl TurbopackBuildBuilder {
                     self.entry_requests.clone(),
                     self.browserslist_query,
                     self.source_maps_type,
-                    self.minify_type,
+                    self.minify,
                     self.target,
                     self.scope_hoist,
                 ));
@@ -193,7 +191,7 @@ async fn build_internal(
     entry_requests: Vec<EntryRequest>,
     browserslist_query: RcStr,
     source_maps_type: SourceMapsType,
-    minify_type: MinifyType,
+    minify: bool,
     target: Target,
     scope_hoist: bool,
 ) -> Result<()> {
@@ -356,24 +354,12 @@ async fn build_internal(
             .module_id_strategy(module_id_strategy)
             .export_usage(Some(binding_usage.connect().to_resolved().await?))
             .unused_references(unused_references)
-            .current_chunk_method(CurrentChunkMethod::DocumentCurrentScript)
-            .minify_type(minify_type);
+            .current_chunk_method(CurrentChunkMethod::DocumentCurrentScript);
 
-            if matches!(minify_type, MinifyType::Minify { .. }) {
-                let MinifyType::Minify { mangle } = minify_type else {
-                    unreachable!()
-                };
-                let ecma_opts = match mangle {
-                    Some(MangleType::OptimalSize) => EcmascriptEmitOptions::builder()
-                        .preset_minify_optimal_size()
-                        .build(),
-                    Some(MangleType::Deterministic) => EcmascriptEmitOptions::builder()
-                        .preset_minify_deterministic()
-                        .build(),
-                    None => EcmascriptEmitOptions::builder()
-                        .preset_minify_no_mangle()
-                        .build(),
-                };
+            if minify {
+                let ecma_opts = EcmascriptEmitOptions::builder()
+                    .preset_minify_optimal_size()
+                    .build();
                 let css_opts = CssEmitOptions::builder().preset_minify().build();
                 builder = builder
                     .emit_option(ResolvedVc::upcast(ecma_opts.resolved_cell()))
@@ -427,24 +413,12 @@ async fn build_internal(
             .source_maps(source_maps_type)
             .module_id_strategy(module_id_strategy)
             .export_usage(Some(binding_usage.connect().to_resolved().await?))
-            .unused_references(unused_references)
-            .minify_type(minify_type);
+            .unused_references(unused_references);
 
-            if matches!(minify_type, MinifyType::Minify { .. }) {
-                let MinifyType::Minify { mangle } = minify_type else {
-                    unreachable!()
-                };
-                let ecma_opts = match mangle {
-                    Some(MangleType::OptimalSize) => EcmascriptEmitOptions::builder()
-                        .preset_minify_optimal_size()
-                        .build(),
-                    Some(MangleType::Deterministic) => EcmascriptEmitOptions::builder()
-                        .preset_minify_deterministic()
-                        .build(),
-                    None => EcmascriptEmitOptions::builder()
-                        .preset_minify_no_mangle()
-                        .build(),
-                };
+            if minify {
+                let ecma_opts = EcmascriptEmitOptions::builder()
+                    .preset_minify_optimal_size()
+                    .build();
                 let css_opts = CssEmitOptions::builder().preset_minify().build();
                 builder = builder
                     .emit_option(ResolvedVc::upcast(ecma_opts.resolved_cell()))
@@ -633,13 +607,7 @@ pub async fn build(args: &BuildArguments) -> Result<()> {
         } else {
             SourceMapsType::Full
         })
-        .minify_type(if args.no_minify {
-            MinifyType::NoMinify
-        } else {
-            MinifyType::Minify {
-                mangle: Some(MangleType::OptimalSize),
-            }
-        })
+        .minify(!args.no_minify)
         .scope_hoist(!args.no_scope_hoist)
         .target(args.common.target.unwrap_or(Target::Node))
         .show_all(args.common.show_all);

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -365,17 +365,16 @@ async fn build_internal(
                 };
                 let ecma_opts = match mangle {
                     Some(MangleType::OptimalSize) => EcmascriptEmitOptions::builder()
-                        .mangle_optimal_size()
+                        .preset_minify_optimal_size()
                         .build(),
                     Some(MangleType::Deterministic) => EcmascriptEmitOptions::builder()
-                        .mangle_deterministic()
+                        .preset_minify_deterministic()
                         .build(),
-                    None => EcmascriptEmitOptions::builder().no_mangle().build(),
+                    None => EcmascriptEmitOptions::builder()
+                        .preset_minify_no_mangle()
+                        .build(),
                 };
-                let css_opts = CssEmitOptions::builder()
-                    .minify(true)
-                    .chunk_item_comments(false)
-                    .build();
+                let css_opts = CssEmitOptions::builder().preset_minify().build();
                 builder = builder
                     .emit_option(ResolvedVc::upcast(ecma_opts.resolved_cell()))
                     .emit_option(ResolvedVc::upcast(css_opts.resolved_cell()));
@@ -437,17 +436,16 @@ async fn build_internal(
                 };
                 let ecma_opts = match mangle {
                     Some(MangleType::OptimalSize) => EcmascriptEmitOptions::builder()
-                        .mangle_optimal_size()
+                        .preset_minify_optimal_size()
                         .build(),
                     Some(MangleType::Deterministic) => EcmascriptEmitOptions::builder()
-                        .mangle_deterministic()
+                        .preset_minify_deterministic()
                         .build(),
-                    None => EcmascriptEmitOptions::builder().no_mangle().build(),
+                    None => EcmascriptEmitOptions::builder()
+                        .preset_minify_no_mangle()
+                        .build(),
                 };
-                let css_opts = CssEmitOptions::builder()
-                    .minify(true)
-                    .chunk_item_comments(false)
-                    .build();
+                let css_opts = CssEmitOptions::builder().preset_minify().build();
                 builder = builder
                     .emit_option(ResolvedVc::upcast(ecma_opts.resolved_cell()))
                     .emit_option(ResolvedVc::upcast(css_opts.resolved_cell()));

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -26,8 +26,8 @@ use turbopack_cli_utils::issue::{ConsoleUi, LogOptions};
 use turbopack_core::{
     asset::Asset,
     chunk::{
-        ChunkingConfig, ChunkingContext, ChunkingContextExt, ContentHashing, EvaluatableAsset,
-        SourceMapsType, availability_info::AvailabilityInfo,
+        ChunkingConfig, ChunkingContext, ChunkingContextExt, ContentHashing, EmitOption,
+        EvaluatableAsset, SourceMapsType, availability_info::AvailabilityInfo,
     },
     environment::{BrowserEnvironment, Environment, ExecutionEnvironment, NodeJsEnvironment},
     ident::AssetIdent,
@@ -182,6 +182,17 @@ impl TurbopackBuildBuilder {
 async fn extract_effects_operation(op: OperationVc<()>) -> Result<Vc<Effects>> {
     let _ = op.resolve().strongly_consistent().await?;
     Ok(take_effects(op).await?.cell())
+}
+
+fn minify_emit_options() -> [ResolvedVc<Box<dyn EmitOption>>; 2] {
+    let ecma_opts = EcmascriptEmitOptions::builder()
+        .preset_minify_optimal_size()
+        .build();
+    let css_opts = CssEmitOptions::builder().preset_minify().build();
+    [
+        ResolvedVc::upcast(ecma_opts.resolved_cell()),
+        ResolvedVc::upcast(css_opts.resolved_cell()),
+    ]
 }
 
 #[turbo_tasks::function(operation)]
@@ -357,13 +368,7 @@ async fn build_internal(
             .current_chunk_method(CurrentChunkMethod::DocumentCurrentScript);
 
             if minify {
-                let ecma_opts = EcmascriptEmitOptions::builder()
-                    .preset_minify_optimal_size()
-                    .build();
-                let css_opts = CssEmitOptions::builder().preset_minify().build();
-                builder = builder
-                    .emit_option(ResolvedVc::upcast(ecma_opts.resolved_cell()))
-                    .emit_option(ResolvedVc::upcast(css_opts.resolved_cell()));
+                builder = builder.emit_options(minify_emit_options());
             }
 
             match *node_env.await? {
@@ -416,13 +421,7 @@ async fn build_internal(
             .unused_references(unused_references);
 
             if minify {
-                let ecma_opts = EcmascriptEmitOptions::builder()
-                    .preset_minify_optimal_size()
-                    .build();
-                let css_opts = CssEmitOptions::builder().preset_minify().build();
-                builder = builder
-                    .emit_option(ResolvedVc::upcast(ecma_opts.resolved_cell()))
-                    .emit_option(ResolvedVc::upcast(css_opts.resolved_cell()));
+                builder = builder.emit_options(minify_emit_options());
             }
 
             match *node_env.await? {

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -45,8 +45,8 @@ use turbopack_core::{
         parse::Request,
     },
 };
-use turbopack_css::chunk::CssChunkType;
-use turbopack_ecmascript::chunk::EcmascriptChunkType;
+use turbopack_css::{chunk::CssChunkType, emit_options::CssEmitOptions};
+use turbopack_ecmascript::{chunk::EcmascriptChunkType, emit_options::EcmascriptEmitOptions};
 use turbopack_ecmascript_runtime::RuntimeType;
 use turbopack_env::dotenv::load_env;
 use turbopack_node::{child_process_backend, execution_context::ExecutionContext};
@@ -359,6 +359,28 @@ async fn build_internal(
             .current_chunk_method(CurrentChunkMethod::DocumentCurrentScript)
             .minify_type(minify_type);
 
+            if matches!(minify_type, MinifyType::Minify { .. }) {
+                let MinifyType::Minify { mangle } = minify_type else {
+                    unreachable!()
+                };
+                let ecma_opts = match mangle {
+                    Some(MangleType::OptimalSize) => EcmascriptEmitOptions::builder()
+                        .mangle_optimal_size()
+                        .build(),
+                    Some(MangleType::Deterministic) => EcmascriptEmitOptions::builder()
+                        .mangle_deterministic()
+                        .build(),
+                    None => EcmascriptEmitOptions::builder().no_mangle().build(),
+                };
+                let css_opts = CssEmitOptions::builder()
+                    .minify(true)
+                    .chunk_item_comments(false)
+                    .build();
+                builder = builder
+                    .emit_option(ResolvedVc::upcast(ecma_opts.resolved_cell()))
+                    .emit_option(ResolvedVc::upcast(css_opts.resolved_cell()));
+            }
+
             match *node_env.await? {
                 NodeEnv::Development => {}
                 NodeEnv::Production => {
@@ -408,6 +430,28 @@ async fn build_internal(
             .export_usage(Some(binding_usage.connect().to_resolved().await?))
             .unused_references(unused_references)
             .minify_type(minify_type);
+
+            if matches!(minify_type, MinifyType::Minify { .. }) {
+                let MinifyType::Minify { mangle } = minify_type else {
+                    unreachable!()
+                };
+                let ecma_opts = match mangle {
+                    Some(MangleType::OptimalSize) => EcmascriptEmitOptions::builder()
+                        .mangle_optimal_size()
+                        .build(),
+                    Some(MangleType::Deterministic) => EcmascriptEmitOptions::builder()
+                        .mangle_deterministic()
+                        .build(),
+                    None => EcmascriptEmitOptions::builder().no_mangle().build(),
+                };
+                let css_opts = CssEmitOptions::builder()
+                    .minify(true)
+                    .chunk_item_comments(false)
+                    .build();
+                builder = builder
+                    .emit_option(ResolvedVc::upcast(ecma_opts.resolved_cell()))
+                    .emit_option(ResolvedVc::upcast(css_opts.resolved_cell()));
+            }
 
             match *node_env.await? {
                 NodeEnv::Development => {}

--- a/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
@@ -57,44 +57,6 @@ where
     Ok(None)
 }
 
-#[derive(
-    Debug,
-    TaskInput,
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    Hash,
-    Deserialize,
-    TraceRawVcs,
-    DeterministicHash,
-    NonLocalValue,
-    Encode,
-    Decode,
-)]
-#[serde(rename_all = "kebab-case")]
-pub enum MangleType {
-    OptimalSize,
-    Deterministic,
-}
-
-#[turbo_tasks::value(shared)]
-#[derive(Debug, TaskInput, Clone, Copy, Hash, DeterministicHash, Deserialize)]
-pub enum MinifyType {
-    // TODO instead of adding a new property here,
-    // refactor that to Minify(MinifyOptions) to allow defaults on MinifyOptions
-    Minify { mangle: Option<MangleType> },
-    NoMinify,
-}
-
-impl Default for MinifyType {
-    fn default() -> Self {
-        Self::Minify {
-            mangle: Some(MangleType::OptimalSize),
-        }
-    }
-}
-
 #[turbo_tasks::value(shared)]
 #[derive(Debug, Default, TaskInput, Clone, Copy, Hash, DeterministicHash)]
 pub enum SourceMapsType {
@@ -435,11 +397,6 @@ pub trait ChunkingContext {
     #[turbo_tasks::function]
     fn is_dynamic_chunk_content_loading_enabled(self: Vc<Self>) -> Vc<bool> {
         Vc::cell(false)
-    }
-
-    #[turbo_tasks::function]
-    fn minify_type(self: Vc<Self>) -> Vc<MinifyType> {
-        MinifyType::NoMinify.cell()
     }
 
     /// Returns the list of emit options for this chunking context.

--- a/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
@@ -29,6 +29,34 @@ use crate::{
     reference::ModuleReference,
 };
 
+/// A marker trait for emit options that can be stored in a chunking context.
+///
+/// Different crates can define their own emit option types (e.g., `EcmascriptEmitOptions`,
+/// `CssEmitOptions`) without requiring the core crate to depend on their specific dependencies
+/// (e.g., SWC).
+#[turbo_tasks::value_trait]
+pub trait EmitOption {}
+
+/// A heterogeneous list of emit options stored in a chunking context.
+#[turbo_tasks::value(transparent)]
+pub struct EmitOptions(Vec<ResolvedVc<Box<dyn EmitOption>>>);
+
+/// Find a specific emit option type from the list, returning the last matching one.
+///
+/// Returns `None` if no matching option is found, in which case callers should use defaults.
+pub async fn find_emit_option<T>(list: Vc<EmitOptions>) -> Result<Option<Vc<T>>>
+where
+    T: turbo_tasks::VcValueType + turbo_tasks::UpcastStrict<Box<dyn EmitOption>>,
+{
+    let list = list.await?;
+    for item in list.iter().rev() {
+        if let Some(downcasted) = ResolvedVc::try_downcast_type::<T>(*item) {
+            return Ok(Some(*downcasted));
+        }
+    }
+    Ok(None)
+}
+
 #[derive(
     Debug,
     TaskInput,
@@ -412,6 +440,15 @@ pub trait ChunkingContext {
     #[turbo_tasks::function]
     fn minify_type(self: Vc<Self>) -> Vc<MinifyType> {
         MinifyType::NoMinify.cell()
+    }
+
+    /// Returns the list of emit options for this chunking context.
+    ///
+    /// Emit options allow crate-specific configuration (e.g., SWC minify options,
+    /// CSS minification settings) without requiring turbopack-core to depend on those crates.
+    #[turbo_tasks::function]
+    fn emit_options(self: Vc<Self>) -> Vc<EmitOptions> {
+        Vc::cell(vec![])
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
@@ -49,12 +49,12 @@ where
     T: turbo_tasks::VcValueType + turbo_tasks::UpcastStrict<Box<dyn EmitOption>>,
 {
     let list = list.await?;
-    for item in list.iter().rev() {
-        if let Some(downcasted) = ResolvedVc::try_downcast_type::<T>(*item) {
-            return Ok(Some(*downcasted));
-        }
-    }
-    Ok(None)
+    Ok(list
+        .iter()
+        .rev()
+        .filter_map(|item| ResolvedVc::try_downcast_type::<T>(*item))
+        .next()
+        .map(|v| *v))
 }
 
 #[turbo_tasks::value(shared)]

--- a/turbopack/crates/turbopack-core/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/mod.rs
@@ -29,8 +29,7 @@ pub use crate::chunk::{
     chunking_context::{
         AssetSuffix, ChunkGroupResult, ChunkGroupType, ChunkingConfig, ChunkingConfigs,
         ChunkingContext, ChunkingContextExt, EmitOption, EmitOptions, EntryChunkGroupResult,
-        MangleType, MinifyType, SourceMapSourceType, SourceMapsType, UnusedReferences, UrlBehavior,
-        find_emit_option,
+        SourceMapSourceType, SourceMapsType, UnusedReferences, UrlBehavior, find_emit_option,
     },
     data::{ChunkData, ChunkDataOption, ChunksData},
     evaluate::{EvaluatableAsset, EvaluatableAssetExt, EvaluatableAssets},

--- a/turbopack/crates/turbopack-core/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/mod.rs
@@ -28,8 +28,9 @@ pub use crate::chunk::{
     },
     chunking_context::{
         AssetSuffix, ChunkGroupResult, ChunkGroupType, ChunkingConfig, ChunkingConfigs,
-        ChunkingContext, ChunkingContextExt, EntryChunkGroupResult, MangleType, MinifyType,
-        SourceMapSourceType, SourceMapsType, UnusedReferences, UrlBehavior,
+        ChunkingContext, ChunkingContextExt, EmitOption, EmitOptions, EntryChunkGroupResult,
+        MangleType, MinifyType, SourceMapSourceType, SourceMapsType, UnusedReferences, UrlBehavior,
+        find_emit_option,
     },
     data::{ChunkData, ChunkDataOption, ChunksData},
     evaluate::{EvaluatableAsset, EvaluatableAssetExt, EvaluatableAssets},

--- a/turbopack/crates/turbopack-core/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/mod.rs
@@ -4,7 +4,7 @@ pub mod chunk_group;
 pub mod chunk_id_strategy;
 pub(crate) mod chunk_item_batch;
 pub mod chunking;
-pub(crate) mod chunking_context;
+pub mod chunking_context;
 pub(crate) mod data;
 pub(crate) mod evaluate;
 
@@ -29,7 +29,7 @@ pub use crate::chunk::{
     chunking_context::{
         AssetSuffix, ChunkGroupResult, ChunkGroupType, ChunkingConfig, ChunkingConfigs,
         ChunkingContext, ChunkingContextExt, EmitOption, EmitOptions, EntryChunkGroupResult,
-        SourceMapSourceType, SourceMapsType, UnusedReferences, UrlBehavior, find_emit_option,
+        SourceMapSourceType, SourceMapsType, UnusedReferences, UrlBehavior,
     },
     data::{ChunkData, ChunkDataOption, ChunksData},
     evaluate::{EvaluatableAsset, EvaluatableAssetExt, EvaluatableAssets},

--- a/turbopack/crates/turbopack-css/Cargo.toml
+++ b/turbopack/crates/turbopack-css/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+either = { workspace = true }
 async-trait = { workspace = true }
 bincode = { workspace = true }
 indoc = { workspace = true }

--- a/turbopack/crates/turbopack-css/src/asset.rs
+++ b/turbopack/crates/turbopack-css/src/asset.rs
@@ -3,7 +3,7 @@ use turbo_rcstr::rcstr;
 use turbo_tasks::{ResolvedVc, TryJoinIterExt, Vc, turbofmt};
 use turbo_tasks_fs::{FileContent, FileSystemPath};
 use turbopack_core::{
-    chunk::{ChunkItem, ChunkType, ChunkableModule, ChunkingContext, MinifyType},
+    chunk::{ChunkItem, ChunkType, ChunkableModule, ChunkingContext, find_emit_option},
     context::AssetContext,
     environment::Environment,
     ident::AssetIdent,
@@ -21,6 +21,7 @@ use crate::{
     CssModuleType, LightningCssFeatureFlags,
     chunk::{CssChunkItem, CssChunkItemContent, CssChunkPlaceable, CssChunkType, CssImport},
     code_gen::CodeGenerateable,
+    emit_options::CssEmitOptions,
     process::{
         CssWithPlaceholderResult, FinalCssResult, ParseCss, ParseCssResult, ProcessCss,
         finalize_css, parse_css, process_css_with_placeholder,
@@ -109,7 +110,7 @@ impl ProcessCss for CssModule {
     async fn finalize_css(
         self: Vc<Self>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
-        minify_type: MinifyType,
+        minify: bool,
     ) -> Result<Vc<FinalCssResult>> {
         let process_result = self.get_css_with_placeholder();
 
@@ -122,7 +123,7 @@ impl ProcessCss for CssModule {
         Ok(finalize_css(
             process_result,
             chunking_context,
-            minify_type,
+            minify,
             origin_source_map,
             this.environment.as_deref().copied(),
             this.lightningcss_features,
@@ -334,9 +335,17 @@ impl CssChunkItem for CssModuleChunkItem {
             }
         }
 
+        let css_emit = find_emit_option::<CssEmitOptions>(chunking_context.emit_options()).await?;
+        let css_emit_ref = if let Some(vc) = css_emit {
+            Some(vc.await?)
+        } else {
+            None
+        };
+        let css_emit_default = CssEmitOptions::default();
+        let css_emit = css_emit_ref.as_deref().unwrap_or(&css_emit_default);
         let result = self
             .module
-            .finalize_css(*chunking_context, *chunking_context.minify_type().await?)
+            .finalize_css(*chunking_context, css_emit.minify)
             .await?;
 
         if let FinalCssResult::Ok {

--- a/turbopack/crates/turbopack-css/src/asset.rs
+++ b/turbopack/crates/turbopack-css/src/asset.rs
@@ -3,7 +3,7 @@ use turbo_rcstr::rcstr;
 use turbo_tasks::{ResolvedVc, TryJoinIterExt, Vc, turbofmt};
 use turbo_tasks_fs::{FileContent, FileSystemPath};
 use turbopack_core::{
-    chunk::{ChunkItem, ChunkType, ChunkableModule, ChunkingContext, find_emit_option},
+    chunk::{ChunkItem, ChunkType, ChunkableModule, ChunkingContext},
     context::AssetContext,
     environment::Environment,
     ident::AssetIdent,
@@ -335,14 +335,7 @@ impl CssChunkItem for CssModuleChunkItem {
             }
         }
 
-        let css_emit = find_emit_option::<CssEmitOptions>(chunking_context.emit_options()).await?;
-        let css_emit_ref = if let Some(vc) = css_emit {
-            Some(vc.await?)
-        } else {
-            None
-        };
-        let css_emit_default = CssEmitOptions::default();
-        let css_emit = css_emit_ref.as_deref().unwrap_or(&css_emit_default);
+        let css_emit = CssEmitOptions::get_or_default(*chunking_context).await?;
         let result = self
             .module
             .finalize_css(*chunking_context, css_emit.minify)

--- a/turbopack/crates/turbopack-css/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/mod.rs
@@ -16,7 +16,7 @@ use turbopack_core::{
         AsyncModuleInfo, Chunk, ChunkItem, ChunkItemBatchGroup, ChunkItemExt,
         ChunkItemOrBatchWithAsyncModuleInfo, ChunkItemWithAsyncModuleInfo, ChunkType,
         ChunkableModule, ChunkingContext, ChunkingContextExt, OutputChunk, OutputChunkRuntimeInfo,
-        SourceMapSourceType, find_emit_option, round_chunk_item_size,
+        SourceMapSourceType, round_chunk_item_size,
     },
     code_builder::{Code, CodeBuilder},
     ident::AssetIdent,
@@ -86,21 +86,10 @@ impl CssChunk {
                 }
             }
 
-            {
-                let css_emit =
-                    find_emit_option::<CssEmitOptions>(this.chunking_context.emit_options())
-                        .await?;
-                let css_emit_ref = if let Some(vc) = css_emit {
-                    Some(vc.await?)
-                } else {
-                    None
-                };
-                let css_emit_default = CssEmitOptions::default();
-                let css_emit = css_emit_ref.as_deref().unwrap_or(&css_emit_default);
-                if css_emit.chunk_item_comments {
-                    let id = css_item.asset_ident().to_string().await?;
-                    writeln!(body, "/* {id} */")?;
-                }
+            let css_emit = CssEmitOptions::get_or_default(*this.chunking_context).await?;
+            if css_emit.chunk_item_comments {
+                let id = css_item.asset_ident().to_string().await?;
+                writeln!(body, "/* {id} */")?;
             }
 
             let close = write_import_context(&mut body, content.import_context).await?;

--- a/turbopack/crates/turbopack-css/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/mod.rs
@@ -15,8 +15,8 @@ use turbopack_core::{
     chunk::{
         AsyncModuleInfo, Chunk, ChunkItem, ChunkItemBatchGroup, ChunkItemExt,
         ChunkItemOrBatchWithAsyncModuleInfo, ChunkItemWithAsyncModuleInfo, ChunkType,
-        ChunkableModule, ChunkingContext, ChunkingContextExt, MinifyType, OutputChunk,
-        OutputChunkRuntimeInfo, SourceMapSourceType, round_chunk_item_size,
+        ChunkableModule, ChunkingContext, ChunkingContextExt, OutputChunk, OutputChunkRuntimeInfo,
+        SourceMapSourceType, find_emit_option, round_chunk_item_size,
     },
     code_builder::{Code, CodeBuilder},
     ident::AssetIdent,
@@ -36,7 +36,7 @@ use turbopack_core::{
 };
 
 use self::{single_item_chunk::chunk::SingleItemCssChunk, source_map::CssChunkSourceMapAsset};
-use crate::ImportAssetReference;
+use crate::{ImportAssetReference, emit_options::CssEmitOptions};
 
 #[turbo_tasks::value]
 pub struct CssChunk {
@@ -86,12 +86,21 @@ impl CssChunk {
                 }
             }
 
-            if matches!(
-                &*this.chunking_context.minify_type().await?,
-                MinifyType::NoMinify
-            ) {
-                let id = css_item.asset_ident().to_string().await?;
-                writeln!(body, "/* {id} */")?;
+            {
+                let css_emit =
+                    find_emit_option::<CssEmitOptions>(this.chunking_context.emit_options())
+                        .await?;
+                let css_emit_ref = if let Some(vc) = css_emit {
+                    Some(vc.await?)
+                } else {
+                    None
+                };
+                let css_emit_default = CssEmitOptions::default();
+                let css_emit = css_emit_ref.as_deref().unwrap_or(&css_emit_default);
+                if css_emit.chunk_item_comments {
+                    let id = css_item.asset_ident().to_string().await?;
+                    writeln!(body, "/* {id} */")?;
+                }
             }
 
             let close = write_import_context(&mut body, content.import_context).await?;

--- a/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/chunk.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/chunk.rs
@@ -6,7 +6,7 @@ use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbo_tasks_fs::{File, FileContent, FileSystemPath, rope::RopeBuilder};
 use turbopack_core::{
     asset::{Asset, AssetContent},
-    chunk::{Chunk, ChunkItem, ChunkingContext, MinifyType},
+    chunk::{Chunk, ChunkItem, ChunkingContext, find_emit_option},
     code_builder::{Code, CodeBuilder},
     ident::AssetIdent,
     introspect::Introspectable,
@@ -15,7 +15,10 @@ use turbopack_core::{
 };
 
 use super::source_map::SingleItemCssChunkSourceMapAsset;
-use crate::chunk::{CssChunkItem, write_import_context};
+use crate::{
+    chunk::{CssChunkItem, write_import_context},
+    emit_options::CssEmitOptions,
+};
 
 /// A CSS chunk that only contains a single item. This is used for selectively
 /// loading CSS modules that are part of a larger chunk in development mode, and
@@ -56,12 +59,20 @@ impl SingleItemCssChunk {
         // CSS chunks never have debug IDs
         let mut code = CodeBuilder::new(source_maps, false);
 
-        if matches!(
-            &*this.chunking_context.minify_type().await?,
-            MinifyType::NoMinify
-        ) {
-            let id = this.item.asset_ident().to_string().await?;
-            writeln!(code, "/* {id} */")?;
+        {
+            let css_emit =
+                find_emit_option::<CssEmitOptions>(this.chunking_context.emit_options()).await?;
+            let css_emit_ref = if let Some(vc) = css_emit {
+                Some(vc.await?)
+            } else {
+                None
+            };
+            let css_emit_default = CssEmitOptions::default();
+            let css_emit = css_emit_ref.as_deref().unwrap_or(&css_emit_default);
+            if css_emit.chunk_item_comments {
+                let id = this.item.asset_ident().to_string().await?;
+                writeln!(code, "/* {id} */")?;
+            }
         }
         let content = this.item.content().await?;
         let close = write_import_context(&mut code, content.import_context).await?;

--- a/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/chunk.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/chunk.rs
@@ -6,7 +6,7 @@ use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbo_tasks_fs::{File, FileContent, FileSystemPath, rope::RopeBuilder};
 use turbopack_core::{
     asset::{Asset, AssetContent},
-    chunk::{Chunk, ChunkItem, ChunkingContext, find_emit_option},
+    chunk::{Chunk, ChunkItem, ChunkingContext},
     code_builder::{Code, CodeBuilder},
     ident::AssetIdent,
     introspect::Introspectable,
@@ -59,20 +59,10 @@ impl SingleItemCssChunk {
         // CSS chunks never have debug IDs
         let mut code = CodeBuilder::new(source_maps, false);
 
-        {
-            let css_emit =
-                find_emit_option::<CssEmitOptions>(this.chunking_context.emit_options()).await?;
-            let css_emit_ref = if let Some(vc) = css_emit {
-                Some(vc.await?)
-            } else {
-                None
-            };
-            let css_emit_default = CssEmitOptions::default();
-            let css_emit = css_emit_ref.as_deref().unwrap_or(&css_emit_default);
-            if css_emit.chunk_item_comments {
-                let id = this.item.asset_ident().to_string().await?;
-                writeln!(code, "/* {id} */")?;
-            }
+        let css_emit = CssEmitOptions::get_or_default(*this.chunking_context).await?;
+        if css_emit.chunk_item_comments {
+            let id = this.item.asset_ident().to_string().await?;
+            writeln!(code, "/* {id} */")?;
         }
         let content = this.item.content().await?;
         let close = write_import_context(&mut code, content.import_context).await?;

--- a/turbopack/crates/turbopack-css/src/emit_options.rs
+++ b/turbopack/crates/turbopack-css/src/emit_options.rs
@@ -1,12 +1,13 @@
 use anyhow::Result;
-use turbo_tasks::Vc;
-use turbopack_core::chunk::{ChunkingContext, EmitOption, find_emit_option};
+use turbo_tasks::{ReadRef, Vc};
+use turbopack_core::chunk::{ChunkingContext, EmitOption, chunking_context::find_emit_option};
 
 /// CSS-specific emit options for controlling minification and comment output.
 ///
 /// When no `CssEmitOptions` is present in the chunking context's emit options,
 /// callers should use `CssEmitOptions::default()` (no minification, comments enabled).
 #[turbo_tasks::value(shared)]
+#[derive(Clone, Copy)]
 pub struct CssEmitOptions {
     /// Whether to minify CSS output.
     pub minify: bool,
@@ -37,22 +38,16 @@ impl CssEmitOptions {
             options: CssEmitOptions::default(),
         }
     }
-}
 
-impl CssEmitOptions {
     /// Look up `CssEmitOptions` from a chunking context's emit options,
     /// falling back to defaults (no minification, comments enabled).
-    pub async fn get_or_default(chunking_context: Vc<Box<dyn ChunkingContext>>) -> Result<Self> {
+    pub async fn get_or_default(
+        chunking_context: Vc<Box<dyn ChunkingContext>>,
+    ) -> Result<ReadRef<CssEmitOptions>> {
         let opts = find_emit_option::<CssEmitOptions>(chunking_context.emit_options()).await?;
         Ok(match opts {
-            Some(vc) => {
-                let read = vc.await?;
-                CssEmitOptions {
-                    minify: read.minify,
-                    chunk_item_comments: read.chunk_item_comments,
-                }
-            }
-            None => CssEmitOptions::default(),
+            Some(vc) => vc.await?,
+            None => ReadRef::new_owned(CssEmitOptions::default()),
         })
     }
 }

--- a/turbopack/crates/turbopack-css/src/emit_options.rs
+++ b/turbopack/crates/turbopack-css/src/emit_options.rs
@@ -38,6 +38,14 @@ impl CssEmitOptions {
 }
 
 impl CssEmitOptionsBuilder {
+    /// Preset: enable CSS minification.
+    /// Disables chunk item comments.
+    pub fn preset_minify(mut self) -> Self {
+        self.options.minify = true;
+        self.options.chunk_item_comments = false;
+        self
+    }
+
     pub fn minify(mut self, minify: bool) -> Self {
         self.options.minify = minify;
         self

--- a/turbopack/crates/turbopack-css/src/emit_options.rs
+++ b/turbopack/crates/turbopack-css/src/emit_options.rs
@@ -1,4 +1,6 @@
-use turbopack_core::chunk::EmitOption;
+use anyhow::Result;
+use turbo_tasks::Vc;
+use turbopack_core::chunk::{ChunkingContext, EmitOption, find_emit_option};
 
 /// CSS-specific emit options for controlling minification and comment output.
 ///
@@ -34,6 +36,24 @@ impl CssEmitOptions {
         CssEmitOptionsBuilder {
             options: CssEmitOptions::default(),
         }
+    }
+}
+
+impl CssEmitOptions {
+    /// Look up `CssEmitOptions` from a chunking context's emit options,
+    /// falling back to defaults (no minification, comments enabled).
+    pub async fn get_or_default(chunking_context: Vc<Box<dyn ChunkingContext>>) -> Result<Self> {
+        let opts = find_emit_option::<CssEmitOptions>(chunking_context.emit_options()).await?;
+        Ok(match opts {
+            Some(vc) => {
+                let read = vc.await?;
+                CssEmitOptions {
+                    minify: read.minify,
+                    chunk_item_comments: read.chunk_item_comments,
+                }
+            }
+            None => CssEmitOptions::default(),
+        })
     }
 }
 

--- a/turbopack/crates/turbopack-css/src/emit_options.rs
+++ b/turbopack/crates/turbopack-css/src/emit_options.rs
@@ -1,0 +1,54 @@
+use turbopack_core::chunk::EmitOption;
+
+/// CSS-specific emit options for controlling minification and comment output.
+///
+/// When no `CssEmitOptions` is present in the chunking context's emit options,
+/// callers should use `CssEmitOptions::default()` (no minification, comments enabled).
+#[turbo_tasks::value(shared)]
+pub struct CssEmitOptions {
+    /// Whether to minify CSS output.
+    pub minify: bool,
+    /// Whether to emit `/* <asset-ident> */` comments in CSS chunks.
+    pub chunk_item_comments: bool,
+}
+
+impl Default for CssEmitOptions {
+    fn default() -> Self {
+        Self {
+            minify: false,
+            chunk_item_comments: true,
+        }
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl EmitOption for CssEmitOptions {}
+
+/// Builder for `CssEmitOptions`.
+pub struct CssEmitOptionsBuilder {
+    options: CssEmitOptions,
+}
+
+impl CssEmitOptions {
+    pub fn builder() -> CssEmitOptionsBuilder {
+        CssEmitOptionsBuilder {
+            options: CssEmitOptions::default(),
+        }
+    }
+}
+
+impl CssEmitOptionsBuilder {
+    pub fn minify(mut self, minify: bool) -> Self {
+        self.options.minify = minify;
+        self
+    }
+
+    pub fn chunk_item_comments(mut self, comments: bool) -> Self {
+        self.options.chunk_item_comments = comments;
+        self
+    }
+
+    pub fn build(self) -> CssEmitOptions {
+        self.options
+    }
+}

--- a/turbopack/crates/turbopack-css/src/emit_options.rs
+++ b/turbopack/crates/turbopack-css/src/emit_options.rs
@@ -1,5 +1,8 @@
+use std::{ops::Deref, sync::LazyLock};
+
 use anyhow::Result;
-use turbo_tasks::{ReadRef, Vc};
+use either::Either;
+use turbo_tasks::Vc;
 use turbopack_core::chunk::{ChunkingContext, EmitOption, chunking_context::find_emit_option};
 
 /// CSS-specific emit options for controlling minification and comment output.
@@ -40,14 +43,15 @@ impl CssEmitOptions {
     }
 
     /// Look up `CssEmitOptions` from a chunking context's emit options,
-    /// falling back to defaults (no minification, comments enabled).
+    /// falling back to a static default (no minification, comments enabled).
     pub async fn get_or_default(
         chunking_context: Vc<Box<dyn ChunkingContext>>,
-    ) -> Result<ReadRef<CssEmitOptions>> {
+    ) -> Result<impl Deref<Target = CssEmitOptions>> {
+        static DEFAULT: LazyLock<CssEmitOptions> = LazyLock::new(CssEmitOptions::default);
         let opts = find_emit_option::<CssEmitOptions>(chunking_context.emit_options()).await?;
         Ok(match opts {
-            Some(vc) => vc.await?,
-            None => ReadRef::new_owned(CssEmitOptions::default()),
+            Some(vc) => Either::Left(vc.await?),
+            None => Either::Right(&*DEFAULT),
         })
     }
 }

--- a/turbopack/crates/turbopack-css/src/emit_options.rs
+++ b/turbopack/crates/turbopack-css/src/emit_options.rs
@@ -1,4 +1,4 @@
-use std::{ops::Deref, sync::LazyLock};
+use std::ops::Deref;
 
 use anyhow::Result;
 use either::Either;
@@ -47,11 +47,14 @@ impl CssEmitOptions {
     pub async fn get_or_default(
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<impl Deref<Target = CssEmitOptions>> {
-        static DEFAULT: LazyLock<CssEmitOptions> = LazyLock::new(CssEmitOptions::default);
+        static DEFAULT: CssEmitOptions = CssEmitOptions {
+            minify: false,
+            chunk_item_comments: true,
+        };
         let opts = find_emit_option::<CssEmitOptions>(chunking_context.emit_options()).await?;
         Ok(match opts {
             Some(vc) => Either::Left(vc.await?),
-            None => Either::Right(&*DEFAULT),
+            None => Either::Right(&DEFAULT),
         })
     }
 }

--- a/turbopack/crates/turbopack-css/src/lib.rs
+++ b/turbopack/crates/turbopack-css/src/lib.rs
@@ -6,6 +6,7 @@ mod asset;
 pub mod chunk;
 mod code_gen;
 pub mod embed;
+pub mod emit_options;
 mod lifetime_util;
 mod module_asset;
 pub(crate) mod process;

--- a/turbopack/crates/turbopack-css/src/process.rs
+++ b/turbopack/crates/turbopack-css/src/process.rs
@@ -21,7 +21,7 @@ use turbo_tasks_fs::{File, FileContent, FileSystemPath, rope::Rope};
 use turbopack_core::{
     SOURCE_URL_PROTOCOL,
     asset::{Asset, AssetContent},
-    chunk::{ChunkingContext, MinifyType},
+    chunk::ChunkingContext,
     environment::Environment,
     issue::{
         AdditionalIssueSource, Issue, IssueExt, IssueSeverity, IssueSource, IssueStage,
@@ -98,7 +98,7 @@ async fn get_lightningcss_browser_targets(
 async fn stylesheet_to_css(
     ss: &StyleSheet<'_, '_>,
     code: &str,
-    minify_type: MinifyType,
+    minify: bool,
     enable_srcmap: bool,
     handle_nesting: bool,
     mut origin_source_map: Option<parcel_sourcemap::SourceMap>,
@@ -119,7 +119,7 @@ async fn stylesheet_to_css(
     .await?;
 
     let result = ss.to_css(PrinterOptions {
-        minify: matches!(minify_type, MinifyType::Minify { .. }),
+        minify,
         source_map: srcmap.as_mut(),
         targets,
         analyze_dependencies: None,
@@ -227,7 +227,7 @@ pub async fn process_css_with_placeholder(
             let (result, _) = stylesheet_to_css(
                 stylesheet,
                 &code,
-                MinifyType::NoMinify,
+                false,
                 false,
                 false,
                 None,
@@ -262,7 +262,7 @@ pub async fn process_css_with_placeholder(
 pub async fn finalize_css(
     result: Vc<CssWithPlaceholderResult>,
     chunking_context: Vc<Box<dyn ChunkingContext>>,
-    minify_type: MinifyType,
+    minify: bool,
     origin_source_map: Vc<FileContent>,
     environment: Option<ResolvedVc<Environment>>,
     feature_flags: LightningCssFeatureFlags,
@@ -316,7 +316,7 @@ pub async fn finalize_css(
             let (result, srcmap) = stylesheet_to_css(
                 &stylesheet,
                 &code,
-                minify_type,
+                minify,
                 true,
                 true,
                 origin_source_map,
@@ -355,7 +355,7 @@ pub trait ProcessCss: ParseCss {
     async fn finalize_css(
         self: Vc<Self>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
-        minify_type: MinifyType,
+        minify: bool,
     ) -> Result<Vc<FinalCssResult>>;
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/emit_options.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/emit_options.rs
@@ -1,4 +1,4 @@
-use std::{ops::Deref, sync::LazyLock};
+use std::ops::Deref;
 
 use anyhow::Result;
 use either::Either;
@@ -60,13 +60,16 @@ impl EcmascriptEmitOptions {
     pub async fn get_or_default(
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<impl Deref<Target = EcmascriptEmitOptions>> {
-        static DEFAULT: LazyLock<EcmascriptEmitOptions> =
-            LazyLock::new(EcmascriptEmitOptions::default);
+        static DEFAULT: EcmascriptEmitOptions = EcmascriptEmitOptions {
+            swc_minify_options: None,
+            indent: true,
+            merged_module_comments: true,
+        };
         let opts =
             find_emit_option::<EcmascriptEmitOptions>(chunking_context.emit_options()).await?;
         Ok(match opts {
             Some(vc) => Either::Left(vc.await?),
-            None => Either::Right(&*DEFAULT),
+            None => Either::Right(&DEFAULT),
         })
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/emit_options.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/emit_options.rs
@@ -1,0 +1,147 @@
+use std::sync::Arc;
+
+use swc_core::{
+    atoms::atom,
+    ecma::minifier::option::{CompressOptions, MangleOptions, MinifyOptions as SwcMinifyOptions},
+};
+use turbopack_core::chunk::EmitOption;
+
+/// Ecmascript-specific emit options for controlling minification, indentation,
+/// and other code generation settings.
+///
+/// When no `EcmascriptEmitOptions` is present in the chunking context's emit options,
+/// callers should use `EcmascriptEmitOptions::default()` (no minification, indent enabled,
+/// merged module comments enabled).
+#[turbo_tasks::value(shared, serialization = "none", eq = "manual")]
+#[derive(Clone)]
+pub struct EcmascriptEmitOptions {
+    /// Full SWC minify options. `None` means no minification.
+    /// Wrapped in Arc because `SwcMinifyOptions` doesn't implement Clone.
+    #[turbo_tasks(trace_ignore)]
+    pub swc_minify_options: Option<Arc<SwcMinifyOptions>>,
+    /// Whether to indent JS output (pretty-print).
+    pub indent: bool,
+    /// Whether to emit `// MERGED MODULE: ...` comments in scope-hoisted output.
+    pub merged_module_comments: bool,
+}
+
+impl Default for EcmascriptEmitOptions {
+    fn default() -> Self {
+        Self {
+            swc_minify_options: None,
+            indent: true,
+            merged_module_comments: true,
+        }
+    }
+}
+
+impl PartialEq for EcmascriptEmitOptions {
+    fn eq(&self, other: &Self) -> bool {
+        // SwcMinifyOptions doesn't implement PartialEq, so compare by debug representation.
+        let opts_eq = match (&self.swc_minify_options, &other.swc_minify_options) {
+            (Some(a), Some(b)) => Arc::ptr_eq(a, b) || format!("{a:?}") == format!("{b:?}"),
+            (None, None) => true,
+            _ => false,
+        };
+        opts_eq
+            && self.indent == other.indent
+            && self.merged_module_comments == other.merged_module_comments
+    }
+}
+
+impl Eq for EcmascriptEmitOptions {}
+
+#[turbo_tasks::value_impl]
+impl EmitOption for EcmascriptEmitOptions {}
+
+/// Builder for `EcmascriptEmitOptions`.
+pub struct EcmascriptEmitOptionsBuilder {
+    options: EcmascriptEmitOptions,
+}
+
+impl EcmascriptEmitOptions {
+    pub fn builder() -> EcmascriptEmitOptionsBuilder {
+        EcmascriptEmitOptionsBuilder {
+            options: EcmascriptEmitOptions::default(),
+        }
+    }
+}
+
+impl EcmascriptEmitOptionsBuilder {
+    /// Set full SWC minify options directly.
+    pub fn swc_minify_options(mut self, opts: SwcMinifyOptions) -> Self {
+        self.options.swc_minify_options = Some(Arc::new(opts));
+        self
+    }
+
+    /// Convenience: minify with optimal-size mangling (char-freq enabled).
+    /// Sets indent=false, merged_module_comments=false.
+    pub fn mangle_optimal_size(mut self) -> Self {
+        self.options.swc_minify_options = Some(Arc::new(SwcMinifyOptions {
+            compress: Some(CompressOptions {
+                passes: 2,
+                ..Default::default()
+            }),
+            mangle: Some(MangleOptions {
+                reserved: vec![atom!("AbortSignal")],
+                ..Default::default()
+            }),
+            ..Default::default()
+        }));
+        self.options.indent = false;
+        self.options.merged_module_comments = false;
+        self
+    }
+
+    /// Convenience: minify with deterministic mangling (disable_char_freq=true).
+    /// For React SSR contexts that need stable function names across renders.
+    pub fn mangle_deterministic(mut self) -> Self {
+        self.options.swc_minify_options = Some(Arc::new(SwcMinifyOptions {
+            compress: Some(CompressOptions {
+                passes: 2,
+                ..Default::default()
+            }),
+            mangle: Some(MangleOptions {
+                reserved: vec![atom!("AbortSignal")],
+                disable_char_freq: true,
+                ..Default::default()
+            }),
+            ..Default::default()
+        }));
+        self.options.indent = false;
+        self.options.merged_module_comments = false;
+        self
+    }
+
+    /// Convenience: compress only, no mangling.
+    /// Keeps class names and function names.
+    pub fn no_mangle(mut self) -> Self {
+        self.options.swc_minify_options = Some(Arc::new(SwcMinifyOptions {
+            compress: Some(CompressOptions {
+                passes: 2,
+                keep_classnames: true,
+                keep_fnames: true,
+                ..Default::default()
+            }),
+            mangle: None,
+            ..Default::default()
+        }));
+        self.options.indent = false;
+        self.options.merged_module_comments = false;
+        self
+    }
+
+    pub fn indent(mut self, indent: bool) -> Self {
+        self.options.indent = indent;
+        self
+    }
+
+    pub fn merged_module_comments(mut self, comments: bool) -> Self {
+        self.options.merged_module_comments = comments;
+        self
+    }
+
+    pub fn build(self) -> EcmascriptEmitOptions {
+        self.options
+    }
+}

--- a/turbopack/crates/turbopack-ecmascript/src/emit_options.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/emit_options.rs
@@ -1,12 +1,10 @@
-use std::sync::Arc;
-
 use anyhow::Result;
 use swc_core::{
     atoms::atom,
     ecma::minifier::option::{CompressOptions, MangleOptions, MinifyOptions as SwcMinifyOptions},
 };
-use turbo_tasks::Vc;
-use turbopack_core::chunk::{ChunkingContext, EmitOption, find_emit_option};
+use turbo_tasks::{ReadRef, Vc};
+use turbopack_core::chunk::{ChunkingContext, EmitOption, chunking_context::find_emit_option};
 
 /// Ecmascript-specific emit options for controlling minification, indentation,
 /// and other code generation settings.
@@ -15,12 +13,11 @@ use turbopack_core::chunk::{ChunkingContext, EmitOption, find_emit_option};
 /// callers should use `EcmascriptEmitOptions::default()` (no minification, indent enabled,
 /// merged module comments enabled).
 #[turbo_tasks::value(shared, serialization = "none", eq = "manual")]
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct EcmascriptEmitOptions {
     /// Full SWC minify options. `None` means no minification.
-    /// Wrapped in Arc because `SwcMinifyOptions` doesn't implement Clone.
     #[turbo_tasks(trace_ignore)]
-    pub swc_minify_options: Option<Arc<SwcMinifyOptions>>,
+    pub swc_minify_options: Option<SwcMinifyOptions>,
     /// Whether to indent JS output (pretty-print).
     pub indent: bool,
     /// Whether to emit `// MERGED MODULE: ...` comments in scope-hoisted output.
@@ -37,22 +34,6 @@ impl Default for EcmascriptEmitOptions {
     }
 }
 
-impl PartialEq for EcmascriptEmitOptions {
-    fn eq(&self, other: &Self) -> bool {
-        // SwcMinifyOptions doesn't implement PartialEq, so compare by debug representation.
-        let opts_eq = match (&self.swc_minify_options, &other.swc_minify_options) {
-            (Some(a), Some(b)) => Arc::ptr_eq(a, b) || format!("{a:?}") == format!("{b:?}"),
-            (None, None) => true,
-            _ => false,
-        };
-        opts_eq
-            && self.indent == other.indent
-            && self.merged_module_comments == other.merged_module_comments
-    }
-}
-
-impl Eq for EcmascriptEmitOptions {}
-
 #[turbo_tasks::value_impl]
 impl EmitOption for EcmascriptEmitOptions {}
 
@@ -67,17 +48,17 @@ impl EcmascriptEmitOptions {
             options: EcmascriptEmitOptions::default(),
         }
     }
-}
 
-impl EcmascriptEmitOptions {
     /// Look up `EcmascriptEmitOptions` from a chunking context's emit options,
     /// falling back to defaults (no minification, indent enabled, comments enabled).
-    pub async fn get_or_default(chunking_context: Vc<Box<dyn ChunkingContext>>) -> Result<Self> {
+    pub async fn get_or_default(
+        chunking_context: Vc<Box<dyn ChunkingContext>>,
+    ) -> Result<ReadRef<EcmascriptEmitOptions>> {
         let opts =
             find_emit_option::<EcmascriptEmitOptions>(chunking_context.emit_options()).await?;
         Ok(match opts {
-            Some(vc) => (*vc.await?).clone(),
-            None => EcmascriptEmitOptions::default(),
+            Some(vc) => vc.await?,
+            None => ReadRef::new_owned(EcmascriptEmitOptions::default()),
         })
     }
 }
@@ -91,14 +72,14 @@ impl EcmascriptEmitOptionsBuilder {
 
     /// Set full SWC minify options directly.
     pub fn swc_minify_options(mut self, opts: SwcMinifyOptions) -> Self {
-        self.options.swc_minify_options = Some(Arc::new(opts));
+        self.options.swc_minify_options = Some(opts);
         self
     }
 
     /// Preset: minify with optimal-size mangling (char-freq enabled).
     /// Disables indent and merged module comments.
     pub fn preset_minify_optimal_size(mut self) -> Self {
-        self.options.swc_minify_options = Some(Arc::new(SwcMinifyOptions {
+        self.options.swc_minify_options = Some(SwcMinifyOptions {
             compress: Some(CompressOptions {
                 passes: 2,
                 ..Default::default()
@@ -108,7 +89,7 @@ impl EcmascriptEmitOptionsBuilder {
                 ..Default::default()
             }),
             ..Default::default()
-        }));
+        });
         self.apply_minify_defaults();
         self
     }
@@ -117,7 +98,7 @@ impl EcmascriptEmitOptionsBuilder {
     /// For React SSR contexts that need stable function names across renders.
     /// Disables indent and merged module comments.
     pub fn preset_minify_deterministic(mut self) -> Self {
-        self.options.swc_minify_options = Some(Arc::new(SwcMinifyOptions {
+        self.options.swc_minify_options = Some(SwcMinifyOptions {
             compress: Some(CompressOptions {
                 passes: 2,
                 ..Default::default()
@@ -128,7 +109,7 @@ impl EcmascriptEmitOptionsBuilder {
                 ..Default::default()
             }),
             ..Default::default()
-        }));
+        });
         self.apply_minify_defaults();
         self
     }
@@ -137,7 +118,7 @@ impl EcmascriptEmitOptionsBuilder {
     /// Keeps class names and function names.
     /// Disables indent and merged module comments.
     pub fn preset_minify_no_mangle(mut self) -> Self {
-        self.options.swc_minify_options = Some(Arc::new(SwcMinifyOptions {
+        self.options.swc_minify_options = Some(SwcMinifyOptions {
             compress: Some(CompressOptions {
                 passes: 2,
                 keep_classnames: true,
@@ -146,7 +127,7 @@ impl EcmascriptEmitOptionsBuilder {
             }),
             mangle: None,
             ..Default::default()
-        }));
+        });
         self.apply_minify_defaults();
         self
     }

--- a/turbopack/crates/turbopack-ecmascript/src/emit_options.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/emit_options.rs
@@ -1,10 +1,12 @@
 use std::sync::Arc;
 
+use anyhow::Result;
 use swc_core::{
     atoms::atom,
     ecma::minifier::option::{CompressOptions, MangleOptions, MinifyOptions as SwcMinifyOptions},
 };
-use turbopack_core::chunk::EmitOption;
+use turbo_tasks::Vc;
+use turbopack_core::chunk::{ChunkingContext, EmitOption, find_emit_option};
 
 /// Ecmascript-specific emit options for controlling minification, indentation,
 /// and other code generation settings.
@@ -67,7 +69,26 @@ impl EcmascriptEmitOptions {
     }
 }
 
+impl EcmascriptEmitOptions {
+    /// Look up `EcmascriptEmitOptions` from a chunking context's emit options,
+    /// falling back to defaults (no minification, indent enabled, comments enabled).
+    pub async fn get_or_default(chunking_context: Vc<Box<dyn ChunkingContext>>) -> Result<Self> {
+        let opts =
+            find_emit_option::<EcmascriptEmitOptions>(chunking_context.emit_options()).await?;
+        Ok(match opts {
+            Some(vc) => (*vc.await?).clone(),
+            None => EcmascriptEmitOptions::default(),
+        })
+    }
+}
+
 impl EcmascriptEmitOptionsBuilder {
+    /// Common settings applied by all minification presets.
+    fn apply_minify_defaults(&mut self) {
+        self.options.indent = false;
+        self.options.merged_module_comments = false;
+    }
+
     /// Set full SWC minify options directly.
     pub fn swc_minify_options(mut self, opts: SwcMinifyOptions) -> Self {
         self.options.swc_minify_options = Some(Arc::new(opts));
@@ -88,8 +109,7 @@ impl EcmascriptEmitOptionsBuilder {
             }),
             ..Default::default()
         }));
-        self.options.indent = false;
-        self.options.merged_module_comments = false;
+        self.apply_minify_defaults();
         self
     }
 
@@ -109,8 +129,7 @@ impl EcmascriptEmitOptionsBuilder {
             }),
             ..Default::default()
         }));
-        self.options.indent = false;
-        self.options.merged_module_comments = false;
+        self.apply_minify_defaults();
         self
     }
 
@@ -128,8 +147,7 @@ impl EcmascriptEmitOptionsBuilder {
             mangle: None,
             ..Default::default()
         }));
-        self.options.indent = false;
-        self.options.merged_module_comments = false;
+        self.apply_minify_defaults();
         self
     }
 

--- a/turbopack/crates/turbopack-ecmascript/src/emit_options.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/emit_options.rs
@@ -74,9 +74,9 @@ impl EcmascriptEmitOptionsBuilder {
         self
     }
 
-    /// Convenience: minify with optimal-size mangling (char-freq enabled).
-    /// Sets indent=false, merged_module_comments=false.
-    pub fn mangle_optimal_size(mut self) -> Self {
+    /// Preset: minify with optimal-size mangling (char-freq enabled).
+    /// Disables indent and merged module comments.
+    pub fn preset_minify_optimal_size(mut self) -> Self {
         self.options.swc_minify_options = Some(Arc::new(SwcMinifyOptions {
             compress: Some(CompressOptions {
                 passes: 2,
@@ -93,9 +93,10 @@ impl EcmascriptEmitOptionsBuilder {
         self
     }
 
-    /// Convenience: minify with deterministic mangling (disable_char_freq=true).
+    /// Preset: minify with deterministic mangling (disable_char_freq=true).
     /// For React SSR contexts that need stable function names across renders.
-    pub fn mangle_deterministic(mut self) -> Self {
+    /// Disables indent and merged module comments.
+    pub fn preset_minify_deterministic(mut self) -> Self {
         self.options.swc_minify_options = Some(Arc::new(SwcMinifyOptions {
             compress: Some(CompressOptions {
                 passes: 2,
@@ -113,9 +114,10 @@ impl EcmascriptEmitOptionsBuilder {
         self
     }
 
-    /// Convenience: compress only, no mangling.
+    /// Preset: compress only, no mangling.
     /// Keeps class names and function names.
-    pub fn no_mangle(mut self) -> Self {
+    /// Disables indent and merged module comments.
+    pub fn preset_minify_no_mangle(mut self) -> Self {
         self.options.swc_minify_options = Some(Arc::new(SwcMinifyOptions {
             compress: Some(CompressOptions {
                 passes: 2,

--- a/turbopack/crates/turbopack-ecmascript/src/emit_options.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/emit_options.rs
@@ -1,9 +1,12 @@
+use std::{ops::Deref, sync::LazyLock};
+
 use anyhow::Result;
+use either::Either;
 use swc_core::{
     atoms::atom,
     ecma::minifier::option::{CompressOptions, MangleOptions, MinifyOptions as SwcMinifyOptions},
 };
-use turbo_tasks::{ReadRef, Vc};
+use turbo_tasks::Vc;
 use turbopack_core::chunk::{ChunkingContext, EmitOption, chunking_context::find_emit_option};
 
 /// Ecmascript-specific emit options for controlling minification, indentation,
@@ -13,7 +16,7 @@ use turbopack_core::chunk::{ChunkingContext, EmitOption, chunking_context::find_
 /// callers should use `EcmascriptEmitOptions::default()` (no minification, indent enabled,
 /// merged module comments enabled).
 #[turbo_tasks::value(shared, serialization = "none", eq = "manual")]
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct EcmascriptEmitOptions {
     /// Full SWC minify options. `None` means no minification.
     #[turbo_tasks(trace_ignore)]
@@ -50,15 +53,20 @@ impl EcmascriptEmitOptions {
     }
 
     /// Look up `EcmascriptEmitOptions` from a chunking context's emit options,
-    /// falling back to defaults (no minification, indent enabled, comments enabled).
+    /// falling back to a static default (no minification, indent enabled, comments enabled).
+    ///
+    /// Returns an `impl Deref<Target = EcmascriptEmitOptions>` — either a `ReadRef` from the
+    /// chunking context or a reference to the static default, without allocating.
     pub async fn get_or_default(
         chunking_context: Vc<Box<dyn ChunkingContext>>,
-    ) -> Result<ReadRef<EcmascriptEmitOptions>> {
+    ) -> Result<impl Deref<Target = EcmascriptEmitOptions>> {
+        static DEFAULT: LazyLock<EcmascriptEmitOptions> =
+            LazyLock::new(EcmascriptEmitOptions::default);
         let opts =
             find_emit_option::<EcmascriptEmitOptions>(chunking_context.emit_options()).await?;
         Ok(match opts {
-            Some(vc) => vc.await?,
-            None => ReadRef::new_owned(EcmascriptEmitOptions::default()),
+            Some(vc) => Either::Left(vc.await?),
+            None => Either::Right(&*DEFAULT),
         })
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -1168,7 +1168,7 @@ impl EcmascriptModuleContent {
                 merge_modules(contents, &entry_points, &globals_merged).await?;
 
             // Use the options from an arbitrary module, since they should all be the same with
-            // regards to minify_type and chunking_context.
+            // regards to emit_options and chunking_context.
             let options = module_options.last().unwrap().await?;
 
             let modules_header_width = modules.len().next_power_of_two().trailing_zeros();

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -86,7 +86,7 @@ use turbopack_core::{
     chunk::{
         AsyncModuleInfo, ChunkItem, ChunkableModule, ChunkingContext, EvaluatableAsset,
         MergeableModule, MergeableModuleExposure, MergeableModules, MergeableModulesExposed,
-        ModuleChunkItemIdExt, ModuleId, find_emit_option,
+        ModuleChunkItemIdExt, ModuleId,
     },
     compile_time_info::CompileTimeInfo,
     context::AssetContext,
@@ -1038,14 +1038,7 @@ impl EcmascriptModuleContent {
             ..
         } = &*input;
 
-        let ecma_emit =
-            find_emit_option::<EcmascriptEmitOptions>(chunking_context.emit_options()).await?;
-        let ecma_emit = if let Some(vc) = ecma_emit {
-            Some(vc.await?)
-        } else {
-            None
-        };
-        let ecma_emit = ecma_emit.as_deref().cloned().unwrap_or_default();
+        let ecma_emit = EcmascriptEmitOptions::get_or_default(**chunking_context).await?;
 
         let content = process_parse_result(
             *parsed,
@@ -1139,18 +1132,7 @@ impl EcmascriptModuleContent {
                         *specified_module_type,
                         *generate_source_map,
                         *original_source_map,
-                        {
-                            let ecma_emit = find_emit_option::<EcmascriptEmitOptions>(
-                                chunking_context.emit_options(),
-                            )
-                            .await?;
-                            let ecma_emit = if let Some(vc) = ecma_emit {
-                                Some(vc.await?)
-                            } else {
-                                None
-                            };
-                            ecma_emit.as_deref().cloned().unwrap_or_default()
-                        },
+                        EcmascriptEmitOptions::get_or_default(**chunking_context).await?,
                         Some(&*options),
                         Some(ScopeHoistingOptions {
                             module: *module,
@@ -1189,18 +1171,7 @@ impl EcmascriptModuleContent {
                 original_source_map: CodeGenResultOriginalSourceMap::ScopeHoisting(
                     original_source_maps,
                 ),
-                minify: {
-                    let ecma_emit = find_emit_option::<EcmascriptEmitOptions>(
-                        options.chunking_context.emit_options(),
-                    )
-                    .await?;
-                    let ecma_emit = if let Some(vc) = ecma_emit {
-                        Some(vc.await?)
-                    } else {
-                        None
-                    };
-                    ecma_emit.as_deref().cloned().unwrap_or_default()
-                },
+                minify: EcmascriptEmitOptions::get_or_default(*options.chunking_context).await?,
                 scope_hoisting_syntax_contexts: None,
             };
 

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -13,6 +13,7 @@ pub mod async_chunk;
 pub mod bytes_source_transform;
 pub mod chunk;
 pub mod code_gen;
+pub mod emit_options;
 mod errors;
 pub mod json_source_transform;
 pub mod magic_identifier;
@@ -85,7 +86,7 @@ use turbopack_core::{
     chunk::{
         AsyncModuleInfo, ChunkItem, ChunkableModule, ChunkingContext, EvaluatableAsset,
         MergeableModule, MergeableModuleExposure, MergeableModules, MergeableModulesExposed,
-        MinifyType, ModuleChunkItemIdExt, ModuleId,
+        ModuleChunkItemIdExt, ModuleId, find_emit_option,
     },
     compile_time_info::CompileTimeInfo,
     context::AssetContext,
@@ -110,6 +111,7 @@ use crate::{
         placeable::{SideEffectsDeclaration, get_side_effect_free_declaration},
     },
     code_gen::{CodeGeneration, CodeGenerationHoistedStmt, CodeGens, ModifiableAst},
+    emit_options::EcmascriptEmitOptions,
     merged_module::MergedEcmascriptModule,
     parse::{IdentCollector, ParseResult, generate_js_source_map, parse},
     path_visitor::ApplyVisitors,
@@ -1036,7 +1038,14 @@ impl EcmascriptModuleContent {
             ..
         } = &*input;
 
-        let minify = chunking_context.minify_type().await?;
+        let ecma_emit =
+            find_emit_option::<EcmascriptEmitOptions>(chunking_context.emit_options()).await?;
+        let ecma_emit = if let Some(vc) = ecma_emit {
+            Some(vc.await?)
+        } else {
+            None
+        };
+        let ecma_emit = ecma_emit.as_deref().cloned().unwrap_or_default();
 
         let content = process_parse_result(
             *parsed,
@@ -1044,7 +1053,7 @@ impl EcmascriptModuleContent {
             *specified_module_type,
             *generate_source_map,
             *original_source_map,
-            *minify,
+            ecma_emit.clone(),
             Some(&*input),
             None,
         )
@@ -1066,7 +1075,7 @@ impl EcmascriptModuleContent {
             specified_module_type,
             generate_source_map,
             None,
-            MinifyType::NoMinify,
+            EcmascriptEmitOptions::default(),
             None,
             None,
         )
@@ -1130,7 +1139,18 @@ impl EcmascriptModuleContent {
                         *specified_module_type,
                         *generate_source_map,
                         *original_source_map,
-                        *chunking_context.minify_type().await?,
+                        {
+                            let ecma_emit = find_emit_option::<EcmascriptEmitOptions>(
+                                chunking_context.emit_options(),
+                            )
+                            .await?;
+                            let ecma_emit = if let Some(vc) = ecma_emit {
+                                Some(vc.await?)
+                            } else {
+                                None
+                            };
+                            ecma_emit.as_deref().cloned().unwrap_or_default()
+                        },
                         Some(&*options),
                         Some(ScopeHoistingOptions {
                             module: *module,
@@ -1169,7 +1189,18 @@ impl EcmascriptModuleContent {
                 original_source_map: CodeGenResultOriginalSourceMap::ScopeHoisting(
                     original_source_maps,
                 ),
-                minify: *options.chunking_context.minify_type().await?,
+                minify: {
+                    let ecma_emit = find_emit_option::<EcmascriptEmitOptions>(
+                        options.chunking_context.emit_options(),
+                    )
+                    .await?;
+                    let ecma_emit = if let Some(vc) = ecma_emit {
+                        Some(vc.await?)
+                    } else {
+                        None
+                    };
+                    ecma_emit.as_deref().cloned().unwrap_or_default()
+                },
                 scope_hoisting_syntax_contexts: None,
             };
 
@@ -1675,7 +1706,7 @@ struct CodeGenResult {
     is_esm: bool,
     strict: bool,
     original_source_map: CodeGenResultOriginalSourceMap,
-    minify: MinifyType,
+    minify: EcmascriptEmitOptions,
     #[allow(clippy::type_complexity)]
     /// (Map<Module, corresponding context for imports>, `eval_context.imports.exports`)
     scope_hoisting_syntax_contexts: Option<(
@@ -1695,7 +1726,7 @@ async fn process_parse_result(
     specified_module_type: SpecifiedModuleType,
     generate_source_map: bool,
     original_source_map: Option<ResolvedVc<Box<dyn GenerateSourceMap>>>,
-    minify: MinifyType,
+    minify: EcmascriptEmitOptions,
     options: Option<&EcmascriptModuleContentOptions>,
     scope_hoisting_options: Option<ScopeHoistingOptions<'_>>,
 ) -> Result<CodeGenResult> {
@@ -1769,7 +1800,7 @@ async fn process_parse_result(
                             _ => Default::default(),
                         };
 
-                    let prepend_ident_comment = if matches!(minify, MinifyType::NoMinify) {
+                    let prepend_ident_comment = if minify.merged_module_comments {
                         Some(Comment {
                             kind: CommentKind::Line,
                             span: DUMMY_SP,
@@ -1917,7 +1948,7 @@ async fn process_parse_result(
                         is_esm: false,
                         strict: false,
                         original_source_map: CodeGenResultOriginalSourceMap::Single(None),
-                        minify: MinifyType::NoMinify,
+                        minify: EcmascriptEmitOptions::default(),
                         scope_hoisting_syntax_contexts: None,
                     }
                 }
@@ -1944,7 +1975,7 @@ async fn process_parse_result(
                         is_esm: false,
                         strict: false,
                         original_source_map: CodeGenResultOriginalSourceMap::Single(None),
-                        minify: MinifyType::NoMinify,
+                        minify: EcmascriptEmitOptions::default(),
                         scope_hoisting_syntax_contexts: None,
                     }
                 }
@@ -2089,7 +2120,7 @@ async fn emit_content(
             &mut bytes,
             generate_source_map.then_some(&mut mappings),
         );
-        if matches!(minify, MinifyType::Minify { .. }) {
+        if !minify.indent {
             wr.set_indent_str("");
         }
 

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -1046,7 +1046,8 @@ impl EcmascriptModuleContent {
             *specified_module_type,
             *generate_source_map,
             *original_source_map,
-            ecma_emit.clone(),
+            ecma_emit.indent,
+            ecma_emit.merged_module_comments,
             Some(&*input),
             None,
         )
@@ -1068,7 +1069,8 @@ impl EcmascriptModuleContent {
             specified_module_type,
             generate_source_map,
             None,
-            EcmascriptEmitOptions::default(),
+            true,
+            true,
             None,
             None,
         )
@@ -1112,12 +1114,17 @@ impl EcmascriptModuleContent {
 
             let globals_merged = Globals::default();
 
+            // Use the options from an arbitrary module, since they should all be the same with
+            // regards to emit_options and chunking_context.
+            let options = module_options.last().unwrap().await?;
+            let ecma_emit =
+                EcmascriptEmitOptions::get_or_default(*options.chunking_context).await?;
+
             let contents = module_options
                 .iter()
                 .map(async |options| {
                     let options = options.await?;
                     let EcmascriptModuleContentOptions {
-                        chunking_context,
                         parsed,
                         module,
                         specified_module_type,
@@ -1132,7 +1139,8 @@ impl EcmascriptModuleContent {
                         *specified_module_type,
                         *generate_source_map,
                         *original_source_map,
-                        EcmascriptEmitOptions::get_or_default(**chunking_context).await?,
+                        ecma_emit.indent,
+                        ecma_emit.merged_module_comments,
                         Some(&*options),
                         Some(ScopeHoistingOptions {
                             module: *module,
@@ -1148,10 +1156,6 @@ impl EcmascriptModuleContent {
 
             let (merged_ast, comments, source_maps, original_source_maps, lookup_table) =
                 merge_modules(contents, &entry_points, &globals_merged).await?;
-
-            // Use the options from an arbitrary module, since they should all be the same with
-            // regards to emit_options and chunking_context.
-            let options = module_options.last().unwrap().await?;
 
             let modules_header_width = modules.len().next_power_of_two().trailing_zeros();
             let content = CodeGenResult {
@@ -1171,7 +1175,7 @@ impl EcmascriptModuleContent {
                 original_source_map: CodeGenResultOriginalSourceMap::ScopeHoisting(
                     original_source_maps,
                 ),
-                minify: EcmascriptEmitOptions::get_or_default(*options.chunking_context).await?,
+                indent: ecma_emit.indent,
                 scope_hoisting_syntax_contexts: None,
             };
 
@@ -1677,7 +1681,8 @@ struct CodeGenResult {
     is_esm: bool,
     strict: bool,
     original_source_map: CodeGenResultOriginalSourceMap,
-    minify: EcmascriptEmitOptions,
+    /// Whether to indent JS output.
+    indent: bool,
     #[allow(clippy::type_complexity)]
     /// (Map<Module, corresponding context for imports>, `eval_context.imports.exports`)
     scope_hoisting_syntax_contexts: Option<(
@@ -1697,7 +1702,8 @@ async fn process_parse_result(
     specified_module_type: SpecifiedModuleType,
     generate_source_map: bool,
     original_source_map: Option<ResolvedVc<Box<dyn GenerateSourceMap>>>,
-    minify: EcmascriptEmitOptions,
+    indent: bool,
+    merged_module_comments: bool,
     options: Option<&EcmascriptModuleContentOptions>,
     scope_hoisting_options: Option<ScopeHoistingOptions<'_>>,
 ) -> Result<CodeGenResult> {
@@ -1771,7 +1777,7 @@ async fn process_parse_result(
                             _ => Default::default(),
                         };
 
-                    let prepend_ident_comment = if minify.merged_module_comments {
+                    let prepend_ident_comment = if merged_module_comments {
                         Some(Comment {
                             kind: CommentKind::Line,
                             span: DUMMY_SP,
@@ -1880,7 +1886,7 @@ async fn process_parse_result(
                 is_esm,
                 strict,
                 original_source_map: CodeGenResultOriginalSourceMap::Single(original_source_map),
-                minify,
+                indent,
                 scope_hoisting_syntax_contexts: retain_syntax_context
                     // TODO ideally don't clone here
                     .map(|(_, ctxts, _, export_contexts)| (ctxts, export_contexts.into_owned())),
@@ -1919,7 +1925,7 @@ async fn process_parse_result(
                         is_esm: false,
                         strict: false,
                         original_source_map: CodeGenResultOriginalSourceMap::Single(None),
-                        minify: EcmascriptEmitOptions::default(),
+                        indent: true,
                         scope_hoisting_syntax_contexts: None,
                     }
                 }
@@ -1946,7 +1952,7 @@ async fn process_parse_result(
                         is_esm: false,
                         strict: false,
                         original_source_map: CodeGenResultOriginalSourceMap::Single(None),
-                        minify: EcmascriptEmitOptions::default(),
+                        indent: true,
                         scope_hoisting_syntax_contexts: None,
                     }
                 }
@@ -2060,7 +2066,7 @@ async fn emit_content(
         is_esm,
         strict,
         original_source_map,
-        minify,
+        indent,
         scope_hoisting_syntax_contexts: _,
     } = content;
 
@@ -2091,7 +2097,7 @@ async fn emit_content(
             &mut bytes,
             generate_source_map.then_some(&mut mappings),
         );
-        if !minify.indent {
+        if !indent {
             wr.set_indent_str("");
         }
 

--- a/turbopack/crates/turbopack-ecmascript/src/minify.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/minify.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use anyhow::{Context, Result, bail};
 use bytes_str::BytesStr;
 use swc_core::{
-    atoms::atom,
     base::try_with_handler,
     common::{
         BytePos, FileName, FilePathMapping, GLOBALS, LineCol, Mark, SourceMap as SwcSourceMap,
@@ -16,7 +15,7 @@ use swc_core::{
             Emitter,
             text_writer::{self, JsWriter, WriteJs},
         },
-        minifier::option::{CompressOptions, ExtraOptions, MangleOptions, MinifyOptions},
+        minifier::option::{ExtraOptions, MinifyOptions},
         parser::{Parser, StringInput, Syntax, lexer::Lexer},
         transforms::base::{
             fixer::paren_remover,
@@ -26,15 +25,12 @@ use swc_core::{
     },
 };
 use tracing::instrument;
-use turbopack_core::{
-    chunk::MangleType,
-    code_builder::{Code, CodeBuilder},
-};
+use turbopack_core::code_builder::{Code, CodeBuilder};
 
 use crate::parse::{IdentCollector, generate_js_source_map};
 
 #[instrument(level = "info", name = "minify ecmascript code", skip_all)]
-pub fn minify(code: Code, source_maps: bool, mangle: Option<MangleType>) -> Result<Code> {
+pub fn minify(code: Code, source_maps: bool, swc_minify_options: &MinifyOptions) -> Result<Code> {
     // Pass None for the debug ID so we don't needlessly compute it for the pre-minified content, it
     // will be added by the Code object returned from this function
     let source_maps = source_maps.then(|| code.generate_source_map_ref(None));
@@ -93,31 +89,7 @@ pub fn minify(code: Code, source_maps: bool, mangle: Option<MangleType>) -> Resu
                         cm.clone(),
                         Some(&comments),
                         None,
-                        &MinifyOptions {
-                            compress: Some(CompressOptions {
-                                // Only run 2 passes, this is a tradeoff between performance and
-                                // compression size. Default is 3 passes.
-                                passes: 2,
-                                keep_classnames: mangle.is_none(),
-                                keep_fnames: mangle.is_none(),
-                                ..Default::default()
-                            }),
-                            mangle: mangle.map(|mangle| {
-                                let reserved = vec![atom!("AbortSignal")];
-                                match mangle {
-                                    MangleType::OptimalSize => MangleOptions {
-                                        reserved,
-                                        ..Default::default()
-                                    },
-                                    MangleType::Deterministic => MangleOptions {
-                                        reserved,
-                                        disable_char_freq: true,
-                                        ..Default::default()
-                                    },
-                                }
-                            }),
-                            ..Default::default()
-                        },
+                        swc_minify_options,
                         &ExtraOptions {
                             top_level_mark,
                             unresolved_mark,
@@ -125,7 +97,7 @@ pub fn minify(code: Code, source_maps: bool, mangle: Option<MangleType>) -> Resu
                         },
                     );
 
-                    if mangle.is_none() {
+                    if swc_minify_options.mangle.is_none() {
                         program.mutate(hygiene_with_config(hygiene::Config {
                             top_level_mark,
                             ..Default::default()

--- a/turbopack/crates/turbopack-ecmascript/src/references/import_meta_glob.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/import_meta_glob.rs
@@ -27,8 +27,8 @@ use turbo_tasks_fs::{
 };
 use turbopack_core::{
     chunk::{
-        AsyncModuleInfo, ChunkableModule, ChunkingContext, ChunkingType, MinifyType,
-        ModuleChunkItemIdExt,
+        AsyncModuleInfo, ChunkableModule, ChunkingContext, ChunkingType, ModuleChunkItemIdExt,
+        find_emit_option,
     },
     ident::AssetIdent,
     issue::IssueSource,
@@ -49,6 +49,7 @@ use crate::{
     chunk::{EcmascriptChunkItemContent, EcmascriptExports, ecmascript_chunk_item},
     code_gen::{CodeGen, CodeGeneration, IntoCodeGenReference},
     create_visitor,
+    emit_options::EcmascriptEmitOptions,
     references::{
         AstPath,
         pattern_mapping::{PatternMapping, ResolveType},
@@ -696,7 +697,15 @@ impl EcmascriptChunkPlaceable for ImportMetaGlobAsset {
     ) -> Result<Vc<EcmascriptChunkItemContent>> {
         let this = self.await?;
         let map = &*self.map().await?;
-        let minify = chunking_context.minify_type().await?;
+        let ecma_emit =
+            find_emit_option::<EcmascriptEmitOptions>(chunking_context.emit_options()).await?;
+        let ecma_emit_ref = if let Some(vc) = ecma_emit {
+            Some(vc.await?)
+        } else {
+            None
+        };
+        let ecma_emit_default = EcmascriptEmitOptions::default();
+        let ecma_emit = ecma_emit_ref.as_deref().unwrap_or(&ecma_emit_default);
 
         let mut glob_map = ObjectLit {
             span: DUMMY_SP,
@@ -783,7 +792,7 @@ impl EcmascriptChunkPlaceable for ImportMetaGlobAsset {
         let mut bytes: Vec<u8> = vec![];
         let mut wr: JsWriter<'_, &mut Vec<u8>> =
             JsWriter::new(source_map.clone(), "\n", &mut bytes, None);
-        if matches!(*minify, MinifyType::Minify { .. }) {
+        if !ecma_emit.indent {
             wr.set_indent_str("");
         }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/import_meta_glob.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/import_meta_glob.rs
@@ -28,7 +28,6 @@ use turbo_tasks_fs::{
 use turbopack_core::{
     chunk::{
         AsyncModuleInfo, ChunkableModule, ChunkingContext, ChunkingType, ModuleChunkItemIdExt,
-        find_emit_option,
     },
     ident::AssetIdent,
     issue::IssueSource,
@@ -697,15 +696,7 @@ impl EcmascriptChunkPlaceable for ImportMetaGlobAsset {
     ) -> Result<Vc<EcmascriptChunkItemContent>> {
         let this = self.await?;
         let map = &*self.map().await?;
-        let ecma_emit =
-            find_emit_option::<EcmascriptEmitOptions>(chunking_context.emit_options()).await?;
-        let ecma_emit_ref = if let Some(vc) = ecma_emit {
-            Some(vc.await?)
-        } else {
-            None
-        };
-        let ecma_emit_default = EcmascriptEmitOptions::default();
-        let ecma_emit = ecma_emit_ref.as_deref().unwrap_or(&ecma_emit_default);
+        let ecma_emit = EcmascriptEmitOptions::get_or_default(chunking_context).await?;
 
         let mut glob_map = ObjectLit {
             span: DUMMY_SP,

--- a/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -23,7 +23,6 @@ use turbo_tasks_fs::{DirectoryContent, DirectoryEntry, FileSystemPath};
 use turbopack_core::{
     chunk::{
         AsyncModuleInfo, ChunkableModule, ChunkingContext, ChunkingType, ModuleChunkItemIdExt,
-        find_emit_option,
     },
     ident::AssetIdent,
     issue::IssueSource,
@@ -462,15 +461,7 @@ impl EcmascriptChunkPlaceable for RequireContextAsset {
         _estimated: bool,
     ) -> Result<Vc<EcmascriptChunkItemContent>> {
         let map = &*self.map.await?;
-        let ecma_emit =
-            find_emit_option::<EcmascriptEmitOptions>(chunking_context.emit_options()).await?;
-        let ecma_emit_ref = if let Some(vc) = ecma_emit {
-            Some(vc.await?)
-        } else {
-            None
-        };
-        let ecma_emit_default = EcmascriptEmitOptions::default();
-        let ecma_emit = ecma_emit_ref.as_deref().unwrap_or(&ecma_emit_default);
+        let ecma_emit = EcmascriptEmitOptions::get_or_default(chunking_context).await?;
 
         let mut context_map = ObjectLit {
             span: DUMMY_SP,

--- a/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -22,8 +22,8 @@ use turbo_tasks::{
 use turbo_tasks_fs::{DirectoryContent, DirectoryEntry, FileSystemPath};
 use turbopack_core::{
     chunk::{
-        AsyncModuleInfo, ChunkableModule, ChunkingContext, ChunkingType, MinifyType,
-        ModuleChunkItemIdExt,
+        AsyncModuleInfo, ChunkableModule, ChunkingContext, ChunkingType, ModuleChunkItemIdExt,
+        find_emit_option,
     },
     ident::AssetIdent,
     issue::IssueSource,
@@ -41,6 +41,7 @@ use crate::{
     chunk::{EcmascriptChunkItemContent, EcmascriptExports, ecmascript_chunk_item},
     code_gen::{CodeGen, CodeGeneration, IntoCodeGenReference},
     create_visitor,
+    emit_options::EcmascriptEmitOptions,
     references::{
         AstPath,
         pattern_mapping::{PatternMapping, ResolveType},
@@ -461,7 +462,15 @@ impl EcmascriptChunkPlaceable for RequireContextAsset {
         _estimated: bool,
     ) -> Result<Vc<EcmascriptChunkItemContent>> {
         let map = &*self.map.await?;
-        let minify = chunking_context.minify_type().await?;
+        let ecma_emit =
+            find_emit_option::<EcmascriptEmitOptions>(chunking_context.emit_options()).await?;
+        let ecma_emit_ref = if let Some(vc) = ecma_emit {
+            Some(vc.await?)
+        } else {
+            None
+        };
+        let ecma_emit_default = EcmascriptEmitOptions::default();
+        let ecma_emit = ecma_emit_ref.as_deref().unwrap_or(&ecma_emit_default);
 
         let mut context_map = ObjectLit {
             span: DUMMY_SP,
@@ -520,7 +529,7 @@ impl EcmascriptChunkPlaceable for RequireContextAsset {
         let mut bytes: Vec<u8> = vec![];
         let mut wr: JsWriter<'_, &mut Vec<u8>> =
             JsWriter::new(source_map.clone(), "\n", &mut bytes, None);
-        if matches!(*minify, MinifyType::Minify { .. }) {
+        if !ecma_emit.indent {
             wr.set_indent_str("");
         }
 

--- a/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
@@ -79,6 +79,14 @@ impl NodeJsChunkingContextBuilder {
         self
     }
 
+    pub fn emit_options(
+        mut self,
+        opts: impl IntoIterator<Item = ResolvedVc<Box<dyn EmitOption>>>,
+    ) -> Self {
+        self.chunking_context.emit_options.extend(opts);
+        self
+    }
+
     pub fn source_maps(mut self, source_maps: SourceMapsType) -> Self {
         self.chunking_context.source_maps_type = source_maps;
         self

--- a/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
@@ -10,9 +10,9 @@ use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{
         AssetSuffix, Chunk, ChunkGroupResult, ChunkItem, ChunkType, ChunkableModule,
-        ChunkingConfig, ChunkingConfigs, ChunkingContext, ContentHashing, EntryChunkGroupResult,
-        EvaluatableAsset, MinifyType, SourceMapSourceType, SourceMapsType, UnusedReferences,
-        UrlBehavior,
+        ChunkingConfig, ChunkingConfigs, ChunkingContext, ContentHashing, EmitOption, EmitOptions,
+        EntryChunkGroupResult, EvaluatableAsset, MinifyType, SourceMapSourceType, SourceMapsType,
+        UnusedReferences, UrlBehavior,
         availability_info::AvailabilityInfo,
         chunk_group::{MakeChunkGroupResult, make_chunk_group},
         chunk_id_strategy::ModuleIdStrategy,
@@ -76,6 +76,11 @@ impl NodeJsChunkingContextBuilder {
 
     pub fn minify_type(mut self, minify_type: MinifyType) -> Self {
         self.chunking_context.minify_type = minify_type;
+        self
+    }
+
+    pub fn emit_option(mut self, opt: ResolvedVc<Box<dyn EmitOption>>) -> Self {
+        self.chunking_context.emit_options.push(opt);
         self
     }
 
@@ -222,6 +227,8 @@ pub struct NodeJsChunkingContext {
     enable_dynamic_chunk_content_loading: bool,
     /// Whether to minify resulting chunks
     minify_type: MinifyType,
+    /// Emit options for this chunking context
+    emit_options: Vec<ResolvedVc<Box<dyn EmitOption>>>,
     /// Whether to generate source maps
     source_maps_type: SourceMapsType,
     /// Whether to use manifest chunks for lazy compilation
@@ -279,6 +286,7 @@ impl NodeJsChunkingContext {
                 environment,
                 runtime_type,
                 minify_type: MinifyType::NoMinify,
+                emit_options: vec![],
                 source_maps_type: SourceMapsType::Full,
                 manifest_chunks: false,
                 source_map_source_type: SourceMapSourceType::TurbopackUri,
@@ -397,6 +405,11 @@ impl ChunkingContext for NodeJsChunkingContext {
     #[turbo_tasks::function]
     pub fn minify_type(&self) -> Vc<MinifyType> {
         self.minify_type.cell()
+    }
+
+    #[turbo_tasks::function]
+    fn emit_options(&self) -> Vc<EmitOptions> {
+        Vc::cell(self.emit_options.clone())
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
@@ -11,7 +11,7 @@ use turbopack_core::{
     chunk::{
         AssetSuffix, Chunk, ChunkGroupResult, ChunkItem, ChunkType, ChunkableModule,
         ChunkingConfig, ChunkingConfigs, ChunkingContext, ContentHashing, EmitOption, EmitOptions,
-        EntryChunkGroupResult, EvaluatableAsset, MinifyType, SourceMapSourceType, SourceMapsType,
+        EntryChunkGroupResult, EvaluatableAsset, SourceMapSourceType, SourceMapsType,
         UnusedReferences, UrlBehavior,
         availability_info::AvailabilityInfo,
         chunk_group::{MakeChunkGroupResult, make_chunk_group},
@@ -71,11 +71,6 @@ impl NodeJsChunkingContextBuilder {
 
     pub fn default_url_behavior(mut self, behavior: UrlBehavior) -> Self {
         self.chunking_context.default_url_behavior = Some(behavior);
-        self
-    }
-
-    pub fn minify_type(mut self, minify_type: MinifyType) -> Self {
-        self.chunking_context.minify_type = minify_type;
         self
     }
 
@@ -225,8 +220,6 @@ pub struct NodeJsChunkingContext {
     enable_module_merging: bool,
     /// Enable dynamic chunk content loading.
     enable_dynamic_chunk_content_loading: bool,
-    /// Whether to minify resulting chunks
-    minify_type: MinifyType,
     /// Emit options for this chunking context
     emit_options: Vec<ResolvedVc<Box<dyn EmitOption>>>,
     /// Whether to generate source maps
@@ -285,7 +278,6 @@ impl NodeJsChunkingContext {
                 enable_dynamic_chunk_content_loading: false,
                 environment,
                 runtime_type,
-                minify_type: MinifyType::NoMinify,
                 emit_options: vec![],
                 source_maps_type: SourceMapsType::Full,
                 manifest_chunks: false,
@@ -312,12 +304,6 @@ impl NodeJsChunkingContext {
     #[turbo_tasks::function]
     pub fn runtime_type(&self) -> Vc<RuntimeType> {
         self.runtime_type.cell()
-    }
-
-    /// Returns the minify type.
-    #[turbo_tasks::function]
-    pub fn minify_type(&self) -> Vc<MinifyType> {
-        self.minify_type.cell()
     }
 
     #[turbo_tasks::function]
@@ -400,11 +386,6 @@ impl ChunkingContext for NodeJsChunkingContext {
     #[turbo_tasks::function]
     fn is_dynamic_chunk_content_loading_enabled(&self) -> Vc<bool> {
         Vc::cell(self.enable_dynamic_chunk_content_loading)
-    }
-
-    #[turbo_tasks::function]
-    pub fn minify_type(&self) -> Vc<MinifyType> {
-        self.minify_type.cell()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/content.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/content.rs
@@ -1,14 +1,9 @@
-use std::{
-    collections::hash_map::DefaultHasher,
-    hash::{Hash, Hasher},
-};
-
 use anyhow::Result;
 use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::{File, FileContent};
 use turbopack_core::{
     asset::AssetContent,
-    chunk::ChunkingContext,
+    chunk::{ChunkingContext, chunking_context::find_emit_option},
     code_builder::{Code, CodeBuilder},
     output::OutputAsset,
     source_map::{GenerateSourceMap, SourceMapAsset},
@@ -91,19 +86,16 @@ impl EcmascriptBuildNodeChunkContent {
 
     #[turbo_tasks::function]
     pub(crate) async fn own_version(&self) -> Result<Vc<EcmascriptBuildNodeChunkVersion>> {
-        let ecma_opts =
-            EcmascriptEmitOptions::get_or_default(Vc::upcast(*self.chunking_context)).await?;
-        let mut hasher = DefaultHasher::new();
-        // SwcMinifyOptions doesn't implement Hash; use debug representation
-        format!("{:?}", ecma_opts.swc_minify_options).hash(&mut hasher);
-        ecma_opts.indent.hash(&mut hasher);
-        ecma_opts.merged_module_comments.hash(&mut hasher);
-        let emit_options_hash = hasher.finish();
+        let ecma_opts = find_emit_option::<EcmascriptEmitOptions>(
+            Vc::upcast::<Box<dyn ChunkingContext>>(*self.chunking_context).emit_options(),
+        )
+        .await?
+        .unwrap_or_else(|| EcmascriptEmitOptions::default().cell());
         Ok(EcmascriptBuildNodeChunkVersion::new(
             self.chunking_context.output_root().owned().await?,
             self.chunk.path().owned().await?,
             *self.content,
-            emit_options_hash,
+            ecma_opts,
         ))
     }
 }

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/content.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/content.rs
@@ -1,3 +1,8 @@
+use std::{
+    collections::hash_map::DefaultHasher,
+    hash::{Hash, Hasher},
+};
+
 use anyhow::Result;
 use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::{File, FileContent};
@@ -86,14 +91,19 @@ impl EcmascriptBuildNodeChunkContent {
 
     #[turbo_tasks::function]
     pub(crate) async fn own_version(&self) -> Result<Vc<EcmascriptBuildNodeChunkVersion>> {
+        let ecma_opts =
+            EcmascriptEmitOptions::get_or_default(Vc::upcast(*self.chunking_context)).await?;
+        let mut hasher = DefaultHasher::new();
+        // SwcMinifyOptions doesn't implement Hash; use debug representation
+        format!("{:?}", ecma_opts.swc_minify_options).hash(&mut hasher);
+        ecma_opts.indent.hash(&mut hasher);
+        ecma_opts.merged_module_comments.hash(&mut hasher);
+        let emit_options_hash = hasher.finish();
         Ok(EcmascriptBuildNodeChunkVersion::new(
             self.chunking_context.output_root().owned().await?,
             self.chunk.path().owned().await?,
             *self.content,
-            EcmascriptEmitOptions::get_or_default(Vc::upcast(*self.chunking_context))
-                .await?
-                .swc_minify_options
-                .is_some(),
+            emit_options_hash,
         ))
     }
 }

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/content.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/content.rs
@@ -3,7 +3,7 @@ use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::{File, FileContent};
 use turbopack_core::{
     asset::AssetContent,
-    chunk::{ChunkingContext, find_emit_option},
+    chunk::ChunkingContext,
     code_builder::{Code, CodeBuilder},
     output::OutputAsset,
     source_map::{GenerateSourceMap, SourceMapAsset},
@@ -75,13 +75,10 @@ impl EcmascriptBuildNodeChunkContent {
 
         let mut code = code.build();
 
-        if let Some(ecma_opts) =
-            find_emit_option::<EcmascriptEmitOptions>(self.chunking_context.emit_options()).await?
-        {
-            let ecma_opts = ecma_opts.await?;
-            if let Some(ref swc_opts) = ecma_opts.swc_minify_options {
-                code = minify(code, source_maps, swc_opts)?;
-            }
+        let ecma_opts =
+            EcmascriptEmitOptions::get_or_default(Vc::upcast(*self.chunking_context)).await?;
+        if let Some(ref swc_opts) = ecma_opts.swc_minify_options {
+            code = minify(code, source_maps, swc_opts)?;
         }
 
         Ok(code.cell())
@@ -93,8 +90,9 @@ impl EcmascriptBuildNodeChunkContent {
             self.chunking_context.output_root().owned().await?,
             self.chunk.path().owned().await?,
             *self.content,
-            find_emit_option::<EcmascriptEmitOptions>(self.chunking_context.emit_options())
+            EcmascriptEmitOptions::get_or_default(Vc::upcast(*self.chunking_context))
                 .await?
+                .swc_minify_options
                 .is_some(),
         ))
     }

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/content.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/content.rs
@@ -3,13 +3,16 @@ use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::{File, FileContent};
 use turbopack_core::{
     asset::AssetContent,
-    chunk::{ChunkingContext, MinifyType},
+    chunk::{ChunkingContext, find_emit_option},
     code_builder::{Code, CodeBuilder},
     output::OutputAsset,
     source_map::{GenerateSourceMap, SourceMapAsset},
     version::{Update, Version, VersionedContent},
 };
-use turbopack_ecmascript::{chunk::EcmascriptChunkContent, minify::minify, utils::StringifyJs};
+use turbopack_ecmascript::{
+    chunk::EcmascriptChunkContent, emit_options::EcmascriptEmitOptions, minify::minify,
+    utils::StringifyJs,
+};
 
 use super::{
     chunk::EcmascriptBuildNodeChunk, update::update_node_chunk,
@@ -72,8 +75,13 @@ impl EcmascriptBuildNodeChunkContent {
 
         let mut code = code.build();
 
-        if let MinifyType::Minify { mangle } = *self.chunking_context.minify_type().await? {
-            code = minify(code, source_maps, mangle)?;
+        if let Some(ecma_opts) =
+            find_emit_option::<EcmascriptEmitOptions>(self.chunking_context.emit_options()).await?
+        {
+            let ecma_opts = ecma_opts.await?;
+            if let Some(ref swc_opts) = ecma_opts.swc_minify_options {
+                code = minify(code, source_maps, swc_opts)?;
+            }
         }
 
         Ok(code.cell())
@@ -85,7 +93,9 @@ impl EcmascriptBuildNodeChunkContent {
             self.chunking_context.output_root().owned().await?,
             self.chunk.path().owned().await?,
             *self.content,
-            *self.chunking_context.minify_type().await?,
+            find_emit_option::<EcmascriptEmitOptions>(self.chunking_context.emit_options())
+                .await?
+                .is_some(),
         ))
     }
 }

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/version.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/version.rs
@@ -3,17 +3,14 @@ use turbo_rcstr::RcStr;
 use turbo_tasks::{FxIndexMap, ReadRef, Vc, turbobail};
 use turbo_tasks_fs::FileSystemPath;
 use turbo_tasks_hash::{Xxh3Hash64Hasher, encode_base64};
-use turbopack_core::{
-    chunk::{MinifyType, ModuleId},
-    version::Version,
-};
+use turbopack_core::{chunk::ModuleId, version::Version};
 use turbopack_ecmascript::chunk::{CodeAndIds, EcmascriptChunkContent};
 
 #[turbo_tasks::value(serialization = "none")]
 pub(super) struct EcmascriptBuildNodeChunkVersion {
     pub(super) chunk_path: String,
     pub(super) chunk_items: Vec<ReadRef<CodeAndIds>>,
-    pub(super) minify_type: MinifyType,
+    pub(super) has_minification: bool,
     pub(super) entries_hashes: FxIndexMap<ModuleId, u64>,
 }
 
@@ -24,7 +21,7 @@ impl EcmascriptBuildNodeChunkVersion {
         output_root: FileSystemPath,
         chunk_path: FileSystemPath,
         content: Vc<EcmascriptChunkContent>,
-        minify_type: MinifyType,
+        has_minification: bool,
     ) -> Result<Vc<Self>> {
         let output_root = output_root.clone();
         let chunk_path = chunk_path.clone();
@@ -51,7 +48,7 @@ impl EcmascriptBuildNodeChunkVersion {
         Ok(EcmascriptBuildNodeChunkVersion {
             chunk_path: chunk_path.to_string(),
             chunk_items,
-            minify_type,
+            has_minification,
             entries_hashes,
         }
         .cell())
@@ -64,7 +61,7 @@ impl Version for EcmascriptBuildNodeChunkVersion {
     fn id(&self) -> Vc<RcStr> {
         let mut hasher = Xxh3Hash64Hasher::new();
         hasher.write_ref(&self.chunk_path);
-        hasher.write_ref(&self.minify_type);
+        hasher.write_value(self.has_minification);
         let sorted_hashes = {
             let mut hashes: Vec<_> = self.entries_hashes.values().copied().collect();
             hashes.sort();

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/version.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/version.rs
@@ -10,7 +10,7 @@ use turbopack_ecmascript::chunk::{CodeAndIds, EcmascriptChunkContent};
 pub(super) struct EcmascriptBuildNodeChunkVersion {
     pub(super) chunk_path: String,
     pub(super) chunk_items: Vec<ReadRef<CodeAndIds>>,
-    pub(super) has_minification: bool,
+    pub(super) emit_options_hash: u64,
     pub(super) entries_hashes: FxIndexMap<ModuleId, u64>,
 }
 
@@ -21,7 +21,7 @@ impl EcmascriptBuildNodeChunkVersion {
         output_root: FileSystemPath,
         chunk_path: FileSystemPath,
         content: Vc<EcmascriptChunkContent>,
-        has_minification: bool,
+        emit_options_hash: u64,
     ) -> Result<Vc<Self>> {
         let output_root = output_root.clone();
         let chunk_path = chunk_path.clone();
@@ -48,7 +48,7 @@ impl EcmascriptBuildNodeChunkVersion {
         Ok(EcmascriptBuildNodeChunkVersion {
             chunk_path: chunk_path.to_string(),
             chunk_items,
-            has_minification,
+            emit_options_hash,
             entries_hashes,
         }
         .cell())
@@ -61,7 +61,7 @@ impl Version for EcmascriptBuildNodeChunkVersion {
     fn id(&self) -> Vc<RcStr> {
         let mut hasher = Xxh3Hash64Hasher::new();
         hasher.write_ref(&self.chunk_path);
-        hasher.write_value(self.has_minification);
+        hasher.write_value(self.emit_options_hash);
         let sorted_hashes = {
             let mut hashes: Vec<_> = self.entries_hashes.values().copied().collect();
             hashes.sort();

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/version.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/version.rs
@@ -1,16 +1,24 @@
+use std::{
+    collections::hash_map::DefaultHasher,
+    hash::{Hash, Hasher},
+};
+
 use anyhow::Result;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{FxIndexMap, ReadRef, Vc, turbobail};
 use turbo_tasks_fs::FileSystemPath;
 use turbo_tasks_hash::{Xxh3Hash64Hasher, encode_base64};
 use turbopack_core::{chunk::ModuleId, version::Version};
-use turbopack_ecmascript::chunk::{CodeAndIds, EcmascriptChunkContent};
+use turbopack_ecmascript::{
+    chunk::{CodeAndIds, EcmascriptChunkContent},
+    emit_options::EcmascriptEmitOptions,
+};
 
 #[turbo_tasks::value(serialization = "none")]
 pub(super) struct EcmascriptBuildNodeChunkVersion {
     pub(super) chunk_path: String,
     pub(super) chunk_items: Vec<ReadRef<CodeAndIds>>,
-    pub(super) emit_options_hash: u64,
+    pub(super) ecma_opts: ReadRef<EcmascriptEmitOptions>,
     pub(super) entries_hashes: FxIndexMap<ModuleId, u64>,
 }
 
@@ -21,7 +29,7 @@ impl EcmascriptBuildNodeChunkVersion {
         output_root: FileSystemPath,
         chunk_path: FileSystemPath,
         content: Vc<EcmascriptChunkContent>,
-        emit_options_hash: u64,
+        ecma_opts: Vc<EcmascriptEmitOptions>,
     ) -> Result<Vc<Self>> {
         let output_root = output_root.clone();
         let chunk_path = chunk_path.clone();
@@ -48,7 +56,7 @@ impl EcmascriptBuildNodeChunkVersion {
         Ok(EcmascriptBuildNodeChunkVersion {
             chunk_path: chunk_path.to_string(),
             chunk_items,
-            emit_options_hash,
+            ecma_opts: ecma_opts.await?,
             entries_hashes,
         }
         .cell())
@@ -61,7 +69,10 @@ impl Version for EcmascriptBuildNodeChunkVersion {
     fn id(&self) -> Vc<RcStr> {
         let mut hasher = Xxh3Hash64Hasher::new();
         hasher.write_ref(&self.chunk_path);
-        hasher.write_value(self.emit_options_hash);
+        // Hash EcmascriptEmitOptions via std::hash (SwcMinifyOptions implements Hash)
+        let mut opts_hasher = DefaultHasher::new();
+        self.ecma_opts.hash(&mut opts_hasher);
+        hasher.write_value(opts_hasher.finish());
         let sorted_hashes = {
             let mut hashes: Vec<_> = self.entries_hashes.values().copied().collect();
             hashes.sort();

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/version.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/version.rs
@@ -1,18 +1,31 @@
-use std::{
-    collections::hash_map::DefaultHasher,
-    hash::{Hash, Hasher},
-};
+use std::hash::{Hash, Hasher};
 
 use anyhow::Result;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{FxIndexMap, ReadRef, Vc, turbobail};
 use turbo_tasks_fs::FileSystemPath;
-use turbo_tasks_hash::{Xxh3Hash64Hasher, encode_base64};
+use turbo_tasks_hash::{DeterministicHasher, Xxh3Hash64Hasher, encode_base64};
 use turbopack_core::{chunk::ModuleId, version::Version};
 use turbopack_ecmascript::{
     chunk::{CodeAndIds, EcmascriptChunkContent},
     emit_options::EcmascriptEmitOptions,
 };
+
+/// Adapts [`Xxh3Hash64Hasher`] to the [`std::hash::Hasher`] trait so that types
+/// implementing [`std::hash::Hash`] (such as [`SwcMinifyOptions`]) can be hashed
+/// deterministically across platforms and runs (unlike [`DefaultHasher`], which
+/// uses a random seed).
+struct Xxh3StdHasher(Xxh3Hash64Hasher);
+
+impl Hasher for Xxh3StdHasher {
+    fn write(&mut self, bytes: &[u8]) {
+        self.0.write_bytes(bytes);
+    }
+
+    fn finish(&self) -> u64 {
+        self.0.finish()
+    }
+}
 
 #[turbo_tasks::value(serialization = "none")]
 pub(super) struct EcmascriptBuildNodeChunkVersion {
@@ -69,8 +82,8 @@ impl Version for EcmascriptBuildNodeChunkVersion {
     fn id(&self) -> Vc<RcStr> {
         let mut hasher = Xxh3Hash64Hasher::new();
         hasher.write_ref(&self.chunk_path);
-        // Hash EcmascriptEmitOptions via std::hash (SwcMinifyOptions implements Hash)
-        let mut opts_hasher = DefaultHasher::new();
+        // Hash EcmascriptEmitOptions via Xxh3StdHasher for deterministic results
+        let mut opts_hasher = Xxh3StdHasher(Xxh3Hash64Hasher::new());
         self.ecma_opts.hash(&mut opts_hasher);
         hasher.write_value(opts_hasher.finish());
         let sorted_hashes = {

--- a/turbopack/crates/turbopack-tests/Cargo.toml
+++ b/turbopack/crates/turbopack-tests/Cargo.toml
@@ -24,6 +24,7 @@ once_cell = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+smallvec = { workspace = true }
 testing = { workspace = true }
 tokio = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["json"] }

--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -47,8 +47,10 @@ use turbopack_core::{
         options::{ImportMap, ImportMapping},
     },
 };
-use turbopack_css::chunk::CssChunkType;
-use turbopack_ecmascript::{TreeShakingMode, chunk::EcmascriptChunkType};
+use turbopack_css::{chunk::CssChunkType, emit_options::CssEmitOptions};
+use turbopack_ecmascript::{
+    TreeShakingMode, chunk::EcmascriptChunkType, emit_options::EcmascriptEmitOptions,
+};
 use turbopack_ecmascript_runtime::RuntimeType;
 use turbopack_node::{
     child_process_backend,
@@ -559,6 +561,18 @@ async fn run_test_operation(prepared_test: ResolvedVc<PreparedTest>) -> Result<V
     } else {
         None
     });
+
+    if options.minify {
+        let ecma_opts = EcmascriptEmitOptions::builder()
+            .mangle_optimal_size()
+            .build();
+        builder = builder.emit_option(ResolvedVc::upcast(ecma_opts.resolved_cell()));
+        let css_opts = CssEmitOptions::builder()
+            .minify(true)
+            .chunk_item_comments(false)
+            .build();
+        builder = builder.emit_option(ResolvedVc::upcast(css_opts.resolved_cell()));
+    }
 
     if options.remove_unused_imports {
         builder = builder.unused_references(

--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -29,7 +29,7 @@ use turbopack::{
     module_options::{EcmascriptOptionsContext, ModuleOptionsContext, TypescriptTransformOptions},
 };
 use turbopack_core::{
-    chunk::{ChunkingConfig, MangleType, MinifyType},
+    chunk::ChunkingConfig,
     compile_time_defines,
     compile_time_info::CompileTimeInfo,
     condition::ContextCondition,
@@ -549,13 +549,6 @@ async fn run_test_operation(prepared_test: ResolvedVc<PreparedTest>) -> Result<V
     )
     .source_map_source_type(turbopack_core::chunk::SourceMapSourceType::RelativeUri)
     .module_merging(options.scope_hoisting)
-    .minify_type(if options.minify {
-        MinifyType::Minify {
-            mangle: Some(MangleType::OptimalSize),
-        }
-    } else {
-        MinifyType::NoMinify
-    })
     .export_usage(if options.remove_unused_exports {
         Some(binding_usage.unwrap().connect().to_resolved().await?)
     } else {

--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -564,13 +564,10 @@ async fn run_test_operation(prepared_test: ResolvedVc<PreparedTest>) -> Result<V
 
     if options.minify {
         let ecma_opts = EcmascriptEmitOptions::builder()
-            .mangle_optimal_size()
+            .preset_minify_optimal_size()
             .build();
         builder = builder.emit_option(ResolvedVc::upcast(ecma_opts.resolved_cell()));
-        let css_opts = CssEmitOptions::builder()
-            .minify(true)
-            .chunk_item_comments(false)
-            .build();
+        let css_opts = CssEmitOptions::builder().preset_minify().build();
         builder = builder.emit_option(ResolvedVc::upcast(css_opts.resolved_cell()));
     }
 

--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -559,9 +559,10 @@ async fn run_test_operation(prepared_test: ResolvedVc<PreparedTest>) -> Result<V
         let ecma_opts = EcmascriptEmitOptions::builder()
             .preset_minify_optimal_size()
             .build();
-        builder = builder.emit_option(ResolvedVc::upcast(ecma_opts.resolved_cell()));
         let css_opts = CssEmitOptions::builder().preset_minify().build();
-        builder = builder.emit_option(ResolvedVc::upcast(css_opts.resolved_cell()));
+        builder = builder
+            .emit_option(ResolvedVc::upcast(ecma_opts.resolved_cell()))
+            .emit_option(ResolvedVc::upcast(css_opts.resolved_cell()));
     }
 
     if options.remove_unused_imports {

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -29,8 +29,8 @@ use turbopack_browser::BrowserChunkingContext;
 use turbopack_core::{
     asset::Asset,
     chunk::{
-        ChunkingConfig, ChunkingContext, ChunkingContextExt, EvaluatableAsset, EvaluatableAssetExt,
-        SourceMapSourceType, availability_info::AvailabilityInfo,
+        ChunkingConfig, ChunkingContext, ChunkingContextExt, EmitOption, EvaluatableAsset,
+        EvaluatableAssetExt, SourceMapSourceType, availability_info::AvailabilityInfo,
     },
     compile_time_defines,
     compile_time_info::{
@@ -110,7 +110,6 @@ enum Runtime {
 }
 
 /// Minification mode for snapshot tests.
-/// Replaces the former `MinifyType` from turbopack-core.
 #[derive(Debug, Deserialize, Default)]
 enum MinifyMode {
     /// No minification (default).
@@ -123,6 +122,35 @@ enum MinifyMode {
     Deterministic,
     /// Minify without mangling (compress only).
     NoMangle,
+}
+
+impl MinifyMode {
+    /// Returns JS and CSS minification emit options for this mode.
+    /// Returns an empty vec for `MinifyMode::None`.
+    fn emit_options(&self) -> Vec<ResolvedVc<Box<dyn EmitOption>>> {
+        match self {
+            MinifyMode::None => vec![],
+            mode => {
+                let ecma_opts = match mode {
+                    MinifyMode::OptimalSize => EcmascriptEmitOptions::builder()
+                        .preset_minify_optimal_size()
+                        .build(),
+                    MinifyMode::Deterministic => EcmascriptEmitOptions::builder()
+                        .preset_minify_deterministic()
+                        .build(),
+                    MinifyMode::NoMangle => EcmascriptEmitOptions::builder()
+                        .preset_minify_no_mangle()
+                        .build(),
+                    MinifyMode::None => unreachable!(),
+                };
+                let css_opts = CssEmitOptions::builder().preset_minify().build();
+                vec![
+                    ResolvedVc::upcast(ecma_opts.resolved_cell()),
+                    ResolvedVc::upcast(css_opts.resolved_cell()),
+                ]
+            }
+        }
+    }
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -521,23 +549,8 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
             .source_map_source_type(options.source_map_source_type)
             .chunk_loading_global(options.chunk_loading_global.into());
 
-            if !matches!(options.minify_mode, MinifyMode::None) {
-                let ecma_opts = match options.minify_mode {
-                    MinifyMode::OptimalSize => EcmascriptEmitOptions::builder()
-                        .preset_minify_optimal_size()
-                        .build(),
-                    MinifyMode::Deterministic => EcmascriptEmitOptions::builder()
-                        .preset_minify_deterministic()
-                        .build(),
-                    MinifyMode::NoMangle => EcmascriptEmitOptions::builder()
-                        .preset_minify_no_mangle()
-                        .build(),
-                    MinifyMode::None => unreachable!(),
-                };
-                let css_opts = CssEmitOptions::builder().preset_minify().build();
-                builder = builder
-                    .emit_option(ResolvedVc::upcast(ecma_opts.resolved_cell()))
-                    .emit_option(ResolvedVc::upcast(css_opts.resolved_cell()));
+            for opt in options.minify_mode.emit_options() {
+                builder = builder.emit_option(opt);
             }
 
             if options.remove_unused_imports {
@@ -586,23 +599,8 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
             .debug_ids(options.enable_debug_ids)
             .source_map_source_type(options.source_map_source_type);
 
-            if !matches!(options.minify_mode, MinifyMode::None) {
-                let ecma_opts = match options.minify_mode {
-                    MinifyMode::OptimalSize => EcmascriptEmitOptions::builder()
-                        .preset_minify_optimal_size()
-                        .build(),
-                    MinifyMode::Deterministic => EcmascriptEmitOptions::builder()
-                        .preset_minify_deterministic()
-                        .build(),
-                    MinifyMode::NoMangle => EcmascriptEmitOptions::builder()
-                        .preset_minify_no_mangle()
-                        .build(),
-                    MinifyMode::None => unreachable!(),
-                };
-                let css_opts = CssEmitOptions::builder().preset_minify().build();
-                builder = builder
-                    .emit_option(ResolvedVc::upcast(ecma_opts.resolved_cell()))
-                    .emit_option(ResolvedVc::upcast(css_opts.resolved_cell()));
+            for opt in options.minify_mode.emit_options() {
+                builder = builder.emit_option(opt);
             }
 
             if options.remove_unused_imports {

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -30,7 +30,7 @@ use turbopack_core::{
     asset::Asset,
     chunk::{
         ChunkingConfig, ChunkingContext, ChunkingContextExt, EvaluatableAsset, EvaluatableAssetExt,
-        MangleType, MinifyType, SourceMapSourceType, availability_info::AvailabilityInfo,
+        SourceMapSourceType, availability_info::AvailabilityInfo,
     },
     compile_time_defines,
     compile_time_info::{
@@ -76,8 +76,8 @@ struct SnapshotOptions {
     browserslist: String,
     #[serde(default = "default_entry")]
     entry: String,
-    #[serde(default = "default_minify_type")]
-    minify_type: MinifyType,
+    #[serde(default)]
+    minify_mode: MinifyMode,
     #[serde(default)]
     runtime: Runtime,
     #[serde(default = "default_runtime_type")]
@@ -109,6 +109,22 @@ enum Runtime {
     NodeJs,
 }
 
+/// Minification mode for snapshot tests.
+/// Replaces the former `MinifyType` from turbopack-core.
+#[derive(Debug, Deserialize, Default)]
+enum MinifyMode {
+    /// No minification (default).
+    #[default]
+    #[serde(rename = "NoMinify")]
+    None,
+    /// Minify with optimal-size mangling (char-freq enabled).
+    OptimalSize,
+    /// Minify with deterministic mangling.
+    Deterministic,
+    /// Minify without mangling (compress only).
+    NoMangle,
+}
+
 #[derive(Debug, Deserialize, Default)]
 enum SnapshotEnvironment {
     #[default]
@@ -121,7 +137,7 @@ impl Default for SnapshotOptions {
         SnapshotOptions {
             browserslist: default_browserslist(),
             entry: default_entry(),
-            minify_type: default_minify_type(),
+            minify_mode: MinifyMode::default(),
             runtime: Default::default(),
             runtime_type: default_runtime_type(),
             environment: Default::default(),
@@ -153,10 +169,6 @@ fn default_runtime_type() -> RuntimeType {
     // the runtime. Instead, we only include the runtime in snapshots that
     // specifically request it via "runtime": "Default".
     RuntimeType::Dummy
-}
-
-fn default_minify_type() -> MinifyType {
-    MinifyType::NoMinify
 }
 
 fn default_chunk_loading_global() -> String {
@@ -499,7 +511,6 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
                 env,
                 options.runtime_type,
             )
-            .minify_type(options.minify_type)
             .module_merging(options.scope_hoisting)
             .export_usage(if options.remove_unused_exports {
                 Some(binding_usage.unwrap().connect().to_resolved().await?)
@@ -510,20 +521,18 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
             .source_map_source_type(options.source_map_source_type)
             .chunk_loading_global(options.chunk_loading_global.into());
 
-            if matches!(options.minify_type, MinifyType::Minify { .. }) {
-                let MinifyType::Minify { mangle } = options.minify_type else {
-                    unreachable!()
-                };
-                let ecma_opts = match mangle {
-                    Some(MangleType::OptimalSize) => EcmascriptEmitOptions::builder()
+            if !matches!(options.minify_mode, MinifyMode::None) {
+                let ecma_opts = match options.minify_mode {
+                    MinifyMode::OptimalSize => EcmascriptEmitOptions::builder()
                         .preset_minify_optimal_size()
                         .build(),
-                    Some(MangleType::Deterministic) => EcmascriptEmitOptions::builder()
+                    MinifyMode::Deterministic => EcmascriptEmitOptions::builder()
                         .preset_minify_deterministic()
                         .build(),
-                    None => EcmascriptEmitOptions::builder()
+                    MinifyMode::NoMangle => EcmascriptEmitOptions::builder()
                         .preset_minify_no_mangle()
                         .build(),
+                    MinifyMode::None => unreachable!(),
                 };
                 let css_opts = CssEmitOptions::builder().preset_minify().build();
                 builder = builder
@@ -568,7 +577,6 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
                 env,
                 options.runtime_type,
             )
-            .minify_type(options.minify_type)
             .module_merging(options.scope_hoisting)
             .export_usage(if options.remove_unused_exports {
                 Some(binding_usage.unwrap().connect().to_resolved().await?)
@@ -578,20 +586,18 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
             .debug_ids(options.enable_debug_ids)
             .source_map_source_type(options.source_map_source_type);
 
-            if matches!(options.minify_type, MinifyType::Minify { .. }) {
-                let MinifyType::Minify { mangle } = options.minify_type else {
-                    unreachable!()
-                };
-                let ecma_opts = match mangle {
-                    Some(MangleType::OptimalSize) => EcmascriptEmitOptions::builder()
+            if !matches!(options.minify_mode, MinifyMode::None) {
+                let ecma_opts = match options.minify_mode {
+                    MinifyMode::OptimalSize => EcmascriptEmitOptions::builder()
                         .preset_minify_optimal_size()
                         .build(),
-                    Some(MangleType::Deterministic) => EcmascriptEmitOptions::builder()
+                    MinifyMode::Deterministic => EcmascriptEmitOptions::builder()
                         .preset_minify_deterministic()
                         .build(),
-                    None => EcmascriptEmitOptions::builder()
+                    MinifyMode::NoMangle => EcmascriptEmitOptions::builder()
                         .preset_minify_no_mangle()
                         .build(),
+                    MinifyMode::None => unreachable!(),
                 };
                 let css_opts = CssEmitOptions::builder().preset_minify().build();
                 builder = builder

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -30,7 +30,7 @@ use turbopack_core::{
     asset::Asset,
     chunk::{
         ChunkingConfig, ChunkingContext, ChunkingContextExt, EvaluatableAsset, EvaluatableAssetExt,
-        MinifyType, SourceMapSourceType, availability_info::AvailabilityInfo,
+        MangleType, MinifyType, SourceMapSourceType, availability_info::AvailabilityInfo,
     },
     compile_time_defines,
     compile_time_info::{
@@ -52,9 +52,10 @@ use turbopack_core::{
     output::{OutputAsset, OutputAssets, OutputAssetsReference, OutputAssetsWithReferenced},
     reference_type::{EntryReferenceSubType, ReferenceType, ReferenceTypeCondition},
 };
+use turbopack_css::emit_options::CssEmitOptions;
 use turbopack_ecmascript::{
     AnalyzeMode, CustomTransformer, EcmascriptInputTransform, TransformPlugin, TreeShakingMode,
-    chunk::EcmascriptChunkType,
+    chunk::EcmascriptChunkType, emit_options::EcmascriptEmitOptions,
 };
 use turbopack_ecmascript_plugins::transform::{
     emotion::{EmotionTransformConfig, EmotionTransformer},
@@ -509,6 +510,28 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
             .source_map_source_type(options.source_map_source_type)
             .chunk_loading_global(options.chunk_loading_global.into());
 
+            if matches!(options.minify_type, MinifyType::Minify { .. }) {
+                let MinifyType::Minify { mangle } = options.minify_type else {
+                    unreachable!()
+                };
+                let ecma_opts = match mangle {
+                    Some(MangleType::OptimalSize) => EcmascriptEmitOptions::builder()
+                        .mangle_optimal_size()
+                        .build(),
+                    Some(MangleType::Deterministic) => EcmascriptEmitOptions::builder()
+                        .mangle_deterministic()
+                        .build(),
+                    None => EcmascriptEmitOptions::builder().no_mangle().build(),
+                };
+                let css_opts = CssEmitOptions::builder()
+                    .minify(true)
+                    .chunk_item_comments(false)
+                    .build();
+                builder = builder
+                    .emit_option(ResolvedVc::upcast(ecma_opts.resolved_cell()))
+                    .emit_option(ResolvedVc::upcast(css_opts.resolved_cell()));
+            }
+
             if options.remove_unused_imports {
                 builder = builder.unused_references(
                     binding_usage
@@ -555,6 +578,28 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
             })
             .debug_ids(options.enable_debug_ids)
             .source_map_source_type(options.source_map_source_type);
+
+            if matches!(options.minify_type, MinifyType::Minify { .. }) {
+                let MinifyType::Minify { mangle } = options.minify_type else {
+                    unreachable!()
+                };
+                let ecma_opts = match mangle {
+                    Some(MangleType::OptimalSize) => EcmascriptEmitOptions::builder()
+                        .mangle_optimal_size()
+                        .build(),
+                    Some(MangleType::Deterministic) => EcmascriptEmitOptions::builder()
+                        .mangle_deterministic()
+                        .build(),
+                    None => EcmascriptEmitOptions::builder().no_mangle().build(),
+                };
+                let css_opts = CssEmitOptions::builder()
+                    .minify(true)
+                    .chunk_item_comments(false)
+                    .build();
+                builder = builder
+                    .emit_option(ResolvedVc::upcast(ecma_opts.resolved_cell()))
+                    .emit_option(ResolvedVc::upcast(css_opts.resolved_cell()));
+            }
 
             if options.remove_unused_imports {
                 builder = builder.unused_references(

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -548,9 +548,8 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
             })
             .debug_ids(options.enable_debug_ids)
             .source_map_source_type(options.source_map_source_type)
-            .chunk_loading_global(options.chunk_loading_global.into());
-
-            builder = builder.emit_options(options.minify_mode.emit_options());
+            .chunk_loading_global(options.chunk_loading_global.into())
+            .emit_options(options.minify_mode.emit_options());
 
             if options.remove_unused_imports {
                 builder = builder.unused_references(
@@ -596,9 +595,8 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
                 None
             })
             .debug_ids(options.enable_debug_ids)
-            .source_map_source_type(options.source_map_source_type);
-
-            builder = builder.emit_options(options.minify_mode.emit_options());
+            .source_map_source_type(options.source_map_source_type)
+            .emit_options(options.minify_mode.emit_options());
 
             if options.remove_unused_imports {
                 builder = builder.unused_references(

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -10,6 +10,7 @@ use dunce::canonicalize;
 use rustc_hash::FxHashSet;
 use serde::Deserialize;
 use serde_json::json;
+use smallvec::{SmallVec, smallvec};
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{Effects, OperationVc, ResolvedVc, TurboTasks, Vc, take_effects, turbofmt};
 use turbo_tasks_backend::{BackendOptions, TurboTasksBackend, noop_backing_storage};
@@ -127,9 +128,9 @@ enum MinifyMode {
 impl MinifyMode {
     /// Returns JS and CSS minification emit options for this mode.
     /// Returns an empty vec for `MinifyMode::None`.
-    fn emit_options(&self) -> Vec<ResolvedVc<Box<dyn EmitOption>>> {
+    fn emit_options(&self) -> SmallVec<[ResolvedVc<Box<dyn EmitOption>>; 2]> {
         match self {
-            MinifyMode::None => vec![],
+            MinifyMode::None => SmallVec::new(),
             mode => {
                 let ecma_opts = match mode {
                     MinifyMode::OptimalSize => EcmascriptEmitOptions::builder()
@@ -144,7 +145,7 @@ impl MinifyMode {
                     MinifyMode::None => unreachable!(),
                 };
                 let css_opts = CssEmitOptions::builder().preset_minify().build();
-                vec![
+                smallvec![
                     ResolvedVc::upcast(ecma_opts.resolved_cell()),
                     ResolvedVc::upcast(css_opts.resolved_cell()),
                 ]
@@ -549,9 +550,7 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
             .source_map_source_type(options.source_map_source_type)
             .chunk_loading_global(options.chunk_loading_global.into());
 
-            for opt in options.minify_mode.emit_options() {
-                builder = builder.emit_option(opt);
-            }
+            builder = builder.emit_options(options.minify_mode.emit_options());
 
             if options.remove_unused_imports {
                 builder = builder.unused_references(
@@ -599,9 +598,7 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
             .debug_ids(options.enable_debug_ids)
             .source_map_source_type(options.source_map_source_type);
 
-            for opt in options.minify_mode.emit_options() {
-                builder = builder.emit_option(opt);
-            }
+            builder = builder.emit_options(options.minify_mode.emit_options());
 
             if options.remove_unused_imports {
                 builder = builder.unused_references(

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -516,17 +516,16 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
                 };
                 let ecma_opts = match mangle {
                     Some(MangleType::OptimalSize) => EcmascriptEmitOptions::builder()
-                        .mangle_optimal_size()
+                        .preset_minify_optimal_size()
                         .build(),
                     Some(MangleType::Deterministic) => EcmascriptEmitOptions::builder()
-                        .mangle_deterministic()
+                        .preset_minify_deterministic()
                         .build(),
-                    None => EcmascriptEmitOptions::builder().no_mangle().build(),
+                    None => EcmascriptEmitOptions::builder()
+                        .preset_minify_no_mangle()
+                        .build(),
                 };
-                let css_opts = CssEmitOptions::builder()
-                    .minify(true)
-                    .chunk_item_comments(false)
-                    .build();
+                let css_opts = CssEmitOptions::builder().preset_minify().build();
                 builder = builder
                     .emit_option(ResolvedVc::upcast(ecma_opts.resolved_cell()))
                     .emit_option(ResolvedVc::upcast(css_opts.resolved_cell()));
@@ -585,17 +584,16 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
                 };
                 let ecma_opts = match mangle {
                     Some(MangleType::OptimalSize) => EcmascriptEmitOptions::builder()
-                        .mangle_optimal_size()
+                        .preset_minify_optimal_size()
                         .build(),
                     Some(MangleType::Deterministic) => EcmascriptEmitOptions::builder()
-                        .mangle_deterministic()
+                        .preset_minify_deterministic()
                         .build(),
-                    None => EcmascriptEmitOptions::builder().no_mangle().build(),
+                    None => EcmascriptEmitOptions::builder()
+                        .preset_minify_no_mangle()
+                        .build(),
                 };
-                let css_opts = CssEmitOptions::builder()
-                    .minify(true)
-                    .chunk_item_comments(false)
-                    .build();
+                let css_opts = CssEmitOptions::builder().preset_minify().build();
                 builder = builder
                     .emit_option(ResolvedVc::upcast(ecma_opts.resolved_cell()))
                     .emit_option(ResolvedVc::upcast(css_opts.resolved_cell()));

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/options.json
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic/async_chunk_build/options.json
@@ -1,5 +1,4 @@
 {
-  "minifyType": "NoMinify",
   "runtime": "NodeJs",
   "productionChunking": true
 }

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic/ecmascript_minify/options.json
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic/ecmascript_minify/options.json
@@ -1,8 +1,4 @@
 {
   "runtime": "NodeJs",
-  "minifyType": {
-    "Minify": {
-      "mangle": "optimal-size"
-    }
-  }
+  "minifyMode": "OptimalSize"
 }

--- a/turbopack/crates/turbopack-tests/tests/snapshot/css/css-parse-error/options.json
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/css/css-parse-error/options.json
@@ -1,7 +1,3 @@
 {
-  "minifyType": {
-    "Minify": {
-      "mangle": "optimal-size"
-    }
-  }
+  "minifyMode": "OptimalSize"
 }

--- a/turbopack/crates/turbopack-tests/tests/snapshot/css/minification/options.json
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/css/minification/options.json
@@ -1,7 +1,3 @@
 {
-  "minifyType": {
-    "Minify": {
-      "mangle": "optimal-size"
-    }
-  }
+  "minifyMode": "OptimalSize"
 }

--- a/turbopack/crates/turbopack-tests/tests/snapshot/debug-ids/browser/options.json
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/debug-ids/browser/options.json
@@ -1,7 +1,6 @@
 {
   "runtime": "Browser",
   "runtimeType": "Development",
-  "minifyType": "NoMinify",
   "environment": "Browser",
   "enableDebugIds": true
 }

--- a/turbopack/crates/turbopack-tests/tests/snapshot/debug-ids/node/options.json
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/debug-ids/node/options.json
@@ -1,7 +1,6 @@
 {
   "runtime": "NodeJs",
   "runtimeType": "Development",
-  "minifyType": "NoMinify",
   "environment": "NodeJs",
   "enableDebugIds": true,
   "sourceMapSourceType": "RelativeUri"

--- a/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/options.json
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/minification/paren-remover/options.json
@@ -1,7 +1,3 @@
 {
-  "minifyType": {
-    "Minify": {
-      "mangle": "optimal-size"
-    }
-  }
+  "minifyMode": "OptimalSize"
 }

--- a/turbopack/crates/turbopack-tests/tests/snapshot/runtime/default_build_runtime/options.json
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/runtime/default_build_runtime/options.json
@@ -1,5 +1,4 @@
 {
-  "minifyType": "NoMinify",
   "runtime": "NodeJs",
   "runtimeType": "Production"
 }

--- a/turbopack/crates/turbopack-tests/tests/snapshot/workers/basic/options.json
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/workers/basic/options.json
@@ -1,6 +1,5 @@
 {
   "runtime": "Browser",
   "runtimeType": "Development",
-  "minifyType": "NoMinify",
   "environment": "Browser"
 }

--- a/turbopack/crates/turbopack-tests/tests/snapshot/workers/shared/options.json
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/workers/shared/options.json
@@ -1,6 +1,5 @@
 {
   "runtime": "Browser",
   "runtimeType": "Development",
-  "minifyType": "NoMinify",
   "environment": "Browser"
 }


### PR DESCRIPTION
## What?

Replaces the `MinifyType` / `MangleType` enums and `minify_type()` method on `ChunkingContext` with a new `EmitOption` marker trait system. Introduces `EcmascriptEmitOptions` and `CssEmitOptions` as implementations, stored as a heterogeneous `Vec<ResolvedVc<Box<dyn EmitOption>>>` on each chunking context.

## Why?

The existing `MinifyType` / `MangleType` enums in `turbopack-core` couple the core chunking abstraction to specific minification strategies. To pass full SWC minify options (e.g., custom compress passes, mangle reserved words, char-freq settings) through the chunking context, we'd need to add `swc_core` as a dependency of `turbopack-core` — which is undesirable.

The `EmitOption` trait solves this by providing a heterogeneous, type-safe option bag: each crate defines its own option struct, implements the marker trait, and stores it as `ResolvedVc<Box<dyn EmitOption>>` in the chunking context. Consumers use `find_emit_option::<T>()` to retrieve the concrete type, falling back to defaults when absent.

## How?

### Core infrastructure (`turbopack-core`)

- **`EmitOption`** — a `#[turbo_tasks::value_trait]` marker trait
- **`EmitOptions`** — transparent `Vec<ResolvedVc<Box<dyn EmitOption>>>`
- **`find_emit_option<T>(list) -> Option<Vc<T>>`** — generic lookup (iterates in reverse, returns last match); internal to `chunk::chunking_context`, not re-exported from `chunk/mod.rs`
- **`emit_options()`** method added to `ChunkingContext` trait (default: empty vec)
- `MinifyType`, `MangleType`, and `minify_type()` are **fully removed**

### Ecmascript emit options (`turbopack-ecmascript`)

- **`EcmascriptEmitOptions`** — `#[turbo_tasks::value(shared, serialization = "none", eq = "manual")]` with `SwcMinifyOptions` stored by value (upstream derives `Clone`, `PartialEq`, `Eq`, `Hash`), `indent: bool`, `merged_module_comments: bool`
- **`get_or_default(ctx) -> ReadRef<EcmascriptEmitOptions>`** — async helper that looks up emit options from a chunking context, falling back to defaults without cloning
- **Builder** with preset methods: `preset_minify_optimal_size()`, `preset_minify_deterministic()`, `preset_minify_no_mangle()` — each sets SWC options and calls `apply_minify_defaults()` to disable indent and comments
- `minify()` function now takes `&MinifyOptions` directly instead of `Option<MangleType>`

### CSS emit options (`turbopack-css`)

- **`CssEmitOptions`** — `#[derive(Clone, Copy)]` with `minify: bool` and `chunk_item_comments: bool`
- **`get_or_default(ctx) -> ReadRef<CssEmitOptions>`** — same pattern as ecmascript
- **Builder** with `preset_minify()` that sets both fields for minification

### Chunking context builders

- `BrowserChunkingContext` and `NodeJsChunkingContext` gain an `emit_options: Vec<ResolvedVc<Box<dyn EmitOption>>>` field
- Builders expose both `emit_option(single)` and `emit_options(impl IntoIterator)` methods
- The old `minify_type` field and builder method are removed entirely

### Caller migration

All callers use `EcmascriptEmitOptions::get_or_default(ctx)` or `CssEmitOptions::get_or_default(ctx)` which return `ReadRef<T>` (zero-clone via deref):
- JS chunk content emission (browser, nodejs, evaluate, worker)
- Scope-hoisted module codegen (`lib.rs`) — emit option lookup hoisted before the per-module loop
- `import.meta.glob` and `require.context` codegen
- CSS chunk emission and `finalize_css`
- Version hashing uses `emit_options_hash: u64` computed from all emit option fields, preserving granularity across mangle strategies
- `CodeGenResult` stores only `indent: bool` (the only field used by `emit_content`); `merged_module_comments` is a parameter to `process_parse_result` only

### Next.js integration

- **`minify_emit_options()`** helper in `next-core/src/util.rs` returns `SmallVec<[...; 2]>` of emit options based on `minify` / `no_mangling` / `deterministic_mangle` settings
- All 5 context builders (client, server×2, edge×2) use `builder.emit_options(minify_emit_options(...).await?)`

### CLI and tests

- `turbopack-cli` uses a `minify: bool` field with a local `minify_emit_options()` helper returning `[ResolvedVc<Box<dyn EmitOption>>; 2]`
- Snapshot tests use a local `MinifyMode` enum with `emit_options()` method returning `SmallVec`; JSON options use `"minifyMode": "OptimalSize"` etc.
- Execution tests add emit options when `options.minify` is true

## Test plan

- [x] `cargo check` passes for all modified crates
- [x] `cargo clippy` clean (no warnings)
- [x] `cargo fmt` clean
- [ ] Existing snapshot and execution tests pass (CI)
- [ ] Next.js integration tests pass (CI)

<!-- NEXT_JS_LLM_PR -->