### PR TITLE
[ci]: remove unused workflow

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -528,42 +528,6 @@ jobs:
         env:
           RELEASE_BOT_GITHUB_TOKEN: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
 
-  publish-turbopack-npm-packages:
-    # Matches the commit message written by turbopack/xtask/src/publish.rs:377
-    if: "${{(github.ref == 'refs/heads/canary') && startsWith(github.event.head_commit.message, 'chore: release turbopack npm packages')}}"
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      id-token: write
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: ${{ env.NODE_LTS_VERSION }}
-          check-latest: true
-      - name: Setup corepack
-        run: |
-          npm i -g corepack@0.31
-          corepack enable
-
-      - uses: ./.github/actions/setup-rust
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - run: pnpm install --frozen-lockfile
-
-      - name: Build packages
-        run: pnpx turbo@canary run build --only --filter='./turbopack/packages/*'
-
-      - name: Write NPM_TOKEN
-        run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN_ELEVATED}" > ~/.npmrc
-        env:
-          NPM_TOKEN_ELEVATED: ${{ secrets.NPM_TOKEN_ELEVATED }}
-
-      - name: Publish
-        run: cargo xtask workspace --publish
-
   buildPassed:
     needs: ['deploy-target', 'build', 'build-wasm', 'build-native']
     if: ${{ always() && needs.deploy-target.outputs.value != '' }}


### PR DESCRIPTION
These packages have not been actively published and aren't in a working state. This removes the workflow for now. 