### PR TITLE
Revert "Node.js streams: Add forkpoint for prerenderToStream"

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -4109,8 +4109,7 @@ async function renderToStream(
           requestStore,
           renderToNodeFizzStream,
           appElement,
-          fizzOptions,
-          { waitForAllReady: generateStaticHTML }
+          fizzOptions
         )
 
         // End the render span only after React completed rendering (including anything inside Suspense boundaries)
@@ -4396,8 +4395,7 @@ async function renderToStream(
                 bootstrapScriptContent,
                 bootstrapScripts: [errorBootstrapScript],
                 formState,
-              },
-              { waitForAllReady: generateStaticHTML }
+              }
             )
 
           errorAllReady.finally(() => {
@@ -7085,16 +7083,6 @@ async function prerenderToStream(
 
   const { cachedNavigations } = renderOpts.experimental
 
-  const renderFlightStream = process.env.__NEXT_USE_NODE_STREAMS
-    ? renderToNodeFlightStream
-    : renderToWebFlightStream
-  const renderFizzStream = process.env.__NEXT_USE_NODE_STREAMS
-    ? renderToNodeFizzStream
-    : renderToWebFizzStream
-  const createInlinedDataStream = process.env.__NEXT_USE_NODE_STREAMS
-    ? createNodeInlinedDataStream
-    : createWebInlinedDataStream
-
   const allowEmptyStaticShell =
     (renderOpts.allowEmptyStaticShell ?? false) ||
     (await isPageAllowedToBlock(tree))
@@ -7943,13 +7931,13 @@ async function prerenderToStream(
           // segments, since those are the only ones whose data is not complete.
           const emptyReactServerResult =
             await createReactServerPrerenderResultFromRender(
-              renderFlightStream(ComponentMod, [], clientModules, {
+              renderToWebFlightStream(ComponentMod, [], clientModules, {
                 filterStackFrame,
                 onError: serverComponentsErrorHandler,
               })
             )
           finalStream = await continueStaticFallbackPrerender(htmlStream, {
-            inlinedDataStream: createInlinedDataStream(
+            inlinedDataStream: createWebInlinedDataStream(
               emptyReactServerResult.consumeAsStream(),
               nonce,
               formState
@@ -7961,7 +7949,7 @@ async function prerenderToStream(
         } else {
           // Normal static prerender case, no fallback param handling needed
           finalStream = await continueStaticPrerender(htmlStream, {
-            inlinedDataStream: createInlinedDataStream(
+            inlinedDataStream: createWebInlinedDataStream(
               reactServerResult.consumeAsStream(),
               nonce,
               formState
@@ -8020,7 +8008,7 @@ async function prerenderToStream(
         await createReactServerPrerenderResultFromRender(
           workUnitAsyncStorage.run(
             reactServerPrerenderStore,
-            renderFlightStream,
+            renderToWebFlightStream,
             ComponentMod,
             RSCPayload,
             clientModules,
@@ -8215,7 +8203,7 @@ async function prerenderToStream(
           digestErrorsMap: reactServerErrorsByDigest,
           ssrErrors: allCapturedErrors,
           stream: await continueStaticPrerender(htmlStream, {
-            inlinedDataStream: createInlinedDataStream(
+            inlinedDataStream: createWebInlinedDataStream(
               reactServerResult.consumeAsStream(),
               nonce,
               formState
@@ -8258,7 +8246,7 @@ async function prerenderToStream(
         await createReactServerPrerenderResultFromRender(
           workUnitAsyncStorage.run(
             prerenderLegacyStore,
-            renderFlightStream,
+            renderToWebFlightStream,
             ComponentMod,
             RSCPayload,
             clientModules,
@@ -8271,7 +8259,7 @@ async function prerenderToStream(
 
       const { stream: htmlStream } = await workUnitAsyncStorage.run(
         prerenderLegacyStore,
-        renderFizzStream,
+        renderToWebFizzStream,
         // eslint-disable-next-line @next/internal/no-ambiguous-jsx
         <App
           reactServerStream={reactServerResult.asUnclosingStream()}
@@ -8286,8 +8274,7 @@ async function prerenderToStream(
           onError: htmlRendererErrorHandler,
           nonce,
           bootstrapScripts: [bootstrapScript],
-        },
-        { waitForAllReady: true }
+        }
       )
 
       if (shouldGenerateStaticFlightData(workStore)) {
@@ -8314,7 +8301,7 @@ async function prerenderToStream(
         digestErrorsMap: reactServerErrorsByDigest,
         ssrErrors: allCapturedErrors,
         stream: await continueFizzStream(htmlStream, {
-          inlinedDataStream: createInlinedDataStream(
+          inlinedDataStream: createWebInlinedDataStream(
             reactServerResult.consumeAsStream(),
             nonce,
             formState
@@ -8459,7 +8446,7 @@ async function prerenderToStream(
 
     const errorServerStreamRaw = workUnitAsyncStorage.run(
       prerenderLegacyStore,
-      renderFlightStream,
+      renderToWebFlightStream,
       ComponentMod,
       errorRSCPayload,
       clientModules,
@@ -8485,7 +8472,7 @@ async function prerenderToStream(
     try {
       const { stream: errorHtmlStream } = await workUnitAsyncStorage.run(
         prerenderLegacyStore,
-        renderFizzStream,
+        renderToWebFizzStream,
         // eslint-disable-next-line @next/internal/no-ambiguous-jsx
         <ErrorApp
           reactServerStream={errorServerStream}
@@ -8498,8 +8485,7 @@ async function prerenderToStream(
           nonce,
           bootstrapScripts: [errorBootstrapScript],
           formState,
-        },
-        { waitForAllReady: true }
+        }
       )
 
       const resolvedFlightResult = errorFlightResultPromise
@@ -8528,7 +8514,7 @@ async function prerenderToStream(
         digestErrorsMap: reactServerErrorsByDigest,
         ssrErrors: allCapturedErrors,
         stream: await continueFizzStream(errorHtmlStream, {
-          inlinedDataStream: createInlinedDataStream(
+          inlinedDataStream: createWebInlinedDataStream(
             flightStream,
             nonce,
             formState

--- a/packages/next/src/server/app-render/stream-ops.node.ts
+++ b/packages/next/src/server/app-render/stream-ops.node.ts
@@ -597,13 +597,11 @@ export { renderToWebFizzStream } from './stream-ops.web'
 
 export async function renderToNodeFizzStream(
   element: React.ReactElement,
-  streamOptions: any,
-  options?: { waitForAllReady?: boolean }
+  streamOptions: any
 ): Promise<FizzStreamResult> {
   const pt = new PassThrough()
   const shellReady = new DetachedPromise<void>()
   const allReady = new DetachedPromise<void>()
-  const deferPipe = options?.waitForAllReady === true
 
   const pipeable = getTracer().trace(AppRenderSpan.renderToReadableStream, () =>
     renderToPipeableStream(element, {
@@ -611,9 +609,7 @@ export async function renderToNodeFizzStream(
       onHeaders: streamOptions?.onHeaders,
       onShellReady() {
         streamOptions?.onShellReady?.()
-        if (!deferPipe) {
-          pipeable.pipe(pt)
-        }
+        pipeable.pipe(pt)
         shellReady.resolve()
       },
       onShellError(error: unknown) {
@@ -622,9 +618,6 @@ export async function renderToNodeFizzStream(
       },
       onAllReady() {
         streamOptions?.onAllReady?.()
-        if (deferPipe) {
-          pipeable.pipe(pt)
-        }
         allReady.resolve()
       },
       onError: streamOptions?.onError,

--- a/packages/next/src/server/app-render/stream-ops.web.ts
+++ b/packages/next/src/server/app-render/stream-ops.web.ts
@@ -253,8 +253,7 @@ export async function streamToString(stream: AnyStream): Promise<string> {
 
 export async function renderToWebFizzStream(
   element: React.ReactElement,
-  streamOptions: any,
-  _options?: { waitForAllReady?: boolean }
+  streamOptions: any
 ): Promise<FizzStreamResult> {
   const stream = await renderToInitialFizzStream({
     ReactDOMServer: { renderToReadableStream },
@@ -266,8 +265,7 @@ export async function renderToWebFizzStream(
 
 export async function renderToNodeFizzStream(
   _element: React.ReactElement,
-  _streamOptions: any,
-  _options?: { waitForAllReady?: boolean }
+  _streamOptions: any
 ): Promise<FizzStreamResult> {
   throw new Error('Not implemented')
 }


### PR DESCRIPTION
Canary was having a test failure that did not happen on the PR. This reverts so that we can re-apply after investigating a fix.

Reverts vercel/next.js#92513