### PR TITLE
OTel: share rootSpanAttributesStore across CJS/ESM tracer copies

### DIFF
--- a/packages/next/src/server/lib/trace/tracer.ts
+++ b/packages/next/src/server/lib/trace/tracer.ts
@@ -176,14 +176,37 @@ type NextAttributeNames =
 type OTELAttributeNames = `http.${string}` | `net.${string}`
 type AttributeNames = NextAttributeNames | OTELAttributeNames
 
-/** we use this map to propagate attributes from nested spans to the top span */
-const rootSpanAttributesStore = new Map<
-  number,
-  Map<AttributeNames, AttributeValue | undefined>
->()
+/**
+ * We use this map to propagate attributes from nested spans to the top span.
+ *
+ * The store and the span id counter must live on `globalThis` via
+ * `Symbol.for` keys so they are singletons across the CJS and ESM copies of
+ * this module. `rootSpanIdKey` already resolves to a shared symbol (OTEL's
+ * `createContextKey` delegates to `Symbol.for`), so without these singletons
+ * each module realm would observe the same spanId through the OTEL context
+ * but look it up in its own empty Map, producing false-positive
+ * "Unexpected root span type" warnings when build templates loaded via a
+ * different module system (e.g. metadata resolution) inspect the root span.
+ * See #91831.
+ */
+const rootSpanAttributesStoreKey = Symbol.for('next.rootSpanAttributesStore')
+const rootSpanIdCounterKey = Symbol.for('next.tracerSpanIdCounter')
+type TracerGlobals = typeof globalThis & {
+  [rootSpanAttributesStoreKey]?: Map<
+    number,
+    Map<AttributeNames, AttributeValue | undefined>
+  >
+  [rootSpanIdCounterKey]?: { value: number }
+}
+const tracerGlobals = globalThis as TracerGlobals
+const rootSpanAttributesStore =
+  tracerGlobals[rootSpanAttributesStoreKey] ??
+  (tracerGlobals[rootSpanAttributesStoreKey] = new Map())
+const rootSpanIdCounter =
+  tracerGlobals[rootSpanIdCounterKey] ??
+  (tracerGlobals[rootSpanIdCounterKey] = { value: 0 })
 const rootSpanIdKey = api.createContextKey('next.rootSpanId')
-let lastSpanId = 0
-const getSpanId = () => lastSpanId++
+const getSpanId = () => rootSpanIdCounter.value++
 
 export interface ClientTraceDataEntry {
   key: string

--- a/test/unit/tracer-dual-module-singleton.test.ts
+++ b/test/unit/tracer-dual-module-singleton.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Regression test for https://github.com/vercel/next.js/issues/91831
+ *
+ * Next.js ships a CJS and an ESM copy of
+ * `packages/next/src/server/lib/trace/tracer.ts`. `rootSpanIdKey` is an OTEL
+ * context key created with `api.createContextKey('next.rootSpanId')`, which
+ * resolves to `Symbol.for('next.rootSpanId')` — a shared global symbol. That
+ * means both module realms observe the same spanId through the OTEL context.
+ *
+ * If the attribute store and the span id counter were module-local, each realm
+ * would look up the shared spanId in its own empty Map and mis-classify
+ * downstream spans as new root spans. The fix is to move both onto `globalThis`
+ * via `Symbol.for` keys, so requiring the tracer from any module system shares
+ * a single store.
+ *
+ * This test asserts the mechanism: after loading the tracer, the store and
+ * counter must live on `globalThis` under the expected `Symbol.for` keys, and
+ * reloading the tracer in an isolated module scope must not replace them.
+ */
+
+const STORE_KEY = Symbol.for('next.rootSpanAttributesStore')
+const COUNTER_KEY = Symbol.for('next.tracerSpanIdCounter')
+
+describe('tracer dual-module singleton store (#91831)', () => {
+  it('exposes the attribute store and span id counter on globalThis', () => {
+    require('next/dist/server/lib/trace/tracer')
+
+    const store = (globalThis as any)[STORE_KEY]
+    const counter = (globalThis as any)[COUNTER_KEY]
+
+    expect(store).toBeInstanceOf(Map)
+    expect(counter).toEqual({ value: expect.any(Number) })
+  })
+
+  it('reuses the same globalThis store when the tracer is re-required in isolation', () => {
+    require('next/dist/server/lib/trace/tracer')
+    const storeBefore = (globalThis as any)[STORE_KEY]
+    const counterBefore = (globalThis as any)[COUNTER_KEY]
+
+    jest.isolateModules(() => {
+      // Simulates a second module realm (e.g. the ESM copy of tracer.ts
+      // loaded by a build template like app-page.ts) requiring the tracer
+      // again. Without the globalThis singletons, this would create a fresh
+      // module-local Map and counter.
+      require('next/dist/server/lib/trace/tracer')
+    })
+
+    expect((globalThis as any)[STORE_KEY]).toBe(storeBefore)
+    expect((globalThis as any)[COUNTER_KEY]).toBe(counterBefore)
+  })
+})


### PR DESCRIPTION
Fixes #91831

### What?

`packages/next/src/server/lib/trace/tracer.ts` ships in both CJS and ESM builds. `rootSpanIdKey` is created via `api.createContextKey('next.rootSpanId')`, which delegates to `Symbol.for(...)` — so both module copies already read and write the same slot on the OTEL context. The attribute store and the span id counter, however, were plain module-local state:

```ts
const rootSpanAttributesStore = new Map<...>()
let lastSpanId = 0
```

Each realm observed the shared spanId via the context, but looked it up in its own empty `Map`. On the ESM side the lookup always missed, the incoming span was mis-classified as a new root span, and `getRootSpanAttributes()` later returned those metadata attributes — producing false-positive `Unexpected root span type 'ResolveMetadata.generateMetadata'` warnings in cold metadata resolution under `next dev --turbopack` when a user-registered OpenTelemetry `TracerProvider` was active (e.g. from `@sentry/nextjs` or `@opentelemetry/sdk-node`).

### How?

Move the store and the span id counter onto `globalThis` via `Symbol.for` keys (matching the `Symbol.for` semantics of `createContextKey`), so every module realm backing `tracer.ts` shares a single store.

- Store: `globalThis[Symbol.for('next.rootSpanAttributesStore')]`
- Counter: `globalThis[Symbol.for('next.tracerSpanIdCounter')] = { value: number }`

No public API change — internal state only.

### Reproduction

Install `@sentry/nextjs` (or any OTEL TracerProvider), create an app route with an async `generateMetadata` (e.g. `await fetch(...)`), and run `next dev --turbopack`. The first cold request to the route previously logged `Unexpected root span type 'ResolveMetadata.generateMetadata'` once per cold-start; with this change the warning no longer fires.

Additionally verified by patching the built `dist/server/lib/trace/tracer.js` and `dist/esm/server/lib/trace/tracer.js` in the reporter's repro with this singleton pattern — warning count went from 1 to 0 on cold request, and instrumentation-injected `TRACE_DBG` logs confirm the ESM-side tracer now sees `isRootSpan=false` with a shared `spanId` counter continuing the CJS-side sequence.

### Tests

Added `test/unit/tracer-dual-module-singleton.test.ts` that locks in the mechanism: after requiring `next/dist/server/lib/trace/tracer`, the `Symbol.for`-keyed store and counter must live on `globalThis`, and re-requiring the tracer in an isolated module scope must not replace them. Without the fix, the first assertion fails (the globalThis slots stay `undefined`); with it, both pass.

<!-- NEXT_JS_LLM_PR -->