### PR TITLE
fix: skip flushDetached if telemetry is disabled

### DIFF
--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -141,17 +141,19 @@ const handleSessionStop = async (signal: NodeJS.Signals | number | null) => {
         distDir: path.join(dir, distDir || '.next'),
       })
 
-    telemetry.record(
-      eventCliSessionStopped({
-        cliCommand: 'dev',
-        turboFlag: isTurbopack,
-        durationMilliseconds: Date.now() - sessionStarted,
-        pagesDir,
-        appDir,
-      }),
-      true
-    )
-    telemetry.flushDetached('dev', dir)
+    if (telemetry.isEnabled) {
+      telemetry.record(
+        eventCliSessionStopped({
+          cliCommand: 'dev',
+          turboFlag: isTurbopack,
+          durationMilliseconds: Date.now() - sessionStarted,
+          pagesDir,
+          appDir,
+        }),
+        true
+      )
+      telemetry.flushDetached('dev', dir)
+    }
   } catch (_) {
     // errors here aren't actionable so don't add
     // noise to the output

--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -436,7 +436,7 @@ export async function startServer(
                       typeof import('../../telemetry/storage').Telemetry
                     >
                   | undefined
-                if (telemetry) {
+                if (telemetry && telemetry.isEnabled) {
                   // Use flushDetached to avoid blocking process exit
                   // Each process writes to a unique file (_events_${pid}.json)
                   // to avoid race conditions with the parent process


### PR DESCRIPTION
When running Next, I have noticed several `detached-flush.js` processes building up over time. This is especially rampant when running E2E tests locally that constantly start/stop the dev server between runs. I started a discussion [here](https://github.com/vercel/next.js/discussions/92805), and marked resolved because I made sure telemetry was disabled (`pnpm next telemetry disable` _and_ set `NEXT_TELEMETRY_DISABLED=1` in `~/.zshrc`). However, I noticed more of these processes today.

Digging into where this is called, it looks like these two places are not checking for `telemetry.isEnabled`. I think this is the right fix, but if not, I'd love to know what to do about this.