### PR TITLE
fix: AppType generic parameter applies to props, not pageProps

### DIFF
--- a/packages/next/src/shared/lib/utils.ts
+++ b/packages/next/src/shared/lib/utils.ts
@@ -174,7 +174,8 @@ export type AppInitialProps<PageProps = any> = {
 export type AppPropsType<
   Router extends NextRouter = NextRouter,
   PageProps = {},
-> = AppInitialProps<PageProps> & {
+> = PageProps & {
+  pageProps: PageProps
   Component: NextComponentType<NextPageContext, any, any>
   router: Router
   __N_SSG?: boolean


### PR DESCRIPTION
## Fix: AppType generic parameter misuse (closes #42846)

### Problem
Prop types defined by the generic parameter on `AppType` were incorrectly applied to `MyApp`'s `props.pageProps` instead of `MyApp`'s `props`.

### Example from issue:
```tsx
type MyInitialProps = { foo: string };
type MyAppType = AppType<MyInitialProps>;
const MyApp: MyAppType = ({ Component, foo, pageProps }) => {
  // foo should be in props, NOT pageProps.foo
  return <Component {...pageProps} />;
}
```

Error: `Property 'foo' does not exist on type 'AppPropsType<any, MyInitialProps>'`

### Root Cause
In `AppPropsType<Router, PageProps>`, the `PageProps` type was nested inside `AppInitialProps<PageProps>` which wraps it as `{ pageProps: PageProps }`. This caused custom props to end up inside `pageProps` rather than on the root props object.

### Fix
Changed `AppPropsType` to merge `PageProps` directly onto the root props object:

```diff
- export type AppPropsType<...> = AppInitialProps<PageProps> & {
+ export type AppPropsType<...> = PageProps & {
+   pageProps: PageProps
```

This ensures:
1. Custom props (e.g., `foo`) are directly on `props`
2. `pageProps` field still exists with the same type for backwards compatibility

### Breaking Changes
None — `pageProps` is still accessible, just also exposes custom props at the root level (which is the expected behavior based on how `_app` actually works at runtime).