### PR TITLE
Turbopack: move assignment_scopes computation into ImportMap

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/benches/analyzer.rs
+++ b/turbopack/crates/turbopack-ecmascript/benches/analyzer.rs
@@ -20,7 +20,7 @@ use turbopack_core::{
 use turbopack_ecmascript::{
     AnalyzeMode,
     analyzer::{
-        graph::{EvalContext, VarGraph, VarMeta, create_graph},
+        graph::{EvalContext, VarGraph, create_graph},
         imports::ImportAttributes,
         linker::link,
         test_utils::{early_visitor, visitor},
@@ -115,7 +115,7 @@ fn bench_link(b: &mut Bencher, input: &BenchInput) {
 
     b.to_async(rt).iter(|| async {
         let var_cache = Default::default();
-        for VarMeta { value, .. } in input.var_graph.values.values() {
+        for value in input.var_graph.values.values() {
             VcStorage::with(async {
                 let compile_time_info = CompileTimeInfo::builder(
                     Environment::new(ExecutionEnvironment::NodeJsLambda(

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/graph.rs
@@ -32,9 +32,7 @@ use crate::{
     analyzer::{WellKnownObjectKind, is_unresolved},
     code_gen::CodeGen,
     references::{
-        constant_value::parse_single_expr_lit,
-        esm::{EsmModuleItem, Liveness},
-        for_each_ident_in_pat,
+        constant_value::parse_single_expr_lit, esm::EsmModuleItem, for_each_ident_in_pat,
     },
     utils::{AstPathRange, unparen},
 };
@@ -273,26 +271,34 @@ impl Effect {
     }
 }
 
+#[derive(Debug)]
 pub enum AssignmentScope {
+    /// assigned in the root scope
     ModuleEval,
+    /// assigned in a function scopes
     Function,
 }
 
+/// Tracks the locations where this was assigned to:
+/// This is used to track the _liveness_ of exports.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum AssignmentScopes {
+    /// assigned only in the root scope
     AllInModuleEvalScope,
+    /// assigned in any set of function scopes
     AllInFunctionScopes,
+    /// assigned in both module and function scopes
     Mixed,
 }
 impl AssignmentScopes {
-    fn new(initial: AssignmentScope) -> Self {
+    pub fn new(initial: AssignmentScope) -> Self {
         match initial {
             AssignmentScope::ModuleEval => AssignmentScopes::AllInModuleEvalScope,
             AssignmentScope::Function => AssignmentScopes::AllInFunctionScopes,
         }
     }
 
-    fn merge(self, other: AssignmentScope) -> Self {
+    pub fn merge(self, other: AssignmentScope) -> Self {
         // If the other assignment kind is the same as the current one, return the current one.
         if self == Self::new(other) {
             self
@@ -305,31 +311,19 @@ impl AssignmentScopes {
 #[derive(Debug, Clone)]
 pub struct VarMeta {
     pub value: JsValue,
-    /// Tracks the locations where this was assigned to:
-    /// - [`AssignmentScopes::AllInModuleEvalScope`] if it was assigned only in the root scope
-    /// - [`AssignmentScopes::AllInFunctionScopes`] if it was assigned in any set of function
-    ///   scopes
-    /// - [`AssignmentScopes::Mixed`] if it was assigned in both
-    ///
-    /// This is used to track the _liveness_ of exports.
-    pub assignment_scopes: AssignmentScopes,
 }
 
 impl VarMeta {
-    pub fn new(value: JsValue, kind: AssignmentScope) -> Self {
-        Self {
-            value,
-            assignment_scopes: AssignmentScopes::new(kind),
-        }
+    pub fn new(value: JsValue) -> Self {
+        Self { value }
     }
 
     pub fn normalize(&mut self) {
         self.value.normalize();
     }
 
-    fn add_alt(&mut self, value: JsValue, kind: AssignmentScope) {
+    fn add_alt(&mut self, value: JsValue) {
         self.value.add_alt(value);
-        self.assignment_scopes = self.assignment_scopes.merge(kind);
     }
 }
 
@@ -386,29 +380,6 @@ impl VarGraph {
         }
         for effect in self.effects.iter_mut() {
             effect.normalize();
-        }
-    }
-
-    /// Returns the liveness of a given export identifier.  An export is live if it might
-    /// change values after module evaluation.
-    pub fn get_export_ident_liveness(&self, id: Id) -> Liveness {
-        if let Some(VarMeta {
-            value: _,
-            assignment_scopes: assignment_kinds,
-        }) = self.values.get(&id)
-        {
-            // If all assignments are in module scope, the export is not live.
-            if *assignment_kinds != AssignmentScopes::AllInModuleEvalScope {
-                Liveness::Live
-            } else {
-                Liveness::Constant
-            }
-        } else {
-            // If we haven't computed a value for it, that means it might be
-            // - A free variable or
-            // - an imported variable
-            // In those cases, we just assume that the value is live since we don't know anything
-            Liveness::Live
         }
     }
 }
@@ -1556,15 +1527,10 @@ impl Analyzer<'_> {
             self.data.free_var_ids.insert(id.0.clone(), id.clone());
         }
 
-        let kind = if self.is_in_fn() {
-            AssignmentScope::Function
-        } else {
-            AssignmentScope::ModuleEval
-        };
         if let Some(prev) = self.data.values.get_mut(&id) {
-            prev.add_alt(value, kind);
+            prev.add_alt(value);
         } else {
-            self.data.values.insert(id, VarMeta::new(value, kind));
+            self.data.values.insert(id, VarMeta::new(value));
         }
         // TODO(kdy1): We may need to report an error for this.
         // Variables declared with `var` are hoisted, but using undefined as its

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/graph.rs
@@ -308,25 +308,6 @@ impl AssignmentScopes {
     }
 }
 
-#[derive(Debug, Clone)]
-pub struct VarMeta {
-    pub value: JsValue,
-}
-
-impl VarMeta {
-    pub fn new(value: JsValue) -> Self {
-        Self { value }
-    }
-
-    pub fn normalize(&mut self) {
-        self.value.normalize();
-    }
-
-    fn add_alt(&mut self, value: JsValue) {
-        self.value.add_alt(value);
-    }
-}
-
 #[derive(Clone, Debug)]
 pub enum DeclUsage {
     SideEffects,
@@ -353,7 +334,7 @@ impl DeclUsage {
 
 #[derive(Debug)]
 pub struct VarGraph {
-    pub values: FxHashMap<Id, VarMeta>,
+    pub values: FxHashMap<Id, JsValue>,
 
     /// Map [`JsValue::FreeVar`] names to their [`Id`] to facilitate lookups into [`Self::values`].
     ///
@@ -1530,7 +1511,7 @@ impl Analyzer<'_> {
         if let Some(prev) = self.data.values.get_mut(&id) {
             prev.add_alt(value);
         } else {
-            self.data.values.insert(id, VarMeta::new(value));
+            self.data.values.insert(id, value);
         }
         // TODO(kdy1): We may need to report an error for this.
         // Variables declared with `var` are hoisted, but using undefined as its

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
@@ -1,4 +1,9 @@
-use std::{borrow::Cow, collections::BTreeMap, fmt::Display, sync::Arc};
+use std::{
+    borrow::Cow,
+    collections::{BTreeMap, hash_map::Entry},
+    fmt::Display,
+    sync::Arc,
+};
 
 use anyhow::{Context, Result};
 use once_cell::sync::Lazy;
@@ -711,10 +716,10 @@ impl Analyzer<'_> {
         };
 
         match self.data.assignment_scopes.entry(id) {
-            std::collections::hash_map::Entry::Occupied(mut e) => {
+            Entry::Occupied(mut e) => {
                 *e.get_mut() = e.get().merge(scope);
             }
-            std::collections::hash_map::Entry::Vacant(e) => {
+            Entry::Vacant(e) => {
                 e.insert(AssignmentScopes::new(scope));
             }
         }

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
@@ -22,7 +22,10 @@ use turbopack_core::loader::WebpackLoaderItem;
 use super::{JsValue, ModuleValue, top_level_await::has_top_level_await};
 use crate::{
     SpecifiedModuleType,
-    analyzer::{ConstantValue, ObjectPart, graph::VarGraph},
+    analyzer::{
+        ConstantValue, ObjectPart,
+        graph::{AssignmentScope, AssignmentScopes, EvalContext},
+    },
     magic_identifier::{MAGIC_IDENTIFIER_DEFAULT_EXPORT, MAGIC_IDENTIFIER_DEFAULT_EXPORT_ATOM},
     references::{
         esm::{EsmAssetReference, EsmExport, Liveness},
@@ -311,6 +314,10 @@ pub(crate) struct ImportMap {
     /// as a whole.
     full_star_imports: FxHashSet<Wtf8Atom>,
 
+    /// Map from export binding id to the scopes where it's assigned. This is used to determine
+    /// whether an export is live or not.
+    pub(super) assignment_scopes: FxHashMap<Id, AssignmentScopes>,
+
     /// Map from exported name to local binding id (includes the syntax context).
     pub(crate) exports_ids: FxHashMap<RcStr, Id>,
 }
@@ -481,7 +488,7 @@ impl ImportMap {
     pub fn as_esm_exports(
         &self,
         import_references: &[ResolvedVc<EsmAssetReference>],
-        var_graph: &VarGraph,
+        eval_context: &EvalContext,
     ) -> Result<FrozenMap<RcStr, EsmExport>> {
         Ok(FrozenMap::from(
             self.exports
@@ -494,7 +501,7 @@ impl ImportMap {
                                 // it is likely that these are not always actually mutable.
                                 Liveness::Mutable
                             } else {
-                                var_graph.get_export_ident_liveness(
+                                eval_context.imports.get_export_ident_liveness(
                                     self.exports_ids.get(name).cloned().with_context(|| {
                                         format!("Exported binding {name} not found in exports_ids")
                                     })?,
@@ -523,6 +530,25 @@ impl ImportMap {
         self.reexport_namespaces.iter().copied()
     }
 
+    /// Returns the liveness of a given export identifier. An export is live if it might change
+    /// values after module evaluation.
+    pub fn get_export_ident_liveness(&self, id: Id) -> Liveness {
+        if let Some(assignment_scopes) = self.assignment_scopes.get(&id) {
+            // If all assignments are in module scope, the export is not live.
+            if *assignment_scopes != AssignmentScopes::AllInModuleEvalScope {
+                Liveness::Live
+            } else {
+                Liveness::Constant
+            }
+        } else {
+            // If we haven't computed a value for it, that means it might be
+            // - A free variable or
+            // - an imported variable
+            // In those cases, we just assume that the value is live since we don't know anything
+            Liveness::Live
+        }
+    }
+
     /// Analyze ES import
     pub(super) fn analyze(m: &Program, comments: Option<&dyn Comments>) -> Self {
         let mut data = ImportMap::default();
@@ -530,6 +556,7 @@ impl ImportMap {
             data: &mut data,
             comments,
             namespace_imports_to_specifier: FxIndexMap::default(),
+            is_in_fn: false,
         };
 
         // A prepass to detect imports to be able to rewrite import+export pairs to true reexports
@@ -649,6 +676,8 @@ struct Analyzer<'a> {
     /// Map from local identifier of namespace imports to module path, used temporarily during
     /// analysis to detect dynamic accesses to namespace imports.
     namespace_imports_to_specifier: FxIndexMap<Id, Wtf8Atom>,
+
+    is_in_fn: bool,
 }
 
 impl Analyzer<'_> {
@@ -671,6 +700,23 @@ impl Analyzer<'_> {
             let i = self.data.references.len();
             self.data.references.insert(r);
             i
+        }
+    }
+
+    fn register_assignment_scope(&mut self, id: Id) {
+        let scope = if self.is_in_fn {
+            AssignmentScope::Function
+        } else {
+            AssignmentScope::ModuleEval
+        };
+
+        match self.data.assignment_scopes.entry(id) {
+            std::collections::hash_map::Entry::Occupied(mut e) => {
+                *e.get_mut() = e.get().merge(scope);
+            }
+            std::collections::hash_map::Entry::Vacant(e) => {
+                e.insert(AssignmentScopes::new(scope));
+            }
         }
     }
 }
@@ -970,6 +1016,25 @@ impl Visit for Analyzer<'_> {
         n.visit_children_with(self);
     }
 
+    fn visit_function(&mut self, node: &Function) {
+        let old_is_in_fn = self.is_in_fn;
+        self.is_in_fn = true;
+        node.visit_children_with(self);
+        self.is_in_fn = old_is_in_fn;
+    }
+    fn visit_constructor(&mut self, node: &Constructor) {
+        let old_is_in_fn = self.is_in_fn;
+        self.is_in_fn = true;
+        node.visit_children_with(self);
+        self.is_in_fn = old_is_in_fn;
+    }
+    fn visit_arrow_expr(&mut self, node: &ArrowExpr) {
+        let old_is_in_fn = self.is_in_fn;
+        self.is_in_fn = true;
+        node.visit_children_with(self);
+        self.is_in_fn = old_is_in_fn;
+    }
+
     fn visit_member_expr(&mut self, node: &MemberExpr) {
         if let MemberProp::Ident(..) | MemberProp::PrivateName(..) = &node.prop
             && node.obj.is_ident()
@@ -982,32 +1047,74 @@ impl Visit for Analyzer<'_> {
     }
 
     fn visit_pat(&mut self, pat: &Pat) {
-        if let Pat::Ident(i) = pat
-            && let Some(module_path) = self.namespace_imports_to_specifier.get(&i.to_id())
-        {
-            self.data.full_star_imports.insert(module_path.clone());
+        if let Pat::Ident(i) = pat {
+            self.register_assignment_scope(i.to_id());
+            if let Some(module_path) = self.namespace_imports_to_specifier.get(&i.to_id()) {
+                self.data.full_star_imports.insert(module_path.clone());
+            }
+        } else {
+            pat.visit_children_with(self);
         }
-
-        pat.visit_children_with(self);
     }
 
     fn visit_simple_assign_target(&mut self, node: &SimpleAssignTarget) {
-        if let SimpleAssignTarget::Ident(i) = node
-            && let Some(module_path) = self.namespace_imports_to_specifier.get(&i.to_id())
-        {
-            self.data.full_star_imports.insert(module_path.clone());
+        if let SimpleAssignTarget::Ident(i) = node {
+            self.register_assignment_scope(i.to_id());
+            if let Some(module_path) = self.namespace_imports_to_specifier.get(&i.to_id()) {
+                self.data.full_star_imports.insert(module_path.clone());
+            }
+        } else {
+            node.visit_children_with(self);
         }
-
-        node.visit_children_with(self);
     }
 
     fn visit_expr(&mut self, node: &Expr) {
-        if let Expr::Ident(i) = node
-            && let Some(module_path) = self.namespace_imports_to_specifier.get(&i.to_id())
-        {
-            self.data.full_star_imports.insert(module_path.clone());
+        if let Expr::Ident(i) = node {
+            if let Some(module_path) = self.namespace_imports_to_specifier.get(&i.to_id()) {
+                self.data.full_star_imports.insert(module_path.clone());
+            }
+        } else {
+            node.visit_children_with(self);
         }
+    }
 
+    fn visit_fn_expr(&mut self, node: &FnExpr) {
+        if let Some(ident) = &node.ident {
+            self.register_assignment_scope(ident.to_id());
+        }
+        node.visit_children_with(self);
+    }
+
+    fn visit_decl(&mut self, node: &Decl) {
+        match node {
+            Decl::Class(c) => {
+                self.register_assignment_scope(c.ident.to_id());
+            }
+            Decl::Fn(f) => {
+                self.register_assignment_scope(f.ident.to_id());
+            }
+            Decl::Using(v) => {
+                let ids: Vec<Id> = find_pat_ids(&v.decls);
+                for id in ids {
+                    self.register_assignment_scope(id);
+                }
+            }
+            Decl::Var(v) => {
+                let ids: Vec<Id> = find_pat_ids(&v.decls);
+                for id in ids {
+                    self.register_assignment_scope(id);
+                }
+            }
+            Decl::TsInterface(_) | Decl::TsTypeAlias(_) | Decl::TsEnum(_) | Decl::TsModule(_) => {}
+        }
+        node.visit_children_with(self);
+    }
+
+    fn visit_update_expr(&mut self, node: &UpdateExpr) {
+        if let Some(key) = node.arg.as_ident() {
+            // node.arg can also be a member expression
+            self.register_assignment_scope(key.to_id());
+        }
         node.visit_children_with(self);
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
@@ -1021,6 +1021,18 @@ impl Visit for Analyzer<'_> {
         n.visit_children_with(self);
     }
 
+    fn visit_getter_prop(&mut self, node: &GetterProp) {
+        let old_is_in_fn = self.is_in_fn;
+        self.is_in_fn = true;
+        node.visit_children_with(self);
+        self.is_in_fn = old_is_in_fn;
+    }
+    fn visit_setter_prop(&mut self, node: &SetterProp) {
+        let old_is_in_fn = self.is_in_fn;
+        self.is_in_fn = true;
+        node.visit_children_with(self);
+        self.is_in_fn = old_is_in_fn;
+    }
     fn visit_function(&mut self, node: &Function) {
         let old_is_in_fn = self.is_in_fn;
         self.is_in_fn = true;

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/linker.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/linker.rs
@@ -6,7 +6,6 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use swc_core::ecma::ast::Id;
 
 use super::{JsValue, graph::VarGraph};
-use crate::analyzer::graph::VarMeta;
 
 pub async fn link<'a, B, RB, F, RF>(
     graph: &VarGraph,
@@ -123,7 +122,7 @@ where
                     if let Some(val) = var_cache_lock.as_deref().and_then(|cache| cache.get(&var)) {
                         total_nodes += val.total_nodes();
                         done.push(val.clone());
-                    } else if let Some(VarMeta { value, .. }) = graph.values.get(&var) {
+                    } else if let Some(value) = graph.values.get(&var) {
                         cycle_stack.insert(var.clone());
                         work_queue_stack.push(Step::LeaveVar(var));
                         total_nodes += value.total_nodes();

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -3861,16 +3861,13 @@ mod tests {
                         .unwrap();
                     }
                     NormalizedOutput::from(explain_all(named_values.iter().map(
-                        |(
-                            name,
+                        |(name, (id, VarMeta { value }))| {
                             (
-                                _,
-                                VarMeta {
-                                    value,
-                                    assignment_scopes,
-                                },
-                            ),
-                        )| (name, value, Some(*assignment_scopes)),
+                                name,
+                                value,
+                                eval_context.imports.assignment_scopes.get(id).copied(),
+                            )
+                        },
                     )))
                     .compare_to_file(&graph_explained_snapshot_path)
                     .unwrap();

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -3756,10 +3756,7 @@ mod tests {
     };
     use crate::{
         AnalyzeMode,
-        analyzer::{
-            graph::{AssignmentScopes, VarMeta},
-            imports::ImportAttributes,
-        },
+        analyzer::{graph::AssignmentScopes, imports::ImportAttributes},
     };
 
     #[fixture("tests/analyzer/graph/**/input.js")]
@@ -3854,14 +3851,14 @@ mod tests {
                             "{:#?}",
                             named_values
                                 .iter()
-                                .map(|(name, (_, VarMeta { value, .. }))| (name, value))
+                                .map(|(name, (_, value))| (name, value))
                                 .collect::<Vec<_>>()
                         ))
                         .compare_to_file(&graph_snapshot_path)
                         .unwrap();
                     }
                     NormalizedOutput::from(explain_all(named_values.iter().map(
-                        |(name, (id, VarMeta { value }))| {
+                        |(name, (id, value))| {
                             (
                                 name,
                                 value,

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -867,7 +867,7 @@ async fn analyze_ecmascript_module_internal(
             .collect();
         let esm_exports = eval_context
             .imports
-            .as_esm_exports(&import_references, &var_graph)?;
+            .as_esm_exports(&import_references, eval_context)?;
 
         for idx in eval_context.imports.reexports_reference_idxs() {
             analysis.add_esm_reexport_reference(idx);

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/array-map/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/array-map/graph-explained.snapshot
@@ -1,8 +1,8 @@
-*anonymous function 170* (const after eval) = (...) => [file]
+*anonymous function 170* = (...) => [file]
 
-*anonymous function 254* (const after eval) = (...) => FreeVar(require)["resolve"](file)
+*anonymous function 254* = (...) => FreeVar(require)["resolve"](file)
 
-*anonymous function 88* (const after eval) = (...) => file
+*anonymous function 88* = (...) => file
 
 a (const after eval) = ["../lib/a.js", "../lib/b.js"]
 

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/arrow/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/arrow/graph-explained.snapshot
@@ -1,8 +1,8 @@
-*anonymous function 116* (const after eval) = (...) => 3
+*anonymous function 116* = (...) => 3
 
 *anonymous function 339* = (...) => 3
 
-*arrow function 11* (const after eval) = (...) => 1
+*arrow function 11* = (...) => 1
 
 *arrow function 214* = (...) => 1
 
@@ -12,11 +12,11 @@
 
 *arrow function 299* = (...) => 2
 
-*arrow function 30* (const after eval) = (...) => 2
+*arrow function 30* = (...) => 2
 
-*arrow function 50* (const after eval) = (...) => 1
+*arrow function 50* = (...) => 1
 
-*arrow function 83* (const after eval) = (...) => 2
+*arrow function 83* = (...) => 2
 
 a (const after eval) = *arrow function 11*
 

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/cycle-cache/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/cycle-cache/graph-explained.snapshot
@@ -1,4 +1,4 @@
-*arrow function 425* (const after eval) = (...) => *arrow function 431*
+*arrow function 425* = (...) => *arrow function 431*
 
 *arrow function 431* = (...) => *arrow function 437*
 
@@ -8,7 +8,7 @@
 
 *arrow function 449* = (...) => 1
 
-*arrow function 468* (const after eval) = (...) => *arrow function 474*
+*arrow function 468* = (...) => *arrow function 474*
 
 *arrow function 474* = (...) => *arrow function 480*
 
@@ -18,7 +18,7 @@
 
 *arrow function 492* = (...) => 2
 
-*arrow function 511* (const after eval) = (...) => *arrow function 517*
+*arrow function 511* = (...) => *arrow function 517*
 
 *arrow function 517* = (...) => *arrow function 523*
 
@@ -28,7 +28,7 @@
 
 *arrow function 535* = (...) => 2
 
-*arrow function 554* (const after eval) = (...) => *arrow function 560*
+*arrow function 554* = (...) => *arrow function 560*
 
 *arrow function 560* = (...) => *arrow function 566*
 

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/declarations/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/declarations/graph-explained.snapshot
@@ -1,4 +1,4 @@
-*anonymous function 25* (const after eval) = (...) => undefined
+*anonymous function 25* = (...) => undefined
 
 a (const after eval) = (...) => undefined
 

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/default-args/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/default-args/graph-explained.snapshot
@@ -1,4 +1,4 @@
-*arrow function 105* (const after eval) = (...) => value2
+*arrow function 105* = (...) => value2
 
 Fun (const after eval) = (...) => value
 

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/esbuild/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/esbuild/graph-explained.snapshot
@@ -1,4 +1,4 @@
-*arrow function 2666* (const after eval) = (...) => (
+*arrow function 2666* = (...) => (
   | [
         "node",
         [

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/issue-77126/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/issue-77126/graph-explained.snapshot
@@ -1,4 +1,4 @@
-*arrow function 19* (const after eval) = (...) => false
+*arrow function 19* = (...) => false
 
 run (const after eval) = (...) => ("should not run" | "should run")
 

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/nested/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/nested/graph-explained.snapshot
@@ -1,8 +1,8 @@
-*anonymous function 66* (const after eval) = (...) => undefined
+*anonymous function 66* = (...) => undefined
 
-*arrow function 118* (const after eval) = (...) => undefined
+*arrow function 118* = (...) => undefined
 
-*arrow function 229* (const after eval) = (...) => undefined
+*arrow function 229* = (...) => undefined
 
 a (const after eval) = (...) => undefined
 

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/non-root-assignments/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/non-root-assignments/graph-explained.snapshot
@@ -1,4 +1,4 @@
-*arrow function 907* (const after eval) = (...) => undefined
+*arrow function 907* = (...) => undefined
 
 ConstAfterEvalClass (const after eval) = ???*0*
 - *0* unsupported expression

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/non-root-assignments/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/non-root-assignments/graph-explained.snapshot
@@ -8,6 +8,14 @@ d1 (const after eval) = 2
 
 default_function_export_const_after_eval (const after eval) = (...) => undefined
 
+foo_const_after_eval (const after eval) = {...???*0*, ...???*1*}
+- *0* unsupported object part
+  ⚠️  This value might have side effects
+- *1* unsupported object part
+  ⚠️  This value might have side effects
+
+getter_not_const_after_eval = (1 | 2)
+
 i (const after eval) = (0 | ???*0*)
 - *0* updated with update expression
   ⚠️  This value might have side effects
@@ -25,3 +33,9 @@ named_let_export_const_after_eval_2 (const after eval) = (???*0* | 5)
 named_let_export_not_const_after_eval = (1 | 5)
 
 named_let_export_not_const_after_eval_2 = (1 | 3)
+
+setter_not_const_after_eval = (1 | 2)
+
+v = ???*0*
+- *0* v
+  ⚠️  pattern without value

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/non-root-assignments/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/non-root-assignments/graph.snapshot
@@ -40,6 +40,56 @@
         ),
     ),
     (
+        "foo_const_after_eval",
+        Object {
+            total_nodes: 3,
+            parts: [
+                Spread(
+                    Unknown {
+                        original_value: None,
+                        reason: "unsupported object part",
+                        has_side_effects: true,
+                    },
+                ),
+                Spread(
+                    Unknown {
+                        original_value: None,
+                        reason: "unsupported object part",
+                        has_side_effects: true,
+                    },
+                ),
+            ],
+            mutable: true,
+        },
+    ),
+    (
+        "getter_not_const_after_eval",
+        Alternatives {
+            total_nodes: 3,
+            values: [
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                1.0,
+                            ),
+                        ),
+                    ),
+                ),
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                2.0,
+                            ),
+                        ),
+                    ),
+                ),
+            ],
+            logical_property: None,
+        },
+    ),
+    (
         "i",
         Alternatives {
             total_nodes: 3,
@@ -193,6 +243,48 @@
                 ),
             ],
             logical_property: None,
+        },
+    ),
+    (
+        "setter_not_const_after_eval",
+        Alternatives {
+            total_nodes: 3,
+            values: [
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                1.0,
+                            ),
+                        ),
+                    ),
+                ),
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            TotalOrderF64(
+                                2.0,
+                            ),
+                        ),
+                    ),
+                ),
+            ],
+            logical_property: None,
+        },
+    ),
+    (
+        "v",
+        Unknown {
+            original_value: Some(
+                Variable(
+                    (
+                        "v",
+                        #11,
+                    ),
+                ),
+            ),
+            reason: "pattern without value",
+            has_side_effects: false,
         },
     ),
 ]

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/non-root-assignments/input.js
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/non-root-assignments/input.js
@@ -37,5 +37,13 @@ export class ConstAfterEvalClass {
   }
 }
 
-
-
+let getter_not_const_after_eval = 1
+let setter_not_const_after_eval = 1
+let foo_const_after_eval = {
+  get x() {
+    getter_not_const_after_eval = 2
+  },
+  set x(v) {
+    setter_not_const_after_eval = 2
+  },
+}

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/non-root-assignments/resolved-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/non-root-assignments/resolved-explained.snapshot
@@ -8,6 +8,14 @@ d1 = 2
 
 default_function_export_const_after_eval = (...) => undefined
 
+foo_const_after_eval = {...???*0*, ...???*1*}
+- *0* unsupported object part
+  ⚠️  This value might have side effects
+- *1* unsupported object part
+  ⚠️  This value might have side effects
+
+getter_not_const_after_eval = (1 | 2)
+
 i = (0 | ???*0*)
 - *0* updated with update expression
   ⚠️  This value might have side effects
@@ -25,3 +33,9 @@ named_let_export_const_after_eval_2 = (???*0* | 5)
 named_let_export_not_const_after_eval = (1 | 5)
 
 named_let_export_not_const_after_eval_2 = (1 | 3)
+
+setter_not_const_after_eval = (1 | 2)
+
+v = ???*0*
+- *0* v
+  ⚠️  pattern without value

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/pack-2682/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/pack-2682/graph-explained.snapshot
@@ -1,4 +1,4 @@
-*arrow function 24* (const after eval) = (...) => FreeVar(JSON)["stringify"](
+*arrow function 24* = (...) => FreeVar(JSON)["stringify"](
     {
         "condition": (variable === "true"),
         "buggedConditionalCheck": ((variable === "true") ? "true" : "false")

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/peg/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/peg/graph-explained.snapshot
@@ -140,7 +140,7 @@
 
 *anonymous function 5936* = (...) => {"type": "sort_expression", "expression": expression, "order": order}
 
-*anonymous function 625* (const after eval) = (...) => `Expected ${describeExpected(expected)} but ${describeFound(found)} found.`
+*anonymous function 625* = (...) => `Expected ${describeExpected(expected)} but ${describeFound(found)} found.`
 
 *anonymous function 6287* = (...) => {"type": "scalar_function_expression", "name": name, "arguments": args, "udf": true}
 

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/react-dom-production/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/react-dom-production/graph-explained.snapshot
@@ -51,7 +51,7 @@ $k (const after eval) = (...) => ((bj(a) ? 1 : 0) | 11 | 14 | 2)
 
 *anonymous function 114743* = (...) => null
 
-*anonymous function 117815* (const after eval) = (...) => (
+*anonymous function 117815* = (...) => (
   | ???*0*
   | b
   | pj(a, b, c)
@@ -64,15 +64,15 @@ $k (const after eval) = (...) => ((bj(a) ? 1 : 0) | 11 | 14 | 2)
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 
-*anonymous function 126145* (const after eval) = (...) => undefined
+*anonymous function 126145* = (...) => undefined
 
-*anonymous function 126252* (const after eval) = (...) => undefined
+*anonymous function 126252* = (...) => undefined
 
-*anonymous function 126382* (const after eval) = (...) => undefined
+*anonymous function 126382* = (...) => undefined
 
 *anonymous function 126480* = (...) => undefined
 
-*anonymous function 126604* (const after eval) = (...) => undefined
+*anonymous function 126604* = (...) => undefined
 
 *anonymous function 127055* = (...) => undefined
 
@@ -82,40 +82,40 @@ $k (const after eval) = (...) => ((bj(a) ? 1 : 0) | 11 | 14 | 2)
 
 *anonymous function 127571* = (...) => undefined
 
-*anonymous function 127654* (const after eval) = (...) => undefined
+*anonymous function 127654* = (...) => undefined
 
 *anonymous function 127846* = (...) => undefined
 
-*anonymous function 127923* (const after eval) = (...) => undefined
+*anonymous function 127923* = (...) => undefined
 
-*anonymous function 128036* (const after eval) = (...) => undefined
+*anonymous function 128036* = (...) => undefined
 
-*anonymous function 128133* (const after eval) = (...) => C
+*anonymous function 128133* = (...) => C
 
-*anonymous function 128157* (const after eval) = (...) => (???*0* | undefined)
+*anonymous function 128157* = (...) => (???*0* | undefined)
 - *0* b()
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 
-*anonymous function 128216* (const after eval) = (...) => undefined
+*anonymous function 128216* = (...) => undefined
 
-*anonymous function 129223* (const after eval) = (...) => ((null === a) ? null : a["stateNode"])
+*anonymous function 129223* = (...) => ((null === a) ? null : a["stateNode"])
 
-*anonymous function 129753* (const after eval) = (...) => dl(a, b, null, c)
+*anonymous function 129753* = (...) => dl(a, b, null, c)
 
-*anonymous function 129905* (const after eval) = (...) => new ml(b)
+*anonymous function 129905* = (...) => new ml(b)
 
-*anonymous function 130256* (const after eval) = (...) => (null | a)
+*anonymous function 130256* = (...) => (null | a)
 
-*anonymous function 130523* (const after eval) = (...) => Sk(a)
+*anonymous function 130523* = (...) => Sk(a)
 
-*anonymous function 130565* (const after eval) = (...) => sl(null, a, b, !(0), c)
+*anonymous function 130565* = (...) => sl(null, a, b, !(0), c)
 
-*anonymous function 130658* (const after eval) = (...) => new nl(b)
+*anonymous function 130658* = (...) => new nl(b)
 
-*anonymous function 131212* (const after eval) = (...) => sl(null, a, b, !(1), c)
+*anonymous function 131212* = (...) => sl(null, a, b, !(1), c)
 
-*anonymous function 131315* (const after eval) = (...) => (a["_reactRootContainer"] ? ???*0* : !(1))
+*anonymous function 131315* = (...) => (a["_reactRootContainer"] ? ???*0* : !(1))
 - *0* !(0)
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
@@ -124,31 +124,31 @@ $k (const after eval) = (...) => ((bj(a) ? 1 : 0) | 11 | 14 | 2)
 
 *anonymous function 131418* = (...) => undefined
 
-*anonymous function 131559* (const after eval) = (...) => sl(a, b, c, !(1), d)
+*anonymous function 131559* = (...) => sl(a, b, c, !(1), d)
 
 *anonymous function 13525* = (...) => undefined
 
 *anonymous function 13573* = (...) => a(b, c, d, e)
 
-*anonymous function 13608* (const after eval) = (...) => undefined
+*anonymous function 13608* = (...) => undefined
 
-*anonymous function 14731* (const after eval) = (...) => undefined
+*anonymous function 14731* = (...) => undefined
 
 *anonymous function 14754* = (...) => undefined
 
-*anonymous function 17157* (const after eval) = (...) => undefined
+*anonymous function 17157* = (...) => undefined
 
-*anonymous function 17435* (const after eval) = (...) => undefined
+*anonymous function 17435* = (...) => undefined
 
-*anonymous function 2285* (const after eval) = (...) => undefined
+*anonymous function 2285* = (...) => undefined
 
 *anonymous function 23424* = (...) => undefined
 
-*anonymous function 2443* (const after eval) = (...) => undefined
+*anonymous function 2443* = (...) => undefined
 
-*anonymous function 2564* (const after eval) = (...) => undefined
+*anonymous function 2564* = (...) => undefined
 
-*anonymous function 2705* (const after eval) = (...) => undefined
+*anonymous function 2705* = (...) => undefined
 
 *anonymous function 27645* = (...) => undefined
 
@@ -156,21 +156,21 @@ $k (const after eval) = (...) => ((bj(a) ? 1 : 0) | 11 | 14 | 2)
 
 *anonymous function 28013* = (...) => undefined
 
-*anonymous function 28108* (const after eval) = (...) => (a["timeStamp"] || FreeVar(Date)["now"]())
+*anonymous function 28108* = (...) => (a["timeStamp"] || FreeVar(Date)["now"]())
 
-*anonymous function 28404* (const after eval) = (...) => ((undefined === a["relatedTarget"]) ? ((a["fromElement"] === a["srcElement"]) ? a["toElement"] : a["fromElement"]) : a["relatedTarget"])
+*anonymous function 28404* = (...) => ((undefined === a["relatedTarget"]) ? ((a["fromElement"] === a["srcElement"]) ? a["toElement"] : a["fromElement"]) : a["relatedTarget"])
 
-*anonymous function 28530* (const after eval) = (...) => (a["movementX"] | wd)
+*anonymous function 28530* = (...) => (a["movementX"] | wd)
 
-*anonymous function 28699* (const after eval) = (...) => (???*0* ? a["movementY"] : xd)
+*anonymous function 28699* = (...) => (???*0* ? a["movementY"] : xd)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 
-*anonymous function 28936* (const after eval) = (...) => (???*0* ? a["clipboardData"] : FreeVar(window)["clipboardData"])
+*anonymous function 28936* = (...) => (???*0* ? a["clipboardData"] : FreeVar(window)["clipboardData"])
 - *0* unsupported expression
   ⚠️  This value might have side effects
 
-*anonymous function 29891* (const after eval) = (...) => (
+*anonymous function 29891* = (...) => (
   | b
   | (("keypress" === a["type"]) ? ???*0* : ((("keydown" === a["type"]) || ("keyup" === a["type"])) ? (Nd[a["keyCode"]] || "Unidentified") : ""))
 )
@@ -178,15 +178,15 @@ $k (const after eval) = (...) => ((bj(a) ? 1 : 0) | 11 | 14 | 2)
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 
-*anonymous function 3008* (const after eval) = (...) => undefined
+*anonymous function 3008* = (...) => undefined
 
-*anonymous function 30217* (const after eval) = (...) => (("keypress" === a["type"]) ? od(a) : 0)
+*anonymous function 30217* = (...) => (("keypress" === a["type"]) ? od(a) : 0)
 
-*anonymous function 30272* (const after eval) = (...) => ((("keydown" === a["type"]) || ("keyup" === a["type"])) ? a["keyCode"] : 0)
+*anonymous function 30272* = (...) => ((("keydown" === a["type"]) || ("keyup" === a["type"])) ? a["keyCode"] : 0)
 
-*anonymous function 30346* (const after eval) = (...) => (("keypress" === a["type"]) ? od(a) : ((("keydown" === a["type"]) || ("keyup" === a["type"])) ? a["keyCode"] : 0))
+*anonymous function 30346* = (...) => (("keypress" === a["type"]) ? od(a) : ((("keydown" === a["type"]) || ("keyup" === a["type"])) ? a["keyCode"] : 0))
 
-*anonymous function 30803* (const after eval) = (...) => (???*0* ? a["deltaX"] : (???*1* ? ???*2* : 0))
+*anonymous function 30803* = (...) => (???*0* ? a["deltaX"] : (???*1* ? ???*2* : 0))
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* unsupported expression
@@ -194,7 +194,7 @@ $k (const after eval) = (...) => ((bj(a) ? 1 : 0) | 11 | 14 | 2)
 - *2* unsupported expression
   ⚠️  This value might have side effects
 
-*anonymous function 30887* (const after eval) = (...) => (???*0* ? a["deltaY"] : (???*1* ? ???*2* : (???*3* ? ???*4* : 0)))
+*anonymous function 30887* = (...) => (???*0* ? a["deltaY"] : (???*1* ? ???*2* : (???*3* ? ???*4* : 0)))
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* unsupported expression
@@ -206,41 +206,41 @@ $k (const after eval) = (...) => ((bj(a) ? 1 : 0) | 11 | 14 | 2)
 - *4* unsupported expression
   ⚠️  This value might have side effects
 
-*anonymous function 3119* (const after eval) = (...) => undefined
+*anonymous function 3119* = (...) => undefined
 
-*anonymous function 3196* (const after eval) = (...) => undefined
+*anonymous function 3196* = (...) => undefined
 
-*anonymous function 3280* (const after eval) = (...) => undefined
+*anonymous function 3280* = (...) => undefined
 
-*anonymous function 3354* (const after eval) = (...) => undefined
+*anonymous function 3354* = (...) => undefined
 
 *anonymous function 39904* = (...) => undefined
 
 *anonymous function 40883* = (...) => undefined
 
-*anonymous function 4580* (const after eval) = (...) => undefined
+*anonymous function 4580* = (...) => undefined
 
-*anonymous function 45964* (const after eval) = (...) => Hf["resolve"](null)["then"](a)["catch"](If)
+*anonymous function 45964* = (...) => Hf["resolve"](null)["then"](a)["catch"](If)
 
 *anonymous function 46048* = (...) => undefined
 
-*anonymous function 4744* (const after eval) = (...) => undefined
+*anonymous function 4744* = (...) => undefined
 
-*anonymous function 4883* (const after eval) = (...) => undefined
+*anonymous function 4883* = (...) => undefined
 
-*anonymous function 5021* (const after eval) = (...) => undefined
+*anonymous function 5021* = (...) => undefined
 
-*anonymous function 5213* (const after eval) = (...) => undefined
+*anonymous function 5213* = (...) => undefined
 
-*anonymous function 55504* (const after eval) = (...) => (???*0* ? (Vb(a) === a) : !(1))
+*anonymous function 55504* = (...) => (???*0* ? (Vb(a) === a) : !(1))
 - *0* assignment expression
   ⚠️  This value might have side effects
 
-*anonymous function 55574* (const after eval) = (...) => undefined
+*anonymous function 55574* = (...) => undefined
 
-*anonymous function 55754* (const after eval) = (...) => undefined
+*anonymous function 55754* = (...) => undefined
 
-*anonymous function 55941* (const after eval) = (...) => undefined
+*anonymous function 55941* = (...) => undefined
 
 *anonymous function 58064* = (...) => undefined
 
@@ -258,49 +258,49 @@ $k (const after eval) = (...) => ((bj(a) ? 1 : 0) | 11 | 14 | 2)
 
 *anonymous function 69089* = (...) => undefined
 
-*anonymous function 71076* (const after eval) = (...) => a
+*anonymous function 71076* = (...) => a
 
-*anonymous function 71188* (const after eval) = (...) => ti(4194308, 4, yi["bind"](null, b, a), c)
+*anonymous function 71188* = (...) => ti(4194308, 4, yi["bind"](null, b, a), c)
 
-*anonymous function 71305* (const after eval) = (...) => ti(4194308, 4, a, b)
+*anonymous function 71305* = (...) => ti(4194308, 4, a, b)
 
-*anonymous function 71364* (const after eval) = (...) => ti(4, 2, a, b)
+*anonymous function 71364* = (...) => ti(4, 2, a, b)
 
-*anonymous function 71406* (const after eval) = (...) => a
+*anonymous function 71406* = (...) => a
 
-*anonymous function 71500* (const after eval) = (...) => [d["memoizedState"], a]
+*anonymous function 71500* = (...) => [d["memoizedState"], a]
 
-*anonymous function 71750* (const after eval) = (...) => ???*0*
+*anonymous function 71750* = (...) => ???*0*
 - *0* assignment expression
   ⚠️  This value might have side effects
 
-*anonymous function 71860* (const after eval) = (...) => ???*0*
+*anonymous function 71860* = (...) => ???*0*
 - *0* assignment expression
   ⚠️  This value might have side effects
 
-*anonymous function 71915* (const after eval) = (...) => [b, a]
+*anonymous function 71915* = (...) => [b, a]
 
-*anonymous function 72018* (const after eval) = (...) => undefined
+*anonymous function 72018* = (...) => undefined
 
-*anonymous function 72052* (const after eval) = (...) => c
+*anonymous function 72052* = (...) => c
 
-*anonymous function 72352* (const after eval) = (...) => ???*0*
+*anonymous function 72352* = (...) => ???*0*
 - *0* assignment expression
   ⚠️  This value might have side effects
 
-*anonymous function 72781* (const after eval) = (...) => fi(ei)
+*anonymous function 72781* = (...) => fi(ei)
 
-*anonymous function 72842* (const after eval) = (...) => Di(b, O["memoizedState"], a)
+*anonymous function 72842* = (...) => Di(b, O["memoizedState"], a)
 
-*anonymous function 72911* (const after eval) = (...) => [a, b]
+*anonymous function 72911* = (...) => [a, b]
 
-*anonymous function 73223* (const after eval) = (...) => gi(ei)
+*anonymous function 73223* = (...) => gi(ei)
 
-*anonymous function 73283* (const after eval) = (...) => ((null === O) ? ???*0* : Di(b, O["memoizedState"], a))
+*anonymous function 73283* = (...) => ((null === O) ? ???*0* : Di(b, O["memoizedState"], a))
 - *0* assignment expression
   ⚠️  This value might have side effects
 
-*anonymous function 73380* (const after eval) = (...) => [a, b]
+*anonymous function 73380* = (...) => [a, b]
 
 *anonymous function 73860* = (...) => undefined
 
@@ -312,13 +312,13 @@ $k (const after eval) = (...) => ((bj(a) ? 1 : 0) | 11 | 14 | 2)
 
 *anonymous function 74327* = (...) => undefined
 
-*anonymous function 86042* (const after eval) = (...) => undefined
+*anonymous function 86042* = (...) => undefined
 
-*anonymous function 86340* (const after eval) = (...) => undefined
+*anonymous function 86340* = (...) => undefined
 
-*anonymous function 86357* (const after eval) = (...) => undefined
+*anonymous function 86357* = (...) => undefined
 
-*anonymous function 87803* (const after eval) = (...) => undefined
+*anonymous function 87803* = (...) => undefined
 
 *anonymous function 9947* = (...) => e["call"](???*0*)
 - *0* unsupported expression


### PR DESCRIPTION
I'm moving all of the export-related logic into `EvalContext` (and thus `ImportMap`) so that `VarGraph` is only needed for computing the references, and not the exports.

The change in the snapshots is 
```diff
-*anonymous function 170* (const after eval) = (...) => [file]
+*anonymous function 170* = (...) => [file]
```
which is fine, since computing the "is reassigned" data for something that isn't actually a variable was non-sensical anyway.