### PR TITLE
[rust-deps] Update tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9579,9 +9579,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -9590,9 +9590,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9612,9 +9612,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -350,7 +350,7 @@ thiserror = "1.0.48"
 thread_local = "1.1.8"
 tokio = "~1.47.3"
 tokio-util = { version = "0.7.13", features = ["io", "rt"] }
-tracing = "0.1.37"
+tracing = "0.1.44"
 tracing-subscriber = "0.3.16"
 triomphe = { git = "https://github.com/sokra/triomphe", branch = "sokra/unstable" }
 xxhash-rust = { version = "0.8.12", features = ["xxh3"] }

--- a/crates/next-build-test/Cargo.toml
+++ b/crates/next-build-test/Cargo.toml
@@ -20,7 +20,7 @@ swc_core = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tokio-stream = "0.1.15"
-tracing = "0.1"
+tracing = { workspace = true }
 tracing-subscriber = "0.3"
 turbo-rcstr = { workspace = true }
 turbo-tasks = { workspace = true }

--- a/crates/next-custom-transforms/Cargo.toml
+++ b/crates/next-custom-transforms/Cargo.toml
@@ -23,7 +23,7 @@ rustc-hash = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true, features = ["preserve_order"] }
 sha1 = "0.10.1"
-tracing = { version = "0.1.37" }
+tracing = { workspace = true }
 anyhow = { workspace = true }
 
 swc_core = { workspace = true, features = [


### PR DESCRIPTION
### What?

Updates the `tracing` crate and its related dependencies to their latest versions:

- `tracing`: 0.1.37 → 0.1.44
- `tracing-attributes`: 0.1.30 → 0.1.31  
- `tracing-core`: 0.1.34 → 0.1.36

### Why?

Keep Rust dependencies up to date with security patches and performance improvements.

### How?

Updated the version specification in `Cargo.toml` and regenerated `Cargo.lock`.

<!-- NEXT_JS_LLM_PR -->