### PR TITLE
fix(types): apply AppType generic to component props instead of pageProps

### DIFF
--- a/packages/next/src/shared/lib/utils.ts
+++ b/packages/next/src/shared/lib/utils.ts
@@ -31,7 +31,7 @@ export type DocumentType = NextComponentType<
 export type AppType<P = {}> = NextComponentType<
   AppContextType,
   P,
-  AppPropsType<any, P>
+  AppPropsType<any, {}> & P
 >
 
 export type AppTreeType = ComponentType<


### PR DESCRIPTION
## For Contributors

### Fixing a bug

- Related issues linked using `fixes #number`: fixes #42846
- Tests added: existing type-level coverage in `test/integration/` for `AppType` exercises this path
- Errors have a helpful link attached: N/A (types-only change)

## For Maintainers

### What?

Fix the `AppType<P>` generic so custom props are applied to the component, not nested under `pageProps`.

### Why?

The `P` generic on `AppType` was applied to `pageProps` via `AppPropsType<any, P>`, which meant any custom props consumers added through `P` ended up nested under `pageProps` instead of being available as top-level component props — not what the `AppType<P>` contract implies and contradicts the docs.

### How?

Changed:

```ts
export type AppType<P = {}> = NextComponentType<AppContextType, P, AppPropsType<any, P>>
```

To:

```ts
export type AppType<P = {}> = NextComponentType<AppContextType, P, AppPropsType<any, {}> & P>
```

This ensures the generic `P` is intersected with the full `AppPropsType` so custom props appear at the component level, not inside `pageProps`.

Fixes #42846
