### PR TITLE
remove flag guarding `unstable_io`

### DIFF
--- a/docs/01-app/03-api-reference/04-functions/unstable_io.mdx
+++ b/docs/01-app/03-api-reference/04-functions/unstable_io.mdx
@@ -1,0 +1,95 @@
+---
+title: unstable_io
+description: API Reference for the unstable_io function.
+version: draft
+---
+
+`unstable_io()` informs Next.js that an IO operation will follow this call. When [Cache Components](/docs/app/api-reference/config/next-config-js/cacheComponents) is not enabled or when rendering in Pages Router, signifying IO in this way is not meaningful and the call will always resolve immediately. When Cache Components is enabled, you may be required to add `await unstable_io()` preceding synchronous IO that is encountered while prerendering pages (`new Date()` for example). Additionally, if you want to avoid having genuine uncached IO invoked while prerendering, you shield it by preceeding it with `await unstable_io()`.
+
+```ts filename="app/page.tsx" switcher
+import { unstable_io } from 'next/cache'
+import { db } from '@/lib/db'
+
+export default async function Page() {
+  // Synchronous IO: new Date() would fail during prerender without this
+  await unstable_io()
+  const now = new Date().toISOString()
+
+  // Async IO: the query would run and be discarded during prerender;
+  // unstable_io() above lets Next.js skip it entirely
+  const orders = await db.query('SELECT * FROM orders LIMIT 10')
+
+  return (
+    <main>
+      <p>Generated at: {now}</p>
+      <ul>
+        {orders.map((order) => (
+          <li key={order.id}>{order.name}</li>
+        ))}
+      </ul>
+    </main>
+  )
+}
+```
+
+```js filename="app/page.js" switcher
+import { unstable_io } from 'next/cache'
+import { db } from '@/lib/db'
+
+export default async function Page() {
+  // Synchronous IO: new Date() would fail during prerender without this
+  await unstable_io()
+  const now = new Date().toISOString()
+
+  // Async IO: the query would run and be discarded during prerender;
+  // unstable_io() above lets Next.js skip it entirely
+  const orders = await db.query('SELECT * FROM orders LIMIT 10')
+
+  return (
+    <main>
+      <p>Generated at: {now}</p>
+      <ul>
+        {orders.map((order) => (
+          <li key={order.id}>{order.name}</li>
+        ))}
+      </ul>
+    </main>
+  )
+}
+```
+
+## How is this different from `connection()`?
+
+[`connection()`](/docs/app/api-reference/functions/connection) requires an active HTTP request context and signals that the component needs request-specific data. It is imported from `next/server`.
+
+`unstable_io()` does not require a request context. It can be used inside `"use cache"` scopes, client components, and anywhere you perform IO that should not be included in a static prerender. It is imported from `next/cache`.
+
+Use `connection()` when you need the request itself (cookies, headers, etc.). Use `unstable_io()` when you perform IO that is independent of the request but should still prevent static prerendering.
+
+## Reference
+
+### Type
+
+```ts
+function unstable_io(): Promise<void>
+```
+
+### Parameters
+
+- The function does not accept any parameters.
+
+### Returns
+
+- A `Promise<void>` that resolves immediately during a real request or inside a cache scope, and suspends indefinitely during prerendering to prevent static output from including IO-dependent content.
+
+## Good to know
+
+- `unstable_io()` is imported from `next/cache`, not `next/server`.
+- Inside `"use cache"` scopes, `unstable_io()` resolves immediately. The cache captures the IO result at fill time.
+- In client components, `unstable_io()` resolves immediately since there is no prerender context in the browser.
+
+### Version History
+
+| Version   | Changes              |
+| --------- | -------------------- |
+| `v16.x.x` | `unstable_io` added. |

--- a/packages/next/src/build/define-env.ts
+++ b/packages/next/src/build/define-env.ts
@@ -247,7 +247,6 @@ export function getDefineEnv({
       config.experimental.dynamicOnHover
     ),
     'process.env.__NEXT_USE_OFFLINE': Boolean(config.experimental.useOffline),
-    'process.env.__NEXT_UNSTABLE_IO': Boolean(config.experimental.unstableIO),
     'process.env.__NEXT_PREFETCH_INLINING': Boolean(
       config.experimental.prefetchInlining
     ),

--- a/packages/next/src/client/request/io.browser.ts
+++ b/packages/next/src/client/request/io.browser.ts
@@ -9,11 +9,5 @@ const resolvedIOPromise: Promise<void> = Promise.resolve(undefined)
  * prerender context so we always resolve immediately.
  */
 export function unstable_io(): Promise<void> {
-  if (!process.env.__NEXT_UNSTABLE_IO) {
-    throw new Error(
-      '`unstable_io()` requires the `experimental.unstableIO` option to be enabled in your Next.js config.'
-    )
-  }
-
   return resolvedIOPromise
 }

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -223,7 +223,6 @@ export const experimentalSchema = {
   partialFallbacks: z.boolean().optional(),
   dynamicOnHover: z.boolean().optional(),
   useOffline: z.boolean().optional(),
-  unstableIO: z.boolean().optional(),
   optimisticRouting: z.boolean().optional(),
   varyParams: z.boolean().optional(),
   prefetchInlining: z

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -427,7 +427,6 @@ export interface ExperimentalConfig {
   partialFallbacks?: boolean
   dynamicOnHover?: boolean
   useOffline?: boolean
-  unstableIO?: boolean
   optimisticRouting?: boolean
   varyParams?: boolean
   prefetchInlining?:
@@ -1841,7 +1840,6 @@ export const defaultConfig = Object.freeze({
     partialFallbacks: true,
     dynamicOnHover: false,
     useOffline: false,
-    unstableIO: false,
     varyParams: false,
     prefetchInlining: true,
     preloadEntriesOnStart: true,
@@ -1988,7 +1986,6 @@ export interface NextConfigRuntime {
     | 'staleTimes'
     | 'dynamicOnHover'
     | 'useOffline'
-    | 'unstableIO'
     | 'optimisticRouting'
     | 'inlineCss'
     | 'prefetchInlining'
@@ -2056,7 +2053,6 @@ export function getNextConfigRuntime(
         staleTimes: ex.staleTimes,
         dynamicOnHover: ex.dynamicOnHover,
         useOffline: ex.useOffline,
-        unstableIO: ex.unstableIO,
         optimisticRouting: ex.optimisticRouting,
         inlineCss: ex.inlineCss,
         prefetchInlining: ex.prefetchInlining,

--- a/packages/next/src/server/request/io.ts
+++ b/packages/next/src/server/request/io.ts
@@ -25,12 +25,6 @@ const resolvedIOPromise: Promise<void> = Promise.resolve(undefined)
  * request and can be used freely inside cache scopes and client components.
  */
 export function unstable_io(): Promise<void> {
-  if (!process.env.__NEXT_UNSTABLE_IO) {
-    throw new Error(
-      '`unstable_io()` requires the `experimental.unstableIO` option to be enabled in your Next.js config.'
-    )
-  }
-
   const workStore = workAsyncStorage.getStore()
   const workUnitStore = workUnitAsyncStorage.getStore()
 

--- a/test/e2e/app-dir/unstable-io/fixtures/cache-components/next.config.js
+++ b/test/e2e/app-dir/unstable-io/fixtures/cache-components/next.config.js
@@ -3,9 +3,6 @@
  */
 const nextConfig = {
   cacheComponents: true,
-  experimental: {
-    unstableIO: true,
-  },
 }
 
 module.exports = nextConfig

--- a/test/e2e/app-dir/unstable-io/fixtures/default/next.config.js
+++ b/test/e2e/app-dir/unstable-io/fixtures/default/next.config.js
@@ -1,10 +1,6 @@
 /**
  * @type {import('next').NextConfig}
  */
-const nextConfig = {
-  experimental: {
-    unstableIO: true,
-  },
-}
+const nextConfig = {}
 
 module.exports = nextConfig


### PR DESCRIPTION
removes the flag guarding `unstable_io`.

The API isn't likely to change semantic meaning but could still be removed. Do not rely on it extensively yet