### PR TITLE
Resolve relative `sources` against source map URL in webpack plugin

### DIFF
--- a/packages/next/src/build/webpack/plugins/eval-source-map-dev-tool-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/eval-source-map-dev-tool-plugin.ts
@@ -15,6 +15,7 @@ import {
   SourceMapDevToolModuleOptionsPlugin,
 } from 'next/dist/compiled/webpack/webpack'
 import type { RawSourceMap } from 'next/dist/compiled/source-map'
+import * as path from 'path'
 
 const cache = new WeakMap<webpack.sources.Source, webpack.sources.Source>()
 
@@ -154,11 +155,38 @@ export default class EvalSourceMapDevToolPlugin {
             sourceMap = { ...sourceMap }
             const context = compiler.options.context!
             const root = compiler.root
+
+            // Relative `sources` entries in a source map resolve against the
+            // map's own URL per the source-map spec
+            // (https://tc39.es/source-map/#resolving-sources). Recover the
+            // map's location from the module's `//# sourceMappingURL=`
+            // trailer. For `ConcatenatedModule` we use `rootModule.resource`
+            // as the base for all constituent sources; that's a heuristic
+            // and can be wrong for non-root sources, but failed lookups fall
+            // back to the `compilation.findModule` path below.
+            const ownerModule =
+              m instanceof NormalModule
+                ? m
+                : m instanceof ConcatenatedModule &&
+                    m.rootModule instanceof NormalModule
+                  ? m.rootModule
+                  : null
+            const mapBase = ownerModule
+              ? getSourceMapBase(
+                  ownerModule.resource,
+                  typeof content === 'string' ? content : content.toString()
+                )
+              : null
+            // Fall back to the compilation context when we can't derive a map
+            // location (no `sourceMappingURL`, virtual/non-NormalModule
+            // source).
+            const base = mapBase ?? context
+
             const modules = sourceMap.sources.map((sourceMapSource) => {
               if (!sourceMapSource.startsWith('webpack://'))
                 return sourceMapSource
               sourceMapSource = makePathsAbsolute(
-                context,
+                base,
                 sourceMapSource.slice(10),
                 root
               )
@@ -298,4 +326,25 @@ export default class EvalSourceMapDevToolPlugin {
       }
     )
   }
+}
+
+/**
+ * Parses `//# sourceMappingURL=` from a module's source and returns the
+ * directory the map lives in. For inline `data:` maps the map's "location" is
+ * the module source itself. Returns `null` if there's no trailer so callers
+ * can fall back.
+ */
+function getSourceMapBase(
+  moduleResource: string,
+  moduleSource: string
+): string | null {
+  const match = /\/\/# sourceMappingURL=(\S+)\s*$/m.exec(moduleSource)
+  if (!match) {
+    return null
+  }
+  const url = match[1]
+  if (url.startsWith('data:')) {
+    return path.dirname(moduleResource)
+  }
+  return path.dirname(path.resolve(path.dirname(moduleResource), url))
 }


### PR DESCRIPTION
`EvalSourceMapDevToolPlugin` is a fork of webpack's plugin that adds `ignoreList` support. When it processes a module whose source map carries relative `sources` entries (e.g. `../../../../src/server/web/adapter.ts` emitted by our SWC compile step), the plugin was absolutizing them via `makePathsAbsolute(compiler.options.context, sourceMapSource.slice(10), compiler.root)`. Per the source-map spec, relative source entries must resolve against the source map's own URL, not the compilation root. As a result, a relative entry pointing four levels up from `.../next/dist/esm/server/web/adapter.js.map` would resolve to something like `/private/var/folders/src/server/web/adapter.ts` instead of `.../next/src/server/web/adapter.ts`. The resulting path contains neither `node_modules` nor `next/dist`, so `shouldIgnorePath` no longer flags the source as ignored, and framework-internal frames leak into user-facing error output.

The `adapter.ts` edits in #93070 happened to shift source-map emission enough that webpack started prefixing the module's entry with `webpack://` and thus hitting this branch, which made the existing bug newly visible in `test/development/middleware-errors/index.test.ts`. Framework-frame leakage from the same cause has also been observed in other dev-mode stack assertions in the past.

The fix recovers the map's location from the module's `//# sourceMappingURL=` trailer (available on the module content passed into the plugin hook) and uses `path.dirname` of that as the base for `makePathsAbsolute`. Inline `data:` maps fall back to `path.dirname(moduleResource)` since the map is embedded in the module source. When the trailer is absent or the module is neither a `NormalModule` nor a `ConcatenatedModule` whose `rootModule` is one, the plugin still uses `compiler.options.context` so the pre-existing behavior for those cases is unchanged.

`ConcatenatedModule` is handled heuristically: all constituent sources are resolved against `rootModule.resource`, which can be wrong for a non-root constituent that had its own relative source-map entries. Failed lookups still fall through to `compilation.findModule`, so the worst case matches prior behavior.

Preserving the input map's `ignoreList` directly was not viable because `webpack-sources` strips it before the map reaches this plugin (verified empirically: `sourceMap.ignoreList` is `undefined` at the hook's entry). Correct source-path resolution is therefore the only place the ignore-list decision can be restored.

Verified by the upstack PR not failing with `test/development/middleware-errors/index.test.ts` anymore ([previous failure](https://github.com/vercel/next.js/actions/runs/24686651521/job/72200274266)).

closes NEXT-4398