### PR TITLE
Support more prefetch configuration options

### DIFF
--- a/docs/01-app/03-api-reference/03-file-conventions/02-route-segment-config/prefetch.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/02-route-segment-config/prefetch.mdx
@@ -1,0 +1,92 @@
+---
+title: prefetch
+description: API reference for the prefetch route segment config.
+version: draft
+related:
+  title: Next Steps
+  description: Learn how to use instant navigations in practice.
+  links:
+    - app/guides/instant-navigation
+    - app/api-reference/file-conventions/route-segment-config/instant
+---
+
+The `unstable_prefetch` route segment config controls how a segment is prefetched during client-side navigation. By default (`'auto'`), the framework decides based on the segment's instant validation configuration and caching structure. The `force-` options let you declare a specific behavior. Use the force options with care since they can have implications for the speed of navigation and cost of naviagation. If you are configuring prefetching using this export consider pairing it with `unstable_instant` to validate that navigations to this Segment will in fact produce an instant UI with the prefetched data. This is especially important with runtime prefetching.
+
+> **Good to know**:
+>
+> - The `unstable_prefetch` export only works when [`cacheComponents`](/docs/app/api-reference/config/next-config-js/cacheComponents) is enabled.
+> - `unstable_prefetch` cannot be used when your Segment is a Client Component.
+
+```tsx filename="layout.tsx | page.tsx" switcher
+export const unstable_prefetch = 'force-runtime'
+
+export default function Page() {
+  return <div>...</div>
+}
+```
+
+```jsx filename="layout.js | page.js" switcher
+export const unstable_prefetch = 'force-runtime'
+
+export default function Page() {
+  return <div>...</div>
+}
+```
+
+## Options
+
+### `'auto'` (default)
+
+The framework decides how to prefetch this segment. Segments with instant validation enabled are prefetched statically. Segments without instant validation may not be prefetched at all. You do not need to set this explicitly. While this option is available for completeness it is generally not expected that you use it and insteaed expect that you just omit the export from this segment.
+
+### `'force-runtime'`
+
+Always prefetch this segment at runtime. The server renders a fresh response for the segment during prefetch, allowing runtime data like cookies, headers, and search params to be included. This is useful for personalized content that should still be available instantly on navigation.
+
+When using `'force-runtime'`, you should also configure [`unstable_instant`](/docs/app/api-reference/file-conventions/route-segment-config/instant) with `samples` so that instant validation can verify your caching structure against realistic request data.
+
+> **Good to know**: When a segment uses runtime prefetching, all downstream segments are included in the same runtime prefetch request. This means segments deeper in the tree that are configured with `'force-static'` or `'force-disabled'` will still be prefetched as part of the runtime response.
+
+```tsx filename="page.tsx"
+export const unstable_prefetch = 'force-runtime'
+export const unstable_instant = {
+  samples: [
+    {
+      cookies: [{ name: 'session', value: 'test' }],
+    },
+  ],
+}
+```
+
+### `'force-static'`
+
+Always prefetch this segment statically, even if it has not been validated with `unstable_instant`. Use this when you know the segment produces a valid static shell but do not want to set up instant validation.
+
+### `'force-disabled'`
+
+Never prefetch this segment. The client will not request segment data ahead of navigation. Use this for segments where prefetching would be wasteful, for example pages behind authentication that are rarely visited.
+
+> **Good to know**: `'force-disabled'` does not prevent Next.js from prefetching metadata about the route. However, the actual segment data for this segment and all deeper segments will be omitted from prefetching.
+
+## Relationship with the `<Link prefetch>` prop
+
+The `unstable_prefetch` segment config and the [`<Link prefetch>` prop](/docs/app/api-reference/components/link#prefetch) control different aspects of prefetching:
+
+- The **segment config** informs Next.js about a segment's caching characteristics — whether its data can be prefetched statically, requires a runtime prefetch with the user's session, or should be skipped entirely. This applies to the segment regardless of which link points to it.
+- The **`<Link prefetch>` prop** reflects the anticipated intent of a specific link on a specific page. A link that users rarely click can be deprioritized with `prefetch={false}`, independent of how the destination segments are configured.
+
+In general, both of these are special circumstances. The default behavior — where Next.js decides what to prefetch based on [`unstable_instant`](/docs/app/api-reference/file-conventions/route-segment-config/instant) validation and the segment's caching structure — is optimized to provide a good navigation experience without manual configuration.
+
+## TypeScript
+
+```tsx
+type Prefetch = 'auto' | 'force-disabled' | 'force-static' | 'force-runtime'
+
+export const unstable_prefetch: Prefetch = 'force-runtime'
+```
+
+## Version History
+
+| Version   | Changes                                                       |
+| --------- | ------------------------------------------------------------- |
+| `v16.x.x` | `unstable_prefetch` export introduced (Cache Components only) |

--- a/packages/next/src/build/segment-config/app/app-segment-config.ts
+++ b/packages/next/src/build/segment-config/app/app-segment-config.ts
@@ -49,11 +49,20 @@ const InstantConfigSchema = z.union([
   z.literal(false),
 ])
 
-const PrefetchSchema = z.enum(['static', 'runtime'])
+const PrefetchSchema = z.enum([
+  'auto',
+  'force-disabled',
+  'force-static',
+  'force-runtime',
+])
 
 export type Instant = InstantConfigStatic | InstantConfigRuntime | false
 
-export type Prefetch = 'static' | 'runtime'
+export type Prefetch =
+  | 'auto'
+  | 'force-disabled'
+  | 'force-static'
+  | 'force-runtime'
 
 export type InstantConfigForTypeCheckInternal = __GenericInstantConfig | Instant
 // the __GenericPrefetch type is used to avoid type widening issues with
@@ -208,7 +217,7 @@ export function parseAppSegmentConfig(
           }
           case 'unstable_prefetch': {
             return {
-              message: `Invalid unstable_prefetch value ${JSON.stringify(ctx.data)} on "${route}", must be "static" or "runtime".`,
+              message: `Invalid unstable_prefetch value ${JSON.stringify(ctx.data)} on "${route}", must be "auto", "force-disabled", "force-static", or "force-runtime".`,
             }
           }
           case 'unstable_dynamicStaleTime': {

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -246,7 +246,7 @@ async function createComponentTreeInternal(
   const prefetchConfig = layoutOrPageMod
     ? (layoutOrPageMod as AppSegmentConfig).unstable_prefetch
     : undefined
-  const hasRuntimePrefetch = prefetchConfig === 'runtime'
+  const hasRuntimePrefetch = prefetchConfig === 'force-runtime'
   const isRuntimePrefetchable = hasRuntimePrefetch || parentRuntimePrefetchable
 
   const [Forbidden, forbiddenStyles] =

--- a/packages/next/src/server/app-render/create-flight-router-state-from-loader-tree.ts
+++ b/packages/next/src/server/app-render/create-flight-router-state-from-loader-tree.ts
@@ -88,13 +88,13 @@ async function createFlightRouterStateFromLoaderTreeImpl(
     prefetchHints |= PrefetchHint.IsRootLayout
   }
 
-  if (instantConfig === false) {
-    prefetchHints |= PrefetchHint.PrefetchDisabled
-  } else if (instantConfig && typeof instantConfig === 'object') {
+  if (instantConfig && typeof instantConfig === 'object') {
     prefetchHints |= PrefetchHint.SubtreeHasInstant
   }
 
-  if (prefetchConfig === 'runtime') {
+  if (prefetchConfig === 'force-disabled') {
+    prefetchHints |= PrefetchHint.PrefetchDisabled
+  } else if (prefetchConfig === 'force-runtime') {
     prefetchHints |= PrefetchHint.HasRuntimePrefetch
   }
 

--- a/packages/next/src/server/app-render/instant-validation/instant-config.tsx
+++ b/packages/next/src/server/app-render/instant-validation/instant-config.tsx
@@ -19,7 +19,7 @@ export async function anySegmentHasRuntimePrefetchEnabled(
   const prefetchConfig = layoutOrPageMod
     ? (layoutOrPageMod as AppSegmentConfig).unstable_prefetch
     : undefined
-  if (prefetchConfig === 'runtime') {
+  if (prefetchConfig === 'force-runtime') {
     return true
   }
 

--- a/packages/next/src/server/app-render/instant-validation/instant-validation.tsx
+++ b/packages/next/src/server/app-render/instant-validation/instant-validation.tsx
@@ -1163,7 +1163,7 @@ export async function createCombinedPayloadAtDepth(
       }
     }
 
-    const segmentHasRuntimePrefetch = prefetchConfig === 'runtime'
+    const segmentHasRuntimePrefetch = prefetchConfig === 'force-runtime'
 
     let childIsInsideRuntimePrefetch = isInsideRuntimePrefetch
     let stage: SegmentStage

--- a/packages/next/src/server/typescript/rules/config.ts
+++ b/packages/next/src/server/typescript/rules/config.ts
@@ -156,6 +156,18 @@ const API_DOCS: Record<
     // `getSemanticDiagnosticsForExportVariableStatement` below, and only provide hover a tooltip + autocomplete.
     insertText: 'unstable_instant = { prefetch: "static" };',
   },
+  unstable_prefetch: {
+    description: `Controls prefetching behavior for this segment. This configuration is currently under development and will change.`,
+    link: '(docs coming soon)',
+    type: `"auto" | "force-disabled" | "force-static" | "force-runtime"`,
+    options: {
+      auto: 'Default. Framework decides based on instant validation and segment configuration. You do not need to set this explicitly.',
+      'force-disabled': 'Never prefetch this segment.',
+      'force-static': 'Always prefetch this segment statically.',
+      'force-runtime': 'Always prefetch this segment at runtime.',
+    },
+    insertText: `unstable_prefetch = 'force-runtime';`,
+  },
   unstable_dynamicStaleTime: {
     description: `Controls how long the client-side router cache retains dynamic page data (in seconds). Pages only — not allowed in layouts. Cannot be combined with \`unstable_instant\`.`,
     link: '(docs coming soon)',

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/apis/[param]/page.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/apis/[param]/page.tsx
@@ -4,7 +4,7 @@ import { connection } from 'next/server'
 import { Suspense } from 'react'
 
 export const unstable_instant = { prefetch: 'runtime', samples: [{}] }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 const CACHE_KEY = __dirname + '/__PAGE__'
 

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/private-cache/layout.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/private-cache/layout.tsx
@@ -3,7 +3,7 @@ import { UncachedFetch, CachedData } from '../data-fetching'
 import { PrivateCachedData } from './data-fetching'
 
 export const unstable_instant = { prefetch: 'runtime', samples: [{}] }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 const CACHE_KEY = '/private-cache/__LAYOUT__'
 

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/short-lived-cache/layout.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/short-lived-cache/layout.tsx
@@ -3,7 +3,7 @@ import { UncachedFetch, CachedData } from '../data-fetching'
 import { ShortLivedCache } from './data-fetching'
 
 export const unstable_instant = { prefetch: 'runtime', samples: [{}] }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 const CACHE_KEY = __dirname + '/__LAYOUT__'
 

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/simple/layout.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/simple/layout.tsx
@@ -2,7 +2,7 @@ import { Suspense } from 'react'
 import { UncachedFetch, CachedFetch, CachedData } from '../data-fetching'
 
 export const unstable_instant = { prefetch: 'runtime', samples: [{}] }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 const CACHE_KEY = __dirname + '/__LAYOUT__'
 

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/successive-caches/page.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/successive-caches/page.tsx
@@ -1,5 +1,5 @@
 export const unstable_instant = { prefetch: 'runtime', samples: [{}] }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {
   return (

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/sync-io/runtime/page.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/sync-io/runtime/page.tsx
@@ -3,7 +3,7 @@ import { CachedData, getCachedData } from '../../data-fetching'
 import { cookies } from 'next/headers'
 
 export const unstable_instant = { prefetch: 'runtime', samples: [{}] }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 const CACHE_KEY = __dirname + '/__PAGE__'
 

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/sync-io/static/page.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/sync-io/static/page.tsx
@@ -1,7 +1,7 @@
 import { CachedData, getCachedData } from '../../data-fetching'
 
 export const unstable_instant = { prefetch: 'runtime', samples: [{}] }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 const CACHE_KEY = __dirname + '/__PAGE__'
 

--- a/test/development/app-dir/cache-components-tasks/fixtures/with-prefetch-config/app/simple/layout.tsx
+++ b/test/development/app-dir/cache-components-tasks/fixtures/with-prefetch-config/app/simple/layout.tsx
@@ -2,7 +2,7 @@ import { Suspense } from 'react'
 import { Static, Runtime, Dynamic } from '../shared'
 
 export const unstable_instant = { prefetch: 'runtime', samples: [{}] }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default function Root({ children }: { children: React.ReactNode }) {
   return (

--- a/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/app/runtime-prefetch-target/page.tsx
+++ b/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/app/runtime-prefetch-target/page.tsx
@@ -5,7 +5,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ searchParams: { myParam: 'testValue' } }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 type SearchParams = { [key: string]: string | string[] | undefined }
 

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/invalid-undeclared-cookie-get-caught/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/invalid-undeclared-cookie-get-caught/page.tsx
@@ -6,7 +6,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/invalid-undeclared-cookie-get/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/invalid-undeclared-cookie-get/page.tsx
@@ -6,7 +6,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/invalid-undeclared-cookie-has/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/invalid-undeclared-cookie-has/page.tsx
@@ -6,7 +6,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/valid-cookies-in-samples/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/valid-cookies-in-samples/page.tsx
@@ -15,7 +15,7 @@ export const unstable_instant: Instant = {
     },
   ],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/valid-cookies-passed-to-cache/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/valid-cookies-passed-to-cache/page.tsx
@@ -10,7 +10,7 @@ export const unstable_instant: Instant = {
     },
   ],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/valid-cookies-passed-to-client/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/valid-cookies-passed-to-client/page.tsx
@@ -10,7 +10,7 @@ export const unstable_instant: Instant = {
     },
   ],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/gsp/[slug]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/gsp/[slug]/page.tsx
@@ -16,7 +16,7 @@ export const unstable_instant: Instant = {
     },
   ],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export function generateStaticParams() {
   return [{ slug: 'foo' }, { slug: 'bar' }]

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/headers/invalid-undeclared-header-get-caught/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/headers/invalid-undeclared-header-get-caught/page.tsx
@@ -6,7 +6,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ headers: [] }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/headers/invalid-undeclared-header-get/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/headers/invalid-undeclared-header-get/page.tsx
@@ -6,7 +6,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ headers: [] }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/headers/invalid-undeclared-header-has/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/headers/invalid-undeclared-header-has/page.tsx
@@ -6,7 +6,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ headers: [] }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/headers/valid-headers-in-samples/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/headers/valid-headers-in-samples/page.tsx
@@ -15,7 +15,7 @@ export const unstable_instant: Instant = {
     },
   ],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/headers/valid-headers-passed-to-cache/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/headers/valid-headers-passed-to-cache/page.tsx
@@ -10,7 +10,7 @@ export const unstable_instant: Instant = {
     },
   ],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/headers/valid-headers-passed-to-client/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/headers/valid-headers-passed-to-client/page.tsx
@@ -10,7 +10,7 @@ export const unstable_instant: Instant = {
     },
   ],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/invalid-missing-suspense-around-runtime/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/invalid-missing-suspense-around-runtime/page.tsx
@@ -5,7 +5,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [{ name: 'auth', value: '1' }] }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {
   const c = await cookies()

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/params/invalid-param-not-provided-caught/[one]/[two]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/params/invalid-param-not-provided-caught/[one]/[two]/page.tsx
@@ -13,7 +13,7 @@ export const unstable_instant: Instant = {
     },
   ],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page({
   params,

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/params/invalid-param-not-provided/[one]/[two]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/params/invalid-param-not-provided/[one]/[two]/page.tsx
@@ -13,7 +13,7 @@ export const unstable_instant: Instant = {
     },
   ],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page({
   params,

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/params/valid-params-in-samples/[one]/[two]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/params/valid-params-in-samples/[one]/[two]/page.tsx
@@ -12,7 +12,7 @@ export const unstable_instant: Instant = {
     },
   ],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page({
   params,

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/params/valid-params-passed-to-cache/[slug]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/params/valid-params-passed-to-cache/[slug]/page.tsx
@@ -5,7 +5,7 @@ export const unstable_instant: Instant = {
   prefetch: 'runtime',
   samples: [{ params: { slug: 'hello' } }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page({
   params,

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/params/valid-params-passed-to-client/[slug]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/params/valid-params-passed-to-client/[slug]/page.tsx
@@ -5,7 +5,7 @@ export const unstable_instant: Instant = {
   prefetch: 'runtime',
   samples: [{ params: { slug: 'hello' } }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page({
   params,

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/invalid-undeclared-search-param-caught/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/invalid-undeclared-search-param-caught/page.tsx
@@ -4,7 +4,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ searchParams: { q: 'test' } }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page({
   searchParams,

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/invalid-undeclared-search-param/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/invalid-undeclared-search-param/page.tsx
@@ -4,7 +4,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ searchParams: { q: 'test' } }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page({
   searchParams,

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/invalid-undeclared-use-search-params-caught/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/invalid-undeclared-use-search-params-caught/page.tsx
@@ -12,7 +12,7 @@ export const unstable_instant: Instant = {
     },
   ],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/invalid-undeclared-use-search-params/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/invalid-undeclared-use-search-params/page.tsx
@@ -11,7 +11,7 @@ export const unstable_instant: Instant = {
     },
   ],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/valid-search-params-in-samples/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/valid-search-params-in-samples/page.tsx
@@ -16,7 +16,7 @@ export const unstable_instant: Instant = {
     },
   ],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 type SearchParams = Record<string, string | string[]>
 

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/valid-search-params-passed-to-cache/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/valid-search-params-passed-to-cache/page.tsx
@@ -12,7 +12,7 @@ export const unstable_instant: Instant = {
     },
   ],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page({
   searchParams,

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/valid-search-params-passed-to-client/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/valid-search-params-passed-to-client/page.tsx
@@ -14,7 +14,7 @@ export const unstable_instant: Instant = {
     },
   ],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page({
   searchParams,

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/valid-use-search-params/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/valid-use-search-params/page.tsx
@@ -14,7 +14,7 @@ export const unstable_instant: Instant = {
     },
   ],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/server-errors/error-passed-to-client-and-ignored/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/server-errors/error-passed-to-client-and-ignored/page.tsx
@@ -5,7 +5,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/server-errors/page-throws-with-suspense/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/server-errors/page-throws-with-suspense/page.tsx
@@ -4,7 +4,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/server-errors/page-throws/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/server-errors/page-throws/page.tsx
@@ -4,7 +4,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/valid-await-cache-without-suspense/mixed/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/valid-await-cache-without-suspense/mixed/page.tsx
@@ -4,7 +4,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{}],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {
   await cachedIO('static')

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/valid-await-cache-without-suspense/private/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/valid-await-cache-without-suspense/private/page.tsx
@@ -2,7 +2,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{}],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {
   await privateCachedIO()

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/valid-await-cache-without-suspense/runtime/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/valid-await-cache-without-suspense/runtime/page.tsx
@@ -4,7 +4,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{}],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {
   await cookies()

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/valid-suspense-around-runtime/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/valid-suspense-around-runtime/page.tsx
@@ -6,7 +6,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [{ name: 'auth', value: '1' }] }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/root-params/[lang]/invalid-root-param-not-provided-caught/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/root-params/[lang]/invalid-root-param-not-provided-caught/page.tsx
@@ -8,7 +8,7 @@ export const unstable_instant: Instant = {
   // no samples
   samples: [{}],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {
   // Guard behind cookies() so that the rest of this component only runs during validation

--- a/test/e2e/app-dir/instant-validation-build/app/root-params/[lang]/invalid-root-param-not-provided/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/root-params/[lang]/invalid-root-param-not-provided/page.tsx
@@ -8,7 +8,7 @@ export const unstable_instant: Instant = {
   // no samples
   samples: [{}],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {
   // Guard behind cookies() so that the rest of this component only runs during validation

--- a/test/e2e/app-dir/instant-validation-build/app/root-params/[lang]/valid-root-param-in-samples/runtime/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/root-params/[lang]/valid-root-param-in-samples/runtime/page.tsx
@@ -7,7 +7,7 @@ export const unstable_instant: Instant = {
   prefetch: 'runtime',
   samples: [{ params: { lang: 'en-from-samples' } }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {
   // Guard behind cookies() so that the rest of this component only runs during validation

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/disable-validation/in-layout/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/disable-validation/in-layout/layout.tsx
@@ -3,7 +3,7 @@ export const unstable_instant = {
   samples: [{ cookies: [] }],
   unstable_disableValidation: true,
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default function Layout({ children }) {
   return <>{children}</>

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/disable-validation/in-page-with-outer/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/disable-validation/in-page-with-outer/page.tsx
@@ -5,7 +5,7 @@ export const unstable_instant = {
   samples: [{ cookies: [] }],
   unstable_disableValidation: true,
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {
   await connection()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/disable-validation/in-page/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/disable-validation/in-page/page.tsx
@@ -5,7 +5,7 @@ export const unstable_instant = {
   samples: [{ cookies: [] }],
   unstable_disableValidation: true,
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {
   await connection()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/invalid-dynamic-viewport-in-runtime/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/invalid-dynamic-viewport-in-runtime/page.tsx
@@ -7,7 +7,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 // Note that we're inside a root layout with suspense, so we skip the static shell
 export async function generateViewport(): Promise<Viewport> {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/invalid-runtime-viewport-in-static/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/invalid-runtime-viewport-in-static/layout.tsx
@@ -2,7 +2,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Layout({ children }) {
   return <>{children}</>

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/valid-dynamic-metadata-in-runtime/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/valid-dynamic-metadata-in-runtime/page.tsx
@@ -7,7 +7,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export async function generateMetadata(): Promise<Metadata> {
   await connection()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/valid-runtime-viewport-in-runtime/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/valid-runtime-viewport-in-runtime/page.tsx
@@ -5,7 +5,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export async function generateViewport(): Promise<Viewport> {
   await cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/slot-runtime-config/@slot/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/slot-runtime-config/@slot/page.tsx
@@ -5,7 +5,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{}],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default function SlotPage() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-blocking-inside-runtime/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-blocking-inside-runtime/layout.tsx
@@ -4,7 +4,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function RuntimeLayout({ children }) {
   await cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-after-cache-with-cookie-input/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-after-cache-with-cookie-input/layout.tsx
@@ -1,6 +1,6 @@
 // Avoid static shell validation -- we only want to test the validation of `prefetch: 'runtime'` here.
 export const unstable_instant = false
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default function DisableStaticShell({ children }) {
   return <>{children}</>

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-after-cache-with-cookie-input/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-after-cache-with-cookie-input/page.tsx
@@ -4,7 +4,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 // This page HAS runtime prefetch enabled. cookies() is passed as a promise
 // input to a public "use cache" function. The cache doesn't read the cookies

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-in-generate-metadata/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-in-generate-metadata/page.tsx
@@ -5,7 +5,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export async function generateMetadata() {
   await cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-in-layout-generate-metadata/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-in-layout-generate-metadata/page.tsx
@@ -5,7 +5,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 async function Runtime() {
   await cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-in-runtime-with-valid-static-parent/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-in-runtime-with-valid-static-parent/page.tsx
@@ -4,7 +4,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 // This page HAS runtime prefetch enabled. The sync IO (Date.now()) after
 // cookies() is invalid here because during a runtime prefetch, cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io/page.tsx
@@ -4,7 +4,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {
   await cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/missing-suspense-around-dynamic-layout/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/missing-suspense-around-dynamic-layout/layout.tsx
@@ -5,7 +5,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Layout({ children }: { children: ReactNode }) {
   await connection()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/missing-suspense-around-dynamic/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/missing-suspense-around-dynamic/page.tsx
@@ -5,7 +5,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {
   await cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/static-layout-above-runtime-config/inner/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/static-layout-above-runtime-config/inner/layout.tsx
@@ -7,7 +7,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default function InnerLayout({ children }: { children: ReactNode }) {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/suspense-around-dynamic/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/suspense-around-dynamic/page.tsx
@@ -6,7 +6,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/suspense-too-high/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/suspense-too-high/page.tsx
@@ -5,7 +5,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {
   await cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-blocking-inside-runtime/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-blocking-inside-runtime/layout.tsx
@@ -5,7 +5,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function RuntimeLayout({ children }) {
   await cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-no-suspense-around-params/[param]/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-no-suspense-around-params/[param]/page.tsx
@@ -5,7 +5,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [], params: { param: '123' } }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page({
   params,

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-no-suspense-around-search-params/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-no-suspense-around-search-params/page.tsx
@@ -5,7 +5,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [], searchParams: { foo: 'bar' } }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page({
   searchParams,

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-sync-io-in-static-parent/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-sync-io-in-static-parent/page.tsx
@@ -5,7 +5,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 async function Runtime() {
   await cookies()

--- a/test/e2e/app-dir/prefetch-true-instant/app/layout-instant/layout.tsx
+++ b/test/e2e/app-dir/prefetch-true-instant/app/layout-instant/layout.tsx
@@ -4,7 +4,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [{ name: 'test', value: null }] }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default function Layout({ children }: { children: ReactNode }) {
   return <div>{children}</div>

--- a/test/e2e/app-dir/prefetch-true-instant/app/target-page/page.tsx
+++ b/test/e2e/app-dir/prefetch-true-instant/app/target-page/page.tsx
@@ -6,7 +6,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [{ name: 'test', value: null }] }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/cached-navigations/app/runtime-prefetchable/page.tsx
+++ b/test/e2e/app-dir/segment-cache/cached-navigations/app/runtime-prefetchable/page.tsx
@@ -14,7 +14,7 @@ export const unstable_instant = {
     },
   ],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page({
   searchParams,

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-independent-head/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-independent-head/layout.tsx
@@ -15,7 +15,7 @@ export const unstable_instant = {
     },
   ],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 async function LayoutContent({ children }: { children: ReactNode }) {
   const cookieStore = await cookies()

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-instant-false-passthrough/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-instant-false-passthrough/layout.tsx
@@ -1,12 +1,12 @@
-// This layout has prefetching disabled (unstable_instant = false) because it
-// performs uncached dynamic I/O (connection()). Static parents above it should
-// be able to inline through it and into the static child below, because this
-// layout acts as a transparent pass-through — its slot in the bundle is null
-// but the chain isn't broken.
+// This layout has prefetching disabled because it performs uncached dynamic
+// I/O (connection()). Static parents above it should be able to inline through
+// it and into the static child below, because this layout acts as a transparent
+// pass-through — its slot in the bundle is null but the chain isn't broken.
 import { ReactNode, Suspense } from 'react'
 import { connection } from 'next/server'
 
 export const unstable_instant = false
+export const unstable_prefetch = 'force-disabled'
 
 async function DynamicContent() {
   await connection()

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-instant-false-root/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-instant-false-root/layout.tsx
@@ -2,6 +2,7 @@ import { ReactNode } from 'react'
 import { connection } from 'next/server'
 
 export const unstable_instant = false
+export const unstable_prefetch = 'force-disabled'
 
 export default async function Layout({ children }: { children: ReactNode }) {
   await connection()

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-runtime-bailout/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-runtime-bailout/page.tsx
@@ -4,7 +4,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [{ name: 'theme', value: 'default' }] }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function RuntimeBailoutPage() {
   const cookieStore = await cookies()

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-runtime-parallel/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-runtime-parallel/layout.tsx
@@ -9,7 +9,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [{ name: 'theme', value: 'default' }] }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 async function DynamicContent() {
   const cookieStore = await cookies()

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-runtime-passthrough/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-runtime-passthrough/layout.tsx
@@ -9,7 +9,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [{ name: 'theme', value: 'default' }] }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 async function DynamicContent() {
   const cookieStore = await cookies()

--- a/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/segment-config/runtime-prefetchable/configured-as-runtime/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/segment-config/runtime-prefetchable/configured-as-runtime/page.tsx
@@ -5,7 +5,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/segment-config/runtime-prefetchable/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/segment-config/runtime-prefetchable/layout.tsx
@@ -6,7 +6,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 export default async function Layout({ children }) {
   return (
     <main>

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/private-seconds/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/private-seconds/page.tsx
@@ -6,7 +6,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/private-short-stale/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/private-short-stale/page.tsx
@@ -6,7 +6,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/public-seconds/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/public-seconds/page.tsx
@@ -6,7 +6,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/public-short-expire-long-stale/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/public-short-expire-long-stale/page.tsx
@@ -6,7 +6,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/public-short-expire-short-stale/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/public-short-expire-short-stale/page.tsx
@@ -6,7 +6,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/error-after-cookies/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/error-after-cookies/page.tsx
@@ -10,7 +10,7 @@ export const unstable_instant = {
   unstable_disableValidation: true,
   samples: [{ cookies: [{ name: 'user-agent', value: null }] }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/cookies/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/cookies/page.tsx
@@ -9,7 +9,7 @@ export const unstable_instant = {
   unstable_disableValidation: true,
   samples: [{ cookies: [] }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/dynamic-params/[id]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/dynamic-params/[id]/page.tsx
@@ -10,7 +10,7 @@ export const unstable_instant = {
   unstable_disableValidation: true,
   samples: [{ cookies: [] }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page({ params }: { params: Promise<Params> }) {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/headers/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/headers/page.tsx
@@ -9,7 +9,7 @@ export const unstable_instant = {
   unstable_disableValidation: true,
   samples: [{ cookies: [] }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/private-cache/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/private-cache/page.tsx
@@ -8,7 +8,7 @@ export const unstable_instant = {
   unstable_disableValidation: true,
   samples: [{ cookies: [] }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/quickly-expiring-public-cache/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/quickly-expiring-public-cache/page.tsx
@@ -9,7 +9,7 @@ export const unstable_instant = {
   unstable_disableValidation: true,
   samples: [{ cookies: [] }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/search-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/search-params/page.tsx
@@ -10,7 +10,7 @@ export const unstable_instant = {
   unstable_disableValidation: true,
   samples: [{ cookies: [] }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page({
   searchParams,

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/fully-static/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/fully-static/page.tsx
@@ -7,7 +7,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/cookies-only/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/cookies-only/page.tsx
@@ -6,7 +6,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [{ name: 'testCookie', value: 'testValue' }] }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/cookies/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/cookies/page.tsx
@@ -7,7 +7,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [{ name: 'testCookie', value: 'testValue' }] }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/dynamic-params/[id]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/dynamic-params/[id]/page.tsx
@@ -6,7 +6,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ params: { id: 'test' } }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 type Params = { id: string }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/headers/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/headers/page.tsx
@@ -7,7 +7,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ headers: [['host', 'test-host']] }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/search-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/search-params/page.tsx
@@ -6,7 +6,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ searchParams: { searchParam: 'value' } }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 type AnySearchParams = { [key: string]: string | string[] | undefined }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/cookies-only/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/cookies-only/page.tsx
@@ -6,7 +6,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [{ name: 'testCookie', value: 'testValue' }] }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/cookies/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/cookies/page.tsx
@@ -7,7 +7,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [{ name: 'testCookie', value: 'testValue' }] }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/date-now/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/date-now/page.tsx
@@ -6,7 +6,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/dynamic-params/[id]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/dynamic-params/[id]/page.tsx
@@ -6,7 +6,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ params: { id: 'test' } }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 type Params = { id: string }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/headers/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/headers/page.tsx
@@ -7,7 +7,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ headers: [['host', 'test-host']] }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/search-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/search-params/page.tsx
@@ -6,7 +6,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ searchParams: { searchParam: 'value' } }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 type AnySearchParams = { [key: string]: string | string[] | undefined }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/cookies-only/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/cookies-only/page.tsx
@@ -6,7 +6,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [{ name: 'testCookie', value: 'testValue' }] }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/cookies/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/cookies/page.tsx
@@ -7,7 +7,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ cookies: [{ name: 'testCookie', value: 'testValue' }] }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/dynamic-params/[id]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/dynamic-params/[id]/page.tsx
@@ -7,7 +7,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ params: { id: 'test' } }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 type Params = { id: string }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/headers/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/headers/page.tsx
@@ -7,7 +7,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ headers: [['host', 'test-host']] }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/search-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/search-params/page.tsx
@@ -7,7 +7,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ searchParams: { searchParam: 'value' } }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 type AnySearchParams = { [key: string]: string | string[] | undefined }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/in-page/root-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/in-page/root-params/page.tsx
@@ -8,7 +8,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ params: { lang: 'en' } }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/in-private-cache/root-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/in-private-cache/root-params/page.tsx
@@ -7,7 +7,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ params: { lang: 'en' } }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/passed-to-public-cache/root-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/passed-to-public-cache/root-params/page.tsx
@@ -7,7 +7,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ params: { lang: 'en' } }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/staleness/app/runtime-stale-2-minutes/page.tsx
+++ b/test/e2e/app-dir/segment-cache/staleness/app/runtime-stale-2-minutes/page.tsx
@@ -3,7 +3,7 @@ import { cacheLife } from 'next/cache'
 import { cookies } from 'next/headers'
 
 export const unstable_instant = { prefetch: 'runtime', samples: [{}] }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/staleness/app/runtime-stale-4-minutes/page.tsx
+++ b/test/e2e/app-dir/segment-cache/staleness/app/runtime-stale-4-minutes/page.tsx
@@ -3,7 +3,7 @@ import { cacheLife } from 'next/cache'
 import { cookies } from 'next/headers'
 
 export const unstable_instant = { prefetch: 'runtime', samples: [{}] }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-all-vary/[category]/[itemId]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-all-vary/[category]/[itemId]/page.tsx
@@ -18,7 +18,7 @@ export const unstable_instant: {
     { params: { category: 'clothing', itemId: 'shirt' } },
   ],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 type Params = { category: string; itemId: string }
 

--- a/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-layout-split/[category]/[itemId]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-layout-split/[category]/[itemId]/page.tsx
@@ -19,7 +19,7 @@ export const unstable_instant: {
     { params: { category: 'clothing', itemId: 'shirt' } },
   ],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 type Params = { category: string; itemId: string }
 

--- a/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-metadata/[slug]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-metadata/[slug]/page.tsx
@@ -17,7 +17,7 @@ export const unstable_instant: {
   prefetch: 'runtime',
   samples: [{ params: { slug: 'aaa' } }, { params: { slug: 'bbb' } }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 type Params = { slug: string }
 

--- a/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-no-vary/[category]/[itemId]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-no-vary/[category]/[itemId]/page.tsx
@@ -18,7 +18,7 @@ export const unstable_instant: {
     { params: { category: 'clothing', itemId: 'shirt' } },
   ],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 type Params = { category: string; itemId: string }
 

--- a/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-search-params/target-page/page.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-search-params/target-page/page.tsx
@@ -11,7 +11,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ searchParams: { q: '1' } }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default async function RuntimePrefetchSearchParamsTargetPage() {
   // Intentionally NOT accessing searchParams

--- a/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch/[category]/[itemId]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch/[category]/[itemId]/page.tsx
@@ -21,7 +21,7 @@ export const unstable_instant: {
     { params: { category: 'clothing', itemId: 'shirt' } },
   ],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 type Params = { category: string; itemId: string }
 

--- a/test/e2e/app-dir/segment-cache/vary-params/app/(main)/search-params/target-page/page.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params/app/(main)/search-params/target-page/page.tsx
@@ -18,7 +18,7 @@ export const unstable_instant = {
   prefetch: 'runtime',
   samples: [{ searchParams: { foo: '1' } }],
 }
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 type SearchParams = { foo?: string }
 

--- a/test/production/app-dir/use-cache-non-deterministic-args/app/[slug]/page.tsx
+++ b/test/production/app-dir/use-cache-non-deterministic-args/app/[slug]/page.tsx
@@ -3,7 +3,7 @@ import { Suspense, cacheSignal } from 'react'
 import { setTimeout } from 'timers/promises'
 import { cookies } from 'next/headers'
 
-export const unstable_prefetch = 'runtime'
+export const unstable_prefetch = 'force-runtime'
 
 const callCounts = new Map<string, number>()
 


### PR DESCRIPTION
"auto" mode is the default. It does not need to be explicitly exported "force-" modes suggest overriding framework heuristics "force-disabled" disables prefetching for this segment "force-static" forces any prefetching of this segment to be static "force-runtime" forces any prefetching of this segment to do runtime prefetching

It's worth noting that when runtime prefetching we fetch the necessary segment and all child segments in a single request. This means that a deeper segment might specify disabled or static and still get conditionally rendered as a runtime prefetch. This was already the behavior of runtime prefetching and not changing in this PR just something to call out since it may be confusing to folks trying to understand how the implementation of prefetching actually work