### PR TITLE
Auto-generate AGENTS.md / CLAUDE.md in next dev

### DIFF
--- a/docs/01-app/02-guides/ai-agents.mdx
+++ b/docs/01-app/02-guides/ai-agents.mdx
@@ -59,9 +59,7 @@ npx create-next-app@canary --no-agents-md
 
 ### Existing projects
 
-Ensure you are on Next.js `v16.2.0-canary.37` or later, then add the following files to the root of your project.
-
-`AGENTS.md` contains the instructions that agents will read:
+On Next.js 16.3 or later, just run `next dev`. When an AI coding agent is detected in the environment and no managed block is present, Next.js auto-generates `AGENTS.md` and `CLAUDE.md` at the project root. Existing `AGENTS.md` or `CLAUDE.md` files are upserted — content outside the managed block is preserved:
 
 ```md filename="AGENTS.md"
 <!-- BEGIN:nextjs-agent-rules -->
@@ -73,24 +71,31 @@ This version has breaking changes — APIs, conventions, and file structure may 
 <!-- END:nextjs-agent-rules -->
 ```
 
-`CLAUDE.md` uses the `@` import syntax to include `AGENTS.md`, so [Claude Code](https://docs.anthropic.com/en/docs/claude-code) users get the same instructions without duplicating content:
-
 ```md filename="CLAUDE.md"
 @AGENTS.md
 ```
 
-<details>
-<summary>For earlier versions</summary>
+### Opting out
 
-On version 16.1 and earlier, use the codemod to generate these files automatically:
+We believe leaving auto-generation on is a good default—[benchmark results on nextjs.org/evals](https://nextjs.org/evals) show agents do better when they read the bundled docs. If you really want to opt out, set `agentRules` to `false` in your config:
 
-```bash
-npx @next/codemod@latest agents-md
+```ts filename="next.config.ts"
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  agentRules: false,
+}
+
+export default nextConfig
 ```
 
-The codemod outputs the bundled docs to `.next-docs/` in the project root instead of `node_modules/next/dist/docs/`, and the generated agent files will point to that directory.
+### For earlier versions
 
-</details>
+On version 16.1 and earlier, use the legacy `agents-md` command, which downloads the docs to `.next-docs/` in the project root:
+
+```bash
+npx @next/codemod@canary agents-md
+```
 
 ## Understanding AGENTS.md
 

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -429,6 +429,7 @@ export const experimentalSchema = {
 export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
   z.strictObject({
     adapterPath: z.string().optional(),
+    agentRules: z.boolean().optional(),
     allowedDevOrigins: z.array(z.string()).optional(),
     assetPrefix: z.string().optional(),
     basePath: z.string().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1658,6 +1658,17 @@ export interface NextConfig {
   expireTime?: number
 
   /**
+   * When `next dev` detects an AI coding agent and no managed
+   * agent-rules block is present, Next.js auto-generates `AGENTS.md`
+   * and `CLAUDE.md` at the project root so the agent reads
+   * version-matched docs from `node_modules/next/dist/docs/` instead
+   * of stale training data. Set to `false` to disable this behavior.
+   *
+   * @default true
+   */
+  agentRules?: boolean
+
+  /**
    * Enable experimental features. Note that all experimental features are subject to breaking changes in the future.
    */
   experimental?: ExperimentalConfig
@@ -1954,6 +1965,7 @@ export interface NextConfigRuntime {
 
   distDir: NextConfigComplete['distDir']
   cacheComponents: NextConfigComplete['cacheComponents']
+  agentRules: NextConfigComplete['agentRules']
   htmlLimitedBots: NextConfigComplete['htmlLimitedBots']
   assetPrefix: NextConfigComplete['assetPrefix']
   output: NextConfigComplete['output']
@@ -2106,6 +2118,7 @@ export function getNextConfigRuntime(
 
     distDir: config.distDir,
     cacheComponents: config.cacheComponents,
+    agentRules: config.agentRules,
     htmlLimitedBots: config.htmlLimitedBots,
     assetPrefix: config.assetPrefix,
     output: config.output,

--- a/packages/next/src/server/lib/app-info-log.ts
+++ b/packages/next/src/server/lib/app-info-log.ts
@@ -4,6 +4,12 @@ import * as Log from '../../build/output/log'
 import { bold, purple, strikethrough } from '../../lib/picocolors'
 import type { ConfiguredExperimentalFeature } from '../config'
 import { experimentalSchema } from '../config-schema'
+import { detectAgent } from '../../telemetry/detect-agent'
+import {
+  hasAgentRulesInstalled,
+  writeAgentFiles,
+  type AgentFilesResult,
+} from './generate-agent-files'
 
 // Re-export the type for consumers
 export type { ConfiguredExperimentalFeature }
@@ -111,6 +117,23 @@ export function logExperimentalInfo({
 
   // New line after the bootstrap info
   Log.info('')
+}
+
+/**
+ * When `next dev` detects an AI coding agent but the managed
+ * agent-rules block is missing from AGENTS.md / CLAUDE.md,
+ * auto-generate the files so the agent has access to version-matched
+ * docs. Returns the write result when files were generated, or `null`
+ * when no action was needed.
+ *
+ * Callers gate this on `config.agentRules !== false` — opt-out is
+ * declarative in next.config, not inside this function.
+ */
+export function ensureAgentRulesForDev(dir: string): AgentFilesResult | null {
+  if (detectAgent() === null) return null
+  if (hasAgentRulesInstalled(dir)) return null
+
+  return writeAgentFiles(dir)
 }
 
 /**

--- a/packages/next/src/server/lib/generate-agent-files.ts
+++ b/packages/next/src/server/lib/generate-agent-files.ts
@@ -1,0 +1,175 @@
+/**
+ * Auto-generate AGENTS.md / CLAUDE.md with the managed Next.js agent-rules
+ * block when `next dev` detects an AI coding agent but the block is missing.
+ *
+ * Keep the marker and block content in sync with:
+ *   - packages/create-next-app/helpers/generate-agent-files.ts
+ *   - packages/next-codemod/lib/agents-md.ts
+ */
+
+import fs from 'fs'
+import path from 'path'
+
+export const AGENT_RULES_START_MARKER = '<!-- BEGIN:nextjs-agent-rules -->'
+export const AGENT_RULES_END_MARKER = '<!-- END:nextjs-agent-rules -->'
+
+/**
+ * Markers written by the pre-bundled-docs version of `agents-md`.
+ * Stripped on upsert so projects that ran the old codemod end up with
+ * a single current block instead of two stale-and-current blocks.
+ */
+const LEGACY_AGENT_RULES_START_MARKER = '<!-- NEXT-AGENTS-MD-START -->'
+const LEGACY_AGENT_RULES_END_MARKER = '<!-- NEXT-AGENTS-MD-END -->'
+
+function buildAgentRulesBlock(): string {
+  return `${AGENT_RULES_START_MARKER}
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in \`node_modules/next/dist/docs/\` before writing any code. Heed deprecation notices.
+${AGENT_RULES_END_MARKER}`
+}
+
+const CLAUDE_MD_CONTENT = `@AGENTS.md\n`
+
+export type AgentFileAction = 'created' | 'updated' | 'unchanged' | 'skipped'
+
+export interface AgentFilesResult {
+  agentsMd: AgentFileAction
+  claudeMd: AgentFileAction
+}
+
+/**
+ * Returns true when `AGENTS.md` or `CLAUDE.md` at `dir` contains the
+ * managed agent-rules marker.
+ */
+export function hasAgentRulesInstalled(dir: string): boolean {
+  const agentsContent = tryReadFile(path.join(dir, 'AGENTS.md'))
+  if (agentsContent?.includes(AGENT_RULES_START_MARKER)) return true
+
+  const claudeContent = tryReadFile(path.join(dir, 'CLAUDE.md'))
+  if (claudeContent?.includes(AGENT_RULES_START_MARKER)) return true
+
+  return false
+}
+
+/**
+ * Write the agent-rules block into `projectDir`, respecting whichever
+ * file the user already uses:
+ *
+ *   - `AGENTS.md` exists → upsert into it, leave `CLAUDE.md` alone.
+ *   - `CLAUDE.md` exists (but not `AGENTS.md`) → upsert into it.
+ *   - Neither exists → create both (`AGENTS.md` + `CLAUDE.md` with
+ *     `@AGENTS.md` import), matching `create-next-app`.
+ *
+ * Idempotent: a file already containing the canonical block is
+ * reported as `unchanged`.
+ */
+export function writeAgentFiles(projectDir: string): AgentFilesResult {
+  const agentsMdPath = path.join(projectDir, 'AGENTS.md')
+  const claudeMdPath = path.join(projectDir, 'CLAUDE.md')
+  const block = buildAgentRulesBlock()
+
+  const agentsMdExists = fs.existsSync(agentsMdPath)
+  const claudeMdExists = fs.existsSync(claudeMdPath)
+
+  if (agentsMdExists) {
+    return {
+      agentsMd: upsertFile(agentsMdPath, block),
+      claudeMd: 'skipped',
+    }
+  }
+
+  if (claudeMdExists) {
+    return {
+      agentsMd: 'skipped',
+      claudeMd: upsertFile(claudeMdPath, block),
+    }
+  }
+
+  // Neither file exists — scaffold both, matching create-next-app.
+  fs.writeFileSync(agentsMdPath, block + '\n', 'utf-8')
+  fs.writeFileSync(claudeMdPath, CLAUDE_MD_CONTENT, 'utf-8')
+  return { agentsMd: 'created', claudeMd: 'created' }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function tryReadFile(filePath: string): string | null {
+  try {
+    return fs.readFileSync(filePath, 'utf-8')
+  } catch {
+    return null
+  }
+}
+
+function upsertFile(filePath: string, block: string): AgentFileAction {
+  const existing = fs.readFileSync(filePath, 'utf-8')
+  const updated = upsertAgentRulesBlock(existing, block)
+  if (updated === existing) return 'unchanged'
+  fs.writeFileSync(filePath, updated, 'utf-8')
+  return 'updated'
+}
+
+/**
+ * Detect the predominant line-ending style. Returns `'\r\n'` if any
+ * CRLF is present, `'\n'` otherwise — avoids mixed EOLs on Windows.
+ */
+function detectEol(content: string): '\r\n' | '\n' {
+  return /\r\n/.test(content) ? '\r\n' : '\n'
+}
+
+function normalizeEol(s: string, eol: '\r\n' | '\n'): string {
+  return s.replace(/\r?\n/g, eol)
+}
+
+function upsertAgentRulesBlock(existing: string, block: string): string {
+  const eol = detectEol(existing)
+  const normalizedBlock = normalizeEol(block, eol)
+
+  existing = stripLegacyAgentRulesBlock(existing, eol)
+
+  const startIdx = existing.indexOf(AGENT_RULES_START_MARKER)
+  const endIdx = existing.indexOf(AGENT_RULES_END_MARKER)
+
+  if (startIdx !== -1 && endIdx !== -1 && endIdx > startIdx) {
+    const before = existing.slice(0, startIdx)
+    const after = existing.slice(endIdx + AGENT_RULES_END_MARKER.length)
+    const replaced = before + normalizedBlock + after
+    return replaced === existing ? existing : replaced
+  }
+
+  const separator =
+    existing.length === 0 || /\r?\n$/.test(existing) ? eol : eol + eol
+  return existing + separator + normalizedBlock + eol
+}
+
+function stripLegacyAgentRulesBlock(
+  existing: string,
+  eol: '\r\n' | '\n' = '\n'
+): string {
+  while (true) {
+    const startIdx = existing.indexOf(LEGACY_AGENT_RULES_START_MARKER)
+    if (startIdx === -1) return existing
+    const endIdx = existing.indexOf(LEGACY_AGENT_RULES_END_MARKER, startIdx)
+    if (endIdx === -1) return existing
+
+    let cutStart = startIdx
+    while (cutStart > 0 && /\s/.test(existing[cutStart - 1])) {
+      cutStart--
+    }
+    let cutEnd = endIdx + LEGACY_AGENT_RULES_END_MARKER.length
+    while (cutEnd < existing.length && /\s/.test(existing[cutEnd])) {
+      cutEnd++
+    }
+
+    const before = existing.slice(0, cutStart)
+    const after = existing.slice(cutEnd)
+
+    existing =
+      before.length > 0 && after.length > 0
+        ? before + eol + eol + after
+        : before + after
+  }
+}

--- a/packages/next/src/server/lib/render-server.ts
+++ b/packages/next/src/server/lib/render-server.ts
@@ -22,6 +22,8 @@ export type ServerInitResult = {
   experimentalFeatures: ConfiguredExperimentalFeature[]
   // Whether cache components is enabled
   cacheComponents: boolean
+  // Whether AGENTS.md / CLAUDE.md auto-generation is enabled (default true)
+  agentRules?: boolean
 }
 
 let initializations: Record<string, Promise<ServerInitResult> | undefined> = {}

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -930,5 +930,6 @@ export async function initialize(opts: {
     distDir: config.distDir,
     experimentalFeatures,
     cacheComponents: config.cacheComponents,
+    agentRules: config.agentRules,
   }
 }

--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -25,7 +25,12 @@ import {
   CONFIG_FILES,
   PHASE_DEVELOPMENT_SERVER,
 } from '../../shared/lib/constants'
-import { getEnvInfo, logExperimentalInfo, logStartInfo } from './app-info-log'
+import {
+  ensureAgentRulesForDev,
+  getEnvInfo,
+  logExperimentalInfo,
+  logStartInfo,
+} from './app-info-log'
 import { validateTurboNextConfig } from '../../lib/turbopack-warning'
 import {
   type Span,
@@ -501,6 +506,31 @@ export async function startServer(
             experimentalFeatures: initResult.experimentalFeatures,
             cacheComponents: initResult.cacheComponents,
           })
+
+          // Auto-generate AGENTS.md / CLAUDE.md when an AI coding agent
+          // is detected but the managed agent-rules block is missing.
+          // Gated on `agentRules` in next.config (default true).
+          if (initResult.agentRules !== false) {
+            const result = ensureAgentRulesForDev(dir)
+            if (result) {
+              const generated: string[] = []
+              if (
+                result.agentsMd === 'created' ||
+                result.agentsMd === 'updated'
+              )
+                generated.push('AGENTS.md')
+              if (
+                result.claudeMd === 'created' ||
+                result.claudeMd === 'updated'
+              )
+                generated.push('CLAUDE.md')
+              if (generated.length > 0) {
+                Log.event(
+                  `Generated ${generated.join(' and ')} for AI agents. Set \`agentRules: false\` in next.config to disable.`
+                )
+              }
+            }
+          }
         }
 
         handlersReady()

--- a/packages/next/src/telemetry/detect-agent.ts
+++ b/packages/next/src/telemetry/detect-agent.ts
@@ -1,0 +1,83 @@
+// NOTE: This file duplicates the detection helper added in
+// https://github.com/vercel/next.js/pull/91854 (branch: imm/agent-telemetry).
+// When that PR lands, whichever branch merges second should collapse the
+// duplicate — the contents are intentionally identical so the merge is a
+// no-op. The env variable checks mirror the same functionality in the
+// `vercel` CLI.
+
+export type AgentName =
+  | 'cursor'
+  | 'cursor-cli'
+  | 'claude'
+  | 'cowork'
+  | 'devin'
+  | 'replit'
+  | 'gemini'
+  | 'codex'
+  | 'antigravity'
+  | 'augment-cli'
+  | 'opencode'
+  | 'github-copilot'
+
+export function detectAgent(): AgentName | null {
+  if (process.env.AI_AGENT) {
+    const name = process.env.AI_AGENT.trim()
+    if (name) {
+      const normalized = name === 'github-copilot-cli' ? 'github-copilot' : name
+      return normalized as AgentName
+    }
+  }
+
+  if (process.env.CURSOR_TRACE_ID) {
+    return 'cursor'
+  }
+
+  if (process.env.CURSOR_AGENT) {
+    return 'cursor-cli'
+  }
+
+  if (process.env.GEMINI_CLI) {
+    return 'gemini'
+  }
+
+  if (
+    process.env.CODEX_SANDBOX ||
+    process.env.CODEX_CI ||
+    process.env.CODEX_THREAD_ID
+  ) {
+    return 'codex'
+  }
+
+  if (process.env.ANTIGRAVITY_AGENT) {
+    return 'antigravity'
+  }
+
+  if (process.env.AUGMENT_AGENT) {
+    return 'augment-cli'
+  }
+
+  if (process.env.OPENCODE_CLIENT) {
+    return 'opencode'
+  }
+
+  if (process.env.CLAUDECODE || process.env.CLAUDE_CODE) {
+    if (process.env.CLAUDE_CODE_IS_COWORK) {
+      return 'cowork'
+    }
+    return 'claude'
+  }
+
+  if (process.env.REPL_ID) {
+    return 'replit'
+  }
+
+  if (
+    process.env.COPILOT_MODEL ||
+    process.env.COPILOT_ALLOW_ALL ||
+    process.env.COPILOT_GITHUB_TOKEN
+  ) {
+    return 'github-copilot'
+  }
+
+  return null
+}

--- a/test/development/app-dir/agent-rules-auto-generate/agent-rules-auto-generate.test.ts
+++ b/test/development/app-dir/agent-rules-auto-generate/agent-rules-auto-generate.test.ts
@@ -1,0 +1,147 @@
+import { nextTestSetup } from 'e2e-utils'
+import fs from 'fs'
+import path from 'path'
+
+const AGENT_RULES_MARKER = '<!-- BEGIN:nextjs-agent-rules -->'
+
+describe('agent-rules auto-generate on next dev (agent detected)', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    env: { CLAUDECODE: '1' },
+  })
+
+  it('creates AGENTS.md and CLAUDE.md at the project root when neither exists', async () => {
+    const agentsContent = fs.readFileSync(
+      path.join(next.testDir, 'AGENTS.md'),
+      'utf-8'
+    )
+    expect(agentsContent).toContain(AGENT_RULES_MARKER)
+    expect(agentsContent).toContain('node_modules/next/dist/docs/')
+
+    const claudeContent = fs.readFileSync(
+      path.join(next.testDir, 'CLAUDE.md'),
+      'utf-8'
+    )
+    expect(claudeContent).toBe('@AGENTS.md\n')
+  })
+})
+
+describe('agent-rules auto-generate on next dev (no agent)', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    // Explicitly clear every env var `detectAgent()` inspects so the
+    // test doesn't inherit one from the host shell (e.g. running it
+    // inside Claude Code would otherwise trigger generation).
+    env: {
+      AI_AGENT: '',
+      CURSOR_TRACE_ID: '',
+      CURSOR_AGENT: '',
+      GEMINI_CLI: '',
+      CODEX_SANDBOX: '',
+      CODEX_CI: '',
+      CODEX_THREAD_ID: '',
+      ANTIGRAVITY_AGENT: '',
+      AUGMENT_AGENT: '',
+      OPENCODE_CLIENT: '',
+      CLAUDECODE: '',
+      CLAUDE_CODE: '',
+      REPL_ID: '',
+      COPILOT_MODEL: '',
+      COPILOT_ALLOW_ALL: '',
+      COPILOT_GITHUB_TOKEN: '',
+    },
+  })
+
+  it('does not create AGENTS.md or CLAUDE.md when no agent is detected', async () => {
+    expect(fs.existsSync(path.join(next.testDir, 'AGENTS.md'))).toBe(false)
+    expect(fs.existsSync(path.join(next.testDir, 'CLAUDE.md'))).toBe(false)
+  })
+})
+
+describe('agent-rules auto-generate on next dev (agentRules: false)', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    env: { CLAUDECODE: '1' },
+    nextConfig: {
+      agentRules: false,
+    },
+  })
+
+  it('does not generate files when agentRules is disabled in next.config', async () => {
+    expect(fs.existsSync(path.join(next.testDir, 'AGENTS.md'))).toBe(false)
+    expect(fs.existsSync(path.join(next.testDir, 'CLAUDE.md'))).toBe(false)
+  })
+})
+
+describe('agent-rules auto-generate on next dev (AGENTS.md already has marker)', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    env: { CLAUDECODE: '1' },
+    skipStart: true,
+  })
+
+  beforeAll(async () => {
+    // Pre-populate AGENTS.md WITH the managed marker before the dev
+    // server starts, so the auto-gen sees it as already installed.
+    await next.patchFile('AGENTS.md', `${AGENT_RULES_MARKER}\n`)
+    await next.start()
+  })
+
+  it('leaves the file untouched and does not create CLAUDE.md', async () => {
+    const content = fs.readFileSync(
+      path.join(next.testDir, 'AGENTS.md'),
+      'utf-8'
+    )
+    expect(content).toBe(`${AGENT_RULES_MARKER}\n`)
+    expect(fs.existsSync(path.join(next.testDir, 'CLAUDE.md'))).toBe(false)
+  })
+})
+
+describe('agent-rules auto-generate on next dev (AGENTS.md exists without marker)', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    env: { CLAUDECODE: '1' },
+    skipStart: true,
+  })
+
+  beforeAll(async () => {
+    // User-authored AGENTS.md without the managed marker — auto-gen
+    // should upsert the block while preserving existing content.
+    await next.patchFile('AGENTS.md', '# Team rules\n\nUse tabs, not spaces.\n')
+    await next.start()
+  })
+
+  it('upserts the managed block and preserves existing content', async () => {
+    const content = fs.readFileSync(
+      path.join(next.testDir, 'AGENTS.md'),
+      'utf-8'
+    )
+    expect(content).toContain('Use tabs, not spaces.')
+    expect(content).toContain(AGENT_RULES_MARKER)
+    // CLAUDE.md must stay alone when AGENTS.md already exists.
+    expect(fs.existsSync(path.join(next.testDir, 'CLAUDE.md'))).toBe(false)
+  })
+})
+
+describe('agent-rules auto-generate on next dev (CLAUDE.md exists, no AGENTS.md)', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    env: { CLAUDECODE: '1' },
+    skipStart: true,
+  })
+
+  beforeAll(async () => {
+    await next.patchFile('CLAUDE.md', '# My rules\n\nBe concise.\n')
+    await next.start()
+  })
+
+  it('upserts into CLAUDE.md and does not create AGENTS.md', async () => {
+    const claudeContent = fs.readFileSync(
+      path.join(next.testDir, 'CLAUDE.md'),
+      'utf-8'
+    )
+    expect(claudeContent).toContain('Be concise.')
+    expect(claudeContent).toContain(AGENT_RULES_MARKER)
+    expect(fs.existsSync(path.join(next.testDir, 'AGENTS.md'))).toBe(false)
+  })
+})

--- a/test/development/app-dir/agent-rules-auto-generate/agent-rules-auto-generate.test.ts
+++ b/test/development/app-dir/agent-rules-auto-generate/agent-rules-auto-generate.test.ts
@@ -11,6 +11,12 @@ describe('agent-rules auto-generate on next dev (agent detected)', () => {
   })
 
   it('creates AGENTS.md and CLAUDE.md at the project root when neither exists', async () => {
+    // A request is required to synchronize the test with the auto-gen
+    // hook — `✓ Ready in X` is logged before the config load that runs
+    // the hook, so `next.start()` resolves too early. `next.fetch` blocks
+    // on the request handler, which only becomes ready after the hook.
+    await next.fetch('/')
+
     const agentsContent = fs.readFileSync(
       path.join(next.testDir, 'AGENTS.md'),
       'utf-8'
@@ -53,6 +59,7 @@ describe('agent-rules auto-generate on next dev (no agent)', () => {
   })
 
   it('does not create AGENTS.md or CLAUDE.md when no agent is detected', async () => {
+    await next.fetch('/')
     expect(fs.existsSync(path.join(next.testDir, 'AGENTS.md'))).toBe(false)
     expect(fs.existsSync(path.join(next.testDir, 'CLAUDE.md'))).toBe(false)
   })
@@ -68,6 +75,7 @@ describe('agent-rules auto-generate on next dev (agentRules: false)', () => {
   })
 
   it('does not generate files when agentRules is disabled in next.config', async () => {
+    await next.fetch('/')
     expect(fs.existsSync(path.join(next.testDir, 'AGENTS.md'))).toBe(false)
     expect(fs.existsSync(path.join(next.testDir, 'CLAUDE.md'))).toBe(false)
   })
@@ -88,6 +96,7 @@ describe('agent-rules auto-generate on next dev (AGENTS.md already has marker)',
   })
 
   it('leaves the file untouched and does not create CLAUDE.md', async () => {
+    await next.fetch('/')
     const content = fs.readFileSync(
       path.join(next.testDir, 'AGENTS.md'),
       'utf-8'
@@ -112,6 +121,7 @@ describe('agent-rules auto-generate on next dev (AGENTS.md exists without marker
   })
 
   it('upserts the managed block and preserves existing content', async () => {
+    await next.fetch('/')
     const content = fs.readFileSync(
       path.join(next.testDir, 'AGENTS.md'),
       'utf-8'
@@ -136,6 +146,7 @@ describe('agent-rules auto-generate on next dev (CLAUDE.md exists, no AGENTS.md)
   })
 
   it('upserts into CLAUDE.md and does not create AGENTS.md', async () => {
+    await next.fetch('/')
     const claudeContent = fs.readFileSync(
       path.join(next.testDir, 'CLAUDE.md'),
       'utf-8'

--- a/test/development/app-dir/agent-rules-auto-generate/app/layout.tsx
+++ b/test/development/app-dir/agent-rules-auto-generate/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/agent-rules-auto-generate/app/page.tsx
+++ b/test/development/app-dir/agent-rules-auto-generate/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/production/next-server-nft/next-server-nft.test.ts
+++ b/test/production/next-server-nft/next-server-nft.test.ts
@@ -356,6 +356,7 @@ async function readNormalizedNFT(next, name) {
            "/node_modules/next/dist/shared/*",
            "/node_modules/next/dist/telemetry/anonymous-meta.js",
            "/node_modules/next/dist/telemetry/detached-flush.js",
+           "/node_modules/next/dist/telemetry/detect-agent.js",
            "/node_modules/next/dist/telemetry/events/build.js",
            "/node_modules/next/dist/telemetry/events/index.js",
            "/node_modules/next/dist/telemetry/events/plugins.js",


### PR DESCRIPTION
When `next dev` detects an AI coding agent via env vars like `CLAUDECODE` or `CURSOR_TRACE_ID` and neither `AGENTS.md` nor `CLAUDE.md` contains the managed marker, Next.js scaffolds them at the project root so the agent reads version-matched docs from `node_modules/next/dist/docs/` instead of stale training data. Existing files are upserted — content outside the `<!-- BEGIN:nextjs-agent-rules -->` markers is preserved. Opt out with `agentRules: false` in `next.config`.

<!-- NEXT_JS_LLM_PR -->