### PR TITLE
fix: normalize implicit cache tags for non-ASCII paths

### DIFF
--- a/packages/next/src/server/lib/cache-tag-path.test.ts
+++ b/packages/next/src/server/lib/cache-tag-path.test.ts
@@ -1,0 +1,21 @@
+import { normalizePathnameToCacheTag } from './cache-tag-path'
+
+describe('normalizePathnameToCacheTag()', () => {
+  it('encodes non-ascii path segments', () => {
+    expect(normalizePathnameToCacheTag('/wiki/ヤクルト')).toBe(
+      '/wiki/%E3%83%A4%E3%82%AF%E3%83%AB%E3%83%88'
+    )
+  })
+
+  it('does not double-encode already encoded path segments', () => {
+    expect(
+      normalizePathnameToCacheTag('/wiki/%E3%83%A4%E3%82%AF%E3%83%AB%E3%83%88')
+    ).toBe('/wiki/%E3%83%A4%E3%82%AF%E3%83%AB%E3%83%88')
+  })
+
+  it('handles malformed segments by encoding them safely', () => {
+    expect(normalizePathnameToCacheTag('/wiki/%E3%83%A4%ZZ')).toBe(
+      '/wiki/%25E3%2583%25A4%25ZZ'
+    )
+  })
+})

--- a/packages/next/src/server/lib/cache-tag-path.ts
+++ b/packages/next/src/server/lib/cache-tag-path.ts
@@ -1,0 +1,23 @@
+/**
+ * Cache tags are serialized into HTTP headers, so each path segment must be
+ * ASCII-safe. We canonicalize every segment by decoding (when possible) and
+ * re-encoding, which also prevents double-encoding existing `%xx` segments.
+ */
+export function normalizePathnameToCacheTag(pathname: string): string {
+  return pathname
+    .split('/')
+    .map((segment) => {
+      if (!segment) return segment
+
+      try {
+        return encodeURIComponent(decodeURIComponent(segment))
+          .replace(/%5B/g, '[')
+          .replace(/%5D/g, ']')
+      } catch {
+        return encodeURIComponent(segment)
+          .replace(/%5B/g, '[')
+          .replace(/%5D/g, ']')
+      }
+    })
+    .join('/')
+}

--- a/packages/next/src/server/lib/implicit-tags.test.ts
+++ b/packages/next/src/server/lib/implicit-tags.test.ts
@@ -73,6 +73,30 @@ describe('getImplicitTags()', () => {
         '_N_T_/foo/bar/baz',
       ],
     },
+    {
+      page: '/wiki/[slug]/page',
+      pathname: '/wiki/ヤクルト',
+      fallbackRouteParams: null,
+      expectedTags: [
+        '_N_T_/layout',
+        '_N_T_/wiki/layout',
+        '_N_T_/wiki/[slug]/layout',
+        '_N_T_/wiki/[slug]/page',
+        '_N_T_/wiki/%E3%83%A4%E3%82%AF%E3%83%AB%E3%83%88',
+      ],
+    },
+    {
+      page: '/wiki/[slug]/page',
+      pathname: '/wiki/%E3%83%A4%E3%82%AF%E3%83%AB%E3%83%88',
+      fallbackRouteParams: null,
+      expectedTags: [
+        '_N_T_/layout',
+        '_N_T_/wiki/layout',
+        '_N_T_/wiki/[slug]/layout',
+        '_N_T_/wiki/[slug]/page',
+        '_N_T_/wiki/%E3%83%A4%E3%82%AF%E3%83%AB%E3%83%88',
+      ],
+    },
   ])(
     'for page $page with pathname $pathname',
     async ({ page, pathname, fallbackRouteParams, expectedTags }) => {

--- a/packages/next/src/server/lib/implicit-tags.ts
+++ b/packages/next/src/server/lib/implicit-tags.ts
@@ -2,6 +2,7 @@ import { NEXT_CACHE_IMPLICIT_TAG_ID } from '../../lib/constants'
 import type { OpaqueFallbackRouteParams } from '../request/fallback-params'
 import { getCacheHandlerEntries } from '../use-cache/handlers'
 import { createLazyResult, type LazyResult } from './lazy-result'
+import { normalizePathnameToCacheTag } from './cache-tag-path'
 
 export interface ImplicitTags {
   /**
@@ -81,14 +82,14 @@ export async function getImplicitTags(
   // Add the derived tags from the page.
   const derivedTags = getDerivedTags(page)
   for (let tag of derivedTags) {
-    tag = `${NEXT_CACHE_IMPLICIT_TAG_ID}${tag}`
+    tag = `${NEXT_CACHE_IMPLICIT_TAG_ID}${normalizePathnameToCacheTag(tag)}`
     tags.add(tag)
   }
 
   // Add the tags from the pathname. If the route has unknown params, we don't
   // want to add the pathname as a tag, as it will be invalid.
   if (pathname && (!fallbackRouteParams || fallbackRouteParams.size === 0)) {
-    const tag = `${NEXT_CACHE_IMPLICIT_TAG_ID}${pathname}`
+    const tag = `${NEXT_CACHE_IMPLICIT_TAG_ID}${normalizePathnameToCacheTag(pathname)}`
     tags.add(tag)
   }
 

--- a/packages/next/src/server/web/spec-extension/revalidate.ts
+++ b/packages/next/src/server/web/spec-extension/revalidate.ts
@@ -16,6 +16,7 @@ import {
   ActionDidRevalidateStaticAndDynamic as ActionDidRevalidate,
 } from '../../../shared/lib/action-revalidation-kind'
 import { removeTrailingSlash } from '../../../shared/lib/router/utils/remove-trailing-slash'
+import { normalizePathnameToCacheTag } from '../../lib/cache-tag-path'
 
 type CacheLifeConfig = {
   expire?: number
@@ -97,7 +98,9 @@ export function revalidatePath(originalPath: string, type?: 'layout' | 'page') {
     return
   }
 
-  let normalizedPath = `${NEXT_CACHE_IMPLICIT_TAG_ID}${removeTrailingSlash(originalPath)}`
+  let normalizedPath = `${NEXT_CACHE_IMPLICIT_TAG_ID}${removeTrailingSlash(
+    normalizePathnameToCacheTag(originalPath)
+  )}`
 
   if (type) {
     normalizedPath += `${normalizedPath.endsWith('/') ? '' : '/'}${type}`

--- a/test/production/standalone-mode/required-server-files/required-server-files-app.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files-app.test.ts
@@ -281,12 +281,20 @@ describe('required server files app router', () => {
         '_N_T_/layout,_N_T_/isr/layout,_N_T_/isr/[slug]/layout,_N_T_/isr/[slug]/page,_N_T_/isr/second,isr-page',
       ],
       [
+        '/isr/%E3%83%A4%E3%82%AF%E3%83%AB%E3%83%88',
+        '_N_T_/layout,_N_T_/isr/layout,_N_T_/isr/[slug]/layout,_N_T_/isr/[slug]/page,_N_T_/isr/%E3%83%A4%E3%82%AF%E3%83%AB%E3%83%88,isr-page',
+      ],
+      [
         '/api/isr/first',
         '_N_T_/layout,_N_T_/api/layout,_N_T_/api/isr/layout,_N_T_/api/isr/[slug]/layout,_N_T_/api/isr/[slug]/route,_N_T_/api/isr/first,isr-page',
       ],
       [
         '/api/isr/second',
         '_N_T_/layout,_N_T_/api/layout,_N_T_/api/isr/layout,_N_T_/api/isr/[slug]/layout,_N_T_/api/isr/[slug]/route,_N_T_/api/isr/second,isr-page',
+      ],
+      [
+        '/api/isr/%E3%83%A4%E3%82%AF%E3%83%AB%E3%83%88',
+        '_N_T_/layout,_N_T_/api/layout,_N_T_/api/isr/layout,_N_T_/api/isr/[slug]/layout,_N_T_/api/isr/[slug]/route,_N_T_/api/isr/%E3%83%A4%E3%82%AF%E3%83%AB%E3%83%88,isr-page',
       ],
     ]) {
       require('console').error('checking', { path, tags })
@@ -299,7 +307,9 @@ describe('required server files app router', () => {
         })
       )
       expect(res.status).toBe(200)
-      expect(res.headers.get('x-next-cache-tags')).toBe(tags)
+      const cacheTags = res.headers.get('x-next-cache-tags')
+      expect(cacheTags).toBe(tags)
+      expect(cacheTags).toMatch(/^[\x20-\x7e]+$/)
     }
   })
 


### PR DESCRIPTION
Encode pathname-derived cache tags to ASCII-safe values before serializing x-next-cache-tags headers, and align revalidatePath normalization so invalidation still matches. Add unit and standalone ISR production coverage for unicode slugs to prevent ERR_INVALID_CHAR regressions.

