### PR TITLE
NoFallbackError: replace internal-jargon message with actionable guidance

### DIFF
--- a/packages/next/src/shared/lib/no-fallback-error.external.ts
+++ b/packages/next/src/shared/lib/no-fallback-error.external.ts
@@ -1,6 +1,22 @@
+/**
+ * Thrown when an app router page or route handler can't render a fallback
+ * for the requested route — typically because the request's params were not
+ * returned by `generateStaticParams()` and a parent segment has
+ * `dynamicParams: false`.
+ *
+ * The framework usually catches this and turns it into a 404, so the
+ * message is rarely seen by end users. When it does leak to a server log
+ * the previous "Internal: NoFallbackError" wording offered no guidance
+ * about what caused it; the new message names the most common cause and
+ * links to the relevant docs (#87738).
+ */
 export class NoFallbackError extends Error {
   constructor() {
-    super()
-    this.message = 'Internal: NoFallbackError'
+    super(
+      'No fallback was rendered for this route, so the request returned a 404. ' +
+        'A common cause is `dynamicParams: false` on a parent segment combined ' +
+        'with a request whose params were not returned by `generateStaticParams()`. ' +
+        'See https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#dynamicparams'
+    )
   }
 }

--- a/test/unit/no-fallback-error.test.ts
+++ b/test/unit/no-fallback-error.test.ts
@@ -1,0 +1,18 @@
+import { NoFallbackError } from 'next/dist/shared/lib/no-fallback-error.external'
+
+describe('NoFallbackError', () => {
+  it('is an Error subclass', () => {
+    expect(new NoFallbackError()).toBeInstanceOf(Error)
+  })
+
+  it('mentions the most common cause and links to the docs', () => {
+    // Regression for #87738: previously the message was the unhelpful
+    // "Internal: NoFallbackError". The new message must point users at
+    // the dynamicParams/generateStaticParams interaction that produces
+    // this condition in practice.
+    const err = new NoFallbackError()
+    expect(err.message).toMatch(/dynamicParams/)
+    expect(err.message).toMatch(/generateStaticParams/)
+    expect(err.message).toMatch(/nextjs\.org\/docs\//)
+  })
+})


### PR DESCRIPTION
### What?

Replace the `NoFallbackError` message from the unhelpful `"Internal: NoFallbackError"` with one that names the most common cause and links to the relevant docs.

### Why?

`NoFallbackError` is an internal control-flow signal — the framework normally catches it and turns it into a 404 response, so the message is rarely seen by end users. But when it *does* leak to a server log (as reproduced in #87738 — a parent app router segment with `dynamicParams: false` plus a request whose params aren't in `generateStaticParams()`), the user sees:

\`\`\`
Error: Internal: NoFallbackError
    at <anonymous> (.next/server/chunks/ssr/_babdf1ac._.js:2:1128)
    ...
\`\`\`

…which gives them no idea what went wrong, what to look for in their app, or where to read more. They have to chase it through Next.js source code to figure out the connection to `dynamicParams`.

### How?

Replace the static message with one that names the common cause and links to the route segment config docs:

\`\`\`
No fallback was rendered for this route, so the request returned a 404.
A common cause is `dynamicParams: false` on a parent segment combined with
a request whose params were not returned by `generateStaticParams()`.
See https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#dynamicparams
\`\`\`

Also switched from `super(); this.message = ...` (the old form) to the conventional `super(message)`.

The error message is the only public surface of the class — no behavior change for the framework's normal catch-and-handle flow. Every `instanceof NoFallbackError` check in `base-server.ts`, `next-server.ts`, `router-server.ts`, etc., still works exactly as before.

### Scope

Just the message. The PR deliberately does **not** try to enrich `NoFallbackError` with per-call context (which segment / route / params triggered it). That would require plumbing through every throw site (see grep for `new NoFallbackError()` in `app-page.ts`, `app-route.ts`, `pages-handler.ts`) and is a separate, larger change. The static message is already a substantial improvement on the no-info-at-all status quo.

### Test plan

Added `test/unit/no-fallback-error.test.ts` with two cases:

- The class is an `Error` subclass (sanity check).
- The message contains `dynamicParams`, `generateStaticParams`, and a `nextjs.org/docs/` URL — locks in the actionable wording so a future edit can't silently regress to "Internal: NoFallbackError".

`npx jest test/unit/no-fallback-error.test.ts` → 2 passed.

Fixes #87738