### PR TITLE
fix(eslint): respect pageExtensions in no-html-link-for-pages rule

### DIFF
--- a/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
+++ b/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
@@ -62,6 +62,19 @@ export default defineRule({
           },
         ],
       },
+      {
+        type: 'object',
+        properties: {
+          pageExtensions: {
+            type: 'array',
+            uniqueItems: true,
+            items: {
+              type: 'string',
+            },
+          },
+        },
+        additionalProperties: false,
+      },
     ],
   },
 
@@ -69,8 +82,21 @@ export default defineRule({
    * Creates an ESLint rule listener.
    */
   create(context) {
-    const ruleOptions: (string | string[])[] = context.options
-    const [customPagesDirectory] = ruleOptions
+    const ruleOptions: (string | string[] | { pageExtensions?: string[] })[] =
+      context.options
+
+    // First option: custom pages directory (string or string[])
+    const customPagesDirectory =
+      typeof ruleOptions[0] === 'string' || Array.isArray(ruleOptions[0])
+        ? ruleOptions[0]
+        : undefined
+
+    // Second option: config object with pageExtensions
+    const configOption = ruleOptions.find(
+      (opt): opt is { pageExtensions?: string[] } =>
+        typeof opt === 'object' && opt !== null && !Array.isArray(opt)
+    )
+    const pageExtensions = configOption?.pageExtensions
 
     const rootDirs = getRootDirs(context)
 
@@ -107,8 +133,16 @@ export default defineRule({
       return {}
     }
 
-    const pageUrls = cachedGetUrlFromPagesDirectories('/', foundPagesDirs)
-    const appDirUrls = cachedGetUrlFromAppDirectory('/', foundAppDirs)
+    const pageUrls = cachedGetUrlFromPagesDirectories(
+      '/',
+      foundPagesDirs,
+      pageExtensions
+    )
+    const appDirUrls = cachedGetUrlFromAppDirectory(
+      '/',
+      foundAppDirs,
+      pageExtensions
+    )
     const allUrlRegex = [...pageUrls, ...appDirUrls]
 
     return {

--- a/packages/eslint-plugin-next/src/utils/url.ts
+++ b/packages/eslint-plugin-next/src/utils/url.ts
@@ -5,28 +5,48 @@ import * as fs from 'fs'
 // Prevent multiple blocking IO requests that have already been calculated.
 const fsReadDirSyncCache = {}
 
+const defaultPageExtensions = ['js', 'jsx', 'ts', 'tsx']
+
+/**
+ * Builds a regex string matching the given file extensions.
+ * Handles compound extensions like 'page.tsx' by escaping dots.
+ */
+function getExtensionRegexString(extensions: string[]): string {
+  const escaped = extensions.map((ext) => ext.replace(/\./g, '\\.'))
+  return `(\\.(${escaped.join('|')}))`
+}
+
 /**
  * Recursively parse directory for page URLs.
  */
-function parseUrlForPages(urlprefix: string, directory: string) {
+function parseUrlForPages(
+  urlprefix: string,
+  directory: string,
+  pageExtensions?: string[]
+) {
   fsReadDirSyncCache[directory] ??= fs.readdirSync(directory, {
     withFileTypes: true,
   })
+  const extPattern = getExtensionRegexString(
+    pageExtensions || defaultPageExtensions
+  )
+  const fileRegex = new RegExp(`${extPattern}$`)
+  const indexRegex = new RegExp(`^index${extPattern}$`)
   const res = []
   fsReadDirSyncCache[directory].forEach((dirent) => {
-    // TODO: this should account for all page extensions
-    // not just js(x) and ts(x)
-    if (/(\.(j|t)sx?)$/.test(dirent.name)) {
-      if (/^index(\.(j|t)sx?)$/.test(dirent.name)) {
+    if (fileRegex.test(dirent.name)) {
+      if (indexRegex.test(dirent.name)) {
         res.push(
-          `${urlprefix}${dirent.name.replace(/^index(\.(j|t)sx?)$/, '')}`
+          `${urlprefix}${dirent.name.replace(indexRegex, '')}`
         )
       }
-      res.push(`${urlprefix}${dirent.name.replace(/(\.(j|t)sx?)$/, '')}`)
+      res.push(`${urlprefix}${dirent.name.replace(fileRegex, '')}`)
     } else {
       const dirPath = path.join(directory, dirent.name)
       if (dirent.isDirectory() && !dirent.isSymbolicLink()) {
-        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath))
+        res.push(
+          ...parseUrlForPages(urlprefix + dirent.name + '/', dirPath, pageExtensions)
+        )
       }
     }
   })
@@ -36,24 +56,34 @@ function parseUrlForPages(urlprefix: string, directory: string) {
 /**
  * Recursively parse app directory for URLs.
  */
-function parseUrlForAppDir(urlprefix: string, directory: string) {
+function parseUrlForAppDir(
+  urlprefix: string,
+  directory: string,
+  pageExtensions?: string[]
+) {
   fsReadDirSyncCache[directory] ??= fs.readdirSync(directory, {
     withFileTypes: true,
   })
+  const extPattern = getExtensionRegexString(
+    pageExtensions || defaultPageExtensions
+  )
+  const fileRegex = new RegExp(`${extPattern}$`)
+  const pageRegex = new RegExp(`^page${extPattern}$`)
+  const layoutRegex = new RegExp(`^layout${extPattern}$`)
   const res = []
   fsReadDirSyncCache[directory].forEach((dirent) => {
-    // TODO: this should account for all page extensions
-    // not just js(x) and ts(x)
-    if (/(\.(j|t)sx?)$/.test(dirent.name)) {
-      if (/^page(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(`${urlprefix}${dirent.name.replace(/^page(\.(j|t)sx?)$/, '')}`)
-      } else if (!/^layout(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(`${urlprefix}${dirent.name.replace(/(\.(j|t)sx?)$/, '')}`)
+    if (fileRegex.test(dirent.name)) {
+      if (pageRegex.test(dirent.name)) {
+        res.push(`${urlprefix}${dirent.name.replace(pageRegex, '')}`)
+      } else if (!layoutRegex.test(dirent.name)) {
+        res.push(`${urlprefix}${dirent.name.replace(fileRegex, '')}`)
       }
     } else {
       const dirPath = path.join(directory, dirent.name)
       if (dirent.isDirectory(dirPath) && !dirent.isSymbolicLink()) {
-        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath))
+        res.push(
+          ...parseUrlForAppDir(urlprefix + dirent.name + '/', dirPath, pageExtensions)
+        )
       }
     }
   })
@@ -136,13 +166,16 @@ export function normalizeAppPath(route: string) {
  */
 export function getUrlFromPagesDirectories(
   urlPrefix: string,
-  directories: string[]
+  directories: string[],
+  pageExtensions?: string[]
 ) {
   return Array.from(
     // De-duplicate similar pages across multiple directories.
     new Set(
       directories
-        .flatMap((directory) => parseUrlForPages(urlPrefix, directory))
+        .flatMap((directory) =>
+          parseUrlForPages(urlPrefix, directory, pageExtensions)
+        )
         .map(
           // Since the URLs are normalized we add `^` and `$` to the RegExp to make sure they match exactly.
           (url) => `^${normalizeURL(url)}$`
@@ -156,13 +189,16 @@ export function getUrlFromPagesDirectories(
 
 export function getUrlFromAppDirectory(
   urlPrefix: string,
-  directories: string[]
+  directories: string[],
+  pageExtensions?: string[]
 ) {
   return Array.from(
     // De-duplicate similar pages across multiple directories.
     new Set(
       directories
-        .map((directory) => parseUrlForAppDir(urlPrefix, directory))
+        .map((directory) =>
+          parseUrlForAppDir(urlPrefix, directory, pageExtensions)
+        )
         .flat()
         .map(
           // Since the URLs are normalized we add `^` and `$` to the RegExp to make sure they match exactly.


### PR DESCRIPTION
## Summary

Fixes #53473

The `@next/next/no-html-link-for-pages` ESLint rule hardcodes file extensions as `(j|t)sx?` when scanning for pages. Projects using custom `pageExtensions` (e.g., `['page.tsx', 'page.ts']`) are not recognized, so the rule fails to flag `<a>` tags linking to those routes.

The source code even has TODO comments acknowledging this: `// TODO: this should account for all page extensions not just js(x) and ts(x)`.

## Changes

### `packages/eslint-plugin-next/src/utils/url.ts`
- Added `defaultPageExtensions` constant (`['js', 'jsx', 'ts', 'tsx']`) for backward compatibility
- Added `getExtensionRegexString()` helper that builds a regex from an array of extensions, properly escaping dots in compound extensions like `page.tsx`
- Modified `parseUrlForPages()` and `parseUrlForAppDir()` to accept an optional `pageExtensions` parameter and use dynamic regex instead of hardcoded `(j|t)sx?`
- Modified `getUrlFromPagesDirectories()` and `getUrlFromAppDirectory()` to pass through the optional `pageExtensions` parameter
- Fixed a pre-existing bug where `parseUrlForAppDir()` recursively called `parseUrlForPages()` instead of itself

### `packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts`
- Added `pageExtensions` as a second JSON schema option (object with `pageExtensions` array)
- Passes extensions through to `cachedGetUrlFromPagesDirectories()` and `cachedGetUrlFromAppDirectory()`
- Backward compatible: no changes needed for existing configs

## Usage

```json
{
  "rules": {
    "@next/next/no-html-link-for-pages": [2, "pages", { "pageExtensions": ["page.tsx", "page.ts"] }]
  }
}
```

When no `pageExtensions` option is provided, the rule defaults to `['js', 'jsx', 'ts', 'tsx']` — identical to current behavior.

## Test Plan
- Default behavior unchanged when no `pageExtensions` specified
- Custom `pageExtensions` are respected for both pages and app directories
- Compound extensions (e.g., `page.tsx`) are properly escaped in regex
