### PR TITLE
turbo-tasks: add info_span for blocking waits during task restore

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -14,6 +14,7 @@ use std::{
 
 use anyhow::{Context, Result, bail};
 use bincode::{Decode, Encode};
+use tracing::info_span;
 #[cfg(feature = "trace_prepare_tasks")]
 use tracing::trace_span;
 use turbo_tasks::{
@@ -264,6 +265,7 @@ impl<'e, B: BackingStorage> ExecuteContextImpl<'e, B> {
 
             // Still restoring; drop the lock and block until notified, then loop to re-check.
             drop(task);
+            let _span = info_span!("blocking").entered();
             listener.wait();
         }
     }


### PR DESCRIPTION
### What?

Adds a `tracing::info_span!("blocking")` around `listener.wait()` calls in `ExecuteContextImpl::task()` when a task is still being restored from backing storage.

### Why?

When a task is locked for restoration by another thread, the current thread spins in a loop and calls `listener.wait()` until notified. CPU time accounting treats this waiting time as active CPU usage, which skews profiling results.

By wrapping the wait in a `"blocking"` span, the tracing infrastructure can correctly exclude this idle blocking time from CPU time — ensuring CPU metrics reflect actual computation rather than time spent waiting for another thread to finish restoring a task.

### How?

Import `tracing::info_span` and enter a `"blocking"` span immediately before `listener.wait()` in the restore-wait loop in `turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs`. The span is dropped when the wait returns (or when the loop continues to re-check the condition).

<!-- NEXT_JS_LLM_PR -->