### PR TITLE
[ci] Skip sccache on Windows runners

### DIFF
--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -213,6 +213,11 @@ jobs:
       - run: corepack enable
       - run: pwd
 
+      - name: Kill stale sccache processes
+        if: ${{ runner.os == 'Windows' }}
+        shell: powershell
+        run: Get-Process sccache -ErrorAction SilentlyContinue | Stop-Process -Force
+
       - run: rm -rf .git
 
       - uses: actions/checkout@v4

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -264,7 +264,7 @@ jobs:
 
       - name: Start sccache
         uses: ./.github/actions/sccache
-        if: ${{ (inputs.uploadNativeArtifact != '') || inputs.needsNextest == 'yes' || inputs.needsRust == 'yes' }}
+        if: ${{ runner.os != 'Windows' && ((inputs.uploadNativeArtifact != '') || inputs.needsNextest == 'yes' || inputs.needsRust == 'yes') }}
         with:
           turbo-token: ${{ secrets.TURBO_REMOTE_CACHE_TOKEN }}
 


### PR DESCRIPTION
## What

Skip the sccache setup step when running on Windows.

## Why

sccache is currently not "winning" with cache hits when building on Windows which is increasing the size of the turborepo cache. In addition, sccache servers appear to be lingering on some of the windows runners.
