### PR TITLE
perf: pre-compile middleware matcher regexes

### DIFF
--- a/packages/next/src/shared/lib/router/utils/middleware-route-matcher.ts
+++ b/packages/next/src/shared/lib/router/utils/middleware-route-matcher.ts
@@ -14,13 +14,17 @@ export interface MiddlewareRouteMatch {
 export function getMiddlewareRouteMatcher(
   matchers: ProxyMatcher[]
 ): MiddlewareRouteMatch {
+  const compiled = matchers.map((matcher) => ({
+    ...matcher,
+    re: new RegExp(matcher.regexp),
+  }))
   return (
     pathname: string | null | undefined,
     req: BaseNextRequest,
     query: Params
   ) => {
-    for (const matcher of matchers) {
-      const routeMatch = new RegExp(matcher.regexp).exec(pathname!)
+    for (const matcher of compiled) {
+      const routeMatch = matcher.re.exec(pathname!)
       if (!routeMatch) {
         continue
       }


### PR DESCRIPTION
`getMiddlewareRouteMatcher` currently rebuilds a RegExp from `matcher.regexp` on every request, even though the source string doesn't change for the life of the matcher. This moves the compile out of the returned closure so each matcher's regex is built once and reused.