### PR TITLE
bundle-analyzer: add 'Sync only' filter toggle

### DIFF
--- a/apps/bundle-analyzer/app/page.tsx
+++ b/apps/bundle-analyzer/app/page.tsx
@@ -11,6 +11,7 @@ import { Sidebar } from '@/components/sidebar'
 import { TreemapVisualizer } from '@/components/treemap-visualizer'
 
 import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
 import { TreemapSkeleton } from '@/components/ui/skeleton'
 import {
   Select,
@@ -32,6 +33,7 @@ import {
   FileJson,
   Palette,
   Package,
+  Zap,
 } from 'lucide-react'
 
 enum Environment {
@@ -45,6 +47,7 @@ export default function Home() {
     Environment.Client
   )
   const [typeFilter, setTypeFilter] = useState(['js', 'css', 'json'])
+  const [syncOnly, setSyncOnly] = useState(false)
   const [selectedSourceIndex, setSelectedSourceIndex] = useState<number | null>(
     null
   )
@@ -139,9 +142,32 @@ export default function Home() {
         (typeFilter.includes('json') && flags.json) ||
         (typeFilter.includes('asset') && flags.asset)
 
+      // Check sync-only filter: exclude sources that are only reachable
+      // through an async import() boundary. computeModuleDepthMap adds 1000
+      // per async hop, so any module with depth < 1000 is synchronously
+      // reachable from an entry. A source is kept if at least one of its
+      // module indices is sync-reachable.
+      if (syncOnly && modulesData) {
+        const sourcePath = analyzeData.getFullSourcePath(sourceIndex)
+        const moduleIndices = sourcePath
+          ? modulesData.getModuleIndiciesFromPath(sourcePath)
+          : []
+        const hasSyncModule = moduleIndices.some(
+          (mi) => (moduleDepthMap.get(mi) ?? Infinity) < 1000
+        )
+        if (!hasSyncModule) return false
+      }
+
       return hasEnvironment && hasType
     }
-  }, [analyzeData, environmentFilter, typeFilter])
+  }, [
+    analyzeData,
+    environmentFilter,
+    typeFilter,
+    syncOnly,
+    modulesData,
+    moduleDepthMap,
+  ])
 
   const handleMouseDown = () => {
     setIsResizing(true)
@@ -177,6 +203,8 @@ export default function Home() {
         setFocusedSourceIndex={setFocusedSourceIndex}
         typeFilter={typeFilter}
         setTypeFilter={setTypeFilter}
+        syncOnly={syncOnly}
+        setSyncOnly={setSyncOnly}
         searchQuery={searchQuery}
         setSearchQuery={setSearchQuery}
       />
@@ -307,6 +335,8 @@ function TopBar({
   setFocusedSourceIndex,
   typeFilter,
   setTypeFilter,
+  syncOnly,
+  setSyncOnly,
   searchQuery,
   setSearchQuery,
 }: {
@@ -319,6 +349,8 @@ function TopBar({
   setFocusedSourceIndex: (index: number | null) => void
   typeFilter: string[]
   setTypeFilter: (types: string[]) => void
+  syncOnly: boolean
+  setSyncOnly: (value: boolean) => void
   searchQuery: string
   setSearchQuery: (query: string) => void
 }) {
@@ -372,6 +404,17 @@ function TopBar({
               triggerClassName="w-36"
               aria-label="Filter by file type"
             />
+
+            <Button
+              variant={syncOnly ? 'default' : 'outline'}
+              size="sm"
+              onClick={() => setSyncOnly(!syncOnly)}
+              aria-pressed={syncOnly}
+              title="Show only modules in the initial synchronous load (exclude modules reached through dynamic import() boundaries)"
+            >
+              <Zap className="h-3.5 w-3.5" />
+              <span className="text-xs">Sync only</span>
+            </Button>
 
             <ControlDivider />
 


### PR DESCRIPTION
## What

Adds a **Sync only** toggle to the bundle-analyzer toolbar that filters the treemap to show only modules reachable from an entry without crossing an async `import()` boundary.

## Why

When analyzing a route, the treemap currently shows every reachable module, including anything behind one or more `(async)` hops. For example a 418KB `cytoscape.esm.mjs` can show up on the home-page treemap even though it's only reachable via:

```
page.tsx → (async) ConversationContent.tsx → (async) BlockRenderer.tsx → MermaidDiagram.tsx → mermaid → cytoscape
```

That makes it hard to see what's actually in the critical initial load. The data model already distinguishes sync vs async edges — this just exposes it as a filter.

## How

`computeModuleDepthMap` already encodes this: each async hop adds 1000 to a module's depth. So any module whose depth is `>= 1000` is behind at least one async boundary.

`filterSource` receives a `sourceIndex`, so we bridge through `modulesData.getModuleIndiciesFromPath(fullSourcePath(sourceIndex))` and keep the source if any of its module indices has depth `< 1000`. Existing filters (environment, file type) are unchanged.

The toggle button sits next to the existing environment/type filters. No change to the import-chain view — it still shows the `(async)` markers in the chain so users can see where the boundary is.

## Verification

Tested against a minimal demo app with a home page that sync-imports a small utility and uses `dynamic(() => import('./HeavyChart'))` where `HeavyChart` pulls in a 25-file `big-lib/*` tree.

- **Off:** 199 modules, 247 KB
- **On:** 164 modules, 172 KB (−25 `big-lib/*` files, −75 KB)

All `big-lib` modules landed at depth 1005–1006 in the depth map, confirming they're correctly detected as async-only.

`tsc --noEmit` and `next build` pass in `apps/bundle-analyzer`.

<!-- NEXT_JS_LLM_PR -->