### PR TITLE
[ci] Skip Playwright system deps install on subsequent self-hosted runs

### DIFF
--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -315,8 +315,29 @@ jobs:
       - run: ANALYZE=1 pnpm build
         if: ${{ inputs.skipInstallBuild != 'yes' }}
 
-      - run: pnpm playwright install --with-deps ${{ inputs.browser }}
+      - name: Install Playwright browsers
         if: ${{ inputs.skipInstallBuild != 'yes' }}
+        run: |
+          PW_VERSION=$(pnpm playwright --version 2>/dev/null || echo "unknown")
+          CACHE_DIR="$HOME/.cache"
+          VERSION_FILE="$CACHE_DIR/playwright-version"
+          STAMP="$CACHE_DIR/playwright-deps-$(echo "${{ inputs.browser }}" | tr ' ' '-')"
+
+          # Clear stamp files when Playwright version changes
+          if [ -f "$VERSION_FILE" ] && [ "$(cat "$VERSION_FILE")" != "$PW_VERSION" ]; then
+            echo "Playwright version changed ($(cat "$VERSION_FILE") -> $PW_VERSION), clearing stamps"
+            rm -f "$CACHE_DIR"/playwright-deps-*
+          fi
+
+          mkdir -p "$CACHE_DIR"
+          echo "$PW_VERSION" > "$VERSION_FILE"
+
+          if [ -f "$STAMP" ]; then
+            pnpm playwright install ${{ inputs.browser }}
+          else
+            pnpm playwright install --with-deps ${{ inputs.browser }}
+            touch "$STAMP"
+          fi
 
       - name: Download pre-built test timings
         if: ${{ inputs.testTimingsArtifact != '' }}


### PR DESCRIPTION
## What

Use a stamp file to skip `playwright install --with-deps` after the first successful run on a self-hosted runner.

## Why

`--with-deps` runs `sudo apt-get install` for Playwright's system dependencies every time, even when they're already installed. On self-hosted runners this takes ~10s of no-op `apt-get` checking. After the first install, subsequent runs only need `playwright install` (which downloads browser binaries if the version changed, and is instant when cached).

The assumption is that on most of the runners, `playwright` will be the same version on each, and the deps that are installed are compatible within each version.

Most of the time this step is ~3s, when everything is healthy and up-to-date.

Occasionally these steps will hiccup on builds when we're already really got these deps installed so this chops a little bit off each one. This also helps when APT mirrors go down.

## How

- First run: `playwright install --with-deps` + write `~/.cache/playwright-deps-installed`
- Subsequent runs: stamp file exists, run `playwright install` without `--with-deps`
- The stamp persists on self-hosted runners across jobs
- Fresh/reimaged runners don't have the stamp, so they get the full install
- The cache is ignored if the most recently installed playwright version doesn't match

<!-- NEXT_JS_LLM_PR -->