### PR TITLE
Return 400 instead of 500 for unparseable router state header

### DIFF
--- a/packages/next/src/server/app-render/parse-and-validate-flight-router-state.test.ts
+++ b/packages/next/src/server/app-render/parse-and-validate-flight-router-state.test.ts
@@ -1,0 +1,43 @@
+import { DecodeError } from '../../shared/lib/utils'
+import { parseAndValidateFlightRouterState } from './parse-and-validate-flight-router-state'
+
+describe('parseAndValidateFlightRouterState', () => {
+  it('should return undefined when stateHeader is undefined', () => {
+    expect(parseAndValidateFlightRouterState(undefined)).toBeUndefined()
+  })
+
+  it('should parse a valid flight router state header', () => {
+    const validState = [['', 'b', 'c', null], {}]
+    const encoded = encodeURIComponent(JSON.stringify(validState))
+    const result = parseAndValidateFlightRouterState(encoded)
+    expect(result).toEqual(validState)
+  })
+
+  it('should throw DecodeError for multiple headers (array)', () => {
+    expect(() => parseAndValidateFlightRouterState(['a', 'b'])).toThrow(
+      DecodeError
+    )
+  })
+
+  it('should throw DecodeError when header is too large', () => {
+    const oversized = 'x'.repeat(20 * 2000 + 1)
+    expect(() => parseAndValidateFlightRouterState(oversized)).toThrow(
+      DecodeError
+    )
+  })
+
+  it('should throw DecodeError for invalid JSON', () => {
+    expect(() => parseAndValidateFlightRouterState('not-valid-json')).toThrow(
+      DecodeError
+    )
+  })
+
+  it('should throw DecodeError for valid JSON that fails schema validation', () => {
+    // Simulates v14 schema with boolean 5th element instead of number
+    const v14State = [['', 'b', 'c', null], {}, null, null, true]
+    const encoded = encodeURIComponent(JSON.stringify(v14State))
+    expect(() => parseAndValidateFlightRouterState(encoded)).toThrow(
+      DecodeError
+    )
+  })
+})

--- a/packages/next/src/server/app-render/parse-and-validate-flight-router-state.tsx
+++ b/packages/next/src/server/app-render/parse-and-validate-flight-router-state.tsx
@@ -1,4 +1,5 @@
 import type { FlightRouterState } from '../../shared/lib/app-router-types'
+import { DecodeError } from '../../shared/lib/utils'
 import { flightRouterStateSchema } from './types'
 import { assert } from 'next/dist/compiled/superstruct'
 
@@ -18,7 +19,7 @@ export function parseAndValidateFlightRouterState(
     return undefined
   }
   if (Array.isArray(stateHeader)) {
-    throw new Error(
+    throw new DecodeError(
       'Multiple router state headers were sent. This is not allowed.'
     )
   }
@@ -29,14 +30,17 @@ export function parseAndValidateFlightRouterState(
   // This is around 2,000 nested or parallel route segment states:
   // '{"children":["",{}]}'.length === 20.
   if (stateHeader.length > 20 * 2000) {
-    throw new Error('The router state header was too large.')
+    throw new DecodeError('The router state header was too large.')
   }
 
   try {
     const state = JSON.parse(decodeURIComponent(stateHeader))
     assert(state, flightRouterStateSchema)
     return state
-  } catch {
-    throw new Error('The router state header was sent but could not be parsed.')
+  } catch (cause) {
+    throw new DecodeError(
+      'The router state header was sent but could not be parsed.',
+      { cause }
+    )
   }
 }


### PR DESCRIPTION
## Summary

- When a client sends an invalid `Next-Router-State-Tree` header (e.g. cross-version same-origin navigation from Next.js 14 to 16), the server now returns **400** instead of **500**
- Changed `parseAndValidateFlightRouterState` to throw `DecodeError` instead of plain `Error`, which is already handled as 400 by `base-server.ts`
- Added unit tests for all error paths (multiple headers, oversized header, invalid JSON, schema mismatch)

Closes NEXT-4909

<!-- NEXT_JS_LLM_PR -->