### PR TITLE
turbo-tasks: drop once_cell, const-init TRAIT_METHOD, ctor WORKER_TASKS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2007,20 +2007,19 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.10.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95d0d11eb38e7642efca359c3cf6eb7b2e528182d09110165de70192b0352775"
+checksum = "352d39c2f7bef1d6ad73db6f5160efcaed66d94ef8c6c573a8410c00bf909a98"
 dependencies = [
  "ctor-proc-macro",
  "dtor",
- "link-section",
 ]
 
 [[package]]
 name = "ctor-proc-macro"
-version = "0.0.12"
+version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7ab264ea985f1bd27887d7b21ea2bb046728e05d11909ca138d700c494730db"
+checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "ctrlc"
@@ -2400,18 +2399,18 @@ dependencies = [
 
 [[package]]
 name = "dtor"
-version = "0.7.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f72721db8027a4e96dd6fb50d2a1d32259c9d3da1b63dee612ccd981e14293"
+checksum = "f1057d6c64987086ff8ed0fd3fbf377a6b7d205cc7715868cd401705f715cbe4"
 dependencies = [
  "dtor-proc-macro",
 ]
 
 [[package]]
 name = "dtor-proc-macro"
-version = "0.0.12"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c98b077c7463d01d22dde8a24378ddf1ca7263dc687cffbed38819ea6c21131"
+checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
 name = "dunce"
@@ -4213,12 +4212,6 @@ dependencies = [
  "serde_bytes",
  "smallvec",
 ]
-
-[[package]]
-name = "link-section"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "468808413fa8bdf0edbe61c2bbc182dfc59885b94f496cf3fb42c9c96b1e0149"
 
 [[package]]
 name = "linked-hash-map"
@@ -9900,7 +9893,7 @@ dependencies = [
  "bincode 2.0.1",
  "codspeed-criterion-compat",
  "concurrent-queue",
- "ctor 0.10.0",
+ "ctor 0.8.0",
  "dashmap 6.1.0",
  "either",
  "erased-serde",
@@ -10123,7 +10116,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
- "ctor 0.10.0",
+ "ctor 0.8.0",
  "serde",
  "tokio",
  "trybuild",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9893,7 +9893,6 @@ dependencies = [
  "bincode 2.0.1",
  "codspeed-criterion-compat",
  "concurrent-queue",
- "ctor 0.8.0",
  "dashmap 6.1.0",
  "either",
  "erased-serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2007,19 +2007,20 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "352d39c2f7bef1d6ad73db6f5160efcaed66d94ef8c6c573a8410c00bf909a98"
+checksum = "95d0d11eb38e7642efca359c3cf6eb7b2e528182d09110165de70192b0352775"
 dependencies = [
  "ctor-proc-macro",
  "dtor",
+ "link-section",
 ]
 
 [[package]]
 name = "ctor-proc-macro"
-version = "0.0.7"
+version = "0.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
+checksum = "a7ab264ea985f1bd27887d7b21ea2bb046728e05d11909ca138d700c494730db"
 
 [[package]]
 name = "ctrlc"
@@ -2399,18 +2400,18 @@ dependencies = [
 
 [[package]]
 name = "dtor"
-version = "0.3.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1057d6c64987086ff8ed0fd3fbf377a6b7d205cc7715868cd401705f715cbe4"
+checksum = "17f72721db8027a4e96dd6fb50d2a1d32259c9d3da1b63dee612ccd981e14293"
 dependencies = [
  "dtor-proc-macro",
 ]
 
 [[package]]
 name = "dtor-proc-macro"
-version = "0.0.6"
+version = "0.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
+checksum = "8c98b077c7463d01d22dde8a24378ddf1ca7263dc687cffbed38819ea6c21131"
 
 [[package]]
 name = "dunce"
@@ -4212,6 +4213,12 @@ dependencies = [
  "serde_bytes",
  "smallvec",
 ]
+
+[[package]]
+name = "link-section"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "468808413fa8bdf0edbe61c2bbc182dfc59885b94f496cf3fb42c9c96b1e0149"
 
 [[package]]
 name = "linked-hash-map"
@@ -9893,6 +9900,7 @@ dependencies = [
  "bincode 2.0.1",
  "codspeed-criterion-compat",
  "concurrent-queue",
+ "ctor 0.10.0",
  "dashmap 6.1.0",
  "either",
  "erased-serde",
@@ -9900,9 +9908,7 @@ dependencies = [
  "futures",
  "indexmap 2.13.0",
  "inventory",
- "once_cell",
  "parking_lot",
- "phf",
  "pin-project-lite",
  "rayon",
  "regex",
@@ -9942,7 +9948,6 @@ dependencies = [
  "indexmap 2.13.0",
  "indoc",
  "lzzzz",
- "once_cell",
  "parking_lot",
  "rand 0.10.0",
  "regex",
@@ -9975,7 +9980,6 @@ dependencies = [
  "arbitrary",
  "bincode 2.0.1",
  "libfuzzer-sys",
- "once_cell",
  "serde",
  "tokio",
  "turbo-tasks",
@@ -10119,7 +10123,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
- "ctor 0.8.0",
+ "ctor 0.10.0",
  "serde",
  "tokio",
  "trybuild",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -258,7 +258,7 @@ console-subscriber = "0.4.1"
 const_format = "0.2.30"
 crc32fast = "1.4.2"
 criterion = { package = "codspeed-criterion-compat", version = "4.3.0" }
-ctor = "0.8"
+ctor = "0.10"
 crossbeam-channel = "0.5.8"
 crossbeam-utils = "0.8"
 dashmap = "6.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -258,7 +258,7 @@ console-subscriber = "0.4.1"
 const_format = "0.2.30"
 crc32fast = "1.4.2"
 criterion = { package = "codspeed-criterion-compat", version = "4.3.0" }
-ctor = "0.10"
+ctor = "0.8"
 crossbeam-channel = "0.5.8"
 crossbeam-utils = "0.8"
 dashmap = "6.1.0"

--- a/turbopack/crates/turbo-tasks-backend/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-backend/Cargo.toml
@@ -44,7 +44,6 @@ either = { workspace = true }
 hashbrown = { workspace = true, features = ["raw"] }
 indexmap = { workspace = true }
 lzzzz = { workspace = true, optional = true }
-once_cell = { workspace = true }
 parking_lot = { workspace = true }
 rand = { workspace = true }
 ringmap = { workspace = true, features = ["serde"] }

--- a/turbopack/crates/turbo-tasks-backend/fuzz/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-backend/fuzz/Cargo.toml
@@ -13,7 +13,6 @@ anyhow = { workspace = true }
 arbitrary = { version = "1.4.1", features = ["derive"] }
 bincode = { workspace = true }
 libfuzzer-sys = "0.4.9"
-once_cell = { workspace = true }
 serde = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 turbo-tasks = { workspace = true, features = ["non_operation_vc_strongly_consistent"] }

--- a/turbopack/crates/turbo-tasks-backend/fuzz/src/graph.rs
+++ b/turbopack/crates/turbo-tasks-backend/fuzz/src/graph.rs
@@ -1,9 +1,8 @@
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 
 use anyhow::Result;
 use arbitrary::Arbitrary;
 use bincode::{Decode, Encode};
-use once_cell::sync::Lazy;
 use turbo_tasks::{self, NonLocalValue, State, TaskInput, TurboTasks, Vc, trace::TraceRawVcs};
 use turbo_tasks_malloc::TurboMalloc;
 
@@ -81,7 +80,7 @@ impl<'a> Iterator for Iter<'a> {
     }
 }
 
-static RUNTIME: Lazy<tokio::runtime::Runtime> = Lazy::new(|| {
+static RUNTIME: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| {
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .on_thread_stop(|| {

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_cell.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_cell.rs
@@ -1,7 +1,6 @@
-use std::mem::take;
+use std::{cell::LazyCell, mem::take};
 
 use bincode::{Decode, Encode};
-use once_cell::unsync::Lazy;
 use rustc_hash::FxHashSet;
 use smallvec::SmallVec;
 use turbo_tasks::{
@@ -131,7 +130,7 @@ impl UpdateCellOperation {
             #[cfg(feature = "trace_task_dirty")]
             let has_updated_key_hashes = updated_key_hashes.is_some();
             let updated_key_hashes_set = updated_key_hashes.map(|updated_key_hashes| {
-                Lazy::new(|| updated_key_hashes.into_iter().collect::<FxHashSet<u64>>())
+                LazyCell::new(|| updated_key_hashes.into_iter().collect::<FxHashSet<u64>>())
             });
 
             // Collect dependent tasks only when not skipping invalidation.

--- a/turbopack/crates/turbo-tasks-macros/src/func.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/func.rs
@@ -559,11 +559,11 @@ impl TurboFn<'_> {
                 let this = #converted_this;
                 let persistence = #persistence;
                 let mut arg = turbo_tasks::StackDynTaskInputsSlot::new(inputs);
-                static TRAIT_METHOD: turbo_tasks::macro_helpers::Lazy<&'static turbo_tasks::TraitMethod> =
-                        turbo_tasks::macro_helpers::Lazy::new(|| #trait_type_ident.get(stringify!(#ident)));
+                static TRAIT_METHOD: &'static turbo_tasks::TraitMethod =
+                    #trait_type_ident.get(stringify!(#ident));
                 <#output as turbo_tasks::task::TaskOutput>::try_from_raw_vc(
                     turbo_tasks::trait_call(
-                        *TRAIT_METHOD,
+                        TRAIT_METHOD,
                         this,
                         &mut arg,
                         persistence,

--- a/turbopack/crates/turbo-tasks-macros/src/func.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/func.rs
@@ -560,8 +560,8 @@ impl TurboFn<'_> {
                 let persistence = #persistence;
                 let mut arg = turbo_tasks::StackDynTaskInputsSlot::new(inputs);
                 static TRAIT_METHOD: &'static turbo_tasks::TraitMethod = &#trait_type_ident
-                    .methods[turbo_tasks::macro_helpers::index_of_name(
-                        #trait_type_ident.method_names,
+                    .methods[turbo_tasks::macro_helpers::index_of_method_name(
+                        #trait_type_ident.methods,
                         stringify!(#ident),
                     )];
                 <#output as turbo_tasks::task::TaskOutput>::try_from_raw_vc(

--- a/turbopack/crates/turbo-tasks-macros/src/func.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/func.rs
@@ -559,8 +559,11 @@ impl TurboFn<'_> {
                 let this = #converted_this;
                 let persistence = #persistence;
                 let mut arg = turbo_tasks::StackDynTaskInputsSlot::new(inputs);
-                static TRAIT_METHOD: &'static turbo_tasks::TraitMethod =
-                    #trait_type_ident.get(stringify!(#ident));
+                static TRAIT_METHOD: &'static turbo_tasks::TraitMethod = &#trait_type_ident
+                    .methods[turbo_tasks::macro_helpers::index_of_name(
+                        #trait_type_ident.method_names,
+                        stringify!(#ident),
+                    )];
                 <#output as turbo_tasks::task::TaskOutput>::try_from_raw_vc(
                     turbo_tasks::trait_call(
                         TRAIT_METHOD,

--- a/turbopack/crates/turbo-tasks-macros/src/value_trait_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/value_trait_macro.rs
@@ -69,7 +69,6 @@ pub fn value_trait(args: TokenStream, input: TokenStream) -> TokenStream {
     let trait_type_ident = get_trait_type_ident(trait_ident);
     let mut dynamic_trait_fns = Vec::new();
     let mut trait_methods: Vec<TokenStream2> = Vec::new();
-    let mut method_names: Vec<TokenStream2> = Vec::new();
     let mut default_methods: Vec<TokenStream2> = Vec::new();
     let mut native_functions = Vec::new();
     let mut items: Vec<TokenStream2> = Vec::with_capacity(raw_items.len());
@@ -231,7 +230,6 @@ pub fn value_trait(args: TokenStream, input: TokenStream) -> TokenStream {
                     index: #index,
                 },
             });
-            method_names.push(quote! { #method_name_str });
             default_methods.push(quote! { Some(&#native_function_ident) });
 
             native_functions.push(quote! {
@@ -269,7 +267,6 @@ pub fn value_trait(args: TokenStream, input: TokenStream) -> TokenStream {
                     index: #index,
                 },
             });
-            method_names.push(quote! { #method_name_str });
             default_methods.push(quote! { None });
             quote! { ; }
         };
@@ -311,7 +308,7 @@ pub fn value_trait(args: TokenStream, input: TokenStream) -> TokenStream {
         extended_supertraits.push(quote!(turbo_tasks::debug::ValueDebug));
     }
 
-    let num_methods = method_names.len();
+    let num_methods = default_methods.len();
     let trait_name = global_name_for_type(quote! { dyn #trait_ident });
     let expanded = quote! {
         #[must_use]
@@ -329,14 +326,12 @@ pub fn value_trait(args: TokenStream, input: TokenStream) -> TokenStream {
                     stringify!(#trait_ident),
                     #trait_name,
                     &[#(#trait_methods)*],
-                    &[#(#method_names),*],
                     &[#(#default_methods),*]
                 )
         );
 
         impl turbo_tasks::macro_helpers::TraitVtablePrototype for Box<dyn #trait_ident> {
             const LEN: usize = #num_methods;
-            const NAMES: &[&str] = &[#(#method_names),*];
             const DEFAULTS: &[Option<&turbo_tasks::macro_helpers::NativeFunction>] = &[#(#default_methods),*];
         }
 

--- a/turbopack/crates/turbo-tasks-macros/src/value_trait_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/value_trait_macro.rs
@@ -223,7 +223,7 @@ pub fn value_trait(args: TokenStream, input: TokenStream) -> TokenStream {
             let method_name_str = syn::LitStr::new(&ident.to_string(), ident.span());
             let index = trait_methods.len() as u8;
             trait_methods.push(quote! {
-                #method_name_str => turbo_tasks::TraitMethod {
+                turbo_tasks::TraitMethod {
                     trait_type: &#trait_type_ident,
                     trait_name: stringify!(#trait_ident),
                     method_name: #method_name_str,
@@ -261,7 +261,7 @@ pub fn value_trait(args: TokenStream, input: TokenStream) -> TokenStream {
             let method_name_str = syn::LitStr::new(&ident.to_string(), ident.span());
             let index = trait_methods.len() as u8;
             trait_methods.push(quote! {
-                #method_name_str => turbo_tasks::TraitMethod {
+                turbo_tasks::TraitMethod {
                     trait_type: &#trait_type_ident,
                     trait_name: stringify!(#trait_ident),
                     method_name: #method_name_str,
@@ -324,18 +324,14 @@ pub fn value_trait(args: TokenStream, input: TokenStream) -> TokenStream {
         #(#native_functions)*
 
         turbo_tasks::macro_helpers::turbo_register!(
-            Box<dyn #trait_ident> => #trait_type_ident: turbo_tasks::TraitType = {
-                use turbo_tasks::macro_helpers::{phf, phf::phf_map};
+            Box<dyn #trait_ident> => #trait_type_ident: turbo_tasks::TraitType =
                 turbo_tasks::TraitType::new::<&'static dyn #trait_ident>(
                     stringify!(#trait_ident),
                     #trait_name,
-                    phf_map! {
-                        #(#trait_methods)*
-                    },
+                    &[#(#trait_methods)*],
                     &[#(#method_names),*],
                     &[#(#default_methods),*]
                 )
-            }
         );
 
         impl turbo_tasks::macro_helpers::TraitVtablePrototype for Box<dyn #trait_ident> {
@@ -354,8 +350,8 @@ pub fn value_trait(args: TokenStream, input: TokenStream) -> TokenStream {
 
             // TODO: Remove this Lazy VTableRegistry once trait resolution is fully migrated
             fn get_impl_vtables() -> &'static turbo_tasks::macro_helpers::VTableRegistry<Self::ValueTrait> {
-                static registry: turbo_tasks::macro_helpers::Lazy<turbo_tasks::macro_helpers::VTableRegistry<dyn # trait_ident>> =
-                    turbo_tasks::macro_helpers::Lazy::new(|| turbo_tasks::macro_helpers::VTableRegistry::new(turbo_tasks::registry::get_trait_type_id(&#trait_type_ident)));
+                static registry: ::std::sync::LazyLock<turbo_tasks::macro_helpers::VTableRegistry<dyn # trait_ident>> =
+                    ::std::sync::LazyLock::new(|| turbo_tasks::macro_helpers::VTableRegistry::new(turbo_tasks::registry::get_trait_type_id(&#trait_type_ident)));
 
                 &*registry
             }

--- a/turbopack/crates/turbo-tasks/Cargo.toml
+++ b/turbopack/crates/turbo-tasks/Cargo.toml
@@ -28,7 +28,6 @@ async-trait = { workspace = true }
 auto-hash-map = { workspace = true }
 bincode = { workspace = true }
 concurrent-queue = { workspace = true }
-ctor = { workspace = true }
 dashmap = { workspace = true }
 either = { workspace = true }
 erased-serde = { workspace = true }

--- a/turbopack/crates/turbo-tasks/Cargo.toml
+++ b/turbopack/crates/turbo-tasks/Cargo.toml
@@ -28,6 +28,7 @@ async-trait = { workspace = true }
 auto-hash-map = { workspace = true }
 bincode = { workspace = true }
 concurrent-queue = { workspace = true }
+ctor = { workspace = true }
 dashmap = { workspace = true }
 either = { workspace = true }
 erased-serde = { workspace = true }
@@ -35,9 +36,7 @@ event-listener = "5.4.0"
 futures = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
 inventory = { workspace = true }
-once_cell = { workspace = true }
 parking_lot = { workspace = true, features = ["serde"]}
-phf = { workspace = true }
 pin-project-lite = { workspace = true }
 rayon = { workspace = true }
 regex = { workspace = true }

--- a/turbopack/crates/turbo-tasks/src/macro_helpers.rs
+++ b/turbopack/crates/turbo-tasks/src/macro_helpers.rs
@@ -27,7 +27,7 @@ pub use crate::{
     registry::RegistryDef,
     task::function::{into_task_fn, into_task_fn_with_this},
     turbo_register,
-    value_type::{TraitVtablePrototype, build_trait_vtable},
+    value_type::{TraitVtablePrototype, build_trait_vtable, index_of_name},
 };
 
 #[cfg(debug_assertions)]

--- a/turbopack/crates/turbo-tasks/src/macro_helpers.rs
+++ b/turbopack/crates/turbo-tasks/src/macro_helpers.rs
@@ -1,10 +1,10 @@
 //! Runtime helpers for [turbo-tasks-macro].
 
+use std::sync::LazyLock;
+
 pub use async_trait::async_trait;
 pub use bincode;
 pub use inventory;
-pub use once_cell::sync::{Lazy, OnceCell};
-pub use phf;
 use rustc_hash::FxHashMap;
 pub use shrink_to_fit;
 pub use tracing;
@@ -209,18 +209,19 @@ unsafe impl Sync for RawPtr {}
 unsafe impl Send for RawPtr {}
 
 // Accumulate all trait impls by trait id
-static TRAIT_CAST_FNS: Lazy<FxDashMap<TraitTypeId, Vec<(ValueTypeId, RawPtr)>>> = Lazy::new(|| {
-    let map: FxDashMap<TraitTypeId, Vec<(ValueTypeId, RawPtr)>> = FxDashMap::default();
-    for CollectableTraitCastFunctions(trait_id_fn, value_id_fn, cast_fn) in
-        inventory::iter::<CollectableTraitCastFunctions>
-    {
-        map.entry(trait_id_fn())
-            .or_default()
-            .value_mut()
-            .push((value_id_fn(), RawPtr(*cast_fn)));
-    }
-    map
-});
+static TRAIT_CAST_FNS: LazyLock<FxDashMap<TraitTypeId, Vec<(ValueTypeId, RawPtr)>>> =
+    LazyLock::new(|| {
+        let map: FxDashMap<TraitTypeId, Vec<(ValueTypeId, RawPtr)>> = FxDashMap::default();
+        for CollectableTraitCastFunctions(trait_id_fn, value_id_fn, cast_fn) in
+            inventory::iter::<CollectableTraitCastFunctions>
+        {
+            map.entry(trait_id_fn())
+                .or_default()
+                .value_mut()
+                .push((value_id_fn(), RawPtr(*cast_fn)));
+        }
+        map
+    });
 
 // Holds a raw pointer to a function that can perform a fat pointer cast
 pub struct CollectableTraitCastFunctions(

--- a/turbopack/crates/turbo-tasks/src/macro_helpers.rs
+++ b/turbopack/crates/turbo-tasks/src/macro_helpers.rs
@@ -27,7 +27,7 @@ pub use crate::{
     registry::RegistryDef,
     task::function::{into_task_fn, into_task_fn_with_this},
     turbo_register,
-    value_type::{TraitVtablePrototype, build_trait_vtable, index_of_name},
+    value_type::{TraitVtablePrototype, build_trait_vtable, index_of_method_name},
 };
 
 #[cfg(debug_assertions)]

--- a/turbopack/crates/turbo-tasks/src/registry/mod.rs
+++ b/turbopack/crates/turbo-tasks/src/registry/mod.rs
@@ -1,7 +1,6 @@
-use std::{cell::SyncUnsafeCell, num::NonZeroU16};
+use std::{cell::SyncUnsafeCell, num::NonZeroU16, sync::LazyLock};
 
 use anyhow::Error;
-use once_cell::sync::Lazy;
 
 use crate::{
     TraitType, ValueType,
@@ -134,16 +133,16 @@ fn init_registry<T: Registerable>(mut items: Vec<&'static T>) -> Box<[&'static T
 
 /// Get an item by its ID from a registry slice
 #[inline]
-fn get_item<T: Registerable>(registry: &Lazy<Box<[&'static T]>>, id: T::Id) -> &'static T {
+fn get_item<T: Registerable>(registry: &LazyLock<Box<[&'static T]>>, id: T::Id) -> &'static T {
     registry[*id as usize - 1]
 }
 
 /// Get the ID for a registered item. Forces registry init if needed, which
 /// assigns IDs to all items as a side effect.
 #[inline]
-fn get_id<T: Registerable>(registry: &Lazy<Box<[&'static T]>>, item: &'static T) -> T::Id {
-    Lazy::force(registry);
-    // SAFETY: The ID write happens-before this read thanks to the fence inside of Lazy
+fn get_id<T: Registerable>(registry: &LazyLock<Box<[&'static T]>>, item: &'static T) -> T::Id {
+    LazyLock::force(registry);
+    // SAFETY: The ID write happens-before this read thanks to the fence inside of LazyLock
     let n = unsafe { std::ptr::read(item.ty().id.get()) };
     let Some(id) = NonZeroU16::new(n) else {
         panic!(
@@ -156,7 +155,10 @@ fn get_id<T: Registerable>(registry: &Lazy<Box<[&'static T]>>, item: &'static T)
 }
 
 /// Validate that an ID is within the valid range
-fn validate_id<T: Registerable>(registry: &Lazy<Box<[&'static T]>>, id: T::Id) -> Option<Error> {
+fn validate_id<T: Registerable>(
+    registry: &LazyLock<Box<[&'static T]>>,
+    id: T::Id,
+) -> Option<Error> {
     let len = registry.len();
     if *id as usize <= len {
         None
@@ -168,7 +170,7 @@ fn validate_id<T: Registerable>(registry: &Lazy<Box<[&'static T]>>, id: T::Id) -
     }
 }
 
-static FUNCTIONS: Lazy<Box<[&'static NativeFunction]>> = Lazy::new(|| {
+static FUNCTIONS: LazyLock<Box<[&'static NativeFunction]>> = LazyLock::new(|| {
     init_registry(
         inventory::iter::<&'static NativeFunction>
             .into_iter()
@@ -191,7 +193,7 @@ pub fn validate_function_id(id: FunctionId) -> Option<Error> {
     validate_id(&FUNCTIONS, id)
 }
 
-pub(crate) static VALUES: Lazy<Box<[&'static ValueType]>> = Lazy::new(|| {
+pub(crate) static VALUES: LazyLock<Box<[&'static ValueType]>> = LazyLock::new(|| {
     let items = init_registry(
         inventory::iter::<&'static ValueType>
             .into_iter()
@@ -222,7 +224,7 @@ pub(crate) fn trait_type_count() -> usize {
     TRAITS.len()
 }
 
-static TRAITS: Lazy<Box<[&'static TraitType]>> = Lazy::new(|| {
+static TRAITS: LazyLock<Box<[&'static TraitType]>> = LazyLock::new(|| {
     init_registry(
         inventory::iter::<&'static TraitType>
             .into_iter()

--- a/turbopack/crates/turbo-tasks/src/scope.rs
+++ b/turbopack/crates/turbo-tasks/src/scope.rs
@@ -13,7 +13,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-use once_cell::sync::Lazy;
 use parking_lot::{Condvar, Mutex};
 use tokio::{runtime::Handle, task::block_in_place};
 use tracing::{Span, info_span};
@@ -21,8 +20,9 @@ use tracing::{Span, info_span};
 use crate::{TurboTasksApi, manager::try_turbo_tasks, turbo_tasks_scope};
 
 /// Number of worker tasks to spawn that process jobs. It's 1 less than the number of cpus as we
-/// also use the current task as worker.
-static WORKER_TASKS: Lazy<usize> = Lazy::new(|| available_parallelism().map_or(0, |n| n.get() - 1));
+/// also use the current task as worker. Initialized at program load via `#[ctor]`.
+#[ctor::ctor]
+static WORKER_TASKS: usize = unsafe { available_parallelism().map_or(0, |n| n.get() - 1) };
 
 enum WorkQueueJob {
     Job(usize, Box<dyn FnOnce() + Send + 'static>),

--- a/turbopack/crates/turbo-tasks/src/scope.rs
+++ b/turbopack/crates/turbo-tasks/src/scope.rs
@@ -20,7 +20,7 @@ use tracing::{Span, info_span};
 use crate::{TurboTasksApi, manager::try_turbo_tasks, turbo_tasks_scope};
 
 /// Number of worker tasks to spawn that process jobs. It's 1 less than the number of cpus as we
-/// also use the current task as worker. Initialized at program load via `#[ctor]`.
+/// also use the current task as worker.
 #[ctor::ctor]
 static WORKER_TASKS: usize = unsafe { available_parallelism().map_or(0, |n| n.get() - 1) };
 

--- a/turbopack/crates/turbo-tasks/src/scope.rs
+++ b/turbopack/crates/turbo-tasks/src/scope.rs
@@ -6,7 +6,7 @@ use std::{
     marker::PhantomData,
     panic::{self, AssertUnwindSafe, catch_unwind},
     sync::{
-        Arc,
+        Arc, LazyLock,
         atomic::{AtomicUsize, Ordering},
     },
     thread::{self, Thread, available_parallelism},
@@ -21,8 +21,8 @@ use crate::{TurboTasksApi, manager::try_turbo_tasks, turbo_tasks_scope};
 
 /// Number of worker tasks to spawn that process jobs. It's 1 less than the number of cpus as we
 /// also use the current task as worker.
-#[ctor::ctor]
-static WORKER_TASKS: usize = unsafe { available_parallelism().map_or(0, |n| n.get() - 1) };
+static WORKER_TASKS: LazyLock<usize> =
+    LazyLock::new(|| available_parallelism().map_or(0, |n| n.get() - 1));
 
 enum WorkQueueJob {
     Job(usize, Box<dyn FnOnce() + Send + 'static>),

--- a/turbopack/crates/turbo-tasks/src/value_type.rs
+++ b/turbopack/crates/turbo-tasks/src/value_type.rs
@@ -255,8 +255,6 @@ impl TraitMethod {
 
 pub struct TraitType {
     pub ty: RegistryType,
-    /// Method metadata in the same order as `method_names`. Index `i` corresponds to
-    /// `method_names[i]`.
     pub methods: &'static [TraitMethod],
     pub method_names: &'static [&'static str],
     pub default_methods: &'static [Option<&'static NativeFunction>],
@@ -295,8 +293,6 @@ impl TraitType {
         }
     }
 
-    /// Look up a method by name. `const` so callers can store the resulting reference in a
-    /// `static`/`const` item instead of a `LazyLock`.
     pub const fn get(&'static self, name: &'static str) -> &'static TraitMethod {
         &self.methods[index_of_name(self.method_names, name)]
     }

--- a/turbopack/crates/turbo-tasks/src/value_type.rs
+++ b/turbopack/crates/turbo-tasks/src/value_type.rs
@@ -255,7 +255,9 @@ impl TraitMethod {
 
 pub struct TraitType {
     pub ty: RegistryType,
-    pub methods: phf::Map<&'static str, TraitMethod>,
+    /// Method metadata in the same order as `method_names`. Index `i` corresponds to
+    /// `method_names[i]`.
+    pub methods: &'static [TraitMethod],
     pub method_names: &'static [&'static str],
     pub default_methods: &'static [Option<&'static NativeFunction>],
 }
@@ -264,7 +266,7 @@ impl Debug for TraitType {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let mut d = f.debug_struct("TraitType");
         d.field("name", &self.ty.name);
-        for (name, method) in self.methods.entries() {
+        for (name, method) in self.method_names.iter().zip(self.methods.iter()) {
             d.field(name, method);
         }
         d.finish()
@@ -281,7 +283,7 @@ impl TraitType {
     pub const fn new<T: 'static>(
         name: &'static str,
         global_name: &'static str,
-        methods: phf::Map<&'static str, TraitMethod>,
+        methods: &'static [TraitMethod],
         method_names: &'static [&'static str],
         default_methods: &'static [Option<&'static NativeFunction>],
     ) -> Self {
@@ -293,8 +295,10 @@ impl TraitType {
         }
     }
 
-    pub fn get(&self, name: &str) -> &TraitMethod {
-        self.methods.get(name).unwrap()
+    /// Look up a method by name. `const` so callers can store the resulting reference in a
+    /// `static`/`const` item instead of a `LazyLock`.
+    pub const fn get(&'static self, name: &'static str) -> &'static TraitMethod {
+        &self.methods[index_of_name(self.method_names, name)]
     }
 }
 

--- a/turbopack/crates/turbo-tasks/src/value_type.rs
+++ b/turbopack/crates/turbo-tasks/src/value_type.rs
@@ -256,7 +256,6 @@ impl TraitMethod {
 pub struct TraitType {
     pub ty: RegistryType,
     pub methods: &'static [TraitMethod],
-    pub method_names: &'static [&'static str],
     pub default_methods: &'static [Option<&'static NativeFunction>],
 }
 
@@ -264,8 +263,8 @@ impl Debug for TraitType {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let mut d = f.debug_struct("TraitType");
         d.field("name", &self.ty.name);
-        for (name, method) in self.method_names.iter().zip(self.methods.iter()) {
-            d.field(name, method);
+        for method in self.methods.iter() {
+            d.field(method.method_name, method);
         }
         d.finish()
     }
@@ -282,13 +281,11 @@ impl TraitType {
         name: &'static str,
         global_name: &'static str,
         methods: &'static [TraitMethod],
-        method_names: &'static [&'static str],
         default_methods: &'static [Option<&'static NativeFunction>],
     ) -> Self {
         Self {
             ty: RegistryType::new::<T>(name, global_name),
             methods,
-            method_names,
             default_methods,
         }
     }
@@ -297,8 +294,7 @@ impl TraitType {
     pub fn get(&self, name: &str) -> &TraitMethod {
         self.methods
             .iter()
-            .zip(self.method_names)
-            .find_map(|(method, method_name)| (*method_name == name).then_some(method))
+            .find(|method| method.method_name == name)
             .expect("Method not found!")
     }
 }
@@ -307,17 +303,20 @@ turbo_registry!("Trait", TraitType);
 
 pub trait TraitVtablePrototype {
     const LEN: usize;
-    const NAMES: &'static [&'static str];
     const DEFAULTS: &'static [Option<&'static NativeFunction>];
 }
 
-pub const fn index_of_name(array: &'static [&'static str], name: &'static str) -> usize {
+/// Linear-scan lookup of a [`TraitMethod`] by `method_name` in a `&'static [TraitMethod]`. Const
+/// so the `value_trait` macro's per-method dispatch site can resolve to an array index at
+/// compile time.
+pub const fn index_of_method_name(methods: &'static [TraitMethod], name: &'static str) -> usize {
     let mut i = 0;
-    'outer: while i < array.len() {
-        if array[i].len() == name.len() {
+    'outer: while i < methods.len() {
+        let entry = methods[i].method_name;
+        if entry.len() == name.len() {
             let mut j = 0;
             while j < name.len() {
-                if array[i].as_bytes()[j] != name.as_bytes()[j] {
+                if entry.as_bytes()[j] != name.as_bytes()[j] {
                     i += 1;
                     continue 'outer;
                 }
@@ -330,7 +329,10 @@ pub const fn index_of_name(array: &'static [&'static str], name: &'static str) -
     panic!("Method not found!")
 }
 
-pub const fn build_trait_vtable<B: TraitVtablePrototype, const LEN: usize>(
+pub const fn build_trait_vtable<
+    B: TraitVtablePrototype + crate::registry::RegistryDef<TraitType>,
+    const LEN: usize,
+>(
     overrides: &[(&'static str, &'static NativeFunction)],
 ) -> [&'static NativeFunction; LEN] {
     let mut methods = [&crate::native_function::VTABLE_DEFAULT; LEN];
@@ -345,7 +347,10 @@ pub const fn build_trait_vtable<B: TraitVtablePrototype, const LEN: usize>(
     let mut i = 0;
     while i < overrides.len() {
         let (name, f) = overrides[i];
-        methods[index_of_name(B::NAMES, name)] = f;
+        methods[index_of_method_name(
+            <B as crate::registry::RegistryDef<TraitType>>::DEF.methods,
+            name,
+        )] = f;
         i += 1;
     }
     methods

--- a/turbopack/crates/turbo-tasks/src/value_type.rs
+++ b/turbopack/crates/turbo-tasks/src/value_type.rs
@@ -293,8 +293,13 @@ impl TraitType {
         }
     }
 
-    pub const fn get(&'static self, name: &'static str) -> &'static TraitMethod {
-        &self.methods[index_of_name(self.method_names, name)]
+    #[cfg(test)]
+    pub fn get(&self, name: &str) -> &TraitMethod {
+        self.methods
+            .iter()
+            .zip(self.method_names)
+            .find_map(|(method, method_name)| (*method_name == name).then_some(method))
+            .expect("Method not found!")
     }
 }
 
@@ -306,7 +311,7 @@ pub trait TraitVtablePrototype {
     const DEFAULTS: &'static [Option<&'static NativeFunction>];
 }
 
-pub(crate) const fn index_of_name(array: &'static [&'static str], name: &'static str) -> usize {
+pub const fn index_of_name(array: &'static [&'static str], name: &'static str) -> usize {
     let mut i = 0;
     'outer: while i < array.len() {
         if array[i].len() == name.len() {


### PR DESCRIPTION
## What

Clean up the Lazy-locks we re-export or use internally in the turbo-tasks crates, migrating to `std::sync::LazyLock` / `std::cell::LazyCell` where still needed and eliminating a couple of them where they weren't.

## Why

One less dep, using standard Rust features, a smaller number of Lazy items.

## Details

- **Re-exports:** drop unused `macro_helpers::OnceCell` and the now-unused `macro_helpers::phf` (since `TraitType` no longer stores a `phf::Map`). Replace `once_cell::sync::Lazy` with `std::sync::LazyLock` in `macro_helpers::TRAIT_CAST_FNS` and in the two macro-generated call sites.
- **`once_cell::sync::Lazy` → `std::sync::LazyLock`** in `scope.rs`, `registry/mod.rs`, and `turbo-tasks-backend-fuzz`'s `graph.rs`.
- **`once_cell::unsync::Lazy` → `std::cell::LazyCell`** in `update_cell.rs`.
- **`TRAIT_METHOD` → plain const-init static:** `TraitType::methods` changes from `phf::Map<&'static str, TraitMethod>` to `&'static [TraitMethod]` (parallel to `method_names`), and `TraitType::get` becomes a `const fn` that does `index_of_name` + array indexing. The `value_trait` macro now emits a slice literal instead of `phf_map!`, and the `function` macro emits `static TRAIT_METHOD: &'static TraitMethod = TRAIT.get(stringify!(..));` — evaluated at const-eval time rather than behind a `LazyLock<&TraitMethod>`.
- **Dropped `once_cell` and `phf` Cargo deps** from `turbo-tasks`, and `once_cell` from `turbo-tasks-backend` and its fuzz crate.
