### PR TITLE
[next/image] Stop using deprecated `url.parse`

### DIFF
--- a/packages/next/src/server/image-optimizer.ts
+++ b/packages/next/src/server/image-optimizer.ts
@@ -7,7 +7,6 @@ import imageSizeOf from 'next/dist/compiled/image-size'
 import { detector } from 'next/dist/compiled/image-detector/detector.js'
 import isAnimated from 'next/dist/compiled/is-animated'
 import { join } from 'path'
-import nodeUrl, { type UrlWithParsedQuery } from 'url'
 
 import { getImageBlurSvg } from '../shared/lib/image-blur-svg'
 import type { ImageConfigComplete } from '../shared/lib/image-config'
@@ -31,7 +30,7 @@ import * as Log from '../build/output/log'
 import isError from '../lib/is-error'
 import { isPrivateIp } from './is-private-ip'
 import { getOrInitDiskLRU } from './lib/disk-lru-cache.external'
-import { parseUrl } from '../lib/url'
+import { parseUrl, parseReqUrl } from '../lib/url'
 import type { CacheControl } from './lib/cache-control'
 import { InvariantError } from '../shared/lib/invariant-error'
 import { lookup } from 'dns/promises'
@@ -380,7 +379,7 @@ export class ImageOptimizerCache {
 
   static validateParams(
     req: IncomingMessage,
-    query: UrlWithParsedQuery['query'],
+    query: NextUrlWithParsedQuery['query'],
     nextConfig: NextConfigRuntime,
     isDev: boolean
   ): ImageParamsResult | { errorMessage: string } {
@@ -993,7 +992,7 @@ export async function fetchInternalImage(
       maximumResponseBody,
     })
 
-    await handleRequest(mocked.req, mocked.res, nodeUrl.parse(href, true))
+    await handleRequest(mocked.req, mocked.res, parseReqUrl(href))
     await mocked.res.hasStreamed
 
     if (!mocked.res.statusCode) {


### PR DESCRIPTION
Didn't catch this in https://github.com/vercel/next.js/pull/87286