### PR TITLE
Turbopack: move get_inner_asset into ecmascript module

### DIFF
--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -616,8 +616,11 @@ export interface TraceQueryOptions {
   parent?: string
   /** When `true` (default), aggregate child spans with the same name. */
   aggregated?: boolean
-  /** Sort mode: `"value"` for duration descending, `"name"` for alphabetical. Omit for execution order. */
-  sort?: 'value' | 'name'
+  /**
+   * Sort mode: `"value"` for duration descending, `"name"` for alphabetical.
+   * Omit for execution order (no sorting).
+   */
+  sort?: string
   /** Optional substring search query applied to span name/category. */
   search?: string
   /** 1-based page number. Default `1`. */

--- a/turbopack/crates/turbopack-core/src/resolve/origin.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/origin.rs
@@ -6,7 +6,7 @@ use turbo_tasks::{ResolvedVc, Upcast, Vc};
 use turbo_tasks_fs::FileSystemPath;
 
 use super::{ModuleResolveResult, options::ResolveOptions, parse::Request};
-use crate::{context::AssetContext, module::OptionModule, reference_type::ReferenceType};
+use crate::{context::AssetContext, reference_type::ReferenceType};
 
 /// A location where resolving can occur from. It carries some meta information
 /// that are needed for resolving from here.
@@ -23,14 +23,6 @@ pub trait ResolveOrigin {
     /// subgraph.
     #[turbo_tasks::function]
     fn asset_context(self: Vc<Self>) -> Vc<Box<dyn AssetContext>>;
-
-    /// Get an inner asset form this origin that doesn't require resolving but
-    /// is directly attached
-    #[turbo_tasks::function]
-    fn get_inner_asset(self: Vc<Self>, request: Vc<Request>) -> Vc<OptionModule> {
-        let _ = request;
-        Vc::cell(None)
-    }
 
     /// Get the resolve options that apply for this origin.
     #[turbo_tasks::function]
@@ -62,18 +54,18 @@ impl<T> ResolveOriginExt for T
 where
     T: ResolveOrigin + Upcast<Box<dyn ResolveOrigin>>,
 {
-    fn resolve_asset(
+    async fn resolve_asset(
         self: Vc<Self>,
         request: Vc<Request>,
         options: Vc<ResolveOptions>,
         reference_type: ReferenceType,
-    ) -> impl Future<Output = Result<Vc<ModuleResolveResult>>> + Send {
-        resolve_asset(
-            Vc::upcast_non_strict(self),
-            request,
-            options,
+    ) -> Result<Vc<ModuleResolveResult>> {
+        Ok(self.asset_context().to_resolved().await?.resolve_asset(
+            self.origin_path().owned().await?,
+            *request.to_resolved().await?,
+            *options.to_resolved().await?,
             reference_type,
-        )
+        ))
     }
 
     fn with_transition(self: ResolvedVc<Self>, transition: RcStr) -> Vc<Box<dyn ResolveOrigin>> {
@@ -85,27 +77,6 @@ where
             .cell(),
         )
     }
-}
-
-async fn resolve_asset(
-    resolve_origin: Vc<Box<dyn ResolveOrigin>>,
-    request: Vc<Request>,
-    options: Vc<ResolveOptions>,
-    reference_type: ReferenceType,
-) -> Result<Vc<ModuleResolveResult>> {
-    if let Some(asset) = *resolve_origin.get_inner_asset(request).await? {
-        return Ok(*ModuleResolveResult::module(asset));
-    }
-    Ok(resolve_origin
-        .asset_context()
-        .to_resolved()
-        .await?
-        .resolve_asset(
-            resolve_origin.origin_path().owned().await?,
-            *request.to_resolved().await?,
-            *options.to_resolved().await?,
-            reference_type,
-        ))
 }
 
 /// A resolve origin for some path and context without additional modifications.
@@ -162,10 +133,5 @@ impl ResolveOrigin for ResolveOriginWithTransition {
         self.previous
             .asset_context()
             .with_transition(self.transition.clone())
-    }
-
-    #[turbo_tasks::function]
-    fn get_inner_asset(&self, request: Vc<Request>) -> Vc<OptionModule> {
-        self.previous.get_inner_asset(request)
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -91,14 +91,11 @@ use turbopack_core::{
     compile_time_info::CompileTimeInfo,
     context::AssetContext,
     ident::AssetIdent,
-    module::{Module, ModuleSideEffects, OptionModule},
+    module::{Module, ModuleSideEffects},
     module_graph::ModuleGraph,
     reference::ModuleReferences,
     reference_type::InnerAssets,
-    resolve::{
-        FindContextFileResult, find_context_file, origin::ResolveOrigin, package_json,
-        parse::Request,
-    },
+    resolve::{FindContextFileResult, find_context_file, origin::ResolveOrigin, package_json},
     source::Source,
     source_map::GenerateSourceMap,
 };
@@ -976,19 +973,6 @@ impl ResolveOrigin for EcmascriptModuleAsset {
     #[turbo_tasks::function]
     fn asset_context(&self) -> Vc<Box<dyn AssetContext>> {
         *self.asset_context
-    }
-
-    #[turbo_tasks::function]
-    async fn get_inner_asset(&self, request: Vc<Request>) -> Result<Vc<OptionModule>> {
-        Ok(Vc::cell(if let Some(inner_assets) = &self.inner_assets {
-            if let Some(request) = request.await?.request() {
-                inner_assets.await?.get(&request).copied()
-            } else {
-                None
-            }
-        } else {
-            None
-        }))
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/cjs.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/cjs.rs
@@ -29,6 +29,7 @@ use crate::{
     runtime_functions::TURBOPACK_CACHE,
 };
 
+/// Generic CommonJS reference that doesn't perform any codegen. Used for tracing
 #[turbo_tasks::value]
 #[derive(Hash, Debug, ValueToString)]
 #[value_to_string("generic commonjs {request}")]
@@ -224,6 +225,7 @@ pub struct CjsRequireResolveAssetReference {
     issue_source: IssueSource,
     error_mode: ResolveErrorMode,
     chunking_type_attribute: Option<SpecifiedChunkingType>,
+    resolve_override: Option<ResolvedVc<Box<dyn Module>>>,
 }
 
 impl CjsRequireResolveAssetReference {
@@ -233,6 +235,7 @@ impl CjsRequireResolveAssetReference {
         issue_source: IssueSource,
         error_mode: ResolveErrorMode,
         chunking_type_attribute: Option<SpecifiedChunkingType>,
+        resolve_override: Option<ResolvedVc<Box<dyn Module>>>,
     ) -> Self {
         CjsRequireResolveAssetReference {
             origin,
@@ -240,6 +243,7 @@ impl CjsRequireResolveAssetReference {
             issue_source,
             error_mode,
             chunking_type_attribute,
+            resolve_override,
         }
     }
 }
@@ -248,6 +252,10 @@ impl CjsRequireResolveAssetReference {
 impl ModuleReference for CjsRequireResolveAssetReference {
     #[turbo_tasks::function]
     fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
+        if let Some(resolved) = &self.resolve_override {
+            return *ModuleResolveResult::module(*resolved);
+        }
+
         cjs_resolve(
             *self.origin,
             *self.request,

--- a/turbopack/crates/turbopack-ecmascript/src/references/cjs.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/cjs.rs
@@ -11,6 +11,7 @@ use turbo_tasks::{
 use turbopack_core::{
     chunk::{ChunkingContext, ChunkingType},
     issue::IssueSource,
+    module::Module,
     reference::ModuleReference,
     reference_type::CommonJsReferenceSubType,
     resolve::{ModuleResolveResult, ResolveErrorMode, origin::ResolveOrigin, parse::Request},
@@ -86,6 +87,7 @@ pub struct CjsRequireAssetReference {
     issue_source: IssueSource,
     error_mode: ResolveErrorMode,
     chunking_type_attribute: Option<SpecifiedChunkingType>,
+    resolve_override: Option<ResolvedVc<Box<dyn Module>>>,
 }
 
 impl CjsRequireAssetReference {
@@ -95,6 +97,7 @@ impl CjsRequireAssetReference {
         issue_source: IssueSource,
         error_mode: ResolveErrorMode,
         chunking_type_attribute: Option<SpecifiedChunkingType>,
+        resolve_override: Option<ResolvedVc<Box<dyn Module>>>,
     ) -> Self {
         CjsRequireAssetReference {
             origin,
@@ -102,6 +105,7 @@ impl CjsRequireAssetReference {
             issue_source,
             error_mode,
             chunking_type_attribute,
+            resolve_override,
         }
     }
 }
@@ -110,6 +114,10 @@ impl CjsRequireAssetReference {
 impl ModuleReference for CjsRequireAssetReference {
     #[turbo_tasks::function]
     fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
+        if let Some(resolved) = &self.resolve_override {
+            return *ModuleResolveResult::module(*resolved);
+        }
+
         cjs_resolve(
             *self.origin,
             *self.request,

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -333,6 +333,7 @@ pub struct EsmAssetReference {
     pub import_externals: bool,
     pub tree_shaking_mode: Option<TreeShakingMode>,
     pub is_pure_import: bool,
+    pub resolve_override: Option<ResolvedVc<Box<dyn Module>>>,
 }
 
 impl EsmAssetReference {
@@ -356,6 +357,7 @@ impl EsmAssetReference {
         import_usage: ImportUsage,
         import_externals: bool,
         tree_shaking_mode: Option<TreeShakingMode>,
+        resolve_override: Option<ResolvedVc<Box<dyn Module>>>,
     ) -> Self {
         EsmAssetReference {
             module,
@@ -368,6 +370,7 @@ impl EsmAssetReference {
             import_externals,
             tree_shaking_mode,
             is_pure_import: false,
+            resolve_override,
         }
     }
 
@@ -381,6 +384,7 @@ impl EsmAssetReference {
         import_usage: ImportUsage,
         import_externals: bool,
         tree_shaking_mode: Option<TreeShakingMode>,
+        resolve_override: Option<ResolvedVc<Box<dyn Module>>>,
     ) -> Self {
         EsmAssetReference {
             module,
@@ -393,6 +397,7 @@ impl EsmAssetReference {
             import_externals,
             tree_shaking_mode,
             is_pure_import: true,
+            resolve_override,
         }
     }
     pub(crate) fn get_referenced_asset(self: Vc<Self>) -> Vc<ReferencedAsset> {
@@ -404,6 +409,9 @@ impl EsmAssetReference {
 impl ModuleReference for EsmAssetReference {
     #[turbo_tasks::function]
     async fn resolve_reference(&self) -> Result<Vc<ModuleResolveResult>> {
+        if let Some(resolved) = &self.resolve_override {
+            return Ok(*ModuleResolveResult::module(*resolved));
+        }
         let ty = if let Some(loader) = self.annotations.as_ref().and_then(|a| a.turbopack_loader())
         {
             // Resolve the loader path relative to the importing file

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/dynamic.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/dynamic.rs
@@ -12,6 +12,7 @@ use turbopack_core::{
     chunk::{ChunkingContext, ChunkingType},
     environment::ChunkLoading,
     issue::IssueSource,
+    module::Module,
     reference::ModuleReference,
     reference_type::EcmaScriptModulesReferenceSubType,
     resolve::{
@@ -46,6 +47,7 @@ pub struct EsmAsyncAssetReference {
     /// Detected from destructured await, member access on await, .then()
     /// callback destructuring, or webpackExports/turbopackExports comments.
     pub export_usage: ExportUsage,
+    pub resolve_override: Option<ResolvedVc<Box<dyn Module>>>,
 }
 
 impl EsmAsyncAssetReference {
@@ -67,6 +69,7 @@ impl EsmAsyncAssetReference {
         error_mode: ResolveErrorMode,
         import_externals: bool,
         export_usage: ExportUsage,
+        resolve_override: Option<ResolvedVc<Box<dyn Module>>>,
     ) -> Self {
         EsmAsyncAssetReference {
             origin,
@@ -76,6 +79,7 @@ impl EsmAsyncAssetReference {
             error_mode,
             import_externals,
             export_usage,
+            resolve_override,
         }
     }
 }
@@ -84,6 +88,10 @@ impl EsmAsyncAssetReference {
 impl ModuleReference for EsmAsyncAssetReference {
     #[turbo_tasks::function]
     async fn resolve_reference(&self) -> Result<Vc<ModuleResolveResult>> {
+        if let Some(resolved) = &self.resolve_override {
+            return Ok(*ModuleResolveResult::module(*resolved));
+        }
+
         esm_resolve(
             *self.get_origin().to_resolved().await?,
             *self.request,

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -1799,6 +1799,7 @@ async fn handle_dynamic_import<G: Fn(Vec<Effect>) + Send + Sync>(
         handler,
         origin,
         source,
+        &state.inner_assets,
         ignore_dynamic_requests,
         analysis,
         error_mode,
@@ -1815,6 +1816,7 @@ async fn handle_dynamic_import_with_linked_args(
     handler: &Handler,
     origin: ResolvedVc<Box<dyn ResolveOrigin>>,
     source: ResolvedVc<Box<dyn Source>>,
+    inner_assets: &Option<ReadRef<InnerAssets>>,
     ignore_dynamic_requests: bool,
     analysis: &mut AnalyzeEcmascriptModuleResultBuilder,
     error_mode: ResolveErrorMode,
@@ -1858,6 +1860,16 @@ async fn handle_dynamic_import_with_linked_args(
                 return Ok(());
             }
         }
+
+        let resolve_override = if let Some(inner_assets) = &inner_assets
+            && let Some(req) = pat.as_constant_string()
+            && let Some(a) = inner_assets.get(req)
+        {
+            Some(*a)
+        } else {
+            None
+        };
+
         analysis.add_reference_code_gen(
             EsmAsyncAssetReference::new(
                 origin,
@@ -1867,6 +1879,7 @@ async fn handle_dynamic_import_with_linked_args(
                 error_mode,
                 import_externals,
                 export_usage,
+                resolve_override,
             ),
             ast_path.to_vec().into(),
         );
@@ -2158,6 +2171,7 @@ where
                 handler,
                 origin,
                 source,
+                &state.inner_assets,
                 ignore_dynamic_requests,
                 analysis,
                 error_mode,

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -2315,6 +2315,16 @@ where
                         return Ok(());
                     }
                 }
+
+                let resolve_override = if let Some(inner_assets) = &state.inner_assets
+                    && let Some(req) = pat.as_constant_string()
+                    && let Some(a) = inner_assets.get(req)
+                {
+                    Some(*a)
+                } else {
+                    None
+                };
+
                 analysis.add_reference_code_gen(
                     CjsRequireResolveAssetReference::new(
                         origin,
@@ -2322,6 +2332,7 @@ where
                         issue_source(source, span),
                         error_mode,
                         attributes.chunking_type,
+                        resolve_override,
                     ),
                     ast_path.to_vec().into(),
                 );

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -77,7 +77,7 @@ use turbopack_core::{
     issue::{IssueExt, IssueSeverity, IssueSource, StyledString, analyze::AnalyzeIssue},
     module::{Module, ModuleSideEffects},
     reference::{ModuleReference, ModuleReferences},
-    reference_type::CommonJsReferenceSubType,
+    reference_type::{CommonJsReferenceSubType, InnerAssets},
     resolve::{
         ExportUsage, FindContextFileResult, ImportUsage, ModulePart, ResolveErrorMode,
         find_context_file,
@@ -479,6 +479,8 @@ struct AnalysisState<'a> {
     import_references: &'a [ResolvedVc<EsmAssetReference>],
     // The import map from the eval context, used to match dep strings to import references.
     imports: &'a ImportMap,
+    // Resolve overrides for imports
+    inner_assets: Option<ReadRef<InnerAssets>>,
 }
 
 impl AnalysisState<'_> {
@@ -556,6 +558,12 @@ async fn analyze_ecmascript_module_internal(
     {
         analysis.ident = source.ident().to_string().owned().await?;
     }
+
+    let inner_assets = if let Some(assets) = raw_module.inner_assets {
+        Some(assets.await?)
+    } else {
+        None
+    };
 
     // Is this a typescript file that requires analyzing type references?
     let analyze_types = match &ty {
@@ -756,6 +764,16 @@ async fn analyze_ecmascript_module_internal(
         let mut import_references = Vec::with_capacity(eval_context.imports.references().len());
         for (i, r) in eval_context.imports.references().enumerate() {
             let mut should_add_evaluation = false;
+
+            let resolve_override = if let Some(inner_assets) = &inner_assets
+                && let Some(req) = r.module_path.as_str()
+                && let Some(a) = inner_assets.get(req)
+            {
+                Some(*a)
+            } else {
+                None
+            };
+
             let reference = EsmAssetReference::new(
                 module,
                 ResolvedVc::upcast(module),
@@ -799,6 +817,7 @@ async fn analyze_ecmascript_module_internal(
                     .unwrap_or_default(),
                 import_externals,
                 options.tree_shaking_mode,
+                resolve_override,
             )
             .resolved_cell();
 
@@ -972,6 +991,7 @@ async fn analyze_ecmascript_module_internal(
             is_esm,
             import_references: &import_references,
             imports: &eval_context.imports,
+            inner_assets,
         };
 
         enum Action {
@@ -1411,6 +1431,7 @@ async fn analyze_ecmascript_module_internal(
                                                 original_reference.import_usage.clone(),
                                                 original_reference.import_externals,
                                                 original_reference.tree_shaking_mode,
+                                                original_reference.resolve_override,
                                             )
                                             .resolved_cell()
                                         },
@@ -2163,6 +2184,16 @@ where
                         return Ok(());
                     }
                 }
+
+                let resolve_override = if let Some(inner_assets) = &state.inner_assets
+                    && let Some(req) = pat.as_constant_string()
+                    && let Some(a) = inner_assets.get(req)
+                {
+                    Some(*a)
+                } else {
+                    None
+                };
+
                 analysis.add_reference_code_gen(
                     CjsRequireAssetReference::new(
                         origin,
@@ -2170,6 +2201,7 @@ where
                         issue_source(source, span),
                         error_mode,
                         attributes.chunking_type,
+                        resolve_override,
                     ),
                     ast_path.to_vec().into(),
                 );
@@ -2221,6 +2253,7 @@ where
                         issue_source(source, span),
                         error_mode,
                         attributes.chunking_type,
+                        None,
                     ),
                     ast_path.to_vec().into(),
                 );
@@ -3219,6 +3252,7 @@ async fn handle_free_var_reference(
                         ImportUsage::TopLevel,
                         state.import_externals,
                         state.tree_shaking_mode,
+                        None,
                     )
                     .resolved_cell())
                 })

--- a/turbopack/crates/turbopack-wasm/src/module_asset.rs
+++ b/turbopack/crates/turbopack-wasm/src/module_asset.rs
@@ -8,12 +8,12 @@ use turbopack_core::{
     },
     context::AssetContext,
     ident::AssetIdent,
-    module::{Module, ModuleSideEffects, OptionModule},
+    module::{Module, ModuleSideEffects},
     module_graph::ModuleGraph,
     output::OutputAssetsWithReferenced,
     reference::{ModuleReferences, SingleChunkableModuleReference},
     reference_type::ReferenceType,
-    resolve::{ExportUsage, origin::ResolveOrigin, parse::Request},
+    resolve::{ExportUsage, origin::ResolveOrigin},
     source::{OptionSource, Source},
 };
 use turbopack_ecmascript::{
@@ -214,10 +214,5 @@ impl ResolveOrigin for WebAssemblyModuleAsset {
     #[turbo_tasks::function]
     fn asset_context(&self) -> Vc<Box<dyn AssetContext>> {
         *self.asset_context
-    }
-
-    #[turbo_tasks::function]
-    fn get_inner_asset(self: Vc<Self>, request: Vc<Request>) -> Vc<OptionModule> {
-        self.loader_as_resolve_origin().get_inner_asset(request)
     }
 }


### PR DESCRIPTION
`resolve_origin.get_inner_asset` showed up in Luke's statistics at a very high place.
But in reality, there are only 1-3 modules per page that have any inner assets (the templates, and the edge wrapper modules).
`resolve_origin.get_inner_asset` is in the hottest hot path (resolving references), so let's simply move this logic into the EcmascriptModuleAsset itself.

Behavioral differences to before:
- only works with static ESM `import`s, dynamic `import()`, `require`, `require.resolve`. But these are the only places that currently use it anyway.

```
0d9738112f mischnic/remove-get-inner-asset
pnpm next build --experimental-build-mode=compile  353.40s user 52.96s system 748% cpu 54.265 total
pnpm next build --experimental-build-mode=compile  349.42s user 53.84s system 744% cpu 54.198 total
pnpm next build --experimental-build-mode=compile  352.42s user 54.46s system 741% cpu 54.874 total

3cb77c844b canary
pnpm next build --experimental-build-mode=compile  367.91s user 58.06s system 726% cpu 58.672 total
pnpm next build --experimental-build-mode=compile  362.97s user 57.68s system 746% cpu 56.379 total
pnpm next build --experimental-build-mode=compile  364.59s user 57.01s system 724% cpu 58.167 total
```