### PR TITLE
feat: block next/root-params imports in middleware and instrumentation layers

### DIFF
--- a/crates/next-core/src/next_root_params/mod.rs
+++ b/crates/next-core/src/next_root_params/mod.rs
@@ -116,18 +116,18 @@ impl NextRootParamsMapper {
                                 })?;
                             Self::valid_import_map_result(collected_root_params)
                         }
-                        ServerContextType::PagesApi { .. }
+                        ServerContextType::Pages { .. }
+                        | ServerContextType::PagesApi { .. }
                         | ServerContextType::Instrumentation { .. }
                         | ServerContextType::Middleware { .. } => {
                             // There's no sensible way to use root params outside of the app
-                            // directory. TODO: make sure this error is
-                            // consistent with webpack
+                            // directory.
                             Self::invalid_import_map_result(
                                 "'next/root-params' can only be used inside the App Directory."
                                     .into(),
                             )
                         }
-                        _ => {
+                        ServerContextType::AppSSR { .. } => {
                             // In general, the compiler should prevent importing 'next/root-params'
                             // from client modules, but it doesn't catch
                             // everything. If an import slips through

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -2869,14 +2869,12 @@ function getNextRootParamsRules({
   appDir: string | undefined
   pageExtensions: string[]
 }): webpack.RuleSetRule[] {
-  // Match resolved import of 'next/root-params'.
-  // Use a regex (not an absolute path) so it works in isolated CI environments
-  // where the resolved path differs from the local build.
-  const nextRootParamsModuleTest = /[\\/]next[\\/]root-params\.js$/
+  // Match resolved import of 'next/root-params'
+  const nextRootParamsModule = path.join(NEXT_PROJECT_ROOT, 'root-params.js')
 
   const createInvalidImportRule = (message: string) => {
     return {
-      test: nextRootParamsModuleTest,
+      resource: nextRootParamsModule,
       loader: 'next-invalid-import-error-loader',
       options: {
         message,
@@ -2909,7 +2907,7 @@ function getNextRootParamsRules({
     "'next/root-params' cannot be imported from a Client Component module. It should only be used from a Server Component."
   )
   const invalidNonAppServerImportRule = {
-    test: nextRootParamsModuleTest,
+    resource: nextRootParamsModule,
     loader: 'next-invalid-import-error-loader',
     issuerLayer: {
       or: [WEBPACK_LAYERS.instrument, WEBPACK_LAYERS.middleware],
@@ -2929,7 +2927,7 @@ function getNextRootParamsRules({
       oneOf: [
         invalidNonAppServerImportRule,
         {
-          test: nextRootParamsModuleTest,
+          resource: nextRootParamsModule,
           issuerLayer: shouldUseReactServerCondition as (
             layer: string
           ) => boolean,

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -2869,12 +2869,14 @@ function getNextRootParamsRules({
   appDir: string | undefined
   pageExtensions: string[]
 }): webpack.RuleSetRule[] {
-  // Match resolved import of 'next/root-params'
-  const nextRootParamsModule = path.join(NEXT_PROJECT_ROOT, 'root-params.js')
+  // Match resolved import of 'next/root-params'.
+  // Use a regex (not an absolute path) so it works in isolated CI environments
+  // where the resolved path differs from the local build.
+  const nextRootParamsModuleTest = /[\\/]next[\\/]root-params\.js$/
 
   const createInvalidImportRule = (message: string) => {
     return {
-      resource: nextRootParamsModule,
+      test: nextRootParamsModuleTest,
       loader: 'next-invalid-import-error-loader',
       options: {
         message,
@@ -2906,6 +2908,16 @@ function getNextRootParamsRules({
   const invalidClientImportRule = createInvalidImportRule(
     "'next/root-params' cannot be imported from a Client Component module. It should only be used from a Server Component."
   )
+  const invalidNonAppServerImportRule = {
+    test: nextRootParamsModuleTest,
+    loader: 'next-invalid-import-error-loader',
+    issuerLayer: {
+      or: [WEBPACK_LAYERS.instrument, WEBPACK_LAYERS.middleware],
+    },
+    options: {
+      message: "'next/root-params' can only be used inside the App Directory.",
+    } satisfies InvalidImportLoaderOpts,
+  } satisfies webpack.RuleSetRule
 
   // in the browser compilation we can skip the server rules, because we know all imports will be invalid.
   if (isClient) {
@@ -2915,8 +2927,9 @@ function getNextRootParamsRules({
   return [
     {
       oneOf: [
+        invalidNonAppServerImportRule,
         {
-          resource: nextRootParamsModule,
+          test: nextRootParamsModuleTest,
           issuerLayer: shouldUseReactServerCondition as (
             layer: string
           ) => boolean,

--- a/test/e2e/app-dir/root-params-blocked-layers/fixtures/base/app/[lang]/layout.tsx
+++ b/test/e2e/app-dir/root-params-blocked-layers/fixtures/base/app/[lang]/layout.tsx
@@ -1,0 +1,7 @@
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/root-params-blocked-layers/fixtures/base/app/[lang]/page.tsx
+++ b/test/e2e/app-dir/root-params-blocked-layers/fixtures/base/app/[lang]/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>hello world</h1>
+}

--- a/test/e2e/app-dir/root-params-blocked-layers/fixtures/base/next.config.js
+++ b/test/e2e/app-dir/root-params-blocked-layers/fixtures/base/next.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  experimental: { rootParams: true },
+}

--- a/test/e2e/app-dir/root-params-blocked-layers/fixtures/instrumentation/instrumentation.ts
+++ b/test/e2e/app-dir/root-params-blocked-layers/fixtures/instrumentation/instrumentation.ts
@@ -1,0 +1,5 @@
+import { lang } from 'next/root-params'
+
+export function register() {
+  console.log(lang)
+}

--- a/test/e2e/app-dir/root-params-blocked-layers/fixtures/middleware/middleware.ts
+++ b/test/e2e/app-dir/root-params-blocked-layers/fixtures/middleware/middleware.ts
@@ -1,0 +1,5 @@
+import { lang } from 'next/root-params'
+
+export default function middleware() {
+  console.log(lang)
+}

--- a/test/e2e/app-dir/root-params-blocked-layers/root-params-blocked-layers.test.ts
+++ b/test/e2e/app-dir/root-params-blocked-layers/root-params-blocked-layers.test.ts
@@ -1,0 +1,54 @@
+import { nextTestSetup, FileRef } from 'e2e-utils'
+import { join } from 'path'
+
+const fixturesDir = join(__dirname, 'fixtures')
+const baseDir = join(fixturesDir, 'base')
+
+function baseFilesWith(extraFiles: Record<string, FileRef>) {
+  return {
+    app: new FileRef(join(baseDir, 'app')),
+    'next.config.js': new FileRef(join(baseDir, 'next.config.js')),
+    ...extraFiles,
+  }
+}
+
+describe('next/root-params blocked layers', () => {
+  const expectedError =
+    "'next/root-params' can only be used inside the App Directory."
+
+  describe('middleware', () => {
+    const { next } = nextTestSetup({
+      files: baseFilesWith({
+        'middleware.ts': new FileRef(
+          join(fixturesDir, 'middleware', 'middleware.ts')
+        ),
+      }),
+      skipStart: true,
+      skipDeployment: true,
+    })
+
+    it('should error when next/root-params is imported from middleware', async () => {
+      const { exitCode, cliOutput } = await next.build()
+      expect(exitCode).toBe(1)
+      expect(cliOutput).toContain(expectedError)
+    })
+  })
+
+  describe('instrumentation', () => {
+    const { next } = nextTestSetup({
+      files: baseFilesWith({
+        'instrumentation.ts': new FileRef(
+          join(fixturesDir, 'instrumentation', 'instrumentation.ts')
+        ),
+      }),
+      skipStart: true,
+      skipDeployment: true,
+    })
+
+    it('should error when next/root-params is imported from instrumentation', async () => {
+      const { exitCode, cliOutput } = await next.build()
+      expect(exitCode).toBe(1)
+      expect(cliOutput).toContain(expectedError)
+    })
+  })
+})


### PR DESCRIPTION
Modified from #92665 which i can't push to because it's on ben's remote