### PR TITLE
fix(next): preserve third-party fetch instrumentation across HMR resets

### DIFF
--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -39,6 +39,8 @@ type PatchedFetcher = Fetcher & {
   readonly __nextPatched: true
   readonly __nextGetStaticStore: () => WorkAsyncStorage
   readonly _nextOriginalFetch: Fetcher
+  /** The globalThis.fetch value before patchFetch() applied any wrapping. */
+  _nextPrePatchFetch: Fetcher
 }
 
 export const NEXT_PATCH_SYMBOL = Symbol.for('next-patch')
@@ -1281,6 +1283,8 @@ export function createPatchedFetcher(
   patched.__nextPatched = true as const
   patched.__nextGetStaticStore = () => workAsyncStorage
   patched._nextOriginalFetch = originFetch
+  // Store the fetch as it was before patchFetch() touched it (pre-dedupe).
+  // resetFetch() uses this to cleanly unwrap without accumulating dedupe layers.
   ;(globalThis as Record<symbol, unknown>)[NEXT_PATCH_SYMBOL] = true
 
   // Assign the function name also as a name property, so that it's preserved
@@ -1296,12 +1300,19 @@ export function patchFetch(options: PatchableModule) {
   // If we've already patched fetch, we should not patch it again.
   if (isFetchPatched()) return
 
+  // Save the current fetch before any wrapping. resetFetch() uses this to
+  // cleanly restore without accumulating createDedupeFetch layers across
+  // HMR cycles.
+  const prePatchFetch = globalThis.fetch
+
   // Grab the original fetch function. We'll attach this so we can use it in
   // the patched fetch function.
-  const original = createDedupeFetch(globalThis.fetch)
+  const original = createDedupeFetch(prePatchFetch)
 
   // Set the global fetch to the patched fetch.
-  globalThis.fetch = createPatchedFetcher(original, options)
+  const patched = createPatchedFetcher(original, options)
+  patched._nextPrePatchFetch = prePatchFetch
+  globalThis.fetch = patched
 }
 
 let currentTimeoutBoundary: null | Promise<void> = null

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -153,16 +153,16 @@ export async function initialize(opts: {
       require('./router-utils/setup-dev-bundler') as typeof import('./router-utils/setup-dev-bundler')
 
     const resetFetch = () => {
-      // If fetch was patched by Next.js, unwrap only the Next.js layer by
-      // restoring _nextOriginalFetch. This preserves any third-party
-      // instrumentation (e.g. OpenTelemetry) that wrapped fetch before
-      // Next.js's patchFetch() ran. Only fall back to the startup snapshot
-      // when there's no Next.js patch layer to unwrap.
+      // Unwrap only the Next.js patchFetch() + createDedupeFetch layers by
+      // restoring the fetch reference from before patchFetch() ran. This
+      // preserves any third-party instrumentation (e.g. OpenTelemetry) that
+      // wrapped globalThis.fetch before Next.js patched it, and avoids
+      // accumulating createDedupeFetch wrappers across HMR cycles.
       const currentFetch: typeof globalThis.fetch & {
-        _nextOriginalFetch?: typeof globalThis.fetch
+        _nextPrePatchFetch?: typeof globalThis.fetch
       } = globalThis.fetch
-      if (currentFetch._nextOriginalFetch) {
-        globalThis.fetch = currentFetch._nextOriginalFetch
+      if (currentFetch._nextPrePatchFetch) {
+        globalThis.fetch = currentFetch._nextPrePatchFetch
       } else {
         globalThis.fetch = originalFetch
       }

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -153,7 +153,19 @@ export async function initialize(opts: {
       require('./router-utils/setup-dev-bundler') as typeof import('./router-utils/setup-dev-bundler')
 
     const resetFetch = () => {
-      globalThis.fetch = originalFetch
+      // If fetch was patched by Next.js, unwrap only the Next.js layer by
+      // restoring _nextOriginalFetch. This preserves any third-party
+      // instrumentation (e.g. OpenTelemetry) that wrapped fetch before
+      // Next.js's patchFetch() ran. Only fall back to the startup snapshot
+      // when there's no Next.js patch layer to unwrap.
+      const currentFetch: typeof globalThis.fetch & {
+        _nextOriginalFetch?: typeof globalThis.fetch
+      } = globalThis.fetch
+      if (currentFetch._nextOriginalFetch) {
+        globalThis.fetch = currentFetch._nextOriginalFetch
+      } else {
+        globalThis.fetch = originalFetch
+      }
       ;(globalThis as Record<symbol, unknown>)[NEXT_PATCH_SYMBOL] = false
     }
 

--- a/test/development/app-dir/dev-fetch-hmr-instrumentation/app/layout.tsx
+++ b/test/development/app-dir/dev-fetch-hmr-instrumentation/app/layout.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import { ReactNode } from 'react'
+
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/dev-fetch-hmr-instrumentation/app/page.tsx
+++ b/test/development/app-dir/dev-fetch-hmr-instrumentation/app/page.tsx
@@ -1,0 +1,19 @@
+export default async function Page() {
+  let instrumented = 'no'
+  try {
+    const res = await fetch('http://fake.url/instrumentation-probe')
+    const text = await res.text()
+    if (text === 'instrumentation-active') {
+      instrumented = 'yes'
+    }
+  } catch {
+    instrumented = 'no'
+  }
+
+  return (
+    <>
+      <div id="update">touch to trigger HMR</div>
+      <div id="instrumented">{instrumented}</div>
+    </>
+  )
+}

--- a/test/development/app-dir/dev-fetch-hmr-instrumentation/dev-fetch-hmr-instrumentation.test.ts
+++ b/test/development/app-dir/dev-fetch-hmr-instrumentation/dev-fetch-hmr-instrumentation.test.ts
@@ -1,0 +1,36 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+import cheerio from 'cheerio'
+
+describe('dev-fetch-hmr-instrumentation', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  // Regression test: resetFetch() in router-server.ts used to restore a
+  // snapshot of globalThis.fetch taken at startup — before instrumentation.ts
+  // had a chance to wrap it. Every HMR event would therefore strip any
+  // third-party fetch instrumentation (e.g. @vercel/otel trace-context
+  // propagation). The fix makes resetFetch() unwrap only the Next.js
+  // patchFetch() layer via _nextOriginalFetch, preserving instrumentation.
+  it('should preserve instrumentation fetch wrapping after HMR', async () => {
+    // 1. Cold start: instrumentation.ts wraps fetch, the probe should work.
+    const html = await next.render('/')
+    expect(cheerio.load(html)('#instrumented').text()).toBe('yes')
+
+    // 2. Trigger HMR by editing the page component.
+    await next.patchFile('app/page.tsx', (content) =>
+      content.replace('touch to trigger HMR', 'touch to trigger HMR 2')
+    )
+
+    // 3. After HMR, the instrumentation wrapper must still be active.
+    await retry(async () => {
+      const html2 = await next.render('/')
+      const $ = cheerio.load(html2)
+      // Confirm HMR actually happened
+      expect($('#update').text()).toBe('touch to trigger HMR 2')
+      // Confirm instrumentation survived
+      expect($('#instrumented').text()).toBe('yes')
+    })
+  })
+})

--- a/test/development/app-dir/dev-fetch-hmr-instrumentation/dev-fetch-hmr-instrumentation.test.ts
+++ b/test/development/app-dir/dev-fetch-hmr-instrumentation/dev-fetch-hmr-instrumentation.test.ts
@@ -1,6 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
-import cheerio from 'cheerio'
 
 describe('dev-fetch-hmr-instrumentation', () => {
   const { next } = nextTestSetup({
@@ -12,11 +11,11 @@ describe('dev-fetch-hmr-instrumentation', () => {
   // had a chance to wrap it. Every HMR event would therefore strip any
   // third-party fetch instrumentation (e.g. @vercel/otel trace-context
   // propagation). The fix makes resetFetch() unwrap only the Next.js
-  // patchFetch() layer via _nextOriginalFetch, preserving instrumentation.
+  // patchFetch() layer via _nextPrePatchFetch, preserving instrumentation.
   it('should preserve instrumentation fetch wrapping after HMR', async () => {
     // 1. Cold start: instrumentation.ts wraps fetch, the probe should work.
-    const html = await next.render('/')
-    expect(cheerio.load(html)('#instrumented').text()).toBe('yes')
+    const $ = await next.render$('/')
+    expect($('#instrumented').text()).toBe('yes')
 
     // 2. Trigger HMR by editing the page component.
     await next.patchFile('app/page.tsx', (content) =>
@@ -25,12 +24,11 @@ describe('dev-fetch-hmr-instrumentation', () => {
 
     // 3. After HMR, the instrumentation wrapper must still be active.
     await retry(async () => {
-      const html2 = await next.render('/')
-      const $ = cheerio.load(html2)
+      const $2 = await next.render$('/')
       // Confirm HMR actually happened
-      expect($('#update').text()).toBe('touch to trigger HMR 2')
+      expect($2('#update').text()).toBe('touch to trigger HMR 2')
       // Confirm instrumentation survived
-      expect($('#instrumented').text()).toBe('yes')
+      expect($2('#instrumented').text()).toBe('yes')
     })
   })
 })

--- a/test/development/app-dir/dev-fetch-hmr-instrumentation/instrumentation.ts
+++ b/test/development/app-dir/dev-fetch-hmr-instrumentation/instrumentation.ts
@@ -1,0 +1,17 @@
+// Simulates what @vercel/otel does: wrap globalThis.fetch during the
+// instrumentation hook to inject trace-context headers into outgoing requests.
+// We use a probe URL to verify the wrapper is still active after HMR.
+const nativeFetch = globalThis.fetch
+
+globalThis.fetch = async function instrumentedFetch(
+  resource: URL | RequestInfo,
+  options?: RequestInit
+) {
+  const request = new Request(resource, options)
+
+  if (request.url === 'http://fake.url/instrumentation-probe') {
+    return new Response('instrumentation-active')
+  }
+
+  return nativeFetch(request)
+}

--- a/test/development/app-dir/dev-fetch-hmr-instrumentation/next.config.js
+++ b/test/development/app-dir/dev-fetch-hmr-instrumentation/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig


### PR DESCRIPTION
resetFetch() in router-server.ts snapshots globalThis.fetch at startup, before instrumentation hooks (e.g. @vercel/otel) have a chance to wrap it. Every HMR event restores that pre-instrumentation snapshot, permanently stripping any fetch wrapping added by third-party libraries.

Instead of always restoring the startup snapshot, unwrap only the Next.js patchFetch() layer via the existing _nextOriginalFetch property. This preserves instrumentation applied between startup and the first patchFetch() call while still allowing patchFetch() to cleanly re-apply on the next request.