### PR TITLE
sorted-routes: fix "an required" → "a required" grammar in catch-all error

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1162,5 +1162,6 @@
   "1161": "\"unstable_prefetch\" is a route segment config and can only be used when the segment is a Server Component module. Remove the \"use client\" directive from \"%s\" to use this API.",
   "1162": "Route \"%s\" cannot use \\`export const unstable_instant = ...\\` without enabling \\`cacheComponents\\`.",
   "1163": "Unexpected cache miss after cache warming phase during prerendering. This is likely caused by non-deterministic arguments that differ between the cache warming phase and the final prerender phase (e.g. unstable array order). Ensure that arguments passed to cached functions are deterministic.",
-  "1164": "Response body exceeded maximum size of %s bytes"
+  "1164": "Response body exceeded maximum size of %s bytes",
+  "1165": "You cannot use both a required and optional catch-all route at the same level (\"[...%s]\" and \"%s\" )."
 }

--- a/packages/next/src/shared/lib/router/utils/sorted-routes.ts
+++ b/packages/next/src/shared/lib/router/utils/sorted-routes.ts
@@ -154,7 +154,7 @@ class UrlNode {
         if (isOptional) {
           if (this.restSlugName != null) {
             throw new Error(
-              `You cannot use both an required and optional catch-all route at the same level ("[...${this.restSlugName}]" and "${urlPaths[0]}" ).`
+              `You cannot use both a required and optional catch-all route at the same level ("[...${this.restSlugName}]" and "${urlPaths[0]}" ).`
             )
           }
 

--- a/test/unit/page-route-sorter.test.ts
+++ b/test/unit/page-route-sorter.test.ts
@@ -172,7 +172,7 @@ describe('getSortedRoutes', () => {
     expect(() =>
       getSortedRoutes(['/[...one]', '/[[...one]]'])
     ).toThrowErrorMatchingInlineSnapshot(
-      `"You cannot use both an required and optional catch-all route at the same level ("[...one]" and "[[...one]]" )."`
+      `"You cannot use both a required and optional catch-all route at the same level ("[...one]" and "[[...one]]" )."`
     )
     expect(() =>
       getSortedRoutes(['/[[...one]]', '/[...one]'])


### PR DESCRIPTION
### What?

Fix the article in the "required + optional catch-all at the same level" error from `sorted-routes.ts`. Today users see:

\`\`\`
You cannot use both an required and optional catch-all route at the same level
("[...one]" and "[[...one]]" )
\`\`\`

`required` starts with a consonant sound, so the article should be "a", not "an".

### Why?

Reported as part of #68933 — the issue body quotes the error verbatim and the typo is right there in `sorted-routes.ts:157`. The other direction of the same error already uses correct grammar ("an optional and required catch-all"), and a sibling error later in `errors.json` (entry 911 — "a required and optional catch-all route at the same level in route") already uses the corrected wording. This entry was the odd one out.

It's purely a string fix — the matching test in `page-route-sorter.test.ts` already pinned the buggy wording via `toThrowErrorMatchingInlineSnapshot`, so it's been a regression-stable typo for a while.

### How?

- Updated the literal in `packages/next/src/shared/lib/router/utils/sorted-routes.ts:157`.
- Updated the matching inline snapshot in `test/unit/page-route-sorter.test.ts`.
- Let `pnpm build` regenerate the corresponding `errors.json` entry (new id 1165), which is how the repo manages these strings.

No behavior change — only the wording.

### Test plan

- `npx jest test/unit/page-route-sorter.test.ts` — 15 passed, 19 snapshots passed (including the updated one for this error path).

Reported in #68933.