### PR TITLE
test: add ts-ignore for data URI import breaking all build/deploy CI

### DIFF
--- a/test/e2e/css-data-url-global-pages/pages/index.tsx
+++ b/test/e2e/css-data-url-global-pages/pages/index.tsx
@@ -1,3 +1,4 @@
+// @ts-ignore: data uri types aren't resolving
 import 'data:text/css,#styled{font-weight:700}'
 
 export default function Home() {


### PR DESCRIPTION
## Summary

`test/e2e/css-data-url-global-pages/pages/index.tsx` uses a CSS data URI import that TypeScript cannot resolve, causing all `next build` CI tests to fail before the test even runs.

The purpose of the test is to confirm that CSS is properly injected — not that TypeScript handles data URIs. Adding `@ts-ignore` unblocks all CI without changing the test's intent.

## Fix

Add `// @ts-ignore: data uri types aren't resolving` before the data URI import.

## Test plan

- [ ] Run `pnpm test-start-turbo test/e2e/css-data-url-global-pages/` — test should now compile and run

<!-- NEXT_JS_LLM_PR -->