### PR TITLE
[ci]: pin rust-musl-cross

### DIFF
--- a/scripts/native-builder.Dockerfile
+++ b/scripts/native-builder.Dockerfile
@@ -15,8 +15,8 @@
 #   - Rust nightly toolchain (pinned to match rust-toolchain.toml)
 #   - @napi-rs/cli for building native Node.js addons
 
-FROM ghcr.io/rust-cross/rust-musl-cross:x86_64-musl AS musl_x86_64
-FROM ghcr.io/rust-cross/rust-musl-cross:aarch64-musl AS musl_aarch64
+FROM ghcr.io/rust-cross/rust-musl-cross:x86_64-musl@sha256:bcf6a66615f9d5bae659e38ab4311260e0488d1c34ad0ab9f9147f4cd5ef64ed AS musl_x86_64
+FROM ghcr.io/rust-cross/rust-musl-cross:aarch64-musl@sha256:eab6a58ff66eaa33fa87fc31ed11403596719ca3f23aa51626fb993d77c1200b AS musl_aarch64
 
 FROM ubuntu:20.04 AS builder
 


### PR DESCRIPTION
Pins these docker dependencies. Follow-up from: https://github.com/vercel/next.js/pull/93164#discussion_r3135035714

x-ref: 
https://github.com/rust-cross/rust-musl-cross/pkgs/container/rust-musl-cross/741104753?tag=x86_64-unknown-linux-musl
https://github.com/rust-cross/rust-musl-cross/pkgs/container/rust-musl-cross/741104508?tag=aarch64-unknown-linux-musl