### PR TITLE
Pin test and auto-installed TypeScript to 5.8.2

### DIFF
--- a/packages/next/src/build/next-config-ts/transpile-config.ts
+++ b/packages/next/src/build/next-config-ts/transpile-config.ts
@@ -6,6 +6,7 @@ import { readFile } from 'node:fs/promises'
 import { deregisterHook, registerHook, requireFromString } from './require-hook'
 import { warn } from '../output/log'
 import { installDependencies } from '../../lib/install-dependencies'
+import { getTypeScriptPackageSpec } from '../../lib/typescript/required-packages'
 
 function resolveSWCOptions(
   cwd: string,
@@ -47,18 +48,20 @@ async function verifyTypeScriptSetup(cwd: string, configFileName: string) {
         `Installing TypeScript as it was not found while loading "${configFileName}".`
       )
 
-      await installDependencies(cwd, [{ pkg: 'typescript' }], true).catch(
-        (err) => {
-          if (err && typeof err === 'object' && 'command' in err) {
-            console.error(
-              `Failed to install TypeScript, please install it manually to continue:\n` +
-                (err as any).command +
-                '\n'
-            )
-          }
-          throw err
+      await installDependencies(
+        cwd,
+        [{ pkg: getTypeScriptPackageSpec('typescript') }],
+        true
+      ).catch((err) => {
+        if (err && typeof err === 'object' && 'command' in err) {
+          console.error(
+            `Failed to install TypeScript, please install it manually to continue:\n` +
+              (err as any).command +
+              '\n'
+          )
         }
-      )
+        throw err
+      })
     }
   }
 }

--- a/packages/next/src/lib/typescript/required-packages.ts
+++ b/packages/next/src/lib/typescript/required-packages.ts
@@ -1,5 +1,13 @@
 export const requiredTypeScriptVersion = '5.8.2'
+export const requiredNodeTypesVersion = '20.17.6'
 
 export function getTypeScriptPackageSpec(pkg: string) {
-  return pkg === 'typescript' ? `${pkg}@${requiredTypeScriptVersion}` : pkg
+  switch (pkg) {
+    case 'typescript':
+      return `${pkg}@${requiredTypeScriptVersion}`
+    case '@types/node':
+      return `${pkg}@${requiredNodeTypesVersion}`
+    default:
+      return pkg
+  }
 }

--- a/packages/next/src/lib/typescript/required-packages.ts
+++ b/packages/next/src/lib/typescript/required-packages.ts
@@ -1,0 +1,5 @@
+export const requiredTypeScriptVersion = '5.8.2'
+
+export function getTypeScriptPackageSpec(pkg: string) {
+  return pkg === 'typescript' ? `${pkg}@${requiredTypeScriptVersion}` : pkg
+}

--- a/packages/next/src/lib/verify-typescript-setup.ts
+++ b/packages/next/src/lib/verify-typescript-setup.ts
@@ -9,6 +9,7 @@ import * as log from '../build/output/log'
 
 import { getTypeScriptIntent } from './typescript/getTypeScriptIntent'
 import type { TypeCheckResult } from './typescript/runTypeCheck'
+import { getTypeScriptPackageSpec } from './typescript/required-packages'
 import { writeAppTypeDeclarations } from './typescript/writeAppTypeDeclarations'
 import { writeConfigurationDefaults } from './typescript/writeConfigurationDefaults'
 import { installDependencies } from './install-dependencies'
@@ -70,10 +71,15 @@ export async function verifyTypeScriptSetup({
     )
 
     if (deps.missing?.length > 0) {
+      const missingPackages = deps.missing.map((pkg) => ({
+        ...pkg,
+        pkg: getTypeScriptPackageSpec(pkg.pkg),
+      }))
+
       if (isCI) {
         // we don't attempt auto install in CI to avoid side-effects
         // and instead log the error for installing needed packages
-        missingDepsError(dir, deps.missing)
+        missingDepsError(dir, missingPackages)
       }
       console.log(
         bold(
@@ -91,7 +97,7 @@ export async function verifyTypeScriptSetup({
           ) +
           '\n'
       )
-      await installDependencies(dir, deps.missing, true).catch((err) => {
+      await installDependencies(dir, missingPackages, true).catch((err) => {
         if (err && typeof err === 'object' && 'command' in err) {
           console.error(
             `Failed to install required TypeScript dependencies, please install them manually to continue:\n` +

--- a/test/development/acceptance-app/app-hmr-changes.test.ts
+++ b/test/development/acceptance-app/app-hmr-changes.test.ts
@@ -13,7 +13,7 @@ describe('Error overlay - RSC build errors', () => {
       'react-tweet': '^3.2.0',
       '@mdx-js/react': '^2.3.0',
       tailwindcss: '^3.2.6',
-      typescript: 'latest',
+      typescript: '5.8.2',
       '@types/react': '^18.0.28',
       '@types/react-dom': '^18.0.10',
       'image-size': '^1.0.2',

--- a/test/development/basic/define-class-fields/define-class-fields.test.ts
+++ b/test/development/basic/define-class-fields/define-class-fields.test.ts
@@ -10,7 +10,7 @@ describe('useDefineForClassFields SWC option', () => {
       mobx: '6.3.7',
       typescript: '5.8.2',
       '@types/react': 'latest',
-      '@types/node': 'latest',
+      '@types/node': '20.17.6',
       'mobx-react': '7.2.1',
     },
   })

--- a/test/development/basic/define-class-fields/define-class-fields.test.ts
+++ b/test/development/basic/define-class-fields/define-class-fields.test.ts
@@ -8,7 +8,7 @@ describe('useDefineForClassFields SWC option', () => {
     files: join(__dirname, 'fixture'),
     dependencies: {
       mobx: '6.3.7',
-      typescript: 'latest',
+      typescript: '5.8.2',
       '@types/react': 'latest',
       '@types/node': 'latest',
       'mobx-react': '7.2.1',

--- a/test/development/correct-tsconfig-defaults/index.test.ts
+++ b/test/development/correct-tsconfig-defaults/index.test.ts
@@ -12,7 +12,7 @@ describe('correct tsconfig.json defaults', () => {
       },
       skipStart: true,
       dependencies: {
-        typescript: 'latest',
+        typescript: '5.8.2',
         '@types/react': 'latest',
         '@types/node': 'latest',
       },

--- a/test/development/correct-tsconfig-defaults/index.test.ts
+++ b/test/development/correct-tsconfig-defaults/index.test.ts
@@ -14,7 +14,7 @@ describe('correct tsconfig.json defaults', () => {
       dependencies: {
         typescript: '5.8.2',
         '@types/react': 'latest',
-        '@types/node': 'latest',
+        '@types/node': '20.17.6',
       },
     })
   })

--- a/test/development/jsconfig-path-reloading/index.test.ts
+++ b/test/development/jsconfig-path-reloading/index.test.ts
@@ -38,7 +38,7 @@ describe('jsconfig-path-reloading', () => {
         dependencies: {
           typescript: '5.8.2',
           '@types/react': 'latest',
-          '@types/node': 'latest',
+          '@types/node': '20.17.6',
         },
       })
 

--- a/test/development/jsconfig-path-reloading/index.test.ts
+++ b/test/development/jsconfig-path-reloading/index.test.ts
@@ -36,7 +36,7 @@ describe('jsconfig-path-reloading', () => {
               }),
         },
         dependencies: {
-          typescript: 'latest',
+          typescript: '5.8.2',
           '@types/react': 'latest',
           '@types/node': 'latest',
         },

--- a/test/development/tsconfig-path-reloading/index.test.ts
+++ b/test/development/tsconfig-path-reloading/index.test.ts
@@ -36,7 +36,7 @@ describe('tsconfig-path-reloading', () => {
               }),
         },
         dependencies: {
-          typescript: 'latest',
+          typescript: '5.8.2',
           '@types/react': 'latest',
           '@types/node': 'latest',
         },

--- a/test/development/tsconfig-path-reloading/index.test.ts
+++ b/test/development/tsconfig-path-reloading/index.test.ts
@@ -38,7 +38,7 @@ describe('tsconfig-path-reloading', () => {
         dependencies: {
           typescript: '5.8.2',
           '@types/react': 'latest',
-          '@types/node': 'latest',
+          '@types/node': '20.17.6',
         },
       })
 

--- a/test/e2e/app-dir/interoperability-with-pages/navigation.test.ts
+++ b/test/e2e/app-dir/interoperability-with-pages/navigation.test.ts
@@ -11,7 +11,7 @@ describe('navigation between pages and app dir', () => {
       dependencies: {
         typescript: '5.8.2',
         '@types/react': 'latest',
-        '@types/node': 'latest',
+        '@types/node': '20.17.6',
       },
     })
   })

--- a/test/e2e/app-dir/interoperability-with-pages/navigation.test.ts
+++ b/test/e2e/app-dir/interoperability-with-pages/navigation.test.ts
@@ -9,7 +9,7 @@ describe('navigation between pages and app dir', () => {
     next = await createNext({
       files: new FileRef(__dirname),
       dependencies: {
-        typescript: 'latest',
+        typescript: '5.8.2',
         '@types/react': 'latest',
         '@types/node': 'latest',
       },

--- a/test/e2e/app-dir/rewrites-redirects/rewrites-redirects.test.ts
+++ b/test/e2e/app-dir/rewrites-redirects/rewrites-redirects.test.ts
@@ -4,7 +4,7 @@ describe('redirects and rewrites', () => {
   const { next } = nextTestSetup({
     files: __dirname,
     dependencies: {
-      typescript: 'latest',
+      typescript: '5.8.2',
       '@types/react': 'latest',
       '@types/node': 'latest',
     },

--- a/test/e2e/app-dir/rewrites-redirects/rewrites-redirects.test.ts
+++ b/test/e2e/app-dir/rewrites-redirects/rewrites-redirects.test.ts
@@ -6,7 +6,7 @@ describe('redirects and rewrites', () => {
     dependencies: {
       typescript: '5.8.2',
       '@types/react': 'latest',
-      '@types/node': 'latest',
+      '@types/node': '20.17.6',
     },
   })
 

--- a/test/e2e/next-test/first-time-setup-ts/package.json
+++ b/test/e2e/next-test/first-time-setup-ts/package.json
@@ -14,6 +14,6 @@
   "devDependencies": {
     "@types/react": "^18",
     "@types/react-dom": "^18",
-    "typescript": "^5"
+    "typescript": "5.8.2"
   }
 }

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -62,6 +62,7 @@ type OmitFirstArgument<F> = F extends (
 // prettier-ignore
 const nextjsReactPeerVersion = "19.1.0";
 const latestSupportedTypeScriptVersion = '5.8.2'
+const latestSupportedNodeTypesVersion = '20.17.6'
 
 export class NextInstance {
   protected files: ResolvedFileConfig
@@ -215,7 +216,7 @@ export class NextInstance {
           '@types/react': '^19.1.1',
           '@types/react-dom': '^19.1.2',
           typescript: latestSupportedTypeScriptVersion,
-          '@types/node': 'latest',
+          '@types/node': latestSupportedNodeTypesVersion,
           ...this.dependencies,
           ...this.packageJson?.dependencies,
         }

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -61,6 +61,7 @@ type OmitFirstArgument<F> = F extends (
 // Do not rename or format. sync-react script relies on this line.
 // prettier-ignore
 const nextjsReactPeerVersion = "19.1.0";
+const latestSupportedTypeScriptVersion = '5.8.2'
 
 export class NextInstance {
   protected files: ResolvedFileConfig
@@ -213,7 +214,7 @@ export class NextInstance {
           'react-dom': reactVersion,
           '@types/react': '^19.1.1',
           '@types/react-dom': '^19.1.2',
-          typescript: 'latest',
+          typescript: latestSupportedTypeScriptVersion,
           '@types/node': 'latest',
           ...this.dependencies,
           ...this.packageJson?.dependencies,

--- a/test/production/eslint-plugin-deps/index.test.ts
+++ b/test/production/eslint-plugin-deps/index.test.ts
@@ -136,7 +136,7 @@ describe('eslint plugin deps', () => {
         // Use minimum peer dep version instead of v9 of eslint to avoid breaking changes
         eslint: '8.56.0',
         'eslint-config-next': 'latest',
-        typescript: 'latest',
+        typescript: '5.8.2',
       },
       packageJson: {
         scripts: {

--- a/test/production/eslint-plugin-deps/index.test.ts
+++ b/test/production/eslint-plugin-deps/index.test.ts
@@ -130,7 +130,7 @@ describe('eslint plugin deps', () => {
         'eslint-config-prettier': 'latest',
         'eslint-plugin-import': 'latest',
         'eslint-plugin-react': 'latest',
-        '@types/node': 'latest',
+        '@types/node': '20.17.6',
         '@types/react': 'latest',
         '@types/react-dom': 'latest',
         // Use minimum peer dep version instead of v9 of eslint to avoid breaking changes

--- a/test/production/supports-module-resolution-nodenext/supports-moduleresolution-nodenext.test.ts
+++ b/test/production/supports-module-resolution-nodenext/supports-moduleresolution-nodenext.test.ts
@@ -13,7 +13,7 @@ describe('Does not override tsconfig moduleResolution field during build', () =>
     dependencies: {
       typescript: '5.8.2',
       '@types/react': 'latest',
-      '@types/node': 'latest',
+      '@types/node': '20.17.6',
       pkg: './pkg',
     },
   })

--- a/test/production/supports-module-resolution-nodenext/supports-moduleresolution-nodenext.test.ts
+++ b/test/production/supports-module-resolution-nodenext/supports-moduleresolution-nodenext.test.ts
@@ -11,7 +11,7 @@ describe('Does not override tsconfig moduleResolution field during build', () =>
       pkg: new FileRef(join(__dirname, 'pkg')),
     },
     dependencies: {
-      typescript: 'latest',
+      typescript: '5.8.2',
       '@types/react': 'latest',
       '@types/node': 'latest',
       pkg: './pkg',

--- a/test/production/typescript-basic/index.test.ts
+++ b/test/production/typescript-basic/index.test.ts
@@ -11,7 +11,7 @@ describe('TypeScript basic', () => {
       files: new FileRef(path.join(__dirname, 'app')),
       dependencies: {
         '@next/bundle-analyzer': 'canary',
-        typescript: 'latest',
+        typescript: '5.8.2',
         '@types/node': 'latest',
         '@types/react': 'latest',
         '@types/react-dom': 'latest',

--- a/test/production/typescript-basic/index.test.ts
+++ b/test/production/typescript-basic/index.test.ts
@@ -12,7 +12,7 @@ describe('TypeScript basic', () => {
       dependencies: {
         '@next/bundle-analyzer': 'canary',
         typescript: '5.8.2',
-        '@types/node': 'latest',
+        '@types/node': '20.17.6',
         '@types/react': 'latest',
         '@types/react-dom': 'latest',
       },


### PR DESCRIPTION
## Summary
- pin the shared test harness and affected TypeScript tests to `typescript@5.8.2`
- pin Next.js TypeScript auto-install paths to `typescript@5.8.2` so missing deps do not resolve to v6
- lock the first-time TypeScript test fixture to the same exact version

## Testing
- `pnpm exec tsc -v`
- `pnpm why typescript --depth 0`
- `pnpm types:test-lib` *(still fails on existing declaration/type surface errors, but no longer fails on the TS6 `moduleResolution=node10` deprecation)*