### PR TITLE
[partial fallbacks]: include prefetch requests in shell upgrade handling

### DIFF
--- a/packages/next/src/build/adapter/build-complete.ts
+++ b/packages/next/src/build/adapter/build-complete.ts
@@ -1263,7 +1263,7 @@ export async function handleBuildComplete({
               config: {
                 ...initialOutput.config,
                 bypassFor: undefined,
-                partialFallback: undefined,
+                partialFallback: initialOutput.config.partialFallback,
               },
 
               fallback: {

--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -1176,11 +1176,7 @@ export async function handler(
                 !exposeTestingApi &&
                 // Instant Navigation Testing API requests intentionally keep
                 // the route in shell mode; don't upgrade these in background.
-                !isInstantNavigationTest &&
-                // Avoid background revalidate during prefetches; this can trigger
-                // static prerender errors that surface as 500s for the prefetch
-                // request itself.
-                !isPrefetchRSCRequest
+                !isInstantNavigationTest
               ) {
                 scheduleOnNextTick(async () => {
                   const responseCache = routeModule.getResponseCache(req)

--- a/test/e2e/app-dir/partial-fallback-shell-upgrade/partial-fallback-shell-upgrade.test.ts
+++ b/test/e2e/app-dir/partial-fallback-shell-upgrade/partial-fallback-shell-upgrade.test.ts
@@ -1,7 +1,7 @@
 import cheerio from 'cheerio'
 import { nextTestSetup } from 'e2e-utils'
 import { splitResponseWithPPRSentinel } from 'e2e-utils/ppr'
-import { retry } from 'next-test-utils'
+import { retry, waitFor } from 'next-test-utils'
 import path from 'path'
 
 const isAdapterTest = Boolean(process.env.NEXT_ENABLE_ADAPTER)
@@ -104,6 +104,31 @@ describe('partial-fallback-shell-upgrade', () => {
       expect(secondResult.dynamicPart).toContain('<div id="two">bar</div>')
       expect(secondResult.dynamicPart).not.toContain('<div id="two">foo</div>')
     })
+  })
+
+  it('should let a segment prefetch trigger the background shell upgrade', async () => {
+    const prefetchResponse = await next.fetch('/prefix/z/foo', {
+      headers: {
+        rsc: '1',
+        'next-router-prefetch': '1',
+        'next-router-segment-prefetch': '/_tree',
+      },
+    })
+
+    expect(prefetchResponse.status).toBe(200)
+
+    // Wait a moment to let the background upgrade to finish
+    await waitFor(3000)
+
+    const result = await fetchSplitHTML('/prefix/z/bar')
+
+    expect(result.response.status).toBe(200)
+    expect(result.static$('#one').text()).toBe('z')
+    expect(result.static$('#one-fallback').length).toBe(0)
+    expect(result.static$('#two-fallback').text()).toBe('loading two...')
+    expect(result.static$('#two').length).toBe(0)
+    expect(result.dynamicPart).toContain('<div id="two">bar</div>')
+    expect(result.dynamicPart).not.toContain('<div id="two">foo</div>')
   })
 
   it('should not keep upgrading once only fully dynamic params remain', async () => {

--- a/test/production/app-dir/adapter-partial-fallback/adapter-partial-fallback.test.ts
+++ b/test/production/app-dir/adapter-partial-fallback/adapter-partial-fallback.test.ts
@@ -13,11 +13,38 @@ describe('adapter-partial-fallback', () => {
     const withGspPrerender = outputs.prerenders.find(
       (output) => output.pathname === '/with-gsp/[slug]'
     )
+    const withGspRouteTreePrerender = outputs.prerenders.find(
+      (output) =>
+        output.pathname === '/with-gsp/[slug].segments/_tree.segment.rsc'
+    )
+    const withGspOtherSegmentPrerenders = outputs.prerenders.filter(
+      (output) =>
+        output.pathname.startsWith('/with-gsp/[slug].segments/') &&
+        output.pathname !== '/with-gsp/[slug].segments/_tree.segment.rsc'
+    )
     const withoutGspPrerender = outputs.prerenders.find(
       (output) => output.pathname === '/without-gsp/[slug]'
     )
+    const withoutGspRouteTreePrerender = outputs.prerenders.find(
+      (output) =>
+        output.pathname === '/without-gsp/[slug].segments/_tree.segment.rsc'
+    )
+    const withoutGspOtherSegmentPrerenders = outputs.prerenders.filter(
+      (output) =>
+        output.pathname.startsWith('/without-gsp/[slug].segments/') &&
+        output.pathname !== '/without-gsp/[slug].segments/_tree.segment.rsc'
+    )
     const genericPrefixPrerender = outputs.prerenders.find(
       (output) => output.pathname === '/prefix/[one]/[two]'
+    )
+    const genericPrefixRouteTreePrerender = outputs.prerenders.find(
+      (output) =>
+        output.pathname === '/prefix/[one]/[two].segments/_tree.segment.rsc'
+    )
+    const genericPrefixOtherSegmentPrerenders = outputs.prerenders.filter(
+      (output) =>
+        output.pathname.startsWith('/prefix/[one]/[two].segments/') &&
+        output.pathname !== '/prefix/[one]/[two].segments/_tree.segment.rsc'
     )
     const generatedPrefixPrerender = outputs.prerenders.find(
       (output) => output.pathname === '/prefix/b/[two]'
@@ -30,20 +57,46 @@ describe('adapter-partial-fallback', () => {
     )
 
     expect(withGspPrerender).toBeDefined()
+    expect(withGspRouteTreePrerender).toBeDefined()
+    expect(withGspOtherSegmentPrerenders.length).toBeGreaterThan(0)
     expect(withoutGspPrerender).toBeDefined()
+    expect(withoutGspRouteTreePrerender).toBeDefined()
+    expect(withoutGspOtherSegmentPrerenders.length).toBeGreaterThan(0)
     expect(genericPrefixPrerender).toBeDefined()
+    expect(genericPrefixRouteTreePrerender).toBeDefined()
+    expect(genericPrefixOtherSegmentPrerenders.length).toBeGreaterThan(0)
     expect(generatedPrefixPrerender).toBeDefined()
     expect(genericDashedPrerender).toBeDefined()
     expect(generatedDashedPrerender).toBeDefined()
 
     expect(withGspPrerender.config.partialFallback).toBe(true)
     expect(withGspPrerender.config.allowQuery).toEqual(['nxtPslug'])
+    expect(withGspRouteTreePrerender.config.partialFallback).toBe(true)
+    expect(withGspRouteTreePrerender.config.allowQuery).toEqual(['nxtPslug'])
+    for (const output of withGspOtherSegmentPrerenders) {
+      expect(output.config.partialFallback).toBe(true)
+      expect(output.config.allowQuery).toEqual(['nxtPslug'])
+    }
 
     expect(withoutGspPrerender.config.partialFallback).toBeUndefined()
     expect(withoutGspPrerender.config.allowQuery).toEqual([])
+    expect(withoutGspRouteTreePrerender.config.partialFallback).toBeUndefined()
+    expect(withoutGspRouteTreePrerender.config.allowQuery).toEqual([])
+    for (const output of withoutGspOtherSegmentPrerenders) {
+      expect(output.config.partialFallback).toBeUndefined()
+      expect(output.config.allowQuery).toEqual([])
+    }
 
     expect(genericPrefixPrerender.config.partialFallback).toBe(true)
     expect(genericPrefixPrerender.config.allowQuery).toEqual(['nxtPone'])
+    expect(genericPrefixRouteTreePrerender.config.partialFallback).toBe(true)
+    expect(genericPrefixRouteTreePrerender.config.allowQuery).toEqual([
+      'nxtPone',
+    ])
+    for (const output of genericPrefixOtherSegmentPrerenders) {
+      expect(output.config.partialFallback).toBe(true)
+      expect(output.config.allowQuery).toEqual(['nxtPone'])
+    }
 
     expect(generatedPrefixPrerender.config.partialFallback).toBeUndefined()
     expect(generatedPrefixPrerender.config.allowQuery).toEqual([])


### PR DESCRIPTION
With the new `partialFallbacks` heuristic, routes that weren't part of `generateStaticParams` will now upgrade their shells to include the params as if they had been in `generateStaticParams`, but only when the page with the unknown param was lazily visited.

This tweaks the heuristic to allow segment prefetches to also trigger the upgrade behavior. This will ensure subsequent clients, when prefetching the upgraded route, will receive the entry with params filled in rather than showing the generic fallback.

In a subsequent PR, we'll make it so that the requesting client that triggers the upgrade path can also benefit from the params being upgraded, as the client router currently has no awareness that a background revalidation completed. 