### PR TITLE
Enable prefetchInlining by default

### DIFF
--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1846,7 +1846,7 @@ export const defaultConfig = Object.freeze({
     useOffline: false,
     unstableIO: false,
     varyParams: false,
-    prefetchInlining: false,
+    prefetchInlining: true,
     preloadEntriesOnStart: true,
     clientRouterFilter: true,
     clientRouterFilterRedirects: false,

--- a/test/e2e/app-dir-export/next.config.js
+++ b/test/e2e/app-dir-export/next.config.js
@@ -3,6 +3,9 @@ const nextConfig = {
   output: 'export',
   trailingSlash: true,
   // distDir: '.next-custom',
+  experimental: {
+    prefetchInlining: false,
+  },
 }
 
 module.exports = nextConfig

--- a/test/e2e/app-dir/actions-unrecognized/next.config.ts
+++ b/test/e2e/app-dir/actions-unrecognized/next.config.ts
@@ -3,6 +3,7 @@ import type { NextConfig } from 'next'
 const nextConfig: NextConfig = {
   productionBrowserSourceMaps: true,
   experimental: {
+    prefetchInlining: false,
     serverSourceMaps: true,
   },
 }

--- a/test/e2e/app-dir/app-static/next.config.js
+++ b/test/e2e/app-dir/app-static/next.config.js
@@ -1,5 +1,8 @@
 /** @type {import('next').NextConfig} */
 module.exports = {
+  experimental: {
+    prefetchInlining: false,
+  },
   logging: {
     fetches: {},
   },

--- a/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/next.config.js
+++ b/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/next.config.js
@@ -7,6 +7,7 @@ const nextConfig = {
     // Enable the testing API in production builds for these tests
     exposeTestingApiInProductionBuild: true,
     instantNavigationDevToolsToggle: true,
+    prefetchInlining: false,
   },
 }
 

--- a/test/e2e/app-dir/instant-navigation-testing-api/fixtures/root-params/next.config.js
+++ b/test/e2e/app-dir/instant-navigation-testing-api/fixtures/root-params/next.config.js
@@ -6,6 +6,7 @@ const nextConfig = {
   experimental: {
     exposeTestingApiInProductionBuild: true,
     instantNavigationDevToolsToggle: true,
+    prefetchInlining: false,
   },
 }
 

--- a/test/e2e/app-dir/segment-cache/cached-navigations/next.config.ts
+++ b/test/e2e/app-dir/segment-cache/cached-navigations/next.config.ts
@@ -5,6 +5,7 @@ const nextConfig: NextConfig = {
   productionBrowserSourceMaps: true,
   experimental: {
     cachedNavigations: true,
+    prefetchInlining: false,
     exposeTestingApiInProductionBuild: true,
     instantNavigationDevToolsToggle: true,
     optimisticRouting: true,

--- a/test/e2e/app-dir/segment-cache/dynamic-on-hover/next.config.js
+++ b/test/e2e/app-dir/segment-cache/dynamic-on-hover/next.config.js
@@ -5,6 +5,7 @@ const nextConfig = {
   cacheComponents: true,
   experimental: {
     dynamicOnHover: true,
+    prefetchInlining: false,
   },
 }
 

--- a/test/e2e/app-dir/segment-cache/force-stale/next.config.js
+++ b/test/e2e/app-dir/segment-cache/force-stale/next.config.js
@@ -4,6 +4,9 @@
 const nextConfig = {
   cacheComponents: true,
   productionBrowserSourceMaps: true,
+  experimental: {
+    prefetchInlining: false,
+  },
 }
 
 module.exports = nextConfig

--- a/test/e2e/app-dir/segment-cache/memory-pressure/next.config.js
+++ b/test/e2e/app-dir/segment-cache/memory-pressure/next.config.js
@@ -3,6 +3,9 @@
  */
 const nextConfig = {
   cacheComponents: true,
+  experimental: {
+    prefetchInlining: false,
+  },
 }
 
 module.exports = nextConfig

--- a/test/e2e/app-dir/segment-cache/optimistic-route-cache-keying-regression/next.config.js
+++ b/test/e2e/app-dir/segment-cache/optimistic-route-cache-keying-regression/next.config.js
@@ -12,6 +12,7 @@ const nextConfig = {
     //
     // Once the client cache writes segment data during navigations more
     // broadly, this test could be rewritten without this config.
+    prefetchInlining: false,
     staleTimes: {
       dynamic: 180,
     },

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/next.config.js
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/next.config.js
@@ -4,7 +4,6 @@
 const nextConfig = {
   cacheComponents: true,
   experimental: {
-    prefetchInlining: true,
     optimisticRouting: true,
   },
 }

--- a/test/e2e/app-dir/segment-cache/vary-params-base-dynamic/next.config.js
+++ b/test/e2e/app-dir/segment-cache/vary-params-base-dynamic/next.config.js
@@ -12,6 +12,7 @@ const nextConfig = {
   },
   experimental: {
     optimisticRouting: true,
+    prefetchInlining: false,
     varyParams: true,
   },
 }

--- a/test/e2e/app-dir/segment-cache/vary-params/next.config.js
+++ b/test/e2e/app-dir/segment-cache/vary-params/next.config.js
@@ -5,6 +5,7 @@ const nextConfig = {
   cacheComponents: true,
   experimental: {
     optimisticRouting: true,
+    prefetchInlining: false,
     varyParams: true,
   },
 }

--- a/test/e2e/app-dir/sub-shell-generation-middleware/next.config.js
+++ b/test/e2e/app-dir/sub-shell-generation-middleware/next.config.js
@@ -3,6 +3,7 @@
  */
 const nextConfig = {
   experimental: {
+    prefetchInlining: false,
     useCache: true,
   },
   rewrites: async () => {

--- a/test/e2e/app-dir/use-offline/next.config.js
+++ b/test/e2e/app-dir/use-offline/next.config.js
@@ -8,7 +8,6 @@ const nextConfig = {
     varyParams: true,
     optimisticRouting: true,
     cachedNavigations: true,
-    prefetchInlining: true,
   },
 }
 


### PR DESCRIPTION
Flips the `experimental.prefetchInlining` default from `false` to `true`. This is the first step toward removing the flag entirely.

Tests that explicitly set `prefetchInlining: true` have been cleaned up since they now match the default. Any CI failures from this PR will be addressed in follow-up PRs by temporarily opting out individual tests with `prefetchInlining: false` until they are migrated.

<!-- NEXT_JS_LLM_PR -->