### PR TITLE
fix: normalize CRLF line endings in metadata descriptions to prevent duplicate metadata tags

### DIFF
--- a/packages/next/src/lib/metadata/generate/utils.test.ts
+++ b/packages/next/src/lib/metadata/generate/utils.test.ts
@@ -1,0 +1,29 @@
+import { normalizeMetadataString } from './utils'
+
+describe('normalizeMetadataString', () => {
+  it('should strip carriage returns from string', () => {
+    expect(normalizeMetadataString('line1\r\nline2\r\nline3')).toBe(
+      'line1\nline2\nline3'
+    )
+  })
+
+  it('should handle string with only carriage returns', () => {
+    expect(normalizeMetadataString('a\rb\rc')).toBe('abc')
+  })
+
+  it('should return string unchanged if no carriage returns', () => {
+    expect(normalizeMetadataString('line1\nline2')).toBe('line1\nline2')
+  })
+
+  it('should return null as-is', () => {
+    expect(normalizeMetadataString(null)).toBeNull()
+  })
+
+  it('should return undefined as-is', () => {
+    expect(normalizeMetadataString(undefined)).toBeUndefined()
+  })
+
+  it('should handle empty string', () => {
+    expect(normalizeMetadataString('')).toBe('')
+  })
+})

--- a/packages/next/src/lib/metadata/generate/utils.ts
+++ b/packages/next/src/lib/metadata/generate/utils.ts
@@ -25,4 +25,24 @@ function getOrigin(url: string | URL): string | undefined {
   return origin
 }
 
-export { resolveAsArrayOrUndefined, resolveArray, getOrigin }
+/**
+ * Normalizes a metadata string value by stripping carriage return characters.
+ * This prevents duplicate meta tags caused by CRLF line endings in metadata.
+ *
+ * @see https://github.com/vercel/next.js/issues/93089
+ */
+function normalizeMetadataString<T extends string | null | undefined>(
+  value: T
+): T {
+  if (typeof value === 'string') {
+    return value.replace(/\r/g, '') as T
+  }
+  return value
+}
+
+export {
+  resolveAsArrayOrUndefined,
+  resolveArray,
+  getOrigin,
+  normalizeMetadataString,
+}

--- a/packages/next/src/lib/metadata/resolve-metadata.ts
+++ b/packages/next/src/lib/metadata/resolve-metadata.ts
@@ -36,7 +36,10 @@ import {
 } from './default-metadata'
 import { resolveOpenGraph, resolveTwitter } from './resolvers/resolve-opengraph'
 import { resolveTitle } from './resolvers/resolve-title'
-import { resolveAsArrayOrUndefined } from './generate/utils'
+import {
+  resolveAsArrayOrUndefined,
+  normalizeMetadataString,
+} from './generate/utils'
 import {
   getComponentTypeModule,
   getLayoutOrPageModule,
@@ -352,7 +355,9 @@ async function mergeMetadata(
         newResolvedMetadata[key] = metadata[key] ?? null
         break
       case 'description':
-        newResolvedMetadata[key] = metadata[key] ?? null
+        newResolvedMetadata[key] = normalizeMetadataString(
+          metadata[key] ?? null
+        )
         break
       case 'generator':
         newResolvedMetadata[key] = metadata[key] ?? null

--- a/packages/next/src/lib/metadata/resolvers/resolve-opengraph.ts
+++ b/packages/next/src/lib/metadata/resolvers/resolve-opengraph.ts
@@ -10,7 +10,11 @@ import type {
   MetadataContext,
 } from '../types/resolvers'
 import type { ResolvedTwitterMetadata, Twitter } from '../types/twitter-types'
-import { resolveArray, resolveAsArrayOrUndefined } from '../generate/utils'
+import {
+  resolveArray,
+  resolveAsArrayOrUndefined,
+  normalizeMetadataString,
+} from '../generate/utils'
 import {
   getSocialImageMetadataBaseFallback,
   isStringOrURL,
@@ -191,6 +195,7 @@ export const resolveOpenGraph: AsyncFieldResolverExtraArgs<
   const resolved = {
     ...openGraph,
     title: resolveTitle(openGraph.title, titleTemplate),
+    description: normalizeMetadataString(openGraph.description),
   } as ResolvedOpenGraph
   resolveProps(resolved, openGraph)
 
@@ -227,6 +232,8 @@ export const resolveTwitter: FieldResolverExtraArgs<
   for (const infoKey of TwitterBasicInfoKeys) {
     resolved[infoKey] = twitter[infoKey] || null
   }
+  // Normalize description to prevent hydration mismatch from CRLF line endings
+  resolved.description = normalizeMetadataString(resolved.description)
 
   resolved.images = resolveImages(
     twitter.images,


### PR DESCRIPTION
Fixes https://github.com/vercel/next.js/issues/93089.

When metadata contains Windows-style line endings (CRLF), these become normalized to LF in the HTML payload of the page. However, the RSC payload retains the original CRLF. This mismatch causes React hydration to see different values and create duplicate meta tags.

## Before

Using the [minimal repro app](https://github.com/henrycatalinismith/carriage-return-duplicate-description-bug-demo) created for the issue you can see the duplicate meta descriptions here.

<img width="1451" height="882" alt="Skärmavbild 2026-04-21 kl  15 27 26" src="https://github.com/user-attachments/assets/a563e67d-f659-4926-a835-bca22599c6c1" />

## After

Running the same app with this fixed version of Next.

<img width="1451" height="882" alt="Skärmavbild 2026-04-21 kl  15 30 08" src="https://github.com/user-attachments/assets/223298c6-1e6a-437b-ad4e-a507bf2fa314" />
 