### PR TITLE
output export fallback: move fallback e2e suites onto fixtures

### DIFF
--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/another/[slug]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/another/[slug]/page.js
@@ -1,0 +1,21 @@
+import Link from 'next/link'
+import { Suspense } from 'react'
+import SlugClient from './slug-client'
+
+export default function Page() {
+  return (
+    <main>
+      <Suspense fallback={<h1>Loading slug...</h1>}>
+        <SlugClient />
+      </Suspense>
+      <ul>
+        <li>
+          <Link href="/another">Visit another page</Link>
+        </li>
+        <li>
+          <Link href="/org/acme/chat/thread-flat">Visit org thread</Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/another/[slug]/slug-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/another/[slug]/slug-client.js
@@ -1,0 +1,9 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function SlugClient() {
+  const params = useParams()
+
+  return <h1>{params.slug}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/another/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/another/page.js
@@ -1,0 +1,20 @@
+import Link from 'next/link'
+
+export default function Another() {
+  return (
+    <main>
+      <h1>Another</h1>
+      <ul>
+        <li>
+          <Link href="/">Visit the home page</Link>
+        </li>
+        <li>
+          <Link href="/another">another page</Link>
+        </li>
+        <li>
+          <Link href="/another/third">another third page</Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/layout.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/not-found.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/not-found.js
@@ -1,0 +1,3 @@
+export default function NotFound() {
+  return <h1>My custom not found page</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/org/[org]/chat/[thread]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/org/[org]/chat/[thread]/page.js
@@ -1,0 +1,18 @@
+import Link from 'next/link'
+import { Suspense } from 'react'
+import OrgThreadClient from './thread-client'
+
+export default function OrgThreadPage() {
+  return (
+    <>
+      <Suspense fallback={<h1>Loading org thread...</h1>}>
+        <OrgThreadClient />
+      </Suspense>
+      <ul>
+        <li>
+          <Link href="/org">Visit org index</Link>
+        </li>
+      </ul>
+    </>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/org/[org]/chat/[thread]/thread-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/org/[org]/chat/[thread]/thread-client.js
@@ -1,0 +1,13 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function OrgThreadClient() {
+  const params = useParams()
+
+  return (
+    <h1>
+      {params.org}:{params.thread}
+    </h1>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/org/[org]/layout.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/org/[org]/layout.js
@@ -1,0 +1,13 @@
+import { Suspense } from 'react'
+import OrgClient from './org-client'
+
+export default function OrgLayout({ children }) {
+  return (
+    <main>
+      <Suspense fallback={<p id="org-name">Loading org...</p>}>
+        <OrgClient />
+      </Suspense>
+      {children}
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/org/[org]/org-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/org/[org]/org-client.js
@@ -1,0 +1,9 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function OrgClient() {
+  const params = useParams()
+
+  return <p id="org-name">Org {params.org}</p>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/org/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/org/page.js
@@ -1,0 +1,16 @@
+import Link from 'next/link'
+
+export default function OrgIndexPage() {
+  return (
+    <main>
+      <h1>Org index</h1>
+      <ul>
+        <li>
+          <Link href="/org/acme/chat/thread-123">
+            Visit org chat thread 123
+          </Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/next.config.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/next.config.js
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  output: 'export',
+  trailingSlash: false,
+  cacheComponents: true,
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/(grouped)/grouped/[slug]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/(grouped)/grouped/[slug]/page.js
@@ -1,0 +1,18 @@
+import Link from 'next/link'
+import { Suspense } from 'react'
+import GroupedSlugClient from './slug-client'
+
+export default function GroupedSlugPage() {
+  return (
+    <main>
+      <Suspense fallback={<h1>Loading grouped slug...</h1>}>
+        <GroupedSlugClient />
+      </Suspense>
+      <ul>
+        <li>
+          <Link href="/grouped">Visit grouped index</Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/(grouped)/grouped/[slug]/slug-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/(grouped)/grouped/[slug]/slug-client.js
@@ -1,0 +1,9 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function GroupedSlugClient() {
+  const params = useParams()
+
+  return <h1>{params.slug}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/(grouped)/grouped/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/(grouped)/grouped/page.js
@@ -1,0 +1,14 @@
+import Link from 'next/link'
+
+export default function GroupedIndexPage() {
+  return (
+    <main>
+      <h1>Grouped index</h1>
+      <ul>
+        <li>
+          <Link href="/grouped/from-group">Visit grouped fallback page</Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/another/[slug]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/another/[slug]/page.js
@@ -1,0 +1,23 @@
+import Link from 'next/link'
+import { Suspense } from 'react'
+import SlugClient from './slug-client'
+
+export default function Page() {
+  return (
+    <main>
+      <Suspense fallback={<h1>Loading slug...</h1>}>
+        <SlugClient />
+      </Suspense>
+      <ul>
+        <li>
+          <Link href="/another">Visit another page</Link>
+        </li>
+        <li>
+          <Link href="/org/acme/chat/thread-cross">
+            Visit org thread (cross-subtree)
+          </Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/another/[slug]/slug-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/another/[slug]/slug-client.js
@@ -1,0 +1,9 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function SlugClient() {
+  const params = useParams()
+
+  return <h1>{params.slug}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/another/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/another/page.js
@@ -1,0 +1,20 @@
+import Link from 'next/link'
+
+export default function Another() {
+  return (
+    <main>
+      <h1>Another</h1>
+      <ul>
+        <li>
+          <Link href="/">Visit the home page</Link>
+        </li>
+        <li>
+          <Link href="/another">another page</Link>
+        </li>
+        <li>
+          <Link href="/another/third">another third page</Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/docs/[...slug]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/docs/[...slug]/page.js
@@ -1,0 +1,18 @@
+import Link from 'next/link'
+import { Suspense } from 'react'
+import DocsSlugClient from './slug-client'
+
+export default function DocsCatchAllPage() {
+  return (
+    <main>
+      <Suspense fallback={<h1>Loading docs...</h1>}>
+        <DocsSlugClient />
+      </Suspense>
+      <ul>
+        <li>
+          <Link href="/docs">Visit docs index</Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/docs/[...slug]/slug-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/docs/[...slug]/slug-client.js
@@ -1,0 +1,11 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function DocsSlugClient() {
+  const params = useParams()
+
+  return (
+    <h1>{Array.isArray(params.slug) ? params.slug.join('/') : 'missing'}</h1>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/docs/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/docs/page.js
@@ -1,0 +1,16 @@
+import Link from 'next/link'
+
+export default function DocsIndex() {
+  return (
+    <main>
+      <h1>Docs</h1>
+      <ul>
+        <li>
+          <Link href="/docs/guides/export/fallback">
+            docs export fallback page
+          </Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/inbox/@modal/[thread]/modal-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/inbox/@modal/[thread]/modal-client.js
@@ -1,0 +1,9 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function InboxModalClient() {
+  const params = useParams()
+
+  return <p id="modal-thread">Modal {params.thread}</p>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/inbox/@modal/[thread]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/inbox/@modal/[thread]/page.js
@@ -1,0 +1,10 @@
+import { Suspense } from 'react'
+import InboxModalClient from './modal-client'
+
+export default function InboxModalPage() {
+  return (
+    <Suspense fallback={<p id="modal-thread">Loading modal...</p>}>
+      <InboxModalClient />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/inbox/@modal/default.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/inbox/@modal/default.js
@@ -1,0 +1,3 @@
+export default function InboxModalDefault() {
+  return <p id="modal-thread">No modal</p>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/inbox/[thread]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/inbox/[thread]/page.js
@@ -1,0 +1,18 @@
+import Link from 'next/link'
+import { Suspense } from 'react'
+import InboxThreadClient from './thread-client'
+
+export default function InboxThreadPage() {
+  return (
+    <>
+      <Suspense fallback={<h1>Loading inbox thread...</h1>}>
+        <InboxThreadClient />
+      </Suspense>
+      <ul>
+        <li>
+          <Link href="/inbox">Visit inbox index</Link>
+        </li>
+      </ul>
+    </>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/inbox/[thread]/thread-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/inbox/[thread]/thread-client.js
@@ -1,0 +1,9 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function InboxThreadClient() {
+  const params = useParams()
+
+  return <h1>{params.thread}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/inbox/layout.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/inbox/layout.js
@@ -1,0 +1,8 @@
+export default function InboxLayout({ children, modal }) {
+  return (
+    <main>
+      {children}
+      <section id="modal-slot">{modal}</section>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/inbox/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/inbox/page.js
@@ -1,0 +1,14 @@
+import Link from 'next/link'
+
+export default function InboxIndexPage() {
+  return (
+    <main>
+      <h1>Inbox</h1>
+      <ul>
+        <li>
+          <Link href="/inbox/thread-123">Visit inbox thread</Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/layout.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/not-found.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/not-found.js
@@ -1,0 +1,3 @@
+export default function NotFound() {
+  return <h1>My custom not found page</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/optional/[[...slug]]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/optional/[[...slug]]/page.js
@@ -1,0 +1,18 @@
+import Link from 'next/link'
+import { Suspense } from 'react'
+import OptionalSlugClient from './slug-client'
+
+export default function OptionalCatchAllPage() {
+  return (
+    <main>
+      <Suspense fallback={<h1>Loading optional...</h1>}>
+        <OptionalSlugClient />
+      </Suspense>
+      <ul>
+        <li>
+          <Link href="/optional/deep/path">Visit optional deep path</Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/optional/[[...slug]]/slug-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/optional/[[...slug]]/slug-client.js
@@ -1,0 +1,10 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function OptionalSlugClient() {
+  const params = useParams()
+  const slug = params.slug
+
+  return <h1>{Array.isArray(slug) ? slug.join('/') : 'optional index'}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/org/[org]/chat/[thread]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/org/[org]/chat/[thread]/page.js
@@ -1,0 +1,23 @@
+import Link from 'next/link'
+import { Suspense } from 'react'
+import OrgThreadClient from './thread-client'
+
+export default function OrgThreadPage() {
+  return (
+    <>
+      <Suspense fallback={<h1>Loading org thread...</h1>}>
+        <OrgThreadClient />
+      </Suspense>
+      <ul>
+        <li>
+          <Link href="/org">Visit org index</Link>
+        </li>
+        <li>
+          <Link href="/org/acme/chat/thread-456">
+            Visit org chat thread 456
+          </Link>
+        </li>
+      </ul>
+    </>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/org/[org]/chat/[thread]/thread-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/org/[org]/chat/[thread]/thread-client.js
@@ -1,0 +1,13 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function OrgThreadClient() {
+  const params = useParams()
+
+  return (
+    <h1>
+      {params.org}:{params.thread}
+    </h1>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/org/[org]/layout.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/org/[org]/layout.js
@@ -1,0 +1,13 @@
+import { Suspense } from 'react'
+import OrgClient from './org-client'
+
+export default function OrgLayout({ children }) {
+  return (
+    <main>
+      <Suspense fallback={<p id="org-name">Loading org...</p>}>
+        <OrgClient />
+      </Suspense>
+      {children}
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/org/[org]/org-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/org/[org]/org-client.js
@@ -1,0 +1,9 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function OrgClient() {
+  const params = useParams()
+
+  return <p id="org-name">Org {params.org}</p>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/org/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/org/page.js
@@ -1,0 +1,16 @@
+import Link from 'next/link'
+
+export default function OrgIndexPage() {
+  return (
+    <main>
+      <h1>Org index</h1>
+      <ul>
+        <li>
+          <Link href="/org/acme/chat/thread-123">
+            Visit org chat thread 123
+          </Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/page.js
@@ -1,0 +1,7 @@
+export default function Home() {
+  return (
+    <main>
+      <h1>Home</h1>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/next.config.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/next.config.js
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  output: 'export',
+  trailingSlash: true,
+  cacheComponents: true,
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/another/[slug]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/another/[slug]/page.js
@@ -1,0 +1,25 @@
+import Link from 'next/link'
+import { Suspense } from 'react'
+import SlugClient from './slug-client'
+
+export function generateStaticParams() {
+  return [{ slug: 'first' }, { slug: 'second' }]
+}
+
+export default function Page() {
+  return (
+    <main>
+      <Suspense fallback={<h1>Loading slug...</h1>}>
+        <SlugClient />
+      </Suspense>
+      <ul>
+        <li>
+          <Link href="/another">Visit another page</Link>
+        </li>
+        <li>
+          <Link href="/another/third">Visit another third (fallback)</Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/another/[slug]/slug-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/another/[slug]/slug-client.js
@@ -1,0 +1,9 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function SlugClient() {
+  const params = useParams()
+
+  return <h1>{params.slug}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/another/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/another/page.js
@@ -1,0 +1,26 @@
+import Link from 'next/link'
+
+export default function Another() {
+  return (
+    <main>
+      <h1>Another</h1>
+      <ul>
+        <li>
+          <Link href="/">Visit the home page</Link>
+        </li>
+        <li>
+          <Link href="/another">another page</Link>
+        </li>
+        <li>
+          <Link href="/another/first">another first page</Link>
+        </li>
+        <li>
+          <Link href="/another/second">another second page</Link>
+        </li>
+        <li>
+          <Link href="/another/third">another third page</Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/layout.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/not-found.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/not-found.js
@@ -1,0 +1,3 @@
+export default function NotFound() {
+  return <h1>My custom not found page</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/org/[org]/chat/[thread]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/org/[org]/chat/[thread]/page.js
@@ -1,0 +1,30 @@
+import Link from 'next/link'
+import { Suspense } from 'react'
+import OrgThreadClient from './thread-client'
+
+export function generateStaticParams() {
+  return [
+    { org: 'acme', thread: 'thread-123' },
+    { org: 'acme', thread: 'thread-456' },
+  ]
+}
+
+export default function OrgThreadPage() {
+  return (
+    <>
+      <Suspense fallback={<h1>Loading org thread...</h1>}>
+        <OrgThreadClient />
+      </Suspense>
+      <ul>
+        <li>
+          <Link href="/org">Visit org index</Link>
+        </li>
+        <li>
+          <Link href="/org/acme/chat/thread-789">
+            Visit fallback org chat thread
+          </Link>
+        </li>
+      </ul>
+    </>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/org/[org]/chat/[thread]/thread-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/org/[org]/chat/[thread]/thread-client.js
@@ -1,0 +1,13 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function OrgThreadClient() {
+  const params = useParams()
+
+  return (
+    <h1>
+      {params.org}:{params.thread}
+    </h1>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/org/[org]/layout.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/org/[org]/layout.js
@@ -1,0 +1,13 @@
+import { Suspense } from 'react'
+import OrgClient from './org-client'
+
+export default function OrgLayout({ children }) {
+  return (
+    <main>
+      <Suspense fallback={<p id="org-name">Loading org...</p>}>
+        <OrgClient />
+      </Suspense>
+      {children}
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/org/[org]/org-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/org/[org]/org-client.js
@@ -1,0 +1,9 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function OrgClient() {
+  const params = useParams()
+
+  return <p id="org-name">Org {params.org}</p>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/org/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/org/page.js
@@ -1,0 +1,21 @@
+import Link from 'next/link'
+
+export default function OrgIndexPage() {
+  return (
+    <main>
+      <h1>Org index</h1>
+      <ul>
+        <li>
+          <Link href="/org/acme/chat/thread-123">
+            Visit known org chat thread
+          </Link>
+        </li>
+        <li>
+          <Link href="/org/acme/chat/thread-789">
+            Visit fallback org chat thread
+          </Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/next.config.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/next.config.js
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  output: 'export',
+  trailingSlash: true,
+  cacheComponents: true,
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir-export/test/dynamic-fallback-cache-components-flat.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-fallback-cache-components-flat.test.ts
@@ -1,14 +1,17 @@
 import { join } from 'path'
 import { nextTestSetup } from 'e2e-utils'
-import { findPort, retry, stopApp } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import fs from 'fs-extra'
-import express from 'express'
-import http from 'http'
-import { createReadStream } from 'fs'
+import { buildAndStartOutputExportServer } from './utils'
 
 const { next, skipped, isNextDev } = nextTestSetup({
-  files: join(__dirname, '..'),
+  files: join(
+    __dirname,
+    '..',
+    'fixtures',
+    'dynamic-fallback-cache-components-flat'
+  ),
   skipDeployment: true,
   skipStart: true,
   disableAutoSkewProtection: true,
@@ -26,179 +29,10 @@ if (skipped) {
       let stopOrKill: (() => Promise<void>) | undefined
 
       beforeAll(async () => {
-        await next.patchFile('next.config.js', (content) =>
-          content.replace(
-            'trailingSlash: true,',
-            `trailingSlash: false,
-  cacheComponents: true,`
-          )
-        )
-
-        await next.patchFile(
-          'app/another/[slug]/slug-client.js',
-          `'use client'
-
-import { useParams } from 'next/navigation'
-
-export default function SlugClient() {
-  const params = useParams()
-
-  return <h1>{params.slug}</h1>
-}
-`
-        )
-
-        await next.patchFile(
-          'app/another/[slug]/page.js',
-          () => `import Link from 'next/link'
-import { Suspense } from 'react'
-import SlugClient from './slug-client'
-
-export default function Page() {
-  return (
-    <main>
-      <Suspense fallback={<h1>Loading slug...</h1>}>
-        <SlugClient />
-      </Suspense>
-      <ul>
-        <li>
-          <Link href="/another">Visit another page</Link>
-        </li>
-        <li>
-          <Link href="/org/acme/chat/thread-flat">Visit org thread</Link>
-        </li>
-      </ul>
-    </main>
-  )
-}
-`
-        )
-
-        await next.patchFile(
-          'app/org/page.js',
-          `import Link from 'next/link'
-
-export default function OrgIndexPage() {
-  return (
-    <main>
-      <h1>Org index</h1>
-      <ul>
-        <li>
-          <Link href="/org/acme/chat/thread-123">Visit org chat thread 123</Link>
-        </li>
-      </ul>
-    </main>
-  )
-}
-`
-        )
-
-        await next.patchFile(
-          'app/org/[org]/org-client.js',
-          `'use client'
-
-import { useParams } from 'next/navigation'
-
-export default function OrgClient() {
-  const params = useParams()
-
-  return <p id="org-name">Org {params.org}</p>
-}
-`
-        )
-
-        await next.patchFile(
-          'app/org/[org]/layout.js',
-          `import { Suspense } from 'react'
-import OrgClient from './org-client'
-
-export default function OrgLayout({ children }) {
-  return (
-    <main>
-      <Suspense fallback={<p id="org-name">Loading org...</p>}>
-        <OrgClient />
-      </Suspense>
-      {children}
-    </main>
-  )
-}
-`
-        )
-
-        await next.patchFile(
-          'app/org/[org]/chat/[thread]/thread-client.js',
-          `'use client'
-
-import { useParams } from 'next/navigation'
-
-export default function OrgThreadClient() {
-  const params = useParams()
-
-  return <h1>{params.org}:{params.thread}</h1>
-}
-`
-        )
-
-        await next.patchFile(
-          'app/org/[org]/chat/[thread]/page.js',
-          `import Link from 'next/link'
-import { Suspense } from 'react'
-import OrgThreadClient from './thread-client'
-
-export default function OrgThreadPage() {
-  return (
-    <>
-      <Suspense fallback={<h1>Loading org thread...</h1>}>
-        <OrgThreadClient />
-      </Suspense>
-      <ul>
-        <li>
-          <Link href="/org">Visit org index</Link>
-        </li>
-      </ul>
-    </>
-  )
-}
-`
-        )
-
-        await next.deleteFile('app/api/json/route.js')
-        await next.deleteFile('app/api/txt/route.js')
-
-        await next.patchFile('app/another/page.js', (content) =>
-          content.replace(
-            `        <li>
-          <Link href="/image-import">image import page</Link>
-        </li>`,
-            `        <li>
-          <Link href="/another/third">another third page</Link>
-        </li>
-        <li>
-          <Link href="/image-import">image import page</Link>
-        </li>`
-          )
-        )
-
-        await next.build()
-
-        port = await findPort()
-        const app = express()
-        const server = http.createServer(app)
-        const outDir = join(next.testDir, 'out')
-        const fallbackHtml = join(outDir, '_fallback.html')
-
-        app.use(
-          express.static(outDir, {
-            extensions: ['html'],
-            redirect: false,
-          })
-        )
-        app.use((req, res) => {
-          createReadStream(fallbackHtml).pipe(res)
-        })
-
-        await new Promise<void>((resolve) => server.listen(port, resolve))
-        stopOrKill = () => stopApp(server)
+        ;({ port, stopOrKill } = await buildAndStartOutputExportServer(next, {
+          trailingSlash: false,
+          useFallbackDocument: true,
+        }))
       })
 
       afterAll(async () => {

--- a/test/e2e/app-dir-export/test/dynamic-fallback-cache-components.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-fallback-cache-components.test.ts
@@ -1,11 +1,12 @@
 import { join } from 'path'
 import { nextTestSetup } from 'e2e-utils'
-import { findPort, retry, startStaticServer, stopApp } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import fs from 'fs-extra'
+import { buildAndStartOutputExportServer } from './utils'
 
 const { next, skipped, isNextDev } = nextTestSetup({
-  files: join(__dirname, '..'),
+  files: join(__dirname, '..', 'fixtures', 'dynamic-fallback-cache-components'),
   skipDeployment: true,
   skipStart: true,
   disableAutoSkewProtection: true,
@@ -23,433 +24,10 @@ if (skipped) {
       let stopOrKill: (() => Promise<void>) | undefined
 
       beforeAll(async () => {
-        await next.patchFile('next.config.js', (content) =>
-          content.replace(
-            'trailingSlash: true,',
-            `trailingSlash: true,
-  cacheComponents: true,`
-          )
-        )
-
-        await next.patchFile(
-          'app/another/[slug]/slug-client.js',
-          `'use client'
-
-import { useParams } from 'next/navigation'
-
-export default function SlugClient() {
-  const params = useParams()
-
-  return <h1>{params.slug}</h1>
-}
-`
-        )
-
-        await next.patchFile(
-          'app/another/[slug]/page.js',
-          () => `import Link from 'next/link'
-import { Suspense } from 'react'
-import SlugClient from './slug-client'
-
-export default function Page(props) {
-  return (
-    <main>
-      <Suspense fallback={<h1>Loading slug...</h1>}>
-        <SlugClient />
-      </Suspense>
-      <ul>
-        <li>
-          <Link href="/another">Visit another page</Link>
-        </li>
-        <li>
-          <Link href="/org/acme/chat/thread-cross">Visit org thread (cross-subtree)</Link>
-        </li>
-      </ul>
-    </main>
-  )
-}
-`
-        )
-
-        await next.patchFile(
-          'app/docs/page.js',
-          `import Link from 'next/link'
-
-export default function DocsIndex() {
-  return (
-    <main>
-      <h1>Docs</h1>
-      <ul>
-        <li>
-          <Link href="/docs/guides/export/fallback">
-            docs export fallback page
-          </Link>
-        </li>
-      </ul>
-    </main>
-  )
-}
-`
-        )
-
-        await next.patchFile(
-          'app/docs/[...slug]/slug-client.js',
-          `'use client'
-
-import { useParams } from 'next/navigation'
-
-export default function DocsSlugClient() {
-  const params = useParams()
-
-  return <h1>{Array.isArray(params.slug) ? params.slug.join('/') : 'missing'}</h1>
-}
-`
-        )
-
-        await next.patchFile(
-          'app/docs/[...slug]/page.js',
-          `import Link from 'next/link'
-import { Suspense } from 'react'
-import DocsSlugClient from './slug-client'
-
-export default function DocsCatchAllPage() {
-  return (
-    <main>
-      <Suspense fallback={<h1>Loading docs...</h1>}>
-        <DocsSlugClient />
-      </Suspense>
-      <ul>
-        <li>
-          <Link href="/docs">Visit docs index</Link>
-        </li>
-      </ul>
-    </main>
-  )
-}
-`
-        )
-
-        await next.patchFile(
-          'app/optional/[[...slug]]/slug-client.js',
-          `'use client'
-
-import { useParams } from 'next/navigation'
-
-export default function OptionalSlugClient() {
-  const params = useParams()
-  const slug = params.slug
-
-  return <h1>{Array.isArray(slug) ? slug.join('/') : 'optional index'}</h1>
-}
-`
-        )
-
-        await next.patchFile(
-          'app/optional/[[...slug]]/page.js',
-          `import Link from 'next/link'
-import { Suspense } from 'react'
-import OptionalSlugClient from './slug-client'
-
-export default function OptionalCatchAllPage() {
-  return (
-    <main>
-      <Suspense fallback={<h1>Loading optional...</h1>}>
-        <OptionalSlugClient />
-      </Suspense>
-      <ul>
-        <li>
-          <Link href="/optional/deep/path">Visit optional deep path</Link>
-        </li>
-      </ul>
-    </main>
-  )
-}
-`
-        )
-
-        await next.patchFile(
-          'app/(grouped)/grouped/page.js',
-          `import Link from 'next/link'
-
-export default function GroupedIndexPage() {
-  return (
-    <main>
-      <h1>Grouped index</h1>
-      <ul>
-        <li>
-          <Link href="/grouped/from-group">Visit grouped fallback page</Link>
-        </li>
-      </ul>
-    </main>
-  )
-}
-`
-        )
-
-        await next.patchFile(
-          'app/(grouped)/grouped/[slug]/slug-client.js',
-          `'use client'
-
-import { useParams } from 'next/navigation'
-
-export default function GroupedSlugClient() {
-  const params = useParams()
-
-  return <h1>{params.slug}</h1>
-}
-`
-        )
-
-        await next.patchFile(
-          'app/(grouped)/grouped/[slug]/page.js',
-          `import Link from 'next/link'
-import { Suspense } from 'react'
-import GroupedSlugClient from './slug-client'
-
-export default function GroupedSlugPage() {
-  return (
-    <main>
-      <Suspense fallback={<h1>Loading grouped slug...</h1>}>
-        <GroupedSlugClient />
-      </Suspense>
-      <ul>
-        <li>
-          <Link href="/grouped">Visit grouped index</Link>
-        </li>
-      </ul>
-    </main>
-  )
-}
-`
-        )
-
-        await next.patchFile(
-          'app/inbox/layout.js',
-          `export default function InboxLayout({ children, modal }) {
-  return (
-    <main>
-      {children}
-      <section id="modal-slot">{modal}</section>
-    </main>
-  )
-}
-`
-        )
-
-        await next.patchFile(
-          'app/inbox/page.js',
-          `import Link from 'next/link'
-
-export default function InboxIndexPage() {
-  return (
-    <main>
-      <h1>Inbox</h1>
-      <ul>
-        <li>
-          <Link href="/inbox/thread-123">Visit inbox thread</Link>
-        </li>
-      </ul>
-    </main>
-  )
-}
-`
-        )
-
-        await next.patchFile(
-          'app/inbox/[thread]/thread-client.js',
-          `'use client'
-
-import { useParams } from 'next/navigation'
-
-export default function InboxThreadClient() {
-  const params = useParams()
-
-  return <h1>{params.thread}</h1>
-}
-`
-        )
-
-        await next.patchFile(
-          'app/inbox/[thread]/page.js',
-          `import Link from 'next/link'
-import { Suspense } from 'react'
-import InboxThreadClient from './thread-client'
-
-export default function InboxThreadPage() {
-  return (
-    <>
-      <Suspense fallback={<h1>Loading inbox thread...</h1>}>
-        <InboxThreadClient />
-      </Suspense>
-      <ul>
-        <li>
-          <Link href="/inbox">Visit inbox index</Link>
-        </li>
-      </ul>
-    </>
-  )
-}
-`
-        )
-
-        await next.patchFile(
-          'app/inbox/@modal/default.js',
-          `export default function InboxModalDefault() {
-  return <p id="modal-thread">No modal</p>
-}
-`
-        )
-
-        await next.patchFile(
-          'app/inbox/@modal/[thread]/modal-client.js',
-          `'use client'
-
-import { useParams } from 'next/navigation'
-
-export default function InboxModalClient() {
-  const params = useParams()
-
-  return <p id="modal-thread">Modal {params.thread}</p>
-}
-`
-        )
-
-        await next.patchFile(
-          'app/inbox/@modal/[thread]/page.js',
-          `import { Suspense } from 'react'
-import InboxModalClient from './modal-client'
-
-export default function InboxModalPage() {
-  return (
-    <Suspense fallback={<p id="modal-thread">Loading modal...</p>}>
-      <InboxModalClient />
-    </Suspense>
-  )
-}
-`
-        )
-
-        await next.patchFile(
-          'app/org/page.js',
-          `import Link from 'next/link'
-
-export default function OrgIndexPage() {
-  return (
-    <main>
-      <h1>Org index</h1>
-      <ul>
-        <li>
-          <Link href="/org/acme/chat/thread-123">
-            Visit org chat thread 123
-          </Link>
-        </li>
-      </ul>
-    </main>
-  )
-}
-`
-        )
-
-        await next.patchFile(
-          'app/org/[org]/org-client.js',
-          `'use client'
-
-import { useParams } from 'next/navigation'
-
-export default function OrgClient() {
-  const params = useParams()
-
-  return <p id="org-name">Org {params.org}</p>
-}
-`
-        )
-
-        await next.patchFile(
-          'app/org/[org]/layout.js',
-          `import { Suspense } from 'react'
-import OrgClient from './org-client'
-
-export default function OrgLayout({ children }) {
-  return (
-    <main>
-      <Suspense fallback={<p id="org-name">Loading org...</p>}>
-        <OrgClient />
-      </Suspense>
-      {children}
-    </main>
-  )
-}
-`
-        )
-
-        await next.patchFile(
-          'app/org/[org]/chat/[thread]/thread-client.js',
-          `'use client'
-
-import { useParams } from 'next/navigation'
-
-export default function OrgThreadClient() {
-  const params = useParams()
-
-  return <h1>{params.org}:{params.thread}</h1>
-}
-`
-        )
-
-        await next.patchFile(
-          'app/org/[org]/chat/[thread]/page.js',
-          `import Link from 'next/link'
-import { Suspense } from 'react'
-import OrgThreadClient from './thread-client'
-
-export default function OrgThreadPage() {
-  return (
-    <>
-      <Suspense fallback={<h1>Loading org thread...</h1>}>
-        <OrgThreadClient />
-      </Suspense>
-      <ul>
-        <li>
-          <Link href="/org">Visit org index</Link>
-        </li>
-        <li>
-          <Link href="/org/acme/chat/thread-456">
-            Visit org chat thread 456
-          </Link>
-        </li>
-      </ul>
-    </>
-  )
-}
-`
-        )
-
-        await next.deleteFile('app/api/json/route.js')
-        await next.deleteFile('app/api/txt/route.js')
-
-        await next.patchFile('app/another/page.js', (content) =>
-          content.replace(
-            `        <li>
-          <Link href="/image-import">image import page</Link>
-        </li>`,
-            `        <li>
-          <Link href="/another/third">another third page</Link>
-        </li>
-        <li>
-          <Link href="/image-import">image import page</Link>
-        </li>`
-          )
-        )
-
-        await next.build()
-
-        port = await findPort()
-        const app = await startStaticServer(
-          join(next.testDir, 'out'),
-          join(next.testDir, 'out', '_fallback.html'),
-          port
-        )
-        stopOrKill = () => stopApp(app)
+        ;({ port, stopOrKill } = await buildAndStartOutputExportServer(next, {
+          trailingSlash: true,
+          useFallbackDocument: true,
+        }))
       })
 
       afterAll(async () => {
@@ -696,14 +274,8 @@ export default function OrgThreadPage() {
           'utf8'
         )
 
-        // Must contain the bootstrap script
         expect(fallbackHtml).toContain('__NEXT_EXPORT_FALLBACK=1')
-
-        // Should be based on a __fallback PPR shell, not index.html.
-        // The homepage has <h1>Home</h1> which should NOT appear.
         expect(fallbackHtml).not.toContain('>Home<')
-
-        // A PPR shell should not need the visibility:hidden workaround
         expect(fallbackHtml).not.toContain('__next-export-fallback-style')
       })
 
@@ -715,19 +287,16 @@ export default function OrgThreadPage() {
             expect(await browser.elementByCss('h1').text()).toBe('slug-a')
           })
 
-          // Navigate to a static page
           await browser.elementByCss('a[href="/another/"]').click()
           await retry(async () => {
             expect(await browser.elementByCss('h1').text()).toBe('Another')
           })
 
-          // Back to the fallback route
           await browser.back()
           await retry(async () => {
             expect(await browser.elementByCss('h1').text()).toBe('slug-a')
           })
 
-          // Forward to the static page
           await browser.forward()
           await retry(async () => {
             expect(await browser.elementByCss('h1').text()).toBe('Another')
@@ -767,7 +336,6 @@ export default function OrgThreadPage() {
             expect(await browser.elementByCss('h1').text()).toBe('cross-test')
           })
 
-          // Client navigate from /another/[slug] to /org/[org]/chat/[thread]
           await browser
             .elementByCss('a[href="/org/acme/chat/thread-cross/"]')
             .click()
@@ -780,7 +348,6 @@ export default function OrgThreadPage() {
             )
           })
 
-          // Back to the original subtree
           await browser.back()
           await retry(async () => {
             expect(await browser.elementByCss('h1').text()).toBe('cross-test')
@@ -856,16 +423,12 @@ export default function OrgThreadPage() {
         const browser = await webdriver(port, '/another/suspense-test/')
 
         try {
-          // The page should eventually render the param value.
-          // During loading, the Suspense fallback "Loading slug..." is shown.
-          // We verify the final state is correct (the Suspense boundary resolved).
           await retry(async () => {
             expect(await browser.elementByCss('h1').text()).toBe(
               'suspense-test'
             )
           })
 
-          // Verify the Suspense fallback text is NOT still visible after load
           const html = await browser.eval('document.documentElement.innerHTML')
           expect(html).not.toContain('Loading slug...')
         } finally {

--- a/test/e2e/app-dir-export/test/dynamic-fallback-known-params-cache-components.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-fallback-known-params-cache-components.test.ts
@@ -1,11 +1,17 @@
 import { join } from 'path'
 import { nextTestSetup } from 'e2e-utils'
-import { findPort, retry, startStaticServer, stopApp } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import fs from 'fs-extra'
+import { buildAndStartOutputExportServer } from './utils'
 
 const { next, skipped, isNextDev } = nextTestSetup({
-  files: join(__dirname, '..'),
+  files: join(
+    __dirname,
+    '..',
+    'fixtures',
+    'dynamic-fallback-known-params-cache-components'
+  ),
   skipDeployment: true,
   skipStart: true,
   disableAutoSkewProtection: true,
@@ -23,191 +29,10 @@ if (skipped) {
       let stopOrKill: (() => Promise<void>) | undefined
 
       beforeAll(async () => {
-        await next.patchFile('next.config.js', (content) =>
-          content.replace(
-            'trailingSlash: true,',
-            `trailingSlash: true,
-  cacheComponents: true,`
-          )
-        )
-
-        await next.patchFile(
-          'app/another/[slug]/slug-client.js',
-          `'use client'
-
-import { useParams } from 'next/navigation'
-
-export default function SlugClient() {
-  const params = useParams()
-
-  return <h1>{params.slug}</h1>
-}
-`
-        )
-
-        await next.patchFile(
-          'app/another/[slug]/page.js',
-          () => `import Link from 'next/link'
-import { Suspense } from 'react'
-import SlugClient from './slug-client'
-
-export function generateStaticParams() {
-  return [{ slug: 'first' }, { slug: 'second' }]
-}
-
-export default function Page(props) {
-  return (
-    <main>
-      <Suspense fallback={<h1>Loading slug...</h1>}>
-        <SlugClient />
-      </Suspense>
-      <ul>
-        <li>
-          <Link href="/another">Visit another page</Link>
-        </li>
-        <li>
-          <Link href="/another/third">Visit another third (fallback)</Link>
-        </li>
-      </ul>
-    </main>
-  )
-}
-`
-        )
-
-        await next.patchFile(
-          'app/org/page.js',
-          `import Link from 'next/link'
-
-export default function OrgIndexPage() {
-  return (
-    <main>
-      <h1>Org index</h1>
-      <ul>
-        <li>
-          <Link href="/org/acme/chat/thread-123">
-            Visit known org chat thread
-          </Link>
-        </li>
-        <li>
-          <Link href="/org/acme/chat/thread-789">
-            Visit fallback org chat thread
-          </Link>
-        </li>
-      </ul>
-    </main>
-  )
-}
-`
-        )
-
-        await next.patchFile(
-          'app/org/[org]/org-client.js',
-          `'use client'
-
-import { useParams } from 'next/navigation'
-
-export default function OrgClient() {
-  const params = useParams()
-
-  return <p id="org-name">Org {params.org}</p>
-}
-`
-        )
-
-        await next.patchFile(
-          'app/org/[org]/layout.js',
-          `import { Suspense } from 'react'
-import OrgClient from './org-client'
-
-export default function OrgLayout({ children }) {
-  return (
-    <main>
-      <Suspense fallback={<p id="org-name">Loading org...</p>}>
-        <OrgClient />
-      </Suspense>
-      {children}
-    </main>
-  )
-}
-`
-        )
-
-        await next.patchFile(
-          'app/org/[org]/chat/[thread]/thread-client.js',
-          `'use client'
-
-import { useParams } from 'next/navigation'
-
-export default function OrgThreadClient() {
-  const params = useParams()
-
-  return <h1>{params.org}:{params.thread}</h1>
-}
-`
-        )
-
-        await next.patchFile(
-          'app/org/[org]/chat/[thread]/page.js',
-          `import Link from 'next/link'
-import { Suspense } from 'react'
-import OrgThreadClient from './thread-client'
-
-export function generateStaticParams() {
-  return [
-    { org: 'acme', thread: 'thread-123' },
-    { org: 'acme', thread: 'thread-456' },
-  ]
-}
-
-export default function OrgThreadPage() {
-  return (
-    <>
-      <Suspense fallback={<h1>Loading org thread...</h1>}>
-        <OrgThreadClient />
-      </Suspense>
-      <ul>
-        <li>
-          <Link href="/org">Visit org index</Link>
-        </li>
-        <li>
-          <Link href="/org/acme/chat/thread-789">
-            Visit fallback org chat thread
-          </Link>
-        </li>
-      </ul>
-    </>
-  )
-}
-`
-        )
-
-        await next.deleteFile('app/api/json/route.js')
-        await next.deleteFile('app/api/txt/route.js')
-
-        await next.patchFile('app/another/page.js', (content) =>
-          content.replace(
-            `        <li>
-          <Link href="/image-import">image import page</Link>
-        </li>`,
-            `        <li>
-          <Link href="/another/third">another third page</Link>
-        </li>
-        <li>
-          <Link href="/image-import">image import page</Link>
-        </li>`
-          )
-        )
-
-        await next.build()
-
-        port = await findPort()
-        const app = await startStaticServer(
-          join(next.testDir, 'out'),
-          join(next.testDir, 'out', '_fallback.html'),
-          port
-        )
-        stopOrKill = () => stopApp(app)
+        ;({ port, stopOrKill } = await buildAndStartOutputExportServer(next, {
+          trailingSlash: true,
+          useFallbackDocument: true,
+        }))
       })
 
       afterAll(async () => {
@@ -297,7 +122,6 @@ export default function OrgThreadPage() {
       })
 
       it('client navigates from a prerendered page to a fallback route', async () => {
-        // Start on a prerendered page (known from generateStaticParams)
         const browser = await webdriver(port, '/another/first/')
 
         try {
@@ -305,19 +129,16 @@ export default function OrgThreadPage() {
             expect(await browser.elementByCss('h1').text()).toBe('first')
           })
 
-          // Client navigate to an unenumerated slug (fallback)
           await browser.elementByCss('a[href="/another/third/"]').click()
           await retry(async () => {
             expect(await browser.elementByCss('h1').text()).toBe('third')
           })
 
-          // Navigate back to the prerendered page
           await browser.elementByCss('a[href="/another/"]').click()
           await retry(async () => {
             expect(await browser.elementByCss('h1').text()).toBe('Another')
           })
 
-          // Navigate to a different prerendered page
           await browser.elementByCss('a[href="/another/first/"]').click()
           await retry(async () => {
             expect(await browser.elementByCss('h1').text()).toBe('first')
@@ -328,7 +149,6 @@ export default function OrgThreadPage() {
       })
 
       it('client navigates from a fallback route to a prerendered page', async () => {
-        // Start on a fallback route (not in generateStaticParams)
         const browser = await webdriver(port, '/org/acme/chat/thread-789/')
 
         try {
@@ -338,7 +158,6 @@ export default function OrgThreadPage() {
             )
           })
 
-          // Client navigate to a prerendered page (known from generateStaticParams)
           await browser.elementByCss('a[href="/org/"]').click()
           await retry(async () => {
             expect(await browser.elementByCss('h1').text()).toBe('Org index')
@@ -370,7 +189,6 @@ export default function OrgThreadPage() {
             )
           })
 
-          // Client navigate to a fallback param
           await browser
             .elementByCss('a[href="/org/acme/chat/thread-789/"]')
             .click()
@@ -380,7 +198,6 @@ export default function OrgThreadPage() {
             )
           })
 
-          // Browser back to the prerendered page
           await browser.back()
           await retry(async () => {
             expect(await browser.elementByCss('h1').text()).toBe(

--- a/test/e2e/app-dir-export/test/utils.ts
+++ b/test/e2e/app-dir-export/test/utils.ts
@@ -4,6 +4,9 @@ import { join } from 'path'
 import { promisify } from 'util'
 import fs from 'fs-extra'
 import globOrig from 'glob'
+import express from 'express'
+import http from 'http'
+import { createReadStream } from 'fs'
 import {
   waitForRedbox,
   getRedboxHeader,
@@ -18,6 +21,68 @@ import { nextTestSetup } from 'e2e-utils'
 import webdriver from 'next-webdriver'
 
 const glob = promisify(globOrig)
+
+type ExportTestNext = {
+  build(): Promise<void>
+  testDir: string
+}
+
+export async function buildAndStartOutputExportServer(
+  next: Pick<ExportTestNext, 'build' | 'testDir'>,
+  {
+    trailingSlash,
+    useFallbackDocument,
+  }: {
+    trailingSlash: boolean
+    useFallbackDocument: boolean
+  }
+) {
+  await next.build()
+
+  const port = await findPort()
+  const outDir = join(next.testDir, 'out')
+
+  if (!useFallbackDocument) {
+    const app = await startStaticServer(outDir, null, port)
+    return {
+      port,
+      stopOrKill: () => stopApp(app),
+    }
+  }
+
+  if (trailingSlash) {
+    const app = await startStaticServer(
+      outDir,
+      join(outDir, '_fallback.html'),
+      port
+    )
+    return {
+      port,
+      stopOrKill: () => stopApp(app),
+    }
+  }
+
+  const app = express()
+  const server = http.createServer(app)
+  const fallbackHtml = join(outDir, '_fallback.html')
+
+  app.use(
+    express.static(outDir, {
+      extensions: ['html'],
+      redirect: false,
+    })
+  )
+  app.use((req, res) => {
+    createReadStream(fallbackHtml).pipe(res)
+  })
+
+  await new Promise<void>((resolve) => server.listen(port, resolve))
+
+  return {
+    port,
+    stopOrKill: () => stopApp(server),
+  }
+}
 
 export const expectedWhenTrailingSlashTrue = [
   '404.html',

--- a/test/e2e/app-dir-export/test/utils.ts
+++ b/test/e2e/app-dir-export/test/utils.ts
@@ -17,18 +17,13 @@ import {
   stopApp,
   fetchViaHTTP,
 } from 'next-test-utils'
-import { nextTestSetup } from 'e2e-utils'
+import { nextTestSetup, type NextInstance } from 'e2e-utils'
 import webdriver from 'next-webdriver'
 
 const glob = promisify(globOrig)
 
-type ExportTestNext = {
-  build(): Promise<void>
-  testDir: string
-}
-
 export async function buildAndStartOutputExportServer(
-  next: Pick<ExportTestNext, 'build' | 'testDir'>,
+  next: Pick<NextInstance, 'build' | 'testDir'>,
   {
     trailingSlash,
     useFallbackDocument,


### PR DESCRIPTION
## Summary
- Move the fallback export e2e suites onto dedicated fixture apps instead of patching repo files inline.
- Keep the shared export test server helper typed and reusable for the later stack layers.

## Why
- The later runtime slices depend on stable fixture apps and a shared test harness. Pulling that support work into its own PR keeps the higher-level runtime PRs easier to review.

## Validation
- `pnpm --filter=next build`
- `NEXT_SKIP_ISOLATE=1 NEXT_TEST_MODE=start pnpm testheadless test/e2e/app-dir-export/test/dynamic-fallback-cache-components-flat.test.ts test/e2e/app-dir-export/test/dynamic-fallback-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-known-params-cache-components.test.ts`

## Stack
- Previous: [#93013](https://github.com/vercel/next.js/pull/93013)
- Next: [#93015](https://github.com/vercel/next.js/pull/93015)

Full stack:
1. [#93013](https://github.com/vercel/next.js/pull/93013) output export fallback: cover flat fallbacks and fix resume path
2. [#93014](https://github.com/vercel/next.js/pull/93014) output export fallback: move fallback e2e suites onto fixtures <- current
3. [#93015](https://github.com/vercel/next.js/pull/93015) output export fallback: support conflicting routes
4. [#93016](https://github.com/vercel/next.js/pull/93016) output export fallback: hide the bootstrap shell
5. [#93017](https://github.com/vercel/next.js/pull/93017) output export fallback: guard server-only APIs
6. [#93018](https://github.com/vercel/next.js/pull/93018) output export fallback: cover server IO boundaries
7. [#93019](https://github.com/vercel/next.js/pull/93019) output export fallback: avoid fallback document URL swaps
8. [#93020](https://github.com/vercel/next.js/pull/93020) output export fallback: prefetch and dedupe fallback payloads
9. [#93021](https://github.com/vercel/next.js/pull/93021) output export fallback: carry fallback bases through hydration
10. [#93022](https://github.com/vercel/next.js/pull/93022) output export fallback: prefer deeper static prefixes
11. [#92555](https://github.com/vercel/next.js/pull/92555) output export fallback: recover unmatched routes with _not-found

<!-- NEXT_JS_LLM_PR -->
