### PR TITLE
Re-enable sccache with correct fork binary via musl target

### DIFF
--- a/.github/actions/sccache/start.sh
+++ b/.github/actions/sccache/start.sh
@@ -34,7 +34,18 @@ pkill -9 -x rustc 2>/dev/null || true
 
 # Install vercel/sccache fork via cargo-binstall.
 # cargo-binstall is installed by .github/actions/setup-rust.
-cargo binstall --no-confirm --git https://github.com/vercel/sccache sccache
+#
+# Two constraints:
+#  - Force musl target: vercel/sccache only publishes musl binaries.
+#    musl is statically linked, so it runs fine on glibc systems.
+#  - --strategies crate-meta-data: only use the fork's pkg-url, no
+#    fallback to QuickInstall or cargo-install. Fail loudly if the fork
+#    binary is missing instead of silently installing upstream
+#    mozilla/sccache 0.14.0 (which lacks the vercel_artifacts backend).
+ARCH=$(uname -m)
+cargo binstall --no-confirm --strategies crate-meta-data \
+  --targets "${ARCH}-unknown-linux-musl" \
+  --git https://github.com/vercel/sccache sccache
 sccache --version
 
 # Set env vars for the sccache server (export) and subsequent steps (GITHUB_ENV).
@@ -43,8 +54,7 @@ set_env() {
   echo "$1=$2" >> "$GITHUB_ENV"
 }
 
-# Temporary disable while we work out binstall issue
-#set_env RUSTC_WRAPPER sccache
+set_env RUSTC_WRAPPER sccache
 set_env SCCACHE_BASEDIRS "${INPUT_BASE_DIR:-${GITHUB_WORKSPACE}}"
 set_env CARGO_INCREMENTAL 0
 set_env SCCACHE_IDLE_TIMEOUT 0

--- a/scripts/native-builder.Dockerfile
+++ b/scripts/native-builder.Dockerfile
@@ -92,7 +92,7 @@ RUN ARCH=$(uname -m) && \
       | tar xz -C /root/.cargo/bin && \
     npm i -g @napi-rs/cli@2.18.4 && \
     cargo binstall --no-confirm --targets "${ARCH}-unknown-linux-musl" cargo-rustflags@0.4.0 && \
-    cargo binstall --no-confirm --git https://github.com/vercel/sccache sccache && \
+    cargo binstall --no-confirm --strategies crate-meta-data --targets "${ARCH}-unknown-linux-musl" --git https://github.com/vercel/sccache sccache && \
     node --version && rustc --version && napi -h > /dev/null && cargo rustflags --help > /dev/null && sccache --version
 
 WORKDIR /build


### PR DESCRIPTION
## What

Re-enables \`RUSTC_WRAPPER=sccache\` and forces \`cargo-binstall\` to install the vercel/sccache musl binary.

## Why

The vercel/sccache fork only publishes musl binaries in its GitHub releases. When CI ran \`cargo binstall --git https://github.com/vercel/sccache sccache\` on a glibc Ubuntu system, the default target resolved to \`x86_64-unknown-linux-gnu\`, which doesn't exist in the fork's releases. binstall silently fell back to QuickInstall and installed upstream \`mozilla/sccache 0.14.0\` — missing the \`vercel_artifacts\` cache backend we rely on.

## How

Force \`--targets=x86_64-unknown-linux-musl\` (or aarch64-linux-musl) on the binstall command so it fetches the correct vercel fork binary. Musl binaries are statically linked and work on glibc systems.

Also uncomments \`RUSTC_WRAPPER=sccache\` in \`.github/actions/sccache/start.sh\`.

<!-- NEXT_JS_LLM_PR -->