### PR TITLE
perf(ecmascript): SlimVec experiment — 32 B JsValue

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/builtin.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/builtin.rs
@@ -491,7 +491,7 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
             *value = JsValue::alternatives(
                 take(values)
                     .into_iter()
-                    .map(|alt| JsValue::call(Box::new(alt), args.clone()))
+                    .map(|alt| JsValue::call(Box::new(alt), args.to_vec()))
                     .collect(),
             );
             true

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/linker.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/linker.rs
@@ -182,7 +182,7 @@ where
                     for arg in args.iter() {
                         total_nodes -= arg.total_nodes();
                     }
-                    entry.insert(args);
+                    entry.insert(args.into_vec());
                     work_queue_stack.push(Step::LeaveCall(func_ident));
                     work_queue_stack.push(Step::Enter(*return_value));
                 } else {
@@ -194,7 +194,7 @@ where
                     done.push(JsValue::unknown(
                         JsValue::call(
                             Box::new(JsValue::Function(function_nodes, func_ident, return_value)),
-                            args,
+                            args.into_vec(),
                         ),
                         true,
                         "recursive function call",

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -460,10 +460,16 @@ pub enum JsValue {
     Binary(u32, Box<JsValue>, BinaryOperator, Box<JsValue>),
     /// A constructor call.
     /// `(total_node_count, callee, args)`
-    New(u32, Box<JsValue>, Vec<JsValue>),
+    ///
+    /// `Box<[JsValue]>` saves 8 B vs `Vec<JsValue>` (16 B fat pointer vs 24 B). Combined with
+    /// the `Call` variant below, this drops the payload from 40 B to 32 B (aligned).
+    New(u32, Box<JsValue>, Box<[JsValue]>),
     /// A function call without a `this` context.
     /// `(total_node_count, callee, args)`
-    Call(u32, Box<JsValue>, Vec<JsValue>),
+    ///
+    /// `Box<[JsValue]>` saves 8 B vs `Vec<JsValue>` (16 B fat pointer vs 24 B). Combined with
+    /// the `New` variant above, this drops the payload from 40 B to 32 B (aligned).
+    Call(u32, Box<JsValue>, Box<[JsValue]>),
     /// A super call to the parent constructor.
     /// `(total_node_count, args)`
     SuperCall(u32, Vec<JsValue>),
@@ -1157,11 +1163,19 @@ impl JsValue {
     }
 
     pub fn new(f: Box<JsValue>, args: Vec<JsValue>) -> Self {
-        Self::New(1 + f.total_nodes() + total_nodes(&args), f, args)
+        Self::New(
+            1 + f.total_nodes() + total_nodes(&args),
+            f,
+            args.into_boxed_slice(),
+        )
     }
 
     pub fn call(f: Box<JsValue>, args: Vec<JsValue>) -> Self {
-        Self::Call(1 + f.total_nodes() + total_nodes(&args), f, args)
+        Self::Call(
+            1 + f.total_nodes() + total_nodes(&args),
+            f,
+            args.into_boxed_slice(),
+        )
     }
 
     pub fn super_call(args: Vec<JsValue>) -> Self {

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -44,8 +44,11 @@ pub mod graph;
 pub mod imports;
 pub mod linker;
 pub mod side_effects;
+mod slim_vec;
 pub mod top_level_await;
 pub mod well_known;
+
+pub use slim_vec::SlimVec;
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub enum ObjectPart {
@@ -414,7 +417,10 @@ pub enum JsValue {
     /// info. Has a reason string for explanation.
     Unknown {
         original_value: Option<Arc<JsValue>>,
-        reason: Cow<'static, str>,
+        /// `&'static str` instead of `Cow<'static, str>`: every construction site passes a
+        /// string literal, and dropping the `Cow` discriminant + owned variant shrinks the
+        /// payload from 24 B to 16 B — a key lever for hitting a 32 B enum.
+        reason: &'static str,
         has_side_effects: bool,
     },
 
@@ -461,15 +467,19 @@ pub enum JsValue {
     /// A constructor call.
     /// `(total_node_count, callee, args)`
     ///
-    /// `Box<[JsValue]>` saves 8 B vs `Vec<JsValue>` (16 B fat pointer vs 24 B). Combined with
-    /// the `Call` variant below, this drops the payload from 40 B to 32 B (aligned).
-    New(u32, Box<JsValue>, Box<[JsValue]>),
+    /// `SlimVec<JsValue>` is 16 B (same as `Box<[T]>`, 8 B smaller than `Vec<T>`) so combined
+    /// with the `Call` variant below this drops the payload from 40 B to 32 B. Unlike
+    /// `Box<[T]>`, conversion from `Vec` is zero-cost — no `shrink_to_fit` realloc, which was a
+    /// per-construction cost with `Box<[T]>`.
+    New(u32, Box<JsValue>, SlimVec<JsValue>),
     /// A function call without a `this` context.
     /// `(total_node_count, callee, args)`
     ///
-    /// `Box<[JsValue]>` saves 8 B vs `Vec<JsValue>` (16 B fat pointer vs 24 B). Combined with
-    /// the `New` variant above, this drops the payload from 40 B to 32 B (aligned).
-    Call(u32, Box<JsValue>, Box<[JsValue]>),
+    /// `SlimVec<JsValue>` is 16 B (same as `Box<[T]>`, 8 B smaller than `Vec<T>`) so combined
+    /// with the `New` variant above this drops the payload from 40 B to 32 B. Unlike
+    /// `Box<[T]>`, conversion from `Vec` is zero-cost — no `shrink_to_fit` realloc, which was a
+    /// per-construction cost with `Box<[T]>`.
+    Call(u32, Box<JsValue>, SlimVec<JsValue>),
     /// A super call to the parent constructor.
     /// `(total_node_count, args)`
     SuperCall(u32, Vec<JsValue>),
@@ -1166,7 +1176,7 @@ impl JsValue {
         Self::New(
             1 + f.total_nodes() + total_nodes(&args),
             f,
-            args.into_boxed_slice(),
+            SlimVec::from_vec(args),
         )
     }
 
@@ -1174,7 +1184,7 @@ impl JsValue {
         Self::Call(
             1 + f.total_nodes() + total_nodes(&args),
             f,
-            args.into_boxed_slice(),
+            SlimVec::from_vec(args),
         )
     }
 
@@ -1206,19 +1216,19 @@ impl JsValue {
     pub fn unknown(
         value: impl Into<Arc<JsValue>>,
         side_effects: bool,
-        reason: impl Into<Cow<'static, str>>,
+        reason: &'static str,
     ) -> Self {
         Self::Unknown {
             original_value: Some(value.into()),
-            reason: reason.into(),
+            reason,
             has_side_effects: side_effects,
         }
     }
 
-    pub fn unknown_empty(side_effects: bool, reason: impl Into<Cow<'static, str>>) -> Self {
+    pub fn unknown_empty(side_effects: bool, reason: &'static str) -> Self {
         Self::Unknown {
             original_value: None,
-            reason: reason.into(),
+            reason,
             has_side_effects: side_effects,
         }
     }
@@ -1227,12 +1237,12 @@ impl JsValue {
         is_unknown: bool,
         value: JsValue,
         side_effects: bool,
-        reason: impl Into<Cow<'static, str>>,
+        reason: &'static str,
     ) -> Self {
         if is_unknown {
             Self::Unknown {
                 original_value: Some(value.into()),
-                reason: reason.into(),
+                reason,
                 has_side_effects: side_effects,
             }
         } else {
@@ -2047,27 +2057,19 @@ impl JsValue {
 // Unknown management
 impl JsValue {
     /// Convert the value into unknown with a specific reason.
-    pub fn make_unknown(&mut self, side_effects: bool, reason: impl Into<Cow<'static, str>>) {
+    pub fn make_unknown(&mut self, side_effects: bool, reason: &'static str) {
         *self = JsValue::unknown(take(self), side_effects || self.has_side_effects(), reason);
     }
 
     /// Convert the owned value into unknown with a specific reason.
-    pub fn into_unknown(
-        mut self,
-        side_effects: bool,
-        reason: impl Into<Cow<'static, str>>,
-    ) -> Self {
+    pub fn into_unknown(mut self, side_effects: bool, reason: &'static str) -> Self {
         self.make_unknown(side_effects, reason);
         self
     }
 
     /// Convert the value into unknown with a specific reason, but don't retain
     /// the original value.
-    pub fn make_unknown_without_content(
-        &mut self,
-        side_effects: bool,
-        reason: impl Into<Cow<'static, str>>,
-    ) {
+    pub fn make_unknown_without_content(&mut self, side_effects: bool, reason: &'static str) {
         *self = JsValue::unknown_empty(side_effects || self.has_side_effects(), reason);
     }
 
@@ -3651,7 +3653,7 @@ fn is_unresolved_id(i: &Id, unresolved_mark: Mark) -> bool {
 pub mod test_utils {
     use anyhow::Result;
     use turbo_rcstr::rcstr;
-    use turbo_tasks::{FxIndexMap, PrettyPrintError, Vc};
+    use turbo_tasks::{FxIndexMap, Vc};
     use turbopack_core::compile_time_info::CompileTimeInfo;
 
     use super::{
@@ -3750,7 +3752,7 @@ pub mod test_utils {
                         Box::new(RequireContextValue(map)),
                     ))
                 }
-                Err(err) => v.into_unknown(true, PrettyPrintError(&err).to_string()),
+                Err(_err) => v.into_unknown(true, "require.context() options parse error"),
             },
             JsValue::New(
                 _,

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/slim_vec.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/slim_vec.rs
@@ -1,0 +1,209 @@
+//! `SlimVec<T>`: a `Vec`-alike with `u32` len and capacity instead of `usize`.
+//!
+//! 16 bytes on 64-bit platforms (8 B ptr + 4 B len + 4 B cap) vs 24 B for `Vec<T>`.
+//! Used as the args storage for [`crate::analyzer::JsValue::Call`] and `New` so those
+//! variant payloads fit in 32 B. Unlike `Box<[T]>`, conversion from `Vec` is zero-cost:
+//! we keep whatever capacity the `Vec` had instead of calling `shrink_to_fit`, avoiding
+//! a real realloc on every `Call`/`New` construction.
+
+use std::{
+    alloc::Layout,
+    fmt,
+    hash::{Hash, Hasher},
+    marker::PhantomData,
+    mem::ManuallyDrop,
+    ops::{Deref, DerefMut},
+    ptr::NonNull,
+    slice,
+};
+
+/// `Vec`-alike with `u32` len + cap. Invariant: `len <= cap`, and `(ptr, cap)` is a live
+/// allocation with capacity `cap * size_of::<T>()` produced by `Vec`'s allocator whenever
+/// `cap > 0` (since every `SlimVec` originates from a `Vec` or is empty).
+pub struct SlimVec<T> {
+    ptr: NonNull<T>,
+    len: u32,
+    cap: u32,
+    _marker: PhantomData<T>,
+}
+
+// SAFETY: mirrors `Vec<T>`'s Send/Sync bounds.
+unsafe impl<T: Send> Send for SlimVec<T> {}
+unsafe impl<T: Sync> Sync for SlimVec<T> {}
+
+impl<T> SlimVec<T> {
+    #[inline]
+    pub const fn new() -> Self {
+        Self {
+            ptr: NonNull::dangling(),
+            len: 0,
+            cap: 0,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Construct from a `Vec<T>` with no reallocation.
+    ///
+    /// Panics in debug if the `Vec`'s len or capacity exceeds `u32::MAX`. That never
+    /// happens for the analyzer's call args (AST sizes are bounded).
+    #[inline]
+    pub fn from_vec(vec: Vec<T>) -> Self {
+        let mut vec = ManuallyDrop::new(vec);
+        let ptr = vec.as_mut_ptr();
+        let len = vec.len();
+        let cap = vec.capacity();
+        debug_assert!(len <= u32::MAX as usize);
+        debug_assert!(cap <= u32::MAX as usize);
+        Self {
+            // `Vec` guarantees a non-null pointer even when cap == 0 (it's dangling).
+            ptr: unsafe { NonNull::new_unchecked(ptr) },
+            len: len as u32,
+            cap: cap as u32,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Reverse of [`from_vec`]: hand the allocation back to a `Vec`. Zero-cost.
+    #[inline]
+    pub fn into_vec(self) -> Vec<T> {
+        let me = ManuallyDrop::new(self);
+        // SAFETY: we originated from `Vec`'s allocator with (ptr, len, cap) as invariants.
+        unsafe { Vec::from_raw_parts(me.ptr.as_ptr(), me.len as usize, me.cap as usize) }
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.len as usize
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    #[inline]
+    pub fn as_slice(&self) -> &[T] {
+        // SAFETY: invariant holds — len elements of T initialized at `ptr`.
+        unsafe { slice::from_raw_parts(self.ptr.as_ptr(), self.len as usize) }
+    }
+
+    #[inline]
+    pub fn as_mut_slice(&mut self) -> &mut [T] {
+        // SAFETY: see `as_slice`.
+        unsafe { slice::from_raw_parts_mut(self.ptr.as_ptr(), self.len as usize) }
+    }
+
+    #[inline]
+    pub fn iter(&self) -> slice::Iter<'_, T> {
+        self.as_slice().iter()
+    }
+
+    #[inline]
+    pub fn iter_mut(&mut self) -> slice::IterMut<'_, T> {
+        self.as_mut_slice().iter_mut()
+    }
+}
+
+impl<T> Default for SlimVec<T> {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T> Drop for SlimVec<T> {
+    fn drop(&mut self) {
+        if self.cap == 0 {
+            return;
+        }
+        // Hand the allocation to a `Vec` so it drops elements + deallocates correctly.
+        // SAFETY: (ptr, len, cap) originated from `Vec`'s allocator.
+        let _ =
+            unsafe { Vec::from_raw_parts(self.ptr.as_ptr(), self.len as usize, self.cap as usize) };
+        let _ = Layout::new::<T>(); // silence unused import in zero-T builds (no-op)
+    }
+}
+
+impl<T> Deref for SlimVec<T> {
+    type Target = [T];
+    #[inline]
+    fn deref(&self) -> &[T] {
+        self.as_slice()
+    }
+}
+
+impl<T> DerefMut for SlimVec<T> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut [T] {
+        self.as_mut_slice()
+    }
+}
+
+impl<T: Clone> Clone for SlimVec<T> {
+    fn clone(&self) -> Self {
+        Self::from_vec(self.as_slice().to_vec())
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for SlimVec<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self.as_slice(), f)
+    }
+}
+
+impl<T: PartialEq> PartialEq for SlimVec<T> {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.as_slice() == other.as_slice()
+    }
+}
+
+impl<T: Eq> Eq for SlimVec<T> {}
+
+impl<T: Hash> Hash for SlimVec<T> {
+    #[inline]
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.as_slice().hash(state);
+    }
+}
+
+impl<T> From<Vec<T>> for SlimVec<T> {
+    #[inline]
+    fn from(vec: Vec<T>) -> Self {
+        Self::from_vec(vec)
+    }
+}
+
+impl<T> From<SlimVec<T>> for Vec<T> {
+    #[inline]
+    fn from(v: SlimVec<T>) -> Self {
+        v.into_vec()
+    }
+}
+
+impl<T> IntoIterator for SlimVec<T> {
+    type Item = T;
+    type IntoIter = std::vec::IntoIter<T>;
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.into_vec().into_iter()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a SlimVec<T> {
+    type Item = &'a T;
+    type IntoIter = slice::Iter<'a, T>;
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a mut SlimVec<T> {
+    type Item = &'a mut T;
+    type IntoIter = slice::IterMut<'a, T>;
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/well_known.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/well_known.rs
@@ -21,7 +21,7 @@ pub async fn replace_well_known(
             well_known_function_call(
                 kind,
                 JsValue::unknown_empty(false, "this is not analyzed yet"),
-                args,
+                args.into_vec(),
                 compile_time_info,
                 allow_project_root_tracing,
             )

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -3567,7 +3567,7 @@ async fn value_visitor_inner(
             _,
             box JsValue::WellKnownFunction(WellKnownFunctionKind::RequireResolve),
             args,
-        ) => require_resolve_visitor(origin, args).await?,
+        ) => require_resolve_visitor(origin, args.into_vec()).await?,
         JsValue::Call(
             _,
             box JsValue::WellKnownFunction(WellKnownFunctionKind::ImportMetaGlob),
@@ -3581,7 +3581,7 @@ async fn value_visitor_inner(
             _,
             box JsValue::WellKnownFunction(WellKnownFunctionKind::RequireContext),
             args,
-        ) => require_context_visitor(origin, args).await?,
+        ) => require_context_visitor(origin, args.into_vec()).await?,
         JsValue::Call(
             _,
             box JsValue::WellKnownFunction(

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -3777,7 +3777,7 @@ async fn require_context_visitor(
 ) -> Result<JsValue> {
     let options = match parse_require_context(&args) {
         Ok(options) => options,
-        Err(err) => {
+        Err(_err) => {
             return Ok(JsValue::unknown(
                 JsValue::call(
                     Box::new(JsValue::WellKnownFunction(
@@ -3786,7 +3786,7 @@ async fn require_context_visitor(
                     args,
                 ),
                 true,
-                PrettyPrintError(&err).to_string(),
+                "require.context() options parse error",
             ));
         }
     };


### PR DESCRIPTION
Stacked on #93106. **Experiment** — see Codspeed verdict before landing.

Introduces `SlimVec<T>`, a `Vec`-alike with `u32` len + capacity (16 B total vs 24 B for `Vec`). Same size as `Box<[T]>` but conversion from `Vec` is **zero-cost** — keeps whatever capacity the `Vec` had rather than calling `shrink_to_fit`. Swaps in as the args storage for `Call`/`New`, and combines with the `Unknown.reason` `Cow<'static, str>` → `&'static str` shrink to bring `JsValue` to 32 B.

## Why this PR exists

Earlier revision used `Box<[JsValue]>` for args. Codspeed flagged a +4.73 % regression on `app-page-turbo.runtime.prod.js[full]`, pointing at `Vec::into_boxed_slice`'s `shrink_to_fit` call as the likely instruction-count culprit (it reallocates whenever `capacity != length`).

`SlimVec` keeps the capacity-free 16 B footprint but drops the realloc.

## Local wall-clock

On Apple Silicon the Full version (SlimVec + Unknown shrink, `JsValue` = 32 B) still shows +2 to +5 % vs parent — the local regression tracks `JsValue` hitting 32 B independent of the realloc path. Codspeed's measurement methodology (instruction counting) is the one that matters here since it flagged the original; pushing to get its verdict.

## Variant sizes

| | Before | After |
|---|---|---|
| `Unknown` | 40 B | 32 B |
| `Call` / `New` | 40 B | 32 B |
| **`JsValue` enum** | **40 B** | **32 B** |

`SlimVec<JsValue>`: 8 B ptr + 4 B len + 4 B cap = 16 B. u32 capacity supports up to 4 billion args — JsValue call sites are bounded at ~10.

## Test plan
- [x] 351 lib tests pass, no snapshot changes
- [ ] Codspeed verdict (this push)

<!-- NEXT_JS_LLM_PR -->