### PR TITLE
fix(typegen): include link.d.ts in next-env.d.ts when typedRoutes is enabled

### DIFF
--- a/packages/next/src/lib/typescript/writeAppTypeDeclarations.ts
+++ b/packages/next/src/lib/typescript/writeAppTypeDeclarations.ts
@@ -87,14 +87,14 @@ export async function writeAppTypeDeclarations({
       'types/validator.ts'
     )
     lines.push(`import "./${routeValidatorPath}";`)
+  }
 
-    if (typedRoutes === true) {
-      const linkTypesPath = path.posix.join(
-        distDir.replaceAll(path.win32.sep, path.posix.sep),
-        'types/link.d.ts'
-      )
-      lines.push(`import "./${linkTypesPath}";`)
-    }
+  if (typedRoutes === true) {
+    const linkTypesPath = path.posix.join(
+      distDir.replaceAll(path.win32.sep, path.posix.sep),
+      'types/link.d.ts'
+    )
+    lines.push(`import "./${linkTypesPath}";`)
   }
 
   // Push the notice in.

--- a/packages/next/src/lib/typescript/writeAppTypeDeclarations.ts
+++ b/packages/next/src/lib/typescript/writeAppTypeDeclarations.ts
@@ -91,14 +91,14 @@ export async function writeAppTypeDeclarations({
       'types/validator.ts'
     )
     lines.push(`import "./${routeValidatorPath}";`)
+  }
 
-    if (typedRoutes === true) {
-      const linkTypesPath = path.posix.join(
-        distDir.replaceAll(path.win32.sep, path.posix.sep),
-        'types/link.d.ts'
-      )
-      lines.push(`import "./${linkTypesPath}";`)
-    }
+  if (typedRoutes === true) {
+    const linkTypesPath = path.posix.join(
+      distDir.replaceAll(path.win32.sep, path.posix.sep),
+      'types/link.d.ts'
+    )
+    lines.push(`import "./${linkTypesPath}";`)
   }
 
   // Push the notice in.

--- a/test/unit/write-app-declarations.test.ts
+++ b/test/unit/write-app-declarations.test.ts
@@ -26,6 +26,8 @@ describe('find config', () => {
       eol +
       `import "./.next/types/root-params.d.ts";` +
       eol +
+      `import "./.next/types/link.d.ts";` +
+      eol +
       eol +
       '// NOTE: This file should not be edited' +
       eol +
@@ -58,6 +60,8 @@ describe('find config', () => {
       eol +
       `import "./.next/types/root-params.d.ts";` +
       eol +
+      `import "./.next/types/link.d.ts";` +
+      eol +
       eol +
       '// NOTE: This file should not be edited' +
       eol +
@@ -89,6 +93,8 @@ describe('find config', () => {
       `import "./.next/types/routes.d.ts";` +
       eol +
       `import "./.next/types/root-params.d.ts";` +
+      eol +
+      `import "./.next/types/link.d.ts";` +
       eol +
       eol +
       '// NOTE: This file should not be edited' +

--- a/test/unit/write-app-declarations.test.ts
+++ b/test/unit/write-app-declarations.test.ts
@@ -24,6 +24,8 @@ describe('find config', () => {
         : '') +
       `import "./.next/types/routes.d.ts";` +
       eol +
+      `import "./.next/types/link.d.ts";` +
+      eol +
       eol +
       '// NOTE: This file should not be edited' +
       eol +
@@ -55,6 +57,8 @@ describe('find config', () => {
         : '') +
       `import "./.next/types/routes.d.ts";` +
       eol +
+      `import "./.next/types/link.d.ts";` +
+      eol +
       eol +
       '// NOTE: This file should not be edited' +
       eol +
@@ -85,6 +89,8 @@ describe('find config', () => {
         ? '/// <reference types="next/image-types/global" />' + eol
         : '') +
       `import "./.next/types/routes.d.ts";` +
+      eol +
+      `import "./.next/types/link.d.ts";` +
       eol +
       eol +
       '// NOTE: This file should not be edited' +


### PR DESCRIPTION
## What

When `typedRoutes: true` is configured, `next-env.d.ts` must include an import of `link.d.ts` for TypeScript to enforce typed routes. Previously the import was nested inside the `strictRouteTypes` conditional block, so it was only emitted when `experimental.strictRouteTypes` was also enabled.

## Why

In workspace/monorepo setups TypeScript resolves module augmentations differently — the `import './.next/types/link.d.ts'` in `next-env.d.ts` is required for the `next/link` route type to be augmented and invalid `href` values to be caught by `tsc`.

## Fix

Move the `link.d.ts` import to a standalone `typedRoutes` check so it is always included when `typedRoutes: true`, regardless of `strictRouteTypes`. Updated unit tests to reflect the new expected output.

Fixes #93007