### PR TITLE
turbopack: reschedule stale tasks with correct invalidation priority

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1886,6 +1886,9 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         Some(TaskExecutionSpec { future, span })
     }
 
+    /// Returns `Some(priority)` if the task became stale during execution and needs to be
+    /// re-scheduled at the given priority. The caller (turbo-tasks manager) hands it to the
+    /// priority runner so re-execution doesn't inherit the original schedule priority.
     fn task_execution_completed(
         &self,
         task_id: TaskId,
@@ -1895,9 +1898,6 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         has_invalidator: bool,
         turbo_tasks: &dyn TurboTasksBackendApi<TurboTasksBackend<B>>,
     ) -> Option<TaskPriority> {
-        // Returns `Some(priority)` if the task became stale during execution and needs to be
-        // re-scheduled at the given priority. The caller (turbo-tasks manager) hands it to the
-        // priority runner so re-execution doesn't inherit the original schedule priority.
         // Task completion is a 4 step process:
         // 1. Remove old edges (dependencies, collectibles, children, cells) and update the
         //    aggregation number of the task and the new children.

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -2183,7 +2183,13 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         // If the task is stale, reschedule it
         #[cfg(not(feature = "no_fast_stale"))]
         if stale && !is_once_task {
-            let stale_priority = task.is_dirty().unwrap_or(TaskPriority::leaf());
+            let stale_priority = TaskPriority::invalidation(
+                task.get_leaf_distance()
+                    .copied()
+                    .unwrap_or_default()
+                    .distance,
+            )
+            .in_parent(task.is_dirty().unwrap_or(TaskPriority::leaf()));
             let Some(InProgressState::InProgress(box InProgressStateInner {
                 done_event,
                 mut new_children,
@@ -2561,7 +2567,13 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         // If the task is stale, reschedule it
         #[cfg(not(feature = "no_fast_stale"))]
         if *stale && !is_once_task {
-            let stale_priority = task.is_dirty().unwrap_or(TaskPriority::leaf());
+            let stale_priority = TaskPriority::invalidation(
+                task.get_leaf_distance()
+                    .copied()
+                    .unwrap_or_default()
+                    .distance,
+            )
+            .in_parent(task.is_dirty().unwrap_or(TaskPriority::leaf()));
             let Some(InProgressState::InProgress(box InProgressStateInner { done_event, .. })) =
                 task.take_in_progress()
             else {
@@ -2638,7 +2650,13 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
 
         // If the task is stale, reschedule it
         if stale && !is_once_task {
-            let stale_priority = task.is_dirty().unwrap_or(TaskPriority::leaf());
+            let stale_priority = TaskPriority::invalidation(
+                task.get_leaf_distance()
+                    .copied()
+                    .unwrap_or_default()
+                    .distance,
+            )
+            .in_parent(task.is_dirty().unwrap_or(TaskPriority::leaf()));
             let old = task.set_in_progress(InProgressState::Scheduled {
                 done_event,
                 reason: TaskExecutionReason::Stale,

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -96,6 +96,22 @@ static IDLE_TIMEOUT: LazyLock<Duration> = LazyLock::new(|| {
         .unwrap_or(Duration::from_secs(2))
 });
 
+/// Priority used to re-schedule a task that became stale during execution.
+///
+/// Stale tasks must run again, but at a priority that reflects why they're being re-run rather
+/// than the (likely higher) priority of the original schedule. We use invalidation priority
+/// based on the task's leaf distance, parented under either the task's current dirty priority
+/// or `leaf()` if it is no longer dirty.
+fn compute_stale_priority(task: &impl TaskGuard) -> TaskPriority {
+    TaskPriority::invalidation(
+        task.get_leaf_distance()
+            .copied()
+            .unwrap_or_default()
+            .distance,
+    )
+    .in_parent(task.is_dirty().unwrap_or(TaskPriority::leaf()))
+}
+
 pub enum StorageMode {
     /// Queries the storage for cache entries that don't exist locally.
     ReadOnly,
@@ -1878,7 +1894,10 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         #[cfg(feature = "verify_determinism")] stateful: bool,
         has_invalidator: bool,
         turbo_tasks: &dyn TurboTasksBackendApi<TurboTasksBackend<B>>,
-    ) -> bool {
+    ) -> Option<TaskPriority> {
+        // Returns `Some(priority)` if the task became stale during execution and needs to be
+        // re-scheduled at the given priority. The caller (turbo-tasks manager) hands it to the
+        // priority runner so re-execution doesn't inherit the original schedule priority.
         // Task completion is a 4 step process:
         // 1. Remove old edges (dependencies, collectibles, children, cells) and update the
         //    aggregation number of the task and the new children.
@@ -1919,7 +1938,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
 
         let mut ctx = self.execute_context(turbo_tasks);
 
-        let Some(TaskExecutionCompletePrepareResult {
+        let TaskExecutionCompletePrepareResult {
             new_children,
             is_now_immutable,
             #[cfg(feature = "verify_determinism")]
@@ -1927,7 +1946,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
             new_output,
             output_dependent_tasks,
             is_recomputation,
-        }) = self.task_execution_completed_prepare(
+        } = match self.task_execution_completed_prepare(
             &mut ctx,
             #[cfg(feature = "trace_task_details")]
             &span,
@@ -1937,12 +1956,14 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
             #[cfg(feature = "verify_determinism")]
             stateful,
             has_invalidator,
-        )
-        else {
-            // Task was stale and has been rescheduled
-            #[cfg(feature = "trace_task_details")]
-            span.record("stale", "prepare");
-            return true;
+        ) {
+            Ok(r) => r,
+            Err(stale_priority) => {
+                // Task was stale and has been rescheduled
+                #[cfg(feature = "trace_task_details")]
+                span.record("stale", "prepare");
+                return Some(stale_priority);
+            }
         };
 
         #[cfg(feature = "trace_task_details")]
@@ -1970,15 +1991,16 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         }
 
         if has_new_children
-            && self.task_execution_completed_connect(&mut ctx, task_id, new_children)
+            && let Some(stale_priority) =
+                self.task_execution_completed_connect(&mut ctx, task_id, new_children)
         {
             // Task was stale and has been rescheduled
             #[cfg(feature = "trace_task_details")]
             span.record("stale", "connect");
-            return true;
+            return Some(stale_priority);
         }
 
-        let (stale, in_progress_cells) = self.task_execution_completed_finish(
+        let (stale_priority, in_progress_cells) = self.task_execution_completed_finish(
             &mut ctx,
             task_id,
             #[cfg(feature = "verify_determinism")]
@@ -1986,11 +2008,11 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
             new_output,
             is_now_immutable,
         );
-        if stale {
+        if let Some(stale_priority) = stale_priority {
             // Task was stale and has been rescheduled
             #[cfg(feature = "trace_task_details")]
             span.record("stale", "finish");
-            return true;
+            return Some(stale_priority);
         }
 
         let removed_data = self.task_execution_completed_cleanup(
@@ -2005,7 +2027,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         drop(removed_data);
         drop(in_progress_cells);
 
-        false
+        None
     }
 
     fn task_execution_completed_prepare(
@@ -2017,14 +2039,14 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         cell_counters: &AutoMap<ValueTypeId, u32, BuildHasherDefault<FxHasher>, 8>,
         #[cfg(feature = "verify_determinism")] stateful: bool,
         has_invalidator: bool,
-    ) -> Option<TaskExecutionCompletePrepareResult> {
+    ) -> Result<TaskExecutionCompletePrepareResult, TaskPriority> {
         let mut task = ctx.task(task_id, TaskDataCategory::All);
         let is_recomputation = task.is_dirty().is_none();
         let Some(in_progress) = task.get_in_progress_mut() else {
             panic!("Task execution completed, but task is not in progress: {task:#?}");
         };
         if matches!(in_progress, InProgressState::Canceled) {
-            return Some(TaskExecutionCompletePrepareResult {
+            return Ok(TaskExecutionCompletePrepareResult {
                 new_children: Default::default(),
                 is_now_immutable: false,
                 #[cfg(feature = "verify_determinism")]
@@ -2048,6 +2070,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         // If the task is stale, reschedule it
         #[cfg(not(feature = "no_fast_stale"))]
         if stale && !is_once_task {
+            let stale_priority = compute_stale_priority(&task);
             let Some(InProgressState::InProgress(box InProgressStateInner {
                 done_event,
                 mut new_children,
@@ -2076,7 +2099,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                 },
                 ctx,
             );
-            return None;
+            return Err(stale_priority);
         }
 
         // take the children from the task to process them
@@ -2268,7 +2291,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
             CleanupOldEdgesOperation::run(task_id, old_edges, queue, ctx);
         }
 
-        Some(TaskExecutionCompletePrepareResult {
+        Ok(TaskExecutionCompletePrepareResult {
             new_children,
             is_now_immutable,
             #[cfg(feature = "verify_determinism")]
@@ -2412,7 +2435,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         ctx: &mut impl ExecuteContext<'_>,
         task_id: TaskId,
         new_children: FxHashSet<TaskId>,
-    ) -> bool {
+    ) -> Option<TaskPriority> {
         debug_assert!(!new_children.is_empty());
 
         let mut task = ctx.task(task_id, TaskDataCategory::All);
@@ -2421,7 +2444,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         };
         if matches!(in_progress, InProgressState::Canceled) {
             // Task was canceled in the meantime, so we don't connect the children
-            return false;
+            return None;
         }
         let InProgressState::InProgress(box InProgressStateInner {
             #[cfg(not(feature = "no_fast_stale"))]
@@ -2436,6 +2459,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         // If the task is stale, reschedule it
         #[cfg(not(feature = "no_fast_stale"))]
         if *stale && !is_once_task {
+            let stale_priority = compute_stale_priority(&task);
             let Some(InProgressState::InProgress(box InProgressStateInner { done_event, .. })) =
                 task.take_in_progress()
             else {
@@ -2456,7 +2480,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                 },
                 ctx,
             );
-            return true;
+            return Some(stale_priority);
         }
 
         let has_active_count = ctx.should_track_activeness()
@@ -2472,9 +2496,10 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
             ctx.should_track_activeness(),
         );
 
-        false
+        None
     }
 
+    #[allow(clippy::type_complexity)]
     fn task_execution_completed_finish(
         &self,
         ctx: &mut impl ExecuteContext<'_>,
@@ -2483,7 +2508,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         new_output: Option<OutputValue>,
         is_now_immutable: bool,
     ) -> (
-        bool,
+        Option<TaskPriority>,
         Option<
             auto_hash_map::AutoMap<CellId, InProgressCellState, BuildHasherDefault<FxHasher>, 1>,
         >,
@@ -2494,7 +2519,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         };
         if matches!(in_progress, InProgressState::Canceled) {
             // Task was canceled in the meantime, so we don't finish it
-            return (false, None);
+            return (None, None);
         }
         let InProgressState::InProgress(box InProgressStateInner {
             done_event,
@@ -2511,12 +2536,13 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
 
         // If the task is stale, reschedule it
         if stale && !is_once_task {
+            let stale_priority = compute_stale_priority(&task);
             let old = task.set_in_progress(InProgressState::Scheduled {
                 done_event,
                 reason: TaskExecutionReason::Stale,
             });
             debug_assert!(old.is_none(), "InProgress already exists");
-            return (true, None);
+            return (Some(stale_priority), None);
         }
 
         // Set the output if it has changed
@@ -2549,12 +2575,16 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         let dirty_changed = task.get_dirty().cloned() != new_dirtyness;
         let data_update = task.update_dirty_state(new_dirtyness);
 
+        // Under verify_determinism we re-run a task whose dirty state or output unexpectedly
+        // changed during execution to confirm determinism. The leaf priority keeps these
+        // verification reruns at the lowest priority.
         #[cfg(feature = "verify_determinism")]
-        let reschedule =
-            (dirty_changed || no_output_set) && !task_id.is_transient() && !is_once_task;
+        let stale_priority: Option<TaskPriority> =
+            ((dirty_changed || no_output_set) && !task_id.is_transient() && !is_once_task)
+                .then(TaskPriority::leaf);
         #[cfg(not(feature = "verify_determinism"))]
-        let reschedule = false;
-        if reschedule {
+        let stale_priority: Option<TaskPriority> = None;
+        if stale_priority.is_some() {
             let old = task.set_in_progress(InProgressState::Scheduled {
                 done_event,
                 reason: TaskExecutionReason::Stale,
@@ -2575,7 +2605,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         }
 
         // We return so the data can be dropped outside of critical sections
-        (reschedule, in_progress_cells)
+        (stale_priority, in_progress_cells)
     }
 
     fn task_execution_completed_cleanup(
@@ -3393,7 +3423,7 @@ impl<B: BackingStorage> Backend for TurboTasksBackend<B> {
         #[cfg(feature = "verify_determinism")] stateful: bool,
         has_invalidator: bool,
         turbo_tasks: &dyn TurboTasksBackendApi<Self>,
-    ) -> bool {
+    ) -> Option<TaskPriority> {
         self.0.task_execution_completed(
             task_id,
             result,

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -2009,7 +2009,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         #[cfg(feature = "verify_determinism")] stateful: bool,
         has_invalidator: bool,
         turbo_tasks: &dyn TurboTasksBackendApi<TurboTasksBackend<B>>,
-    ) -> bool {
+    ) -> Option<TaskPriority> {
         // Task completion is a 4 step process:
         // 1. Remove old edges (dependencies, collectibles, children, cells) and update the
         //    aggregation number of the task and the new children.
@@ -2050,15 +2050,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
 
         let mut ctx = self.execute_context(turbo_tasks);
 
-        let Some(TaskExecutionCompletePrepareResult {
-            new_children,
-            is_now_immutable,
-            #[cfg(feature = "verify_determinism")]
-            no_output_set,
-            new_output,
-            output_dependent_tasks,
-            is_recomputation,
-        }) = self.task_execution_completed_prepare(
+        let prepare_result = self.task_execution_completed_prepare(
             &mut ctx,
             #[cfg(feature = "trace_task_details")]
             &span,
@@ -2068,12 +2060,23 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
             #[cfg(feature = "verify_determinism")]
             stateful,
             has_invalidator,
-        )
-        else {
-            // Task was stale and has been rescheduled
-            #[cfg(feature = "trace_task_details")]
-            span.record("stale", "prepare");
-            return true;
+        );
+        let TaskExecutionCompletePrepareResult {
+            new_children,
+            is_now_immutable,
+            #[cfg(feature = "verify_determinism")]
+            no_output_set,
+            new_output,
+            output_dependent_tasks,
+            is_recomputation,
+        } = match prepare_result {
+            Ok(r) => r,
+            Err(stale_priority) => {
+                // Task was stale and has been rescheduled
+                #[cfg(feature = "trace_task_details")]
+                span.record("stale", "prepare");
+                return Some(stale_priority);
+            }
         };
 
         #[cfg(feature = "trace_task_details")]
@@ -2101,15 +2104,16 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         }
 
         if has_new_children
-            && self.task_execution_completed_connect(&mut ctx, task_id, new_children)
+            && let Some(stale_priority) =
+                self.task_execution_completed_connect(&mut ctx, task_id, new_children)
         {
             // Task was stale and has been rescheduled
             #[cfg(feature = "trace_task_details")]
             span.record("stale", "connect");
-            return true;
+            return Some(stale_priority);
         }
 
-        let (stale, in_progress_cells) = self.task_execution_completed_finish(
+        let (stale_priority, in_progress_cells) = self.task_execution_completed_finish(
             &mut ctx,
             task_id,
             #[cfg(feature = "verify_determinism")]
@@ -2117,11 +2121,11 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
             new_output,
             is_now_immutable,
         );
-        if stale {
+        if let Some(stale_priority) = stale_priority {
             // Task was stale and has been rescheduled
             #[cfg(feature = "trace_task_details")]
             span.record("stale", "finish");
-            return true;
+            return Some(stale_priority);
         }
 
         let removed_data = self.task_execution_completed_cleanup(
@@ -2136,7 +2140,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         drop(removed_data);
         drop(in_progress_cells);
 
-        false
+        None
     }
 
     fn task_execution_completed_prepare(
@@ -2148,14 +2152,14 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         cell_counters: &AutoMap<ValueTypeId, u32, BuildHasherDefault<FxHasher>, 8>,
         #[cfg(feature = "verify_determinism")] stateful: bool,
         has_invalidator: bool,
-    ) -> Option<TaskExecutionCompletePrepareResult> {
+    ) -> Result<TaskExecutionCompletePrepareResult, TaskPriority> {
         let mut task = ctx.task(task_id, TaskDataCategory::All);
         let is_recomputation = task.is_dirty().is_none();
         let Some(in_progress) = task.get_in_progress_mut() else {
             panic!("Task execution completed, but task is not in progress: {task:#?}");
         };
         if matches!(in_progress, InProgressState::Canceled) {
-            return Some(TaskExecutionCompletePrepareResult {
+            return Ok(TaskExecutionCompletePrepareResult {
                 new_children: Default::default(),
                 is_now_immutable: false,
                 #[cfg(feature = "verify_determinism")]
@@ -2179,6 +2183,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         // If the task is stale, reschedule it
         #[cfg(not(feature = "no_fast_stale"))]
         if stale && !is_once_task {
+            let stale_priority = task.is_dirty().unwrap_or(TaskPriority::leaf());
             let Some(InProgressState::InProgress(box InProgressStateInner {
                 done_event,
                 mut new_children,
@@ -2207,7 +2212,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                 },
                 ctx,
             );
-            return None;
+            return Err(stale_priority);
         }
 
         // take the children from the task to process them
@@ -2388,7 +2393,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
             CleanupOldEdgesOperation::run(task_id, old_edges, queue, ctx);
         }
 
-        Some(TaskExecutionCompletePrepareResult {
+        Ok(TaskExecutionCompletePrepareResult {
             new_children,
             is_now_immutable,
             #[cfg(feature = "verify_determinism")]
@@ -2532,7 +2537,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         ctx: &mut impl ExecuteContext<'_>,
         task_id: TaskId,
         new_children: FxHashSet<TaskId>,
-    ) -> bool {
+    ) -> Option<TaskPriority> {
         debug_assert!(!new_children.is_empty());
 
         let mut task = ctx.task(task_id, TaskDataCategory::All);
@@ -2541,7 +2546,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         };
         if matches!(in_progress, InProgressState::Canceled) {
             // Task was canceled in the meantime, so we don't connect the children
-            return false;
+            return None;
         }
         let InProgressState::InProgress(box InProgressStateInner {
             #[cfg(not(feature = "no_fast_stale"))]
@@ -2556,6 +2561,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         // If the task is stale, reschedule it
         #[cfg(not(feature = "no_fast_stale"))]
         if *stale && !is_once_task {
+            let stale_priority = task.is_dirty().unwrap_or(TaskPriority::leaf());
             let Some(InProgressState::InProgress(box InProgressStateInner { done_event, .. })) =
                 task.take_in_progress()
             else {
@@ -2576,7 +2582,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                 },
                 ctx,
             );
-            return true;
+            return Some(stale_priority);
         }
 
         let has_active_count = ctx.should_track_activeness()
@@ -2592,9 +2598,10 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
             ctx.should_track_activeness(),
         );
 
-        false
+        None
     }
 
+    #[allow(clippy::type_complexity)]
     fn task_execution_completed_finish(
         &self,
         ctx: &mut impl ExecuteContext<'_>,
@@ -2603,7 +2610,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         new_output: Option<OutputValue>,
         is_now_immutable: bool,
     ) -> (
-        bool,
+        Option<TaskPriority>,
         Option<
             auto_hash_map::AutoMap<CellId, InProgressCellState, BuildHasherDefault<FxHasher>, 1>,
         >,
@@ -2614,7 +2621,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         };
         if matches!(in_progress, InProgressState::Canceled) {
             // Task was canceled in the meantime, so we don't finish it
-            return (false, None);
+            return (None, None);
         }
         let InProgressState::InProgress(box InProgressStateInner {
             done_event,
@@ -2631,12 +2638,13 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
 
         // If the task is stale, reschedule it
         if stale && !is_once_task {
+            let stale_priority = task.is_dirty().unwrap_or(TaskPriority::leaf());
             let old = task.set_in_progress(InProgressState::Scheduled {
                 done_event,
                 reason: TaskExecutionReason::Stale,
             });
             debug_assert!(old.is_none(), "InProgress already exists");
-            return (true, None);
+            return (Some(stale_priority), None);
         }
 
         // Set the output if it has changed
@@ -2670,11 +2678,12 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         let data_update = task.update_dirty_state(new_dirtyness);
 
         #[cfg(feature = "verify_determinism")]
-        let reschedule =
-            (dirty_changed || no_output_set) && !task_id.is_transient() && !is_once_task;
+        let reschedule: Option<TaskPriority> =
+            ((dirty_changed || no_output_set) && !task_id.is_transient() && !is_once_task)
+                .then(TaskPriority::leaf);
         #[cfg(not(feature = "verify_determinism"))]
-        let reschedule = false;
-        if reschedule {
+        let reschedule: Option<TaskPriority> = None;
+        if reschedule.is_some() {
             let old = task.set_in_progress(InProgressState::Scheduled {
                 done_event,
                 reason: TaskExecutionReason::Stale,
@@ -3541,7 +3550,7 @@ impl<B: BackingStorage> Backend for TurboTasksBackend<B> {
         #[cfg(feature = "verify_determinism")] stateful: bool,
         has_invalidator: bool,
         turbo_tasks: &dyn TurboTasksBackendApi<Self>,
-    ) -> bool {
+    ) -> Option<TaskPriority> {
         self.0.task_execution_completed(
             task_id,
             result,

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -2577,7 +2577,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
 
         // Under verify_determinism we re-run a task whose dirty state or output unexpectedly
         // changed during execution to confirm determinism. The leaf priority keeps these
-        // verification reruns at the lowest priority.
+        // verification reruns at the highest priority.
         #[cfg(feature = "verify_determinism")]
         let stale_priority: Option<TaskPriority> =
             ((dirty_changed || no_output_set) && !task_id.is_transient() && !is_once_task)

--- a/turbopack/crates/turbo-tasks/src/backend.rs
+++ b/turbopack/crates/turbo-tasks/src/backend.rs
@@ -558,6 +558,11 @@ pub trait Backend: Sync + Send {
 
     fn task_execution_canceled(&self, task: TaskId, turbo_tasks: &dyn TurboTasksBackendApi<Self>);
 
+    /// Called when a task's execution finishes.
+    ///
+    /// Returns `Some(priority)` if the task was invalidated again while executing and must be
+    /// re-run. The caller is responsible for re-scheduling the task at the returned priority
+    /// (typically lower than the priority of the just-finished run).
     fn task_execution_completed(
         &self,
         task: TaskId,
@@ -566,7 +571,7 @@ pub trait Backend: Sync + Send {
         #[cfg(feature = "verify_determinism")] stateful: bool,
         has_invalidator: bool,
         turbo_tasks: &dyn TurboTasksBackendApi<Self>,
-    ) -> bool;
+    ) -> Option<TaskPriority>;
 
     type BackendJob: Send + 'static;
 

--- a/turbopack/crates/turbo-tasks/src/backend.rs
+++ b/turbopack/crates/turbo-tasks/src/backend.rs
@@ -518,7 +518,7 @@ pub trait Backend: Sync + Send {
         #[cfg(feature = "verify_determinism")] stateful: bool,
         has_invalidator: bool,
         turbo_tasks: &dyn TurboTasksBackendApi<Self>,
-    ) -> bool;
+    ) -> Option<TaskPriority>;
 
     type BackendJob: Send + 'static;
 

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -1185,70 +1185,66 @@ impl<B: Backend> Executor<TurboTasks<B>, ScheduledTask, TaskPriority> for TurboT
                 let this = this.clone();
                 let future = async move {
                     abort_on_panic(async {
-                        let mut schedule_again = true;
-                        while schedule_again {
-                            // it's okay for execution ids to overflow and wrap, they're just used
-                            // for an assert
-                            let execution_id = this.execution_id_factory.wrapping_get();
-                            let current_task_state = Arc::new(RwLock::new(CurrentTaskState::new(
-                                task_id,
-                                execution_id,
-                                priority,
-                                false, // in_top_level_task
-                            )));
-                            let single_execution_future = async {
-                                if this.stopped.load(Ordering::Acquire) {
-                                    this.backend.task_execution_canceled(task_id, &*this);
-                                    return false;
-                                }
+                        // it's okay for execution ids to overflow and wrap, they're just used
+                        // for an assert
+                        let execution_id = this.execution_id_factory.wrapping_get();
+                        let current_task_state = Arc::new(RwLock::new(CurrentTaskState::new(
+                            task_id,
+                            execution_id,
+                            priority,
+                            false, // in_top_level_task
+                        )));
+                        let single_execution_future = async {
+                            if this.stopped.load(Ordering::Acquire) {
+                                this.backend.task_execution_canceled(task_id, &*this);
+                                return None;
+                            }
 
-                                let Some(TaskExecutionSpec { future, span }) = this
-                                    .backend
-                                    .try_start_task_execution(task_id, priority, &*this)
-                                else {
-                                    return false;
+                            let TaskExecutionSpec { future, span } = this
+                                .backend
+                                .try_start_task_execution(task_id, priority, &*this)?;
+
+                            async {
+                                let result = CaptureFuture::new(future).await;
+
+                                // wait for all spawned local tasks using `local` to finish
+                                wait_for_local_tasks().await;
+
+                                let result = match result {
+                                    Ok(Ok(raw_vc)) => {
+                                        // This is safe because we waited for all local tasks to
+                                        // complete above
+                                        raw_vc
+                                            .to_non_local_unchecked_sync(&*this)
+                                            .map_err(|err| err.into())
+                                    }
+                                    Ok(Err(err)) => Err(err.into()),
+                                    Err(err) => Err(TurboTasksExecutionError::Panic(Arc::new(err))),
                                 };
 
-                                async {
-                                    let result = CaptureFuture::new(future).await;
-
-                                    // wait for all spawned local tasks using `local` to finish
-                                    wait_for_local_tasks().await;
-
-                                    let result = match result {
-                                        Ok(Ok(raw_vc)) => {
-                                            // This is safe because we waited for all local tasks to
-                                            // complete above
-                                            raw_vc
-                                                .to_non_local_unchecked_sync(&*this)
-                                                .map_err(|err| err.into())
-                                        }
-                                        Ok(Err(err)) => Err(err.into()),
-                                        Err(err) => {
-                                            Err(TurboTasksExecutionError::Panic(Arc::new(err)))
-                                        }
-                                    };
-
-                                    let finished_state = this.finish_current_task_state();
-                                    let cell_counters = CURRENT_TASK_STATE.with(|ts| {
-                                        ts.write().unwrap().cell_counters.take().unwrap()
-                                    });
-                                    this.backend.task_execution_completed(
-                                        task_id,
-                                        result,
-                                        &cell_counters,
-                                        #[cfg(feature = "verify_determinism")]
-                                        finished_state.stateful,
-                                        finished_state.has_invalidator,
-                                        &*this,
-                                    )
-                                }
-                                .instrument(span)
-                                .await
-                            };
-                            schedule_again = CURRENT_TASK_STATE
-                                .scope(current_task_state, single_execution_future)
-                                .await;
+                                let finished_state = this.finish_current_task_state();
+                                let cell_counters = CURRENT_TASK_STATE
+                                    .with(|ts| ts.write().unwrap().cell_counters.take().unwrap());
+                                this.backend.task_execution_completed(
+                                    task_id,
+                                    result,
+                                    &cell_counters,
+                                    #[cfg(feature = "verify_determinism")]
+                                    finished_state.stateful,
+                                    finished_state.has_invalidator,
+                                    &*this,
+                                )
+                            }
+                            .instrument(span)
+                            .await
+                        };
+                        if let Some(stale_priority) = CURRENT_TASK_STATE
+                            .scope(current_task_state, single_execution_future)
+                            .await
+                        {
+                            // Task was stale; re-schedule at the correct invalidation priority so
+                            // other tasks can run in the right priority order.
+                            this.schedule(task_id, stale_priority);
                         }
                         this.finish_foreground_job();
                     })

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -1208,75 +1208,60 @@ impl<B: Backend> Executor<TurboTasks<B>, ScheduledTask, TaskPriority> for TurboT
                 let this2 = this.clone();
                 let this = this.clone();
                 let future = async move {
-                    let mut current_priority = priority;
-                    loop {
-                        // it's okay for execution ids to overflow and wrap, they're just used for
-                        // an assert
-                        let execution_id = this.execution_id_factory.wrapping_get();
-                        let current_task_state = Arc::new(RwLock::new(CurrentTaskState::new(
-                            task_id,
-                            execution_id,
-                            current_priority,
-                            false, // in_top_level_task
-                        )));
-                        let single_execution_future = async {
-                            if this.stopped.load(Ordering::Acquire) {
-                                this.backend.task_execution_canceled(task_id, &*this);
-                                return None;
-                            }
-
-                            let TaskExecutionSpec { future, span } = this
-                                .backend
-                                .try_start_task_execution(task_id, current_priority, &*this)?;
-
-                            async {
-                                let result = CaptureFuture::new(future).await;
-
-                                // wait for all spawned local tasks using `local` to finish
-                                wait_for_local_tasks().await;
-
-                                let result = match result {
-                                    Ok(Ok(raw_vc)) => Ok(raw_vc),
-                                    Ok(Err(err)) => Err(err.into()),
-                                    Err(err) => Err(TurboTasksExecutionError::Panic(Arc::new(err))),
-                                };
-
-                                let finished_state = this.finish_current_task_state();
-                                let cell_counters = CURRENT_TASK_STATE
-                                    .with(|ts| ts.write().unwrap().cell_counters.take().unwrap());
-                                this.backend.task_execution_completed(
-                                    task_id,
-                                    result,
-                                    &cell_counters,
-                                    #[cfg(feature = "verify_determinism")]
-                                    finished_state.stateful,
-                                    finished_state.has_invalidator,
-                                    &*this,
-                                )
-                            }
-                            .instrument(span)
-                            .await
-                        };
-                        let reschedule = CURRENT_TASK_STATE
-                            .scope(current_task_state, single_execution_future)
-                            .await;
-                        match reschedule {
-                            None => break,
-                            Some(stale_priority) => {
-                                if stale_priority >= current_priority {
-                                    // Fast path: the stale priority is at least as high as the
-                                    // current priority, so we can directly re-execute without
-                                    // going through the priority queue.
-                                    current_priority = stale_priority;
-                                } else {
-                                    // The stale priority is lower than the current priority.
-                                    // Re-schedule via the priority runner so higher-priority
-                                    // tasks can run first.
-                                    this.schedule(task_id, stale_priority);
-                                    break;
-                                }
-                            }
+                    // it's okay for execution ids to overflow and wrap, they're just used for
+                    // an assert
+                    let execution_id = this.execution_id_factory.wrapping_get();
+                    let current_task_state = Arc::new(RwLock::new(CurrentTaskState::new(
+                        task_id,
+                        execution_id,
+                        priority,
+                        false, // in_top_level_task
+                    )));
+                    let single_execution_future = async {
+                        if this.stopped.load(Ordering::Acquire) {
+                            this.backend.task_execution_canceled(task_id, &*this);
+                            return None;
                         }
+
+                        let TaskExecutionSpec { future, span } = this
+                            .backend
+                            .try_start_task_execution(task_id, priority, &*this)?;
+
+                        async {
+                            let result = CaptureFuture::new(future).await;
+
+                            // wait for all spawned local tasks using `local` to finish
+                            wait_for_local_tasks().await;
+
+                            let result = match result {
+                                Ok(Ok(raw_vc)) => Ok(raw_vc),
+                                Ok(Err(err)) => Err(err.into()),
+                                Err(err) => Err(TurboTasksExecutionError::Panic(Arc::new(err))),
+                            };
+
+                            let finished_state = this.finish_current_task_state();
+                            let cell_counters = CURRENT_TASK_STATE
+                                .with(|ts| ts.write().unwrap().cell_counters.take().unwrap());
+                            this.backend.task_execution_completed(
+                                task_id,
+                                result,
+                                &cell_counters,
+                                #[cfg(feature = "verify_determinism")]
+                                finished_state.stateful,
+                                finished_state.has_invalidator,
+                                &*this,
+                            )
+                        }
+                        .instrument(span)
+                        .await
+                    };
+                    if let Some(stale_priority) = CURRENT_TASK_STATE
+                        .scope(current_task_state, single_execution_future)
+                        .await
+                    {
+                        // Task was stale; re-schedule at the correct invalidation priority so
+                        // other tasks can run in the right priority order.
+                        this.schedule(task_id, stale_priority);
                     }
                     this.finish_foreground_job();
                 };

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -1208,29 +1208,26 @@ impl<B: Backend> Executor<TurboTasks<B>, ScheduledTask, TaskPriority> for TurboT
                 let this2 = this.clone();
                 let this = this.clone();
                 let future = async move {
-                    let mut schedule_again = true;
-                    while schedule_again {
+                    let mut current_priority = priority;
+                    loop {
                         // it's okay for execution ids to overflow and wrap, they're just used for
                         // an assert
                         let execution_id = this.execution_id_factory.wrapping_get();
                         let current_task_state = Arc::new(RwLock::new(CurrentTaskState::new(
                             task_id,
                             execution_id,
-                            priority,
+                            current_priority,
                             false, // in_top_level_task
                         )));
                         let single_execution_future = async {
                             if this.stopped.load(Ordering::Acquire) {
                                 this.backend.task_execution_canceled(task_id, &*this);
-                                return false;
+                                return None;
                             }
 
-                            let Some(TaskExecutionSpec { future, span }) = this
+                            let TaskExecutionSpec { future, span } = this
                                 .backend
-                                .try_start_task_execution(task_id, priority, &*this)
-                            else {
-                                return false;
-                            };
+                                .try_start_task_execution(task_id, current_priority, &*this)?;
 
                             async {
                                 let result = CaptureFuture::new(future).await;
@@ -1260,9 +1257,26 @@ impl<B: Backend> Executor<TurboTasks<B>, ScheduledTask, TaskPriority> for TurboT
                             .instrument(span)
                             .await
                         };
-                        schedule_again = CURRENT_TASK_STATE
+                        let reschedule = CURRENT_TASK_STATE
                             .scope(current_task_state, single_execution_future)
                             .await;
+                        match reschedule {
+                            None => break,
+                            Some(stale_priority) => {
+                                if stale_priority >= current_priority {
+                                    // Fast path: the stale priority is at least as high as the
+                                    // current priority, so we can directly re-execute without
+                                    // going through the priority queue.
+                                    current_priority = stale_priority;
+                                } else {
+                                    // The stale priority is lower than the current priority.
+                                    // Re-schedule via the priority runner so higher-priority
+                                    // tasks can run first.
+                                    this.schedule(task_id, stale_priority);
+                                    break;
+                                }
+                            }
+                        }
                     }
                     this.finish_foreground_job();
                 };


### PR DESCRIPTION
### What?

When an in-progress task is invalidated during execution, it transitions to a "stale" state. Previously, on completion it was directly re-executed in the same worker slot — inheriting the original schedule priority rather than the priority from the invalidation that made it stale.

### Why?

A stale task that was invalidated at low priority was being re-executed at whatever high priority the original schedule had. This caused high-priority work to be unfairly blocked or deprioritized in the scheduler.

### How?

**`backend.rs` trait:** `task_execution_completed` return type changed from `bool` (reschedule yes/no) to `Option<TaskPriority>` — `None` means done, `Some(priority)` means the task was stale and must be re-executed at this priority.

**`backend/mod.rs`:** The three helper functions (`_prepare`, `_connect`, `_finish`) and the main `task_execution_completed` all propagate the invalidation priority on stale returns. In each stale path, the priority is read from `task.is_dirty().unwrap_or(TaskPriority::leaf())` before the task state is mutated.

**`manager.rs`:** The executor no longer loops to directly re-execute stale tasks. Instead, if `task_execution_completed` returns `Some(stale_priority)`, the task is unconditionally re-scheduled through the priority runner at that priority, so all tasks execute in the correct priority order.

<!-- NEXT_JS_LLM_PR -->