### PR TITLE
Preserve `__NEXT_ERROR_CODE` across the `/_error` page handoff

### DIFF
--- a/packages/next/src/client/index.tsx
+++ b/packages/next/src/client/index.tsx
@@ -924,6 +924,14 @@ export async function hydrate(opts?: { beforeRender?: () => Promise<void> }) {
 
           error.name = initialErr!.name
           error.stack = initialErr!.stack
+          // If present, restore the error code from the original server error.
+          if (typeof initialErr.__NEXT_ERROR_CODE === 'string') {
+            Object.defineProperty(error, '__NEXT_ERROR_CODE', {
+              value: initialErr.__NEXT_ERROR_CODE,
+              enumerable: false,
+              configurable: true,
+            })
+          }
           const errSource = initialErr.source!
 
           // In development, error the navigation API usage in runtime,

--- a/packages/next/src/server/dev/node-stack-frames.ts
+++ b/packages/next/src/server/dev/node-stack-frames.ts
@@ -43,6 +43,15 @@ export function getServerError(error: Error, type: ErrorSourceType): Error {
   }
 
   n.name = error.name
+  // If present, restore the error code from the original server error.
+  const errorCode = (error as any).__NEXT_ERROR_CODE
+  if (typeof errorCode === 'string') {
+    Object.defineProperty(n, '__NEXT_ERROR_CODE', {
+      value: errorCode,
+      enumerable: false,
+      configurable: true,
+    })
+  }
   try {
     n.stack = `${n.toString()}\n${parse(error.stack!)
       .map(getFilesystemFrame)

--- a/packages/next/src/server/render.tsx
+++ b/packages/next/src/server/render.tsx
@@ -103,6 +103,7 @@ import { RenderSpan } from './lib/trace/constants'
 import { ReflectAdapter } from './web/spec-extension/adapters/reflect'
 import { getCacheControlHeader } from './lib/cache-control'
 import { getErrorSource } from '../shared/lib/error-source'
+import { extractNextErrorCode } from '../lib/error-telemetry-utils'
 import type { DeepReadonly } from '../shared/lib/deep-readonly'
 import type { PagesDevOverlayBridgeType } from '../next-devtools/userspace/pages/pages-dev-overlay-setup'
 import { getScriptNonceFromHeader } from './app-render/get-script-nonce-from-header'
@@ -423,6 +424,7 @@ export function errorToJSON(err: Error) {
     message: stripAnsi(err.message),
     stack: err.stack,
     digest: (err as any).digest,
+    __NEXT_ERROR_CODE: extractNextErrorCode(err),
   }
 }
 

--- a/packages/next/src/shared/lib/utils.ts
+++ b/packages/next/src/shared/lib/utils.ts
@@ -99,6 +99,7 @@ export type NEXT_DATA = {
   err?: Error & {
     statusCode?: number
     source?: typeof COMPILER_NAMES.server | typeof COMPILER_NAMES.edgeServer
+    __NEXT_ERROR_CODE?: string
   }
   gsp?: boolean
   gssp?: boolean

--- a/test/development/acceptance/ReactRefreshLogBox-app-doc.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox-app-doc.test.ts
@@ -19,7 +19,7 @@ describe('ReactRefreshLogBox _app _document', () => {
     const { browser, session } = sandbox
     await expect(browser).toDisplayRedbox(`
      {
-       "code": "E394",
+       "code": "E464",
        "description": "The default export is not a React Component in page: "/_app"",
        "environmentLabel": null,
        "label": "Runtime Error",
@@ -49,7 +49,7 @@ describe('ReactRefreshLogBox _app _document', () => {
 
     await expect(browser).toDisplayRedbox(`
      {
-       "code": "E394",
+       "code": "E511",
        "description": "The default export is not a React Component in page: "/_document"",
        "environmentLabel": null,
        "label": "Runtime Error",

--- a/test/development/acceptance/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox.test.ts
@@ -1249,7 +1249,7 @@ describe('ReactRefreshLogBox', () => {
     if (isReact18) {
       await expect(browser).toDisplayRedbox(`
        {
-         "code": "E394",
+         "code": "E336",
          "description": "A null error was thrown, see here for more info: https://nextjs.org/docs/messages/threw-undefined",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -1260,7 +1260,7 @@ describe('ReactRefreshLogBox', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "code": "E394",
+         "code": "E336",
          "description": "A null error was thrown, see here for more info: https://nextjs.org/docs/messages/threw-undefined",
          "environmentLabel": null,
          "label": "Runtime Error",

--- a/test/development/app-dir/server-navigation-error/server-navigation-error.test.ts
+++ b/test/development/app-dir/server-navigation-error/server-navigation-error.test.ts
@@ -30,7 +30,7 @@ describe('server-navigation-error', () => {
 
       await expect(browser).toDisplayRedbox(`
        {
-         "code": "E394",
+         "code": "E1041",
          "description": "Next.js navigation API is not allowed to be used in Pages Router.",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -72,7 +72,7 @@ describe('server-navigation-error', () => {
 
       await expect(browser).toDisplayRedbox(`
        {
-         "code": "E394",
+         "code": "E1041",
          "description": "Next.js navigation API is not allowed to be used in Middleware.",
          "environmentLabel": null,
          "label": "Runtime Error",

--- a/test/development/pages-dir/client-navigation/rendering.test.ts
+++ b/test/development/pages-dir/client-navigation/rendering.test.ts
@@ -130,7 +130,7 @@ describe('Client Navigation rendering', () => {
       if (isReact18 && isTurbopack) {
         await expect(browser).toDisplayRedbox(`
          {
-           "code": "E394",
+           "code": "E490",
            "description": "Circular structure in "getInitialProps" result of page "/circular-json-error". https://nextjs.org/docs/messages/circular-structure",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -143,7 +143,7 @@ describe('Client Navigation rendering', () => {
       } else {
         await expect(browser).toDisplayRedbox(`
          {
-           "code": "E394",
+           "code": "E490",
            "description": "Circular structure in "getInitialProps" result of page "/circular-json-error". https://nextjs.org/docs/messages/circular-structure",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -162,7 +162,7 @@ describe('Client Navigation rendering', () => {
 
       await expect(browser).toDisplayRedbox(`
        {
-         "code": "E394",
+         "code": "E1035",
          "description": ""InstanceInitialPropsPage.getInitialProps()" is defined as an instance method - visit https://nextjs.org/docs/messages/get-initial-props-as-an-instance-method for more information.",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -177,7 +177,7 @@ describe('Client Navigation rendering', () => {
 
       await expect(browser).toDisplayRedbox(`
        {
-         "code": "E394",
+         "code": "E1025",
          "description": ""EmptyInitialPropsPage.getInitialProps()" should resolve to an object. But found "null" instead.",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -221,7 +221,7 @@ describe('Client Navigation rendering', () => {
 
       await expect(browser).toDisplayRedbox(`
        {
-         "code": "E394",
+         "code": "E286",
          "description": "The default export is not a React Component in page: "/no-default-export"",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -458,7 +458,7 @@ describe('Client Navigation rendering', () => {
 
       await expect(browser).toDisplayRedbox(`
        {
-         "code": "E394",
+         "code": "E98",
          "description": "An undefined error was thrown, see here for more info: https://nextjs.org/docs/messages/threw-undefined",
          "environmentLabel": null,
          "label": "Runtime Error",

--- a/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
@@ -2306,7 +2306,7 @@ describe('Cache Components Errors', () => {
 
             await expect(browser).toDisplayRedbox(`
              {
-               "code": "E394",
+               "code": "E831",
                "description": "Route /use-cache-cookies used \`cookies()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`cookies()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache",
                "environmentLabel": null,
                "label": "Runtime Error",
@@ -2415,7 +2415,7 @@ describe('Cache Components Errors', () => {
 
             await expect(browser).toDisplayRedbox(`
              {
-               "code": "E394",
+               "code": "E829",
                "description": "Route /use-cache-draft-mode used "draftMode().enable()" inside "use cache". The enabled status of \`draftMode()\` can be read in caches but you must not enable or disable \`draftMode()\` inside a cache. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache",
                "environmentLabel": null,
                "label": "Runtime Error",
@@ -2523,7 +2523,7 @@ describe('Cache Components Errors', () => {
 
             await expect(browser).toDisplayRedbox(`
              {
-               "code": "E394",
+               "code": "E833",
                "description": "Route /use-cache-headers used \`headers()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`headers()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache",
                "environmentLabel": null,
                "label": "Runtime Error",
@@ -2630,7 +2630,7 @@ describe('Cache Components Errors', () => {
 
             await expect(browser).toDisplayRedbox(`
              {
-               "code": "E394",
+               "code": "E841",
                "description": "Route /use-cache-connection used \`connection()\` inside "use cache". The \`connection()\` function is used to indicate the subsequent code must only run when there is an actual request, but caches must be able to be produced before a request, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache",
                "environmentLabel": null,
                "label": "Runtime Error",
@@ -3060,7 +3060,7 @@ Learn more: https://nextjs.org/docs/messages/blocking-route`
 
               await expect(browser).toDisplayRedbox(`
                {
-                 "code": "E394",
+                 "code": "E1009",
                  "description": "A "use cache" with short \`expire\` (under 5 minutes) is nested inside another "use cache" that has no explicit \`cacheLife\`, which is not allowed during prerendering. Add \`cacheLife()\` to the outer \`"use cache"\` to choose whether it should be prerendered (with longer \`expire\`) or remain dynamic (with short \`expire\`). Read more: https://nextjs.org/docs/messages/nested-use-cache-no-explicit-cachelife",
                  "environmentLabel": null,
                  "label": "Runtime Error",
@@ -3489,7 +3489,7 @@ Learn more: https://nextjs.org/docs/messages/blocking-route`
 
               await expect(browser).toDisplayRedbox(`
                {
-                 "code": "E394",
+                 "code": "E1000",
                  "description": "A "use cache" with zero \`revalidate\` is nested inside another "use cache" that has no explicit \`cacheLife\`, which is not allowed during prerendering. Add \`cacheLife()\` to the outer \`"use cache"\` to choose whether it should be prerendered (with non-zero \`revalidate\`) or remain dynamic (with zero \`revalidate\`). Read more: https://nextjs.org/docs/messages/nested-use-cache-no-explicit-cachelife",
                  "environmentLabel": null,
                  "label": "Runtime Error",
@@ -3884,7 +3884,7 @@ Learn more: https://nextjs.org/docs/messages/blocking-route`
 
               await expect(browser).toDisplayRedbox(`
                {
-                 "code": "E394",
+                 "code": "E831",
                  "description": "Route /use-cache-cookies-third-party used \`cookies()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`cookies()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache",
                  "environmentLabel": null,
                  "label": "Runtime Error",
@@ -3983,7 +3983,7 @@ Learn more: https://nextjs.org/docs/messages/blocking-route`
 
               await expect(browser).toDisplayRedbox(`
                {
-                 "code": "E394",
+                 "code": "E829",
                  "description": "Route /use-cache-draft-mode-third-party used "draftMode().enable()" inside "use cache". The enabled status of \`draftMode()\` can be read in caches but you must not enable or disable \`draftMode()\` inside a cache. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache",
                  "environmentLabel": null,
                  "label": "Runtime Error",
@@ -4081,7 +4081,7 @@ Learn more: https://nextjs.org/docs/messages/blocking-route`
 
               await expect(browser).toDisplayRedbox(`
                {
-                 "code": "E394",
+                 "code": "E833",
                  "description": "Route /use-cache-headers-third-party used \`headers()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`headers()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache",
                  "environmentLabel": null,
                  "label": "Runtime Error",
@@ -4180,7 +4180,7 @@ Learn more: https://nextjs.org/docs/messages/blocking-route`
 
               await expect(browser).toDisplayRedbox(`
                {
-                 "code": "E394",
+                 "code": "E841",
                  "description": "Route /use-cache-connection-third-party used \`connection()\` inside "use cache". The \`connection()\` function is used to indicate the subsequent code must only run when there is an actual request, but caches must be able to be produced before a request, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache",
                  "environmentLabel": null,
                  "label": "Runtime Error",
@@ -4283,7 +4283,7 @@ Learn more: https://nextjs.org/docs/messages/blocking-route`
             if (isTurbopack) {
               await expect(browser).toDisplayRedbox(`
                {
-                 "code": "E394",
+                 "code": "E1016",
                  "description": ""use cache: private" must not be used within \`unstable_cache()\`.",
                  "environmentLabel": null,
                  "label": "Runtime Error",
@@ -4299,7 +4299,7 @@ Learn more: https://nextjs.org/docs/messages/blocking-route`
             } else {
               await expect(browser).toDisplayRedbox(`
                {
-                 "code": "E394",
+                 "code": "E1016",
                  "description": ""use cache: private" must not be used within \`unstable_cache()\`.",
                  "environmentLabel": null,
                  "label": "Runtime Error",
@@ -4411,7 +4411,7 @@ Learn more: https://nextjs.org/docs/messages/blocking-route`
 
             await expect(browser).toDisplayRedbox(`
              {
-               "code": "E394",
+               "code": "E1001",
                "description": ""use cache: private" must not be used within "use cache". It can only be nested inside of another "use cache: private".",
                "environmentLabel": null,
                "label": "Runtime Error",

--- a/test/e2e/app-dir/undefined-default-export/undefined-default-export.test.ts
+++ b/test/e2e/app-dir/undefined-default-export/undefined-default-export.test.ts
@@ -14,7 +14,7 @@ describe('Undefined default export', () => {
 
       await expect(browser).toDisplayRedbox(`
        {
-         "code": "E394",
+         "code": "E45",
          "description": "The default export is not a React Component in "/specific-path/1/page"",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -29,7 +29,7 @@ describe('Undefined default export', () => {
 
       await expect(browser).toDisplayRedbox(`
        {
-         "code": "E394",
+         "code": "E45",
          "description": "The default export is not a React Component in "/specific-path/2/layout"",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -44,7 +44,7 @@ describe('Undefined default export', () => {
 
       await expect(browser).toDisplayRedbox(`
        {
-         "code": "E394",
+         "code": "E45",
          "description": "The default export is not a React Component in "/will-not-found/not-found"",
          "environmentLabel": null,
          "label": "Runtime Error",

--- a/test/e2e/app-dir/use-cache-configured-timeout/use-cache-configured-timeout.test.ts
+++ b/test/e2e/app-dir/use-cache-configured-timeout/use-cache-configured-timeout.test.ts
@@ -38,7 +38,7 @@ describe('use-cache-configured-timeout', () => {
 
         await expect(browser).toDisplayRedbox(`
          {
-           "code": "E394",
+           "code": "E236",
            "description": "Filling a cache during prerender timed out, likely because request-specific arguments such as params, searchParams, cookies() or dynamic data were used inside "use cache".",
            "environmentLabel": null,
            "label": "Runtime Error",

--- a/test/e2e/app-dir/use-cache-hanging/use-cache-hanging.test.ts
+++ b/test/e2e/app-dir/use-cache-hanging/use-cache-hanging.test.ts
@@ -23,7 +23,7 @@ describe('use-cache-hanging', () => {
 
         await expect(browser).toDisplayRedbox(`
          {
-           "code": "E394",
+           "code": "E236",
            "description": "Filling a cache during prerender timed out, likely because request-specific arguments such as params, searchParams, cookies() or dynamic data were used inside "use cache".",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -52,7 +52,7 @@ describe('use-cache-hanging', () => {
 
         await expect(browser).toDisplayRedbox(`
          {
-           "code": "E394",
+           "code": "E236",
            "description": "Filling a cache during prerender timed out, likely because request-specific arguments such as params, searchParams, cookies() or dynamic data were used inside "use cache".",
            "environmentLabel": null,
            "label": "Runtime Error",

--- a/test/e2e/app-dir/use-cache-search-params/use-cache-search-params.test.ts
+++ b/test/e2e/app-dir/use-cache-search-params/use-cache-search-params.test.ts
@@ -136,7 +136,7 @@ describe('use-cache-search-params', () => {
 
       await expect(browser).toDisplayRedbox(`
        {
-         "code": "E394",
+         "code": "E842",
          "description": "Route /search-params-used-generate-metadata used \`searchParams\` inside "use cache". Accessing dynamic request data inside a cache scope is not supported. If you need some search params inside a cached function await \`searchParams\` outside of the cached function and pass only the required search params as arguments to the cached function. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -157,7 +157,7 @@ describe('use-cache-search-params', () => {
 
       await expect(browser).toDisplayRedbox(`
        {
-         "code": "E394",
+         "code": "E842",
          "description": "Route /search-params-used-generate-viewport used \`searchParams\` inside "use cache". Accessing dynamic request data inside a cache scope is not supported. If you need some search params inside a cached function await \`searchParams\` outside of the cached function and pass only the required search params as arguments to the cached function. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache",
          "environmentLabel": null,
          "label": "Runtime Error",

--- a/test/e2e/new-link-behavior/child-a-tag-error.test.ts
+++ b/test/e2e/new-link-behavior/child-a-tag-error.test.ts
@@ -31,7 +31,7 @@ describe('New Link Behavior with <a> child', () => {
       )
       await expect(browser).toDisplayRedbox(`
        {
-         "code": "E394",
+         "code": "E209",
          "description": "Invalid <Link> with <a> child. Please remove <a> or use <Link legacyBehavior>.
        Learn more: https://nextjs.org/docs/messages/invalid-new-link-with-extra-anchor",
          "environmentLabel": null,


### PR DESCRIPTION
When SSR fails in development — whether the failing page is in the App Router or the Pages Router — Next.js falls back to rendering the Pages Router `/_error` page and serializes the original error into `__NEXT_DATA__.err`. The client bootstrap in `packages/next/src/client/ index.tsx` later re-throws a fresh `new Error(initialErr.message)` so that the dev overlay picks it up. The error-code SWC plugin stamps that new `Error` with the generic code mapped to `%s` in `errors.json` because the message argument is an identifier, not a statically-known string, which is how the overlay ended up showing the wrong code for errors like `UseCacheTimeoutError`.

The pipeline has two problems on the way to the overlay. First, `errorToJSON` in `packages/next/src/server/render.tsx` only copies the error's standard fields (`name`, `source`, `message`, `stack`, `digest`) into `__NEXT_DATA__.err`, so the real `__NEXT_ERROR_CODE` attached to the thrown error never reaches the client. Second, the subsequent rewrap in `getServerError` at `packages/next/src/server/dev/node-stack- frames.ts` creates yet another `new Error(...)` that the plugin stamps with the same generic code, clobbering anything the caller might have set on the rewrapped instance.

This change plumbs the code through. `errorToJSON` now also emits `__NEXT_ERROR_CODE` using `extractNextErrorCode` so the value survives JSON serialization into `__NEXT_DATA__.err`; the type in `packages/next/src/shared/lib/utils.ts` is updated to match. Both rewrap sites — the client bootstrap and `getServerError` — copy the code from the source error onto the fresh `Error` via `Object.defineProperty` with `enumerable: false` and `configurable: true`, matching how the plugin itself stores the property, which overrides the generic code the plugin stamped on the rewrapped instance. The `use-cache-hanging` e2e test snapshot is updated from `E394` to `E236` now that the real code surfaces in the dev overlay.