### PR TITLE
Use existing commitId for tarball URL in stats action

### DIFF
--- a/.github/actions/next-stats-action/src/add-comment.js
+++ b/.github/actions/next-stats-action/src/add-comment.js
@@ -974,13 +974,13 @@ function generateDiffsSection(result) {
 }
 
 function generatePrTarballSection(actionInfo) {
-  if (actionInfo.isRelease || !actionInfo.githubHeadSha) return ''
+  if (actionInfo.isRelease || !actionInfo.commitId) return ''
 
   return `<details>
 <summary><strong>📎 Tarball URL</strong></summary>
 
 \`\`\`
-https://vercel-packages.vercel.app/next/commits/${actionInfo.githubHeadSha}/next
+https://vercel-packages.vercel.app/next/commits/${actionInfo.commitId}/next
 \`\`\`
 
 </details>

--- a/.github/actions/next-stats-action/src/prepare/action-info.js
+++ b/.github/actions/next-stats-action/src/prepare/action-info.js
@@ -8,7 +8,6 @@ module.exports = function actionInfo() {
     ISSUE_ID,
     SKIP_CLONE,
     GITHUB_REF,
-    GITHUB_SHA,
     LOCAL_STATS,
     GIT_ROOT_DIR,
     GITHUB_ACTION,
@@ -56,9 +55,6 @@ module.exports = function actionInfo() {
     prRef: GITHUB_REF,
     isLocal: LOCAL_STATS,
     commitId: null,
-    // Mirrors github.event.after || github.sha used by build_and_deploy.yml
-    // to ensure the tarball URL matches the deployed artifact.
-    githubHeadSha: GITHUB_SHA || null,
     issueId: ISSUE_ID,
     isRelease:
       GITHUB_REPOSITORY === 'vercel/next.js' &&
@@ -73,10 +69,6 @@ module.exports = function actionInfo() {
   if (GITHUB_EVENT_PATH) {
     const event = require(GITHUB_EVENT_PATH)
     info.actionName = event.action || info.actionName
-
-    if (event.after) {
-      info.githubHeadSha = event.after
-    }
 
     if (releaseTypes.has(info.actionName)) {
       info.isRelease = true


### PR DESCRIPTION
## Summary

PR #90709 introduced a `githubHeadSha` field in the stats action using `event.after || GITHUB_SHA`, which can resolve to the wrong SHA for PR events. The correct value was already available as `commitId` (from `getCommitId()` = `git rev-parse HEAD` on the cloned PR branch).

- Use `commitId` for the tarball URL in `add-comment.js`
- Remove the redundant `githubHeadSha` field from `action-info.js`

## Test plan

- [ ] Verify the stats comment on a PR shows the correct tarball URL matching the deployed artifact