### PR TITLE
Turbopack: add memory usage to trace server initial read report

### DIFF
--- a/turbopack/crates/turbopack-trace-server/src/reader/mod.rs
+++ b/turbopack/crates/turbopack-trace-server/src/reader/mod.rs
@@ -15,6 +15,7 @@ use std::{
 
 use anyhow::Result;
 use flate2::bufread::GzDecoder;
+use turbo_tasks_malloc::TurboMalloc;
 
 use crate::{
     reader::{heaptrack::HeaptrackFormat, nextjs::NextJsFormat, turbopack::TurbopackFormat},
@@ -343,9 +344,10 @@ impl TraceReader {
             }
             if total > MIN_INITIAL_REPORT_SIZE {
                 println!(
-                    "Initial read completed ({} MB, {}s)",
+                    "Initial read completed ({} MB, {}s, Memory usage: {} GB)",
                     total / (1024 * 1024),
-                    (start.elapsed().as_millis() / 100) as f32 / 10.0
+                    (start.elapsed().as_millis() / 100) as f32 / 10.0,
+                    (TurboMalloc::memory_usage() * 10 / (1024 * 1024 * 1024)) as f32 / 10.0
                 );
             }
         }


### PR DESCRIPTION
### What?

Adds current process memory usage (reported by `TurboMalloc`) to the "Initial read completed" log line emitted by the `turbopack-trace-server` after finishing its initial read of a trace file.

Before:
```
Initial read completed (1234 MB, 5.6s)
```

After:
```
Initial read completed (1234 MB, 5.6s, Memory usage: 3.4 GB)
```

### Why?

When loading large traces, the trace server can use significantly more memory than the raw size of the trace file. Surfacing the resident memory usage alongside the existing size/duration metrics makes it easy to see the real memory cost of a trace at a glance, which helps when diagnosing OOMs and comparing the memory overhead of different trace formats or trace sizes.

### How?

- Imports `TurboMalloc` from `turbo_tasks_malloc` in `turbopack/crates/turbopack-trace-server/src/reader/mod.rs`.
- Extends the `Initial read completed` `println!` to include `TurboMalloc::memory_usage()` formatted as gigabytes with one decimal place.

<!-- NEXT_JS_LLM_PR -->