### PR TITLE
Reduce allocations in the next_debug_instant_stack transform

### DIFF
--- a/crates/next-core/src/next_client/transforms.rs
+++ b/crates/next-core/src/next_client/transforms.rs
@@ -77,7 +77,7 @@ pub async fn get_next_client_transforms_rules(
                         ExportFilter::StripDataExports,
                         enable_mdx_rs,
                         vec![],
-                        &*next_config.page_extensions().await?,
+                        &next_config.page_extensions().await?,
                     )
                     .await?,
                 );

--- a/crates/next-core/src/next_client/transforms.rs
+++ b/crates/next-core/src/next_client/transforms.rs
@@ -32,12 +32,7 @@ pub async fn get_next_client_transforms_rules(
 
     let modularize_imports_config = next_config.modularize_imports();
     let enable_mdx_rs = next_config.mdx_rs().await?.is_some();
-    let page_extensions: Vec<String> = next_config
-        .page_extensions()
-        .await?
-        .iter()
-        .map(|s| s.to_string())
-        .collect();
+    let page_extensions: &Vec<RcStr> = &*next_config.page_extensions().await?;
 
     if !foreign_code {
         rules.push(get_next_lint_transform_rule(enable_mdx_rs).await?);
@@ -83,7 +78,7 @@ pub async fn get_next_client_transforms_rules(
                         ExportFilter::StripDataExports,
                         enable_mdx_rs,
                         vec![],
-                        &page_extensions,
+                        page_extensions,
                     )
                     .await?,
                 );

--- a/crates/next-core/src/next_client/transforms.rs
+++ b/crates/next-core/src/next_client/transforms.rs
@@ -32,7 +32,6 @@ pub async fn get_next_client_transforms_rules(
 
     let modularize_imports_config = next_config.modularize_imports();
     let enable_mdx_rs = next_config.mdx_rs().await?.is_some();
-    let page_extensions: &Vec<RcStr> = &*next_config.page_extensions().await?;
 
     if !foreign_code {
         rules.push(get_next_lint_transform_rule(enable_mdx_rs).await?);
@@ -78,7 +77,7 @@ pub async fn get_next_client_transforms_rules(
                         ExportFilter::StripDataExports,
                         enable_mdx_rs,
                         vec![],
-                        page_extensions,
+                        &*next_config.page_extensions().await?,
                     )
                     .await?,
                 );

--- a/crates/next-core/src/next_server/transforms.rs
+++ b/crates/next-core/src/next_server/transforms.rs
@@ -86,7 +86,7 @@ pub async fn get_next_server_transforms_rules(
                         vec![RuleCondition::ReferenceType(ReferenceTypeCondition::Entry(
                             Some(EntryReferenceSubType::PageData),
                         ))],
-                        &*next_config.page_extensions().await?,
+                        &next_config.page_extensions().await?,
                     )
                     .await?,
                 );

--- a/crates/next-core/src/next_server/transforms.rs
+++ b/crates/next-core/src/next_server/transforms.rs
@@ -38,8 +38,7 @@ pub async fn get_next_server_transforms_rules(
     let mut rules = vec![];
 
     let modularize_imports_config = next_config.modularize_imports();
-    let mdx_rs = next_config.mdx_rs().await?.is_some();
-    let page_extensions: &Vec<RcStr> = &*next_config.page_extensions().await?;
+    let mdx_rs: bool = next_config.mdx_rs().await?.is_some();
 
     if !foreign_code {
         rules.push(get_next_lint_transform_rule(mdx_rs).await?);

--- a/crates/next-core/src/next_server/transforms.rs
+++ b/crates/next-core/src/next_server/transforms.rs
@@ -87,7 +87,7 @@ pub async fn get_next_server_transforms_rules(
                         vec![RuleCondition::ReferenceType(ReferenceTypeCondition::Entry(
                             Some(EntryReferenceSubType::PageData),
                         ))],
-                        page_extensions,
+                        &*next_config.page_extensions().await?,
                     )
                     .await?,
                 );

--- a/crates/next-core/src/next_server/transforms.rs
+++ b/crates/next-core/src/next_server/transforms.rs
@@ -39,12 +39,7 @@ pub async fn get_next_server_transforms_rules(
 
     let modularize_imports_config = next_config.modularize_imports();
     let mdx_rs = next_config.mdx_rs().await?.is_some();
-    let page_extensions: Vec<String> = next_config
-        .page_extensions()
-        .await?
-        .iter()
-        .map(|s| s.to_string())
-        .collect();
+    let page_extensions: &Vec<RcStr> = &*next_config.page_extensions().await?;
 
     if !foreign_code {
         rules.push(get_next_lint_transform_rule(mdx_rs).await?);
@@ -92,7 +87,7 @@ pub async fn get_next_server_transforms_rules(
                         vec![RuleCondition::ReferenceType(ReferenceTypeCondition::Entry(
                             Some(EntryReferenceSubType::PageData),
                         ))],
-                        &page_extensions,
+                        page_extensions,
                     )
                     .await?,
                 );
@@ -157,7 +152,7 @@ pub async fn get_next_server_transforms_rules(
     };
 
     if is_app_dir {
-        rules.push(get_next_debug_instant_stack_rule(mdx_rs, page_extensions.clone()).await?);
+        rules.push(get_next_debug_instant_stack_rule(mdx_rs, next_config.page_extensions()).await?);
     }
 
     if is_app_dir &&

--- a/crates/next-core/src/next_shared/transforms/next_debug_instant_stack.rs
+++ b/crates/next-core/src/next_shared/transforms/next_debug_instant_stack.rs
@@ -1,7 +1,8 @@
 use anyhow::Result;
 use async_trait::async_trait;
-use next_custom_transforms::transforms::debug_instant_stack::debug_instant_stack;
+use next_custom_transforms::transforms::debug_instant_stack::DebugInstantStack;
 use swc_core::ecma::ast::Program;
+use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, Vc};
 use turbopack::module_options::{ModuleRule, ModuleRuleEffect};
 use turbopack_ecmascript::{
@@ -12,9 +13,9 @@ use super::module_rule_match_js_no_url;
 
 pub async fn get_next_debug_instant_stack_rule(
     enable_mdx_rs: bool,
-    page_extensions: Vec<String>,
+    page_extensions: Vc<Vec<RcStr>>,
 ) -> Result<ModuleRule> {
-    let transform = EcmascriptInputTransform::Plugin(
+    let transform: EcmascriptInputTransform = EcmascriptInputTransform::Plugin(
         next_debug_instant_stack_transform_plugin(page_extensions)
             .to_resolved()
             .await?,
@@ -32,24 +33,27 @@ pub async fn get_next_debug_instant_stack_rule(
 }
 
 #[turbo_tasks::function]
-fn next_debug_instant_stack_transform_plugin(page_extensions: Vec<String>) -> Vc<TransformPlugin> {
-    Vc::cell(Box::new(NextDebugInstantStack { page_extensions })
-        as Box<dyn CustomTransformer + Send + Sync>)
+async fn next_debug_instant_stack_transform_plugin(
+    page_extensions: ResolvedVc<Vec<RcStr>>,
+) -> Result<Vc<TransformPlugin>> {
+    Ok(Vc::cell(Box::new(NextDebugInstantStack {
+        debug_instant_stack: DebugInstantStack::new(&*page_extensions.await?),
+    }) as Box<dyn CustomTransformer + Send + Sync>))
 }
 
 #[derive(Debug)]
 struct NextDebugInstantStack {
-    page_extensions: Vec<String>,
+    debug_instant_stack: DebugInstantStack,
 }
 
 #[async_trait]
 impl CustomTransformer for NextDebugInstantStack {
     #[tracing::instrument(level = tracing::Level::TRACE, name = "debug_instant_stack", skip_all)]
     async fn transform(&self, program: &mut Program, ctx: &TransformContext<'_>) -> Result<()> {
-        program.mutate(debug_instant_stack(
-            ctx.file_path_str.to_string(),
-            self.page_extensions.clone(),
-        ));
+        program.mutate(
+            self.debug_instant_stack
+                .get_pass(ctx.file_path_str.to_string()),
+        );
         Ok(())
     }
 }

--- a/crates/next-core/src/next_shared/transforms/next_strip_page_exports.rs
+++ b/crates/next-core/src/next_shared/transforms/next_strip_page_exports.rs
@@ -5,6 +5,7 @@ use next_custom_transforms::transforms::strip_page_exports::{
     ExportFilter, next_transform_strip_page_exports,
 };
 use swc_core::ecma::ast::Program;
+use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, TaskInput, Vc, trace::TraceRawVcs};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::module_options::{ModuleRule, ModuleRuleEffect, RuleCondition};
@@ -45,7 +46,7 @@ pub async fn get_next_pages_transforms_rule(
     export_filter: ExportFilter,
     enable_mdx_rs: bool,
     extra_conditions: Vec<RuleCondition>,
-    page_extensions: &[String],
+    page_extensions: &[RcStr],
 ) -> Result<ModuleRule> {
     // Apply the Next SSG transform to all pages.
     let strip_transform = EcmascriptInputTransform::Plugin(

--- a/crates/next-custom-transforms/src/chain_transforms.rs
+++ b/crates/next-custom-transforms/src/chain_transforms.rs
@@ -348,15 +348,15 @@ where
                 crate::transforms::debug_fn_name::debug_fn_name(),
                 opts.debug_function_name,
             ),
-            crate::transforms::debug_instant_stack::debug_instant_stack(
-                file_path_for_instant_stack,
+            crate::transforms::debug_instant_stack::DebugInstantStack::new(
                 match &opts.server_components {
                     Some(react_server_components::Config::WithOptions(options)) => {
                         options.page_extensions.clone()
                     }
                     _ => vec![],
                 },
-            ),
+            )
+            .get_pass(file_path_for_instant_stack),
             visit_mut_pass(crate::transforms::pure::pure_magic(comments.clone())),
             Optional::new(
                 linter(lint_codemod_comments(comments)),

--- a/crates/next-custom-transforms/src/transforms/debug_instant_stack.rs
+++ b/crates/next-custom-transforms/src/transforms/debug_instant_stack.rs
@@ -8,30 +8,51 @@ use swc_core::{
     quote,
 };
 
-fn build_page_extensions_regex(page_extensions: &[String]) -> String {
-    if page_extensions.is_empty() {
+fn build_page_extensions_regex<I, S>(page_extensions: I) -> String
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let escaped: Vec<String> = page_extensions
+        .into_iter()
+        .map(|ext| regex::escape(ext.as_ref()))
+        .collect();
+    if escaped.is_empty() {
         "(ts|js)x?".to_string()
     } else {
-        let escaped: Vec<String> = page_extensions
-            .iter()
-            .map(|ext| regex::escape(ext))
-            .collect();
         format!("({})", escaped.join("|"))
     }
 }
 
-pub fn debug_instant_stack(filepath: String, page_extensions: Vec<String>) -> impl Pass {
-    visit_mut_pass(DebugInstantStack {
-        filepath,
-        instant_export_span: None,
-        page_extensions,
-    })
+#[derive(Debug)]
+pub struct DebugInstantStack {
+    page_or_layout: Regex,
 }
 
-struct DebugInstantStack {
+impl DebugInstantStack {
+    pub fn new<I, S>(page_extensions: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let ext_pattern = build_page_extensions_regex(page_extensions);
+        let page_or_layout =
+            Regex::new(&format!(r"[\\/](page|layout|default)\.{ext_pattern}$")).unwrap();
+        Self { page_or_layout }
+    }
+    pub fn get_pass(&self, filepath: String) -> impl Pass + use<> {
+        visit_mut_pass(DebugInstantStackPass {
+            filepath,
+            instant_export_span: None,
+            page_or_layout: self.page_or_layout.clone(),
+        })
+    }
+}
+
+struct DebugInstantStackPass {
     filepath: String,
     instant_export_span: Option<Span>,
-    page_extensions: Vec<String>,
+    page_or_layout: Regex,
 }
 
 /// Given an export specifier, returns `Some((exported_name, local_name))` if
@@ -80,12 +101,9 @@ fn find_var_init_span(items: &[ModuleItem], local_name: &str) -> Option<Span> {
     None
 }
 
-impl VisitMut for DebugInstantStack {
+impl VisitMut for DebugInstantStackPass {
     fn visit_mut_module_items(&mut self, items: &mut Vec<ModuleItem>) {
-        let ext_pattern = build_page_extensions_regex(&self.page_extensions);
-        let page_or_layout_re =
-            Regex::new(&format!(r"[\\/](page|layout|default)\.{ext_pattern}$")).unwrap();
-        if !page_or_layout_re.is_match(&self.filepath) {
+        if !self.page_or_layout.is_match(&self.filepath) {
             return;
         }
 

--- a/crates/next-custom-transforms/src/transforms/debug_instant_stack.rs
+++ b/crates/next-custom-transforms/src/transforms/debug_instant_stack.rs
@@ -8,22 +8,6 @@ use swc_core::{
     quote,
 };
 
-fn build_page_extensions_regex<I, S>(page_extensions: I) -> String
-where
-    I: IntoIterator<Item = S>,
-    S: AsRef<str>,
-{
-    let escaped: Vec<String> = page_extensions
-        .into_iter()
-        .map(|ext| regex::escape(ext.as_ref()))
-        .collect();
-    if escaped.is_empty() {
-        "(ts|js)x?".to_string()
-    } else {
-        format!("({})", escaped.join("|"))
-    }
-}
-
 #[derive(Debug)]
 pub struct DebugInstantStack {
     page_or_layout: Regex,
@@ -35,10 +19,23 @@ impl DebugInstantStack {
         I: IntoIterator<Item = S>,
         S: AsRef<str>,
     {
-        let ext_pattern = build_page_extensions_regex(page_extensions);
-        let page_or_layout =
-            Regex::new(&format!(r"[\\/](page|layout|default)\.{ext_pattern}$")).unwrap();
-        Self { page_or_layout }
+        let mut result = String::from(r"[\\/](page|layout|default)\.");
+        let mut iter = page_extensions.into_iter();
+        if let Some(first) = iter.next() {
+            result.push('(');
+            result.push_str(&regex::escape(first.as_ref()));
+            for ext in iter {
+                result.push('|');
+                result.push_str(&regex::escape(ext.as_ref()));
+            }
+            result.push(')');
+        } else {
+            result.push_str("(ts|js)x?");
+        }
+        result.push('$');
+        Self {
+            page_or_layout: Regex::new(&result).unwrap(),
+        }
     }
     pub fn get_pass(&self, filepath: String) -> impl Pass + use<> {
         visit_mut_pass(DebugInstantStackPass {

--- a/crates/next-custom-transforms/tests/fixture.rs
+++ b/crates/next-custom-transforms/tests/fixture.rs
@@ -8,7 +8,7 @@ use bytes_str::BytesStr;
 use next_custom_transforms::transforms::{
     cjs_optimizer::cjs_optimizer,
     debug_fn_name::debug_fn_name,
-    debug_instant_stack::debug_instant_stack,
+    debug_instant_stack::DebugInstantStack,
     dynamic::{NextDynamicMode, next_dynamic},
     fonts::{Config as FontLoaderConfig, next_font_loaders},
     named_import_transform::named_import_transform,
@@ -878,7 +878,7 @@ fn test_debug_instant_stack(input: PathBuf) {
 
     test_fixture(
         syntax(),
-        &|_| debug_instant_stack("app/page.js".to_string(), vec![]),
+        &|_| DebugInstantStack::new::<Vec<&str>, &str>(vec![]).get_pass("app/page.js".to_string()),
         &input,
         &output,
         FixtureTestConfig {


### PR DESCRIPTION
This was allocating a regex on every transform, we can hoist that regex up to avoid the work

I noticed this as a major source of temporary allocations in a dev benchmark

also avoid a bunch of tiny string copies