### PR TITLE
Support template literal expressions in middleware config matcher

### DIFF
--- a/packages/next/src/build/analysis/extract-const-value.test.ts
+++ b/packages/next/src/build/analysis/extract-const-value.test.ts
@@ -315,6 +315,96 @@ describe('extractExportedConstValue', () => {
     })
   })
 
+  describe('edge cases', () => {
+    it('evaluates numeric expressions in template literals', () => {
+      // const version = 2
+      // export const config = { matcher: `/api/v${version}` }
+      const module = createModule([
+        constDeclaration('version', numericLiteral(2)),
+        constDeclaration(
+          'config',
+          objectExpression({
+            matcher: templateLiteral(['/api/v', ''], [identifier('version')]),
+          }),
+          true
+        ),
+      ])
+
+      const result = extractExportedConstValue(module, 'config')
+      expect(result).toEqual({ value: { matcher: '/api/v2' } })
+    })
+
+    it('evaluates Array.join() on an empty array', () => {
+      const module = createModule([
+        constDeclaration('empty', arrayExpression([])),
+        constDeclaration(
+          'config',
+          objectExpression({
+            value: callExpression(identifier('empty'), 'join', [stringLiteral('|')]),
+          }),
+          true
+        ),
+      ])
+
+      const result = extractExportedConstValue(module, 'config')
+      expect(result).toEqual({ value: { value: '' } })
+    })
+
+    it('resolves identifiers through multiple levels', () => {
+      // const a = b; const b = '/path'
+      // export const config = { matcher: a }
+      const module = createModule([
+        constDeclaration('a', identifier('b')),
+        constDeclaration('b', stringLiteral('/path')),
+        constDeclaration(
+          'config',
+          objectExpression({ matcher: identifier('a') }),
+          true
+        ),
+      ])
+
+      const result = extractExportedConstValue(module, 'config')
+      expect(result).toEqual({ value: { matcher: '/path' } })
+    })
+
+    it('evaluates Array.join() with numeric array values', () => {
+      const module = createModule([
+        constDeclaration(
+          'nums',
+          arrayExpression([numericLiteral(1), numericLiteral(2), numericLiteral(3)])
+        ),
+        constDeclaration(
+          'config',
+          objectExpression({
+            value: callExpression(identifier('nums'), 'join', [stringLiteral('|')]),
+          }),
+          true
+        ),
+      ])
+
+      const result = extractExportedConstValue(module, 'config')
+      expect(result).toEqual({ value: { value: '1|2|3' } })
+    })
+
+    it('handles mixed identifier and literal in template literal', () => {
+      // const prefix = 'api'
+      // export const config = { matcher: `/${prefix}-v1/:path*` }
+      const module = createModule([
+        constDeclaration('prefix', stringLiteral('api')),
+        constDeclaration(
+          'config',
+          objectExpression({
+            matcher: templateLiteral(['/', '-v1/:path*'], [identifier('prefix')]),
+          }),
+          true
+        ),
+      ])
+
+      const result = extractExportedConstValue(module, 'config')
+      expect(result).toEqual({ value: { matcher: '/api-v1/:path*' } })
+    })
+  })
+
   describe('i18n middleware matcher pattern', () => {
     it('evaluates the common i18n locale pattern', () => {
       // const locales = ['en', 'de', 'fr'] as const

--- a/packages/next/src/build/analysis/extract-const-value.test.ts
+++ b/packages/next/src/build/analysis/extract-const-value.test.ts
@@ -1,0 +1,355 @@
+import { extractExportedConstValue } from './extract-const-value'
+import type { Module } from '@swc/core'
+
+/**
+ * Helper to create a minimal SWC Module AST from source code.
+ * Uses a simplified representation matching SWC's output structure.
+ */
+function createModule(body: any[]): Module {
+  return {
+    type: 'Module',
+    span: { start: 0, end: 0, ctxt: 0 },
+    body,
+    interpreter: null,
+  } as Module
+}
+
+function stringLiteral(value: string) {
+  return { type: 'StringLiteral', span: { start: 0, end: 0, ctxt: 0 }, value, hasEscape: false }
+}
+
+function numericLiteral(value: number) {
+  return { type: 'NumericLiteral', span: { start: 0, end: 0, ctxt: 0 }, value }
+}
+
+function identifier(value: string) {
+  return { type: 'Identifier', span: { start: 0, end: 0, ctxt: 0 }, value, optional: false }
+}
+
+function arrayExpression(elements: any[]) {
+  return {
+    type: 'ArrayExpression',
+    span: { start: 0, end: 0, ctxt: 0 },
+    elements: elements.map((e) => (e ? { spread: undefined, expression: e } : null)),
+  }
+}
+
+function templateLiteral(quasis: string[], expressions: any[]) {
+  return {
+    type: 'TemplateLiteral',
+    span: { start: 0, end: 0, ctxt: 0 },
+    expressions,
+    quasis: quasis.map((q) => ({
+      span: { start: 0, end: 0, ctxt: 0 },
+      cooked: q,
+      raw: q,
+    })),
+  }
+}
+
+function callExpression(object: any, method: string, args: any[]) {
+  return {
+    type: 'CallExpression',
+    span: { start: 0, end: 0, ctxt: 0 },
+    callee: {
+      type: 'MemberExpression',
+      span: { start: 0, end: 0, ctxt: 0 },
+      object,
+      property: identifier(method),
+    },
+    arguments: args.map((a) => ({ spread: undefined, expression: a })),
+    typeArguments: undefined,
+  }
+}
+
+function constDeclaration(name: string, init: any, exported = false) {
+  const varDecl = {
+    type: 'VariableDeclaration',
+    span: { start: 0, end: 0, ctxt: 0 },
+    kind: 'const' as const,
+    declare: false,
+    declarations: [
+      {
+        type: 'VariableDeclarator',
+        span: { start: 0, end: 0, ctxt: 0 },
+        id: identifier(name),
+        init,
+        definite: false,
+      },
+    ],
+  }
+
+  if (exported) {
+    return {
+      type: 'ExportDeclaration',
+      span: { start: 0, end: 0, ctxt: 0 },
+      declaration: varDecl,
+    }
+  }
+
+  return varDecl
+}
+
+function objectExpression(properties: Record<string, any>) {
+  return {
+    type: 'ObjectExpression',
+    span: { start: 0, end: 0, ctxt: 0 },
+    properties: Object.entries(properties).map(([key, value]) => ({
+      type: 'KeyValueProperty',
+      key: identifier(key),
+      value,
+    })),
+  }
+}
+
+function tsAsConst(expression: any) {
+  return {
+    type: 'TsConstAssertion',
+    span: { start: 0, end: 0, ctxt: 0 },
+    expression,
+  }
+}
+
+describe('extractExportedConstValue', () => {
+  describe('template literals with expressions', () => {
+    it('evaluates a template literal with a string expression', () => {
+      // export const config = { matcher: `/${'api'}` }
+      const module = createModule([
+        constDeclaration(
+          'config',
+          objectExpression({
+            matcher: templateLiteral(['/', ''], [stringLiteral('api')]),
+          }),
+          true
+        ),
+      ])
+
+      const result = extractExportedConstValue(module, 'config')
+      expect(result).toEqual({ value: { matcher: '/api' } })
+    })
+
+    it('evaluates a template literal with multiple expressions', () => {
+      // export const config = { matcher: `/${prefix}/${suffix}` }
+      const module = createModule([
+        constDeclaration('prefix', stringLiteral('api')),
+        constDeclaration('suffix', stringLiteral('users')),
+        constDeclaration(
+          'config',
+          objectExpression({
+            matcher: templateLiteral(['/', '/', ''], [identifier('prefix'), identifier('suffix')]),
+          }),
+          true
+        ),
+      ])
+
+      const result = extractExportedConstValue(module, 'config')
+      expect(result).toEqual({ value: { matcher: '/api/users' } })
+    })
+
+    it('evaluates a template literal with no expressions', () => {
+      // export const config = { matcher: `/api` }
+      const module = createModule([
+        constDeclaration(
+          'config',
+          objectExpression({
+            matcher: templateLiteral(['/api'], []),
+          }),
+          true
+        ),
+      ])
+
+      const result = extractExportedConstValue(module, 'config')
+      expect(result).toEqual({ value: { matcher: '/api' } })
+    })
+  })
+
+  describe('identifier resolution', () => {
+    it('resolves a const identifier from module scope', () => {
+      // const basePath = '/api'
+      // export const config = { matcher: basePath }
+      const module = createModule([
+        constDeclaration('basePath', stringLiteral('/api')),
+        constDeclaration(
+          'config',
+          objectExpression({ matcher: identifier('basePath') }),
+          true
+        ),
+      ])
+
+      const result = extractExportedConstValue(module, 'config')
+      expect(result).toEqual({ value: { matcher: '/api' } })
+    })
+
+    it('resolves an exported const identifier', () => {
+      // export const basePath = '/api'
+      // export const config = { matcher: basePath }
+      const module = createModule([
+        constDeclaration('basePath', stringLiteral('/api'), true),
+        constDeclaration(
+          'config',
+          objectExpression({ matcher: identifier('basePath') }),
+          true
+        ),
+      ])
+
+      const result = extractExportedConstValue(module, 'config')
+      expect(result).toEqual({ value: { matcher: '/api' } })
+    })
+
+    it('resolves an array identifier', () => {
+      // const paths = ['/foo', '/bar']
+      // export const config = { matcher: paths }
+      const module = createModule([
+        constDeclaration(
+          'paths',
+          arrayExpression([stringLiteral('/foo'), stringLiteral('/bar')])
+        ),
+        constDeclaration(
+          'config',
+          objectExpression({ matcher: identifier('paths') }),
+          true
+        ),
+      ])
+
+      const result = extractExportedConstValue(module, 'config')
+      expect(result).toEqual({ value: { matcher: ['/foo', '/bar'] } })
+    })
+
+    it('detects circular references', () => {
+      // const a = b; const b = a;
+      // export const config = { matcher: a }
+      const module = createModule([
+        constDeclaration('a', identifier('b')),
+        constDeclaration('b', identifier('a')),
+        constDeclaration(
+          'config',
+          objectExpression({ matcher: identifier('a') }),
+          true
+        ),
+      ])
+
+      const result = extractExportedConstValue(module, 'config')
+      expect(result).toHaveProperty('unsupported')
+      expect((result as any).unsupported).toContain('Circular reference')
+    })
+
+    it('returns unsupported for unknown identifiers', () => {
+      // export const config = { matcher: unknownVar }
+      const module = createModule([
+        constDeclaration(
+          'config',
+          objectExpression({ matcher: identifier('unknownVar') }),
+          true
+        ),
+      ])
+
+      const result = extractExportedConstValue(module, 'config')
+      expect(result).toHaveProperty('unsupported')
+      expect((result as any).unsupported).toContain('Unknown identifier')
+    })
+  })
+
+  describe('method calls', () => {
+    it('evaluates Array.join()', () => {
+      // const locales = ['en', 'de']
+      // export const config = { matcher: locales.join('|') }
+      const module = createModule([
+        constDeclaration(
+          'locales',
+          arrayExpression([stringLiteral('en'), stringLiteral('de')])
+        ),
+        constDeclaration(
+          'config',
+          objectExpression({
+            matcher: callExpression(identifier('locales'), 'join', [
+              stringLiteral('|'),
+            ]),
+          }),
+          true
+        ),
+      ])
+
+      const result = extractExportedConstValue(module, 'config')
+      expect(result).toEqual({ value: { matcher: 'en|de' } })
+    })
+
+    it('evaluates Array.join() with no separator', () => {
+      // const arr = ['a', 'b']
+      // export const config = { value: arr.join() }
+      const module = createModule([
+        constDeclaration(
+          'arr',
+          arrayExpression([stringLiteral('a'), stringLiteral('b')])
+        ),
+        constDeclaration(
+          'config',
+          objectExpression({
+            value: callExpression(identifier('arr'), 'join', []),
+          }),
+          true
+        ),
+      ])
+
+      const result = extractExportedConstValue(module, 'config')
+      expect(result).toEqual({ value: { value: 'a,b' } })
+    })
+
+    it('returns unsupported for unknown methods', () => {
+      const module = createModule([
+        constDeclaration(
+          'arr',
+          arrayExpression([stringLiteral('a')])
+        ),
+        constDeclaration(
+          'config',
+          objectExpression({
+            value: callExpression(identifier('arr'), 'map', []),
+          }),
+          true
+        ),
+      ])
+
+      const result = extractExportedConstValue(module, 'config')
+      expect(result).toHaveProperty('unsupported')
+      expect((result as any).unsupported).toContain('.map()')
+    })
+  })
+
+  describe('i18n middleware matcher pattern', () => {
+    it('evaluates the common i18n locale pattern', () => {
+      // const locales = ['en', 'de', 'fr'] as const
+      // export const config = {
+      //   matcher: ['/', `/(${locales.join('|')})/:path*`]
+      // }
+      const localesArray = arrayExpression([
+        stringLiteral('en'),
+        stringLiteral('de'),
+        stringLiteral('fr'),
+      ])
+
+      const module = createModule([
+        constDeclaration('locales', tsAsConst(localesArray)),
+        constDeclaration(
+          'config',
+          objectExpression({
+            matcher: arrayExpression([
+              stringLiteral('/'),
+              templateLiteral(
+                ['/(', ')/:path*'],
+                [callExpression(identifier('locales'), 'join', [stringLiteral('|')])]
+              ),
+            ]),
+          }),
+          true
+        ),
+      ])
+
+      const result = extractExportedConstValue(module, 'config')
+      expect(result).toEqual({
+        value: {
+          matcher: ['/', '/(en|de|fr)/:path*'],
+        },
+      })
+    })
+  })
+})

--- a/packages/next/src/build/analysis/extract-const-value.ts
+++ b/packages/next/src/build/analysis/extract-const-value.ts
@@ -125,8 +125,8 @@ function buildModuleScope(module: Module): Map<string, Node> {
     let declaration: Node | undefined
     if (isExportDeclaration(item)) {
       declaration = item.declaration
-    } else if (isVariableDeclaration(item as Node)) {
-      declaration = item as Node
+    } else if ((item as Node).type === 'VariableDeclaration') {
+      declaration = item as VariableDeclaration
     }
 
     if (!declaration || !isVariableDeclaration(declaration)) continue
@@ -152,7 +152,7 @@ function evaluateMethodCall(
   path?: string[]
 ): ExtractValueResult {
   if (Array.isArray(obj) && methodName === 'join') {
-    return { value: obj.join(...(args as [string?])) }
+    return { value: obj.join(args[0]) }
   }
 
   return {
@@ -295,7 +295,8 @@ function extractValue(
         const exprResult = extractValue(
           node.expressions[i],
           path,
-          scope
+          scope,
+          resolving
         )
         if ('unsupported' in exprResult) return exprResult
         result += String(exprResult.value)
@@ -311,7 +312,7 @@ function extractValue(
       }
     }
 
-    const objResult = extractValue(node.callee.object, path, scope)
+    const objResult = extractValue(node.callee.object, path, scope, resolving)
     if ('unsupported' in objResult) return objResult
 
     let methodName: string | undefined
@@ -333,7 +334,7 @@ function extractValue(
           path: formatCodePath(path),
         }
       }
-      const argResult = extractValue(arg.expression, path, scope)
+      const argResult = extractValue(arg.expression, path, scope, resolving)
       if ('unsupported' in argResult) return argResult
       args.push(argResult.value)
     }
@@ -345,7 +346,7 @@ function extractValue(
     isTsTypeAssertion(node) ||
     isTsConstAssertion(node)
   ) {
-    return extractValue(node.expression, undefined, scope)
+    return extractValue(node.expression, path, scope, resolving)
   } else {
     return {
       unsupported: `Unsupported node type "${node.type}"`,

--- a/packages/next/src/build/analysis/extract-const-value.ts
+++ b/packages/next/src/build/analysis/extract-const-value.ts
@@ -1,9 +1,11 @@
 import type {
   ArrayExpression,
   BooleanLiteral,
+  CallExpression,
   ExportDeclaration,
   Identifier,
   KeyValueProperty,
+  MemberExpression,
   Module,
   Node,
   NullLiteral,
@@ -83,6 +85,14 @@ function isTsSatisfiesExpression(node: Node): node is TsSatisfiesExpression {
   return node.type === 'TsSatisfiesExpression'
 }
 
+function isCallExpression(node: Node): node is CallExpression {
+  return node.type === 'CallExpression'
+}
+
+function isMemberExpression(node: Node): node is MemberExpression {
+  return node.type === 'MemberExpression'
+}
+
 export type ExtractValueResult =
   | { value: any }
   | { unsupported: string; path?: string }
@@ -105,7 +115,58 @@ function formatCodePath(paths?: string[]): string | undefined {
   return codePath
 }
 
-function extractValue(node: Node, path?: string[]): ExtractValueResult {
+/**
+ * Collects module-level const declarations into a scope map for identifier resolution.
+ * Only const declarations are collected since let/var could be reassigned.
+ */
+function buildModuleScope(module: Module): Map<string, Node> {
+  const scope = new Map<string, Node>()
+  for (const item of module.body) {
+    let declaration: Node | undefined
+    if (isExportDeclaration(item)) {
+      declaration = item.declaration
+    } else if (isVariableDeclaration(item as Node)) {
+      declaration = item as Node
+    }
+
+    if (!declaration || !isVariableDeclaration(declaration)) continue
+    if (declaration.kind !== 'const') continue
+
+    for (const decl of declaration.declarations) {
+      if (isIdentifier(decl.id) && decl.init) {
+        scope.set(decl.id.value, decl.init)
+      }
+    }
+  }
+  return scope
+}
+
+/**
+ * Evaluates a safe method call on a resolved value.
+ * Only a limited set of side-effect-free methods are supported.
+ */
+function evaluateMethodCall(
+  obj: any,
+  methodName: string,
+  args: any[],
+  path?: string[]
+): ExtractValueResult {
+  if (Array.isArray(obj) && methodName === 'join') {
+    return { value: obj.join(...(args as [string?])) }
+  }
+
+  return {
+    unsupported: `Unsupported method call ".${methodName}()"`,
+    path: formatCodePath(path),
+  }
+}
+
+function extractValue(
+  node: Node,
+  path?: string[],
+  scope?: Map<string, Node>,
+  resolving?: Set<string>
+): ExtractValueResult {
   if (isNullLiteral(node)) {
     return { value: null }
   } else if (isBooleanLiteral(node)) {
@@ -124,11 +185,28 @@ function extractValue(node: Node, path?: string[]): ExtractValueResult {
     switch (node.value) {
       case 'undefined':
         return { value: undefined }
-      default:
+      default: {
+        // Try to resolve from module-level const declarations
+        if (scope) {
+          const init = scope.get(node.value)
+          if (init) {
+            // Guard against circular references (e.g. const a = b; const b = a;)
+            const visited = resolving ?? new Set<string>()
+            if (visited.has(node.value)) {
+              return {
+                unsupported: `Circular reference in identifier "${node.value}"`,
+                path: formatCodePath(path),
+              }
+            }
+            visited.add(node.value)
+            return extractValue(init, path, scope, visited)
+          }
+        }
         return {
           unsupported: `Unknown identifier "${node.value}"`,
           path: formatCodePath(path),
         }
+      }
     }
   } else if (isArrayExpression(node)) {
     // e.g. [1, 2, 3]
@@ -146,7 +224,8 @@ function extractValue(node: Node, path?: string[]): ExtractValueResult {
 
         const result = extractValue(
           elem.expression,
-          path && [...path, `[${i}]`]
+          path && [...path, `[${i}]`],
+          scope
         )
         if ('unsupported' in result) return result
         arr.push(result.value)
@@ -183,41 +262,90 @@ function extractValue(node: Node, path?: string[]): ExtractValueResult {
         }
       }
 
-      const result = extractValue(prop.value, path && [...path, key])
+      const result = extractValue(prop.value, path && [...path, key], scope)
       if ('unsupported' in result) return result
       obj[key] = result.value
     }
 
     return { value: obj }
   } else if (isTemplateLiteral(node)) {
-    // e.g. `abc`
-    if (node.expressions.length !== 0) {
-      // TODO: should we add support for `${'e'}d${'g'}'e'`?
+    // e.g. `abc` or `/${locale}/:path*`
+    if (node.expressions.length === 0) {
+      // When TemplateLiteral has 0 expressions, the length of quasis is always 1.
+      // Because when parsing TemplateLiteral, the parser yields the first quasi,
+      // then the first expression, then the next quasi, then the next expression, etc.,
+      // until the last quasi.
+      // Thus if there is no expression, the parser ends at the frst and also last quasis
+      //
+      // A "cooked" interpretation where backslashes have special meaning, while a
+      // "raw" interpretation where backslashes do not have special meaning
+      // https://exploringjs.com/impatient-js/ch_template-literals.html#template-strings-cooked-vs-raw
+      const [{ cooked, raw }] = node.quasis
+      return { value: cooked ?? raw }
+    }
+
+    // Evaluate each expression and concatenate with quasis
+    // e.g. `/(${locales.join("|")})/:path*` → "/(en|de)/:path*"
+    let result = ''
+    for (let i = 0; i < node.quasis.length; i++) {
+      const { cooked, raw } = node.quasis[i]
+      result += cooked ?? raw
+
+      if (i < node.expressions.length) {
+        const exprResult = extractValue(
+          node.expressions[i],
+          path,
+          scope
+        )
+        if ('unsupported' in exprResult) return exprResult
+        result += String(exprResult.value)
+      }
+    }
+    return { value: result }
+  } else if (isCallExpression(node)) {
+    // e.g. locales.join("|")
+    if (!isMemberExpression(node.callee)) {
       return {
-        unsupported: 'Unsupported template literal with expressions',
+        unsupported: 'Unsupported call expression',
         path: formatCodePath(path),
       }
     }
 
-    // When TemplateLiteral has 0 expressions, the length of quasis is always 1.
-    // Because when parsing TemplateLiteral, the parser yields the first quasi,
-    // then the first expression, then the next quasi, then the next expression, etc.,
-    // until the last quasi.
-    // Thus if there is no expression, the parser ends at the frst and also last quasis
-    //
-    // A "cooked" interpretation where backslashes have special meaning, while a
-    // "raw" interpretation where backslashes do not have special meaning
-    // https://exploringjs.com/impatient-js/ch_template-literals.html#template-strings-cooked-vs-raw
-    const [{ cooked, raw }] = node.quasis
+    const objResult = extractValue(node.callee.object, path, scope)
+    if ('unsupported' in objResult) return objResult
 
-    return { value: cooked ?? raw }
+    let methodName: string | undefined
+    if (isIdentifier(node.callee.property)) {
+      methodName = node.callee.property.value
+    } else {
+      return {
+        unsupported: 'Unsupported computed method call',
+        path: formatCodePath(path),
+      }
+    }
+
+    // Evaluate arguments
+    const args: any[] = []
+    for (const arg of node.arguments) {
+      if (arg.spread) {
+        return {
+          unsupported: 'Unsupported spread operator in call arguments',
+          path: formatCodePath(path),
+        }
+      }
+      const argResult = extractValue(arg.expression, path, scope)
+      if ('unsupported' in argResult) return argResult
+      args.push(argResult.value)
+    }
+
+    return evaluateMethodCall(objResult.value, methodName, args, path)
   } else if (
     isTsSatisfiesExpression(node) ||
     isTsAsExpression(node) ||
     isTsTypeAssertion(node) ||
     isTsConstAssertion(node)
   ) {
-    return extractValue(node.expression)
+    return extractValue(node.expression, undefined, scope)
   } else {
     return {
       unsupported: `Unsupported node type "${node.type}"`,
@@ -237,6 +365,9 @@ function extractValue(node: Node, path?: string[]): ExtractValueResult {
  *   - undefined
  *   - array containing values listed in this list
  *   - object containing values listed in this list
+ *   - template literal with expressions that resolve to the above
+ *   - references to module-level const declarations
+ *   - safe method calls (e.g. Array.join) on resolved values
  *
  * Returns null if the declaration is not found.
  * Returns { unsupported, path? } if the value contains unsupported nodes.
@@ -246,6 +377,9 @@ export function extractExportedConstValue(
   exportedName: string
 ): ExtractValueResult | null {
   if (!module) return null
+
+  const scope = buildModuleScope(module)
+
   for (const moduleItem of module.body) {
     if (!isExportDeclaration(moduleItem)) {
       continue
@@ -266,7 +400,7 @@ export function extractExportedConstValue(
         decl.id.value === exportedName &&
         decl.init
       ) {
-        return extractValue(decl.init, [exportedName])
+        return extractValue(decl.init, [exportedName], scope)
       }
     }
   }

--- a/test/e2e/middleware-matcher-template-literal/middleware-matcher-template-literal.test.ts
+++ b/test/e2e/middleware-matcher-template-literal/middleware-matcher-template-literal.test.ts
@@ -1,0 +1,28 @@
+import { nextTestSetup } from 'e2e-utils'
+import { fetchViaHTTP } from 'next-test-utils'
+
+describe('middleware-matcher-template-literal', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('applies middleware on root path', async () => {
+    const response = await fetchViaHTTP(next.url, '/')
+    expect(response.headers.get('X-From-Middleware')).toBe('true')
+  })
+
+  it('applies middleware on matched template literal path', async () => {
+    const response = await fetchViaHTTP(next.url, '/dashboard')
+    expect(response.headers.get('X-From-Middleware')).toBe('true')
+  })
+
+  it('applies middleware on another matched path', async () => {
+    const response = await fetchViaHTTP(next.url, '/settings')
+    expect(response.headers.get('X-From-Middleware')).toBe('true')
+  })
+
+  it('does not apply middleware on unmatched path', async () => {
+    const response = await fetchViaHTTP(next.url, '/unmatched')
+    expect(response.headers.get('X-From-Middleware')).toBeFalsy()
+  })
+})

--- a/test/e2e/middleware-matcher-template-literal/middleware.js
+++ b/test/e2e/middleware-matcher-template-literal/middleware.js
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server'
+
+const segments = ['dashboard', 'settings'] as const
+
+export const config = {
+  matcher: ['/', `/(${segments.join('|')})/:path*`],
+}
+
+export default (req) => {
+  const res = NextResponse.next()
+  res.headers.set('X-From-Middleware', 'true')
+  return res
+}

--- a/test/e2e/middleware-matcher-template-literal/middleware.js
+++ b/test/e2e/middleware-matcher-template-literal/middleware.js
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
 
-const segments = ['dashboard', 'settings'] as const
+const segments = ['dashboard', 'settings']
 
 export const config = {
   matcher: ['/', `/(${segments.join('|')})/:path*`],

--- a/test/e2e/middleware-matcher-template-literal/pages/dashboard.js
+++ b/test/e2e/middleware-matcher-template-literal/pages/dashboard.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p id="dashboard">dashboard page</p>
+}

--- a/test/e2e/middleware-matcher-template-literal/pages/index.js
+++ b/test/e2e/middleware-matcher-template-literal/pages/index.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p id="index">root page</p>
+}

--- a/test/e2e/middleware-matcher-template-literal/pages/settings.js
+++ b/test/e2e/middleware-matcher-template-literal/pages/settings.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p id="settings">settings page</p>
+}

--- a/test/e2e/middleware-matcher-template-literal/pages/unmatched.js
+++ b/test/e2e/middleware-matcher-template-literal/pages/unmatched.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p id="unmatched">unmatched page</p>
+}

--- a/test/production/exported-runtimes-value-validation/index.test.ts
+++ b/test/production/exported-runtimes-value-validation/index.test.ts
@@ -51,7 +51,7 @@ describe('Exported runtimes value validation', () => {
 
       expect(result.stderr).toEqual(
         expect.stringContaining(
-          'Unknown identifier "dynamicPath" at "config.matcher[1]"'
+          'Unsupported call expression at "config.matcher[1]"'
         )
       )
     }

--- a/test/production/exported-runtimes-value-validation/index.test.ts
+++ b/test/production/exported-runtimes-value-validation/index.test.ts
@@ -88,7 +88,7 @@ describe('Exported runtimes value validation', () => {
       )
       expect(result.stderr).toEqual(
         expect.stringContaining(
-          'Unsupported template literal with expressions at "config.runtime".'
+          'Unsupported node type "BinaryExpression" at "config.runtime".'
         )
       )
     }

--- a/test/production/exported-runtimes-value-validation/invalid-middleware/middleware.js
+++ b/test/production/exported-runtimes-value-validation/invalid-middleware/middleware.js
@@ -1,7 +1,9 @@
 export default function () {}
 
-const dynamicPath = `/:foobar`
+function getDynamicPath() {
+  return `/:foobar`
+}
 
 export const config = {
-  matcher: ['/foo', dynamicPath],
+  matcher: ['/foo', getDynamicPath()],
 }


### PR DESCRIPTION
## Change Summary

Resolves #56398.

The static config extractor (`extractExportedConstValue`) now supports:

- **Template literals with expressions** — evaluates each expression and concatenates with quasis
- **Module-level const identifier resolution** — resolves references to `const` declarations in the same file
- **Safe method calls** — supports `Array.prototype.join()` on resolved array values

This enables the common i18n pattern that was previously blocked:

```typescript
const locales = ['en', 'de', 'fr'] as const

export const config = {
  matcher: ['/', `/(${locales.join('|')})/:path*`],
}
// Previously: ❌ "Unsupported template literal with expressions"
// Now:        ✅ Resolves to ['/', '/(en|de|fr)/:path*']
```

### Safety guarantees

- Only `const` declarations are resolved (no `let`/`var` since they could be reassigned)
- Circular references are detected and reported as errors
- Only a whitelist of side-effect-free methods is supported (`Array.join`)
- Truly unresolvable expressions (function calls, imports, binary expressions) still produce clear error messages

### Turbopack

This PR updates the webpack/SWC config extraction path only. Turbopack has its own config analysis in Rust — happy to follow up with a separate PR for Turbopack parity if needed, or coordinate with the team on the best approach.

## Related issue number

Fixes #56398

## Checklist

- [x] PR title is a good summary (used in changelog)
- [x] Unit tests exist for changes
- [x] E2e test verifies middleware matcher with template literals works end-to-end
- [x] Documentation reflects changes

<!-- NEXT_JS_LLM_PR -->