### PR TITLE
Fix monorepo `@next/swc` binary postinstall

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -29,6 +29,8 @@ ignoredBuiltDependencies:
   - ssh2
   - unrs-resolver
   - wasm-pack
+# Keep security related settings in sync with pnpm-workspace.yaml written to
+# temporary fixture dirs in file://./scripts/install-native.mjs
 blockExoticSubdeps: true
 minimumReleaseAge: 2880 # 48 hrs
 minimumReleaseAgeExclude:

--- a/scripts/install-native.mjs
+++ b/scripts/install-native.mjs
@@ -91,7 +91,6 @@ import fsp from 'fs/promises'
     fs.rmSync(tmpdir, { recursive: true, force: true })
     console.log('Installed the following binary packages:', pkgs)
   } catch (e) {
-    console.error(e)
-    console.error('Failed to load @next/swc binary packages')
+    throw new Error('Failed to install @next/swc binary packages', { cause: e })
   }
 })()

--- a/scripts/install-native.mjs
+++ b/scripts/install-native.mjs
@@ -3,6 +3,7 @@ import path from 'path'
 import execa from 'execa'
 import fs from 'fs'
 import fsp from 'fs/promises'
+import { outdent } from 'outdent'
 ;(async function () {
   if (process.env.NEXT_SKIP_NATIVE_POSTINSTALL) {
     console.log(
@@ -58,20 +59,43 @@ import fsp from 'fs/promises'
       packageManager,
     }
     fs.writeFileSync(path.join(tmpdir, 'package.json'), JSON.stringify(pkgJson))
-    fs.writeFileSync(path.join(tmpdir, '.npmrc'), 'node-linker=hoisted')
+    fs.writeFileSync(
+      path.join(tmpdir, 'pnpm-workspace.yaml'),
+      '' +
+        outdent`
+          nodeLinker: hoisted
+        ` +
+        '\n' +
+        // Propagate security related settings from file://./../../pnpm-workspace.yaml
+        outdent`
+          blockExoticSubdeps: true
+          minimumReleaseAge: 2880 # 48 hrs
+          minimumReleaseAgeExclude:
+            - '@next/*'
+            - '@turbo/*'
+            - '@vercel/*'
+            - '@workflow/*'
+            - babel-plugin-react-compiler
+            - next
+            - react
+            - react-dom
+            - react-is
+            - react-server-dom-*
+            - scheduler
+            - turbo
+        `
+    )
 
     const args = [
       'add',
       `next@${nextVersion}`,
       '--lockfile=false',
-      '--ignore-workspace',
       '--ignore-scripts',
     ]
     if (preferOffline) {
       args.push('--prefer-offline')
     }
-    let { stdout } = await execa('pnpm', args, { cwd: tmpdir })
-    console.log(stdout)
+    await execa('pnpm', args, { cwd: tmpdir })
 
     let pkgs = fs.readdirSync(path.join(tmpdir, 'node_modules/@next'))
     fs.mkdirSync(path.join(cwd, 'node_modules/@next'), { recursive: true })


### PR DESCRIPTION
Same issue as in https://github.com/vercel/next.js/pull/92568/ but here we can actually forward all the security related settigns.

We now also fail `postinstall` if the binary install fails so that errors aren't swallowed (pnpm only shows the last 10 or so lines of stdout of postinstall).