### PR TITLE
Fix fallback route params case in app-page handler

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -21,8 +21,11 @@ env:
   NAPI_CLI_VERSION: 2.18.4
   TURBO_VERSION: 2.8.11
   NODE_LTS_VERSION: 20
-  TURBO_TEAM: 'vercel'
-  TURBO_CACHE: 'remote:rw'
+  TURBO_TEAM: 'vtest314-next-adapter-e2e-tests'
+  # Prefer shared remote cache across runs, but keep local cache enabled so jobs
+  # degrade gracefully if the remote cache or token is unavailable.
+  TURBO_CACHE: 'local:rw,remote:rw'
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   # Without this environment variable, rust-lld will fail because some dependencies defaults to newer version of macOS by default.
   #
   # See https://doc.rust-lang.org/rustc/platform-support/apple-darwin.html#os-version for more details
@@ -158,11 +161,7 @@ jobs:
               target: ${{ needs.deploy-target.outputs.value == 'automated-preview' && 'x86_64-apple-darwin' }}
 
         settings:
-          - host:
-              - 'self-hosted'
-              - 'macos'
-              - 'arm64'
-
+          - host: 'macos-15-intel'
             target: 'x86_64-apple-darwin'
             # --env-mode loose is a breaking change required with turbo 2.x since Strict mode is now the default
             # TODO: we should add the relevant envs later to to switch to strict mode
@@ -171,11 +170,7 @@ jobs:
               pnpm dlx turbo@${TURBO_VERSION} run build-native-release -vvv --env-mode loose --remote-cache-timeout 90 --summarize -- --target x86_64-apple-darwin
               strip -x packages/next-swc/native/next-swc.*.node
 
-          - host:
-              - 'self-hosted'
-              - 'macos'
-              - 'arm64'
-
+          - host: 'macos-15'
             target: 'aarch64-apple-darwin'
             # --env-mode loose is a breaking change required with turbo 2.x since Strict mode is now the default
             # TODO: we should add the relevant envs later to to switch to strict mode
@@ -184,11 +179,7 @@ jobs:
               pnpm dlx turbo@${TURBO_VERSION} run build-native-release -vvv --env-mode loose --remote-cache-timeout 90 --summarize -- --target aarch64-apple-darwin
               strip -x packages/next-swc/native/next-swc.*.node
 
-          - host:
-              - 'self-hosted'
-              - 'windows'
-              - 'x64'
-
+          - host: 'windows-latest-8-core-oss'
             # --env-mode loose is a breaking change required with turbo 2.x since Strict mode is now the default
             # TODO: we should add the relevant envs later to to switch to strict mode
             build: |
@@ -197,11 +188,7 @@ jobs:
               pnpm dlx turbo@${TURBO_VERSION} run build-native-release -vvv --env-mode loose --remote-cache-timeout 90 --summarize -- --target x86_64-pc-windows-msvc
             target: 'x86_64-pc-windows-msvc'
 
-          - host:
-              - 'self-hosted'
-              - 'windows'
-              - 'x64'
-
+          - host: 'windows-latest-8-core-oss'
             target: 'aarch64-pc-windows-msvc'
             # --env-mode loose is a breaking change required with turbo 2.x since Strict mode is now the default
             # TODO: we should add the relevant envs later to to switch to strict mode
@@ -210,12 +197,7 @@ jobs:
               npm i -g "@napi-rs/cli@${NAPI_CLI_VERSION}"
               pnpm dlx turbo@${TURBO_VERSION} run build-native-no-plugin-release -vvv --env-mode loose --remote-cache-timeout 90 --summarize -- --target aarch64-pc-windows-msvc
 
-          - host:
-              - 'self-hosted'
-              - 'linux'
-              - 'x64'
-              - 'metal'
-
+          - host: 'ubuntu-latest-16-core-oss'
             target: 'x86_64-unknown-linux-gnu'
             # [NOTE] If you want to update / modify build steps, check these things:
             # - We use docker images to pin the glibc version to link against,
@@ -241,12 +223,7 @@ jobs:
               strip native/next-swc.*.node
               objdump -T native/next-swc.*.node | grep GLIBC_
 
-          - host:
-              - 'self-hosted'
-              - 'linux'
-              - 'x64'
-              - 'metal'
-
+          - host: 'ubuntu-latest-16-core-oss'
             target: 'x86_64-unknown-linux-musl'
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:stable-2023-09-17-alpine
             build: |
@@ -262,12 +239,7 @@ jobs:
               npm run build-native-release -- --target x86_64-unknown-linux-musl
               strip native/next-swc.*.node
 
-          - host:
-              - 'self-hosted'
-              - 'linux'
-              - 'x64'
-              - 'metal'
-
+          - host: 'ubuntu-latest-16-core-oss'
             target: 'aarch64-unknown-linux-gnu'
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:stable-2023-09-17-aarch64
             build: |
@@ -288,12 +260,7 @@ jobs:
               llvm-strip -x native/next-swc.*.node
               objdump -T native/next-swc.*.node | grep GLIBC_
 
-          - host:
-              - 'self-hosted'
-              - 'linux'
-              - 'x64'
-              - 'metal'
-
+          - host: 'ubuntu-latest-16-core-oss'
             target: 'aarch64-unknown-linux-musl'
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:stable-2023-09-17-alpine
             build: |
@@ -310,23 +277,17 @@ jobs:
               npm run build-native-release -- --target aarch64-unknown-linux-musl
               llvm-strip -x native/next-swc.*.node
 
-    name: stable - ${{ matrix.settings.target }} - node@16
+    name: stable - ${{ matrix.settings.target }} - node@20
     runs-on: ${{ matrix.settings.host }}
-    timeout-minutes: 45
+    timeout-minutes: ${{ contains(matrix.settings.target, 'apple-darwin') && 90 || 45 }}
     steps:
       # https://github.com/actions/virtual-environments/issues/1187
       - name: tune linux network
         run: sudo ethtool -K eth0 tx off rx off
-        if: ${{ matrix.settings.host == 'ubuntu-latest' }}
-      - name: tune linux network
-        run: sudo ethtool -K eth0 tx off rx off
-        if: ${{ matrix.settings.host == 'ubuntu-latest' }}
-      - name: tune windows network
-        run: Disable-NetAdapterChecksumOffload -Name * -TcpIPv4 -UdpIPv4 -TcpIPv6 -UdpIPv6
-        if: ${{ matrix.settings.host == 'windows-latest' }}
+        if: ${{ matrix.settings.host == 'ubuntu-latest-16-core-oss' }}
       - name: tune mac network
         run: sudo sysctl -w net.link.generic.system.hwcksum_tx=0 && sudo sysctl -w net.link.generic.system.hwcksum_rx=0
-        if: ${{ matrix.settings.host == 'macos-latest' }}
+        if: ${{ startsWith(matrix.settings.host, 'macos-15') }}
       # we use checkout here instead of the build cache since
       # it can fail to restore in different OS'
       - uses: actions/checkout@v4
@@ -342,10 +303,12 @@ jobs:
           node-version: ${{ env.NODE_LTS_VERSION }}
           check-latest: true
 
+      - name: Prepare corepack
+        if: ${{ matrix.settings.host != 'windows-latest-8-core-oss' }}
+        run: npm i -g corepack@0.31
+
       - name: Setup corepack
-        run: |
-          npm i -g corepack@0.31
-          corepack enable
+        run: corepack enable
 
       # we always want to run this to set environment variables
       - name: Install Rust
@@ -388,10 +351,10 @@ jobs:
           # put the command in an environment variable to avoid escaping issues
           DOCKER_CMD: ${{ matrix.settings.build }}
         run: |
-          docker run -v "/var/run/docker.sock":"/var/run/docker.sock" \
+          docker run --rm -v "/var/run/docker.sock":"/var/run/docker.sock" \
             -e CI -e RUST_BACKTRACE -e NAPI_CLI_VERSION -e CARGO_TERM_COLOR -e CARGO_INCREMENTAL \
             -e CARGO_PROFILE_RELEASE_LTO -e CARGO_REGISTRIES_CRATES_IO_PROTOCOL -e TURBO_API \
-            -e TURBO_TEAM -e TURBO_TOKEN -e TURBO_VERSION -e TURBO_CACHE="remote:rw" \
+            -e TURBO_TEAM -e TURBO_TOKEN -e TURBO_VERSION -e TURBO_CACHE="local:rw,remote:rw" \
             -v ${{ env.HOME }}/.cargo/git:/root/.cargo/git \
             -v ${{ env.HOME }}/.cargo/registry:/root/.cargo/registry \
             -v ${{ github.workspace }}:/build \
@@ -457,11 +420,7 @@ jobs:
       matrix:
         target: [web, nodejs]
 
-    runs-on:
-      - 'self-hosted'
-      - 'linux'
-      - 'x64'
-      - 'metal'
+    runs-on: ubuntu-latest-16-core-oss
 
     steps:
       - uses: actions/checkout@v4
@@ -709,6 +668,7 @@ jobs:
           path: turbopack-bin-size
 
       - name: Upload to Datadog
+        if: ${{ env.DATADOG_API_KEY != '' }}
         run: |
           ls -al turbopack-bin-size
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -81,7 +81,7 @@ jobs:
     with:
       skipInstallBuild: 'yes'
       stepName: 'build-native-windows'
-      runs_on_labels: '["windows","self-hosted","x64"]'
+      runs_on_labels: '["windows-latest-8-core-oss"]'
       buildNativeTarget: 'x86_64-pc-windows-msvc'
 
     secrets: inherit
@@ -711,7 +711,7 @@ jobs:
       nodeVersion: ${{ matrix.node }}
       afterBuild: node run-tests.js --type unit
       stepName: 'test-unit-windows-${{ matrix.node }}'
-      runs_on_labels: '["windows","self-hosted","x64"]'
+      runs_on_labels: '["windows-latest-8-core-oss"]'
       buildNativeTarget: 'x86_64-pc-windows-msvc'
 
     secrets: inherit
@@ -884,7 +884,7 @@ jobs:
           test/e2e/app-dir/proxy-runtime-nodejs/proxy-runtime-nodejs.test.ts \
           test/development/app-dir/segment-explorer/segment-explorer.test.ts
       stepName: 'test-dev-windows'
-      runs_on_labels: '["windows","self-hosted","x64"]'
+      runs_on_labels: '["windows-latest-8-core-oss"]'
       buildNativeTarget: 'x86_64-pc-windows-msvc'
     secrets: inherit
 
@@ -914,7 +914,7 @@ jobs:
           test/integration/create-next-app/index.test.ts \
           test/integration/create-next-app/package-manager/pnpm.test.ts
       stepName: 'test-integration-windows'
-      runs_on_labels: '["windows","self-hosted","x64"]'
+      runs_on_labels: '["windows-latest-8-core-oss"]'
       buildNativeTarget: 'x86_64-pc-windows-msvc'
     secrets: inherit
 
@@ -944,7 +944,7 @@ jobs:
           test/e2e/app-dir/non-root-project-monorepo/non-root-project-monorepo.test.ts \
           test/e2e/app-dir/proxy-runtime-nodejs/proxy-runtime-nodejs.test.ts
       stepName: 'test-prod-windows'
-      runs_on_labels: '["windows","self-hosted","x64"]'
+      runs_on_labels: '["windows-latest-8-core-oss"]'
       buildNativeTarget: 'x86_64-pc-windows-msvc'
     secrets: inherit
 

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -68,7 +68,7 @@ on:
         description: 'List of runner labels'
         required: false
         type: string
-        default: '["self-hosted", "linux", "x64", "metal"]'
+        default: '["ubuntu-latest-16-core-oss"]'
       buildNativeTarget:
         description: 'Target for build-native step'
         required: false
@@ -101,9 +101,11 @@ env:
   # disable backtrace for test snapshots
   RUST_BACKTRACE: 0
 
-  TURBO_TEAM: 'vtest314-next-e2e-tests'
-  TURBO_CACHE: 'remote:rw'
-  TURBO_TOKEN: ${{ secrets.TURBO_REMOTE_CACHE_TOKEN }}
+  TURBO_TEAM: 'vtest314-next-adapter-e2e-tests'
+  # Prefer shared remote cache across runs, but keep local cache enabled so jobs
+  # degrade gracefully if the remote cache or token is unavailable.
+  TURBO_CACHE: 'local:rw,remote:rw'
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
 
   NEXT_TELEMETRY_DISABLED: 1
   # allow not skipping install-native postinstall script if we don't have a binary available already
@@ -147,7 +149,7 @@ jobs:
     steps:
       # enforce consistent line endings for git on windows
       - name: Configure git to use LF endings
-        if: ${{ contains(fromJson(inputs.runs_on_labels), 'windows') }}
+        if: ${{ runner.os == 'Windows' }}
         run: |
           git config --global core.autocrlf false
           git config --global core.eol lf
@@ -167,9 +169,10 @@ jobs:
       - name: Install fnm
         if: steps.check-fnm.outputs.found != 'true'
         run: |
+          export FNM_DIR="${HOME}/.local/share/fnm"
           curl -fsSL https://fnm.vercel.app/install | bash
-          export PATH="/home/runner/.local/share/fnm:$PATH"
-          echo "/home/runner/.local/share/fnm" >> $GITHUB_PATH
+          export PATH="$FNM_DIR:$PATH"
+          echo "$FNM_DIR" >> $GITHUB_PATH
           fnm env --json | jq -r 'to_entries|map("\(.key)=\(.value|tostring)")|.[]' | xargs -I {} echo "{}" >> $GITHUB_ENV
 
       - name: Normalize input step names into path key
@@ -202,7 +205,7 @@ jobs:
           which node
           node --version
       - name: Prepare corepack
-        if: ${{ contains(fromJson(inputs.runs_on_labels), 'ubuntu-latest') }}
+        if: ${{ runner.os == 'Linux' }}
         run: |
           npm i -g corepack@0.31
       - run: corepack enable
@@ -353,7 +356,7 @@ jobs:
           path: packages/next/dist/compiled/next-server/report.*.html
 
       - name: Upload test report to datadog
-        if: ${{ inputs.afterBuild && always() && !github.event.pull_request.head.repo.fork }}
+        if: ${{ inputs.afterBuild && always() && !github.event.pull_request.head.repo.fork && env.DATADOG_API_KEY != '' }}
         run: |
           # Add a `test.type` tag to distinguish between turbopack and next.js runs
           # Add a `nextjs.test_session.name` tag to help identify the job

--- a/.github/workflows/integration_tests_reusable.yml
+++ b/.github/workflows/integration_tests_reusable.yml
@@ -56,7 +56,7 @@ jobs:
     secrets: inherit
 
   generate-matrices:
-    runs-on: [self-hosted, linux, x64, metal]
+    runs-on: ubuntu-latest-16-core-oss
     steps:
       - id: out
         run: |
@@ -147,7 +147,7 @@ jobs:
   collect_nextjs_development_integration_stat:
     needs: [test-e2e, test-integration]
     name: Next.js integration test development status report
-    runs-on: [self-hosted, linux, x64, metal]
+    runs-on: ubuntu-latest-16-core-oss
     if: always()
     permissions:
       pull-requests: write

--- a/.github/workflows/pull_request_stats.yml
+++ b/.github/workflows/pull_request_stats.yml
@@ -18,8 +18,11 @@ env:
   NODE_LTS_VERSION: 20
   TEST_CONCURRENCY: 6
 
-  TURBO_TEAM: 'vercel'
-  TURBO_CACHE: 'remote:rw'
+  TURBO_TEAM: 'vtest314-next-adapter-e2e-tests'
+  # Prefer shared remote cache across runs, but keep local cache enabled so jobs
+  # degrade gracefully if the remote cache or token is unavailable.
+  TURBO_CACHE: 'local:rw,remote:rw'
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   NEXT_TELEMETRY_DISABLED: 1
   # we build a dev binary for use in CI so skip downloading
   # canary next-swc binaries in the monorepo
@@ -47,11 +50,7 @@ jobs:
       fail-fast: false
       matrix:
         bundler: [webpack, turbopack]
-    runs-on:
-      - 'self-hosted'
-      - 'linux'
-      - 'x64'
-      - 'metal'
+    runs-on: ubuntu-latest-16-core-oss
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/setup-nextjs-build.yml
+++ b/.github/workflows/setup-nextjs-build.yml
@@ -16,11 +16,7 @@ on:
 jobs:
   build_nextjs:
     name: Build Next.js for the turbopack integration test
-    runs-on:
-      - 'self-hosted'
-      - 'linux'
-      - 'x64'
-      - 'metal'
+    runs-on: ubuntu-latest-16-core-oss
     outputs:
       output1: ${{ steps.build-next-swc-turbopack-patch.outputs.success }}
     steps:

--- a/.github/workflows/test-turbopack-rust-bench-test.yml
+++ b/.github/workflows/test-turbopack-rust-bench-test.yml
@@ -4,7 +4,7 @@ on:
     inputs:
       runner:
         type: string
-        default: '["self-hosted", "linux", "x64", "metal"]'
+        default: '["ubuntu-latest-16-core-oss"]'
       os:
         type: string
         default: 'linux'
@@ -17,6 +17,8 @@ env:
   TURBOPACK_BENCH_PROGRESS: '1'
 
   NODE_LTS_VERSION: 20
+  TURBO_TEAM: 'vtest314-next-adapter-e2e-tests'
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
 
 jobs:
   test:

--- a/.github/workflows/test_e2e_deploy_release.yml
+++ b/.github/workflows/test_e2e_deploy_release.yml
@@ -240,6 +240,7 @@ jobs:
           merge-multiple: true
 
       - name: Upload test report to datadog
+        if: ${{ env.DATADOG_API_KEY != '' }}
         run: |
           if [ -d ./test/test-junit-report ]; then
             DD_ENV=ci npx @datadog/datadog-ci@2.23.1 junit upload --tags test.type:deploy --service nextjs ./test/test-junit-report

--- a/.github/workflows/test_e2e_project_reset_cron.yml
+++ b/.github/workflows/test_e2e_project_reset_cron.yml
@@ -13,8 +13,11 @@ env:
   VERCEL_ADAPTER_TEST_TEAM: vtest314-next-adapter-e2e-tests
   VERCEL_ADAPTER_TEST_TOKEN: ${{ secrets.VERCEL_ADAPTER_TEST_TOKEN }}
   NODE_LTS_VERSION: 20
-  TURBO_TEAM: 'vercel'
-  TURBO_CACHE: 'remote:rw'
+  TURBO_TEAM: 'vtest314-next-adapter-e2e-tests'
+  # Prefer shared remote cache across runs, but keep local cache enabled so jobs
+  # degrade gracefully if the remote cache or token is unavailable.
+  TURBO_CACHE: 'local:rw,remote:rw'
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
 
 run-name: test-e2e-project-reset (scheduled)
 

--- a/.github/workflows/turbopack-benchmark.yml
+++ b/.github/workflows/turbopack-benchmark.yml
@@ -22,13 +22,16 @@ env:
   CARGO_INCREMENTAL: 0
   # For faster CI
   RUST_LOG: 'off'
-  TURBO_TEAM: 'vercel'
-  TURBO_CACHE: 'remote:rw'
+  TURBO_TEAM: 'vtest314-next-adapter-e2e-tests'
+  # Prefer shared remote cache across runs, but keep local cache enabled so jobs
+  # degrade gracefully if the remote cache or token is unavailable.
+  TURBO_CACHE: 'local:rw,remote:rw'
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
 
 jobs:
   benchmark-small-apps:
     name: Benchmark Rust Crates (small apps)
-    runs-on: ['self-hosted', 'linux', 'x64', 'metal']
+    runs-on: ubuntu-latest-16-core-oss
     steps:
       - uses: actions/checkout@v4
 
@@ -68,7 +71,7 @@ jobs:
 
   benchmark-analyzer:
     name: Benchmark Rust Crates (analyzer)
-    runs-on: ['self-hosted', 'linux', 'x64', 'metal']
+    runs-on: ubuntu-latest-16-core-oss
     steps:
       - uses: actions/checkout@v4
 
@@ -109,7 +112,7 @@ jobs:
   benchmark-large:
     name: Benchmark Rust Crates (large)
     if: ${{ github.event.label.name == 'benchmark' || github.event_name == 'workflow_dispatch' }}
-    runs-on: ['self-hosted', 'linux', 'x64', 'metal']
+    runs-on: ubuntu-latest-16-core-oss
     steps:
       - uses: actions/checkout@v4
 

--- a/crates/next-napi-bindings/build.rs
+++ b/crates/next-napi-bindings/build.rs
@@ -4,7 +4,9 @@ use serde_json::Value;
 
 fn main() -> anyhow::Result<()> {
     println!("cargo:rerun-if-env-changed=CI");
+    println!("cargo:rerun-if-env-changed=CARGO_CFG_TARGET_OS");
     let is_ci = env::var("CI").is_ok_and(|value| !value.is_empty());
+    let is_macos_target = env::var("CARGO_CFG_TARGET_OS").is_ok_and(|value| value == "macos");
 
     let nextjs_version = {
         let package_json_path = Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -68,12 +70,12 @@ fn main() -> anyhow::Result<()> {
         _ => println!("cargo:warning=`git rev-parse HEAD` failed"),
     }
 
-    #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
-    napi_build::setup();
+    if !is_macos_target {
+        napi_build::setup();
+    }
 
-    // This is a workaround for napi always including a GCC specific flag.
-    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
-    {
+    // This is a workaround for napi always including a GCC-specific flag on macOS.
+    if is_macos_target {
         println!("cargo:rerun-if-env-changed=DEBUG_GENERATED_CODE");
         println!("cargo:rerun-if-env-changed=TYPE_DEF_TMP_PATH");
         println!("cargo:rerun-if-env-changed=CARGO_CFG_NAPI_RS_CLI_VERSION");

--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -88,6 +88,7 @@ import {
   getPostponedStateExceededErrorMessage,
   readBodyWithSizeLimit,
 } from '../../server/lib/postponed-request-body' with { 'turbopack-transition': 'next-server-utility' }
+import { parseUrl } from '../../lib/url'
 
 // These are injected by the loader afterwards.
 
@@ -1647,9 +1648,15 @@ export async function handler(
           getRequestMeta(req, 'onCacheEntry'))
         : getRequestMeta(req, 'onCacheEntry')
       if (onCacheEntry) {
+        const rawCacheEntryUrl = getRequestMeta(req, 'initURL') ?? req.url
+        const cacheEntryUrl = rawCacheEntryUrl
+          ? (parseUrl(rawCacheEntryUrl)?.pathname ?? rawCacheEntryUrl)
+          : undefined
+
         const finished = await onCacheEntry(cacheEntry, {
-          url: getRequestMeta(req, 'initURL') ?? req.url,
+          url: cacheEntryUrl,
         })
+
         if (finished) return null
       }
 

--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -31,6 +31,8 @@ import {
 import { checkIsAppPPREnabled } from '../../server/lib/experimental/ppr' with { 'turbopack-transition': 'next-server-utility' }
 import {
   getFallbackRouteParams,
+  getPlaceholderFallbackRouteParams,
+  buildDynamicSegmentPlaceholder,
   createOpaqueFallbackRouteParams,
   type OpaqueFallbackRouteParams,
 } from '../../server/request/fallback-params' with { 'turbopack-transition': 'next-server-utility' }
@@ -115,10 +117,7 @@ import { RedirectStatusCode } from '../../client/components/redirect-status-code
 import { InvariantError } from '../../shared/lib/invariant-error' with { 'turbopack-transition': 'next-server-utility' }
 import { scheduleOnNextTick } from '../../lib/scheduler' with { 'turbopack-transition': 'next-server-utility' }
 import { isInterceptionRouteAppPath } from '../../shared/lib/router/utils/interception-routes' with { 'turbopack-transition': 'next-server-utility' }
-import {
-  getParamProperties,
-  getSegmentParam,
-} from '../../shared/lib/router/utils/get-segment-param' with { 'turbopack-transition': 'next-server-utility' }
+import { getSegmentParam } from '../../shared/lib/router/utils/get-segment-param' with { 'turbopack-transition': 'next-server-utility' }
 
 export * from '../../server/app-render/entry-base' with { 'turbopack-transition': 'next-server-utility' }
 
@@ -139,22 +138,6 @@ export const routeModule = new AppPageRouteModule({
   distDir: process.env.__NEXT_RELATIVE_DIST_DIR || '',
   relativeProjectDir: process.env.__NEXT_RELATIVE_PROJECT_DIR || '',
 })
-
-function buildDynamicSegmentPlaceholder(
-  param: Pick<FallbackRouteParam, 'paramName' | 'paramType'>
-): string {
-  const { repeat, optional } = getParamProperties(param.paramType)
-
-  if (optional) {
-    return `[[...${param.paramName}]]`
-  }
-
-  if (repeat) {
-    return `[...${param.paramName}]`
-  }
-
-  return `[${param.paramName}]`
-}
 
 /**
  * Builds the cache key for the most complete prerenderable shell we can derive
@@ -1342,17 +1325,65 @@ export async function handler(
           }
         }
 
+        const placeholderFallbackRouteParams =
+          // When a request carries dynamic placeholder values (e.g. "[slug]"),
+          // defer only the unresolved subset instead of forcing all fallback
+          // params to suspend.
+          !routeModule.isDev &&
+          pageIsDynamic &&
+          prerenderInfo?.fallbackRouteParams
+            ? getPlaceholderFallbackRouteParams(
+                params as
+                  | Record<string, undefined | string | string[]>
+                  | undefined,
+                prerenderInfo.fallbackRouteParams
+              )
+            : null
+
+        const fallbackRouteParamsForRender =
+          placeholderFallbackRouteParams &&
+          placeholderFallbackRouteParams.length > 0
+            ? placeholderFallbackRouteParams
+            : prerenderInfo?.fallbackRouteParams
+
+        const hasPlaceholderFallbackRouteParams =
+          placeholderFallbackRouteParams != null &&
+          placeholderFallbackRouteParams.length > 0
+
+        // When route-module.ts resolved partial nxtP* params during
+        // background revalidation, filter fallbackRouteParams to only the
+        // params that are still unresolved. This lets doRender produce an
+        // intermediate PPR shell that suspends only for those params.
+        let effectiveFallbackRouteParams: FallbackRouteParam[] | null = null
+        if (nextConfig.cacheComponents && prerenderInfo?.fallbackRouteParams) {
+          const resolvedKeys = getRequestMeta(req, 'resolvedRouteParamKeys')
+          if (resolvedKeys && resolvedKeys.size > 0) {
+            effectiveFallbackRouteParams =
+              prerenderInfo.fallbackRouteParams.filter(
+                (param) => !resolvedKeys.has(param.paramName)
+              )
+          }
+        }
         const fallbackRouteParams =
           // In production or when debugging the static shell for a
           // non-prerendered URL, use the prerender manifest's fallback route
           // params which correctly identifies which params are unknown.
           ((isProduction && getRequestMeta(req, 'renderFallbackShell')) ||
+            hasPlaceholderFallbackRouteParams ||
             (isDebugStaticShell && !isPrerendered)) &&
-          prerenderInfo?.fallbackRouteParams
-            ? createOpaqueFallbackRouteParams(prerenderInfo.fallbackRouteParams)
-            : isDebugFallbackShell
-              ? getFallbackRouteParams(normalizedSrcPage, routeModule)
-              : null
+          fallbackRouteParamsForRender
+            ? createOpaqueFallbackRouteParams(fallbackRouteParamsForRender)
+            : // For intermediate shells where some params are resolved and
+              // others still have placeholders, use the filtered subset so the
+              // prerender suspends only for the unresolved params.
+              effectiveFallbackRouteParams &&
+                effectiveFallbackRouteParams.length > 0 &&
+                effectiveFallbackRouteParams.length <
+                  (prerenderInfo?.fallbackRouteParams?.length ?? 0)
+              ? createOpaqueFallbackRouteParams(effectiveFallbackRouteParams)
+              : isDebugFallbackShell
+                ? getFallbackRouteParams(normalizedSrcPage, routeModule)
+                : null
 
         // For staged dynamic rendering (Cached Navigations) and debug static
         // shell rendering, pass the fallback params via request meta so the
@@ -1366,7 +1397,7 @@ export async function handler(
           prerenderInfo?.fallbackRouteParams
         ) {
           const fallbackParams = createOpaqueFallbackRouteParams(
-            prerenderInfo.fallbackRouteParams
+            fallbackRouteParamsForRender ?? prerenderInfo.fallbackRouteParams
           )
 
           if (fallbackParams) {

--- a/packages/next/src/server/request-meta.ts
+++ b/packages/next/src/server/request-meta.ts
@@ -300,6 +300,13 @@ export interface RequestMeta {
   minimalMode?: boolean
 
   /**
+   * When background revalidation resolves some route params but not others,
+   * tracks the param keys that are no longer placeholders so only the
+   * unresolved subset suspends in intermediate PPR shells.
+   */
+  resolvedRouteParamKeys?: Set<string>
+
+  /**
    * The fallback params for this route. In dev, used for validating prerenders.
    * In production, used to defer params resolution during staged rendering.
    */

--- a/packages/next/src/server/request/fallback-params.test.ts
+++ b/packages/next/src/server/request/fallback-params.test.ts
@@ -190,6 +190,24 @@ describe('getFallbackRouteParams', () => {
       expect(result!.has('projectSlug')).toBe(true)
       expect(result!.has('teamSlug')).toBe(false)
     })
+
+    it('should treat encoded placeholders as dynamic segments', () => {
+      // Tree: /[teamSlug]/[projectSlug] but page is /vercel/%5BprojectSlug%5D
+      const loaderTree = createLoaderTree(
+        '',
+        {},
+        createLoaderTree('[teamSlug]', {}, createLoaderTree('[projectSlug]'))
+      )
+      const routeModule = createMockRouteModule(loaderTree)
+      const result = getFallbackRouteParams(
+        '/vercel/%5BprojectSlug%5D',
+        routeModule
+      )
+
+      expect(result).not.toBeNull()
+      expect(result!.has('projectSlug')).toBe(true)
+      expect(result!.has('teamSlug')).toBe(false)
+    })
   })
 
   describe('Route Groups', () => {

--- a/packages/next/src/server/request/fallback-params.test.ts
+++ b/packages/next/src/server/request/fallback-params.test.ts
@@ -1,6 +1,8 @@
 import {
+  buildDynamicSegmentPlaceholder,
   createOpaqueFallbackRouteParams,
   getFallbackRouteParams,
+  getPlaceholderFallbackRouteParams,
 } from './fallback-params'
 import type { FallbackRouteParam } from '../../build/static-paths/types'
 import type AppPageRouteModule from '../route-modules/app-page/module'
@@ -69,6 +71,54 @@ describe('createOpaqueFallbackRouteParams', () => {
       expect(name).toBe('slug')
       expect(value).toMatch(/^%%drp:slug:[a-f0-9]+%%$/)
     })
+  })
+})
+
+describe('placeholder fallback route params', () => {
+  it('builds route placeholders by dynamic param type', () => {
+    expect(
+      buildDynamicSegmentPlaceholder({
+        paramName: 'slug',
+        paramType: 'dynamic',
+      })
+    ).toBe('[slug]')
+    expect(
+      buildDynamicSegmentPlaceholder({
+        paramName: 'slug',
+        paramType: 'catchall',
+      })
+    ).toBe('[...slug]')
+    expect(
+      buildDynamicSegmentPlaceholder({
+        paramName: 'slug',
+        paramType: 'optional-catchall',
+      })
+    ).toBe('[[...slug]]')
+  })
+
+  it('returns only fallback params that are still placeholders', () => {
+    const fallbackParams: readonly FallbackRouteParam[] = [
+      { paramName: 'team', paramType: 'dynamic' },
+      { paramName: 'project', paramType: 'dynamic' },
+      { paramName: 'slug', paramType: 'catchall' },
+      { paramName: 'optional', paramType: 'optional-catchall' },
+    ]
+
+    const result = getPlaceholderFallbackRouteParams(
+      {
+        team: '[team]',
+        project: 'dashboard',
+        slug: ['[...slug]'],
+        optional: '[[...optional]]',
+      },
+      fallbackParams
+    )
+
+    expect(result).toEqual([
+      { paramName: 'team', paramType: 'dynamic' },
+      { paramName: 'slug', paramType: 'catchall' },
+      { paramName: 'optional', paramType: 'optional-catchall' },
+    ])
   })
 })
 

--- a/packages/next/src/server/request/fallback-params.ts
+++ b/packages/next/src/server/request/fallback-params.ts
@@ -5,6 +5,7 @@ import { dynamicParamTypes } from '../app-render/get-short-dynamic-param-type'
 import type AppPageRouteModule from '../route-modules/app-page/module'
 import { parseAppRoute } from '../../shared/lib/router/routes/app'
 import { extractPathnameRouteParamSegmentsFromLoaderTree } from '../../build/static-paths/app/extract-pathname-route-param-segments-from-loader-tree'
+import { getParamProperties } from '../../shared/lib/router/utils/get-segment-param'
 
 export type OpaqueFallbackRouteParamValue = [
   /**
@@ -72,6 +73,37 @@ export function createOpaqueFallbackRouteParams(
   }
 
   return keys
+}
+
+export function buildDynamicSegmentPlaceholder(
+  param: Pick<FallbackRouteParam, 'paramName' | 'paramType'>
+): string {
+  const { repeat, optional } = getParamProperties(param.paramType)
+
+  if (optional) {
+    return `[[...${param.paramName}]]`
+  }
+
+  if (repeat) {
+    return `[...${param.paramName}]`
+  }
+
+  return `[${param.paramName}]`
+}
+
+export function getPlaceholderFallbackRouteParams(
+  params: Record<string, undefined | string | string[]> | undefined,
+  fallbackRouteParams: readonly FallbackRouteParam[]
+): FallbackRouteParam[] {
+  return fallbackRouteParams.filter((param) => {
+    const placeholder = buildDynamicSegmentPlaceholder(param)
+    const value = params?.[param.paramName]
+
+    return (
+      value === placeholder ||
+      (Array.isArray(value) && value.length === 1 && value[0] === placeholder)
+    )
+  })
 }
 
 /**

--- a/packages/next/src/server/server-utils.test.ts
+++ b/packages/next/src/server/server-utils.test.ts
@@ -71,3 +71,134 @@ describe('getParamsFromRouteMatches', () => {
     expect(params).toEqual({ slug: 'hello-world', rest: ['im-the', 'rest'] })
   })
 })
+
+describe('normalizeDynamicRouteParams', () => {
+  it('should reject encoded default placeholders for dynamic params', () => {
+    const { normalizeDynamicRouteParams } = getServerUtils({
+      page: '/[teamSlug]/[project]',
+      basePath: '',
+      rewrites: {},
+      i18n: undefined,
+      pageIsDynamic: true,
+      caseSensitive: false,
+    })
+
+    const result = normalizeDynamicRouteParams(
+      {
+        teamSlug: '%5BteamSlug%5D',
+        project: '%5Bproject%5D',
+      },
+      true
+    )
+
+    expect(result).toEqual({
+      params: {},
+      hasValidParams: false,
+    })
+  })
+
+  it('should reject doubly encoded default placeholders for dynamic params', () => {
+    const { normalizeDynamicRouteParams } = getServerUtils({
+      page: '/[teamSlug]/[project]',
+      basePath: '',
+      rewrites: {},
+      i18n: undefined,
+      pageIsDynamic: true,
+      caseSensitive: false,
+    })
+
+    const result = normalizeDynamicRouteParams(
+      {
+        teamSlug: '%255BteamSlug%255D',
+        project: '%255Bproject%255D',
+      },
+      true
+    )
+
+    expect(result).toEqual({
+      params: {},
+      hasValidParams: false,
+    })
+  })
+
+  it('should continue accepting regular dynamic values', () => {
+    const { normalizeDynamicRouteParams } = getServerUtils({
+      page: '/[teamSlug]/[project]',
+      basePath: '',
+      rewrites: {},
+      i18n: undefined,
+      pageIsDynamic: true,
+      caseSensitive: false,
+    })
+
+    const result = normalizeDynamicRouteParams(
+      {
+        teamSlug: 'vercel',
+        project: 'nextjs',
+      },
+      true
+    )
+
+    expect(result).toEqual({
+      params: {
+        teamSlug: 'vercel',
+        project: 'nextjs',
+      },
+      hasValidParams: true,
+    })
+  })
+
+  it('should not decode matched params beyond the route matcher decode', () => {
+    const { normalizeDynamicRouteParams } = getServerUtils({
+      page: '/[teamSlug]/[project]',
+      basePath: '',
+      rewrites: {},
+      i18n: undefined,
+      pageIsDynamic: true,
+      caseSensitive: false,
+    })
+
+    const result = normalizeDynamicRouteParams(
+      {
+        teamSlug: 'acme',
+        project: '%23hash',
+      },
+      true
+    )
+
+    expect(result).toEqual({
+      params: {
+        teamSlug: 'acme',
+        project: '%23hash',
+      },
+      hasValidParams: true,
+    })
+  })
+
+  it('should not reject non-placeholder values that only contain decoded placeholder text', () => {
+    const { normalizeDynamicRouteParams } = getServerUtils({
+      page: '/[teamSlug]/[project]',
+      basePath: '',
+      rewrites: {},
+      i18n: undefined,
+      pageIsDynamic: true,
+      caseSensitive: false,
+    })
+
+    const result = normalizeDynamicRouteParams(
+      {
+        teamSlug: 'acme',
+        project: '%5Bproject%5D-suffix',
+      },
+      true
+    )
+
+    expect(result).toEqual({
+      params: {
+        teamSlug: 'acme',
+        project: '%5Bproject%5D-suffix',
+      },
+      hasValidParams: true,
+    })
+  })
+})

--- a/packages/next/src/server/server-utils.ts
+++ b/packages/next/src/server/server-utils.ts
@@ -112,6 +112,34 @@ export function normalizeDynamicRouteParams(
   defaultRouteMatches: ParsedUrlQuery,
   ignoreMissingOptional: boolean
 ) {
+  const isDefaultValueMatch = (
+    candidateValue: string | undefined,
+    defaultValue: string
+  ) => {
+    if (!candidateValue) {
+      return false
+    }
+
+    let normalizedCandidateValue = normalizeRscURL(candidateValue)
+    for (let i = 0; i < 3; i++) {
+      if (normalizedCandidateValue === defaultValue) {
+        return true
+      }
+
+      const decodedCandidateValue = decodeQueryPathParameter(
+        normalizedCandidateValue
+      )
+
+      if (decodedCandidateValue === normalizedCandidateValue) {
+        break
+      }
+
+      normalizedCandidateValue = decodedCandidateValue
+    }
+
+    return false
+  }
+
   let hasValidParams = true
   let params: ParsedUrlQuery = {}
 
@@ -133,10 +161,12 @@ export function normalizeDynamicRouteParams(
     const isDefaultValue = Array.isArray(defaultValue)
       ? defaultValue.some((defaultVal) => {
           return Array.isArray(value)
-            ? value.some((val) => val.includes(defaultVal))
-            : value?.includes(defaultVal)
+            ? value.some((val) => isDefaultValueMatch(val, defaultVal))
+            : isDefaultValueMatch(value, defaultVal)
         })
-      : value?.includes(defaultValue as string)
+      : Array.isArray(value)
+        ? value.some((val) => isDefaultValueMatch(val, defaultValue as string))
+        : isDefaultValueMatch(value, defaultValue as string)
 
     if (
       isDefaultValue ||

--- a/packages/next/src/shared/lib/router/routes/app.ts
+++ b/packages/next/src/shared/lib/router/routes/app.ts
@@ -60,6 +60,19 @@ export type NormalizedAppRouteSegment =
   | StaticAppRouteSegment
   | DynamicAppRouteSegment
 
+function normalizeEncodedDynamicPlaceholder(segment: string): string {
+  if (!/%5b|%5d/i.test(segment)) {
+    return segment
+  }
+
+  try {
+    const decodedSegment = decodeURIComponent(segment)
+    return getSegmentParam(decodedSegment) ? decodedSegment : segment
+  } catch {
+    return segment
+  }
+}
+
 export function parseAppRouteSegment(segment: string): AppRouteSegment | null {
   if (segment === '') {
     return null
@@ -180,8 +193,10 @@ export function parseAppRoute(
   let interceptedRoute: AppRoute | NormalizedAppRoute | undefined
 
   for (const segment of pathnameSegments) {
+    const normalizedSegment = normalizeEncodedDynamicPlaceholder(segment)
+
     // Parse the segment into an AppSegment.
-    const appSegment = parseAppRouteSegment(segment)
+    const appSegment = parseAppRouteSegment(normalizedSegment)
     if (!appSegment) {
       continue
     }

--- a/test/e2e/app-dir/cache-components/cache-components.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.test.ts
@@ -425,7 +425,7 @@ describe('cache-components', () => {
 
         const stateTree = JSON.stringify(['', {}])
         const requestUrl = new URL('/cases/static', `http://localhost:${port}`)
-        const cacheBustingParam = computeCacheBustingSearchParam(
+        const cacheBustingParam = await computeCacheBustingSearchParam(
           undefined,
           undefined,
           stateTree,

--- a/test/e2e/app-dir/ppr-root-param-rsc-fallback/app/[tenant]/layout.tsx
+++ b/test/e2e/app-dir/ppr-root-param-rsc-fallback/app/[tenant]/layout.tsx
@@ -1,0 +1,52 @@
+import { Suspense } from 'react'
+import type { ReactNode } from 'react'
+
+export function generateStaticParams() {
+  return [{ tenant: 'tenant-a' }, { tenant: 'tenant-b' }]
+}
+
+async function CachedTenantMarker({
+  params,
+}: {
+  params: Promise<{ tenant: string }>
+}) {
+  'use cache'
+
+  return (
+    <div hidden id="cached-tenant-marker">
+      {(await params).tenant}
+    </div>
+  )
+}
+
+async function EnsureTenant({
+  params,
+}: {
+  params: Promise<{ tenant: string }>
+}) {
+  const { tenant } = await params
+
+  if (typeof tenant !== 'string') {
+    throw new Error('Failed to read `tenant` from params')
+  }
+
+  return null
+}
+
+export default function TenantLayout({
+  children,
+  params,
+}: {
+  children: ReactNode
+  params: Promise<{ tenant: string }>
+}) {
+  return (
+    <>
+      <Suspense>{children}</Suspense>
+      <Suspense fallback={null}>
+        <CachedTenantMarker params={params} />
+      </Suspense>
+      <EnsureTenant params={params} />
+    </>
+  )
+}

--- a/test/e2e/app-dir/ppr-root-param-rsc-fallback/app/[tenant]/samples/page.tsx
+++ b/test/e2e/app-dir/ppr-root-param-rsc-fallback/app/[tenant]/samples/page.tsx
@@ -1,0 +1,63 @@
+import { Suspense } from 'react'
+import { cacheLife, cacheTag } from 'next/cache'
+import { connection } from 'next/server'
+
+async function CachedShell({ tenant }: { tenant: string }) {
+  'use cache'
+
+  cacheLife({
+    stale: 300,
+    revalidate: 300,
+    expire: 3600,
+  })
+  cacheTag(`sample-shell:${tenant}`)
+
+  return (
+    <>
+      <p id="cached-tenant">
+        Tenant: <strong>{tenant}</strong>
+      </p>
+      <p id="cached-at">
+        Cached shell token: <strong>{crypto.randomUUID()}</strong>
+      </p>
+    </>
+  )
+}
+
+async function DynamicRequestContent({
+  params,
+}: {
+  params: Promise<{ tenant: string }>
+}) {
+  const { tenant } = await params
+
+  await connection()
+
+  return (
+    <p id="dynamic">
+      Request-time content for <strong>{tenant}</strong>.
+    </p>
+  )
+}
+
+export default function SamplesPage({
+  params,
+}: {
+  params: Promise<{ tenant: string }>
+}) {
+  const shell = params.then(async ({ tenant }) => (
+    <CachedShell tenant={tenant} />
+  ))
+
+  return (
+    <main>
+      <h1>Samples Route</h1>
+      <Suspense fallback={<p id="shell-fallback">Loading cached shell...</p>}>
+        {shell}
+      </Suspense>
+      <Suspense fallback={<p id="fallback">Loading request-time content...</p>}>
+        <DynamicRequestContent params={params} />
+      </Suspense>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/ppr-root-param-rsc-fallback/app/layout.tsx
+++ b/test/e2e/app-dir/ppr-root-param-rsc-fallback/app/layout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from 'react'
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/ppr-root-param-rsc-fallback/next.config.js
+++ b/test/e2e/app-dir/ppr-root-param-rsc-fallback/next.config.js
@@ -1,0 +1,11 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+  experimental: {
+    rootParams: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/ppr-root-param-rsc-fallback/ppr-root-param-rsc-fallback.test.ts
+++ b/test/e2e/app-dir/ppr-root-param-rsc-fallback/ppr-root-param-rsc-fallback.test.ts
@@ -1,0 +1,41 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('ppr-root-param-rsc-fallback', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: __dirname,
+  })
+
+  if (isNextDev) {
+    it('skipped in dev', () => {})
+    return
+  }
+
+  it('does not return HTML for a pregenerated root param full-route rsc request', async () => {
+    const response = await next.fetch(`/tenant-a/samples`, {
+      headers: {
+        RSC: '1',
+      },
+    })
+    const body = await response.text()
+    const contentType = response.headers.get('content-type') ?? ''
+
+    expect(response.status).toBe(200)
+    expect(contentType).toContain('text/x-component')
+    expect(body).not.toContain('<!DOCTYPE html>')
+  })
+
+  it('does not return HTML for a non-pregenerated root param full-route rsc request', async () => {
+    const tenant = `tenant-${Date.now()}`
+    const response = await next.fetch(`/${tenant}/samples`, {
+      headers: {
+        RSC: '1',
+      },
+    })
+    const body = await response.text()
+    const contentType = response.headers.get('content-type') ?? ''
+
+    expect(response.status).toBe(200)
+    expect(contentType).toContain('text/x-component')
+    expect(body).not.toContain('<!DOCTYPE html>')
+  })
+})

--- a/test/e2e/app-dir/segment-cache/vary-params-base-dynamic/app/[teamSlug]/[project]/(domains)/settings/domains/loading.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params-base-dynamic/app/[teamSlug]/[project]/(domains)/settings/domains/loading.tsx
@@ -1,0 +1,7 @@
+export default function ProjectDomainsSettingsLoading() {
+  return (
+    <div data-team-project-settings-domains-loading="true">
+      Loading project domains settings...
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/vary-params-base-dynamic/app/[teamSlug]/[project]/(domains)/settings/domains/page.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params-base-dynamic/app/[teamSlug]/[project]/(domains)/settings/domains/page.tsx
@@ -1,39 +1,28 @@
 import { cacheLife } from 'next/cache'
 import Link from 'next/link'
 import { Suspense } from 'react'
-import { LinkAccordion } from '../../../components/link-accordion'
+import { LinkAccordion } from '../../../../../../components/link-accordion'
 
 type Params = { teamSlug: string; project: string }
 
-export default function TeamProjectPage({
+export default function ProjectDomainsSettingsPage({
   params,
 }: {
   params: Promise<Params>
 }) {
   return (
-    <div id="team-project-page">
+    <div id="team-project-settings-domains-page">
       <Suspense
-        fallback={<div data-loading="true">Loading team/project route...</div>}
+        fallback={
+          <div data-loading="true">
+            Loading project settings domains page...
+          </div>
+        }
       >
-        <TeamProjectContent params={params} />
+        <ProjectDomainsSettingsContent params={params} />
       </Suspense>
       <nav data-nav-link-list="true">
         <ul>
-          <li>
-            <Link href="/" data-nav-link="/">
-              Navigate: home
-            </Link>
-          </li>
-          <li>
-            <Link href="/acme/dashboard" data-nav-link="/acme/dashboard">
-              Navigate: acme/dashboard
-            </Link>
-          </li>
-          <li>
-            <Link href="/globex/portal" data-nav-link="/globex/portal">
-              Navigate: globex/portal
-            </Link>
-          </li>
           <li>
             <Link
               href="/acme/dashboard/settings"
@@ -69,12 +58,6 @@ export default function TeamProjectPage({
         </ul>
       </nav>
       <div data-related-link-list="true">
-        <LinkAccordion href="/acme/dashboard">
-          Related route: acme/dashboard
-        </LinkAccordion>
-        <LinkAccordion href="/globex/portal">
-          Related route: globex/portal
-        </LinkAccordion>
         <LinkAccordion href="/acme/dashboard/settings/domains">
           Related route: acme/dashboard/settings/domains
         </LinkAccordion>
@@ -86,7 +69,11 @@ export default function TeamProjectPage({
   )
 }
 
-async function TeamProjectContent({ params }: { params: Promise<Params> }) {
+async function ProjectDomainsSettingsContent({
+  params,
+}: {
+  params: Promise<Params>
+}) {
   'use cache'
   cacheLife({ stale: 0, revalidate: 1, expire: 60 })
 
@@ -94,8 +81,8 @@ async function TeamProjectContent({ params }: { params: Promise<Params> }) {
   const marker = Date.now()
 
   return (
-    <div data-team-project-content="true">
-      {`Team project content - team: ${teamSlug}, project: ${project}, marker: ${marker}`}
+    <div data-team-project-settings-domains-content="true">
+      {`Project domains settings content - team: ${teamSlug}, project: ${project}, marker: ${marker}`}
     </div>
   )
 }

--- a/test/e2e/app-dir/segment-cache/vary-params-base-dynamic/app/[teamSlug]/[project]/(domains)/settings/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params-base-dynamic/app/[teamSlug]/[project]/(domains)/settings/layout.tsx
@@ -1,0 +1,14 @@
+import { ReactNode } from 'react'
+
+export default function ProjectSettingsLayout({
+  children,
+}: {
+  children: ReactNode
+}) {
+  return (
+    <div data-project-settings-layout="domains-variant">
+      <h2>Project Settings Layout (domains variant)</h2>
+      {children}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/vary-params-base-dynamic/app/[teamSlug]/[project]/loading.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params-base-dynamic/app/[teamSlug]/[project]/loading.tsx
@@ -1,0 +1,5 @@
+export default function TeamProjectLoading() {
+  return (
+    <div data-team-project-loading="true">Loading team project page...</div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/vary-params-base-dynamic/app/[teamSlug]/[project]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params-base-dynamic/app/[teamSlug]/[project]/page.tsx
@@ -1,0 +1,34 @@
+import { cacheLife } from 'next/cache'
+import { Suspense } from 'react'
+
+type Params = { teamSlug: string; project: string }
+
+export default function TeamProjectPage({
+  params,
+}: {
+  params: Promise<Params>
+}) {
+  return (
+    <div id="team-project-page">
+      <Suspense
+        fallback={<div data-loading="true">Loading team/project route...</div>}
+      >
+        <TeamProjectContent params={params} />
+      </Suspense>
+    </div>
+  )
+}
+
+async function TeamProjectContent({ params }: { params: Promise<Params> }) {
+  'use cache'
+  cacheLife({ stale: 0, revalidate: 1, expire: 60 })
+
+  const { teamSlug, project } = await params
+  const marker = Date.now()
+
+  return (
+    <div data-team-project-content="true">
+      {`Team project content - team: ${teamSlug}, project: ${project}, marker: ${marker}`}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/vary-params-base-dynamic/app/[teamSlug]/[project]/settings/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params-base-dynamic/app/[teamSlug]/[project]/settings/layout.tsx
@@ -1,0 +1,14 @@
+import { ReactNode } from 'react'
+
+export default function ProjectSettingsLayout({
+  children,
+}: {
+  children: ReactNode
+}) {
+  return (
+    <div data-project-settings-layout="default">
+      <h2>Project Settings Layout</h2>
+      {children}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/vary-params-base-dynamic/app/[teamSlug]/[project]/settings/page.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params-base-dynamic/app/[teamSlug]/[project]/settings/page.tsx
@@ -1,53 +1,27 @@
 import { cacheLife } from 'next/cache'
 import Link from 'next/link'
 import { Suspense } from 'react'
-import { LinkAccordion } from '../../../components/link-accordion'
+import { LinkAccordion } from '../../../../components/link-accordion'
 
 type Params = { teamSlug: string; project: string }
 
-export default function TeamProjectPage({
+export default function ProjectSettingsPage({
   params,
 }: {
   params: Promise<Params>
 }) {
   return (
-    <div id="team-project-page">
+    <div id="team-project-settings-page">
       <Suspense
-        fallback={<div data-loading="true">Loading team/project route...</div>}
+        fallback={<div data-loading="true">Loading settings page...</div>}
       >
-        <TeamProjectContent params={params} />
+        <ProjectSettingsContent params={params} />
       </Suspense>
       <nav data-nav-link-list="true">
         <ul>
           <li>
             <Link href="/" data-nav-link="/">
               Navigate: home
-            </Link>
-          </li>
-          <li>
-            <Link href="/acme/dashboard" data-nav-link="/acme/dashboard">
-              Navigate: acme/dashboard
-            </Link>
-          </li>
-          <li>
-            <Link href="/globex/portal" data-nav-link="/globex/portal">
-              Navigate: globex/portal
-            </Link>
-          </li>
-          <li>
-            <Link
-              href="/acme/dashboard/settings"
-              data-nav-link="/acme/dashboard/settings"
-            >
-              Navigate: acme/dashboard/settings
-            </Link>
-          </li>
-          <li>
-            <Link
-              href="/globex/portal/settings"
-              data-nav-link="/globex/portal/settings"
-            >
-              Navigate: globex/portal/settings
             </Link>
           </li>
           <li>
@@ -69,12 +43,6 @@ export default function TeamProjectPage({
         </ul>
       </nav>
       <div data-related-link-list="true">
-        <LinkAccordion href="/acme/dashboard">
-          Related route: acme/dashboard
-        </LinkAccordion>
-        <LinkAccordion href="/globex/portal">
-          Related route: globex/portal
-        </LinkAccordion>
         <LinkAccordion href="/acme/dashboard/settings/domains">
           Related route: acme/dashboard/settings/domains
         </LinkAccordion>
@@ -86,7 +54,7 @@ export default function TeamProjectPage({
   )
 }
 
-async function TeamProjectContent({ params }: { params: Promise<Params> }) {
+async function ProjectSettingsContent({ params }: { params: Promise<Params> }) {
   'use cache'
   cacheLife({ stale: 0, revalidate: 1, expire: 60 })
 
@@ -94,8 +62,8 @@ async function TeamProjectContent({ params }: { params: Promise<Params> }) {
   const marker = Date.now()
 
   return (
-    <div data-team-project-content="true">
-      {`Team project content - team: ${teamSlug}, project: ${project}, marker: ${marker}`}
+    <div data-team-project-settings-content="true">
+      {`Project settings overview content - team: ${teamSlug}, project: ${project}, marker: ${marker}`}
     </div>
   )
 }

--- a/test/e2e/app-dir/segment-cache/vary-params-base-dynamic/app/api/revalidate-layout/route.ts
+++ b/test/e2e/app-dir/segment-cache/vary-params-base-dynamic/app/api/revalidate-layout/route.ts
@@ -1,0 +1,59 @@
+import { revalidatePath, revalidateTag } from 'next/cache'
+import { NextRequest } from 'next/server'
+
+type RevalidateMode =
+  | 'tag-layout-expireNow'
+  | 'tag-layout-max'
+  | 'tag-layout-legacy'
+  | 'path-root-layout'
+  | 'path-team-layout'
+  | 'path-team-page'
+
+function isRevalidateMode(value: string): value is RevalidateMode {
+  return (
+    value === 'tag-layout-expireNow' ||
+    value === 'tag-layout-max' ||
+    value === 'tag-layout-legacy' ||
+    value === 'path-root-layout' ||
+    value === 'path-team-layout' ||
+    value === 'path-team-page'
+  )
+}
+
+export async function GET(request: NextRequest) {
+  const modeQuery = request.nextUrl.searchParams.get('mode')
+  const mode: RevalidateMode =
+    modeQuery && isRevalidateMode(modeQuery)
+      ? modeQuery
+      : 'tag-layout-expireNow'
+
+  switch (mode) {
+    case 'tag-layout-expireNow':
+      revalidateTag('_N_T_/layout', 'expireNow')
+      break
+    case 'tag-layout-max':
+      revalidateTag('_N_T_/layout', 'max')
+      break
+    case 'tag-layout-legacy':
+      // Intentionally test the deprecated call shape without a profile arg.
+      // @ts-expect-error
+      revalidateTag('_N_T_/layout')
+      break
+    case 'path-root-layout':
+      revalidatePath('/', 'layout')
+      break
+    case 'path-team-layout':
+      revalidatePath('/acme/dashboard', 'layout')
+      break
+    case 'path-team-page':
+      revalidatePath('/acme/dashboard')
+      break
+    default:
+      break
+  }
+
+  return Response.json({
+    revalidated: true,
+    mode,
+  })
+}

--- a/test/e2e/app-dir/segment-cache/vary-params-base-dynamic/app/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params-base-dynamic/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/vary-params-base-dynamic/app/page.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params-base-dynamic/app/page.tsx
@@ -1,0 +1,25 @@
+import { LinkAccordion } from '../components/link-accordion'
+
+export default function HomePage() {
+  return (
+    <div id="home-page">
+      <h1>Root Dynamic Route Vary Params</h1>
+      <p>
+        Prefetch dynamic team/project routes and validate segment payload
+        params.
+      </p>
+      <ul>
+        <li>
+          <LinkAccordion href="/acme/dashboard">
+            Team project: acme/dashboard
+          </LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/globex/portal">
+            Team project: globex/portal
+          </LinkAccordion>
+        </li>
+      </ul>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/vary-params-base-dynamic/app/page.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params-base-dynamic/app/page.tsx
@@ -1,4 +1,6 @@
+import Link from 'next/link'
 import { LinkAccordion } from '../components/link-accordion'
+import { RevalidateControls } from '../components/revalidate-controls'
 
 export default function HomePage() {
   return (
@@ -8,6 +10,34 @@ export default function HomePage() {
         Prefetch dynamic team/project routes and validate segment payload
         params.
       </p>
+      <ul data-nav-link-list="true">
+        <li>
+          <Link href="/acme/dashboard" data-nav-link="/acme/dashboard">
+            Navigate: acme/dashboard
+          </Link>
+        </li>
+        <li>
+          <Link href="/globex/portal" data-nav-link="/globex/portal">
+            Navigate: globex/portal
+          </Link>
+        </li>
+        <li>
+          <Link
+            href="/acme/dashboard/settings/domains"
+            data-nav-link="/acme/dashboard/settings/domains"
+          >
+            Navigate: acme/dashboard/settings/domains
+          </Link>
+        </li>
+        <li>
+          <Link
+            href="/globex/portal/settings/domains"
+            data-nav-link="/globex/portal/settings/domains"
+          >
+            Navigate: globex/portal/settings/domains
+          </Link>
+        </li>
+      </ul>
       <ul>
         <li>
           <LinkAccordion href="/acme/dashboard">
@@ -20,6 +50,7 @@ export default function HomePage() {
           </LinkAccordion>
         </li>
       </ul>
+      <RevalidateControls />
     </div>
   )
 }

--- a/test/e2e/app-dir/segment-cache/vary-params-base-dynamic/app/revalidate-actions.ts
+++ b/test/e2e/app-dir/segment-cache/vary-params-base-dynamic/app/revalidate-actions.ts
@@ -1,0 +1,29 @@
+'use server'
+
+import { revalidateTag } from 'next/cache'
+
+export async function revalidateLayoutByTagExpireNowAction() {
+  revalidateTag('_N_T_/layout', 'expireNow')
+  return {
+    mode: 'server-action-tag-layout-expireNow',
+    revalidated: true,
+  }
+}
+
+export async function revalidateLayoutByTagMaxAction() {
+  revalidateTag('_N_T_/layout', 'max')
+  return {
+    mode: 'server-action-tag-layout-max',
+    revalidated: true,
+  }
+}
+
+export async function revalidateLayoutByTagLegacyAction() {
+  // Intentionally test the deprecated call shape without a profile arg.
+  // @ts-expect-error
+  revalidateTag('_N_T_/layout')
+  return {
+    mode: 'server-action-tag-layout-legacy',
+    revalidated: true,
+  }
+}

--- a/test/e2e/app-dir/segment-cache/vary-params-base-dynamic/components/link-accordion.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params-base-dynamic/components/link-accordion.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import Link, { type LinkProps } from 'next/link'
+import { useState } from 'react'
+
+export function LinkAccordion({
+  href,
+  children,
+  prefetch,
+}: {
+  href: string
+  children?: React.ReactNode
+  prefetch?: LinkProps['prefetch']
+}) {
+  const [isVisible, setIsVisible] = useState(false)
+  const displayChildren = children !== undefined ? children : href
+
+  return (
+    <>
+      <input
+        type="checkbox"
+        checked={isVisible}
+        onChange={() => setIsVisible(!isVisible)}
+        data-link-accordion={href}
+      />
+      {isVisible ? (
+        <Link href={href} prefetch={prefetch}>
+          {displayChildren}
+        </Link>
+      ) : (
+        <>{displayChildren} (link is hidden)</>
+      )}
+    </>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/vary-params-base-dynamic/components/revalidate-controls.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params-base-dynamic/components/revalidate-controls.tsx
@@ -1,0 +1,129 @@
+'use client'
+
+import { useState } from 'react'
+import {
+  revalidateLayoutByTagExpireNowAction,
+  revalidateLayoutByTagLegacyAction,
+  revalidateLayoutByTagMaxAction,
+} from '../app/revalidate-actions'
+
+type ApiRevalidateMode =
+  | 'tag-layout-expireNow'
+  | 'tag-layout-max'
+  | 'tag-layout-legacy'
+  | 'path-root-layout'
+  | 'path-team-layout'
+  | 'path-team-page'
+type ServerActionMode =
+  | 'server-action-tag-layout-expireNow'
+  | 'server-action-tag-layout-max'
+  | 'server-action-tag-layout-legacy'
+
+export function RevalidateControls() {
+  const [result, setResult] = useState('idle')
+  const [isPending, setIsPending] = useState(false)
+
+  const runApiRevalidate = async (mode: ApiRevalidateMode) => {
+    setIsPending(true)
+    try {
+      const response = await fetch(`/api/revalidate-layout?mode=${mode}`, {
+        method: 'GET',
+      })
+      const data = await response.json()
+      setResult(JSON.stringify(data))
+    } catch (error) {
+      setResult(
+        JSON.stringify({
+          error: error instanceof Error ? error.message : 'unknown error',
+          mode,
+        })
+      )
+    } finally {
+      setIsPending(false)
+    }
+  }
+
+  const runServerActionRevalidate = async (mode: ServerActionMode) => {
+    setIsPending(true)
+    try {
+      const data =
+        mode === 'server-action-tag-layout-expireNow'
+          ? await revalidateLayoutByTagExpireNowAction()
+          : mode === 'server-action-tag-layout-max'
+            ? await revalidateLayoutByTagMaxAction()
+            : await revalidateLayoutByTagLegacyAction()
+      setResult(JSON.stringify(data))
+    } catch (error) {
+      setResult(
+        JSON.stringify({
+          error: error instanceof Error ? error.message : 'unknown error',
+          mode,
+        })
+      )
+    } finally {
+      setIsPending(false)
+    }
+  }
+
+  return (
+    <div data-revalidate-controls="true">
+      <button
+        id="revalidate-in-browser-tag-layout-expireNow"
+        type="button"
+        disabled={isPending}
+        onClick={() => runApiRevalidate('tag-layout-expireNow')}
+      >
+        Browser Revalidate Tag Layout (expireNow)
+      </button>
+      <button
+        id="revalidate-in-browser-tag-layout-max"
+        type="button"
+        disabled={isPending}
+        onClick={() => runApiRevalidate('tag-layout-max')}
+      >
+        Browser Revalidate Tag Layout (max)
+      </button>
+      <button
+        id="revalidate-in-browser-tag-layout-legacy"
+        type="button"
+        disabled={isPending}
+        onClick={() => runApiRevalidate('tag-layout-legacy')}
+      >
+        Browser Revalidate Tag Layout (legacy)
+      </button>
+      <button
+        id="revalidate-in-browser-server-action-tag-layout-expireNow"
+        type="button"
+        disabled={isPending}
+        onClick={() =>
+          runServerActionRevalidate('server-action-tag-layout-expireNow')
+        }
+      >
+        Server Action Revalidate Tag Layout (expireNow)
+      </button>
+      <button
+        id="revalidate-in-browser-server-action-tag-layout-max"
+        type="button"
+        disabled={isPending}
+        onClick={() =>
+          runServerActionRevalidate('server-action-tag-layout-max')
+        }
+      >
+        Server Action Revalidate Tag Layout (max)
+      </button>
+      <button
+        id="revalidate-in-browser-server-action-tag-layout-legacy"
+        type="button"
+        disabled={isPending}
+        onClick={() =>
+          runServerActionRevalidate('server-action-tag-layout-legacy')
+        }
+      >
+        Server Action Revalidate Tag Layout (legacy)
+      </button>
+      <div id="revalidate-result" data-revalidate-result={result}>
+        {result}
+      </div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/vary-params-base-dynamic/next.config.js
+++ b/test/e2e/app-dir/segment-cache/vary-params-base-dynamic/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+  experimental: {
+    optimisticRouting: true,
+    varyParams: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/segment-cache/vary-params-base-dynamic/next.config.js
+++ b/test/e2e/app-dir/segment-cache/vary-params-base-dynamic/next.config.js
@@ -3,6 +3,13 @@
  */
 const nextConfig = {
   cacheComponents: true,
+  cacheLife: {
+    expireNow: {
+      stale: 0,
+      revalidate: 0,
+      expire: 0,
+    },
+  },
   experimental: {
     optimisticRouting: true,
     varyParams: true,

--- a/test/e2e/app-dir/segment-cache/vary-params-base-dynamic/vary-params-base-dynamic.test.ts
+++ b/test/e2e/app-dir/segment-cache/vary-params-base-dynamic/vary-params-base-dynamic.test.ts
@@ -1,0 +1,145 @@
+import { nextTestSetup } from 'e2e-utils'
+import { waitFor } from 'next-test-utils'
+import type * as Playwright from 'playwright'
+import { createRouterAct } from 'router-act'
+
+describe('segment cache - vary params base dynamic', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: __dirname,
+  })
+
+  if (isNextDev) {
+    test('prefetching is disabled in dev mode', () => {})
+    return
+  }
+
+  it('keeps dynamic segment params valid before and after time-based revalidation', async () => {
+    const collectSegmentPrefetchResponses = async (href: string) => {
+      let act: ReturnType<typeof createRouterAct>
+      const segmentPrefetchResponses: Array<
+        Promise<{ body: string; segmentPrefetchPath: string }>
+      > = []
+
+      const browser = await next.browser('/', {
+        beforePageLoad(p: Playwright.Page) {
+          act = createRouterAct(p)
+          p.on('response', (response) => {
+            const request = response.request()
+            const segmentPath =
+              request.headers()['next-router-segment-prefetch']
+
+            if (segmentPath) {
+              const pathname = new URL(request.url()).pathname
+              const segmentPrefetchPath = pathname.endsWith('.rsc')
+                ? `${pathname.slice(0, -'.rsc'.length)}.segments${segmentPath}.segment.rsc`
+                : `${pathname}.segments${segmentPath}.segment.rsc`
+
+              segmentPrefetchResponses.push(
+                response
+                  .text()
+                  .then((body) => ({ body, segmentPrefetchPath }))
+                  .catch(() => ({ body: '', segmentPrefetchPath }))
+              )
+            }
+          })
+        },
+      })
+
+      await act(async () => {
+        const toggle = await browser.elementByCss(
+          `input[data-link-accordion="${href}"]`
+        )
+        await toggle.click()
+      })
+
+      const settledResponses = await Promise.all(segmentPrefetchResponses)
+      await browser.close()
+
+      return settledResponses
+    }
+
+    const readRouteMarker = async (path: string, expectedText: string) => {
+      const browser = await next.browser(path)
+      const content = await browser.elementByCss('[data-team-project-content]')
+      const text = await content.text()
+      await browser.close()
+
+      expect(text).toContain(expectedText)
+      const markerMatch = text.match(/marker: (\d+)/)
+      expect(markerMatch).not.toBeNull()
+      return Number(markerMatch![1])
+    }
+
+    const assertValidSegmentResponses = (
+      responses: Array<{ body: string; segmentPrefetchPath: string }>
+    ) => {
+      const bodies = responses.map((response) => response.body)
+      const allBodies = bodies.join('\n')
+      const segmentPrefetchPaths = [
+        ...new Set(responses.map((response) => response.segmentPrefetchPath)),
+      ]
+
+      expect(bodies.length).toBeGreaterThan(0)
+      expect(allBodies.includes('%5BteamSlug%5D')).toBe(false)
+      expect(allBodies.includes('%5Bproject%5D')).toBe(false)
+      expect(
+        segmentPrefetchPaths.some((path) =>
+          path.startsWith('/acme/dashboard.segments/')
+        )
+      ).toBe(true)
+      expect(
+        segmentPrefetchPaths.some((path) =>
+          path.startsWith('/globex/portal.segments/')
+        )
+      ).toBe(true)
+      expect(
+        segmentPrefetchPaths.every(
+          (path) => path.includes('.segments/') && path.endsWith('.segment.rsc')
+        )
+      ).toBe(true)
+    }
+
+    const initialAcmeMarker = await readRouteMarker(
+      '/acme/dashboard',
+      'Team project content - team: acme, project: dashboard'
+    )
+    const initialGlobexMarker = await readRouteMarker(
+      '/globex/portal',
+      'Team project content - team: globex, project: portal'
+    )
+
+    const initialResponses = [
+      ...(await collectSegmentPrefetchResponses('/acme/dashboard')),
+      ...(await collectSegmentPrefetchResponses('/globex/portal')),
+    ]
+    assertValidSegmentResponses(initialResponses)
+
+    let lastAcmeMarker = initialAcmeMarker
+    let lastGlobexMarker = initialGlobexMarker
+
+    for (let checkIndex = 0; checkIndex < 5; checkIndex++) {
+      await waitFor(2_000)
+
+      const revalidatedResponses = [
+        ...(await collectSegmentPrefetchResponses('/acme/dashboard')),
+        ...(await collectSegmentPrefetchResponses('/globex/portal')),
+      ]
+      assertValidSegmentResponses(revalidatedResponses)
+
+      const revalidatedAcmeMarker = await readRouteMarker(
+        '/acme/dashboard',
+        'Team project content - team: acme, project: dashboard'
+      )
+      const revalidatedGlobexMarker = await readRouteMarker(
+        '/globex/portal',
+        'Team project content - team: globex, project: portal'
+      )
+
+      expect(revalidatedAcmeMarker).not.toBe(lastAcmeMarker)
+      expect(revalidatedGlobexMarker).not.toBe(lastGlobexMarker)
+
+      lastAcmeMarker = revalidatedAcmeMarker
+      lastGlobexMarker = revalidatedGlobexMarker
+    }
+  })
+})

--- a/test/e2e/app-dir/segment-cache/vary-params-base-dynamic/vary-params-base-dynamic.test.ts
+++ b/test/e2e/app-dir/segment-cache/vary-params-base-dynamic/vary-params-base-dynamic.test.ts
@@ -1,7 +1,30 @@
 import { nextTestSetup } from 'e2e-utils'
-import { waitFor } from 'next-test-utils'
+import { retry, waitFor } from 'next-test-utils'
 import type * as Playwright from 'playwright'
 import { createRouterAct } from 'router-act'
+
+type RevalidateMode =
+  | 'tag-layout-expireNow'
+  | 'tag-layout-max'
+  | 'tag-layout-legacy'
+  | 'path-root-layout'
+  | 'path-team-layout'
+  | 'path-team-page'
+type BrowserRevalidateMode =
+  | 'tag-layout-expireNow'
+  | 'tag-layout-max'
+  | 'tag-layout-legacy'
+  | 'server-action-tag-layout-expireNow'
+  | 'server-action-tag-layout-max'
+  | 'server-action-tag-layout-legacy'
+
+type SegmentPrefetchResponse = {
+  body: string
+  requestPathname: string
+  requestSegmentPath: string
+  segmentPrefetchPath: string
+  status: number
+}
 
 describe('segment cache - vary params base dynamic', () => {
   const { next, isNextDev } = nextTestSetup({
@@ -13,51 +36,380 @@ describe('segment cache - vary params base dynamic', () => {
     return
   }
 
-  it('keeps dynamic segment params valid before and after time-based revalidation', async () => {
-    const collectSegmentPrefetchResponses = async (href: string) => {
-      let act: ReturnType<typeof createRouterAct>
-      const segmentPrefetchResponses: Array<
-        Promise<{ body: string; segmentPrefetchPath: string }>
-      > = []
+  const expectedTextByHref: Record<string, string> = {
+    '/acme/dashboard': 'Team project content - team: acme, project: dashboard',
+    '/globex/portal': 'Team project content - team: globex, project: portal',
+    '/acme/dashboard/settings':
+      'Project settings overview content - team: acme, project: dashboard',
+    '/globex/portal/settings':
+      'Project settings overview content - team: globex, project: portal',
+    '/acme/dashboard/settings/domains':
+      'Project domains settings content - team: acme, project: dashboard',
+    '/globex/portal/settings/domains':
+      'Project domains settings content - team: globex, project: portal',
+  }
 
-      const browser = await next.browser('/', {
+  const toSegmentPrefetchResponse = (
+    response: Playwright.Response
+  ): Promise<SegmentPrefetchResponse> | null => {
+    const request = response.request()
+    const segmentPath = request.headers()['next-router-segment-prefetch']
+
+    if (!segmentPath) {
+      return null
+    }
+
+    const pathname = new URL(request.url()).pathname
+    const segmentPrefetchPath = pathname.endsWith('.rsc')
+      ? `${pathname.slice(0, -'.rsc'.length)}.segments${segmentPath}.segment.rsc`
+      : `${pathname}.segments${segmentPath}.segment.rsc`
+
+    return response
+      .text()
+      .then((body) => ({
+        body,
+        requestPathname: pathname,
+        requestSegmentPath: segmentPath,
+        segmentPrefetchPath,
+        status: response.status(),
+      }))
+      .catch(() => ({
+        body: '',
+        requestPathname: pathname,
+        requestSegmentPath: segmentPath,
+        segmentPrefetchPath,
+        status: response.status(),
+      }))
+  }
+
+  const collectSegmentPrefetchResponses = async (
+    href: string,
+    startPath: string = '/'
+  ) => {
+    let act: ReturnType<typeof createRouterAct>
+    const segmentPrefetchResponses: Array<Promise<SegmentPrefetchResponse>> = []
+
+    const browser = await next.browser(startPath, {
+      beforePageLoad(p: Playwright.Page) {
+        act = createRouterAct(p)
+        p.on('response', (response) => {
+          const prefetchResponse = toSegmentPrefetchResponse(response)
+          if (prefetchResponse !== null) {
+            segmentPrefetchResponses.push(prefetchResponse)
+          }
+        })
+      },
+    })
+
+    await act(async () => {
+      const toggle = await browser.elementByCss(
+        `input[data-link-accordion="${href}"]`
+      )
+      await toggle.click()
+    })
+
+    const settledResponses = await Promise.all(segmentPrefetchResponses)
+    await browser.close()
+
+    return settledResponses
+  }
+
+  const collectSegmentPrefetchResponsesFromBackForwardNavigation = async (
+    browserRevalidateMode?: BrowserRevalidateMode
+  ) => {
+    const segmentPrefetchResponses: Array<Promise<SegmentPrefetchResponse>> = []
+    const pageErrors: Array<string> = []
+
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        p.on('response', (response) => {
+          const prefetchResponse = toSegmentPrefetchResponse(response)
+          if (prefetchResponse !== null) {
+            segmentPrefetchResponses.push(prefetchResponse)
+          }
+        })
+        p.on('pageerror', (error) => {
+          pageErrors.push(error.message)
+        })
+      },
+    })
+
+    const expectHomePage = async () => {
+      await retry(async () => {
+        const content = await browser.elementByCss('#home-page')
+        expect(await content.text()).toContain('Root Dynamic Route Vary Params')
+      })
+    }
+
+    const expectTeamPage = async (
+      href: '/acme/dashboard' | '/globex/portal'
+    ) => {
+      const expectedText = expectedTextByHref[href]
+
+      await retry(async () => {
+        const content = await browser.elementByCss(
+          '[data-team-project-content]'
+        )
+        expect(await content.text()).toContain(expectedText)
+      })
+    }
+
+    const clickVisibleLink = async (href: string) => {
+      const link = await browser.elementByCss(`a[data-nav-link="${href}"]`)
+      await link.click()
+    }
+
+    await expectHomePage()
+
+    if (browserRevalidateMode) {
+      const button = await browser.elementById(
+        `revalidate-in-browser-${browserRevalidateMode}`
+      )
+      await button.click()
+
+      await retry(async () => {
+        const result = await browser.elementById('revalidate-result').text()
+        expect(result).toContain('"revalidated":true')
+        expect(result).toContain(`"mode":"${browserRevalidateMode}"`)
+      })
+
+      await waitFor(500)
+    }
+
+    await waitFor(300)
+
+    await clickVisibleLink('/acme/dashboard')
+    await expectTeamPage('/acme/dashboard')
+
+    for (let cycle = 0; cycle < 3; cycle++) {
+      await browser.back()
+      await expectHomePage()
+      await waitFor(250)
+
+      await browser.forward()
+      await expectTeamPage('/acme/dashboard')
+      await waitFor(250)
+    }
+
+    await clickVisibleLink('/globex/portal')
+    await expectTeamPage('/globex/portal')
+
+    for (let cycle = 0; cycle < 2; cycle++) {
+      await browser.back()
+      await expectTeamPage('/acme/dashboard')
+      await waitFor(250)
+
+      await browser.forward()
+      await expectTeamPage('/globex/portal')
+      await waitFor(250)
+    }
+
+    await browser.back()
+    await expectTeamPage('/acme/dashboard')
+    await browser.back()
+    await expectHomePage()
+    await waitFor(500)
+
+    const settledResponses = await Promise.all(segmentPrefetchResponses)
+    await browser.close()
+
+    return {
+      pageErrors,
+      responses: settledResponses,
+    }
+  }
+
+  const collectSegmentPrefetchResponsesFromProductionShapeNavigation =
+    async () => {
+      const segmentPrefetchResponses: Array<Promise<SegmentPrefetchResponse>> =
+        []
+      const pageErrors: Array<string> = []
+
+      const browser = await next.browser('/acme/dashboard/settings', {
         beforePageLoad(p: Playwright.Page) {
-          act = createRouterAct(p)
           p.on('response', (response) => {
-            const request = response.request()
-            const segmentPath =
-              request.headers()['next-router-segment-prefetch']
-
-            if (segmentPath) {
-              const pathname = new URL(request.url()).pathname
-              const segmentPrefetchPath = pathname.endsWith('.rsc')
-                ? `${pathname.slice(0, -'.rsc'.length)}.segments${segmentPath}.segment.rsc`
-                : `${pathname}.segments${segmentPath}.segment.rsc`
-
-              segmentPrefetchResponses.push(
-                response
-                  .text()
-                  .then((body) => ({ body, segmentPrefetchPath }))
-                  .catch(() => ({ body: '', segmentPrefetchPath }))
-              )
+            const prefetchResponse = toSegmentPrefetchResponse(response)
+            if (prefetchResponse !== null) {
+              segmentPrefetchResponses.push(prefetchResponse)
             }
+          })
+          p.on('pageerror', (error) => {
+            pageErrors.push(error.message)
           })
         },
       })
 
-      await act(async () => {
-        const toggle = await browser.elementByCss(
-          `input[data-link-accordion="${href}"]`
-        )
-        await toggle.click()
-      })
+      const clickVisibleLink = async (href: string) => {
+        const link = await browser.elementByCss(`a[data-nav-link="${href}"]`)
+        await link.click()
+      }
+
+      const expectProjectSettingsPage = async (
+        team: 'acme' | 'globex',
+        project: 'dashboard' | 'portal'
+      ) => {
+        const expectedText = expectedTextByHref[`/${team}/${project}/settings`]
+        await retry(async () => {
+          const content = await browser.elementByCss(
+            '[data-team-project-settings-content]'
+          )
+          expect(await content.text()).toContain(expectedText)
+        })
+      }
+
+      const expectProjectDomainsPage = async (
+        team: 'acme' | 'globex',
+        project: 'dashboard' | 'portal'
+      ) => {
+        const expectedText =
+          expectedTextByHref[`/${team}/${project}/settings/domains`]
+        await retry(async () => {
+          const content = await browser.elementByCss(
+            '[data-team-project-settings-domains-content]'
+          )
+          expect(await content.text()).toContain(expectedText)
+        })
+      }
+
+      await expectProjectSettingsPage('acme', 'dashboard')
+      await waitFor(300)
+
+      await clickVisibleLink('/acme/dashboard/settings/domains')
+      await expectProjectDomainsPage('acme', 'dashboard')
+
+      for (let cycle = 0; cycle < 3; cycle++) {
+        await browser.back()
+        await expectProjectSettingsPage('acme', 'dashboard')
+        await waitFor(250)
+
+        await browser.forward()
+        await expectProjectDomainsPage('acme', 'dashboard')
+        await waitFor(250)
+      }
+
+      await clickVisibleLink('/globex/portal/settings/domains')
+      await expectProjectDomainsPage('globex', 'portal')
+
+      for (let cycle = 0; cycle < 2; cycle++) {
+        await browser.back()
+        await expectProjectDomainsPage('acme', 'dashboard')
+        await waitFor(250)
+
+        await browser.forward()
+        await expectProjectDomainsPage('globex', 'portal')
+        await waitFor(250)
+      }
+
+      await browser.back()
+      await expectProjectDomainsPage('acme', 'dashboard')
+      await browser.back()
+      await expectProjectSettingsPage('acme', 'dashboard')
+      await waitFor(500)
 
       const settledResponses = await Promise.all(segmentPrefetchResponses)
       await browser.close()
 
-      return settledResponses
+      return {
+        pageErrors,
+        responses: settledResponses,
+      }
     }
 
+  const assertNoEncodedDynamicPlaceholders = (value: string) => {
+    expect(value.includes('%5BteamSlug%5D')).toBe(false)
+    expect(value.includes('%5Bproject%5D')).toBe(false)
+    expect(value.includes('%255BteamSlug%255D')).toBe(false)
+    expect(value.includes('%255Bproject%255D')).toBe(false)
+    expect(value.includes('[teamSlug]')).toBe(false)
+    expect(value.includes('[project]')).toBe(false)
+  }
+
+  const assertValidSegmentResponses = (
+    responses: Array<SegmentPrefetchResponse>,
+    expectedRoutePrefixes: Array<string> = ['/acme/dashboard', '/globex/portal']
+  ) => {
+    const bodies = responses.map((response) => response.body)
+    const requestPathnames = responses.map(
+      (response) => response.requestPathname
+    )
+    const requestSegmentPaths = responses.map(
+      (response) => response.requestSegmentPath
+    )
+
+    // Webpack flight payloads can include module chunk references like:
+    // `static/chunks/app/%5Bslug%5D/page-*.js`. These are build artifact paths,
+    // not route params, so strip them before placeholder assertions.
+    const cleanedBodies = bodies.map((body) =>
+      body.replace(/static\/chunks\/app\/[^"'\n]+\.js/g, '')
+    )
+    const allBodies = cleanedBodies.join('\n')
+    const allRequestPathnames = requestPathnames.join('\n')
+    const allRequestSegmentPaths = requestSegmentPaths.join('\n')
+    const segmentPrefetchPaths = [
+      ...new Set(responses.map((response) => response.segmentPrefetchPath)),
+    ]
+
+    expect(bodies.length).toBeGreaterThan(0)
+    expect(responses.some((response) => response.status >= 400)).toBe(false)
+
+    assertNoEncodedDynamicPlaceholders(allBodies)
+    assertNoEncodedDynamicPlaceholders(allRequestPathnames)
+    assertNoEncodedDynamicPlaceholders(allRequestSegmentPaths)
+
+    expect(segmentPrefetchPaths.some((path) => path.includes('%5B'))).toBe(
+      false
+    )
+    expect(segmentPrefetchPaths.some((path) => path.includes('%255B'))).toBe(
+      false
+    )
+    expect(
+      segmentPrefetchPaths.some((path) => path.includes('[teamSlug]'))
+    ).toBe(false)
+    expect(
+      segmentPrefetchPaths.some((path) => path.includes('[project]'))
+    ).toBe(false)
+    for (const routePrefix of expectedRoutePrefixes) {
+      expect(
+        segmentPrefetchPaths.some((path) =>
+          path.startsWith(`${routePrefix}.segments/`)
+        )
+      ).toBe(true)
+    }
+    expect(
+      segmentPrefetchPaths.every(
+        (path) => path.includes('.segments/') && path.endsWith('.segment.rsc')
+      )
+    ).toBe(true)
+  }
+
+  const warmSegmentCache = async () => {
+    const warmedResponses = [
+      ...(await collectSegmentPrefetchResponses('/acme/dashboard')),
+      ...(await collectSegmentPrefetchResponses('/globex/portal')),
+    ]
+    assertValidSegmentResponses(warmedResponses)
+  }
+
+  const primeProductionShapeRouteCache = async () => {
+    const acmeDomains = await next.fetch('/acme/dashboard/settings/domains')
+    const globexDomains = await next.fetch('/globex/portal/settings/domains')
+
+    expect(acmeDomains.status).toBe(200)
+    expect(globexDomains.status).toBe(200)
+  }
+
+  const triggerRevalidation = async (mode: RevalidateMode) => {
+    const revalidateResponse = await next.fetch(
+      `/api/revalidate-layout?mode=${mode}`
+    )
+    expect(revalidateResponse.status).toBe(200)
+    expect(await revalidateResponse.json()).toEqual({
+      revalidated: true,
+      mode,
+    })
+  }
+
+  it('keeps dynamic segment params valid before and after time-based revalidation', async () => {
     const readRouteMarker = async (path: string, expectedText: string) => {
       const browser = await next.browser(path)
       const content = await browser.elementByCss('[data-team-project-content]')
@@ -68,35 +420,6 @@ describe('segment cache - vary params base dynamic', () => {
       const markerMatch = text.match(/marker: (\d+)/)
       expect(markerMatch).not.toBeNull()
       return Number(markerMatch![1])
-    }
-
-    const assertValidSegmentResponses = (
-      responses: Array<{ body: string; segmentPrefetchPath: string }>
-    ) => {
-      const bodies = responses.map((response) => response.body)
-      const allBodies = bodies.join('\n')
-      const segmentPrefetchPaths = [
-        ...new Set(responses.map((response) => response.segmentPrefetchPath)),
-      ]
-
-      expect(bodies.length).toBeGreaterThan(0)
-      expect(allBodies.includes('%5BteamSlug%5D')).toBe(false)
-      expect(allBodies.includes('%5Bproject%5D')).toBe(false)
-      expect(
-        segmentPrefetchPaths.some((path) =>
-          path.startsWith('/acme/dashboard.segments/')
-        )
-      ).toBe(true)
-      expect(
-        segmentPrefetchPaths.some((path) =>
-          path.startsWith('/globex/portal.segments/')
-        )
-      ).toBe(true)
-      expect(
-        segmentPrefetchPaths.every(
-          (path) => path.includes('.segments/') && path.endsWith('.segment.rsc')
-        )
-      ).toBe(true)
     }
 
     const initialAcmeMarker = await readRouteMarker(
@@ -142,4 +465,86 @@ describe('segment cache - vary params base dynamic', () => {
       lastGlobexMarker = revalidatedGlobexMarker
     }
   })
+
+  it.each<RevalidateMode>([
+    'tag-layout-expireNow',
+    'tag-layout-max',
+    'tag-layout-legacy',
+    'path-root-layout',
+    'path-team-layout',
+    'path-team-page',
+  ])(
+    'keeps dynamic segment params valid after %s with in-view Link back/forward navigations',
+    async (mode) => {
+      await warmSegmentCache()
+      await triggerRevalidation(mode)
+
+      const navigationResult =
+        await collectSegmentPrefetchResponsesFromBackForwardNavigation()
+
+      assertValidSegmentResponses(navigationResult.responses)
+
+      expect(
+        navigationResult.pageErrors.some(
+          (error) =>
+            error.includes('Minified React error') ||
+            error.includes('not-found') ||
+            error.includes('Invariant')
+        )
+      ).toBe(false)
+    }
+  )
+
+  it.each<BrowserRevalidateMode>([
+    'tag-layout-expireNow',
+    'tag-layout-max',
+    'tag-layout-legacy',
+    'server-action-tag-layout-expireNow',
+    'server-action-tag-layout-max',
+    'server-action-tag-layout-legacy',
+  ])(
+    'keeps dynamic segment params valid when browser-triggered revalidation uses %s',
+    async (mode) => {
+      await warmSegmentCache()
+
+      const navigationResult =
+        await collectSegmentPrefetchResponsesFromBackForwardNavigation(mode)
+
+      assertValidSegmentResponses(navigationResult.responses)
+
+      expect(
+        navigationResult.pageErrors.some(
+          (error) =>
+            error.includes('Minified React error') ||
+            error.includes('not-found') ||
+            error.includes('Invariant')
+        )
+      ).toBe(false)
+    }
+  )
+
+  it.each<RevalidateMode>(['tag-layout-expireNow', 'tag-layout-legacy'])(
+    'keeps params valid for production route shape /[team]/[project]/settings/domains after %s',
+    async (mode) => {
+      await primeProductionShapeRouteCache()
+      await triggerRevalidation(mode)
+
+      const navigationResult =
+        await collectSegmentPrefetchResponsesFromProductionShapeNavigation()
+
+      assertValidSegmentResponses(navigationResult.responses, [
+        '/acme/dashboard/settings/domains',
+        '/globex/portal/settings/domains',
+      ])
+
+      expect(
+        navigationResult.pageErrors.some(
+          (error) =>
+            error.includes('Minified React error') ||
+            error.includes('not-found') ||
+            error.includes('Invariant')
+        )
+      ).toBe(false)
+    }
+  )
 })

--- a/test/e2e/app-dir/segment-cache/vary-params/pages/api/revalidate.ts
+++ b/test/e2e/app-dir/segment-cache/vary-params/pages/api/revalidate.ts
@@ -1,0 +1,22 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<{ revalidated: boolean }>
+) {
+  const pathParam = req.query['path']
+
+  if (!pathParam) {
+    return res.status(400).json({ revalidated: false })
+  }
+
+  const paths = Array.isArray(pathParam) ? pathParam : [pathParam]
+
+  try {
+    await Promise.all(paths.map((path) => res.revalidate(path)))
+    return res.status(200).json({ revalidated: true })
+  } catch (error) {
+    console.error('Failed to revalidate paths:', paths, error)
+    return res.status(500).json({ revalidated: false })
+  }
+}

--- a/test/e2e/app-dir/segment-cache/vary-params/root-params-segment-prefetch.test.ts
+++ b/test/e2e/app-dir/segment-cache/vary-params/root-params-segment-prefetch.test.ts
@@ -1,0 +1,61 @@
+import { nextTestSetup } from 'e2e-utils'
+import type * as Playwright from 'playwright'
+import { createRouterAct } from 'router-act'
+
+describe('segment cache - root params segment prefetch', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: __dirname,
+  })
+
+  if (isNextDev) {
+    test('prefetching is disabled in dev mode', () => {})
+    return
+  }
+
+  it('does not encode root param placeholders in segment-prefetch responses', async () => {
+    let act: ReturnType<typeof createRouterAct>
+    const segmentPrefetchBodies: Array<Promise<string>> = []
+    const browser = await next.browser('/root-params', {
+      beforePageLoad(p: Playwright.Page) {
+        act = createRouterAct(p)
+        p.on('response', (response) => {
+          const request = response.request()
+          if (request.headers()['next-router-segment-prefetch']) {
+            segmentPrefetchBodies.push(response.text().catch(() => ''))
+          }
+        })
+      },
+    })
+
+    await act(
+      async () => {
+        const toggle = await browser.elementByCss(
+          'input[data-link-accordion="/aaa"]'
+        )
+        await toggle.click()
+      },
+      { includes: 'Root param page content - param: aaa' }
+    )
+
+    await act(
+      async () => {
+        const toggle = await browser.elementByCss(
+          'input[data-link-accordion="/bbb"]'
+        )
+        await toggle.click()
+      },
+      { includes: 'Root param page content - param: bbb' }
+    )
+
+    const settledSegmentPrefetchBodies = await Promise.all(
+      segmentPrefetchBodies
+    )
+
+    expect(settledSegmentPrefetchBodies.length).toBeGreaterThan(0)
+    expect(
+      settledSegmentPrefetchBodies.some((body) =>
+        body.includes('%5BrootParam%5D')
+      )
+    ).toBe(false)
+  })
+})

--- a/test/e2e/css-data-url-global-pages/data-url-css.d.ts
+++ b/test/e2e/css-data-url-global-pages/data-url-css.d.ts
@@ -1,0 +1,2 @@
+// Test-local typing for Turbopack's CSS data URL side-effect import.
+declare module 'data:text/css,*' {}

--- a/test/e2e/rewrite-request-smuggling/next.config.js
+++ b/test/e2e/rewrite-request-smuggling/next.config.js
@@ -1,0 +1,13 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  async rewrites() {
+    return [
+      {
+        source: '/rewrites/:path*',
+        destination: `http://127.0.0.1:${process.env.TEST_INTERMEDIARY_PORT}/rewrites/:path*`,
+      },
+    ]
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/rewrite-request-smuggling/pages/index.tsx
+++ b/test/e2e/rewrite-request-smuggling/pages/index.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/e2e/rewrite-request-smuggling/rewrite-request-smuggling.test.ts
+++ b/test/e2e/rewrite-request-smuggling/rewrite-request-smuggling.test.ts
@@ -1,0 +1,234 @@
+import net from 'net'
+import http from 'http'
+import { createNext, NextInstance } from 'e2e-utils'
+import { findPort, retry } from 'next-test-utils'
+
+describe('rewrite-request-smuggling', () => {
+  if ((global as any).isNextDeploy) {
+    it('should skip deploy', () => {})
+    return
+  }
+
+  let backend: http.Server
+  let backendPort: number
+  let intermediary: http.Server
+  let intermediaryPort: number
+  let next: NextInstance
+  const backendRequests: string[] = []
+
+  async function sendSmugglingPayload({
+    nextPort,
+    connectionHeader,
+    method = 'DELETE',
+    rewritePath = '/rewrites/poc',
+  }: {
+    nextPort: number
+    connectionHeader: string
+    method?: 'DELETE' | 'OPTIONS'
+    rewritePath?: string
+  }) {
+    const smuggledRequest = Buffer.from(
+      `GET /secret HTTP/1.1\r\nHost: 127.0.0.1:${nextPort}\r\n\r\n`,
+      'latin1'
+    )
+    const chunkSize = Buffer.from(
+      `${smuggledRequest.length.toString(16).toUpperCase()}\r\n`,
+      'latin1'
+    )
+
+    const payload = Buffer.concat([
+      Buffer.from(
+        `${method} ${rewritePath} HTTP/1.1\r\nHost: 127.0.0.1:${nextPort}\r\nTransfer-Encoding: chunked\r\nConnection: ${connectionHeader}\r\n\r\n`,
+        'latin1'
+      ),
+      chunkSize,
+      smuggledRequest,
+      Buffer.from('\r\n0\r\n\r\n', 'latin1'),
+    ])
+
+    await new Promise<void>((resolve, reject) => {
+      const socket = net.createConnection({
+        host: '127.0.0.1',
+        port: nextPort,
+      })
+
+      socket.once('connect', () => {
+        socket.write(payload)
+      })
+      socket.once('error', reject)
+      socket.setTimeout(1000, () => socket.destroy())
+      socket.once('close', () => resolve())
+    })
+  }
+
+  beforeAll(async () => {
+    backendPort = await findPort()
+    intermediaryPort = await findPort()
+
+    backend = http.createServer((req, res) => {
+      backendRequests.push(`${req.method} ${req.url}`)
+
+      if (req.url?.startsWith('/rewrites/')) {
+        res.statusCode = 200
+        res.end('rewrite-ok')
+        return
+      }
+
+      if (req.url === '/secret') {
+        res.statusCode = 200
+        res.end('secret')
+        return
+      }
+
+      res.statusCode = 404
+      res.end('not-found')
+    })
+
+    intermediary = http.createServer((req, res) => {
+      const connectionHeader = Array.isArray(req.headers['connection'])
+        ? req.headers['connection'].join(',')
+        : req.headers['connection'] || ''
+      const hopByHopHeaders = connectionHeader
+        .split(',')
+        .map((h) => h.trim().toLowerCase())
+        .filter(Boolean)
+      const stripTransferEncodingUnconditionally =
+        req.url?.startsWith('/rewrites/non-rfc-strip') || false
+
+      const forwardHeaders: Record<string, string | string[]> = {}
+      for (const [key, value] of Object.entries(req.headers)) {
+        if (key === 'connection') continue
+        if (stripTransferEncodingUnconditionally && key === 'transfer-encoding')
+          continue
+        if (hopByHopHeaders.includes(key)) continue
+        if (value !== undefined) {
+          forwardHeaders[key] = value
+        }
+      }
+      forwardHeaders.connection = stripTransferEncodingUnconditionally
+        ? connectionHeader.toLowerCase().includes('close')
+          ? 'close'
+          : 'keep-alive'
+        : 'keep-alive'
+
+      const proxyReq = http.request(
+        {
+          hostname: '127.0.0.1',
+          port: backendPort,
+          method: req.method,
+          path: req.url,
+          headers: forwardHeaders,
+        },
+        (proxyRes) => {
+          res.writeHead(proxyRes.statusCode || 500, proxyRes.headers)
+          proxyRes.pipe(res)
+        }
+      )
+
+      proxyReq.on('error', () => {
+        res.statusCode = 502
+        res.end('Bad Gateway')
+      })
+
+      req.pipe(proxyReq)
+    })
+
+    await new Promise<void>((resolve, reject) => {
+      backend.listen(backendPort, '127.0.0.1', resolve)
+      backend.once('error', reject)
+    })
+
+    await new Promise<void>((resolve, reject) => {
+      intermediary.listen(intermediaryPort, '127.0.0.1', resolve)
+      intermediary.once('error', reject)
+    })
+
+    next = await createNext({
+      files: __dirname,
+      env: {
+        TEST_INTERMEDIARY_PORT: String(intermediaryPort),
+      },
+    })
+  })
+
+  afterAll(async () => {
+    await next?.destroy()
+    await new Promise<void>((resolve) => intermediary.close(() => resolve()))
+    await new Promise<void>((resolve) => backend.close(() => resolve()))
+  })
+
+  it('does not smuggle a second request when using keep-alive only', async () => {
+    backendRequests.length = 0
+
+    const nextPort = Number(new URL(next.url).port)
+    await sendSmugglingPayload({ nextPort, connectionHeader: 'keep-alive' })
+
+    await retry(async () => {
+      expect(backendRequests).toContain('DELETE /rewrites/poc')
+    })
+    expect(backendRequests).not.toContain('GET /secret')
+  })
+
+  it('does not smuggle a second request with keep-alive, upgrade', async () => {
+    backendRequests.length = 0
+
+    const nextPort = Number(new URL(next.url).port)
+    await sendSmugglingPayload({
+      nextPort,
+      connectionHeader: 'keep-alive, upgrade',
+    })
+
+    await retry(async () => {
+      expect(backendRequests).toContain('DELETE /rewrites/poc')
+    })
+    expect(backendRequests).not.toContain('GET /secret')
+  })
+
+  it('does not smuggle a second request with Transfer-Encoding, upgrade', async () => {
+    backendRequests.length = 0
+
+    const nextPort = Number(new URL(next.url).port)
+    await sendSmugglingPayload({
+      nextPort,
+      connectionHeader: 'Transfer-Encoding, upgrade',
+    })
+
+    await retry(async () => {
+      expect(backendRequests).toContain('DELETE /rewrites/poc')
+    })
+    expect(backendRequests).not.toContain('GET /secret')
+  })
+
+  it('does not smuggle a second request for OPTIONS with Transfer-Encoding, upgrade', async () => {
+    backendRequests.length = 0
+
+    const nextPort = Number(new URL(next.url).port)
+    await sendSmugglingPayload({
+      nextPort,
+      method: 'OPTIONS',
+      connectionHeader: 'Transfer-Encoding, upgrade',
+    })
+
+    await retry(async () => {
+      expect(backendRequests).toContain('OPTIONS /rewrites/poc')
+    })
+    expect(backendRequests).not.toContain('GET /secret')
+  })
+
+  it('does not smuggle a second request when an intermediary strips transfer-encoding unconditionally', async () => {
+    backendRequests.length = 0
+
+    const nextPort = Number(new URL(next.url).port)
+    await sendSmugglingPayload({
+      nextPort,
+      method: 'OPTIONS',
+      rewritePath: '/rewrites/non-rfc-strip',
+      connectionHeader: 'keep-alive, upgrade',
+    })
+
+    await retry(async () => {
+      expect(backendRequests).toContain('OPTIONS /rewrites/non-rfc-strip')
+    })
+    expect(backendRequests).not.toContain('GET /secret')
+  })
+})

--- a/test/integration/cli/test/index.test.ts
+++ b/test/integration/cli/test/index.test.ts
@@ -831,9 +831,14 @@ describe('CLI Usage', () => {
 
     test('-p reserved', async () => {
       const TCP_MUX_PORT = 1
-      const { stderr, stdout } = await runAndCaptureOutput({
-        port: TCP_MUX_PORT,
-      })
+      const { stderr, stdout } = await runNextCommand(
+        [dirBasic, '-p', '' + TCP_MUX_PORT],
+        {
+          stdout: true,
+          stderr: true,
+          ignoreFail: true,
+        }
+      )
 
       expect(stdout).toMatch('')
       expect(stderr).toMatch(


### PR DESCRIPTION
## Summary
- backport the fallback route params fix from #91737 onto `next-16-2`
- preserve intermediate shells that suspend only for unresolved fallback params during staged rendering
- add the missing `resolvedRouteParamKeys` request metadata needed by this branch
