### PR TITLE
Fix: Add HTTP method validation for page requests in dev mode

### DIFF
--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -617,7 +617,12 @@ export async function initialize(opts: {
 
         // Validate HTTP method for page requests to match production behavior
         // Only GET and HEAD methods are allowed for page rendering
-        if (!(req.method === 'GET' || req.method === 'HEAD')) {
+        // This applies to pageFile and appFile types, not API routes or other handlers
+        if (
+          (matchedOutput.type === 'pageFile' ||
+            matchedOutput.type === 'appFile') &&
+          !(req.method === 'GET' || req.method === 'HEAD')
+        ) {
           res.setHeader('Allow', ['GET', 'HEAD'])
           res.statusCode = 405
           return await invokeRender(parseUrlUtil('/405'), '/405', handleIndex, {

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -615,6 +615,16 @@ export async function initialize(opts: {
       if (matchedOutput) {
         invokedOutputs.add(matchedOutput.itemPath)
 
+        // Validate HTTP method for page requests to match production behavior
+        // Only GET and HEAD methods are allowed for page rendering
+        if (!(req.method === 'GET' || req.method === 'HEAD')) {
+          res.setHeader('Allow', ['GET', 'HEAD'])
+          res.statusCode = 405
+          return await invokeRender(parseUrlUtil('/405'), '/405', handleIndex, {
+            invokeStatus: 405,
+          })
+        }
+
         return await invokeRender(
           parsedUrl,
           parsedUrl.pathname || '/',


### PR DESCRIPTION
Fixes #38863

In development mode, page requests were not validating HTTP methods.