### PR TITLE
fix(app-router): preserve duplicate search-param keys in ppr cache key

### DIFF
--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -739,10 +739,17 @@ function createSegmentFromRouteTree(newRouteTree: RouteTree): Segment {
       return PAGE_SEGMENT_KEY
     }
     // This is based on equivalent logic in addSearchParamsIfPageSegment, used
-    // on the server.
-    const stringifiedQuery = JSON.stringify(
-      Object.fromEntries(new URLSearchParams(renderedSearch))
-    )
+    // on the server. We must preserve duplicate keys (e.g. `?color=red&color=blue`)
+    // because they form distinct cache keys — `Object.fromEntries` would only
+    // keep the last value per key and cause a cache hit when navigating away
+    // from `?color=red&color=blue` to `?color=blue`. See vercel/next.js#92787.
+    const params = new URLSearchParams(renderedSearch)
+    const queryEntries: Record<string, string | string[]> = {}
+    for (const key of new Set(params.keys())) {
+      const all = params.getAll(key)
+      queryEntries[key] = all.length === 1 ? all[0] : all
+    }
+    const stringifiedQuery = JSON.stringify(queryEntries)
     return stringifiedQuery !== '{}'
       ? PAGE_SEGMENT_KEY + '?' + stringifiedQuery
       : PAGE_SEGMENT_KEY

--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -10,6 +10,7 @@ import {
   PAGE_SEGMENT_KEY,
   DEFAULT_SEGMENT_KEY,
   NOT_FOUND_SEGMENT_KEY,
+  renderedSearchToSearchParamsObject,
 } from '../../../shared/lib/segment'
 import { matchSegment } from '../match-segments'
 import { createHrefFromUrl } from './create-href-from-url'
@@ -739,17 +740,11 @@ function createSegmentFromRouteTree(newRouteTree: RouteTree): Segment {
       return PAGE_SEGMENT_KEY
     }
     // This is based on equivalent logic in addSearchParamsIfPageSegment, used
-    // on the server. We must preserve duplicate keys (e.g. `?color=red&color=blue`)
-    // because they form distinct cache keys — `Object.fromEntries` would only
-    // keep the last value per key and cause a cache hit when navigating away
-    // from `?color=red&color=blue` to `?color=blue`. See vercel/next.js#92787.
-    const params = new URLSearchParams(renderedSearch)
-    const queryEntries: Record<string, string | string[]> = {}
-    for (const key of new Set(params.keys())) {
-      const all = params.getAll(key)
-      queryEntries[key] = all.length === 1 ? all[0] : all
-    }
-    const stringifiedQuery = JSON.stringify(queryEntries)
+    // on the server. See #92787 for why we cannot use
+    // `Object.fromEntries(new URLSearchParams(...))` here.
+    const stringifiedQuery = JSON.stringify(
+      renderedSearchToSearchParamsObject(renderedSearch)
+    )
     return stringifiedQuery !== '{}'
       ? PAGE_SEGMENT_KEY + '?' + stringifiedQuery
       : PAGE_SEGMENT_KEY

--- a/packages/next/src/client/components/segment-cache/scheduler.ts
+++ b/packages/next/src/client/components/segment-cache/scheduler.ts
@@ -43,6 +43,7 @@ import {
 import {
   addSearchParamsIfPageSegment,
   PAGE_SEGMENT_KEY,
+  renderedSearchToSearchParamsObject,
 } from '../../../shared/lib/segment'
 import type { SegmentRequestKey } from '../../../shared/lib/segment-cache/segment-value-encoding'
 import { cleanup } from './lru'
@@ -1804,7 +1805,7 @@ function doesCurrentSegmentMatchCachedSegment(
       currentSegment ===
       addSearchParamsIfPageSegment(
         PAGE_SEGMENT_KEY,
-        Object.fromEntries(new URLSearchParams(route.renderedSearch))
+        renderedSearchToSearchParamsObject(route.renderedSearch)
       )
     )
   }

--- a/packages/next/src/client/route-params.ts
+++ b/packages/next/src/client/route-params.ts
@@ -3,6 +3,7 @@ import {
   addSearchParamsIfPageSegment,
   DEFAULT_SEGMENT_KEY,
   PAGE_SEGMENT_KEY,
+  renderedSearchToSearchParamsObject,
 } from '../shared/lib/segment'
 import { ROOT_SEGMENT_REQUEST_KEY } from '../shared/lib/segment-cache/segment-value-encoding'
 import {
@@ -168,7 +169,7 @@ export function getCacheKeyForDynamicParam(
     // search string instead of turning it into JSON.
     const pageSegmentWithSearchParams = addSearchParamsIfPageSegment(
       paramValue,
-      Object.fromEntries(new URLSearchParams(renderedSearch))
+      renderedSearchToSearchParamsObject(renderedSearch)
     ) as string
     return pageSegmentWithSearchParams
   } else if (paramValue === null) {

--- a/packages/next/src/shared/lib/segment.ts
+++ b/packages/next/src/shared/lib/segment.ts
@@ -13,6 +13,25 @@ export function isParallelRouteSegment(segment: string) {
   return segment.startsWith('@') && segment !== '@children'
 }
 
+/**
+ * Build the object passed to `addSearchParamsIfPageSegment` from a rendered
+ * search string. We cannot use `Object.fromEntries(new URLSearchParams(...))`
+ * because it silently drops duplicate keys, which would produce colliding
+ * page-segment cache keys for URLs like `?color=red&color=blue` vs
+ * `?color=blue`. Instead, collapse duplicate keys into an array.
+ */
+export function renderedSearchToSearchParamsObject(
+  renderedSearch: string
+): Record<string, string | string[]> {
+  const params = new URLSearchParams(renderedSearch)
+  const out: Record<string, string | string[]> = {}
+  for (const key of new Set(params.keys())) {
+    const all = params.getAll(key)
+    out[key] = all.length === 1 ? all[0] : all
+  }
+  return out
+}
+
 export function addSearchParamsIfPageSegment(
   segment: Segment,
   searchParams: Record<string, string | string[] | undefined>


### PR DESCRIPTION
Per #92787, `ppr-navigations.ts` stringified the search params via `Object.fromEntries(new URLSearchParams(...))`, which silently drops duplicate keys. Navigating from `?color=red&color=blue` to `?color=blue` produced an identical cache key, so the router skipped re-rendering and the UI stayed stale.

Build the cache-key object via `URLSearchParams.getAll()` so duplicate keys produce an array entry, making the keys distinct across navigations that change the multiplicity of a query parameter. Single-value keys still serialise as a string, so the cache key shape is unchanged for the common case.

Closes #92787

<!-- NEXT_JS_LLM_PR -->