### PR TITLE
fix(turbopack-node): make tokio a required dependency for pool_stats

### DIFF
--- a/turbopack/crates/turbopack-node/Cargo.toml
+++ b/turbopack/crates/turbopack-node/Cargo.toml
@@ -14,7 +14,7 @@ default = ["process_pool"]
 # enable "HMR" for embedded assets
 dynamic_embed_contents = ["turbo-tasks-fs/dynamic_embed_contents"]
 process_pool = ["tokio/full"]
-worker_pool = ["tokio/sync", "napi", "napi-derive", "turbo-rcstr/napi"]
+worker_pool = ["napi", "napi-derive", "turbo-rcstr/napi"]
 
 [lints]
 workspace = true
@@ -40,7 +40,7 @@ rustc-hash = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_with = { workspace = true, features = ["base64"] }
-tokio = { workspace = true, optional = true }
+tokio = { workspace = true, features = ["sync"] }
 tracing = { workspace = true }
 turbo-bincode = { workspace = true }
 turbo-rcstr = { workspace = true }


### PR DESCRIPTION
`pool_stats.rs` uses `tokio::sync::OwnedSemaphorePermit` unconditionally, but `tokio` was marked as optional. This causes a build error when `turbopack-node` is compiled without the `process_pool` or `worker_pool` features (e.g. `cargo test -p turbopack`).

Make `tokio` with `sync` a required dependency.

<!-- NEXT_JS_LLM_PR -->