### PR TITLE
[ci]: fix backport sync script

### DIFF
--- a/.github/workflows/sync_backport_canary_release.yml
+++ b/.github/workflows/sync_backport_canary_release.yml
@@ -37,7 +37,6 @@ jobs:
       reason: ${{ steps.evaluate.outputs.reason }}
       current_canary_version: ${{ steps.evaluate.outputs.current_canary_version }}
       released_version: ${{ steps.evaluate.outputs.released_version }}
-      latest_version: ${{ steps.evaluate.outputs.latest_version }}
     steps:
       - name: Check whether head commit is a stable release
         id: precheck
@@ -65,8 +64,25 @@ jobs:
       - uses: actions/checkout@v6
         if: steps.precheck.outputs.should_evaluate == 'true'
         with:
-          ref: canary
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || 'canary' }}
           fetch-depth: 1
+
+      - name: Setup node
+        if: steps.precheck.outputs.should_evaluate == 'true'
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          check-latest: true
+
+      - name: Setup corepack
+        if: steps.precheck.outputs.should_evaluate == 'true'
+        run: |
+          npm i -g corepack@0.31
+          corepack enable
+
+      - name: Install dependencies
+        if: steps.precheck.outputs.should_evaluate == 'true'
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Evaluate backport release
         id: evaluate
@@ -83,7 +99,6 @@ jobs:
           echo "should_dispatch=${{ steps.evaluate.outputs.should_dispatch || steps.precheck.outputs.should_dispatch }}"
           echo "reason=${{ steps.evaluate.outputs.reason || steps.precheck.outputs.reason }}"
           echo "released_version=${{ steps.evaluate.outputs.released_version }}"
-          echo "latest_version=${{ steps.evaluate.outputs.latest_version }}"
           echo "current_canary_version=${{ steps.evaluate.outputs.current_canary_version }}"
           echo "dispatch_input=${{ github.event_name == 'workflow_dispatch' && inputs.dispatch || false }}"
           echo "auto_dispatch_enabled=${{ vars.ENABLE_BACKPORT_CANARY_SYNC || 'false' }}"

--- a/scripts/check-backport-canary-release.js
+++ b/scripts/check-backport-canary-release.js
@@ -25,17 +25,7 @@ function parseReleaseVersion(commitMessage) {
     : null
 }
 
-function compareSemver(left, right) {
-  const result = semver.compare(left, right)
-
-  if (Number.isNaN(result)) {
-    throw new Error(`Invalid semver comparison "${left}" vs "${right}"`)
-  }
-
-  return result
-}
-
-async function fetchJson(url, token) {
+async function fetchGitHubJson(url, token) {
   const headers = {
     Accept: 'application/vnd.github+json',
   }
@@ -78,7 +68,7 @@ async function getWorkflowRunJobs(owner, repo, workflowRunId, token) {
       per_page: '100',
       page: String(page),
     })
-    const data = await fetchJson(
+    const data = await fetchGitHubJson(
       `https://api.github.com/repos/${owner}/${repo}/actions/runs/${workflowRunId}/jobs?${params}`,
       token
     )
@@ -98,7 +88,7 @@ async function getActiveTriggerReleaseRun(owner, repo, token) {
       status,
       per_page: '100',
     })
-    const data = await fetchJson(
+    const data = await fetchGitHubJson(
       `https://api.github.com/repos/${owner}/${repo}/actions/workflows/${TRIGGER_RELEASE_WORKFLOW}/runs?${params}`,
       token
     )
@@ -112,7 +102,7 @@ async function getActiveTriggerReleaseRun(owner, repo, token) {
 }
 
 async function getCommitMessage(owner, repo, sha, token) {
-  const data = await fetchJson(
+  const data = await fetchGitHubJson(
     `https://api.github.com/repos/${owner}/${repo}/commits/${sha}`,
     token
   )
@@ -197,31 +187,12 @@ async function main() {
     return
   }
 
-  const distTags = await fetchJson(
-    'https://registry.npmjs.org/-/package/next/dist-tags'
-  )
-  const latestStableVersion = distTags.latest
-
-  // Backports publish a stable version lower than npm's current latest.
-  // If the released version is not lower than latest, this was not a backport.
-  if (compareSemver(releasedVersion, latestStableVersion) >= 0) {
-    await finish({
-      should_dispatch: 'false',
-      reason: `Released version ${releasedVersion} is not a backport`,
-      current_canary_version: currentCanaryVersion,
-      released_version: releasedVersion,
-      latest_version: latestStableVersion,
-    })
-    return
-  }
-
-  if (compareSemver(currentCanaryVersion, releasedVersion) > 0) {
+  if (semver.gt(currentCanaryVersion, releasedVersion)) {
     await finish({
       should_dispatch: 'false',
       reason: `Current canary version ${currentCanaryVersion} is already ahead of ${releasedVersion}`,
       current_canary_version: currentCanaryVersion,
       released_version: releasedVersion,
-      latest_version: latestStableVersion,
     })
     return
   }
@@ -241,17 +212,15 @@ async function main() {
       active_trigger_release_url: activeTriggerReleaseRun.html_url,
       current_canary_version: currentCanaryVersion,
       released_version: releasedVersion,
-      latest_version: latestStableVersion,
     })
     return
   }
 
   await finish({
     should_dispatch: 'true',
-    reason: `Dispatching canary preminor release because backport ${releasedVersion} is ahead of ${currentCanaryVersion}`,
+    reason: `Dispatching canary preminor release because stable release ${releasedVersion} is ahead of ${currentCanaryVersion}`,
     current_canary_version: currentCanaryVersion,
     released_version: releasedVersion,
-    latest_version: latestStableVersion,
   })
 }
 


### PR DESCRIPTION
Fixes a few things:

- semver wasn't available because deps weren't being installed
- Fixed it to compare latest release with latest canary -- it was erroneously marking a backport as not a backport.

Test plan:
Dry run results here: https://github.com/vercel/next.js/actions/runs/24571828615/job/71846911677

```
should_dispatch=true
reason=Dispatching canary preminor release because stable release 16.2.4 is ahead of 16.2.1-canary.46
released_version=16.2.4
current_canary_version=16.2.1-canary.46
dispatch_input=false
auto_dispatch_enabled=true
```