### PR TITLE
output export fallback: hide the bootstrap shell

### DIFF
--- a/docs/01-app/02-guides/static-exports.mdx
+++ b/docs/01-app/02-guides/static-exports.mdx
@@ -233,6 +233,29 @@ When a user visits an unenumerated route, the host serves `_fallback.html`. The 
 
 For client-side navigations (clicking a `<Link>`), the fallback shell is prefetched during hover, so navigation is instant.
 
+For example, with App Router dynamic routes, `output: 'export'`, and `cacheComponents: true`, an Nginx config can serve both prerendered files and unknown params like this:
+
+```nginx filename="nginx.conf"
+server {
+  listen 80;
+  server_name acme.com;
+
+  root /var/www/out;
+
+  location / {
+    # Serve prerendered files when they exist. Otherwise fall back to the
+    # export bootstrap document so the client router can recover the route.
+    try_files $uri $uri.html $uri/ /_fallback.html;
+  }
+
+  location = /_fallback.html {
+    internal;
+  }
+}
+```
+
+With `trailingSlash: true`, the same config works because prerendered routes are emitted as `/route/index.html` and unknown paths still fall back to `/_fallback.html`. With `trailingSlash: false`, keep the `try_files $uri $uri.html $uri/ /_fallback.html;` order so prerendered flat files are served before the fallback bootstrap.
+
 > **Good to know**:
 >
 > - Param-dependent content for fallback routes renders on the client, so use client-side fetching patterns like `fetch`, SWR, or React Query in those parts of the tree.

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -1264,7 +1264,7 @@ async function writeOutputExportFallbackHtml(
   fallbackHtmlPaths: string[]
 ): Promise<void> {
   // Prefer a shallow __fallback shell for the global fallback entry point so
-  // hard loads start from a real PPR shell instead of unrelated index content.
+  // the bootstrap document still carries the right root structure and assets.
   // Fall back to a generic document only if no __fallback shell exists.
   const genericSource = [
     join(outDir, 'index.html'),
@@ -1282,20 +1282,12 @@ async function writeOutputExportFallbackHtml(
 
   const fallbackHtml = await fs.readFile(fallbackSource, 'utf8')
   const exportFallbackScript = '<script>self.__NEXT_EXPORT_FALLBACK=1</script>'
-
-  let injection: string
-  if (fallbackSource === pprShellSource) {
-    // PPR shell already has meaningful content (root layout + Suspense
-    // boundaries), no need to hide it
-    injection = exportFallbackScript
-  } else {
-    // Generic source (index.html / 404.html) has wrong page content.
-    // Hide it to prevent a flash of the wrong page before React takes
-    // over with createRoot. Removed in app-index.tsx after React commits.
-    const exportFallbackStyle =
-      '<style id="__next-export-fallback-style">#__next{visibility:hidden}</style>'
-    injection = `${exportFallbackStyle}${exportFallbackScript}`
-  }
+  // The global fallback document is only a bootstrap shell. Keep it hidden
+  // until the client resolves the actual route-specific fallback payload and
+  // React commits the real tree. Removed in app-index.tsx after hydration.
+  const exportFallbackStyle =
+    '<style id="__next-export-fallback-style">#__next{visibility:hidden}</style>'
+  const injection = `${exportFallbackStyle}${exportFallbackScript}`
 
   const patchedFallbackHtml = fallbackHtml.includes('</head>')
     ? fallbackHtml.replace('</head>', `${injection}</head>`)

--- a/test/e2e/app-dir-export/test/dynamic-fallback-cache-components.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-fallback-cache-components.test.ts
@@ -267,7 +267,7 @@ if (skipped) {
         }
       })
 
-      it('generates _fallback.html from a PPR shell instead of index.html', async () => {
+      it('generates a hidden _fallback.html bootstrap document', async () => {
         const outDir = join(next.testDir, 'out')
         const fallbackHtml = await fs.readFile(
           join(outDir, '_fallback.html'),
@@ -276,7 +276,7 @@ if (skipped) {
 
         expect(fallbackHtml).toContain('__NEXT_EXPORT_FALLBACK=1')
         expect(fallbackHtml).not.toContain('>Home<')
-        expect(fallbackHtml).not.toContain('__next-export-fallback-style')
+        expect(fallbackHtml).toContain('__next-export-fallback-style')
       })
 
       it('supports browser back/forward between fallback routes', async () => {


### PR DESCRIPTION
## Summary
- Turn `_fallback.html` into a hidden bootstrap document instead of visible page content.
- Update the docs and e2e assertions around the bootstrap shell.

## Why
- The bootstrap document should be an implementation detail. This keeps that change isolated before the later runtime changes stop relying on document swaps entirely.

## Validation
- `pnpm --filter=next build`
- `NEXT_SKIP_ISOLATE=1 NEXT_TEST_MODE=start pnpm testheadless test/e2e/app-dir-export/test/dynamic-fallback-cache-components.test.ts`

## Stack
- Previous: [#93015](https://github.com/vercel/next.js/pull/93015)
- Next: [#93017](https://github.com/vercel/next.js/pull/93017)

Full stack:
1. [#93013](https://github.com/vercel/next.js/pull/93013) output export fallback: cover flat fallbacks and fix resume path
2. [#93014](https://github.com/vercel/next.js/pull/93014) output export fallback: move fallback e2e suites onto fixtures
3. [#93015](https://github.com/vercel/next.js/pull/93015) output export fallback: support conflicting routes
4. [#93016](https://github.com/vercel/next.js/pull/93016) output export fallback: hide the bootstrap shell <- current
5. [#93017](https://github.com/vercel/next.js/pull/93017) output export fallback: guard server-only APIs
6. [#93018](https://github.com/vercel/next.js/pull/93018) output export fallback: cover server IO boundaries
7. [#93019](https://github.com/vercel/next.js/pull/93019) output export fallback: avoid fallback document URL swaps
8. [#93020](https://github.com/vercel/next.js/pull/93020) output export fallback: prefetch and dedupe fallback payloads
9. [#93021](https://github.com/vercel/next.js/pull/93021) output export fallback: carry fallback bases through hydration
10. [#93022](https://github.com/vercel/next.js/pull/93022) output export fallback: prefer deeper static prefixes
11. [#92555](https://github.com/vercel/next.js/pull/92555) output export fallback: recover unmatched routes with _not-found

<!-- NEXT_JS_LLM_PR -->
