### PR TITLE
fix: add type check for non-string path params in getStaticPaths (#41281)

### DIFF
--- a/packages/next/src/shared/lib/router/utils/escape-path-delimiters.ts
+++ b/packages/next/src/shared/lib/router/utils/escape-path-delimiters.ts
@@ -3,6 +3,12 @@ export default function escapePathDelimiters(
   segment: string,
   escapeEncoded?: boolean
 ): string {
+  if (typeof segment !== 'string') {
+    throw new Error(
+      `A required parameter was not provided as a string received ${typeof segment === 'object' ? JSON.stringify(segment) : segment} (${typeof segment}). All path parameters in getStaticPaths must be strings.`
+    )
+  }
+
   return segment.replace(
     new RegExp(`([/#?]${escapeEncoded ? '|%(2f|23|3f|5c)' : ''})`, 'gi'),
     (char: string) => encodeURIComponent(char)


### PR DESCRIPTION
Fixes #41281

## What
Added a runtime type check in `escapePathDelimiters` that throws a 
clear, actionable error when a non-string value is passed as a path 
parameter in `getStaticPaths`.

## Why
Previously, passing a number or object as a path param caused a cryptic 
internal error. Now developers get a message that tells them exactly 
what went wrong and what to fix.

## Test
Pass a number as a path param in getStaticPaths and observe the new 
clear error message.