### PR TITLE
fix: correct AppType generic placement so P is applied to AppPropsType instead of pageProps

### DIFF
--- a/packages/next/src/shared/lib/utils.ts
+++ b/packages/next/src/shared/lib/utils.ts
@@ -31,7 +31,7 @@ export type DocumentType = NextComponentType<
 export type AppType<P = {}> = NextComponentType<
   AppContextType,
   P,
-  AppPropsType<any, P>
+  AppPropsType<P, P>
 >
 
 export type AppTreeType = ComponentType<


### PR DESCRIPTION
Good day

## Problem

When using `AppType<{ foo: string }>` in a custom `_app.tsx`, the generic parameter `P` (representing App-level props like `{ foo: string }`) is currently applied only to `pageProps`, not to the top-level App props. This causes:

1. `props.foo` — a valid top-level App prop added via `getInitialProps` — has a TypeScript error "Property 'foo' does not exist on type 'AppPropsType<any, { foo: string }>'"
2. `props.pageProps.foo` — which does NOT exist at runtime — has NO TypeScript error

This is backwards from the actual runtime behavior.

## Root Cause

In `packages/next/src/shared/lib/utils.ts`, the `AppType` definition passes `any` for the first parameter of `AppPropsType`:

```typescript
export type AppType<P = {}> = NextComponentType<
  AppContextType,
  P,
  AppPropsType<any, P>  // <-- 'any' fills the Router slot, leaving P only for pageProps
>
```

## Fix

Changed `AppPropsType<any, P>` to `AppPropsType<P, P>`:

```diff
- AppPropsType<any, P>
+ AppPropsType<P, P>
```

This correctly applies the generic parameter `P` to both the Router slot and the pageProps slot, ensuring that custom App-level props (like `foo`) are correctly typed on `props` itself.

## Verification

The existing test file `test/integration/typescript/pages/_app.tsx` already uses `AppType<{ foo: string }>` with `getInitialProps` returning `{ foo: 'bar' }`, which is exactly the scenario this fix addresses.

Fixes #42846

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly,
RoomWithOutRoof