### PR TITLE
fix(turbopack): support workspace packages in optimizePackageImports

### DIFF
--- a/test/production/app-dir/barrel-optimization/workspace/app/layout.js
+++ b/test/production/app-dir/barrel-optimization/workspace/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/barrel-optimization/workspace/app/page.js
+++ b/test/production/app-dir/barrel-optimization/workspace/app/page.js
@@ -1,0 +1,9 @@
+import { Button } from '@test/workspace-lib'
+
+export default function Home() {
+  return (
+    <div id="workspace-button">
+      <Button />
+    </div>
+  )
+}

--- a/test/production/app-dir/barrel-optimization/workspace/index.test.ts
+++ b/test/production/app-dir/barrel-optimization/workspace/index.test.ts
@@ -1,0 +1,12 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('app-dir - optimizePackageImports - workspace packages', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should build and render workspace package barrel imports', async () => {
+    const $ = await next.render$('/')
+    expect($('#workspace-button').text()).toContain('workspace button')
+  })
+})

--- a/test/production/app-dir/barrel-optimization/workspace/next.config.js
+++ b/test/production/app-dir/barrel-optimization/workspace/next.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  transpilePackages: ['@test/workspace-lib'],
+  experimental: {
+    optimizePackageImports: ['@test/workspace-lib'],
+  },
+}

--- a/test/production/app-dir/barrel-optimization/workspace/node_modules/@test/workspace-lib
+++ b/test/production/app-dir/barrel-optimization/workspace/node_modules/@test/workspace-lib
@@ -1,0 +1,1 @@
+../../packages/workspace-lib

--- a/test/production/app-dir/barrel-optimization/workspace/packages/workspace-lib/package.json
+++ b/test/production/app-dir/barrel-optimization/workspace/packages/workspace-lib/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@test/workspace-lib",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.js"
+  }
+}

--- a/test/production/app-dir/barrel-optimization/workspace/packages/workspace-lib/src/button.js
+++ b/test/production/app-dir/barrel-optimization/workspace/packages/workspace-lib/src/button.js
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export function Button(props) {
+  return React.createElement('button', props, 'workspace button')
+}

--- a/test/production/app-dir/barrel-optimization/workspace/packages/workspace-lib/src/card.js
+++ b/test/production/app-dir/barrel-optimization/workspace/packages/workspace-lib/src/card.js
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export function Card(props) {
+  return React.createElement('div', { ...props, className: 'card' }, 'workspace card')
+}

--- a/test/production/app-dir/barrel-optimization/workspace/packages/workspace-lib/src/index.js
+++ b/test/production/app-dir/barrel-optimization/workspace/packages/workspace-lib/src/index.js
@@ -1,0 +1,3 @@
+export { Button } from './button'
+export { Card } from './card'
+export { UnusedHeavy } from './unused-heavy'

--- a/test/production/app-dir/barrel-optimization/workspace/packages/workspace-lib/src/unused-heavy.js
+++ b/test/production/app-dir/barrel-optimization/workspace/packages/workspace-lib/src/unused-heavy.js
@@ -1,0 +1,9 @@
+import React from 'react'
+
+// This is intentionally "heavy" - if barrel optimization works, this module
+// should not be included in the bundle when only Button is imported.
+const LARGE_DATA = Array.from({ length: 1000 }, (_, i) => `unused_item_${i}`)
+
+export function UnusedHeavy() {
+  return React.createElement('div', null, LARGE_DATA.join(','))
+}

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
@@ -36,7 +36,7 @@ pub use self::{
         EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkItemExt,
         EcmascriptChunkItemOptions, EcmascriptChunkItemWithAsyncInfo, ecmascript_chunk_item,
     },
-    placeable::{EcmascriptChunkPlaceable, EcmascriptExports},
+    placeable::{EcmascriptChunkPlaceable, EcmascriptExports, SideEffectFreePackages},
 };
 
 #[turbo_tasks::value]

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use either::Either;
 use itertools::Itertools;
-use turbo_rcstr::rcstr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{PrettyPrintError, ResolvedVc, TryJoinIterExt, Vc};
 use turbo_tasks_fs::{
     FileJsonContent, FileSystemPath,
@@ -223,20 +223,51 @@ pub enum SideEffectsDeclaration {
     None,
 }
 
+#[turbo_tasks::value(shared)]
+pub struct SideEffectFreePackages {
+    pub glob: ResolvedVc<Glob>,
+    pub package_names: ResolvedVc<Vec<RcStr>>,
+}
+
+#[turbo_tasks::function]
+async fn package_name_from_package_json(package_json: FileSystemPath) -> Result<Vc<Option<RcStr>>> {
+    let package_json_file = FileSource::new(package_json).to_resolved().await?;
+    let package_json = &*package_json_file.content().parse_json().await?;
+    if let FileJsonContent::Content(content) = package_json
+        && let Some(name) = content.get("name").and_then(|n| n.as_str())
+    {
+        return Ok(Vc::cell(Some(name.into())));
+    }
+    Ok(Vc::cell(None))
+}
+
 #[turbo_tasks::function]
 pub async fn get_side_effect_free_declaration(
     path: FileSystemPath,
-    side_effect_free_packages: Option<Vc<Glob>>,
+    side_effect_free_packages: Option<Vc<SideEffectFreePackages>>,
 ) -> Result<Vc<SideEffectsDeclaration>> {
-    if let Some(side_effect_free_packages) = side_effect_free_packages
-        && side_effect_free_packages.await?.matches(&path.path)
-    {
-        return Ok(SideEffectsDeclaration::SideEffectFree.cell());
+    if let Some(side_effect_free_packages) = side_effect_free_packages {
+        let pkgs = side_effect_free_packages.await?;
+        if pkgs.glob.await?.matches(&path.path) {
+            return Ok(SideEffectsDeclaration::SideEffectFree.cell());
+        }
     }
 
     let find_package_json = find_context_file(path.parent(), package_json(), false).await?;
 
     if let FindContextFileResult::Found(package_json, _) = &*find_package_json {
+        // Check if this package is in the optimizePackageImports list by name.
+        // This handles workspace packages whose resolved paths don't go through
+        // node_modules/ and thus don't match the glob.
+        if let Some(sfp) = side_effect_free_packages {
+            let pkgs = sfp.await?;
+            if let Some(name) = &*package_name_from_package_json(package_json.clone()).await? {
+                if pkgs.package_names.await?.contains(name) {
+                    return Ok(SideEffectsDeclaration::SideEffectFree.cell());
+                }
+            }
+        }
+
         match *side_effects_from_package_json(package_json.clone()).await? {
             SideEffectsValue::None => {}
             SideEffectsValue::Constant(side_effects) => {

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -80,7 +80,7 @@ use turbo_tasks::{
     FxDashMap, FxIndexMap, NonLocalValue, ReadRef, ResolvedVc, TaskInput, TryJoinIterExt, Upcast,
     ValueToString, Vc, trace::TraceRawVcs, turbofmt,
 };
-use turbo_tasks_fs::{FileJsonContent, FileSystemPath, glob::Glob, rope::Rope};
+use turbo_tasks_fs::{FileJsonContent, FileSystemPath, rope::Rope};
 use turbopack_core::{
     chunk::{
         AsyncModuleInfo, ChunkItem, ChunkableModule, ChunkingContext, EvaluatableAsset,
@@ -107,7 +107,9 @@ use crate::{
     chunk::{
         EcmascriptChunkItemContent, EcmascriptChunkPlaceable, EcmascriptExports,
         ecmascript_chunk_item,
-        placeable::{SideEffectsDeclaration, get_side_effect_free_declaration},
+        placeable::{
+            SideEffectFreePackages, SideEffectsDeclaration, get_side_effect_free_declaration,
+        },
     },
     code_gen::{CodeGeneration, CodeGenerationHoistedStmt, CodeGens, ModifiableAst},
     merged_module::MergedEcmascriptModule,
@@ -322,7 +324,7 @@ pub struct EcmascriptModuleAssetBuilder {
     transforms: ResolvedVc<EcmascriptInputTransforms>,
     options: ResolvedVc<EcmascriptOptions>,
     compile_time_info: ResolvedVc<CompileTimeInfo>,
-    side_effect_free_packages: Option<ResolvedVc<Glob>>,
+    side_effect_free_packages: Option<ResolvedVc<SideEffectFreePackages>>,
     inner_assets: Option<ResolvedVc<InnerAssets>>,
 }
 
@@ -371,7 +373,7 @@ pub struct EcmascriptModuleAsset {
     pub transforms: ResolvedVc<EcmascriptInputTransforms>,
     pub options: ResolvedVc<EcmascriptOptions>,
     pub compile_time_info: ResolvedVc<CompileTimeInfo>,
-    pub side_effect_free_packages: Option<ResolvedVc<Glob>>,
+    pub side_effect_free_packages: Option<ResolvedVc<SideEffectFreePackages>>,
     pub inner_assets: Option<ResolvedVc<InnerAssets>>,
     #[turbo_tasks(debug_ignore)]
     last_successful_parse: turbo_tasks::TransientState<ReadRef<ParseResult>>,
@@ -454,7 +456,7 @@ impl EcmascriptModuleAsset {
         transforms: ResolvedVc<EcmascriptInputTransforms>,
         options: ResolvedVc<EcmascriptOptions>,
         compile_time_info: ResolvedVc<CompileTimeInfo>,
-        side_effect_free_packages: Option<ResolvedVc<Glob>>,
+        side_effect_free_packages: Option<ResolvedVc<SideEffectFreePackages>>,
     ) -> EcmascriptModuleAssetBuilder {
         EcmascriptModuleAssetBuilder {
             source,
@@ -631,7 +633,7 @@ impl EcmascriptModuleAsset {
         transforms: ResolvedVc<EcmascriptInputTransforms>,
         options: ResolvedVc<EcmascriptOptions>,
         compile_time_info: ResolvedVc<CompileTimeInfo>,
-        side_effect_free_packages: Option<ResolvedVc<Glob>>,
+        side_effect_free_packages: Option<ResolvedVc<SideEffectFreePackages>>,
     ) -> Vc<Self> {
         Self::cell(EcmascriptModuleAsset {
             source,
@@ -654,7 +656,7 @@ impl EcmascriptModuleAsset {
         transforms: ResolvedVc<EcmascriptInputTransforms>,
         options: ResolvedVc<EcmascriptOptions>,
         compile_time_info: ResolvedVc<CompileTimeInfo>,
-        side_effect_free_packages: Option<ResolvedVc<Glob>>,
+        side_effect_free_packages: Option<ResolvedVc<SideEffectFreePackages>>,
         inner_assets: ResolvedVc<InnerAssets>,
     ) -> Result<Vc<Self>> {
         if inner_assets.await?.is_empty() {

--- a/turbopack/crates/turbopack/src/module_options/module_options_context.rs
+++ b/turbopack/crates/turbopack/src/module_options/module_options_context.rs
@@ -14,8 +14,8 @@ use turbopack_core::{
     environment::Environment, resolve::options::ImportMapping,
 };
 use turbopack_ecmascript::{
-    AnalyzeMode, TreeShakingMode, TypeofWindow, references::esm::UrlRewriteBehavior,
-    transform::PresetEnvConfig,
+    AnalyzeMode, TreeShakingMode, TypeofWindow, chunk::SideEffectFreePackages,
+    references::esm::UrlRewriteBehavior, transform::PresetEnvConfig,
 };
 pub use turbopack_mdx::MdxTransformOptions;
 use turbopack_node::{
@@ -215,7 +215,7 @@ pub struct ModuleOptionsContext {
 
     pub environment: Option<ResolvedVc<Environment>>,
     pub execution_context: Option<ResolvedVc<ExecutionContext>>,
-    pub side_effect_free_packages: Option<ResolvedVc<Glob>>,
+    pub side_effect_free_packages: Option<ResolvedVc<SideEffectFreePackages>>,
     pub tree_shaking_mode: Option<TreeShakingMode>,
 
     pub static_url_tag: Option<RcStr>,
@@ -322,16 +322,25 @@ impl ValueDefault for ModuleOptionsContext {
 #[turbo_tasks::function]
 pub async fn side_effect_free_packages_glob(
     side_effect_free_packages: ResolvedVc<Vec<RcStr>>,
-) -> Result<Vc<Glob>> {
-    let side_effect_free_packages = &*side_effect_free_packages.await?;
-    if side_effect_free_packages.is_empty() {
-        return Ok(Glob::new(rcstr!(""), GlobOptions::default()));
+) -> Result<Vc<SideEffectFreePackages>> {
+    let packages = &*side_effect_free_packages.await?;
+    let glob = if packages.is_empty() {
+        Glob::new(rcstr!(""), GlobOptions::default())
+            .to_resolved()
+            .await?
+    } else {
+        let mut globs = String::new();
+        globs.push_str("**/node_modules/{");
+        globs.push_str(&packages.join(","));
+        globs.push_str("}/**");
+        Glob::new(globs.into(), GlobOptions::default())
+            .to_resolved()
+            .await?
+    };
+
+    Ok(SideEffectFreePackages {
+        glob,
+        package_names: side_effect_free_packages,
     }
-
-    let mut globs = String::new();
-    globs.push_str("**/node_modules/{");
-    globs.push_str(&side_effect_free_packages.join(","));
-    globs.push_str("}/**");
-
-    Ok(Glob::new(globs.into(), GlobOptions::default()))
+    .cell())
 }


### PR DESCRIPTION
Fixes: #75148 

The `side_effect_free_packages_glob` function generates a glob pattern `**/node_modules/{pkg}/**` that only matches files resolved through `node_modules/`. Workspace packages (e.g., `"@repo/ui": "workspace:*"`) resolve to their real paths (e.g., `packages/ui/src/button.tsx`), so the glob never matches and the optimization silently fails.

Introduce a `SideEffectFreePackages` struct that carries both the glob (fast path for node_modules packages) and the raw package name list. When the glob check fails, fall back to reading the nearest `package.json` `name` field and checking it against the list. This adds zero extra I/O since the same `package.json` is already read for the `sideEffects` field check.

https://claude.ai/code/session_01CrnBvLzW1ifEhCrKmiHSi9

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
