### PR TITLE
[turbopack] Fix max_level_hint to return most verbose per-target level

### DIFF
--- a/turbopack/crates/turbopack-trace-utils/src/filter_layer.rs
+++ b/turbopack/crates/turbopack-trace-utils/src/filter_layer.rs
@@ -51,6 +51,13 @@ impl<S: Subscriber> Layer<S> for FilterLayer {
     }
 
     fn max_level_hint(&self) -> Option<LevelFilter> {
-        self.config.values().copied().max()
+        Some(
+            self.config
+                .values()
+                .copied()
+                .max()
+                .unwrap_or(LevelFilter::OFF)
+                .max(self.global_level),
+        )
     }
 }

--- a/turbopack/crates/turbopack-trace-utils/src/filter_layer.rs
+++ b/turbopack/crates/turbopack-trace-utils/src/filter_layer.rs
@@ -51,6 +51,6 @@ impl<S: Subscriber> Layer<S> for FilterLayer {
     }
 
     fn max_level_hint(&self) -> Option<LevelFilter> {
-        self.config.values().copied().min()
+        self.config.values().copied().max()
     }
 }


### PR DESCRIPTION
### What?

Fix `FilterLayer::max_level_hint` in `turbopack-trace-utils` to return the most verbose `LevelFilter` across per-target configs instead of the least verbose one.

### Why?

`tracing`'s `Subscriber` uses `max_level_hint` to short-circuit event dispatch globally: any event whose level is more verbose than the hint is dropped before `enabled()` is consulted. The previous implementation returned `self.config.values().copied().min()`, i.e. the *least* verbose configured level. As soon as any target was filtered to a low verbosity (e.g. `WARN`), events at more verbose levels (`INFO`/`DEBUG`/`TRACE`) were discarded for *all* targets, even those whose own per-target config would have allowed them.

### How?

Swap `min()` → `max()` in `FilterLayer::max_level_hint` so the hint reflects the most verbose level any configured target could enable. Per-target filtering in `enabled()` is unchanged and continues to enforce the correct level for each target.

<!-- NEXT_JS_LLM_PR -->