### PR TITLE
Turbopack: Use lld again on ARM64 glibc Linux

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -60,6 +60,24 @@ rustflags = [
   "-Clink-arg=/Brepro",
 ]
 
+# Why `linker-flavor=gnu-lld-cc` instead of `linker = "rust-lld"`?
+#
+# `linker = "rust-lld"` invokes lld directly, bypassing the cc linker driver.
+# This fails because lld alone can't find system libraries (-lgcc_s, -lc) and
+# doesn't understand -Wl, prefixed args from crate build scripts.
+# `gnu-lld-cc` + `link-self-contained=+linker` routes lld through cc, which
+# resolves library paths and translates -Wl, args.
+#
+# On x86_64-unknown-linux-gnu, this is already the nightly default since
+# Rust 1.90, so no explicit config is needed for GNU targets.
+# Not yet default on aarch64-unknown-linux-gnu or any musl target.
+# https://blog.rust-lang.org/2025/09/01/rust-lld-on-1.90.0-stable/
+[target.'cfg(all(target_os = "linux", target_env = "gnu", not(target_arch = "x86_64")))']
+rustflags = [
+  "-Clinker-flavor=gnu-lld-cc",
+  "-Clink-self-contained=+linker",
+]
+
 # Musl targets: disable static CRT linking. We produce dynamic .node shared
 # libraries (N-API addons), not static binaries.
 [target.'cfg(all(target_os = "linux", target_env = "musl"))']


### PR DESCRIPTION
`lld` is much faster than the default gnu `ld` linker on most Linux systems.

Timeline:
- https://github.com/vercel/next.js/pull/91477 removed these flags as part of cleanup because they're now default on x86-64 glibc linux. However, they are not default on arm64.
- https://github.com/vercel/next.js/pull/91799 removed these flags from musl, and lost the comment explaining reason for the `gnu-lld-cc` option.

Without this change, doing a dev build of a trivial change to `crates/next-napi-bindings/src/lib.rs` can take over a minute.

I tested this by looking at htop near the end of a build and observing `lld` instead of `ld`.