### PR TITLE
[ci]: switch to GitHub runners

### DIFF
--- a/.github/actions/sccache/action.yml
+++ b/.github/actions/sccache/action.yml
@@ -6,7 +6,7 @@ inputs:
     required: false
     default: ''
   turbo-token:
-    description: 'Fallback TURBO_TOKEN if not set in environment (e.g. from secrets.TURBO_REMOTE_CACHE_TOKEN)'
+    description: 'Fallback TURBO_TOKEN if not set in environment (e.g. from secrets.TURBO_TOKEN)'
     required: false
     default: ''
 runs:

--- a/.github/actions/sccache/start.sh
+++ b/.github/actions/sccache/start.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Normalize TURBO_API and TURBO_TOKEN: prefer runner .bashrc values,
+# Normalize TURBO_API and TURBO_TOKEN: prefer environment values and
 # fall back to Vercel's public API and the secret passed as an action input.
 if [ -z "${TURBO_API:-}" ]; then
   export TURBO_API="https://api.vercel.com"
@@ -18,7 +18,7 @@ if [ -z "${TURBO_TOKEN:-}" ]; then
 fi
 
 if [ -z "${TURBO_TEAM:-}" ]; then
-  export TURBO_TEAM="vercel"
+  export TURBO_TEAM="vtest314-next-adapter-e2e-tests"
   echo "TURBO_TEAM=${TURBO_TEAM}" >> "$GITHUB_ENV"
 fi
 

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -183,10 +183,13 @@ jobs:
             build_task: build-native-release
             os:
               mac:
-                host: "['macos-15-intel']"
-                arch: [x86_64, aarch64]
                 vendor: apple
                 sys: darwin
+                arch:
+                  x86_64:
+                    host: "['macos-15-intel']"
+                  aarch64:
+                    host: "['macos-15']"
               windows:
                 host: "['windows-latest-8-core-oss']"
                 vendor: pc
@@ -223,7 +226,7 @@ jobs:
 
     name: stable - ${{ matrix.target }} - node@20
     runs-on: ${{ fromJSON(matrix.host) }}
-    timeout-minutes: 45
+    timeout-minutes: ${{ matrix.os == 'mac' && 90 || 45 }}
     env:
       # Disable all build caches for production/staging/force-preview deploys
       NEXT_SKIP_BUILD_CACHE: ${{ contains(fromJSON('["production","staging","force-preview"]'), needs.deploy-target.outputs.value) && '1' || '' }}

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -24,8 +24,11 @@ env:
   # TODO: we should add the relevant envs later to to switch to strict mode
   TURBO_ARGS: '-v --env-mode loose --remote-cache-timeout 90 --summarize --log-order stream'
   NODE_LTS_VERSION: 20
-  TURBO_TEAM: 'vercel'
-  TURBO_CACHE: 'remote:rw'
+  TURBO_TEAM: 'vtest314-next-adapter-e2e-tests'
+  # Prefer shared remote cache across runs, but keep local cache enabled so jobs
+  # degrade gracefully if the remote cache or token is unavailable.
+  TURBO_CACHE: 'local:rw,remote:rw'
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   # Without this environment variable, rust-lld will fail because some dependencies defaults to newer version of macOS by default.
   #
   # See https://doc.rust-lang.org/rustc/platform-support/apple-darwin.html#os-version for more details
@@ -180,12 +183,12 @@ jobs:
             build_task: build-native-release
             os:
               mac:
-                host: "['self-hosted', 'macos', 'arm64']"
+                host: "['macos-15-intel']"
                 arch: [x86_64, aarch64]
                 vendor: apple
                 sys: darwin
               windows:
-                host: "['self-hosted', 'windows', 'x64']"
+                host: "['windows-latest-8-core-oss']"
                 vendor: pc
                 sys: windows
                 abi: msvc
@@ -193,7 +196,7 @@ jobs:
                   x86_64: {}
                   aarch64: {}
               linux:
-                host: "['self-hosted', 'linux', 'x64', 'metal']"
+                host: "['ubuntu-latest-16-core-oss']"
                 docker: next-swc-builder:latest
                 vendor: unknown
                 sys: linux
@@ -295,7 +298,7 @@ jobs:
           docker run --rm \
             -e CI -e RUST_BACKTRACE -e CARGO_TERM_COLOR \
             -e CARGO_INCREMENTAL=0 -e CARGO_REGISTRIES_CRATES_IO_PROTOCOL \
-            ${{ env.NEXT_SKIP_BUILD_CACHE && ' ' || '-e TURBO_API -e TURBO_TEAM -e TURBO_TOKEN -e TURBO_VERSION -e TURBO_CACHE=remote:rw' }} \
+            ${{ env.NEXT_SKIP_BUILD_CACHE && ' ' || '-e TURBO_API -e TURBO_TEAM -e TURBO_TOKEN -e TURBO_VERSION -e TURBO_CACHE=local:rw,remote:rw' }} \
             -e TARGET="${{ matrix.target }}" \
             -e ABI="${{ matrix.abi }}" \
             -e ARCH="${{ matrix.arch }}" \
@@ -386,11 +389,7 @@ jobs:
       matrix:
         target: [web, nodejs]
 
-    runs-on:
-      - 'self-hosted'
-      - 'linux'
-      - 'x64'
-      - 'metal'
+    runs-on: ubuntu-latest-16-core-oss
 
     steps:
       - uses: actions/checkout@v6
@@ -580,9 +579,11 @@ jobs:
           path: turbopack-bin-size
 
       - name: Install datadog-ci
+        if: ${{ env.DATADOG_API_KEY != '' }}
         uses: ./.github/actions/setup-datadog-ci
 
       - name: Upload to Datadog
+        if: ${{ env.DATADOG_API_KEY != '' }}
         run: |
           ls -al turbopack-bin-size
 

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -249,10 +249,12 @@ jobs:
           node-version: ${{ env.NODE_LTS_VERSION }}
           check-latest: true
 
+      - name: Prepare corepack
+        if: ${{ matrix.os != 'windows' }}
+        run: npm i -g corepack@0.31
+
       - name: Setup corepack
-        run: |
-          npm i -g corepack@0.31
-          corepack enable
+        run: corepack enable
 
       # we always want to run this to set environment variables
       # (skip for docker builds - rust is already in the image)

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -82,7 +82,7 @@ jobs:
     with:
       skipInstallBuild: 'yes'
       stepName: 'build-native-windows'
-      runs_on_labels: '["windows","self-hosted","x64"]'
+      runs_on_labels: '["windows-latest-8-core-oss"]'
       buildNativeTarget: 'x86_64-pc-windows-msvc'
       uploadNativeArtifact: 'next-swc-windows'
 
@@ -713,7 +713,7 @@ jobs:
       nodeVersion: ${{ matrix.node }}
       afterBuild: node run-tests.js --type unit
       stepName: 'test-unit-windows-${{ matrix.node }}'
-      runs_on_labels: '["windows","self-hosted","x64"]'
+      runs_on_labels: '["windows-latest-8-core-oss"]'
       buildNativeTarget: 'x86_64-pc-windows-msvc'
 
     secrets: inherit
@@ -885,7 +885,7 @@ jobs:
           test/e2e/app-dir/proxy-runtime-nodejs/proxy-runtime-nodejs.test.ts \
           test/development/app-dir/segment-explorer/segment-explorer.test.ts
       stepName: 'test-dev-windows'
-      runs_on_labels: '["windows","self-hosted","x64"]'
+      runs_on_labels: '["windows-latest-8-core-oss"]'
       buildNativeTarget: 'x86_64-pc-windows-msvc'
     secrets: inherit
 
@@ -908,7 +908,7 @@ jobs:
           test/integration/create-next-app/index.test.ts \
           test/integration/create-next-app/package-manager/pnpm.test.ts
       stepName: 'test-integration-windows'
-      runs_on_labels: '["windows","self-hosted","x64"]'
+      runs_on_labels: '["windows-latest-8-core-oss"]'
       buildNativeTarget: 'x86_64-pc-windows-msvc'
     secrets: inherit
 
@@ -931,7 +931,7 @@ jobs:
           test/e2e/app-dir/non-root-project-monorepo/non-root-project-monorepo.test.ts \
           test/e2e/app-dir/proxy-runtime-nodejs/proxy-runtime-nodejs.test.ts
       stepName: 'test-prod-windows'
-      runs_on_labels: '["windows","self-hosted","x64"]'
+      runs_on_labels: '["windows-latest-8-core-oss"]'
       buildNativeTarget: 'x86_64-pc-windows-msvc'
     secrets: inherit
 

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -62,7 +62,7 @@ on:
         description: 'List of runner labels'
         required: false
         type: string
-        default: '["self-hosted", "linux", "x64", "metal"]'
+        default: '["ubuntu-latest-16-core-oss"]'
       buildNativeTarget:
         description: 'Target for build-native step'
         required: false
@@ -107,8 +107,11 @@ env:
   # disable backtrace for test snapshots
   RUST_BACKTRACE: 0
 
-  TURBO_TEAM: 'vtest314-next-e2e-tests'
-  TURBO_CACHE: 'remote:rw'
+  TURBO_TEAM: 'vtest314-next-adapter-e2e-tests'
+  # Prefer shared remote cache across runs, but keep local cache enabled so jobs
+  # degrade gracefully if the remote cache or token is unavailable.
+  TURBO_CACHE: 'local:rw,remote:rw'
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
 
   NEXT_TELEMETRY_DISABLED: 1
   # allow not skipping install-native postinstall script if we don't have a binary available already
@@ -152,7 +155,7 @@ jobs:
     steps:
       # enforce consistent line endings for git on windows
       - name: Configure git to use LF endings
-        if: ${{ contains(fromJson(inputs.runs_on_labels), 'windows') }}
+        if: ${{ runner.os == 'Windows' }}
         run: |
           git config --global core.autocrlf false
           git config --global core.eol lf
@@ -172,9 +175,10 @@ jobs:
       - name: Install fnm
         if: steps.check-fnm.outputs.found != 'true'
         run: |
+          export FNM_DIR="${HOME}/.local/share/fnm"
           curl -fsSL https://fnm.vercel.app/install | bash
-          export PATH="/home/runner/.local/share/fnm:$PATH"
-          echo "/home/runner/.local/share/fnm" >> $GITHUB_PATH
+          export PATH="$FNM_DIR:$PATH"
+          echo "$FNM_DIR" >> $GITHUB_PATH
           fnm env --json | jq -r 'to_entries|map("\(.key)=\(.value|tostring)")|.[]' | xargs -I {} echo "{}" >> $GITHUB_ENV
 
       - name: Normalize input step names into path key
@@ -207,7 +211,7 @@ jobs:
           which node
           node --version
       - name: Prepare corepack
-        if: ${{ contains(fromJson(inputs.runs_on_labels), 'ubuntu-latest') }}
+        if: ${{ runner.os == 'Linux' }}
         run: |
           npm i -g corepack@0.31
       - run: corepack enable
@@ -271,7 +275,7 @@ jobs:
         uses: ./.github/actions/sccache
         if: ${{ runner.os != 'Windows' && ((inputs.uploadNativeArtifact != '') || inputs.needsNextest == 'yes' || inputs.needsRust == 'yes') }}
         with:
-          turbo-token: ${{ secrets.TURBO_REMOTE_CACHE_TOKEN }}
+          turbo-token: ${{ secrets.TURBO_TOKEN }}
 
       - name: Download pre-built native binary
         if: ${{ inputs.skipNativeBuild != 'yes' && inputs.uploadNativeArtifact == '' }}
@@ -279,7 +283,7 @@ jobs:
         continue-on-error: true
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: ${{ contains(fromJson(inputs.runs_on_labels), 'windows') && 'next-swc-windows' || 'next-swc-linux' }}
+          name: ${{ runner.os == 'Windows' && 'next-swc-windows' || 'next-swc-linux' }}
           path: packages/next-swc/native/
 
       - run: pnpm dlx turbo@${TURBO_VERSION} run build-native-${{ inputs.rustBuildProfile }} ${TURBO_ARGS} --summarize -- --target ${{ inputs.buildNativeTarget }}
@@ -398,11 +402,11 @@ jobs:
           path: packages/next/dist/compiled/next-server/report.*.html
 
       - name: Install datadog-ci
-        if: ${{ inputs.afterBuild && always() && !github.event.pull_request.head.repo.fork }}
+        if: ${{ inputs.afterBuild && always() && !github.event.pull_request.head.repo.fork && env.DATADOG_API_KEY != '' }}
         uses: ./.github/actions/setup-datadog-ci
 
       - name: Upload test report to datadog
-        if: ${{ inputs.afterBuild && always() && !github.event.pull_request.head.repo.fork }}
+        if: ${{ inputs.afterBuild && always() && !github.event.pull_request.head.repo.fork && env.DATADOG_API_KEY != '' }}
         run: |
           # Add a `test.type` tag to distinguish between turbopack and next.js runs
           # Add a `nextjs.test_session.name` tag to help identify the job

--- a/.github/workflows/integration_tests_reusable.yml
+++ b/.github/workflows/integration_tests_reusable.yml
@@ -56,7 +56,7 @@ jobs:
     secrets: inherit
 
   generate-matrices:
-    runs-on: [self-hosted, linux, x64, metal]
+    runs-on: ubuntu-latest-16-core-oss
     steps:
       - id: out
         run: |
@@ -147,7 +147,7 @@ jobs:
   collect_nextjs_development_integration_stat:
     needs: [test-e2e, test-integration]
     name: Next.js integration test development status report
-    runs-on: [self-hosted, linux, x64, metal]
+    runs-on: ubuntu-latest-16-core-oss
     if: always()
     permissions:
       pull-requests: write

--- a/.github/workflows/pull_request_stats.yml
+++ b/.github/workflows/pull_request_stats.yml
@@ -18,8 +18,10 @@ env:
   NODE_LTS_VERSION: 20
   TEST_CONCURRENCY: 6
 
-  TURBO_TEAM: 'vercel'
-  TURBO_CACHE: 'remote:rw'
+  TURBO_TEAM: 'vtest314-next-adapter-e2e-tests'
+  # Prefer shared remote cache across runs, but keep local cache enabled so jobs
+  # degrade gracefully if the remote cache or token is unavailable.
+  TURBO_CACHE: 'local:rw,remote:rw'
   NEXT_TELEMETRY_DISABLED: 1
   # we build a dev binary for use in CI so skip downloading
   # canary next-swc binaries in the monorepo
@@ -47,11 +49,7 @@ jobs:
       fail-fast: false
       matrix:
         bundler: [webpack, turbopack]
-    runs-on:
-      - 'self-hosted'
-      - 'linux'
-      - 'x64'
-      - 'metal'
+    runs-on: ubuntu-latest-16-core-oss
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/pull_request_stats.yml
+++ b/.github/workflows/pull_request_stats.yml
@@ -22,6 +22,7 @@ env:
   # Prefer shared remote cache across runs, but keep local cache enabled so jobs
   # degrade gracefully if the remote cache or token is unavailable.
   TURBO_CACHE: 'local:rw,remote:rw'
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   NEXT_TELEMETRY_DISABLED: 1
   # we build a dev binary for use in CI so skip downloading
   # canary next-swc binaries in the monorepo

--- a/.github/workflows/setup-nextjs-build.yml
+++ b/.github/workflows/setup-nextjs-build.yml
@@ -16,11 +16,7 @@ on:
 jobs:
   build_nextjs:
     name: Build Next.js for the turbopack integration test
-    runs-on:
-      - 'self-hosted'
-      - 'linux'
-      - 'x64'
-      - 'metal'
+    runs-on: ubuntu-latest-16-core-oss
     outputs:
       output1: ${{ steps.build-next-swc-turbopack-patch.outputs.success }}
     steps:

--- a/.github/workflows/test-turbopack-rust-bench-test.yml
+++ b/.github/workflows/test-turbopack-rust-bench-test.yml
@@ -17,6 +17,7 @@ env:
   TURBOPACK_BENCH_PROGRESS: '1'
   NODE_LTS_VERSION: 20
   TURBO_TEAM: 'vtest314-next-adapter-e2e-tests'
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
 
 jobs:
   test:

--- a/.github/workflows/test-turbopack-rust-bench-test.yml
+++ b/.github/workflows/test-turbopack-rust-bench-test.yml
@@ -4,7 +4,7 @@ on:
     inputs:
       runner:
         type: string
-        default: '["self-hosted", "linux", "x64", "metal"]'
+        default: '["ubuntu-latest-16-core-oss"]'
       os:
         type: string
         default: 'linux'
@@ -16,6 +16,7 @@ env:
   TURBOPACK_BENCH_COUNTS: '100'
   TURBOPACK_BENCH_PROGRESS: '1'
   NODE_LTS_VERSION: 20
+  TURBO_TEAM: 'vtest314-next-adapter-e2e-tests'
 
 jobs:
   test:
@@ -48,7 +49,7 @@ jobs:
       - name: Start sccache
         uses: ./.github/actions/sccache
         with:
-          turbo-token: ${{ secrets.TURBO_REMOTE_CACHE_TOKEN }}
+          turbo-token: ${{ secrets.TURBO_TOKEN }}
 
       - name: Build benchmarks for tests
         timeout-minutes: 120

--- a/.github/workflows/test_e2e_deploy_release.yml
+++ b/.github/workflows/test_e2e_deploy_release.yml
@@ -245,9 +245,11 @@ jobs:
           merge-multiple: true
 
       - name: Install datadog-ci
+        if: ${{ env.DATADOG_API_KEY != '' }}
         uses: ./.github/actions/setup-datadog-ci
 
       - name: Upload test report to datadog
+        if: ${{ env.DATADOG_API_KEY != '' }}
         run: |
           if [ -d ./test/test-junit-report ]; then
             DD_ENV=ci "$DATADOG_CI_PATH" junit upload --tags test.type:deploy --service nextjs ./test/test-junit-report

--- a/.github/workflows/test_e2e_project_reset_cron.yml
+++ b/.github/workflows/test_e2e_project_reset_cron.yml
@@ -17,6 +17,7 @@ env:
   # Prefer shared remote cache across runs, but keep local cache enabled so jobs
   # degrade gracefully if the remote cache or token is unavailable.
   TURBO_CACHE: 'local:rw,remote:rw'
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
 
 run-name: test-e2e-project-reset (scheduled)
 

--- a/.github/workflows/test_e2e_project_reset_cron.yml
+++ b/.github/workflows/test_e2e_project_reset_cron.yml
@@ -13,8 +13,10 @@ env:
   VERCEL_ADAPTER_TEST_TEAM: vtest314-next-adapter-e2e-tests
   VERCEL_ADAPTER_TEST_TOKEN: ${{ secrets.VERCEL_ADAPTER_TEST_TOKEN }}
   NODE_LTS_VERSION: 20
-  TURBO_TEAM: 'vercel'
-  TURBO_CACHE: 'remote:rw'
+  TURBO_TEAM: 'vtest314-next-adapter-e2e-tests'
+  # Prefer shared remote cache across runs, but keep local cache enabled so jobs
+  # degrade gracefully if the remote cache or token is unavailable.
+  TURBO_CACHE: 'local:rw,remote:rw'
 
 run-name: test-e2e-project-reset (scheduled)
 

--- a/.github/workflows/turbopack-benchmark.yml
+++ b/.github/workflows/turbopack-benchmark.yml
@@ -24,6 +24,7 @@ env:
   # Prefer shared remote cache across runs, but keep local cache enabled so jobs
   # degrade gracefully if the remote cache or token is unavailable.
   TURBO_CACHE: 'local:rw,remote:rw'
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
 
 permissions:
   contents: read

--- a/.github/workflows/turbopack-benchmark.yml
+++ b/.github/workflows/turbopack-benchmark.yml
@@ -20,8 +20,10 @@ concurrency:
 env:
   CI: 1
   RUST_LOG: 'off'
-  TURBO_TEAM: 'vercel'
-  TURBO_CACHE: 'remote:rw'
+  TURBO_TEAM: 'vtest314-next-adapter-e2e-tests'
+  # Prefer shared remote cache across runs, but keep local cache enabled so jobs
+  # degrade gracefully if the remote cache or token is unavailable.
+  TURBO_CACHE: 'local:rw,remote:rw'
 
 permissions:
   contents: read
@@ -30,7 +32,7 @@ permissions:
 jobs:
   benchmark-small-apps:
     name: Benchmark Rust Crates (small apps)
-    runs-on: ['self-hosted', 'linux', 'x64', 'metal']
+    runs-on: ubuntu-latest-16-core-oss
     steps:
       - uses: actions/checkout@v4
 
@@ -43,7 +45,7 @@ jobs:
       - name: Start sccache
         uses: ./.github/actions/sccache
         with:
-          turbo-token: ${{ secrets.TURBO_REMOTE_CACHE_TOKEN }}
+          turbo-token: ${{ secrets.TURBO_TOKEN }}
 
       - name: Install pnpm dependencies
         working-directory: turbopack/benchmark-apps
@@ -65,7 +67,7 @@ jobs:
 
   benchmark-analyzer:
     name: Benchmark Rust Crates (analyzer)
-    runs-on: ['self-hosted', 'linux', 'x64', 'metal']
+    runs-on: ubuntu-latest-16-core-oss
     steps:
       - uses: actions/checkout@v4
 
@@ -78,7 +80,7 @@ jobs:
       - name: Start sccache
         uses: ./.github/actions/sccache
         with:
-          turbo-token: ${{ secrets.TURBO_REMOTE_CACHE_TOKEN }}
+          turbo-token: ${{ secrets.TURBO_TOKEN }}
 
       - name: Install pnpm dependencies
         working-directory: turbopack/benchmark-apps
@@ -101,7 +103,7 @@ jobs:
   benchmark-large:
     name: Benchmark Rust Crates (large)
     if: ${{ github.event.label.name == 'benchmark' || github.event_name == 'workflow_dispatch' }}
-    runs-on: ['self-hosted', 'linux', 'x64', 'metal']
+    runs-on: ubuntu-latest-16-core-oss
     steps:
       - uses: actions/checkout@v4
 
@@ -114,7 +116,7 @@ jobs:
       - name: Start sccache
         uses: ./.github/actions/sccache
         with:
-          turbo-token: ${{ secrets.TURBO_REMOTE_CACHE_TOKEN }}
+          turbo-token: ${{ secrets.TURBO_TOKEN }}
 
       - name: Build the benchmark target(s)
         env:

--- a/crates/next-napi-bindings/build.rs
+++ b/crates/next-napi-bindings/build.rs
@@ -5,11 +5,8 @@ use serde_json::Value;
 fn main() -> anyhow::Result<()> {
     println!("cargo:rerun-if-env-changed=CI");
     println!("cargo:rerun-if-env-changed=CARGO_CFG_TARGET_OS");
-    println!("cargo:rerun-if-env-changed=CARGO_CFG_TARGET_ARCH");
     let is_ci = env::var("CI").is_ok_and(|value| !value.is_empty());
-    let is_macos_aarch64_target = env::var("CARGO_CFG_TARGET_OS")
-        .is_ok_and(|value| value == "macos")
-        && env::var("CARGO_CFG_TARGET_ARCH").is_ok_and(|value| value == "aarch64");
+    let is_macos_target = env::var("CARGO_CFG_TARGET_OS").is_ok_and(|value| value == "macos");
 
     let nextjs_version = {
         let package_json_path = Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -73,12 +70,12 @@ fn main() -> anyhow::Result<()> {
         _ => println!("cargo:warning=`git rev-parse HEAD` failed"),
     }
 
-    if !is_macos_aarch64_target {
+    if !is_macos_target {
         napi_build::setup();
     }
 
-    // This is a workaround for napi always including a GCC specific flag.
-    if is_macos_aarch64_target {
+    // This is a workaround for napi always including a GCC-specific flag on macOS.
+    if is_macos_target {
         println!("cargo:rerun-if-env-changed=DEBUG_GENERATED_CODE");
         println!("cargo:rerun-if-env-changed=TYPE_DEF_TMP_PATH");
         println!("cargo:rerun-if-env-changed=CARGO_CFG_NAPI_RS_CLI_VERSION");

--- a/crates/next-napi-bindings/build.rs
+++ b/crates/next-napi-bindings/build.rs
@@ -4,7 +4,12 @@ use serde_json::Value;
 
 fn main() -> anyhow::Result<()> {
     println!("cargo:rerun-if-env-changed=CI");
+    println!("cargo:rerun-if-env-changed=CARGO_CFG_TARGET_OS");
+    println!("cargo:rerun-if-env-changed=CARGO_CFG_TARGET_ARCH");
     let is_ci = env::var("CI").is_ok_and(|value| !value.is_empty());
+    let is_macos_aarch64_target = env::var("CARGO_CFG_TARGET_OS")
+        .is_ok_and(|value| value == "macos")
+        && env::var("CARGO_CFG_TARGET_ARCH").is_ok_and(|value| value == "aarch64");
 
     let nextjs_version = {
         let package_json_path = Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -68,12 +73,12 @@ fn main() -> anyhow::Result<()> {
         _ => println!("cargo:warning=`git rev-parse HEAD` failed"),
     }
 
-    #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
-    napi_build::setup();
+    if !is_macos_aarch64_target {
+        napi_build::setup();
+    }
 
     // This is a workaround for napi always including a GCC specific flag.
-    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
-    {
+    if is_macos_aarch64_target {
         println!("cargo:rerun-if-env-changed=DEBUG_GENERATED_CODE");
         println!("cargo:rerun-if-env-changed=TYPE_DEF_TMP_PATH");
         println!("cargo:rerun-if-env-changed=CARGO_CFG_NAPI_RS_CLI_VERSION");

--- a/scripts/native-builder.Dockerfile
+++ b/scripts/native-builder.Dockerfile
@@ -10,10 +10,13 @@
 #   - Ubuntu 20.04 (glibc 2.31 — broad compatibility baseline)
 #   - Clang/LLD for all compilation and linking via --target
 #   - GNU cross-sysroots via crossbuild-essential (Ubuntu multiarch)
-#   - musl sysroots from musl.cc (headers + libs only; clang/lld do the work)
+#   - musl sysroots from GHCR-hosted rust-musl-cross images
 #   - Node.js 20 (glibc-linked, used as build tool for all targets)
 #   - Rust nightly toolchain (pinned to match rust-toolchain.toml)
 #   - @napi-rs/cli for building native Node.js addons
+
+FROM ghcr.io/rust-cross/rust-musl-cross:x86_64-musl AS musl_x86_64
+FROM ghcr.io/rust-cross/rust-musl-cross:aarch64-musl AS musl_aarch64
 
 FROM ubuntu:20.04 AS builder
 
@@ -54,19 +57,20 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certifi
     crossbuild-essential-amd64 crossbuild-essential-arm64 \
     && rm -rf /var/lib/apt/lists/*
 
-# Download musl cross-toolchains from musl.cc for their sysroots
-# (headers, crt files, libc, libgcc). Clang + rust-lld handle compilation
-# and linking; we only need the target libraries.
-# Also copy GCC's crt files and libgcc into the sysroot lib dir — clang 10
-# doesn't search the --gcc-toolchain path for these files.
-# https://musl.cc/
-RUN cd /opt && \
-    for TRIPLE in aarch64-linux-musl x86_64-linux-musl; do \
-      wget -qO- "https://musl.cc/${TRIPLE}-cross.tgz" | tar xz && \
-      cp /opt/${TRIPLE}-cross/lib/gcc/${TRIPLE}/*/crt*.o \
-         /opt/${TRIPLE}-cross/lib/gcc/${TRIPLE}/*/libgcc.a \
-         /opt/${TRIPLE}-cross/${TRIPLE}/lib/; \
-    done
+# Import prebuilt musl sysroots from the rust-musl-cross images and stage them
+# under /opt/*-cross for docker-native-build.sh. The symlinks provide the
+# target names that our clang --sysroot flags use, and libgcc/crt objects are
+# copied into the sysroot lib dir so clang/rust-lld can find them while linking.
+COPY --from=musl_x86_64 /usr/local/musl /opt/x86_64-linux-musl-cross
+COPY --from=musl_aarch64 /usr/local/musl /opt/aarch64-linux-musl-cross
+RUN ln -s x86_64-unknown-linux-musl /opt/x86_64-linux-musl-cross/x86_64-linux-musl && \
+    ln -s aarch64-unknown-linux-musl /opt/aarch64-linux-musl-cross/aarch64-linux-musl && \
+    cp /opt/x86_64-linux-musl-cross/lib/gcc/x86_64-unknown-linux-musl/*/crt*.o \
+       /opt/x86_64-linux-musl-cross/lib/gcc/x86_64-unknown-linux-musl/*/libgcc.a \
+       /opt/x86_64-linux-musl-cross/x86_64-linux-musl/lib/ && \
+    cp /opt/aarch64-linux-musl-cross/lib/gcc/aarch64-unknown-linux-musl/*/crt*.o \
+       /opt/aarch64-linux-musl-cross/lib/gcc/aarch64-unknown-linux-musl/*/libgcc.a \
+       /opt/aarch64-linux-musl-cross/aarch64-linux-musl/lib/
 
 # Install Rust — pinned nightly from rust-toolchain.toml
 # The COPY of rust-toolchain.toml ensures the image rebuilds when the toolchain changes.

--- a/test/integration/cli/test/index.test.ts
+++ b/test/integration/cli/test/index.test.ts
@@ -831,9 +831,14 @@ describe('CLI Usage', () => {
 
     test('-p reserved', async () => {
       const TCP_MUX_PORT = 1
-      const { stderr, stdout } = await runAndCaptureOutput({
-        port: TCP_MUX_PORT,
-      })
+      const { stderr, stdout } = await runNextCommand(
+        [dirBasic, '-p', '' + TCP_MUX_PORT],
+        {
+          stdout: true,
+          stderr: true,
+          ignoreFail: true,
+        }
+      )
 
       expect(stdout).toMatch('')
       expect(stderr).toMatch(


### PR DESCRIPTION
## Summary

Switch CI from self-hosted runners to GitHub-hosted runners and fix the follow-up issues that showed up once the hosted jobs were exercised.

## Changes

- Move Linux workflows onto `ubuntu-latest-16-core-oss`, Windows workflows onto `windows-latest-8-core-oss`, and the native mac release lane onto `macos-15-intel`.
- Update the reusable build workflow to work in hosted environments by relying on `runner.os` instead of label string matching, and by removing the hardcoded `/home/runner` `fnm` path.
- Make Turbo/sccache configuration explicit for hosted runners:
  - unify on `vtest314-next-adapter-e2e-tests`
  - pass `TURBO_TOKEN` via workflow env/secrets instead of assuming runner-level env
  - switch Turbo cache mode to `local:rw,remote:rw` so jobs still have local cache behavior when remote cache is unavailable
- Update the `sccache` action defaults/docs to use the hosted-runner secret setup (`TURBO_TOKEN`) instead of the old self-hosted token wiring.
- Make Datadog reporting fail open so missing `DATA_DOG_API_KEY` does not block CI.
- Fix the CLI reserved-port test so it asserts Next’s own `-p 1` validation instead of failing earlier on hosted Linux due to privileged-port binding.
- Replace the live `musl.cc` dependency in `native-builder.Dockerfile` with musl sysroots imported from GHCR-hosted `rust-musl-cross` images, keeping the existing `/opt/*-cross` layout used by the Linux native build scripts.
- Fix the macOS native build workaround s so it applies to all *-apple-darwin targets based on the Cargo target OS rather than the host architecture, which avoids napi-build injecting the unsupported -Wl linker arg when @next/swc is linked with rust-lld on hosted mac runners.

Test Plan:
- This PR's CI
- This [build_and_deploy](https://github.com/vercel/next.js/actions/runs/24865715983/job/72801225722) job running on every arch