### PR TITLE
feat(turbopack): add NEXT_TURBOPACK_TRACING_PATH to control trace output location

### DIFF
--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -454,10 +454,28 @@ pub fn project_new(
     }
     let mut compress = Compression::None;
     if let Some(mut trace) = trace {
-        let internal_dir = PathBuf::from(&options.root_path)
-            .join(&options.project_path)
-            .join(".next-profiles");
-        let trace_file = internal_dir.join("trace-turbopack");
+        let trace_path_override = std::env::var_os("NEXT_TURBOPACK_TRACING_PATH")
+            .filter(|v| !v.is_empty())
+            .map(PathBuf::from);
+        let trace_file = if let Some(path) = trace_path_override {
+            if path.is_absolute() {
+                path
+            } else {
+                std::env::current_dir()
+                    .context("Unable to read current working directory")
+                    .unwrap()
+                    .join(path)
+            }
+        } else {
+            PathBuf::from(&options.root_path)
+                .join(&options.project_path)
+                .join(".next-profiles")
+                .join("trace-turbopack")
+        };
+        let trace_dir = trace_file
+            .parent()
+            .expect("Trace file path must have a parent directory")
+            .to_path_buf();
 
         println!("Turbopack tracing enabled with targets: {trace}");
         println!("  Note that this might have a small performance impact.");
@@ -496,8 +514,13 @@ pub fn project_new(
 
         let subscriber = subscriber.with(FilterLayer::try_new(&trace).unwrap());
 
-        std::fs::create_dir_all(&internal_dir)
-            .context("Unable to create .next-profiles directory")
+        std::fs::create_dir_all(&trace_dir)
+            .with_context(|| {
+                format!(
+                    "Unable to create trace output directory {}",
+                    trace_dir.display()
+                )
+            })
             .unwrap();
         let (trace_writer, trace_writer_guard) = match compress {
             Compression::None => {


### PR DESCRIPTION
### What?

Adds a new environment variable `NEXT_TURBOPACK_TRACING_PATH` that lets users specify the full output path (including filename) for the Turbopack trace file.

### Why?

Some users need to control where the `trace-turbopack` file is written — for example, to redirect it outside the project directory, to a shared volume, or to a custom filename. Previously the path was hardcoded to `<project>/.next-profiles/trace-turbopack` with no override mechanism.

### How?

When `NEXT_TURBOPACK_TRACING` is set (tracing is enabled) and `NEXT_TURBOPACK_TRACING_PATH` is also set, the trace is written to the specified path instead of the default:

- **Absolute paths** are used as-is.
- **Relative paths** are resolved against the process CWD.
- The **parent directory is auto-created** recursively (equivalent to `mkdir -p`), so pointing to a non-existent subdirectory works without manual setup.
- Setting `NEXT_TURBOPACK_TRACING_PATH` alone (without `NEXT_TURBOPACK_TRACING`) has no effect — tracing is not enabled by it.
- The "Trace output will be written to …" message reflects the resolved path.

The change is confined to `crates/next-napi-bindings/src/next_api/project.rs`.

**Example:**
```sh
NEXT_TURBOPACK_TRACING=overview \
NEXT_TURBOPACK_TRACING_PATH=/tmp/my-project-trace \
next dev
```

<!-- NEXT_JS_LLM_PR -->