### PR TITLE
fix: encode route groups

### DIFF
--- a/packages/next/src/server/lib/router-utils/filesystem.ts
+++ b/packages/next/src/server/lib/router-utils/filesystem.ts
@@ -621,8 +621,8 @@ export async function setupFsCheck(opts: {
             // x-ref: https://github.com/vercel/next.js/issues/54008
             // There're cases that urls get decoded before requests, we should support both encoded and decoded ones.
             // e.g. nginx could decode the proxy urls, the below ones should be treated as the same:
-            // decoded version: `/_next/static/chunks/pages/blog/[slug]-d4858831b91b69f6.js`
-            // encoded version: `/_next/static/chunks/pages/blog/%5Bslug%5D-d4858831b91b69f6.js`
+            // decoded version: `/_next/static/chunks/pages/blog/(group)/[slug]-d4858831b91b69f6.js`
+            // encoded version: `/_next/static/chunks/pages/blog/%28group%29/%5Bslug%5D-d4858831b91b69f6.js`
             try {
               // encode the special characters in the path and retrieve again to determine if path exists.
               const encodedCurItemPath = encodeURIPath(curItemPath)

--- a/packages/next/src/shared/lib/encode-uri-path.ts
+++ b/packages/next/src/shared/lib/encode-uri-path.ts
@@ -1,6 +1,14 @@
 export function encodeURIPath(file: string) {
-  return file
-    .split('/')
-    .map((p) => encodeURIComponent(p))
-    .join('/')
+  return (
+    file
+      .split('/')
+      // encodeURIComponent does not encode parenthesis, used by route groups, while they do need to be encoded to comply with RFC 3986
+      .map((p) =>
+        encodeURIComponent(p).replace(
+          /[()]/g,
+          (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`
+        )
+      )
+      .join('/')
+  )
 }

--- a/test/e2e/app-dir/app/app/dynamic-client/(group)/group/page.js
+++ b/test/e2e/app-dir/app/app/dynamic-client/(group)/group/page.js
@@ -1,0 +1,9 @@
+'use client'
+
+export default function GroupPage(props) {
+  return (
+    <>
+      <p id="id-page-route-group">Group Page</p>
+    </>
+  )
+}

--- a/test/e2e/app-dir/app/index.test.ts
+++ b/test/e2e/app-dir/app/index.test.ts
@@ -218,7 +218,7 @@ describe('app dir - basic', () => {
     })
   }
 
-  it('should encode chunk path correctly', async () => {
+  it('should encode chunk path param correctly', async () => {
     const requests = []
     const browser = await next.browser('/dynamic-client/first/second', {
       beforePageLoad(page) {
@@ -241,6 +241,31 @@ describe('app dir - basic', () => {
         expect.arrayContaining([
           expect.stringMatching(/.*%5Bcategory%5D\/%5Bid%5D.*\.js/),
         ])
+      )
+    }
+  })
+
+  it('should encode chunk path route group correctly', async () => {
+    const requests = []
+    const browser = await next.browser('/dynamic-client/group', {
+      beforePageLoad(page) {
+        page.on('request', (req) => {
+          requests.push(req.url())
+        })
+      },
+    })
+
+    await browser.waitForElementByCss('#id-page-route-group')
+
+    expect(requests).not.toEqual(
+      expect.arrayContaining([expect.stringContaining('(group)')])
+    )
+
+    // Turbopack doesn't recreate the original folder structure for the output chunks
+    if (!process.env.IS_TURBOPACK_TEST) {
+      expect(requests).toEqual(
+        // e.g. _next/static/chunks/app/dynamic-client/%28group%29/group/page-083f99d18ae1767f.js?dpl=...
+        expect.arrayContaining([expect.stringMatching(/.*%28group%29.*\.js/)])
       )
     }
   })


### PR DESCRIPTION
### What?

Route groups were not encoded when fetching chunks, altho it is valid to leave parenthesis unencoded in route segments accoding to RFC 3986, but could be helpful to do.

`.../(group)/....` -> `.../&28group&29/...`

Added e2e test to verify chunk fetch URL

### Why?

encodeURIComponent escapes all characters, except `A–Z a–z 0–9 - _ . ! ~ * ' ( )`

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent#description

### How?

Fixes #92890
