### PR TITLE
docs: add quick-reference tables to cache components migration guide

### DIFF
--- a/docs/01-app/02-guides/migrating-to-cache-components.mdx
+++ b/docs/01-app/02-guides/migrating-to-cache-components.mdx
@@ -6,6 +6,57 @@ description: Learn how to migrate from route segment configs to Cache Components
 
 When [Cache Components](/docs/app/api-reference/config/next-config-js/cacheComponents) is enabled, route segment configs like `dynamic`, `revalidate`, and `fetchCache` are replaced by [`use cache`](/docs/app/api-reference/directives/use-cache) and [`cacheLife`](/docs/app/api-reference/functions/cacheLife).
 
+## Quick reference
+
+### Cache directives
+
+| Directive                                                                      | Scope                     | Server-side storage          | Can access `cookies()`/`headers()` | Use case                                                      |
+| ------------------------------------------------------------------------------ | ------------------------- | ---------------------------- | ---------------------------------- | ------------------------------------------------------------- |
+| [`'use cache'`](/docs/app/api-reference/directives/use-cache)                  | Shared (all users)        | In-memory (or cache handler) | No — pass values as arguments      | Default choice for caching data, components, or pages         |
+| [`'use cache: remote'`](/docs/app/api-reference/directives/use-cache-remote)   | Shared (all users)        | Remote cache handler         | No — pass values as arguments      | High-traffic data that must survive across instances          |
+| [`'use cache: private'`](/docs/app/api-reference/directives/use-cache-private) | Per-client (browser only) | None                         | Yes                                | Compliance needs or when runtime data can't be refactored out |
+
+### `cacheLife` profiles
+
+Use [`cacheLife`](/docs/app/api-reference/functions/cacheLife) inside a `use cache` scope to control how long cached output is kept. These are the built-in profiles:
+
+| Profile                                                                        | `stale` (client) | `revalidate` (server) | `expire` | Typical content                            |
+| ------------------------------------------------------------------------------ | ---------------- | --------------------- | -------- | ------------------------------------------ |
+| `default`                                                                      | 5 min            | 15 min                | never    | Standard content                           |
+| [`seconds`](/docs/app/api-reference/functions/cacheLife#using-preset-profiles) | 30 s             | 1 s                   | 1 min    | Real-time data (stock prices, live scores) |
+| [`minutes`](/docs/app/api-reference/functions/cacheLife#using-preset-profiles) | 5 min            | 1 min                 | 1 h      | Social feeds, news                         |
+| [`hours`](/docs/app/api-reference/functions/cacheLife#using-preset-profiles)   | 5 min            | 1 h                   | 1 day    | Product inventory, weather                 |
+| [`days`](/docs/app/api-reference/functions/cacheLife#using-preset-profiles)    | 5 min            | 1 day                 | 1 week   | Blog posts, articles                       |
+| [`weeks`](/docs/app/api-reference/functions/cacheLife#using-preset-profiles)   | 5 min            | 1 week                | 30 days  | Podcasts, newsletters                      |
+| [`max`](/docs/app/api-reference/functions/cacheLife#using-preset-profiles)     | 5 min            | 30 days               | 1 year   | Legal pages, archived content              |
+
+You can also define [custom profiles](/docs/app/api-reference/functions/cacheLife#custom-cache-profiles) in `next.config.ts` or pass an [inline object](/docs/app/api-reference/functions/cacheLife#inline-cache-profiles) directly.
+
+### Revalidation and invalidation functions
+
+Use [`cacheTag`](/docs/app/api-reference/functions/cacheTag) to tag cached data, then invalidate it on-demand with one of these functions:
+
+| Function                                                                       | Where it can be called         | Behavior                                                                   | Best for                                                 |
+| ------------------------------------------------------------------------------ | ------------------------------ | -------------------------------------------------------------------------- | -------------------------------------------------------- |
+| [`updateTag(tag)`](/docs/app/api-reference/functions/updateTag)                | Server Actions only            | Expires immediately — next request waits for fresh data                    | Read-your-own-writes (user sees their change right away) |
+| [`revalidateTag(tag, 'max')`](/docs/app/api-reference/functions/revalidateTag) | Server Actions, Route Handlers | Stale-while-revalidate — serves cached data while refreshing in background | Content updates where a brief delay is acceptable        |
+| [`revalidatePath(path)`](/docs/app/api-reference/functions/revalidatePath)     | Server Actions, Route Handlers | Invalidates all cache entries for a specific path                          | Page-level invalidation                                  |
+
+> **Good to know:**
+>
+> - The single-argument form `revalidateTag(tag)` is **deprecated**. Always pass a profile as the second argument (e.g. `'max'`).
+> - Use `updateTag` in Server Actions when the user needs to see their mutation immediately. Use `revalidateTag` when background revalidation is fine or when invalidating from a Route Handler.
+
+### Route segment config migration
+
+| Before (route segment config)             | After (Cache Components)             | Notes                                                                                                                                                                               |
+| ----------------------------------------- | ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `export const dynamic = 'force-dynamic'`  | Remove it                            | Pages are dynamic by default                                                                                                                                                        |
+| `export const dynamic = 'force-static'`   | `'use cache'` + `cacheLife('max')`   | Add near the data access                                                                                                                                                            |
+| `export const revalidate = 3600`          | `'use cache'` + `cacheLife('hours')` | [Choose a profile](/docs/app/api-reference/functions/cacheLife#using-preset-profiles) or pass an [inline object](/docs/app/api-reference/functions/cacheLife#inline-cache-profiles) |
+| `export const fetchCache = 'force-cache'` | `'use cache'`                        | All fetches inside the scope are cached automatically                                                                                                                               |
+| `export const runtime = 'edge'`           | Remove it                            | Cache Components requires Node.js runtime. Use [Proxy](/docs/app/api-reference/file-conventions/proxy) for edge behavior                                                            |
+
 ## `dynamic = "force-dynamic"`
 
 **Not needed.** All pages are dynamic by default.

--- a/docs/01-app/02-guides/migrating-to-cache-components.mdx
+++ b/docs/01-app/02-guides/migrating-to-cache-components.mdx
@@ -12,35 +12,35 @@ When [Cache Components](/docs/app/api-reference/config/next-config-js/cacheCompo
 
 | Directive                                                                      | Scope                     | Server-side storage          | Can access `cookies()`/`headers()` | Use case                                                      |
 | ------------------------------------------------------------------------------ | ------------------------- | ---------------------------- | ---------------------------------- | ------------------------------------------------------------- |
-| [`'use cache'`](/docs/app/api-reference/directives/use-cache)                  | Shared (all users)        | In-memory (or cache handler) | No — pass values as arguments      | Default choice for caching data, components, or pages         |
-| [`'use cache: remote'`](/docs/app/api-reference/directives/use-cache-remote)   | Shared (all users)        | Remote cache handler         | No — pass values as arguments      | High-traffic data that must survive across instances          |
+| [`'use cache'`](/docs/app/api-reference/directives/use-cache)                  | Shared (all users)        | In-memory (or cache handler) | No (pass values as arguments)      | Default choice for caching data, components, or pages         |
+| [`'use cache: remote'`](/docs/app/api-reference/directives/use-cache-remote)   | Shared (all users)        | Remote cache handler         | No (pass values as arguments)      | High-traffic data that must survive across instances          |
 | [`'use cache: private'`](/docs/app/api-reference/directives/use-cache-private) | Per-client (browser only) | None                         | Yes                                | Compliance needs or when runtime data can't be refactored out |
 
 ### `cacheLife` profiles
 
 Use [`cacheLife`](/docs/app/api-reference/functions/cacheLife) inside a `use cache` scope to control how long cached output is kept. These are the built-in profiles:
 
-| Profile                                                                        | `stale` (client) | `revalidate` (server) | `expire` | Typical content                            |
-| ------------------------------------------------------------------------------ | ---------------- | --------------------- | -------- | ------------------------------------------ |
-| `default`                                                                      | 5 min            | 15 min                | never    | Standard content                           |
-| [`seconds`](/docs/app/api-reference/functions/cacheLife#using-preset-profiles) | 30 s             | 1 s                   | 1 min    | Real-time data (stock prices, live scores) |
-| [`minutes`](/docs/app/api-reference/functions/cacheLife#using-preset-profiles) | 5 min            | 1 min                 | 1 h      | Social feeds, news                         |
-| [`hours`](/docs/app/api-reference/functions/cacheLife#using-preset-profiles)   | 5 min            | 1 h                   | 1 day    | Product inventory, weather                 |
-| [`days`](/docs/app/api-reference/functions/cacheLife#using-preset-profiles)    | 5 min            | 1 day                 | 1 week   | Blog posts, articles                       |
-| [`weeks`](/docs/app/api-reference/functions/cacheLife#using-preset-profiles)   | 5 min            | 1 week                | 30 days  | Podcasts, newsletters                      |
-| [`max`](/docs/app/api-reference/functions/cacheLife#using-preset-profiles)     | 5 min            | 30 days               | 1 year   | Legal pages, archived content              |
+| Profile   | `stale` (client) | `revalidate` (server) | `expire` (server) | Typical content                            |
+| --------- | ---------------- | --------------------- | ----------------- | ------------------------------------------ |
+| `default` | 5 min            | 15 min                | never             | Standard content                           |
+| `seconds` | 30 s             | 1 s                   | 1 min             | Real-time data (stock prices, live scores) |
+| `minutes` | 5 min            | 1 min                 | 1 h               | Social feeds, news                         |
+| `hours`   | 5 min            | 1 h                   | 1 day             | Product inventory, weather                 |
+| `days`    | 5 min            | 1 day                 | 1 week            | Blog posts, articles                       |
+| `weeks`   | 5 min            | 1 week                | 30 days           | Podcasts, newsletters                      |
+| `max`     | 5 min            | 30 days               | 1 year            | Legal pages, archived content              |
 
-You can also define [custom profiles](/docs/app/api-reference/functions/cacheLife#custom-cache-profiles) in `next.config.ts` or pass an [inline object](/docs/app/api-reference/functions/cacheLife#inline-cache-profiles) directly.
+Read more about [preset cache profiles](/docs/app/api-reference/functions/cacheLife#preset-cache-profiles), [custom profiles](/docs/app/api-reference/functions/cacheLife#custom-cache-profiles) in `next.config.ts`, or [inline profile objects](/docs/app/api-reference/functions/cacheLife#inline-cache-profiles).
 
 ### Revalidation and invalidation functions
 
 Use [`cacheTag`](/docs/app/api-reference/functions/cacheTag) to tag cached data, then invalidate it on-demand with one of these functions:
 
-| Function                                                                       | Where it can be called         | Behavior                                                                   | Best for                                                 |
-| ------------------------------------------------------------------------------ | ------------------------------ | -------------------------------------------------------------------------- | -------------------------------------------------------- |
-| [`updateTag(tag)`](/docs/app/api-reference/functions/updateTag)                | Server Actions only            | Expires immediately — next request waits for fresh data                    | Read-your-own-writes (user sees their change right away) |
-| [`revalidateTag(tag, 'max')`](/docs/app/api-reference/functions/revalidateTag) | Server Actions, Route Handlers | Stale-while-revalidate — serves cached data while refreshing in background | Content updates where a brief delay is acceptable        |
-| [`revalidatePath(path)`](/docs/app/api-reference/functions/revalidatePath)     | Server Actions, Route Handlers | Invalidates all cache entries for a specific path                          | Page-level invalidation                                  |
+| Function                                                                       | Where it can be called         | Behavior                                                                  | Best for                                                 |
+| ------------------------------------------------------------------------------ | ------------------------------ | ------------------------------------------------------------------------- | -------------------------------------------------------- |
+| [`updateTag(tag)`](/docs/app/api-reference/functions/updateTag)                | Server Actions only            | Expires immediately; next request waits for fresh data                    | Read-your-own-writes (user sees their change right away) |
+| [`revalidateTag(tag, 'max')`](/docs/app/api-reference/functions/revalidateTag) | Server Actions, Route Handlers | Stale-while-revalidate: serves cached data while refreshing in background | Content updates where a brief delay is acceptable        |
+| [`revalidatePath(path)`](/docs/app/api-reference/functions/revalidatePath)     | Server Actions, Route Handlers | Invalidates all cache entries for a specific path                         | Page-level invalidation                                  |
 
 > **Good to know:**
 >
@@ -53,7 +53,7 @@ Use [`cacheTag`](/docs/app/api-reference/functions/cacheTag) to tag cached data,
 | ----------------------------------------- | ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `export const dynamic = 'force-dynamic'`  | Remove it                            | Pages are dynamic by default                                                                                                                                                        |
 | `export const dynamic = 'force-static'`   | `'use cache'` + `cacheLife('max')`   | Add near the data access                                                                                                                                                            |
-| `export const revalidate = 3600`          | `'use cache'` + `cacheLife('hours')` | [Choose a profile](/docs/app/api-reference/functions/cacheLife#using-preset-profiles) or pass an [inline object](/docs/app/api-reference/functions/cacheLife#inline-cache-profiles) |
+| `export const revalidate = 3600`          | `'use cache'` + `cacheLife('hours')` | [Choose a profile](/docs/app/api-reference/functions/cacheLife#preset-cache-profiles) or pass an [inline object](/docs/app/api-reference/functions/cacheLife#inline-cache-profiles) |
 | `export const fetchCache = 'force-cache'` | `'use cache'`                        | All fetches inside the scope are cached automatically                                                                                                                               |
 | `export const runtime = 'edge'`           | Remove it                            | Cache Components requires Node.js runtime. Use [Proxy](/docs/app/api-reference/file-conventions/proxy) for edge behavior                                                            |
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds a **Quick reference** section at the top of the "Migrating to Cache Components" guide (`docs/01-app/02-guides/migrating-to-cache-components.mdx`) with four concise comparison tables:

1. **Cache directives** — `'use cache'` vs `'use cache: remote'` vs `'use cache: private'` (scope, storage, runtime API access, use case)
2. **`cacheLife` profiles** — all built-in profiles with `stale`, `revalidate`, `expire` timings and typical content
3. **Revalidation and invalidation functions** — `updateTag` vs `revalidateTag` vs `revalidatePath` (where callable, behavior, best use case)
4. **Route segment config migration** — before/after mapping for `dynamic`, `revalidate`, `fetchCache`, and `runtime`

## Why

Motivated by a [DX friction run](https://nextjs-dx-agent.labs.vercel.dev/dashboard/runs/1776538184462-d4ta3a) that identified these gaps:

- The `updateTag` vs `revalidateTag` distinction is consequential but only reachable by navigating through multiple doc pages
- The deprecated single-arg `revalidateTag(tag)` compiles silently — easy to miss
- No at-a-glance cheatsheet exists for the new caching APIs in the migration guide
- The Slack thread specifically called for "cheatsheets" and "tables comparing the caching directives"

Every table entry cross-references the relevant API reference docs so readers can drill into details.

<!-- NEXT_JS_LLM_PR -->
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://vercel.slack.com/archives/C0ANB536V62/p1776538334356499?thread_ts=1776538334.356499&cid=C0ANB536V62)

<div><a href="https://cursor.com/agents/bc-2182fc11-b1a8-592d-b1a8-78378787e5da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2182fc11-b1a8-592d-b1a8-78378787e5da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

