### PR TITLE
[turbopack-trace-server] Performance improvements for span event handling

### DIFF
--- a/turbopack/crates/turbopack-trace-server/src/lazy_sorted_vec.rs
+++ b/turbopack/crates/turbopack-trace-server/src/lazy_sorted_vec.rs
@@ -1,0 +1,60 @@
+use std::{cell::UnsafeCell, ops::Deref, sync::Once};
+
+pub struct LazySortedVec<T> {
+    vec: UnsafeCell<Vec<T>>,
+    once: Once,
+}
+
+unsafe impl<T> Send for LazySortedVec<T> where T: Send {}
+unsafe impl<T> Sync for LazySortedVec<T> where T: Sync {}
+
+impl<T> LazySortedVec<T> {
+    pub fn new() -> Self {
+        Self {
+            vec: UnsafeCell::new(Vec::new()),
+            once: Once::new(),
+        }
+    }
+
+    pub fn push(&mut self, value: T) {
+        self.once = Once::new();
+        self.vec.get_mut().push(value);
+    }
+
+    pub fn retain_unordered(&mut self, f: impl FnMut(&T) -> bool) {
+        self.vec.get_mut().retain(f);
+    }
+}
+
+impl<T: Ord> Deref for LazySortedVec<T> {
+    type Target = Vec<T>;
+
+    fn deref(&self) -> &Self::Target {
+        let ptr = self.vec.get();
+        self.once.call_once(|| {
+            // SAFETY: The only access to the `vec` is through this `Deref` implementation, or we
+            // have a `&mut self` which prevents a simultaneous `Deref`. So we can guarantee that
+            // there are no other accesses to the `vec` while we sort it.
+            unsafe { &mut *ptr }.sort()
+        });
+        // SAFETY: Returning this reference is safe because the lifetime guarantees that there is no
+        // `&mut self` that could cause a simultaneous access to the `vec`, and the `Once`
+        // guarantees that the sorting is complete before we return the reference.
+        unsafe { &*ptr }
+    }
+}
+
+impl<T> Default for LazySortedVec<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T> From<Vec<T>> for LazySortedVec<T> {
+    fn from(vec: Vec<T>) -> Self {
+        Self {
+            vec: UnsafeCell::new(vec),
+            once: Once::new(),
+        }
+    }
+}

--- a/turbopack/crates/turbopack-trace-server/src/lazy_sorted_vec.rs
+++ b/turbopack/crates/turbopack-trace-server/src/lazy_sorted_vec.rs
@@ -24,6 +24,10 @@ impl<T> LazySortedVec<T> {
     pub fn retain_unordered(&mut self, f: impl FnMut(&T) -> bool) {
         self.vec.get_mut().retain(f);
     }
+
+    pub fn iter_mut_unordered(&mut self) -> std::slice::IterMut<'_, T> {
+        self.vec.get_mut().iter_mut()
+    }
 }
 
 impl<T: Ord> Deref for LazySortedVec<T> {

--- a/turbopack/crates/turbopack-trace-server/src/lib.rs
+++ b/turbopack/crates/turbopack-trace-server/src/lib.rs
@@ -17,6 +17,7 @@ use self::{
 };
 
 mod bottom_up;
+mod lazy_sorted_vec;
 mod reader;
 mod self_time_tree;
 mod server;

--- a/turbopack/crates/turbopack-trace-server/src/main.rs
+++ b/turbopack/crates/turbopack-trace-server/src/main.rs
@@ -12,6 +12,7 @@ use rustc_hash::FxHasher;
 use self::{reader::TraceReader, server::serve, store_container::StoreContainer};
 
 mod bottom_up;
+mod lazy_sorted_vec;
 mod reader;
 mod self_time_tree;
 mod server;

--- a/turbopack/crates/turbopack-trace-server/src/reader/turbopack.rs
+++ b/turbopack/crates/turbopack-trace-server/src/reader/turbopack.rs
@@ -452,7 +452,6 @@ impl TurbopackFormat {
                 );
             }
             InternalRowType::End { ts: _ } => {
-                let id = id;
                 store.complete_span(id.unwrap());
             }
             InternalRowType::SelfTime { start, end } => {

--- a/turbopack/crates/turbopack-trace-server/src/reader/turbopack.rs
+++ b/turbopack/crates/turbopack-trace-server/src/reader/turbopack.rs
@@ -128,6 +128,8 @@ impl InternalRowType<'_> {
 pub struct TurbopackFormat {
     store: Arc<StoreContainer>,
     id_mapping: FxHashMap<u64, SpanIndex>,
+    dropped_ids: FxHashSet<u64>,
+    remaining_ids_to_drop: usize,
     queued_rows: FxHashMap<u64, Vec<InternalRow<'static>>>,
     outdated_spans: FxHashSet<SpanIndex>,
     thread_stacks: FxHashMap<u64, Vec<u64>>,
@@ -141,9 +143,15 @@ pub struct TurbopackFormat {
 
 impl TurbopackFormat {
     pub fn new(store: Arc<StoreContainer>) -> Self {
+        let drop_ids = std::env::var("DROP_SPANS")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .unwrap_or_default();
         Self {
             store,
             id_mapping: FxHashMap::with_capacity_and_hasher(131_072, Default::default()),
+            dropped_ids: FxHashSet::with_capacity_and_hasher(drop_ids, Default::default()),
+            remaining_ids_to_drop: drop_ids,
             queued_rows: FxHashMap::with_capacity_and_hasher(1_024, Default::default()),
             outdated_spans: FxHashSet::with_capacity_and_hasher(8_192, Default::default()),
             thread_stacks: FxHashMap::with_capacity_and_hasher(64, Default::default()),
@@ -377,6 +385,16 @@ impl TurbopackFormat {
         queue: &mut Vec<InternalRow<'static>>,
     ) {
         let id = if let Some(id) = row.id {
+            if matches!(
+                row.ty,
+                InternalRowType::End { .. }
+                    | InternalRowType::Event { .. }
+                    | InternalRowType::Record { .. }
+                    | InternalRowType::SelfTime { .. }
+            ) && self.dropped_ids.contains(&id)
+            {
+                return;
+            }
             if let Some(id) = self.id_mapping.get(&id) {
                 Some(*id)
             } else {
@@ -397,18 +415,28 @@ impl TurbopackFormat {
                 target,
                 values,
             } => {
-                let span_id = store.add_span(
-                    id,
-                    ts,
-                    self.interner.intern_cow(target),
-                    self.interner.intern_cow(name),
-                    values
-                        .iter()
-                        .map(|(k, v)| (self.interner.intern(k), self.interner.intern_display(v)))
-                        .collect(),
-                    &mut self.outdated_spans,
-                );
-                self.id_mapping.insert(new_id, span_id);
+                if self.remaining_ids_to_drop > 0
+                    && let Some(id) = id
+                {
+                    self.remaining_ids_to_drop -= 1;
+                    self.dropped_ids.insert(new_id);
+                    self.id_mapping.insert(new_id, id);
+                } else {
+                    let span_id = store.add_span(
+                        id,
+                        ts,
+                        self.interner.intern_cow(target),
+                        self.interner.intern_cow(name),
+                        values
+                            .iter()
+                            .map(|(k, v)| {
+                                (self.interner.intern(k), self.interner.intern_display(v))
+                            })
+                            .collect(),
+                        &mut self.outdated_spans,
+                    );
+                    self.id_mapping.insert(new_id, span_id);
+                }
                 if let Some(rows) = self.queued_rows.remove(&new_id) {
                     queue.extend(rows);
                 }
@@ -424,6 +452,7 @@ impl TurbopackFormat {
                 );
             }
             InternalRowType::End { ts: _ } => {
+                let id = id;
                 store.complete_span(id.unwrap());
             }
             InternalRowType::SelfTime { start, end } => {
@@ -496,7 +525,23 @@ impl TraceFormat for TurbopackFormat {
     }
 
     fn stats(&self) -> String {
-        format!("{} spans", self.id_mapping.len())
+        use std::fmt::Write;
+
+        let spans = self.id_mapping.len();
+        let mut stats = format!("{spans} spans");
+
+        let dropped_spans = self.dropped_ids.len();
+        if dropped_spans > 0 {
+            let total_drop = dropped_spans + self.remaining_ids_to_drop;
+            write!(stats, ", {dropped_spans}/{total_drop} dropped").unwrap();
+        }
+
+        let queued_spans = self.queued_rows.len();
+        if queued_spans > 0 {
+            write!(stats, ", {queued_spans} queued").unwrap();
+        }
+
+        stats
     }
 
     fn read(&mut self, mut buffer: &[u8], reuse: &mut Self::Reused) -> Result<usize> {

--- a/turbopack/crates/turbopack-trace-server/src/span.rs
+++ b/turbopack/crates/turbopack-trace-server/src/span.rs
@@ -20,6 +20,7 @@ pub struct Span {
     pub args: Vec<(RcStr, RcStr)>,
 
     // This might change during writing:
+    /// The list of events sorted by start time
     pub events: Vec<SpanEvent>,
     pub is_complete: bool,
 
@@ -41,6 +42,19 @@ pub struct Span {
     pub time_data: OnceLock<Box<SpanTimeData>>,
     pub extra: OnceLock<Box<SpanExtra>>,
     pub names: OnceLock<Box<SpanNames>>,
+}
+
+impl Span {
+    pub fn insert_event(&mut self, event: SpanEvent) {
+        // Insertion sort to insert sorted
+        let id = self.events.len();
+        self.events.push(event);
+        let mut current = id;
+        while current > 0 && self.events[current].start() < self.events[current - 1].start() {
+            self.events.swap(current, current - 1);
+            current -= 1;
+        }
+    }
 }
 
 #[derive(Default)]
@@ -108,7 +122,7 @@ pub struct SpanEventSelfTime {
 
 pub enum SpanEvent {
     SelfTime(SpanEventSelfTime),
-    Child { index: SpanIndex },
+    Child { start: Timestamp, index: SpanIndex },
 }
 
 impl SpanEvent {
@@ -118,6 +132,13 @@ impl SpanEvent {
             end,
             corrected_self_time: OnceLock::new(),
         })
+    }
+
+    pub fn start(&self) -> Timestamp {
+        match self {
+            SpanEvent::SelfTime(self_time) => self_time.start,
+            SpanEvent::Child { start, .. } => *start,
+        }
     }
 }
 

--- a/turbopack/crates/turbopack-trace-server/src/span.rs
+++ b/turbopack/crates/turbopack-trace-server/src/span.rs
@@ -100,10 +100,25 @@ impl Span {
     }
 }
 
-#[derive(Copy, Clone, PartialEq, Eq)]
+pub struct SpanEventSelfTime {
+    pub start: Timestamp,
+    pub end: Timestamp,
+    pub corrected_self_time: OnceLock<Timestamp>,
+}
+
 pub enum SpanEvent {
-    SelfTime { start: Timestamp, end: Timestamp },
+    SelfTime(SpanEventSelfTime),
     Child { index: SpanIndex },
+}
+
+impl SpanEvent {
+    pub fn self_time(start: Timestamp, end: Timestamp) -> Self {
+        Self::SelfTime(SpanEventSelfTime {
+            start,
+            end,
+            corrected_self_time: OnceLock::new(),
+        })
+    }
 }
 
 #[derive(Clone)]

--- a/turbopack/crates/turbopack-trace-server/src/span.rs
+++ b/turbopack/crates/turbopack-trace-server/src/span.rs
@@ -6,7 +6,7 @@ use std::{
 use hashbrown::HashMap;
 use turbo_rcstr::RcStr;
 
-use crate::timestamp::Timestamp;
+use crate::{lazy_sorted_vec::LazySortedVec, timestamp::Timestamp};
 
 pub type SpanIndex = NonZeroUsize;
 
@@ -21,7 +21,7 @@ pub struct Span {
 
     // This might change during writing:
     /// The list of events sorted by start time
-    pub events: Vec<SpanEvent>,
+    pub events: LazySortedVec<SpanEvent>,
     pub is_complete: bool,
 
     // These values are computed automatically:
@@ -42,19 +42,6 @@ pub struct Span {
     pub time_data: OnceLock<Box<SpanTimeData>>,
     pub extra: OnceLock<Box<SpanExtra>>,
     pub names: OnceLock<Box<SpanNames>>,
-}
-
-impl Span {
-    pub fn insert_event(&mut self, event: SpanEvent) {
-        // Insertion sort to insert sorted
-        let id = self.events.len();
-        self.events.push(event);
-        let mut current = id;
-        while current > 0 && self.events[current].start() < self.events[current - 1].start() {
-            self.events.swap(current, current - 1);
-            current -= 1;
-        }
-    }
 }
 
 #[derive(Default)]
@@ -139,6 +126,36 @@ impl SpanEvent {
             SpanEvent::SelfTime(self_time) => self_time.start,
             SpanEvent::Child { start, .. } => *start,
         }
+    }
+}
+
+impl PartialEq for SpanEvent {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == std::cmp::Ordering::Equal
+    }
+}
+
+impl Eq for SpanEvent {}
+
+impl PartialOrd for SpanEvent {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for SpanEvent {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.start()
+            .cmp(&other.start())
+            .then_with(|| match (self, other) {
+                (SpanEvent::SelfTime(_), SpanEvent::Child { .. }) => std::cmp::Ordering::Less,
+                (SpanEvent::Child { .. }, SpanEvent::SelfTime(_)) => std::cmp::Ordering::Greater,
+                (SpanEvent::SelfTime(a), SpanEvent::SelfTime(b)) => a.end.cmp(&b.end),
+                (
+                    SpanEvent::Child { start: _, index: a },
+                    SpanEvent::Child { start: _, index: b },
+                ) => a.cmp(b),
+            })
     }
 }
 

--- a/turbopack/crates/turbopack-trace-server/src/span_ref.rs
+++ b/turbopack/crates/turbopack-trace-server/src/span_ref.rs
@@ -13,7 +13,10 @@ use turbo_rcstr::{RcStr, rcstr};
 use crate::{
     FxIndexMap,
     bottom_up::build_bottom_up_graph,
-    span::{Span, SpanEvent, SpanExtra, SpanGraphEvent, SpanIndex, SpanNames, SpanTimeData},
+    span::{
+        Span, SpanEvent, SpanEventSelfTime, SpanExtra, SpanGraphEvent, SpanIndex, SpanNames,
+        SpanTimeData,
+    },
     span_bottom_up_ref::SpanBottomUpRef,
     span_graph_ref::{SpanGraphEventRef, SpanGraphRef, event_map_to_list},
     store::{SpanId, Store},
@@ -181,10 +184,11 @@ impl<'a> SpanRef<'a> {
     #[allow(dead_code)]
     pub fn events(&self) -> impl DoubleEndedIterator<Item = SpanEventRef<'a>> {
         self.span.events.iter().map(|event| match event {
-            &SpanEvent::SelfTime { start, end } => SpanEventRef::SelfTime {
-                store: self.store,
-                start,
-                end,
+            SpanEvent::SelfTime(self_time) => SpanEventRef::SelfTime {
+                self_time: SpanEventSelfTimeRef {
+                    store: self.store,
+                    self_time,
+                },
             },
             SpanEvent::Child { index } => SpanEventRef::Child {
                 span: SpanRef {
@@ -286,16 +290,10 @@ impl<'a> SpanRef<'a> {
                 .events
                 .par_iter()
                 .filter_map(|event| {
-                    if let SpanEvent::SelfTime { start, end } = event {
-                        let duration = *end - *start;
-                        if !duration.is_zero() {
-                            store.set_max_self_time_lookup(*end);
-                            let corrected_time =
-                                store.self_time_tree.as_ref().map_or(duration, |tree| {
-                                    tree.lookup_range_corrected_time(*start, *end)
-                                });
-                            return Some(corrected_time);
-                        }
+                    if let SpanEvent::SelfTime(self_time) = event {
+                        return Some(
+                            SpanEventSelfTimeRef { store, self_time }.corrected_self_time(),
+                        );
                     }
                     None
                 })
@@ -558,47 +556,62 @@ impl Debug for SpanRef<'_> {
     }
 }
 
-#[allow(dead_code)]
-#[derive(Copy, Clone)]
+pub struct SpanEventSelfTimeRef<'a> {
+    store: &'a Store,
+    self_time: &'a SpanEventSelfTime,
+}
+
+impl<'a> SpanEventSelfTimeRef<'a> {
+    pub fn start(&self) -> Timestamp {
+        self.self_time.start
+    }
+
+    pub fn end(&self) -> Timestamp {
+        self.self_time.end
+    }
+
+    pub fn corrected_self_time(&self) -> Timestamp {
+        *self.self_time.corrected_self_time.get_or_init(|| {
+            let duration = self.self_time.end - self.self_time.start;
+            if !duration.is_zero() {
+                self.store.set_max_self_time_lookup(self.self_time.end);
+                self.store.self_time_tree.as_ref().map_or(duration, |tree| {
+                    tree.lookup_range_corrected_time(self.self_time.start, self.self_time.end)
+                })
+            } else {
+                Timestamp::ZERO
+            }
+        })
+    }
+}
+
 pub enum SpanEventRef<'a> {
-    SelfTime {
-        store: &'a Store,
-        start: Timestamp,
-        end: Timestamp,
-    },
-    Child {
-        span: SpanRef<'a>,
-    },
+    SelfTime { self_time: SpanEventSelfTimeRef<'a> },
+    Child { span: SpanRef<'a> },
 }
 
 impl SpanEventRef<'_> {
     pub fn start(&self) -> Timestamp {
         match self {
-            SpanEventRef::SelfTime { start, .. } => *start,
+            SpanEventRef::SelfTime {
+                self_time: event, ..
+            } => event.start(),
             SpanEventRef::Child { span } => span.start(),
         }
     }
 
     pub fn total_time(&self) -> Timestamp {
         match self {
-            SpanEventRef::SelfTime { start, end, .. } => end.saturating_sub(*start),
+            SpanEventRef::SelfTime {
+                self_time: event, ..
+            } => event.end().saturating_sub(event.start()),
             SpanEventRef::Child { span } => span.total_time(),
         }
     }
 
     pub fn corrected_self_time(&self) -> Timestamp {
         match self {
-            SpanEventRef::SelfTime { store, start, end } => {
-                let duration = *end - *start;
-                if !duration.is_zero() {
-                    store.set_max_self_time_lookup(*end);
-                    store.self_time_tree.as_ref().map_or(duration, |tree| {
-                        tree.lookup_range_corrected_time(*start, *end)
-                    })
-                } else {
-                    Timestamp::ZERO
-                }
-            }
+            SpanEventRef::SelfTime { self_time: event } => event.corrected_self_time(),
             SpanEventRef::Child { span } => span.corrected_self_time(),
         }
     }

--- a/turbopack/crates/turbopack-trace-server/src/span_ref.rs
+++ b/turbopack/crates/turbopack-trace-server/src/span_ref.rs
@@ -182,21 +182,24 @@ impl<'a> SpanRef<'a> {
 
     /// Events sorted by start time, including self time and children.
     pub fn events(&self) -> impl DoubleEndedIterator<Item = SpanEventRef<'a>> {
-        self.span.events.iter().map(|event| match event {
-            SpanEvent::SelfTime(self_time) => SpanEventRef::SelfTime {
-                self_time: SpanEventSelfTimeRef {
-                    store: self.store,
-                    self_time,
+        self.span
+            .events
+            .iter()
+            .map(|event: &'a SpanEvent| match event {
+                SpanEvent::SelfTime(self_time) => SpanEventRef::SelfTime {
+                    self_time: SpanEventSelfTimeRef {
+                        store: self.store,
+                        self_time,
+                    },
                 },
-            },
-            SpanEvent::Child { index, .. } => SpanEventRef::Child {
-                span: SpanRef {
-                    span: &self.store.spans[index.get()],
-                    store: self.store,
-                    index: index.get(),
+                SpanEvent::Child { index, .. } => SpanEventRef::Child {
+                    span: SpanRef {
+                        span: &self.store.spans[index.get()],
+                        store: self.store,
+                        index: index.get(),
+                    },
                 },
-            },
-        })
+            })
     }
 
     /// Children sorted by start time, excluding self time.
@@ -290,7 +293,7 @@ impl<'a> SpanRef<'a> {
                 .span
                 .events
                 .par_iter()
-                .filter_map(|event| {
+                .filter_map(|event: &'a SpanEvent| {
                     if let SpanEvent::SelfTime(self_time) = event {
                         return Some(
                             SpanEventSelfTimeRef { store, self_time }.corrected_self_time(),
@@ -592,15 +595,6 @@ pub enum SpanEventRef<'a> {
 }
 
 impl SpanEventRef<'_> {
-    pub fn start(&self) -> Timestamp {
-        match self {
-            SpanEventRef::SelfTime {
-                self_time: event, ..
-            } => event.start(),
-            SpanEventRef::Child { span } => span.start(),
-        }
-    }
-
     pub fn total_time(&self) -> Timestamp {
         match self {
             SpanEventRef::SelfTime {

--- a/turbopack/crates/turbopack-trace-server/src/span_ref.rs
+++ b/turbopack/crates/turbopack-trace-server/src/span_ref.rs
@@ -180,8 +180,7 @@ impl<'a> SpanRef<'a> {
         1
     }
 
-    // TODO(sokra) use events instead of children for visualizing span graphs
-    #[allow(dead_code)]
+    /// Events sorted by start time, including self time and children.
     pub fn events(&self) -> impl DoubleEndedIterator<Item = SpanEventRef<'a>> {
         self.span.events.iter().map(|event| match event {
             SpanEvent::SelfTime(self_time) => SpanEventRef::SelfTime {
@@ -190,7 +189,7 @@ impl<'a> SpanRef<'a> {
                     self_time,
                 },
             },
-            SpanEvent::Child { index } => SpanEventRef::Child {
+            SpanEvent::Child { index, .. } => SpanEventRef::Child {
                 span: SpanRef {
                     span: &self.store.spans[index.get()],
                     store: self.store,
@@ -200,10 +199,11 @@ impl<'a> SpanRef<'a> {
         })
     }
 
+    /// Children sorted by start time, excluding self time.
     pub fn children(&self) -> impl DoubleEndedIterator<Item = SpanRef<'a>> + 'a + use<'a> {
         self.span.events.iter().filter_map(|event| match event {
             SpanEvent::SelfTime { .. } => None,
-            SpanEvent::Child { index } => Some(SpanRef {
+            SpanEvent::Child { index, .. } => Some(SpanRef {
                 span: &self.store.spans[index.get()],
                 store: self.store,
                 index: index.get(),
@@ -211,10 +211,11 @@ impl<'a> SpanRef<'a> {
         })
     }
 
+    /// Children sorted by start time, excluding self time, in parallel.
     pub fn children_par(&self) -> impl ParallelIterator<Item = SpanRef<'a>> + 'a {
         self.span.events.par_iter().filter_map(|event| match event {
             SpanEvent::SelfTime { .. } => None,
-            SpanEvent::Child { index } => Some(SpanRef {
+            SpanEvent::Child { index, .. } => Some(SpanRef {
                 span: &self.store.spans[index.get()],
                 store: self.store,
                 index: index.get(),

--- a/turbopack/crates/turbopack-trace-server/src/store.rs
+++ b/turbopack/crates/turbopack-trace-server/src/store.rs
@@ -221,7 +221,7 @@ impl Store {
         outdated_spans.insert(span_index);
         time_data.self_time += end - start;
         time_data.self_end = max(time_data.self_end, end);
-        span.events.push(SpanEvent::SelfTime { start, end });
+        span.events.push(SpanEvent::self_time(start, end));
         self.insert_self_time(start, end, span_index, outdated_spans);
     }
 
@@ -249,18 +249,12 @@ impl Store {
         for (start, end, index) in children {
             if start > current {
                 if start > self_end {
-                    events.push(SpanEvent::SelfTime {
-                        start: current,
-                        end: self_end,
-                    });
+                    events.push(SpanEvent::self_time(current, self_end));
                     self.insert_self_time(current, self_end, span_index, outdated_spans);
                     self_time += self_end - current;
                     break;
                 }
-                events.push(SpanEvent::SelfTime {
-                    start: current,
-                    end: start,
-                });
+                events.push(SpanEvent::self_time(current, start));
                 self.insert_self_time(current, start, span_index, outdated_spans);
                 self_time += start - current;
             }
@@ -270,10 +264,10 @@ impl Store {
         current -= start_time;
         if current < total_time {
             self_time += total_time - current;
-            events.push(SpanEvent::SelfTime {
-                start: current + start_time,
-                end: start_time + total_time,
-            });
+            events.push(SpanEvent::self_time(
+                current + start_time,
+                start_time + total_time,
+            ));
             self.insert_self_time(
                 current + start_time,
                 start_time + total_time,
@@ -309,7 +303,7 @@ impl Store {
         if let Some(index) = old_parent
             .events
             .iter()
-            .position(|event| *event == SpanEvent::Child { index: span_index })
+            .position(|event| matches!(event, SpanEvent::Child { index } if *index == span_index))
         {
             old_parent.events.remove(index);
         }

--- a/turbopack/crates/turbopack-trace-server/src/store.rs
+++ b/turbopack/crates/turbopack-trace-server/src/store.rs
@@ -152,7 +152,7 @@ impl Store {
             depth = CUT_OFF_DEPTH - 1;
         }
         if depth < CUT_OFF_DEPTH {
-            parent.events.push(SpanEvent::Child { index: id });
+            parent.insert_event(SpanEvent::Child { start, index: id });
         }
         parent.start = min(parent.start, start);
         let span = &mut self.spans[id.get()];
@@ -221,7 +221,7 @@ impl Store {
         outdated_spans.insert(span_index);
         time_data.self_time += end - start;
         time_data.self_end = max(time_data.self_end, end);
-        span.events.push(SpanEvent::self_time(start, end));
+        span.insert_event(SpanEvent::self_time(start, end));
         self.insert_self_time(start, end, span_index, outdated_spans);
     }
 
@@ -258,7 +258,7 @@ impl Store {
                 self.insert_self_time(current, start, span_index, outdated_spans);
                 self_time += start - current;
             }
-            events.push(SpanEvent::Child { index });
+            events.push(SpanEvent::Child { start, index });
             current = max(current, end);
         }
         current -= start_time;
@@ -292,6 +292,7 @@ impl Store {
     ) {
         outdated_spans.insert(span_index);
         let span = &mut self.spans[span_index.get()];
+        let span_start = span.start;
 
         let old_parent = span.parent.replace(parent);
         let old_parent = if let Some(parent) = old_parent {
@@ -300,17 +301,18 @@ impl Store {
         } else {
             &mut self.spans[0]
         };
-        if let Some(index) = old_parent
-            .events
-            .iter()
-            .position(|event| matches!(event, SpanEvent::Child { index } if *index == span_index))
-        {
+        if let Some(index) = old_parent.events.iter().position(
+            |event| matches!(event, SpanEvent::Child { index, .. } if *index == span_index),
+        ) {
             old_parent.events.remove(index);
         }
 
         outdated_spans.insert(parent);
         let parent = &mut self.spans[parent.get()];
-        parent.events.push(SpanEvent::Child { index: span_index });
+        parent.insert_event(SpanEvent::Child {
+            start: span_start,
+            index: span_index,
+        });
     }
 
     pub fn add_allocation(
@@ -418,7 +420,7 @@ impl Store {
 
     pub fn root_spans(&self) -> impl Iterator<Item = SpanRef<'_>> {
         self.spans[0].events.iter().filter_map(|event| match event {
-            &SpanEvent::Child { index: id } => Some(SpanRef {
+            &SpanEvent::Child { index: id, .. } => Some(SpanRef {
                 span: &self.spans[id.get()],
                 store: self,
                 index: id.get(),

--- a/turbopack/crates/turbopack-trace-server/src/store.rs
+++ b/turbopack/crates/turbopack-trace-server/src/store.rs
@@ -46,7 +46,7 @@ fn new_root_span() -> Span {
         category: RcStr::default(),
         name: rcstr!("(root)"),
         args: vec![],
-        events: vec![],
+        events: Default::default(),
         is_complete: true,
         max_depth: OnceLock::new(),
         self_allocations: 0,
@@ -120,7 +120,7 @@ impl Store {
             category,
             name,
             args,
-            events: vec![],
+            events: vec![].into(),
             is_complete: false,
             max_depth: OnceLock::new(),
             self_allocations: 0,
@@ -152,7 +152,7 @@ impl Store {
             depth = CUT_OFF_DEPTH - 1;
         }
         if depth < CUT_OFF_DEPTH {
-            parent.insert_event(SpanEvent::Child { start, index: id });
+            parent.events.push(SpanEvent::Child { start, index: id });
         }
         parent.start = min(parent.start, start);
         let span = &mut self.spans[id.get()];
@@ -221,7 +221,7 @@ impl Store {
         outdated_spans.insert(span_index);
         time_data.self_time += end - start;
         time_data.self_end = max(time_data.self_end, end);
-        span.insert_event(SpanEvent::self_time(start, end));
+        span.events.push(SpanEvent::self_time(start, end));
         self.insert_self_time(start, end, span_index, outdated_spans);
     }
 
@@ -280,7 +280,7 @@ impl Store {
         let time_data = span.time_data_mut();
         time_data.self_time = self_time;
         time_data.self_end = self_end;
-        span.events = events;
+        span.events = events.into();
         span.start = start_time;
     }
 
@@ -301,15 +301,13 @@ impl Store {
         } else {
             &mut self.spans[0]
         };
-        if let Some(index) = old_parent.events.iter().position(
-            |event| matches!(event, SpanEvent::Child { index, .. } if *index == span_index),
-        ) {
-            old_parent.events.remove(index);
-        }
+        old_parent.events.retain_unordered(
+            |event: &SpanEvent| !matches!(event, SpanEvent::Child { index, .. } if *index == span_index),
+        );
 
         outdated_spans.insert(parent);
         let parent = &mut self.spans[parent.get()];
-        parent.insert_event(SpanEvent::Child {
+        parent.events.push(SpanEvent::Child {
             start: span_start,
             index: span_index,
         });

--- a/turbopack/crates/turbopack-trace-server/src/store.rs
+++ b/turbopack/crates/turbopack-trace-server/src/store.rs
@@ -391,6 +391,11 @@ impl Store {
                 time_data.corrected_self_time.take();
                 time_data.corrected_total_time.take();
             }
+            for event in span.events.iter_mut_unordered() {
+                if let SpanEvent::SelfTime(self_time) = event {
+                    self_time.corrected_self_time.take();
+                }
+            }
             span.total_allocations.take();
             span.total_deallocations.take();
             span.total_persistent_allocations.take();

--- a/turbopack/crates/turbopack-trace-server/src/viewer.rs
+++ b/turbopack/crates/turbopack-trace-server/src/viewer.rs
@@ -706,9 +706,7 @@ impl Viewer {
                                     (title.to_string(), cat.to_string())
                                 }))
                             }
-                            SortMode::ExecutionOrder => {
-                                Either::Right(span.events().sorted_by_key(|child| child.start()))
-                            }
+                            SortMode::ExecutionOrder => Either::Right(span.events()),
                         };
                         for child in spans {
                             match child {


### PR DESCRIPTION
## What?

Performance improvements for the turbopack-trace-server, optimizing how span events are stored, sorted, and retrieved.

## Why?

When processing large traces, the trace server was spending significant time on:
1. Repeated sorting of events for each render in ExecutionOrder mode
2. Recomputing corrected self time on repeated lookups
3. Memory pressure from very large traces

## How?

### Lazy Sorting with LazySortedVec

Introduces a new `LazySortedVec<T>` data structure that stores events unsorted and defers sorting until first read via `Deref`. Uses `UnsafeCell` + `Once` for thread-safe one-time sorting. This avoids repeated sorting overhead during trace ingestion.

### Pre-sorted Span Events by Start Time

- `SpanEvent::Child` now stores its `start: Timestamp` alongside the index
- `SpanEvent` implements `Ord` to sort by start time (with SelfTime before Child for equal timestamps)
- The viewer's `ExecutionOrder` mode no longer needs to sort - events are already in order

### Cached Corrected Self Time

- `SpanEvent::SelfTime` now wraps a `SpanEventSelfTime` struct containing an `OnceLock<Timestamp>` for `corrected_self_time`
- The expensive tree lookup is performed once and cached for subsequent accesses
- `SpanEventSelfTimeRef` provides access to the cached value via `corrected_self_time()`

### DROP_SPANS Environment Variable

Adds `DROP_SPANS=<count>` env var to skip the first N spans when loading traces:
- Useful for reducing memory usage with very large traces
- Tracks dropped span IDs to also skip their subsequent events (End, SelfTime, etc.)
- Stats output shows dropped span progress (e.g., "1000 spans, 500/1000 dropped")

<!-- NEXT_JS_LLM_PR -->