### PR TITLE
Fix cookie encode option support

### DIFF
--- a/package.json
+++ b/package.json
@@ -354,7 +354,8 @@
       "@rspack/core@1.6.7": "patches/@rspack__core@1.6.7.patch",
       "@modelcontextprotocol/sdk": "patches/@modelcontextprotocol__sdk.patch",
       "@vercel/blob": "patches/@vercel__blob.patch",
-      "postcss-scss": "patches/postcss-scss.patch"
+      "postcss-scss": "patches/postcss-scss.patch",
+      "@edge-runtime/cookies@6.0.0": "patches/@edge-runtime__cookies@6.0.0.patch"
     }
   }
 }

--- a/packages/next/src/compiled/@edge-runtime/cookies/index.d.ts
+++ b/packages/next/src/compiled/@edge-runtime/cookies/index.d.ts
@@ -129,9 +129,9 @@ interface CookieListItem extends Pick<CookieSerializeOptions, 'domain' | 'path' 
 }
 /**
  * Superset of {@link CookieListItem} extending it with
- * the `httpOnly`, `maxAge` and `priority` properties.
+ * the `httpOnly`, `maxAge`, `priority` and `encode` properties.
  */
-type ResponseCookie = CookieListItem & Pick<CookieSerializeOptions, 'httpOnly' | 'maxAge' | 'priority'>;
+type ResponseCookie = CookieListItem & Pick<CookieSerializeOptions, 'httpOnly' | 'maxAge' | 'priority' | 'encode'>;
 /**
  * Subset of {@link CookieListItem}, only containing `name` and `value`
  * since other cookie attributes aren't be available on a `Request`.

--- a/packages/next/src/compiled/@edge-runtime/cookies/index.js
+++ b/packages/next/src/compiled/@edge-runtime/cookies/index.js
@@ -42,7 +42,8 @@ function stringifyCookie(c) {
     "partitioned" in c && c.partitioned && "Partitioned",
     "priority" in c && c.priority && `Priority=${c.priority}`
   ].filter(Boolean);
-  const stringified = `${c.name}=${encodeURIComponent((_a = c.value) != null ? _a : "")}`;
+  const encode = "encode" in c && typeof c.encode === "function" ? c.encode : encodeURIComponent;
+  const stringified = `${c.name}=${encode((_a = c.value) != null ? _a : "")}`;
   return attrs.length === 0 ? stringified : `${stringified}; ${attrs.join("; ")}`;
 }
 function parseCookie(cookie) {
@@ -56,12 +57,16 @@ function parseCookie(cookie) {
       continue;
     }
     const [key, value] = [pair.slice(0, splitAt), pair.slice(splitAt + 1)];
-    try {
-      map.set(key, decodeURIComponent(value != null ? value : "true"));
-    } catch {
-    }
+    map.set(key, decodeCookieValue(value != null ? value : "true"));
   }
   return map;
+}
+function decodeCookieValue(value) {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
 }
 function parseSetCookie(setCookie) {
   if (!setCookie) {
@@ -86,7 +91,7 @@ function parseSetCookie(setCookie) {
   );
   const cookie = {
     name,
-    value: decodeURIComponent(value),
+    value: decodeCookieValue(value),
     domain,
     ...expires && { expires: new Date(expires) },
     ...httponly && { httpOnly: true },

--- a/packages/next/src/server/web/spec-extension/adapters/request-cookies.test.ts
+++ b/packages/next/src/server/web/spec-extension/adapters/request-cookies.test.ts
@@ -100,6 +100,35 @@ describe('MutableRequestCookiesAdapter', () => {
       expect.stringContaining('bar=;'),
     ])
   })
+
+  it('preserves custom cookie value encoders in update callbacks', () => {
+    const headers = new Headers({})
+    const underlyingCookies = new RequestCookies(headers)
+    const onUpdateCookies = jest.fn<void, [string[]]>()
+
+    const wrappedCookies = MutableRequestCookiesAdapter.wrap(
+      underlyingCookies,
+      onUpdateCookies
+    )
+
+    wrappedCookies.set('raw', 'qwerty123=', { encode: String })
+
+    expect(onUpdateCookies).toHaveBeenLastCalledWith(['raw=qwerty123=; Path=/'])
+  })
+
+  it('preserves raw percent values when reparsing custom encoded cookies', () => {
+    const headers = new Headers({})
+    const responseCookies = new ResponseCookies(headers)
+
+    responseCookies.set('raw', '100%', { encode: String })
+
+    expect(headers.get('set-cookie')).toBe('raw=100%; Path=/')
+    expect(new ResponseCookies(headers).get('raw')).toEqual({
+      name: 'raw',
+      value: '100%',
+      path: '/',
+    })
+  })
 })
 
 describe('wrapWithMutableAccessCheck', () => {

--- a/patches/@edge-runtime__cookies@6.0.0.patch
+++ b/patches/@edge-runtime__cookies@6.0.0.patch
@@ -1,0 +1,61 @@
+diff --git a/dist/index.d.ts b/dist/index.d.ts
+index db116a23a851701ca2e550ec2917825665a56f0a..e2f65617a6513d5481f5b7c6b2726d2838eeb159 100644
+--- a/dist/index.d.ts
++++ b/dist/index.d.ts
+@@ -129,9 +129,9 @@ interface CookieListItem extends Pick<CookieSerializeOptions, 'domain' | 'path'
+ }
+ /**
+  * Superset of {@link CookieListItem} extending it with
+- * the `httpOnly`, `maxAge` and `priority` properties.
++ * the `httpOnly`, `maxAge`, `priority` and `encode` properties.
+  */
+-type ResponseCookie = CookieListItem & Pick<CookieSerializeOptions, 'httpOnly' | 'maxAge' | 'priority'>;
++type ResponseCookie = CookieListItem & Pick<CookieSerializeOptions, 'httpOnly' | 'maxAge' | 'priority' | 'encode'>;
+ /**
+  * Subset of {@link CookieListItem}, only containing `name` and `value`
+  * since other cookie attributes aren't be available on a `Request`.
+diff --git a/dist/index.js b/dist/index.js
+index e82cb32f5e416cdf85a228ab036e89a41a7fe547..9e600e3936bf07fb81047c4ac1bb942ac703062a 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -42,7 +42,8 @@ function stringifyCookie(c) {
+     "partitioned" in c && c.partitioned && "Partitioned",
+     "priority" in c && c.priority && `Priority=${c.priority}`
+   ].filter(Boolean);
+-  const stringified = `${c.name}=${encodeURIComponent((_a = c.value) != null ? _a : "")}`;
++  const encode = "encode" in c && typeof c.encode === "function" ? c.encode : encodeURIComponent;
++  const stringified = `${c.name}=${encode((_a = c.value) != null ? _a : "")}`;
+   return attrs.length === 0 ? stringified : `${stringified}; ${attrs.join("; ")}`;
+ }
+ function parseCookie(cookie) {
+@@ -56,13 +57,17 @@ function parseCookie(cookie) {
+       continue;
+     }
+     const [key, value] = [pair.slice(0, splitAt), pair.slice(splitAt + 1)];
+-    try {
+-      map.set(key, decodeURIComponent(value != null ? value : "true"));
+-    } catch {
+-    }
++    map.set(key, decodeCookieValue(value != null ? value : "true"));
+   }
+   return map;
+ }
++function decodeCookieValue(value) {
++  try {
++    return decodeURIComponent(value);
++  } catch {
++    return value;
++  }
++}
+ function parseSetCookie(setCookie) {
+   if (!setCookie) {
+     return void 0;
+@@ -86,7 +91,7 @@ function parseSetCookie(setCookie) {
+   );
+   const cookie = {
+     name,
+-    value: decodeURIComponent(value),
++    value: decodeCookieValue(value),
+     domain,
+     ...expires && { expires: new Date(expires) },
+     ...httponly && { httpOnly: true },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,9 @@ overrides:
 packageExtensionsChecksum: sha256-ylDR55omOZlT4Sfpfh6n7mO2r/cLCmlirAikJ/E/LAw=
 
 patchedDependencies:
+  '@edge-runtime/cookies@6.0.0':
+    hash: 29c60d926c91241f1d940a701c1faa392b75cb3464b50f65360d08b51adb5a5b
+    path: patches/@edge-runtime__cookies@6.0.0.patch
   '@modelcontextprotocol/sdk':
     hash: 680fe4edb7abd1de29d08cdf217a22506e815a8cc1c2282201d5d47aa3e5da12
     path: patches/@modelcontextprotocol__sdk.patch
@@ -1204,7 +1207,7 @@ importers:
         version: 3.4.0
       '@edge-runtime/cookies':
         specifier: 6.0.0
-        version: 6.0.0
+        version: 6.0.0(patch_hash=29c60d926c91241f1d940a701c1faa392b75cb3464b50f65360d08b51adb5a5b)
       '@edge-runtime/ponyfill':
         specifier: 4.0.0
         version: 4.0.0
@@ -20223,7 +20226,7 @@ snapshots:
 
   '@discoveryjs/json-ext@0.5.7': {}
 
-  '@edge-runtime/cookies@6.0.0': {}
+  '@edge-runtime/cookies@6.0.0(patch_hash=29c60d926c91241f1d940a701c1faa392b75cb3464b50f65360d08b51adb5a5b)': {}
 
   '@edge-runtime/format@4.0.0': {}
 

--- a/test/unit/web-runtime/next-response-cookies.test.ts
+++ b/test/unit/web-runtime/next-response-cookies.test.ts
@@ -119,3 +119,11 @@ it('response.cookie does not modify options', async () => {
   response.cookies.set('cookieName', 'cookieValue', options)
   expect(options).toEqual({ maxAge: 10000 })
 })
+
+it('supports a custom cookie value encoder', () => {
+  const response = new NextResponse()
+
+  response.cookies.set('raw', 'qwerty123=', { encode: String })
+
+  expect(response.headers.get('set-cookie')).toBe('raw=qwerty123=; Path=/')
+})


### PR DESCRIPTION
### What?

Adds support for custom cookie value encoders in Next.js response cookie serialization.

`ResponseCookies` now honors the `encode` option when serializing `Set-Cookie` headers, while preserving `encodeURIComponent` as the default behavior. The `ResponseCookie` type also exposes `encode` so `cookies().set()` and `NextResponse.cookies.set()` can accept values like `{ encode: String }`.

### Why?

Users integrating with services that expect raw cookie values could not opt out of URL encoding. For example, setting a cookie value like `qwerty123=` was serialized as `qwerty123%3D`, even when passing `encode: String`.

Fixes #64346

### How?

- Patch `@edge-runtime/cookies@6.0.0` so `stringifyCookie()` uses a provided `encode` function.
- Regenerate Next.js vendored `@edge-runtime/cookies` output from the patched dependency.
- Add regression tests for:
  - `NextResponse.cookies.set(..., { encode: String })`
  - mutable cookies update callbacks used by `cookies().set()`

### Tests

```bash
pnpm testonly packages/next/src/server/web/spec-extension/adapters/request-cookies.test.ts test/unit/web-runtime/next-response-cookies.test.ts
```

<!-- NEXT_JS_LLM_PR -->
