### PR TITLE
fix(dev): serve _clientMiddlewareManifest.js with text/javascript content type

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -200,6 +200,7 @@ import { HTML_LIMITED_BOT_UA_RE_STRING } from '../shared/lib/router/utils/is-bot
 import type { UseCacheTrackerKey } from './webpack/plugins/telemetry-plugin/use-cache-tracker-utils'
 
 import { turbopackBuild } from './turbopack-build'
+import { buildClientMiddlewareManifestJs } from '../shared/lib/turbopack/utils'
 import { inlineStaticEnv } from '../lib/inline-static-env'
 import { populateStaticEnv } from '../lib/static-env'
 import { durationToString, hrtimeDurationToString } from './duration-to-string'
@@ -2622,11 +2623,10 @@ export default async function build(
           }
 
           if (bundler === Bundler.Turbopack) {
-            const clientMiddlewareManifestJs = `self.__MIDDLEWARE_MATCHERS = ${JSON.stringify(
+            const clientMiddlewareManifestJs = buildClientMiddlewareManifestJs(
               functionsConfigManifest.functions['/_middleware'].matchers || [],
-              null,
               2
-            )};self.__MIDDLEWARE_MATCHERS_CB && self.__MIDDLEWARE_MATCHERS_CB()`
+            )
 
             let clientMiddlewareManifestPath = path.join(
               CLIENT_STATIC_FILES_PATH,

--- a/packages/next/src/lib/constants.ts
+++ b/packages/next/src/lib/constants.ts
@@ -3,6 +3,7 @@ import type { ServerRuntime } from '../types'
 export const TEXT_PLAIN_CONTENT_TYPE_HEADER = 'text/plain'
 export const HTML_CONTENT_TYPE_HEADER = 'text/html; charset=utf-8'
 export const JSON_CONTENT_TYPE_HEADER = 'application/json; charset=utf-8'
+export const JAVASCRIPT_CONTENT_TYPE_HEADER = 'text/javascript; charset=utf-8'
 export const NEXT_QUERY_PARAM_PREFIX = 'nxtP'
 export const NEXT_INTERCEPTION_MARKER_PREFIX = 'nxtI'
 

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -71,6 +71,7 @@ import {
 import { JsConfigPathsPlugin } from '../../../build/webpack/plugins/jsconfig-paths-plugin'
 import { store as consoleStore } from '../../../build/output/store'
 import {
+  buildClientMiddlewareManifestJs,
   isFileSystemCacheEnabledForDev,
   ModuleBuildError,
 } from '../../../shared/lib/turbopack/utils'
@@ -1224,7 +1225,9 @@ async function startWatcher(
     const parsedUrl = parseUrl(req.url || '/')
     const pathname = parsedUrl !== undefined ? parsedUrl.pathname : null
 
-    if (pathname !== null && pathname.includes(clientPagesManifestPath)) {
+    if (pathname === null) return { finished: false }
+
+    if (pathname.includes(clientPagesManifestPath)) {
       res.statusCode = 200
       res.setHeader('Content-Type', JSON_CONTENT_TYPE_HEADER)
       res.end(
@@ -1237,22 +1240,18 @@ async function startWatcher(
       return { finished: true }
     }
 
-    if (pathname !== null && pathname.includes(devMiddlewareManifestPath)) {
+    if (pathname.includes(devMiddlewareManifestPath)) {
       res.statusCode = 200
       res.setHeader('Content-Type', JSON_CONTENT_TYPE_HEADER)
       res.end(JSON.stringify(serverFields.middleware?.matchers || []))
       return { finished: true }
     }
 
-    if (
-      pathname !== null &&
-      pathname.includes(devTurbopackMiddlewareManifestPath)
-    ) {
+    if (pathname.includes(devTurbopackMiddlewareManifestPath)) {
       res.statusCode = 200
       res.setHeader('Content-Type', JAVASCRIPT_CONTENT_TYPE_HEADER)
-      const matchers = serverFields.middleware?.matchers || []
       res.end(
-        `self.__MIDDLEWARE_MATCHERS = ${JSON.stringify(matchers)};self.__MIDDLEWARE_MATCHERS_CB && self.__MIDDLEWARE_MATCHERS_CB()`
+        buildClientMiddlewareManifestJs(serverFields.middleware?.matchers || [])
       )
       return { finished: true }
     }

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -79,6 +79,7 @@ import { TurbopackInternalError } from '../../../shared/lib/turbopack/internal-e
 import { normalizePath } from '../../../lib/normalize-path'
 import {
   JSON_CONTENT_TYPE_HEADER,
+  JAVASCRIPT_CONTENT_TYPE_HEADER,
   MIDDLEWARE_FILENAME,
   PROXY_FILENAME,
 } from '../../../lib/constants'
@@ -1236,14 +1237,23 @@ async function startWatcher(
       return { finished: true }
     }
 
-    if (
-      pathname !== null &&
-      (pathname.includes(devMiddlewareManifestPath) ||
-        pathname.includes(devTurbopackMiddlewareManifestPath))
-    ) {
+    if (pathname !== null && pathname.includes(devMiddlewareManifestPath)) {
       res.statusCode = 200
       res.setHeader('Content-Type', JSON_CONTENT_TYPE_HEADER)
       res.end(JSON.stringify(serverFields.middleware?.matchers || []))
+      return { finished: true }
+    }
+
+    if (
+      pathname !== null &&
+      pathname.includes(devTurbopackMiddlewareManifestPath)
+    ) {
+      res.statusCode = 200
+      res.setHeader('Content-Type', JAVASCRIPT_CONTENT_TYPE_HEADER)
+      const matchers = serverFields.middleware?.matchers || []
+      res.end(
+        `self.__MIDDLEWARE_MATCHERS = ${JSON.stringify(matchers)};self.__MIDDLEWARE_MATCHERS_CB && self.__MIDDLEWARE_MATCHERS_CB()`
+      )
       return { finished: true }
     }
     return { finished: false }

--- a/packages/next/src/shared/lib/turbopack/manifest-loader.ts
+++ b/packages/next/src/shared/lib/turbopack/manifest-loader.ts
@@ -21,6 +21,7 @@ import {
   TURBOPACK_CLIENT_BUILD_MANIFEST,
   TURBOPACK_CLIENT_MIDDLEWARE_MANIFEST,
 } from '../constants'
+import { buildClientMiddlewareManifestJs } from './utils'
 import { join, posix } from 'path'
 import { readFileSync } from 'fs'
 import type { SetupOpts } from '../../../server/lib/router-utils/setup-dev-bundler'
@@ -793,11 +794,10 @@ export class TurbopackManifestLoader {
     // writes the mainfest again for builds.
     const matchers = middlewareManifest?.middleware['/']?.matchers || []
 
-    const clientMiddlewareManifestJs = `self.__MIDDLEWARE_MATCHERS = ${JSON.stringify(
+    const clientMiddlewareManifestJs = buildClientMiddlewareManifestJs(
       matchers,
-      null,
       2
-    )};self.__MIDDLEWARE_MATCHERS_CB && self.__MIDDLEWARE_MATCHERS_CB()`
+    )
 
     this.pendingCacheDeletes.push(clientMiddlewareManifestPath)
     writeFileAtomic(

--- a/packages/next/src/shared/lib/turbopack/utils.ts
+++ b/packages/next/src/shared/lib/turbopack/utils.ts
@@ -4,6 +4,7 @@ import type {
   StyledString,
   TurbopackResult,
 } from '../../../build/swc/types'
+import type { ProxyMatcher } from '../../../build/analysis/get-page-static-info'
 
 import { bold, green, magenta, red } from '../../../lib/picocolors'
 import { deobfuscateText } from '../magic-identifier'
@@ -307,4 +308,11 @@ export function isFileSystemCacheEnabledForDev(
   config: NextConfigComplete
 ): boolean {
   return config.experimental?.turbopackFileSystemCacheForDev || false
+}
+
+export function buildClientMiddlewareManifestJs(
+  matchers: ProxyMatcher[],
+  space?: number
+): string {
+  return `self.__MIDDLEWARE_MATCHERS = ${JSON.stringify(matchers, null, space)};self.__MIDDLEWARE_MATCHERS_CB && self.__MIDDLEWARE_MATCHERS_CB()`
 }


### PR DESCRIPTION
## Summary

The Turbopack client middleware manifest (`_clientMiddlewareManifest.js`) is a JavaScript file (contains `self.__MIDDLEWARE_MATCHERS = ...`) that is loaded via a `<script>` tag. However, it was being served with `application/json; charset=utf-8` content type.

When `X-Content-Type-Options: nosniff` is set (e.g. by a proxy), Chrome refuses to execute the script because its MIME type is not executable.

## Fix

- Add `JAVASCRIPT_CONTENT_TYPE_HEADER` constant to `packages/next/src/lib/constants.ts`
- Split the single handler into two: one for the JSON manifest (webpack) with `application/json`, one for the Turbopack JS manifest with `text/javascript`

## Test plan

- [ ] Start dev server with Turbopack
- [ ] Set `X-Content-Type-Options: nosniff` via a proxy or middleware
- [ ] Verify Chrome no longer refuses to execute `_clientMiddlewareManifest.js`

<!-- NEXT_JS_LLM_PR -->