### PR TITLE
docs(static-exports): list Middleware as an unsupported feature

### DIFF
--- a/docs/01-app/02-guides/static-exports.mdx
+++ b/docs/01-app/02-guides/static-exports.mdx
@@ -280,6 +280,7 @@ Features that require a Node.js server, or dynamic logic that cannot be computed
 - [Dynamic Routes](/docs/app/api-reference/file-conventions/dynamic-routes) with `dynamicParams: true`
 - [Dynamic Routes](/docs/app/api-reference/file-conventions/dynamic-routes) without `generateStaticParams()`
 - [Route Handlers](/docs/app/api-reference/file-conventions/route) that rely on Request
+- [Middleware](/docs/app/api-reference/file-conventions/middleware)
 - [Cookies](/docs/app/api-reference/functions/cookies)
 - [Rewrites](/docs/app/api-reference/config/next-config-js/rewrites)
 - [Redirects](/docs/app/api-reference/config/next-config-js/redirects)
@@ -303,6 +304,7 @@ export const dynamic = 'error'
 
 - [Internationalized Routing](/docs/pages/guides/internationalization)
 - [API Routes](/docs/pages/building-your-application/routing/api-routes)
+- [Middleware](/docs/app/api-reference/file-conventions/middleware)
 - [Rewrites](/docs/pages/api-reference/config/next-config-js/rewrites)
 - [Redirects](/docs/pages/api-reference/config/next-config-js/redirects)
 - [Headers](/docs/pages/api-reference/config/next-config-js/headers)


### PR DESCRIPTION
### What?

Add \`Middleware\` to the \"Unsupported Features\" list of the static-exports guide, for both the App Router and Pages Router sections.

\`\`\`diff
  - [Route Handlers](/docs/app/api-reference/file-conventions/route) that rely on Request
+ - [Middleware](/docs/app/api-reference/file-conventions/middleware)
\`\`\`

\`docs/01-app/02-guides/static-exports.mdx\` only; the Pages Router version of the page is a \`source:\` re-export of the same file, so one edit covers both.

### Why?

Next.js actively errors when \`output: \"export\"\` is combined with a root-level \`middleware.ts\`/\`middleware.js\`:

> \`Middleware cannot be used with \"output: export\"\`

Raised here:
- [\`packages/next/src/server/lib/router-utils/setup-dev-bundler.ts#L571-L574\`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts)

The existing unsupported-features list already covers Route Handlers that depend on \`Request\`, Cookies, Server Actions, Rewrites/Redirects/Headers, etc. Middleware is omitted even though it triggers the same class of build-time rejection. I hit this while wiring a Next.js 14 app to deploy to Firebase Hosting — the error surfaces at \`next dev\` / \`next build\` startup with no pointer back to this guide, and this guide implies anything not on the list should work.

### How?

Single-line addition in both list blocks. Link target is \`/docs/app/api-reference/file-conventions/middleware\` — the canonical middleware doc (the same target other pages use when linking \`[Middleware]\` from Pages-Router content, per \`grep -r '\\[Middleware\\](' docs/\`).

### Checks

- \`npx prettier --check docs/01-app/02-guides/static-exports.mdx\` → passes.
- Docs-only; no code, telemetry, or test changes.

Closes the discoverability gap flagged in the dev-time error messages that reference this same guide URL.