### PR TITLE
Ignore TS on a test that's breaking build and deploy tests

### DIFF
--- a/test/e2e/css-data-url-global-pages/pages/index.tsx
+++ b/test/e2e/css-data-url-global-pages/pages/index.tsx
@@ -1,3 +1,4 @@
+// @ts-ignore: data uri types aren't resolving
 import 'data:text/css,#styled{font-weight:700}'
 
 export default function Home() {


### PR DESCRIPTION
All of our `next build` tests are failing because this test fails to compile:
`test/e2e/css-data-url-global-pages/css-data-url-global-pages.test.ts`

It uses a data URI, and TypeScript bails because it doesn't know how to type it.

The purpose of the test is to confirm that the CSS is properly injected, not that TS properly types data attributes. The fact that it fails before it even runs renders it useless, and it's making all of our CI runs red.