### PR TITLE
docs(contributing): retarget dev-overlay README link after restructure

### DIFF
--- a/contributing/core/developing.md
+++ b/contributing/core/developing.md
@@ -162,7 +162,7 @@ $ pnpm unpack-next path/to/project
 
 ## Developing the Dev Overlay
 
-The dev overlay is a feature of Next.js that allows you to see the internal state of the app including the errors. To learn more about contributing to the dev overlay, see the [Dev Overlay README.md](../../packages/next/src/client/components/react-dev-overlay/README.md).
+The dev overlay is a feature of Next.js that allows you to see the internal state of the app including the errors. To learn more about contributing to the dev overlay, see the [Dev Overlay README.md](../../packages/next/src/next-devtools/README.md).
 
 ## `NODE_ENV` vs `__NEXT_DEV_SERVER`
 


### PR DESCRIPTION
### What?

Fix a broken link in `contributing/core/developing.md` that pointed new contributors at the old dev-overlay README path, which no longer exists.

```diff
-see the [Dev Overlay README.md](../../packages/next/src/client/components/react-dev-overlay/README.md).
+see the [Dev Overlay README.md](../../packages/next/src/next-devtools/README.md).
```

### Why?

The dev-overlay code moved out of `packages/next/src/client/components/react-dev-overlay/` some time back; it now lives under `packages/next/src/next-devtools/`. The README that covers it — titled **"Dev Overlay"** — is at `packages/next/src/next-devtools/README.md`. The "Developing the Dev Overlay" section in the contributor guide still pointed at the old path, so the link 404s for anyone clicking through.

### How?

Single-line retarget, same `../../` prefix. Verified:

- Old target (`packages/next/src/client/components/react-dev-overlay/`) doesn't exist on `canary`.
- New target (`packages/next/src/next-devtools/README.md`) exists and its first line is `# Dev Overlay`.
- No other doc in the repo still references `react-dev-overlay/README`.

Docs-only change. No test / e2e / telemetry touched. Not a package change, so no changeset is needed (the repo doesn't use `.changeset/` anyway). Commit is SSH-signed.
