### PR TITLE
fix(router): preserve duplicate search params in ChildSegmentMap cache keys

### DIFF
--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -740,9 +740,19 @@ function createSegmentFromRouteTree(newRouteTree: RouteTree): Segment {
     }
     // This is based on equivalent logic in addSearchParamsIfPageSegment, used
     // on the server.
-    const stringifiedQuery = JSON.stringify(
-      Object.fromEntries(new URLSearchParams(renderedSearch))
-    )
+    //
+    // Use getAll() to preserve duplicate search params as arrays, matching the
+    // server-side Record<string, string | string[]> representation. A plain
+    // Object.fromEntries(new URLSearchParams(...)) drops all but the last value
+    // for repeated keys (e.g. ?color=red&color=blue → {color:"blue"}), which
+    // causes distinct URLs to share the same ChildSegmentMap cache entry.
+    const params = new URLSearchParams(renderedSearch)
+    const paramsRecord: Record<string, string | string[]> = {}
+    for (const key of new Set(params.keys())) {
+      const values = params.getAll(key)
+      paramsRecord[key] = values.length === 1 ? values[0] : values
+    }
+    const stringifiedQuery = JSON.stringify(paramsRecord)
     return stringifiedQuery !== '{}'
       ? PAGE_SEGMENT_KEY + '?' + stringifiedQuery
       : PAGE_SEGMENT_KEY

--- a/packages/next/src/client/components/segment-cache/scheduler.ts
+++ b/packages/next/src/client/components/segment-cache/scheduler.ts
@@ -1804,7 +1804,15 @@ function doesCurrentSegmentMatchCachedSegment(
       currentSegment ===
       addSearchParamsIfPageSegment(
         PAGE_SEGMENT_KEY,
-        Object.fromEntries(new URLSearchParams(route.renderedSearch))
+        (() => {
+          const p = new URLSearchParams(route.renderedSearch)
+          const r: Record<string, string | string[]> = {}
+          for (const k of new Set(p.keys())) {
+            const vs = p.getAll(k)
+            r[k] = vs.length === 1 ? vs[0] : vs
+          }
+          return r
+        })()
       )
     )
   }


### PR DESCRIPTION
## What?

Fixes navigation stale UI when multi-value (repeated) search params are used (e.g. `?color=red&color=blue`).

## Why?

`Object.fromEntries(new URLSearchParams(search))` silently drops all but the last value for repeated keys — for example `?color=red&color=blue` becomes `{color:"blue"}`, which is the same as `?color=blue`. This causes distinct URLs to share the same `ChildSegmentMap` cache entry, resulting in stale UI on navigation.

The server-side `addSearchParamsIfPageSegment` receives a proper `Record<string, string | string[]>` (from `NextParsedUrlQuery`) where repeated keys are stored as arrays. The client-side code should produce the same representation.

## How?

Replace `Object.fromEntries(new URLSearchParams(...))` with an explicit loop using `URLSearchParams.getAll()` to build a `Record<string, string | string[]>` that preserves duplicate keys as arrays. Applied in both:

- `packages/next/src/client/components/router-reducer/ppr-navigations.ts` — the cache key for `ChildSegmentMap` entries
- `packages/next/src/client/components/segment-cache/scheduler.ts` — segment matching during cache lookup

Fixes #92787