### PR TITLE
Refactor trace server sort to SortMode enum (execution order / value / name)

### DIFF
--- a/crates/next-napi-bindings/src/turbo_trace_server.rs
+++ b/crates/next-napi-bindings/src/turbo_trace_server.rs
@@ -2,7 +2,8 @@ use std::{path::PathBuf, sync::Arc};
 
 use napi_derive::napi;
 use turbopack_trace_server::{
-    QueryOptions, query_spans, start_turbopack_trace_server, store_container::StoreContainer,
+    QueryOptions, SortMode, query_spans, start_turbopack_trace_server,
+    store_container::StoreContainer,
 };
 
 /// An opaque handle to a running trace server instance.
@@ -21,8 +22,9 @@ pub struct TraceQueryOptions {
     pub parent: Option<String>,
     /// When `true` (default), aggregate child spans with the same name.
     pub aggregated: Option<bool>,
-    /// When `true`, sort results by corrected duration descending. Default `false`.
-    pub sort: Option<bool>,
+    /// Sort mode: `"value"` for duration descending, `"name"` for alphabetical.
+    /// Omit for execution order (no sorting).
+    pub sort: Option<String>,
     /// Optional substring search query applied to span name/category.
     pub search: Option<String>,
     /// 1-based page number. Default `1`.
@@ -94,7 +96,11 @@ pub fn query_trace_spans(
         QueryOptions {
             parent: options.parent,
             aggregated: options.aggregated.unwrap_or(true),
-            sort: options.sort.unwrap_or(false),
+            sort: match options.sort.as_deref() {
+                Some("value") => SortMode::Value,
+                Some("name") => SortMode::Name,
+                _ => SortMode::ExecutionOrder,
+            },
             search: options.search,
             page: options.page.unwrap_or(1) as usize,
         },

--- a/packages/next/src/bin/next.ts
+++ b/packages/next/src/bin/next.ts
@@ -643,9 +643,9 @@ internal
   )
   .addOption(
     new Option(
-      '--sort',
-      'Sort results by corrected duration descending (default: false).'
-    )
+      '--sort <mode>',
+      'Sort mode: "value" for corrected duration descending, "name" for alphabetical.'
+    ).choices(['value', 'name'])
   )
   .addOption(
     new Option('--search <search>', 'Substring filter on span name/category.')

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -624,8 +624,8 @@ export interface TraceQueryOptions {
   parent?: string
   /** When `true` (default), aggregate child spans with the same name. */
   aggregated?: boolean
-  /** When `true`, sort results by corrected duration descending. Default `false`. */
-  sort?: boolean
+  /** Sort mode: `"value"` for duration descending, `"name"` for alphabetical. Omit for execution order. */
+  sort?: 'value' | 'name'
   /** Optional substring search query applied to span name/category. */
   search?: string
   /** 1-based page number. Default `1`. */

--- a/packages/next/src/cli/internal/query-trace.ts
+++ b/packages/next/src/cli/internal/query-trace.ts
@@ -12,7 +12,7 @@ interface QueryTraceOptions {
   port: number | undefined
   parent: string | undefined
   aggregated: boolean | undefined
-  sort: boolean | undefined
+  sort: string | undefined
   search: string | undefined
   page: number | undefined
   json: boolean | undefined

--- a/packages/next/src/cli/internal/turbo-trace-server.ts
+++ b/packages/next/src/cli/internal/turbo-trace-server.ts
@@ -136,10 +136,10 @@ export async function startTurboTraceServerCli(
             'When true (default), aggregate spans with the same name into a single entry. Set to false to see individual raw spans.'
           ),
         sort: z
-          .boolean()
+          .enum(['value', 'name'])
           .optional()
           .describe(
-            'When true, sort results by corrected duration descending. Default false.'
+            'Sort mode: "value" for corrected duration descending, "name" for alphabetical. Omit for execution order.'
           ),
         search: z
           .string()
@@ -160,7 +160,7 @@ export async function startTurboTraceServerCli(
       const result = bindings.turbo.queryTraceSpans(handle, {
         parent: args.parent,
         aggregated: args.aggregated ?? true,
-        sort: args.sort ?? false,
+        sort: args.sort,
         search: args.search,
         page: args.page ?? 1,
       })

--- a/test/e2e/turbopack-trace-server-query/turbopack-trace-server.test.ts
+++ b/test/e2e/turbopack-trace-server-query/turbopack-trace-server.test.ts
@@ -256,7 +256,7 @@ describe('turbopack-trace-server', () => {
   })
 
   it('should drill into children of a span using its ID', async () => {
-    const { spans } = await querySpansJson(mcpPort, { sort: true })
+    const { spans } = await querySpansJson(mcpPort, { sort: 'value' })
     const spanId = spans[0].id
 
     const childMd = await callMcpTool(mcpPort, 'query_spans', {
@@ -275,7 +275,7 @@ describe('turbopack-trace-server', () => {
 
   it('should return results when searching for a real span name', async () => {
     // Get a real span name from the root level via JSON output.
-    const { spans } = await querySpansJson(mcpPort, { sort: true })
+    const { spans } = await querySpansJson(mcpPort, { sort: 'value' })
     const searchTerm = spans[0].name.slice(0, 20)
 
     const md = await callMcpTool(mcpPort, 'query_spans', {
@@ -286,8 +286,14 @@ describe('turbopack-trace-server', () => {
     expect(md).toMatch(/###/)
   })
 
-  it('should support sort by duration', async () => {
-    const md = await callMcpTool(mcpPort, 'query_spans', { sort: true })
+  it('should support sort by value', async () => {
+    const md = await callMcpTool(mcpPort, 'query_spans', { sort: 'value' })
+    expect(md).toContain('## Spans at root level')
+    expect(md).toMatch(/###/)
+  })
+
+  it('should support sort by name', async () => {
+    const md = await callMcpTool(mcpPort, 'query_spans', { sort: 'name' })
     expect(md).toContain('## Spans at root level')
     expect(md).toMatch(/###/)
   })
@@ -321,11 +327,24 @@ describe('turbopack-trace-server', () => {
     expect(stdout).toMatch(/CPU Duration|Corrected Duration/)
   })
 
-  it('CLI: should support --sort flag', async () => {
+  it('CLI: should support --sort value flag', async () => {
     const { stdout, exitCode } = await runQueryTraceCli([
       '--port',
       String(mcpPort),
       '--sort',
+      'value',
+    ])
+    expect(exitCode).toBe(0)
+    expect(stdout).toContain('## Spans at root level')
+    expect(stdout).toMatch(/###/)
+  })
+
+  it('CLI: should support --sort name flag', async () => {
+    const { stdout, exitCode } = await runQueryTraceCli([
+      '--port',
+      String(mcpPort),
+      '--sort',
+      'name',
     ])
     expect(exitCode).toBe(0)
     expect(stdout).toContain('## Spans at root level')
@@ -334,7 +353,7 @@ describe('turbopack-trace-server', () => {
 
   it('CLI: should support --search flag with a real match', async () => {
     // Get a real span name to search for via JSON output.
-    const { spans } = await querySpansJson(mcpPort, { sort: true })
+    const { spans } = await querySpansJson(mcpPort, { sort: 'value' })
     const searchTerm = spans[0].name.slice(0, 20)
 
     const { stdout, exitCode } = await runQueryTraceCli([
@@ -372,7 +391,7 @@ describe('turbopack-trace-server', () => {
   })
 
   it('CLI: should support --parent to drill into children', async () => {
-    const { spans } = await querySpansJson(mcpPort, { sort: true })
+    const { spans } = await querySpansJson(mcpPort, { sort: 'value' })
     const spanId = spans[0].id
 
     const { stdout, exitCode } = await runQueryTraceCli([

--- a/turbopack/crates/turbopack-trace-server/src/lib.rs
+++ b/turbopack/crates/turbopack-trace-server/src/lib.rs
@@ -57,6 +57,18 @@ pub fn start_turbopack_trace_server(path: PathBuf, port: Option<u16>) -> Arc<Sto
 
 const PAGE_SIZE: usize = 20;
 
+/// How spans should be sorted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SortMode {
+    /// No sorting — spans appear in execution/natural order.
+    #[default]
+    ExecutionOrder,
+    /// Sort by value (corrected duration descending).
+    Value,
+    /// Sort alphabetically by name, then by category.
+    Name,
+}
+
 /// Options for querying spans from the trace store.
 pub struct QueryOptions {
     /// Optional parent span ID (as produced by `SpanInfo::id`).
@@ -64,8 +76,8 @@ pub struct QueryOptions {
     pub parent: Option<String>,
     /// When true, aggregate child spans with the same name.
     pub aggregated: bool,
-    /// When true, sort results by corrected duration descending.
-    pub sort: bool,
+    /// How to sort the results.
+    pub sort: SortMode,
     /// Optional substring search query.
     pub search: Option<String>,
     /// 1-based page number.
@@ -224,12 +236,22 @@ pub fn query_spans(store: &Arc<StoreContainer>, options: QueryOptions) -> QueryR
         };
 
         // Sort if requested.
-        if options.sort {
-            filtered.sort_by(|a, b| {
-                b.corrected_total_time()
-                    .cmp(&a.corrected_total_time())
-                    .then_with(|| b.total_time().cmp(&a.total_time()))
-            });
+        match options.sort {
+            SortMode::Value => {
+                filtered.sort_by(|a, b| {
+                    b.corrected_total_time()
+                        .cmp(&a.corrected_total_time())
+                        .then_with(|| b.total_time().cmp(&a.total_time()))
+                });
+            }
+            SortMode::Name => {
+                filtered.sort_by(|a, b| {
+                    let (a_cat, a_title) = a.nice_name();
+                    let (b_cat, b_title) = b.nice_name();
+                    a_title.cmp(b_title).then_with(|| a_cat.cmp(b_cat))
+                });
+            }
+            SortMode::ExecutionOrder => {}
         }
 
         let (page_items, page, total_pages, total_count) = paginate(filtered, options.page);
@@ -307,12 +329,22 @@ pub fn query_spans(store: &Arc<StoreContainer>, options: QueryOptions) -> QueryR
         };
 
         // Sort if requested.
-        if options.sort {
-            filtered.sort_by(|a, b| {
-                b.corrected_total_time()
-                    .cmp(&a.corrected_total_time())
-                    .then_with(|| b.total_time().cmp(&a.total_time()))
-            });
+        match options.sort {
+            SortMode::Value => {
+                filtered.sort_by(|a, b| {
+                    b.corrected_total_time()
+                        .cmp(&a.corrected_total_time())
+                        .then_with(|| b.total_time().cmp(&a.total_time()))
+                });
+            }
+            SortMode::Name => {
+                filtered.sort_by(|a, b| {
+                    let (a_cat, a_title) = a.nice_name();
+                    let (b_cat, b_title) = b.nice_name();
+                    a_title.cmp(b_title).then_with(|| a_cat.cmp(b_cat))
+                });
+            }
+            SortMode::ExecutionOrder => {}
         }
 
         let (page_items, page, total_pages, total_count) = paginate(filtered, options.page);

--- a/turbopack/crates/turbopack-trace-server/src/server.rs
+++ b/turbopack/crates/turbopack-trace-server/src/server.rs
@@ -13,7 +13,7 @@ use crate::{
     store_container::StoreContainer,
     timestamp::Timestamp,
     u64_string,
-    viewer::{Update, ViewLineUpdate, ViewMode, Viewer},
+    viewer::{SortMode, Update, ViewLineUpdate, ViewMode, Viewer},
 };
 
 #[derive(Serialize, Debug)]
@@ -211,34 +211,39 @@ fn handle_connection(
                         )?;
                     }
                     ClientToServerMessage::ViewMode { id, mode, inherit } => {
-                        let (mode, sorted) = if let Some(mode) = mode.strip_suffix("-sorted") {
-                            (mode, true)
-                        } else {
-                            (mode.as_str(), false)
-                        };
+                        let (mode, sort_mode) =
+                            if let Some(mode) = mode.strip_suffix("-sorted-by-name") {
+                                (mode, SortMode::Name)
+                            } else if let Some(mode) = mode.strip_suffix("-sorted-by-value") {
+                                (mode, SortMode::Value)
+                            } else if let Some(mode) = mode.strip_suffix("-sorted") {
+                                (mode, SortMode::Value)
+                            } else {
+                                (mode.as_str(), SortMode::ExecutionOrder)
+                            };
                         match mode {
                             "raw-spans" => {
                                 state.viewer.set_view_mode(
                                     id,
-                                    Some((ViewMode::RawSpans { sorted }, inherit)),
+                                    Some((ViewMode::RawSpans { sort_mode }, inherit)),
                                 );
                             }
                             "aggregated" => {
                                 state.viewer.set_view_mode(
                                     id,
-                                    Some((ViewMode::Aggregated { sorted }, inherit)),
+                                    Some((ViewMode::Aggregated { sort_mode }, inherit)),
                                 );
                             }
                             "bottom-up" => {
                                 state.viewer.set_view_mode(
                                     id,
-                                    Some((ViewMode::BottomUp { sorted }, inherit)),
+                                    Some((ViewMode::BottomUp { sort_mode }, inherit)),
                                 );
                             }
                             "aggregated-bottom-up" => {
                                 state.viewer.set_view_mode(
                                     id,
-                                    Some((ViewMode::AggregatedBottomUp { sorted }, inherit)),
+                                    Some((ViewMode::AggregatedBottomUp { sort_mode }, inherit)),
                                 );
                             }
                             _ => {

--- a/turbopack/crates/turbopack-trace-server/src/viewer.rs
+++ b/turbopack/crates/turbopack-trace-server/src/viewer.rs
@@ -187,30 +187,39 @@ fn value_over_time(value: u64, time: Timestamp) -> u64 {
     value.checked_div(*time).unwrap_or(0)
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SortMode {
+    ExecutionOrder,
+    Value,
+    Name,
+}
+
 #[derive(Clone, Copy, Debug)]
 pub enum ViewMode {
-    RawSpans { sorted: bool },
-    Aggregated { sorted: bool },
-    BottomUp { sorted: bool },
-    AggregatedBottomUp { sorted: bool },
+    RawSpans { sort_mode: SortMode },
+    Aggregated { sort_mode: SortMode },
+    BottomUp { sort_mode: SortMode },
+    AggregatedBottomUp { sort_mode: SortMode },
 }
 
 impl ViewMode {
     fn as_spans(self) -> Self {
         match self {
-            ViewMode::RawSpans { sorted } => ViewMode::RawSpans { sorted },
-            ViewMode::Aggregated { sorted } => ViewMode::RawSpans { sorted },
-            ViewMode::BottomUp { sorted } => ViewMode::BottomUp { sorted },
-            ViewMode::AggregatedBottomUp { sorted } => ViewMode::BottomUp { sorted },
+            ViewMode::RawSpans { sort_mode } => ViewMode::RawSpans { sort_mode },
+            ViewMode::Aggregated { sort_mode } => ViewMode::RawSpans { sort_mode },
+            ViewMode::BottomUp { sort_mode } => ViewMode::BottomUp { sort_mode },
+            ViewMode::AggregatedBottomUp { sort_mode } => ViewMode::BottomUp { sort_mode },
         }
     }
 
     fn as_bottom_up(self) -> Self {
         match self {
-            ViewMode::RawSpans { sorted } => ViewMode::BottomUp { sorted },
-            ViewMode::Aggregated { sorted } => ViewMode::AggregatedBottomUp { sorted },
-            ViewMode::BottomUp { sorted } => ViewMode::BottomUp { sorted },
-            ViewMode::AggregatedBottomUp { sorted } => ViewMode::AggregatedBottomUp { sorted },
+            ViewMode::RawSpans { sort_mode } => ViewMode::BottomUp { sort_mode },
+            ViewMode::Aggregated { sort_mode } => ViewMode::AggregatedBottomUp { sort_mode },
+            ViewMode::BottomUp { sort_mode } => ViewMode::BottomUp { sort_mode },
+            ViewMode::AggregatedBottomUp { sort_mode } => {
+                ViewMode::AggregatedBottomUp { sort_mode }
+            }
         }
     }
 
@@ -232,12 +241,12 @@ impl ViewMode {
         }
     }
 
-    fn sort_children(&self) -> bool {
+    fn sort_children(&self) -> SortMode {
         match self {
-            ViewMode::RawSpans { sorted } => *sorted,
-            ViewMode::Aggregated { sorted } => *sorted,
-            ViewMode::BottomUp { sorted } => *sorted,
-            ViewMode::AggregatedBottomUp { sorted } => *sorted,
+            ViewMode::RawSpans { sort_mode } => *sort_mode,
+            ViewMode::Aggregated { sort_mode } => *sort_mode,
+            ViewMode::BottomUp { sort_mode } => *sort_mode,
+            ViewMode::AggregatedBottomUp { sort_mode } => *sort_mode,
         }
     }
 }
@@ -357,49 +366,56 @@ impl Viewer {
         };
 
         let default_view_mode = view_rect.view_mode.as_str();
-        let (default_view_mode, default_sorted) = default_view_mode
-            .strip_suffix("-sorted")
-            .map_or((default_view_mode, false), |s| (s, true));
+        let (default_view_mode, default_sort_mode) =
+            if let Some(s) = default_view_mode.strip_suffix("-sorted-by-name") {
+                (s, SortMode::Name)
+            } else if let Some(s) = default_view_mode.strip_suffix("-sorted-by-value") {
+                (s, SortMode::Value)
+            } else if let Some(s) = default_view_mode.strip_suffix("-sorted") {
+                (s, SortMode::Value)
+            } else {
+                (default_view_mode, SortMode::ExecutionOrder)
+            };
         let (default_view_mode, with_root) = match default_view_mode {
             "aggregated" => (
                 ViewMode::Aggregated {
-                    sorted: default_sorted,
+                    sort_mode: default_sort_mode,
                 },
                 false,
             ),
             "root-aggregated" => (
                 ViewMode::Aggregated {
-                    sorted: default_sorted,
+                    sort_mode: default_sort_mode,
                 },
                 true,
             ),
             "raw-spans" => (
                 ViewMode::RawSpans {
-                    sorted: default_sorted,
+                    sort_mode: default_sort_mode,
                 },
                 false,
             ),
             "bottom-up" => (
                 ViewMode::BottomUp {
-                    sorted: default_sorted,
+                    sort_mode: default_sort_mode,
                 },
                 false,
             ),
             "aggregated-bottom-up" => (
                 ViewMode::AggregatedBottomUp {
-                    sorted: default_sorted,
+                    sort_mode: default_sort_mode,
                 },
                 false,
             ),
             "root-aggregated-bottom-up" => (
                 ViewMode::AggregatedBottomUp {
-                    sorted: default_sorted,
+                    sort_mode: default_sort_mode,
                 },
                 true,
             ),
             _ => (
                 ViewMode::Aggregated {
-                    sorted: default_sorted,
+                    sort_mode: default_sort_mode,
                 },
                 false,
             ),
@@ -616,12 +632,19 @@ impl Viewer {
                     if selected_view_mode.bottom_up() {
                         let bottom_up = span.bottom_up();
                         if selected_view_mode.aggregate_children() {
-                            let bottom_up = if selected_view_mode.sort_children() {
-                                Either::Left(bottom_up.sorted_by_cached_key(|child| {
-                                    Reverse(value_mode.value_from_bottom_up(child))
-                                }))
-                            } else {
-                                Either::Right(bottom_up)
+                            let bottom_up = match selected_view_mode.sort_children() {
+                                SortMode::Value => {
+                                    Either::Left(bottom_up.sorted_by_cached_key(|child| {
+                                        Reverse(value_mode.value_from_bottom_up(child))
+                                    }))
+                                }
+                                SortMode::Name => {
+                                    Either::Left(bottom_up.sorted_by_cached_key(|child| {
+                                        let (cat, title) = child.nice_name();
+                                        (title.to_string(), cat.to_string())
+                                    }))
+                                }
+                                SortMode::ExecutionOrder => Either::Right(bottom_up),
                             };
                             for child in bottom_up {
                                 // TODO search
@@ -639,12 +662,19 @@ impl Viewer {
                         } else {
                             let bottom_up = bottom_up
                                 .flat_map(|bottom_up| bottom_up.spans().collect::<Vec<_>>());
-                            let bottom_up = if selected_view_mode.sort_children() {
-                                Either::Left(bottom_up.sorted_by_cached_key(|child| {
-                                    Reverse(value_mode.value_from_bottom_up_span(child))
-                                }))
-                            } else {
-                                Either::Right(bottom_up)
+                            let bottom_up = match selected_view_mode.sort_children() {
+                                SortMode::Value => {
+                                    Either::Left(bottom_up.sorted_by_cached_key(|child| {
+                                        Reverse(value_mode.value_from_bottom_up_span(child))
+                                    }))
+                                }
+                                SortMode::Name => {
+                                    Either::Left(bottom_up.sorted_by_cached_key(|child| {
+                                        let (cat, title) = child.nice_name();
+                                        (title.to_string(), cat.to_string())
+                                    }))
+                                }
+                                SortMode::ExecutionOrder => Either::Right(bottom_up),
                             };
                             for child in bottom_up {
                                 let filtered = get_filter_mode(child.id());
@@ -661,12 +691,24 @@ impl Viewer {
                             }
                         }
                     } else if !selected_view_mode.aggregate_children() {
-                        let spans = if selected_view_mode.sort_children() {
-                            Either::Left(span.events().sorted_by_cached_key(|child| {
-                                Reverse(value_mode.value_from_event(child))
-                            }))
-                        } else {
-                            Either::Right(span.events().sorted_by_key(|child| child.start()))
+                        let spans = match selected_view_mode.sort_children() {
+                            SortMode::Value => {
+                                Either::Left(span.events().sorted_by_cached_key(|child| {
+                                    Reverse(value_mode.value_from_event(child))
+                                }))
+                            }
+                            SortMode::Name => {
+                                Either::Left(span.events().sorted_by_cached_key(|child| {
+                                    let (cat, title) = match child {
+                                        SpanEventRef::Child { span } => span.nice_name(),
+                                        SpanEventRef::SelfTime { .. } => ("", ""),
+                                    };
+                                    (title.to_string(), cat.to_string())
+                                }))
+                            }
+                            SortMode::ExecutionOrder => {
+                                Either::Right(span.events().sorted_by_key(|child| child.start()))
+                            }
                         };
                         for child in spans {
                             match child {
@@ -689,12 +731,22 @@ impl Viewer {
                             }
                         }
                     } else {
-                        let events = if selected_view_mode.sort_children() {
-                            Either::Left(span.graph().sorted_by_cached_key(|child| {
-                                Reverse(value_mode.value_from_graph_event(child))
-                            }))
-                        } else {
-                            Either::Right(span.graph())
+                        let events = match selected_view_mode.sort_children() {
+                            SortMode::Value => {
+                                Either::Left(span.graph().sorted_by_cached_key(|child| {
+                                    Reverse(value_mode.value_from_graph_event(child))
+                                }))
+                            }
+                            SortMode::Name => {
+                                Either::Left(span.graph().sorted_by_cached_key(|child| {
+                                    let (cat, title) = match child {
+                                        SpanGraphEventRef::Child { graph } => graph.nice_name(),
+                                        SpanGraphEventRef::SelfTime { .. } => ("", ""),
+                                    };
+                                    (title.to_string(), cat.to_string())
+                                }))
+                            }
+                            SortMode::ExecutionOrder => Either::Right(span.graph()),
                         };
                         for event in events {
                             let filtered = if search_mode {
@@ -735,12 +787,19 @@ impl Viewer {
                     if selected_view_mode.bottom_up() {
                         let bottom_up = span_graph.bottom_up();
                         if selected_view_mode.aggregate_children() {
-                            let bottom_up = if selected_view_mode.sort_children() {
-                                Either::Left(bottom_up.sorted_by_cached_key(|child| {
-                                    Reverse(value_mode.value_from_bottom_up(child))
-                                }))
-                            } else {
-                                Either::Right(bottom_up)
+                            let bottom_up = match selected_view_mode.sort_children() {
+                                SortMode::Value => {
+                                    Either::Left(bottom_up.sorted_by_cached_key(|child| {
+                                        Reverse(value_mode.value_from_bottom_up(child))
+                                    }))
+                                }
+                                SortMode::Name => {
+                                    Either::Left(bottom_up.sorted_by_cached_key(|child| {
+                                        let (cat, title) = child.nice_name();
+                                        (title.to_string(), cat.to_string())
+                                    }))
+                                }
+                                SortMode::ExecutionOrder => Either::Right(bottom_up),
                             };
                             for child in bottom_up {
                                 // TODO search
@@ -758,12 +817,21 @@ impl Viewer {
                         } else {
                             let bottom_up = bottom_up
                                 .flat_map(|bottom_up| bottom_up.spans().collect::<Vec<_>>());
-                            let bottom_up = if selected_view_mode.sort_children() {
-                                Either::Left(bottom_up.sorted_by_cached_key(|child| {
-                                    Reverse(value_mode.value_from_bottom_up_span(child))
-                                }))
-                            } else {
-                                Either::Right(bottom_up.sorted_by_key(|child| child.start()))
+                            let bottom_up = match selected_view_mode.sort_children() {
+                                SortMode::Value => {
+                                    Either::Left(bottom_up.sorted_by_cached_key(|child| {
+                                        Reverse(value_mode.value_from_bottom_up_span(child))
+                                    }))
+                                }
+                                SortMode::Name => {
+                                    Either::Left(bottom_up.sorted_by_cached_key(|child| {
+                                        let (cat, title) = child.nice_name();
+                                        (title.to_string(), cat.to_string())
+                                    }))
+                                }
+                                SortMode::ExecutionOrder => {
+                                    Either::Right(bottom_up.sorted_by_key(|child| child.start()))
+                                }
                             };
                             for child in bottom_up {
                                 let filtered = get_filter_mode(child.id());
@@ -780,14 +848,21 @@ impl Viewer {
                             }
                         }
                     } else if !selected_view_mode.aggregate_children() && span_graph.count() > 1 {
-                        let spans = if selected_view_mode.sort_children() {
-                            Either::Left(span_graph.root_spans().sorted_by_cached_key(|child| {
-                                Reverse(value_mode.value_from_span(child))
-                            }))
-                        } else {
-                            Either::Right(
+                        let spans = match selected_view_mode.sort_children() {
+                            SortMode::Value => {
+                                Either::Left(span_graph.root_spans().sorted_by_cached_key(
+                                    |child| Reverse(value_mode.value_from_span(child)),
+                                ))
+                            }
+                            SortMode::Name => Either::Left(
+                                span_graph.root_spans().sorted_by_cached_key(|child| {
+                                    let (cat, title) = child.nice_name();
+                                    (title.to_string(), cat.to_string())
+                                }),
+                            ),
+                            SortMode::ExecutionOrder => Either::Right(
                                 span_graph.root_spans().sorted_by_key(|child| child.start()),
-                            )
+                            ),
                         };
                         for child in spans {
                             let filtered = get_filter_mode(child.id());
@@ -803,12 +878,22 @@ impl Viewer {
                             );
                         }
                     } else {
-                        let events = if selected_view_mode.sort_children() {
-                            Either::Left(span_graph.events().sorted_by_cached_key(|child| {
-                                Reverse(value_mode.value_from_graph_event(child))
-                            }))
-                        } else {
-                            Either::Right(span_graph.events())
+                        let events = match selected_view_mode.sort_children() {
+                            SortMode::Value => {
+                                Either::Left(span_graph.events().sorted_by_cached_key(|child| {
+                                    Reverse(value_mode.value_from_graph_event(child))
+                                }))
+                            }
+                            SortMode::Name => {
+                                Either::Left(span_graph.events().sorted_by_cached_key(|child| {
+                                    let (cat, title) = match child {
+                                        SpanGraphEventRef::Child { graph } => graph.nice_name(),
+                                        SpanGraphEventRef::SelfTime { .. } => ("", ""),
+                                    };
+                                    (title.to_string(), cat.to_string())
+                                }))
+                            }
+                            SortMode::ExecutionOrder => Either::Right(span_graph.events()),
                         };
                         for child in events {
                             if let SpanGraphEventRef::Child { graph } = child {
@@ -840,12 +925,19 @@ impl Viewer {
                         .unwrap_or(view_mode);
 
                     if view_mode.aggregate_children() {
-                        let bottom_up = if view_mode.sort_children() {
-                            Either::Left(bottom_up.children().sorted_by_cached_key(|child| {
-                                Reverse(value_mode.value_from_bottom_up(child))
-                            }))
-                        } else {
-                            Either::Right(bottom_up.children())
+                        let bottom_up = match view_mode.sort_children() {
+                            SortMode::Value => {
+                                Either::Left(bottom_up.children().sorted_by_cached_key(|child| {
+                                    Reverse(value_mode.value_from_bottom_up(child))
+                                }))
+                            }
+                            SortMode::Name => {
+                                Either::Left(bottom_up.children().sorted_by_cached_key(|child| {
+                                    let (cat, title) = child.nice_name();
+                                    (title.to_string(), cat.to_string())
+                                }))
+                            }
+                            SortMode::ExecutionOrder => Either::Right(bottom_up.children()),
                         };
                         for child in bottom_up {
                             // TODO search
@@ -861,12 +953,21 @@ impl Viewer {
                             );
                         }
                     } else {
-                        let spans = if view_mode.sort_children() {
-                            Either::Left(bottom_up.spans().sorted_by_cached_key(|child| {
-                                Reverse(value_mode.value_from_bottom_up_span(child))
-                            }))
-                        } else {
-                            Either::Right(bottom_up.spans().sorted_by_key(|child| child.start()))
+                        let spans = match view_mode.sort_children() {
+                            SortMode::Value => {
+                                Either::Left(bottom_up.spans().sorted_by_cached_key(|child| {
+                                    Reverse(value_mode.value_from_bottom_up_span(child))
+                                }))
+                            }
+                            SortMode::Name => {
+                                Either::Left(bottom_up.spans().sorted_by_cached_key(|child| {
+                                    let (cat, title) = child.nice_name();
+                                    (title.to_string(), cat.to_string())
+                                }))
+                            }
+                            SortMode::ExecutionOrder => Either::Right(
+                                bottom_up.spans().sorted_by_key(|child| child.start()),
+                            ),
                         };
                         for child in spans {
                             let filtered = get_filter_mode(child.id());


### PR DESCRIPTION
### What?

Replaces the boolean `sort` flag in the trace server with a `SortMode` enum supporting three modes:
- **`ExecutionOrder`** — no sorting, spans appear in natural/execution order (previous `false`)
- **`Value`** — sort by corrected duration descending (previous `true`)
- **`Name`** — sort alphabetically by span name (title), then by category

### Why?

The boolean `sort` only allowed toggling duration-based sorting on/off. Adding alphabetical sorting by name makes it easier to find duplicate spans and locate a specific span by name in the trace viewer. The enum is extensible for future sort modes without breaking changes.

### How?

**Rust (`turbopack-trace-server`):**
- Added `SortMode { ExecutionOrder, Value, Name }` enum to both `lib.rs` (for the query API) and `viewer.rs` (for the WebSocket viewer).
- `ViewMode` variants changed from `sorted: bool` to `sort_mode: SortMode`.
- `sort_children()` now returns `SortMode` instead of `bool`; all 10 sorting branches in `viewer.rs` converted from `if/else` to a 3-arm `match`.
- `Name` sort uses `nice_name()` — sorts by title first, then category, both ascending.
- `SpanEventRef::SelfTime` and `SpanGraphEventRef::SelfTime` (which have no name) sort as `("", "")` under `Name` mode.

**WebSocket protocol (backward compatible):**
- `-sorted` suffix → `SortMode::Value` (existing clients unaffected)
- `-sorted-by-value` suffix → `SortMode::Value`
- `-sorted-by-name` suffix → `SortMode::Name`
- no suffix → `SortMode::ExecutionOrder`

**napi bindings (`next-napi-bindings`):**
- `TraceQueryOptions.sort` changed from `Option<bool>` to `Option<String>` (`"value"` | `"name"` | omit).

**TypeScript:**
- `generated-native.d.ts`: `sort?: 'value' | 'name'`
- MCP tool schema: `z.enum(['value', 'name']).optional()`
- CLI: `--sort <mode>` with `.choices(['value', 'name'])` replacing the boolean `--sort` flag
- Tests updated; added new test cases for `sort: 'name'` and `--sort name`

<!-- NEXT_JS_LLM_PR -->