### PR TITLE
Filter Node watch flags from managed workers

### DIFF
--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -11,6 +11,7 @@ import {
   printAndExit,
   formatNodeOptions,
   formatDebugAddress,
+  getNodeOptionsWithoutInspectAndWatch,
   getParsedNodeOptions,
   type DebugAddress,
 } from '../server/lib/utils'
@@ -332,7 +333,9 @@ const nextDev = async (
       let resolved = false
       const defaultEnv = (initialEnv || process.env) as typeof process.env
 
-      const nodeOptions = getParsedNodeOptions()
+      const originalNodeOptions = getParsedNodeOptions()
+      const nodeOptions =
+        getNodeOptionsWithoutInspectAndWatch(originalNodeOptions)
 
       let maxOldSpaceSize: string | number | undefined = getMaxOldSpaceSize()
       if (!maxOldSpaceSize && !process.env.NEXT_DISABLE_MEM_OVERRIDE) {
@@ -352,12 +355,11 @@ const nextDev = async (
         nodeOptions['enable-source-maps'] = true
       }
 
-      const nodeDebugType = getNodeDebugType(nodeOptions)
+      const nodeDebugType = getNodeDebugType(originalNodeOptions)
       const originalAddress =
-        nodeDebugType === undefined ? undefined : nodeOptions[nodeDebugType]
-      delete nodeOptions.inspect
-      delete nodeOptions['inspect-brk']
-      delete nodeOptions['inspect_brk']
+        nodeDebugType === undefined
+          ? undefined
+          : originalNodeOptions[nodeDebugType]
       if (nodeDebugType !== undefined) {
         const address = getParsedDebugAddress(originalAddress)
         address.port = address.port === 0 ? 0 : address.port + 1

--- a/packages/next/src/lib/worker.test.ts
+++ b/packages/next/src/lib/worker.test.ts
@@ -1,10 +1,12 @@
 import { PassThrough } from 'stream'
 
 let latestForkEnv: NodeJS.ProcessEnv | undefined
+let latestForkExecArgv: string[] | undefined
 
 jest.mock('next/dist/compiled/jest-worker', () => {
   const WorkerMock = jest.fn().mockImplementation((_path, options) => {
     latestForkEnv = options?.forkOptions?.env
+    latestForkExecArgv = options?.forkOptions?.execArgv
     return {
       _workerPool: { _workers: [] },
       getStdout: () => new PassThrough(),
@@ -48,6 +50,7 @@ const overrideBooleanDescriptor = (
 
 describe('lib/worker color propagation', () => {
   const originalEnv = { ...process.env }
+  const originalExecArgv = [...process.execArgv]
 
   const restoreEnv = () => {
     for (const key of Object.keys(process.env)) {
@@ -58,12 +61,14 @@ describe('lib/worker color propagation', () => {
 
   afterEach(() => {
     restoreEnv()
+    process.execArgv.splice(0, process.execArgv.length, ...originalExecArgv)
     while (restoreDescriptors.length > 0) {
       const restore = restoreDescriptors.pop()
       restore?.()
     }
     jest.resetModules()
     latestForkEnv = undefined
+    latestForkExecArgv = undefined
   })
 
   it('enables FORCE_COLOR when the parent supports colors', () => {
@@ -123,5 +128,27 @@ describe('lib/worker color propagation', () => {
     worker.close()
 
     expect(latestForkEnv?.FORCE_COLOR).toBeUndefined()
+  })
+
+  it('does not forward node watch options to child process workers', () => {
+    process.execArgv.push(
+      '--watch',
+      '--watch-path=app',
+      '--watch-preserve-output',
+      '--experimental-network-inspection'
+    )
+
+    const { Worker } = require('./worker') as typeof import('./worker')
+
+    const worker = new Worker(__filename, noopOptions)
+    worker.close()
+
+    expect(latestForkExecArgv).toContain('--experimental-network-inspection')
+    expect(latestForkExecArgv).not.toContain('--watch')
+    expect(latestForkExecArgv).not.toContain('--watch-path=app')
+    expect(latestForkExecArgv).not.toContain('--watch-preserve-output')
+    expect(latestForkEnv?.NODE_OPTIONS).not.toContain('--watch')
+    expect(latestForkEnv?.NODE_OPTIONS).not.toContain('--watch-path')
+    expect(latestForkEnv?.NODE_OPTIONS).not.toContain('--watch-preserve-output')
   })
 })

--- a/packages/next/src/lib/worker.ts
+++ b/packages/next/src/lib/worker.ts
@@ -5,6 +5,7 @@ import {
   formatDebugAddress,
   formatNodeOptions,
   getNodeDebugType,
+  getNodeOptionsWithoutInspectAndWatch,
   getParsedDebugAddress,
   getParsedNodeOptions,
   type DebugAddress,
@@ -87,11 +88,8 @@ export class Worker {
       this.close()
     })
 
-    const nodeOptions = getParsedNodeOptions()
-    const originalOptions = { ...nodeOptions }
-    delete nodeOptions.inspect
-    delete nodeOptions['inspect-brk']
-    delete nodeOptions['inspect_brk']
+    const originalOptions = getParsedNodeOptions()
+    const nodeOptions = getNodeOptionsWithoutInspectAndWatch(originalOptions)
     if (debuggerPortOffset !== -1) {
       const nodeDebugType = getNodeDebugType(originalOptions)
       if (nodeDebugType) {

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -48,7 +48,10 @@ import {
 } from '../../trace'
 import { traceGlobals } from '../../trace/shared'
 import { findPageFile } from '../lib/find-page-file'
-import { getFormattedNodeOptionsWithoutInspect } from '../lib/utils'
+import {
+  formatNodeOptions,
+  getParsedNodeOptionsWithoutInspectAndWatch,
+} from '../lib/utils'
 import { withCoalescedInvoke } from '../../lib/coalesced-function'
 import {
   loadDefaultErrorComponents,
@@ -150,6 +153,10 @@ export default class DevServer extends Server {
   private getStaticPathsWorker(): { [key: string]: any } & {
     loadStaticPaths: typeof import('./static-paths-worker').loadStaticPaths
   } {
+    const { nodeOptions: formattedNodeOptions, execArgv } = formatNodeOptions(
+      getParsedNodeOptionsWithoutInspectAndWatch()
+    )
+
     const worker = new Worker(require.resolve('./static-paths-worker'), {
       maxRetries: 1,
       // For dev server, it's not necessary to spin up too many workers as long as you are not doing a load test.
@@ -157,13 +164,13 @@ export default class DevServer extends Server {
       numWorkers: 1,
       enableWorkerThreads: this.nextConfig.experimental.workerThreads,
       forkOptions: {
+        execArgv,
         env: {
           ...process.env,
-          // discard --inspect/--inspect-brk flags from process.env.NODE_OPTIONS. Otherwise multiple Node.js debuggers
-          // would be started if user launch Next.js in debugging mode. The number of debuggers is linked to
-          // the number of workers Next.js tries to launch. The only worker users are interested in debugging
-          // is the main Next.js one
-          NODE_OPTIONS: getFormattedNodeOptionsWithoutInspect(),
+          // Discard --inspect/--inspect-brk and --watch* flags. Debug flags
+          // would start duplicate debuggers, and watch flags make managed
+          // workers emit Node watch messages that jest-worker cannot handle.
+          NODE_OPTIONS: formattedNodeOptions,
         },
       },
     }) as Worker & {

--- a/packages/next/src/server/lib/utils.test.ts
+++ b/packages/next/src/server/lib/utils.test.ts
@@ -1,5 +1,6 @@
 import {
   getFormattedNodeOptionsWithoutInspect,
+  getNodeOptionsWithoutInspectAndWatch,
   getParsedDebugAddress,
   formatNodeOptions,
   tokenizeArgs,
@@ -91,6 +92,28 @@ describe('getParsedDebugAddress', () => {
     const nodeOptions = getParsedNodeOptions()
     const result = getParsedDebugAddress(nodeOptions.inspect)
     expect(result).toEqual({ host: undefined, port: 1234 })
+  })
+})
+
+describe('getNodeOptionsWithoutInspectAndWatch', () => {
+  it('removes debug and watch options', () => {
+    const result = getNodeOptionsWithoutInspectAndWatch({
+      inspect: '9229',
+      'inspect-brk': true,
+      inspect_brk: true,
+      watch: true,
+      'watch-path': 'app',
+      watch_path: 'pages',
+      'watch-preserve-output': true,
+      watch_preserve_output: true,
+      require: './register.js',
+      'enable-source-maps': true,
+    })
+
+    expect(result).toEqual({
+      require: './register.js',
+      'enable-source-maps': true,
+    })
   })
 })
 

--- a/packages/next/src/server/lib/utils.ts
+++ b/packages/next/src/server/lib/utils.ts
@@ -13,6 +13,16 @@ export function printAndExit(message: string, code = 1) {
 
 export type NodeOptions = Record<string, string | boolean | undefined>
 
+const NODE_INSPECT_OPTIONS = ['inspect', 'inspect-brk', 'inspect_brk'] as const
+
+const NODE_WATCH_OPTIONS = [
+  'watch',
+  'watch-path',
+  'watch_path',
+  'watch-preserve-output',
+  'watch_preserve_output',
+] as const
+
 const parseNodeArgs = (args: string[]): NodeOptions => {
   const { values, tokens } = parseArgs({ args, strict: false, tokens: true })
 
@@ -240,6 +250,26 @@ export function getParsedNodeOptions(): Record<
   return parseNodeArgs(args)
 }
 
+export function getNodeOptionsWithoutInspectAndWatch(
+  nodeOptions: NodeOptions
+): NodeOptions {
+  const result = { ...nodeOptions }
+
+  for (const key of NODE_INSPECT_OPTIONS) {
+    delete result[key]
+  }
+
+  for (const key of NODE_WATCH_OPTIONS) {
+    delete result[key]
+  }
+
+  return result
+}
+
+export function getParsedNodeOptionsWithoutInspectAndWatch(): NodeOptions {
+  return getNodeOptionsWithoutInspectAndWatch(getParsedNodeOptions())
+}
+
 /**
  * Get the node options from the `NODE_OPTIONS` environment variable and parse
  * them into an object without the inspect options.
@@ -253,9 +283,9 @@ export function getParsedNodeOptionsWithoutInspect() {
   const parsed = parseNodeArgs(args)
 
   // Remove inspect options.
-  delete parsed.inspect
-  delete parsed['inspect-brk']
-  delete parsed['inspect_brk']
+  for (const key of NODE_INSPECT_OPTIONS) {
+    delete parsed[key]
+  }
 
   return parsed
 }


### PR DESCRIPTION
Fixes #92836.

### What changed

This prevents managed child process workers from inheriting Node watch-mode flags such as `--watch`, `--watch-path`, and `--watch-preserve-output` through `process.execArgv` or `NODE_OPTIONS`.

In particular, the dev static-paths worker now passes sanitized `forkOptions.execArgv`, avoiding Node watch-mode messages being sent over the `jest-worker` IPC channel.

### Tests

```bash
pnpm testonly packages/next/src/server/lib/utils.test.ts packages/next/src/lib/worker.test.ts
```