### PR TITLE
output export fallback: cover server IO boundaries

### DIFF
--- a/docs/01-app/02-guides/static-exports.mdx
+++ b/docs/01-app/02-guides/static-exports.mdx
@@ -256,6 +256,32 @@ server {
 
 With `trailingSlash: true`, the same config works because prerendered routes are emitted as `/route/index.html` and unknown paths still fall back to `/_fallback.html`. With `trailingSlash: false`, keep the `try_files $uri $uri.html $uri/ /_fallback.html;` order so prerendered flat files are served before the fallback bootstrap.
 
+#### Server and client boundaries
+
+Fallback routes in `output: 'export'` do not have a runtime server request. For unenumerated paths, request-specific APIs and unresolved fallback params are only available on the client.
+
+Move long-tail fallback content into Client Components if it depends on:
+
+- `await params` for values that were not returned from `generateStaticParams`
+- `searchParams`
+- `headers()`
+- `cookies()`
+- `connection()`
+
+Synchronous platform IO such as `Date.now()`, `Math.random()`, and `crypto.randomUUID()` still follows the normal Cache Components rules. If you want to prerender those values into static output, wrap the read in `use cache`:
+
+```tsx filename="app/page.tsx"
+async function getBuildTimeValue() {
+  'use cache'
+
+  return Date.now()
+}
+
+export default async function Page() {
+  return <p>{await getBuildTimeValue()}</p>
+}
+```
+
 > **Good to know**:
 >
 > - Param-dependent content for fallback routes renders on the client, so use client-side fetching patterns like `fetch`, SWR, or React Query in those parts of the tree.

--- a/test/e2e/app-dir-export/fixtures/output-export-server-io-use-cache/app/cached-crypto/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-io-use-cache/app/cached-crypto/page.js
@@ -1,0 +1,14 @@
+async function getCachedCryptoValue() {
+  'use cache'
+
+  return crypto.randomUUID()
+}
+
+export default async function CachedCryptoPage() {
+  return (
+    <>
+      <p>Cached crypto</p>
+      <h1 id="value">{await getCachedCryptoValue()}</h1>
+    </>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-io-use-cache/app/cached-random/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-io-use-cache/app/cached-random/page.js
@@ -1,0 +1,14 @@
+async function getCachedRandom() {
+  'use cache'
+
+  return Math.random()
+}
+
+export default async function CachedRandomPage() {
+  return (
+    <>
+      <p>Cached random</p>
+      <h1 id="value">{String(await getCachedRandom())}</h1>
+    </>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-io-use-cache/app/cached-time/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-io-use-cache/app/cached-time/page.js
@@ -1,0 +1,14 @@
+async function getCachedTime() {
+  'use cache'
+
+  return Date.now()
+}
+
+export default async function CachedTimePage() {
+  return (
+    <>
+      <p>Cached time</p>
+      <h1 id="value">{String(await getCachedTime())}</h1>
+    </>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-io-use-cache/app/layout.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-io-use-cache/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-io-use-cache/app/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-io-use-cache/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>home</p>
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-io-use-cache/next.config.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-io-use-cache/next.config.js
@@ -1,0 +1,9 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  output: 'export',
+  cacheComponents: true,
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir-export/fixtures/output-export-server-io/app/cached-request/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-io/app/cached-request/page.js
@@ -1,0 +1,12 @@
+import { headers } from 'next/headers'
+
+async function getHeadersInCache() {
+  'use cache'
+
+  const requestHeaders = await headers()
+  return requestHeaders.get('user-agent') ?? 'unknown'
+}
+
+export default async function CachedRequestPage() {
+  return <h1>{await getHeadersInCache()}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-io/app/layout.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-io/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-io/app/needs-crypto/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-io/app/needs-crypto/page.js
@@ -1,0 +1,3 @@
+export default function CryptoPage() {
+  return <h1>{crypto.randomUUID()}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-io/app/needs-random/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-io/app/needs-random/page.js
@@ -1,0 +1,3 @@
+export default function RandomPage() {
+  return <h1>{Math.random()}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-io/app/needs-time/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-io/app/needs-time/page.js
@@ -1,0 +1,3 @@
+export default function TimePage() {
+  return <h1>{Date.now()}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-io/app/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-io/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>home</p>
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-io/next.config.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-io/next.config.js
@@ -1,0 +1,9 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  output: 'export',
+  cacheComponents: true,
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir-export/test/output-export-server-io-use-cache.test.ts
+++ b/test/e2e/app-dir-export/test/output-export-server-io-use-cache.test.ts
@@ -1,0 +1,63 @@
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import fs from 'fs-extra'
+
+const { next, skipped, isNextDev } = nextTestSetup({
+  files: join(__dirname, '..', 'fixtures', 'output-export-server-io-use-cache'),
+  skipStart: true,
+  skipDeployment: true,
+  disableAutoSkewProtection: true,
+})
+
+if (skipped) {
+  describe.skip('app dir - output export server io use cache', () => {})
+} else {
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  describeProduction('app dir - output export server io use cache', () => {
+    afterAll(async () => {
+      await next.destroy()
+    })
+
+    it('exports Date.now() successfully when the read is wrapped in use cache', async () => {
+      const { exitCode, cliOutput } = await next.build()
+      const html = await fs.readFile(
+        join(next.testDir, 'out', 'cached-time.html'),
+        'utf8'
+      )
+
+      expect(exitCode).toBe(0)
+      expect(cliOutput).not.toContain('used `Date.now()`')
+      expect(html).toContain('Cached time')
+      expect(html).toMatch(/<h1 id="value">\d+<\/h1>/)
+    })
+
+    it('exports Math.random() successfully when the read is wrapped in use cache', async () => {
+      const { exitCode, cliOutput } = await next.build()
+      const html = await fs.readFile(
+        join(next.testDir, 'out', 'cached-random.html'),
+        'utf8'
+      )
+
+      expect(exitCode).toBe(0)
+      expect(cliOutput).not.toContain('used `Math.random()`')
+      expect(html).toContain('Cached random')
+      expect(html).toMatch(/<h1 id="value">0?\.\d+<\/h1>/)
+    })
+
+    it('exports crypto.randomUUID() successfully when the read is wrapped in use cache', async () => {
+      const { exitCode, cliOutput } = await next.build()
+      const html = await fs.readFile(
+        join(next.testDir, 'out', 'cached-crypto.html'),
+        'utf8'
+      )
+
+      expect(exitCode).toBe(0)
+      expect(cliOutput).not.toContain('used `crypto.randomUUID()`')
+      expect(html).toContain('Cached crypto')
+      expect(html).toMatch(
+        /<h1 id="value">[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}<\/h1>/i
+      )
+    })
+  })
+}

--- a/test/e2e/app-dir-export/test/output-export-server-io.test.ts
+++ b/test/e2e/app-dir-export/test/output-export-server-io.test.ts
@@ -1,0 +1,148 @@
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+import {
+  expectOutputExportDevRedbox,
+  startOutputExportDevServer,
+} from './utils'
+
+const { next, skipped, isNextDev } = nextTestSetup({
+  files: join(__dirname, '..', 'fixtures', 'output-export-server-io'),
+  skipStart: true,
+  skipDeployment: true,
+  disableAutoSkewProtection: true,
+})
+
+if (skipped) {
+  describe.skip('app dir - output export server io', () => {})
+} else {
+  const describeDevelopment = isNextDev ? describe : describe.skip
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  async function expectSyncIOOutputExportDevError({
+    path,
+    expectedMessage,
+    expectedSource,
+  }: {
+    path: string
+    expectedMessage: string
+    expectedSource: string
+  }) {
+    const outputIndex = next.cliOutput.length
+    const browser = await next.browser(path)
+
+    try {
+      await retry(async () => {
+        const logs = await browser.log()
+
+        expect(
+          logs.some(
+            (log) =>
+              log.message.includes(expectedMessage) &&
+              log.message.includes(expectedSource)
+          )
+        ).toBe(true)
+      })
+
+      const cliOutput = next.cliOutput.slice(outputIndex)
+
+      expect(cliOutput).toContain(expectedMessage)
+      expect(cliOutput).toContain(expectedSource)
+    } finally {
+      await browser.close()
+    }
+  }
+
+  describeDevelopment('app dir - output export server io', () => {
+    let port: number
+
+    beforeAll(async () => {
+      port = await startOutputExportDevServer(next)
+    })
+
+    afterAll(async () => {
+      await next.destroy()
+    })
+
+    it('shows a redbox when Date.now() is read outside use cache', async () => {
+      await expectSyncIOOutputExportDevError({
+        path: '/needs-time',
+        expectedMessage:
+          'used `Date.now()` before accessing either uncached data',
+        expectedSource: 'Date.now()',
+      })
+    })
+
+    it('shows a redbox when Math.random() is read outside use cache', async () => {
+      await expectSyncIOOutputExportDevError({
+        path: '/needs-random',
+        expectedMessage:
+          'used `Math.random()` before accessing either uncached data',
+        expectedSource: 'Math.random()',
+      })
+    })
+
+    it('shows a redbox when crypto.randomUUID() is read outside use cache', async () => {
+      await expectSyncIOOutputExportDevError({
+        path: '/needs-crypto',
+        expectedMessage:
+          'used `crypto.randomUUID()` before accessing either uncached data',
+        expectedSource: 'crypto.randomUUID()',
+      })
+    })
+
+    it('still shows a redbox when request APIs are used inside use cache', async () => {
+      await expectOutputExportDevRedbox({
+        port,
+        path: '/cached-request',
+        expectedMessage: 'used `headers()` inside "use cache"',
+        expectedSource: 'await headers()',
+      })
+    })
+  })
+
+  describeProduction('app dir - output export server io', () => {
+    afterAll(async () => {
+      await next.destroy()
+    })
+
+    it.each([
+      [
+        '/needs-time',
+        'app/needs-time/page.js',
+        'used `Date.now()` before accessing either uncached data',
+      ],
+      [
+        '/needs-random',
+        'app/needs-random/page.js',
+        'used `Math.random()` before accessing either uncached data',
+      ],
+      [
+        '/needs-crypto',
+        'app/needs-crypto/page.js',
+        'used `crypto.randomUUID()` before accessing either uncached data',
+      ],
+    ])(
+      'errors when sync IO is used outside use cache for %s in output export',
+      async (route, buildPath, expectedMessage) => {
+        const { exitCode, cliOutput } = await next.build({
+          args: ['--debug-build-paths', buildPath],
+        })
+
+        expect(exitCode).toBe(1)
+        expect(cliOutput).toContain(expectedMessage)
+        expect(cliOutput).toContain(route)
+      }
+    )
+
+    it('still errors when request APIs are used inside use cache in output export', async () => {
+      const { exitCode, cliOutput } = await next.build({
+        args: ['--debug-build-paths', 'app/cached-request/page.js'],
+      })
+
+      expect(exitCode).toBe(1)
+      expect(cliOutput).toContain('used `headers()` inside "use cache"')
+      expect(cliOutput).toContain('/cached-request')
+    })
+  })
+}

--- a/test/e2e/app-dir-export/test/output-export-server-io.test.ts
+++ b/test/e2e/app-dir-export/test/output-export-server-io.test.ts
@@ -1,7 +1,7 @@
 import { join } from 'path'
 import { nextTestSetup } from 'e2e-utils'
-import { retry } from 'next-test-utils'
 import {
+  expectOutputExportDevCollapsedRedbox,
   expectOutputExportDevRedbox,
   startOutputExportDevServer,
 } from './utils'
@@ -19,40 +19,6 @@ if (skipped) {
   const describeDevelopment = isNextDev ? describe : describe.skip
   const describeProduction = isNextDev ? describe.skip : describe
 
-  async function expectSyncIOOutputExportDevError({
-    path,
-    expectedMessage,
-    expectedSource,
-  }: {
-    path: string
-    expectedMessage: string
-    expectedSource: string
-  }) {
-    const outputIndex = next.cliOutput.length
-    const browser = await next.browser(path)
-
-    try {
-      await retry(async () => {
-        const logs = await browser.log()
-
-        expect(
-          logs.some(
-            (log) =>
-              log.message.includes(expectedMessage) &&
-              log.message.includes(expectedSource)
-          )
-        ).toBe(true)
-      })
-
-      const cliOutput = next.cliOutput.slice(outputIndex)
-
-      expect(cliOutput).toContain(expectedMessage)
-      expect(cliOutput).toContain(expectedSource)
-    } finally {
-      await browser.close()
-    }
-  }
-
   describeDevelopment('app dir - output export server io', () => {
     let port: number
 
@@ -65,7 +31,8 @@ if (skipped) {
     })
 
     it('shows a redbox when Date.now() is read outside use cache', async () => {
-      await expectSyncIOOutputExportDevError({
+      await expectOutputExportDevCollapsedRedbox({
+        port,
         path: '/needs-time',
         expectedMessage:
           'used `Date.now()` before accessing either uncached data',
@@ -74,7 +41,8 @@ if (skipped) {
     })
 
     it('shows a redbox when Math.random() is read outside use cache', async () => {
-      await expectSyncIOOutputExportDevError({
+      await expectOutputExportDevCollapsedRedbox({
+        port,
         path: '/needs-random',
         expectedMessage:
           'used `Math.random()` before accessing either uncached data',
@@ -83,7 +51,8 @@ if (skipped) {
     })
 
     it('shows a redbox when crypto.randomUUID() is read outside use cache', async () => {
-      await expectSyncIOOutputExportDevError({
+      await expectOutputExportDevCollapsedRedbox({
+        port,
         path: '/needs-crypto',
         expectedMessage:
           'used `crypto.randomUUID()` before accessing either uncached data',

--- a/test/e2e/app-dir-export/test/utils.ts
+++ b/test/e2e/app-dir-export/test/utils.ts
@@ -10,7 +10,9 @@ import { createReadStream } from 'fs'
 import {
   waitForRedbox,
   getRedboxHeader,
+  getRedboxDescription,
   getRedboxSource,
+  openRedbox,
   retry,
   findPort,
   startStaticServer,
@@ -106,6 +108,35 @@ export async function expectOutputExportDevRedbox({
     const source = await getRedboxSource(browser)
 
     expect(header).toContain(expectedMessage)
+
+    if (expectedSource && source !== null) {
+      expect(source).toContain(expectedSource)
+    }
+  } finally {
+    await browser.close()
+  }
+}
+
+export async function expectOutputExportDevCollapsedRedbox({
+  port,
+  path,
+  expectedMessage,
+  expectedSource,
+}: {
+  port: number
+  path: string
+  expectedMessage: string
+  expectedSource?: string
+}) {
+  const browser = await webdriver(port, path)
+
+  try {
+    await openRedbox(browser)
+
+    const description = await getRedboxDescription(browser)
+    const source = await getRedboxSource(browser)
+
+    expect(description).toContain(expectedMessage)
 
     if (expectedSource && source !== null) {
       expect(source).toContain(expectedSource)


### PR DESCRIPTION
## Summary
- Add sync IO and `use cache` coverage for output-export fallback routes.
- Document the fallback server/client boundary and the related static-host setup details.

## Why
- Before the stack moves deeper into navigation and hydration, we need explicit coverage for what still works at build time and what must stay on the client.

## Validation
- `pnpm --filter=next build`
- `NEXT_SKIP_ISOLATE=1 NEXT_TEST_MODE=start pnpm testheadless test/e2e/app-dir-export/test/output-export-server-io.test.ts`

## Stack
- Previous: [#93017](https://github.com/vercel/next.js/pull/93017)
- Next: [#93019](https://github.com/vercel/next.js/pull/93019)

Full stack:
1. [#93013](https://github.com/vercel/next.js/pull/93013) output export fallback: cover flat fallbacks and fix resume path
2. [#93014](https://github.com/vercel/next.js/pull/93014) output export fallback: move fallback e2e suites onto fixtures
3. [#93015](https://github.com/vercel/next.js/pull/93015) output export fallback: support conflicting routes
4. [#93016](https://github.com/vercel/next.js/pull/93016) output export fallback: hide the bootstrap shell
5. [#93017](https://github.com/vercel/next.js/pull/93017) output export fallback: guard server-only APIs
6. [#93018](https://github.com/vercel/next.js/pull/93018) output export fallback: cover server IO boundaries <- current
7. [#93019](https://github.com/vercel/next.js/pull/93019) output export fallback: avoid fallback document URL swaps
8. [#93020](https://github.com/vercel/next.js/pull/93020) output export fallback: prefetch and dedupe fallback payloads
9. [#93021](https://github.com/vercel/next.js/pull/93021) output export fallback: carry fallback bases through hydration
10. [#93022](https://github.com/vercel/next.js/pull/93022) output export fallback: prefer deeper static prefixes
11. [#92555](https://github.com/vercel/next.js/pull/92555) output export fallback: recover unmatched routes with _not-found

<!-- NEXT_JS_LLM_PR -->
