### PR TITLE
fix(trace-server): default MCP port to --port + 1 to avoid conflicts

### DIFF
--- a/packages/next/src/bin/next.ts
+++ b/packages/next/src/bin/next.ts
@@ -604,7 +604,7 @@ internal
   .addOption(
     new Option(
       '--mcp-port <mcpPort>',
-      'Port for the MCP (Model Context Protocol) server. Defaults to 5748.'
+      'Port for the MCP (Model Context Protocol) server. Defaults to --port + 1.'
     ).argParser(parseValidPositiveInteger)
   )
   .action(

--- a/packages/next/src/cli/internal/turbo-trace-server.ts
+++ b/packages/next/src/cli/internal/turbo-trace-server.ts
@@ -9,7 +9,6 @@ const { StreamableHTTPServerTransport } =
   require('next/dist/compiled/@modelcontextprotocol/sdk/server/streamableHttp') as typeof import('next/dist/compiled/@modelcontextprotocol/sdk/server/streamableHttp')
 
 const DEFAULT_WS_PORT = 5747
-const DEFAULT_MCP_PORT = 5748 // Keep in sync with query-trace.ts
 
 /** 100 internal ticks = 1 µs */
 const TICKS_PER_US = 100
@@ -85,7 +84,7 @@ export async function startTurboTraceServerCli(
   mcpPort: number | undefined
 ) {
   const wsPort = port ?? DEFAULT_WS_PORT
-  const httpPort = mcpPort ?? DEFAULT_MCP_PORT
+  const httpPort = mcpPort ?? wsPort + 1
 
   let bindings
   try {


### PR DESCRIPTION
### What?

When `--mcp-port` is not explicitly provided to `next internal trace`, the MCP HTTP server now defaults to `--port + 1` (the WebSocket port plus one) instead of the hardcoded value `5748`.

The `DEFAULT_WS_PORT` remains `5747`, so when neither flag is passed the behavior is unchanged: WS=5747, MCP=5748.

### Why?

Starting the trace server twice with different `--port` values (e.g. to analyze two trace files simultaneously) caused both instances to attempt to bind the same hardcoded MCP port `5748`:

```
Error: MCP port 5748 is already in use. Use --mcp-port to specify a different port.
```

Making the MCP port default relative to the WS port means each invocation with a unique `--port` automatically gets a unique `--mcp-port` without any extra flags.

### How?

In `startTurboTraceServerCli`, changed:
```ts
const httpPort = mcpPort ?? DEFAULT_MCP_PORT  // always 5748
```
to:
```ts
const httpPort = mcpPort ?? wsPort + 1        // e.g. 5748, 6001, 7001, …
```

The now-unused `DEFAULT_MCP_PORT` constant in `turbo-trace-server.ts` was removed. The identical constant in `query-trace.ts` is kept — it is the client-side default for *connecting* to an MCP server and `5748` remains a sensible default there.

The `--mcp-port` help text was updated to reflect the dynamic default.

<!-- NEXT_JS_LLM_PR -->