### PR TITLE
Forward invalid dynamic usage errors on client-side navigations

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1575,6 +1575,23 @@ async function generateDynamicFlightRenderResultWithStagesInDev(
       )
     } else {
       logValidationSkipped(ctx)
+
+      // The main render may record an invalid dynamic usage error on the work
+      // store, e.g. a `'use cache'` fill timeout, or a request API like
+      // `cookies()` being called inside a `'use cache'` scope. Even when we
+      // don't spawn the static shell validation, surface any recorded error
+      // through the dev overlay so client-side navigations see the same error
+      // as initial HTML loads, where the spawned validation forwards it. Wait
+      // for the full stream to finish accumulating so we also catch errors from
+      // the dynamic stage.
+      void accumulatedChunksPromise.then(() => {
+        if (workStore.invalidDynamicUsageError) {
+          logMessagesAndSendErrorsToBrowser(
+            [workStore.invalidDynamicUsageError],
+            ctx
+          )
+        }
+      })
     }
 
     debugChannel = returnedDebugChannel

--- a/test/e2e/app-dir/use-cache-hanging/app/layout.tsx
+++ b/test/e2e/app-dir/use-cache-hanging/app/layout.tsx
@@ -1,8 +1,20 @@
+import Link from 'next/link'
 import { ReactNode } from 'react'
 export default function Root({ children }: { children: ReactNode }) {
   return (
     <html>
-      <body>{children}</body>
+      <body>
+        <nav>
+          <Link href="/">Home</Link>
+          {' | '}
+          <Link href="/static">Static</Link>
+          {' | '}
+          <Link href="/runtime">Runtime</Link>
+          {' | '}
+          <Link href="/dynamic">Dynamic</Link>
+        </nav>
+        {children}
+      </body>
     </html>
   )
 }

--- a/test/e2e/app-dir/use-cache-hanging/app/page.tsx
+++ b/test/e2e/app-dir/use-cache-hanging/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>Home</p>
+}

--- a/test/e2e/app-dir/use-cache-hanging/use-cache-hanging.test.ts
+++ b/test/e2e/app-dir/use-cache-hanging/use-cache-hanging.test.ts
@@ -1,4 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
 import stripAnsi from 'strip-ansi'
 
 const expectedTimeoutErrorMessage =
@@ -17,7 +18,7 @@ describe('use-cache-hanging', () => {
 
   if (isNextDev) {
     describe('when a "use cache" fill hangs in the static stage', () => {
-      it('should show an error toast after a timeout', async () => {
+      it('should show an error after a timeout', async () => {
         const outputIndex = next.cliOutput.length
         const browser = await next.browser('/static')
 
@@ -46,7 +47,7 @@ describe('use-cache-hanging', () => {
     })
 
     describe('when a "use cache" fill hangs in the runtime stage', () => {
-      it('should show an error toast after a timeout', async () => {
+      it('should show an error after a timeout', async () => {
         const outputIndex = next.cliOutput.length
         const browser = await next.browser('/runtime')
 
@@ -71,6 +72,72 @@ describe('use-cache-hanging', () => {
 
         expect(cliOutput).toContain(`Error: ${expectedTimeoutErrorMessage}
     at getCachedData (app/runtime/page.tsx:8:1)`)
+      })
+    })
+
+    describe('when navigating to the static page', () => {
+      it('should show an error toast after a timeout', async () => {
+        const outputIndex = next.cliOutput.length
+        const browser = await next.browser('/')
+
+        await browser.elementByCss('a[href="/static"]').click()
+
+        await retry(() => {
+          const cliOutput = stripAnsi(next.cliOutput.slice(outputIndex))
+
+          expect(cliOutput).toContain(`Error: ${expectedTimeoutErrorMessage}
+    at getCachedData (app/static/page.tsx:6:1)`)
+        }, 20_000)
+
+        await expect(browser).toDisplayCollapsedRedbox(`
+         {
+           "code": "E236",
+           "description": "Filling a cache during prerender timed out, likely because request-specific arguments such as params, searchParams, cookies() or dynamic data were used inside "use cache".",
+           "environmentLabel": "Server",
+           "label": "Console Error",
+           "source": "app/static/page.tsx (6:1) @ getCachedData
+         > 6 | async function getCachedData(): Promise<string> {
+             | ^",
+           "stack": [
+             "getCachedData app/static/page.tsx (6:1)",
+             "Cached app/static/page.tsx (18:24)",
+             "Page app/static/page.tsx (32:10)",
+           ],
+         }
+        `)
+      })
+    })
+
+    describe('when navigating to the runtime page', () => {
+      it('should show an error toast after a timeout', async () => {
+        const outputIndex = next.cliOutput.length
+        const browser = await next.browser('/')
+
+        await browser.elementByCss('a[href="/runtime"]').click()
+
+        await retry(() => {
+          const cliOutput = stripAnsi(next.cliOutput.slice(outputIndex))
+
+          expect(cliOutput).toContain(`Error: ${expectedTimeoutErrorMessage}
+    at getCachedData (app/runtime/page.tsx:8:1)`)
+        }, 20_000)
+
+        await expect(browser).toDisplayCollapsedRedbox(`
+         {
+           "code": "E236",
+           "description": "Filling a cache during prerender timed out, likely because request-specific arguments such as params, searchParams, cookies() or dynamic data were used inside "use cache".",
+           "environmentLabel": "Server",
+           "label": "Console Error",
+           "source": "app/runtime/page.tsx (8:1) @ getCachedData
+         >  8 | async function getCachedData(): Promise<string> {
+              | ^",
+           "stack": [
+             "getCachedData app/runtime/page.tsx (8:1)",
+             "Cached app/runtime/page.tsx (20:24)",
+             "Page app/runtime/page.tsx (42:7)",
+           ],
+         }
+        `)
       })
     })
 


### PR DESCRIPTION
In dev mode, the static shell validation only runs during the initial page load and HMR refreshes, not during client-side navigations. During a client-side navigation an invalid dynamic usage error — for example a `'use cache'` fill timeout, or a request API like `cookies()` called inside a `'use cache'` scope — does still reach the browser via the errored `'use cache'` stream. But when the cache invocation is wrapped in a user-space `try`/`catch`, the error is caught and swallowed in user code, and because the static shell validation isn't running to surface it separately, the error is then neither sent to the browser nor logged to the terminal.

When we skip the validation, we now wait for the full render stream to finish and then, if an error was recorded during the render, send it to the browser and log it to the terminal. Waiting for the stream to finish mirrors what the static shell validation already does, and ensures we also catch errors from `'use cache'` invocations that only run in the dynamic stage.