### PR TITLE
Fix route handler SWR blocking on Node runtime

### DIFF
--- a/packages/next/src/build/templates/app-route.ts
+++ b/packages/next/src/build/templates/app-route.ts
@@ -408,7 +408,7 @@ export async function handler(
               nodeNextReq,
               nodeNextRes,
               response,
-              context.renderOpts.pendingWaitUntil
+              pendingWaitUntil
             )
             return null
           }

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -3342,9 +3342,6 @@ describe('app-dir static/dynamic handling', () => {
     // Prime the cache.
     let res = await next.fetch(path)
     expect(res.status).toBe(200)
-
-    // Consume the cache, the revalidations are completed on the end of the
-    // stream so we need to wait for that to complete.
     await res.text()
 
     for (let i = 0; i < 6; i++) {
@@ -3374,6 +3371,7 @@ describe('app-dir static/dynamic handling', () => {
           )
         }
       }
+      const finishedAt = Date.now()
 
       const startedResponding = +data.start
       if (Number.isNaN(startedResponding)) {
@@ -3387,12 +3385,17 @@ describe('app-dir static/dynamic handling', () => {
         )
       }
 
-      // We just want to ensure the response isn't blocked on revalidating the fetch.
-      // So we use the start time when route started processing not when we
-      // send off the response because that includes cold boots of the infra.
+      // The response must not be blocked on the 3s background revalidation:
+      // neither the first byte (TTFB) nor the terminating chunk (res.end).
+      // Using the route-start time excludes cold-boot/infra latency.
       if (startedStreaming - startedResponding >= 3000) {
         throw new Error(
-          `Response #${i} took too long to complete: ${startedStreaming - startedResponding}ms`
+          `Response #${i} first byte took too long: ${startedStreaming - startedResponding}ms`
+        )
+      }
+      if (finishedAt - startedResponding >= 3000) {
+        throw new Error(
+          `Response #${i} took too long to complete: ${finishedAt - startedResponding}ms`
         )
       }
     }

--- a/test/e2e/app-dir/use-cache-swr/app/delayed-route/route.ts
+++ b/test/e2e/app-dir/use-cache-swr/app/delayed-route/route.ts
@@ -1,0 +1,19 @@
+import { cacheLife } from 'next/cache'
+import { setTimeout } from 'timers/promises'
+
+async function getCachedData() {
+  'use cache'
+
+  cacheLife('seconds')
+
+  await setTimeout(1000)
+
+  return new Date().toISOString()
+}
+
+export async function GET() {
+  const cached = await getCachedData()
+  const dynamic = new Date().toISOString()
+
+  return Response.json({ cached, dynamic })
+}

--- a/test/e2e/app-dir/use-cache-swr/use-cache-swr.test.ts
+++ b/test/e2e/app-dir/use-cache-swr/use-cache-swr.test.ts
@@ -103,6 +103,49 @@ describe('use-cache-swr', () => {
     expect(duration3).toBeLessThan(1000)
   })
 
+  it('should serve stale data without blocking on the background regeneration (route handler)', async () => {
+    // Fetch 1: cold cache. The cached function blocks for ~1s.
+    const res1 = await next.fetch('/delayed-route')
+    const { cached: cached1, dynamic: dynamic1 } = await res1.json()
+    expect(cached1).toBeDateString()
+    expect(dynamic1).toBeDateString()
+
+    // Wait past the 1s revalidate window (cacheLife('seconds')).
+    await new Promise((resolve) => setTimeout(resolve, 1200))
+
+    outputIndex = next.cliOutput.length
+
+    // Fetch 2: stale hit. Should return the stale entry immediately and kick
+    // off the regeneration in the background, rather than blocking on the 1s
+    // delay in the cached function.
+    const start2 = Date.now()
+    const res2 = await next.fetch('/delayed-route')
+    const { cached: cached2, dynamic: dynamic2 } = await res2.json()
+    const duration2 = Date.now() - start2
+
+    expect(cached2).toBe(cached1)
+    expect(dynamic2).not.toBe(dynamic1)
+    expect(duration2).toBeLessThan(1000)
+
+    // Wait for the background regen to finish writing the fresh entry.
+    await retry(() => {
+      expect(next.cliOutput.slice(outputIndex)).toMatch(
+        /PersistentCacheHandler::set/
+      )
+    })
+
+    // Fetch 3: should serve the pre-warmed fresh entry from the background
+    // regen, not a new stale value.
+    const start3 = Date.now()
+    const res3 = await next.fetch('/delayed-route')
+    const { cached: cached3, dynamic: dynamic3 } = await res3.json()
+    const duration3 = Date.now() - start3
+
+    expect(cached3).not.toBe(cached1)
+    expect(dynamic3).not.toBe(dynamic2)
+    expect(duration3).toBeLessThan(1000)
+  })
+
   it('should pass implicit tags to cache handler get() for nested caches during SWR', async () => {
     const browser = await next.browser('/')
     await browser.elementById('outer-data').text()


### PR DESCRIPTION
In a Node-runtime app route handler, `'use cache'` and fetch-cache stale-while-revalidate block the client response on the full background regeneration. A second request after the cache has gone stale does not return the stale value promptly. It waits the entire regen duration and then returns the freshly regenerated value, as described in issue
 #93146. The symptom is visible both on self-hosted Node and on Vercel Node. Edge route handlers were unaffected because they route through `edge-route-module-wrapper.ts`, which hands `pendingWaitUntil` directly to `evt.waitUntil` and never awaits it before the response completes.

The root cause is independent of the `await ignoredStream.cancel()` change proposed in that issue, and also independent of #92636, which removed a separate blocking await inside `use-cache-wrapper.ts`. Both of those sit inside the `'use cache'` wrapper and affect how the stale entry is returned to the caller. The blocking that remains is in the transport layer and applies equally to any revalidation pushed into `pendingRevalidates` or `pendingRevalidateWrites`, not just `'use cache'`.

#74164 migrated pending revalidate handling from the "keep the response stream open until the promise resolves" pattern introduced in #55978 and reinforced in #58744 to a conditional hand-off. If a platform `waitUntil` is available, revalidations run out of band via `ctx.waitUntil`. Otherwise `pipe-readable.ts` keeps `res.end` deferred until they settle, so minimal-mode deployments stay alive long enough for writes to persist.

That migration landed correctly for app pages. `app-render.tsx` only assigns `options.waitUntil` in the `else` branch, so once `renderOpts.waitUntil` is present the `pipe-readable.ts` path receives nothing and does not block. The matching code for route handlers was added to `base-server.ts` in the same PR. It declared `let pendingWaitUntil = context.renderOpts.pendingWaitUntil`, cleared it when handing off to `ctx.waitUntil`, and then passed `context.renderOpts.pendingWaitUntil` into `sendResponse`. That is the unmutated property, not the cleared local. The local variable was never read. The hand-off therefore never displaced the pipe-readable await. The same promise was awaited twice. `ctx.waitUntil` registered it redundantly and `pipe-readable.ts` still held `res.end` open for the full revalidation.

#80189 copied the block verbatim into `packages/next/src/build/templates/app-route.ts`, carrying the bug forward when response handling moved into the route template. Fixing it is a one-line change. Pass the local `pendingWaitUntil` (which is `undefined` once handed off) into `sendResponse`, so Node route handlers match both app pages and edge route handlers and the original intent of #74164 is restored.

The existing `stale-cache-serving/route-handler` test in `app-static.test.ts` did not catch this. It only measured time-to-first-byte against the route start time, and first-byte was already fast pre-fix. Chunks are written before `pipe-readable.ts`'s close handler awaits `waitUntilForEnd`. Only the terminating chunk was delayed. The test is updated to also assert total response time against the route start. Pre-fix that new assertion fails at ~3000ms for the Node route handler variant while the page and edge variants continue to pass, which is exactly the scope of the regression. A new e2e test in `use-cache-swr` exercises the symmetric `'use cache'` path through a route handler fixture.

fixes #93146
closes #93177 (incorrect fix)
closes #93188 (incorrect fix)