### PR TITLE
[test] Deflake `shallow-routing`

### DIFF
--- a/test/development/pages-dir/client-navigation/shallow-routing.test.ts
+++ b/test/development/pages-dir/client-navigation/shallow-routing.test.ts
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 
-import { waitFor } from 'next-test-utils'
+import { retry, waitFor } from 'next-test-utils'
 import path from 'path'
 import { nextTestSetup } from 'e2e-utils'
 
@@ -14,14 +14,16 @@ describe('Client navigation with shallow routing', () => {
 
   it('should update the url without running getInitialProps', async () => {
     const browser = await next.browser('/nav/shallow-routing')
-    const counter = await browser
+    await browser
       .elementByCss('#increase')
       .click()
       .elementByCss('#increase')
       .click()
-      .elementByCss('#counter')
-      .text()
-    expect(counter).toBe('Counter: 2')
+
+    await retry(async () => {
+      const counter = await browser.elementByCss('#counter').text()
+      expect(counter).toBe('Counter: 2')
+    })
 
     const getInitialPropsRunCount = await browser
       .elementByCss('#get-initial-props-run-count')
@@ -33,17 +35,23 @@ describe('Client navigation with shallow routing', () => {
 
   it('should handle the back button and should not run getInitialProps', async () => {
     const browser = await next.browser('/nav/shallow-routing')
-    let counter = await browser
+    await browser
       .elementByCss('#increase')
       .click()
       .elementByCss('#increase')
       .click()
-      .elementByCss('#counter')
-      .text()
-    expect(counter).toBe('Counter: 2')
 
-    counter = await browser.back().elementByCss('#counter').text()
-    expect(counter).toBe('Counter: 1')
+    await retry(async () => {
+      const counter = await browser.elementByCss('#counter').text()
+      expect(counter).toBe('Counter: 2')
+    })
+
+    await browser.back()
+
+    await retry(async () => {
+      const counter = await browser.elementByCss('#counter').text()
+      expect(counter).toBe('Counter: 1')
+    })
 
     const getInitialPropsRunCount = await browser
       .elementByCss('#get-initial-props-run-count')


### PR DESCRIPTION
Rarely flakes because the Router hasn't updated yet.

[`@test.source.file:test/development/pages-dir/client-navigation/shallow-routing.test.ts -@test.status:pass `](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40test.source.file%3Atest%2Fdevelopment%2Fpages-dir%2Fclient-navigation%2Fshallow-routing.test.ts%20-%40test.status%3Apass&agg_m=count&agg_m_source=base&agg_q=%40test.name&agg_q_source=base&agg_t=count&currentTab=overview&eventStack=&fromUser=false&index=citest&top_n=10&top_o=top&viz=toplist&x_missing=true&start=1776022337626&end=1776627137626&paused=false)

<img width="2496" height="906" alt="CleanShot 2026-04-19 at 21 32 45@2x" src="https://github.com/user-attachments/assets/50d6af2f-8dfe-4765-ab92-3e42985a9da4" />

