### PR TITLE
output export fallback: carry fallback bases through hydration

### DIFF
--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -249,6 +249,7 @@ if (
 }
 
 let initialServerResponse: Promise<InitialRSCPayload>
+let initialOutputExportFallbackBasePath: string | null = null
 const decodeFallbackPrerenderPayload = async (
   responsePromise: Promise<Response>,
   renderedUrl?: URL
@@ -294,6 +295,7 @@ if (instantTestStaticFetch) {
     )
 
     if (fallbackResult !== null) {
+      initialOutputExportFallbackBasePath = fallbackResult.fallbackUrl.pathname
       return decodeFallbackPrerenderPayload(
         Promise.resolve(fallbackResult.response),
         renderedUrl
@@ -454,6 +456,7 @@ export async function hydrate(
       initialRSCPayload,
       initialFlightStreamForCache,
       location: window.location,
+      outputExportFallbackBasePath: initialOutputExportFallbackBasePath,
     }),
     instrumentationHooks
   )

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.test.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.test.ts
@@ -1,0 +1,92 @@
+import type { InitialRSCPayload } from '../../../shared/lib/app-router-types'
+import { createInitialRouterState } from './create-initial-router-state'
+
+const mockGetFlightDataPartsFromPath = jest.fn()
+const mockCreateInitialCacheNodeForHydration = jest.fn()
+const mockConvertRootFlightRouterStateToRouteTree = jest.fn()
+const mockDiscoverKnownRoute = jest.fn()
+
+jest.mock('../../flight-data-helpers', () => ({
+  getFlightDataPartsFromPath: (...args: Array<unknown>) =>
+    mockGetFlightDataPartsFromPath(...args),
+}))
+
+jest.mock('./ppr-navigations', () => ({
+  createInitialCacheNodeForHydration: (...args: Array<unknown>) =>
+    mockCreateInitialCacheNodeForHydration(...args),
+}))
+
+jest.mock('../segment-cache/cache', () => ({
+  convertRootFlightRouterStateToRouteTree: (...args: Array<unknown>) =>
+    mockConvertRootFlightRouterStateToRouteTree(...args),
+  getStaleTimeMs: jest.fn((staleTime: number) => staleTime),
+  getStaleAt: jest.fn(),
+  processRuntimePrefetchStream: jest.fn(),
+  writeDynamicRenderResponseIntoCache: jest.fn(),
+  writeStaticStageResponseIntoCache: jest.fn(),
+}))
+
+jest.mock('../segment-cache/optimistic-routes', () => ({
+  discoverKnownRoute: (...args: Array<unknown>) =>
+    mockDiscoverKnownRoute(...args),
+}))
+
+describe('createInitialRouterState output export fallback', () => {
+  const discoveredRouteEntry = {
+    outputExportFallbackBasePath: null as string | null,
+  }
+
+  const initialRSCPayload: InitialRSCPayload = {
+    c: ['', 'hydrated', 'first'],
+    q: '',
+    i: false,
+    f: [[] as any],
+    m: new Set(),
+    G: [(() => null) as any, undefined],
+    S: false,
+    h: null,
+  }
+
+  beforeEach(() => {
+    mockGetFlightDataPartsFromPath.mockReset()
+    mockCreateInitialCacheNodeForHydration.mockReset()
+    mockConvertRootFlightRouterStateToRouteTree.mockReset()
+    mockDiscoverKnownRoute.mockReset()
+
+    discoveredRouteEntry.outputExportFallbackBasePath = null
+
+    mockGetFlightDataPartsFromPath.mockReturnValue({
+      tree: ['', {}],
+      seedData: null,
+      head: null,
+    })
+    mockCreateInitialCacheNodeForHydration.mockReturnValue({
+      rsc: null,
+      prefetchRsc: null,
+      prefetchHead: null,
+      head: null,
+      slots: null,
+      scrollRef: null,
+    })
+    mockConvertRootFlightRouterStateToRouteTree.mockImplementation(
+      (_tree, _renderedSearch, acc) => {
+        acc.metadataVaryPath = '__PAGE__'
+        return { path: '/hydrated/[thread]' }
+      }
+    )
+    mockDiscoverKnownRoute.mockReturnValue(discoveredRouteEntry)
+  })
+
+  it('stores the learned fallback artifact base path on the hydrated route entry', () => {
+    createInitialRouterState({
+      navigatedAt: Date.now(),
+      initialRSCPayload,
+      location: new URL('https://example.com/hydrated/first/') as Location,
+      outputExportFallbackBasePath: '/hydrated/__fallback',
+    })
+
+    expect(discoveredRouteEntry.outputExportFallbackBasePath).toBe(
+      '/hydrated/__fallback'
+    )
+  })
+})

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -27,6 +27,7 @@ export interface InitialRouterStateParameters {
   initialRSCPayload: InitialRSCPayload
   initialFlightStreamForCache?: ReadableStream<Uint8Array> | null
   location: Location | null
+  outputExportFallbackBasePath?: string | null
 }
 
 export function createInitialRouterState({
@@ -34,6 +35,7 @@ export function createInitialRouterState({
   initialRSCPayload,
   initialFlightStreamForCache,
   location,
+  outputExportFallbackBasePath = null,
 }: InitialRouterStateParameters): AppRouterState {
   const {
     c: initialCanonicalUrlParts,
@@ -103,7 +105,7 @@ export function createInitialRouterState({
   // route learning nor segment cache state persists from SSR to client.
   if (location !== null && metadataVaryPath !== null) {
     // Learn the route pattern so we can predict it for future navigations.
-    discoverKnownRoute(
+    const initialRouteEntry = discoverKnownRoute(
       Date.now(),
       location.pathname,
       null, // nextUrl — initial render is never an interception
@@ -115,6 +117,10 @@ export function createInitialRouterState({
       initialSupportsPerSegmentPrefetching,
       false // hasDynamicRewrite
     )
+    if (outputExportFallbackBasePath !== null) {
+      initialRouteEntry.outputExportFallbackBasePath =
+        outputExportFallbackBasePath
+    }
 
     // Write the initial seed data into the segment cache so subsequent
     // navigations to the initial page can serve cached segments instantly.

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.test.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.test.ts
@@ -125,6 +125,7 @@ describe('fetchServerResponse output export fallback', () => {
     expect(typeof result).not.toBe('string')
     if (typeof result !== 'string') {
       expect(result.canonicalUrl.href).toBe(`${origin}/another/third`)
+      expect(result.outputExportFallbackBasePath).toBe('/another/__fallback')
     }
     expect(global.fetch).toHaveBeenCalledTimes(1)
     expect(mockFetchOutputExportFallbackResponse).toHaveBeenCalledTimes(1)

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -86,6 +86,7 @@ type SpaFetchServerResponseResult = {
   flightData: NormalizedFlightData[]
   canonicalUrl: URL
   renderedSearch: NormalizedSearch
+  outputExportFallbackBasePath: string | null
   couldBeIntercepted: boolean
   supportsPerSegmentPrefetching: boolean
   postponed: boolean
@@ -172,6 +173,7 @@ export async function fetchServerResponse(
 
   try {
     let usedCachedOutputExportFallback = false
+    let outputExportFallbackBasePath: string | null = null
     if (process.env.NODE_ENV === 'production') {
       if (process.env.__NEXT_CONFIG_OUTPUT === 'export') {
         // In "output: export" mode, we can't rely on headers to distinguish
@@ -244,6 +246,7 @@ export async function fetchServerResponse(
 
       if (fallbackResult !== null) {
         usedOutputExportFallback = true
+        outputExportFallbackBasePath = fallbackResult.fallbackUrl.pathname
         const { response: processed, cacheData } = await processFetch(
           fallbackResult.response
         )
@@ -352,6 +355,7 @@ export async function fetchServerResponse(
       // header alone. So we need to investigate why the header is sometimes
       // wrong for interception routes.
       renderedSearch: flightResponse.q as NormalizedSearch,
+      outputExportFallbackBasePath,
       couldBeIntercepted: interception,
       supportsPerSegmentPrefetching: flightResponse.S,
       postponed,

--- a/packages/next/src/client/components/segment-cache/cache.test.ts
+++ b/packages/next/src/client/components/segment-cache/cache.test.ts
@@ -2,7 +2,13 @@ import {
   HEAD_REQUEST_KEY,
   type SegmentRequestKey,
 } from '../../../shared/lib/segment-cache/segment-value-encoding'
-import { getOutputExportSegmentRequestUrl } from './cache'
+import { FetchStrategy } from './types'
+import { Fallback } from './cache-map'
+import {
+  getOutputExportSegmentRequestUrl,
+  readOrCreateSegmentCacheEntry,
+} from './cache'
+import { finalizeMetadataVaryPath } from './vary-path'
 
 describe('getOutputExportSegmentRequestUrl', () => {
   it('uses the concrete rendered route when no fallback base path is known', () => {
@@ -39,5 +45,62 @@ describe('getOutputExportSegmentRequestUrl', () => {
     ).toBe(
       'https://example.com/docs/__fallback/__route_0/__next.docs.$d$section.$d$page.txt'
     )
+  })
+})
+
+describe('readOrCreateSegmentCacheEntry output export fallback', () => {
+  it('dedupes pending metadata entries across sibling fallback params', () => {
+    const now = Date.now()
+    const firstTree = {
+      requestKey: HEAD_REQUEST_KEY,
+      segment: HEAD_REQUEST_KEY,
+      refreshState: null,
+      varyPath: finalizeMetadataVaryPath(
+        '/hydrated/$d$thread/__PAGE__' as SegmentRequestKey,
+        '' as any,
+        {
+          id: 'thread',
+          value: 'first' as any,
+          parent: null,
+        } as any
+      ),
+      isPage: true as const,
+      slots: null,
+      prefetchHints: 0,
+    }
+    const secondTree = {
+      ...firstTree,
+      varyPath: finalizeMetadataVaryPath(
+        '/hydrated/$d$thread/__PAGE__' as SegmentRequestKey,
+        '' as any,
+        {
+          id: 'thread',
+          value: 'second' as any,
+          parent: null,
+        } as any
+      ),
+    }
+
+    const firstEntry = readOrCreateSegmentCacheEntry(
+      now,
+      FetchStrategy.PPR,
+      firstTree,
+      '/hydrated/__fallback'
+    )
+    const secondEntry = readOrCreateSegmentCacheEntry(
+      now,
+      FetchStrategy.PPR,
+      secondTree,
+      '/hydrated/__fallback'
+    )
+
+    expect(firstEntry).toBe(secondEntry)
+    expect(secondTree.varyPath.parent.parent.value).toBe('second')
+    expect(
+      (
+        secondTree.varyPath.parent
+          .parent as typeof secondTree.varyPath.parent.parent
+      ).value
+    ).not.toBe(Fallback)
   })
 })

--- a/packages/next/src/client/components/segment-cache/cache.test.ts
+++ b/packages/next/src/client/components/segment-cache/cache.test.ts
@@ -1,0 +1,43 @@
+import {
+  HEAD_REQUEST_KEY,
+  type SegmentRequestKey,
+} from '../../../shared/lib/segment-cache/segment-value-encoding'
+import { getOutputExportSegmentRequestUrl } from './cache'
+
+describe('getOutputExportSegmentRequestUrl', () => {
+  it('uses the concrete rendered route when no fallback base path is known', () => {
+    expect(
+      getOutputExportSegmentRequestUrl(
+        new URL('https://example.com/org/acme/chat/thread-456/?mode=full'),
+        HEAD_REQUEST_KEY,
+        null
+      ).href
+    ).toBe(
+      'https://example.com/org/acme/chat/thread-456/__next._head.txt?mode=full'
+    )
+  })
+
+  it('reuses the learned fallback base path for sibling segment requests', () => {
+    expect(
+      getOutputExportSegmentRequestUrl(
+        new URL('https://example.com/org/acme/chat/thread-456/?mode=full'),
+        '/t/$d$threadId' as SegmentRequestKey,
+        '/org/__fallback'
+      ).href
+    ).toBe(
+      'https://example.com/org/__fallback/__next.t.$d$threadId.txt?mode=full'
+    )
+  })
+
+  it('keeps the matched branch fallback base path for conflicting routes', () => {
+    expect(
+      getOutputExportSegmentRequestUrl(
+        new URL('https://example.com/docs/api/reference'),
+        '/docs/$d$section/$d$page' as SegmentRequestKey,
+        '/docs/__fallback/__route_0'
+      ).href
+    ).toBe(
+      'https://example.com/docs/__fallback/__route_0/__next.docs.$d$section.$d$page.txt'
+    )
+  })
+})

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -770,7 +770,8 @@ function deprecated_createOptimisticRouteTree(
 export function readOrCreateSegmentCacheEntry(
   now: number,
   fetchStrategy: FetchStrategy,
-  tree: RouteTree
+  tree: RouteTree,
+  outputExportFallbackBasePath: string | null = null
 ): SegmentCacheEntry {
   const existingEntry = readSegmentCacheEntry(now, tree.varyPath)
   if (existingEntry !== null) {
@@ -779,7 +780,11 @@ export function readOrCreateSegmentCacheEntry(
   // Create a pending entry and add it to the cache. The stale time is set to a
   // default value; the actual stale time will be set when the entry is
   // fulfilled with data from the server response.
-  const varyPathForRequest = getSegmentVaryPathForRequest(fetchStrategy, tree)
+  const varyPathForRequest = getSegmentVaryPathForRequest(
+    fetchStrategy,
+    tree,
+    outputExportFallbackBasePath
+  )
   const pendingEntry = createDetachedSegmentCacheEntry(now)
   const isRevalidation = false
   setInCacheMap(
@@ -794,7 +799,8 @@ export function readOrCreateSegmentCacheEntry(
 export function readOrCreateRevalidatingSegmentEntry(
   now: number,
   fetchStrategy: FetchStrategy,
-  tree: RouteTree
+  tree: RouteTree,
+  outputExportFallbackBasePath: string | null = null
 ): SegmentCacheEntry {
   // This function is called when we've already confirmed that a particular
   // segment is cached, but we want to perform another request anyway in case it
@@ -830,7 +836,11 @@ export function readOrCreateRevalidatingSegmentEntry(
   // Create a pending entry and add it to the cache. The stale time is set to a
   // default value; the actual stale time will be set when the entry is
   // fulfilled with data from the server response.
-  const varyPathForRequest = getSegmentVaryPathForRequest(fetchStrategy, tree)
+  const varyPathForRequest = getSegmentVaryPathForRequest(
+    fetchStrategy,
+    tree,
+    outputExportFallbackBasePath
+  )
   const pendingEntry = createDetachedSegmentCacheEntry(now)
   const isRevalidation = true
   setInCacheMap(
@@ -2316,8 +2326,16 @@ export async function fetchSegmentsOnCacheMiss(
       // generic path. Otherwise use the request vary path.
       const canonicalVaryPath =
         process.env.__NEXT_VARY_PARAMS && data.varyParams !== null
-          ? getFulfilledSegmentVaryPath(node.tree.varyPath, data.varyParams)
-          : getSegmentVaryPathForRequest(FetchStrategy.PPR, node.tree)
+          ? getFulfilledSegmentVaryPath(
+              node.tree.varyPath,
+              data.varyParams,
+              route.outputExportFallbackBasePath !== null
+            )
+          : getSegmentVaryPathForRequest(
+              FetchStrategy.PPR,
+              node.tree,
+              route.outputExportFallbackBasePath
+            )
 
       let fulfilled: FulfilledSegmentCacheEntry | null = null
       const nodeEntry = node.entry

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -230,6 +230,7 @@ export type FulfilledRouteCacheEntry = RouteCacheEntryShared & {
   metadata: RouteTree
   supportsPerSegmentPrefetching: boolean
   hasInlinedSegments: boolean
+  outputExportFallbackBasePath: string | null
   // When true, this entry should not be used as a template for route
   // prediction. Set when we discover that the URL was rewritten by middleware
   // to a different route structure (e.g., /foo was rewritten to /bar). Since
@@ -695,6 +696,8 @@ export function deprecated_requestOptimisticRouteCacheEntry(
     supportsPerSegmentPrefetching:
       routeWithNoSearchParams.supportsPerSegmentPrefetching,
     hasInlinedSegments: routeWithNoSearchParams.hasInlinedSegments,
+    outputExportFallbackBasePath:
+      routeWithNoSearchParams.outputExportFallbackBasePath,
     hasDynamicRewrite: routeWithNoSearchParams.hasDynamicRewrite,
 
     // Override the rendered search with the optimistic value.
@@ -1116,6 +1119,7 @@ export function fulfillRouteCacheEntry(
   fulfilledEntry.renderedSearch = renderedSearch
   fulfilledEntry.supportsPerSegmentPrefetching = supportsPerSegmentPrefetching
   fulfilledEntry.hasInlinedSegments = false
+  fulfilledEntry.outputExportFallbackBasePath = null
   fulfilledEntry.hasDynamicRewrite = false
   pingBlockedTasks(entry)
   return fulfilledEntry
@@ -1912,6 +1916,7 @@ type OutputExportFallbackNavigationData = {
   couldBeIntercepted: boolean
   flightDatas: NormalizedFlightData[]
   headVaryParams: VaryParams | null
+  outputExportFallbackBasePath: string
   responseSize: number
   staleAt: number
   supportsPerSegmentPrefetching: boolean
@@ -1977,6 +1982,7 @@ async function fetchOutputExportFallbackNavigationData(
     couldBeIntercepted: serverData.i,
     flightDatas,
     headVaryParams,
+    outputExportFallbackBasePath: fallbackResult.fallbackUrl.pathname,
     responseSize,
     staleAt: await getStaleAt(now, serverData.s),
     supportsPerSegmentPrefetching: serverData.S,
@@ -2007,6 +2013,7 @@ async function fetchRouteOnCacheMissFromOutputExportFallback(
     couldBeIntercepted,
     flightDatas,
     headVaryParams,
+    outputExportFallbackBasePath,
     responseSize,
     staleAt,
     supportsPerSegmentPrefetching,
@@ -2054,6 +2061,7 @@ async function fetchRouteOnCacheMissFromOutputExportFallback(
     false
   )
   fulfilledEntry.hasInlinedSegments = true
+  fulfilledEntry.outputExportFallbackBasePath = outputExportFallbackBasePath
 
   if (!couldBeIntercepted) {
     const fulfilledVaryPath = getFulfilledRouteVaryPath(
@@ -2200,10 +2208,14 @@ export async function fetchSegmentsOnCacheMiss(
   // Testing API. Static pre-renders don't normally happen during development.
   addInstantPrefetchHeaderIfLocked(headers)
 
-  const requestUrl = isOutputExportMode
-    ? // In output: "export" mode, we need to add the segment path to the URL.
-      addSegmentPathToUrlInOutputExportMode(url, normalizedRequestKey)
-    : url
+  let requestUrl = url
+  if (isOutputExportMode) {
+    requestUrl = getOutputExportSegmentRequestUrl(
+      url,
+      normalizedRequestKey,
+      route.outputExportFallbackBasePath
+    )
+  }
   try {
     const response = await fetchPrefetchResponse(requestUrl, headers)
     if (
@@ -3100,6 +3112,24 @@ function createIncrementalPrefetchResponseStream(
   })
 }
 
+export function getOutputExportSegmentRequestUrl(
+  url: URL,
+  segmentPath: SegmentRequestKey,
+  outputExportFallbackBasePath: string | null
+): URL {
+  const staticUrl = new URL(url)
+  if (outputExportFallbackBasePath !== null) {
+    staticUrl.pathname = outputExportFallbackBasePath
+  }
+  const routeDir = staticUrl.pathname.endsWith('/')
+    ? staticUrl.pathname.slice(0, -1)
+    : staticUrl.pathname
+  const staticExportFilename =
+    convertSegmentPathToStaticExportFilename(segmentPath)
+  staticUrl.pathname = `${routeDir}/${staticExportFilename}`
+  return staticUrl
+}
+
 function addSegmentPathToUrlInOutputExportMode(
   url: URL,
   segmentPath: SegmentRequestKey
@@ -3107,14 +3137,7 @@ function addSegmentPathToUrlInOutputExportMode(
   if (isOutputExportMode) {
     // In output: "export" mode, we cannot use a header to encode the segment
     // path. Instead, we append it to the end of the pathname.
-    const staticUrl = new URL(url)
-    const routeDir = staticUrl.pathname.endsWith('/')
-      ? staticUrl.pathname.slice(0, -1)
-      : staticUrl.pathname
-    const staticExportFilename =
-      convertSegmentPathToStaticExportFilename(segmentPath)
-    staticUrl.pathname = `${routeDir}/${staticExportFilename}`
-    return staticUrl
+    return getOutputExportSegmentRequestUrl(url, segmentPath, null)
   }
   return url
 }

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -407,6 +407,7 @@ async function navigateToUnknownRoute(
     flightData,
     canonicalUrl,
     renderedSearch,
+    outputExportFallbackBasePath,
     couldBeIntercepted,
     supportsPerSegmentPrefetching,
     dynamicStaleTime,
@@ -434,7 +435,7 @@ async function navigateToUnknownRoute(
   // retrying after a tree mismatch (see dispatchRetryDueToTreeMismatch).
   const metadataVaryPath = navigationSeed.metadataVaryPath
   if (metadataVaryPath !== null) {
-    discoverKnownRoute(
+    const discoveredRoute = discoverKnownRoute(
       now,
       url.pathname,
       nextUrl,
@@ -446,6 +447,10 @@ async function navigateToUnknownRoute(
       supportsPerSegmentPrefetching,
       false // hasDynamicRewrite - not a retry, rewrite detection happens during traversal
     )
+    if (outputExportFallbackBasePath !== null) {
+      discoveredRoute.outputExportFallbackBasePath =
+        outputExportFallbackBasePath
+    }
 
     if (staticStageData !== null) {
       const { response: staticStageResponse, isResponsePartial } =

--- a/packages/next/src/client/components/segment-cache/optimistic-routes.ts
+++ b/packages/next/src/client/components/segment-cache/optimistic-routes.ts
@@ -588,6 +588,7 @@ export function matchKnownRoute(
     couldBeIntercepted: pattern.couldBeIntercepted,
     supportsPerSegmentPrefetching: pattern.supportsPerSegmentPrefetching,
     hasInlinedSegments: pattern.hasInlinedSegments,
+    outputExportFallbackBasePath: pattern.outputExportFallbackBasePath,
     hasDynamicRewrite: false,
     renderedSearch: search,
     ref: null,

--- a/packages/next/src/client/components/segment-cache/scheduler.ts
+++ b/packages/next/src/client/components/segment-cache/scheduler.ts
@@ -908,7 +908,8 @@ function pingStaticHead(
     entry: readOrCreateSegmentCacheEntry(
       now,
       FetchStrategy.PPR,
-      route.metadata
+      route.metadata,
+      route.outputExportFallbackBasePath
     ),
     parent: null,
   }
@@ -1268,7 +1269,12 @@ function pingPPRDisabledRouteTreeUpToLoadingBoundary(
   let refetchMarker: 'refetch' | 'inside-shared-layout' | null =
     refetchMarkerContext === null ? 'inside-shared-layout' : null
 
-  const segment = readOrCreateSegmentCacheEntry(now, task.fetchStrategy, tree)
+  const segment = readOrCreateSegmentCacheEntry(
+    now,
+    task.fetchStrategy,
+    tree,
+    route.outputExportFallbackBasePath
+  )
   switch (segment.status) {
     case EntryStatus.Empty: {
       // This segment is not cached. Add a refetch marker so the server knows
@@ -1378,7 +1384,8 @@ function pingRouteTreeAndIncludeDynamicData(
     // always use runtime prefetching (via `export const prefetch`), and those should check for
     // entries that include search params.
     fetchStrategy,
-    tree
+    tree,
+    route.outputExportFallbackBasePath
   )
 
   let spawnedSegment: PendingSegmentCacheEntry | null = null
@@ -1427,7 +1434,12 @@ function pingRouteTreeAndIncludeDynamicData(
             break
           }
         }
-        spawnedSegment = pingFullSegmentRevalidation(now, tree, fetchStrategy)
+        spawnedSegment = pingFullSegmentRevalidation(
+          now,
+          route,
+          tree,
+          fetchStrategy
+        )
       }
       break
     }
@@ -1441,7 +1453,12 @@ function pingRouteTreeAndIncludeDynamicData(
           fetchStrategy
         )
       ) {
-        spawnedSegment = pingFullSegmentRevalidation(now, tree, fetchStrategy)
+        spawnedSegment = pingFullSegmentRevalidation(
+          now,
+          route,
+          tree,
+          fetchStrategy
+        )
       }
       break
     }
@@ -1661,7 +1678,12 @@ function accumulateSegmentBundle(
     }
   }
 
-  const segment = readOrCreateSegmentCacheEntry(now, task.fetchStrategy, tree)
+  const segment = readOrCreateSegmentCacheEntry(
+    now,
+    task.fetchStrategy,
+    tree,
+    route.outputExportFallbackBasePath
+  )
 
   if (
     process.env.__NEXT_PREFETCH_INLINING &&
@@ -1687,7 +1709,8 @@ function accumulateSegmentBundle(
       entry: readOrCreateSegmentCacheEntry(
         now,
         FetchStrategy.PPR,
-        route.metadata
+        route.metadata,
+        route.outputExportFallbackBasePath
       ),
       parent: parentBundle,
     }
@@ -1727,13 +1750,15 @@ function finishStaticBundleOnRuntimeBailout(
 
 function pingFullSegmentRevalidation(
   now: number,
+  route: FulfilledRouteCacheEntry,
   tree: RouteTree,
   fetchStrategy: FetchStrategy.Full | FetchStrategy.PPRRuntime
 ): PendingSegmentCacheEntry | null {
   const revalidatingSegment = readOrCreateRevalidatingSegmentEntry(
     now,
     fetchStrategy,
-    tree
+    tree,
+    route.outputExportFallbackBasePath
   )
   if (revalidatingSegment.status === EntryStatus.Empty) {
     // During a Full/PPRRuntime prefetch, a single dynamic request is made for all the

--- a/packages/next/src/client/components/segment-cache/vary-path.test.ts
+++ b/packages/next/src/client/components/segment-cache/vary-path.test.ts
@@ -1,0 +1,88 @@
+import { Fallback } from './cache-map'
+import { FetchStrategy } from './types'
+import {
+  finalizeMetadataVaryPath,
+  finalizePageVaryPath,
+  getFulfilledSegmentVaryPath,
+  getSegmentVaryPathForRequest,
+} from './vary-path'
+
+describe('getSegmentVaryPathForRequest output export fallback', () => {
+  it('reuses path params for normal static prefetches', () => {
+    const varyPath = finalizeMetadataVaryPath(
+      '/t/$d$threadId/__PAGE__',
+      '' as any,
+      {
+        id: 'threadId',
+        value: 'j97358' as any,
+        parent: null,
+      } as any
+    )
+
+    const requestVaryPath = getSegmentVaryPathForRequest(
+      FetchStrategy.PPR,
+      {
+        requestKey: '/_head',
+        segment: '/_head',
+        refreshState: null,
+        varyPath,
+        isPage: true,
+        slots: null,
+        prefetchHints: 0,
+      },
+      null
+    )
+
+    expect(requestVaryPath.parent.parent.value).toBe('j97358')
+  })
+
+  it('treats path params as reusable for learned output export fallback routes', () => {
+    const varyPath = finalizePageVaryPath(
+      '/t/$d$threadId/__PAGE__',
+      '' as any,
+      {
+        id: 'threadId',
+        value: 'j97358' as any,
+        parent: null,
+      } as any
+    )
+
+    const requestVaryPath = getSegmentVaryPathForRequest(
+      FetchStrategy.PPR,
+      {
+        requestKey: '/t/$d$threadId/__PAGE__',
+        segment: '/t/$d$threadId',
+        refreshState: null,
+        varyPath,
+        isPage: true,
+        slots: null,
+        prefetchHints: 0,
+      },
+      '/t/__fallback'
+    )
+
+    expect(requestVaryPath.parent.value).toBe(Fallback)
+    expect(requestVaryPath.parent.parent.value).toBe(Fallback)
+  })
+
+  it('keeps fulfilled fallback segment path params generic even when vary params include them', () => {
+    const varyPath = finalizeMetadataVaryPath(
+      '/t/$d$threadId/__PAGE__',
+      '' as any,
+      {
+        id: 'threadId',
+        value: 'j97358' as any,
+        parent: null,
+      } as any
+    )
+
+    const fulfilledVaryPath = getFulfilledSegmentVaryPath(
+      varyPath,
+      new Set(['?', 'threadId']),
+      true
+    )
+
+    expect(fulfilledVaryPath.parent.value).toBe('')
+    expect(fulfilledVaryPath.parent.parent.value).toBe(Fallback)
+  })
+})

--- a/packages/next/src/client/components/segment-cache/vary-path.ts
+++ b/packages/next/src/client/components/segment-cache/vary-path.ts
@@ -244,7 +244,8 @@ export function finalizeMetadataVaryPath(
 
 export function getSegmentVaryPathForRequest(
   fetchStrategy: FetchStrategy,
-  tree: RouteTree
+  tree: RouteTree,
+  outputExportFallbackBasePath: string | null = null
 ): SegmentVaryPath {
   // This is used for storing pending requests in the cache. We want to choose
   // the most generic vary path based on the strategy used to fetch it, i.e.
@@ -272,6 +273,15 @@ export function getSegmentVaryPathForRequest(
   // Only page segments (and the special "metadata" segment, which is treated
   // like a page segment for the purposes of caching) may contain search
   // params. There's no reason to include them in the vary path otherwise.
+  const originalPathParamsVaryPath = tree.isPage
+    ? getPartialPageVaryPath(originalVaryPath as PageVaryPath)
+    : getPartialLayoutVaryPath(originalVaryPath as LayoutVaryPath)
+
+  const pathParamsVaryPath =
+    outputExportFallbackBasePath !== null
+      ? clonePathParamsVaryPathWithFallback(originalPathParamsVaryPath)
+      : originalPathParamsVaryPath
+
   if (tree.isPage) {
     // Only a runtime prefetch will include search params in the vary path.
     // Static prefetches never include search params, so they can be reused
@@ -287,8 +297,6 @@ export function getSegmentVaryPathForRequest(
       //
       // requestKey -> searchParams -> pathParams
       //               ^ This part gets replaced with Fallback
-      const searchParamsVaryPath = (originalVaryPath as PageVaryPath).parent
-      const pathParamsVaryPath = searchParamsVaryPath.parent
       const patchedVaryPath: VaryPath = {
         id: null,
         value: originalVaryPath.value,
@@ -300,10 +308,51 @@ export function getSegmentVaryPathForRequest(
       }
       return patchedVaryPath as SegmentVaryPath
     }
+
+    if (pathParamsVaryPath !== originalPathParamsVaryPath) {
+      const searchParamsVaryPath = (originalVaryPath as PageVaryPath).parent
+      const patchedVaryPath: VaryPath = {
+        id: null,
+        value: originalVaryPath.value,
+        parent: {
+          id: '?',
+          value: searchParamsVaryPath.value,
+          parent: pathParamsVaryPath,
+        },
+      }
+      return patchedVaryPath as SegmentVaryPath
+    }
+  }
+
+  if (pathParamsVaryPath !== originalPathParamsVaryPath) {
+    const patchedVaryPath: VaryPath = {
+      id: null,
+      value: originalVaryPath.value,
+      parent: pathParamsVaryPath,
+    }
+    return patchedVaryPath as SegmentVaryPath
   }
 
   // The request does vary on search params. We don't need to modify anything.
   return originalVaryPath as SegmentVaryPath
+}
+
+function clonePathParamsVaryPathWithFallback(
+  originalVaryPath: PartialSegmentVaryPath | null
+): PartialSegmentVaryPath | null {
+  if (originalVaryPath === null) {
+    return null
+  }
+
+  const clonedParent = clonePathParamsVaryPathWithFallback(
+    originalVaryPath.parent as PartialSegmentVaryPath | null
+  )
+  const clonedVaryPath: VaryPath = {
+    id: originalVaryPath.id,
+    value: originalVaryPath.id === null ? originalVaryPath.value : Fallback,
+    parent: clonedParent,
+  }
+  return clonedVaryPath as PartialSegmentVaryPath
 }
 
 export function clonePageVaryPathWithNewSearchParams(
@@ -336,7 +385,8 @@ export function getRenderedSearchFromVaryPath(
 
 export function getFulfilledSegmentVaryPath(
   original: VaryPath,
-  varyParams: Set<string>
+  varyParams: Set<string>,
+  forceFallbackPathParams: boolean = false
 ): SegmentVaryPath {
   // Re-keys a segment's vary path based on which params the segment actually
   // depends on. Params that are NOT in the varyParams set are replaced with
@@ -348,17 +398,26 @@ export function getFulfilledSegmentVaryPath(
   // accessed during rendering.
   const clone: VaryPath = {
     id: original.id,
-    // If the id is null, this node is not a param (e.g., it's a request key).
-    // If the id is in the varyParams set, keep the original value.
-    // Otherwise, replace with Fallback to make it reusable.
+    // If the id is null, this node is not a param (e.g., it's a request key),
+    // so always preserve it. For output export fallback routes, path params
+    // are always generic even if the server reports them as accessed, because
+    // the emitted fallback artifacts are shared across all param values.
     value:
-      original.id === null || varyParams.has(original.id)
+      original.id === null
         ? original.value
-        : Fallback,
+        : forceFallbackPathParams && original.id !== '?'
+          ? Fallback
+          : varyParams.has(original.id)
+            ? original.value
+            : Fallback,
     parent:
       original.parent === null
         ? null
-        : getFulfilledSegmentVaryPath(original.parent, varyParams),
+        : getFulfilledSegmentVaryPath(
+            original.parent,
+            varyParams,
+            forceFallbackPathParams
+          ),
   }
   return clone as SegmentVaryPath
 }

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/hydrated/[thread]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/hydrated/[thread]/page.js
@@ -1,0 +1,20 @@
+import { Suspense } from 'react'
+import { LinkAccordion } from '../../components/link-accordion'
+import HydratedThreadClient from './thread-client'
+
+export default function HydratedThreadPage() {
+  return (
+    <>
+      <Suspense fallback={<h1>Loading hydrated thread...</h1>}>
+        <HydratedThreadClient />
+      </Suspense>
+      <ul>
+        <li>
+          <LinkAccordion href="/hydrated/second">
+            Visit hydrated thread second
+          </LinkAccordion>
+        </li>
+      </ul>
+    </>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/hydrated/[thread]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/hydrated/[thread]/page.js
@@ -14,6 +14,11 @@ export default function HydratedThreadPage() {
             Visit hydrated thread second
           </LinkAccordion>
         </li>
+        <li>
+          <LinkAccordion href="/hydrated/third">
+            Visit hydrated thread third
+          </LinkAccordion>
+        </li>
       </ul>
     </>
   )

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/hydrated/[thread]/thread-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/hydrated/[thread]/thread-client.js
@@ -1,0 +1,9 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function HydratedThreadClient() {
+  const params = useParams()
+
+  return <h1>{params.thread}</h1>
+}

--- a/test/e2e/app-dir-export/test/dynamic-fallback-cache-components.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-fallback-cache-components.test.ts
@@ -423,6 +423,7 @@ if (skipped) {
             expect(await browser.elementByCss('h1').text()).toBe('first')
           })
 
+          await act(async () => {})
           clearRequests()
 
           await act(async () => {
@@ -454,6 +455,49 @@ if (skipped) {
               requestPath.startsWith('/hydrated/__fallback')
             )
           ).toBe(true)
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('dedupes hydrated sibling metadata prefetches by fallback artifact path', async () => {
+        let act!: ReturnType<typeof createRouterAct>
+        const browser = await webdriver(port, '/hydrated/first/', {
+          beforePageLoad(page: Playwright.Page) {
+            act = createRouterAct(page)
+          },
+        })
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('first')
+          })
+
+          clearRequests()
+
+          await act(async () => {
+            await browser
+              .elementByCss('input[data-link-accordion="/hydrated/second"]')
+              .click()
+            await browser
+              .elementByCss('input[data-link-accordion="/hydrated/third"]')
+              .click()
+          })
+
+          const prefetchRequests = getRequests()
+
+          expect(
+            prefetchRequests.filter((requestPath) =>
+              requestPath.startsWith('/hydrated/__fallback/__next._head.txt')
+            )
+          ).toHaveLength(1)
+          expect(
+            prefetchRequests.filter((requestPath) =>
+              requestPath.includes(
+                '/hydrated/__fallback/__next.hydrated.$d$thread.__PAGE__.txt'
+              )
+            )
+          ).toHaveLength(1)
         } finally {
           await browser.close()
         }

--- a/test/e2e/app-dir-export/test/dynamic-fallback-cache-components.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-fallback-cache-components.test.ts
@@ -423,7 +423,6 @@ if (skipped) {
             expect(await browser.elementByCss('h1').text()).toBe('first')
           })
 
-          await act(async () => {})
           clearRequests()
 
           await act(async () => {

--- a/test/e2e/app-dir-export/test/dynamic-fallback-cache-components.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-fallback-cache-components.test.ts
@@ -410,6 +410,55 @@ if (skipped) {
         }
       })
 
+      it('reuses the hydrated fallback artifact base for sibling segment prefetches', async () => {
+        let act!: ReturnType<typeof createRouterAct>
+        const browser = await webdriver(port, '/hydrated/first/', {
+          beforePageLoad(page: Playwright.Page) {
+            act = createRouterAct(page)
+          },
+        })
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('first')
+          })
+
+          clearRequests()
+
+          await act(async () => {
+            await browser
+              .elementByCss('input[data-link-accordion="/hydrated/second"]')
+              .click()
+          })
+
+          const prefetchRequests = getRequests()
+
+          expect(prefetchRequests.length).toBeGreaterThan(0)
+          expect(
+            prefetchRequests.some((requestPath) =>
+              requestPath.startsWith('/hydrated/second/?_rsc=')
+            )
+          ).toBe(false)
+          expect(
+            prefetchRequests.some((requestPath) =>
+              requestPath.startsWith('/hydrated/second/index.txt')
+            )
+          ).toBe(false)
+          expect(
+            prefetchRequests.some((requestPath) =>
+              requestPath.startsWith('/hydrated/second/__next.')
+            )
+          ).toBe(false)
+          expect(
+            prefetchRequests.some((requestPath) =>
+              requestPath.startsWith('/hydrated/__fallback')
+            )
+          ).toBe(true)
+        } finally {
+          await browser.close()
+        }
+      })
+
       it('generates a hidden _fallback.html bootstrap document', async () => {
         const outDir = join(next.testDir, 'out')
         const fallbackHtml = await fs.readFile(


### PR DESCRIPTION
## Summary
- Preserve learned fallback artifact bases through optimistic routes and hydration.
- Deduplicate post-hydration fallback segment prefetches once the router has resumed on the client.

## Why
- The prefetch work teaches the client which fallback artifact to use. Hydration needs to preserve that knowledge or the client regresses into redundant or incorrect follow-up requests.

## Validation
- `pnpm --filter=next build`
- `pnpm testonly packages/next/src/client/components/segment-cache/cache.test.ts packages/next/src/client/components/router-reducer/create-initial-router-state.test.ts packages/next/src/client/components/segment-cache/vary-path.test.ts`
- `NEXT_SKIP_ISOLATE=1 NEXT_TEST_MODE=start pnpm testheadless test/e2e/app-dir-export/test/dynamic-fallback-cache-components.test.ts`

## Stack
- Previous: [#93020](https://github.com/vercel/next.js/pull/93020)
- Next: [#93022](https://github.com/vercel/next.js/pull/93022)

Full stack:
1. [#93013](https://github.com/vercel/next.js/pull/93013) output export fallback: cover flat fallbacks and fix resume path
2. [#93014](https://github.com/vercel/next.js/pull/93014) output export fallback: move fallback e2e suites onto fixtures
3. [#93015](https://github.com/vercel/next.js/pull/93015) output export fallback: support conflicting routes
4. [#93016](https://github.com/vercel/next.js/pull/93016) output export fallback: hide the bootstrap shell
5. [#93017](https://github.com/vercel/next.js/pull/93017) output export fallback: guard server-only APIs
6. [#93018](https://github.com/vercel/next.js/pull/93018) output export fallback: cover server IO boundaries
7. [#93019](https://github.com/vercel/next.js/pull/93019) output export fallback: avoid fallback document URL swaps
8. [#93020](https://github.com/vercel/next.js/pull/93020) output export fallback: prefetch and dedupe fallback payloads
9. [#93021](https://github.com/vercel/next.js/pull/93021) output export fallback: carry fallback bases through hydration <- current
10. [#93022](https://github.com/vercel/next.js/pull/93022) output export fallback: prefer deeper static prefixes
11. [#92555](https://github.com/vercel/next.js/pull/92555) output export fallback: recover unmatched routes with _not-found

<!-- NEXT_JS_LLM_PR -->
