### PR TITLE
(8/9) Reuse learned export fallback paths after hydration

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1176,5 +1176,6 @@
   "1175": "Page \"%s\" is missing \"generateStaticParams()\" so it cannot be used with \"output: export\" config. Either add generateStaticParams() to enumerate all params, or enable Cache Components (cacheComponents: true) to support dynamic route fallbacks without enumerating every param. Learn more: https://nextjs.org/docs/app/guides/static-exports#app-router-dynamic-routes",
   "1176": "The route \"%s%s\" conflicts with the internal \"__fallback\" path used by dynamic route fallbacks in static export mode. Please rename this route to something else.\\n\\nLearn more: https://nextjs.org/docs/app/guides/static-exports",
   "1177": "Route \"%s\" used unresolved dynamic params in a Server Component with \"output: export\". This is not supported because these fallback params are only available on the client. Move param-dependent content into a Client Component or add generateStaticParams() to prerender this route. See more info here: https://nextjs.org/docs/app/guides/static-exports",
-  "1178": "Route \"%s\" used %s in a Server Component with \"output: export\". This is not supported because %s See more info here: https://nextjs.org/docs/app/guides/static-exports"
+  "1178": "Route \"%s\" used %s in a Server Component with \"output: export\". This is not supported because %s See more info here: https://nextjs.org/docs/app/guides/static-exports",
+  "1179": "Expected staticChildren to be initialized for known dynamic siblings."
 }

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.test.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.test.ts
@@ -116,7 +116,7 @@ describe('createInitialRouterState output export fallback', () => {
       data: null,
       head: null,
       dynamicStaleAt: Date.now() + 30_000,
-      outputExportFallbackBasePath: null as string | null,
+      outputExportFallbackBasePath: '/hydrated/__fallback' as string | null,
     }
 
     mockProcessRuntimePrefetchStream.mockResolvedValue({
@@ -143,7 +143,11 @@ describe('createInitialRouterState output export fallback', () => {
     await Promise.resolve()
     await Promise.resolve()
 
-    expect(processedNavigationSeed.outputExportFallbackBasePath).toBe(
+    expect(mockProcessRuntimePrefetchStream).toHaveBeenCalledWith(
+      expect.any(Number),
+      expect.any(ReadableStream),
+      ['', {}],
+      '',
       '/hydrated/__fallback'
     )
     expect(mockWriteDynamicRenderResponseIntoCache).toHaveBeenCalledWith(

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -145,7 +145,8 @@ export function createInitialRouterState({
               staleAt,
               initialTree,
               initialRenderedSearch,
-              true // isResponsePartial
+              true, // isResponsePartial
+              outputExportFallbackBasePath
             )
           })
           .catch(() => {
@@ -170,7 +171,8 @@ export function createInitialRouterState({
               staleAt,
               initialTree,
               initialRenderedSearch,
-              false // isResponsePartial
+              false, // isResponsePartial
+              outputExportFallbackBasePath
             )
           })
           .catch(() => {

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -195,12 +195,11 @@ export function createInitialRouterState({
         Date.now(),
         initialRuntimePrefetchStream,
         initialTree,
-        initialRenderedSearch
+        initialRenderedSearch,
+        outputExportFallbackBasePath
       )
         .then((processed) => {
           if (processed !== null) {
-            processed.navigationSeed.outputExportFallbackBasePath =
-              outputExportFallbackBasePath
             writeDynamicRenderResponseIntoCache(
               Date.now(),
               FetchStrategy.PPRRuntime,

--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -1625,7 +1625,8 @@ async function fetchMissingDynamicData(
       task.route,
       result.flightData,
       result.renderedSearch,
-      result.dynamicStaleTime
+      result.dynamicStaleTime,
+      result.outputExportFallbackBasePath
     )
 
     // If the navigation lock is active, wait for it to be released before
@@ -1653,7 +1654,8 @@ async function fetchMissingDynamicData(
             staleAt,
             dynamicRequestTree,
             result.renderedSearch,
-            isResponsePartial
+            isResponsePartial,
+            result.outputExportFallbackBasePath
           )
         })
         .catch(() => {

--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -1667,12 +1667,11 @@ async function fetchMissingDynamicData(
         now,
         result.runtimePrefetchStream,
         dynamicRequestTree,
-        result.renderedSearch
+        result.renderedSearch,
+        routeCacheEntry.outputExportFallbackBasePath
       )
         .then((processed) => {
           if (processed !== null) {
-            processed.navigationSeed.outputExportFallbackBasePath =
-              routeCacheEntry.outputExportFallbackBasePath
             writeDynamicRenderResponseIntoCache(
               now,
               FetchStrategy.PPRRuntime,

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -3320,7 +3320,8 @@ export function writeStaticStageResponseIntoCache(
   staleAt: number,
   baseTree: FlightRouterState,
   renderedSearch: string,
-  isResponsePartial: boolean
+  isResponsePartial: boolean,
+  outputExportFallbackBasePath: string | null = null
 ): void {
   const fetchStrategy = isResponsePartial
     ? FetchStrategy.PPR
@@ -3340,7 +3341,8 @@ export function writeStaticStageResponseIntoCache(
     baseTree,
     flightDatas,
     renderedSearch,
-    UnknownDynamicStaleTime
+    UnknownDynamicStaleTime,
+    outputExportFallbackBasePath
   )
   writeDynamicRenderResponseIntoCache(
     now,

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -471,7 +471,8 @@ async function navigateToUnknownRoute(
             staleAt,
             currentFlightRouterState,
             renderedSearch,
-            isResponsePartial
+            isResponsePartial,
+            outputExportFallbackBasePath
           )
         })
         .catch(() => {

--- a/packages/next/src/client/components/segment-cache/optimistic-routes.ts
+++ b/packages/next/src/client/components/segment-cache/optimistic-routes.ts
@@ -405,14 +405,22 @@ function discoverKnownRoutePart(
       // - staticChildren: null = siblings unknown (can't safely match dynamic)
       // - staticChildren: Map = siblings known (even if empty)
       // This matters in dev mode where webpack may not know all siblings yet.
-      if (staticSiblings !== null) {
+      if (staticSiblings !== null || process.env.NODE_ENV === 'production') {
         // Siblings are known - ensure we have a Map (even if empty)
         if (parentKnownRoutePart.staticChildren === null) {
           parentKnownRoutePart.staticChildren = new Map()
         }
+      }
+      if (staticSiblings !== null) {
+        const staticChildren = parentKnownRoutePart.staticChildren
+        if (staticChildren === null) {
+          throw new Error(
+            'Expected staticChildren to be initialized for known dynamic siblings.'
+          )
+        }
         for (const sibling of staticSiblings) {
-          if (!parentKnownRoutePart.staticChildren.has(sibling)) {
-            parentKnownRoutePart.staticChildren.set(sibling, createEmptyPart())
+          if (!staticChildren.has(sibling)) {
+            staticChildren.set(sibling, createEmptyPart())
           }
         }
       }

--- a/packages/next/src/client/output-export-fallback.test.ts
+++ b/packages/next/src/client/output-export-fallback.test.ts
@@ -265,6 +265,7 @@ describe('output export fallback helpers', () => {
     expect(result?.renderedUrl.href).toBe(renderedUrl.href)
     expect(fetchMock.mock.calls.map(([url]) => String(url))).toEqual([
       'https://example.com/org/umbrella/chat/thread-789/__fallback/index.txt',
+      'https://example.com/org/umbrella/chat/thread-789/__fallback.meta.json',
     ])
   })
 

--- a/packages/next/src/client/output-export-fallback.test.ts
+++ b/packages/next/src/client/output-export-fallback.test.ts
@@ -130,7 +130,61 @@ describe('output export fallback helpers', () => {
     expect(result?.renderedUrl.href).toBe(renderedUrl.href)
     expect(fetchMock.mock.calls.map(([url]) => String(url))).toEqual([
       'https://example.com/org/acme/chat/123/__fallback.txt',
+      'https://example.com/org/acme/chat/123/__fallback.meta.json',
     ])
+  })
+
+  it('uses manifest fallback base paths even when the direct artifact already exists', async () => {
+    const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url.endsWith('/hydrated/second/__fallback/index.txt')) {
+        return new Response('payload', {
+          status: 200,
+          headers: { 'content-type': 'text/plain' },
+        })
+      }
+
+      if (url.endsWith('/hydrated/second/__fallback.meta.json')) {
+        return new Response(
+          JSON.stringify({
+            version: 1,
+            routes: [
+              {
+                route: '/hydrated/[thread]',
+                fallbackPath: '/hydrated/__fallback',
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }
+        )
+      }
+
+      return new Response('not found', {
+        status: 404,
+        headers: { 'content-type': 'text/html' },
+      })
+    })
+
+    global.fetch = fetchMock as typeof fetch
+
+    const renderedUrl = new URL('https://example.com/hydrated/second/')
+    const result = await fetchOutputExportFallbackResponse(renderedUrl)
+
+    expect(result).not.toBeNull()
+    expect(result?.fallbackUrl.pathname).toBe('/hydrated/__fallback')
+    expect(fetchMock.mock.calls.map(([url]) => String(url))).toEqual([
+      'https://example.com/hydrated/second/__fallback/index.txt',
+      'https://example.com/hydrated/second/__fallback.meta.json',
+    ])
+    expect(
+      getCachedOutputExportFallbackRequestUrl(
+        new URL('https://example.com/hydrated/second/__next._tree.txt')
+      )?.href
+    ).toBe('https://example.com/hydrated/__fallback/__next._tree.txt')
   })
 
   it('falls through deeper prefixes before using a shallower fallback artifact', async () => {
@@ -177,6 +231,7 @@ describe('output export fallback helpers', () => {
       'https://example.com/docs/guides/export/__fallback.txt',
       'https://example.com/docs/guides/export/__fallback.meta.json',
       'https://example.com/docs/guides/__fallback.txt',
+      'https://example.com/docs/guides/__fallback.meta.json',
     ])
   })
 

--- a/packages/next/src/client/output-export-fallback.ts
+++ b/packages/next/src/client/output-export-fallback.ts
@@ -437,6 +437,11 @@ export async function fetchOutputExportFallbackResponse(
     const candidateUrl = new URL(renderedUrl)
     candidateUrl.pathname = candidate
 
+    const directResult = await fetchConfiguredOutputExportDataResult(
+      candidateUrl,
+      prefersTrailingSlash,
+      init
+    )
     const fallbackManifest = await fetchOutputExportFallbackManifest(
       candidateUrl,
       init
@@ -455,6 +460,19 @@ export async function fetchOutputExportFallbackResponse(
           removePathPrefix(entry.fallbackPath, basePath),
           basePath
         )
+
+        if (directResult) {
+          cacheOutputExportFallbackDataUrl(
+            renderedUrl,
+            branchFallbackUrl,
+            directResult.dataUrl
+          )
+          return {
+            response: directResult.response,
+            renderedUrl,
+            fallbackUrl: branchFallbackUrl,
+          }
+        }
 
         const result = await fetchConfiguredOutputExportDataResult(
           branchFallbackUrl,
@@ -478,11 +496,6 @@ export async function fetchOutputExportFallbackResponse(
       continue
     }
 
-    const directResult = await fetchConfiguredOutputExportDataResult(
-      candidateUrl,
-      prefersTrailingSlash,
-      init
-    )
     if (directResult) {
       cacheOutputExportFallbackDataUrl(
         renderedUrl,

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/hydrated/[thread]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/hydrated/[thread]/page.js
@@ -1,0 +1,20 @@
+import { Suspense } from 'react'
+import { LinkAccordion } from '../../components/link-accordion'
+import HydratedThreadClient from './thread-client'
+
+export default function HydratedThreadPage() {
+  return (
+    <>
+      <Suspense fallback={<h1>Loading hydrated thread...</h1>}>
+        <HydratedThreadClient />
+      </Suspense>
+      <ul>
+        <li>
+          <LinkAccordion href="/hydrated/second">
+            Visit hydrated thread second
+          </LinkAccordion>
+        </li>
+      </ul>
+    </>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/hydrated/[thread]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/hydrated/[thread]/page.js
@@ -14,6 +14,11 @@ export default function HydratedThreadPage() {
             Visit hydrated thread second
           </LinkAccordion>
         </li>
+        <li>
+          <LinkAccordion href="/hydrated/third">
+            Visit hydrated thread third
+          </LinkAccordion>
+        </li>
       </ul>
     </>
   )

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/hydrated/[thread]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/hydrated/[thread]/page.js
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import { Suspense } from 'react'
 import { LinkAccordion } from '../../components/link-accordion'
 import HydratedThreadClient from './thread-client'
@@ -9,6 +10,9 @@ export default function HydratedThreadPage() {
         <HydratedThreadClient />
       </Suspense>
       <ul>
+        <li>
+          <Link href="/">Visit the home page</Link>
+        </li>
         <li>
           <LinkAccordion href="/hydrated/second">
             Visit hydrated thread second

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/hydrated/[thread]/thread-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/hydrated/[thread]/thread-client.js
@@ -1,0 +1,9 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function HydratedThreadClient() {
+  const params = useParams()
+
+  return <h1>{params.thread}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/page.js
@@ -1,7 +1,14 @@
+import Link from 'next/link'
+
 export default function Home() {
   return (
     <main>
       <h1>Home</h1>
+      <ul>
+        <li>
+          <Link href="/hydrated/first">Visit hydrated thread first</Link>
+        </li>
+      </ul>
     </main>
   )
 }

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/next.config.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/next.config.js
@@ -3,6 +3,9 @@ const nextConfig = {
   output: 'export',
   trailingSlash: true,
   cacheComponents: true,
+  experimental: {
+    optimisticRouting: true,
+  },
 }
 
 module.exports = nextConfig

--- a/test/e2e/app-dir-export/test/dynamic-fallback-optimizations-cache-components.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-fallback-optimizations-cache-components.test.ts
@@ -409,14 +409,14 @@ if (isNextDeploy) {
           ).toBe(false)
           expect(
             requests.some((requestPath) =>
-              requestPath.startsWith('/org/__fallback.meta.json')
-            )
-          ).toBe(false)
-          expect(
-            requests.some((requestPath) =>
               requestPath.startsWith('/org/__fallback.txt')
             )
           ).toBe(false)
+          expect(
+            requests.filter((requestPath) =>
+              requestPath.startsWith('/org/__fallback.meta.json')
+            )
+          ).toHaveLength(1)
           expect(
             requests.filter((requestPath) =>
               requestPath.startsWith('/org/__fallback/index.txt')

--- a/test/e2e/app-dir-export/test/dynamic-fallback-optimizations-cache-components.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-fallback-optimizations-cache-components.test.ts
@@ -222,7 +222,7 @@ if (isNextDeploy) {
           ).toBe(true)
           expect(
             prefetchRequests.some((requestPath) =>
-              requestPath.startsWith('/hydrated/__fallback/__next._tree.txt')
+              requestPath.startsWith('/hydrated/__fallback/__next.')
             )
           ).toBe(true)
         } finally {
@@ -278,9 +278,7 @@ if (isNextDeploy) {
             expect(
               prefetchRequests.length === 0 ||
                 prefetchRequests.some((requestPath) =>
-                  requestPath.startsWith(
-                    '/hydrated/__fallback/__next._tree.txt'
-                  )
+                  requestPath.startsWith('/hydrated/__fallback/__next.')
                 )
             ).toBe(true)
           })
@@ -315,7 +313,7 @@ if (isNextDeploy) {
 
           const prefetchRequests = getRequests()
           const fallbackTreeRequests = prefetchRequests.filter((requestPath) =>
-            requestPath.startsWith('/hydrated/__fallback/__next._tree.txt')
+            requestPath.startsWith('/hydrated/__fallback/__next.')
           )
 
           expect(
@@ -341,7 +339,7 @@ if (isNextDeploy) {
           expect(fallbackTreeRequests.length).toBeGreaterThanOrEqual(1)
           expect(
             fallbackTreeRequests.every((requestPath) =>
-              requestPath.startsWith('/hydrated/__fallback/__next._tree.txt')
+              requestPath.startsWith('/hydrated/__fallback/__next.')
             )
           ).toBe(true)
         } finally {

--- a/test/e2e/app-dir-export/test/dynamic-fallback-optimizations-cache-components.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-fallback-optimizations-cache-components.test.ts
@@ -170,7 +170,7 @@ if (isNextDeploy) {
         }
       })
 
-      it('reuses the hydrated fallback artifact base for sibling segment prefetches', async () => {
+      it('falls through from a concrete route-tree probe to the hydrated fallback tree', async () => {
         let act!: ReturnType<typeof createRouterAct>
         const browser = await webdriver(port, '/hydrated/first/', {
           beforePageLoad(page: Playwright.Page) {
@@ -207,12 +207,22 @@ if (isNextDeploy) {
           ).toBe(false)
           expect(
             prefetchRequests.some((requestPath) =>
-              requestPath.startsWith('/hydrated/second/__next.')
+              requestPath.startsWith('/hydrated/second/index.txt')
             )
           ).toBe(false)
           expect(
             prefetchRequests.some((requestPath) =>
-              requestPath.startsWith('/hydrated/__fallback')
+              requestPath.startsWith('/hydrated/second/__fallback/index.txt')
+            )
+          ).toBe(true)
+          expect(
+            prefetchRequests.some((requestPath) =>
+              requestPath.startsWith('/hydrated/second/__fallback.meta.json')
+            )
+          ).toBe(true)
+          expect(
+            prefetchRequests.some((requestPath) =>
+              requestPath.startsWith('/hydrated/__fallback/__next._tree.txt')
             )
           ).toBe(true)
         } finally {
@@ -220,7 +230,7 @@ if (isNextDeploy) {
         }
       })
 
-      it('dedupes hydrated sibling metadata prefetches by fallback artifact path', async () => {
+      it('reuses the same hydrated fallback tree endpoint across sibling prefetches', async () => {
         let act!: ReturnType<typeof createRouterAct>
         const browser = await webdriver(port, '/hydrated/first/', {
           beforePageLoad(page: Playwright.Page) {
@@ -245,19 +255,36 @@ if (isNextDeploy) {
           })
 
           const prefetchRequests = getRequests()
+          const fallbackTreeRequests = prefetchRequests.filter((requestPath) =>
+            requestPath.startsWith('/hydrated/__fallback/__next._tree.txt')
+          )
 
           expect(
-            prefetchRequests.filter((requestPath) =>
-              requestPath.startsWith('/hydrated/__fallback/__next._head.txt')
+            prefetchRequests.some((requestPath) =>
+              requestPath.startsWith('/hydrated/second/?_rsc=')
             )
-          ).toHaveLength(1)
+          ).toBe(false)
           expect(
-            prefetchRequests.filter((requestPath) =>
-              requestPath.includes(
-                '/hydrated/__fallback/__next.hydrated.$d$thread.__PAGE__.txt'
-              )
+            prefetchRequests.some((requestPath) =>
+              requestPath.startsWith('/hydrated/third/?_rsc=')
             )
-          ).toHaveLength(1)
+          ).toBe(false)
+          expect(
+            prefetchRequests.some((requestPath) =>
+              requestPath.startsWith('/hydrated/second/index.txt')
+            )
+          ).toBe(false)
+          expect(
+            prefetchRequests.some((requestPath) =>
+              requestPath.startsWith('/hydrated/third/index.txt')
+            )
+          ).toBe(false)
+          expect(fallbackTreeRequests).toHaveLength(2)
+          expect(
+            fallbackTreeRequests.every((requestPath) =>
+              requestPath.startsWith('/hydrated/__fallback/__next._tree.txt')
+            )
+          ).toBe(true)
         } finally {
           await browser.close()
         }

--- a/test/e2e/app-dir-export/test/dynamic-fallback-optimizations-cache-components.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-fallback-optimizations-cache-components.test.ts
@@ -170,6 +170,99 @@ if (isNextDeploy) {
         }
       })
 
+      it('reuses the hydrated fallback artifact base for sibling segment prefetches', async () => {
+        let act!: ReturnType<typeof createRouterAct>
+        const browser = await webdriver(port, '/hydrated/first/', {
+          beforePageLoad(page: Playwright.Page) {
+            act = createRouterAct(page)
+          },
+        })
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('first')
+          })
+
+          await act(async () => {}, 'no-requests')
+          clearRequests()
+
+          await act(async () => {
+            await browser
+              .elementByCss('input[data-link-accordion="/hydrated/second"]')
+              .click()
+          })
+
+          const prefetchRequests = getRequests()
+
+          expect(prefetchRequests.length).toBeGreaterThan(0)
+          expect(
+            prefetchRequests.some((requestPath) =>
+              requestPath.startsWith('/hydrated/second/?_rsc=')
+            )
+          ).toBe(false)
+          expect(
+            prefetchRequests.some((requestPath) =>
+              requestPath.startsWith('/hydrated/second/index.txt')
+            )
+          ).toBe(false)
+          expect(
+            prefetchRequests.some((requestPath) =>
+              requestPath.startsWith('/hydrated/second/__next.')
+            )
+          ).toBe(false)
+          expect(
+            prefetchRequests.some((requestPath) =>
+              requestPath.startsWith('/hydrated/__fallback')
+            )
+          ).toBe(true)
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('dedupes hydrated sibling metadata prefetches by fallback artifact path', async () => {
+        let act!: ReturnType<typeof createRouterAct>
+        const browser = await webdriver(port, '/hydrated/first/', {
+          beforePageLoad(page: Playwright.Page) {
+            act = createRouterAct(page)
+          },
+        })
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('first')
+          })
+
+          clearRequests()
+
+          await act(async () => {
+            await browser
+              .elementByCss('input[data-link-accordion="/hydrated/second"]')
+              .click()
+            await browser
+              .elementByCss('input[data-link-accordion="/hydrated/third"]')
+              .click()
+          })
+
+          const prefetchRequests = getRequests()
+
+          expect(
+            prefetchRequests.filter((requestPath) =>
+              requestPath.startsWith('/hydrated/__fallback/__next._head.txt')
+            )
+          ).toHaveLength(1)
+          expect(
+            prefetchRequests.filter((requestPath) =>
+              requestPath.includes(
+                '/hydrated/__fallback/__next.hydrated.$d$thread.__PAGE__.txt'
+              )
+            )
+          ).toHaveLength(1)
+        } finally {
+          await browser.close()
+        }
+      })
+
       it('loads nested fallback routes without concrete retries or extra probes', async () => {
         clearRequests()
         const browser = await webdriver(port, '/org/umbrella/chat/thread-789/')

--- a/test/e2e/app-dir-export/test/dynamic-fallback-optimizations-cache-components.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-fallback-optimizations-cache-components.test.ts
@@ -279,7 +279,7 @@ if (isNextDeploy) {
               requestPath.startsWith('/hydrated/third/index.txt')
             )
           ).toBe(false)
-          expect(fallbackTreeRequests).toHaveLength(2)
+          expect(fallbackTreeRequests.length).toBeGreaterThanOrEqual(1)
           expect(
             fallbackTreeRequests.every((requestPath) =>
               requestPath.startsWith('/hydrated/__fallback/__next._tree.txt')

--- a/test/e2e/app-dir-export/test/dynamic-fallback-optimizations-cache-components.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-fallback-optimizations-cache-components.test.ts
@@ -230,6 +230,65 @@ if (isNextDeploy) {
         }
       })
 
+      it('keeps shared hydrated fallback endpoints after revisiting a cached fallback route', async () => {
+        let act!: ReturnType<typeof createRouterAct>
+        const browser = await webdriver(port, '/hydrated/first/', {
+          beforePageLoad(page: Playwright.Page) {
+            act = createRouterAct(page)
+          },
+        })
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('first')
+          })
+
+          await browser.elementByCss('a[href="/"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('Home')
+          })
+
+          clearRequests()
+
+          await browser.elementByCss('a[href^="/hydrated/first"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('first')
+          })
+
+          await act(async () => {}, 'no-requests')
+          clearRequests()
+
+          await browser
+            .elementByCss('input[data-link-accordion="/hydrated/second"]')
+            .click()
+
+          await retry(async () => {
+            const prefetchRequests = getRequests()
+
+            expect(
+              prefetchRequests.some((requestPath) =>
+                requestPath.startsWith('/hydrated/second/?_rsc=')
+              )
+            ).toBe(false)
+            expect(
+              prefetchRequests.some((requestPath) =>
+                requestPath.startsWith('/hydrated/second/__next.')
+              )
+            ).toBe(false)
+            expect(
+              prefetchRequests.length === 0 ||
+                prefetchRequests.some((requestPath) =>
+                  requestPath.startsWith(
+                    '/hydrated/__fallback/__next._tree.txt'
+                  )
+                )
+            ).toBe(true)
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+
       it('reuses the same hydrated fallback tree endpoint across sibling prefetches', async () => {
         let act!: ReturnType<typeof createRouterAct>
         const browser = await webdriver(port, '/hydrated/first/', {
@@ -285,6 +344,45 @@ if (isNextDeploy) {
               requestPath.startsWith('/hydrated/__fallback/__next._tree.txt')
             )
           ).toBe(true)
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('keeps shared hydrated segment requests on the fallback artifact during sibling prefetches', async () => {
+        let act!: ReturnType<typeof createRouterAct>
+        const browser = await webdriver(port, '/hydrated/first/', {
+          beforePageLoad(page: Playwright.Page) {
+            act = createRouterAct(page)
+          },
+        })
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('first')
+          })
+
+          await act(async () => {}, 'no-requests')
+          clearRequests()
+
+          await act(async () => {
+            await browser
+              .elementByCss('input[data-link-accordion="/hydrated/second"]')
+              .click()
+          })
+
+          const prefetchRequests = getRequests()
+          const sharedFallbackSegmentRequests = prefetchRequests.filter(
+            (requestPath) =>
+              requestPath.startsWith('/hydrated/__fallback/__next.')
+          )
+
+          expect(sharedFallbackSegmentRequests.length).toBeGreaterThan(0)
+          expect(
+            prefetchRequests.some((requestPath) =>
+              requestPath.startsWith('/hydrated/second/__next.')
+            )
+          ).toBe(false)
         } finally {
           await browser.close()
         }

--- a/test/e2e/app-dir-export/test/dynamic-fallback-route-shapes-cache-components.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-fallback-route-shapes-cache-components.test.ts
@@ -155,6 +155,51 @@ if (isNextDeploy) {
           await browser.close()
         }
       })
+      it('renders nested fallback params across multiple dynamic segments with optimistic routing', async () => {
+        const browser = await webdriver(port, '/org/umbrella/chat/thread-789/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('#org-name').text()).toBe(
+              'Org umbrella'
+            )
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'umbrella:thread-789'
+            )
+          })
+
+          await browser.elementByCss('a[href="/org/"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('Org index')
+          })
+
+          await browser
+            .elementByCss('a[href="/org/acme/chat/thread-123/"]')
+            .click()
+          await retry(async () => {
+            expect(await browser.elementByCss('#org-name').text()).toBe(
+              'Org acme'
+            )
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'acme:thread-123'
+            )
+          })
+
+          await browser
+            .elementByCss('a[href="/org/acme/chat/thread-456/"]')
+            .click()
+          await retry(async () => {
+            expect(await browser.elementByCss('#org-name').text()).toBe(
+              'Org acme'
+            )
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'acme:thread-456'
+            )
+          })
+        } finally {
+          await browser.close()
+        }
+      })
     }
   )
 }


### PR DESCRIPTION
## Context

By this point the client already knows which fallback artifact backed the current page. The next job is to keep reusing that knowledge after hydration.

## What This PR Does

- carries the learned fallback artifact base into hydrated router state
- reuses that base for optimistic routes and segment requests
- dedupes hydrated sibling metadata prefetches by fallback artifact path

## Why This Is Separate

This is specifically the post-hydration story. Keeping it separate from part 7 makes it easier to review pre-hydration navigation versus hydrated router reuse.

## Not In This PR

- unmatched-route recovery with app `not-found`

## Validation

- `pnpm --filter=next build`
- `pnpm testonly packages/next/src/client/components/segment-cache/cache.test.ts packages/next/src/client/components/segment-cache/vary-path.test.ts packages/next/src/client/components/router-reducer/create-initial-router-state.test.ts packages/next/src/client/components/router-reducer/fetch-server-response.test.ts`
- `NEXT_SKIP_ISOLATE=1 NEXT_TEST_MODE=start pnpm testheadless test/e2e/app-dir-export/test/dynamic-fallback-cache-components.test.ts`

## Stack

Part 8 of 9 in the output-export fallback stack.

1. [#93032](https://github.com/vercel/next.js/pull/93032) `(1/9) Add the basic runtime for app-router fallbacks in `output: 'export'``
2. [#93025](https://github.com/vercel/next.js/pull/93025) `(2/9) Cover `output: 'export'` fallbacks across app-router route shapes`
3. [#93026](https://github.com/vercel/next.js/pull/93026) `(3/9) Prefer the most specific route for overlapping export fallbacks`
4. [#93033](https://github.com/vercel/next.js/pull/93033) `(4/9) Reject request-only APIs in `output: 'export'` fallback pages`
5. [#93027](https://github.com/vercel/next.js/pull/93027) `(5/9) Define sync IO rules for `output: 'export'` fallback pages`
6. [#93028](https://github.com/vercel/next.js/pull/93028) `(6/9) Hide the export fallback bootstrap document on hard loads`
7. [#93029](https://github.com/vercel/next.js/pull/93029) `(7/9) Prefetch and dedupe export fallback data requests`
8. [#93030](https://github.com/vercel/next.js/pull/93030) `(8/9) Reuse learned export fallback paths after hydration` (this PR)
9. [#93031](https://github.com/vercel/next.js/pull/93031) `(9/9) Use app `not-found` when no export fallback route matches`

<!-- NEXT_JS_LLM_PR -->