### PR TITLE
docs: fix "preceeding" typo in unstable_io docs and launch-editor comment

### DIFF
--- a/docs/01-app/03-api-reference/04-functions/unstable_io.mdx
+++ b/docs/01-app/03-api-reference/04-functions/unstable_io.mdx
@@ -4,7 +4,7 @@ description: API Reference for the unstable_io function.
 version: draft
 ---
 
-`unstable_io()` informs Next.js that an IO operation will follow this call. When [Cache Components](/docs/app/api-reference/config/next-config-js/cacheComponents) is not enabled or when rendering in Pages Router, signifying IO in this way is not meaningful and the call will always resolve immediately. When Cache Components is enabled, you may be required to add `await unstable_io()` preceding synchronous IO that is encountered while prerendering pages (`new Date()` for example). Additionally, if you want to avoid having genuine uncached IO invoked while prerendering, you shield it by preceeding it with `await unstable_io()`.
+`unstable_io()` informs Next.js that an IO operation will follow this call. When [Cache Components](/docs/app/api-reference/config/next-config-js/cacheComponents) is not enabled or when rendering in Pages Router, signifying IO in this way is not meaningful and the call will always resolve immediately. When Cache Components is enabled, you may be required to add `await unstable_io()` preceding synchronous IO that is encountered while prerendering pages (`new Date()` for example). Additionally, if you want to avoid having genuine uncached IO invoked while prerendering, you can shield it by preceding it with `await unstable_io()`.
 
 ```ts filename="app/page.tsx" switcher
 import { unstable_io } from 'next/cache'

--- a/packages/next/src/next-devtools/server/launch-editor.ts
+++ b/packages/next/src/next-devtools/server/launch-editor.ts
@@ -307,7 +307,7 @@ function printInstructions(fileName: string, errorMessage: string | null) {
 
 export function escapeApplescriptStringFragment(input: string): string {
   // The only two special characters in a quoted applescript string are
-  // backslash and double quote. Both are escaped with a preceeding backslash.
+  // backslash and double quote. Both are escaped with a preceding backslash.
   //
   // Some whitespace characters (like newlines) can be escaped (as `\n`), but
   // aren't required to be escaped (so we're not bothering to do that).


### PR DESCRIPTION

**Repo:** vercel/next.js (⭐ 125000)
**Type:** docs
**Files changed:** 2
**Lines:** +2/-2

## What
Fixes the misspelling "preceeding" → "preceding" in two places: the user-facing
`unstable_io` API reference doc (`docs/01-app/03-api-reference/04-functions/unstable_io.mdx`)
and a code comment in `packages/next/src/next-devtools/server/launch-editor.ts`. Also
tightens the doc sentence ("you shield it" → "you can shield it") for readability.

## Why
"Preceeding" is a common misspelling; the correct form is "preceding". The typo
appears in published documentation that users read when adopting the new
`unstable_io()` Cache Components API, so fixing it improves the docs' polish.
The comment fix keeps the codebase internally consistent.

## Testing
Pure text/comment change — no behavior impact. Verified the only remaining
occurrences of "preceeding" in the repo were the two fixed here (`grep -rn
preceeding`). No build or test run required.

## Risk
Low — documentation typo and a comment, no code paths affected.
