### PR TITLE
build: detect instrumentation/middleware/proxy with multi-segment pageExtensions

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1251,22 +1251,25 @@ export default async function build(
       let middlewareFilePath: string | undefined
 
       for (const rootPath of rootPaths) {
-        const { name: fileBaseName, dir: fileDir } = path.parse(rootPath)
+        const { base: fileBase, dir: fileDir } = path.parse(rootPath)
 
         const normalizedFileDir = normalizePathSep(fileDir)
         const isAtConventionLevel =
           normalizedFileDir === '/' || normalizedFileDir === '/src'
 
-        if (isAtConventionLevel && fileBaseName === MIDDLEWARE_FILENAME) {
+        if (!isAtConventionLevel) continue
+
+        // Use the same regexes that filtered `rootPaths` above to assign each
+        // matched file to its convention bucket. Comparing against the bare
+        // `path.parse(...).name` would miss files using a multi-segment
+        // custom `pageExtensions` entry such as `'universal.ts'`, because
+        // `path.parse('/instrumentation.universal.ts').name` is
+        // `'instrumentation.universal'` — not `INSTRUMENTATION_HOOK_FILENAME`.
+        if (middlewareDetectionRegExp.test(fileBase)) {
           middlewareFilePath = rootPath
-        }
-        if (isAtConventionLevel && fileBaseName === PROXY_FILENAME) {
+        } else if (proxyDetectionRegExp.test(fileBase)) {
           proxyFilePath = rootPath
-        }
-        if (
-          isAtConventionLevel &&
-          fileBaseName === INSTRUMENTATION_HOOK_FILENAME
-        ) {
+        } else if (instrumentationHookDetectionRegExp.test(fileBase)) {
           instrumentationHookFilePath = rootPath
         }
       }

--- a/test/integration/instrumentation-page-extensions/app/next.config.js
+++ b/test/integration/instrumentation-page-extensions/app/next.config.js
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+module.exports = {
+  pageExtensions: ['ts', 'tsx', 'js', 'jsx', 'universal.ts', 'universal.tsx'],
+}

--- a/test/integration/instrumentation-page-extensions/app/src/instrumentation.universal.ts
+++ b/test/integration/instrumentation-page-extensions/app/src/instrumentation.universal.ts
@@ -1,0 +1,5 @@
+export function register() {
+  // Marker so the test can confirm the build picked the hook up; in
+  // practice, just compiling `instrumentation.js` into `.next/server/`
+  // is the signal we assert on.
+}

--- a/test/integration/instrumentation-page-extensions/app/src/pages/index.tsx
+++ b/test/integration/instrumentation-page-extensions/app/src/pages/index.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello</p>
+}

--- a/test/integration/instrumentation-page-extensions/app/tsconfig.json
+++ b/test/integration/instrumentation-page-extensions/app/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "noEmit": true,
+    "incremental": true,
+    "module": "esnext",
+    "esModuleInterop": true,
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["next-env.d.ts", "**/*.mts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/test/integration/instrumentation-page-extensions/test/index.test.ts
+++ b/test/integration/instrumentation-page-extensions/test/index.test.ts
@@ -1,0 +1,36 @@
+/* eslint-env jest */
+
+import { existsSync } from 'fs'
+import { join } from 'path'
+import { nextBuild } from 'next-test-utils'
+
+const appDir = join(__dirname, '../app')
+
+describe('instrumentation hook detection with custom multi-segment pageExtensions', () => {
+  ;(process.env.IS_TURBOPACK_TEST ? describe.skip : describe)(
+    'production mode (webpack)',
+    () => {
+      it('compiles src/instrumentation.universal.ts when it matches pageExtensions', async () => {
+        const result = await nextBuild(appDir, undefined, {
+          cwd: appDir,
+          stderr: true,
+          stdout: true,
+        })
+        expect(result.code).toBe(0)
+
+        // If the hook was detected, the build emits the compiled
+        // instrumentation entry to `.next/server/instrumentation.js`.
+        // Before the fix for #92342, custom multi-segment pageExtensions
+        // (e.g. `universal.ts`) caused the file to be matched by the
+        // detection regex but then dropped because
+        // `path.parse('instrumentation.universal.ts').name` is
+        // `'instrumentation.universal'` — not `'instrumentation'` — so
+        // the equality check against `INSTRUMENTATION_HOOK_FILENAME`
+        // failed and `instrumentation.js` was never produced.
+        expect(
+          existsSync(join(appDir, '.next/server/instrumentation.js'))
+        ).toBe(true)
+      })
+    }
+  )
+})


### PR DESCRIPTION
### What?

Make `next build` detect `instrumentation`, `middleware`, and `proxy` files when the user configures a **multi-segment** `pageExtensions` entry (e.g. `'universal.ts'`) and names their hook accordingly:

```js
// next.config.js
module.exports = {
  pageExtensions: ['ts', 'tsx', 'js', 'jsx', 'universal.ts', 'universal.tsx'],
}
```

```ts
// src/instrumentation.universal.ts
export function register() { /* ... */ }
```

Today this hook is silently dropped — the file is never compiled to `.next/server/instrumentation.js` and `register()` never runs. Same for `middleware.universal.ts` and `proxy.universal.ts`.

### Why?

`packages/next/src/build/index.ts` builds three regexes from `config.pageExtensions` and uses them to filter root-level files into `rootPaths`. That part works — `instrumentation.universal.ts` correctly survives the filter (the unescaped `.` in the extension list is treated as `\.|.`, which still matches the literal `.` in the filename).

The bug is in the *bucketing* loop right after, which iterates `rootPaths` and assigns each match to one of the three target paths via:

```ts
const { name: fileBaseName } = path.parse(rootPath)
if (fileBaseName === INSTRUMENTATION_HOOK_FILENAME) instrumentationHookFilePath = rootPath
```

`path.parse('/src/instrumentation.universal.ts').name` is `'instrumentation.universal'` — Node only strips the *last* extension. So the equality check fails and the file is dropped on the floor. The filter said yes, the bucket said no.

The same pattern applies to `MIDDLEWARE_FILENAME` and `PROXY_FILENAME`, so any user with `proxy.<custom>.ts` / `middleware.<custom>.ts` hits the identical bug.

### How?

Reuse the three detection regexes that already filter `rootPaths` to also assign each matched file to its bucket, comparing against `path.parse(rootPath).base` (the full filename including extension). The filter and the bucketing now agree on the same matching rule:

```ts
if (middlewareDetectionRegExp.test(fileBase))            middlewareFilePath = rootPath
else if (proxyDetectionRegExp.test(fileBase))            proxyFilePath = rootPath
else if (instrumentationHookDetectionRegExp.test(fileBase)) instrumentationHookFilePath = rootPath
```

Behavior with the default `pageExtensions` (`['ts', 'tsx', 'js', 'jsx', 'mts', 'mjs', ...]`) is unchanged — those are all single-segment, and a file named `instrumentation.ts` matches the regex and lands in the bucket exactly as before.

### Scope

This fixes the *detection* gap reported as the primary issue (instrumentation never registered with custom multi-segment `pageExtensions`). The reporter also notes a secondary observation in their case 3 (adding `proxy.universal.ts` makes instrumentation register but with `NEXT_RUNTIME=edge`). That smells like a separate downstream runtime-routing issue and is out of scope here — once detection works correctly with this PR, that scenario is worth re-evaluating against canary.

### Test plan

Added `test/integration/instrumentation-page-extensions/`:

- **Fixture**: project with `pageExtensions: ['ts', 'tsx', 'js', 'jsx', 'universal.ts', 'universal.tsx']`, `src/instrumentation.universal.ts` exporting `register()`, and a minimal `pages/index.tsx`.
- **Test**: runs `nextBuild`, asserts exit code 0 and that `.next/server/instrumentation.js` exists — the latter only happens if detection succeeded.
- Webpack-only (gated on `IS_TURBOPACK_TEST`), mirroring the existing `build-trace-extra-entries` integration suite.

Verified locally on Windows + webpack: test fails on canary without the fix and passes after it.

Fixes #92342