### PR TITLE
fix: update Partytown package from @builder.io to @qwik.dev

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -984,7 +984,7 @@ export default async function getBaseWebpackConfig(
             ...(isEdgeServer
               ? [
                   {
-                    '@builder.io/partytown': '{}',
+                    '@qwik.dev/partytown': '{}',
                     'next/dist/compiled/etag': '{}',
                   },
                   getEdgePolyfilledModules(),

--- a/packages/next/src/lib/verify-partytown-setup.ts
+++ b/packages/next/src/lib/verify-partytown-setup.ts
@@ -27,7 +27,7 @@ async function missingDependencyError(dir: string) {
             ? 'yarn add --dev'
             : packageManager === 'pnpm'
               ? 'pnpm install --save-dev'
-              : 'npm install --save-dev') + ' @builder.io/partytown'
+              : 'npm install --save-dev') + ' @qwik.dev/partytown'
         )
       )}` +
       '\n\n' +
@@ -55,7 +55,7 @@ async function copyPartytownStaticFiles(
   }
 
   const { copyLibFiles } = await Promise.resolve(
-    require(path.join(deps.resolved.get('@builder.io/partytown')!, '../utils'))
+    require(path.join(deps.resolved.get('@qwik.dev/partytown')!, '../utils'))
   )
 
   await copyLibFiles(partytownLibDir)
@@ -68,8 +68,8 @@ export async function verifyPartytownSetup(
   try {
     const partytownDeps: NecessaryDependencies = hasNecessaryDependencies(dir, [
       {
-        file: '@builder.io/partytown',
-        pkg: '@builder.io/partytown',
+        file: '@qwik.dev/partytown',
+        pkg: '@qwik.dev/partytown',
         exportsRestrict: false,
       },
     ])
@@ -82,7 +82,7 @@ export async function verifyPartytownSetup(
       } catch (err) {
         Log.warn(
           `Partytown library files could not be copied to the static directory. Please ensure that ${bold(
-            cyan('@builder.io/partytown')
+            cyan('@qwik.dev/partytown')
           )} is installed as a dependency.`
         )
       }

--- a/packages/next/src/pages/_document.tsx
+++ b/packages/next/src/pages/_document.tsx
@@ -176,7 +176,7 @@ function getPreNextWorkerScripts(context: HtmlProps, props: OriginProps) {
   try {
     // @ts-expect-error: Prevent webpack from processing this require
     let { partytownSnippet } = __non_webpack_require__(
-      '@builder.io/partytown/integration'!
+      '@qwik.dev/partytown/integration'!
     )
 
     const children = Array.isArray(props.children)

--- a/test/e2e/next-script/index.test.ts
+++ b/test/e2e/next-script/index.test.ts
@@ -299,7 +299,7 @@ describe('empty strategy in document body', () => {
         `,
           },
           dependencies: {
-            '@builder.io/partytown': '0.4.2',
+            '@qwik.dev/partytown': '0.4.2',
           },
         })
       })
@@ -386,7 +386,7 @@ describe('empty strategy in document body', () => {
       `,
           },
           dependencies: {
-            '@builder.io/partytown': '0.4.2',
+            '@qwik.dev/partytown': '0.4.2',
           },
         })
 
@@ -499,7 +499,7 @@ describe('empty strategy in document body', () => {
         `,
           },
           dependencies: {
-            '@builder.io/partytown': '0.4.2',
+            '@qwik.dev/partytown': '0.4.2',
           },
         })
       })


### PR DESCRIPTION
## What

This PR fixes the discrepancy between the Next.js documentation and runtime code regarding the Partytown package name.

The docs recommend installing `@qwik.dev/partytown` (the new, non-deprecated package), but the runtime code still references `@builder.io/partytown` (which is deprecated).

## Changes

- Updated `packages/next/src/lib/verify-partytown-setup.ts` to check for and copy `@qwik.dev/partytown`
- Updated `packages/next/src/build/webpack-config.ts` alias to resolve `@qwik.dev/partytown`
- Updated `packages/next/src/pages/_document.tsx` to use `@qwik.dev/partytown`
- Updated test file references accordingly

## Why

- `@builder.io/partytown` is deprecated on npm
- Users following the docs install the new package but get build errors
- This aligns the runtime with the documented behavior

## Testing

1. Enable `experimental.nextScriptWorkers: true` in next.config.js
2. Add a Script component with strategy="worker" to any page
3. Install `@qwik.dev/partytown` (as the docs say)
4. Run `next dev` - should work now instead of failing with missing package error

Closes #92826