### PR TITLE
fix(lazy-dynamic): pass crossOrigin to preload call for next/dynamic chunks

### DIFF
--- a/packages/next/src/shared/lib/lazy-dynamic/preload-chunks.tsx
+++ b/packages/next/src/shared/lib/lazy-dynamic/preload-chunks.tsx
@@ -66,6 +66,7 @@ export function PreloadChunks({
             as: 'script',
             fetchPriority: 'low',
             nonce: workStore.nonce,
+            crossOrigin: process.env.__NEXT_CROSS_ORIGIN,
           })
           return null
         }


### PR DESCRIPTION
## Summary

When `assetPrefix` and `crossOrigin` are configured in `next.config.js`, the `ReactDOM.preload()` call for `next/dynamic` scripts was missing the `crossOrigin` option, causing CORS warnings in Chrome when assets are served from a different domain.

## Fix

Use `process.env.__NEXT_CROSS_ORIGIN` (the same env variable used by the client-side route-loader) to pass the configured `crossOrigin` value to `preload()`, consistent with how other parts of Next.js handle this.

Fixes #92797

## Test plan

- [ ] Configure `assetPrefix` and `crossOrigin` in `next.config.js`
- [ ] Use `next/dynamic` to lazy-load a component
- [ ] Verify no CORS warnings appear in Chrome DevTools

<!-- NEXT_JS_LLM_PR -->