### PR TITLE
Expose static export fallback routes to adapters

### DIFF
--- a/docs/01-app/03-api-reference/07-adapters/10-routing-information.mdx
+++ b/docs/01-app/03-api-reference/07-adapters/10-routing-information.mdx
@@ -21,6 +21,30 @@ Rewrite routes checked after filesystem route matching.
 
 Dynamic matchers generated from route segments such as `[slug]` and catch-all routes.
 
+For `output: 'export'`, this array can also include generated document-only fallback routes for unenumerated dynamic app paths. Those entries use the same route shape, set `destination` to an emitted `__fallback` shell, and include an `accept: text/html` `has` condition so internal RSC and data probes are not rewritten to HTML.
+
+Adapters should apply dynamic routes after checking emitted static files. That lets `/blog/first` keep serving prerendered HTML when it exists, while `/blog/new-post` can use `/blog/__fallback` instead of the broader `/_fallback.html` bootstrap.
+
+For hosts with declarative routing config, preserve the provided dynamic route order. For example:
+
+```json
+[
+  {
+    "source": "/blog/:slug",
+    "destination": "/blog/__fallback",
+    "has": [{ "type": "header", "key": "accept", "value": ".*text/html.*" }],
+    "continue": false
+  },
+  {
+    "source": "/:path*",
+    "destination": "/_fallback.html",
+    "continue": false
+  }
+]
+```
+
+The exact route syntax depends on the host. Use `sourceRegex` when the platform accepts regular expressions, or translate `source` into the platform's native path pattern. Keep normal static asset and prerendered file serving ahead of these generated fallback rules, and place any global `_fallback.html` catch-all after dynamic routes.
+
 ## `routing.onMatch`
 
 Routes that apply after a successful match, such as immutable cache headers for hashed static assets.

--- a/packages/next/src/build/adapter/build-complete.ts
+++ b/packages/next/src/build/adapter/build-complete.ts
@@ -7,7 +7,7 @@ import { RenderingMode } from '../rendering-mode'
 import { interopDefault } from '../../lib/interop-default'
 import type { RouteHas } from '../../lib/load-custom-routes'
 import { recursiveReadDir } from '../../lib/recursive-readdir'
-import { isDynamicRoute } from '../../shared/lib/router/utils'
+import { getSortedRoutes, isDynamicRoute } from '../../shared/lib/router/utils'
 import type { Revalidate } from '../../server/lib/cache-control'
 import type { NextConfigComplete } from '../../server/config-shared'
 import { normalizeAppPath } from '../../shared/lib/router/utils/app-paths'
@@ -51,6 +51,11 @@ import { sortSortableRoutes } from '../../shared/lib/router/utils/sortable-route
 import { defaultOverrides } from '../../server/require-hook'
 import { generateRoutesManifest } from '../generate-routes-manifest'
 import { Bundler } from '../../lib/bundler'
+import {
+  getOutputExportFallbackPath,
+  getOutputExportFallbackStaticPrefix,
+  getOutputExportFallbackVariantPath,
+} from '../../lib/output-export-dynamic-fallback'
 
 interface SharedRouteFields {
   /**
@@ -1936,12 +1941,28 @@ export async function handleBuildComplete({
     const dynamicRoutes: DynamicRouteItem[] = []
     const dynamicDataRoutes: DynamicRouteItem[] = []
     const dynamicSegmentRoutes: DynamicRouteItem[] = []
+    const staticExportFallbackDynamicRoutes: DynamicRouteItem[] = []
 
     const getDestinationQuery = (routeKeys: Record<string, string>) => {
       const items = Object.entries(routeKeys ?? {})
       if (items.length === 0) return ''
 
       return '?' + items.map(([key, value]) => `${value}=$${key}`).join('&')
+    }
+
+    const getPublicExportPathname = (pathname: string) => {
+      const publicPathname = addPathPrefix(pathname, config.basePath || '')
+      return publicPathname.length > 1 && publicPathname.endsWith('/')
+        ? publicPathname.slice(0, -1)
+        : publicPathname
+    }
+
+    const getDynamicRouteSourceRegex = (namedRegex: string) => {
+      const shouldLocalize = config.i18n
+      return namedRegex.replace(
+        '^',
+        `^${config.basePath && config.basePath !== '/' ? path.posix.join('/', config.basePath || '') : ''}[/]?${shouldLocalize ? '(?<nextLocale>[^/]{1,})' : ''}`
+      )
     }
 
     const fallbackFalseHasCondition: RouteHas[] = [
@@ -1956,6 +1977,100 @@ export async function handleBuildComplete({
       },
     ]
 
+    const documentRequestHasCondition: RouteHas = {
+      type: 'header',
+      key: 'accept',
+      value: '.*text/html.*',
+    }
+
+    if (config.output === 'export') {
+      const fallbackEntriesByRoute = new Map<
+        string,
+        Array<{
+          page: string
+          sourcePrefix: string
+        }>
+      >()
+
+      for (const route of routesManifest.dynamicRoutes) {
+        const prerenderInfo = prerenderManifest.dynamicRoutes[route.page]
+        if (
+          !prerenderInfo?.fallbackSourceRoute ||
+          !prerenderInfo.fallbackRouteParams ||
+          prerenderInfo.fallbackRouteParams.length === 0
+        ) {
+          continue
+        }
+
+        const staticPrefix = getOutputExportFallbackStaticPrefix(route.page)
+        if (staticPrefix === null) {
+          continue
+        }
+
+        const fallbackRoute = getOutputExportFallbackPath(staticPrefix)
+        const entries = fallbackEntriesByRoute.get(fallbackRoute)
+        const entry = {
+          page: route.page,
+          sourcePrefix: getPublicExportPathname(
+            staticPrefix.length > 0 ? `/${staticPrefix}` : '/'
+          ),
+        }
+
+        if (entries) {
+          entries.push(entry)
+        } else {
+          fallbackEntriesByRoute.set(fallbackRoute, [entry])
+        }
+      }
+
+      const sortedFallbackEntries = Array.from(fallbackEntriesByRoute).flatMap(
+        ([fallbackRoute, entries]) => {
+          const sortedEntries =
+            entries.length === 1
+              ? entries
+              : getSortedRoutes(entries.map((entry) => entry.page)).map(
+                  (page) => entries.find((entry) => entry.page === page)!
+                )
+
+          return sortedEntries.map((entry, index) => ({
+            page: entry.page,
+            sourcePrefix: entry.sourcePrefix,
+            destination: getPublicExportPathname(
+              entries.length === 1
+                ? fallbackRoute
+                : getOutputExportFallbackVariantPath(fallbackRoute, index)
+            ),
+          }))
+        }
+      )
+
+      sortedFallbackEntries.sort((a, b) => {
+        const prefixDepthDelta =
+          b.sourcePrefix.split('/').filter(Boolean).length -
+          a.sourcePrefix.split('/').filter(Boolean).length
+
+        if (prefixDepthDelta !== 0) {
+          return prefixDepthDelta
+        }
+
+        return a.page < b.page ? -1 : a.page > b.page ? 1 : 0
+      })
+
+      for (const entry of sortedFallbackEntries) {
+        staticExportFallbackDynamicRoutes.push({
+          source: entry.page,
+          sourceRegex: getDynamicRouteSourceRegex(
+            getNamedRouteRegex(entry.page, {
+              prefixRouteKeys: true,
+            }).namedRegex
+          ),
+          destination: entry.destination,
+          has: [documentRequestHasCondition],
+          missing: undefined,
+        })
+      }
+    }
+
     for (const route of routesManifest.dynamicRoutes) {
       const shouldLocalize = config.i18n
 
@@ -1966,10 +2081,7 @@ export async function handleBuildComplete({
       const isFallbackFalse =
         prerenderManifest.dynamicRoutes[route.page]?.fallback === false
 
-      const sourceRegex = routeRegex.namedRegex.replace(
-        '^',
-        `^${config.basePath && config.basePath !== '/' ? path.posix.join('/', config.basePath || '') : ''}[/]?${shouldLocalize ? '(?<nextLocale>[^/]{1,})' : ''}`
-      )
+      const sourceRegex = getDynamicRouteSourceRegex(routeRegex.namedRegex)
       const destination =
         path.posix.join(
           '/',
@@ -2124,6 +2236,7 @@ export async function handleBuildComplete({
       const combinedDynamicRoutes = [
         ...dynamicDataRoutes,
         ...dynamicSegmentRoutes,
+        ...staticExportFallbackDynamicRoutes,
         ...dynamicRoutes,
       ] satisfies Route[]
 

--- a/packages/next/src/build/adapter/build-complete.ts
+++ b/packages/next/src/build/adapter/build-complete.ts
@@ -7,7 +7,7 @@ import { RenderingMode } from '../rendering-mode'
 import { interopDefault } from '../../lib/interop-default'
 import type { RouteHas } from '../../lib/load-custom-routes'
 import { recursiveReadDir } from '../../lib/recursive-readdir'
-import { getSortedRoutes, isDynamicRoute } from '../../shared/lib/router/utils'
+import { isDynamicRoute } from '../../shared/lib/router/utils'
 import type { Revalidate } from '../../server/lib/cache-control'
 import type { NextConfigComplete } from '../../server/config-shared'
 import { normalizeAppPath } from '../../shared/lib/router/utils/app-paths'
@@ -52,10 +52,9 @@ import { defaultOverrides } from '../../server/require-hook'
 import { generateRoutesManifest } from '../generate-routes-manifest'
 import { Bundler } from '../../lib/bundler'
 import {
-  getOutputExportFallbackPath,
-  getOutputExportFallbackStaticPrefix,
-  getOutputExportFallbackVariantPath,
-} from '../../lib/output-export-dynamic-fallback'
+  planOutputExportFallbackRoutes,
+  type OutputExportDynamicRouteInfo,
+} from '../../lib/output-export-fallback-routes'
 
 interface SharedRouteFields {
   /**
@@ -1984,64 +1983,28 @@ export async function handleBuildComplete({
     }
 
     if (config.output === 'export') {
-      const fallbackEntriesByRoute = new Map<
+      const outputExportFallbackRoutes: Record<
         string,
-        Array<{
-          page: string
-          sourcePrefix: string
-        }>
-      >()
+        OutputExportDynamicRouteInfo
+      > = {}
 
       for (const route of routesManifest.dynamicRoutes) {
         const prerenderInfo = prerenderManifest.dynamicRoutes[route.page]
-        if (
-          !prerenderInfo?.fallbackSourceRoute ||
-          !prerenderInfo.fallbackRouteParams ||
-          prerenderInfo.fallbackRouteParams.length === 0
-        ) {
-          continue
-        }
-
-        const staticPrefix = getOutputExportFallbackStaticPrefix(route.page)
-        if (staticPrefix === null) {
-          continue
-        }
-
-        const fallbackRoute = getOutputExportFallbackPath(staticPrefix)
-        const entries = fallbackEntriesByRoute.get(fallbackRoute)
-        const entry = {
-          page: route.page,
-          sourcePrefix: getPublicExportPathname(
-            staticPrefix.length > 0 ? `/${staticPrefix}` : '/'
-          ),
-        }
-
-        if (entries) {
-          entries.push(entry)
-        } else {
-          fallbackEntriesByRoute.set(fallbackRoute, [entry])
+        if (prerenderInfo) {
+          outputExportFallbackRoutes[route.page] = prerenderInfo
         }
       }
 
-      const sortedFallbackEntries = Array.from(fallbackEntriesByRoute).flatMap(
-        ([fallbackRoute, entries]) => {
-          const sortedEntries =
-            entries.length === 1
-              ? entries
-              : getSortedRoutes(entries.map((entry) => entry.page)).map(
-                  (page) => entries.find((entry) => entry.page === page)!
-                )
-
-          return sortedEntries.map((entry, index) => ({
-            page: entry.page,
-            sourcePrefix: entry.sourcePrefix,
-            destination: getPublicExportPathname(
-              entries.length === 1
-                ? fallbackRoute
-                : getOutputExportFallbackVariantPath(fallbackRoute, index)
-            ),
-          }))
-        }
+      const sortedFallbackEntries = planOutputExportFallbackRoutes(
+        outputExportFallbackRoutes
+      ).flatMap(({ entries }) =>
+        entries.map((entry) => ({
+          page: entry.route,
+          sourcePrefix: getPublicExportPathname(
+            entry.staticPrefix.length > 0 ? `/${entry.staticPrefix}` : '/'
+          ),
+          destination: getPublicExportPathname(entry.fallbackPath),
+        }))
       )
 
       sortedFallbackEntries.sort((a, b) => {

--- a/test/production/adapter-config/adapter-config-export.test.ts
+++ b/test/production/adapter-config/adapter-config-export.test.ts
@@ -74,26 +74,44 @@ describe('adapter-config export', () => {
       rsc: expect.toBeObject(),
     })
 
-    const staticExportFallbackRoute = routing.dynamicRoutes.find(
-      (route) => route.destination === '/docs/isr-app/__fallback'
+    const staticExportFallbackRoutes = routing.dynamicRoutes.filter((route) =>
+      route.destination?.startsWith('/docs/isr-app/__fallback')
     )
-    expect(staticExportFallbackRoute).toEqual(
-      expect.objectContaining({
-        source: '/isr-app/[slug]',
-        destination: '/docs/isr-app/__fallback',
-        has: [
-          {
-            type: 'header',
-            key: 'accept',
-            value: '.*text/html.*',
-          },
-        ],
-      })
+    expect(staticExportFallbackRoutes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: '/isr-app/[slug]',
+          destination: '/docs/isr-app/__fallback/__route_0',
+          has: [
+            {
+              type: 'header',
+              key: 'accept',
+              value: '.*text/html.*',
+            },
+          ],
+        }),
+        expect.objectContaining({
+          source: '/isr-app/[slug]/comments',
+          destination: '/docs/isr-app/__fallback/__route_1',
+          has: [
+            {
+              type: 'header',
+              key: 'accept',
+              value: '.*text/html.*',
+            },
+          ],
+        }),
+      ])
     )
 
     const staticFilePathnames = new Set(
       outputs.staticFiles.map((output) => output.pathname)
     )
-    expect(staticFilePathnames.has('/docs/isr-app/__fallback')).toBe(true)
+    expect(staticFilePathnames.has('/docs/isr-app/__fallback/__route_0')).toBe(
+      true
+    )
+    expect(staticFilePathnames.has('/docs/isr-app/__fallback/__route_1')).toBe(
+      true
+    )
   })
 })

--- a/test/production/adapter-config/adapter-config-export.test.ts
+++ b/test/production/adapter-config/adapter-config-export.test.ts
@@ -1,37 +1,19 @@
 import fs from 'fs'
+import path from 'path'
 import type { NextAdapter } from 'next'
 import { nextTestSetup } from 'e2e-utils'
 import { version as nextVersion } from 'next/package.json'
 
 process.env.TEST_EXPORT = '1'
+process.env.TEST_CACHE_COMPONENTS = '1'
 
 describe('adapter-config export', () => {
   const { next } = nextTestSetup({
-    files: __dirname,
+    files: path.join(__dirname, 'fixtures/export'),
     skipStart: true,
   })
 
   it('should call onBuildComplete with correct context', async () => {
-    const nonExportFiles = [
-      'app/node-app/page.tsx',
-      'app/node-route/route.ts',
-      'app/edge-route/route.ts',
-      'app/isr-route/route.ts',
-      'app/isr-route/[slug]/route.ts',
-      'app/edge-app/page.tsx',
-      'pages/api/edge-pages.ts',
-      'pages/api/node-pages.ts',
-      'pages/edge-pages/index.tsx',
-      'pages/node-pages/index.tsx',
-      'app/node-app/[slug]/page.tsx',
-      'app/node-app/@dialog/default.tsx',
-      'app/node-app/@dialog/[slug]/page.tsx',
-    ]
-
-    for (const file of nonExportFiles) {
-      await next.remove(file)
-    }
-
     await next.build()
     expect(next.cliOutput).toContain('onBuildComplete called')
 
@@ -91,5 +73,27 @@ describe('adapter-config export', () => {
       shouldNormalizeNextData: expect.toBeBoolean(),
       rsc: expect.toBeObject(),
     })
+
+    const staticExportFallbackRoute = routing.dynamicRoutes.find(
+      (route) => route.destination === '/docs/isr-app/__fallback'
+    )
+    expect(staticExportFallbackRoute).toEqual(
+      expect.objectContaining({
+        source: '/isr-app/[slug]',
+        destination: '/docs/isr-app/__fallback',
+        has: [
+          {
+            type: 'header',
+            key: 'accept',
+            value: '.*text/html.*',
+          },
+        ],
+      })
+    )
+
+    const staticFilePathnames = new Set(
+      outputs.staticFiles.map((output) => output.pathname)
+    )
+    expect(staticFilePathnames.has('/docs/isr-app/__fallback')).toBe(true)
   })
 })

--- a/test/production/adapter-config/fixtures/export/app/isr-app/[slug]/comments/page.tsx
+++ b/test/production/adapter-config/fixtures/export/app/isr-app/[slug]/comments/page.tsx
@@ -1,0 +1,12 @@
+export function generateStaticParams() {
+  return [{ slug: 'first' }]
+}
+
+export default function Page() {
+  return (
+    <>
+      <p>/isr-app/[slug]/comments</p>
+      <p>now: static</p>
+    </>
+  )
+}

--- a/test/production/adapter-config/fixtures/export/app/isr-app/[slug]/page.tsx
+++ b/test/production/adapter-config/fixtures/export/app/isr-app/[slug]/page.tsx
@@ -1,0 +1,18 @@
+import { Suspense } from 'react'
+import { SlugClient } from './slug-client'
+
+export function generateStaticParams() {
+  return [{ slug: 'first' }]
+}
+
+export default function Page() {
+  return (
+    <>
+      <p>/isr-app/[slug]</p>
+      <p>now: static</p>
+      <Suspense fallback={<p>loading slug</p>}>
+        <SlugClient />
+      </Suspense>
+    </>
+  )
+}

--- a/test/production/adapter-config/fixtures/export/app/isr-app/[slug]/slug-client.tsx
+++ b/test/production/adapter-config/fixtures/export/app/isr-app/[slug]/slug-client.tsx
@@ -1,0 +1,8 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export function SlugClient() {
+  const params = useParams<{ slug: string }>()
+  return <p>slug: {params?.slug}</p>
+}

--- a/test/production/adapter-config/fixtures/export/app/isr-app/page.tsx
+++ b/test/production/adapter-config/fixtures/export/app/isr-app/page.tsx
@@ -1,0 +1,8 @@
+export default function Page() {
+  return (
+    <>
+      <p>/isr-app</p>
+      <p>now: static</p>
+    </>
+  )
+}

--- a/test/production/adapter-config/fixtures/export/app/layout.tsx
+++ b/test/production/adapter-config/fixtures/export/app/layout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from 'react'
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/adapter-config/fixtures/export/app/page.tsx
+++ b/test/production/adapter-config/fixtures/export/app/page.tsx
@@ -1,0 +1,8 @@
+export default function Page() {
+  return (
+    <>
+      <p>/</p>
+      <p>now: static</p>
+    </>
+  )
+}

--- a/test/production/adapter-config/fixtures/export/my-adapter.mjs
+++ b/test/production/adapter-config/fixtures/export/my-adapter.mjs
@@ -1,0 +1,24 @@
+import fs from 'fs'
+
+/** @type {import('next').NextAdapter} */
+const myAdapter = {
+  name: 'my-custom-adapter',
+  modifyConfig(config, { phase }) {
+    if (process.env.NODE_ENV !== 'production') return config
+    if (typeof phase !== 'string') {
+      throw new Error(`invalid phase value provided to modifyConfig ${phase}`)
+    }
+    console.log('called modify config in adapter with phase', phase)
+    config.basePath = '/docs'
+    return config
+  },
+  async onBuildComplete(ctx) {
+    console.log('onBuildComplete called')
+    await fs.promises.writeFile(
+      'build-complete.json',
+      JSON.stringify(ctx, null, 2)
+    )
+  },
+}
+
+export default myAdapter

--- a/test/production/adapter-config/fixtures/export/next.config.mjs
+++ b/test/production/adapter-config/fixtures/export/next.config.mjs
@@ -1,0 +1,12 @@
+import Module from 'module'
+
+const require = Module.createRequire(import.meta.url)
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  adapterPath: require.resolve('./my-adapter.mjs'),
+  cacheComponents: process.env.TEST_CACHE_COMPONENTS === '1',
+  output: process.env.TEST_EXPORT ? 'export' : undefined,
+}
+
+export default nextConfig


### PR DESCRIPTION
## Summary

- expose static export fallback shell routing through existing `routing.dynamicRoutes` entries
- keep the adapter routing contract stable, with document-only `Accept: text/html` matching for fallback shell rewrites
- document how adapters can preserve route order and add a global `_fallback.html` catch-all after dynamic routes

## Tests

- `pnpm --filter=next types`
- `pnpm --filter=next build`
- `pnpm test-start-turbo test/production/adapter-config/adapter-config-export.test.ts`
- `pnpm test-start-turbo test/production/adapter-config/adapter-config.test.ts`

<!-- NEXT_JS_LLM_PR -->