### PR TITLE
Patch setHeader for direct route handlers

### DIFF
--- a/packages/next/src/server/lib/patch-set-header.ts
+++ b/packages/next/src/server/lib/patch-set-header.ts
@@ -1,7 +1,11 @@
 import { getRequestMeta, type NextIncomingMessage } from '../request-meta'
 
+const PATCHED_SET_HEADER = Symbol('next.patchSetHeaderWithCookieSupport')
+
 type PatchableResponse = {
   setHeader(key: string, value: string | string[]): PatchableResponse
+  headersSent?: boolean
+  [PATCHED_SET_HEADER]?: true
 }
 
 /**
@@ -15,7 +19,16 @@ export function patchSetHeaderWithCookieSupport(
   req: NextIncomingMessage,
   res: PatchableResponse
 ) {
+  if (res[PATCHED_SET_HEADER]) {
+    return
+  }
+
   const setHeader = res.setHeader.bind(res)
+
+  Object.defineProperty(res, PATCHED_SET_HEADER, {
+    value: true,
+  })
+
   res.setHeader = (
     name: string,
     value: string | string[]

--- a/packages/next/src/server/route-modules/route-module.ts
+++ b/packages/next/src/server/route-modules/route-module.ts
@@ -49,6 +49,7 @@ import {
   getRequestMeta,
   type NextIncomingMessage,
 } from '../request-meta'
+import { patchSetHeaderWithCookieSupport } from '../lib/patch-set-header'
 import { normalizePagePath } from '../../shared/lib/page-path/normalize-page-path'
 import { isStaticMetadataRoute } from '../../lib/metadata/is-metadata-route'
 import { IncrementalCache } from '../lib/incremental-cache'
@@ -647,6 +648,10 @@ export abstract class RouteModule<
 
     // edge runtime handles loading instrumentation at the edge adapter level
     if (process.env.NEXT_RUNTIME !== 'edge') {
+      if (res) {
+        patchSetHeaderWithCookieSupport(req, res)
+      }
+
       const { join, relative } =
         require('node:path') as typeof import('node:path')
 

--- a/test/e2e/app-dir/cache-components/cache-components.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.test.ts
@@ -1,8 +1,12 @@
+import http from 'node:http'
+import path from 'node:path'
 import { nextTestSetup } from 'e2e-utils'
+import { computeCacheBustingSearchParam } from 'next/dist/shared/lib/router/utils/cache-busting-search-param'
 import cheerio from 'cheerio'
+import { fetchViaHTTP, findPort } from 'next-test-utils'
 
 describe('cache-components', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev, isNextStart, skipped } = nextTestSetup({
     files: __dirname,
     skipDeployment: true,
   })
@@ -348,6 +352,144 @@ describe('cache-components', () => {
       expect($('#page-children').text()).toBe('at buildtime')
     }
   })
+
+  if (isNextStart) {
+    it('should ignore late setHeader calls for direct RSC handlers after headers are sent', async () => {
+      const pageModulePath = path.join(
+        next.testDir,
+        '.next',
+        'server',
+        'app',
+        'cases',
+        'static',
+        'page.js'
+      )
+      const previousCwd = process.cwd()
+      const port = await findPort()
+      let server: http.Server | undefined
+      let handlerError: unknown
+      let lateHeaderAttempted = false
+      let lateHeaderError: unknown
+      let resolveHandled: (() => void) | undefined
+      const handled = new Promise<void>((resolve) => {
+        resolveHandled = resolve
+      })
+
+      try {
+        process.chdir(next.testDir)
+
+        const { handler } = require(pageModulePath) as {
+          handler: (
+            req: http.IncomingMessage,
+            res: http.ServerResponse,
+            ctx: {
+              requestMeta?: Record<string, unknown>
+              waitUntil?: (promise: Promise<void>) => void
+            }
+          ) => Promise<void>
+        }
+
+        server = http.createServer(async (req, res) => {
+          const originalWriteHead = res.writeHead.bind(res)
+          res.writeHead = ((...args: any[]) => {
+            const result = originalWriteHead(...args)
+
+            if (!lateHeaderAttempted) {
+              lateHeaderAttempted = true
+
+              try {
+                res.setHeader('x-test-late', '1')
+              } catch (error) {
+                lateHeaderError = error
+              }
+            }
+
+            return result
+          }) as typeof res.writeHead
+
+          try {
+            await handler(req, res, {
+              waitUntil: () => {},
+              requestMeta: {
+                initURL: `https://localhost:${port}${req.url ?? '/'}`,
+                minimalMode: true,
+                relativeProjectDir: '.',
+              },
+            })
+          } catch (error) {
+            handlerError = error
+
+            if (!res.writableEnded) {
+              if (!res.headersSent) {
+                res.statusCode = 500
+              }
+              res.end()
+            }
+          } finally {
+            resolveHandled?.()
+          }
+        })
+
+        await new Promise<void>((resolve, reject) => {
+          server.listen(port, () => {
+            resolve()
+          })
+          server.once('error', reject)
+        })
+
+        const stateTree = JSON.stringify(['', {}])
+        const requestUrl = new URL('/cases/static', `http://localhost:${port}`)
+        const cacheBustingParam = computeCacheBustingSearchParam(
+          undefined,
+          undefined,
+          stateTree,
+          undefined
+        )
+
+        if (cacheBustingParam) {
+          requestUrl.searchParams.set('_rsc', cacheBustingParam)
+        }
+
+        const res = await fetchViaHTTP(
+          port,
+          requestUrl.pathname + requestUrl.search,
+          undefined,
+          {
+            headers: {
+              rsc: '1',
+              'next-router-state-tree': stateTree,
+            },
+            redirect: 'manual',
+          }
+        )
+        const flight = await res.text()
+
+        expect(res.status).toBe(200)
+        expect(res.headers.get('content-type')).toContain('text/x-component')
+        await handled
+
+        expect(handlerError).toBeUndefined()
+        expect(lateHeaderAttempted).toBe(true)
+        expect(lateHeaderError).toBeUndefined()
+        expect(flight.length).toBeGreaterThan(0)
+      } finally {
+        process.chdir(previousCwd)
+
+        if (server) {
+          await new Promise<void>((resolve, reject) => {
+            server.close((error) => {
+              if (error) {
+                reject(error)
+                return
+              }
+
+              resolve()
+            })
+          })
+        }
+      }
+    })
+  }
 
   it('should not resume when client components are dynamic but the RSC render was static', async () => {
     let html = await next.render('/cases/static-rsc-dynamic-client', {})


### PR DESCRIPTION
## Summary
- apply the `setHeader` cookie-support patch to direct route module handlers in `prepare()`
- make `patchSetHeaderWithCookieSupport()` idempotent so both entry paths can call it safely
- add an adapter-like direct RSC regression test that fails without the patch

Closes: NEXT-4919

## Testing
- `NEXT_SKIP_ISOLATE=1 NEXT_TEST_MODE=start pnpm testheadless test/e2e/app-dir/cache-components/cache-components.test.ts -t "should ignore late setHeader calls for direct RSC handlers after headers are sent"`

<!-- NEXT_JS_LLM_PR -->
