### PR TITLE
output export fallback: support conflicting routes

### DIFF
--- a/docs/01-app/02-guides/static-exports.mdx
+++ b/docs/01-app/02-guides/static-exports.mdx
@@ -210,6 +210,14 @@ export function generateStaticParams() {
 }
 ```
 
+If multiple dynamic route patterns share the same static prefix, fallback matching follows the same specificity rules as the App Router:
+
+- Static segments are matched before dynamic segments.
+- Dynamic segments are matched before catch-all segments.
+- Catch-all segments are matched before optional catch-all segments.
+
+For example, `/docs/[section]/[page]` is matched before `/docs/[...slug]`, so `/docs/api/reference` uses the more specific route while `/docs/guides/export/fallback` still falls through to the catch-all route.
+
 #### Static host configuration
 
 To serve unenumerated params on a static host, configure the host's 404 or error document to serve `_fallback.html` from the export output:

--- a/docs/01-app/03-api-reference/03-file-conventions/dynamic-routes.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/dynamic-routes.mdx
@@ -150,7 +150,7 @@ When using [Cache Components](/docs/app/getting-started/caching) with dynamic ro
 
 Without `generateStaticParams`, param values are unknown during prerendering, making params runtime data. You must wrap param access in `<Suspense>` boundaries to provide fallback UI.
 
-With `generateStaticParams`, you provide sample param values that can be used at build time. The build process validates that dynamic content and other runtime APIs are correctly handled, then generates static HTML files for the samples. Pages rendered with runtime params are saved to disk after a successful first request.
+With `generateStaticParams`, you provide sample param values that can be used at build time. The build process validates that dynamic content and other runtime APIs are correctly handled, then generates static HTML files for the samples. On server deployments, pages rendered with runtime params are saved to disk after a successful first request. With [`output: 'export'`](/docs/app/guides/static-exports), unknown params instead use the export fallback shell and continue rendering on the client until you rebuild.
 
 The sections below demonstrate both patterns.
 
@@ -194,6 +194,8 @@ async function Content({ slug }: { slug: string }) {
 Provide params ahead of time to prerender pages at build time. You can prerender all routes or a subset depending on your needs.
 
 During the build process, the route is executed with each sample param to collect the HTML result. If dynamic content or runtime data are accessed incorrectly, the build will fail.
+
+When multiple dynamic route patterns overlap, matching still follows normal App Router specificity. For example, `/docs/[section]/[page]` is matched before `/docs/[...slug]`.
 
 ```tsx filename="app/blog/[slug]/page.tsx" highlight={3-5,8,19}
 import { Suspense } from 'react'

--- a/docs/01-app/03-api-reference/04-functions/generate-static-params.mdx
+++ b/docs/01-app/03-api-reference/04-functions/generate-static-params.mdx
@@ -313,6 +313,8 @@ For server deployments, `generateStaticParams` must return **at least one param*
 
 When using [`output: 'export'`](/docs/app/guides/static-exports) with App Router dynamic routes, `generateStaticParams` becomes optional when `cacheComponents: true` is enabled. If you omit it, Next.js emits a fallback shell for the route and resolves param-dependent content on the client. If you provide it, the returned params are prerendered and all other params use the fallback shell.
 
+When multiple dynamic route patterns share the same static prefix in `output: 'export'`, the fallback shell still follows normal App Router route specificity. For example, if both `/docs/[section]/[page]` and `/docs/[...slug]` exist, params returned by `generateStaticParams` for the specific route are prerendered as usual, while unknown params still fall back and match the most specific route first.
+
 > **Good to know**: If you don't know the actual param values at build time, you can return a placeholder param (e.g., `[{ slug: '__placeholder__' }]`) for validation, then handle it in your page with `notFound()`. However, this prevents build time validation from working effectively and may cause runtime errors.
 
 See the [dynamic routes section](/docs/app/api-reference/file-conventions/dynamic-routes#with-cache-components) for detailed walkthroughs.

--- a/packages/next/src/client/output-export-fallback.test.ts
+++ b/packages/next/src/client/output-export-fallback.test.ts
@@ -119,7 +119,60 @@ describe('output export fallback helpers', () => {
     expect(result).not.toBeNull()
     expect(result?.renderedUrl.href).toBe(renderedUrl.href)
     expect(fetchMock.mock.calls.map(([url]) => String(url))).toEqual([
+      'https://example.com/org/__fallback.meta.json',
       'https://example.com/org/__fallback.txt',
+    ])
+  })
+
+  it('uses fallback metadata to select the most specific conflicting route', async () => {
+    const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url.endsWith('/docs/__fallback.meta.json')) {
+        return new Response(
+          JSON.stringify({
+            version: 1,
+            routes: [
+              {
+                route: '/docs/[section]/[page]',
+                fallbackPath: '/docs/__fallback/__route_0',
+              },
+              {
+                route: '/docs/[...slug]',
+                fallbackPath: '/docs/__fallback/__route_1',
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }
+        )
+      }
+
+      if (url.endsWith('/docs/__fallback/__route_0.txt')) {
+        return new Response('payload', {
+          status: 200,
+          headers: { 'content-type': 'text/plain' },
+        })
+      }
+
+      return new Response('not found', {
+        status: 404,
+        headers: { 'content-type': 'text/html' },
+      })
+    })
+
+    global.fetch = fetchMock as typeof fetch
+
+    const renderedUrl = new URL('https://example.com/docs/api/reference')
+    const result = await fetchOutputExportFallbackResponse(renderedUrl)
+
+    expect(result).not.toBeNull()
+    expect(result?.fallbackUrl.pathname).toBe('/docs/__fallback/__route_0')
+    expect(fetchMock.mock.calls.map(([url]) => String(url))).toEqual([
+      'https://example.com/docs/__fallback.meta.json',
+      'https://example.com/docs/__fallback/__route_0.txt',
     ])
   })
 })

--- a/packages/next/src/client/output-export-fallback.ts
+++ b/packages/next/src/client/output-export-fallback.ts
@@ -1,5 +1,11 @@
-import { getOutputExportFallbackPath } from '../lib/output-export-dynamic-fallback'
+import {
+  getOutputExportFallbackMetadataPath,
+  getOutputExportFallbackPath,
+  type OutputExportFallbackManifestEntry,
+} from '../lib/output-export-dynamic-fallback'
 import { RSC_CONTENT_TYPE_HEADER } from './components/app-router-headers'
+import { getRouteMatcher } from '../shared/lib/router/utils/route-matcher'
+import { getRouteRegex } from '../shared/lib/router/utils/route-regex'
 
 export function getOutputExportFallbackCandidates(pathname: string): string[] {
   const segments = pathname.split('/').filter(Boolean)
@@ -33,6 +39,46 @@ export function stripOutputExportDataSuffix(url: URL): URL {
     nextUrl.pathname = `${nextUrl.pathname.slice(0, -4)}.html`
   }
   return nextUrl
+}
+
+function getOutputExportFallbackMetadataUrl(url: URL): URL {
+  const nextUrl = new URL(url)
+  nextUrl.pathname = getOutputExportFallbackMetadataPath(nextUrl.pathname)
+  return nextUrl
+}
+
+function matchOutputExportFallbackManifestEntry(
+  entry: OutputExportFallbackManifestEntry,
+  pathname: string
+): boolean {
+  const matcher = getRouteMatcher(getRouteRegex(entry.route))
+  return matcher(pathname) !== false
+}
+
+async function fetchOutputExportFallbackManifest(
+  fallbackUrl: URL,
+  init?: RequestInit
+): Promise<{
+  version: 1
+  routes: OutputExportFallbackManifestEntry[]
+} | null> {
+  const metadataResponse = await fetch(
+    getOutputExportFallbackMetadataUrl(fallbackUrl),
+    init
+  )
+  if (!metadataResponse.ok) {
+    return null
+  }
+
+  const contentType = metadataResponse.headers.get('content-type') || ''
+  if (
+    !contentType.startsWith('application/json') &&
+    !contentType.startsWith('text/json')
+  ) {
+    return null
+  }
+
+  return metadataResponse.json()
 }
 
 function getOutputExportDataCandidates(url: URL): URL[] {
@@ -78,6 +124,35 @@ export async function fetchOutputExportFallbackResponse(
   )) {
     const candidateUrl = new URL(renderedUrl)
     candidateUrl.pathname = candidate
+
+    const fallbackManifest = await fetchOutputExportFallbackManifest(
+      candidateUrl,
+      init
+    )
+    if (fallbackManifest !== null) {
+      for (const entry of fallbackManifest.routes) {
+        if (
+          !matchOutputExportFallbackManifestEntry(entry, renderedUrl.pathname)
+        ) {
+          continue
+        }
+
+        const branchFallbackUrl = new URL(renderedUrl)
+        branchFallbackUrl.pathname = entry.fallbackPath
+
+        const response = await fetchOutputExportDataResponse(
+          branchFallbackUrl,
+          init
+        )
+        if (response) {
+          return {
+            response,
+            renderedUrl,
+            fallbackUrl: branchFallbackUrl,
+          }
+        }
+      }
+    }
 
     const response = await fetchOutputExportDataResponse(candidateUrl, init)
     if (response) {

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -28,8 +28,10 @@ import {
 } from '../lib/constants'
 import { recursiveCopy } from '../lib/recursive-copy'
 import {
+  getOutputExportFallbackMetadataPath,
   getOutputExportFallbackPath,
   getOutputExportFallbackStaticPrefix,
+  getOutputExportFallbackVariantPath,
   isOutputExportDynamicFallbackEnabled,
   isOutputExportOptimisticRoutingEnabled,
 } from '../lib/output-export-dynamic-fallback'
@@ -80,6 +82,7 @@ import { isDynamicRoute } from '../shared/lib/router/utils/is-dynamic'
 import { normalizeAppPath } from '../shared/lib/router/utils/app-paths'
 import type { Params } from '../server/request/params'
 import { Bundler } from '../lib/bundler'
+import { getSortedRoutes } from '../shared/lib/router/utils'
 
 export class ExportError extends Error {
   code = 'NEXT_EXPORT_ERROR'
@@ -1018,95 +1021,174 @@ async function exportAppImpl(
     )
 
     const fallbackHtmlPaths: string[] = []
+    const fallbackEntriesByRoute = new Map<
+      string,
+      Array<{
+        dynamicRoute: string
+        orig: string
+      }>
+    >()
+
+    for (const [dynamicRoute, prerenderInfo] of Object.entries(
+      prerenderManifest.dynamicRoutes
+    )) {
+      if (
+        !prerenderInfo.fallbackSourceRoute ||
+        !prerenderInfo.fallbackRouteParams ||
+        prerenderInfo.fallbackRouteParams.length === 0
+      ) {
+        continue
+      }
+
+      const fallbackRoute = getFallbackExportPath(dynamicRoute)
+      if (!fallbackRoute) {
+        continue
+      }
+
+      const appPageName = mapAppRouteToPage.get(
+        prerenderInfo.fallbackSourceRoute
+      )
+      if (!appPageName) {
+        continue
+      }
+
+      const pagePath = getPagePath(appPageName, distDir, undefined, true)
+      const distPagesDir = join(
+        pagePath,
+        appPageName
+          .slice(1)
+          .split('/')
+          .map(() => '..')
+          .join('/')
+      )
+
+      const sourceRoute = normalizePagePath(dynamicRoute)
+      const orig = join(distPagesDir, sourceRoute)
+      const htmlSrc = `${orig}.html`
+      const jsonSrc = `${orig}${RSC_SUFFIX}`
+
+      if (!existsSync(htmlSrc) || !existsSync(jsonSrc)) {
+        continue
+      }
+
+      const entries = fallbackEntriesByRoute.get(fallbackRoute)
+      const entry = {
+        dynamicRoute,
+        orig,
+      }
+      if (entries) {
+        entries.push(entry)
+      } else {
+        fallbackEntriesByRoute.set(fallbackRoute, [entry])
+      }
+    }
+
+    async function emitFallbackArtifacts(
+      fallbackRoute: string,
+      orig: string,
+      checkRouteCollision: boolean
+    ) {
+      const route = normalizePagePath(fallbackRoute)
+      const htmlDest = join(
+        outDir,
+        `${route}${subFolders && route !== '/index' ? `${sep}index` : ''}.html`
+      )
+      const jsonDest = join(
+        outDir,
+        `${route}${subFolders && route !== '/index' ? `${sep}index` : ''}.txt`
+      )
+
+      if (
+        checkRouteCollision &&
+        (existsSync(htmlDest) || existsSync(jsonDest))
+      ) {
+        throw new ExportError(
+          `The route "${fallbackRoute}" conflicts with the internal "__fallback" path used by dynamic route fallbacks in static export mode. ` +
+            `Please rename this route to something else.\n\n` +
+            `Learn more: https://nextjs.org/docs/app/guides/static-exports`
+        )
+      }
+
+      await fs.mkdir(dirname(htmlDest), { recursive: true })
+      await fs.mkdir(dirname(jsonDest), { recursive: true })
+      await fs.copyFile(`${orig}.html`, htmlDest)
+      await fs.copyFile(`${orig}${RSC_SUFFIX}`, jsonDest)
+      fallbackHtmlPaths.push(htmlDest)
+
+      const segmentsDir = `${orig}${RSC_SEGMENTS_DIR_SUFFIX}`
+      if (existsSync(segmentsDir)) {
+        const segmentsDirDest = join(outDir, fallbackRoute)
+        const segmentPaths = await collectSegmentPaths(segmentsDir)
+        await Promise.all(
+          segmentPaths.map(async (segmentFileSrc) => {
+            const segmentPath =
+              '/' + segmentFileSrc.slice(0, -RSC_SEGMENT_SUFFIX.length)
+            const segmentFilename =
+              convertSegmentPathToStaticExportFilename(segmentPath)
+            const segmentFileDest = join(segmentsDirDest, segmentFilename)
+            await fs.mkdir(dirname(segmentFileDest), { recursive: true })
+            await fs.copyFile(
+              join(segmentsDir, segmentFileSrc),
+              segmentFileDest
+            )
+          })
+        )
+      }
+    }
 
     await Promise.all(
-      Object.entries(prerenderManifest.dynamicRoutes).map(
-        async ([dynamicRoute, prerenderInfo]) => {
-          if (
-            !prerenderInfo.fallbackSourceRoute ||
-            !prerenderInfo.fallbackRouteParams ||
-            prerenderInfo.fallbackRouteParams.length === 0
-          ) {
+      Array.from(fallbackEntriesByRoute.entries()).map(
+        async ([fallbackRoute, entries]) => {
+          if (entries.length === 1) {
+            await emitFallbackArtifacts(fallbackRoute, entries[0].orig, true)
             return
           }
 
-          const fallbackRoute = getFallbackExportPath(dynamicRoute)
-          if (!fallbackRoute) {
-            return
-          }
-
-          const appPageName = mapAppRouteToPage.get(
-            prerenderInfo.fallbackSourceRoute
+          const sortedDynamicRoutes = getSortedRoutes(
+            entries.map((entry) => entry.dynamicRoute)
           )
-          if (!appPageName) {
-            return
-          }
-
-          const pagePath = getPagePath(appPageName, distDir, undefined, true)
-          const distPagesDir = join(
-            pagePath,
-            appPageName
-              .slice(1)
-              .split('/')
-              .map(() => '..')
-              .join('/')
+          const sortedEntries = sortedDynamicRoutes.map(
+            (dynamicRoute) =>
+              entries.find((entry) => entry.dynamicRoute === dynamicRoute)!
           )
 
-          const sourceRoute = normalizePagePath(dynamicRoute)
-          const route = normalizePagePath(fallbackRoute)
-          const orig = join(distPagesDir, sourceRoute)
-          const htmlSrc = `${orig}.html`
-          const jsonSrc = `${orig}${RSC_SUFFIX}`
-
-          if (!existsSync(htmlSrc) || !existsSync(jsonSrc)) {
-            return
-          }
-
-          const htmlDest = join(
-            outDir,
-            `${route}${subFolders && route !== '/index' ? `${sep}index` : ''}.html`
-          )
-          const jsonDest = join(
-            outDir,
-            `${route}${subFolders && route !== '/index' ? `${sep}index` : ''}.txt`
-          )
-
-          // Check for route name collision: a user-defined route may
-          // already occupy the __fallback path (e.g. app/blog/__fallback/page.js)
-          if (existsSync(htmlDest) || existsSync(jsonDest)) {
-            throw new ExportError(
-              `The route "${fallbackRoute}" conflicts with the internal "__fallback" path used by dynamic route fallbacks in static export mode. ` +
-                `Please rename this route to something else.\n\n` +
-                `Learn more: https://nextjs.org/docs/app/guides/static-exports`
+          const manifestEntries = sortedEntries.map((entry, index) => {
+            const variantFallbackPath = getOutputExportFallbackVariantPath(
+              fallbackRoute,
+              index
             )
-          }
+            return {
+              route: entry.dynamicRoute,
+              fallbackPath: variantFallbackPath,
+              orig: entry.orig,
+            }
+          })
 
-          await fs.mkdir(dirname(htmlDest), { recursive: true })
-          await fs.mkdir(dirname(jsonDest), { recursive: true })
-          await fs.copyFile(htmlSrc, htmlDest)
-          await fs.copyFile(jsonSrc, jsonDest)
-          fallbackHtmlPaths.push(htmlDest)
-
-          const segmentsDir = `${orig}${RSC_SEGMENTS_DIR_SUFFIX}`
-
-          if (existsSync(segmentsDir)) {
-            const segmentsDirDest = join(outDir, fallbackRoute)
-            const segmentPaths = await collectSegmentPaths(segmentsDir)
-            await Promise.all(
-              segmentPaths.map(async (segmentFileSrc) => {
-                const segmentPath =
-                  '/' + segmentFileSrc.slice(0, -RSC_SEGMENT_SUFFIX.length)
-                const segmentFilename =
-                  convertSegmentPathToStaticExportFilename(segmentPath)
-                const segmentFileDest = join(segmentsDirDest, segmentFilename)
-                await fs.mkdir(dirname(segmentFileDest), { recursive: true })
-                await fs.copyFile(
-                  join(segmentsDir, segmentFileSrc),
-                  segmentFileDest
-                )
-              })
+          const manifestPath = join(
+            outDir,
+            getOutputExportFallbackMetadataPath(fallbackRoute)
+          )
+          await fs.mkdir(dirname(manifestPath), { recursive: true })
+          await fs.writeFile(
+            manifestPath,
+            JSON.stringify(
+              {
+                version: 1,
+                routes: manifestEntries.map(({ route, fallbackPath }) => ({
+                  route,
+                  fallbackPath,
+                })),
+              },
+              null,
+              2
             )
-          }
+          )
+
+          await Promise.all(
+            manifestEntries.map(({ fallbackPath, orig }) =>
+              emitFallbackArtifacts(fallbackPath, orig, false)
+            )
+          )
         }
       )
     )

--- a/packages/next/src/lib/output-export-dynamic-fallback.test.ts
+++ b/packages/next/src/lib/output-export-dynamic-fallback.test.ts
@@ -1,6 +1,9 @@
 import {
+  getOutputExportFallbackConflicts,
+  getOutputExportFallbackMetadataPath,
   getOutputExportFallbackPath,
   getOutputExportFallbackStaticPrefix,
+  getOutputExportFallbackVariantPath,
   isOutputExportDynamicFallbackEnabled,
   isOutputExportOptimisticRoutingEnabled,
   isOutputExportVaryParamsEnabled,
@@ -12,6 +15,12 @@ describe('output export dynamic fallback flags', () => {
       '/org/acme/chat/__fallback'
     )
     expect(getOutputExportFallbackPath('')).toBe('/__fallback')
+    expect(getOutputExportFallbackMetadataPath('/org/__fallback')).toBe(
+      '/org/__fallback.meta.json'
+    )
+    expect(getOutputExportFallbackVariantPath('/org/__fallback', 1)).toBe(
+      '/org/__fallback/__route_1'
+    )
   })
 
   it('derives the static prefix before the first dynamic segment', () => {
@@ -22,6 +31,31 @@ describe('output export dynamic fallback flags', () => {
       ''
     )
     expect(getOutputExportFallbackStaticPrefix('/org/acme/chat')).toBeNull()
+  })
+
+  it('detects conflicting dynamic fallback routes that share one static prefix', () => {
+    expect(
+      getOutputExportFallbackConflicts([
+        '/docs/[...slug]',
+        '/docs/[section]/[page]',
+        '/blog/[slug]',
+      ])
+    ).toEqual([
+      {
+        fallbackPath: '/docs/__fallback',
+        routes: ['/docs/[...slug]', '/docs/[section]/[page]'],
+      },
+    ])
+  })
+
+  it('does not flag non-conflicting fallback routes with different prefixes', () => {
+    expect(
+      getOutputExportFallbackConflicts([
+        '/org/[org]/chat/[thread]',
+        '/org/acme/chat/[thread]',
+        '/docs/[...slug]',
+      ])
+    ).toEqual([])
   })
 
   it('enables export fallback only for output export with cache components', () => {

--- a/packages/next/src/lib/output-export-dynamic-fallback.ts
+++ b/packages/next/src/lib/output-export-dynamic-fallback.ts
@@ -7,8 +7,31 @@ type OutputExportDynamicFallbackConfig = {
   }
 }
 
+type OutputExportFallbackConflict = {
+  fallbackPath: string
+  routes: string[]
+}
+
+export type OutputExportFallbackManifestEntry = {
+  route: string
+  fallbackPath: string
+}
+
 export function getOutputExportFallbackPath(staticPrefix: string): string {
   return staticPrefix.length > 0 ? `/${staticPrefix}/__fallback` : '/__fallback'
+}
+
+export function getOutputExportFallbackMetadataPath(
+  fallbackPath: string
+): string {
+  return `${fallbackPath}.meta.json`
+}
+
+export function getOutputExportFallbackVariantPath(
+  fallbackPath: string,
+  index: number
+): string {
+  return `${fallbackPath}/__route_${index}`
 }
 
 export function getOutputExportFallbackStaticPrefix(
@@ -24,6 +47,45 @@ export function getOutputExportFallbackStaticPrefix(
   }
 
   return segments.slice(0, firstDynamicIndex).join('/')
+}
+
+export function getOutputExportFallbackConflicts(
+  routePaths: Iterable<string>
+): OutputExportFallbackConflict[] {
+  const fallbackPathToRoutes = new Map<string, string[]>()
+
+  for (const routePath of routePaths) {
+    const staticPrefix = getOutputExportFallbackStaticPrefix(routePath)
+    if (staticPrefix === null) {
+      continue
+    }
+
+    const fallbackPath = getOutputExportFallbackPath(staticPrefix)
+    const routes = fallbackPathToRoutes.get(fallbackPath)
+    if (routes) {
+      routes.push(routePath)
+    } else {
+      fallbackPathToRoutes.set(fallbackPath, [routePath])
+    }
+  }
+
+  const conflicts: OutputExportFallbackConflict[] = []
+  for (const [fallbackPath, routes] of fallbackPathToRoutes) {
+    if (routes.length > 1) {
+      conflicts.push({
+        fallbackPath,
+        routes: routes.sort(),
+      })
+    }
+  }
+
+  return conflicts.sort((a, b) =>
+    a.fallbackPath < b.fallbackPath
+      ? -1
+      : a.fallbackPath > b.fallbackPath
+        ? 1
+        : 0
+  )
 }
 
 export function isOutputExportDynamicFallbackEnabled(

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/app/docs/[...slug]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/app/docs/[...slug]/page.js
@@ -1,0 +1,12 @@
+import { Suspense } from 'react'
+import DocsCatchAllClient from './slug-client'
+
+export default function DocsCatchAllPage() {
+  return (
+    <main>
+      <Suspense fallback={<h1>Loading docs catch-all...</h1>}>
+        <DocsCatchAllClient />
+      </Suspense>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/app/docs/[...slug]/slug-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/app/docs/[...slug]/slug-client.js
@@ -1,0 +1,15 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function DocsCatchAllClient() {
+  const params = useParams()
+
+  return (
+    <h1>
+      {Array.isArray(params.slug)
+        ? `catchall:${params.slug.join('/')}`
+        : 'catchall:missing'}
+    </h1>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/app/docs/[section]/[page]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/app/docs/[section]/[page]/page.js
@@ -1,0 +1,16 @@
+import { Suspense } from 'react'
+import DocsSectionPageClient from './params-client'
+
+export function generateStaticParams() {
+  return [{ section: 'api', page: 'reference' }]
+}
+
+export default function DocsSectionPage() {
+  return (
+    <main>
+      <Suspense fallback={<h1>Loading docs section page...</h1>}>
+        <DocsSectionPageClient />
+      </Suspense>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/app/docs/[section]/[page]/params-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/app/docs/[section]/[page]/params-client.js
@@ -1,0 +1,13 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function DocsSectionPageClient() {
+  const params = useParams()
+
+  return (
+    <h1>
+      {params.section}:{params.page}
+    </h1>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/app/docs/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/app/docs/page.js
@@ -1,0 +1,3 @@
+export default function DocsIndexPage() {
+  return <h1>Docs</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/app/layout.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/app/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/app/page.js
@@ -1,0 +1,10 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <main>
+      <h1>Home</h1>
+      <Link href="/docs/guides/export/fallback">Visit docs fallback route</Link>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/next.config.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/next.config.js
@@ -1,0 +1,9 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  output: 'export',
+  cacheComponents: true,
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir-export/test/dynamic-fallback-conflict.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-fallback-conflict.test.ts
@@ -1,0 +1,118 @@
+import { join } from 'path'
+import fs from 'fs-extra'
+import { nextTestSetup } from 'e2e-utils'
+import webdriver from 'next-webdriver'
+import { retry } from 'next-test-utils'
+import { buildAndStartOutputExportServer } from './utils'
+
+describe('app dir - output export fallback conflicts', () => {
+  const { next, skipped } = nextTestSetup({
+    files: join(__dirname, '..', 'fixtures', 'dynamic-fallback-conflict'),
+    skipStart: true,
+    skipDeployment: true,
+    disableAutoSkewProtection: true,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  let port: number
+  let stopOrKill: (() => Promise<void>) | undefined
+
+  beforeAll(async () => {
+    ;({ port, stopOrKill } = await buildAndStartOutputExportServer(next, {
+      trailingSlash: true,
+      useFallbackDocument: true,
+    }))
+  })
+
+  afterAll(async () => {
+    await stopOrKill?.()
+  })
+
+  it('emits fallback metadata and branch-specific fallback artifacts', async () => {
+    const outDir = join(next.testDir, 'out')
+    const manifestPath = join(outDir, 'docs', '__fallback.meta.json')
+    const knownSpecificParamExists =
+      (await fs.pathExists(
+        join(outDir, 'docs', 'api', 'reference', 'index.html')
+      )) || (await fs.pathExists(join(outDir, 'docs', 'api', 'reference.html')))
+    const unknownSpecificParamExists =
+      (await fs.pathExists(
+        join(outDir, 'docs', 'api', 'guide', 'index.html')
+      )) || (await fs.pathExists(join(outDir, 'docs', 'api', 'guide.html')))
+
+    expect(await fs.pathExists(join(outDir, '_fallback.html'))).toBe(true)
+    expect(await fs.pathExists(manifestPath)).toBe(true)
+    expect(knownSpecificParamExists).toBe(true)
+    expect(unknownSpecificParamExists).toBe(false)
+
+    const manifest = await fs.readJson(manifestPath)
+    expect(manifest).toEqual({
+      version: 1,
+      routes: [
+        {
+          route: '/docs/[section]/[page]',
+          fallbackPath: '/docs/__fallback/__route_0',
+        },
+        {
+          route: '/docs/[...slug]',
+          fallbackPath: '/docs/__fallback/__route_1',
+        },
+      ],
+    })
+
+    for (const entry of manifest.routes) {
+      const relativeFallbackPath = entry.fallbackPath.slice(1)
+      const hasBranchPayload =
+        (await fs.pathExists(join(outDir, `${relativeFallbackPath}.txt`))) ||
+        (await fs.pathExists(join(outDir, relativeFallbackPath, 'index.txt')))
+
+      expect(hasBranchPayload).toBe(true)
+    }
+  })
+
+  it('keeps known params prerendered while unknown params on the same branch fall back', async () => {
+    const browser = await webdriver(port, '/docs/api/reference/')
+
+    try {
+      await retry(async () => {
+        expect(await browser.elementByCss('h1').text()).toBe('api:reference')
+      })
+
+      await browser.get(`http://localhost:${port}/docs/api/guide/`)
+      await retry(async () => {
+        expect(await browser.elementByCss('h1').text()).toBe('api:guide')
+      })
+    } finally {
+      await browser.close()
+    }
+  })
+
+  it('prefers the more specific route when multiple fallback branches match', async () => {
+    const browser = await webdriver(port, '/docs/api/reference/')
+
+    try {
+      await retry(async () => {
+        expect(await browser.elementByCss('h1').text()).toBe('api:reference')
+      })
+    } finally {
+      await browser.close()
+    }
+  })
+
+  it('falls through to the catch-all branch when the specific route does not match', async () => {
+    const browser = await webdriver(port, '/docs/guides/export/fallback/')
+
+    try {
+      await retry(async () => {
+        expect(await browser.elementByCss('h1').text()).toBe(
+          'catchall:guides/export/fallback'
+        )
+      })
+    } finally {
+      await browser.close()
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- Emit and read fallback metadata for overlapping dynamic routes under the same static prefix.
- Add conflict e2e coverage and collision error coverage for ambiguous fallback output.

## Why
- Once the basic fallback path exists, the next capability is choosing the right route when multiple dynamic branches can match the same exported prefix.

## Validation
- `pnpm --filter=next build`
- `pnpm testonly packages/next/src/client/output-export-fallback.test.ts packages/next/src/lib/output-export-dynamic-fallback.test.ts`
- `NEXT_SKIP_ISOLATE=1 NEXT_TEST_MODE=start pnpm testheadless test/e2e/app-dir-export/test/dynamic-fallback-conflict.test.ts`

## Stack
- Previous: [#93014](https://github.com/vercel/next.js/pull/93014)
- Next: [#93016](https://github.com/vercel/next.js/pull/93016)

Full stack:
1. [#93013](https://github.com/vercel/next.js/pull/93013) output export fallback: cover flat fallbacks and fix resume path
2. [#93014](https://github.com/vercel/next.js/pull/93014) output export fallback: move fallback e2e suites onto fixtures
3. [#93015](https://github.com/vercel/next.js/pull/93015) output export fallback: support conflicting routes <- current
4. [#93016](https://github.com/vercel/next.js/pull/93016) output export fallback: hide the bootstrap shell
5. [#93017](https://github.com/vercel/next.js/pull/93017) output export fallback: guard server-only APIs
6. [#93018](https://github.com/vercel/next.js/pull/93018) output export fallback: cover server IO boundaries
7. [#93019](https://github.com/vercel/next.js/pull/93019) output export fallback: avoid fallback document URL swaps
8. [#93020](https://github.com/vercel/next.js/pull/93020) output export fallback: prefetch and dedupe fallback payloads
9. [#93021](https://github.com/vercel/next.js/pull/93021) output export fallback: carry fallback bases through hydration
10. [#93022](https://github.com/vercel/next.js/pull/93022) output export fallback: prefer deeper static prefixes
11. [#92555](https://github.com/vercel/next.js/pull/92555) output export fallback: recover unmatched routes with _not-found

<!-- NEXT_JS_LLM_PR -->
