### PR TITLE
[turbopack] Persistent last_successful_parse

### DIFF
--- a/turbopack/crates/turbo-tasks/src/id.rs
+++ b/turbopack/crates/turbo-tasks/src/id.rs
@@ -150,6 +150,8 @@ impl Debug for TaskId {
     }
 }
 
+unsafe impl crate::NonLocalValue for TaskId {}
+
 pub const TRANSIENT_TASK_BIT: u32 = 0x8000_0000;
 
 impl TaskId {

--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -101,7 +101,7 @@ pub use crate::{
     read_ref::ReadRef,
     serialization_invalidation::SerializationInvalidator,
     spawn::{JoinHandle, block_for_future, block_in_place, spawn, spawn_blocking, spawn_thread},
-    state::{State, TransientState},
+    state::{State, TransientState, parking_lot_mutex_bincode},
     task::{
         SharedReference, TypedSharedReference,
         task_input::{EitherTaskInput, TaskInput},

--- a/turbopack/crates/turbo-tasks/src/serialization_invalidation.rs
+++ b/turbopack/crates/turbo-tasks/src/serialization_invalidation.rs
@@ -1,14 +1,9 @@
 use std::hash::Hash;
 
-use bincode::{
-    Decode, Encode,
-    de::Decoder,
-    enc::Encoder,
-    error::{DecodeError, EncodeError},
-    impl_borrow_decode,
-};
-use serde::{Deserialize, Serialize, de::Visitor};
+use bincode::{Decode, Encode};
+use turbo_tasks_macros::NonLocalValue;
 
+use crate as turbo_tasks;
 use crate::{TaskId, manager::with_turbo_tasks, trace::TraceRawVcs};
 
 /// Allows a turbo-tasks value type to notify the backend that its serialized
@@ -19,24 +14,10 @@ use crate::{TaskId, manager::with_turbo_tasks, trace::TraceRawVcs};
 /// context (i.e. inside a `#[turbo_tasks::function]` body or a `State`
 /// mutation triggered from one), so `TURBO_TASKS` task-local is always
 /// available and we do not need to capture handles at construction time.
-#[derive(Clone)]
+#[derive(Clone, Hash, Eq, PartialEq, Encode, Decode, TraceRawVcs, NonLocalValue)]
 pub struct SerializationInvalidator {
     task: TaskId,
 }
-
-impl Hash for SerializationInvalidator {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.task.hash(state);
-    }
-}
-
-impl PartialEq for SerializationInvalidator {
-    fn eq(&self, other: &Self) -> bool {
-        self.task == other.task
-    }
-}
-
-impl Eq for SerializationInvalidator {}
 
 impl SerializationInvalidator {
     pub fn invalidate(&self) {
@@ -47,61 +28,3 @@ impl SerializationInvalidator {
         Self { task: task_id }
     }
 }
-
-impl TraceRawVcs for SerializationInvalidator {
-    fn trace_raw_vcs(&self, _context: &mut crate::trace::TraceRawVcsContext) {
-        // nothing here
-    }
-}
-
-impl Serialize for SerializationInvalidator {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.serialize_newtype_struct("SerializationInvalidator", &self.task)
-    }
-}
-
-impl<'de> Deserialize<'de> for SerializationInvalidator {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        struct V;
-
-        impl<'de> Visitor<'de> for V {
-            type Value = SerializationInvalidator;
-
-            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-                write!(f, "an SerializationInvalidator")
-            }
-
-            fn visit_newtype_struct<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
-            where
-                D: serde::Deserializer<'de>,
-            {
-                Ok(SerializationInvalidator {
-                    task: TaskId::deserialize(deserializer)?,
-                })
-            }
-        }
-        deserializer.deserialize_newtype_struct("SerializationInvalidator", V)
-    }
-}
-
-impl Encode for SerializationInvalidator {
-    fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
-        Encode::encode(&self.task, encoder)
-    }
-}
-
-impl<Context> Decode<Context> for SerializationInvalidator {
-    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
-        Ok(SerializationInvalidator {
-            task: Decode::decode(decoder)?,
-        })
-    }
-}
-
-impl_borrow_decode!(SerializationInvalidator);

--- a/turbopack/crates/turbo-tasks/src/serialization_invalidation.rs
+++ b/turbopack/crates/turbo-tasks/src/serialization_invalidation.rs
@@ -1,7 +1,4 @@
-use std::{
-    hash::Hash,
-    sync::{Arc, Weak},
-};
+use std::hash::Hash;
 
 use bincode::{
     Decode, Encode,
@@ -11,15 +8,20 @@ use bincode::{
     impl_borrow_decode,
 };
 use serde::{Deserialize, Serialize, de::Visitor};
-use tokio::runtime::Handle;
 
-use crate::{TaskId, TurboTasksApi, manager::with_turbo_tasks, trace::TraceRawVcs};
+use crate::{TaskId, manager::with_turbo_tasks, trace::TraceRawVcs};
 
+/// Allows a turbo-tasks value type to notify the backend that its serialized
+/// state has changed out-of-band (i.e. without going through the normal
+/// output-cell mechanism).
+///
+/// `invalidate` must always be called from within a turbo-tasks execution
+/// context (i.e. inside a `#[turbo_tasks::function]` body or a `State`
+/// mutation triggered from one), so `TURBO_TASKS` task-local is always
+/// available and we do not need to capture handles at construction time.
 #[derive(Clone)]
 pub struct SerializationInvalidator {
     task: TaskId,
-    turbo_tasks: Weak<dyn TurboTasksApi>,
-    handle: Handle,
 }
 
 impl Hash for SerializationInvalidator {
@@ -38,23 +40,11 @@ impl Eq for SerializationInvalidator {}
 
 impl SerializationInvalidator {
     pub fn invalidate(&self) {
-        let SerializationInvalidator {
-            task,
-            turbo_tasks,
-            handle,
-        } = self;
-        let _guard = handle.enter();
-        if let Some(turbo_tasks) = turbo_tasks.upgrade() {
-            turbo_tasks.invalidate_serialization(*task);
-        }
+        with_turbo_tasks(|tt| tt.invalidate_serialization(self.task));
     }
 
     pub(crate) fn new(task_id: TaskId) -> Self {
-        Self {
-            task: task_id,
-            turbo_tasks: with_turbo_tasks(Arc::downgrade),
-            handle: Handle::current(),
-        }
+        Self { task: task_id }
     }
 }
 
@@ -93,8 +83,6 @@ impl<'de> Deserialize<'de> for SerializationInvalidator {
             {
                 Ok(SerializationInvalidator {
                     task: TaskId::deserialize(deserializer)?,
-                    turbo_tasks: with_turbo_tasks(Arc::downgrade),
-                    handle: tokio::runtime::Handle::current(),
                 })
             }
         }
@@ -112,8 +100,6 @@ impl<Context> Decode<Context> for SerializationInvalidator {
     fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
         Ok(SerializationInvalidator {
             task: Decode::decode(decoder)?,
-            turbo_tasks: with_turbo_tasks(Arc::downgrade),
-            handle: tokio::runtime::Handle::current(),
         })
     }
 }

--- a/turbopack/crates/turbo-tasks/src/state.rs
+++ b/turbopack/crates/turbo-tasks/src/state.rs
@@ -123,7 +123,7 @@ impl<T> Drop for StateRef<'_, T> {
     }
 }
 
-mod parking_lot_mutex_bincode {
+pub mod parking_lot_mutex_bincode {
     use bincode::{
         BorrowDecode,
         de::{BorrowDecoder, Decoder},

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -78,8 +78,8 @@ use tracing::{Instrument, Level, instrument};
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     FxDashMap, FxIndexMap, NonLocalValue, ReadRef, ResolvedVc, SerializationInvalidator, TaskInput,
-    TryJoinIterExt, Upcast, ValueToString, Vc, parking_lot_mutex_bincode, trace::TraceRawVcs,
-    turbofmt,
+    TryJoinIterExt, Upcast, ValueToString, Vc, get_serialization_invalidator,
+    parking_lot_mutex_bincode, trace::TraceRawVcs, turbofmt,
 };
 use turbo_tasks_fs::{FileJsonContent, FileSystemPath, glob::Glob, rope::Rope};
 use turbopack_core::{
@@ -369,10 +369,8 @@ impl EcmascriptModuleAssetBuilder {
 /// This is used by `failsafe_parse` to serve the last good AST when the file has a syntax error.
 /// The newtype is always-equal and no-op-hash so it is invisible to turbo-tasks cache key logic,
 /// but serializes the `Rope` contents so the fallback survives eviction and restarts.
-#[derive(TraceRawVcs, Encode, Decode)]
+#[derive(TraceRawVcs, Encode, Decode, NonLocalValue)]
 struct LastSuccessfulSource {
-    /// `parking_lot::Mutex` does not implement `Encode`/`Decode` directly; the
-    /// `parking_lot_mutex_bincode` helper provides the encoding.
     #[bincode(with = "parking_lot_mutex_bincode")]
     source: parking_lot::Mutex<Option<Rope>>,
     /// Notifies the backend when the in-memory `source` changes so that the
@@ -400,7 +398,7 @@ impl Default for LastSuccessfulSource {
     fn default() -> Self {
         Self {
             source: parking_lot::Mutex::new(None),
-            serialization_invalidator: turbo_tasks::get_serialization_invalidator(),
+            serialization_invalidator: get_serialization_invalidator(),
         }
     }
 }
@@ -425,10 +423,6 @@ impl Eq for LastSuccessfulSource {}
 impl std::hash::Hash for LastSuccessfulSource {
     fn hash<H: std::hash::Hasher>(&self, _state: &mut H) {}
 }
-
-// `SerializationInvalidator` does not implement `NonLocalValue`, so this
-// cannot be derived. The field contains no `Vc`s, so the impl is sound.
-unsafe impl turbo_tasks::NonLocalValue for LastSuccessfulSource {}
 
 #[turbo_tasks::value]
 pub struct EcmascriptModuleAsset {

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -78,7 +78,7 @@ use tracing::{Instrument, Level, instrument};
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     FxDashMap, FxIndexMap, NonLocalValue, ReadRef, ResolvedVc, SerializationInvalidator, TaskInput,
-    TryJoinIterExt, Upcast, ValueToString, Vc, get_serialization_invalidator, trace::TraceRawVcs,
+    TryJoinIterExt, Upcast, ValueToString, Vc, parking_lot_mutex_bincode, trace::TraceRawVcs,
     turbofmt,
 };
 use turbo_tasks_fs::{FileJsonContent, FileSystemPath, glob::Glob, rope::Rope};
@@ -369,9 +369,12 @@ impl EcmascriptModuleAssetBuilder {
 /// This is used by `failsafe_parse` to serve the last good AST when the file has a syntax error.
 /// The newtype is always-equal and no-op-hash so it is invisible to turbo-tasks cache key logic,
 /// but serializes the `Rope` contents so the fallback survives eviction and restarts.
-#[derive(TraceRawVcs)]
+#[derive(TraceRawVcs, Encode, Decode)]
 struct LastSuccessfulSource {
-    source: Mutex<Option<Rope>>,
+    /// `parking_lot::Mutex` does not implement `Encode`/`Decode` directly; the
+    /// `parking_lot_mutex_bincode` helper provides the encoding.
+    #[bincode(with = "parking_lot_mutex_bincode")]
+    source: parking_lot::Mutex<Option<Rope>>,
     /// Notifies the backend when the in-memory `source` changes so that the
     /// serialized task state is written back to the persistence layer.
     serialization_invalidator: SerializationInvalidator,
@@ -379,16 +382,16 @@ struct LastSuccessfulSource {
 
 impl LastSuccessfulSource {
     fn get(&self) -> Option<Rope> {
-        self.source.lock().unwrap().clone()
+        self.source.lock().clone()
     }
 
     fn set(&self, rope: Rope) {
-        *self.source.lock().unwrap() = Some(rope);
+        *self.source.lock() = Some(rope);
         self.serialization_invalidator.invalidate();
     }
 
     fn clear(&self) {
-        *self.source.lock().unwrap() = None;
+        *self.source.lock() = None;
         self.serialization_invalidator.invalidate();
     }
 }
@@ -396,8 +399,8 @@ impl LastSuccessfulSource {
 impl Default for LastSuccessfulSource {
     fn default() -> Self {
         Self {
-            source: Mutex::new(None),
-            serialization_invalidator: get_serialization_invalidator(),
+            source: parking_lot::Mutex::new(None),
+            serialization_invalidator: turbo_tasks::get_serialization_invalidator(),
         }
     }
 }
@@ -421,43 +424,6 @@ impl Eq for LastSuccessfulSource {}
 
 impl std::hash::Hash for LastSuccessfulSource {
     fn hash<H: std::hash::Hasher>(&self, _state: &mut H) {}
-}
-
-// `Mutex` does not support `#[derive(Encode/Decode)]`, so these are written
-// by hand. They encode/decode only the `source` field; the
-// `serialization_invalidator` is re-created from the running task context on
-// decode (matching the pattern used by `turbo_tasks::State`).
-impl bincode::Encode for LastSuccessfulSource {
-    fn encode<E: bincode::enc::Encoder>(
-        &self,
-        encoder: &mut E,
-    ) -> Result<(), bincode::error::EncodeError> {
-        self.source.lock().unwrap().encode(encoder)
-    }
-}
-
-impl<C> bincode::Decode<C> for LastSuccessfulSource {
-    fn decode<D: bincode::de::Decoder<Context = C>>(
-        decoder: &mut D,
-    ) -> Result<Self, bincode::error::DecodeError> {
-        let val: Option<Rope> = bincode::Decode::decode(decoder)?;
-        Ok(Self {
-            source: Mutex::new(val),
-            serialization_invalidator: get_serialization_invalidator(),
-        })
-    }
-}
-
-impl<'de, C> bincode::BorrowDecode<'de, C> for LastSuccessfulSource {
-    fn borrow_decode<D: bincode::de::BorrowDecoder<'de, Context = C>>(
-        decoder: &mut D,
-    ) -> Result<Self, bincode::error::DecodeError> {
-        let val: Option<Rope> = bincode::BorrowDecode::borrow_decode(decoder)?;
-        Ok(Self {
-            source: Mutex::new(val),
-            serialization_invalidator: get_serialization_invalidator(),
-        })
-    }
 }
 
 // `SerializationInvalidator` does not implement `NonLocalValue`, so this

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -80,7 +80,7 @@ use turbo_tasks::{
     FxDashMap, FxIndexMap, NonLocalValue, ReadRef, ResolvedVc, TaskInput, TryJoinIterExt, Upcast,
     ValueToString, Vc, trace::TraceRawVcs, turbofmt,
 };
-use turbo_tasks_fs::{FileJsonContent, FileSystemPath, glob::Glob, rope::Rope};
+use turbo_tasks_fs::{File, FileJsonContent, FileSystemPath, glob::Glob, rope::Rope};
 use turbopack_core::{
     chunk::{
         AsyncModuleInfo, ChunkItem, ChunkableModule, ChunkingContext, EvaluatableAsset,
@@ -363,6 +363,81 @@ impl EcmascriptModuleAssetBuilder {
     }
 }
 
+/// Stores the raw file bytes of the last successfully parsed version of a module.
+///
+/// This is used by `failsafe_parse` to serve the last good AST when the file has a syntax error.
+/// The newtype is always-equal and no-op-hash so it is invisible to turbo-tasks cache key logic,
+/// but it serializes the `File` contents fully so the fallback survives eviction and restarts.
+struct LastSuccessfulSource(Mutex<Option<ReadRef<File>>>);
+
+impl LastSuccessfulSource {
+    fn get(&self) -> Option<ReadRef<File>> {
+        self.0.lock().unwrap().clone()
+    }
+
+    fn set(&self, file: File) {
+        *self.0.lock().unwrap() = Some(ReadRef::new_owned(file));
+    }
+}
+
+impl Default for LastSuccessfulSource {
+    fn default() -> Self {
+        Self(Mutex::new(None))
+    }
+}
+
+impl std::fmt::Debug for LastSuccessfulSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("LastSuccessfulSource")
+    }
+}
+
+impl PartialEq for LastSuccessfulSource {
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
+}
+
+impl Eq for LastSuccessfulSource {}
+
+impl std::hash::Hash for LastSuccessfulSource {
+    fn hash<H: std::hash::Hasher>(&self, _state: &mut H) {}
+}
+
+impl bincode::Encode for LastSuccessfulSource {
+    fn encode<E: bincode::enc::Encoder>(
+        &self,
+        encoder: &mut E,
+    ) -> Result<(), bincode::error::EncodeError> {
+        let guard = self.0.lock().unwrap();
+        guard.as_deref().encode(encoder)
+    }
+}
+
+impl<C> bincode::Decode<C> for LastSuccessfulSource {
+    fn decode<D: bincode::de::Decoder<Context = C>>(
+        decoder: &mut D,
+    ) -> Result<Self, bincode::error::DecodeError> {
+        let val: Option<File> = bincode::Decode::decode(decoder)?;
+        Ok(Self(Mutex::new(val.map(ReadRef::new_owned))))
+    }
+}
+
+impl<'de, C> bincode::BorrowDecode<'de, C> for LastSuccessfulSource {
+    fn borrow_decode<D: bincode::de::BorrowDecoder<'de, Context = C>>(
+        decoder: &mut D,
+    ) -> Result<Self, bincode::error::DecodeError> {
+        let val: Option<File> = bincode::BorrowDecode::borrow_decode(decoder)?;
+        Ok(Self(Mutex::new(val.map(ReadRef::new_owned))))
+    }
+}
+
+impl turbo_tasks::trace::TraceRawVcs for LastSuccessfulSource {
+    fn trace_raw_vcs(&self, _context: &mut turbo_tasks::trace::TraceRawVcsContext) {}
+}
+
+unsafe impl turbo_tasks::NonLocalValue for LastSuccessfulSource {}
+
 #[turbo_tasks::value]
 pub struct EcmascriptModuleAsset {
     pub source: ResolvedVc<Box<dyn Source>>,
@@ -374,7 +449,7 @@ pub struct EcmascriptModuleAsset {
     pub side_effect_free_packages: Option<ResolvedVc<Glob>>,
     pub inner_assets: Option<ResolvedVc<InnerAssets>>,
     #[turbo_tasks(debug_ignore)]
-    last_successful_parse: turbo_tasks::TransientState<ReadRef<ParseResult>>,
+    last_successful_source: LastSuccessfulSource,
 }
 impl core::fmt::Debug for EcmascriptModuleAsset {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
@@ -505,15 +580,21 @@ impl EcmascriptParsable for EcmascriptModuleAsset {
         let real_result = self.parse().await?;
         if self.options.await?.keep_last_successful_parse {
             let real_result_value = real_result.await?;
-            let result_value = if matches!(*real_result_value, ParseResult::Ok { .. }) {
-                self.last_successful_parse
-                    .set_unconditionally(real_result_value.clone());
-                real_result_value
+            if matches!(*real_result_value, ParseResult::Ok { .. }) {
+                // Store the current file bytes as the last-known-good source
+                if let Some(file) = crate::parse::get_file_from_source(self.source).await? {
+                    self.last_successful_source.set(file);
+                }
+                Ok(real_result)
             } else {
-                let state_ref = self.last_successful_parse.get();
-                state_ref.as_ref().unwrap_or(&real_result_value).clone()
-            };
-            Ok(ReadRef::cell(result_value))
+                // Fall back: re-parse from saved file bytes if available
+                if let Some(file_ref) = self.last_successful_source.get() {
+                    crate::parse::parse_from_file(&file_ref, self.source, self.ty, self.transforms)
+                        .await
+                } else {
+                    Ok(real_result)
+                }
+            }
         } else {
             Ok(real_result)
         }
@@ -642,7 +723,7 @@ impl EcmascriptModuleAsset {
             compile_time_info,
             side_effect_free_packages,
             inner_assets: None,
-            last_successful_parse: Default::default(),
+            last_successful_source: Default::default(),
         })
     }
 
@@ -677,7 +758,7 @@ impl EcmascriptModuleAsset {
                 compile_time_info,
                 side_effect_free_packages,
                 inner_assets: Some(inner_assets),
-                last_successful_parse: Default::default(),
+                last_successful_source: Default::default(),
             }))
         }
     }

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -80,7 +80,7 @@ use turbo_tasks::{
     FxDashMap, FxIndexMap, NonLocalValue, ReadRef, ResolvedVc, TaskInput, TryJoinIterExt, Upcast,
     ValueToString, Vc, trace::TraceRawVcs, turbofmt,
 };
-use turbo_tasks_fs::{File, FileJsonContent, FileSystemPath, glob::Glob, rope::Rope};
+use turbo_tasks_fs::{FileJsonContent, FileSystemPath, glob::Glob, rope::Rope};
 use turbopack_core::{
     chunk::{
         AsyncModuleInfo, ChunkItem, ChunkableModule, ChunkingContext, EvaluatableAsset,
@@ -363,20 +363,20 @@ impl EcmascriptModuleAssetBuilder {
     }
 }
 
-/// Stores the raw file bytes of the last successfully parsed version of a module.
+/// Stores the raw bytes of the last successfully parsed version of a module.
 ///
 /// This is used by `failsafe_parse` to serve the last good AST when the file has a syntax error.
 /// The newtype is always-equal and no-op-hash so it is invisible to turbo-tasks cache key logic,
-/// but it serializes the `File` contents fully so the fallback survives eviction and restarts.
-struct LastSuccessfulSource(Mutex<Option<ReadRef<File>>>);
+/// but serializes the `Rope` contents so the fallback survives eviction and restarts.
+struct LastSuccessfulSource(Mutex<Option<Rope>>);
 
 impl LastSuccessfulSource {
-    fn get(&self) -> Option<ReadRef<File>> {
+    fn get(&self) -> Option<Rope> {
         self.0.lock().unwrap().clone()
     }
 
-    fn set(&self, file: File) {
-        *self.0.lock().unwrap() = Some(ReadRef::new_owned(file));
+    fn set(&self, rope: Rope) {
+        *self.0.lock().unwrap() = Some(rope);
     }
 
     fn clear(&self) {
@@ -413,8 +413,7 @@ impl bincode::Encode for LastSuccessfulSource {
         &self,
         encoder: &mut E,
     ) -> Result<(), bincode::error::EncodeError> {
-        let guard = self.0.lock().unwrap();
-        guard.as_deref().encode(encoder)
+        self.0.lock().unwrap().encode(encoder)
     }
 }
 
@@ -422,8 +421,8 @@ impl<C> bincode::Decode<C> for LastSuccessfulSource {
     fn decode<D: bincode::de::Decoder<Context = C>>(
         decoder: &mut D,
     ) -> Result<Self, bincode::error::DecodeError> {
-        let val: Option<File> = bincode::Decode::decode(decoder)?;
-        Ok(Self(Mutex::new(val.map(ReadRef::new_owned))))
+        let val: Option<Rope> = bincode::Decode::decode(decoder)?;
+        Ok(Self(Mutex::new(val)))
     }
 }
 
@@ -431,8 +430,8 @@ impl<'de, C> bincode::BorrowDecode<'de, C> for LastSuccessfulSource {
     fn borrow_decode<D: bincode::de::BorrowDecoder<'de, Context = C>>(
         decoder: &mut D,
     ) -> Result<Self, bincode::error::DecodeError> {
-        let val: Option<File> = bincode::BorrowDecode::borrow_decode(decoder)?;
-        Ok(Self(Mutex::new(val.map(ReadRef::new_owned))))
+        let val: Option<Rope> = bincode::BorrowDecode::borrow_decode(decoder)?;
+        Ok(Self(Mutex::new(val)))
     }
 }
 
@@ -584,7 +583,7 @@ impl EcmascriptModuleAsset {
     /// which case the caller should fall back to the current (broken) result.
     /// On failure the cached source is cleared so we don't keep retrying it.
     async fn try_parse_last_successful_source(&self) -> Option<Vc<ParseResult>> {
-        let file_ref = self.last_successful_source.get()?;
+        let rope = self.last_successful_source.get()?;
         let result: Result<Vc<ParseResult>> = async {
             let node_env = self
                 .compile_time_info
@@ -594,14 +593,8 @@ impl EcmascriptModuleAsset {
                 .owned()
                 .await?
                 .unwrap_or_else(|| rcstr!("development"));
-            crate::parse::parse_from_file(
-                &file_ref,
-                self.source,
-                self.ty,
-                self.transforms,
-                node_env,
-            )
-            .await
+            crate::parse::parse_from_rope(&rope, self.source, self.ty, self.transforms, node_env)
+                .await
         }
         .await;
         match result {
@@ -624,8 +617,11 @@ impl EcmascriptParsable for EcmascriptModuleAsset {
             let real_result_value = real_result.await?;
             if matches!(*real_result_value, ParseResult::Ok { .. }) {
                 // Store the current file bytes as the last-known-good source
-                if let Some(file) = crate::parse::get_file_from_source(self.source).await? {
-                    self.last_successful_source.set(file);
+                // As long as the file doesn't change, this is _just_ an Arc::clone
+                // If it does change then this will pin the old version
+                // Also after a session restore the bytes will be duplicated
+                if let Some(rope) = crate::parse::get_rope_from_source(self.source).await? {
+                    self.last_successful_source.set(rope);
                 }
                 Ok(real_result)
             } else {

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -77,8 +77,9 @@ use swc_core::{
 use tracing::{Instrument, Level, instrument};
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
-    FxDashMap, FxIndexMap, NonLocalValue, ReadRef, ResolvedVc, TaskInput, TryJoinIterExt, Upcast,
-    ValueToString, Vc, trace::TraceRawVcs, turbofmt,
+    FxDashMap, FxIndexMap, NonLocalValue, ReadRef, ResolvedVc, SerializationInvalidator, TaskInput,
+    TryJoinIterExt, Upcast, ValueToString, Vc, get_serialization_invalidator, trace::TraceRawVcs,
+    turbofmt,
 };
 use turbo_tasks_fs::{FileJsonContent, FileSystemPath, glob::Glob, rope::Rope};
 use turbopack_core::{
@@ -368,25 +369,36 @@ impl EcmascriptModuleAssetBuilder {
 /// This is used by `failsafe_parse` to serve the last good AST when the file has a syntax error.
 /// The newtype is always-equal and no-op-hash so it is invisible to turbo-tasks cache key logic,
 /// but serializes the `Rope` contents so the fallback survives eviction and restarts.
-struct LastSuccessfulSource(Mutex<Option<Rope>>);
+#[derive(TraceRawVcs)]
+struct LastSuccessfulSource {
+    source: Mutex<Option<Rope>>,
+    /// Notifies the backend when the in-memory `source` changes so that the
+    /// serialized task state is written back to the persistence layer.
+    serialization_invalidator: SerializationInvalidator,
+}
 
 impl LastSuccessfulSource {
     fn get(&self) -> Option<Rope> {
-        self.0.lock().unwrap().clone()
+        self.source.lock().unwrap().clone()
     }
 
     fn set(&self, rope: Rope) {
-        *self.0.lock().unwrap() = Some(rope);
+        *self.source.lock().unwrap() = Some(rope);
+        self.serialization_invalidator.invalidate();
     }
 
     fn clear(&self) {
-        *self.0.lock().unwrap() = None;
+        *self.source.lock().unwrap() = None;
+        self.serialization_invalidator.invalidate();
     }
 }
 
 impl Default for LastSuccessfulSource {
     fn default() -> Self {
-        Self(Mutex::new(None))
+        Self {
+            source: Mutex::new(None),
+            serialization_invalidator: get_serialization_invalidator(),
+        }
     }
 }
 
@@ -396,6 +408,9 @@ impl std::fmt::Debug for LastSuccessfulSource {
     }
 }
 
+// Always-equal and no-op hash so that this field is invisible to the
+// turbo-tasks cache key: two `EcmascriptModuleAsset` values with different
+// `last_successful_source` bytes compare equal and hash identically.
 impl PartialEq for LastSuccessfulSource {
     fn eq(&self, _other: &Self) -> bool {
         true
@@ -408,12 +423,16 @@ impl std::hash::Hash for LastSuccessfulSource {
     fn hash<H: std::hash::Hasher>(&self, _state: &mut H) {}
 }
 
+// `Mutex` does not support `#[derive(Encode/Decode)]`, so these are written
+// by hand. They encode/decode only the `source` field; the
+// `serialization_invalidator` is re-created from the running task context on
+// decode (matching the pattern used by `turbo_tasks::State`).
 impl bincode::Encode for LastSuccessfulSource {
     fn encode<E: bincode::enc::Encoder>(
         &self,
         encoder: &mut E,
     ) -> Result<(), bincode::error::EncodeError> {
-        self.0.lock().unwrap().encode(encoder)
+        self.source.lock().unwrap().encode(encoder)
     }
 }
 
@@ -422,7 +441,10 @@ impl<C> bincode::Decode<C> for LastSuccessfulSource {
         decoder: &mut D,
     ) -> Result<Self, bincode::error::DecodeError> {
         let val: Option<Rope> = bincode::Decode::decode(decoder)?;
-        Ok(Self(Mutex::new(val)))
+        Ok(Self {
+            source: Mutex::new(val),
+            serialization_invalidator: get_serialization_invalidator(),
+        })
     }
 }
 
@@ -431,14 +453,15 @@ impl<'de, C> bincode::BorrowDecode<'de, C> for LastSuccessfulSource {
         decoder: &mut D,
     ) -> Result<Self, bincode::error::DecodeError> {
         let val: Option<Rope> = bincode::BorrowDecode::borrow_decode(decoder)?;
-        Ok(Self(Mutex::new(val)))
+        Ok(Self {
+            source: Mutex::new(val),
+            serialization_invalidator: get_serialization_invalidator(),
+        })
     }
 }
 
-impl turbo_tasks::trace::TraceRawVcs for LastSuccessfulSource {
-    fn trace_raw_vcs(&self, _context: &mut turbo_tasks::trace::TraceRawVcsContext) {}
-}
-
+// `SerializationInvalidator` does not implement `NonLocalValue`, so this
+// cannot be derived. The field contains no `Vc`s, so the impl is sound.
 unsafe impl turbo_tasks::NonLocalValue for LastSuccessfulSource {}
 
 #[turbo_tasks::value]
@@ -616,10 +639,13 @@ impl EcmascriptParsable for EcmascriptModuleAsset {
         if self.options.await?.keep_last_successful_parse {
             let real_result_value = real_result.await?;
             if matches!(*real_result_value, ParseResult::Ok { .. }) {
-                // Store the current file bytes as the last-known-good source
-                // As long as the file doesn't change, this is _just_ an Arc::clone
-                // If it does change then this will pin the old version
-                // Also after a session restore the bytes will be duplicated
+                // Store the current file bytes as the last-known-good source.
+                // As long as the file doesn't change, this is _just_ an Arc::clone.
+                // If it does change then this will pin the old version until this
+                // task re-runs (at which point the new bytes are stored or cleared).
+                // After a session restore the bytes will be duplicated in memory
+                // until the task re-runs; making the task session-dependent would
+                // avoid that but is too expensive.
                 if let Some(rope) = crate::parse::get_rope_from_source(self.source).await? {
                     self.last_successful_source.set(rope);
                 }

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -600,18 +600,7 @@ impl EcmascriptParsable for EcmascriptModuleAsset {
             let last_successful_source = LastSuccessfulSource::default().cell().await?;
             if let ParseResult::Ok { program_source, .. } = &*real_result_value {
                 // Store the bytes that `parse()` actually saw as the
-                // last-known-good source. Reading the rope from
-                // `ParseResult::Ok` (rather than re-reading `self.source`)
-                // guarantees the cached bytes correspond to the AST just
-                // produced — under eventual consistency a separate read could
-                // observe a newer file version than `parse()` did.
-                // As long as the file doesn't change, this is _just_ an
-                // Arc::clone. If it does change this will pin the old version
-                // until this task re-runs (at which point the new bytes are
-                // stored or cleared). After a session restore the bytes will
-                // be duplicated in memory until the task re-runs; making the
-                // task session-dependent would avoid that but is too
-                // expensive.
+                // last-known-good source.
                 last_successful_source.set(program_source.clone());
                 Ok(real_result)
             } else {

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -378,6 +378,10 @@ impl LastSuccessfulSource {
     fn set(&self, file: File) {
         *self.0.lock().unwrap() = Some(ReadRef::new_owned(file));
     }
+
+    fn clear(&self) {
+        *self.0.lock().unwrap() = None;
+    }
 }
 
 impl Default for LastSuccessfulSource {
@@ -573,6 +577,44 @@ impl ModuleTypeResult {
     }
 }
 
+impl EcmascriptModuleAsset {
+    /// Attempts to re-parse the module from the last known-good file bytes.
+    ///
+    /// Returns `None` if no saved source is available or if any step fails, in
+    /// which case the caller should fall back to the current (broken) result.
+    /// On failure the cached source is cleared so we don't keep retrying it.
+    async fn try_parse_last_successful_source(&self) -> Option<Vc<ParseResult>> {
+        let file_ref = self.last_successful_source.get()?;
+        let result: Result<Vc<ParseResult>> = async {
+            let node_env = self
+                .compile_time_info
+                .await?
+                .defines
+                .read_process_env(rcstr!("NODE_ENV"))
+                .owned()
+                .await?
+                .unwrap_or_else(|| rcstr!("development"));
+            crate::parse::parse_from_file(
+                &file_ref,
+                self.source,
+                self.ty,
+                self.transforms,
+                node_env,
+            )
+            .await
+        }
+        .await;
+        match result {
+            Ok(result) => Some(result),
+            Err(_) => {
+                // A failure is very unexpected, but we don't want to keep bad bytes around
+                self.last_successful_source.clear();
+                None
+            }
+        }
+    }
+}
+
 #[turbo_tasks::value_impl]
 impl EcmascriptParsable for EcmascriptModuleAsset {
     #[turbo_tasks::function]
@@ -587,13 +629,10 @@ impl EcmascriptParsable for EcmascriptModuleAsset {
                 }
                 Ok(real_result)
             } else {
-                // Fall back: re-parse from saved file bytes if available
-                if let Some(file_ref) = self.last_successful_source.get() {
-                    crate::parse::parse_from_file(&file_ref, self.source, self.ty, self.transforms)
-                        .await
-                } else {
-                    Ok(real_result)
-                }
+                Ok(self
+                    .try_parse_last_successful_source()
+                    .await
+                    .unwrap_or(real_result))
             }
         } else {
             Ok(real_result)

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -366,15 +366,19 @@ impl EcmascriptModuleAssetBuilder {
 
 /// Stores the raw bytes of the last successfully parsed version of a module.
 ///
-/// This is used by `failsafe_parse` to serve the last good AST when the file has a syntax error.
-/// The newtype is always-equal and no-op-hash so it is invisible to turbo-tasks cache key logic,
-/// but serializes the `Rope` contents so the fallback survives eviction and restarts.
-#[derive(TraceRawVcs, Encode, Decode, NonLocalValue)]
+/// Cached as a turbo-tasks cell inside `failsafe_parse`: the always-equal
+/// `PartialEq` impl means that re-running the task does not replace the cell,
+/// so the interior `Mutex<Option<Rope>>` (and its stored rope) survive across
+/// task executions. A `SerializationInvalidator` keeps the persistence layer
+/// in sync with the in-memory mutation.
+#[turbo_tasks::value(eq = "manual")]
 struct LastSuccessfulSource {
     #[bincode(with = "parking_lot_mutex_bincode")]
+    #[turbo_tasks(trace_ignore, debug_ignore)]
     source: parking_lot::Mutex<Option<Rope>>,
     /// Notifies the backend when the in-memory `source` changes so that the
     /// serialized task state is written back to the persistence layer.
+    #[turbo_tasks(debug_ignore)]
     serialization_invalidator: SerializationInvalidator,
 }
 
@@ -409,9 +413,9 @@ impl std::fmt::Debug for LastSuccessfulSource {
     }
 }
 
-// Always-equal and no-op hash so that this field is invisible to the
-// turbo-tasks cache key: two `EcmascriptModuleAsset` values with different
-// `last_successful_source` bytes compare equal and hash identically.
+// Always-equal so that re-celling a freshly constructed `LastSuccessfulSource`
+// does not overwrite the existing cell — the interior `Mutex` holds the
+// cross-execution state and must survive task re-runs.
 impl PartialEq for LastSuccessfulSource {
     fn eq(&self, _other: &Self) -> bool {
         true
@@ -420,11 +424,14 @@ impl PartialEq for LastSuccessfulSource {
 
 impl Eq for LastSuccessfulSource {}
 
+// No-op hash to uphold the `Hash` / `Eq` contract (equal values must hash
+// identically). The interior `Mutex` content is not part of the cache identity.
 impl std::hash::Hash for LastSuccessfulSource {
     fn hash<H: std::hash::Hasher>(&self, _state: &mut H) {}
 }
 
 #[turbo_tasks::value]
+#[derive(Debug)]
 pub struct EcmascriptModuleAsset {
     pub source: ResolvedVc<Box<dyn Source>>,
     pub asset_context: ResolvedVc<Box<dyn AssetContext>>,
@@ -434,22 +441,6 @@ pub struct EcmascriptModuleAsset {
     pub compile_time_info: ResolvedVc<CompileTimeInfo>,
     pub side_effect_free_packages: Option<ResolvedVc<Glob>>,
     pub inner_assets: Option<ResolvedVc<InnerAssets>>,
-    #[turbo_tasks(debug_ignore)]
-    last_successful_source: LastSuccessfulSource,
-}
-impl core::fmt::Debug for EcmascriptModuleAsset {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        f.debug_struct("EcmascriptModuleAsset")
-            .field("source", &self.source)
-            .field("asset_context", &self.asset_context)
-            .field("ty", &self.ty)
-            .field("transforms", &self.transforms)
-            .field("options", &self.options)
-            .field("compile_time_info", &self.compile_time_info)
-            .field("side_effect_free_packages", &self.side_effect_free_packages)
-            .field("inner_assets", &self.inner_assets)
-            .finish()
-    }
 }
 
 #[turbo_tasks::value_trait]
@@ -565,8 +556,11 @@ impl EcmascriptModuleAsset {
     /// Returns `None` if no saved source is available or if any step fails, in
     /// which case the caller should fall back to the current (broken) result.
     /// On failure the cached source is cleared so we don't keep retrying it.
-    async fn try_parse_last_successful_source(&self) -> Option<Vc<ParseResult>> {
-        let rope = self.last_successful_source.get()?;
+    async fn try_parse_last_successful_source(
+        &self,
+        last_successful_source: &LastSuccessfulSource,
+    ) -> Option<Vc<ParseResult>> {
+        let rope = last_successful_source.get()?;
         let result: Result<Vc<ParseResult>> = async {
             let node_env = self
                 .compile_time_info
@@ -576,7 +570,7 @@ impl EcmascriptModuleAsset {
                 .owned()
                 .await?
                 .unwrap_or_else(|| rcstr!("development"));
-            crate::parse::parse_from_rope(&rope, self.source, self.ty, self.transforms, node_env)
+            crate::parse::parse_from_rope(rope, self.source, self.ty, self.transforms, node_env)
                 .await
         }
         .await;
@@ -584,7 +578,7 @@ impl EcmascriptModuleAsset {
             Ok(result) => Some(result),
             Err(_) => {
                 // A failure is very unexpected, but we don't want to keep bad bytes around
-                self.last_successful_source.clear();
+                last_successful_source.clear();
                 None
             }
         }
@@ -598,21 +592,31 @@ impl EcmascriptParsable for EcmascriptModuleAsset {
         let real_result = self.parse().await?;
         if self.options.await?.keep_last_successful_parse {
             let real_result_value = real_result.await?;
-            if matches!(*real_result_value, ParseResult::Ok { .. }) {
-                // Store the current file bytes as the last-known-good source.
-                // As long as the file doesn't change, this is _just_ an Arc::clone.
-                // If it does change then this will pin the old version until this
-                // task re-runs (at which point the new bytes are stored or cleared).
-                // After a session restore the bytes will be duplicated in memory
-                // until the task re-runs; making the task session-dependent would
-                // avoid that but is too expensive.
-                if let Some(rope) = crate::parse::get_rope_from_source(self.source).await? {
-                    self.last_successful_source.set(rope);
-                }
+            // The cell stored here survives re-runs of this task because
+            // `LastSuccessfulSource`'s `PartialEq` is always-equal: the
+            // compare-and-update path preserves the existing cell (and its
+            // interior `Mutex<Option<Rope>>`) whenever this function is
+            // re-executed.
+            let last_successful_source = LastSuccessfulSource::default().cell().await?;
+            if let ParseResult::Ok { program_source, .. } = &*real_result_value {
+                // Store the bytes that `parse()` actually saw as the
+                // last-known-good source. Reading the rope from
+                // `ParseResult::Ok` (rather than re-reading `self.source`)
+                // guarantees the cached bytes correspond to the AST just
+                // produced — under eventual consistency a separate read could
+                // observe a newer file version than `parse()` did.
+                // As long as the file doesn't change, this is _just_ an
+                // Arc::clone. If it does change this will pin the old version
+                // until this task re-runs (at which point the new bytes are
+                // stored or cleared). After a session restore the bytes will
+                // be duplicated in memory until the task re-runs; making the
+                // task session-dependent would avoid that but is too
+                // expensive.
+                last_successful_source.set(program_source.clone());
                 Ok(real_result)
             } else {
                 Ok(self
-                    .try_parse_last_successful_source()
+                    .try_parse_last_successful_source(&last_successful_source)
                     .await
                     .unwrap_or(real_result))
             }
@@ -744,7 +748,6 @@ impl EcmascriptModuleAsset {
             compile_time_info,
             side_effect_free_packages,
             inner_assets: None,
-            last_successful_source: Default::default(),
         })
     }
 
@@ -779,7 +782,6 @@ impl EcmascriptModuleAsset {
                 compile_time_info,
                 side_effect_free_packages,
                 inner_assets: Some(inner_assets),
-                last_successful_source: Default::default(),
             }))
         }
     }

--- a/turbopack/crates/turbopack-ecmascript/src/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/parse.rs
@@ -147,7 +147,6 @@ impl Visit for IdentCollector {
 #[turbo_tasks::value(shared, serialization = "none", eq = "manual", cell = "new")]
 #[allow(clippy::large_enum_variant)]
 pub enum ParseResult {
-    // Note: Ok must not contain any Vc as it's snapshot by failsafe_parse
     Ok {
         #[turbo_tasks(debug_ignore, trace_ignore)]
         program: Program,
@@ -160,6 +159,14 @@ pub enum ParseResult {
         #[turbo_tasks(debug_ignore, trace_ignore)]
         source_map: Arc<swc_core::common::SourceMap>,
         source_mapping_url: Option<RcStr>,
+        /// Raw bytes of the source that produced this parse, captured atomically
+        /// with the AST. `failsafe_parse` stores this alongside the parsed
+        /// result so the cached rope is always consistent with the AST it
+        /// produced — even under eventual consistency, where reading the
+        /// source separately could observe a different file version than the
+        /// one `parse()` saw.
+        #[turbo_tasks(debug_ignore, trace_ignore)]
+        program_source: Rope,
     },
     Unparsable {
         messages: Option<Vec<RcStr>>,
@@ -333,62 +340,29 @@ async fn parse_internal(
         AssetContent::File(file) => match &*file.await? {
             FileContent::NotFound => ParseResult::NotFound.cell(),
             FileContent::Content(file) => {
-                match BytesStr::from_utf8(file.content().clone().into_bytes()) {
-                    Ok(string) => {
-                        let transforms = &*transforms.await?;
-                        match parse_file_content(
-                            string,
-                            &fs_path,
-                            ident,
-                            source.ident().await?.query.clone(),
-                            file_path_hash,
-                            source,
-                            ty,
-                            transforms,
-                            node_env.clone(),
-                            loose_errors,
-                            inline_helpers,
-                        )
-                        .await
-                        {
-                            Ok(result) => result,
-                            Err(e) => {
-                                // ast-grep-ignore: no-context-turbofmt
-                                return Err(e).context(
-                                    turbofmt!(
-                                        "Transforming and/or parsing of {} failed",
-                                        source.ident()
-                                    )
-                                    .await?,
-                                );
-                            }
-                        }
-                    }
-                    Err(error) => {
-                        let error: RcStr = PrettyPrintError(
-                            &anyhow::anyhow!(error).context("failed to convert rope into string"),
-                        )
-                        .to_string()
-                        .into();
-                        ReadSourceIssue {
-                            // Technically we could supply byte offsets to the issue source, but
-                            // that would cause another utf8 error to be produced when we
-                            // attempt to infer line/column
-                            // offsets
-                            source: IssueSource::from_source_only(source),
-                            error: error.clone(),
-                            severity: if loose_errors {
-                                IssueSeverity::Warning
-                            } else {
-                                IssueSeverity::Error
-                            },
-                        }
-                        .resolved_cell()
-                        .emit();
-                        ParseResult::Unparsable {
-                            messages: Some(vec![error]),
-                        }
-                        .cell()
+                let transforms = &*transforms.await?;
+                match parse_file_content(
+                    file.content().clone(),
+                    &fs_path,
+                    ident,
+                    source.ident().await?.query.clone(),
+                    file_path_hash,
+                    source,
+                    ty,
+                    transforms,
+                    node_env.clone(),
+                    loose_errors,
+                    inline_helpers,
+                )
+                .await
+                {
+                    Ok(result) => result,
+                    Err(e) => {
+                        // ast-grep-ignore: no-context-turbofmt
+                        return Err(e).context(
+                            turbofmt!("Transforming and/or parsing of {} failed", source.ident())
+                                .await?,
+                        );
                     }
                 }
             }
@@ -398,7 +372,7 @@ async fn parse_internal(
 }
 
 async fn parse_file_content(
-    string: BytesStr,
+    program_source: Rope,
     fs_path: &FileSystemPath,
     ident: &str,
     query: RcStr,
@@ -410,6 +384,31 @@ async fn parse_file_content(
     loose_errors: bool,
     inline_helpers: bool,
 ) -> Result<Vc<ParseResult>> {
+    let string = match BytesStr::from_utf8(program_source.clone().into_bytes()) {
+        Ok(s) => s,
+        Err(error) => {
+            let error: RcStr = PrettyPrintError(
+                &anyhow::anyhow!(error).context("failed to convert rope into string"),
+            )
+            .to_string()
+            .into();
+            ReadSourceIssue {
+                source: IssueSource::from_source_only(source),
+                error: error.clone(),
+                severity: if loose_errors {
+                    IssueSeverity::Warning
+                } else {
+                    IssueSeverity::Error
+                },
+            }
+            .resolved_cell()
+            .emit();
+            return Ok(ParseResult::Unparsable {
+                messages: Some(vec![error]),
+            }
+            .cell());
+        }
+    };
     let source_map: Arc<swc_core::common::SourceMap> = Default::default();
     let (emitter, collector) = IssueEmitter::new(
         source,
@@ -619,6 +618,7 @@ async fn parse_file_content(
                 globals: Arc::new(Globals::new()),
                 source_map,
                 source_mapping_url: source_mapping_url.map(|s| s.into()),
+                program_source,
             })
         },
         |f, cx| GLOBALS.set(globals_ref, || HANDLER.set(&handler, || f.poll(cx))),
@@ -752,27 +752,11 @@ impl Visit for VarDeclWithTsDeclareCollector {
     }
 }
 
-/// Extracts the raw bytes of a source's content, if it is a regular file.
-/// Returns `None` for `NotFound`, redirects, or read errors.
-pub async fn get_rope_from_source(source: ResolvedVc<Box<dyn Source>>) -> Result<Option<Rope>> {
-    let content = match source.content().await {
-        Ok(c) => c,
-        Err(_) => return Ok(None),
-    };
-    Ok(match &*content {
-        AssetContent::File(file) => match &*file.await? {
-            FileContent::Content(f) => Some(f.content().clone()),
-            FileContent::NotFound => None,
-        },
-        AssetContent::Redirect { .. } => None,
-    })
-}
-
 /// Re-parses a module directly from saved bytes, bypassing `source.content()`.
 ///
 /// Used by `failsafe_parse` to serve the last good AST when the live file has a syntax error.
 pub async fn parse_from_rope(
-    rope: &Rope,
+    rope: Rope,
     source: ResolvedVc<Box<dyn Source>>,
     ty: EcmascriptModuleAssetType,
     transforms: ResolvedVc<EcmascriptInputTransforms>,
@@ -783,25 +767,20 @@ pub async fn parse_from_rope(
     let file_path_hash = hash_xxh3_hash64(ident) as u128;
     let query = source.ident().await?.query.clone();
     let transforms = &*transforms.await?;
-    match bytes_str::BytesStr::from_utf8(rope.clone().into_bytes()) {
-        Ok(string) => {
-            parse_file_content(
-                string,
-                &fs_path,
-                ident,
-                query,
-                file_path_hash,
-                source,
-                ty,
-                transforms,
-                node_env,
-                false,
-                false,
-            )
-            .await
-        }
-        Err(_) => Ok(ParseResult::Unparsable { messages: None }.cell()),
-    }
+    parse_file_content(
+        rope,
+        &fs_path,
+        ident,
+        query,
+        file_path_hash,
+        source,
+        ty,
+        transforms,
+        node_env,
+        false,
+        false,
+    )
+    .await
 }
 
 #[cfg(test)]

--- a/turbopack/crates/turbopack-ecmascript/src/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/parse.rs
@@ -33,7 +33,7 @@ use swc_core::{
 use tracing::{Instrument, instrument};
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{PrettyPrintError, ResolvedVc, ValueToString, Vc, turbofmt, util::WrapFuture};
-use turbo_tasks_fs::{File, FileContent, FileSystemPath, rope::Rope};
+use turbo_tasks_fs::{FileContent, FileSystemPath, rope::Rope};
 use turbo_tasks_hash::hash_xxh3_hash64;
 use turbopack_core::{
     SOURCE_URL_PROTOCOL,
@@ -752,27 +752,27 @@ impl Visit for VarDeclWithTsDeclareCollector {
     }
 }
 
-/// Extracts the raw [`File`] from a source's content, if it is a regular file.
+/// Extracts the raw bytes of a source's content, if it is a regular file.
 /// Returns `None` for `NotFound`, redirects, or read errors.
-pub async fn get_file_from_source(source: ResolvedVc<Box<dyn Source>>) -> Result<Option<File>> {
+pub async fn get_rope_from_source(source: ResolvedVc<Box<dyn Source>>) -> Result<Option<Rope>> {
     let content = match source.content().await {
         Ok(c) => c,
         Err(_) => return Ok(None),
     };
     Ok(match &*content {
         AssetContent::File(file) => match &*file.await? {
-            FileContent::Content(f) => Some(f.clone()),
+            FileContent::Content(f) => Some(f.content().clone()),
             FileContent::NotFound => None,
         },
         AssetContent::Redirect { .. } => None,
     })
 }
 
-/// Re-parses a module directly from a saved [`File`], bypassing `source.content()`.
+/// Re-parses a module directly from saved bytes, bypassing `source.content()`.
 ///
 /// Used by `failsafe_parse` to serve the last good AST when the live file has a syntax error.
-pub async fn parse_from_file(
-    file: &File,
+pub async fn parse_from_rope(
+    rope: &Rope,
     source: ResolvedVc<Box<dyn Source>>,
     ty: EcmascriptModuleAssetType,
     transforms: ResolvedVc<EcmascriptInputTransforms>,
@@ -783,7 +783,7 @@ pub async fn parse_from_file(
     let file_path_hash = hash_xxh3_hash64(ident) as u128;
     let query = source.ident().await?.query.clone();
     let transforms = &*transforms.await?;
-    match bytes_str::BytesStr::from_utf8(file.content().clone().into_bytes()) {
+    match bytes_str::BytesStr::from_utf8(rope.clone().into_bytes()) {
         Ok(string) => {
             parse_file_content(
                 string,

--- a/turbopack/crates/turbopack-ecmascript/src/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/parse.rs
@@ -390,6 +390,10 @@ async fn parse_file_content(
             .to_string()
             .into();
             ReadSourceIssue {
+                // Technically we could supply byte offsets to the issue source, but
+                // that would cause another utf8 error to be produced when we
+                // attempt to infer line/column
+                // offsets
                 source: IssueSource::from_source_only(source),
                 error: error.clone(),
                 severity: if loose_errors {
@@ -759,10 +763,11 @@ pub async fn parse_from_rope(
     transforms: ResolvedVc<EcmascriptInputTransforms>,
     node_env: RcStr,
 ) -> Result<Vc<ParseResult>> {
-    let fs_path = source.ident().path().owned().await?;
-    let ident = &*source.ident().to_string().await?;
+    let ident_vc = source.ident();
+    let fs_path = ident_vc.path().owned().await?;
+    let ident = &*ident_vc.to_string().await?;
     let file_path_hash = hash_xxh3_hash64(ident) as u128;
-    let query = source.ident().await?.query.clone();
+    let query = ident_vc.await?.query.clone();
     let transforms = &*transforms.await?;
     parse_file_content(
         rope,

--- a/turbopack/crates/turbopack-ecmascript/src/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/parse.rs
@@ -776,6 +776,7 @@ pub async fn parse_from_file(
     source: ResolvedVc<Box<dyn Source>>,
     ty: EcmascriptModuleAssetType,
     transforms: ResolvedVc<EcmascriptInputTransforms>,
+    node_env: RcStr,
 ) -> Result<Vc<ParseResult>> {
     let fs_path = source.ident().path().owned().await?;
     let ident = &*source.ident().to_string().await?;
@@ -793,6 +794,7 @@ pub async fn parse_from_file(
                 source,
                 ty,
                 transforms,
+                node_env,
                 false,
                 false,
             )

--- a/turbopack/crates/turbopack-ecmascript/src/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/parse.rs
@@ -160,11 +160,8 @@ pub enum ParseResult {
         source_map: Arc<swc_core::common::SourceMap>,
         source_mapping_url: Option<RcStr>,
         /// Raw bytes of the source that produced this parse, captured atomically
-        /// with the AST. `failsafe_parse` stores this alongside the parsed
-        /// result so the cached rope is always consistent with the AST it
-        /// produced — even under eventual consistency, where reading the
-        /// source separately could observe a different file version than the
-        /// one `parse()` saw.
+        /// with the AST. `failsafe_parse` uses this to recover good parses in development on
+        /// error.
         #[turbo_tasks(debug_ignore, trace_ignore)]
         program_source: Rope,
     },

--- a/turbopack/crates/turbopack-ecmascript/src/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/parse.rs
@@ -33,7 +33,7 @@ use swc_core::{
 use tracing::{Instrument, instrument};
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{PrettyPrintError, ResolvedVc, ValueToString, Vc, turbofmt, util::WrapFuture};
-use turbo_tasks_fs::{FileContent, FileSystemPath, rope::Rope};
+use turbo_tasks_fs::{File, FileContent, FileSystemPath, rope::Rope};
 use turbo_tasks_hash::hash_xxh3_hash64;
 use turbopack_core::{
     SOURCE_URL_PROTOCOL,
@@ -749,6 +749,56 @@ impl Visit for VarDeclWithTsDeclareCollector {
         {
             self.id_with_ts_declare.insert(id.to_id());
         }
+    }
+}
+
+/// Extracts the raw [`File`] from a source's content, if it is a regular file.
+/// Returns `None` for `NotFound`, redirects, or read errors.
+pub async fn get_file_from_source(source: ResolvedVc<Box<dyn Source>>) -> Result<Option<File>> {
+    let content = match source.content().await {
+        Ok(c) => c,
+        Err(_) => return Ok(None),
+    };
+    Ok(match &*content {
+        AssetContent::File(file) => match &*file.await? {
+            FileContent::Content(f) => Some(f.clone()),
+            FileContent::NotFound => None,
+        },
+        AssetContent::Redirect { .. } => None,
+    })
+}
+
+/// Re-parses a module directly from a saved [`File`], bypassing `source.content()`.
+///
+/// Used by `failsafe_parse` to serve the last good AST when the live file has a syntax error.
+pub async fn parse_from_file(
+    file: &File,
+    source: ResolvedVc<Box<dyn Source>>,
+    ty: EcmascriptModuleAssetType,
+    transforms: ResolvedVc<EcmascriptInputTransforms>,
+) -> Result<Vc<ParseResult>> {
+    let fs_path = source.ident().path().owned().await?;
+    let ident = &*source.ident().to_string().await?;
+    let file_path_hash = hash_xxh3_hash64(ident) as u128;
+    let query = source.ident().await?.query.clone();
+    let transforms = &*transforms.await?;
+    match bytes_str::BytesStr::from_utf8(file.content().clone().into_bytes()) {
+        Ok(string) => {
+            parse_file_content(
+                string,
+                &fs_path,
+                ident,
+                query,
+                file_path_hash,
+                source,
+                ty,
+                transforms,
+                false,
+                false,
+            )
+            .await
+        }
+        Err(_) => Ok(ParseResult::Unparsable { messages: None }.cell()),
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -625,6 +625,7 @@ async fn analyze_ecmascript_module_internal(
         comments,
         source_map,
         source_mapping_url,
+        program_source: _,
     } = &*parsed
     else {
         return analysis.build(Default::default(), false).await;

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/mod.rs
@@ -500,6 +500,7 @@ pub(super) async fn split_module(asset: Vc<EcmascriptModuleAsset>) -> Result<Vc<
             eval_context,
             source_map,
             globals,
+            program_source,
             ..
         } => {
             // If the script file is a common js file, we cannot split the module
@@ -578,6 +579,7 @@ pub(super) async fn split_module(asset: Vc<EcmascriptModuleAsset>) -> Result<Vc<
                         source_map: source_map.clone(),
                         eval_context,
                         source_mapping_url: None,
+                        program_source: program_source.clone(),
                     })
                 })
                 .collect();
@@ -623,6 +625,7 @@ pub(crate) async fn part_of_module(
                     eval_context,
                     globals,
                     source_map,
+                    program_source,
                     ..
                 } = &*modules[0].await?
                 {
@@ -703,6 +706,7 @@ pub(crate) async fn part_of_module(
                         globals: globals.clone(),
                         source_map: source_map.clone(),
                         source_mapping_url: None,
+                        program_source: program_source.clone(),
                     }
                     .cell());
                 } else {


### PR DESCRIPTION
## What?

Replaces the `TransientState<ReadRef<ParseResult>>` used by `failsafe_parse` with a persistent `LastSuccessfulSource` turbo-tasks cell that stores the raw bytes of the last successfully parsed version of the module.

## Why?

The previous implementation had three problems:

1. **Memory**: It held a full AST in memory alongside the current one — effectively doubling AST memory for every file with `keep_last_successful_parse` enabled.
2. **Durability**: `TransientState` skips serialization, so the fallback was silently lost on eviction or server restart, meaning the mechanism that prevents whole-graph invalidation on syntax errors didn't survive across restarts.
3. **`final_read_hint` defeat**: `with_consumed_parse_result` uses `final_read_hint()` + `ReadRef::try_unwrap()` to avoid cloning the AST when this is the last reader. But holding a `ReadRef<ParseResult>` in `TransientState` meant there was always a second `Arc` reference alive, so `try_unwrap` always failed and the AST was always cloned — even in the common case where no syntax error had occurred. Now because we are just cloning the Rope, we don't duplicate any memory until things change and even then only if there is an error.

## How?

`LastSuccessfulSource` is a `#[turbo_tasks::value(eq = "manual")]` wrapping `parking_lot::Mutex<Option<Rope>>` and a `SerializationInvalidator` with:
- `PartialEq` always `true` and `Hash` as a no-op — re-celling a freshly constructed `LastSuccessfulSource` inside `failsafe_parse` hits the compare-and-update path and preserves the existing cell (and its interior `Mutex<Option<Rope>>`) across task re-runs. The value is not a field on `EcmascriptModuleAsset`; it lives in the `failsafe_parse` task's own cell storage.
- Serialized via `#[bincode(with = "parking_lot_mutex_bincode")]` on the Mutex field — persisted to the cache and survives both eviction and restarts.
- Calls `serialization_invalidator.invalidate()` on every mutation (`set`/`clear`) so the backend knows to write the updated state back to the persistence layer.

`Rope` is just a ref-counted byte buffer, so cloning it (on cache hit) is a single `Arc::clone`.

### Consistency with the parsed AST

`ParseResult::Ok` now carries a `program_source: Rope` field: the raw bytes that produced the AST, captured atomically inside `parse_file_content`. `failsafe_parse` reads the rope out of `ParseResult::Ok` rather than re-reading `source.content()` separately — otherwise, under eventual consistency, the file could change between the parse task and the rope read, letting `failsafe_parse` cache bytes that didn't match the AST it just stored.

On a successful parse, `program_source` is stored into the cell. On failure, `parse_from_rope` re-derives the AST on demand, reusing the existing `parse_file_content` path. If the fallback itself fails for any reason, the cached bytes are cleared and the real (broken) result is returned.

### Simplification of `SerializationInvalidator`

`SerializationInvalidator` previously captured a `Weak<dyn TurboTasksApi>` and a tokio `Handle` at construction time. Since `invalidate()` is always called from within a turbo-tasks execution context (where the `TURBO_TASKS` task-local is available), these captures are unnecessary. The struct is now just a `TaskId` wrapper with derives for `Clone`, `Hash`, `Eq`, `PartialEq`, `Encode`, `Decode`, `TraceRawVcs`, and `NonLocalValue`.

<!-- NEXT_JS_LLM_PR -->