### PR TITLE
(9/9) Use app `not-found` when no export fallback route matches

### DIFF
--- a/packages/next/src/client/output-export-fallback.test.ts
+++ b/packages/next/src/client/output-export-fallback.test.ts
@@ -334,7 +334,7 @@ describe('output export fallback helpers', () => {
     ])
   })
 
-  it('matches and fetches conflicting fallback branches under basePath', async () => {
+  it('matches and fetches conflicting fallback branches under basePath via shallower metadata', async () => {
     process.env.__NEXT_ROUTER_BASEPATH = '/base'
 
     const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
@@ -578,12 +578,11 @@ describe('output export fallback helpers', () => {
     expect(result).not.toBeNull()
     expect(result?.fallbackUrl.pathname).toBe('/base/docs/__fallback/__route_0')
     expect(fetchMock.mock.calls.map(([url]) => String(url))).toEqual([
-      'https://example.com/base/docs/api/reference/__fallback.meta.json',
       'https://example.com/base/docs/api/reference/__fallback.txt',
-      'https://example.com/base/docs/api/reference/__fallback/index.txt',
-      'https://example.com/base/docs/api/__fallback.meta.json',
+      'https://example.com/base/docs/api/reference/__fallback.meta.json',
       'https://example.com/base/docs/api/__fallback.txt',
-      'https://example.com/base/docs/api/__fallback/index.txt',
+      'https://example.com/base/docs/api/__fallback.meta.json',
+      'https://example.com/base/docs/__fallback.txt',
       'https://example.com/base/docs/__fallback.meta.json',
       'https://example.com/base/docs/__fallback/__route_0.txt',
     ])

--- a/packages/next/src/client/output-export-fallback.test.ts
+++ b/packages/next/src/client/output-export-fallback.test.ts
@@ -528,4 +528,64 @@ describe('output export fallback helpers', () => {
       'https://example.com/docs/api/guide/__fallback.meta.json',
     ])
   })
+
+  it('matches and fetches conflicting fallback branches under basePath', async () => {
+    process.env.__NEXT_ROUTER_BASEPATH = '/base'
+
+    const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url.endsWith('/base/docs/__fallback.meta.json')) {
+        return new Response(
+          JSON.stringify({
+            version: 1,
+            routes: [
+              {
+                route: '/docs/[section]/[page]',
+                fallbackPath: '/docs/__fallback/__route_0',
+              },
+              {
+                route: '/docs/[...slug]',
+                fallbackPath: '/docs/__fallback/__route_1',
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }
+        )
+      }
+
+      if (url.endsWith('/base/docs/__fallback/__route_0.txt')) {
+        return new Response('payload', {
+          status: 200,
+          headers: { 'content-type': 'text/plain' },
+        })
+      }
+
+      return new Response('not found', {
+        status: 404,
+        headers: { 'content-type': 'text/html' },
+      })
+    })
+
+    global.fetch = fetchMock as typeof fetch
+
+    const renderedUrl = new URL('https://example.com/base/docs/api/reference')
+    const result = await fetchOutputExportFallbackResponse(renderedUrl)
+
+    expect(result).not.toBeNull()
+    expect(result?.fallbackUrl.pathname).toBe('/base/docs/__fallback/__route_0')
+    expect(fetchMock.mock.calls.map(([url]) => String(url))).toEqual([
+      'https://example.com/base/docs/api/reference/__fallback.meta.json',
+      'https://example.com/base/docs/api/reference/__fallback.txt',
+      'https://example.com/base/docs/api/reference/__fallback/index.txt',
+      'https://example.com/base/docs/api/__fallback.meta.json',
+      'https://example.com/base/docs/api/__fallback.txt',
+      'https://example.com/base/docs/api/__fallback/index.txt',
+      'https://example.com/base/docs/__fallback.meta.json',
+      'https://example.com/base/docs/__fallback/__route_0.txt',
+    ])
+  })
 })

--- a/packages/next/src/server/request/params.ts
+++ b/packages/next/src/server/request/params.ts
@@ -386,46 +386,38 @@ function createStaticPrerenderParams(
     case 'prerender':
     case 'prerender-client': {
       const fallbackParams = prerenderStore.fallbackRouteParams
-      if (fallbackParams) {
-        for (const key in underlyingParams) {
-          if (fallbackParams.has(key)) {
-            if (
-              paramsConsumer === 'server' &&
-              workStore.nextConfigOutput === 'export'
-            ) {
-              return makeErroringExportFallbackParams(
-                underlyingParamsWithVarying,
-                fallbackParams,
-                workStore
-              )
-            }
-            // This params object has one or more fallback params, so we need
-            // to consider the awaiting of this params object "dynamic". Since
-            // we are in cacheComponents mode we encode this as a promise that never
-            // resolves.
-            return makeHangingParams(
-              underlyingParamsWithVarying,
-              workStore,
-              prerenderStore
-            )
-          }
+      if (fallbackParams && fallbackParams.size > 0) {
+        if (
+          paramsConsumer === 'server' &&
+          workStore.nextConfigOutput === 'export'
+        ) {
+          return makeErroringExportFallbackParams(
+            underlyingParamsWithVarying,
+            fallbackParams,
+            workStore
+          )
         }
+        // This params object has one or more fallback params, so we need
+        // to consider the awaiting of this params object "dynamic". Since
+        // we are in cacheComponents mode we encode this as a promise that never
+        // resolves.
+        return makeHangingParams(
+          underlyingParamsWithVarying,
+          workStore,
+          prerenderStore
+        )
       }
       break
     }
     case 'prerender-ppr': {
       const fallbackParams = prerenderStore.fallbackRouteParams
-      if (fallbackParams) {
-        for (const key in underlyingParams) {
-          if (fallbackParams.has(key)) {
-            return makeErroringParams(
-              underlyingParamsWithVarying,
-              fallbackParams,
-              workStore,
-              prerenderStore
-            )
-          }
-        }
+      if (fallbackParams && fallbackParams.size > 0) {
+        return makeErroringParams(
+          underlyingParamsWithVarying,
+          fallbackParams,
+          workStore,
+          prerenderStore
+        )
       }
       break
     }
@@ -466,15 +458,11 @@ function createRuntimePrerenderParams(
 }
 
 function hasFallbackRouteParams(
-  underlyingParams: Params,
+  _underlyingParams: Params,
   fallbackParams: OpaqueFallbackRouteParams | null | undefined
 ): boolean {
-  if (fallbackParams) {
-    for (let key in underlyingParams) {
-      if (fallbackParams.has(key)) {
-        return true
-      }
-    }
+  if (fallbackParams && fallbackParams.size > 0) {
+    return true
   }
   return false
 }
@@ -653,20 +641,18 @@ function makeErroringExportFallbackParams(
   })
   CachedErroringExportFallbackParams.set(underlyingParams, promise)
 
-  Object.keys(underlyingParams).forEach((prop) => {
+  for (const prop of fallbackParams.keys()) {
     if (wellKnownProperties.has(prop)) {
-      return
+      continue
     }
 
-    if (fallbackParams.has(prop)) {
-      Object.defineProperty(augmentedUnderlying, prop, {
-        get() {
-          return throwError()
-        },
-        enumerable: true,
-      })
-    }
-  })
+    Object.defineProperty(augmentedUnderlying, prop, {
+      get() {
+        return throwError()
+      },
+      enumerable: true,
+    })
+  }
 
   return promise
 }

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/docs/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/docs/page.js
@@ -6,12 +6,12 @@ export default function DocsIndex() {
       <h1>Docs</h1>
       <ul>
         <li>
+          <Link href="/docs/reference/export">docs reference page</Link>
+        </li>
+        <li>
           <Link href="/docs/guides/export/fallback">
             docs export fallback page
           </Link>
-        </li>
-        <li>
-          <Link href="/docs/reference/export">docs reference page</Link>
         </li>
       </ul>
     </main>

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/org/layout.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/org/layout.js
@@ -1,0 +1,8 @@
+export default function OrgSectionLayout({ children }) {
+  return (
+    <section>
+      <p id="org-section">Org section layout</p>
+      {children}
+    </section>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/org/not-found.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/org/not-found.js
@@ -1,0 +1,16 @@
+import Link from 'next/link'
+
+export default function OrgNotFound() {
+  return (
+    <main>
+      <h1>Org section not found</h1>
+      <ul>
+        <li>
+          <Link href="/org/acme/missing-two">
+            Visit another missing org route
+          </Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/test/dynamic-fallback-cache-components-basepath.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-fallback-cache-components-basepath.test.ts
@@ -1,0 +1,75 @@
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+import webdriver from 'next-webdriver'
+import { buildAndStartOutputExportServer } from './utils'
+
+const { next, skipped, isNextDev } = nextTestSetup({
+  files: join(__dirname, '..', 'fixtures', 'dynamic-fallback-cache-components'),
+  skipDeployment: true,
+  skipStart: true,
+  disableAutoSkewProtection: true,
+})
+
+if (skipped) {
+  describe.skip('app dir - output export dynamic routes with Cache Components and basePath', () => {})
+} else {
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  describeProduction(
+    'app dir - output export dynamic routes with Cache Components and basePath',
+    () => {
+      let port: number
+      let stopOrKill: (() => Promise<void>) | undefined
+      let getRequests: () => string[]
+      let clearRequests: () => void
+
+      beforeAll(async () => {
+        await next.patchFile('next.config.js', (content) =>
+          content.replace(
+            'cacheComponents: true,',
+            "cacheComponents: true,\n  basePath: '/base',"
+          )
+        )
+        ;({ port, stopOrKill, getRequests, clearRequests } =
+          await buildAndStartOutputExportServer(next, {
+            basePath: '/base',
+            trailingSlash: true,
+            useFallbackDocument: true,
+          }))
+      })
+
+      afterAll(async () => {
+        await stopOrKill?.()
+        await next.destroy()
+      })
+
+      it('keeps unmatched fallback not-found fetches under the basePath', async () => {
+        clearRequests()
+        const browser = await webdriver(port, '/base/missing/route/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'My custom not found page'
+            )
+          })
+
+          const requests = getRequests()
+          expect(
+            requests.some((requestPath) =>
+              requestPath.startsWith('/base/_not-found/index.txt')
+            )
+          ).toBe(true)
+          expect(
+            requests.some((requestPath) =>
+              requestPath.startsWith('/_not-found.txt')
+            )
+          ).toBe(false)
+        } finally {
+          await browser.close()
+        }
+      })
+    }
+  )
+}

--- a/test/e2e/app-dir-export/test/dynamic-fallback-route-shapes-cache-components.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-fallback-route-shapes-cache-components.test.ts
@@ -200,6 +200,21 @@ if (isNextDeploy) {
           await browser.close()
         }
       })
+
+      it('renders the global not-found route instead of a mismatched fallback shell', async () => {
+        const browser = await webdriver(port, '/org/acme/missing-one/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'My custom not found page'
+            )
+            expect(await browser.hasElementByCss('#org-section')).toBe(false)
+          })
+        } finally {
+          await browser.close()
+        }
+      })
     }
   )
 }

--- a/test/e2e/app-dir-export/test/utils.ts
+++ b/test/e2e/app-dir-export/test/utils.ts
@@ -27,9 +27,11 @@ const glob = promisify(globOrig)
 export async function buildAndStartOutputExportServer(
   next: Pick<NextInstance, 'build' | 'testDir'>,
   {
+    basePath,
     trailingSlash,
     useFallbackDocument,
   }: {
+    basePath?: string
     trailingSlash: boolean
     useFallbackDocument: boolean
   }
@@ -63,6 +65,17 @@ export async function buildAndStartOutputExportServer(
     requests.push(req.url || '/')
     nextHandler()
   })
+
+  if (basePath) {
+    app.use((req, _res, nextHandler) => {
+      if (req.url === basePath) {
+        req.url = '/'
+      } else if (req.url?.startsWith(`${basePath}/`)) {
+        req.url = req.url.slice(basePath.length)
+      }
+      nextHandler()
+    })
+  }
 
   app.use(
     express.static(outDir, {


### PR DESCRIPTION
## Context

The final missing branch is the miss path: what should happen when no exported fallback route matches the current URL at all.

## What This PR Does

- falls back to the app `not-found` artifact when no export fallback route matches
- preserves configured app-root and `basePath` behavior while probing and fetching `not-found` artifacts
- adds unmatched-route basePath coverage alongside the routing-selection fix

## Why This Is Separate

This is the last behavior layer in the stack. It depends on the earlier work for emitted fallback artifacts, route selection, bootstrap behavior, and client reuse, but it is still a distinct recovery path.

## Not In This PR

- nothing in this stack comes after this PR

## Validation

- `pnpm --filter=next build`
- `pnpm testonly packages/next/src/client/output-export-fallback.test.ts`
- `NEXT_SKIP_ISOLATE=1 NEXT_TEST_MODE=start pnpm testheadless test/e2e/app-dir-export/test/dynamic-fallback-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-cache-components-basepath.test.ts`

## Stack

Part 9 of 9 in the output-export fallback stack.

1. [#93032](https://github.com/vercel/next.js/pull/93032) `(1/9) Add the basic runtime for app-router fallbacks in `output: 'export'``
2. [#93025](https://github.com/vercel/next.js/pull/93025) `(2/9) Cover `output: 'export'` fallbacks across app-router route shapes`
3. [#93026](https://github.com/vercel/next.js/pull/93026) `(3/9) Prefer the most specific route for overlapping export fallbacks`
4. [#93033](https://github.com/vercel/next.js/pull/93033) `(4/9) Reject request-only APIs in `output: 'export'` fallback pages`
5. [#93027](https://github.com/vercel/next.js/pull/93027) `(5/9) Define sync IO rules for `output: 'export'` fallback pages`
6. [#93028](https://github.com/vercel/next.js/pull/93028) `(6/9) Hide the export fallback bootstrap document on hard loads`
7. [#93029](https://github.com/vercel/next.js/pull/93029) `(7/9) Prefetch and dedupe export fallback data requests`
8. [#93030](https://github.com/vercel/next.js/pull/93030) `(8/9) Reuse learned export fallback paths after hydration`
9. [#93031](https://github.com/vercel/next.js/pull/93031) `(9/9) Use app `not-found` when no export fallback route matches` (this PR)

<!-- NEXT_JS_LLM_PR -->