### PR TITLE
docs: fix typos in examples

### DIFF
--- a/examples/cms-sitefinity/README.md
+++ b/examples/cms-sitefinity/README.md
@@ -95,7 +95,7 @@ cp .env.local.example .env.local
 
 Then set each variable on `.env.local`
 
-- `SF_API_URL` - This is the url of the 'Default' web service that we configured earlier. E.g. http://locahost/api/default/
+- `SF_API_URL` - This is the url of the 'Default' web service that we configured earlier. E.g. http://localhost/api/default/
 - `SF_URL` - This is the URL of the CMS itself. E.g. http://localhost/
 
 ### Step 6. Run Next.js in development mode

--- a/examples/prisma-postgres/prisma/seed.ts
+++ b/examples/prisma-postgres/prisma/seed.ts
@@ -88,14 +88,14 @@ async function main() {
       {
         title: "Designing Scalable Schemas with Prisma",
         content:
-          "Phasellus ut erat nec elit ultricies egestas. Vestibulum rhoncus urna eget magna varius pharetra.",
+          "Phasellus ut erat nec elit ultricies egestas. Vestibulum rhoncus urna eget magna various pharetra.",
         published: true,
         authorId: userIdMapping.diana!,
       },
       {
         title: "Handling Relations Between Models in ORMs",
         content:
-          "Integer luctus ac augue at tristique. Curabitur varius nisl vitae mi fringilla, vel tincidunt nunc dictum.",
+          "Integer luctus ac augue at tristique. Curabitur various nisl vitae mi fringilla, vel tincidunt nunc dictum.",
         published: false,
         authorId: userIdMapping.diana!,
       },


### PR DESCRIPTION
Fixes spelling errors in example documentation and code:\n- 'locahost' → 'localhost' in cms-sitefinity README\n- 'varius' → 'various' in prisma-postgres seed.ts