### PR TITLE
[tests]: fix cache-components.test.ts type error

### DIFF
--- a/test/e2e/app-dir/cache-components/cache-components.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.test.ts
@@ -439,7 +439,7 @@ describe('cache-components', () => {
 
         const stateTree = JSON.stringify(['', {}])
         const requestUrl = new URL('/cases/static', `http://localhost:${port}`)
-        const cacheBustingParam = computeCacheBustingSearchParam(
+        const cacheBustingParam = await computeCacheBustingSearchParam(
           undefined,
           undefined,
           stateTree,


### PR DESCRIPTION
Fixes a type error on canary after merging two PRs that touched the same test.