### PR TITLE
Turbopack: simplify asset ident constructors

### DIFF
--- a/crates/next-api/src/analyze.rs
+++ b/crates/next-api/src/analyze.rs
@@ -5,7 +5,9 @@ use byteorder::{BE, WriteBytesExt};
 use rustc_hash::FxHashMap;
 use serde::Serialize;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{FxIndexSet, ResolvedVc, TryFlatJoinIterExt, TryJoinIterExt, ValueToString, Vc};
+use turbo_tasks::{
+    FxIndexSet, ResolvedVc, TryFlatJoinIterExt, TryJoinIterExt, ValueToString, ValueToStringRef, Vc,
+};
 use turbo_tasks_fs::{
     File, FileContent, FileSystemPath,
     rope::{Rope, RopeBuilder},
@@ -471,7 +473,7 @@ pub async fn analyze_module_graphs(module_graphs: Vc<ModuleGraphs>) -> Result<Vc
         .copied()
         .map(async |module| {
             let ident = module.ident().to_string().owned().await?;
-            let path = module.ident().path().to_string().owned().await?;
+            let path = module.ident().await?.path.to_string_ref().await?;
             Ok((ident, path))
         })
         .try_join()

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -1283,7 +1283,8 @@ impl AppEndpoint {
         let (availability_info, client_shared_chunks) = if is_app_page {
             let client_shared_chunk_group = get_app_client_shared_chunk_group(
                 AssetIdent::from_path(project.project_path().owned().await?)
-                    .with_modifier(rcstr!("client-shared-chunks")),
+                    .with_modifier(rcstr!("client-shared-chunks"))
+                    .into_vc(),
                 this.app_project.client_runtime_entries(),
                 *module_graphs.full,
                 *client_chunking_context,
@@ -1826,7 +1827,8 @@ impl AppEndpoint {
                                 AssetIdent::from_path(
                                     this.app_project.project().project_path().owned().await?,
                                 )
-                                .with_modifier(rcstr!("server-utils")),
+                                .with_modifier(rcstr!("server-utils"))
+                                .into_vc(),
                                 ChunkGroup::SharedMerged {
                                     merge_tag: NEXT_SERVER_UTILITY_MERGE_TAG.clone(),
                                     entries: server_utils,

--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -82,7 +82,7 @@ impl MiddlewareEndpoint {
             )
             .module();
 
-        let userland_path = userland_module.ident().path().await?;
+        let userland_path = userland_module.ident().await?.path.clone();
         let is_proxy = userland_path.file_stem() == Some("proxy");
 
         let module = get_middleware_module(

--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -82,8 +82,7 @@ impl MiddlewareEndpoint {
             )
             .module();
 
-        let userland_path = userland_module.ident().await?.path.clone();
-        let is_proxy = userland_path.file_stem() == Some("proxy");
+        let is_proxy = userland_module.ident().await?.path.file_stem() == Some("proxy");
 
         let module = get_middleware_module(
             *self.asset_context,

--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -719,13 +719,13 @@ impl Issue for CssGlobalImportIssue {
     }
 
     async fn description(&self) -> Result<Option<StyledString>> {
-        let parent_path = self.parent_module.ident().await?.path.clone();
-        let module_path = self.module.ident().await?.path.clone();
-        let relative_import_location = parent_path.parent();
+        let parent_ident = self.parent_module.ident().await?;
+        let module_ident = self.module.ident().await?;
+        let relative_import_location = parent_ident.path.parent();
 
-        let import_path = match relative_import_location.get_relative_path_to(&module_path) {
+        let import_path = match relative_import_location.get_relative_path_to(&module_ident.path) {
             Some(path) => path,
-            None => module_path.path.clone(),
+            None => module_ident.path.path.clone(),
         };
         let cleaned_import_path =
             if import_path.ends_with(".scss.css") || import_path.ends_with(".sass.css") {
@@ -742,7 +742,7 @@ impl Issue for CssGlobalImportIssue {
             )),
             StyledString::Line(vec![
                 StyledString::Text(rcstr!("Location: ")),
-                StyledString::Code(parent_path.path.clone()),
+                StyledString::Code(parent_ident.path.path.clone()),
             ]),
             StyledString::Line(vec![
                 StyledString::Text(rcstr!("Import path: ")),
@@ -840,7 +840,8 @@ async fn validate_pages_css_imports_individual(
     candidates
         .into_iter()
         .map(async |issue| {
-            let path = issue.module.ident().await?.path.clone();
+            let ident = issue.module.ident().await?;
+            let path = &ident.path;
             // We allow imports of global CSS files which are inside of `node_modules`.
             // We also allow data URL CSS imports (e.g. `data:text/css,...`) since they
             // are mostly tooling-generated and co-located with the importing components

--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -719,8 +719,8 @@ impl Issue for CssGlobalImportIssue {
     }
 
     async fn description(&self) -> Result<Option<StyledString>> {
-        let parent_path = self.parent_module.ident().path().owned().await?;
-        let module_path = self.module.ident().path().owned().await?;
+        let parent_path = self.parent_module.ident().await?.path.clone();
+        let module_path = self.module.ident().await?.path.clone();
         let relative_import_location = parent_path.parent();
 
         let import_path = match relative_import_location.get_relative_path_to(&module_path) {
@@ -756,7 +756,7 @@ impl Issue for CssGlobalImportIssue {
     }
 
     async fn file_path(&self) -> Result<FileSystemPath> {
-        self.parent_module.ident().path().owned().await
+        Ok(self.parent_module.ident().await?.path.clone())
     }
 
     fn stage(&self) -> IssueStage {
@@ -840,7 +840,7 @@ async fn validate_pages_css_imports_individual(
     candidates
         .into_iter()
         .map(async |issue| {
-            let path = issue.module.ident().path().await?;
+            let path = issue.module.ident().await?.path.clone();
             // We allow imports of global CSS files which are inside of `node_modules`.
             // We also allow data URL CSS imports (e.g. `data:text/css,...`) since they
             // are mostly tooling-generated and co-located with the importing components

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -664,7 +664,7 @@ impl PageEndpoint {
         ) && let Some(chunkable) = ResolvedVc::try_downcast(page_loader.to_resolved().await?)
         {
             return Ok(Vc::upcast(HmrEntryModule::new(
-                AssetIdent::from_path(this.page.await?.base_path.clone()),
+                AssetIdent::from_path(this.page.await?.base_path.clone()).into_vc(),
                 *chunkable,
             )));
         }
@@ -783,7 +783,7 @@ impl PageEndpoint {
                 .map(|m| ResolvedVc::upcast(*m))
                 .collect();
             let client_chunk_group = client_chunking_context.evaluated_chunk_group(
-                AssetIdent::from_path(this.page.await?.base_path.clone()),
+                AssetIdent::from_path(this.page.await?.base_path.clone()).into_vc(),
                 ChunkGroup::Entry(evaluatable_assets),
                 module_graph,
                 AvailabilityInfo::root(),

--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -131,7 +131,9 @@ pub(crate) async fn build_server_actions_loader(
     let path = project_path.join(&format!(".next-internal/server/app{page_name}/actions.js"))?;
     let file = File::from(contents.build());
     let source = VirtualSource::new_with_ident(
-        AssetIdent::from_path(path).with_modifier(rcstr!("server actions loader")),
+        AssetIdent::from_path(path)
+            .with_modifier(rcstr!("server actions loader"))
+            .into_vc(),
         AssetContent::file(FileContent::Content(file).cell()),
     );
     let import_map = import_map.into_iter().map(|(k, v)| (v, k)).collect();
@@ -190,7 +192,7 @@ async fn build_manifest(
         let filename = if !meta.source_path.is_empty() {
             meta.source_path.clone()
         } else {
-            let module_path = module.ident().path().await?;
+            let module_path = module.ident().await?.path.clone();
             module_path.to_string()
         };
 
@@ -243,8 +245,8 @@ pub async fn to_rsc_context(
     let source = FileSource::new_with_query(
         client_module
             .ident()
-            .path()
             .await?
+            .path
             .root()
             .await?
             .join(entry_path)?,

--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -192,8 +192,7 @@ async fn build_manifest(
         let filename = if !meta.source_path.is_empty() {
             meta.source_path.clone()
         } else {
-            let module_path = module.ident().await?.path.clone();
-            module_path.to_string()
+            module.ident().await?.path.to_string()
         };
 
         action_metadata.push((hash_id.clone(), (*layer, meta.name.clone(), filename)));

--- a/crates/next-core/src/bootstrap.rs
+++ b/crates/next-core/src/bootstrap.rs
@@ -33,7 +33,7 @@ pub async fn bootstrap(
     inner_assets: Vc<InnerAssets>,
     config: Vc<BootstrapConfig>,
 ) -> Result<Vc<Box<dyn EvaluatableAsset>>> {
-    let path = asset.ident().path().await?;
+    let path = asset.ident().await?.path.clone();
     let Some(path) = base_path.get_path_to(&path) else {
         turbobail!("asset {} is not in base path {base_path}", asset.ident())
     };
@@ -52,7 +52,12 @@ pub async fn bootstrap(
     let config_asset = asset_context
         .process(
             Vc::upcast(VirtualSource::new(
-                asset.ident().path().await?.join("bootstrap-config.ts")?,
+                asset
+                    .ident()
+                    .await?
+                    .path
+                    .clone()
+                    .join("bootstrap-config.ts")?,
                 AssetContent::file(
                     FileContent::Content(File::from(
                         config

--- a/crates/next-core/src/bootstrap.rs
+++ b/crates/next-core/src/bootstrap.rs
@@ -33,8 +33,8 @@ pub async fn bootstrap(
     inner_assets: Vc<InnerAssets>,
     config: Vc<BootstrapConfig>,
 ) -> Result<Vc<Box<dyn EvaluatableAsset>>> {
-    let path = asset.ident().await?.path.clone();
-    let Some(path) = base_path.get_path_to(&path) else {
+    let asset_ident = asset.ident().await?;
+    let Some(path) = base_path.get_path_to(&asset_ident.path) else {
         turbobail!("asset {} is not in base path {base_path}", asset.ident())
     };
     let path = if let Some((name, ext)) = path.rsplit_once('.') {
@@ -52,12 +52,7 @@ pub async fn bootstrap(
     let config_asset = asset_context
         .process(
             Vc::upcast(VirtualSource::new(
-                asset
-                    .ident()
-                    .await?
-                    .path
-                    .clone()
-                    .join("bootstrap-config.ts")?,
+                asset_ident.path.join("bootstrap-config.ts")?,
                 AssetContent::file(
                     FileContent::Content(File::from(
                         config

--- a/crates/next-core/src/hmr_entry.rs
+++ b/crates/next-core/src/hmr_entry.rs
@@ -35,7 +35,8 @@ async fn hmr_entry_point_base_ident() -> Result<Vc<AssetIdent>> {
             .root()
             .await?
             .join("hmr-entry.js")?,
-    ))
+    )
+    .into_vc())
 }
 
 #[turbo_tasks::value(shared)]
@@ -58,8 +59,12 @@ impl HmrEntryModule {
 #[turbo_tasks::value_impl]
 impl Module for HmrEntryModule {
     #[turbo_tasks::function]
-    fn ident(&self) -> Vc<AssetIdent> {
-        hmr_entry_point_base_ident().with_asset(rcstr!("ENTRY"), *self.ident)
+    async fn ident(&self) -> Result<Vc<AssetIdent>> {
+        Ok(hmr_entry_point_base_ident()
+            .owned()
+            .await?
+            .with_asset(rcstr!("ENTRY"), self.ident)
+            .into_vc())
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/middleware.rs
+++ b/crates/next-core/src/middleware.rs
@@ -40,7 +40,7 @@ pub async fn get_middleware_module(
     const INNER: &str = "INNER_MIDDLEWARE_MODULE";
 
     // Determine if this is a proxy file by checking the module path
-    let userland_path = userland_module.ident().path().await?;
+    let userland_path = userland_module.ident().await?.path.clone();
     let (file_type, function_name, page_path) = if is_proxy {
         ("Proxy", "proxy", "/proxy")
     } else {
@@ -78,7 +78,7 @@ pub async fn get_middleware_module(
             MiddlewareMissingExportIssue {
                 file_type: file_type.into(),
                 function_name: function_name.into(),
-                file_path: (*userland_path).clone(),
+                file_path: userland_path.clone(),
             }
             .resolved_cell()
             .emit();

--- a/crates/next-core/src/middleware.rs
+++ b/crates/next-core/src/middleware.rs
@@ -39,8 +39,6 @@ pub async fn get_middleware_module(
 ) -> Result<Vc<Box<dyn Module>>> {
     const INNER: &str = "INNER_MIDDLEWARE_MODULE";
 
-    // Determine if this is a proxy file by checking the module path
-    let userland_path = userland_module.ident().await?.path.clone();
     let (file_type, function_name, page_path) = if is_proxy {
         ("Proxy", "proxy", "/proxy")
     } else {
@@ -78,7 +76,7 @@ pub async fn get_middleware_module(
             MiddlewareMissingExportIssue {
                 file_type: file_type.into(),
                 function_name: function_name.into(),
-                file_path: userland_path.clone(),
+                file_path: userland_module.ident().await?.path.clone(),
             }
             .resolved_cell()
             .emit();

--- a/crates/next-core/src/next_app/app_client_references_chunks.rs
+++ b/crates/next-core/src/next_app/app_client_references_chunks.rs
@@ -183,7 +183,7 @@ pub async fn get_app_client_references_chunks(
                     .get_index_of(ChunkGroup::Shared(ResolvedVc::upcast(server_component)))
                     .await?;
 
-                let base_ident = server_component.ident();
+                let base_ident = server_component.ident().owned().await?;
 
                 let server_path = server_component.server_path().owned().await?;
                 let is_layout = server_path.file_stem() == Some("layout");
@@ -219,16 +219,21 @@ pub async fn get_app_client_references_chunks(
                     )
                     .entered();
 
-                    Some(ssr_chunking_context.chunk_group(
-                        base_ident.with_modifier(rcstr!("ssr modules")),
-                        ChunkGroup::IsolatedMerged {
-                            parent: parent_chunk_group,
-                            merge_tag: ecmascript_client_reference_merge_tag_ssr(),
-                            entries: ssr_modules,
-                        },
-                        module_graph,
-                        availability_info,
-                    ))
+                    Some(
+                        ssr_chunking_context.chunk_group(
+                            base_ident
+                                .clone()
+                                .with_modifier(rcstr!("ssr modules"))
+                                .into_vc(),
+                            ChunkGroup::IsolatedMerged {
+                                parent: parent_chunk_group,
+                                merge_tag: ecmascript_client_reference_merge_tag_ssr(),
+                                entries: ssr_modules,
+                            },
+                            module_graph,
+                            availability_info,
+                        ),
+                    )
                 } else {
                     None
                 };
@@ -257,16 +262,21 @@ pub async fn get_app_client_references_chunks(
                     )
                     .entered();
 
-                    Some(client_chunking_context.chunk_group(
-                        base_ident.with_modifier(rcstr!("client modules")),
-                        ChunkGroup::IsolatedMerged {
-                            parent: parent_chunk_group,
-                            merge_tag: ecmascript_client_reference_merge_tag(),
-                            entries: client_modules,
-                        },
-                        module_graph,
-                        availability_info,
-                    ))
+                    Some(
+                        client_chunking_context.chunk_group(
+                            base_ident
+                                .clone()
+                                .with_modifier(rcstr!("client modules"))
+                                .into_vc(),
+                            ChunkGroup::IsolatedMerged {
+                                parent: parent_chunk_group,
+                                merge_tag: ecmascript_client_reference_merge_tag(),
+                                entries: client_modules,
+                            },
+                            module_graph,
+                            availability_info,
+                        ),
+                    )
                 } else {
                     None
                 };

--- a/crates/next-core/src/next_app/app_client_references_chunks.rs
+++ b/crates/next-core/src/next_app/app_client_references_chunks.rs
@@ -262,21 +262,16 @@ pub async fn get_app_client_references_chunks(
                     )
                     .entered();
 
-                    Some(
-                        client_chunking_context.chunk_group(
-                            base_ident
-                                .clone()
-                                .with_modifier(rcstr!("client modules"))
-                                .into_vc(),
-                            ChunkGroup::IsolatedMerged {
-                                parent: parent_chunk_group,
-                                merge_tag: ecmascript_client_reference_merge_tag(),
-                                entries: client_modules,
-                            },
-                            module_graph,
-                            availability_info,
-                        ),
-                    )
+                    Some(client_chunking_context.chunk_group(
+                        base_ident.with_modifier(rcstr!("client modules")).into_vc(),
+                        ChunkGroup::IsolatedMerged {
+                            parent: parent_chunk_group,
+                            merge_tag: ecmascript_client_reference_merge_tag(),
+                            entries: client_modules,
+                        },
+                        module_graph,
+                        availability_info,
+                    ))
                 } else {
                     None
                 };

--- a/crates/next-core/src/next_app/app_page_entry.rs
+++ b/crates/next-core/src/next_app/app_page_entry.rs
@@ -97,7 +97,12 @@ pub async fn get_app_page_entry(
 
     let file = File::from(result.build());
     let source = VirtualSource::new_with_ident(
-        source.ident().with_query(RcStr::from(format!("?{query}"))),
+        source
+            .ident()
+            .owned()
+            .await?
+            .with_query(RcStr::from(format!("?{query}")))
+            .into_vc(),
         AssetContent::file(FileContent::Content(file).cell()),
     );
 

--- a/crates/next-core/src/next_app/app_route_entry.rs
+++ b/crates/next-core/src/next_app/app_route_entry.rs
@@ -56,7 +56,8 @@ pub async fn get_app_route_entry(
     let original_name: RcStr = page.to_string().into();
     let pathname: RcStr = AppPath::from(page.clone()).to_string().into();
 
-    let path = source.ident().await?.path.clone();
+    let ident = source.ident().await?;
+    let path = &ident.path;
 
     let inner = rcstr!("INNER_APP_ROUTE");
 

--- a/crates/next-core/src/next_app/app_route_entry.rs
+++ b/crates/next-core/src/next_app/app_route_entry.rs
@@ -56,7 +56,7 @@ pub async fn get_app_route_entry(
     let original_name: RcStr = page.to_string().into();
     let pathname: RcStr = AppPath::from(page.clone()).to_string().into();
 
-    let path = source.ident().path().owned().await?;
+    let path = source.ident().await?.path.clone();
 
     let inner = rcstr!("INNER_APP_ROUTE");
 

--- a/crates/next-core/src/next_client_reference/css_client_reference/css_client_reference_module.rs
+++ b/crates/next-core/src/next_client_reference/css_client_reference/css_client_reference_module.rs
@@ -36,10 +36,14 @@ impl CssClientReferenceModule {
 #[turbo_tasks::value_impl]
 impl Module for CssClientReferenceModule {
     #[turbo_tasks::function]
-    fn ident(&self) -> Vc<AssetIdent> {
-        self.client_module
+    async fn ident(&self) -> Result<Vc<AssetIdent>> {
+        Ok(self
+            .client_module
             .ident()
+            .owned()
+            .await?
             .with_modifier(rcstr!("css client reference"))
+            .into_vc())
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
@@ -152,7 +152,7 @@ impl EcmascriptClientReferenceModule {
             AssetContent::file(FileContent::Content(File::from(code.source_code().clone())).cell());
 
         let proxy_source = VirtualSource::new(
-            self.server_ident.await?.path.clone().join(
+            self.server_ident.await?.path.join(
                 // We choose the extension based on the original file because we're placing the
                 // virtual module next to the original code, so its parsing will be
                 // affected by `type` fields in package.json -- a bare `proxy.js`

--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
@@ -152,7 +152,7 @@ impl EcmascriptClientReferenceModule {
             AssetContent::file(FileContent::Content(File::from(code.source_code().clone())).cell());
 
         let proxy_source = VirtualSource::new(
-            self.server_ident.path().await?.join(
+            self.server_ident.await?.path.clone().join(
                 // We choose the extension based on the original file because we're placing the
                 // virtual module next to the original code, so its parsing will be
                 // affected by `type` fields in package.json -- a bare `proxy.js`
@@ -194,8 +194,11 @@ impl Module for EcmascriptClientReferenceModule {
     async fn ident(&self) -> Result<Vc<AssetIdent>> {
         Ok(self
             .server_ident
+            .owned()
+            .await?
             .with_modifier(rcstr!("client reference proxy"))
-            .with_layer(self.server_asset_context.into_trait_ref().await?.layer()))
+            .with_layer(self.server_asset_context.into_trait_ref().await?.layer())
+            .into_vc())
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_transition.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_transition.rs
@@ -62,13 +62,12 @@ impl Transition for NextEcmascriptClientReferenceTransition {
             None => source.ident(),
         };
         let ident_ref = ident.await?;
-        let ident_path = ident_ref.path.clone();
-        let client_source = if ident_path.path.contains("next/dist/esm/") {
+        let client_source = if ident_ref.path.path.contains("next/dist/esm/") {
             let path = ident_ref
                 .path
                 .root()
                 .await?
-                .join(&ident_path.path.replace("next/dist/esm/", "next/dist/"))?;
+                .join(&ident_ref.path.path.replace("next/dist/esm/", "next/dist/"))?;
             Vc::upcast(FileSource::new_with_query_and_fragment(
                 path,
                 ident_ref.query.clone(),

--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_transition.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_transition.rs
@@ -53,7 +53,12 @@ impl Transition for NextEcmascriptClientReferenceTransition {
         let this = self.await?;
 
         let ident = match part {
-            Some(part) => source.ident().with_part(part.clone()),
+            Some(part) => source
+                .ident()
+                .owned()
+                .await?
+                .with_part(part.clone())
+                .into_vc(),
             None => source.ident(),
         };
         let ident_ref = ident.await?;

--- a/crates/next-core/src/next_dynamic/dynamic_module.rs
+++ b/crates/next-core/src/next_dynamic/dynamic_module.rs
@@ -49,10 +49,14 @@ impl NextDynamicEntryModule {
 #[turbo_tasks::value_impl]
 impl Module for NextDynamicEntryModule {
     #[turbo_tasks::function]
-    fn ident(&self) -> Vc<AssetIdent> {
-        self.module
+    async fn ident(&self) -> Result<Vc<AssetIdent>> {
+        Ok(self
+            .module
             .ident()
+            .owned()
+            .await?
             .with_modifier(rcstr!("next/dynamic entry"))
+            .into_vc())
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_edge/unsupported.rs
+++ b/crates/next-core/src/next_edge/unsupported.rs
@@ -74,9 +74,11 @@ fn unsupported_module_source(root_path: FileSystemPath, module: Pattern) -> Vc<V
     };
     let content = AssetContent::file(FileContent::Content(File::from(code)).cell());
     VirtualSource::new_with_ident(
-        AssetIdent::from_path(root_path).with_modifier(
-            format!("unsupported edge import {}", module.describe_as_string()).into(),
-        ),
+        AssetIdent::from_path(root_path)
+            .with_modifier(
+                format!("unsupported edge import {}", module.describe_as_string()).into(),
+            )
+            .into_vc(),
         content,
     )
 }

--- a/crates/next-core/src/next_image/source_asset.rs
+++ b/crates/next-core/src/next_image/source_asset.rs
@@ -34,7 +34,7 @@ pub struct StructuredImageFileSource {
 #[turbo_tasks::value_impl]
 impl Source for StructuredImageFileSource {
     #[turbo_tasks::function]
-    fn ident(&self) -> Vc<AssetIdent> {
+    async fn ident(&self) -> Result<Vc<AssetIdent>> {
         let modifier = match self.blur_placeholder_mode {
             BlurPlaceholderMode::DataUrl => rcstr!("structured image object with data url"),
             BlurPlaceholderMode::NextImageUrl => {
@@ -42,10 +42,15 @@ impl Source for StructuredImageFileSource {
             }
             BlurPlaceholderMode::None => rcstr!("structured image object"),
         };
-        self.image
+        Ok(self
+            .image
             .ident()
+            .owned()
+            .await?
             .with_modifier(modifier)
-            .rename_as(rcstr!("*.mjs"))
+            .rename_as("*.mjs")
+            .await?
+            .into_vc())
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_image/source_asset.rs
+++ b/crates/next-core/src/next_image/source_asset.rs
@@ -49,7 +49,6 @@ impl Source for StructuredImageFileSource {
             .await?
             .with_modifier(modifier)
             .rename_as("*.mjs")
-            .await?
             .into_vc())
     }
 

--- a/crates/next-core/src/next_import_map.rs
+++ b/crates/next-core/src/next_import_map.rs
@@ -1270,7 +1270,7 @@ pub async fn try_get_next_package(
         node_cjs_resolve_options(root.clone()),
     );
     if let Some(source) = &*result.first_source().await? {
-        Ok(Vc::cell(Some(source.ident().await?.path.clone().parent())))
+        Ok(Vc::cell(Some(source.ident().await?.path.parent())))
     } else {
         MissingNextFolderIssue {
             path: context_directory,

--- a/crates/next-core/src/next_import_map.rs
+++ b/crates/next-core/src/next_import_map.rs
@@ -1270,7 +1270,7 @@ pub async fn try_get_next_package(
         node_cjs_resolve_options(root.clone()),
     );
     if let Some(source) = &*result.first_source().await? {
-        Ok(Vc::cell(Some(source.ident().path().await?.parent())))
+        Ok(Vc::cell(Some(source.ident().await?.path.clone().parent())))
     } else {
         MissingNextFolderIssue {
             path: context_directory,

--- a/crates/next-core/src/next_server/resolve.rs
+++ b/crates/next-core/src/next_server/resolve.rs
@@ -257,8 +257,8 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
             break result_from_original_location;
         };
 
-        let path = result_from_original_location.ident().path().await?;
-        let file_type = get_file_type((*path).clone(), &path).await?;
+        let path = result_from_original_location.ident().await?.path.clone();
+        let file_type = get_file_type(path.clone(), &path).await?;
 
         let external_type = match (file_type, is_esm) {
             (FileType::UnsupportedExtension, _) => {
@@ -288,8 +288,8 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
                     node_resolve_options,
                 );
                 let resolves_equal = if let Some(result) = *node_resolved.first_source().await? {
-                    let cjs_path = result.ident().path().owned().await?;
-                    cjs_path == *path
+                    let cjs_path = result.ident().await?.path.clone();
+                    cjs_path == path
                 } else {
                     false
                 };
@@ -320,7 +320,7 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
             }
         };
 
-        let target = result_from_original_location.ident().path().owned().await?;
+        let target = result_from_original_location.ident().await?.path.clone();
 
         Ok(ResolveResultOption::some(
             ResolveResult::primary(ResolveResultItem::External {

--- a/crates/next-core/src/next_server/resolve.rs
+++ b/crates/next-core/src/next_server/resolve.rs
@@ -167,7 +167,7 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
         }
 
         async fn get_file_type(
-            fs_path: FileSystemPath,
+            fs_path: &FileSystemPath,
             raw_fs_path: &FileSystemPath,
         ) -> Result<FileType> {
             // node.js only supports these file extensions
@@ -257,8 +257,9 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
             break result_from_original_location;
         };
 
-        let path = result_from_original_location.ident().await?.path.clone();
-        let file_type = get_file_type(path.clone(), &path).await?;
+        let ident = result_from_original_location.ident().await?;
+        let path = &ident.path;
+        let file_type = get_file_type(path, path).await?;
 
         let external_type = match (file_type, is_esm) {
             (FileType::UnsupportedExtension, _) => {
@@ -288,7 +289,8 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
                     node_resolve_options,
                 );
                 let resolves_equal = if let Some(result) = *node_resolved.first_source().await? {
-                    let cjs_path = result.ident().await?.path.clone();
+                    let ident = result.ident().await?;
+                    let cjs_path = &ident.path;
                     cjs_path == path
                 } else {
                     false

--- a/crates/next-core/src/next_server_component/server_component_module.rs
+++ b/crates/next-core/src/next_server_component/server_component_module.rs
@@ -55,8 +55,8 @@ impl NextServerComponentModule {
     /// Returns the transformed module path (e.g., page.mdx.tsx for MDX files).
     /// This is the path of the actual compiled module.
     #[turbo_tasks::function]
-    pub fn server_path(&self) -> Vc<FileSystemPath> {
-        self.module.ident().path()
+    pub async fn server_path(&self) -> Result<Vc<FileSystemPath>> {
+        Ok(self.module.ident().await?.path.clone().cell())
     }
 }
 
@@ -73,10 +73,14 @@ impl NextServerComponentModule {
 #[turbo_tasks::value_impl]
 impl Module for NextServerComponentModule {
     #[turbo_tasks::function]
-    fn ident(&self) -> Vc<AssetIdent> {
-        self.module
+    async fn ident(&self) -> Result<Vc<AssetIdent>> {
+        Ok(self
+            .module
             .ident()
+            .owned()
+            .await?
             .with_modifier(rcstr!("Next.js Server Component"))
+            .into_vc())
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_server_component/server_component_transition.rs
+++ b/crates/next-core/src/next_server_component/server_component_transition.rs
@@ -41,7 +41,7 @@ impl Transition for NextServerComponentTransition {
         reference_type: ReferenceType,
     ) -> Result<Vc<ProcessResult>> {
         // Capture the original source path before any transformation
-        let source_path = source.ident().path().owned().await?;
+        let source_path = source.ident().await?.path.clone();
 
         let source = self.process_source(source);
         let module_asset_context = self.process_context(module_asset_context);

--- a/crates/next-core/src/next_server_utility/server_utility_module.rs
+++ b/crates/next-core/src/next_server_utility/server_utility_module.rs
@@ -36,8 +36,8 @@ impl NextServerUtilityModule {
     }
 
     #[turbo_tasks::function]
-    pub fn server_path(&self) -> Vc<FileSystemPath> {
-        self.module.ident().path()
+    pub async fn server_path(&self) -> Result<Vc<FileSystemPath>> {
+        Ok(self.module.ident().await?.path.clone().cell())
     }
 }
 
@@ -54,10 +54,14 @@ impl NextServerUtilityModule {
 #[turbo_tasks::value_impl]
 impl Module for NextServerUtilityModule {
     #[turbo_tasks::function]
-    fn ident(&self) -> Vc<AssetIdent> {
-        self.module
+    async fn ident(&self) -> Result<Vc<AssetIdent>> {
+        Ok(self
+            .module
             .ident()
+            .owned()
+            .await?
             .with_modifier(rcstr!("Next.js server utility"))
+            .into_vc())
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_shared/webpack_rules/babel.rs
+++ b/crates/next-core/src/next_shared/webpack_rules/babel.rs
@@ -263,7 +263,8 @@ async fn detect_react_compiler_target(
         return Ok(None);
     };
 
-    let path = source.ident().await?.path.clone();
+    let ident = source.ident().await?;
+    let path = &ident.path;
     let FileContent::Content(file) = &*path.read().await? else {
         return Ok(None);
     };
@@ -352,7 +353,7 @@ pub async fn resolve_babel_plugin_react_compiler(
         // the relative path should only ever fail to resolve when the `fs` is different, which
         // should only happen due to eventual consistency.
         project_path
-            .get_relative_path_to(&source.ident().await?.path.clone().parent())
+            .get_relative_path_to(&source.ident().await?.path.parent())
             .context("failed to resolve relative path for react compiler plugin")?,
     ))
 }

--- a/crates/next-core/src/next_shared/webpack_rules/babel.rs
+++ b/crates/next-core/src/next_shared/webpack_rules/babel.rs
@@ -263,7 +263,7 @@ async fn detect_react_compiler_target(
         return Ok(None);
     };
 
-    let path = source.ident().path().await?;
+    let path = source.ident().await?.path.clone();
     let FileContent::Content(file) = &*path.read().await? else {
         return Ok(None);
     };
@@ -272,7 +272,7 @@ async fn detect_react_compiler_target(
         Ok(pkg) => pkg,
         Err(e) => {
             ReactPackageJsonParseIssue {
-                file_path: (*path).clone(),
+                file_path: path.clone(),
                 error: e.to_string().into(),
             }
             .resolved_cell()
@@ -352,7 +352,7 @@ pub async fn resolve_babel_plugin_react_compiler(
         // the relative path should only ever fail to resolve when the `fs` is different, which
         // should only happen due to eventual consistency.
         project_path
-            .get_relative_path_to(&source.ident().path().await?.parent())
+            .get_relative_path_to(&source.ident().await?.path.clone().parent())
             .context("failed to resolve relative path for react compiler plugin")?,
     ))
 }

--- a/crates/next-core/src/page_loader.rs
+++ b/crates/next-core/src/page_loader.rs
@@ -149,7 +149,8 @@ impl PageLoaderAsset {
             "static/chunks/pages{}",
             get_asset_path_from_pathname(&self.pathname, ".js")
         ))?)
-        .with_modifier(rcstr!("page loader asset")))
+        .with_modifier(rcstr!("page loader asset"))
+        .into_vc())
     }
 }
 
@@ -174,7 +175,7 @@ impl OutputAsset for PageLoaderAsset {
             // `static/chunks/pages/page2.js`, so that the dev runtime can request it at a known
             // path.
             // https://github.com/vercel/next.js/blob/84873e00874e096e6c4951dcf070e8219ed414e5/packages/next/src/client/route-loader.ts#L256-L271
-            Ok(ident.path())
+            Ok(ident.await?.path.clone().cell())
         } else {
             Ok(this
                 .chunking_context

--- a/crates/next-core/src/raw_ecmascript_module.rs
+++ b/crates/next-core/src/raw_ecmascript_module.rs
@@ -89,8 +89,14 @@ impl RawEcmascriptModule {
 #[turbo_tasks::value_impl]
 impl Module for RawEcmascriptModule {
     #[turbo_tasks::function]
-    fn ident(&self) -> Vc<AssetIdent> {
-        self.source.ident().with_modifier(rcstr!("raw"))
+    async fn ident(&self) -> Result<Vc<AssetIdent>> {
+        Ok(self
+            .source
+            .ident()
+            .owned()
+            .await?
+            .with_modifier(rcstr!("raw"))
+            .into_vc())
     }
 
     #[turbo_tasks::function]
@@ -209,7 +215,7 @@ impl EcmascriptChunkPlaceable for RawEcmascriptModule {
             code += "(function(){\n";
             let source_mapping_url = extract_source_mapping_url_from_content(&content_str);
             let source_map = if let Some((source_map, _)) =
-                parse_source_map_comment(source, source_mapping_url, &*self.ident().path().await?)
+                parse_source_map_comment(source, source_mapping_url, &self.ident().await?.path)
                     .await?
             {
                 let source_map = source_map.generate_source_map().await?;

--- a/crates/next-core/src/segment_config.rs
+++ b/crates/next-core/src/segment_config.rs
@@ -262,7 +262,7 @@ impl Issue for NextSegmentConfigParsingIssue {
     }
 
     async fn file_path(&self) -> Result<FileSystemPath> {
-        self.ident.path().owned().await
+        Ok(self.ident.await?.path.clone())
     }
 
     async fn description(&self) -> Result<Option<StyledString>> {
@@ -365,7 +365,7 @@ pub async fn parse_segment_config_from_source(
     source: ResolvedVc<Box<dyn Source>>,
     mode: ParseSegmentMode,
 ) -> Result<Vc<NextSegmentConfig>> {
-    let path = source.ident().path().await?;
+    let path = source.ident().await?.path.clone();
 
     // Don't try parsing if it's not a javascript file, otherwise it will emit an
     // issue causing the build to "fail".

--- a/crates/next-core/src/segment_config.rs
+++ b/crates/next-core/src/segment_config.rs
@@ -365,7 +365,8 @@ pub async fn parse_segment_config_from_source(
     source: ResolvedVc<Box<dyn Source>>,
     mode: ParseSegmentMode,
 ) -> Result<Vc<NextSegmentConfig>> {
-    let path = source.ident().await?.path.clone();
+    let ident = source.ident().await?;
+    let path = &ident.path;
 
     // Don't try parsing if it's not a javascript file, otherwise it will emit an
     // issue causing the build to "fail".

--- a/crates/next-napi-bindings/src/next_api/utils.rs
+++ b/crates/next-napi-bindings/src/next_api/utils.rs
@@ -361,8 +361,8 @@ pub struct NapiSource {
 impl From<&PlainSource> for NapiSource {
     fn from(source: &PlainSource) -> Self {
         Self {
-            ident: (*source.ident).clone(),
-            file_path: (*source.file_path).clone(),
+            ident: source.ident.clone(),
+            file_path: source.file_path.clone(),
         }
     }
 }

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -223,7 +223,7 @@ pub trait FileSystem: ValueToString {
     /// Returns the path to the root of the file system.
     #[turbo_tasks::function]
     fn root(self: ResolvedVc<Self>) -> Vc<FileSystemPath> {
-        FileSystemPath::new_normalized(self, RcStr::default()).cell()
+        FileSystemPath::new_normalized_unchecked(self, RcStr::default()).cell()
     }
     #[turbo_tasks::function]
     fn read(self: Vc<Self>, fs_path: FileSystemPath) -> Vc<FileContent>;
@@ -885,9 +885,12 @@ impl FileSystem for DiskFileSystem {
             let target_string = RcStr::from(relative_to_root_path.to_string_lossy());
             (
                 target_string.clone(),
-                FileSystemPath::new_normalized(fs_path.fs().to_resolved().await?, target_string)
-                    .get_type()
-                    .await?,
+                FileSystemPath::new_normalized_unchecked(
+                    fs_path.fs().to_resolved().await?,
+                    target_string,
+                )
+                .get_type()
+                .await?,
             )
         } else {
             let link_path_string_cow = link_path.to_string_lossy();
@@ -1594,7 +1597,7 @@ impl FileSystemPath {
     /// Create a new FileSystemPath from a path within a FileSystem. The
     /// /-separated path is expected to be already normalized (this is asserted
     /// in dev mode).
-    fn new_normalized(fs: ResolvedVc<Box<dyn FileSystem>>, path: RcStr) -> Self {
+    pub fn new_normalized_unchecked(fs: ResolvedVc<Box<dyn FileSystem>>, path: RcStr) -> Self {
         // On Windows, the path must be converted to a unix path before creating. But on
         // Unix, backslashes are a valid char in file names, and the path can be
         // provided by the user, so we allow it.
@@ -1614,7 +1617,7 @@ impl FileSystemPath {
     /// "." segments, but it must not leave the root of the filesystem.
     pub fn join(&self, path: &str) -> Result<Self> {
         if let Some(path) = join_path(&self.path, path) {
-            Ok(Self::new_normalized(self.fs, path.into()))
+            Ok(Self::new_normalized_unchecked(self.fs, path.into()))
         } else {
             bail!(
                 "FileSystemPath(\"{}\").join(\"{}\") leaves the filesystem root",
@@ -1633,7 +1636,7 @@ impl FileSystemPath {
                 path,
             )
         }
-        Ok(Self::new_normalized(
+        Ok(Self::new_normalized_unchecked(
             self.fs,
             format!("{}{}", self.path, path).into(),
         ))
@@ -1650,12 +1653,12 @@ impl FileSystemPath {
             )
         }
         if let (path, Some(ext)) = self.split_extension() {
-            return Ok(Self::new_normalized(
+            return Ok(Self::new_normalized_unchecked(
                 self.fs,
                 format!("{path}{appending}.{ext}").into(),
             ));
         }
-        Ok(Self::new_normalized(
+        Ok(Self::new_normalized_unchecked(
             self.fs,
             format!("{}{}", self.path, appending).into(),
         ))
@@ -1669,7 +1672,8 @@ impl FileSystemPath {
         #[cfg(target_os = "windows")]
         let path = path.replace('\\', "/");
 
-        join_path(&self.path, &path).map(|p| Self::new_normalized(self.fs, RcStr::from(p)))
+        join_path(&self.path, &path)
+            .map(|p| Self::new_normalized_unchecked(self.fs, RcStr::from(p)))
     }
 
     /// Similar to [FileSystemPath::try_join], but returns [`None`] when the new path would leave
@@ -1679,7 +1683,7 @@ impl FileSystemPath {
         if let Some(p) = join_path(&self.path, path)
             && p.starts_with(&*self.path)
         {
-            return Some(Self::new_normalized(self.fs, RcStr::from(p)));
+            return Some(Self::new_normalized_unchecked(self.fs, RcStr::from(p)));
         }
         None
     }
@@ -1719,7 +1723,7 @@ impl FileSystemPath {
     /// extension.
     pub fn with_extension(&self, extension: &str) -> FileSystemPath {
         let (path_without_extension, _) = self.split_extension();
-        Self::new_normalized(
+        Self::new_normalized_unchecked(
             self.fs,
             // Like `Path::with_extension` and `PathBuf::set_extension`, if the extension is empty,
             // we remove the extension altogether.
@@ -1873,7 +1877,7 @@ impl FileSystemPath {
         if path.is_empty() {
             return self.clone();
         }
-        FileSystemPath::new_normalized(self.fs, RcStr::from(get_parent_path(path)))
+        FileSystemPath::new_normalized_unchecked(self.fs, RcStr::from(get_parent_path(path)))
     }
 
     // It is important that get_type uses read_dir and not stat/metadata.
@@ -2781,7 +2785,7 @@ async fn read_dir(path: FileSystemPath) -> Result<Vc<DirectoryContent>> {
                     RcStr::from(format!("{dir_path}/{name}"))
                 };
 
-                let entry_path = FileSystemPath::new_normalized(fs, path);
+                let entry_path = FileSystemPath::new_normalized_unchecked(fs, path);
                 let entry = match entry {
                     RawDirectoryEntry::File => DirectoryEntry::File(entry_path),
                     RawDirectoryEntry::Directory => DirectoryEntry::Directory(entry_path),
@@ -2973,7 +2977,7 @@ mod tests {
                 .to_resolved()
                 .await?;
 
-            let path_txt = FileSystemPath::new_normalized(fs, rcstr!("foo/bar.txt"));
+            let path_txt = FileSystemPath::new_normalized_unchecked(fs, rcstr!("foo/bar.txt"));
 
             let path_json = path_txt.with_extension("json");
             assert_eq!(&*path_json.path, "foo/bar.json");
@@ -2984,7 +2988,7 @@ mod tests {
             let path_new_ext = path_no_ext.with_extension("json");
             assert_eq!(&*path_new_ext.path, "foo/bar.json");
 
-            let path_no_slash_txt = FileSystemPath::new_normalized(fs, rcstr!("bar.txt"));
+            let path_no_slash_txt = FileSystemPath::new_normalized_unchecked(fs, rcstr!("bar.txt"));
 
             let path_no_slash_json = path_no_slash_txt.with_extension("json");
             assert_eq!(path_no_slash_json.path.as_str(), "bar.json");
@@ -3008,19 +3012,19 @@ mod tests {
                 .to_resolved()
                 .await?;
 
-            let path = FileSystemPath::new_normalized(fs, rcstr!(""));
+            let path = FileSystemPath::new_normalized_unchecked(fs, rcstr!(""));
             assert_eq!(path.file_stem(), None);
 
-            let path = FileSystemPath::new_normalized(fs, rcstr!("foo/bar.txt"));
+            let path = FileSystemPath::new_normalized_unchecked(fs, rcstr!("foo/bar.txt"));
             assert_eq!(path.file_stem(), Some("bar"));
 
-            let path = FileSystemPath::new_normalized(fs, rcstr!("bar.txt"));
+            let path = FileSystemPath::new_normalized_unchecked(fs, rcstr!("bar.txt"));
             assert_eq!(path.file_stem(), Some("bar"));
 
-            let path = FileSystemPath::new_normalized(fs, rcstr!("foo/bar"));
+            let path = FileSystemPath::new_normalized_unchecked(fs, rcstr!("foo/bar"));
             assert_eq!(path.file_stem(), Some("bar"));
 
-            let path = FileSystemPath::new_normalized(fs, rcstr!("foo/.bar"));
+            let path = FileSystemPath::new_normalized_unchecked(fs, rcstr!("foo/.bar"));
             assert_eq!(path.file_stem(), Some(".bar"));
 
             anyhow::Ok(())

--- a/turbopack/crates/turbo-tasks/src/task/task_input.rs
+++ b/turbopack/crates/turbo-tasks/src/task/task_input.rs
@@ -24,7 +24,7 @@ use turbo_tasks_hash::HashAlgorithm;
 // name directly.
 use crate as turbo_tasks;
 use crate::{
-    DynTaskInputs, ReadRef, ResolvedVc, TaskId, TransientInstance, TransientValue, ValueTypeId, Vc,
+    DynTaskInputs, ResolvedVc, TaskId, TransientInstance, TransientValue, ValueTypeId, Vc,
     trace::TraceRawVcs,
 };
 

--- a/turbopack/crates/turbo-tasks/src/task/task_input.rs
+++ b/turbopack/crates/turbo-tasks/src/task/task_input.rs
@@ -22,7 +22,7 @@ use turbo_tasks_hash::HashAlgorithm;
 
 // This import is necessary for derive macros to work, as their expansion refers to the crate
 // name directly.
-use crate as turbo_tasks;
+use crate::{self as turbo_tasks, ReadRef};
 use crate::{
     DynTaskInputs, ResolvedVc, TaskId, TransientInstance, TransientValue, ValueTypeId, Vc,
     trace::TraceRawVcs,

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -656,7 +656,8 @@ impl ChunkingContext for BrowserChunkingContext {
         tag: Option<RcStr>,
     ) -> Result<Vc<FileSystemPath>> {
         let this = self.await?;
-        let source_path = original_asset_ident.await?.path.clone();
+        let ident = original_asset_ident.await?;
+        let source_path = &ident.path;
         let basename = source_path.file_name();
         let ContentHashing::Direct { length } = this.asset_content_hashing;
         let hash = content

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -656,7 +656,7 @@ impl ChunkingContext for BrowserChunkingContext {
         tag: Option<RcStr>,
     ) -> Result<Vc<FileSystemPath>> {
         let this = self.await?;
-        let source_path = original_asset_ident.path().await?;
+        let source_path = original_asset_ident.await?.path.clone();
         let basename = source_path.file_name();
         let ContentHashing::Direct { length } = this.asset_content_hashing;
         let hash = content
@@ -770,11 +770,17 @@ impl ChunkingContext for BrowserChunkingContext {
                 .await?;
 
             if this.enable_hot_module_replacement {
-                let mut ident = ident;
-                if let Some(input_availability_info_ident) = input_availability_info.ident().await?
+                let ident = if let Some(input_availability_info_ident) =
+                    input_availability_info.ident().await?
                 {
-                    ident = ident.with_modifier(input_availability_info_ident);
-                }
+                    ident
+                        .owned()
+                        .await?
+                        .with_modifier(input_availability_info_ident)
+                        .into_vc()
+                } else {
+                    ident
+                };
                 let other_assets = Vc::cell(assets.clone());
                 assets.push(
                     self.generate_chunk_list_register_chunk(
@@ -850,11 +856,17 @@ impl ChunkingContext for BrowserChunkingContext {
             );
 
             if this.enable_hot_module_replacement {
-                let mut ident = ident;
-                if let Some(input_availability_info_ident) = input_availability_info.ident().await?
+                let ident = if let Some(input_availability_info_ident) =
+                    input_availability_info.ident().await?
                 {
-                    ident = ident.with_modifier(input_availability_info_ident);
-                }
+                    ident
+                        .owned()
+                        .await?
+                        .with_modifier(input_availability_info_ident)
+                        .into_vc()
+                } else {
+                    ident
+                };
                 assets.push(
                     self.generate_chunk_list_register_chunk(
                         ident,

--- a/turbopack/crates/turbopack-browser/src/ecmascript/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/chunk.rs
@@ -44,17 +44,21 @@ impl EcmascriptBrowserChunk {
         let this = self.await?;
         Ok(SourceMapAsset::new(
             Vc::upcast(*this.chunking_context),
-            this.ident_for_path(),
+            this.ident_for_path().await?,
             Vc::upcast(self),
         ))
     }
 }
 
 impl EcmascriptBrowserChunk {
-    fn ident_for_path(&self) -> Vc<AssetIdent> {
-        self.chunk
+    async fn ident_for_path(&self) -> Result<Vc<AssetIdent>> {
+        Ok(self
+            .chunk
             .ident()
+            .owned()
+            .await?
             .with_modifier(rcstr!("ecmascript dev chunk"))
+            .into_vc())
     }
 }
 
@@ -123,7 +127,7 @@ impl OutputAsset for EcmascriptBrowserChunk {
     #[turbo_tasks::function]
     async fn path(self: Vc<Self>) -> Result<Vc<FileSystemPath>> {
         let this = self.await?;
-        let ident = this.ident_for_path();
+        let ident = this.ident_for_path().await?;
         Ok(this
             .chunking_context
             .chunk_path(Some(Vc::upcast(self)), ident, None, rcstr!(".js")))

--- a/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
@@ -207,29 +207,34 @@ impl EcmascriptBrowserEvaluateChunk {
 
     #[turbo_tasks::function]
     async fn ident_for_path(&self) -> Result<Vc<AssetIdent>> {
-        let mut ident = self.ident.owned().await?;
-
-        ident.add_modifier(rcstr!("ecmascript browser evaluate chunk"));
+        let mut ident = self
+            .ident
+            .owned()
+            .await?
+            .with_modifier(rcstr!("ecmascript browser evaluate chunk"));
 
         let evaluatable_assets = self.evaluatable_assets.await?;
-        ident.modifiers.extend(
-            evaluatable_assets
-                .iter()
-                .map(|entry| entry.ident().to_string().owned())
-                .try_join()
-                .await?,
-        );
+        for name in evaluatable_assets
+            .iter()
+            .map(|entry| entry.ident().to_string().owned())
+            .try_join()
+            .await?
+        {
+            ident = ident.with_modifier(name);
+        }
 
-        ident.modifiers.extend(
-            self.other_chunks
-                .await?
-                .iter()
-                .map(|chunk| chunk.path().to_string().owned())
-                .try_join()
-                .await?,
-        );
+        for name in self
+            .other_chunks
+            .await?
+            .iter()
+            .map(|chunk| chunk.path().to_string().owned())
+            .try_join()
+            .await?
+        {
+            ident = ident.with_modifier(name);
+        }
 
-        Ok(AssetIdent::new(ident))
+        Ok(ident.into_vc())
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
@@ -214,25 +214,21 @@ impl EcmascriptBrowserEvaluateChunk {
             .with_modifier(rcstr!("ecmascript browser evaluate chunk"));
 
         let evaluatable_assets = self.evaluatable_assets.await?;
-        for name in evaluatable_assets
-            .iter()
-            .map(|entry| entry.ident().to_string().owned())
-            .try_join()
-            .await?
-        {
-            ident = ident.with_modifier(name);
-        }
-
-        for name in self
-            .other_chunks
-            .await?
-            .iter()
-            .map(|chunk| chunk.path().to_string().owned())
-            .try_join()
-            .await?
-        {
-            ident = ident.with_modifier(name);
-        }
+        ident.modifiers.extend(
+            evaluatable_assets
+                .iter()
+                .map(|entry| entry.ident().to_string().owned())
+                .try_join()
+                .await?,
+        );
+        ident.modifiers.extend(
+            self.other_chunks
+                .await?
+                .iter()
+                .map(|chunk| chunk.path().to_string().owned())
+                .try_join()
+                .await?,
+        );
 
         Ok(ident.into_vc())
     }

--- a/turbopack/crates/turbopack-browser/src/ecmascript/list/asset.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/list/asset.rs
@@ -77,13 +77,16 @@ impl OutputAsset for EcmascriptDevChunkList {
     #[turbo_tasks::function]
     async fn path(self: Vc<Self>) -> Result<Vc<FileSystemPath>> {
         let this = self.await?;
-        let mut ident = this.ident.owned().await?;
-        ident.add_modifier(rcstr!("ecmascript dev chunk list"));
+        let mut ident = this
+            .ident
+            .owned()
+            .await?
+            .with_modifier(rcstr!("ecmascript dev chunk list"));
 
         match this.source {
             EcmascriptDevChunkListSource::Entry => {}
             EcmascriptDevChunkListSource::Dynamic => {
-                ident.add_modifier(rcstr!("dynamic"));
+                ident = ident.with_modifier(rcstr!("dynamic"));
             }
         }
 
@@ -91,7 +94,7 @@ impl OutputAsset for EcmascriptDevChunkList {
         // ident, because it must remain stable whenever a chunk is added or
         // removed from the list.
 
-        let ident = AssetIdent::new(ident);
+        let ident = ident.into_vc();
         Ok(this
             .chunking_context
             .chunk_path(Some(Vc::upcast(self)), ident, None, rcstr!(".js")))

--- a/turbopack/crates/turbopack-browser/src/ecmascript/worker.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/worker.rs
@@ -72,7 +72,7 @@ impl EcmascriptBrowserWorkerEntrypoint {
         let ident = AssetIdent::from_path(chunk_root_path)
             .with_modifier(rcstr!("turbopack worker entrypoint"))
             .with_modifier(format!("{globals_hash:08x}").into());
-        Ok(ident)
+        Ok(ident.into_vc())
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -450,15 +450,7 @@ async fn build_internal(
                             Target::Browser => chunking_context.evaluated_chunk_group_assets(
                                 AssetIdent::from_path(
                                     build_output_root
-                                        .join(
-                                            ecmascript
-                                                .ident()
-                                                .await?
-                                                .path
-                                                .clone()
-                                                .file_stem()
-                                                .unwrap(),
-                                        )?
+                                        .join(ecmascript.ident().await?.path.file_stem().unwrap())?
                                         .with_extension("entry.js"),
                                 )
                                 .into_vc(),

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -451,10 +451,17 @@ async fn build_internal(
                                 AssetIdent::from_path(
                                     build_output_root
                                         .join(
-                                            ecmascript.ident().path().await?.file_stem().unwrap(),
+                                            ecmascript
+                                                .ident()
+                                                .await?
+                                                .path
+                                                .clone()
+                                                .file_stem()
+                                                .unwrap(),
                                         )?
                                         .with_extension("entry.js"),
-                                ),
+                                )
+                                .into_vc(),
                                 ChunkGroup::Entry(
                                     [ResolvedVc::upcast(ecmascript)].into_iter().collect(),
                                 ),
@@ -469,8 +476,8 @@ async fn build_internal(
                                                 .join(
                                                     ecmascript
                                                         .ident()
-                                                        .path()
                                                         .await?
+                                                        .path
                                                         .file_stem()
                                                         .unwrap(),
                                                 )?

--- a/turbopack/crates/turbopack-core/src/data_uri_source.rs
+++ b/turbopack/crates/turbopack-core/src/data_uri_source.rs
@@ -67,10 +67,9 @@ impl Source for DataUriSource {
                 &self.encoding
             )))[0..6]
         );
-        Ok(
-            AssetIdent::from_path(self.lookup_path.join(&filename)?)
-                .with_content_type(content_type),
-        )
+        Ok(AssetIdent::from_path(self.lookup_path.join(&filename)?)
+            .with_content_type(content_type)
+            .into_vc())
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/file_source.rs
+++ b/turbopack/crates/turbopack-core/src/file_source.rs
@@ -54,7 +54,7 @@ impl Source for FileSource {
         if !self.fragment.is_empty() {
             ident = ident.with_fragment(self.fragment.clone());
         }
-        ident
+        ident.into_vc()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-core/src/file_source.rs
+++ b/turbopack/crates/turbopack-core/src/file_source.rs
@@ -47,14 +47,10 @@ impl FileSource {
 impl Source for FileSource {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
-        let mut ident = AssetIdent::from_path(self.path.clone());
-        if !self.query.is_empty() {
-            ident = ident.with_query(self.query.clone());
-        }
-        if !self.fragment.is_empty() {
-            ident = ident.with_fragment(self.fragment.clone());
-        }
-        ident.into_vc()
+        AssetIdent::from_path(self.path.clone())
+            .with_query(self.query.clone())
+            .with_fragment(self.fragment.clone())
+            .into_vc()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-core/src/ident.rs
+++ b/turbopack/crates/turbopack-core/src/ident.rs
@@ -103,6 +103,7 @@ impl AssetIdent {
 
     /// Finalizes the builder by turning the owned [`AssetIdent`] into a cached [`Vc<AssetIdent>`].
     pub fn into_vc(self) -> Vc<Self> {
+        // This optimizes cache misses in cold builds by only storing one copy of the AssetIdent.
         AssetIdent::new_inner(ReadRef::new_owned(self))
     }
 

--- a/turbopack/crates/turbopack-core/src/ident.rs
+++ b/turbopack/crates/turbopack-core/src/ident.rs
@@ -6,8 +6,8 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    NonLocalValue, ResolvedVc, TaskInput, ValueToString, ValueToStringRef, Vc, trace::TraceRawVcs,
-    turbofmt,
+    NonLocalValue, ReadRef, ResolvedVc, TaskInput, ValueToString, ValueToStringRef, Vc,
+    trace::TraceRawVcs, turbofmt,
 };
 use turbo_tasks_fs::FileSystemPath;
 use turbo_tasks_hash::{DeterministicHash, Xxh3Hash64Hasher, encode_base38, hash_xxh3_hash64};

--- a/turbopack/crates/turbopack-core/src/ident.rs
+++ b/turbopack/crates/turbopack-core/src/ident.rs
@@ -84,25 +84,77 @@ pub struct AssetIdent {
 }
 
 impl AssetIdent {
-    pub fn new(ident: AssetIdent) -> Vc<Self> {
-        AssetIdent::new_inner(ReadRef::new_owned(ident))
+    /// Creates an [AssetIdent] from a [FileSystemPath].
+    ///
+    /// Returns an owned value; call [`AssetIdent::into_vc`] at the end of the builder chain to
+    /// turn it into a [`Vc<AssetIdent>`].
+    pub fn from_path(path: FileSystemPath) -> Self {
+        AssetIdent {
+            path,
+            query: RcStr::default(),
+            fragment: RcStr::default(),
+            assets: Vec::new(),
+            modifiers: Vec::new(),
+            parts: Vec::new(),
+            layer: None,
+            content_type: None,
+        }
     }
 
-    pub fn add_modifier(&mut self, modifier: RcStr) {
+    /// Finalizes the builder by turning the owned [`AssetIdent`] into a cached [`Vc<AssetIdent>`].
+    ///
+    /// Internally delegates to `new_inner` which is the only cached turbo-task constructor for
+    /// `AssetIdent`, avoiding redundant task executions for every builder step.
+    pub fn into_vc(self) -> Vc<Self> {
+        AssetIdent::new_inner(ReadRef::new_owned(self))
+    }
+
+    pub fn with_query(mut self, query: RcStr) -> Self {
+        self.query = query;
+        self
+    }
+
+    pub fn with_fragment(mut self, fragment: RcStr) -> Self {
+        self.fragment = fragment;
+        self
+    }
+
+    pub fn with_modifier(mut self, modifier: RcStr) -> Self {
         debug_assert!(!modifier.is_empty(), "modifiers cannot be empty.");
         self.modifiers.push(modifier);
+        self
     }
 
-    pub fn add_asset(&mut self, key: RcStr, asset: ResolvedVc<AssetIdent>) {
+    pub fn with_part(mut self, part: ModulePart) -> Self {
+        self.parts.push(part);
+        self
+    }
+
+    pub fn with_path(mut self, path: FileSystemPath) -> Self {
+        self.path = path;
+        self
+    }
+
+    pub fn with_layer(mut self, layer: Layer) -> Self {
+        self.layer = Some(layer);
+        self
+    }
+
+    pub fn with_content_type(mut self, content_type: RcStr) -> Self {
+        self.content_type = Some(content_type);
+        self
+    }
+
+    pub fn with_asset(mut self, key: RcStr, asset: ResolvedVc<AssetIdent>) -> Self {
         self.assets.push((key, asset));
+        self
     }
 
-    pub async fn rename_as_ref(&mut self, pattern: &str) -> Result<()> {
+    pub async fn rename_as(mut self, pattern: &str) -> Result<Self> {
         let root = self.path.root().await?;
-        let path = self.path.clone();
-        self.path = root.join(&pattern.replace('*', &path.path))?;
+        self.path = root.join(&pattern.replace('*', &self.path.path))?;
         self.content_type = None;
-        Ok(())
+        Ok(self)
     }
 }
 
@@ -119,89 +171,6 @@ impl AssetIdent {
             "query should be empty or start with a `?`"
         );
         ReadRef::cell(ident)
-    }
-
-    /// Creates an [AssetIdent] from a [FileSystemPath]
-    #[turbo_tasks::function]
-    pub fn from_path(path: FileSystemPath) -> Vc<Self> {
-        Self::new(AssetIdent {
-            path,
-            query: RcStr::default(),
-            fragment: RcStr::default(),
-            assets: Vec::new(),
-            modifiers: Vec::new(),
-            parts: Vec::new(),
-            layer: None,
-            content_type: None,
-        })
-    }
-
-    #[turbo_tasks::function]
-    pub fn with_query(&self, query: RcStr) -> Vc<Self> {
-        let mut this = self.clone();
-        this.query = query;
-        Self::new(this)
-    }
-
-    #[turbo_tasks::function]
-    pub fn with_fragment(&self, fragment: RcStr) -> Vc<Self> {
-        let mut this = self.clone();
-        this.fragment = fragment;
-        Self::new(this)
-    }
-
-    #[turbo_tasks::function]
-    pub fn with_modifier(&self, modifier: RcStr) -> Vc<Self> {
-        let mut this = self.clone();
-        this.add_modifier(modifier);
-        Self::new(this)
-    }
-
-    #[turbo_tasks::function]
-    pub fn with_part(&self, part: ModulePart) -> Vc<Self> {
-        let mut this = self.clone();
-        this.parts.push(part);
-        Self::new(this)
-    }
-
-    #[turbo_tasks::function]
-    pub fn with_path(&self, path: FileSystemPath) -> Vc<Self> {
-        let mut this = self.clone();
-        this.path = path;
-        Self::new(this)
-    }
-
-    #[turbo_tasks::function]
-    pub fn with_layer(&self, layer: Layer) -> Vc<Self> {
-        let mut this = self.clone();
-        this.layer = Some(layer);
-        Self::new(this)
-    }
-
-    #[turbo_tasks::function]
-    pub fn with_content_type(&self, content_type: RcStr) -> Vc<Self> {
-        let mut this = self.clone();
-        this.content_type = Some(content_type);
-        Self::new(this)
-    }
-
-    #[turbo_tasks::function]
-    pub fn with_asset(&self, key: RcStr, asset: ResolvedVc<AssetIdent>) -> Vc<Self> {
-        let mut this = self.clone();
-        this.add_asset(key, asset);
-        Self::new(this)
-    }
-
-    #[turbo_tasks::function]
-    pub async fn rename_as(&self, pattern: RcStr) -> Result<Vc<Self>> {
-        let mut this = self.clone();
-        this.rename_as_ref(&pattern).await?;
-        Ok(Self::new(this))
-    }
-
-    #[turbo_tasks::function]
-    pub fn path(&self) -> Vc<FileSystemPath> {
-        self.path.clone().cell()
     }
 
     /// Computes a unique output asset name for the given asset identifier.
@@ -466,7 +435,7 @@ pub mod tests {
                 let fs = VirtualFileSystem::new_with_name(rcstr!("test"));
                 let root = fs.root().owned().await?;
 
-                let asset_ident = AssetIdent::from_path(root.join("a:b?c#d.js")?);
+                let asset_ident = AssetIdent::from_path(root.join("a:b?c#d.js")?).into_vc();
                 let output_name = asset_ident
                     .output_name(root, Some(rcstr!("prefix")), rcstr!(".js"))
                     .await?;

--- a/turbopack/crates/turbopack-core/src/ident.rs
+++ b/turbopack/crates/turbopack-core/src/ident.rs
@@ -6,8 +6,8 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    NonLocalValue, ReadRef, ResolvedVc, TaskInput, ValueToString, ValueToStringRef, Vc,
-    trace::TraceRawVcs, turbofmt,
+    NonLocalValue, ResolvedVc, TaskInput, ValueToString, ValueToStringRef, Vc, trace::TraceRawVcs,
+    turbofmt,
 };
 use turbo_tasks_fs::FileSystemPath;
 use turbo_tasks_hash::{DeterministicHash, Xxh3Hash64Hasher, encode_base38, hash_xxh3_hash64};
@@ -102,9 +102,6 @@ impl AssetIdent {
     }
 
     /// Finalizes the builder by turning the owned [`AssetIdent`] into a cached [`Vc<AssetIdent>`].
-    ///
-    /// Internally delegates to `new_inner` which is the only cached turbo-task constructor for
-    /// `AssetIdent`, avoiding redundant task executions for every builder step.
     pub fn into_vc(self) -> Vc<Self> {
         AssetIdent::new_inner(ReadRef::new_owned(self))
     }

--- a/turbopack/crates/turbopack-core/src/ident.rs
+++ b/turbopack/crates/turbopack-core/src/ident.rs
@@ -150,11 +150,13 @@ impl AssetIdent {
         self
     }
 
-    pub async fn rename_as(mut self, pattern: &str) -> Result<Self> {
-        let root = self.path.root().await?;
-        self.path = root.join(&pattern.replace('*', &self.path.path))?;
+    pub fn rename_as(mut self, pattern: &str) -> Self {
+        self.path = FileSystemPath::new_normalized_unchecked(
+            self.path.fs,
+            pattern.replace('*', &self.path.path).into(),
+        );
         self.content_type = None;
-        Ok(self)
+        self
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/issue/analyze.rs
+++ b/turbopack/crates/turbopack-core/src/issue/analyze.rs
@@ -65,7 +65,7 @@ impl Issue for AnalyzeIssue {
     }
 
     async fn file_path(&self) -> Result<FileSystemPath> {
-        self.source_ident.path().owned().await
+        Ok(self.source_ident.await?.path.clone())
     }
 
     async fn description(&self) -> Result<Option<StyledString>> {

--- a/turbopack/crates/turbopack-core/src/issue/mod.rs
+++ b/turbopack/crates/turbopack-core/src/issue/mod.rs
@@ -602,8 +602,8 @@ impl IssueSource {
     }
 
     /// Returns the file path for the source file.
-    pub fn file_path(&self) -> Vc<FileSystemPath> {
-        self.source.ident().path()
+    pub async fn file_path(&self) -> Result<FileSystemPath> {
+        Ok(self.source.ident().await?.path.clone())
     }
 
     /// If this source implements `GenerateSourceMap`, returns an
@@ -1042,7 +1042,7 @@ impl PlainSource {
 
         Ok(PlainSource {
             ident: asset.ident().to_string().await?,
-            file_path: asset.ident().path().to_string().await?,
+            file_path: ReadRef::new_owned(asset.ident().await?.path.to_string_ref().await?),
             content,
         }
         .cell())

--- a/turbopack/crates/turbopack-core/src/issue/mod.rs
+++ b/turbopack/crates/turbopack-core/src/issue/mod.rs
@@ -1024,8 +1024,8 @@ pub struct PlainIssueSource {
 #[turbo_tasks::value(serialization = "skip")]
 #[derive(Clone, Debug, PartialOrd, Ord)]
 pub struct PlainSource {
-    pub ident: ReadRef<RcStr>,
-    pub file_path: ReadRef<RcStr>,
+    pub ident: RcStr,
+    pub file_path: RcStr,
     #[turbo_tasks(debug_ignore)]
     pub content: ReadRef<FileContent>,
 }
@@ -1041,8 +1041,8 @@ impl PlainSource {
         };
 
         Ok(PlainSource {
-            ident: asset.ident().to_string().await?,
-            file_path: ReadRef::new_owned(asset.ident().await?.path.to_string_ref().await?),
+            ident: asset.ident().to_string().owned().await?,
+            file_path: asset.ident().await?.path.to_string_ref().await?,
             content,
         }
         .cell())

--- a/turbopack/crates/turbopack-core/src/issue/module.rs
+++ b/turbopack/crates/turbopack-core/src/issue/module.rs
@@ -42,7 +42,7 @@ impl Issue for ModuleIssue {
     }
 
     async fn file_path(&self) -> Result<FileSystemPath> {
-        self.ident.path().owned().await
+        Ok(self.ident.await?.path.clone())
     }
 
     async fn title(&self) -> Result<StyledString> {

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -602,7 +602,7 @@ impl ModuleGraphImportTracer {
             .await?
             .modules
             .iter()
-            .map(|(&module, _)| async move { Ok((module.ident().path().owned().await?, module)) })
+            .map(|(&module, _)| async move { Ok((module.ident().await?.path.clone(), module)) })
             .try_join()
             .await?;
         let mut map: FxHashMap<FileSystemPath, Vec<ResolvedVc<Box<dyn Module>>>> =
@@ -2498,7 +2498,7 @@ pub mod tests {
     impl Module for MockModule {
         #[turbo_tasks::function]
         fn ident(&self) -> Vc<AssetIdent> {
-            AssetIdent::from_path(self.path.clone())
+            AssetIdent::from_path(self.path.clone()).into_vc()
         }
 
         #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-core/src/node_addon_module.rs
+++ b/turbopack/crates/turbopack-core/src/node_addon_module.rs
@@ -52,7 +52,8 @@ impl Module for NodeAddonModule {
     async fn references(&self) -> Result<Vc<ModuleReferences>> {
         static SHARP_BINARY_REGEX: LazyLock<Regex> =
             LazyLock::new(|| Regex::new("/sharp-(\\w+-\\w+).node$").unwrap());
-        let module_path = self.source.ident().await?.path.clone();
+        let ident = self.source.ident().await?;
+        let module_path = &ident.path;
 
         // For most .node binaries, we usually assume that they are standalone dynamic library
         // binaries that get loaded by some `require` call. So the binary itself doesn't read any

--- a/turbopack/crates/turbopack-core/src/node_addon_module.rs
+++ b/turbopack/crates/turbopack-core/src/node_addon_module.rs
@@ -33,8 +33,14 @@ impl NodeAddonModule {
 #[turbo_tasks::value_impl]
 impl Module for NodeAddonModule {
     #[turbo_tasks::function]
-    fn ident(&self) -> Vc<AssetIdent> {
-        self.source.ident().with_modifier(rcstr!("node addon"))
+    async fn ident(&self) -> Result<Vc<AssetIdent>> {
+        Ok(self
+            .source
+            .ident()
+            .owned()
+            .await?
+            .with_modifier(rcstr!("node addon"))
+            .into_vc())
     }
 
     #[turbo_tasks::function]
@@ -46,7 +52,7 @@ impl Module for NodeAddonModule {
     async fn references(&self) -> Result<Vc<ModuleReferences>> {
         static SHARP_BINARY_REGEX: LazyLock<Regex> =
             LazyLock::new(|| Regex::new("/sharp-(\\w+-\\w+).node$").unwrap());
-        let module_path = self.source.ident().path().await?;
+        let module_path = self.source.ident().await?.path.clone();
 
         // For most .node binaries, we usually assume that they are standalone dynamic library
         // binaries that get loaded by some `require` call. So the binary itself doesn't read any

--- a/turbopack/crates/turbopack-core/src/package_json.rs
+++ b/turbopack/crates/turbopack-core/src/package_json.rs
@@ -82,7 +82,7 @@ impl Issue for PackageJsonIssue {
     }
 
     async fn file_path(&self) -> Result<FileSystemPath> {
-        self.source.file_path().owned().await
+        self.source.file_path().await
     }
 
     async fn description(&self) -> Result<Option<StyledString>> {

--- a/turbopack/crates/turbopack-core/src/raw_module.rs
+++ b/turbopack/crates/turbopack-core/src/raw_module.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, Vc};
 
@@ -18,11 +19,17 @@ pub struct RawModule {
 #[turbo_tasks::value_impl]
 impl Module for RawModule {
     #[turbo_tasks::function]
-    fn ident(&self) -> Vc<AssetIdent> {
-        match &self.modifier {
-            Some(modifier) => self.source.ident().with_modifier(modifier.clone()),
+    async fn ident(&self) -> Result<Vc<AssetIdent>> {
+        Ok(match &self.modifier {
+            Some(modifier) => self
+                .source
+                .ident()
+                .owned()
+                .await?
+                .with_modifier(modifier.clone())
+                .into_vc(),
             None => self.source.ident(),
-        }
+        })
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-core/src/rebase.rs
+++ b/turbopack/crates/turbopack-core/src/rebase.rs
@@ -64,7 +64,7 @@ impl OutputAsset for RebasedAsset {
     #[turbo_tasks::function]
     async fn path(&self) -> Result<Vc<FileSystemPath>> {
         Ok(FileSystemPath::rebase(
-            self.module.ident().path().owned().await?,
+            self.module.ident().await?.path.clone(),
             self.input_dir.clone(),
             self.output_dir.clone(),
         ))

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -1818,7 +1818,7 @@ async fn handle_after_resolve_plugins(
         if let &ResolveResultItem::Source(source) = primary {
             let path = source.ident().await?.path.clone();
             if let Some(new_result) = apply_plugins_to_path(
-                path.clone(),
+                path,
                 lookup_path.clone(),
                 reference_type.clone(),
                 request,

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -1816,7 +1816,7 @@ async fn handle_after_resolve_plugins(
 
     for (key, primary) in result_value.primary.iter() {
         if let &ResolveResultItem::Source(source) = primary {
-            let path = source.ident().path().owned().await?;
+            let path = source.ident().await?.path.clone();
             if let Some(new_result) = apply_plugins_to_path(
                 path.clone(),
                 lookup_path.clone(),

--- a/turbopack/crates/turbopack-core/src/traced_asset.rs
+++ b/turbopack/crates/turbopack-core/src/traced_asset.rs
@@ -46,8 +46,8 @@ impl OutputAssetsReference for TracedAsset {
 #[turbo_tasks::value_impl]
 impl OutputAsset for TracedAsset {
     #[turbo_tasks::function]
-    fn path(&self) -> Vc<FileSystemPath> {
-        self.module.ident().path()
+    async fn path(&self) -> Result<Vc<FileSystemPath>> {
+        Ok(self.module.ident().await?.path.clone().cell())
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/virtual_source.rs
+++ b/turbopack/crates/turbopack-core/src/virtual_source.rs
@@ -21,7 +21,7 @@ impl VirtualSource {
     #[turbo_tasks::function]
     pub async fn new(path: FileSystemPath, content: ResolvedVc<AssetContent>) -> Result<Vc<Self>> {
         Ok(Self::cell(VirtualSource {
-            ident: AssetIdent::from_path(path).to_resolved().await?,
+            ident: AssetIdent::from_path(path).into_vc().to_resolved().await?,
             content,
         }))
     }

--- a/turbopack/crates/turbopack-css/src/asset.rs
+++ b/turbopack/crates/turbopack-css/src/asset.rs
@@ -137,12 +137,14 @@ impl Module for CssModule {
         let mut ident = self
             .source
             .ident()
+            .owned()
+            .await?
             .with_modifier(rcstr!("css"))
             .with_layer(self.asset_context.into_trait_ref().await?.layer());
         if let Some(import_context) = self.import_context {
             ident = ident.with_modifier(import_context.modifier().owned().await?)
         }
-        Ok(ident)
+        Ok(ident.into_vc())
     }
 
     #[turbo_tasks::function]
@@ -201,8 +203,8 @@ impl CssChunkPlaceable for CssModule {}
 #[turbo_tasks::value_impl]
 impl ResolveOrigin for CssModule {
     #[turbo_tasks::function]
-    fn origin_path(&self) -> Vc<FileSystemPath> {
-        self.source.ident().path()
+    async fn origin_path(&self) -> Result<Vc<FileSystemPath>> {
+        Ok(self.source.ident().await?.path.clone().cell())
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-css/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/mod.rs
@@ -206,9 +206,7 @@ impl CssChunk {
             ServerFileSystem::new().root().owned().await?
         };
         let mut ident = AssetIdent::from_path(path);
-        for (key, asset) in assets {
-            ident = ident.with_asset(key, asset);
-        }
+        ident.assets.extend(assets);
 
         Ok(ident.into_vc())
     }

--- a/turbopack/crates/turbopack-css/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/mod.rs
@@ -168,8 +168,8 @@ impl CssChunk {
     async fn ident_for_path(&self) -> Result<Vc<AssetIdent>> {
         let CssChunkContent { chunk_items, .. } = &*self.content.await?;
         let mut common_path = if let Some(chunk_item) = chunk_items.first() {
-            let path = chunk_item.asset_ident().path().owned().await?;
-            Some((path.clone(), path))
+            let path = chunk_item.asset_ident().await?.path.clone();
+            Some(path)
         } else {
             None
         };
@@ -177,16 +177,15 @@ impl CssChunk {
         // The included chunk items and the availability info describe the chunk
         // uniquely
         for &chunk_item in chunk_items.iter() {
-            if let Some((common_path_vc, common_path_ref)) = common_path.as_mut() {
-                let path = chunk_item.asset_ident().path().await?;
+            if let Some(common_path_ref) = common_path.as_mut() {
+                let path = &chunk_item.asset_ident().await?.path;
                 while !path.is_inside_or_equal_ref(common_path_ref) {
-                    let parent = common_path_vc.parent();
-                    if parent == *common_path_vc {
+                    let parent = common_path_ref.parent();
+                    if parent == *common_path_ref {
                         common_path = None;
                         break;
                     }
-                    *common_path_vc = parent;
-                    *common_path_ref = common_path_vc.clone();
+                    *common_path_ref = parent;
                 }
             }
         }
@@ -201,22 +200,17 @@ impl CssChunk {
             .try_join()
             .await?;
 
-        let ident = AssetIdent {
-            path: if let Some((common_path, _)) = common_path {
-                common_path
-            } else {
-                ServerFileSystem::new().root().owned().await?
-            },
-            query: RcStr::default(),
-            fragment: RcStr::default(),
-            assets,
-            modifiers: Vec::new(),
-            parts: Vec::new(),
-            layer: None,
-            content_type: None,
+        let path = if let Some(common_path) = common_path {
+            common_path
+        } else {
+            ServerFileSystem::new().root().owned().await?
         };
+        let mut ident = AssetIdent::from_path(path);
+        for (key, asset) in assets {
+            ident = ident.with_asset(key, asset);
+        }
 
-        Ok(AssetIdent::new(ident))
+        Ok(ident.into_vc())
     }
 }
 
@@ -332,7 +326,7 @@ impl OutputAssetsReference for CssChunk {
 impl Chunk for CssChunk {
     #[turbo_tasks::function]
     async fn ident(self: Vc<Self>) -> Result<Vc<AssetIdent>> {
-        Ok(AssetIdent::from_path(self.path().owned().await?))
+        Ok(AssetIdent::from_path(self.path().owned().await?).into_vc())
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/chunk.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/chunk.rs
@@ -81,9 +81,14 @@ impl SingleItemCssChunk {
     }
 
     #[turbo_tasks::function]
-    pub(super) fn ident_for_path(&self) -> Result<Vc<AssetIdent>> {
-        let item = self.item.asset_ident();
-        Ok(item.with_modifier(rcstr!("single item css chunk")))
+    pub(super) async fn ident_for_path(&self) -> Result<Vc<AssetIdent>> {
+        Ok(self
+            .item
+            .asset_ident()
+            .owned()
+            .await?
+            .with_modifier(rcstr!("single item css chunk"))
+            .into_vc())
     }
 }
 
@@ -115,9 +120,7 @@ impl Chunk for SingleItemCssChunk {
     #[turbo_tasks::function]
     async fn ident(self: Vc<Self>) -> Result<Vc<AssetIdent>> {
         let self_as_output_asset: Vc<Box<dyn OutputAsset>> = Vc::upcast(self);
-        Ok(AssetIdent::from_path(
-            self_as_output_asset.path().owned().await?,
-        ))
+        Ok(AssetIdent::from_path(self_as_output_asset.path().owned().await?).into_vc())
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-css/src/module_asset.rs
+++ b/turbopack/crates/turbopack-css/src/module_asset.rs
@@ -64,8 +64,11 @@ impl Module for EcmascriptCssModule {
         Ok(self
             .source
             .ident()
+            .owned()
+            .await?
             .with_modifier(rcstr!("css module"))
-            .with_layer(self.asset_context.into_trait_ref().await?.layer()))
+            .with_layer(self.asset_context.into_trait_ref().await?.layer())
+            .into_vc())
     }
 
     #[turbo_tasks::function]
@@ -354,8 +357,8 @@ impl EcmascriptChunkPlaceable for EcmascriptCssModule {
 #[turbo_tasks::value_impl]
 impl ResolveOrigin for EcmascriptCssModule {
     #[turbo_tasks::function]
-    fn origin_path(&self) -> Vc<FileSystemPath> {
-        self.source.ident().path()
+    async fn origin_path(&self) -> Result<Vc<FileSystemPath>> {
+        Ok(self.source.ident().await?.path.clone().cell())
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-css/src/process.rs
+++ b/turbopack/crates/turbopack-css/src/process.rs
@@ -765,7 +765,7 @@ impl Issue for ParsingIssue {
     }
 
     async fn file_path(&self) -> Result<FileSystemPath> {
-        self.source.file_path().owned().await
+        self.source.file_path().await
     }
 
     fn stage(&self) -> IssueStage {

--- a/turbopack/crates/turbopack-ecmascript/src/async_chunk/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/async_chunk/module.rs
@@ -51,8 +51,13 @@ impl AsyncLoaderModule {
     }
 
     #[turbo_tasks::function]
-    pub fn asset_ident_for(module: Vc<Box<dyn ChunkableModule>>) -> Vc<AssetIdent> {
-        module.ident().with_modifier(rcstr!("async loader"))
+    pub async fn asset_ident_for(module: Vc<Box<dyn ChunkableModule>>) -> Result<Vc<AssetIdent>> {
+        Ok(module
+            .ident()
+            .owned()
+            .await?
+            .with_modifier(rcstr!("async loader"))
+            .into_vc())
     }
 
     #[turbo_tasks::function]
@@ -265,8 +270,6 @@ impl EcmascriptChunkPlaceable for AsyncLoaderModule {
         _chunking_context: Vc<Box<dyn ChunkingContext>>,
         module_graph: Vc<ModuleGraph>,
     ) -> Result<Vc<AssetIdent>> {
-        let mut ident = self.ident();
-
         let this = self.await?;
 
         let nested_async_availability = this
@@ -286,11 +289,15 @@ impl EcmascriptChunkPlaceable for AsyncLoaderModule {
             this.availability_info.ident().await?
         };
 
-        if let Some(availability_ident) = availability_ident {
-            ident = ident.with_modifier(availability_ident)
-        }
-
-        Ok(ident)
+        Ok(if let Some(availability_ident) = availability_ident {
+            self.ident()
+                .owned()
+                .await?
+                .with_modifier(availability_ident)
+                .into_vc()
+        } else {
+            self.ident()
+        })
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/bytes_source_transform.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/bytes_source_transform.rs
@@ -36,8 +36,8 @@ impl SourceTransform for BytesSourceTransform {
         source: Vc<Box<dyn Source>>,
         _asset_context: Vc<Box<dyn AssetContext>>,
     ) -> Result<Vc<Box<dyn Source>>> {
-        let ident = source.ident();
-        let path = ident.path().await?;
+        let ident = source.ident().owned().await?;
+        let path = ident.path.clone();
         let content = source.content().file_content().await?;
         let bytes = match &*content {
             FileContent::Content(data) => {
@@ -64,7 +64,10 @@ export default base64Decode({});
 
         // Rename to .mjs so module rules recognize it as ESM.
         // The inline source map ensures debuggers show the original file.
-        let new_ident = ident.rename_as(format!("{}.[bytes].mjs", path.path).into());
+        let new_ident = ident
+            .rename_as(&format!("{}.[bytes].mjs", path.path))
+            .await?
+            .into_vc();
 
         Ok(Vc::upcast(VirtualSource::new_with_ident(
             new_ident,

--- a/turbopack/crates/turbopack-ecmascript/src/bytes_source_transform.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/bytes_source_transform.rs
@@ -37,14 +37,13 @@ impl SourceTransform for BytesSourceTransform {
         _asset_context: Vc<Box<dyn AssetContext>>,
     ) -> Result<Vc<Box<dyn Source>>> {
         let ident = source.ident().owned().await?;
-        let path = ident.path.clone();
         let content = source.content().file_content().await?;
         let bytes = match &*content {
             FileContent::Content(data) => {
                 data.read().bytes().collect::<std::io::Result<Vec<u8>>>()?
             }
             FileContent::NotFound => {
-                bail!("File not found: {:?}", path);
+                bail!("File not found: {:?}", ident.path);
             }
         };
 
@@ -59,15 +58,13 @@ export default base64Decode({});
             StringifyJs(&encoded),
             // For binary files, we use an empty string as sourcesContent since the
             // original content isn't meaningful text.
-            inline_source_map_comment(&path.path, "")
+            inline_source_map_comment(&ident.path.path, "")
         );
 
         // Rename to .mjs so module rules recognize it as ESM.
         // The inline source map ensures debuggers show the original file.
-        let new_ident = ident
-            .rename_as(&format!("{}.[bytes].mjs", path.path))
-            .await?
-            .into_vc();
+        let new_pattern = format!("{}.[bytes].mjs", ident.path.path);
+        let new_ident = ident.rename_as(&new_pattern).await?.into_vc();
 
         Ok(Vc::upcast(VirtualSource::new_with_ident(
             new_ident,

--- a/turbopack/crates/turbopack-ecmascript/src/bytes_source_transform.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/bytes_source_transform.rs
@@ -63,8 +63,8 @@ export default base64Decode({});
 
         // Rename to .mjs so module rules recognize it as ESM.
         // The inline source map ensures debuggers show the original file.
-        let new_pattern = format!("{}.[bytes].mjs", ident.path.path);
-        let new_ident = ident.rename_as(&new_pattern).await?.into_vc();
+
+        let new_ident = ident.rename_as("*.[bytes].mjs").into_vc();
 
         Ok(Vc::upcast(VirtualSource::new_with_ident(
             new_ident,

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
@@ -316,7 +316,7 @@ async fn module_factory_with_code_generation_issue(
             let js_error_message = serde_json::to_string(&error_message)?;
             CodeGenerationIssue {
                 severity: IssueSeverity::Error,
-                path: chunk_item.asset_ident().path().owned().await?,
+                path: chunk_item.asset_ident().await?.path.clone(),
                 title: StyledString::Text(rcstr!("Code generation for chunk item errored"))
                     .resolved_cell(),
                 message: StyledString::Text(error_message).resolved_cell(),

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
@@ -114,7 +114,7 @@ impl Chunk for EcmascriptChunk {
     async fn ident(&self) -> Result<Vc<AssetIdent>> {
         let chunk_items = &*self.content.included_chunk_items().await?;
         let mut common_path = if let Some(chunk_item) = chunk_items.first() {
-            let path = chunk_item.asset_ident().path().owned().await?;
+            let path = chunk_item.asset_ident().await?.path.clone();
             Some(path)
         } else {
             None
@@ -123,7 +123,7 @@ impl Chunk for EcmascriptChunk {
         // The included chunk items describe the chunk uniquely
         for &chunk_item in chunk_items.iter() {
             if let Some(common_path_ref) = common_path.as_mut() {
-                let path = chunk_item.asset_ident().path().await?;
+                let path = &chunk_item.asset_ident().await?.path;
                 while !path.is_inside_or_equal_ref(common_path_ref) {
                     let parent = common_path_ref.parent();
                     if parent == *common_path_ref {
@@ -146,22 +146,17 @@ impl Chunk for EcmascriptChunk {
             .try_join()
             .await?;
 
-        let ident = AssetIdent {
-            path: if let Some(common_path) = common_path {
-                common_path
-            } else {
-                ServerFileSystem::new().root().owned().await?
-            },
-            query: RcStr::default(),
-            fragment: RcStr::default(),
-            assets,
-            modifiers: Vec::new(),
-            parts: Vec::new(),
-            layer: None,
-            content_type: None,
+        let path = if let Some(common_path) = common_path {
+            common_path
+        } else {
+            ServerFileSystem::new().root().owned().await?
         };
+        let mut ident = AssetIdent::from_path(path);
+        for (key, asset) in assets {
+            ident = ident.with_asset(key, asset);
+        }
 
-        Ok(AssetIdent::new(ident))
+        Ok(ident.into_vc())
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
@@ -152,9 +152,7 @@ impl Chunk for EcmascriptChunk {
             ServerFileSystem::new().root().owned().await?
         };
         let mut ident = AssetIdent::from_path(path);
-        for (key, asset) in assets {
-            ident = ident.with_asset(key, asset);
-        }
+        ident.assets.extend(assets);
 
         Ok(ident.into_vc())
     }

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
@@ -197,7 +197,7 @@ impl Issue for SideEffectsInPackageJsonIssue {
     }
 
     async fn file_path(&self) -> Result<FileSystemPath> {
-        self.source.file_path().owned().await
+        self.source.file_path().await
     }
 
     async fn title(&self) -> Result<StyledString> {

--- a/turbopack/crates/turbopack-ecmascript/src/json_source_transform.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/json_source_transform.rs
@@ -117,7 +117,10 @@ impl SourceTransform for JsonSourceTransform {
                     "Unable to make a module from invalid JSON: {}",
                     e.message
                 ))?;
-                (format!("throw new Error({js_error_message});"), "js")
+                (
+                    format!("throw new Error({js_error_message});"),
+                    "*.[json].js",
+                )
             }
             FileJsonContent::NotFound => {
                 // This is basically impossible since we wouldn't be called if the module

--- a/turbopack/crates/turbopack-ecmascript/src/json_source_transform.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/json_source_transform.rs
@@ -63,7 +63,7 @@ impl SourceTransform for JsonSourceTransform {
 
         // Parse the JSON to validate it and get the data
         let data = content.parse_json().await?;
-        let (code, extension) = match &*data {
+        let (code, rename_pattern) = match &*data {
             FileJsonContent::Content(data) => {
                 let data_str = data.to_string();
 
@@ -75,14 +75,14 @@ impl SourceTransform for JsonSourceTransform {
                 );
                 code.push_str("\"use turbopack no side effects\";\n");
 
-                let extension = if this.use_esm {
+                let rename_pattern = if this.use_esm {
                     // Spec-compliant ESM: only default export
                     code.push_str("export default ");
-                    "mjs"
+                    "*.[json].mjs"
                 } else {
                     // Webpack-compatible CommonJS: allows named property imports
                     code.push_str("module.exports = ");
-                    "cjs"
+                    "*.[json].cjs"
                 };
                 // For large JSON files, wrap in JSON.parse for better performance
                 // https://v8.dev/blog/cost-of-javascript-2019#json
@@ -96,7 +96,7 @@ impl SourceTransform for JsonSourceTransform {
                 code.push_str(";\n");
                 code.push_str(&inline_source_map_comment(&ident.path.path, &data_str));
 
-                (code, extension)
+                (code, rename_pattern)
             }
             FileJsonContent::Unparsable(e) => {
                 let resolved_source = source.to_resolved().await?;
@@ -127,8 +127,7 @@ impl SourceTransform for JsonSourceTransform {
             }
         };
 
-        let new_pattern = format!("{}.[json].{}", ident.path.path, extension);
-        let new_ident = ident.rename_as(&new_pattern).await?.into_vc();
+        let new_ident = ident.rename_as(rename_pattern).into_vc();
 
         Ok(Vc::upcast(VirtualSource::new_with_ident(
             new_ident,

--- a/turbopack/crates/turbopack-ecmascript/src/json_source_transform.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/json_source_transform.rs
@@ -59,7 +59,6 @@ impl SourceTransform for JsonSourceTransform {
     ) -> Result<Vc<Box<dyn Source>>> {
         let this = self.await?;
         let ident = source.ident().owned().await?;
-        let path = ident.path.clone();
         let content = source.content().file_content();
 
         // Parse the JSON to validate it and get the data
@@ -95,7 +94,7 @@ impl SourceTransform for JsonSourceTransform {
                     code.push_str(&data_str);
                 }
                 code.push_str(";\n");
-                code.push_str(&inline_source_map_comment(&path.path, &data_str));
+                code.push_str(&inline_source_map_comment(&ident.path.path, &data_str));
 
                 (code, extension)
             }
@@ -105,7 +104,7 @@ impl SourceTransform for JsonSourceTransform {
 
                 CodeGenerationIssue {
                     severity: IssueSeverity::Error,
-                    path: path.clone(),
+                    path: ident.path.clone(),
                     title: StyledString::Text(rcstr!("Unable to make a module from invalid JSON"))
                         .resolved_cell(),
                     message: StyledString::Text(e.message.clone()).resolved_cell(),
@@ -124,14 +123,12 @@ impl SourceTransform for JsonSourceTransform {
                 // This is basically impossible since we wouldn't be called if the module
                 // doesn't exist but some kind of eventual consistency situation is
                 // possible where we resolve the file and then it disappears, so bail is appropriate
-                bail!("JSON file not found: {:?}", path);
+                bail!("JSON file not found: {:?}", ident.path);
             }
         };
 
-        let new_ident = ident
-            .rename_as(&format!("{}.[json].{}", path.path, extension))
-            .await?
-            .into_vc();
+        let new_pattern = format!("{}.[json].{}", ident.path.path, extension);
+        let new_ident = ident.rename_as(&new_pattern).await?.into_vc();
 
         Ok(Vc::upcast(VirtualSource::new_with_ident(
             new_ident,

--- a/turbopack/crates/turbopack-ecmascript/src/json_source_transform.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/json_source_transform.rs
@@ -58,8 +58,8 @@ impl SourceTransform for JsonSourceTransform {
         _asset_context: Vc<Box<dyn AssetContext>>,
     ) -> Result<Vc<Box<dyn Source>>> {
         let this = self.await?;
-        let ident = source.ident();
-        let path = ident.path().await?;
+        let ident = source.ident().owned().await?;
+        let path = ident.path.clone();
         let content = source.content().file_content();
 
         // Parse the JSON to validate it and get the data
@@ -105,7 +105,7 @@ impl SourceTransform for JsonSourceTransform {
 
                 CodeGenerationIssue {
                     severity: IssueSeverity::Error,
-                    path: ident.path().owned().await?,
+                    path: path.clone(),
                     title: StyledString::Text(rcstr!("Unable to make a module from invalid JSON"))
                         .resolved_cell(),
                     message: StyledString::Text(e.message.clone()).resolved_cell(),
@@ -128,7 +128,10 @@ impl SourceTransform for JsonSourceTransform {
             }
         };
 
-        let new_ident = ident.rename_as(format!("{}.[json].{}", path.path, extension).into());
+        let new_ident = ident
+            .rename_as(&format!("{}.[json].{}", path.path, extension))
+            .await?
+            .into_vc();
 
         Ok(Vc::upcast(VirtualSource::new_with_ident(
             new_ident,

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -1973,7 +1973,7 @@ async fn process_parse_result(
                         .unwrap_or("".into());
                     let msg = &*turbofmt!(
                         "Could not parse module '{}'\n{error_messages}",
-                        ident.await?.path.clone()
+                        ident.await?.path
                     )
                     .await?;
                     let body = vec![
@@ -2003,7 +2003,7 @@ async fn process_parse_result(
                 ParseResult::NotFound => {
                     let msg = &*turbofmt!(
                         "Could not parse module '{}', file not found",
-                        ident.await?.path.clone()
+                        ident.await?.path
                     )
                     .await?;
                     let body = vec![

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -835,12 +835,13 @@ impl Module for EcmascriptModuleAsset {
         let mut ident = self.source.ident().owned().await?;
         if let Some(inner_assets) = self.inner_assets {
             for (name, asset) in inner_assets.await?.iter() {
-                ident.add_asset(name.clone(), asset.ident().to_resolved().await?);
+                ident = ident.with_asset(name.clone(), asset.ident().to_resolved().await?);
             }
         }
-        ident.add_modifier(rcstr!("ecmascript"));
-        ident.layer = Some(self.asset_context.into_trait_ref().await?.layer());
-        Ok(AssetIdent::new(ident))
+        Ok(ident
+            .with_modifier(rcstr!("ecmascript"))
+            .with_layer(self.asset_context.into_trait_ref().await?.layer())
+            .into_vc())
     }
 
     #[turbo_tasks::function]
@@ -868,7 +869,7 @@ impl Module for EcmascriptModuleAsset {
         // Check package.json first, so that we can skip parsing the module if it's marked that way.
         // We need to respect package.json configuration over any static analysis we might do.
         Ok((match *get_side_effect_free_declaration(
-            self.ident().path().owned().await?,
+            self.ident().await?.path.clone(),
             this.side_effect_free_packages.map(|g| *g),
         )
         .await?
@@ -967,8 +968,8 @@ impl EvaluatableAsset for EcmascriptModuleAsset {}
 #[turbo_tasks::value_impl]
 impl ResolveOrigin for EcmascriptModuleAsset {
     #[turbo_tasks::function]
-    fn origin_path(&self) -> Vc<FileSystemPath> {
-        self.source.ident().path()
+    async fn origin_path(&self) -> Result<Vc<FileSystemPath>> {
+        Ok(self.source.ident().await?.path.clone().cell())
     }
 
     #[turbo_tasks::function]
@@ -1972,7 +1973,7 @@ async fn process_parse_result(
                         .unwrap_or("".into());
                     let msg = &*turbofmt!(
                         "Could not parse module '{}'\n{error_messages}",
-                        ident.path()
+                        ident.await?.path.clone()
                     )
                     .await?;
                     let body = vec![
@@ -2000,9 +2001,11 @@ async fn process_parse_result(
                     }
                 }
                 ParseResult::NotFound => {
-                    let msg =
-                        &*turbofmt!("Could not parse module '{}', file not found", ident.path())
-                            .await?;
+                    let msg = &*turbofmt!(
+                        "Could not parse module '{}', file not found",
+                        ident.await?.path.clone()
+                    )
+                    .await?;
                     let body = vec![
                         quote!(
                             "var e = new Error($msg);" as Stmt,

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
@@ -110,11 +110,18 @@ impl ManifestAsyncModule {
 
     #[turbo_tasks::function]
     pub async fn content_ident(&self) -> Result<Vc<AssetIdent>> {
-        let mut ident = self.inner.ident();
-        if let Some(available_modules) = self.availability_info.available_modules() {
-            ident = ident.with_modifier(available_modules.hash().await?.to_string().into());
-        }
-        Ok(ident)
+        let ident = self.inner.ident();
+        Ok(
+            if let Some(available_modules) = self.availability_info.available_modules() {
+                ident
+                    .owned()
+                    .await?
+                    .with_modifier(available_modules.hash().await?.to_string().into())
+                    .into_vc()
+            } else {
+                ident
+            },
+        )
     }
 
     #[turbo_tasks::function]
@@ -134,10 +141,14 @@ fn manifest_chunk_reference_description() -> RcStr {
 #[turbo_tasks::value_impl]
 impl Module for ManifestAsyncModule {
     #[turbo_tasks::function]
-    fn ident(&self) -> Vc<AssetIdent> {
-        self.inner
+    async fn ident(&self) -> Result<Vc<AssetIdent>> {
+        Ok(self
+            .inner
             .ident()
+            .owned()
+            .await?
             .with_modifier(manifest_chunk_reference_description())
+            .into_vc())
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/loader_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/loader_module.rs
@@ -68,16 +68,27 @@ impl ManifestLoaderModule {
     }
 
     #[turbo_tasks::function]
-    pub fn asset_ident_for(module: Vc<Box<dyn ChunkableModule>>) -> Vc<AssetIdent> {
-        module.ident().with_modifier(modifier())
+    pub async fn asset_ident_for(module: Vc<Box<dyn ChunkableModule>>) -> Result<Vc<AssetIdent>> {
+        Ok(module
+            .ident()
+            .owned()
+            .await?
+            .with_modifier(modifier())
+            .into_vc())
     }
 }
 
 #[turbo_tasks::value_impl]
 impl Module for ManifestLoaderModule {
     #[turbo_tasks::function]
-    fn ident(&self) -> Vc<AssetIdent> {
-        self.manifest.module_ident().with_modifier(modifier())
+    async fn ident(&self) -> Result<Vc<AssetIdent>> {
+        Ok(self
+            .manifest
+            .module_ident()
+            .owned()
+            .await?
+            .with_modifier(modifier())
+            .into_vc())
     }
 
     #[turbo_tasks::function]
@@ -206,7 +217,13 @@ impl EcmascriptChunkPlaceable for ManifestLoaderModule {
 #[turbo_tasks::value_impl]
 impl ManifestLoaderModule {
     #[turbo_tasks::function]
-    pub fn content_ident(&self) -> Vc<AssetIdent> {
-        self.manifest.content_ident().with_modifier(modifier())
+    pub async fn content_ident(&self) -> Result<Vc<AssetIdent>> {
+        Ok(self
+            .manifest
+            .content_ident()
+            .owned()
+            .await?
+            .with_modifier(modifier())
+            .into_vc())
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/parse.rs
@@ -308,7 +308,7 @@ async fn parse_internal(
     inline_helpers: bool,
 ) -> Result<Vc<ParseResult>> {
     let content = source.content();
-    let fs_path = source.ident().path().owned().await?;
+    let fs_path = source.ident().await?.path.clone();
     let ident = &*source.ident().to_string().await?;
     let file_path_hash = hash_xxh3_hash64(&*source.ident().to_string().await?) as u128;
     let content = match content.await {
@@ -648,7 +648,7 @@ struct ReadSourceIssue {
 #[turbo_tasks::value_impl]
 impl Issue for ReadSourceIssue {
     async fn file_path(&self) -> Result<FileSystemPath> {
-        self.source.file_path().owned().await
+        self.source.file_path().await
     }
 
     async fn title(&self) -> Result<StyledString> {
@@ -764,10 +764,11 @@ pub async fn parse_from_rope(
     node_env: RcStr,
 ) -> Result<Vc<ParseResult>> {
     let ident_vc = source.ident();
-    let fs_path = ident_vc.path().owned().await?;
+    let ident_ref = ident_vc.await?;
+    let fs_path = ident_ref.path.clone();
     let ident = &*ident_vc.to_string().await?;
     let file_path_hash = hash_xxh3_hash64(ident) as u128;
-    let query = ident_vc.await?.query.clone();
+    let query = ident_ref.query.clone();
     let transforms = &*transforms.await?;
     parse_file_content(
         rope,

--- a/turbopack/crates/turbopack-ecmascript/src/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/parse.rs
@@ -308,9 +308,10 @@ async fn parse_internal(
     inline_helpers: bool,
 ) -> Result<Vc<ParseResult>> {
     let content = source.content();
-    let fs_path = source.ident().await?.path.clone();
+    let source_ident = source.ident().await?;
+    let fs_path = &source_ident.path;
     let ident = &*source.ident().to_string().await?;
-    let file_path_hash = hash_xxh3_hash64(&*source.ident().to_string().await?) as u128;
+    let file_path_hash = hash_xxh3_hash64(ident) as u128;
     let content = match content.await {
         Ok(content) => content,
         Err(error) => {
@@ -340,9 +341,9 @@ async fn parse_internal(
                 let transforms = &*transforms.await?;
                 match parse_file_content(
                     file.content().clone(),
-                    &fs_path,
+                    fs_path,
                     ident,
-                    source.ident().await?.query.clone(),
+                    source_ident.query.clone(),
                     file_path_hash,
                     source,
                     ty,
@@ -765,14 +766,13 @@ pub async fn parse_from_rope(
 ) -> Result<Vc<ParseResult>> {
     let ident_vc = source.ident();
     let ident_ref = ident_vc.await?;
-    let fs_path = ident_ref.path.clone();
     let ident = &*ident_vc.to_string().await?;
     let file_path_hash = hash_xxh3_hash64(ident) as u128;
     let query = ident_ref.query.clone();
     let transforms = &*transforms.await?;
     parse_file_content(
         rope,
-        &fs_path,
+        &ident_ref.path,
         ident,
         query,
         file_path_hash,

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -476,7 +476,7 @@ impl ModuleReference for EsmAssetReference {
                 origin.resolve_options(),
             );
             let loader_fs_path = if let Some(source) = *resolved.first_source().await? {
-                (*source.ident().path().await?).clone()
+                source.ident().await?.path.clone()
             } else {
                 bail!("Unable to resolve turbopackLoader '{}'", loader.loader);
             };
@@ -839,7 +839,7 @@ impl Issue for InvalidExport {
     }
 
     async fn file_path(&self) -> Result<FileSystemPath> {
-        self.source.file_path().owned().await
+        self.source.file_path().await
     }
 
     async fn description(&self) -> Result<Option<StyledString>> {
@@ -922,7 +922,7 @@ impl Issue for CircularReExport {
     }
 
     async fn file_path(&self) -> Result<FileSystemPath> {
-        self.module.ident().path().owned().await
+        Ok(self.module.ident().await?.path.clone())
     }
 
     async fn description(&self) -> Result<Option<StyledString>> {

--- a/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
@@ -275,7 +275,7 @@ impl Module for CachedExternalModule {
             ident = ident.with_modifier(target.to_string_ref().await?);
         }
 
-        Ok(ident)
+        Ok(ident.into_vc())
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/references/import_meta_glob.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/import_meta_glob.rs
@@ -663,13 +663,15 @@ impl Module for ImportMetaGlobAsset {
     #[turbo_tasks::function]
     async fn ident(&self) -> Result<Vc<AssetIdent>> {
         let origin_path = self.origin.origin_path().owned().await?;
-        Ok(AssetIdent::from_path(origin_path).with_modifier(modifier(
-            &self.patterns,
-            self.eager,
-            &self.import,
-            &self.query,
-            &self.base,
-        )))
+        Ok(AssetIdent::from_path(origin_path)
+            .with_modifier(modifier(
+                &self.patterns,
+                self.eager,
+                &self.import,
+                &self.query,
+                &self.base,
+            ))
+            .into_vc())
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -824,7 +824,7 @@ async fn analyze_ecmascript_module_internal(
                 .await?,
             compile_time_info_ref,
             var_graph: &var_graph,
-            allow_project_root_tracing: !source.ident().path().await?.is_in_node_modules(),
+            allow_project_root_tracing: !source.ident().await?.path.clone().is_in_node_modules(),
             fun_args_values: Default::default(),
             var_cache: Default::default(),
             first_import_meta: true,
@@ -1318,7 +1318,7 @@ async fn analyze_ecmascript_module_internal(
                     if analysis_state.first_import_meta {
                         analysis_state.first_import_meta = false;
                         analysis.add_code_gen(ImportMetaBinding::new(
-                            source.ident().path().owned().await?,
+                            source.ident().await?.path.clone(),
                             analysis_state
                                 .compile_time_info_ref
                                 .hot_module_replacement_enabled,
@@ -1793,7 +1793,7 @@ where
         {
             Ok(cwd)
         } else {
-            Ok(source.ident().path().await?.parent())
+            Ok(source.ident().await?.path.clone().parent())
         }
     };
 
@@ -2373,7 +2373,7 @@ where
             return Ok(());
         }
         WellKnownFunctionKind::PathJoin if analysis.analyze_mode.is_tracing_assets() => {
-            let context_path = source.ident().path().await?;
+            let context_path = source.ident().await?.path.clone();
             // ignore path.join in `node-gyp`, it will includes too many files
             if context_path.path.contains("node_modules/node-gyp") {
                 return Ok(());
@@ -3137,7 +3137,7 @@ async fn handle_free_var_reference(
             ));
         }
         FreeVarReference::InputRelative(kind) => {
-            let source_path = (*state.source).ident().path().owned().await?;
+            let source_path = (*state.source).ident().await?.path.clone();
             let source_path = match kind {
                 InputRelativeConstant::DirName => source_path.parent(),
                 InputRelativeConstant::FileName => source_path,
@@ -3601,15 +3601,16 @@ async fn require_resolve_visitor(
         )
         .to_resolved()
         .await?;
-        let mut values = resolved
-            .primary_sources()
-            .await?
-            .iter()
-            .map(|&source| async move {
-                Ok(require_resolve(source.ident().path().owned().await?).into())
-            })
-            .try_join()
-            .await?;
+        let mut values =
+            resolved
+                .primary_sources()
+                .await?
+                .iter()
+                .map(|&source| async move {
+                    Ok(require_resolve(source.ident().await?.path.clone()).into())
+                })
+                .try_join()
+                .await?;
 
         match values.len() {
             0 => JsValue::unknown(

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -824,7 +824,7 @@ async fn analyze_ecmascript_module_internal(
                 .await?,
             compile_time_info_ref,
             var_graph: &var_graph,
-            allow_project_root_tracing: !source.ident().await?.path.clone().is_in_node_modules(),
+            allow_project_root_tracing: !source.ident().await?.path.is_in_node_modules(),
             fun_args_values: Default::default(),
             var_cache: Default::default(),
             first_import_meta: true,
@@ -1793,7 +1793,7 @@ where
         {
             Ok(cwd)
         } else {
-            Ok(source.ident().await?.path.clone().parent())
+            Ok(source.ident().await?.path.parent())
         }
     };
 
@@ -2373,9 +2373,14 @@ where
             return Ok(());
         }
         WellKnownFunctionKind::PathJoin if analysis.analyze_mode.is_tracing_assets() => {
-            let context_path = source.ident().await?.path.clone();
             // ignore path.join in `node-gyp`, it will includes too many files
-            if context_path.path.contains("node_modules/node-gyp") {
+            if source
+                .ident()
+                .await?
+                .path
+                .path
+                .contains("node_modules/node-gyp")
+            {
                 return Ok(());
             }
             let args = linked_args().await?;

--- a/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -403,10 +403,14 @@ fn modifier(dir: &RcStr, include_subdirs: bool) -> RcStr {
 #[turbo_tasks::value_impl]
 impl Module for RequireContextAsset {
     #[turbo_tasks::function]
-    fn ident(&self) -> Vc<AssetIdent> {
-        self.source
+    async fn ident(&self) -> Result<Vc<AssetIdent>> {
+        Ok(self
+            .source
             .ident()
+            .owned()
+            .await?
             .with_modifier(modifier(&self.dir, self.include_subdirs))
+            .into_vc())
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/references/type_issue.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/type_issue.rs
@@ -15,7 +15,7 @@ pub struct SpecifiedModuleTypeIssue {
 #[turbo_tasks::value_impl]
 impl Issue for SpecifiedModuleTypeIssue {
     async fn file_path(&self) -> Result<FileSystemPath> {
-        self.source.file_path().owned().await
+        self.source.file_path().await
     }
 
     async fn title(&self) -> Result<StyledString> {

--- a/turbopack/crates/turbopack-ecmascript/src/references/util.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/util.rs
@@ -118,7 +118,7 @@ impl Issue for TooManyMatchesWarning {
     }
 
     async fn file_path(&self) -> Result<FileSystemPath> {
-        self.source.file_path().owned().await
+        self.source.file_path().await
     }
 
     fn stage(&self) -> IssueStage {

--- a/turbopack/crates/turbopack-ecmascript/src/rename/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/rename/module.rs
@@ -117,8 +117,14 @@ impl Module for EcmascriptModuleRenameModule {
     }
 
     #[turbo_tasks::function]
-    fn ident(&self) -> Vc<AssetIdent> {
-        self.module.ident().with_part(self.part.clone())
+    async fn ident(&self) -> Result<Vc<AssetIdent>> {
+        Ok(self
+            .module
+            .ident()
+            .owned()
+            .await?
+            .with_part(self.part.clone())
+            .into_vc())
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
@@ -100,8 +100,14 @@ impl EcmascriptModuleFacadeModule {
 #[turbo_tasks::value_impl]
 impl Module for EcmascriptModuleFacadeModule {
     #[turbo_tasks::function]
-    fn ident(&self) -> Vc<AssetIdent> {
-        self.module.ident().with_part(ModulePart::Facade)
+    async fn ident(&self) -> Result<Vc<AssetIdent>> {
+        Ok(self
+            .module
+            .ident()
+            .owned()
+            .await?
+            .with_part(ModulePart::Facade)
+            .into_vc())
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/module.rs
@@ -48,8 +48,14 @@ impl EcmascriptModuleLocalsModule {
 #[turbo_tasks::value_impl]
 impl Module for EcmascriptModuleLocalsModule {
     #[turbo_tasks::function]
-    fn ident(&self) -> Vc<AssetIdent> {
-        self.module.ident().with_part(ModulePart::locals())
+    async fn ident(&self) -> Result<Vc<AssetIdent>> {
+        Ok(self
+            .module
+            .ident()
+            .owned()
+            .await?
+            .with_part(ModulePart::locals())
+            .into_vc())
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/text/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/text/mod.rs
@@ -28,11 +28,16 @@ impl TextContentFileSource {
 #[turbo_tasks::value_impl]
 impl Source for TextContentFileSource {
     #[turbo_tasks::function]
-    fn ident(&self) -> Vc<AssetIdent> {
-        self.source
+    async fn ident(&self) -> Result<Vc<AssetIdent>> {
+        Ok(self
+            .source
             .ident()
+            .owned()
+            .await?
             .with_modifier(rcstr!("text content"))
-            .rename_as(rcstr!("*.mjs"))
+            .rename_as("*.mjs")
+            .await?
+            .into_vc())
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/text/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/text/mod.rs
@@ -36,7 +36,6 @@ impl Source for TextContentFileSource {
             .await?
             .with_modifier(rcstr!("text content"))
             .rename_as("*.mjs")
-            .await?
             .into_vc())
     }
 

--- a/turbopack/crates/turbopack-ecmascript/src/text_source_transform.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/text_source_transform.rs
@@ -34,8 +34,8 @@ impl SourceTransform for TextSourceTransform {
         source: Vc<Box<dyn Source>>,
         _asset_context: Vc<Box<dyn AssetContext>>,
     ) -> Result<Vc<Box<dyn Source>>> {
-        let ident = source.ident();
-        let path = ident.path().await?;
+        let ident = source.ident().owned().await?;
+        let path = ident.path.clone();
         let content = source.content().file_content().await?;
         let text = match &*content {
             FileContent::Content(data) => data.content().to_str()?,
@@ -54,7 +54,10 @@ impl SourceTransform for TextSourceTransform {
 
         // Rename to .mjs so module rules recognize it as ESM.
         // The inline source map ensures debuggers show the original file.
-        let new_ident = ident.rename_as(format!("{}.[text].mjs", path.path).into());
+        let new_ident = ident
+            .rename_as(&format!("{}.[text].mjs", path.path))
+            .await?
+            .into_vc();
 
         Ok(Vc::upcast(VirtualSource::new_with_ident(
             new_ident,

--- a/turbopack/crates/turbopack-ecmascript/src/text_source_transform.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/text_source_transform.rs
@@ -53,8 +53,8 @@ impl SourceTransform for TextSourceTransform {
 
         // Rename to .mjs so module rules recognize it as ESM.
         // The inline source map ensures debuggers show the original file.
-        let new_pattern = format!("{}.[text].mjs", ident.path.path);
-        let new_ident = ident.rename_as(&new_pattern).await?.into_vc();
+
+        let new_ident = ident.rename_as("*.[text].mjs").into_vc();
 
         Ok(Vc::upcast(VirtualSource::new_with_ident(
             new_ident,

--- a/turbopack/crates/turbopack-ecmascript/src/text_source_transform.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/text_source_transform.rs
@@ -35,13 +35,12 @@ impl SourceTransform for TextSourceTransform {
         _asset_context: Vc<Box<dyn AssetContext>>,
     ) -> Result<Vc<Box<dyn Source>>> {
         let ident = source.ident().owned().await?;
-        let path = ident.path.clone();
         let content = source.content().file_content().await?;
         let text = match &*content {
             FileContent::Content(data) => data.content().to_str()?,
             FileContent::NotFound => {
                 // This shouldn't happen because the import was already resolved
-                bail!("File not found: {:?}", path);
+                bail!("File not found: {:?}", ident.path);
             }
         };
 
@@ -49,15 +48,13 @@ impl SourceTransform for TextSourceTransform {
         let code = format!(
             "\"use turbopack no side effects\";\nexport default {};\n{}",
             StringifyJs(&text),
-            inline_source_map_comment(&path.path, &text)
+            inline_source_map_comment(&ident.path.path, &text)
         );
 
         // Rename to .mjs so module rules recognize it as ESM.
         // The inline source map ensures debuggers show the original file.
-        let new_ident = ident
-            .rename_as(&format!("{}.[text].mjs", path.path))
-            .await?
-            .into_vc();
+        let new_pattern = format!("{}.[text].mjs", ident.path.path);
+        let new_ident = ident.rename_as(&new_pattern).await?.into_vc();
 
         Ok(Vc::upcast(VirtualSource::new_with_ident(
             new_ident,

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/part/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/part/module.rs
@@ -291,8 +291,14 @@ async fn follow_reexports_with_side_effects(
 #[turbo_tasks::value_impl]
 impl Module for EcmascriptModulePartAsset {
     #[turbo_tasks::function]
-    fn ident(&self) -> Vc<AssetIdent> {
-        self.full_module.ident().with_part(self.part.clone())
+    async fn ident(&self) -> Result<Vc<AssetIdent>> {
+        Ok(self
+            .full_module
+            .ident()
+            .owned()
+            .await?
+            .with_part(self.part.clone())
+            .into_vc())
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/side_effects/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/side_effects/module.rs
@@ -59,24 +59,26 @@ impl SideEffectsModule {
 impl Module for SideEffectsModule {
     #[turbo_tasks::function]
     async fn ident(&self) -> Result<Vc<AssetIdent>> {
-        let mut ident = self.module.ident().owned().await?;
-        ident.parts.push(self.part.clone());
-
-        ident.add_asset(
-            rcstr!("resolved"),
-            self.resolved_as.ident().to_resolved().await?,
-        );
-
-        ident.add_modifier(rcstr!("side effects"));
+        let mut ident = self
+            .module
+            .ident()
+            .owned()
+            .await?
+            .with_part(self.part.clone())
+            .with_asset(
+                rcstr!("resolved"),
+                self.resolved_as.ident().to_resolved().await?,
+            )
+            .with_modifier(rcstr!("side effects"));
 
         for (i, side_effect) in self.side_effects.iter().enumerate() {
-            ident.add_asset(
+            ident = ident.with_asset(
                 RcStr::from(format!("side effect {i}")),
                 side_effect.ident().to_resolved().await?,
             );
         }
 
-        Ok(AssetIdent::new(ident))
+        Ok(ident.into_vc())
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/typescript/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/typescript/mod.rs
@@ -131,7 +131,7 @@ impl Module for TsConfigModuleAsset {
                 types
             } else {
                 let mut all_types = Vec::new();
-                let mut current = self.source.ident().await?.path.clone().parent();
+                let mut current = self.source.ident().await?.path.parent();
                 loop {
                     if let DirectoryContent::Entries(entries) =
                         &*current.join("node_modules/@types")?.read_dir().await?

--- a/turbopack/crates/turbopack-ecmascript/src/typescript/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/typescript/mod.rs
@@ -131,7 +131,7 @@ impl Module for TsConfigModuleAsset {
                 types
             } else {
                 let mut all_types = Vec::new();
-                let mut current = self.source.ident().path().await?.parent();
+                let mut current = self.source.ident().await?.path.clone().parent();
                 loop {
                     if let DirectoryContent::Entries(entries) =
                         &*current.join("node_modules/@types")?.read_dir().await?

--- a/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
@@ -52,8 +52,14 @@ impl WebpackModuleAsset {
 #[turbo_tasks::value_impl]
 impl Module for WebpackModuleAsset {
     #[turbo_tasks::function]
-    fn ident(&self) -> Vc<AssetIdent> {
-        self.source.ident().with_modifier(rcstr!("webpack"))
+    async fn ident(&self) -> Result<Vc<AssetIdent>> {
+        Ok(self
+            .source
+            .ident()
+            .owned()
+            .await?
+            .with_modifier(rcstr!("webpack"))
+            .into_vc())
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/webpack/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/webpack/parse.rs
@@ -233,7 +233,7 @@ pub async fn webpack_runtime(
 
                     return Ok(WebpackRuntime::Webpack5 {
                         chunk_request_expr: value,
-                        context_path: source.ident().path().await?.parent(),
+                        context_path: source.ident().await?.path.clone().parent(),
                     }
                     .cell());
                 }

--- a/turbopack/crates/turbopack-ecmascript/src/webpack/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/webpack/parse.rs
@@ -233,7 +233,7 @@ pub async fn webpack_runtime(
 
                     return Ok(WebpackRuntime::Webpack5 {
                         chunk_request_expr: value,
-                        context_path: source.ident().await?.path.clone().parent(),
+                        context_path: source.ident().await?.path.parent(),
                     }
                     .cell());
                 }

--- a/turbopack/crates/turbopack-ecmascript/src/worker_chunk/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/worker_chunk/module.rs
@@ -60,15 +60,21 @@ impl WorkerLoaderModule {
     ) -> Result<Vc<OutputAssetsWithReferenced>> {
         let this = self.await?;
         Ok(match this.worker_type {
-            WorkerType::WebWorker | WorkerType::SharedWebWorker => chunking_context
-                .evaluated_chunk_group_assets(
-                    this.inner
-                        .ident()
-                        .with_modifier(this.worker_type.chunk_modifier_str()),
+            WorkerType::WebWorker | WorkerType::SharedWebWorker => {
+                let ident = this
+                    .inner
+                    .ident()
+                    .owned()
+                    .await?
+                    .with_modifier(this.worker_type.chunk_modifier_str())
+                    .into_vc();
+                chunking_context.evaluated_chunk_group_assets(
+                    ident,
                     ChunkGroup::Isolated(ResolvedVc::upcast(this.inner)),
                     module_graph,
                     AvailabilityInfo::root(),
-                ),
+                )
+            }
             // WorkerThreads are treated as an entry point, webworkers probably should too but
             // currently it would lead to a cascade that we need to address.
             WorkerType::NodeWorkerThread => {
@@ -146,10 +152,14 @@ impl WorkerLoaderModule {
 #[turbo_tasks::value_impl]
 impl Module for WorkerLoaderModule {
     #[turbo_tasks::function]
-    fn ident(&self) -> Vc<AssetIdent> {
-        self.inner
+    async fn ident(&self) -> Result<Vc<AssetIdent>> {
+        Ok(self
+            .inner
             .ident()
+            .owned()
+            .await?
             .with_modifier(self.worker_type.modifier_str())
+            .into_vc())
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-env/src/asset.rs
+++ b/turbopack/crates/turbopack-env/src/asset.rs
@@ -35,7 +35,7 @@ impl ProcessEnvAsset {
 impl Source for ProcessEnvAsset {
     #[turbo_tasks::function]
     fn ident(&self) -> Result<Vc<AssetIdent>> {
-        Ok(AssetIdent::from_path(self.root.join(".env.js")?))
+        Ok(AssetIdent::from_path(self.root.join(".env.js")?).into_vc())
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-image/src/process/mod.rs
+++ b/turbopack/crates/turbopack-image/src/process/mod.rs
@@ -346,8 +346,8 @@ pub async fn get_meta_data(
         bail!("Input image not found");
     };
     let bytes = content.content().to_bytes();
-    let path = image.ident().await?.path.clone();
-    let extension = path.extension();
+    let ident = image.ident().await?;
+    let extension = ident.path.extension();
 
     if extension == Some("svg") {
         let content = result_to_issue(
@@ -429,8 +429,8 @@ pub async fn optimize(
         return Ok(FileContent::NotFound.cell());
     };
     let bytes = content.content().to_bytes();
-    let path = source.ident().await?.path.clone();
-    let extension = path.extension();
+    let ident = source.ident().await?;
+    let extension = ident.path.extension();
 
     let Some((image, format)) = load_image(source, &bytes, extension) else {
         return Ok(FileContent::NotFound.cell());

--- a/turbopack/crates/turbopack-image/src/process/mod.rs
+++ b/turbopack/crates/turbopack-image/src/process/mod.rs
@@ -346,7 +346,7 @@ pub async fn get_meta_data(
         bail!("Input image not found");
     };
     let bytes = content.content().to_bytes();
-    let path = image.ident().path().await?;
+    let path = image.ident().await?.path.clone();
     let extension = path.extension();
 
     if extension == Some("svg") {
@@ -429,7 +429,7 @@ pub async fn optimize(
         return Ok(FileContent::NotFound.cell());
     };
     let bytes = content.content().to_bytes();
-    let path = source.ident().path().await?;
+    let path = source.ident().await?.path.clone();
     let extension = path.extension();
 
     let Some((image, format)) = load_image(source, &bytes, extension) else {
@@ -498,7 +498,7 @@ impl Issue for ImageProcessingIssue {
     }
 
     async fn file_path(&self) -> anyhow::Result<FileSystemPath> {
-        self.source.file_path().owned().await
+        self.source.file_path().await
     }
 
     fn stage(&self) -> IssueStage {

--- a/turbopack/crates/turbopack-mdx/src/lib.rs
+++ b/turbopack/crates/turbopack-mdx/src/lib.rs
@@ -106,7 +106,6 @@ impl Source for MdxTransformedAsset {
             .owned()
             .await?
             .rename_as("*.tsx")
-            .await?
             .into_vc())
     }
 

--- a/turbopack/crates/turbopack-mdx/src/lib.rs
+++ b/turbopack/crates/turbopack-mdx/src/lib.rs
@@ -168,7 +168,7 @@ impl MdxTransformedAsset {
                 .jsx_import_source
                 .clone()
                 .map(RcStr::into_owned),
-            filepath: Some(self.source.ident().await?.path.clone().to_string()),
+            filepath: Some(self.source.ident().await?.path.to_string()),
             ..Default::default()
         };
 

--- a/turbopack/crates/turbopack-mdx/src/lib.rs
+++ b/turbopack/crates/turbopack-mdx/src/lib.rs
@@ -99,8 +99,15 @@ struct MdxTransformedAsset {
 #[turbo_tasks::value_impl]
 impl Source for MdxTransformedAsset {
     #[turbo_tasks::function]
-    fn ident(&self) -> Vc<AssetIdent> {
-        self.source.ident().rename_as(rcstr!("*.tsx"))
+    async fn ident(&self) -> Result<Vc<AssetIdent>> {
+        Ok(self
+            .source
+            .ident()
+            .owned()
+            .await?
+            .rename_as("*.tsx")
+            .await?
+            .into_vc())
     }
 
     #[turbo_tasks::function]
@@ -161,7 +168,7 @@ impl MdxTransformedAsset {
                 .jsx_import_source
                 .clone()
                 .map(RcStr::into_owned),
-            filepath: Some(self.source.ident().path().await?.to_string()),
+            filepath: Some(self.source.ident().await?.path.clone().to_string()),
             ..Default::default()
         };
 
@@ -246,7 +253,7 @@ struct MdxIssue {
 #[turbo_tasks::value_impl]
 impl Issue for MdxIssue {
     async fn file_path(&self) -> anyhow::Result<FileSystemPath> {
-        self.source.file_path().owned().await
+        self.source.file_path().await
     }
 
     fn source(&self) -> Option<IssueSource> {

--- a/turbopack/crates/turbopack-node/src/evaluate.rs
+++ b/turbopack/crates/turbopack-node/src/evaluate.rs
@@ -449,12 +449,7 @@ pub async fn get_evaluate_entries(
     let entry_module = asset_context
         .process(
             Vc::upcast(VirtualSource::new(
-                runtime_asset
-                    .ident()
-                    .await?
-                    .path
-                    .clone()
-                    .join("evaluate.js")?,
+                runtime_asset.ident().await?.path.join("evaluate.js")?,
                 AssetContent::file(
                     FileContent::Content(File::from(
                         "import {run} from 'RUNTIME'; run(() => import('INNER'))",

--- a/turbopack/crates/turbopack-node/src/evaluate.rs
+++ b/turbopack/crates/turbopack-node/src/evaluate.rs
@@ -449,7 +449,12 @@ pub async fn get_evaluate_entries(
     let entry_module = asset_context
         .process(
             Vc::upcast(VirtualSource::new(
-                runtime_asset.ident().path().await?.join("evaluate.js")?,
+                runtime_asset
+                    .ident()
+                    .await?
+                    .path
+                    .clone()
+                    .join("evaluate.js")?,
                 AssetContent::file(
                     FileContent::Content(File::from(
                         "import {run} from 'RUNTIME'; run(() => import('INNER'))",
@@ -699,7 +704,7 @@ impl Issue for EvaluationIssue {
     }
 
     async fn file_path(&self) -> Result<FileSystemPath> {
-        self.source.file_path().owned().await
+        self.source.file_path().await
     }
 
     async fn description(&self) -> Result<Option<StyledString>> {

--- a/turbopack/crates/turbopack-node/src/transforms/postcss.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/postcss.rs
@@ -315,8 +315,9 @@ impl Source for JsonSource {
         match &*self.key.await? {
             Some(key) => Ok(AssetIdent::from_path(
                 self.path.append(".")?.append(key)?.append(".json")?,
-            )),
-            None => Ok(AssetIdent::from_path(self.path.append(".json")?)),
+            )
+            .into_vc()),
+            None => Ok(AssetIdent::from_path(self.path.append(".json")?).into_vc()),
         }
     }
 }
@@ -454,11 +455,11 @@ async fn find_config_in_location(
         }
         // Check project root first, fall back to the CSS file's directory.
         PostCssConfigLocation::ProjectPathOrLocalPath => {
-            vec![project_path, source.ident().path().await?.parent()]
+            vec![project_path, source.ident().await?.path.clone().parent()]
         }
         // Check the CSS file's directory first, fall back to the project root.
         PostCssConfigLocation::LocalPathOrProjectPath => {
-            vec![source.ident().path().await?.parent(), project_path]
+            vec![source.ident().await?.path.clone().parent(), project_path]
         }
     };
 
@@ -558,17 +559,16 @@ impl PostCssTransformedAsset {
         .to_resolved()
         .await?;
 
-        let css_fs_path = self.source.ident().path();
+        let css_fs_path = self.source.ident().await?.path.clone();
 
         // We need to get a path relative to the project because the postcss loader
         // runs with the project as the current working directory.
-        let css_path =
-            if let Some(css_path) = project_path.get_relative_path_to(&*css_fs_path.await?) {
-                css_path.into_owned()
-            } else {
-                // This shouldn't be an error since it can happen on virtual assets
-                "".into()
-            };
+        let css_path = if let Some(css_path) = project_path.get_relative_path_to(&css_fs_path) {
+            css_path.into_owned()
+        } else {
+            // This shouldn't be an error since it can happen on virtual assets
+            "".into()
+        };
 
         let config_value = evaluate_webpack_loader(WebpackLoaderContext {
             entries,

--- a/turbopack/crates/turbopack-node/src/transforms/postcss.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/postcss.rs
@@ -455,11 +455,11 @@ async fn find_config_in_location(
         }
         // Check project root first, fall back to the CSS file's directory.
         PostCssConfigLocation::ProjectPathOrLocalPath => {
-            vec![project_path, source.ident().await?.path.clone().parent()]
+            vec![project_path, source.ident().await?.path.parent()]
         }
         // Check the CSS file's directory first, fall back to the project root.
         PostCssConfigLocation::LocalPathOrProjectPath => {
-            vec![source.ident().await?.path.clone().parent(), project_path]
+            vec![source.ident().await?.path.parent(), project_path]
         }
     };
 
@@ -559,11 +559,12 @@ impl PostCssTransformedAsset {
         .to_resolved()
         .await?;
 
-        let css_fs_path = self.source.ident().await?.path.clone();
+        let source_ident = self.source.ident().await?;
 
         // We need to get a path relative to the project because the postcss loader
         // runs with the project as the current working directory.
-        let css_path = if let Some(css_path) = project_path.get_relative_path_to(&css_fs_path) {
+        let css_path = if let Some(css_path) = project_path.get_relative_path_to(&source_ident.path)
+        {
             css_path.into_owned()
         } else {
             // This shouldn't be an error since it can happen on virtual assets

--- a/turbopack/crates/turbopack-node/src/transforms/webpack.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/webpack.rs
@@ -156,7 +156,13 @@ impl Source for WebpackLoadersProcessedAsset {
     async fn ident(&self) -> Result<Vc<AssetIdent>> {
         Ok(
             if let Some(rename_as) = self.transform.await?.rename_as.as_deref() {
-                self.source.ident().rename_as(rename_as.into())
+                self.source
+                    .ident()
+                    .owned()
+                    .await?
+                    .rename_as(rename_as)
+                    .await?
+                    .into_vc()
             } else {
                 self.source.ident()
             },
@@ -286,7 +292,7 @@ impl WebpackLoadersProcessedAsset {
             .to_resolved()
             .await?;
 
-            let resource_fs_path = self.source.ident().path().await?;
+            let resource_fs_path = self.source.ident().await?.path.clone();
             let Some(resource_path) = project_path.get_relative_path_to(&resource_fs_path) else {
                 bail!(
                     "Resource path \"{}\" needs to be on project filesystem \"{}\"",
@@ -656,10 +662,7 @@ impl EvaluateContext for WebpackLoaderContext {
                 );
 
                 if let Some(source) = *resolved.first_source().await? {
-                    if let Some(path) = self
-                        .cwd
-                        .get_relative_path_to(&*source.ident().path().await?)
-                    {
+                    if let Some(path) = self.cwd.get_relative_path_to(&source.ident().await?.path) {
                         Ok(ResponseMessage::Resolve { path })
                     } else {
                         bail!(
@@ -944,7 +947,7 @@ impl Issue for BuildDependencyIssue {
     }
 
     async fn file_path(&self) -> Result<FileSystemPath> {
-        self.source.file_path().owned().await
+        self.source.file_path().await
     }
 
     async fn description(&self) -> Result<Option<StyledString>> {
@@ -979,7 +982,7 @@ pub struct EvaluateEmittedErrorIssue {
 #[turbo_tasks::value_impl]
 impl Issue for EvaluateEmittedErrorIssue {
     async fn file_path(&self) -> Result<FileSystemPath> {
-        self.source.file_path().owned().await
+        self.source.file_path().await
     }
 
     fn stage(&self) -> IssueStage {
@@ -1028,7 +1031,7 @@ pub struct EvaluateErrorLoggingIssue {
 #[turbo_tasks::value_impl]
 impl Issue for EvaluateErrorLoggingIssue {
     async fn file_path(&self) -> Result<FileSystemPath> {
-        self.source.file_path().owned().await
+        self.source.file_path().await
     }
 
     fn stage(&self) -> IssueStage {

--- a/turbopack/crates/turbopack-node/src/transforms/webpack.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/webpack.rs
@@ -161,7 +161,6 @@ impl Source for WebpackLoadersProcessedAsset {
                     .owned()
                     .await?
                     .rename_as(rename_as)
-                    .await?
                     .into_vc()
             } else {
                 self.source.ident()

--- a/turbopack/crates/turbopack-node/src/transforms/webpack.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/webpack.rs
@@ -292,8 +292,9 @@ impl WebpackLoadersProcessedAsset {
             .to_resolved()
             .await?;
 
-            let resource_fs_path = self.source.ident().await?.path.clone();
-            let Some(resource_path) = project_path.get_relative_path_to(&resource_fs_path) else {
+            let source_ident = self.source.ident().await?;
+            let resource_fs_path = &source_ident.path;
+            let Some(resource_path) = project_path.get_relative_path_to(resource_fs_path) else {
                 bail!(
                     "Resource path \"{}\" needs to be on project filesystem \"{}\"",
                     resource_fs_path,
@@ -347,7 +348,7 @@ impl WebpackLoadersProcessedAsset {
                     .map(|source_map| Rope::from(source_map.into_owned()))
             };
             let source_map =
-                resolve_source_map_sources(source_map.as_ref(), &resource_fs_path).await?;
+                resolve_source_map_sources(source_map.as_ref(), resource_fs_path).await?;
 
             let file = match processed.source {
                 Either::Left(str) => File::from(str),

--- a/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
@@ -484,7 +484,7 @@ impl ChunkingContext for NodeJsChunkingContext {
         tag: Option<RcStr>,
     ) -> Result<Vc<FileSystemPath>> {
         let this = self.await?;
-        let source_path = original_asset_ident.path().await?;
+        let source_path = original_asset_ident.await?.path.clone();
         let basename = source_path.file_name();
         let ContentHashing::Direct { length } = this.asset_content_hashing;
         let hash = content

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/chunk.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/chunk.rs
@@ -44,7 +44,12 @@ impl EcmascriptBuildNodeChunk {
         let this = self.await?;
         Ok(SourceMapAsset::new(
             Vc::upcast(*this.chunking_context),
-            this.chunk.ident().with_modifier(modifier()),
+            this.chunk
+                .ident()
+                .owned()
+                .await?
+                .with_modifier(modifier())
+                .into_vc(),
             Vc::upcast(self),
         ))
     }
@@ -102,7 +107,13 @@ impl OutputAsset for EcmascriptBuildNodeChunk {
     #[turbo_tasks::function]
     async fn path(self: Vc<Self>) -> Result<Vc<FileSystemPath>> {
         let this = self.await?;
-        let ident = this.chunk.ident().with_modifier(modifier());
+        let ident = this
+            .chunk
+            .ident()
+            .owned()
+            .await?
+            .with_modifier(modifier())
+            .into_vc();
         Ok(this
             .chunking_context
             .chunk_path(Some(Vc::upcast(self)), ident, None, rcstr!(".js")))

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/runtime.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/runtime.rs
@@ -134,7 +134,8 @@ impl EcmascriptBuildNodeRuntimeChunk {
                 .root()
                 .await?
                 .join("runtime.js")?,
-        ))
+        )
+        .into_vc())
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-resolve/src/node_native_binding.rs
+++ b/turbopack/crates/turbopack-resolve/src/node_native_binding.rs
@@ -102,7 +102,7 @@ async fn resolve_node_pre_gyp_files(
         && let AssetContent::File(file) = &*config_asset.content().await?
         && let FileContent::Content(config_file) = &*file.await?
     {
-        let config_file_path = config_asset.ident().path().owned().await?;
+        let config_file_path = config_asset.ident().await?.path.clone();
         let mut affecting_paths = vec![config_file_path.clone()];
         let config_file_dir = config_file_path.parent();
         let node_pre_gyp_config: NodePreGypConfigJson =

--- a/turbopack/crates/turbopack-resolve/src/node_native_binding.rs
+++ b/turbopack/crates/turbopack-resolve/src/node_native_binding.rs
@@ -102,7 +102,8 @@ async fn resolve_node_pre_gyp_files(
         && let AssetContent::File(file) = &*config_asset.content().await?
         && let FileContent::Content(config_file) = &*file.await?
     {
-        let config_file_path = config_asset.ident().await?.path.clone();
+        let config_asset_ident = config_asset.ident().await?;
+        let config_file_path = &config_asset_ident.path;
         let mut affecting_paths = vec![config_file_path.clone()];
         let config_file_dir = config_file_path.parent();
         let node_pre_gyp_config: NodePreGypConfigJson =

--- a/turbopack/crates/turbopack-resolve/src/typescript.rs
+++ b/turbopack/crates/turbopack-resolve/src/typescript.rs
@@ -119,7 +119,7 @@ async fn resolve_extends(
     extends: &str,
     resolve_options: Vc<ResolveOptions>,
 ) -> Result<Vc<OptionSource>> {
-    let parent_dir = tsconfig.ident().path().await?.parent();
+    let parent_dir = tsconfig.ident().await?.path.clone().parent();
     let request = Request::parse_string(extends.into());
 
     // TS's resolution is weird, and has special behavior for different import
@@ -231,7 +231,13 @@ async fn try_join_base_url(
     base_url: RcStr,
 ) -> Result<Vc<FileSystemPathOption>> {
     Ok(Vc::cell(
-        source.ident().path().await?.parent().try_join(&base_url),
+        source
+            .ident()
+            .await?
+            .path
+            .clone()
+            .parent()
+            .try_join(&base_url),
     ))
 }
 
@@ -268,7 +274,7 @@ pub async fn tsconfig_resolve_options(
         if let FileJsonContent::Content(json) = &*content.await?
             && let JsonValue::Object(paths) = &json["compilerOptions"]["paths"]
         {
-            let mut context_dir = source.ident().path().await?.parent();
+            let mut context_dir = source.ident().await?.path.clone().parent();
             if let Some(base_url) = json["compilerOptions"]["baseUrl"].as_str()
                 && let Some(new_context) = context_dir.try_join(base_url)
             {
@@ -527,7 +533,7 @@ impl Issue for TsConfigIssue {
     }
 
     async fn file_path(&self) -> anyhow::Result<FileSystemPath> {
-        self.source.file_path().owned().await
+        self.source.file_path().await
     }
 
     async fn description(&self) -> anyhow::Result<Option<StyledString>> {

--- a/turbopack/crates/turbopack-resolve/src/typescript.rs
+++ b/turbopack/crates/turbopack-resolve/src/typescript.rs
@@ -119,7 +119,7 @@ async fn resolve_extends(
     extends: &str,
     resolve_options: Vc<ResolveOptions>,
 ) -> Result<Vc<OptionSource>> {
-    let parent_dir = tsconfig.ident().await?.path.clone().parent();
+    let parent_dir = tsconfig.ident().await?.path.parent();
     let request = Request::parse_string(extends.into());
 
     // TS's resolution is weird, and has special behavior for different import
@@ -231,13 +231,7 @@ async fn try_join_base_url(
     base_url: RcStr,
 ) -> Result<Vc<FileSystemPathOption>> {
     Ok(Vc::cell(
-        source
-            .ident()
-            .await?
-            .path
-            .clone()
-            .parent()
-            .try_join(&base_url),
+        source.ident().await?.path.parent().try_join(&base_url),
     ))
 }
 
@@ -274,13 +268,12 @@ pub async fn tsconfig_resolve_options(
         if let FileJsonContent::Content(json) = &*content.await?
             && let JsonValue::Object(paths) = &json["compilerOptions"]["paths"]
         {
-            let mut context_dir = source.ident().await?.path.clone().parent();
+            let mut context_dir = source.ident().await?.path.parent();
             if let Some(base_url) = json["compilerOptions"]["baseUrl"].as_str()
                 && let Some(new_context) = context_dir.try_join(base_url)
             {
                 context_dir = new_context;
             };
-            let context_dir = context_dir.clone();
             for (key, value) in paths.iter() {
                 if let JsonValue::Array(vec) = value {
                     let entries = vec

--- a/turbopack/crates/turbopack-static/src/css.rs
+++ b/turbopack/crates/turbopack-static/src/css.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, Vc};
 use turbopack_core::{
@@ -37,12 +38,17 @@ impl StaticUrlCssModule {
 #[turbo_tasks::value_impl]
 impl Module for StaticUrlCssModule {
     #[turbo_tasks::function]
-    fn ident(&self) -> Vc<AssetIdent> {
-        let mut ident = self.source.ident().with_modifier(rcstr!("static in css"));
+    async fn ident(&self) -> Result<Vc<AssetIdent>> {
+        let mut ident = self
+            .source
+            .ident()
+            .owned()
+            .await?
+            .with_modifier(rcstr!("static in css"));
         if let Some(tag) = &self.tag {
             ident = ident.with_modifier(format!("tag {}", tag).into());
         }
-        ident
+        Ok(ident.into_vc())
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-static/src/ecma.rs
+++ b/turbopack/crates/turbopack-static/src/ecma.rs
@@ -46,15 +46,17 @@ impl StaticUrlJsModule {
 #[turbo_tasks::value_impl]
 impl Module for StaticUrlJsModule {
     #[turbo_tasks::function]
-    fn ident(&self) -> Vc<AssetIdent> {
+    async fn ident(&self) -> Result<Vc<AssetIdent>> {
         let mut ident = self
             .source
             .ident()
+            .owned()
+            .await?
             .with_modifier(rcstr!("static in ecmascript"));
         if let Some(tag) = &self.tag {
             ident = ident.with_modifier(format!("tag {}", tag).into());
         }
-        ident
+        Ok(ident.into_vc())
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -598,15 +598,7 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
                         .entry_chunk_group(
                             // `expected` expects a completely flat output directory.
                             chunk_root_path
-                                .join(
-                                    entry_module
-                                        .ident()
-                                        .await?
-                                        .path
-                                        .clone()
-                                        .file_stem()
-                                        .unwrap(),
-                                )?
+                                .join(entry_module.ident().await?.path.file_stem().unwrap())?
                                 .with_extension("entry.js"),
                             ChunkGroup::Entry(entry_modules),
                             module_graph,

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -598,7 +598,15 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
                         .entry_chunk_group(
                             // `expected` expects a completely flat output directory.
                             chunk_root_path
-                                .join(entry_module.ident().path().await?.file_stem().unwrap())?
+                                .join(
+                                    entry_module
+                                        .ident()
+                                        .await?
+                                        .path
+                                        .clone()
+                                        .file_stem()
+                                        .unwrap(),
+                                )?
                                 .with_extension("entry.js"),
                             ChunkGroup::Entry(entry_modules),
                             module_graph,

--- a/turbopack/crates/turbopack-tracing/tests/unit.rs
+++ b/turbopack/crates/turbopack-tracing/tests/unit.rs
@@ -265,7 +265,7 @@ async fn node_file_trace_operation(package_root: RcStr, input: RcStr) -> Result<
         TracedAsset::new(module).to_resolved().await?,
     )])
     .await?;
-    paths.push(module.ident().path().await?.path.clone());
+    paths.push(module.ident().await?.path.clone().path.clone());
 
     Ok(Vc::cell(paths))
 }

--- a/turbopack/crates/turbopack-tracing/tests/unit.rs
+++ b/turbopack/crates/turbopack-tracing/tests/unit.rs
@@ -265,7 +265,7 @@ async fn node_file_trace_operation(package_root: RcStr, input: RcStr) -> Result<
         TracedAsset::new(module).to_resolved().await?,
     )])
     .await?;
-    paths.push(module.ident().await?.path.clone().path.clone());
+    paths.push(module.ident().await?.path.path.clone());
 
     Ok(Vc::cell(paths))
 }

--- a/turbopack/crates/turbopack-wasm/src/loader.rs
+++ b/turbopack/crates/turbopack-wasm/src/loader.rs
@@ -56,7 +56,7 @@ pub(crate) async fn instantiating_loader_source(
     let code: RcStr = code.into();
 
     Ok(Vc::upcast(VirtualSource::new(
-        source.ident().await?.path.clone().append("_.loader.mjs")?,
+        source.ident().await?.path.append("_.loader.mjs")?,
         AssetContent::file(FileContent::Content(File::from(code)).cell()),
     )))
 }
@@ -80,7 +80,7 @@ pub(crate) async fn compiling_loader_source(
     .into();
 
     Ok(Vc::upcast(VirtualSource::new(
-        source.ident().await?.path.clone().append("_.loader.mjs")?,
+        source.ident().await?.path.append("_.loader.mjs")?,
         AssetContent::file(FileContent::Content(File::from(code)).cell()),
     )))
 }

--- a/turbopack/crates/turbopack-wasm/src/loader.rs
+++ b/turbopack/crates/turbopack-wasm/src/loader.rs
@@ -56,7 +56,7 @@ pub(crate) async fn instantiating_loader_source(
     let code: RcStr = code.into();
 
     Ok(Vc::upcast(VirtualSource::new(
-        source.ident().path().await?.append("_.loader.mjs")?,
+        source.ident().await?.path.clone().append("_.loader.mjs")?,
         AssetContent::file(FileContent::Content(File::from(code)).cell()),
     )))
 }
@@ -80,7 +80,7 @@ pub(crate) async fn compiling_loader_source(
     .into();
 
     Ok(Vc::upcast(VirtualSource::new(
-        source.ident().path().await?.append("_.loader.mjs")?,
+        source.ident().await?.path.clone().append("_.loader.mjs")?,
         AssetContent::file(FileContent::Content(File::from(code)).cell()),
     )))
 }

--- a/turbopack/crates/turbopack-wasm/src/module_asset.rs
+++ b/turbopack/crates/turbopack-wasm/src/module_asset.rs
@@ -124,8 +124,11 @@ impl Module for WebAssemblyModuleAsset {
         Ok(self
             .source
             .ident()
+            .owned()
+            .await?
             .with_modifier(rcstr!("wasm module"))
-            .with_layer(self.asset_context.into_trait_ref().await?.layer()))
+            .with_layer(self.asset_context.into_trait_ref().await?.layer())
+            .into_vc())
     }
 
     #[turbo_tasks::function]
@@ -207,8 +210,8 @@ impl EcmascriptChunkPlaceable for WebAssemblyModuleAsset {
 #[turbo_tasks::value_impl]
 impl ResolveOrigin for WebAssemblyModuleAsset {
     #[turbo_tasks::function]
-    fn origin_path(&self) -> Vc<FileSystemPath> {
-        self.source.ident().path()
+    async fn origin_path(&self) -> Result<Vc<FileSystemPath>> {
+        Ok(self.source.ident().await?.path.clone().cell())
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-wasm/src/output_asset.rs
+++ b/turbopack/crates/turbopack-wasm/src/output_asset.rs
@@ -41,7 +41,13 @@ impl OutputAsset for WebAssemblyAsset {
     #[turbo_tasks::function]
     async fn path(self: Vc<Self>) -> Result<Vc<FileSystemPath>> {
         let this = self.await?;
-        let ident = this.source.ident().with_modifier(rcstr!("wasm"));
+        let ident = this
+            .source
+            .ident()
+            .owned()
+            .await?
+            .with_modifier(rcstr!("wasm"))
+            .into_vc();
         Ok(this
             .chunking_context
             .chunk_path(Some(Vc::upcast(self)), ident, None, rcstr!(".wasm")))

--- a/turbopack/crates/turbopack-wasm/src/raw.rs
+++ b/turbopack/crates/turbopack-wasm/src/raw.rs
@@ -55,8 +55,11 @@ impl Module for RawWebAssemblyModuleAsset {
         Ok(self
             .source
             .ident()
+            .owned()
+            .await?
             .with_modifier(rcstr!("wasm raw"))
-            .with_layer(self.asset_context.into_trait_ref().await?.layer()))
+            .with_layer(self.asset_context.into_trait_ref().await?.layer())
+            .into_vc())
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-wasm/src/source.rs
+++ b/turbopack/crates/turbopack-wasm/src/source.rs
@@ -56,7 +56,7 @@ impl Source for WebAssemblySource {
             WebAssemblySourceType::Binary => self.source.ident(),
             WebAssemblySourceType::Text => {
                 let ident = self.source.ident().owned().await?;
-                let new_path = ident.path.clone().append("_.wasm")?;
+                let new_path = ident.path.append("_.wasm")?;
                 ident.with_path(new_path).into_vc()
             }
         })

--- a/turbopack/crates/turbopack-wasm/src/source.rs
+++ b/turbopack/crates/turbopack-wasm/src/source.rs
@@ -54,10 +54,11 @@ impl Source for WebAssemblySource {
     async fn ident(&self) -> Result<Vc<AssetIdent>> {
         Ok(match self.source_ty {
             WebAssemblySourceType::Binary => self.source.ident(),
-            WebAssemblySourceType::Text => self
-                .source
-                .ident()
-                .with_path(self.source.ident().path().await?.append("_.wasm")?),
+            WebAssemblySourceType::Text => {
+                let ident = self.source.ident().owned().await?;
+                let new_path = ident.path.clone().append("_.wasm")?;
+                ident.with_path(new_path).into_vc()
+            }
         })
     }
 

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -653,7 +653,8 @@ async fn process_default_internal(
     processed_rules: Vec<usize>,
 ) -> Result<Vc<ProcessResult>> {
     let ident = source.ident().to_resolved().await?;
-    let path_ref = ident.path().await?;
+    let ident_ref = ident.await?;
+    let path_ref = &ident_ref.path;
     let options = ModuleOptions::new(
         path_ref.parent(),
         module_asset_context.module_options_context(),
@@ -827,7 +828,7 @@ async fn process_default_internal(
         if processed_rules.contains(&i) {
             continue;
         }
-        if rule.matches(source, &path_ref, &reference_type).await? {
+        if rule.matches(source, path_ref, &reference_type).await? {
             for effect in rule.effects() {
                 match effect {
                     ModuleRuleEffect::Ignore => {

--- a/turbopack/crates/turbopack/src/transition/mod.rs
+++ b/turbopack/crates/turbopack/src/transition/mod.rs
@@ -156,7 +156,7 @@ impl TransitionOptions {
         if self.transition_rules.is_empty() {
             return Ok(None);
         }
-        let path = &*source.ident().path().await?;
+        let path = &source.ident().await?.path;
         for rule in &self.transition_rules {
             if rule.matches(source, path, reference_type).await? {
                 return Ok(Some(rule.transition()));

--- a/turbopack/scripts/analyze_cache_effectiveness.py
+++ b/turbopack/scripts/analyze_cache_effectiveness.py
@@ -108,7 +108,7 @@ def print_analysis(tasks: List[TaskStats]):
 
     # Print summary
     print()
-    print(f"Total tasks: {len(tasks)}")
+    print(f"Total functions: {len(tasks)}")
     print(f"Total cache misses: {total_misses:,}")
     print(f"Overall cache hit rate: {overall_hit_rate:.1%} ({total_hits:,} hits / {total_ops:,} total)")
     print(f"Tasks with <50% hit rate: {low_hit_rate_count}")


### PR DESCRIPTION
### What?

Removes the per-method turbo-task constructors on `AssetIdent` (`from_path`, `with_query`, `with_fragment`, `with_modifier`, `with_part`, `with_path`, `with_layer`, `with_content_type`, `with_asset`, `rename_as`, and `path`). Each of those was its own cached task that returned a small projection or a one-field-changed copy. They are now plain Rust builder methods on the owned value, with a single `into_vc()` at the end of the chain that goes through the existing cached `new_inner` constructor.

Call sites that previously chained `Vc` methods now look like:

```rust
module
    .ident()
    .owned()
    .await?
    .with_modifier(rcstr!("async loader"))
    .into_vc()
```

### Why?

These constructors were tiny "projection" turbo-tasks that paid the cost of a task lookup, cell allocation, and dependency tracking but whose cache layer didn't meaningfully prevent recomputation. The trade-off is invalidation semantics:

- **Before:** a caller doing `module.ident().path()` depended on the cached `path()` projection. If the source `AssetIdent` changed but its `.path` field was unchanged (e.g. a new modifier was added), `path()` re-ran, returned the same `FileSystemPath` cell, and the caller did not re-run.
- **After:** the same caller does `module.ident().await?.path` and depends directly on the `AssetIdent` cell. Any change to the ident (modifier, query, layer, …) invalidates the caller, even if the path is unchanged.

In practice this is rarely a real loss: when an ident changes, the `Module` typically changes too, and the dependent task was going to re-run anyway. `new_inner` already deduplicates structurally-equal idents, so the wrappers were paying overhead per call without buying meaningful invalidation isolation.

Measured on a `vercel-site` build via `NEXT_TURBOPACK_TASK_STATISTICS` and `turbopack/scripts/analyze_cache_effectiveness.py`:

| Task                              | canary (hits / misses) | this branch |
| --------------------------------- | ---------------------- | ----------- |
| `AssetIdent::path`                | 778,273 / 98,018       | removed     |
| `AssetIdent::with_modifier`       | 27,895 / 22,801        | removed     |
| `AssetIdent::from_path`           | 2,954 / 29,650         | removed     |
| `AssetIdent::with_part`           | 2 / 5,440              | removed     |
| `AssetIdent::with_layer`          | 7 / 4,356              | removed     |
| `AssetIdent::rename_as`           | 4,969 / 2,269          | removed     |
| `AssetIdent::with_query`          | 0 / 521                | removed     |
| `AssetIdent::with_content_type`   | 0 / 79                 | removed     |
| `AssetIdent::new_inner`           | 628 / 129,777          | 29,213 / 120,650 |

Aggregate over the whole build:

- Total cached tasks: 1,300 → 1,292
- Total task invocations: 39,361,186 → 38,208,036 (~1.15M fewer lookups)
- Total cache misses: 6,812,198 → 6,639,937 (~172k fewer)
- Overall hit rate: 82.7% → 82.6% (essentially unchanged)

`new_inner` absorbs the construction work that used to be split across the wrappers. Four upstream tasks gained +519 cache hits each (`EsmAssetReference::resolve_reference`, `ReferencedAsset::from_resolve_result`, `NextServerUtilityModule::ident`, `NodeJsChunkingContext::chunk_item_id_strategy`); no task gained any new misses.

### How?

- `AssetIdent::from_path` and the `with_*` methods are now plain `&mut self`/`self`-by-value builder methods on the struct itself, not `#[turbo_tasks::function]`s.
- A new `AssetIdent::into_vc(self)` finalizes the builder by going through the still-cached `new_inner`.
- `AssetIdent::path()` is removed; callers use `.path` on an owned `AssetIdent`.
- All call sites across `turbopack-*` and `next-*` crates are updated. Most go from `ident.with_modifier(m)` (returning `Vc`) to `ident.owned().await?.with_modifier(m).into_vc()`.
- A follow-up commit removes a few `.clone()`s introduced in the conversion that aren't needed once lifetimes are bound to a local.

### Follow-ups (out of scope)

While migrating call sites, two pre-existing entry builders surfaced as candidates for cleanup. Not addressed here, but worth noting:

- `get_app_page_entry` (`crates/next-core/src/next_app/app_page_entry.rs`) replaces the *content* of the source returned by `load_next_js_template` (prefixing imports onto `result.build()`) but reuses the template's `ident` with a `?page=...` query suffix as a disambiguator. The new `VirtualSource` ends up with content from one place and an ident chain pointing at another. A cleaner shape would be to mint a fresh ident from the page path, since the caller already knows what it's building.
- `create_page_ssr_entry_module` (`crates/next-pages/page_entry.rs`) has the same shape on the instrumentation-conflict branch: it appends `export const register = hoist(...)` to the template content and constructs a `VirtualSource` with the original `source.ident()` unchanged. Lower-frequency than the app-page case (fires at most once per build), but the ident still misrepresents the constructed content.

<!-- NEXT_JS_LLM_PR -->
