### PR TITLE
Add skills CTA to hero and tutorial steps

### DIFF
--- a/examples/with-supabase/components/copy-button.tsx
+++ b/examples/with-supabase/components/copy-button.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useState } from "react";
+
+export function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const copy = async () => {
+    if (!window.document.hasFocus()) return;
+
+    if (typeof ClipboardItem !== "undefined" && navigator.clipboard?.write) {
+      // Safari requires the ClipboardItem promise pattern — direct async writes are blocked.
+      const item = new ClipboardItem({
+        "text/plain": Promise.resolve(text).then(
+          (t) => new Blob([t], { type: "text/plain" })
+        ),
+      });
+
+      let resolve = () => {};
+      let reject = () => {};
+      const promise = new Promise<void>((res, rej) => {
+        resolve = res;
+        reject = rej;
+      });
+      // Safari requires the promise to resolve shortly after the write call.
+      setTimeout(() => {
+        navigator.clipboard
+          .write([item])
+          .then(resolve)
+          .catch(reject);
+      }, 0);
+      await promise;
+    } else {
+      await navigator.clipboard?.writeText(text);
+    }
+
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className="flex items-center gap-2 rounded-lg border border-foreground/10 bg-foreground/5 px-4 py-3 text-sm text-foreground/80">
+      <code className="font-mono text-xs">{text}</code>
+      <button
+        onClick={copy}
+        aria-label="Copy"
+        className="ml-2 rounded p-1 hover:bg-foreground/10 transition-colors"
+      >
+        {copied ? (
+          <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <polyline points="20 6 9 17 4 12" />
+          </svg>
+        ) : (
+          <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+            <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+          </svg>
+        )}
+      </button>
+    </div>
+  );
+}

--- a/examples/with-supabase/components/hero.tsx
+++ b/examples/with-supabase/components/hero.tsx
@@ -1,5 +1,6 @@
 import { NextLogo } from "./next-logo";
 import { SupabaseLogo } from "./supabase-logo";
+import { CopyButton } from "./copy-button";
 
 export function Hero() {
   return (
@@ -38,6 +39,21 @@ export function Hero() {
           Next.js
         </a>
       </p>
+      <div className="flex flex-col items-center gap-3">
+        <p className="text-sm text-foreground/70">
+          Install{" "}
+          <a
+            href="https://supabase.com/docs/guides/getting-started/ai-skills"
+            target="_blank"
+            rel="noreferrer"
+            className="font-medium underline"
+          >
+            agent skills
+          </a>{" "}
+          to help you move faster
+        </p>
+        <CopyButton text="npx skills add supabase/agent-skills" />
+      </div>
       <div className="w-full p-[1px] bg-gradient-to-r from-transparent via-foreground/10 to-transparent my-8" />
     </div>
   );

--- a/examples/with-supabase/components/tutorial/connect-supabase-steps.tsx
+++ b/examples/with-supabase/components/tutorial/connect-supabase-steps.tsx
@@ -1,8 +1,28 @@
 import { TutorialStep } from "./tutorial-step";
+import Link from "next/link";
 
 export function ConnectSupabaseSteps() {
   return (
     <ol className="flex flex-col gap-6">
+      <TutorialStep title="Install agent skills">
+        <p>
+          Install agent skills to help you move faster and more effectively.{" "}
+          <Link
+            href="https://supabase.com/docs/guides/getting-started/ai-skills"
+            target="_blank"
+            rel="noreferrer"
+            className="font-bold hover:underline text-foreground/80 inline-flex items-center gap-1"
+          >
+            Learn more
+            <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+              <polyline points="15 3 21 3 21 9" />
+              <line x1="10" y1="14" x2="21" y2="3" />
+            </svg>
+          </Link>
+        </p>
+      </TutorialStep>
+
       <TutorialStep title="Create Supabase project">
         <p>
           Head over to{" "}


### PR DESCRIPTION
Adds a CTA for installing agent skills to the with-supabase example.  

<img width="1734" height="728" alt="CleanShot 2026-04-24 at 09 36 04" src="https://github.com/user-attachments/assets/b2b2eab2-8974-455e-9236-e7e548fd379a" />
