### PR TITLE
Improve "make root node" trace attributes

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -555,7 +555,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                 {
                     let _span = tracing::trace_span!(
                         "make root node for strongly consistent read",
-                        %task_id
+                        task = self.debug_get_task_description(task_id)
                     )
                     .entered();
                     AggregationUpdateQueue::run(

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -112,6 +112,7 @@ pub trait ExecuteContext<'e>: Sized {
         this: Option<RawVc>,
         arg: &dyn DynTaskInputs,
     ) -> Option<(TaskId, Arc<CachedTaskType>)>;
+    fn debug_get_task_description(&self, task_id: TaskId) -> String;
 }
 
 pub trait ChildExecuteContext<'e>: Send + Sized {
@@ -1006,6 +1007,10 @@ impl<'e, B: BackingStorage> ExecuteContext<'e> for ExecuteContextImpl<'e, B> {
             }
         }
         None
+    }
+
+    fn debug_get_task_description(&self, task_id: TaskId) -> String {
+        self.backend.debug_get_task_description(task_id)
     }
 }
 

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_collectible.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_collectible.rs
@@ -36,7 +36,7 @@ impl UpdateCollectibleOperation {
                 {
                     let _span = tracing::trace_span!(
                         "make root node for removing collectible",
-                        %task_id
+                        task = ctx.debug_get_task_description(task_id)
                     )
                     .entered();
                     AggregationUpdateQueue::run(


### PR DESCRIPTION
### What?

Improve the trace span attributes for "make root node" operations in the turbo-tasks backend. Instead of recording only the raw `task_id`, the spans now include a human-readable task description (type name + task ID) via `debug_get_task_description`.

### Why?

When profiling or debugging with tracing tools, raw task IDs are opaque and require additional lookups to understand which task is being processed. Including a human-readable task description (e.g. `TaskId(42) MyFunction(args...)`) makes traces immediately actionable.

Two spans were affected:
- `"make root node for strongly consistent read"` in `backend/mod.rs`
- `"make root node for removing collectible"` in `backend/operation/update_collectible.rs`

### How?

- Added `debug_get_task_description` method to the `ExecuteContext` trait in `operation/mod.rs`
- Implemented it on `ExecuteContextImpl` by delegating to the existing `backend.debug_get_task_description` method (already used in other tracing spans)
- Replaced `%task_id` (which formats only the ID) with `task = self.debug_get_task_description(task_id)` / `task = ctx.debug_get_task_description(task_id)` in both span definitions

<!-- NEXT_JS_LLM_PR -->