### PR TITLE
Turbopack: shorter error message for ModuleBatchesGraph::get_entry_index

### DIFF
--- a/turbopack/crates/turbopack-core/src/module_graph/module_batches.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/module_batches.rs
@@ -4,7 +4,7 @@ use std::{
     mem::take,
 };
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use bincode::{Decode, Encode};
 use either::Either;
 use petgraph::graph::{DiGraph, EdgeIndex, NodeIndex};
@@ -79,19 +79,23 @@ pub struct ModuleBatchesGraph {
 impl ModuleBatchesGraph {
     pub async fn get_entry_index(&self, entry: ResolvedVc<Box<dyn Module>>) -> Result<NodeIndex> {
         let Some(entry) = self.entries.get(&entry) else {
-            let possible_entries = format!(
-                "{:#?}",
-                self.entries
-                    .keys()
-                    .map(|e| e.ident().to_string())
-                    .try_join()
-                    .await?
-            );
-            turbobail!(
-                "Entry {} is not in graph (possible entries: {})",
-                entry.ident(),
-                possible_entries
-            );
+            if cfg!(debug_assertions) {
+                let possible_entries = format!(
+                    "{:#?}",
+                    self.entries
+                        .keys()
+                        .map(|e| e.ident().to_string())
+                        .try_join()
+                        .await?
+                );
+                turbobail!(
+                    "Entry {} is not in graph (possible entries: {})",
+                    entry.ident(),
+                    possible_entries
+                );
+            } else {
+                bail!("Entry is not in graph");
+            }
         };
         Ok(*entry)
     }


### PR DESCRIPTION
### What?

In `ModuleBatchesGraph::get_entry_index`, when an entry module is not found in the graph, the error message included the full list of all possible entries (with their resolved string identifiers). This is an expensive operation that requires async resolution of every entry's `ident().to_string()`.

### Why?

In production builds, this verbose error output is unnecessary overhead and produces very long error messages that are hard to read. The list of possible entries is only useful during development/debugging.

### How?

Gate the expensive "possible entries" diagnostic behind `cfg!(debug_assertions)`. In release builds, a short `bail!("Entry is not in graph")` is used instead. In debug builds, the full diagnostic with all possible entry identifiers is still shown to aid debugging.

This mirrors the same approach already applied to `ChunkGroupInfo::get_index_of`.

<!-- NEXT_JS_LLM_PR -->