### PR TITLE
fix(use-cache): don't await ignoredStream.cancel() to unblock SWR on Node runtime

### DIFF
--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -2665,7 +2665,7 @@ export async function cache(
                     )
                   }
 
-                  await ignoredStream.cancel()
+                  void ignoredStream.cancel().catch(() => {})
                 }
               })
               .catch((error) => {


### PR DESCRIPTION
## What?

Removes the `await` from `ignoredStream.cancel()` in the SWR background revalidation path of the `use-cache` wrapper.

## Why?

Node Web Streams tee semantics cause `cancel()` on a forked branch to block until the **source stream closes** — meaning the full regeneration must complete before the awaited cancel resolves. This defeats stale-while-revalidate on Node runtime: the caller's pending revalidation promise (`revalidatePromise`, pushed to `pendingRevalidateWrites`) doesn't settle until the regen is done, which can force the response to wait.

Edge runtime is unaffected because it uses `evt.waitUntil` instead.

## How?

Change `await ignoredStream.cancel()` → `void ignoredStream.cancel().catch(() => {})`.

The stream is being intentionally discarded (named `ignoredStream`), so silencing the error and not awaiting is the correct behavior.

Fixes #93146