### PR TITLE
extract-const-value: fold arithmetic BinaryExpression and UnaryExpression

### DIFF
--- a/packages/next/src/build/analysis/extract-const-value.ts
+++ b/packages/next/src/build/analysis/extract-const-value.ts
@@ -1,5 +1,6 @@
 import type {
   ArrayExpression,
+  BinaryExpression,
   BooleanLiteral,
   ExportDeclaration,
   Identifier,
@@ -16,6 +17,7 @@ import type {
   TsConstAssertion,
   TsTypeAssertion,
   TsSatisfiesExpression,
+  UnaryExpression,
   VariableDeclaration,
 } from '@swc/core'
 
@@ -81,6 +83,14 @@ function isTsTypeAssertion(node: Node): node is TsTypeAssertion {
 
 function isTsSatisfiesExpression(node: Node): node is TsSatisfiesExpression {
   return node.type === 'TsSatisfiesExpression'
+}
+
+function isBinaryExpression(node: Node): node is BinaryExpression {
+  return node.type === 'BinaryExpression'
+}
+
+function isUnaryExpression(node: Node): node is UnaryExpression {
+  return node.type === 'UnaryExpression'
 }
 
 export type ExtractValueResult =
@@ -218,6 +228,51 @@ function extractValue(node: Node, path?: string[]): ExtractValueResult {
     isTsConstAssertion(node)
   ) {
     return extractValue(node.expression)
+  } else if (isBinaryExpression(node)) {
+    // e.g. `60 * 5` — fold compile-time arithmetic / string-concat
+    // expressions. Restricted to a small set of pure operators so we
+    // don't accidentally evaluate side-effecting or short-circuiting
+    // semantics (logical, comparison, etc.) at extraction time.
+    const left = extractValue(node.left, path)
+    if ('unsupported' in left) return left
+    const right = extractValue(node.right, path)
+    if ('unsupported' in right) return right
+    switch (node.operator) {
+      case '+':
+        return { value: left.value + right.value }
+      case '-':
+        return { value: left.value - right.value }
+      case '*':
+        return { value: left.value * right.value }
+      case '/':
+        return { value: left.value / right.value }
+      case '%':
+        return { value: left.value % right.value }
+      case '**':
+        return { value: left.value ** right.value }
+      default:
+        return {
+          unsupported: `Unsupported binary operator "${node.operator}"`,
+          path: formatCodePath(path),
+        }
+    }
+  } else if (isUnaryExpression(node)) {
+    // e.g. `-5`, `+5`, `~0xff` — same restricted set as binary above.
+    const arg = extractValue(node.argument, path)
+    if ('unsupported' in arg) return arg
+    switch (node.operator) {
+      case '-':
+        return { value: -arg.value }
+      case '+':
+        return { value: +arg.value }
+      case '~':
+        return { value: ~arg.value }
+      default:
+        return {
+          unsupported: `Unsupported unary operator "${node.operator}"`,
+          path: formatCodePath(path),
+        }
+    }
   } else {
     return {
       unsupported: `Unsupported node type "${node.type}"`,

--- a/test/unit/extract-const-value.test.ts
+++ b/test/unit/extract-const-value.test.ts
@@ -1,0 +1,93 @@
+import { extractExportedConstValue } from 'next/dist/build/analysis/extract-const-value'
+import { parseModule } from 'next/dist/build/analysis/parse-module'
+import { installBindings } from 'next/dist/build/swc/install-bindings'
+
+async function extractFor(source: string, exportedName: string) {
+  const mod = await parseModule('virtual.ts', source)
+  return extractExportedConstValue(mod, exportedName)
+}
+
+describe('extractExportedConstValue', () => {
+  beforeAll(async () => {
+    await installBindings()
+  })
+
+  it('extracts plain numeric literals', async () => {
+    const result = await extractFor(
+      `export const revalidate = 60`,
+      'revalidate'
+    )
+    expect(result).toEqual({ value: 60 })
+  })
+
+  it('folds multiplicative BinaryExpression (regression for #72365)', async () => {
+    const result = await extractFor(
+      `export const revalidate = 60 * 5`,
+      'revalidate'
+    )
+    expect(result).toEqual({ value: 300 })
+  })
+
+  it('folds additive BinaryExpression', async () => {
+    const result = await extractFor(
+      `export const revalidate = 60 + 30`,
+      'revalidate'
+    )
+    expect(result).toEqual({ value: 90 })
+  })
+
+  it('folds nested BinaryExpression', async () => {
+    const result = await extractFor(
+      `export const revalidate = 60 * 60 * 24`,
+      'revalidate'
+    )
+    expect(result).toEqual({ value: 86400 })
+  })
+
+  it('folds string concatenation', async () => {
+    const result = await extractFor(
+      `export const runtime = 'edge' + ''`,
+      'runtime'
+    )
+    expect(result).toEqual({ value: 'edge' })
+  })
+
+  it('folds unary minus on a numeric literal', async () => {
+    const result = await extractFor(`export const x = -42`, 'x')
+    expect(result).toEqual({ value: -42 })
+  })
+
+  it('folds unary minus inside a BinaryExpression', async () => {
+    const result = await extractFor(`export const x = 100 + -42`, 'x')
+    expect(result).toEqual({ value: 58 })
+  })
+
+  it('folds the exponentiation operator', async () => {
+    const result = await extractFor(`export const x = 2 ** 10`, 'x')
+    expect(result).toEqual({ value: 1024 })
+  })
+
+  it('reports unsupported binary operators', async () => {
+    const result = await extractFor(`export const x = 1 && 2`, 'x')
+    expect(result).toEqual({
+      unsupported: 'Unsupported binary operator "&&"',
+      path: 'x',
+    })
+  })
+
+  it('reports unsupported unary operators', async () => {
+    const result = await extractFor(`export const x = !true`, 'x')
+    expect(result).toEqual({
+      unsupported: 'Unsupported unary operator "!"',
+      path: 'x',
+    })
+  })
+
+  it('still rejects unsupported nested nodes', async () => {
+    const result = await extractFor(`export const x = 1 + foo`, 'x')
+    expect(result).toEqual({
+      unsupported: 'Unknown identifier "foo"',
+      path: 'x',
+    })
+  })
+})


### PR DESCRIPTION
### What?

Make `next build` recognize compile-time arithmetic in segment-config exports like

```ts
export const revalidate = 60 * 5
export const maxDuration = 60 * 60 * 2
```

Today these fail with

```
Unsupported node type "BinaryExpression" at "revalidate".
Read More - https://nextjs.org/docs/messages/invalid-page-config
```

forcing users to inline the result by hand.

### Why?

`extract-const-value.ts` walks the SWC AST of an exported `const` initializer and folds it down to a runtime value. It already handled literals (`null`, `boolean`, `string`, `number`, `regexp`, template literals with no expressions), `Array`/`Object` expressions, the `undefined` identifier, and TS-only wrappers (`as`, `satisfies`, type/const assertions). It had **no** case for `BinaryExpression` or `UnaryExpression`, so any compound expression — even a trivially constant one like `60 * 5` or `-42` — bailed out as unsupported.

This is reported as #72365, and a few callsites in the wild use the obvious pattern (e.g. `60 * 60 * 24` for a 1-day revalidate window).

### How?

Added cases for `BinaryExpression` and `UnaryExpression`, restricted to a small set of pure operators with no side-effect or short-circuit semantics:

- **Binary**: `+ - * / % **`
- **Unary**: `- + ~`

Logical (`&&`, `||`, `??`), comparison (`<`, `>`, `==`, `===`, `!=`, `!==`, `<=`, `>=`), and unary `!`, `typeof`, `void`, `delete` are intentionally **not** added — they either short-circuit (which would change what the extractor sees as "the value") or invoke runtime semantics that don't belong in a build-time constant. They keep returning `unsupported`.

Recursion handles nesting naturally (`60 * 60 * 24` → folds left-to-right; `100 + -42` works because `-42` is a `UnaryExpression(NumericLiteral(42))` per the SWC AST).

### Test plan

Added `test/unit/extract-const-value.test.ts` with 11 cases:

- Plain numeric literal (baseline).
- The exact #72365 regression: `60 * 5`.
- Additive `BinaryExpression`.
- Nested binary (`60 * 60 * 24`).
- String concat (`'edge' + ''`).
- Unary `-42`.
- Unary inside binary (`100 + -42`).
- Exponentiation (`2 ** 10`).
- Rejection of `&&` (binary).
- Rejection of `!` (unary).
- Rejection of `1 + foo` — confirms an unfoldable identifier in one operand still propagates the original "Unknown identifier" error rather than getting masked by the new code path.

`npx jest test/unit/extract-const-value.test.ts` → 11 passed locally.

The test uses the same `installBindings()` + `parseModule` setup as the existing `parse-page-static-info.test.ts` to exercise real SWC parsing.

Fixes #72365