### PR TITLE
use cache: don't block SWR response on background regeneration

### DIFF
--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -2665,7 +2665,13 @@ export async function cache(
                     )
                   }
 
-                  await ignoredStream.cancel()
+                  // Don't await: on Node's Web Streams, cancelling one
+                  // branch of a tee() waits for the source to close, which
+                  // here means waiting for the background regeneration to
+                  // fully resolve. Awaiting couples the SWR branch to the
+                  // regen lifetime, defeating stale-while-revalidate on the
+                  // Node runtime. Fixes #93146.
+                  void ignoredStream.cancel().catch(() => {})
                 }
               })
               .catch((error) => {


### PR DESCRIPTION
## Summary

`await ignoredStream.cancel()` at
`packages/next/src/server/use-cache/use-cache-wrapper.ts:2668` couples the
Node-runtime response to the full background regeneration lifetime, turning
stale-while-revalidate into "block until fresh". Fixes #93146.

## Root cause

`ignoredStream` is one half of a `tee()` whose source is
`renderToReadableStream(resultPromise, …)`. The other half, `savedStream`,
is actively read by `collectResult` to populate `pendingCacheResult`. That
keeps the source alive, so Node's Web Streams tee-cancel semantics make
`ignoredStream.cancel()` wait until the source closes, i.e. until regen
fully resolves.

The cancel promise lives in `revalidatePromise`, which is pushed into
`workStore.pendingRevalidateWrites`. `executeRevalidates()`
(`revalidation-utils.ts:211-214`) folds those into the `waitUntilForEnd`
handed to `createWriterFromResponse`, whose `close` callback awaits it
before `res.end()` (`pipe-readable.ts:109-120`). So on Node the body
streams normally but `res.end()` is held for the full regen duration. On
Vercel, where `res.end()` gates function close, the user-observable
latency is exactly the regen time.

The Edge runtime wrapper is unaffected: `edge-route-module-wrapper.ts`
hands `pendingWaitUntil` directly to `evt.waitUntil(...)` without
awaiting.

## Fix

```diff
-                  await ignoredStream.cancel()
+                  // Don't await: on Node's Web Streams, cancelling one
+                  // branch of a tee() waits for the source to close, which
+                  // here means waiting for the background regeneration to
+                  // fully resolve. Awaiting couples the SWR branch to the
+                  // regen lifetime, defeating stale-while-revalidate on the
+                  // Node runtime. Fixes #93146.
+                  void ignoredStream.cancel().catch(() => {})
```

Nothing reads `ignoredStream` after this point, so dropping the `await` is
safe. The inner `.catch(() => {})` silences the detached rejection; the
outer `.catch` on `revalidatePromise` (for `generateCacheEntry` /
`saveToCacheHandler`) is retained.

## Tests

`test/e2e/app-dir/use-cache-swr/use-cache-swr.test.ts` all 4 cases pass
with the fix (`NEXT_SKIP_ISOLATE=1 NEXT_TEST_MODE=start pnpm testheadless
…`).

Worth calling out: that suite also passes with the bug reintroduced.
`next.render$` and `next.fetch().text()` return when the response body is
received (~210 ms locally), but the hang sits between end-of-body and
`res.end()`. On the local Node server the TCP connection stays open
beyond the harness read window, so duration measurements don't observe
it. On Vercel the same path measures as the full regen time because
`res.end()` closes the function.

Tried widening the delay and measuring to connection close; still ~210 ms
locally. The symptom really only surfaces in the serverless shape.

## Reproduction

- Route handler returning JSON from an `async "use cache"` function with
  a multi-second body.
- `cacheLife({ revalidate: 60, expire: 86400 })`, Node runtime.
- Populate cache, wait > 60 s, hit again.

Expected: stale returned in < 100 ms, background regen.
Current: blocks for the full regen, returns fresh value.
After this patch: stale returned immediately on Vercel / Node-runtime.

## Checklist

- [x] `pnpm --filter=next build` clean (types OK)
- [x] `pnpm prettier ... --write` + `npx eslint ... --fix` no-op on the patch
- [x] `test/e2e/app-dir/use-cache-swr/use-cache-swr.test.ts` 4/4 pass
- [x] `Fixes` issue linked
- [x] Draft per repo guardrails

<!-- NEXT_JS_LLM_PR -->
