### PR TITLE
[ci] Upload preview builds directly to Vercel Blob

### DIFF
--- a/.github/workflows/upload_preview_tarballs.yml
+++ b/.github/workflows/upload_preview_tarballs.yml
@@ -1,0 +1,71 @@
+# This workflow uploads preview tarballs to Vercel Blob after build-and-deploy
+# completes. It uses workflow_run so it always executes the DEFAULT BRANCH
+# version of this file -- an attacker who modifies this file on a feature branch
+# cannot change the code that touches the blob write token.
+name: upload-preview-tarballs
+
+on:
+  workflow_run:
+    workflows: [ "build-and-deploy" ]
+    types: [ completed ]
+
+env:
+  NODE_LTS_VERSION: 20
+
+permissions:
+  actions: read
+
+jobs:
+  upload:
+    name: Upload preview tarballs to Blob
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event != 'workflow_dispatch'
+    environment: preview-builds
+    steps:
+      - name: Setup node
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_LTS_VERSION }}
+          check-latest: true
+
+      # Checkout from the default branch (canary) -- workflow_run always uses
+      # the default branch's version of the workflow file and this checkout
+      # matches that, ensuring the upload script is trusted.
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 1
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Setup pnpm
+        run: corepack prepare
+
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.pnpm-store
+          key: ${{ runner.os }}-${{ runner.arch }}-pnpm-v2-${{
+            hashFiles('**/pnpm-lock.yaml') }}
+          # Do not use restore-keys since it leads to indefinite growth of the cache.
+
+      - name: Install node_modules
+        run: pnpm install --frozen-lockfile
+
+      - name: Download preview-tarballs artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: preview-tarballs
+          path: ${{ runner.temp }}/preview-tarballs
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Upload tarballs to Vercel Blob
+        run: node scripts/upload-preview-tarballs.js "${{
+          github.event.workflow_run.head_sha }}" "${{ runner.temp
+          }}/preview-tarballs"
+        env:
+          BLOB_READ_WRITE_TOKEN: ${{ secrets.PREVIEW_BUILDS_BLOB_READ_WRITE_TOKEN }}

--- a/.github/workflows/upload_preview_tarballs.yml
+++ b/.github/workflows/upload_preview_tarballs.yml
@@ -6,22 +6,21 @@ name: upload-preview-tarballs
 
 on:
   workflow_run:
-    workflows: [ "build-and-deploy" ]
-    types: [ completed ]
+    workflows: ['build-and-deploy']
+    types: [completed]
 
 env:
   NODE_LTS_VERSION: 20
 
 permissions:
   actions: read
+  contents: read
 
 jobs:
   upload:
     name: Upload preview tarballs to Blob
     runs-on: ubuntu-latest
-    if: >-
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event != 'workflow_dispatch'
+    if: github.event.workflow_run.conclusion == 'success'
     environment: preview-builds
     steps:
       - name: Setup node

--- a/package.json
+++ b/package.json
@@ -169,6 +169,7 @@
     "@types/trusted-types": "2.0.3",
     "@types/yargs": "16.0.11",
     "@vercel/agent-eval": "0.9.5",
+    "@vercel/blob": "2.3.2",
     "@vercel/devlow-bench": "workspace:*",
     "@vercel/kv": "3.0.0",
     "@vercel/og": "0.11.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -258,6 +258,9 @@ importers:
       '@vercel/agent-eval':
         specifier: 0.9.5
         version: 0.9.5
+      '@vercel/blob':
+        specifier: 2.3.2
+        version: 2.3.2(patch_hash=cb53bfa5effb15b3a361e176003df667cadf757b27b7c9b458c2f0fce86ea893)
       '@vercel/devlow-bench':
         specifier: workspace:*
         version: link:turbopack/packages/devlow-bench
@@ -332,7 +335,7 @@ importers:
         version: 5.2.1(eslint@9.37.0(jiti@2.6.1))
       eslint-plugin-import:
         specifier: 2.31.0
-        version: 2.31.0(eslint@9.37.0(jiti@2.6.1))
+        version: 2.31.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@6.0.2))(eslint@9.37.0(jiti@2.6.1))
       eslint-plugin-jest:
         specifier: 27.6.3
         version: 27.6.3(eslint@9.37.0(jiti@2.6.1))(jest@29.7.0(@types/node@20.17.6(patch_hash=9c31d25336aea4076b3cb942c35e59fd160c540947f01ea455a060367153f9fd))(babel-plugin-macros@3.1.0))(typescript@6.0.2)
@@ -11517,10 +11520,6 @@ packages:
 
   is-buffer@1.1.6:
     resolution: {integrity: sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==}
-
-  is-buffer@2.0.4:
-    resolution: {integrity: sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==}
-    engines: {node: '>=4'}
 
   is-buffer@2.0.5:
     resolution: {integrity: sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==}
@@ -27455,26 +27454,6 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
-  eslint-config-next@16.2.0-canary.91(eslint-plugin-import-x@4.3.1(eslint@9.37.0(jiti@2.6.1))(typescript@6.0.2))(eslint@9.37.0(jiti@2.6.1))(typescript@6.0.2):
-    dependencies:
-      '@next/eslint-plugin-next': 16.2.0-canary.91
-      eslint: 9.37.0(jiti@2.6.1)
-      eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.3.1(eslint@9.37.0(jiti@2.6.1))(typescript@6.0.2))(eslint-plugin-import@2.32.0(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.3.1(eslint@9.37.0(jiti@2.6.1))(typescript@6.0.2))(eslint-plugin-import@2.32.0(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1))
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.37.0(jiti@2.6.1))
-      eslint-plugin-react: 7.37.0(eslint@9.37.0(jiti@2.6.1))
-      eslint-plugin-react-hooks: 7.0.0(eslint@9.37.0(jiti@2.6.1))
-      globals: 16.4.0
-      typescript-eslint: 8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@6.0.2)
-    optionalDependencies:
-      typescript: 6.0.2
-    transitivePeerDependencies:
-      - '@typescript-eslint/parser'
-      - eslint-import-resolver-webpack
-      - eslint-plugin-import-x
-      - supports-color
-
   eslint-formatter-codeframe@7.32.1:
     dependencies:
       '@babel/code-frame': 7.12.11
@@ -27485,22 +27464,6 @@ snapshots:
       debug: 3.2.7
       is-core-module: 2.16.1
       resolve: 1.22.10
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.3.1(eslint@9.37.0(jiti@2.6.1))(typescript@6.0.2))(eslint-plugin-import@2.32.0(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.0
-      eslint: 9.37.0(jiti@2.6.1)
-      get-tsconfig: 4.12.0
-      is-bun-module: 2.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.15
-      unrs-resolver: 1.11.1
-    optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.3.1(eslint@9.37.0(jiti@2.6.1))(typescript@6.0.2))(eslint-plugin-import@2.32.0(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1))
-      eslint-plugin-import-x: 4.3.1(eslint@9.37.0(jiti@2.6.1))(typescript@6.0.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -27541,10 +27504,11 @@ snapshots:
       - bluebird
       - supports-color
 
-  eslint-module-utils@2.12.0(eslint-import-resolver-node@0.3.9)(eslint@9.37.0(jiti@2.6.1)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint@9.37.0(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
+      '@typescript-eslint/parser': 8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@6.0.2)
       eslint: 9.37.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
@@ -27558,16 +27522,6 @@ snapshots:
       eslint: 9.37.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.3.1(eslint@9.37.0(jiti@2.6.1))(typescript@6.0.2))(eslint-plugin-import@2.32.0)(eslint@9.37.0(jiti@2.6.1))
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.3.1(eslint@9.37.0(jiti@2.6.1))(typescript@6.0.2))(eslint-plugin-import@2.32.0(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)):
-    dependencies:
-      debug: 3.2.7
-    optionalDependencies:
-      eslint: 9.37.0(jiti@2.6.1)
-      eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.3.1(eslint@9.37.0(jiti@2.6.1))(typescript@6.0.2))(eslint-plugin-import@2.32.0(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -27595,7 +27549,7 @@ snapshots:
       - typescript
     optional: true
 
-  eslint-plugin-import@2.31.0(eslint@9.37.0(jiti@2.6.1)):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@6.0.2))(eslint@9.37.0(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -27606,7 +27560,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.37.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(eslint-import-resolver-node@0.3.9)(eslint@9.37.0(jiti@2.6.1))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint@9.37.0(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -27617,6 +27571,8 @@ snapshots:
       semver: 6.3.1
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@6.0.2)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -27646,33 +27602,6 @@ snapshots:
       tsconfig-paths: 3.15.0
     optionalDependencies:
       '@typescript-eslint/parser': 8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@6.0.2)
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
-
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.3.1(eslint@9.37.0(jiti@2.6.1))(typescript@6.0.2))(eslint-plugin-import@2.32.0(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)):
-    dependencies:
-      '@rtsao/scc': 1.1.0
-      array-includes: 3.1.9
-      array.prototype.findlastindex: 1.2.6
-      array.prototype.flat: 1.3.3
-      array.prototype.flatmap: 1.3.3
-      debug: 3.2.7
-      doctrine: 2.1.0
-      eslint: 9.37.0(jiti@2.6.1)
-      eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.3.1(eslint@9.37.0(jiti@2.6.1))(typescript@6.0.2))(eslint-plugin-import@2.32.0(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1))
-      hasown: 2.0.2
-      is-core-module: 2.16.1
-      is-glob: 4.0.3
-      minimatch: 3.1.2
-      object.fromentries: 2.0.8
-      object.groupby: 1.0.3
-      object.values: 1.2.1
-      semver: 6.3.1
-      string.prototype.trimend: 1.0.9
-      tsconfig-paths: 3.15.0
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -29826,8 +29755,6 @@ snapshots:
       has-tostringtag: 1.0.2
 
   is-buffer@1.1.6: {}
-
-  is-buffer@2.0.4: {}
 
   is-buffer@2.0.5: {}
 
@@ -37132,7 +37059,7 @@ snapshots:
 
   to-vfile@6.1.0:
     dependencies:
-      is-buffer: 2.0.4
+      is-buffer: 2.0.5
       vfile: 4.2.1
 
   toidentifier@1.0.0: {}
@@ -37499,7 +37426,7 @@ snapshots:
       figures: 3.1.0
       glob: 7.1.7
       ignore: 5.3.2
-      is-buffer: 2.0.4
+      is-buffer: 2.0.5
       is-empty: 1.2.0
       is-plain-obj: 2.1.0
       js-yaml: 3.14.1
@@ -37523,7 +37450,7 @@ snapshots:
       '@types/unist': 2.0.3
       bail: 2.0.2
       extend: 3.0.2
-      is-buffer: 2.0.4
+      is-buffer: 2.0.5
       is-plain-obj: 4.1.0
       trough: 2.1.0
       vfile: 5.3.6
@@ -37543,7 +37470,7 @@ snapshots:
       '@types/unist': 2.0.3
       bail: 1.0.4
       extend: 3.0.2
-      is-buffer: 2.0.4
+      is-buffer: 2.0.5
       is-plain-obj: 2.1.0
       trough: 1.0.4
       vfile: 4.2.1
@@ -37992,14 +37919,14 @@ snapshots:
   vfile@4.2.1:
     dependencies:
       '@types/unist': 2.0.3
-      is-buffer: 2.0.4
+      is-buffer: 2.0.5
       unist-util-stringify-position: 2.0.3
       vfile-message: 2.0.4
 
   vfile@5.3.6:
     dependencies:
       '@types/unist': 2.0.3
-      is-buffer: 2.0.4
+      is-buffer: 2.0.5
       unist-util-stringify-position: 3.0.3
       vfile-message: 3.1.3
 

--- a/scripts/upload-preview-tarballs.js
+++ b/scripts/upload-preview-tarballs.js
@@ -1,0 +1,45 @@
+// @ts-check
+const { put } = require('@vercel/blob')
+const fs = require('node:fs/promises')
+const path = require('node:path')
+
+async function main() {
+  const [githubHeadSha, tarballDirectory] = process.argv.slice(2)
+  if (!githubHeadSha || !tarballDirectory) {
+    throw new Error(
+      'Usage: node scripts/upload-preview-tarballs.js <commitSha> <tarballDirectory>'
+    )
+  }
+
+  if (!process.env.BLOB_READ_WRITE_TOKEN) {
+    throw new Error('BLOB_READ_WRITE_TOKEN environment variable is required')
+  }
+
+  const packageDirs = await fs.readdir(tarballDirectory)
+  for (const packageName of packageDirs) {
+    const dir = path.join(tarballDirectory, packageName)
+    const stat = await fs.stat(dir)
+    if (!stat.isDirectory()) continue
+
+    const files = await fs.readdir(dir)
+    const tgzFile = files.find((f) => f.endsWith('.tgz'))
+    if (!tgzFile) continue
+
+    const blobPathname = `next/commits/${githubHeadSha}/${packageName}.tgz`
+
+    const fileBuffer = await fs.readFile(path.join(dir, tgzFile))
+    const { url } = await put(blobPathname, fileBuffer, {
+      access: 'public',
+      addRandomSuffix: false,
+      contentType: 'application/gzip',
+    })
+    console.info(`Uploaded ${packageName} -> ${url}`)
+  }
+
+  console.info('All tarballs uploaded to Vercel Blob')
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
This allows us to drop granting Actions read permissions to vercel-packages. We just upload directly from GitHub to Vercel blob.

We're doing this from a separate workflow that runs after build_and_deploy. [`workflow_run` runs on the default branch](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflow_run) which prevents cache poisoning. You can still upload bad builds to Vercel blob but you can't also control the commit these get uploaded to.

The `PREVIEW_BUILDS_BLOB_READ_WRITE_TOKEN` secret is only available in a protected GitHub deploy environment that is only allowed on `canary` branches.