### PR TITLE
chore(CI): Remove global npm installs of napi CLI

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -298,7 +298,7 @@ jobs:
           echo "Rustc binary: $(file $(which rustc) || echo 'not found')"
           rustc --version --verbose || true
           node -v
-          npm i -g "@napi-rs/cli@${NAPI_CLI_VERSION}"
+          pnpm install --frozen-lockfile --filter @next/swc
           TURBO_CACHE_FLAG="${NEXT_SKIP_BUILD_CACHE:+--force}"
           pnpm dlx turbo@${TURBO_VERSION} run ${{ matrix.build_task }} ${TURBO_ARGS} ${TURBO_CACHE_FLAG} -- --target ${{ matrix.target }}
           if [ "${{ matrix.os }}" != "windows" ]; then

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -413,7 +413,7 @@ jobs:
           echo "Rustc binary: $(file $(which rustc) || echo 'not found')"
           rustc --version --verbose || true
           node -v
-          npm i -g "@napi-rs/cli@${NAPI_CLI_VERSION}"
+          pnpm install --frozen-lockfile --filter @next/swc
           TURBO_CACHE_FLAG="${NEXT_SKIP_BUILD_CACHE:+--force}"
           pnpm dlx turbo@${TURBO_VERSION} run ${{ matrix.build_task }} ${TURBO_ARGS} ${TURBO_CACHE_FLAG} -- --target ${{ matrix.target }}
           if [ "${{ matrix.os }}" != "windows" ]; then

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -69,6 +69,7 @@ jobs:
     needs: ['changes']
     if: ${{ needs.changes.outputs.docs-only == 'false' }}
     with:
+      needsRust: 'yes'
       skipInstallBuild: 'yes'
       stepName: 'build-native'
       uploadNativeArtifact: 'next-swc-linux'
@@ -80,6 +81,7 @@ jobs:
     needs: ['changes']
     if: ${{ needs.changes.outputs.docs-only == 'false' }}
     with:
+      needsRust: 'yes'
       skipInstallBuild: 'yes'
       stepName: 'build-native-windows'
       runs_on_labels: '["windows","self-hosted","x64"]'

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -114,6 +114,7 @@ jobs:
     needs: ['changes']
     if: ${{ needs.changes.outputs.docs-only == 'false' }}
     with:
+      needsRust: 'yes'
       skipInstallBuild: 'yes'
       stepName: 'build-native'
       uploadNativeArtifact: 'next-swc-linux'
@@ -125,6 +126,7 @@ jobs:
     needs: ['changes']
     if: ${{ needs.changes.outputs.docs-only == 'false' }}
     with:
+      needsRust: 'yes'
       skipInstallBuild: 'yes'
       stepName: 'build-native-windows'
       runs_on_labels: '["windows-latest-8-core-oss"]'

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -97,7 +97,6 @@ on:
         type: string
         default: 'chromium'
 env:
-  NAPI_CLI_VERSION: 2.18.4
   TURBO_VERSION: 2.9.4
   TURBO_ARGS: '-v --env-mode loose --remote-cache-timeout 300 --log-order stream'
   NODE_LTS_VERSION: 20.9.0
@@ -252,7 +251,7 @@ jobs:
       - run: rustc --version
         if: ${{ (inputs.uploadNativeArtifact != '') || inputs.needsNextest == 'yes' || inputs.needsRust == 'yes' }}
 
-      - run: corepack prepare --activate yarn@1.22.19 && npm i -g "@napi-rs/cli@${NAPI_CLI_VERSION}"
+      - run: corepack prepare --activate yarn@1.22.19
 
       # clean up any previous artifacts to avoid hitting disk space limits
       - run: git clean -xdf && rm -rf /tmp/next-repo-*; rm -rf /tmp/next-install-* /tmp/yarn-* /tmp/ncc-cache target
@@ -304,8 +303,12 @@ jobs:
       - run: git checkout .
         if: ${{ inputs.skipInstallBuild != 'yes' }}
 
-      - run: pnpm install
+      - run: pnpm install --frozen-lockfile
         if: ${{ inputs.skipInstallBuild != 'yes' }}
+
+      # run a minimal install to make sure we pick up the napi CLI
+      - run: pnpm install --frozen-lockfile --ignore-scripts --filter @next/swc
+        if: ${{ inputs.skipInstallBuild == 'yes' && inputs.needsRust == 'yes' }}
 
       - name: Install node-file-trace test dependencies
         if: ${{ inputs.needsNextest == 'yes' }}

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -102,7 +102,6 @@ on:
         type: string
         default: 'yes'
 env:
-  NAPI_CLI_VERSION: 2.18.4
   TURBO_VERSION: 2.9.4
   TURBO_ARGS: '-v --env-mode loose --remote-cache-timeout 300 --log-order stream'
   NODE_LTS_VERSION: 20.9.0
@@ -250,7 +249,7 @@ jobs:
       - run: rustc --version
         if: ${{ (inputs.uploadNativeArtifact != '') || inputs.needsNextest == 'yes' || inputs.needsRust == 'yes' }}
 
-      - run: corepack prepare --activate yarn@1.22.19 && npm i -g "@napi-rs/cli@${NAPI_CLI_VERSION}"
+      - run: corepack prepare --activate yarn@1.22.19
 
       # clean up any previous artifacts to avoid hitting disk space limits
       - run: git clean -xdf && rm -rf /tmp/next-repo-*; rm -rf /tmp/next-install-* /tmp/yarn-* /tmp/ncc-cache target
@@ -300,7 +299,12 @@ jobs:
 
       # undo normalize version changes for install/build
       - run: git checkout .
-        if: ${{ inputs.skipInstallBuild != 'yes' }}
+        if: |-
+          ${{
+            inputs.skipInstallBuild != 'yes' ||
+            inputs.needsNextest == 'yes' ||
+            inputs.needsRust == 'yes'
+          }}
 
       - name: Cache pnpm store
         # conditions must be subset of runs executing pnpm install, otherwise we
@@ -315,9 +319,14 @@ jobs:
           path: ${{ steps.get-store-path.outputs.STORE_PATH }}
           key: pnpm-store-root-v1-${{ hashFiles('pnpm-lock.yaml') }}
           # Do not use restore-keys since it leads to indefinite growth of the cache.
-      - run: pnpm install
+
+      - run: pnpm install --frozen-lockfile
         # condititions must be superset of cache step, otherwise we risk running install without a cache and then caching the incomplete store.
         if: ${{ inputs.skipInstallBuild != 'yes' || inputs.needsNextest == 'yes' }}
+
+      # run a minimal install to make sure we pick up the napi CLI
+      - run: pnpm install --frozen-lockfile --ignore-scripts --filter @next/swc
+        if: ${{ inputs.skipInstallBuild == 'yes' && inputs.needsRust == 'yes' }}
 
       - name: Install node-file-trace test dependencies
         if: ${{ inputs.needsNextest == 'yes' }}


### PR DESCRIPTION
We should use the version installed into `node_modules` by `pnpm` using the lockfile instead of globally installing it with `npm`, which doesn't respect any lockfiles or `minimumReleaseAge`, though admittedly this package doesn't have any dependencies, so it's not a huge deal.