### PR TITLE
Disable sccache temporarily

### DIFF
--- a/.github/actions/sccache/start.sh
+++ b/.github/actions/sccache/start.sh
@@ -43,7 +43,8 @@ set_env() {
   echo "$1=$2" >> "$GITHUB_ENV"
 }
 
-set_env RUSTC_WRAPPER sccache
+# Disable sccache while we sort out the cache server
+#set_env RUSTC_WRAPPER sccache
 set_env SCCACHE_BASEDIRS "${INPUT_BASE_DIR:-${GITHUB_WORKSPACE}}"
 set_env CARGO_INCREMENTAL 0
 set_env SCCACHE_IDLE_TIMEOUT 0


### PR DESCRIPTION
Fixes https://github.com/vercel/next.js/actions/runs/24632964085/job/72023416915?pr=92945
> sccache: error: Server startup failed: cache storage failed to read: Unexpected (permanent) at read => {"code":"unauthorized","message":"Missing or invalid bearer token"}