### PR TITLE
fix: correct AppType generic parameter usage

### DIFF
--- a/packages/next/src/shared/lib/utils.ts
+++ b/packages/next/src/shared/lib/utils.ts
@@ -31,7 +31,7 @@ export type DocumentType = NextComponentType<
 export type AppType<P = {}> = NextComponentType<
   AppContextType,
   P,
-  AppPropsType<any, P>
+  AppPropsType & P
 >
 
 export type AppTreeType = ComponentType<

--- a/test/integration/typescript/pages/_app.tsx
+++ b/test/integration/typescript/pages/_app.tsx
@@ -1,6 +1,6 @@
 import type { AppType } from 'next/app'
 
-const MyApp: AppType<{ foo: string }> = ({ Component, pageProps }) => {
+const MyApp: AppType<{ foo: string }> = ({ Component, pageProps, foo }) => {
   return <Component {...pageProps} />
 }
 


### PR DESCRIPTION
## Summary

- Fixed the `AppType<P>` generic parameter being incorrectly applied to `props.pageProps` instead of `props` directly
- Changed `AppPropsType<any, P>` to `AppPropsType & P` in the `AppType` type definition so that custom props from `getInitialProps` are correctly typed on the component's own props
- Updated the TypeScript integration test to demonstrate correct usage (destructuring `foo` from props directly)

Fixes #42846

## Bug

When using `AppType<{ foo: string }>`, the generic parameter `P` was passed as the `PageProps` type parameter of `AppPropsType`, which caused `foo` to appear on `props.pageProps.foo` in the type system. At runtime, `foo` actually exists on `props.foo` directly. This mismatch meant:

1. `props.foo` raised a TypeScript error even though it exists at runtime
2. `props.pageProps.foo` had no TypeScript error even though it does not exist at runtime

## Fix

In `packages/next/src/shared/lib/utils.ts`, changed the Props type argument (3rd parameter) of `NextComponentType` in the `AppType` definition from `AppPropsType<any, P>` to `AppPropsType & P`. This intersects `P` with the base app props rather than nesting it inside `pageProps`.

## Test plan

- [x] Verify the existing TypeScript integration test (`test/integration/typescript/`) passes with the updated types
- [x] Confirm that `AppType<{ foo: string }>` correctly types `foo` on the component's props (not on `pageProps`)

<!-- NEXT_JS_LLM_PR -->