### PR TITLE
Turbopack: move import_usage computation into ImportMap

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/graph.rs
@@ -31,9 +31,7 @@ use crate::{
     AnalyzeMode, SpecifiedModuleType,
     analyzer::{WellKnownObjectKind, is_unresolved},
     code_gen::CodeGen,
-    references::{
-        constant_value::parse_single_expr_lit, esm::EsmModuleItem, for_each_ident_in_pat,
-    },
+    references::{constant_value::parse_single_expr_lit, esm::EsmModuleItem},
     utils::{AstPathRange, unparen},
 };
 
@@ -308,30 +306,6 @@ impl AssignmentScopes {
     }
 }
 
-#[derive(Clone, Debug)]
-pub enum DeclUsage {
-    SideEffects,
-    Bindings(FxHashSet<Id>),
-}
-impl Default for DeclUsage {
-    fn default() -> Self {
-        DeclUsage::Bindings(Default::default())
-    }
-}
-impl DeclUsage {
-    fn add_usage(&mut self, user: &Id) {
-        match self {
-            Self::Bindings(set) => {
-                set.insert(user.clone());
-            }
-            Self::SideEffects => {}
-        }
-    }
-    fn make_side_effects(&mut self) {
-        *self = Self::SideEffects;
-    }
-}
-
 #[derive(Debug)]
 pub struct VarGraph {
     pub values: FxHashMap<Id, JsValue>,
@@ -345,13 +319,6 @@ pub struct VarGraph {
     pub effects: Vec<Effect>,
     // Some unconditional codegens, usually for ESM items.
     pub code_gens: Vec<CodeGen>,
-
-    // ident -> immediate usage (top level decl)
-    pub decl_usages: FxHashMap<Id, DeclUsage>,
-    // import -> immediate usage (top level decl)
-    pub import_usages: FxHashMap<usize, DeclUsage>,
-    // export name -> top level decl
-    pub exports: FxHashMap<Atom, Id>,
 }
 
 impl VarGraph {
@@ -376,9 +343,6 @@ pub fn create_graph(
         free_var_ids: Default::default(),
         effects: Default::default(),
         code_gens: Default::default(),
-        decl_usages: Default::default(),
-        import_usages: Default::default(),
-        exports: Default::default(),
     };
 
     m.visit_with_ast_path(
@@ -429,7 +393,9 @@ impl EvalContext {
         Self {
             unresolved_mark,
             top_level_mark,
-            imports: module.map_or(ImportMap::default(), |m| ImportMap::analyze(m, comments)),
+            imports: module.map_or(ImportMap::default(), |m| {
+                ImportMap::analyze(unresolved_mark, m, comments)
+            }),
             force_free_values,
         }
     }
@@ -1014,15 +980,6 @@ mod analyzer_state {
         early_return_stack: Vec<EarlyReturn>,
         lexical_stack: Vec<LexicalContext>,
         var_decl_kind: Option<VarDeclKind>,
-
-        cur_top_level_decl_name: Option<Id>,
-    }
-
-    impl AnalyzerState {
-        /// Returns the identifier of the current top level declaration.
-        pub(super) fn cur_top_level_decl_name(&self) -> &Option<Id> {
-            &self.cur_top_level_decl_name
-        }
     }
 
     impl Analyzer<'_> {
@@ -1316,23 +1273,6 @@ mod analyzer_state {
                 }
             }
             always_returns
-        }
-
-        /// Runs `visitor` with the current top level declaration identifier
-        pub(super) fn enter_top_level_decl<T>(
-            &mut self,
-            name: &Ident,
-            visitor: impl FnOnce(&mut Self) -> T,
-        ) -> T {
-            let is_top_level_fn = self.state.cur_top_level_decl_name.is_none();
-            if is_top_level_fn {
-                self.state.cur_top_level_decl_name = Some(name.to_id());
-            }
-            let result = visitor(self);
-            if is_top_level_fn {
-                self.state.cur_top_level_decl_name = None;
-            }
-            result
         }
     }
 }
@@ -2128,10 +2068,8 @@ impl VisitAstPath for Analyzer<'_> {
         decl: &'ast FnDecl,
         ast_path: &mut AstNodePath<AstParentNodeRef<'r>>,
     ) {
-        let fn_value = self.enter_top_level_decl(&decl.ident, |this| {
-            this.enter_fn(&*decl.function, |this| {
-                decl.visit_children_with_ast_path(this, ast_path);
-            })
+        let fn_value = self.enter_fn(&*decl.function, |this| {
+            decl.visit_children_with_ast_path(this, ast_path);
         });
 
         // Take all effects produced by the function and move them to hoisted effects since
@@ -2608,17 +2546,6 @@ impl VisitAstPath for Analyzer<'_> {
         if let Some((esm_reference_index, export)) =
             self.eval_context.imports.get_binding(&ident.to_id())
         {
-            let usage = self
-                .data
-                .import_usages
-                .entry(esm_reference_index)
-                .or_default();
-            if let Some(top_level) = self.state.cur_top_level_decl_name() {
-                usage.add_usage(top_level);
-            } else {
-                usage.make_side_effects();
-            }
-
             // Optimization: Look for a MemberExpr to see if we only access a few members from the
             // module, add those specific effects instead of depending on the entire module.
             //
@@ -2664,24 +2591,6 @@ impl VisitAstPath for Analyzer<'_> {
                 ast_path: as_parent_path(ast_path),
                 span: ident.span(),
             })
-        }
-
-        if !is_unresolved(ident, self.eval_context.unresolved_mark) {
-            if let Some(top_level) = self.state.cur_top_level_decl_name() {
-                if !(ident.sym == top_level.0 && ident.ctxt == top_level.1) {
-                    self.data
-                        .decl_usages
-                        .entry(ident.to_id())
-                        .or_default()
-                        .add_usage(top_level);
-                }
-            } else {
-                self.data
-                    .decl_usages
-                    .entry(ident.to_id())
-                    .or_default()
-                    .make_side_effects();
-            }
         }
     }
 
@@ -2998,32 +2907,6 @@ impl VisitAstPath for Analyzer<'_> {
         node: &'ast ExportDecl,
         ast_path: &mut swc_core::ecma::visit::AstNodePath<'r>,
     ) {
-        match &node.decl {
-            Decl::Class(node) => {
-                self.data
-                    .exports
-                    .insert(node.ident.sym.clone(), node.ident.to_id());
-            }
-            Decl::Fn(node) => {
-                self.data
-                    .exports
-                    .insert(node.ident.sym.clone(), node.ident.to_id());
-            }
-            Decl::Var(node) => {
-                for VarDeclarator { name, .. } in &node.decls {
-                    for_each_ident_in_pat(name, &mut |name, ctxt| {
-                        self.data.exports.insert(name.clone(), (name.clone(), ctxt));
-                    });
-                }
-            }
-            Decl::Using(_) => {
-                // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export#:~:text=You%20cannot%20use%20export%20on%20a%20using%20or%20await%20using%20declaration
-                unreachable!("using declarations can not be exported");
-            }
-            Decl::TsInterface(_) | Decl::TsTypeAlias(_) | Decl::TsEnum(_) | Decl::TsModule(_) => {
-                // ignore typescript for code generation
-            }
-        };
         self.add_esm_module_item(ast_path);
         node.visit_children_with_ast_path(self, ast_path);
     }
@@ -3036,19 +2919,6 @@ impl VisitAstPath for Analyzer<'_> {
         if node.is_type_only {
             return;
         }
-        let export_name = node
-            .exported
-            .as_ref()
-            .unwrap_or(&node.orig)
-            .atom()
-            .into_owned();
-        self.data.exports.insert(
-            export_name,
-            match &node.orig {
-                ModuleExportName::Ident(ident) => ident.to_id(),
-                ModuleExportName::Str(_) => unreachable!("exporting a string should be impossible"),
-            },
-        );
         node.visit_children_with_ast_path(self, ast_path);
     }
 

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/graph.rs
@@ -2572,7 +2572,7 @@ impl VisitAstPath for Analyzer<'_> {
             } else {
                 self.add_effect(Effect::ImportedBinding {
                     esm_reference_index,
-                    export,
+                    export: export.map(|e| RcStr::from(e.as_str())),
                     ast_path: as_parent_path(ast_path),
                     span: ident.span(),
                 })

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
@@ -22,7 +22,7 @@ use swc_core::{
 use turbo_frozenmap::FrozenMap;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{FxIndexMap, FxIndexSet, ResolvedVc};
-use turbopack_core::loader::WebpackLoaderItem;
+use turbopack_core::{loader::WebpackLoaderItem, resolve::ImportUsage};
 
 use super::{JsValue, ModuleValue, top_level_await::has_top_level_await};
 use crate::{
@@ -280,13 +280,61 @@ impl DeclUsage {
 }
 
 #[derive(Default, Debug)]
-pub(crate) struct ImportUsage {
+pub(crate) struct ProgramDeclUsage {
     // ident -> immediate usage (top level decl)
     pub(crate) decl_usages: FxHashMap<Id, DeclUsage>,
     // import -> immediate usage (top level decl)
     pub(crate) import_usages: FxHashMap<usize, DeclUsage>,
     // export name -> top level decl
     pub(crate) exports: FxHashMap<Atom, Id>,
+}
+impl ProgramDeclUsage {
+    fn compute_import_usage(&self) -> FxHashMap<usize, ImportUsage> {
+        let mut import_usage =
+            FxHashMap::with_capacity_and_hasher(self.import_usages.len(), Default::default());
+        for (reference, usage) in &self.import_usages {
+            // TODO make this more efficient, i.e. cache the result?
+            if let DeclUsage::Bindings(ids) = usage {
+                // compute transitive closure of `ids` over `top_level_mappings`
+                let mut visited = ids.clone();
+                let mut stack = ids.iter().collect::<Vec<_>>();
+                let mut has_global_usage = false;
+                while let Some(id) = stack.pop() {
+                    match self.decl_usages.get(id) {
+                        Some(DeclUsage::SideEffects) => {
+                            has_global_usage = true;
+                            break;
+                        }
+                        Some(DeclUsage::Bindings(callers)) => {
+                            for caller in callers {
+                                if visited.insert(caller.clone()) {
+                                    stack.push(caller);
+                                }
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+
+                // Collect all `visited` declarations which are exported
+                import_usage.insert(
+                    *reference,
+                    if has_global_usage {
+                        ImportUsage::TopLevel
+                    } else {
+                        ImportUsage::Exports(
+                            self.exports
+                                .iter()
+                                .filter(|(_, id)| visited.contains(*id))
+                                .map(|(exported, _)| exported.as_str().into())
+                                .collect(),
+                        )
+                    },
+                );
+            }
+        }
+        import_usage
+    }
 }
 
 /// A version of [crate::references::esm::export::EsmExport] with usize instead of the module
@@ -358,7 +406,7 @@ pub(crate) struct ImportMap {
     /// whether an export is live or not.
     pub(super) assignment_scopes: FxHashMap<Id, AssignmentScopes>,
 
-    pub(crate) import_usage: ImportUsage,
+    pub(crate) import_usage: FxHashMap<usize, ImportUsage>,
 
     /// Map from exported name to local binding id (includes the syntax context).
     pub(crate) exports_ids: FxHashMap<RcStr, Id>,
@@ -604,6 +652,7 @@ impl ImportMap {
             comments,
             namespace_imports_to_specifier: FxIndexMap::default(),
             state: Default::default(),
+            program_decl_usage: Default::default(),
         };
 
         // A prepass to detect imports to be able to rewrite import+export pairs to true reexports
@@ -707,6 +756,8 @@ impl ImportMap {
 
         m.visit_with(&mut analyzer);
 
+        data.import_usage = analyzer.program_decl_usage.compute_import_usage();
+
         data
     }
 
@@ -776,6 +827,8 @@ struct Analyzer<'a> {
     /// Map from local identifier of namespace imports to module path, used temporarily during
     /// analysis to detect dynamic accesses to namespace imports.
     namespace_imports_to_specifier: FxIndexMap<Id, Wtf8Atom>,
+
+    program_decl_usage: ProgramDeclUsage,
 
     state: analyzer_state::AnalyzerState,
 }
@@ -958,8 +1011,7 @@ impl Visit for Analyzer<'_> {
                     .exports
                     .insert(name.clone(), Export::LocalBinding(name.clone(), false));
                 self.data.exports_ids.insert(name, n.ident.to_id());
-                self.data
-                    .import_usage
+                self.program_decl_usage
                     .exports
                     .insert(n.ident.sym.clone(), n.ident.to_id());
             }
@@ -969,8 +1021,7 @@ impl Visit for Analyzer<'_> {
                     .exports
                     .insert(name.clone(), Export::LocalBinding(name.clone(), false));
                 self.data.exports_ids.insert(name, n.ident.to_id());
-                self.data
-                    .import_usage
+                self.program_decl_usage
                     .exports
                     .insert(n.ident.sym.clone(), n.ident.to_id());
             }
@@ -981,8 +1032,7 @@ impl Visit for Analyzer<'_> {
                     self.data
                         .exports
                         .insert(name.clone(), Export::LocalBinding(name.clone(), false));
-                    self.data
-                        .import_usage
+                    self.program_decl_usage
                         .exports
                         .insert(id.0.clone(), id.clone());
                     self.data.exports_ids.insert(name, id);
@@ -1063,8 +1113,7 @@ impl Visit for Analyzer<'_> {
             .exports_ids
             .insert(exported.as_str().into(), local.to_id());
 
-        self.data
-            .import_usage
+        self.program_decl_usage
             .exports
             .insert(exported.into_owned(), local.to_id());
         n.visit_children_with(self);
@@ -1216,8 +1265,7 @@ impl Visit for Analyzer<'_> {
         if let Some((esm_reference_index, _)) = self.data.get_binding(&id) {
             // An import binding
             let usage = self
-                .data
-                .import_usage
+                .program_decl_usage
                 .import_usages
                 .entry(esm_reference_index)
                 .or_default();
@@ -1231,16 +1279,14 @@ impl Visit for Analyzer<'_> {
             if !is_unresolved(node, self.unresolved_mark) {
                 if let Some(top_level) = self.state.cur_top_level_decl_name() {
                     if &id != top_level {
-                        self.data
-                            .import_usage
+                        self.program_decl_usage
                             .decl_usages
                             .entry(id)
                             .or_default()
                             .add_usage(top_level);
                     }
                 } else {
-                    self.data
-                        .import_usage
+                    self.program_decl_usage
                         .decl_usages
                         .entry(id)
                         .or_default()

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
@@ -286,7 +286,7 @@ pub(crate) struct ProgramDeclUsage {
     // import -> immediate usage (top level decl)
     pub(crate) import_usages: FxHashMap<usize, DeclUsage>,
     // export name -> top level decl
-    pub(crate) exports: FxHashMap<Atom, Id>,
+    pub(crate) exports: FxHashMap<RcStr, Id>,
 }
 impl ProgramDeclUsage {
     fn compute_import_usage(&self) -> FxHashMap<usize, ImportUsage> {
@@ -326,7 +326,7 @@ impl ProgramDeclUsage {
                             self.exports
                                 .iter()
                                 .filter(|(_, id)| visited.contains(*id))
-                                .map(|(exported, _)| exported.as_str().into())
+                                .map(|(exported, _)| exported.clone())
                                 .collect(),
                         )
                     },
@@ -1013,20 +1013,20 @@ impl Visit for Analyzer<'_> {
                 self.data
                     .exports
                     .insert(name.clone(), Export::LocalBinding(name.clone(), false));
-                self.data.exports_ids.insert(name, n.ident.to_id());
+                self.data.exports_ids.insert(name.clone(), n.ident.to_id());
                 self.program_decl_usage
                     .exports
-                    .insert(n.ident.sym.clone(), n.ident.to_id());
+                    .insert(name, n.ident.to_id());
             }
             Decl::Fn(n) => {
                 let name = RcStr::from(n.ident.sym.as_str());
                 self.data
                     .exports
                     .insert(name.clone(), Export::LocalBinding(name.clone(), false));
-                self.data.exports_ids.insert(name, n.ident.to_id());
+                self.data.exports_ids.insert(name.clone(), n.ident.to_id());
                 self.program_decl_usage
                     .exports
-                    .insert(n.ident.sym.clone(), n.ident.to_id());
+                    .insert(name, n.ident.to_id());
             }
             Decl::Var(..) => {
                 let ids: Vec<Id> = find_pat_ids(&n.decl);
@@ -1035,10 +1035,8 @@ impl Visit for Analyzer<'_> {
                     self.data
                         .exports
                         .insert(name.clone(), Export::LocalBinding(name.clone(), false));
-                    self.program_decl_usage
-                        .exports
-                        .insert(id.0.clone(), id.clone());
-                    self.data.exports_ids.insert(name, id);
+                    self.data.exports_ids.insert(name.clone(), id.clone());
+                    self.program_decl_usage.exports.insert(name, id);
                 }
             }
             Decl::Using(_) => {
@@ -1108,17 +1106,16 @@ impl Visit for Analyzer<'_> {
     fn visit_export_named_specifier(&mut self, n: &ExportNamedSpecifier) {
         self.data.has_exports = true;
 
-        let exported = n.exported.as_ref().unwrap_or(&n.orig).atom();
         let ModuleExportName::Ident(local) = &n.orig else {
             unreachable!("exporting a string should be impossible")
         };
+        let exported = RcStr::from(n.exported.as_ref().unwrap_or(&n.orig).atom().as_str());
         self.data
             .exports_ids
-            .insert(exported.as_str().into(), local.to_id());
-
+            .insert(exported.clone(), local.to_id());
         self.program_decl_usage
             .exports
-            .insert(exported.into_owned(), local.to_id());
+            .insert(exported, local.to_id());
         n.visit_children_with(self);
     }
 

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
@@ -1229,6 +1229,11 @@ impl Visit for Analyzer<'_> {
         {
             // Skip traversing if obj is a Expr::Ident, so that it doesn't get added to
             // full_star_imports below in visit_expr.
+
+            // TODO this currently doesn't properly mark the import in self.program_decl_usage, see
+            // todo in
+            // turbopack/crates/turbopack-tests/tests/execution/turbopack/remove-unused-imports/
+            // import-star/input/index.js
             return;
         }
         node.visit_children_with(self);

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
@@ -11,7 +11,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::SmallVec;
 use swc_core::{
     atoms::Wtf8Atom,
-    common::{BytePos, Span, Spanned, SyntaxContext, comments::Comments},
+    common::{BytePos, Mark, Span, Spanned, SyntaxContext, comments::Comments},
     ecma::{
         ast::*,
         atoms::{Atom, atom},
@@ -30,6 +30,7 @@ use crate::{
     analyzer::{
         ConstantValue, ObjectPart,
         graph::{AssignmentScope, AssignmentScopes, EvalContext},
+        is_unresolved,
     },
     magic_identifier::{MAGIC_IDENTIFIER_DEFAULT_EXPORT, MAGIC_IDENTIFIER_DEFAULT_EXPORT_ATOM},
     references::{
@@ -254,6 +255,40 @@ impl Display for ImportAnnotations {
     }
 }
 
+#[derive(Clone, Debug)]
+pub enum DeclUsage {
+    SideEffects,
+    Bindings(FxHashSet<Id>),
+}
+impl Default for DeclUsage {
+    fn default() -> Self {
+        DeclUsage::Bindings(Default::default())
+    }
+}
+impl DeclUsage {
+    fn add_usage(&mut self, user: &Id) {
+        match self {
+            Self::Bindings(set) => {
+                set.insert(user.clone());
+            }
+            Self::SideEffects => {}
+        }
+    }
+    fn make_side_effects(&mut self) {
+        *self = Self::SideEffects;
+    }
+}
+
+#[derive(Default, Debug)]
+pub(crate) struct ImportUsage {
+    // ident -> immediate usage (top level decl)
+    pub(crate) decl_usages: FxHashMap<Id, DeclUsage>,
+    // import -> immediate usage (top level decl)
+    pub(crate) import_usages: FxHashMap<usize, DeclUsage>,
+    // export name -> top level decl
+    pub(crate) exports: FxHashMap<Atom, Id>,
+}
+
 /// A version of [crate::references::esm::export::EsmExport] with usize instead of the module
 /// reference Vc, and missing the liveness fields.
 #[derive(Debug)]
@@ -322,6 +357,8 @@ pub(crate) struct ImportMap {
     /// Map from export binding id to the scopes where it's assigned. This is used to determine
     /// whether an export is live or not.
     pub(super) assignment_scopes: FxHashMap<Id, AssignmentScopes>,
+
+    pub(crate) import_usage: ImportUsage,
 
     /// Map from exported name to local binding id (includes the syntax context).
     pub(crate) exports_ids: FxHashMap<RcStr, Id>,
@@ -555,13 +592,18 @@ impl ImportMap {
     }
 
     /// Analyze ES import
-    pub(super) fn analyze(m: &Program, comments: Option<&dyn Comments>) -> Self {
+    pub(super) fn analyze(
+        unresolved_mark: Mark,
+        m: &Program,
+        comments: Option<&dyn Comments>,
+    ) -> Self {
         let mut data = ImportMap::default();
         let mut analyzer = Analyzer {
+            unresolved_mark,
             data: &mut data,
             comments,
             namespace_imports_to_specifier: FxIndexMap::default(),
-            is_in_fn: false,
+            state: Default::default(),
         };
 
         // A prepass to detect imports to be able to rewrite import+export pairs to true reexports
@@ -675,14 +717,67 @@ impl ImportMap {
     }
 }
 
+mod analyzer_state {
+    use swc_core::ecma::ast::{Id, Ident};
+
+    use super::Analyzer;
+
+    #[derive(Default)]
+    pub(super) struct AnalyzerState {
+        is_in_fn: bool,
+        cur_top_level_decl_name: Option<Id>,
+    }
+
+    impl AnalyzerState {
+        /// Returns the identifier of the current top level declaration.
+        pub(super) fn cur_top_level_decl_name(&self) -> &Option<Id> {
+            &self.cur_top_level_decl_name
+        }
+
+        /// Returns whether the current context is inside a function.
+        pub(super) fn is_in_fn(&self) -> bool {
+            self.is_in_fn
+        }
+    }
+
+    impl Analyzer<'_> {
+        /// Runs `visitor` with the current top level declaration identifier
+        pub(super) fn enter_top_level_decl<T>(
+            &mut self,
+            name: &Ident,
+            visitor: impl FnOnce(&mut Self) -> T,
+        ) -> T {
+            let is_top_level_fn = self.state.cur_top_level_decl_name.is_none();
+            if is_top_level_fn {
+                self.state.cur_top_level_decl_name = Some(name.to_id());
+            }
+            let result = visitor(self);
+            if is_top_level_fn {
+                self.state.cur_top_level_decl_name = None;
+            }
+            result
+        }
+
+        /// Runs `visitor` with the right is_in_fn value
+        pub(super) fn enter_fn<T>(&mut self, visitor: impl FnOnce(&mut Self) -> T) -> T {
+            let old_is_in_fn = self.state.is_in_fn;
+            self.state.is_in_fn = true;
+            let result = visitor(self);
+            self.state.is_in_fn = old_is_in_fn;
+            result
+        }
+    }
+}
+
 struct Analyzer<'a> {
+    unresolved_mark: Mark,
     data: &'a mut ImportMap,
     comments: Option<&'a dyn Comments>,
     /// Map from local identifier of namespace imports to module path, used temporarily during
     /// analysis to detect dynamic accesses to namespace imports.
     namespace_imports_to_specifier: FxIndexMap<Id, Wtf8Atom>,
 
-    is_in_fn: bool,
+    state: analyzer_state::AnalyzerState,
 }
 
 impl Analyzer<'_> {
@@ -709,7 +804,7 @@ impl Analyzer<'_> {
     }
 
     fn register_assignment_scope(&mut self, id: Id) {
-        let scope = if self.is_in_fn {
+        let scope = if self.state.is_in_fn() {
             AssignmentScope::Function
         } else {
             AssignmentScope::ModuleEval
@@ -727,6 +822,10 @@ impl Analyzer<'_> {
 }
 
 impl Visit for Analyzer<'_> {
+    fn visit_import_decl(&mut self, _: &ImportDecl) {
+        // We already handled import above. Skip as the Idents in here confuse the analysis
+    }
+
     fn visit_export_all(&mut self, export: &ExportAll) {
         if export.type_only {
             return;
@@ -743,6 +842,7 @@ impl Visit for Analyzer<'_> {
         );
         self.data.reexport_namespaces.push(i);
         self.data.has_exports = true;
+        export.visit_children_with(self);
     }
 
     fn visit_named_export(&mut self, export: &NamedExport) {
@@ -850,9 +950,7 @@ impl Visit for Analyzer<'_> {
     }
 
     fn visit_export_decl(&mut self, n: &ExportDecl) {
-        n.visit_children_with(self);
         self.data.has_exports = true;
-
         match &n.decl {
             Decl::Class(n) => {
                 let name = RcStr::from(n.ident.sym.as_str());
@@ -860,6 +958,10 @@ impl Visit for Analyzer<'_> {
                     .exports
                     .insert(name.clone(), Export::LocalBinding(name.clone(), false));
                 self.data.exports_ids.insert(name, n.ident.to_id());
+                self.data
+                    .import_usage
+                    .exports
+                    .insert(n.ident.sym.clone(), n.ident.to_id());
             }
             Decl::Fn(n) => {
                 let name = RcStr::from(n.ident.sym.as_str());
@@ -867,6 +969,10 @@ impl Visit for Analyzer<'_> {
                     .exports
                     .insert(name.clone(), Export::LocalBinding(name.clone(), false));
                 self.data.exports_ids.insert(name, n.ident.to_id());
+                self.data
+                    .import_usage
+                    .exports
+                    .insert(n.ident.sym.clone(), n.ident.to_id());
             }
             Decl::Var(..) => {
                 let ids: Vec<Id> = find_pat_ids(&n.decl);
@@ -875,6 +981,10 @@ impl Visit for Analyzer<'_> {
                     self.data
                         .exports
                         .insert(name.clone(), Export::LocalBinding(name.clone(), false));
+                    self.data
+                        .import_usage
+                        .exports
+                        .insert(id.0.clone(), id.clone());
                     self.data.exports_ids.insert(name, id);
                 }
             }
@@ -886,10 +996,11 @@ impl Visit for Analyzer<'_> {
                 // ignore typescript for code generation
             }
         }
+
+        n.visit_children_with(self);
     }
 
     fn visit_export_default_decl(&mut self, n: &ExportDefaultDecl) {
-        n.visit_children_with(self);
         self.data.has_exports = true;
 
         let id = match &n.decl {
@@ -920,10 +1031,10 @@ impl Visit for Analyzer<'_> {
             Export::LocalBinding(RcStr::from(id.0.as_str()), false),
         );
         self.data.exports_ids.insert(rcstr!("default"), id);
+        n.visit_children_with(self);
     }
 
     fn visit_export_default_expr(&mut self, n: &ExportDefaultExpr) {
-        n.visit_children_with(self);
         self.data.has_exports = true;
 
         self.data.exports.insert(
@@ -938,21 +1049,34 @@ impl Visit for Analyzer<'_> {
                 SyntaxContext::empty(),
             ),
         );
+        n.visit_children_with(self);
     }
 
     fn visit_export_named_specifier(&mut self, n: &ExportNamedSpecifier) {
-        if let ModuleExportName::Ident(local) = &n.orig {
-            let exported = n.exported.as_ref().unwrap_or(&n.orig);
-            self.data
-                .exports_ids
-                .insert(exported.atom().as_str().into(), local.to_id());
-        }
+        self.data.has_exports = true;
+
+        let exported = n.exported.as_ref().unwrap_or(&n.orig).atom();
+        let ModuleExportName::Ident(local) = &n.orig else {
+            unreachable!("exporting a string should be impossible")
+        };
+        self.data
+            .exports_ids
+            .insert(exported.as_str().into(), local.to_id());
+
+        self.data
+            .import_usage
+            .exports
+            .insert(exported.into_owned(), local.to_id());
+        n.visit_children_with(self);
     }
 
     fn visit_export_default_specifier(&mut self, n: &ExportDefaultSpecifier) {
+        self.data.has_exports = true;
+
         self.data
             .exports_ids
             .insert(rcstr!("default"), n.exported.to_id());
+        n.visit_children_with(self);
     }
 
     fn visit_program(&mut self, m: &Program) {
@@ -1022,42 +1146,37 @@ impl Visit for Analyzer<'_> {
     }
 
     fn visit_getter_prop(&mut self, node: &GetterProp) {
-        let old_is_in_fn = self.is_in_fn;
-        self.is_in_fn = true;
-        node.visit_children_with(self);
-        self.is_in_fn = old_is_in_fn;
+        self.enter_fn(|this| {
+            node.visit_children_with(this);
+        });
     }
     fn visit_setter_prop(&mut self, node: &SetterProp) {
-        let old_is_in_fn = self.is_in_fn;
-        self.is_in_fn = true;
-        node.visit_children_with(self);
-        self.is_in_fn = old_is_in_fn;
+        self.enter_fn(|this| {
+            node.visit_children_with(this);
+        });
     }
     fn visit_function(&mut self, node: &Function) {
-        let old_is_in_fn = self.is_in_fn;
-        self.is_in_fn = true;
-        node.visit_children_with(self);
-        self.is_in_fn = old_is_in_fn;
+        self.enter_fn(|this| {
+            node.visit_children_with(this);
+        });
     }
     fn visit_constructor(&mut self, node: &Constructor) {
-        let old_is_in_fn = self.is_in_fn;
-        self.is_in_fn = true;
-        node.visit_children_with(self);
-        self.is_in_fn = old_is_in_fn;
+        self.enter_fn(|this| {
+            node.visit_children_with(this);
+        });
     }
     fn visit_arrow_expr(&mut self, node: &ArrowExpr) {
-        let old_is_in_fn = self.is_in_fn;
-        self.is_in_fn = true;
-        node.visit_children_with(self);
-        self.is_in_fn = old_is_in_fn;
+        self.enter_fn(|this| {
+            node.visit_children_with(this);
+        });
     }
 
     fn visit_member_expr(&mut self, node: &MemberExpr) {
         if let MemberProp::Ident(..) | MemberProp::PrivateName(..) = &node.prop
             && node.obj.is_ident()
         {
-            // Skip if obj is a Expr::Ident, so that it doesn't get added to full_star_imports below
-            // in visit_expr.
+            // Skip traversing if obj is a Expr::Ident, so that it doesn't get added to
+            // full_star_imports below in visit_expr.
             return;
         }
         node.visit_children_with(self);
@@ -1069,9 +1188,8 @@ impl Visit for Analyzer<'_> {
             if let Some(module_path) = self.namespace_imports_to_specifier.get(&i.to_id()) {
                 self.data.full_star_imports.insert(module_path.clone());
             }
-        } else {
-            pat.visit_children_with(self);
         }
+        pat.visit_children_with(self);
     }
 
     fn visit_simple_assign_target(&mut self, node: &SimpleAssignTarget) {
@@ -1080,18 +1198,55 @@ impl Visit for Analyzer<'_> {
             if let Some(module_path) = self.namespace_imports_to_specifier.get(&i.to_id()) {
                 self.data.full_star_imports.insert(module_path.clone());
             }
-        } else {
-            node.visit_children_with(self);
         }
+        node.visit_children_with(self);
     }
 
     fn visit_expr(&mut self, node: &Expr) {
-        if let Expr::Ident(i) = node {
-            if let Some(module_path) = self.namespace_imports_to_specifier.get(&i.to_id()) {
-                self.data.full_star_imports.insert(module_path.clone());
+        if let Expr::Ident(i) = node
+            && let Some(module_path) = self.namespace_imports_to_specifier.get(&i.to_id())
+        {
+            self.data.full_star_imports.insert(module_path.clone());
+        }
+        node.visit_children_with(self);
+    }
+
+    fn visit_ident(&mut self, node: &Ident) {
+        let id = node.to_id();
+        if let Some((esm_reference_index, _)) = self.data.get_binding(&id) {
+            // An import binding
+            let usage = self
+                .data
+                .import_usage
+                .import_usages
+                .entry(esm_reference_index)
+                .or_default();
+            if let Some(top_level) = self.state.cur_top_level_decl_name() {
+                usage.add_usage(top_level);
+            } else {
+                usage.make_side_effects();
             }
         } else {
-            node.visit_children_with(self);
+            // A regular variable
+            if !is_unresolved(node, self.unresolved_mark) {
+                if let Some(top_level) = self.state.cur_top_level_decl_name() {
+                    if &id != top_level {
+                        self.data
+                            .import_usage
+                            .decl_usages
+                            .entry(id)
+                            .or_default()
+                            .add_usage(top_level);
+                    }
+                } else {
+                    self.data
+                        .import_usage
+                        .decl_usages
+                        .entry(id)
+                        .or_default()
+                        .make_side_effects();
+                }
+            }
         }
     }
 
@@ -1100,6 +1255,12 @@ impl Visit for Analyzer<'_> {
             self.register_assignment_scope(ident.to_id());
         }
         node.visit_children_with(self);
+    }
+
+    fn visit_fn_decl(&mut self, node: &FnDecl) {
+        self.enter_top_level_decl(&node.ident, |this| {
+            node.visit_children_with(this);
+        });
     }
 
     fn visit_decl(&mut self, node: &Decl) {

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
@@ -1081,7 +1081,10 @@ impl Visit for Analyzer<'_> {
             rcstr!("default"),
             Export::LocalBinding(RcStr::from(id.0.as_str()), false),
         );
-        self.data.exports_ids.insert(rcstr!("default"), id);
+        self.data.exports_ids.insert(rcstr!("default"), id.clone());
+        self.program_decl_usage
+            .exports
+            .insert(rcstr!("default"), id);
         n.visit_children_with(self);
     }
 

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
@@ -550,10 +550,9 @@ impl ImportMap {
         self.attributes.get(&span.lo).unwrap_or_default()
     }
 
-    // TODO this could return &str instead of String to avoid cloning
-    pub fn get_binding(&self, id: &Id) -> Option<(usize, Option<RcStr>)> {
+    pub fn get_binding(&self, id: &Id) -> Option<(usize, Option<&Atom>)> {
         if let Some((i, i_sym)) = self.imports.get(id) {
-            return Some((*i, Some(i_sym.as_str().into())));
+            return Some((*i, Some(i_sym)));
         }
         if let Some(i) = self.namespace_imports.get(id) {
             return Some((*i, None));
@@ -983,7 +982,11 @@ impl Visit for Analyzer<'_> {
                                 // This is a export of an imported binding. Rewrite to a true
                                 // reexport.
                                 if let Some(export) = export {
-                                    Export::ImportedBinding(index, export, is_fake_esm)
+                                    Export::ImportedBinding(
+                                        index,
+                                        RcStr::from(export.as_str()),
+                                        is_fake_esm,
+                                    )
                                 } else {
                                     Export::ImportedNamespace(index)
                                 }

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -102,7 +102,7 @@ use crate::{
         ObjectPart, RequireContextValue, WellKnownFunctionKind, WellKnownObjectKind,
         builtin::{early_replace_builtin, replace_builtin},
         graph::{ConditionalKind, Effect, EffectArg, VarGraph, create_graph},
-        imports::{DeclUsage, ImportAnnotations, ImportAttributes, ImportMap, ImportedSymbol},
+        imports::{ImportAnnotations, ImportAttributes, ImportMap, ImportedSymbol},
         linker::link,
         parse_require_context, side_effects,
         top_level_await::has_top_level_await,
@@ -750,56 +750,6 @@ async fn analyze_ecmascript_module_internal(
         .supports_block_scoping()
         .await?;
 
-    let mut import_usage = FxHashMap::with_capacity_and_hasher(
-        eval_context.imports.import_usage.import_usages.len(),
-        Default::default(),
-    );
-    for (reference, usage) in &eval_context.imports.import_usage.import_usages {
-        // TODO move this into EvalContext and only store the one resulting import_usage
-        // TODO make this more efficient, i.e. cache the result?
-        if let DeclUsage::Bindings(ids) = usage {
-            // compute transitive closure of `ids` over `top_level_mappings`
-            let mut visited = ids.clone();
-            let mut stack = ids.iter().collect::<Vec<_>>();
-            let mut has_global_usage = false;
-            while let Some(id) = stack.pop() {
-                match eval_context.imports.import_usage.decl_usages.get(id) {
-                    Some(DeclUsage::SideEffects) => {
-                        has_global_usage = true;
-                        break;
-                    }
-                    Some(DeclUsage::Bindings(callers)) => {
-                        for caller in callers {
-                            if visited.insert(caller.clone()) {
-                                stack.push(caller);
-                            }
-                        }
-                    }
-                    _ => {}
-                }
-            }
-
-            // Collect all `visited` declarations which are exported
-            import_usage.insert(
-                *reference,
-                if has_global_usage {
-                    ImportUsage::TopLevel
-                } else {
-                    ImportUsage::Exports(
-                        eval_context
-                            .imports
-                            .import_usage
-                            .exports
-                            .iter()
-                            .filter(|(_, id)| visited.contains(*id))
-                            .map(|(exported, _)| exported.as_str().into())
-                            .collect(),
-                    )
-                },
-            );
-        }
-    }
-
     let span = tracing::trace_span!("esm import references");
     let import_references = async {
         let mut import_references = Vec::with_capacity(eval_context.imports.references().len());
@@ -840,7 +790,12 @@ async fn analyze_ecmascript_module_internal(
                     )
                     .then(ModulePart::exports),
                 },
-                import_usage.get(&i).cloned().unwrap_or_default(),
+                eval_context
+                    .imports
+                    .import_usage
+                    .get(&i)
+                    .cloned()
+                    .unwrap_or_default(),
                 import_externals,
                 options.tree_shaking_mode,
             )
@@ -3258,6 +3213,8 @@ async fn handle_free_var_reference(
                         ),
                         Default::default(),
                         export.clone().map(ModulePart::export),
+                        // TODO This could be optimized. E.g. referencing `Buffer` in some top
+                        // level function could set ImportUsage properly here
                         ImportUsage::TopLevel,
                         state.import_externals,
                         state.tree_shaking_mode,

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -42,7 +42,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use swc_core::{
     atoms::{Atom, Wtf8Atom, atom},
     common::{
-        GLOBALS, Globals, Span, Spanned, SyntaxContext,
+        GLOBALS, Globals, Span, Spanned,
         comments::{CommentKind, Comments},
         errors::{DiagnosticId, HANDLER, Handler, Level},
         source_map::SmallPos,
@@ -101,8 +101,8 @@ use crate::{
         ConstantNumber, ConstantString, ConstantValue as JsConstantValue, JsValue, JsValueUrlKind,
         ObjectPart, RequireContextValue, WellKnownFunctionKind, WellKnownObjectKind,
         builtin::{early_replace_builtin, replace_builtin},
-        graph::{ConditionalKind, DeclUsage, Effect, EffectArg, VarGraph, create_graph},
-        imports::{ImportAnnotations, ImportAttributes, ImportMap, ImportedSymbol},
+        graph::{ConditionalKind, Effect, EffectArg, VarGraph, create_graph},
+        imports::{DeclUsage, ImportAnnotations, ImportAttributes, ImportMap, ImportedSymbol},
         linker::link,
         parse_require_context, side_effects,
         top_level_await::has_top_level_await,
@@ -750,16 +750,12 @@ async fn analyze_ecmascript_module_internal(
         .supports_block_scoping()
         .await?;
 
-    let mut var_graph = {
-        let _span = tracing::trace_span!("analyze variable values").entered();
-        set_handler_and_globals(&handler, globals, || {
-            create_graph(program, eval_context, analyze_mode, supports_block_scoping)
-        })
-    };
-
-    let mut import_usage =
-        FxHashMap::with_capacity_and_hasher(var_graph.import_usages.len(), Default::default());
-    for (reference, usage) in &var_graph.import_usages {
+    let mut import_usage = FxHashMap::with_capacity_and_hasher(
+        eval_context.imports.import_usage.import_usages.len(),
+        Default::default(),
+    );
+    for (reference, usage) in &eval_context.imports.import_usage.import_usages {
+        // TODO move this into EvalContext and only store the one resulting import_usage
         // TODO make this more efficient, i.e. cache the result?
         if let DeclUsage::Bindings(ids) = usage {
             // compute transitive closure of `ids` over `top_level_mappings`
@@ -767,7 +763,7 @@ async fn analyze_ecmascript_module_internal(
             let mut stack = ids.iter().collect::<Vec<_>>();
             let mut has_global_usage = false;
             while let Some(id) = stack.pop() {
-                match var_graph.decl_usages.get(id) {
+                match eval_context.imports.import_usage.decl_usages.get(id) {
                     Some(DeclUsage::SideEffects) => {
                         has_global_usage = true;
                         break;
@@ -790,7 +786,9 @@ async fn analyze_ecmascript_module_internal(
                     ImportUsage::TopLevel
                 } else {
                     ImportUsage::Exports(
-                        var_graph
+                        eval_context
+                            .imports
+                            .import_usage
                             .exports
                             .iter()
                             .filter(|(_, id)| visited.contains(*id))
@@ -977,6 +975,13 @@ async fn analyze_ecmascript_module_internal(
     }
     .instrument(span)
     .await?;
+
+    let mut var_graph = {
+        let _span = tracing::trace_span!("analyze variable values").entered();
+        set_handler_and_globals(&handler, globals, || {
+            create_graph(program, eval_context, analyze_mode, supports_block_scoping)
+        })
+    };
 
     let span = tracing::trace_span!("effects processing");
     async {
@@ -3811,41 +3816,6 @@ async fn require_context_visitor(
             RequireContextValue::from_context_map(map).await?,
         ),
     ))
-}
-
-pub(crate) fn for_each_ident_in_pat(pat: &Pat, f: &mut impl FnMut(&Atom, SyntaxContext)) {
-    match pat {
-        Pat::Ident(BindingIdent { id, .. }) => {
-            f(&id.sym, id.ctxt);
-        }
-        Pat::Array(ArrayPat { elems, .. }) => elems.iter().for_each(|e| {
-            if let Some(e) = e {
-                for_each_ident_in_pat(e, f);
-            }
-        }),
-        Pat::Rest(RestPat { arg, .. }) => {
-            for_each_ident_in_pat(arg, f);
-        }
-        Pat::Object(ObjectPat { props, .. }) => {
-            props.iter().for_each(|p| match p {
-                ObjectPatProp::KeyValue(KeyValuePatProp { value, .. }) => {
-                    for_each_ident_in_pat(value, f);
-                }
-                ObjectPatProp::Assign(AssignPatProp { key, .. }) => {
-                    f(&key.sym, key.ctxt);
-                }
-                ObjectPatProp::Rest(RestPat { arg, .. }) => {
-                    for_each_ident_in_pat(arg, f);
-                }
-            });
-        }
-        Pat::Assign(AssignPat { left, .. }) => {
-            for_each_ident_in_pat(left, f);
-        }
-        Pat::Invalid(_) | Pat::Expr(_) => {
-            panic!("Unexpected pattern while enumerating idents");
-        }
-    }
 }
 
 #[derive(Hash, Debug, Clone, Eq, PartialEq, TraceRawVcs, Encode, Decode)]

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -42,7 +42,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use swc_core::{
     atoms::{Atom, Wtf8Atom, atom},
     common::{
-        GLOBALS, Globals, Span, Spanned, SyntaxContext,
+        GLOBALS, Globals, Span, Spanned,
         comments::{CommentKind, Comments},
         errors::{DiagnosticId, HANDLER, Handler, Level},
         source_map::SmallPos,
@@ -101,8 +101,8 @@ use crate::{
         ConstantNumber, ConstantString, ConstantValue as JsConstantValue, JsValue, JsValueUrlKind,
         ObjectPart, RequireContextValue, WellKnownFunctionKind, WellKnownObjectKind,
         builtin::{early_replace_builtin, replace_builtin},
-        graph::{ConditionalKind, DeclUsage, Effect, EffectArg, VarGraph, create_graph},
-        imports::{ImportAnnotations, ImportAttributes, ImportMap, ImportedSymbol},
+        graph::{ConditionalKind, Effect, EffectArg, VarGraph, create_graph},
+        imports::{DeclUsage, ImportAnnotations, ImportAttributes, ImportMap, ImportedSymbol},
         linker::link,
         parse_require_context, side_effects,
         top_level_await::has_top_level_await,
@@ -751,16 +751,12 @@ async fn analyze_ecmascript_module_internal(
         .supports_block_scoping()
         .await?;
 
-    let mut var_graph = {
-        let _span = tracing::trace_span!("analyze variable values").entered();
-        set_handler_and_globals(&handler, globals, || {
-            create_graph(program, eval_context, analyze_mode, supports_block_scoping)
-        })
-    };
-
-    let mut import_usage =
-        FxHashMap::with_capacity_and_hasher(var_graph.import_usages.len(), Default::default());
-    for (reference, usage) in &var_graph.import_usages {
+    let mut import_usage = FxHashMap::with_capacity_and_hasher(
+        eval_context.imports.import_usage.import_usages.len(),
+        Default::default(),
+    );
+    for (reference, usage) in &eval_context.imports.import_usage.import_usages {
+        // TODO move this into EvalContext and only store the one resulting import_usage
         // TODO make this more efficient, i.e. cache the result?
         if let DeclUsage::Bindings(ids) = usage {
             // compute transitive closure of `ids` over `top_level_mappings`
@@ -768,7 +764,7 @@ async fn analyze_ecmascript_module_internal(
             let mut stack = ids.iter().collect::<Vec<_>>();
             let mut has_global_usage = false;
             while let Some(id) = stack.pop() {
-                match var_graph.decl_usages.get(id) {
+                match eval_context.imports.import_usage.decl_usages.get(id) {
                     Some(DeclUsage::SideEffects) => {
                         has_global_usage = true;
                         break;
@@ -791,7 +787,9 @@ async fn analyze_ecmascript_module_internal(
                     ImportUsage::TopLevel
                 } else {
                     ImportUsage::Exports(
-                        var_graph
+                        eval_context
+                            .imports
+                            .import_usage
                             .exports
                             .iter()
                             .filter(|(_, id)| visited.contains(*id))
@@ -978,6 +976,13 @@ async fn analyze_ecmascript_module_internal(
     }
     .instrument(span)
     .await?;
+
+    let mut var_graph = {
+        let _span = tracing::trace_span!("analyze variable values").entered();
+        set_handler_and_globals(&handler, globals, || {
+            create_graph(program, eval_context, analyze_mode, supports_block_scoping)
+        })
+    };
 
     let span = tracing::trace_span!("effects processing");
     async {
@@ -3812,41 +3817,6 @@ async fn require_context_visitor(
             RequireContextValue::from_context_map(map).await?,
         ),
     ))
-}
-
-pub(crate) fn for_each_ident_in_pat(pat: &Pat, f: &mut impl FnMut(&Atom, SyntaxContext)) {
-    match pat {
-        Pat::Ident(BindingIdent { id, .. }) => {
-            f(&id.sym, id.ctxt);
-        }
-        Pat::Array(ArrayPat { elems, .. }) => elems.iter().for_each(|e| {
-            if let Some(e) = e {
-                for_each_ident_in_pat(e, f);
-            }
-        }),
-        Pat::Rest(RestPat { arg, .. }) => {
-            for_each_ident_in_pat(arg, f);
-        }
-        Pat::Object(ObjectPat { props, .. }) => {
-            props.iter().for_each(|p| match p {
-                ObjectPatProp::KeyValue(KeyValuePatProp { value, .. }) => {
-                    for_each_ident_in_pat(value, f);
-                }
-                ObjectPatProp::Assign(AssignPatProp { key, .. }) => {
-                    f(&key.sym, key.ctxt);
-                }
-                ObjectPatProp::Rest(RestPat { arg, .. }) => {
-                    for_each_ident_in_pat(arg, f);
-                }
-            });
-        }
-        Pat::Assign(AssignPat { left, .. }) => {
-            for_each_ident_in_pat(left, f);
-        }
-        Pat::Invalid(_) | Pat::Expr(_) => {
-            panic!("Unexpected pattern while enumerating idents");
-        }
-    }
 }
 
 #[derive(Hash, Debug, Clone, Eq, PartialEq, TraceRawVcs, Encode, Decode)]

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -102,7 +102,7 @@ use crate::{
         ObjectPart, RequireContextValue, WellKnownFunctionKind, WellKnownObjectKind,
         builtin::{early_replace_builtin, replace_builtin},
         graph::{ConditionalKind, Effect, EffectArg, VarGraph, create_graph},
-        imports::{DeclUsage, ImportAnnotations, ImportAttributes, ImportMap, ImportedSymbol},
+        imports::{ImportAnnotations, ImportAttributes, ImportMap, ImportedSymbol},
         linker::link,
         parse_require_context, side_effects,
         top_level_await::has_top_level_await,
@@ -751,56 +751,6 @@ async fn analyze_ecmascript_module_internal(
         .supports_block_scoping()
         .await?;
 
-    let mut import_usage = FxHashMap::with_capacity_and_hasher(
-        eval_context.imports.import_usage.import_usages.len(),
-        Default::default(),
-    );
-    for (reference, usage) in &eval_context.imports.import_usage.import_usages {
-        // TODO move this into EvalContext and only store the one resulting import_usage
-        // TODO make this more efficient, i.e. cache the result?
-        if let DeclUsage::Bindings(ids) = usage {
-            // compute transitive closure of `ids` over `top_level_mappings`
-            let mut visited = ids.clone();
-            let mut stack = ids.iter().collect::<Vec<_>>();
-            let mut has_global_usage = false;
-            while let Some(id) = stack.pop() {
-                match eval_context.imports.import_usage.decl_usages.get(id) {
-                    Some(DeclUsage::SideEffects) => {
-                        has_global_usage = true;
-                        break;
-                    }
-                    Some(DeclUsage::Bindings(callers)) => {
-                        for caller in callers {
-                            if visited.insert(caller.clone()) {
-                                stack.push(caller);
-                            }
-                        }
-                    }
-                    _ => {}
-                }
-            }
-
-            // Collect all `visited` declarations which are exported
-            import_usage.insert(
-                *reference,
-                if has_global_usage {
-                    ImportUsage::TopLevel
-                } else {
-                    ImportUsage::Exports(
-                        eval_context
-                            .imports
-                            .import_usage
-                            .exports
-                            .iter()
-                            .filter(|(_, id)| visited.contains(*id))
-                            .map(|(exported, _)| exported.as_str().into())
-                            .collect(),
-                    )
-                },
-            );
-        }
-    }
-
     let span = tracing::trace_span!("esm import references");
     let import_references = async {
         let mut import_references = Vec::with_capacity(eval_context.imports.references().len());
@@ -841,7 +791,12 @@ async fn analyze_ecmascript_module_internal(
                     )
                     .then(ModulePart::exports),
                 },
-                import_usage.get(&i).cloned().unwrap_or_default(),
+                eval_context
+                    .imports
+                    .import_usage
+                    .get(&i)
+                    .cloned()
+                    .unwrap_or_default(),
                 import_externals,
                 options.tree_shaking_mode,
             )
@@ -3259,6 +3214,8 @@ async fn handle_free_var_reference(
                         ),
                         Default::default(),
                         export.clone().map(ModulePart::export),
+                        // TODO This could be optimized. E.g. referencing `Buffer` in some top
+                        // level function could set ImportUsage properly here
                         ImportUsage::TopLevel,
                         state.import_externals,
                         state.tree_shaking_mode,

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/mod.rs
@@ -564,13 +564,16 @@ pub(super) async fn split_module(asset: Vc<EcmascriptModuleAsset>) -> Result<Vc<
                 .into_iter()
                 .map(|module| {
                     let program = Program::Module(module);
-                    let eval_context = EvalContext::new(
-                        Some(&program),
-                        eval_context.unresolved_mark,
-                        eval_context.top_level_mark,
-                        eval_context.force_free_values.clone(),
-                        None,
-                    );
+
+                    let eval_context = GLOBALS.set(globals, || {
+                        EvalContext::new(
+                            Some(&program),
+                            eval_context.unresolved_mark,
+                            eval_context.top_level_mark,
+                            eval_context.force_free_values.clone(),
+                            None,
+                        )
+                    });
 
                     ParseResult::resolved_cell(ParseResult::Ok {
                         program,
@@ -691,13 +694,15 @@ pub(crate) async fn part_of_module(
                     }));
 
                     let program = Program::Module(module);
-                    let eval_context = EvalContext::new(
-                        Some(&program),
-                        eval_context.unresolved_mark,
-                        eval_context.top_level_mark,
-                        eval_context.force_free_values.clone(),
-                        None,
-                    );
+                    let eval_context = GLOBALS.set(globals, || {
+                        EvalContext::new(
+                            Some(&program),
+                            eval_context.unresolved_mark,
+                            eval_context.top_level_mark,
+                            eval_context.force_free_values.clone(),
+                            None,
+                        )
+                    });
 
                     return Ok(ParseResult::Ok {
                         program,

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/mod.rs
@@ -563,13 +563,16 @@ pub(super) async fn split_module(asset: Vc<EcmascriptModuleAsset>) -> Result<Vc<
                 .into_iter()
                 .map(|module| {
                     let program = Program::Module(module);
-                    let eval_context = EvalContext::new(
-                        Some(&program),
-                        eval_context.unresolved_mark,
-                        eval_context.top_level_mark,
-                        eval_context.force_free_values.clone(),
-                        None,
-                    );
+
+                    let eval_context = GLOBALS.set(globals, || {
+                        EvalContext::new(
+                            Some(&program),
+                            eval_context.unresolved_mark,
+                            eval_context.top_level_mark,
+                            eval_context.force_free_values.clone(),
+                            None,
+                        )
+                    });
 
                     ParseResult::resolved_cell(ParseResult::Ok {
                         program,
@@ -688,13 +691,15 @@ pub(crate) async fn part_of_module(
                     }));
 
                     let program = Program::Module(module);
-                    let eval_context = EvalContext::new(
-                        Some(&program),
-                        eval_context.unresolved_mark,
-                        eval_context.top_level_mark,
-                        eval_context.force_free_values.clone(),
-                        None,
-                    );
+                    let eval_context = GLOBALS.set(globals, || {
+                        EvalContext::new(
+                            Some(&program),
+                            eval_context.unresolved_mark,
+                            eval_context.top_level_mark,
+                            eval_context.force_free_values.clone(),
+                            None,
+                        )
+                    });
 
                     return Ok(ParseResult::Ok {
                         program,


### PR DESCRIPTION
I'm moving all of the export-related logic into `EvalContext` (and thus `ImportMap`) so that `VarGraph` is only needed for computing the references, and not the exports.