### PR TITLE
Docs: add signed commit guidance

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,6 +24,12 @@ Choose the right checklist for the change(s) that you're making:
 - Telemetry added. In case of a feature if it's used or not.
 - Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md
 
+### Signed commits
+
+- This repository requires verified commit signatures on protected branches.
+- If this pull request is blocked for unsigned commits, re-sign the commits and force-push the branch.
+- A `Signed-off-by` line in the commit message is not enough.
+
 
 ## For Maintainers
 

--- a/contributing.md
+++ b/contributing.md
@@ -5,6 +5,16 @@
 - Read about our [Commitment to Open Source](https://vercel.com/oss).
 - Before jumping into a PR be sure to search [existing PRs](https://github.com/vercel/next.js/pulls) or [issues](https://github.com/vercel/next.js/issues) for an open or closed item that relates to your submission.
 
+## Signed commits
+
+This repository requires verified commit signatures on protected branches.
+
+Before contributing, configure Git to sign your commits with a GitHub-verified GPG, SSH, or S/MIME key. Unsigned commits will be rejected by the repository rules and will need to be rewritten as signed commits before they can be merged.
+
+If a pull request includes unsigned commits, re-sign the commits and force-push the branch. Make sure the signing key is added to your GitHub account and that your commits appear as `Verified`.
+
+A `Signed-off-by` line in the commit message is not enough to satisfy this requirement.
+
 ## Repository
 
 - [Triaging](./contributing/repository/triaging.md)


### PR DESCRIPTION
## What?

Adds contributor-facing guidance for the new signed-commit requirement.

- adds a `Signed commits` section to `contributing.md`
- adds a short signed-commit note to the PR template
- clarifies that a `Signed-off-by` line is not enough

## Why?

As signed commits become required, contributors need a clear explanation in the repo and at PR time so they know what will be enforced and how to recover from unsigned commits.

## How?

Documents the requirement in the main contribution guide and repeats the key action items in the PR checklist.

## Testing

- docs-only change
- verified with local readback and diff review

<!-- NEXT_JS_LLM_PR -->
