### PR TITLE
Turbopack: Use an async lock in the filesystem watcher

### DIFF
--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -312,10 +312,12 @@ impl DiskFileSystemInner {
 
     /// registers the path as an invalidator for the current task,
     /// has to be called within a turbo-tasks function
-    fn register_read_invalidator(&self, path: &Path) -> Result<()> {
+    async fn register_read_invalidator(&self, path: &Path) -> Result<()> {
         if let Some(invalidator) = turbo_tasks::get_invalidator() {
             self.invalidator_map.insert(path.to_owned(), invalidator);
-            self.watcher.ensure_watched_file(path, self.root_path())?;
+            self.watcher
+                .ensure_watched_file(path, self.root_path())
+                .await?;
         }
         Ok(())
     }
@@ -341,11 +343,13 @@ impl DiskFileSystemInner {
 
     /// registers the path as an invalidator for the current task,
     /// has to be called within a turbo-tasks function
-    fn register_dir_invalidator(&self, path: &Path) -> Result<()> {
+    async fn register_dir_invalidator(&self, path: &Path) -> Result<()> {
         if let Some(invalidator) = turbo_tasks::get_invalidator() {
             self.dir_invalidator_map
                 .insert(path.to_owned(), invalidator);
-            self.watcher.ensure_watched_dir(path, self.root_path())?;
+            self.watcher
+                .ensure_watched_dir(path, self.root_path())
+                .await?;
         }
         Ok(())
     }
@@ -489,7 +493,8 @@ impl DiskFileSystemInner {
             .await?;
 
         self.watcher
-            .start_watching(self.clone(), report_invalidation_reason, poll_interval)?;
+            .start_watching(self.clone(), report_invalidation_reason, poll_interval)
+            .await?;
 
         Ok(())
     }
@@ -546,8 +551,8 @@ impl DiskFileSystem {
             .await
     }
 
-    pub fn stop_watching(&self) {
-        self.inner.watcher.stop_watching();
+    pub async fn stop_watching(&self) {
+        self.inner.watcher.stop_watching().await;
     }
 
     /// Try to convert [`Path`] to [`FileSystemPath`]. Return `None` if the file path leaves the
@@ -711,7 +716,7 @@ impl FileSystem for DiskFileSystem {
         }
         let full_path = self.to_sys_path(&fs_path);
 
-        self.inner.register_read_invalidator(&full_path)?;
+        self.inner.register_read_invalidator(&full_path).await?;
 
         let _lock = self.inner.lock_path(&full_path).await;
         let content = match retry_blocking(|| File::from_path(&full_path))
@@ -739,7 +744,7 @@ impl FileSystem for DiskFileSystem {
         }
         let full_path = self.to_sys_path(&fs_path);
 
-        self.inner.register_dir_invalidator(&full_path)?;
+        self.inner.register_dir_invalidator(&full_path).await?;
 
         // we use the sync std function here as it's a lot faster (600%) in node-file-trace
         let read_dir = match retry_blocking(|| std::fs::read_dir(&full_path))
@@ -829,7 +834,7 @@ impl FileSystem for DiskFileSystem {
         }
         let full_path = self.to_sys_path(&fs_path);
 
-        self.inner.register_read_invalidator(&full_path)?;
+        self.inner.register_read_invalidator(&full_path).await?;
 
         let _lock = self.inner.lock_path(&full_path).await;
         let link_path = match retry_blocking(|| std::fs::read_link(&full_path))
@@ -1374,7 +1379,7 @@ impl FileSystem for DiskFileSystem {
             turbobail!("Cannot read metadata from denied path: {fs_path}");
         }
 
-        self.inner.register_read_invalidator(&full_path)?;
+        self.inner.register_read_invalidator(&full_path).await?;
 
         let _lock = self.inner.lock_path(&full_path).await;
         let meta = retry_blocking(|| std::fs::metadata(&full_path))

--- a/turbopack/crates/turbo-tasks-fs/src/watcher.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/watcher.rs
@@ -5,7 +5,7 @@ use std::{
     mem::take,
     path::{Path, PathBuf},
     sync::{
-        Arc, LazyLock, RwLock, RwLockWriteGuard,
+        Arc, LazyLock,
         mpsc::{Receiver, TryRecvError, channel},
     },
     time::Duration,
@@ -18,6 +18,7 @@ use notify::{
     event::{MetadataKind, ModifyKind, RenameMode},
 };
 use rustc_hash::FxHashSet;
+use tokio::sync::{RwLock, RwLockWriteGuard};
 use tracing::instrument;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
@@ -94,10 +95,10 @@ impl State {
         }
     }
 
-    fn write(&self) -> StateWriteGuard<'_> {
+    async fn write(&self) -> StateWriteGuard<'_> {
         match self {
-            Self::Recursive(state) => StateWriteGuard::Recursive(state.write().unwrap()),
-            Self::NonRecursive(state) => StateWriteGuard::NonRecursive(state.write().unwrap()),
+            Self::Recursive(state) => StateWriteGuard::Recursive(state.write().await),
+            Self::NonRecursive(state) => StateWriteGuard::NonRecursive(state.write().await),
         }
     }
 }
@@ -156,8 +157,11 @@ mod non_recursive_helpers {
 
     /// Called after a rescan in case a previously watched-but-deleted directory was recreated.
     #[instrument(skip_all, level = "trace")]
-    pub fn restore_all_watched_ignore_errors(state: &RwLock<NonRecursiveState>, root_path: &Path) {
-        let mut guard = state.write().unwrap();
+    pub async fn restore_all_watched_ignore_errors(
+        state: &RwLock<NonRecursiveState>,
+        root_path: &Path,
+    ) {
+        let mut guard = state.write().await;
         let NonRecursiveState::Watching(watching_state) = &mut *guard else {
             return;
         };
@@ -174,7 +178,7 @@ mod non_recursive_helpers {
     /// Called when a new directory is found in a parent directory we're watching. Restores the
     /// watcher if we were previously watching it.
     #[instrument(skip_all, level = "trace")]
-    pub fn restore_if_watched(
+    pub async fn restore_if_watched(
         state: &RwLock<NonRecursiveState>,
         dir_path: &Path,
         root_path: &Path,
@@ -188,7 +192,7 @@ mod non_recursive_helpers {
 
         // fast path: the directory isn't in `watched`, only take a read lock and bail out early
         {
-            let guard = state.read().unwrap();
+            let guard = state.read().await;
             let NonRecursiveState::Watching(watching_state) = &*guard else {
                 return Ok(());
             };
@@ -198,7 +202,7 @@ mod non_recursive_helpers {
         }
 
         // slow path: re-watch the path
-        let mut guard = state.write().unwrap();
+        let mut guard = state.write().await;
         let NonRecursiveState::Watching(watching_state) = &mut *guard else {
             return Ok(());
         };
@@ -219,7 +223,7 @@ mod non_recursive_helpers {
     ///
     /// This should be called *before* reading a file to avoid a race condition.
     #[instrument(skip_all, level = "trace")]
-    pub fn ensure_watched(
+    pub async fn ensure_watched(
         state: &RwLock<NonRecursiveState>,
         dir_path: &Path,
         root_path: &Path,
@@ -233,7 +237,7 @@ mod non_recursive_helpers {
         // fast path: the directory is already in `watched`, only take a read lock and bail out
         // early
         {
-            let guard = state.read().unwrap();
+            let guard = state.read().await;
             let NonRecursiveState::Watching(watching_state) = &*guard else {
                 return Ok(());
             };
@@ -243,7 +247,7 @@ mod non_recursive_helpers {
         }
 
         // slow path: watch the path
-        let mut guard = state.write().unwrap();
+        let mut guard = state.write().await;
         let NonRecursiveState::Watching(watching_state) = &mut *guard else {
             return Ok(());
         };
@@ -354,13 +358,13 @@ impl DiskWatcher {
     /// - Emits only one Remove event when deleting a directory (inotify)
     /// - Doesn't emit duplicate create events
     /// - Doesn't emit Modify events after a Create event
-    pub fn start_watching(
+    pub async fn start_watching(
         &self,
         fs_inner: Arc<DiskFileSystemInner>,
         report_invalidation_reason: bool,
         poll_interval: Option<Duration>,
     ) -> Result<()> {
-        let state_guard = self.state.write();
+        let state_guard = self.state.write().await;
 
         // bail out if we're already watching
         if let StateWriteGuard::Recursive(guard) = &state_guard
@@ -458,10 +462,10 @@ impl DiskWatcher {
         Ok(())
     }
 
-    pub fn stop_watching(&self) {
+    pub async fn stop_watching(&self) {
         match &self.state {
-            State::Recursive(state) => *state.write().unwrap() = RecursiveState::Stopped,
-            State::NonRecursive(state) => *state.write().unwrap() = NonRecursiveState::Stopped,
+            State::Recursive(state) => *state.write().await = RecursiveState::Stopped,
+            State::NonRecursive(state) => *state.write().await = NonRecursiveState::Stopped,
         }
         // thread will detect the stop because the channel is disconnected when `NotifyWatcher` is
         // dropped
@@ -512,9 +516,11 @@ impl DiskWatcher {
                                 // we use only one global `notify::Watcher` instance.
                                 //
                                 // TODO: Report diagnostics if an error happens
-                                non_recursive_helpers::restore_all_watched_ignore_errors(
-                                    non_recursive,
-                                    fs_inner.root_path(),
+                                fs_inner.tokio_handle.block_on(
+                                    non_recursive_helpers::restore_all_watched_ignore_errors(
+                                        non_recursive,
+                                        fs_inner.root_path(),
+                                    ),
                                 );
                                 if let Some(batched_new_paths) = &mut batched_new_paths {
                                     batched_new_paths.clear();
@@ -682,11 +688,14 @@ impl DiskWatcher {
             if let State::NonRecursive(non_recursive) = &self.state {
                 for path in batched_new_paths.as_mut().unwrap().drain() {
                     // TODO: Report diagnostics if this error happens
-                    let _ = non_recursive_helpers::restore_if_watched(
-                        non_recursive,
-                        &path,
-                        fs_inner.root_path(),
-                    );
+                    let _ =
+                        fs_inner
+                            .tokio_handle
+                            .block_on(non_recursive_helpers::restore_if_watched(
+                                non_recursive,
+                                &path,
+                                fs_inner.root_path(),
+                            ));
                 }
             }
 
@@ -734,21 +743,21 @@ impl DiskWatcher {
         }
     }
 
-    pub fn ensure_watched_file(&self, path: &Path, root_path: &Path) -> Result<()> {
+    pub async fn ensure_watched_file(&self, path: &Path, root_path: &Path) -> Result<()> {
         // Watch the parent directory instead of the specified file, since directories also track
         // their immediate children (even in non-recursive mode), and we need to watch all the
         // parents anyways.
         if let State::NonRecursive(non_recursive) = &self.state
             && let Some(dir_path) = path.parent()
         {
-            non_recursive_helpers::ensure_watched(non_recursive, dir_path, root_path)?;
+            non_recursive_helpers::ensure_watched(non_recursive, dir_path, root_path).await?;
         }
         Ok(())
     }
 
-    pub fn ensure_watched_dir(&self, dir_path: &Path, root_path: &Path) -> Result<()> {
+    pub async fn ensure_watched_dir(&self, dir_path: &Path, root_path: &Path) -> Result<()> {
         if let State::NonRecursive(non_recursive) = &self.state {
-            non_recursive_helpers::ensure_watched(non_recursive, dir_path, root_path)?;
+            non_recursive_helpers::ensure_watched(non_recursive, dir_path, root_path).await?;
         }
         Ok(())
     }


### PR DESCRIPTION
We know that we have a lot of lock contention when creating watchers, because many watchers are often set up at roughly the same time near the start of building a route. Internal discussion thread: https://vercel.slack.com/archives/C09R44U5HQW/p1776271283799709

@lukesandberg's suggestion was that the lock is held over syscalls and file IO, so it's possible that this could starve the Tokio worker threads, so we should use an async lock so that we can yield back the worker thread.

Because this would simply unblock *other* work, and because this codepath is only used in `dev`, there's no sane way to benchmark or measure this, so we'll just have to hope and pray it's an improvement.

This PR is entirely AI-generated.