### PR TITLE
fix <Link prefetch={true}> on output: "export"

### DIFF
--- a/packages/next/src/client/app-dir/link.tsx
+++ b/packages/next/src/client/app-dir/link.tsx
@@ -781,6 +781,18 @@ export const useLinkStatus = () => {
 function getFetchStrategyFromPrefetchProp(
   prefetchProp: Exclude<LinkProps['prefetch'], undefined | false>
 ): PrefetchTaskFetchStrategy {
+  // In `output: "export"` mode, a Full prefetch issues a dynamic RSC request
+  // via request headers, but the static host can't interpret those headers and
+  // responds with the pre-rendered HTML document instead. Fall back to PPR so
+  // the prefetch reads the per-segment `__next.*.txt` files the exporter
+  // emitted for this route.
+  if (
+    process.env.NODE_ENV === 'production' &&
+    process.env.__NEXT_CONFIG_OUTPUT === 'export'
+  ) {
+    return FetchStrategy.PPR
+  }
+
   if (process.env.__NEXT_CACHE_COMPONENTS) {
     if (prefetchProp === true) {
       return FetchStrategy.Full

--- a/packages/next/src/client/components/links.ts
+++ b/packages/next/src/client/components/links.ts
@@ -275,11 +275,18 @@ export function onNavigationIntent(
   }
   // Prefetch the link on hover/touchstart.
   if (instance !== undefined) {
+    // Switch to a full prefetch, except in `output: "export"` mode — a Full
+    // prefetch issues a dynamic RSC request via request headers, which the
+    // static host cannot interpret, so it would fall back to the HTML
+    // document instead of a per-segment `__next.*.txt` file.
     if (
       process.env.__NEXT_DYNAMIC_ON_HOVER &&
-      unstable_upgradeToDynamicPrefetch
+      unstable_upgradeToDynamicPrefetch &&
+      !(
+        process.env.NODE_ENV === 'production' &&
+        process.env.__NEXT_CONFIG_OUTPUT === 'export'
+      )
     ) {
-      // Switch to a full prefetch
       instance.fetchStrategy = FetchStrategy.Full
     }
     rescheduleLinkPrefetch(instance, PrefetchPriority.Intent)

--- a/test/e2e/app-dir/static-export-link-prefetch-true/app/layout.tsx
+++ b/test/e2e/app-dir/static-export-link-prefetch-true/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/static-export-link-prefetch-true/app/page.tsx
+++ b/test/e2e/app-dir/static-export-link-prefetch-true/app/page.tsx
@@ -1,0 +1,12 @@
+import Link from 'next/link'
+
+export default function Home() {
+  return (
+    <>
+      <p id="home-content">Home page</p>
+      <Link href="/page1" prefetch={true}>
+        Go to page 1
+      </Link>
+    </>
+  )
+}

--- a/test/e2e/app-dir/static-export-link-prefetch-true/app/page1/page.tsx
+++ b/test/e2e/app-dir/static-export-link-prefetch-true/app/page1/page.tsx
@@ -1,0 +1,10 @@
+import Link from 'next/link'
+
+export default function Page1() {
+  return (
+    <>
+      <div id="page1-content">Page 1</div>
+      <Link href="/">Back home</Link>
+    </>
+  )
+}

--- a/test/e2e/app-dir/static-export-link-prefetch-true/next.config.js
+++ b/test/e2e/app-dir/static-export-link-prefetch-true/next.config.js
@@ -1,0 +1,8 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  output: 'export',
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/static-export-link-prefetch-true/server.mjs
+++ b/test/e2e/app-dir/static-export-link-prefetch-true/server.mjs
@@ -1,0 +1,10 @@
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { createServer } from 'node:http'
+import handler from 'serve-handler'
+
+const OUT_DIR = join(dirname(fileURLToPath(import.meta.url)), 'out')
+
+export const server = createServer((request, response) =>
+  handler(request, response, { public: OUT_DIR })
+)

--- a/test/e2e/app-dir/static-export-link-prefetch-true/static-export-link-prefetch-true.test.ts
+++ b/test/e2e/app-dir/static-export-link-prefetch-true/static-export-link-prefetch-true.test.ts
@@ -1,0 +1,86 @@
+import type * as Playwright from 'playwright'
+import webdriver from 'next-webdriver'
+import { findPort, nextBuild, retry } from 'next-test-utils'
+import { isNextStart } from 'e2e-utils'
+import { server } from './server.mjs'
+
+// Regression test for https://github.com/vercel/next.js/issues/92341.
+//
+// In `output: "export"` mode, a `<Link prefetch={true}>` previously routed
+// through the dynamic (Full) prefetch path, which issues an RSC request to
+// the bare route path (e.g. `/page1?_rsc=…`). A static host has no way to
+// answer that, so it returned the HTML document; the client then failed to
+// decode it as Flight and the cache entry was rejected, breaking both the
+// prefetch-at-load and the subsequent click navigation.
+//
+// The fix forces the PPR strategy in export mode so the prefetch reads the
+// per-segment `__next.*.txt` files the exporter writes to disk.
+describe('Link prefetch={true} in output: "export"', () => {
+  if (!isNextStart) {
+    // Only the production build emits the `__next.*.txt` segment files that
+    // this behavior relies on; dev mode has nothing to assert.
+    it('build test should not run during dev test run', () => {})
+    return
+  }
+
+  if (process.env.__NEXT_CACHE_COMPONENTS === 'true') {
+    // Cache Components / PPR is not compatible with `output: "export"`.
+    return it.skip('for Cache Components', () => {})
+  }
+
+  let port: number
+
+  beforeAll(async () => {
+    const appDir = __dirname
+    await nextBuild(appDir, undefined, {
+      cwd: appDir,
+      disableAutoSkewProtection: true,
+    })
+    port = await findPort()
+    server.listen(port)
+  })
+
+  afterAll(() => {
+    server.close()
+  })
+
+  it('prefetches per-segment files and navigates on click', async () => {
+    const requestPathnames: string[] = []
+
+    const browser = await webdriver(port, '/', {
+      beforePageLoad(page: Playwright.Page) {
+        page.on('request', (request) => {
+          const { pathname, search } = new URL(request.url())
+          requestPathnames.push(pathname + search)
+        })
+      },
+    })
+
+    // A visible `<Link prefetch={true}>` should prefetch the target route's
+    // per-segment `__next.*.txt` files (e.g. `__next.page1.__PAGE__.txt`),
+    // which are the only RSC artifacts the exporter emits.
+    await retry(async () => {
+      const segmentRequests = requestPathnames.filter((p) =>
+        /^\/page1\/__next\.[^/]+\.txt(\?|$)/.test(p)
+      )
+      expect(segmentRequests.length).toBeGreaterThan(0)
+    })
+
+    // The regression fetched the HTML document (`/page1` with an `_rsc`
+    // cache-busting query) and tried to decode it as Flight, which rejected
+    // the prefetch cache entry. Guard against that specific URL shape.
+    const htmlFallbackRequests = requestPathnames.filter((p) =>
+      /^\/page1\/?\?.*_rsc=/.test(p)
+    )
+    expect(htmlFallbackRequests).toEqual([])
+
+    // A successful client navigation renders the target without a document
+    // reload. `#page1-content` only exists on the target route, so reading
+    // it proves the click path is wired up end-to-end.
+    await browser.elementByCss('a[href="/page1"]').click()
+
+    await retry(async () => {
+      expect(await browser.elementById('page1-content').text()).toBe('Page 1')
+    })
+  })
+})


### PR DESCRIPTION
### What?

`<Link prefetch={true}>` on `output: "export"` fetches the html document instead of the per-segment `__next.*.txt` files, breaking both the prefetch-at-load and the subsequent click navigation.

### Why?

a full prefetch issues a dynamic rsc request (request header + `_rsc=` cache-buster) against the bare route path. static hosts can't interpret the header and return the html document; the flight decode fails, the prefetch cache entry is rejected, and the click can't be served from it either.

### How?

in export mode, `getFetchStrategyFromPrefetchProp` and the `unstable_dynamicOnHover` upgrade now return `FetchStrategy.PPR`. the ppr path already rewrites urls through `addSegmentPathToUrlInOutputExportMode`. gated on `NODE_ENV === 'production'` to match `isOutputExportMode` and keep `next dev` unchanged.

regression test under `test/e2e/app-dir/static-export-link-prefetch-true/`

fixes #92341
