### PR TITLE
output export fallback: prefer deeper static prefixes

### DIFF
--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -30,8 +30,8 @@ import { getDeploymentId } from '../shared/lib/deployment-id'
 import { setNavigationBuildId } from './navigation-build-id'
 import {
   addOutputExportDataSuffix,
-  fetchOutputExportDataResponse,
   fetchOutputExportFallbackResponse,
+  fetchOutputExportNotFoundDataResponse,
 } from './output-export-fallback'
 
 /// <reference types="react-dom/experimental" />
@@ -303,12 +303,9 @@ if (instantTestStaticFetch) {
     }
 
     const response =
-      (await fetchOutputExportDataResponse(
-        new URL('/_not-found', renderedUrl),
-        {
-          credentials: 'same-origin',
-        }
-      )) ??
+      (await fetchOutputExportNotFoundDataResponse(renderedUrl, {
+        credentials: 'same-origin',
+      })) ??
       (await fetch(
         addOutputExportDataSuffix(new URL('/_not-found', renderedUrl)),
         {

--- a/packages/next/src/client/output-export-fallback.test.ts
+++ b/packages/next/src/client/output-export-fallback.test.ts
@@ -3,9 +3,11 @@ import {
   clearOutputExportFallbackManifestCache,
   fetchOutputExportDataResponse,
   fetchOutputExportFallbackResponse,
+  fetchOutputExportNotFoundDataResponse,
   getCachedOutputExportFallbackDataUrl,
   getCachedOutputExportFallbackRequestUrl,
   getOutputExportFallbackCandidates,
+  getOutputExportNotFoundCandidates,
   stripOutputExportDataSuffix,
 } from './output-export-fallback'
 
@@ -20,12 +22,12 @@ describe('output export fallback helpers', () => {
     jest.restoreAllMocks()
   })
 
-  it('discovers fallback candidates from shallowest static prefix to root', () => {
+  it('discovers fallback candidates from deepest static prefix to root', () => {
     expect(getOutputExportFallbackCandidates('/org/acme/chat/123')).toEqual([
-      '/org/__fallback',
-      '/org/acme/__fallback',
-      '/org/acme/chat/__fallback',
       '/org/acme/chat/123/__fallback',
+      '/org/acme/chat/__fallback',
+      '/org/acme/__fallback',
+      '/org/__fallback',
       '/__fallback',
     ])
   })
@@ -34,6 +36,15 @@ describe('output export fallback helpers', () => {
     expect(getOutputExportFallbackCandidates('/optional/')).toEqual([
       '/optional/__fallback',
       '/__fallback',
+    ])
+  })
+
+  it('discovers not-found candidates from deepest static prefix to root', () => {
+    expect(getOutputExportNotFoundCandidates('/docs/missing/route')).toEqual([
+      '/docs/missing/route/_not-found',
+      '/docs/missing/_not-found',
+      '/docs/_not-found',
+      '/_not-found',
     ])
   })
 
@@ -93,13 +104,27 @@ describe('output export fallback helpers', () => {
     ])
   })
 
-  it('tries the direct fallback artifact before manifest lookups', async () => {
+  it('falls through deeper prefixes before using a shallower direct fallback artifact', async () => {
     process.env.__NEXT_TRAILING_SLASH = 'false'
     const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
       const url = String(input)
 
-      if (url.endsWith('/org/__fallback.txt')) {
-        return new Response('payload', {
+      if (url.endsWith('/docs/guides/export/__fallback.txt')) {
+        return new Response('not found', {
+          status: 404,
+          headers: { 'content-type': 'text/html' },
+        })
+      }
+
+      if (url.endsWith('/docs/guides/export/__fallback.meta.json')) {
+        return new Response('not found', {
+          status: 404,
+          headers: { 'content-type': 'text/html' },
+        })
+      }
+
+      if (url.endsWith('/docs/guides/__fallback.txt')) {
+        return new Response('specific payload', {
           status: 200,
           headers: { 'content-type': 'text/plain' },
         })
@@ -113,13 +138,16 @@ describe('output export fallback helpers', () => {
 
     global.fetch = fetchMock as typeof fetch
 
-    const renderedUrl = new URL('https://example.com/org/acme/chat/123')
+    const renderedUrl = new URL('https://example.com/docs/guides/export')
     const result = await fetchOutputExportFallbackResponse(renderedUrl)
 
     expect(result).not.toBeNull()
     expect(result?.renderedUrl.href).toBe(renderedUrl.href)
+    expect(result?.fallbackUrl.pathname).toBe('/docs/guides/__fallback')
     expect(fetchMock.mock.calls.map(([url]) => String(url))).toEqual([
-      'https://example.com/org/__fallback.txt',
+      'https://example.com/docs/guides/export/__fallback.txt',
+      'https://example.com/docs/guides/export/__fallback.meta.json',
+      'https://example.com/docs/guides/__fallback.txt',
     ])
   })
 
@@ -129,7 +157,7 @@ describe('output export fallback helpers', () => {
     const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
       const url = String(input)
 
-      if (url.endsWith('/org/__fallback/index.txt')) {
+      if (url.endsWith('/optional/__fallback/index.txt')) {
         return new Response('flight', {
           status: 200,
           headers: { 'content-type': 'text/x-component' },
@@ -144,15 +172,13 @@ describe('output export fallback helpers', () => {
 
     global.fetch = fetchMock as typeof fetch
 
-    const renderedUrl = new URL(
-      'https://example.com/org/umbrella/chat/thread-789/'
-    )
+    const renderedUrl = new URL('https://example.com/optional/')
     const result = await fetchOutputExportFallbackResponse(renderedUrl)
 
     expect(result).not.toBeNull()
     expect(result?.renderedUrl.href).toBe(renderedUrl.href)
     expect(fetchMock.mock.calls.map(([url]) => String(url))).toEqual([
-      'https://example.com/org/__fallback/index.txt',
+      'https://example.com/optional/__fallback/index.txt',
     ])
   })
 
@@ -210,11 +236,17 @@ describe('output export fallback helpers', () => {
 
     expect(result).not.toBeNull()
     expect(result?.fallbackUrl.pathname).toBe('/docs/__fallback/__route_0')
-    expect(fetchMock.mock.calls.map(([url]) => String(url))).toEqual([
-      'https://example.com/docs/__fallback.txt',
-      'https://example.com/docs/__fallback.meta.json',
-      'https://example.com/docs/__fallback/__route_0.txt',
-    ])
+    const requestedUrls = fetchMock.mock.calls.map(([url]) => String(url))
+    expect(requestedUrls).toContain('https://example.com/docs/__fallback.txt')
+    expect(requestedUrls).toContain(
+      'https://example.com/docs/__fallback.meta.json'
+    )
+    expect(requestedUrls).toContain(
+      'https://example.com/docs/__fallback/__route_0.txt'
+    )
+    expect(requestedUrls).not.toContain(
+      'https://example.com/docs/__fallback/__route_1.txt'
+    )
   })
 
   it('caches the resolved fallback data URL for later RSC fetches', async () => {
@@ -340,10 +372,50 @@ describe('output export fallback helpers', () => {
       new URL('https://example.com/docs/api/guide')
     )
 
+    const requestedUrls = fetchMock.mock.calls.map(([url]) => String(url))
+    expect(
+      requestedUrls.filter(
+        (url) => url === 'https://example.com/docs/__fallback.meta.json'
+      )
+    ).toHaveLength(1)
+    expect(
+      requestedUrls.filter(
+        (url) => url === 'https://example.com/docs/__fallback/__route_0.txt'
+      )
+    ).toHaveLength(1)
+  })
+
+  it('tries subpath-prefixed not-found payloads before falling back to root', async () => {
+    process.env.__NEXT_TRAILING_SLASH = 'false'
+    const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url.endsWith('/docs/_not-found.txt')) {
+        return new Response('not found payload', {
+          status: 200,
+          headers: { 'content-type': 'text/plain' },
+        })
+      }
+
+      return new Response('<!doctype html><title>fallback</title>', {
+        status: 200,
+        headers: { 'content-type': 'text/html' },
+      })
+    })
+
+    global.fetch = fetchMock as typeof fetch
+
+    const response = await fetchOutputExportNotFoundDataResponse(
+      new URL('https://example.com/docs/missing/route')
+    )
+
+    expect(response).not.toBeNull()
     expect(fetchMock.mock.calls.map(([url]) => String(url))).toEqual([
-      'https://example.com/docs/__fallback.txt',
-      'https://example.com/docs/__fallback.meta.json',
-      'https://example.com/docs/__fallback/__route_0.txt',
+      'https://example.com/docs/missing/route/_not-found.txt',
+      'https://example.com/docs/missing/route/_not-found/index.txt',
+      'https://example.com/docs/missing/_not-found.txt',
+      'https://example.com/docs/missing/_not-found/index.txt',
+      'https://example.com/docs/_not-found.txt',
     ])
   })
 })

--- a/packages/next/src/client/output-export-fallback.ts
+++ b/packages/next/src/client/output-export-fallback.ts
@@ -26,6 +26,19 @@ type OutputExportCachedResponse = {
   statusText: string
 }
 
+function getOutputExportCandidatePrefixes(pathname: string): string[] {
+  const segments = pathname.split('/').filter(Boolean)
+  const candidates: string[] = []
+
+  for (let i = segments.length; i >= 1; i--) {
+    candidates.push(segments.slice(0, i).join('/'))
+  }
+
+  candidates.push('')
+
+  return candidates
+}
+
 function getOutputExportFallbackCacheStore(): OutputExportFallbackCacheStore {
   const globalWithCache = globalThis as typeof globalThis & {
     __NEXT_OUTPUT_EXPORT_FALLBACK_CACHE_STORE?: OutputExportFallbackCacheStore
@@ -49,17 +62,19 @@ function getOutputExportFallbackCacheStore(): OutputExportFallbackCacheStore {
 }
 
 export function getOutputExportFallbackCandidates(pathname: string): string[] {
-  const segments = pathname.split('/').filter(Boolean)
-  const candidates: string[] = []
+  return getOutputExportCandidatePrefixes(pathname).map((prefix) =>
+    getOutputExportFallbackPath(prefix)
+  )
+}
 
-  for (let i = 1; i <= segments.length; i++) {
-    const prefix = segments.slice(0, i).join('/')
-    candidates.push(getOutputExportFallbackPath(prefix))
-  }
+function getOutputExportNotFoundPath(prefix: string): string {
+  return prefix.length > 0 ? `/${prefix}/_not-found` : '/_not-found'
+}
 
-  candidates.push(getOutputExportFallbackPath(''))
-
-  return candidates
+export function getOutputExportNotFoundCandidates(pathname: string): string[] {
+  return getOutputExportCandidatePrefixes(pathname).map((prefix) =>
+    getOutputExportNotFoundPath(prefix)
+  )
 }
 
 export function addOutputExportDataSuffix(url: URL): URL {
@@ -321,6 +336,25 @@ export async function fetchOutputExportDataResponse(
 ): Promise<Response | null> {
   const result = await fetchOutputExportDataResult(renderedUrl, init)
   return result?.response ?? null
+}
+
+export async function fetchOutputExportNotFoundDataResponse(
+  renderedUrl: URL,
+  init?: RequestInit
+): Promise<Response | null> {
+  for (const candidate of getOutputExportNotFoundCandidates(
+    renderedUrl.pathname
+  )) {
+    const candidateUrl = new URL(renderedUrl)
+    candidateUrl.pathname = candidate
+
+    const response = await fetchOutputExportDataResponse(candidateUrl, init)
+    if (response !== null) {
+      return response
+    }
+  }
+
+  return null
 }
 
 export async function fetchOutputExportFallbackResponse(


### PR DESCRIPTION
## Summary
- Prefer deeper static-prefix fallback matches over shallower overlapping candidates.
- Add overlap coverage so deeper route branches win before broad catch-all branches.

## Why
- The existing candidate order was shallowest-first, which can misroute overlapping dynamic routes that live at different static-prefix depths.

## Validation
- `pnpm --filter=next build`
- `pnpm testonly packages/next/src/client/output-export-fallback.test.ts`
- `NEXT_SKIP_ISOLATE=1 NEXT_TEST_MODE=start pnpm testheadless test/e2e/app-dir-export/test/dynamic-fallback-cache-components.test.ts`

## Stack
- Previous: [#93021](https://github.com/vercel/next.js/pull/93021)
- Next: [#92555](https://github.com/vercel/next.js/pull/92555)

Full stack:
1. [#93013](https://github.com/vercel/next.js/pull/93013) output export fallback: cover flat fallbacks and fix resume path
2. [#93014](https://github.com/vercel/next.js/pull/93014) output export fallback: move fallback e2e suites onto fixtures
3. [#93015](https://github.com/vercel/next.js/pull/93015) output export fallback: support conflicting routes
4. [#93016](https://github.com/vercel/next.js/pull/93016) output export fallback: hide the bootstrap shell
5. [#93017](https://github.com/vercel/next.js/pull/93017) output export fallback: guard server-only APIs
6. [#93018](https://github.com/vercel/next.js/pull/93018) output export fallback: cover server IO boundaries
7. [#93019](https://github.com/vercel/next.js/pull/93019) output export fallback: avoid fallback document URL swaps
8. [#93020](https://github.com/vercel/next.js/pull/93020) output export fallback: prefetch and dedupe fallback payloads
9. [#93021](https://github.com/vercel/next.js/pull/93021) output export fallback: carry fallback bases through hydration
10. [#93022](https://github.com/vercel/next.js/pull/93022) output export fallback: prefer deeper static prefixes <- current
11. [#92555](https://github.com/vercel/next.js/pull/92555) output export fallback: recover unmatched routes with _not-found

<!-- NEXT_JS_LLM_PR -->
