### PR TITLE
test: don't show turborepo UI for `pack-for-isolated-tests`

### DIFF
--- a/test/lib/create-next-install.js
+++ b/test/lib/create-next-install.js
@@ -81,12 +81,36 @@ async function createNextInstall({
         pkgPaths = new Map(JSON.parse(pkgPathsEnv))
         require('console').log('using provided pkg paths')
       } else {
-        await rootSpan.traceChild('turbo-run-pack').traceAsyncFn(() =>
-          execa('pnpm', ['turbo', 'run', 'pack-for-isolated-tests'], {
-            cwd: origRepoDir,
-            stdio: ['ignore', 'inherit', 'inherit'],
-          })
-        )
+        await rootSpan.traceChild('turbo-run-pack').traceAsyncFn(async () => {
+          const result = await execa(
+            'pnpm',
+            [
+              'turbo',
+              'run',
+              'pack-for-isolated-tests',
+              // minimize output
+              '--output-logs=errors-only',
+              '--summarize=false',
+              // disable interactive UI when running in a terminal
+              '--ui=stream',
+            ],
+            {
+              cwd: origRepoDir,
+              stdio: ['ignore', 'pipe', 'pipe'],
+              env: {
+                NO_UPDATE_NOTIFIER: '1', // Disable banner informing about new turborepo version
+              },
+              reject: false,
+            }
+          )
+          // Only log output if the command errored, otherwise it's just noise
+          if (result.failed) {
+            require('console').error(result.all)
+            throw new Error(
+              'Errors occurred when running turbo-run-pack, see output above'
+            )
+          }
+        })
 
         if (process.env.NEXT_TEST_WASM) {
           const wasmPath = path.join(origRepoDir, 'crates', 'wasm', 'pkg')


### PR DESCRIPTION
Since #92575, we're running `turbo` inside `createNextInstall`. When run from my terminal, this shows interactive turbo UI, which is 1. very garbled, interleaving jest and turborepo, and 2. entirely unnecessary and distracting:

<img width="1512" height="982" alt="Screenshot 2026-04-22 at 15 22 41" src="https://github.com/user-attachments/assets/506ce8d0-4a46-4c06-b13a-f648153e9cf9" />

This PR fixes this. We capture the task output and only print it if packing failed -- otherwise, it's not interesting and can be hidden.