### PR TITLE
[ci]: remove publish token in favor of OIDC

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -480,14 +480,13 @@ jobs:
     permissions:
       contents: write
       id-token: write
-    env:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}
     steps:
       - name: Setup node
         uses: actions/setup-node@v6
         with:
-          node-version: ${{ env.NODE_LTS_VERSION }}
+          node-version: 24
           check-latest: true
+          registry-url: 'https://registry.npmjs.org'
       - name: Setup corepack
         run: |
           npm i -g corepack@0.31
@@ -521,8 +520,6 @@ jobs:
           merge-multiple: true
           path: crates/wasm
 
-      - run: npm i -g npm@10.4.0 # need latest version for provenance (pinning to avoid bugs)
-      - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
       - run: ./scripts/publish-native.js
       - run: ./scripts/publish-release.js
         env:

--- a/.github/workflows/release-next-rspack.yml
+++ b/.github/workflows/release-next-rspack.yml
@@ -61,9 +61,10 @@ jobs:
             echo "  - 📦 This will PUBLISH packages to npm"
           fi
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Enable corepack
         run: corepack enable
@@ -112,12 +113,6 @@ jobs:
       - name: List npm dirs
         run: ls -R npm
         working-directory: ${{ steps.napi-info.outputs.binding-directory }}
-
-      - name: Create npm token
-        run: |
-          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}
 
       - name: Release npm binding packages
         run: |

--- a/scripts/publish-release.js
+++ b/scripts/publish-release.js
@@ -71,11 +71,6 @@ const cwd = process.cwd()
 
   console.log(`Publishing as "${tag}" dist tag...`)
 
-  if (!process.env.NPM_TOKEN) {
-    console.log('No NPM_TOKEN, exiting...')
-    return
-  }
-
   const packagesDir = path.join(cwd, 'packages')
   const packageDirs = fs.readdirSync(packagesDir)
   const publishSema = new Sema(2)


### PR DESCRIPTION
Switches from a long-lived token to trusted publishing OIDC flow. This requires a bump to Node (for feature support). Otherwise just dropping unnecessary envs.