### PR TITLE
Add MCP `compile_route` tool

### DIFF
--- a/crates/next-napi-bindings/src/turbo_trace_server.rs
+++ b/crates/next-napi-bindings/src/turbo_trace_server.rs
@@ -62,6 +62,13 @@ pub struct TraceSpanInfo {
     pub avg_corrected_duration: Option<i64>,
     /// Raw span ID for aggregated groups (the index of the first span).
     pub first_span_id: Option<String>,
+    /// TurboMalloc memory-usage samples recorded while this span
+    /// (or its example span, for aggregated groups) was live.
+    ///
+    /// Each entry is `[ts_offset_from_span_start_in_ticks, bytes]`.
+    /// `100 ticks = 1 µs`. The offset is always `>= 0` and `<= span_duration`.
+    /// Capped and downsampled by the store.
+    pub memory_samples: Vec<Vec<i64>>,
 }
 
 /// The result of a `query_trace_spans` call.
@@ -125,6 +132,11 @@ pub fn query_trace_spans(
                 total_corrected_duration: s.total_corrected_duration.map(|v| v as i64),
                 avg_corrected_duration: s.avg_corrected_duration.map(|v| v as i64),
                 first_span_id: s.first_span_id,
+                memory_samples: s
+                    .memory_samples
+                    .into_iter()
+                    .map(|(ts, mem)| vec![ts, mem as i64])
+                    .collect(),
             })
             .collect(),
         page: result.page as u32,

--- a/docs/01-app/02-guides/mcp.mdx
+++ b/docs/01-app/02-guides/mcp.mdx
@@ -87,7 +87,7 @@ Through `next-devtools-mcp`, agents can use the following tools:
 - **`get_routes`**: Get all routes that will become entry points by scanning the filesystem. Returns routes grouped by router type (appRouter, pagesRouter). Dynamic segments appear as `[param]` or `[...slug]` patterns
 - **`get_server_action_by_id`**: Look up Server Actions by their ID to find the source file and function name
 - **`get_compilation_issues`**: Retrieve compilation warnings and errors for the whole project from the bundler. Turbopack only.
-- **`compile_route`**: Trigger on-demand compilation of a specific route without making an HTTP request to it. Useful for warming the module graph, measuring compile time, or pre-compiling routes without needing live backends. Returns any compilation issues for the route. Turbopack only.
+- **`compile_route`**: Trigger on-demand compilation of a specific route without making an HTTP request to it. Accepts either a `routeSpecifier` (e.g. `/blog/[slug]`, as returned by `get_routes`) or a `path` (e.g. `/blog/hello-world`) which is resolved to the matching route using the dev router's live route table. Returns any compilation issues for the route. Turbopack only.
 
 ## Using with agents
 

--- a/docs/01-app/02-guides/mcp.mdx
+++ b/docs/01-app/02-guides/mcp.mdx
@@ -86,6 +86,8 @@ Through `next-devtools-mcp`, agents can use the following tools:
 - **`get_project_metadata`**: Retrieve project structure, configuration, and dev server URL
 - **`get_routes`**: Get all routes that will become entry points by scanning the filesystem. Returns routes grouped by router type (appRouter, pagesRouter). Dynamic segments appear as `[param]` or `[...slug]` patterns
 - **`get_server_action_by_id`**: Look up Server Actions by their ID to find the source file and function name
+- **`get_compilation_issues`**: Retrieve compilation warnings and errors for the whole project from the bundler. Turbopack only.
+- **`compile_route`**: Trigger on-demand compilation of a specific route without making an HTTP request to it. Useful for warming the module graph, measuring compile time, or pre-compiling routes without needing live backends. Returns any compilation issues for the route. Turbopack only.
 
 ## Using with agents
 

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1178,5 +1178,6 @@
   "1177": "The middleware \"%s\" accepts an async API directly with the form:\n  \n  export function middleware(request, event) {\n    return NextResponse.redirect('/new-location')\n  }\n  \n  Read more: https://nextjs.org/docs/messages/middleware-new-signature\n  ",
   "1178": "The request.page has been deprecated in favour of \\`URLPattern\\`.\n  Read more: https://nextjs.org/docs/messages/middleware-request-page\n  ",
   "1179": "Invariant: %s This is a bug in Next.js.",
-  "1180": "Cookies can only be modified in a Server Action or Route Handler. Read more: https://nextjs.org/docs/app/api-reference/functions/cookies#options"
+  "1180": "Cookies can only be modified in a Server Action or Route Handler. Read more: https://nextjs.org/docs/app/api-reference/functions/cookies#options",
+  "1181": "Compilation failed but no issues were recorded"
 }

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1179,5 +1179,7 @@
   "1178": "The request.page has been deprecated in favour of \\`URLPattern\\`.\n  Read more: https://nextjs.org/docs/messages/middleware-request-page\n  ",
   "1179": "Invariant: %s This is a bug in Next.js.",
   "1180": "Cookies can only be modified in a Server Action or Route Handler. Read more: https://nextjs.org/docs/app/api-reference/functions/cookies#options",
-  "1181": "Compilation failed but no issues were recorded"
+  "1181": "Compilation failed but no issues were recorded",
+  "1182": "no route matched for path \"%s\"",
+  "1183": "compileRoute: either routeSpecifier or path is required"
 }

--- a/packages/next/src/cli/internal/turbo-trace-server.ts
+++ b/packages/next/src/cli/internal/turbo-trace-server.ts
@@ -34,6 +34,32 @@ function formatRelative(ticks: number): string {
   return prefix + formatDuration(Math.abs(ticks))
 }
 
+function formatBytes(bytes: number): string {
+  const KB = 1024
+  const MB = KB * 1024
+  const GB = MB * 1024
+  if (bytes >= GB) return `${(bytes / GB).toFixed(2)} GB`
+  if (bytes >= MB) return `${(bytes / MB).toFixed(2)} MB`
+  if (bytes >= KB) return `${(bytes / KB).toFixed(2)} KB`
+  return `${bytes} B`
+}
+
+function summarizeMemorySamples(samples: number[][]): string | null {
+  if (!samples || samples.length === 0) return null
+  const bytes = samples.map((s) => s[1])
+  const min = Math.min(...bytes)
+  const max = Math.max(...bytes)
+  const first = bytes[0]
+  const last = bytes[bytes.length - 1]
+  const delta = last - first
+  const deltaSign = delta >= 0 ? '+' : '-'
+  return (
+    `samples=${samples.length}, min=${formatBytes(min)}, max=${formatBytes(max)}, ` +
+    `start=${formatBytes(first)}, end=${formatBytes(last)}, ` +
+    `Δ=${deltaSign}${formatBytes(Math.abs(delta))}`
+  )
+}
+
 /**
  * Render a single span (or aggregated span group) as a markdown section.
  */
@@ -72,6 +98,11 @@ function renderSpanMarkdown(span: TraceSpanInfo): string {
     for (const [k, v] of span.args) {
       md += `- \`${k}\`: ${v}\n`
     }
+  }
+
+  const memSummary = summarizeMemorySamples(span.memorySamples)
+  if (memSummary) {
+    md += `\n**Memory (TurboMalloc live bytes):** ${memSummary}\n`
   }
 
   md += '\n---\n\n'
@@ -121,7 +152,7 @@ export async function startTurboTraceServerCli(
     'query_spans',
     {
       description:
-        'Query spans from a turbopack trace file. Returns spans with timing, CPU usage, and attribute details. Set `outputType` to "json" for machine-readable output or "markdown" (default) for human-readable output. Use the `parent` parameter (with an ID from a previous result) to drill into children. Results are paginated to 20 spans per page.',
+        'Query spans from a turbopack trace file. Returns spans with timing, CPU usage, attribute details, and TurboMalloc live-memory samples recorded while each span was active. Set `outputType` to "json" for machine-readable output (including the raw `memorySamples` array of bytes per span) or "markdown" (default) for a human-readable summary. Use the `parent` parameter (with an ID from a previous result) to drill into children. Results are paginated to 20 spans per page.',
       inputSchema: {
         parent: z
           .string()

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -125,6 +125,7 @@ import {
 } from './hot-reloader-shared-utils'
 import { getMcpMiddleware } from '../mcp/get-mcp-middleware'
 import { formatCompilationIssues } from '../mcp/tools/utils/format-compilation-issues'
+import { resolvePathToRoute } from '../mcp/tools/utils/resolve-path-to-route'
 import { handleErrorStateResponse } from '../mcp/tools/get-errors'
 import { handlePageMetadataResponse } from '../mcp/tools/get-page-metadata'
 import { setStackFrameResolver } from '../mcp/tools/utils/format-errors'
@@ -1048,7 +1049,36 @@ export async function createHotReloaderTurbopack(
               clientsWithoutHtmlRequestId.size + clientsByHtmlRequestId.size,
             getDevServerUrl: () => process.env.__NEXT_PRIVATE_ORIGIN,
             getTurbopackProject: () => project,
-            compileRoute: async (pageOpts) => {
+            compileRoute: async ({ routeSpecifier, path }) => {
+              // Resolve the caller's input to a concrete route specifier. The
+              // path-mode branch reuses the dev router's own live route table
+              // (opts.fsChecker) — the same one resolve-routes.ts consults on
+              // every incoming HTTP request — so first-match ordering and live
+              // route updates are inherited for free.
+              let page: string
+              if (routeSpecifier != null) {
+                page = routeSpecifier
+              } else if (path != null) {
+                const resolved = resolvePathToRoute(path, {
+                  appFiles: opts.fsChecker.appFiles,
+                  pageFiles: opts.fsChecker.pageFiles,
+                  dynamicRoutes: opts.fsChecker.getDynamicRoutes(),
+                })
+                if ('notFound' in resolved) {
+                  const err: NodeJS.ErrnoException = new Error(
+                    `no route matched for path "${resolved.pathname}"`
+                  )
+                  err.code = 'ENOENT'
+                  throw err
+                }
+                page = resolved.routeSpecifier
+              } else {
+                // Tool handler rejects the empty case; defend the boundary.
+                throw new Error(
+                  'compileRoute: either routeSpecifier or path is required'
+                )
+              }
+
               // ensurePage uses findPagePathData when no definition is provided,
               // which calls normalizePagePath("/") → "/index" then findPageFile
               // looking for "index.tsx" — neither of which matches "page.tsx" in
@@ -1060,13 +1090,17 @@ export async function createHotReloaderTurbopack(
               // strip that suffix and find the entry matching the user-facing route.
               let appOriginalName: string | undefined
               for (const [name] of currentEntrypoints.app) {
-                if (normalizeAppPath(name) === pageOpts.page) {
+                if (normalizeAppPath(name) === page) {
                   appOriginalName = name
                   break
                 }
               }
               const ensureOpts = {
-                ...pageOpts,
+                page,
+                // Compile both server and client bundles, matching what happens
+                // on a real page navigation. Client-only compilation isn't a
+                // meaningful MCP use case so we don't expose it as a knob.
+                clientOnly: false,
                 // Skip wiring HMR subscriptions: there is no client to receive
                 // updates for routes compiled this way, and these subscriptions
                 // are never unsubscribed (see TODOs in handleRouteType).
@@ -1122,7 +1156,10 @@ export async function createHotReloaderTurbopack(
                 throw moduleBuildError
               }
 
-              return formatCompilationIssues(rawIssues)
+              return {
+                routeSpecifier: page,
+                issues: formatCompilationIssues(rawIssues),
+              }
             },
           }),
         ]

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -92,6 +92,7 @@ import {
   formatIssue,
   isFileSystemCacheEnabledForDev,
   isWellKnownError,
+  ModuleBuildError,
   processIssues,
   renderStyledStringToErrorAnsi,
   type EntryIssuesMap,
@@ -123,6 +124,7 @@ import {
   matchNextPageBundleRequest,
 } from './hot-reloader-shared-utils'
 import { getMcpMiddleware } from '../mcp/get-mcp-middleware'
+import { formatCompilationIssues } from '../mcp/tools/utils/format-compilation-issues'
 import { handleErrorStateResponse } from '../mcp/tools/get-errors'
 import { handlePageMetadataResponse } from '../mcp/tools/get-page-metadata'
 import { setStackFrameResolver } from '../mcp/tools/utils/format-errors'
@@ -1046,6 +1048,82 @@ export async function createHotReloaderTurbopack(
               clientsWithoutHtmlRequestId.size + clientsByHtmlRequestId.size,
             getDevServerUrl: () => process.env.__NEXT_PRIVATE_ORIGIN,
             getTurbopackProject: () => project,
+            compileRoute: async (pageOpts) => {
+              // ensurePage uses findPagePathData when no definition is provided,
+              // which calls normalizePagePath("/") → "/index" then findPageFile
+              // looking for "index.tsx" — neither of which matches "page.tsx" in
+              // the app dir. Pass a synthetic definition instead.
+              //
+              // currentEntrypoints.app is keyed by originalName which includes the
+              // trailing /page or /route segment (e.g. "/page" for the root route,
+              // "/blog/[slug]/page" for a dynamic page). Use normalizeAppPath to
+              // strip that suffix and find the entry matching the user-facing route.
+              let appOriginalName: string | undefined
+              for (const [name] of currentEntrypoints.app) {
+                if (normalizeAppPath(name) === pageOpts.page) {
+                  appOriginalName = name
+                  break
+                }
+              }
+              const ensureOpts = {
+                ...pageOpts,
+                // Skip wiring HMR subscriptions: there is no client to receive
+                // updates for routes compiled this way, and these subscriptions
+                // are never unsubscribed (see TODOs in handleRouteType).
+                subscribeToChanges: false,
+                ...(appOriginalName
+                  ? {
+                      // Synthesize a definition so ensurePage bypasses findPagePathData.
+                      // Only page and bundlePath are used from the definition:
+                      // - page: the originalName used as the route key for currentEntrypoints lookup
+                      // - bundlePath: must start with "app/" to set isInsideAppDir=true
+                      definition: {
+                        page: appOriginalName,
+                        bundlePath: `app${appOriginalName}`,
+                        filename: '',
+                      } as any,
+                    }
+                  : {}),
+              }
+
+              // Snapshot the current issue maps before compilation so we can
+              // identify which entry keys were added or updated by this call.
+              // processIssues always creates a new Map() reference, so identity
+              // comparison detects changes even for re-compilations.
+              const snapshotBefore = new Map(currentEntryIssues)
+
+              // For app-page routes, processIssues is called with throwIssue=true,
+              // meaning it throws ModuleBuildError when there are compile errors—but
+              // it still writes the issues into currentEntryIssues before throwing.
+              // Catch ModuleBuildError so we can read those issues and return them
+              // as structured output rather than propagating the throw.
+              let moduleBuildError: ModuleBuildError | undefined
+              try {
+                await hotReloader.ensurePage(ensureOpts)
+              } catch (err) {
+                if (err instanceof ModuleBuildError) {
+                  moduleBuildError = err
+                } else {
+                  throw err
+                }
+              }
+
+              const rawIssues = []
+              for (const [key, issueMap] of currentEntryIssues) {
+                if (snapshotBefore.get(key) !== issueMap) {
+                  rawIssues.push(...issueMap.values())
+                }
+              }
+
+              // If ensurePage threw ModuleBuildError but we found no new issues in
+              // the map (shouldn't happen, but be safe), re-surface the original
+              // error so its message and stack are preserved.
+              if (moduleBuildError && rawIssues.length === 0) {
+                throw moduleBuildError
+              }
+
+              return formatCompilationIssues(rawIssues)
+            },
           }),
         ]
       : []),
@@ -1539,6 +1617,7 @@ export async function createHotReloaderTurbopack(
       definition,
       isApp,
       url: requestUrl,
+      subscribeToChanges = true,
     }) {
       // When there is no route definition this is an internal file not a route the user added.
       // Middleware and instrumentation are handled in turbpack-utils.ts handleEntrypoints instead.
@@ -1689,7 +1768,11 @@ export async function createHotReloaderTurbopack(
               logErrors: true,
 
               hooks: {
-                subscribeToChanges: subscribeToClientChanges,
+                // Omit subscribeToChanges to skip wiring HMR subscriptions for
+                // one-shot compilations (e.g. compile_route MCP tool).
+                ...(subscribeToChanges
+                  ? { subscribeToChanges: subscribeToClientChanges }
+                  : null),
                 handleWrittenEndpoint: (id, result, forceDeleteCache) => {
                   currentWrittenEntrypoints.set(id, result)
                   assetMapper.setPathsForKey(id, result.clientPaths)

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -59,6 +59,7 @@ import {
   processTopLevelIssues,
   printNonFatalIssue,
   normalizedPageToTurbopackStructureRoute,
+  type StartChangeSubscription,
 } from './turbopack-utils'
 import {
   propagateServerField,
@@ -1088,10 +1089,20 @@ export async function createHotReloaderTurbopack(
               // trailing /page or /route segment (e.g. "/page" for the root route,
               // "/blog/[slug]/page" for a dynamic page). Use normalizeAppPath to
               // strip that suffix and find the entry matching the user-facing route.
-              let appOriginalName: string | undefined
+              let extraOptions: object | undefined = undefined
               for (const [name] of currentEntrypoints.app) {
                 if (normalizeAppPath(name) === page) {
-                  appOriginalName = name
+                  extraOptions = {
+                    // Synthesize a definition so ensurePage bypasses findPagePathData.
+                    // Only page and bundlePath are used from the definition:
+                    // - page: the originalName used as the route key for currentEntrypoints lookup
+                    // - bundlePath: must start with "app/" to set isInsideAppDir=true
+                    definition: {
+                      page: name,
+                      bundlePath: `app${name}`,
+                      filename: '',
+                    } as any,
+                  }
                   break
                 }
               }
@@ -1105,19 +1116,7 @@ export async function createHotReloaderTurbopack(
                 // updates for routes compiled this way, and these subscriptions
                 // are never unsubscribed (see TODOs in handleRouteType).
                 subscribeToChanges: false,
-                ...(appOriginalName
-                  ? {
-                      // Synthesize a definition so ensurePage bypasses findPagePathData.
-                      // Only page and bundlePath are used from the definition:
-                      // - page: the originalName used as the route key for currentEntrypoints lookup
-                      // - bundlePath: must start with "app/" to set isInsideAppDir=true
-                      definition: {
-                        page: appOriginalName,
-                        bundlePath: `app${appOriginalName}`,
-                        filename: '',
-                      } as any,
-                    }
-                  : {}),
+                ...extraOptions,
               }
 
               // Snapshot the current issue maps before compilation so we can
@@ -1805,11 +1804,11 @@ export async function createHotReloaderTurbopack(
               logErrors: true,
 
               hooks: {
-                // Omit subscribeToChanges to skip wiring HMR subscriptions for
+                // Pass a no-o subscribeToChanges to skip wiring HMR subscriptions for
                 // one-shot compilations (e.g. compile_route MCP tool).
-                ...(subscribeToChanges
-                  ? { subscribeToChanges: subscribeToClientChanges }
-                  : null),
+                subscribeToChanges: subscribeToChanges
+                  ? subscribeToClientChanges
+                  : ((async () => {}) as StartChangeSubscription),
                 handleWrittenEndpoint: (id, result, forceDeleteCache) => {
                   currentWrittenEntrypoints.set(id, result)
                   assetMapper.setPathsForKey(id, result.clientPaths)

--- a/packages/next/src/server/dev/hot-reloader-types.ts
+++ b/packages/next/src/server/dev/hot-reloader-types.ts
@@ -267,13 +267,23 @@ export interface NextJsHotReloaderInterface {
     definition,
     isApp,
     url,
+    subscribeToChanges,
   }: {
     page: string
     clientOnly: boolean
     appPaths?: ReadonlyArray<string> | null
     isApp?: boolean
-    definition: RouteDefinition | undefined
+    definition?: RouteDefinition
     url?: string
+    /**
+     * Whether to wire HMR change subscriptions for the compiled entry.
+     * Defaults to true (the dev server uses these to push updates to
+     * connected browsers). Pass false for one-shot compilations (e.g.
+     * the `compile_route` MCP tool) where there is no client to receive
+     * HMR updates — without this, repeated calls leak subscriptions that
+     * keep firing on every file change for the life of the dev server.
+     */
+    subscribeToChanges?: boolean
   }): Promise<void>
   close(): void
 }

--- a/packages/next/src/server/dev/hot-reloader-webpack.ts
+++ b/packages/next/src/server/dev/hot-reloader-webpack.ts
@@ -1690,6 +1690,7 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
               getActiveConnectionCount: () =>
                 this.webpackHotMiddleware?.getClientCount() ?? 0,
               getDevServerUrl: () => process.env.__NEXT_PRIVATE_ORIGIN,
+              // compile_route is Turbopack-only; intentionally omitted here.
             }),
           ]
         : [])
@@ -1844,6 +1845,10 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
     isApp?: boolean
     definition?: RouteDefinition
     url?: string
+    // subscribeToChanges is accepted for interface compatibility but is a
+    // no-op for webpack: webpack's on-demand entry handler does not wire HMR
+    // subscriptions per entry the way Turbopack does.
+    subscribeToChanges?: boolean
   }): Promise<void> {
     return this.hotReloaderSpan
       .traceChild('ensure-page', {

--- a/packages/next/src/server/dev/turbopack-utils.ts
+++ b/packages/next/src/server/dev/turbopack-utils.ts
@@ -134,9 +134,12 @@ export type ClientState = {
 export type ClientStateMap = WeakMap<ws, ClientState>
 
 // hooks only used by the dev server.
+// subscribeToChanges is optional: omit it to skip wiring HMR subscriptions
+// for one-shot compilations (e.g. the compile_route MCP tool) where there
+// is no client to receive updates and no unsubscribe path.
 type HandleRouteTypeHooks = {
   handleWrittenEndpoint: HandleWrittenEndpoint
-  subscribeToChanges: StartChangeSubscription
+  subscribeToChanges?: StartChangeSubscription
 }
 
 export async function handleRouteType({
@@ -167,6 +170,8 @@ export async function handleRouteType({
 
   readyIds?: ReadyIds // dev
 
+  // hooks.subscribeToChanges may be omitted to skip HMR subscriptions for
+  // one-shot compilations (e.g. the compile_route MCP tool).
   hooks?: HandleRouteTypeHooks // dev
 }) {
   switch (route.type) {
@@ -251,7 +256,7 @@ export async function handleRouteType({
         if (dev) {
           // TODO subscriptions should only be caused by the WebSocket connections
           // otherwise we don't known when to unsubscribe and this leaking
-          hooks?.subscribeToChanges(
+          hooks?.subscribeToChanges?.(
             serverKey,
             false,
             route.dataEndpoint,
@@ -270,7 +275,7 @@ export async function handleRouteType({
               }
             }
           )
-          hooks?.subscribeToChanges(
+          hooks?.subscribeToChanges?.(
             clientKey,
             false,
             route.htmlEndpoint,
@@ -287,7 +292,7 @@ export async function handleRouteType({
             }
           )
           if (entrypoints.global.document) {
-            hooks?.subscribeToChanges(
+            hooks?.subscribeToChanges?.(
               getEntryKey('pages', 'server', '_document'),
               false,
               entrypoints.global.document,
@@ -344,7 +349,7 @@ export async function handleRouteType({
       if (dev) {
         // TODO subscriptions should only be caused by the WebSocket connections
         // otherwise we don't known when to unsubscribe and this leaking
-        hooks?.subscribeToChanges(
+        hooks?.subscribeToChanges?.(
           key,
           true,
           route.rscEndpoint,
@@ -864,7 +869,7 @@ export async function handlePagesErrorRoute({
 
     const writtenEndpoint = await entrypoints.global.app.writeToDisk()
     hooks.handleWrittenEndpoint(key, writtenEndpoint, false)
-    hooks.subscribeToChanges(
+    hooks.subscribeToChanges?.(
       key,
       false,
       entrypoints.global.app,
@@ -893,7 +898,7 @@ export async function handlePagesErrorRoute({
 
     const writtenEndpoint = await entrypoints.global.document.writeToDisk()
     hooks.handleWrittenEndpoint(key, writtenEndpoint, false)
-    hooks.subscribeToChanges(
+    hooks.subscribeToChanges?.(
       key,
       false,
       entrypoints.global.document,
@@ -919,7 +924,7 @@ export async function handlePagesErrorRoute({
 
     const writtenEndpoint = await entrypoints.global.error.writeToDisk()
     hooks.handleWrittenEndpoint(key, writtenEndpoint, false)
-    hooks.subscribeToChanges(
+    hooks.subscribeToChanges?.(
       key,
       false,
       entrypoints.global.error,

--- a/packages/next/src/server/dev/turbopack-utils.ts
+++ b/packages/next/src/server/dev/turbopack-utils.ts
@@ -139,7 +139,7 @@ export type ClientStateMap = WeakMap<ws, ClientState>
 // is no client to receive updates and no unsubscribe path.
 type HandleRouteTypeHooks = {
   handleWrittenEndpoint: HandleWrittenEndpoint
-  subscribeToChanges?: StartChangeSubscription
+  subscribeToChanges: StartChangeSubscription
 }
 
 export async function handleRouteType({
@@ -256,7 +256,7 @@ export async function handleRouteType({
         if (dev) {
           // TODO subscriptions should only be caused by the WebSocket connections
           // otherwise we don't known when to unsubscribe and this leaking
-          hooks?.subscribeToChanges?.(
+          hooks?.subscribeToChanges(
             serverKey,
             false,
             route.dataEndpoint,
@@ -275,7 +275,7 @@ export async function handleRouteType({
               }
             }
           )
-          hooks?.subscribeToChanges?.(
+          hooks?.subscribeToChanges(
             clientKey,
             false,
             route.htmlEndpoint,
@@ -292,7 +292,7 @@ export async function handleRouteType({
             }
           )
           if (entrypoints.global.document) {
-            hooks?.subscribeToChanges?.(
+            hooks?.subscribeToChanges(
               getEntryKey('pages', 'server', '_document'),
               false,
               entrypoints.global.document,
@@ -349,7 +349,7 @@ export async function handleRouteType({
       if (dev) {
         // TODO subscriptions should only be caused by the WebSocket connections
         // otherwise we don't known when to unsubscribe and this leaking
-        hooks?.subscribeToChanges?.(
+        hooks?.subscribeToChanges(
           key,
           true,
           route.rscEndpoint,
@@ -869,7 +869,7 @@ export async function handlePagesErrorRoute({
 
     const writtenEndpoint = await entrypoints.global.app.writeToDisk()
     hooks.handleWrittenEndpoint(key, writtenEndpoint, false)
-    hooks.subscribeToChanges?.(
+    hooks.subscribeToChanges(
       key,
       false,
       entrypoints.global.app,
@@ -898,7 +898,7 @@ export async function handlePagesErrorRoute({
 
     const writtenEndpoint = await entrypoints.global.document.writeToDisk()
     hooks.handleWrittenEndpoint(key, writtenEndpoint, false)
-    hooks.subscribeToChanges?.(
+    hooks.subscribeToChanges(
       key,
       false,
       entrypoints.global.document,
@@ -924,7 +924,7 @@ export async function handlePagesErrorRoute({
 
     const writtenEndpoint = await entrypoints.global.error.writeToDisk()
     hooks.handleWrittenEndpoint(key, writtenEndpoint, false)
-    hooks.subscribeToChanges?.(
+    hooks.subscribeToChanges(
       key,
       false,
       entrypoints.global.error,

--- a/packages/next/src/server/mcp/get-or-create-mcp-server.ts
+++ b/packages/next/src/server/mcp/get-or-create-mcp-server.ts
@@ -23,9 +23,9 @@ export interface McpServerOptions {
   getDevServerUrl: () => string | undefined
   getTurbopackProject?: () => Project | undefined
   compileRoute?: (opts: {
-    page: string
-    clientOnly: boolean
-  }) => Promise<FormattedIssue[]>
+    routeSpecifier?: string
+    path?: string
+  }) => Promise<{ routeSpecifier: string; issues: FormattedIssue[] }>
 }
 
 let mcpServer: McpServer | undefined

--- a/packages/next/src/server/mcp/get-or-create-mcp-server.ts
+++ b/packages/next/src/server/mcp/get-or-create-mcp-server.ts
@@ -6,9 +6,11 @@ import { registerGetLogsTool } from './tools/get-logs'
 import { registerGetActionByIdTool } from './tools/get-server-action-by-id'
 import { registerGetRoutesTool } from './tools/get-routes'
 import { registerGetCompilationIssuesTool } from './tools/get-compilation-issues'
+import { registerCompileRouteTool } from './tools/compile-route'
 import type { HmrMessageSentToBrowser } from '../dev/hot-reloader-types'
 import type { NextConfigComplete } from '../config-shared'
 import type { Project } from '../../build/swc/types'
+import type { FormattedIssue } from './tools/utils/format-compilation-issues'
 
 export interface McpServerOptions {
   projectPath: string
@@ -20,6 +22,10 @@ export interface McpServerOptions {
   getActiveConnectionCount: () => number
   getDevServerUrl: () => string | undefined
   getTurbopackProject?: () => Project | undefined
+  compileRoute?: (opts: {
+    page: string
+    clientOnly: boolean
+  }) => Promise<FormattedIssue[]>
 }
 
 let mcpServer: McpServer | undefined
@@ -60,6 +66,10 @@ export const getOrCreateMcpServer = (options: McpServerOptions) => {
 
   if (options.getTurbopackProject) {
     registerGetCompilationIssuesTool(mcpServer, options.getTurbopackProject)
+  }
+
+  if (options.compileRoute) {
+    registerCompileRouteTool(mcpServer, options.compileRoute)
   }
 
   return mcpServer

--- a/packages/next/src/server/mcp/tools/compile-route.ts
+++ b/packages/next/src/server/mcp/tools/compile-route.ts
@@ -15,9 +15,9 @@ import z from 'next/dist/compiled/zod'
 export function registerCompileRouteTool(
   server: McpServer,
   compileRoute: (opts: {
-    page: string
-    clientOnly: boolean
-  }) => Promise<FormattedIssue[]>
+    routeSpecifier?: string
+    path?: string
+  }) => Promise<{ routeSpecifier: string; issues: FormattedIssue[] }>
 ) {
   server.registerTool(
     'compile_route',
@@ -26,24 +26,57 @@ export function registerCompileRouteTool(
         'Compile a specific route (page or API route) without making an HTTP request. ' +
         'Triggers the same on-demand compilation the dev server uses when a route is first visited. ' +
         'Useful for warming up the module graph, measuring compile time, or pre-compiling routes for memory benchmarking. ' +
-        'Returns { page, issues } on success where issues contains any compilation warnings or errors. ' +
-        'Returns an error if the route does not exist.',
+        'Returns { routeSpecifier, issues } on success where routeSpecifier is the resolved route and issues contains any compilation warnings or errors. ' +
+        'Returns an error if no matching route exists.',
       inputSchema: {
-        page: z
+        routeSpecifier: z
           .string()
           .describe(
-            'The route specifier, e.g. "/", "/about", "/api/hello", "/blog/[slug]"'
-          ),
+            'A route specifier as returned by the get_routes tool (e.g. "/", "/blog/[slug]", "/api/users/[id]"). ' +
+              'Mutually exclusive with `path`; provide exactly one.'
+          )
+          .optional(),
+        path: z
+          .string()
+          .describe(
+            'A URL path on this site (e.g. "/blog/hello-world", "/docs/a/b/c"). ' +
+              'Query strings are allowed and ignored. Do not include scheme/host/port. ' +
+              "The path is resolved to its matching route specifier using the dev router's live route table. " +
+              'Mutually exclusive with `routeSpecifier`; provide exactly one.'
+          )
+          .optional(),
       },
     },
-    async ({ page }) => {
+    async ({ routeSpecifier, path }) => {
       mcpTelemetryTracker.recordToolCall('mcp/compile_route')
-      try {
-        // clientOnly: false ensures both server and client bundles are compiled,
-        // matching what happens on a real page navigation.
-        const issues = await compileRoute({ page, clientOnly: false })
+
+      if ((routeSpecifier == null) === (path == null)) {
         return {
-          content: [{ type: 'text', text: JSON.stringify({ page, issues }) }],
+          isError: true,
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                error: 'Provide exactly one of `routeSpecifier` or `path`.',
+              }),
+            },
+          ],
+        }
+      }
+
+      try {
+        const { routeSpecifier: resolvedRouteSpecifier, issues } =
+          await compileRoute({ routeSpecifier, path })
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                routeSpecifier: resolvedRouteSpecifier,
+                issues,
+              }),
+            },
+          ],
         }
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error)
@@ -56,7 +89,9 @@ export function registerCompileRouteTool(
             {
               type: 'text',
               text: JSON.stringify(
-                notFound ? { page, notFound: true } : { page, error: message }
+                notFound
+                  ? { notFound: true, input: path ?? routeSpecifier }
+                  : { input: path ?? routeSpecifier, error: message }
               ),
             },
           ],

--- a/packages/next/src/server/mcp/tools/compile-route.ts
+++ b/packages/next/src/server/mcp/tools/compile-route.ts
@@ -1,0 +1,67 @@
+/**
+ * MCP tool for compiling a specific route via the on-demand entry handler.
+ *
+ * Triggers on-demand compilation so the route's assets are built without making an
+ * HTTP request to the route. This is the same call path the dev server uses
+ * when a route is first navigated to, making it useful for warming the module
+ * graph, measuring compile time, or pre-compiling routes for memory
+ * benchmarking without requiring live backends.
+ */
+import type { McpServer } from 'next/dist/compiled/@modelcontextprotocol/sdk/server/mcp'
+import { mcpTelemetryTracker } from '../mcp-telemetry-tracker'
+import type { FormattedIssue } from './utils/format-compilation-issues'
+import z from 'next/dist/compiled/zod'
+
+export function registerCompileRouteTool(
+  server: McpServer,
+  compileRoute: (opts: {
+    page: string
+    clientOnly: boolean
+  }) => Promise<FormattedIssue[]>
+) {
+  server.registerTool(
+    'compile_route',
+    {
+      description:
+        'Compile a specific route (page or API route) without making an HTTP request. ' +
+        'Triggers the same on-demand compilation the dev server uses when a route is first visited. ' +
+        'Useful for warming up the module graph, measuring compile time, or pre-compiling routes for memory benchmarking. ' +
+        'Returns { page, issues } on success where issues contains any compilation warnings or errors. ' +
+        'Returns an error if the route does not exist.',
+      inputSchema: {
+        page: z
+          .string()
+          .describe(
+            'The route specifier, e.g. "/", "/about", "/api/hello", "/blog/[slug]"'
+          ),
+      },
+    },
+    async ({ page }) => {
+      mcpTelemetryTracker.recordToolCall('mcp/compile_route')
+      try {
+        // clientOnly: false ensures both server and client bundles are compiled,
+        // matching what happens on a real page navigation.
+        const issues = await compileRoute({ page, clientOnly: false })
+        return {
+          content: [{ type: 'text', text: JSON.stringify({ page, issues }) }],
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        const notFound =
+          error instanceof Error &&
+          (error as NodeJS.ErrnoException).code === 'ENOENT'
+        return {
+          isError: true,
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                notFound ? { page, notFound: true } : { page, error: message }
+              ),
+            },
+          ],
+        }
+      }
+    }
+  )
+}

--- a/packages/next/src/server/mcp/tools/utils/resolve-path-to-route.ts
+++ b/packages/next/src/server/mcp/tools/utils/resolve-path-to-route.ts
@@ -1,0 +1,46 @@
+/**
+ * Resolves a URL path (e.g. "/blog/hello-world") to its matching Next.js route
+ * specifier (e.g. "/blog/[slug]") using the dev router's own live route table.
+ *
+ * The `matchers` argument is a thin view of `fsChecker` from the router-server
+ * process — the same data structure `resolve-routes.ts` iterates on every
+ * incoming HTTP request — so first-match ordering and live route updates are
+ * inherited for free.
+ */
+export interface RouteMatcherView {
+  appFiles: ReadonlySet<string>
+  pageFiles: ReadonlySet<string>
+  dynamicRoutes: ReadonlyArray<{
+    page: string
+    match: (pathname: string) => false | object
+  }>
+}
+
+export function resolvePathToRoute(
+  path: string,
+  matchers: RouteMatcherView
+): { routeSpecifier: string } | { notFound: true; pathname: string } {
+  let pathname = path
+  const q = pathname.indexOf('?')
+  if (q >= 0) pathname = pathname.slice(0, q)
+  const h = pathname.indexOf('#')
+  if (h >= 0) pathname = pathname.slice(0, h)
+  if (!pathname.startsWith('/')) pathname = '/' + pathname
+  if (pathname !== '/' && pathname.endsWith('/')) {
+    pathname = pathname.slice(0, -1)
+  }
+
+  if (matchers.appFiles.has(pathname) || matchers.pageFiles.has(pathname)) {
+    return { routeSpecifier: pathname }
+  }
+
+  for (const route of matchers.dynamicRoutes) {
+    // Skip SSG/SSP data-route variants prepended by setup-dev-bundler.
+    if (route.page.startsWith('/_next/data/')) continue
+    if (route.match(pathname)) {
+      return { routeSpecifier: route.page }
+    }
+  }
+
+  return { notFound: true, pathname }
+}

--- a/packages/next/src/telemetry/events/build.ts
+++ b/packages/next/src/telemetry/events/build.ts
@@ -260,6 +260,7 @@ export type McpToolName =
   | 'mcp/get_routes'
   | 'mcp/get_server_action_by_id'
   | 'mcp/get_compilation_issues'
+  | 'mcp/compile_route'
 
 export type EventMcpToolUsage = {
   toolName: McpToolName

--- a/scripts/benchmark-memory.js
+++ b/scripts/benchmark-memory.js
@@ -1,0 +1,397 @@
+#!/usr/bin/env node
+/**
+ * Memory benchmark for a running Next.js dev server.
+ *
+ * Discovers all routes via the MCP get_routes endpoint, then compiles each
+ * one via the MCP compile_route endpoint — no HTTP requests to the application
+ * are made. Samples RSS/VSZ/physical-footprint throughout and writes a CSV.
+ *
+ * Usage:
+ *   node scripts/benchmark-memory.js <base-url> [output-file] [--pause[=N]]
+ *
+ * Options:
+ *   --pause[=N]   Wait 4 seconds after every N compilations (default: 10)
+ *
+ * Examples:
+ *   node scripts/benchmark-memory.js http://localhost:3000
+ *   node scripts/benchmark-memory.js http://localhost:3000 /tmp/run-a.csv
+ *   node scripts/benchmark-memory.js http://localhost:3000 /tmp/run-a.csv --pause
+ *   node scripts/benchmark-memory.js http://localhost:3000 /tmp/run-a.csv --pause=25
+ *
+ * Output CSV columns:
+ *   timestamp, elapsed_ms, rss_kb, vsz_kb, footprint_kb, event
+ *
+ * 'event' is blank for periodic samples, or "compile:<page>" recorded
+ * immediately after each route is compiled.
+ *
+ * Requires: Next.js dev server with experimental.mcpServer enabled.
+ */
+
+const { spawnSync } = require('child_process')
+const fs = require('fs')
+const http = require('http')
+const https = require('https')
+const { URL } = require('url')
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const MAX_ROUTES = 50
+const SETTLE_MS = 20_000
+const SAMPLE_INTERVAL_MS = 250
+const PAUSE_MS = 10_000
+
+const positional = process.argv.slice(2).filter((a) => !a.startsWith('--'))
+const flagArgs = process.argv.slice(2).filter((a) => a.startsWith('--'))
+const [baseUrlArg, outFileArg] = positional
+
+if (!baseUrlArg) {
+  console.error(
+    'Usage: node scripts/benchmark-memory.js <base-url> [output-file] [--pause[=N]]'
+  )
+  process.exit(1)
+}
+
+const BASE_URL = baseUrlArg.replace(/\/$/, '')
+const OUTFILE =
+  outFileArg ||
+  `/tmp/next-memory-${new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19)}.csv`
+
+// --pause enables pausing, optionally with =N to set the pause interval
+// (pause every N compilations). Default interval is 10.
+const DEFAULT_PAUSE_EVERY = 10
+const pauseFlag = flagArgs.find(
+  (a) => a === '--pause' || a.startsWith('--pause=')
+)
+const PAUSE_EVERY = pauseFlag
+  ? pauseFlag.includes('=')
+    ? parseInt(pauseFlag.slice('--pause='.length), 10)
+    : DEFAULT_PAUSE_EVERY
+  : 0
+if (pauseFlag && (!Number.isFinite(PAUSE_EVERY) || PAUSE_EVERY <= 0)) {
+  console.error(`Invalid --pause value: ${pauseFlag}`)
+  process.exit(1)
+}
+
+// ---------------------------------------------------------------------------
+// Find next-server PID
+// ---------------------------------------------------------------------------
+
+function findNextServerPid() {
+  const result = spawnSync('pgrep', ['-f', 'next-server'], { encoding: 'utf8' })
+  const pids = result.stdout.trim().split('\n').filter(Boolean)
+  if (pids.length === 0) {
+    console.error(
+      'Error: no next-server process found. Start the dev server first.'
+    )
+    process.exit(1)
+  }
+  if (pids.length > 1) {
+    console.error(
+      `Error: multiple next-server processes found (pids: ${pids.join(', ')}).\nStop all but one and retry.`
+    )
+    process.exit(1)
+  }
+  return parseInt(pids[0], 10)
+}
+
+// ---------------------------------------------------------------------------
+// RSS/VSZ sampling (macOS: ps returns KB)
+// ---------------------------------------------------------------------------
+
+function sampleMemory(pid) {
+  const result = spawnSync('ps', ['-o', 'rss=,vsz=', '-p', String(pid)], {
+    encoding: 'utf8',
+  })
+  if (result.status !== 0 || !result.stdout.trim()) return null
+  const [rss, vsz] = result.stdout.trim().split(/\s+/).map(Number)
+  return { rss, vsz }
+}
+
+const PHYSICAL_FOOTPRINT_ONESHOT = `
+import sys, struct, ctypes, ctypes.util
+libc = ctypes.CDLL(ctypes.util.find_library('c'))
+buf = ctypes.create_string_buffer(256)
+ret = libc.proc_pid_rusage(int(sys.argv[1]), 4, buf)
+if ret != 0:
+    sys.exit(1)
+print(struct.unpack_from('<Q', buf, 72)[0] // 1024)
+`
+
+function makeFootprintSampler(pid) {
+  return {
+    sample() {
+      const result = spawnSync(
+        'python3',
+        ['-c', PHYSICAL_FOOTPRINT_ONESHOT, String(pid)],
+        { encoding: 'utf8' }
+      )
+      if (result.status !== 0) return null
+      return Number(result.stdout.trim())
+    },
+    close() {},
+  }
+}
+
+// ---------------------------------------------------------------------------
+// HTTP fetch helper (no external deps)
+// ---------------------------------------------------------------------------
+
+function fetchUrl(url, timeoutMs = 10_000, options = {}) {
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(url)
+    const lib = parsed.protocol === 'https:' ? https : http
+    const reqOptions = {
+      method: options.method ?? 'GET',
+      headers: {
+        'User-Agent': 'next-memory-benchmark',
+        ...options.headers,
+      },
+    }
+    const req = lib.request(url, reqOptions, (res) => {
+      let body = ''
+      res.on('data', (chunk) => (body += chunk))
+      res.on('end', () => resolve({ status: res.statusCode, body }))
+    })
+    req.setTimeout(timeoutMs, () => {
+      req.destroy()
+      reject(new Error(`Timeout fetching ${url}`))
+    })
+    req.on('error', reject)
+    if (options.body) req.write(options.body)
+    req.end()
+  })
+}
+
+// ---------------------------------------------------------------------------
+// MCP helpers
+// ---------------------------------------------------------------------------
+
+// Call a single MCP tool. Returns { isError, body } where body is the parsed
+// JSON content from the tool's response.
+async function callMcpTool(toolName, args, timeoutMs = 5_000) {
+  const url = `${BASE_URL}/_next/mcp`
+  const body = JSON.stringify({
+    jsonrpc: '2.0',
+    method: 'tools/call',
+    params: { name: toolName, arguments: args },
+    id: 1,
+  })
+
+  const res = await fetchUrl(url, timeoutMs, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream',
+    },
+    body,
+  })
+
+  // Response is SSE: "event: message\ndata: {...}\n\n"
+  const dataLine = res.body.split('\n').find((l) => l.startsWith('data:'))
+  if (!dataLine)
+    throw new Error(`MCP: no data line in response for ${toolName}`)
+
+  const envelope = JSON.parse(dataLine.slice('data:'.length).trim())
+  if (envelope.error)
+    throw new Error(`MCP error: ${JSON.stringify(envelope.error)}`)
+  if (!envelope.result?.content?.[0]?.text)
+    throw new Error(`MCP: unexpected response shape for ${toolName}`)
+
+  return {
+    isError: !!envelope.result.isError,
+    body: JSON.parse(envelope.result.content[0].text),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Route discovery and compilation via MCP
+// ---------------------------------------------------------------------------
+
+async function discoverRoutes() {
+  const { isError, body } = await callMcpTool('get_routes', {})
+  if (isError) {
+    throw new Error(`get_routes failed: ${JSON.stringify(body)}`)
+  }
+  const allRoutes = [
+    ...new Set([...(body.appRouter ?? []), ...(body.pagesRouter ?? [])]),
+  ]
+  return {
+    allRoutes,
+    appCount: (body.appRouter ?? []).length,
+    pagesCount: (body.pagesRouter ?? []).length,
+  }
+}
+
+// Compile all routes via MCP compile_route. Calls onCompiled(routeSpecifier)
+// after each successful compilation, where routeSpecifier is the resolved
+// route as returned by the server.
+async function compileRoutes(routes, onCompiled) {
+  let compiledSincePause = 0
+  for (const routeSpecifier of routes) {
+    const { isError, body } = await callMcpTool(
+      'compile_route',
+      { routeSpecifier },
+      // Some compilation can be very slow
+      120_000
+    )
+    if (!isError) {
+      onCompiled(body.routeSpecifier ?? routeSpecifier)
+      compiledSincePause++
+      if (body.issues?.length) {
+        console.warn(
+          `\n  ${routeSpecifier} compiled with ${body.issues.length} issue(s)`
+        )
+      }
+    } else if (body.notFound) {
+      console.warn(`\n  skipped (not found): ${routeSpecifier}`)
+    } else {
+      console.warn(
+        `\n  compile_route error for ${routeSpecifier}: ${body.error}`
+      )
+    }
+    if (PAUSE_EVERY && compiledSincePause >= PAUSE_EVERY) {
+      compiledSincePause = 0
+      await new Promise((r) => setTimeout(r, PAUSE_MS))
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const pid = findNextServerPid()
+  console.log(`Found next-server PID: ${pid}`)
+  console.log(`Base URL:  ${BASE_URL}`)
+  console.log(`Output:    ${OUTFILE}`)
+  if (PAUSE_EVERY)
+    console.log(
+      `Pause mode: ${PAUSE_MS / 1000}s after every ${PAUSE_EVERY} compilations`
+    )
+  console.log('')
+
+  const footprintSampler = makeFootprintSampler(pid)
+  const startTime = Date.now()
+  const rows = [
+    ['timestamp', 'elapsed_ms', 'rss_kb', 'vsz_kb', 'footprint_kb', 'event'],
+  ]
+
+  let routesCompiled = 0
+
+  function now() {
+    return Date.now() - startTime
+  }
+
+  function recordSample(event = '') {
+    const mem = sampleMemory(pid)
+    if (!mem) return null
+    const footprint = footprintSampler.sample() ?? ''
+    rows.push([
+      new Date().toISOString(),
+      now(),
+      mem.rss,
+      mem.vsz,
+      footprint,
+      event,
+    ])
+    return { ...mem, footprint }
+  }
+
+  // Periodic sampler
+  const sampler = setInterval(() => {
+    const mem = recordSample()
+    if (!mem) {
+      console.error('\nProcess exited during benchmark.')
+      clearInterval(sampler)
+      return
+    }
+    const elapsed = (now() / 1000).toFixed(1)
+    const rssMb = (mem.rss / 1024).toFixed(1)
+    const footprintMb = mem.footprint ? (mem.footprint / 1024).toFixed(1) : '?'
+    process.stdout.write(
+      `\r[${elapsed}s] RSS=${rssMb}MB  footprint=${footprintMb}MB  compiled=${routesCompiled}          `
+    )
+  }, SAMPLE_INTERVAL_MS)
+
+  // Discover routes via MCP get_routes
+  let allRoutes, appCount, pagesCount
+  try {
+    ;({ allRoutes, appCount, pagesCount } = await discoverRoutes())
+  } catch (err) {
+    clearInterval(sampler)
+    console.error(`\nFailed to discover routes via MCP: ${err.message}`)
+    console.error(
+      'Make sure the dev server is running with experimental.mcpServer enabled.'
+    )
+    process.exit(1)
+  }
+
+  console.log(
+    `Discovered ${appCount} app router + ${pagesCount} pages router routes via MCP.`
+  )
+
+  // Compile each route via MCP compile_route
+  const routesToCompile = allRoutes.slice(0, MAX_ROUTES)
+  try {
+    await compileRoutes(routesToCompile, (page) => {
+      routesCompiled++
+      recordSample(`compile:${page}`)
+    })
+  } catch (err) {
+    clearInterval(sampler)
+    console.error(`\ncompile_route failed: ${err.message}`)
+    process.exit(1)
+  }
+
+  console.log(`\nCompiled ${routesCompiled} routes.`)
+  console.log(`Settling for ${SETTLE_MS / 1000}s...`)
+  await new Promise((r) => setTimeout(r, SETTLE_MS))
+
+  clearInterval(sampler)
+  footprintSampler.close()
+
+  // Write CSV
+  const csv = rows.map((r) => r.join(',')).join('\n') + '\n'
+  fs.writeFileSync(OUTFILE, csv)
+
+  // Summary
+  const dataRows = rows.slice(1).filter((r) => r[2])
+  const rssValues = dataRows.map((r) => Number(r[2]))
+  const vszValues = dataRows.map((r) => Number(r[3]))
+  const footprintValues = dataRows.map((r) => Number(r[4])).filter(Boolean)
+
+  const minRss = Math.min(...rssValues)
+  const maxRss = Math.max(...rssValues)
+  const finalRss = rssValues[rssValues.length - 1]
+  const minVsz = Math.min(...vszValues)
+  const maxVsz = Math.max(...vszValues)
+  const finalVsz = vszValues[vszValues.length - 1]
+
+  const mb = (kb) => (kb / 1024).toFixed(0) + 'MB'
+
+  console.log('\n=== Memory Summary ===')
+  console.log(
+    `  RSS:       min=${mb(minRss)}  max=${mb(maxRss)}  final=${mb(finalRss)}`
+  )
+  if (footprintValues.length > 0) {
+    const minFp = Math.min(...footprintValues)
+    const maxFp = Math.max(...footprintValues)
+    const finalFp = footprintValues[footprintValues.length - 1]
+    console.log(
+      `  Footprint: min=${mb(minFp)}  max=${mb(maxFp)}  final=${mb(finalFp)}`
+    )
+  }
+  console.log(
+    `  VSZ:       min=${mb(minVsz)}  max=${mb(maxVsz)}  final=${mb(finalVsz)}`
+  )
+  console.log(`  Samples: ${dataRows.length}`)
+  console.log(`\nFull data: ${OUTFILE}`)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/scripts/visualize-memory.js
+++ b/scripts/visualize-memory.js
@@ -1,0 +1,406 @@
+#!/usr/bin/env node
+/**
+ * Visualize memory benchmark output as an SVG chart.
+ *
+ * Usage:
+ *   node scripts/visualize-memory.js [--time|--compile] [--out=output.svg] <file1.csv> [file2.csv ...]
+ *
+ * Modes:
+ *   --time     (default) X-axis is elapsed time in seconds. Vertical dashed
+ *              lines mark compile events, labeled with the route path.
+ *   --compile  X-axis is compile index. Each tick is a route (labeled).
+ *              Y-value is the memory sample taken closest to that compile.
+ *              Good for comparing per-route memory cost across runs without
+ *              timing noise.
+ *
+ * Memory metric:
+ *   Uses physical footprint (footprint_kb) when available (macOS), otherwise
+ *   falls back to RSS (rss_kb) on Linux.
+ *
+ * CSV format (from benchmark-memory.js):
+ *   timestamp, elapsed_ms, rss_kb, vsz_kb, footprint_kb, event
+ */
+
+const fs = require('fs')
+const path = require('path')
+
+// ---------------------------------------------------------------------------
+// Args
+// ---------------------------------------------------------------------------
+
+const args = process.argv.slice(2)
+if (args.length === 0) {
+  console.error(
+    'Usage: node scripts/visualize-memory.js [--time|--compile] [--out=output.svg] <file1.csv> ...'
+  )
+  process.exit(1)
+}
+
+let outFile = '/tmp/memory-chart.svg'
+let mode = 'time' // 'time' | 'compile'
+const csvFiles = []
+
+for (const arg of args) {
+  if (arg === '--time') mode = 'time'
+  else if (arg === '--compile') mode = 'compile'
+  else if (arg.startsWith('--out=')) outFile = arg.slice('--out='.length)
+  else csvFiles.push(arg)
+}
+
+if (csvFiles.length === 0) {
+  console.error('Error: no CSV files specified.')
+  process.exit(1)
+}
+
+// ---------------------------------------------------------------------------
+// Palette
+// ---------------------------------------------------------------------------
+
+const COLORS = [
+  '#2563eb',
+  '#dc2626',
+  '#16a34a',
+  '#9333ea',
+  '#ea580c',
+  '#0891b2',
+]
+
+// ---------------------------------------------------------------------------
+// Parse CSV
+// ---------------------------------------------------------------------------
+
+function parseCsv(filePath) {
+  const lines = fs.readFileSync(filePath, 'utf8').trim().split('\n')
+  const header = lines[0].split(',').map((h) => h.trim())
+  const hasFootprint = header.includes('footprint_kb')
+
+  // { elapsed_ms, mem_mb, compile? }
+  // compile is set on rows that have a compile:<page> annotation
+  const rows = []
+
+  for (const line of lines.slice(1)) {
+    const cols = line.split(',')
+    const elapsed_ms = Number(cols[1])
+    const rss_kb = cols[2]?.trim()
+    const footprint_kb = hasFootprint ? cols[4]?.trim() : ''
+    const event = (hasFootprint ? cols[5] : cols[4])?.trim() ?? ''
+
+    const memKb = hasFootprint && footprint_kb ? footprint_kb : rss_kb
+    if (!memKb) continue
+
+    const row = { elapsed_ms, mem_mb: Number(memKb) / 1024 }
+    if (event.startsWith('compile:')) {
+      // compile:<page> — page is already a route path like "/blog/[slug]"
+      row.compile = event.slice('compile:'.length)
+    }
+    rows.push(row)
+  }
+
+  // Separate samples and compile events
+  const samples = rows.filter((r) => !r.compile)
+  const compileRows = rows.filter((r) => r.compile)
+
+  // For each compile event, find the nearest sample by elapsed_ms
+  const compilePoints = compileRows.map((c) => {
+    const nearest = samples.reduce((best, s) =>
+      Math.abs(s.elapsed_ms - c.elapsed_ms) <
+      Math.abs(best.elapsed_ms - c.elapsed_ms)
+        ? s
+        : best
+    )
+    return {
+      elapsed_ms: c.elapsed_ms,
+      label: c.compile,
+      mem_mb: nearest.mem_mb,
+    }
+  })
+
+  // Session boundary points: first sample before any compile, last sample overall
+  const firstCompileMs =
+    compilePoints.length > 0 ? compilePoints[0].elapsed_ms : Infinity
+  const startMem =
+    samples.find((s) => s.elapsed_ms <= firstCompileMs)?.mem_mb ??
+    samples[0]?.mem_mb
+  const endMem = samples[samples.length - 1]?.mem_mb
+
+  return {
+    samples,
+    compilePoints,
+    startMem,
+    endMem,
+    name: path.basename(filePath, '.csv'),
+    metricLabel: hasFootprint ? 'Physical Footprint (MB)' : 'RSS (MB)',
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Chart dimensions
+// ---------------------------------------------------------------------------
+
+const W = 1100
+const H = 500
+const PAD = { top: 40, right: 180, bottom: 80, left: 70 }
+const CW = W - PAD.left - PAD.right
+const CH = H - PAD.top - PAD.bottom
+
+function escXml(s) {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}
+
+// ---------------------------------------------------------------------------
+// Shared y-axis helpers
+// ---------------------------------------------------------------------------
+
+function yBounds(datasets) {
+  const all = [
+    ...datasets.flatMap((d) => d.samples.map((s) => s.mem_mb)),
+    ...datasets.flatMap((d) => d.compilePoints.map((c) => c.mem_mb)),
+    ...datasets.map((d) => d.startMem ?? 0),
+    ...datasets.map((d) => d.endMem ?? 0),
+  ]
+  return Math.ceil(Math.max(...all, 1) / 100) * 100
+}
+
+function yScale(mb, ceil) {
+  return PAD.top + CH - (mb / ceil) * CH
+}
+
+function yGridLines(ceil) {
+  const out = []
+  const steps = 5
+  for (let i = 0; i <= steps; i++) {
+    const mb = (ceil / steps) * i
+    const y = yScale(mb, ceil).toFixed(1)
+    out.push(
+      `<line x1="${PAD.left}" y1="${y}" x2="${PAD.left + CW}" y2="${y}" stroke="#e5e7eb" stroke-width="1"/>`
+    )
+    out.push(
+      `<text x="${(PAD.left - 8).toFixed(1)}" y="${y}" text-anchor="end" dominant-baseline="middle" font-size="11" fill="#6b7280">${mb.toFixed(0)}</text>`
+    )
+  }
+  return out.join('\n')
+}
+
+function legend(datasets) {
+  const items = []
+  const x = PAD.left + CW + 16
+  let y = PAD.top + 12
+  for (const [i, d] of datasets.entries()) {
+    const color = COLORS[i % COLORS.length]
+    items.push(
+      `<rect x="${x}" y="${y - 4}" width="18" height="3" fill="${color}" rx="1"/>`
+    )
+    items.push(
+      `<text x="${x + 24}" y="${y}" font-size="12" fill="#374151" dominant-baseline="middle">${escXml(d.name)}</text>`
+    )
+    y += 24
+  }
+  return items.join('\n')
+}
+
+function svgWrap(title, xAxisLabel, metricLabel, body, datasets) {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}" font-family="system-ui, sans-serif">
+  <rect width="${W}" height="${H}" fill="white"/>
+  <text x="${PAD.left + CW / 2}" y="22" text-anchor="middle" font-size="14" font-weight="600" fill="#111827">${escXml(title)}</text>
+  <text x="${(PAD.left - 48).toFixed(1)}" y="${(PAD.top + CH / 2).toFixed(1)}" text-anchor="middle" font-size="12" fill="#6b7280" transform="rotate(-90,${(PAD.left - 48).toFixed(1)},${(PAD.top + CH / 2).toFixed(1)})">${escXml(metricLabel)}</text>
+  <text x="${(PAD.left + CW / 2).toFixed(1)}" y="${(H - 6).toFixed(1)}" text-anchor="middle" font-size="12" fill="#6b7280">${escXml(xAxisLabel)}</text>
+  <rect x="${PAD.left}" y="${PAD.top}" width="${CW}" height="${CH}" fill="none" stroke="#d1d5db" stroke-width="1"/>
+  ${body}
+  ${legend(datasets)}
+</svg>`
+}
+
+// ---------------------------------------------------------------------------
+// --time mode
+// ---------------------------------------------------------------------------
+
+function renderTime(datasets) {
+  const ceil = yBounds(datasets)
+  const maxMs = Math.max(
+    ...datasets.flatMap((d) => d.samples.map((s) => s.elapsed_ms)),
+    1
+  )
+
+  function xScale(ms) {
+    return PAD.left + (ms / maxMs) * CW
+  }
+
+  // Grid
+  const grid = [yGridLines(ceil)]
+  const xSteps = 6
+  for (let i = 0; i <= xSteps; i++) {
+    const ms = (maxMs / xSteps) * i
+    const x = xScale(ms).toFixed(1)
+    grid.push(
+      `<line x1="${x}" y1="${PAD.top}" x2="${x}" y2="${PAD.top + CH}" stroke="#e5e7eb" stroke-width="1"/>`,
+      `<text x="${x}" y="${(PAD.top + CH + 16).toFixed(1)}" text-anchor="middle" font-size="11" fill="#6b7280">${(ms / 1000).toFixed(1)}s</text>`
+    )
+  }
+
+  // Compile markers — one set, deduplicated across all datasets, labeled on x-axis
+  // Collect all compiles across datasets, dedup by label, pick earliest elapsed_ms
+  const compileByLabel = new Map()
+  for (const d of datasets) {
+    for (const c of d.compilePoints) {
+      if (
+        !compileByLabel.has(c.label) ||
+        c.elapsed_ms < compileByLabel.get(c.label).elapsed_ms
+      ) {
+        compileByLabel.set(c.label, c)
+      }
+    }
+  }
+
+  const MIN_GAP_PX = 24
+  let lastX = -MIN_GAP_PX * 2
+  const markers = []
+  for (const c of [...compileByLabel.values()].sort(
+    (a, b) => a.elapsed_ms - b.elapsed_ms
+  )) {
+    const x = xScale(c.elapsed_ms)
+    if (x - lastX < MIN_GAP_PX) continue
+    lastX = x
+    markers.push(
+      `<line x1="${x.toFixed(1)}" y1="${PAD.top}" x2="${x.toFixed(1)}" y2="${(PAD.top + CH).toFixed(1)}" stroke="#9ca3af" stroke-width="1" stroke-dasharray="4,3"/>`,
+      `<text transform="translate(${(x + 3).toFixed(1)},${(PAD.top + CH + 4).toFixed(1)}) rotate(-45)" font-size="9" fill="#6b7280">${escXml(c.label)}</text>`
+    )
+  }
+
+  // Lines
+  const lines = []
+  for (const [i, d] of datasets.entries()) {
+    const color = COLORS[i % COLORS.length]
+    const pts = d.samples
+      .map(
+        (s) =>
+          `${xScale(s.elapsed_ms).toFixed(1)},${yScale(s.mem_mb, ceil).toFixed(1)}`
+      )
+      .join(' ')
+    if (pts) {
+      lines.push(
+        `<polyline points="${pts}" fill="none" stroke="${color}" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>`
+      )
+    }
+  }
+
+  const body = [...grid, ...markers, ...lines].join('\n  ')
+  const metricLabel = datasets[0]?.metricLabel ?? 'Memory (MB)'
+  return svgWrap(
+    'Memory Over Time',
+    'Time (seconds)',
+    metricLabel,
+    body,
+    datasets
+  )
+}
+
+// ---------------------------------------------------------------------------
+// --compile mode
+// ---------------------------------------------------------------------------
+
+function renderCompile(datasets) {
+  const ceil = yBounds(datasets)
+
+  // Use the shortest run so all datasets have values at every tick
+  const maxCompiles = Math.min(...datasets.map((d) => d.compilePoints.length))
+  if (maxCompiles === 0) {
+    console.error('No compile events found in CSV files.')
+    process.exit(1)
+  }
+
+  // Total ticks: start + compiles + end
+  const total = 1 + maxCompiles + 1
+
+  // x: evenly spaced. index 0 = start, 1..maxCompiles = compile #, maxCompiles+1 = end
+  function xScale(idx) {
+    return PAD.left + (idx / (total - 1)) * CW
+  }
+
+  // X-axis tick labels: 'start', '1', '2', ..., 'end'
+  const grid = [yGridLines(ceil)]
+  for (let i = 0; i < total; i++) {
+    const x = xScale(i).toFixed(1)
+    const label = i === 0 ? 'start' : i === total - 1 ? 'end' : String(i)
+    grid.push(
+      `<line x1="${x}" y1="${PAD.top}" x2="${x}" y2="${(PAD.top + CH).toFixed(1)}" stroke="#e5e7eb" stroke-width="1"/>`,
+      `<text x="${x}" y="${(PAD.top + CH + 14).toFixed(1)}" text-anchor="middle" font-size="10" fill="${i === 0 || i === total - 1 ? '#374151' : '#6b7280'}" font-weight="${i === 0 || i === total - 1 ? '600' : '400'}">${escXml(label)}</text>`
+    )
+  }
+
+  // Lines + dots
+  const elems = []
+  for (const [i, d] of datasets.entries()) {
+    const color = COLORS[i % COLORS.length]
+
+    const pts = []
+
+    // start
+    if (d.startMem != null) pts.push([xScale(0), yScale(d.startMem, ceil)])
+
+    // one point per compile in order (capped at maxCompiles)
+    for (const [ci, c] of d.compilePoints.slice(0, maxCompiles).entries()) {
+      pts.push([xScale(ci + 1), yScale(c.mem_mb, ceil)])
+    }
+
+    // end
+    if (d.endMem != null) pts.push([xScale(total - 1), yScale(d.endMem, ceil)])
+
+    if (pts.length > 1) {
+      const ptStr = pts
+        .map(([x, y]) => `${x.toFixed(1)},${y.toFixed(1)}`)
+        .join(' ')
+      elems.push(
+        `<polyline points="${ptStr}" fill="none" stroke="${color}" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>`
+      )
+    }
+    for (const [x, y] of pts) {
+      elems.push(
+        `<circle cx="${x.toFixed(1)}" cy="${y.toFixed(1)}" r="3" fill="${color}"/>`
+      )
+    }
+  }
+
+  const body = [...grid, ...elems].join('\n  ')
+  const metricLabel = datasets[0]?.metricLabel ?? 'Memory (MB)'
+  return svgWrap('Memory Per Compile', 'Compile #', metricLabel, body, datasets)
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+const datasets = csvFiles.map(parseCsv)
+
+if (mode === 'compile' && datasets.length > 1) {
+  const reference = datasets[0]
+  for (const d of datasets.slice(1)) {
+    const refLabels = reference.compilePoints.map((c) => c.label)
+    const dLabels = d.compilePoints.map((c) => c.label)
+    const len = Math.min(refLabels.length, dLabels.length)
+    for (let i = 0; i < len; i++) {
+      if (refLabels[i] !== dLabels[i]) {
+        console.error(
+          `Error: compile order mismatch between "${reference.name}" and "${d.name}" at position ${i + 1}:\n` +
+            `  ${reference.name}: ${refLabels[i]}\n` +
+            `  ${d.name}:          ${dLabels[i]}`
+        )
+        process.exit(1)
+      }
+    }
+    if (refLabels.length !== dLabels.length) {
+      console.error(
+        `Warning: "${reference.name}" has ${refLabels.length} compiles but "${d.name}" has ${dLabels.length}. ` +
+          `Extra compiles in the longer run will be omitted from the comparison.`
+      )
+    }
+  }
+}
+
+const svg = mode === 'compile' ? renderCompile(datasets) : renderTime(datasets)
+fs.writeFileSync(outFile, svg)
+console.log(`Chart written to: ${outFile}`)

--- a/test/development/mcp-server/mcp-server-compile-route.test.ts
+++ b/test/development/mcp-server/mcp-server-compile-route.test.ts
@@ -38,46 +38,159 @@ async function callMcpTool(
       return
     }
 
-    it('should compile a valid app router root route', async () => {
-      const result = await callMcpTool(next.url, 'compile_route', {
-        page: '/',
+    describe('routeSpecifier input', () => {
+      it('should compile a valid app router root route', async () => {
+        const result = await callMcpTool(next.url, 'compile_route', {
+          routeSpecifier: '/',
+        })
+        expect(result).toMatchObject({ routeSpecifier: '/', issues: [] })
       })
-      expect(result).toMatchObject({ page: '/', issues: [] })
+
+      it('should compile a valid dynamic app router route', async () => {
+        const result = await callMcpTool(next.url, 'compile_route', {
+          routeSpecifier: '/blog/[slug]',
+        })
+        expect(result).toMatchObject({
+          routeSpecifier: '/blog/[slug]',
+          issues: [],
+        })
+      })
+
+      it('should compile a valid pages router route', async () => {
+        const result = await callMcpTool(next.url, 'compile_route', {
+          routeSpecifier: '/about',
+        })
+        expect(result).toMatchObject({ routeSpecifier: '/about', issues: [] })
+      })
+
+      it('should compile a valid app router API route', async () => {
+        const result = await callMcpTool(next.url, 'compile_route', {
+          routeSpecifier: '/api/users/[id]',
+        })
+        expect(result).toMatchObject({
+          routeSpecifier: '/api/users/[id]',
+          issues: [],
+        })
+      })
+
+      it('should compile a valid pages router API route', async () => {
+        const result = await callMcpTool(next.url, 'compile_route', {
+          routeSpecifier: '/api/legacy',
+        })
+        expect(result).toMatchObject({
+          routeSpecifier: '/api/legacy',
+          issues: [],
+        })
+      })
+
+      it('should return notFound for a non-existent specifier', async () => {
+        const result = (await callMcpTool(next.url, 'compile_route', {
+          routeSpecifier: '/does-not-exist',
+        })) as any
+        expect(result).toMatchObject({
+          notFound: true,
+          input: '/does-not-exist',
+        })
+      })
     })
 
-    it('should compile a valid dynamic app router route', async () => {
-      const result = await callMcpTool(next.url, 'compile_route', {
-        page: '/blog/[slug]',
+    describe('path input', () => {
+      it('should resolve a static app route path', async () => {
+        const result = await callMcpTool(next.url, 'compile_route', {
+          path: '/',
+        })
+        expect(result).toMatchObject({ routeSpecifier: '/', issues: [] })
       })
-      expect(result).toMatchObject({ page: '/blog/[slug]', issues: [] })
+
+      it('should resolve a dynamic app route path', async () => {
+        const result = await callMcpTool(next.url, 'compile_route', {
+          path: '/blog/hello-world',
+        })
+        expect(result).toMatchObject({
+          routeSpecifier: '/blog/[slug]',
+          issues: [],
+        })
+      })
+
+      it('should resolve a catchall app route path', async () => {
+        const result = await callMcpTool(next.url, 'compile_route', {
+          path: '/docs/a/b/c',
+        })
+        expect(result).toMatchObject({
+          routeSpecifier: '/docs/[...slug]',
+          issues: [],
+        })
+      })
+
+      it('should strip query string before matching', async () => {
+        const result = await callMcpTool(next.url, 'compile_route', {
+          path: '/products/42?ref=x',
+        })
+        expect(result).toMatchObject({
+          routeSpecifier: '/products/[id]',
+          issues: [],
+        })
+      })
+
+      it('should resolve a pages router dynamic path', async () => {
+        const result = await callMcpTool(next.url, 'compile_route', {
+          path: '/posts/7',
+        })
+        expect(result).toMatchObject({
+          routeSpecifier: '/posts/[id]',
+          issues: [],
+        })
+      })
+
+      it('should resolve an app router API path', async () => {
+        const result = await callMcpTool(next.url, 'compile_route', {
+          path: '/api/users/42',
+        })
+        expect(result).toMatchObject({
+          routeSpecifier: '/api/users/[id]',
+          issues: [],
+        })
+      })
+
+      it('should resolve a static pages router path', async () => {
+        const result = await callMcpTool(next.url, 'compile_route', {
+          path: '/about',
+        })
+        expect(result).toMatchObject({ routeSpecifier: '/about', issues: [] })
+      })
+
+      it('should strip a trailing slash before matching', async () => {
+        const result = await callMcpTool(next.url, 'compile_route', {
+          path: '/about/',
+        })
+        expect(result).toMatchObject({ routeSpecifier: '/about', issues: [] })
+      })
+
+      it('should return notFound when no route matches', async () => {
+        const result = (await callMcpTool(next.url, 'compile_route', {
+          path: '/nope/x',
+        })) as any
+        expect(result).toMatchObject({ notFound: true, input: '/nope/x' })
+      })
     })
 
-    it('should compile a valid pages router route', async () => {
-      const result = await callMcpTool(next.url, 'compile_route', {
-        page: '/about',
+    describe('input validation', () => {
+      it('should error when both routeSpecifier and path are provided', async () => {
+        const result = (await callMcpTool(next.url, 'compile_route', {
+          routeSpecifier: '/',
+          path: '/',
+        })) as any
+        expect(result).toMatchObject({
+          error: expect.stringContaining('exactly one'),
+        })
       })
-      expect(result).toMatchObject({ page: '/about', issues: [] })
-    })
 
-    it('should compile a valid app router API route', async () => {
-      const result = await callMcpTool(next.url, 'compile_route', {
-        page: '/api/users/[id]',
+      it('should error when neither routeSpecifier nor path is provided', async () => {
+        const result = (await callMcpTool(next.url, 'compile_route', {})) as any
+        expect(result).toMatchObject({
+          error: expect.stringContaining('exactly one'),
+        })
       })
-      expect(result).toMatchObject({ page: '/api/users/[id]', issues: [] })
-    })
-
-    it('should compile a valid pages router API route', async () => {
-      const result = await callMcpTool(next.url, 'compile_route', {
-        page: '/api/legacy',
-      })
-      expect(result).toMatchObject({ page: '/api/legacy', issues: [] })
-    })
-
-    it('should return an error for a non-existent route', async () => {
-      const result = (await callMcpTool(next.url, 'compile_route', {
-        page: '/does-not-exist',
-      })) as any
-      expect(result).toMatchObject({ notFound: true, page: '/does-not-exist' })
     })
   }
 )
@@ -98,14 +211,13 @@ async function callMcpTool(
 
     it('should return compilation issues inline in the response', async () => {
       const result = (await callMcpTool(next.url, 'compile_route', {
-        page: '/missing-module',
+        routeSpecifier: '/missing-module',
       })) as {
-        compiled: boolean
-        page: string
+        routeSpecifier: string
         issues: Array<{ severity: string; filePath: string; title: string }>
       }
 
-      expect(result.page).toBe('/missing-module')
+      expect(result.routeSpecifier).toBe('/missing-module')
       expect(result.issues.length).toBeGreaterThan(0)
 
       const moduleNotFound = result.issues.find(

--- a/test/development/mcp-server/mcp-server-compile-route.test.ts
+++ b/test/development/mcp-server/mcp-server-compile-route.test.ts
@@ -1,0 +1,120 @@
+import path from 'path'
+import { nextTestSetup } from 'e2e-utils'
+
+async function callMcpTool(
+  url: string,
+  toolName: string,
+  args: Record<string, unknown> = {}
+): Promise<unknown> {
+  const response = await fetch(`${url}/_next/mcp`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream',
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: toolName + '-' + Date.now(),
+      method: 'tools/call',
+      params: { name: toolName, arguments: args },
+    }),
+  })
+  const text = await response.text()
+  const match = text.match(/data: ({.*})/s)
+  expect(match).toBeTruthy()
+  const envelope = JSON.parse(match![1])
+  return JSON.parse(envelope.result?.content?.[0]?.text)
+}
+
+// compile_route is Turbopack-only; it is not registered on webpack dev servers.
+;(process.env.IS_TURBOPACK_TEST ? describe : describe.skip)(
+  'mcp-server compile_route tool',
+  () => {
+    const { next, skipped } = nextTestSetup({
+      files: path.join(__dirname, 'fixtures', 'dynamic-routes-app'),
+    })
+
+    if (skipped) {
+      return
+    }
+
+    it('should compile a valid app router root route', async () => {
+      const result = await callMcpTool(next.url, 'compile_route', {
+        page: '/',
+      })
+      expect(result).toMatchObject({ page: '/', issues: [] })
+    })
+
+    it('should compile a valid dynamic app router route', async () => {
+      const result = await callMcpTool(next.url, 'compile_route', {
+        page: '/blog/[slug]',
+      })
+      expect(result).toMatchObject({ page: '/blog/[slug]', issues: [] })
+    })
+
+    it('should compile a valid pages router route', async () => {
+      const result = await callMcpTool(next.url, 'compile_route', {
+        page: '/about',
+      })
+      expect(result).toMatchObject({ page: '/about', issues: [] })
+    })
+
+    it('should compile a valid app router API route', async () => {
+      const result = await callMcpTool(next.url, 'compile_route', {
+        page: '/api/users/[id]',
+      })
+      expect(result).toMatchObject({ page: '/api/users/[id]', issues: [] })
+    })
+
+    it('should compile a valid pages router API route', async () => {
+      const result = await callMcpTool(next.url, 'compile_route', {
+        page: '/api/legacy',
+      })
+      expect(result).toMatchObject({ page: '/api/legacy', issues: [] })
+    })
+
+    it('should return an error for a non-existent route', async () => {
+      const result = (await callMcpTool(next.url, 'compile_route', {
+        page: '/does-not-exist',
+      })) as any
+      expect(result).toMatchObject({ notFound: true, page: '/does-not-exist' })
+    })
+  }
+)
+
+// Compilation errors don't throw from ensurePage — they are collected from
+// Turbopack's per-entry issue map and returned directly in the compile_route
+// response, so no second round-trip to get_compilation_issues is needed.
+;(process.env.IS_TURBOPACK_TEST ? describe : describe.skip)(
+  'mcp-server compile_route with compilation errors',
+  () => {
+    const { next, skipped } = nextTestSetup({
+      files: path.join(__dirname, 'fixtures', 'compilation-errors-app'),
+    })
+
+    if (skipped) {
+      return
+    }
+
+    it('should return compilation issues inline in the response', async () => {
+      const result = (await callMcpTool(next.url, 'compile_route', {
+        page: '/missing-module',
+      })) as {
+        compiled: boolean
+        page: string
+        issues: Array<{ severity: string; filePath: string; title: string }>
+      }
+
+      expect(result.page).toBe('/missing-module')
+      expect(result.issues.length).toBeGreaterThan(0)
+
+      const moduleNotFound = result.issues.find(
+        (issue) =>
+          (issue.severity === 'error' || issue.severity === 'fatal') &&
+          (issue.filePath.includes('missing-module') ||
+            issue.title.includes('non-existent-module'))
+      )
+      expect(moduleNotFound).toBeDefined()
+    })
+  }
+)

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -66,7 +66,7 @@ use crate::{
         storage::Storage,
         storage_schema::{TaskStorage, TaskStorageAccessors},
     },
-    backing_storage::{BackingStorage, SnapshotItem, compute_task_type_hash},
+    backing_storage::{BackingStorage, SnapshotItem, SnapshotMeta, compute_task_type_hash},
     data::{
         ActivenessState, CellRef, CollectibleRef, CollectiblesRef, Dirtyness, InProgressCellState,
         InProgressState, InProgressStateInner, OutputValue, TransientTask,
@@ -1344,13 +1344,32 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         }
 
         let persist_start = Instant::now();
-        let _span = tracing::info_span!(parent: parent_span, "persist", reason = reason).entered();
+        let span = tracing::info_span!(
+            parent: parent_span,
+            "persist",
+            reason = reason,
+            data_items= tracing::field::Empty,
+            meta_items= tracing::field::Empty,
+            task_cache_items= tracing::field::Empty,
+            next_task_id= tracing::field::Empty,)
+        .entered();
         {
             // Tasks were already consumed by take_snapshot, so a future snapshot
             // would not re-persist them — returning an error signals to the caller
             // that further persist attempts would corrupt the task graph in storage.
-            self.backing_storage
+            let SnapshotMeta {
+                task_cache_items,
+                data_items,
+                meta_items,
+                next_task_id,
+            } = self
+                .backing_storage
                 .save_snapshot(suspended_operations, task_snapshots)?;
+            span.record("data_items", data_items);
+            span.record("meta_items", meta_items);
+            span.record("task_cache_items", task_cache_items);
+            span.record("next_task_id", next_task_id);
+
             #[cfg(feature = "print_cache_item_size")]
             {
                 let mut task_cache_stats = task_cache_stats

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
@@ -66,7 +66,8 @@ impl Display for EvictionCounts {
         let skipped: usize = self.unevictable_reasons.iter().sum();
         write!(
             f,
-            "task_cache_evictions={},full={},data_and_meta={},data_only={},meta_only={},skipped={}",
+            "task_cache_evictions={},full={},data_and_meta={},data_only={},meta_only={},\
+             skipped={{total={}",
             self.key_evictions,
             self.full,
             self.data_and_meta,
@@ -75,13 +76,12 @@ impl Display for EvictionCounts {
             skipped,
         )?;
         for reason in UnevictableReason::ALL {
-            write!(
-                f,
-                ",{}={}",
-                reason.span_name(),
-                self.unevictable_reasons[reason.index()],
-            )?;
+            let count = self.unevictable_reasons[reason.index()];
+            if count != 0 {
+                write!(f, ",{}={count}", reason.span_name(),)?;
+            }
         }
+        write!(f, "}}")?;
         Ok(())
     }
 }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
@@ -456,8 +456,72 @@ pub enum UnevictableReason {
     Modified,
     /// The task is transient
     Transient,
-    // Keep `NothingToEvict` last: `COUNT` is derived from its discriminant.
-    NothingToEvict,
+    /// Nothing left to evict — the task has already been fully dropped and only
+    /// holds `current_session_clean` (the benign, expected state: keeps the
+    /// "skip re-read on restore" optimization).
+    NothingToEvictSessionCleanOnly,
+    /// Nothing left to evict and `prefetched` is still set. Unexpected:
+    /// `drop_partial` clears `prefetched`, so seeing this suggests a path that
+    /// sets `prefetched` after eviction without going through restore.
+    NothingToEvictPrefetched,
+    /// Nothing left to evict but `aggregated_current_session_clean_containers`
+    /// is populated — tracks clean-containers in the current session, not
+    /// cleared by `drop_partial`.
+    NothingToEvictAggregatedSessionClean,
+    /// Nothing left to evict but an `outdated_*` lazy field is populated
+    /// (outdated_collectibles / outdated_output_dependencies /
+    /// outdated_cell_dependencies / outdated_collectibles_dependencies).
+    /// These have `shrink_on_completion` so seeing them means completion
+    /// didn't clear them for some reason.
+    NothingToEvictOutdated,
+    /// Nothing left to evict but `transient_cell_data` is populated (cells
+    /// computed in memory that weren't persisted).
+    NothingToEvictTransientCellData,
+    /// Nothing left to evict but `in_progress_cells` is populated (partial
+    /// cell computation state).
+    NothingToEvictInProgressCells,
+    /// Nothing left to evict but some other transient lazy variant is present
+    /// (`activeness`, `in_progress`, `transient_task_type`). These should
+    /// have been caught by earlier evictability guards; seeing them here
+    /// means evictability's filter is inconsistent with reality.
+    NothingToEvictTransientOther,
+    /// Nothing left to evict but the inline `output_dependent` set holds a
+    /// transient TaskId — a reverse-reference from a transient subscriber.
+    NothingToEvictOutputDependent,
+    /// Nothing left to evict but the inline `output` field holds a transient
+    /// output value (references a transient task).
+    NothingToEvictOutputTransient,
+    /// Nothing left to evict but the inline `upper` counter map holds a
+    /// transient TaskId — a transient aggregation-tree parent.
+    NothingToEvictUpperTransient,
+    /// Nothing left to evict but a persistent aggregation-graph lazy field
+    /// (`Children`, `Followers`, `Collectibles`, `AggregatedCollectibles`,
+    /// `AggregatedDirtyContainers`, `CollectiblesDependents`) holds a
+    /// transient TaskId.
+    NothingToEvictAggregationResidue,
+    /// Nothing left to evict but a persistent outbound-dependency lazy field
+    /// (`OutputDependencies`, `CellDependencies`, `CollectiblesDependencies`)
+    /// holds a transient TaskId — "this task read something transient."
+    NothingToEvictDependencyResidue,
+    /// Nothing left to evict but `CellDependents` holds a transient TaskId —
+    /// "a transient task read this task's cells." Analogue of the inline
+    /// `output_dependent` bucket for cell readers.
+    NothingToEvictDependentResidue,
+    /// Nothing left to evict but a persistent lazy variant not covered by
+    /// the two groups above survived drop_partial. Shouldn't happen in
+    /// practice — fallback so we see if a new field leaks.
+    NothingToEvictPersistentResidueOther,
+    /// Nothing left to evict and `leaf_distance` is non-default. Unexpected —
+    /// updates go through a restore-triggering accessor.
+    NothingToEvictLeafDistance,
+    /// Nothing left to evict and `is_empty()` is true — the task should have
+    /// been erased by the eviction pass but wasn't. Bug.
+    NothingToEvictEmpty,
+    /// Nothing left to evict, fallback when none of the more specific
+    /// categories match. Likely multiple blockers or a field we haven't
+    /// categorized.
+    // Keep this last: `COUNT` is derived from its discriminant.
+    NothingToEvictOther,
 }
 
 impl UnevictableReason {
@@ -467,12 +531,28 @@ impl UnevictableReason {
         UnevictableReason::InProgress,
         UnevictableReason::Modified,
         UnevictableReason::Transient,
-        UnevictableReason::NothingToEvict,
+        UnevictableReason::NothingToEvictSessionCleanOnly,
+        UnevictableReason::NothingToEvictPrefetched,
+        UnevictableReason::NothingToEvictAggregatedSessionClean,
+        UnevictableReason::NothingToEvictOutdated,
+        UnevictableReason::NothingToEvictTransientCellData,
+        UnevictableReason::NothingToEvictInProgressCells,
+        UnevictableReason::NothingToEvictTransientOther,
+        UnevictableReason::NothingToEvictOutputDependent,
+        UnevictableReason::NothingToEvictOutputTransient,
+        UnevictableReason::NothingToEvictUpperTransient,
+        UnevictableReason::NothingToEvictAggregationResidue,
+        UnevictableReason::NothingToEvictDependencyResidue,
+        UnevictableReason::NothingToEvictDependentResidue,
+        UnevictableReason::NothingToEvictPersistentResidueOther,
+        UnevictableReason::NothingToEvictLeafDistance,
+        UnevictableReason::NothingToEvictEmpty,
+        UnevictableReason::NothingToEvictOther,
     ];
 
     /// Number of variants. Derived from the last variant's discriminant, so adding a
-    /// new variant before `NothingToEvict` stays correct automatically.
-    pub const COUNT: usize = (UnevictableReason::NothingToEvict as usize) + 1;
+    /// new variant before `NothingToEvictOther` stays correct automatically.
+    pub const COUNT: usize = (UnevictableReason::NothingToEvictOther as usize) + 1;
 
     #[inline]
     pub const fn index(self) -> usize {
@@ -483,10 +563,42 @@ impl UnevictableReason {
     /// of the other span fields in `evict_after_snapshot`.
     pub const fn span_name(self) -> &'static str {
         match self {
-            UnevictableReason::InProgress => "skipped_in_progress",
-            UnevictableReason::Modified => "skipped_modified",
-            UnevictableReason::Transient => "skipped_transient",
-            UnevictableReason::NothingToEvict => "skipped_nothing_to_evict",
+            UnevictableReason::InProgress => "in_progress",
+            UnevictableReason::Modified => "modified",
+            UnevictableReason::Transient => "transient",
+            UnevictableReason::NothingToEvictSessionCleanOnly => {
+                "nothing_to_evict_session_clean_only"
+            }
+            UnevictableReason::NothingToEvictPrefetched => "nothing_to_evict_prefetched",
+            UnevictableReason::NothingToEvictAggregatedSessionClean => {
+                "nothing_to_evict_aggregated_session_clean"
+            }
+            UnevictableReason::NothingToEvictOutdated => "nothing_to_evict_outdated",
+            UnevictableReason::NothingToEvictTransientCellData => {
+                "nothing_to_evict_transient_cell_data"
+            }
+            UnevictableReason::NothingToEvictInProgressCells => {
+                "nothing_to_evict_in_progress_cells"
+            }
+            UnevictableReason::NothingToEvictTransientOther => "nothing_to_evict_transient_other",
+            UnevictableReason::NothingToEvictOutputDependent => "nothing_to_evict_output_dependent",
+            UnevictableReason::NothingToEvictOutputTransient => "nothing_to_evict_output_transient",
+            UnevictableReason::NothingToEvictUpperTransient => "nothing_to_evict_upper_transient",
+            UnevictableReason::NothingToEvictAggregationResidue => {
+                "nothing_to_evict_aggregation_residue"
+            }
+            UnevictableReason::NothingToEvictDependencyResidue => {
+                "nothing_to_evict_dependency_residue"
+            }
+            UnevictableReason::NothingToEvictDependentResidue => {
+                "nothing_to_evict_dependent_residue"
+            }
+            UnevictableReason::NothingToEvictPersistentResidueOther => {
+                "nothing_to_evict_persistent_residue_other"
+            }
+            UnevictableReason::NothingToEvictLeafDistance => "nothing_to_evict_leaf_distance",
+            UnevictableReason::NothingToEvictEmpty => "nothing_to_evict_empty",
+            UnevictableReason::NothingToEvictOther => "nothing_to_evict_other",
         }
     }
 }
@@ -575,7 +687,7 @@ impl TaskStorage {
         if !flags.data_restored() && !flags.meta_restored() {
             return (
                 key_evictability,
-                ValueEvictability::Unevictable(UnevictableReason::NothingToEvict),
+                ValueEvictability::Unevictable(self.classify_nothing_to_evict()),
             );
         }
 
@@ -604,6 +716,168 @@ impl TaskStorage {
                 }
             },
         )
+    }
+
+    /// Classify why a task with `!data_restored && !meta_restored` is still in
+    /// the shard. Diagnostic helper for the eviction skip counters — probes each
+    /// residue source in priority order and returns the first match.
+    ///
+    /// The task has been through `drop_partial` (or was never restored), so
+    /// persistent storage should be empty; anything non-default here points at a
+    /// specific leak source.
+    fn classify_nothing_to_evict(&self) -> UnevictableReason {
+        let flags = &self.flags;
+
+        // If the task is actually empty, the eviction pass should have removed
+        // it. Flag this as a bug rather than letting it hide in another bucket.
+        if self.is_empty() {
+            return UnevictableReason::NothingToEvictEmpty;
+        }
+
+        // Inspect transient lazy variants in priority order. Persistent variants
+        // shouldn't be present after drop_partial — but filter_transient variants
+        // retain transient residue, and we classify those as inline-residue below
+        // since they're keyed on inline fields conceptually. Here we only care
+        // about variants that are inherently transient.
+        let mut has_aggregated_session_clean = false;
+        let mut has_outdated = false;
+        let mut has_in_progress_cells = false;
+        let mut has_cell_data_residue = false;
+        let mut has_other_transient = false;
+        let mut has_aggregation_residue = false;
+        let mut has_dependency_residue = false;
+        let mut has_dependent_residue = false;
+        let mut has_persistent_residue_other = false;
+        for field in &self.lazy {
+            match field {
+                LazyField::AggregatedCurrentSessionCleanContainerCount(_)
+                | LazyField::AggregatedCurrentSessionCleanContainers(_) => {
+                    has_aggregated_session_clean = true;
+                }
+                LazyField::OutdatedCollectibles(_)
+                | LazyField::OutdatedOutputDependencies(_)
+                | LazyField::OutdatedCellDependencies(_)
+                | LazyField::OutdatedCollectiblesDependencies(_) => {
+                    has_outdated = true;
+                }
+                LazyField::InProgressCells(_) => {
+                    has_in_progress_cells = true;
+                }
+                LazyField::CellData(_) => {
+                    // CellData is a persistent lazy field (data category) but
+                    // its bincode filters out non-persistable cells at encode
+                    // time. Those entries remain in memory across drop_partial,
+                    // so CellData variants legitimately survive eviction when
+                    // they hold transient cell values.
+                    has_cell_data_residue = true;
+                }
+                LazyField::Activeness(_)
+                | LazyField::InProgress(_)
+                | LazyField::TransientTaskType(_) => {
+                    has_other_transient = true;
+                }
+                // Aggregation-graph structure: upper/lower links, dirty
+                // propagation, collectibles.
+                LazyField::Children(_)
+                | LazyField::Followers(_)
+                | LazyField::AggregatedDirtyContainers(_)
+                | LazyField::Collectibles(_)
+                | LazyField::AggregatedCollectibles(_)
+                | LazyField::CollectiblesDependents(_) => {
+                    has_aggregation_residue = true;
+                }
+                // Outbound dependencies: what this task reads.
+                LazyField::OutputDependencies(_)
+                | LazyField::CellDependencies(_)
+                | LazyField::CollectiblesDependencies(_) => {
+                    has_dependency_residue = true;
+                }
+                // Reverse / inbound dependency: what reads this task's cells.
+                LazyField::CellDependents(_) => {
+                    has_dependent_residue = true;
+                }
+                _ => {
+                    // Catch-all: any other persistent variant survived
+                    // drop_partial. Shouldn't happen with current field set.
+                    if field.is_persistent() {
+                        has_persistent_residue_other = true;
+                    }
+                }
+            }
+        }
+
+        // Inline filter_transient residue: output_dependent, output, upper keep
+        // transient-keyed entries across drop_partial. These are inline so the
+        // lazy scan above doesn't see them. Classified independently so we can
+        // tell which of the three fields is leaking.
+        let has_output_dependent_residue = !self.output_dependent().is_empty();
+        let has_output_residue = self.get_output().is_some();
+        let has_upper_residue = !self.upper().is_empty();
+
+        // leaf_distance is inline direct with a default; non-default means it
+        // wasn't reset, which shouldn't happen on the post-eviction path.
+        let leaf_distance_nondefault = self
+            .get_leaf_distance()
+            .is_some_and(|ld| *ld != LeafDistance::default());
+
+        // Priority: more specific / more actionable first. Leaf_distance and
+        // persistent_residue_other are the two "shouldn't happen" signals.
+        if leaf_distance_nondefault {
+            return UnevictableReason::NothingToEvictLeafDistance;
+        }
+        if has_persistent_residue_other {
+            return UnevictableReason::NothingToEvictPersistentResidueOther;
+        }
+        // Report the three inline fields independently. If more than one is
+        // non-empty on the same task we pick one, but that overlap should be
+        // rare — the deltas across passes tell us which dominates.
+        if has_output_dependent_residue {
+            return UnevictableReason::NothingToEvictOutputDependent;
+        }
+        if has_upper_residue {
+            return UnevictableReason::NothingToEvictUpperTransient;
+        }
+        if has_output_residue {
+            return UnevictableReason::NothingToEvictOutputTransient;
+        }
+        if has_aggregation_residue {
+            return UnevictableReason::NothingToEvictAggregationResidue;
+        }
+        if has_dependent_residue {
+            return UnevictableReason::NothingToEvictDependentResidue;
+        }
+        if has_dependency_residue {
+            return UnevictableReason::NothingToEvictDependencyResidue;
+        }
+        if has_cell_data_residue {
+            return UnevictableReason::NothingToEvictTransientCellData;
+        }
+        if has_in_progress_cells {
+            return UnevictableReason::NothingToEvictInProgressCells;
+        }
+        if has_outdated {
+            return UnevictableReason::NothingToEvictOutdated;
+        }
+        if has_aggregated_session_clean {
+            return UnevictableReason::NothingToEvictAggregatedSessionClean;
+        }
+        if has_other_transient {
+            return UnevictableReason::NothingToEvictTransientOther;
+        }
+        if flags.prefetched() {
+            return UnevictableReason::NothingToEvictPrefetched;
+        }
+        // At this point only transient flags keep the task alive. The benign
+        // case is `current_session_clean` alone.
+        if flags.current_session_clean() {
+            let flag_bits = flags.0;
+            let mut only_session_clean_bits = TaskFlags::default();
+            only_session_clean_bits.set_current_session_clean(true);
+            if flag_bits == only_session_clean_bits.0 {
+                return UnevictableReason::NothingToEvictSessionCleanOnly;
+            }
+        }
+        UnevictableReason::NothingToEvictOther
     }
 }
 

--- a/turbopack/crates/turbo-tasks-backend/src/backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backing_storage.rs
@@ -82,6 +82,14 @@ pub trait BackingStorage: BackingStorageSealed {
     fn invalidate(&self, reason_code: &str) -> Result<()>;
 }
 
+#[derive(Copy, Clone, Debug)]
+pub struct SnapshotMeta {
+    pub data_items: usize,
+    pub meta_items: usize,
+    pub task_cache_items: usize,
+    pub next_task_id: u32,
+}
+
 /// Private methods used by [`BackingStorage`]. This trait is `pub` (because of the sealed-trait
 /// pattern), but should not be exported outside of the crate.
 ///
@@ -91,7 +99,11 @@ pub trait BackingStorageSealed: 'static + Send + Sync {
     fn next_free_task_id(&self) -> Result<TaskId>;
     fn uncompleted_operations(&self) -> Result<Vec<AnyOperation>>;
 
-    fn save_snapshot<I>(&self, operations: Vec<Arc<AnyOperation>>, snapshots: Vec<I>) -> Result<()>
+    fn save_snapshot<I>(
+        &self,
+        operations: Vec<Arc<AnyOperation>>,
+        snapshots: Vec<I>,
+    ) -> Result<SnapshotMeta>
     where
         I: IntoIterator<Item = SnapshotItem> + Send + Sync;
     /// Returns all task IDs that match the given task type (hash collision candidates).
@@ -160,7 +172,11 @@ where
         either::for_both!(self, this => this.uncompleted_operations())
     }
 
-    fn save_snapshot<I>(&self, operations: Vec<Arc<AnyOperation>>, snapshots: Vec<I>) -> Result<()>
+    fn save_snapshot<I>(
+        &self,
+        operations: Vec<Arc<AnyOperation>>,
+        snapshots: Vec<I>,
+    ) -> Result<SnapshotMeta>
     where
         I: IntoIterator<Item = SnapshotItem> + Send + Sync,
     {

--- a/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
@@ -1,5 +1,6 @@
 use std::{
     borrow::Borrow,
+    cmp::max,
     env,
     path::PathBuf,
     sync::{Arc, LazyLock, Mutex, PoisonError, Weak},
@@ -19,7 +20,8 @@ use crate::{
     GitVersionInfo,
     backend::{AnyOperation, SpecificTaskDataCategory, storage_schema::TaskStorage},
     backing_storage::{
-        BackingStorage, BackingStorageSealed, SnapshotItem, compute_task_type_hash_from_components,
+        BackingStorage, BackingStorageSealed, SnapshotItem, SnapshotMeta,
+        compute_task_type_hash_from_components,
     },
     database::{
         db_invalidation::{StartupCacheState, check_db_invalidation_and_cleanup, invalidate_db},
@@ -224,7 +226,11 @@ impl<T: KeyValueDatabase + Send + Sync + 'static> BackingStorageSealed
         get(&self.inner.database).context("Unable to read uncompleted operations from database")
     }
 
-    fn save_snapshot<I>(&self, operations: Vec<Arc<AnyOperation>>, snapshots: Vec<I>) -> Result<()>
+    fn save_snapshot<I>(
+        &self,
+        operations: Vec<Arc<AnyOperation>>,
+        snapshots: Vec<I>,
+    ) -> Result<SnapshotMeta>
     where
         I: IntoIterator<Item = SnapshotItem> + Send + Sync,
     {
@@ -233,9 +239,12 @@ impl<T: KeyValueDatabase + Send + Sync + 'static> BackingStorageSealed
 
         {
             let _span = tracing::trace_span!("update task data").entered();
-            let max_new_task_id =
+            let (max_new_task_id, data_items, meta_items, task_cache_items) =
                 parallel::map_collect_owned::<_, _, Result<Vec<_>>>(snapshots, |shard: I| {
                     let mut max_new_task_id = 0;
+                    let mut data_items = 0;
+                    let mut meta_items = 0;
+                    let mut task_cache_items = 0;
                     for SnapshotItem {
                         task_id,
                         meta,
@@ -251,6 +260,7 @@ impl<T: KeyValueDatabase + Send + Sync + 'static> BackingStorageSealed
                                 WriteBuffer::Borrowed(key),
                                 WriteBuffer::SmallVec(meta),
                             )?;
+                            meta_items += 1;
                         }
                         if let Some(data) = data {
                             batch.put(
@@ -258,6 +268,7 @@ impl<T: KeyValueDatabase + Send + Sync + 'static> BackingStorageSealed
                                 WriteBuffer::Borrowed(key),
                                 WriteBuffer::SmallVec(data),
                             )?;
+                            data_items += 1;
                         }
                         // Write task cache entry inline if this is a new task
                         if let Some(task_type_hash) = task_type_hash {
@@ -266,13 +277,14 @@ impl<T: KeyValueDatabase + Send + Sync + 'static> BackingStorageSealed
                                 WriteBuffer::Borrowed(&task_type_hash),
                                 WriteBuffer::Borrowed(key),
                             )?;
+                            task_cache_items += 1;
                             max_new_task_id = max_new_task_id.max(*task_id);
                         }
                     }
-                    Ok(max_new_task_id)
+                    Ok((max_new_task_id, data_items, meta_items, task_cache_items))
                 })?
                 .into_iter()
-                .max()
+                .reduce(|t1, t2| (max(t1.0, t2.0), t1.1 + t2.1, t1.2 + t2.2, t1.3 + t2.3))
                 .unwrap_or_default();
 
             let span = tracing::trace_span!("flush task data").entered();
@@ -294,7 +306,12 @@ impl<T: KeyValueDatabase + Send + Sync + 'static> BackingStorageSealed
                 let _span = tracing::trace_span!("commit").entered();
                 batch.commit().context("Unable to commit operations")?;
             }
-            Ok(())
+            Ok(SnapshotMeta {
+                data_items,
+                meta_items,
+                task_cache_items,
+                next_task_id,
+            })
         }
     }
 

--- a/turbopack/crates/turbopack-trace-server/src/lib.rs
+++ b/turbopack/crates/turbopack-trace-server/src/lib.rs
@@ -128,6 +128,16 @@ pub struct SpanInfo {
     pub avg_corrected_duration: Option<u64>,
     /// Raw span ID for aggregated groups (the index of the first span).
     pub first_span_id: Option<String>,
+    /// TurboMalloc memory-usage samples recorded while this span (or its
+    /// example span, for aggregated groups) was live.
+    ///
+    /// Each tuple is `(ts_offset_from_span_start_in_ticks, bytes)`.
+    /// `100 ticks = 1 µs`. The offset is always `>= 0` and `<= span_duration`.
+    ///
+    /// The store caps the series at `MAX_MEMORY_SAMPLES`; when more samples
+    /// exist in the range, consecutive groups are merged by picking the
+    /// group's max-memory sample (timestamp and value kept together).
+    pub memory_samples: Vec<(i64, u64)>,
 }
 
 /// Result of a `query_spans` call.
@@ -282,6 +292,13 @@ pub fn query_spans(store: &Arc<StoreContainer>, options: QueryOptions) -> QueryR
                 let rel_start = (span_start as i64) - (parent_start as i64);
                 let rel_end = (span_end as i64) - (parent_start as i64);
 
+                let first_start_ticks = *first.start();
+                let memory_samples: Vec<(i64, u64)> = store_ref
+                    .memory_samples_for_range_with_ts(first.start(), first.end())
+                    .into_iter()
+                    .map(|(ts, mem)| ((*ts as i64) - (first_start_ticks as i64), mem))
+                    .collect();
+
                 SpanInfo {
                     id: graph_id,
                     name,
@@ -300,6 +317,7 @@ pub fn query_spans(store: &Arc<StoreContainer>, options: QueryOptions) -> QueryR
                     total_corrected_duration: Some(total_corrected),
                     avg_corrected_duration: Some(avg_corrected),
                     first_span_id: Some(first_index.to_string()),
+                    memory_samples,
                 }
             })
             .collect();
@@ -360,6 +378,13 @@ pub fn query_spans(store: &Arc<StoreContainer>, options: QueryOptions) -> QueryR
                 let rel_start = (span_start as i64) - (parent_start as i64);
                 let rel_end = (span_end as i64) - (parent_start as i64);
 
+                let raw_span_start = span_start;
+                let memory_samples: Vec<(i64, u64)> = store_ref
+                    .memory_samples_for_range_with_ts(span.start(), span.end())
+                    .into_iter()
+                    .map(|(ts, mem)| ((*ts as i64) - (raw_span_start as i64), mem))
+                    .collect();
+
                 SpanInfo {
                     id: build_span_id(options.parent.as_deref(), &span.index.to_string()),
                     name,
@@ -378,6 +403,7 @@ pub fn query_spans(store: &Arc<StoreContainer>, options: QueryOptions) -> QueryR
                     total_corrected_duration: None,
                     avg_corrected_duration: None,
                     first_span_id: None,
+                    memory_samples,
                 }
             })
             .collect();

--- a/turbopack/crates/turbopack-trace-server/src/store.rs
+++ b/turbopack/crates/turbopack-trace-server/src/store.rs
@@ -356,6 +356,22 @@ impl Store {
     /// `[start, end]`. When more samples exist, groups of N consecutive
     /// samples are merged by taking the maximum memory value in each group.
     pub fn memory_samples_for_range(&self, start: Timestamp, end: Timestamp) -> Vec<u64> {
+        self.memory_samples_for_range_with_ts(start, end)
+            .into_iter()
+            .map(|(_, mem)| mem)
+            .collect()
+    }
+
+    /// Like `memory_samples_for_range` but keeps the timestamps. Timestamps
+    /// are absolute store timestamps (same reference frame as span start/end).
+    /// When the raw slice exceeds `MAX_MEMORY_SAMPLES`, the timestamp reported
+    /// for each merged group is the timestamp of the sample whose memory
+    /// value was kept (the group's max).
+    pub fn memory_samples_for_range_with_ts(
+        &self,
+        start: Timestamp,
+        end: Timestamp,
+    ) -> Vec<(Timestamp, u64)> {
         // Binary search for the first sample >= start
         let lo = self.memory_samples.partition_point(|(ts, _)| *ts < start);
         // Binary search for the first sample > end
@@ -368,14 +384,15 @@ impl Store {
         }
 
         if count <= MAX_MEMORY_SAMPLES {
-            return slice.iter().map(|(_, mem)| *mem).collect();
+            return slice.to_vec();
         }
 
-        // Merge groups of N samples, taking the max memory in each group.
+        // Merge groups of N samples, taking the max memory in each group and
+        // keeping the timestamp of that max sample.
         let n = count.div_ceil(MAX_MEMORY_SAMPLES);
         slice
             .chunks(n)
-            .map(|chunk| chunk.iter().map(|(_, mem)| *mem).max().unwrap())
+            .map(|chunk| *chunk.iter().max_by_key(|(_, mem)| *mem).unwrap())
             .collect()
     }
 


### PR DESCRIPTION
### What?

Adds a `compile_route` MCP tool that triggers on-demand compilation of a specific route (app or pages) without issuing an HTTP request, and returns any compilation issues.

### Why?

Coding agents and benchmarking workflows need a way to warm the module graph or measure compile time for a route without standing up a live backend to satisfy the request. The existing path — hitting the URL — requires the route's runtime dependencies to be available and couples compile timing to request handling.

### How?

- New tool `mcp/compile_route` registered in `get-or-create-mcp-server.ts`, backed by a `compileRoute({ page, clientOnly })` callback plumbed from both the Turbopack and webpack hot reloaders.
- Reuses the dev server's existing on-demand entry path (`ensurePage` / `handleRouteType`), so the call path matches a first navigation.
- Adds a `subscribeToChanges` opt-out on `ensurePage` and threads it through `handleRouteType` / `handlePagesErrorRoute`. One-shot MCP compilations skip HMR subscription wiring — without this, each call would leak a subscription that fires on every subsequent file change for the life of the dev server.
- Telemetry: registers `mcp/compile_route` in the `McpToolName` union.
- Error 1172 reserved for "compilation failed but no issues were recorded".
- e2e test in `test/development/mcp-server/mcp-server-compile-route.test.ts`.

<!-- NEXT_JS_LLM_PR -->