### PR TITLE
fix(router): prevent discarded action queue nodes from corrupting queue state

### DIFF
--- a/packages/next/src/client/components/app-router-instance.ts
+++ b/packages/next/src/client/components/app-router-instance.ts
@@ -120,9 +120,13 @@ async function runAction({
         // mark that we need to refresh after all actions complete
         actionQueue.needsRefresh = true
       }
-      // Still need to run remaining actions even for discarded actions
-      // to potentially trigger the refresh
-      runRemainingActions(actionQueue, setState)
+      // Do NOT call runRemainingActions for discarded nodes. The
+      // replacement node already owns actionQueue.pending and will
+      // advance the queue when it resolves. Calling runRemainingActions
+      // here would advance pending past the replacement while it's
+      // still in-flight, causing concurrent execution and state loss.
+      // The needsRefresh flag persists on the queue and will be picked
+      // up when the queue eventually empties.
       return
     }
 
@@ -135,6 +139,9 @@ async function runAction({
   // if the action is a promise, set up a callback to resolve it
   if (isThenable(actionResult)) {
     actionResult.then(handleResult, (err) => {
+      if (action.discarded) {
+        return
+      }
       runRemainingActions(actionQueue, setState)
       action.reject(err)
     })
@@ -194,11 +201,15 @@ function dispatchAction(
   ) {
     // Navigations (including back/forward) take priority over any pending actions.
     // Mark the pending action as discarded (so the state is never applied) and start the navigation action immediately.
-    actionQueue.pending.discarded = true
+    const discardedNode = actionQueue.pending
+    discardedNode.discarded = true
 
     // The rest of the current queue should still execute after this navigation.
     // (Note that it can't contain any earlier navigations, because we always put those into `actionQueue.pending` by calling `runAction`)
-    newAction.next = actionQueue.pending.next
+    newAction.next = discardedNode.next
+    // Sever the discarded node's link to the successor chain so it
+    // cannot be accidentally traversed from the discarded node.
+    discardedNode.next = null
 
     runAction({
       actionQueue,


### PR DESCRIPTION
When a navigation is cancelled (e.g., rapid click A → B), the discarded node A's promise eventually resolves and calls runRemainingActions. This advances actionQueue.pending while the replacement node B is still in-flight, corrupting the queue state. Any action dispatched during the window between A's resolution and B's resolution runs concurrently with B, and whichever resolves last silently overwrites the other's state.

Proposed changes:

- Skip runRemainingActions entirely for discarded nodes in both the success and error paths. The replacement node already owns the queue head and will advance it when its own promise resolves.
- Sever the discarded node's .next pointer after transferring the successor chain to the replacement, preventing accidental traversal.



<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Signed commits

- This repository requires verified commit signatures on protected branches.
- If this pull request is blocked for unsigned commits, re-sign the commits and force-push the branch.
- A `Signed-off-by` line in the commit message is not enough.


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?


### Why?

### How?


Closes NEXT-
Fixes #

-->
