### PR TITLE
Fix trace server MCP: flat span IDs, aggregated drill-down, port in help output

### DIFF
--- a/packages/next/src/cli/internal/turbo-trace-server.ts
+++ b/packages/next/src/cli/internal/turbo-trace-server.ts
@@ -255,7 +255,7 @@ export async function startTurboTraceServerCli(
 
   server.listen(httpPort, '127.0.0.1', () => {
     console.log(
-      `Query this trace from the command line: next internal query-trace --help`
+      `Query this trace from the command line: next internal query-trace --port ${httpPort} --help`
     )
     console.log(
       `Alternatively, connect an MCP client to http://127.0.0.1:${httpPort}/mcp`

--- a/test/e2e/turbopack-trace-server-query/turbopack-trace-server.test.ts
+++ b/test/e2e/turbopack-trace-server-query/turbopack-trace-server.test.ts
@@ -266,6 +266,30 @@ describe('turbopack-trace-server', () => {
     expect(childMd).toMatch(/Page \d+ of \d+/)
   })
 
+  it('should drill two levels deep using full path IDs', async () => {
+    // Get a root-level aggregated span.
+    const root = await querySpansJson(mcpPort, { sort: 'value' })
+    const rootId = root.spans[0].id
+    expect(rootId).toMatch(/^a\d+$/)
+
+    // Drill into its children.
+    const children = await querySpansJson(mcpPort, { parent: rootId })
+    expect(children.spans.length).toBeGreaterThan(0)
+    const childId = children.spans[0].id
+    // Child ID should include the parent path prefix.
+    expect(childId).toMatch(new RegExp(`^${rootId}-a\\d+$`))
+
+    // Drill one more level — pass the child's full path ID directly.
+    const grandchildren = await querySpansJson(mcpPort, { parent: childId })
+    expect(grandchildren.page).toBe(1)
+    if (grandchildren.spans.length > 0) {
+      // Grandchild ID should include the full parent chain.
+      expect(grandchildren.spans[0].id).toMatch(
+        new RegExp(`^${childId}-a\\d+$`)
+      )
+    }
+  })
+
   it('should return no results for an impossible search term', async () => {
     const md = await callMcpTool(mcpPort, 'query_spans', {
       search: 'zzz_unlikely_span_name_zzz',

--- a/turbopack/crates/turbopack-trace-server/src/lib.rs
+++ b/turbopack/crates/turbopack-trace-server/src/lib.rs
@@ -12,7 +12,7 @@ use std::{
 use rustc_hash::FxHasher;
 
 use self::{
-    reader::TraceReader, server::serve, span_graph_ref::SpanGraphEventRef, span_ref::SpanRef,
+    reader::TraceReader, server::serve, span_graph_ref::SpanGraphRef, span_ref::SpanRef,
     store_container::StoreContainer,
 };
 
@@ -72,7 +72,7 @@ pub enum SortMode {
 /// Options for querying spans from the trace store.
 pub struct QueryOptions {
     /// Optional parent span ID (as produced by `SpanInfo::id`).
-    /// `None` means root level.
+    /// `None` means root level. Pass the `id` from a previous result directly.
     pub parent: Option<String>,
     /// When true, aggregate child spans with the same name.
     pub aggregated: bool,
@@ -86,16 +86,11 @@ pub struct QueryOptions {
 
 /// Information about a single span (or aggregated group of spans).
 pub struct SpanInfo {
-    /// Span ID string.
+    /// Span ID string. Pass this directly as `parent` to drill into children.
     ///
-    /// The format encodes both the type and the navigation path:
-    /// - A **raw span** leaf is its decimal index: `"123"`.
-    /// - An **aggregated span** leaf is `"a"` + the first-span index: `"a123"`.
-    /// - When the span is a child of another span, the parent's ID is prepended with a dash
-    ///   separator, e.g. `"a5-a34"` or `"1-a5-a34-20"`.
-    ///
-    /// Pass the full ID as the `parent` option of the next `query_spans` call
-    /// to enumerate the children of that span.
+    /// - A **raw span** ID is its unique decimal store index: `"123"`.
+    /// - An **aggregated span** ID is a full `-`-separated path through the aggregation tree:
+    ///   `"a2119"`, `"a2119-a2120"`, etc.
     pub id: String,
     /// Display name: `"category title"` or just `"title"`.
     pub name: String,
@@ -155,12 +150,72 @@ fn format_span_name(cat: &str, title: &str) -> String {
     }
 }
 
-/// Build a span ID by appending a leaf segment to the optional parent path.
-fn build_span_id(parent: Option<&str>, leaf: &str) -> String {
-    match parent {
-        Some(p) => format!("{p}-{leaf}"),
-        None => leaf.to_string(),
+/// Apply the requested sort mode to a list of items with duration and name accessors.
+fn sort_items<T>(
+    items: &mut [T],
+    sort: SortMode,
+    corrected_total_time: impl Fn(&T) -> u64,
+    total_time: impl Fn(&T) -> u64,
+    nice_name: impl Fn(&T) -> (&str, &str),
+) {
+    match sort {
+        SortMode::Value => {
+            items.sort_by(|a, b| {
+                corrected_total_time(b)
+                    .cmp(&corrected_total_time(a))
+                    .then_with(|| total_time(b).cmp(&total_time(a)))
+            });
+        }
+        SortMode::Name => {
+            items.sort_by(|a, b| {
+                let (a_cat, a_title) = nice_name(a);
+                let (b_cat, b_title) = nice_name(b);
+                a_title.cmp(b_title).then_with(|| a_cat.cmp(b_cat))
+            });
+        }
+        SortMode::ExecutionOrder => {}
     }
+}
+
+/// Walk the aggregation graph tree following a `-`-separated path of `a<N>`
+/// segments. Returns the graph node at the end of the path, or `None` if
+/// any segment doesn't match.
+///
+/// Each segment `a<N>` selects the child `SpanGraphRef` whose first span
+/// index equals `N`.
+fn resolve_graph_by_path<'a>(store: &'a store::Store, path: &str) -> Option<SpanGraphRef<'a>> {
+    let mut segments = path.split('-');
+    let first = segments.next()?;
+    let first_index: usize = first.strip_prefix('a')?.parse().ok()?;
+
+    // Start from the root graph children.
+    let mut current: SpanGraphRef<'a> = store
+        .root_span()
+        .graph()
+        .filter_map(|event| match event {
+            span_graph_ref::SpanGraphEventRef::Child { graph } => Some(graph),
+            span_graph_ref::SpanGraphEventRef::SelfTime { .. } => None,
+        })
+        .find(|g| g.first_span().index == first_index)?;
+
+    for segment in segments {
+        let target_index: usize = segment.strip_prefix('a')?.parse().ok()?;
+        let next = current
+            .children()
+            .find(|g| g.first_span().index == target_index)?;
+        current = next;
+    }
+
+    Some(current)
+}
+
+/// Resolve a parent span from an ID string. For raw IDs, use the last segment.
+/// Returns `None` for root level.
+fn resolve_parent_span<'a>(
+    store: &'a store::Store,
+    parent_id: Option<&str>,
+) -> Option<SpanRef<'a>> {
+    parent_id.and_then(|id| resolve_span_by_id(store, id))
 }
 
 /// Query spans from the store.
@@ -187,220 +242,232 @@ pub fn query_spans(store: &Arc<StoreContainer>, options: QueryOptions) -> QueryR
     let store_guard = store.read();
     let store_ref = &*store_guard;
 
-    // Resolve the parent span.
-    let parent_span: Option<SpanRef<'_>> = if let Some(ref parent_id) = options.parent {
-        resolve_span_by_id(store_ref, parent_id)
+    if options.aggregated {
+        query_spans_aggregated(store_ref, &options)
     } else {
-        None
+        query_spans_raw(store_ref, &options)
+    }
+}
+
+/// Aggregated mode: group child spans by name using the SpanGraph tree.
+///
+/// When a search query is provided, uses `SpanRef::search` to find matching
+/// spans anywhere in the subtree and returns them as individual (raw) results
+/// rather than aggregated groups.
+fn query_spans_aggregated(store: &store::Store, options: &QueryOptions) -> QueryResult {
+    // When searching, use SpanRef::search on the parent span (or root) to find
+    // matching spans in the entire subtree. Returns raw spans, not aggregated.
+    if let Some(ref query) = options.search {
+        let parent_span = resolve_parent_span(store, options.parent.as_deref());
+        let parent_start = parent_span.as_ref().map(|s| *s.start()).unwrap_or_default();
+
+        let mut results: Vec<SpanRef<'_>> = if let Some(ref parent) = parent_span {
+            parent.search(query).collect()
+        } else {
+            store.root_span().search(query).collect()
+        };
+
+        sort_items(
+            &mut results,
+            options.sort,
+            |s| *s.corrected_total_time(),
+            |s| *s.total_time(),
+            |s| s.nice_name(),
+        );
+
+        let (page_items, page, total_pages, total_count) = paginate(results, options.page);
+        let spans = page_items
+            .into_iter()
+            .map(|span| span_ref_to_info(&span, parent_start))
+            .collect();
+
+        return QueryResult {
+            spans,
+            page,
+            total_pages,
+            total_count,
+        };
+    }
+
+    // No search — show aggregated graph children.
+    let graph_children: Vec<SpanGraphRef<'_>> = if let Some(ref parent_id) = options.parent {
+        if let Some(parent_graph) = resolve_graph_by_path(store, parent_id) {
+            parent_graph.children().collect()
+        } else {
+            return QueryResult {
+                spans: Vec::new(),
+                page: 1,
+                total_pages: 1,
+                total_count: 0,
+            };
+        }
+    } else {
+        store
+            .root_span()
+            .graph()
+            .filter_map(|event| match event {
+                span_graph_ref::SpanGraphEventRef::Child { graph } => Some(graph),
+                span_graph_ref::SpanGraphEventRef::SelfTime { .. } => None,
+            })
+            .collect()
     };
 
+    // Get parent start time for relative offsets.
+    let parent_start = resolve_parent_span(store, options.parent.as_deref())
+        .map(|s| *s.start())
+        .unwrap_or_default();
+
+    let mut filtered = graph_children;
+
+    sort_items(
+        &mut filtered,
+        options.sort,
+        |g| *g.corrected_total_time(),
+        |g| *g.total_time(),
+        |g| g.nice_name(),
+    );
+
+    let (page_items, page, total_pages, total_count) = paginate(filtered, options.page);
+
+    let parent_path = options.parent.as_deref();
+
+    let spans = page_items
+        .into_iter()
+        .map(|graph| {
+            let first = graph.first_span();
+            let (cat, title) = graph.nice_name();
+            let name = format_span_name(cat, title);
+            let count = graph.count() as u64;
+            let total_cpu = *graph.total_time();
+            let total_corrected = *graph.corrected_total_time();
+            let avg_cpu = total_cpu.checked_div(count).unwrap_or(0);
+            let avg_corrected = total_corrected.checked_div(count).unwrap_or(0);
+
+            let first_index = first.index;
+            // Build full path ID: prepend parent path so this ID can be
+            // passed directly as `parent` to drill into children.
+            let leaf = format!("a{first_index}");
+            let graph_id = match parent_path {
+                Some(p) => format!("{p}-{leaf}"),
+                None => leaf,
+            };
+
+            // start/end of the first/example span relative to parent.
+            let span_start = *first.start();
+            let span_end = *first.end();
+            let rel_start = (span_start as i64) - (parent_start as i64);
+            let rel_end = (span_end as i64) - (parent_start as i64);
+
+            SpanInfo {
+                id: graph_id,
+                name,
+                cpu_duration: *first.total_time(),
+                corrected_duration: *first.corrected_total_time(),
+                start_relative_to_parent: rel_start,
+                end_relative_to_parent: rel_end,
+                args: first
+                    .args()
+                    .map(|(k, v)| (k.to_string(), v.to_string()))
+                    .collect(),
+                is_aggregated: count > 1,
+                count: Some(count),
+                total_cpu_duration: Some(total_cpu),
+                avg_cpu_duration: Some(avg_cpu),
+                total_corrected_duration: Some(total_corrected),
+                avg_corrected_duration: Some(avg_corrected),
+                first_span_id: Some(first_index.to_string()),
+            }
+        })
+        .collect();
+
+    QueryResult {
+        spans,
+        page,
+        total_pages,
+        total_count,
+    }
+}
+
+/// Raw (non-aggregated) mode: list individual child spans.
+fn query_spans_raw(store: &store::Store, options: &QueryOptions) -> QueryResult {
+    let parent_span = resolve_parent_span(store, options.parent.as_deref());
     let parent_start = parent_span.as_ref().map(|s| *s.start()).unwrap_or_default();
 
-    if options.aggregated {
-        // Collect aggregated children (SpanGraphRef) from either the resolved
-        // parent span or the root.
-        let graph_children: Vec<_> = if let Some(ref parent) = parent_span {
-            // The parent might be an aggregated node: look up which graph node
-            // the parent ID refers to, then iterate its children's graph events.
-            // For simplicity, resolve via the parent span's graph().
-            parent
-                .graph()
-                .filter_map(|event| match event {
-                    SpanGraphEventRef::Child { graph } => Some(graph),
-                    SpanGraphEventRef::SelfTime { .. } => None,
-                })
-                .collect()
+    let raw_children: Vec<SpanRef<'_>> = if let Some(ref parent) = parent_span {
+        parent.children().collect()
+    } else {
+        store.root_spans().collect()
+    };
+
+    // Apply search filter using the span's search index.
+    let mut filtered: Vec<_> = if let Some(ref query) = options.search {
+        if let Some(ref parent) = parent_span {
+            parent.search(query).collect()
         } else {
-            // Root level: use root span's graph.
-            store_ref
-                .root_span()
-                .graph()
-                .filter_map(|event| match event {
-                    SpanGraphEventRef::Child { graph } => Some(graph),
-                    SpanGraphEventRef::SelfTime { .. } => None,
-                })
-                .collect()
-        };
-
-        // Apply search filter.
-        let mut filtered: Vec<_> = if let Some(ref query) = options.search {
-            graph_children
-                .into_iter()
-                .filter(|g| {
-                    let (cat, title) = g.nice_name();
-                    cat.contains(query.as_str()) || title.contains(query.as_str())
-                })
-                .collect()
-        } else {
-            graph_children
-        };
-
-        // Sort if requested.
-        match options.sort {
-            SortMode::Value => {
-                filtered.sort_by(|a, b| {
-                    b.corrected_total_time()
-                        .cmp(&a.corrected_total_time())
-                        .then_with(|| b.total_time().cmp(&a.total_time()))
-                });
-            }
-            SortMode::Name => {
-                filtered.sort_by(|a, b| {
-                    let (a_cat, a_title) = a.nice_name();
-                    let (b_cat, b_title) = b.nice_name();
-                    a_title.cmp(b_title).then_with(|| a_cat.cmp(b_cat))
-                });
-            }
-            SortMode::ExecutionOrder => {}
-        }
-
-        let (page_items, page, total_pages, total_count) = paginate(filtered, options.page);
-
-        let spans = page_items
-            .into_iter()
-            .map(|graph| {
-                let first = graph.first_span();
-                let (cat, title) = graph.nice_name();
-                let name = format_span_name(cat, title);
-                let count = graph.count() as u64;
-                let total_cpu = *graph.total_time();
-                let total_corrected = *graph.corrected_total_time();
-                let avg_cpu = total_cpu.checked_div(count).unwrap_or(0);
-                let avg_corrected = total_corrected.checked_div(count).unwrap_or(0);
-
-                // Build the full path ID for this aggregated span.
-                // The leaf segment is "a{first_span_index}"; prepend the parent
-                // path (if any) with a dash so callers can pass the full string
-                // back as `parent` to drill into children.
-                let first_index = first.index;
-                let graph_id = build_span_id(options.parent.as_deref(), &format!("a{first_index}"));
-
-                // start/end of the first/example span relative to parent.
-                let span_start = *first.start();
-                let span_end = *first.end();
-                let rel_start = (span_start as i64) - (parent_start as i64);
-                let rel_end = (span_end as i64) - (parent_start as i64);
-
-                SpanInfo {
-                    id: graph_id,
-                    name,
-                    cpu_duration: *first.total_time(),
-                    corrected_duration: *first.corrected_total_time(),
-                    start_relative_to_parent: rel_start,
-                    end_relative_to_parent: rel_end,
-                    args: first
-                        .args()
-                        .map(|(k, v)| (k.to_string(), v.to_string()))
-                        .collect(),
-                    is_aggregated: count > 1,
-                    count: Some(count),
-                    total_cpu_duration: Some(total_cpu),
-                    avg_cpu_duration: Some(avg_cpu),
-                    total_corrected_duration: Some(total_corrected),
-                    avg_corrected_duration: Some(avg_corrected),
-                    first_span_id: Some(first_index.to_string()),
-                }
-            })
-            .collect();
-
-        QueryResult {
-            spans,
-            page,
-            total_pages,
-            total_count,
+            store.root_span().search(query).collect()
         }
     } else {
-        // Raw spans mode.
-        let raw_children: Vec<SpanRef<'_>> = if let Some(ref parent) = parent_span {
-            parent.children().collect()
-        } else {
-            store_ref.root_spans().collect()
-        };
+        raw_children
+    };
 
-        // Apply search filter using the span's search index.
-        let mut filtered: Vec<_> = if let Some(ref query) = options.search {
-            if let Some(ref parent) = parent_span {
-                parent.search(query).collect()
-            } else {
-                store_ref.root_span().search(query).collect()
-            }
-        } else {
-            raw_children
-        };
+    sort_items(
+        &mut filtered,
+        options.sort,
+        |s| *s.corrected_total_time(),
+        |s| *s.total_time(),
+        |s| s.nice_name(),
+    );
 
-        // Sort if requested.
-        match options.sort {
-            SortMode::Value => {
-                filtered.sort_by(|a, b| {
-                    b.corrected_total_time()
-                        .cmp(&a.corrected_total_time())
-                        .then_with(|| b.total_time().cmp(&a.total_time()))
-                });
-            }
-            SortMode::Name => {
-                filtered.sort_by(|a, b| {
-                    let (a_cat, a_title) = a.nice_name();
-                    let (b_cat, b_title) = b.nice_name();
-                    a_title.cmp(b_title).then_with(|| a_cat.cmp(b_cat))
-                });
-            }
-            SortMode::ExecutionOrder => {}
-        }
+    let (page_items, page, total_pages, total_count) = paginate(filtered, options.page);
+    let spans = page_items
+        .into_iter()
+        .map(|span| span_ref_to_info(&span, parent_start))
+        .collect();
 
-        let (page_items, page, total_pages, total_count) = paginate(filtered, options.page);
+    QueryResult {
+        spans,
+        page,
+        total_pages,
+        total_count,
+    }
+}
 
-        let spans = page_items
-            .into_iter()
-            .map(|span| {
-                let (cat, title) = span.nice_name();
-                let name = format_span_name(cat, title);
-                let span_start = *span.start();
-                let span_end = *span.end();
-                let rel_start = (span_start as i64) - (parent_start as i64);
-                let rel_end = (span_end as i64) - (parent_start as i64);
+/// Convert a raw `SpanRef` to a `SpanInfo` with timings relative to `parent_start`.
+fn span_ref_to_info(span: &SpanRef<'_>, parent_start: u64) -> SpanInfo {
+    let (cat, title) = span.nice_name();
+    let name = format_span_name(cat, title);
+    let span_start = *span.start();
+    let span_end = *span.end();
+    let rel_start = (span_start as i64) - (parent_start as i64);
+    let rel_end = (span_end as i64) - (parent_start as i64);
 
-                SpanInfo {
-                    id: build_span_id(options.parent.as_deref(), &span.index.to_string()),
-                    name,
-                    cpu_duration: *span.total_time(),
-                    corrected_duration: *span.corrected_total_time(),
-                    start_relative_to_parent: rel_start,
-                    end_relative_to_parent: rel_end,
-                    args: span
-                        .args()
-                        .map(|(k, v)| (k.to_string(), v.to_string()))
-                        .collect(),
-                    is_aggregated: false,
-                    count: None,
-                    total_cpu_duration: None,
-                    avg_cpu_duration: None,
-                    total_corrected_duration: None,
-                    avg_corrected_duration: None,
-                    first_span_id: None,
-                }
-            })
-            .collect();
-
-        QueryResult {
-            spans,
-            page,
-            total_pages,
-            total_count,
-        }
+    SpanInfo {
+        id: span.index.to_string(),
+        name,
+        cpu_duration: *span.total_time(),
+        corrected_duration: *span.corrected_total_time(),
+        start_relative_to_parent: rel_start,
+        end_relative_to_parent: rel_end,
+        args: span
+            .args()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect(),
+        is_aggregated: false,
+        count: None,
+        total_cpu_duration: None,
+        avg_cpu_duration: None,
+        total_corrected_duration: None,
+        avg_corrected_duration: None,
+        first_span_id: None,
     }
 }
 
 /// Resolve a span by its MCP ID string.
 ///
-/// IDs use the format `[a]<index>[-[a]<index>...]`:
-/// - A plain decimal segment (e.g. `"123"`) refers to a raw span at that store index.
-/// - A segment prefixed with `"a"` (e.g. `"a123"`) refers to the first span of an aggregated group
-///   at that store index.
-/// - Segments are separated by `-` to form a navigation path, e.g. `"a5-a34-20"`. Only the **last**
-///   segment is needed to look up the span whose children we want to enumerate; the earlier
-///   segments provide navigation context for the caller.
+/// For raw span IDs (e.g. `"123"`) or the last segment of a path
+/// (e.g. `"a2119-a2120"` → span at index 2120), returns the `SpanRef`.
 fn resolve_span_by_id<'a>(store: &'a store::Store, id: &str) -> Option<SpanRef<'a>> {
-    // Take only the last path segment (everything after the final `-`).
+    // For path-style IDs, take the last segment.
     let last = id.split('-').next_back().unwrap_or(id);
     // Strip the optional "a" prefix that marks aggregated spans.
     let index_str = last.strip_prefix('a').unwrap_or(last);


### PR DESCRIPTION
### What?

Follow-up fixes and improvements to the turbopack trace server MCP API (#92030):

1. **Include MCP port in query-trace help output** — the startup message now shows the actual port so users can copy-paste directly.
2. **Flat span IDs** — IDs no longer encode the full parent path (e.g. `a2119-3052` → just `3052`). The caller already knows the parent context.
3. **Fix aggregated parent drill-down** — drilling into aggregated parents like `a2119-a2120` now correctly walks the `SpanGraphRef` tree instead of falling back to the raw span.
4. **Updated MCP tool description** — explains how to build `-`-separated paths for aggregated drill-down.

### Why?

- The help output without the port was not copy-pasteable when using a non-default `--mcp-port`.
- Path-encoded IDs were redundant — the parent context is already tracked by the caller.
- The core aggregated drill-down was broken: `--parent a2119-a2120` resolved to raw span 2120 instead of navigating the aggregation graph tree, showing raw children instead of aggregated groups.

### How?

#### Flat span IDs

Display IDs are now simple leaf values:
- Raw span: `"3052"` (decimal index)
- Aggregated span: `"a2120"` (`a` + first span index)

To drill deeper in aggregated mode, callers concatenate: current parent + `-` + child ID. Example: root shows `a2119`, drill in with `parent=a2119`, its child `a2120` → next call uses `parent=a2119-a2120`.

#### Graph tree walking (`resolve_graph_by_path`)

New function in `turbopack-trace-server/src/lib.rs` that walks the `SpanGraphRef` tree segment-by-segment:

```
a2119-a2120 → root graph child with first_span.index==2119
            → its graph child with first_span.index==2120
            → list that node's aggregated children
```

Previously this fell through to `resolve_span_by_id` which just looked up raw span 2120, ignoring the aggregation hierarchy.

#### Refactored `query_spans`

Split into `query_spans_aggregated` and `query_spans_raw` for clarity. The aggregated path uses `resolve_graph_by_path` while raw mode uses `resolve_span_by_id` (which now re-parses the last `-`-separated segment for backward compatibility with path-style IDs).

<!-- NEXT_JS_LLM_PR -->