### PR TITLE
patch npm-package-arg to support pnpm catalogs

### DIFF
--- a/package.json
+++ b/package.json
@@ -345,7 +345,8 @@
       "@rspack/core@1.6.7": "patches/@rspack__core@1.6.7.patch",
       "@modelcontextprotocol/sdk": "patches/@modelcontextprotocol__sdk.patch",
       "@vercel/blob": "patches/@vercel__blob.patch",
-      "postcss-scss": "patches/postcss-scss.patch"
+      "postcss-scss": "patches/postcss-scss.patch",
+      "npm-package-arg@13.0.1": "patches/npm-package-arg@13.0.1.patch"
     }
   }
 }

--- a/patches/npm-package-arg@13.0.1.patch
+++ b/patches/npm-package-arg@13.0.1.patch
@@ -1,0 +1,179 @@
+diff --git a/lib/npa.js b/lib/npa.js
+index 50121b99efbe362de2770f97b98d8a79c327cb9e..dc6f8ff84b262bbf320e30ee9d6fbb1dbe0c1854 100644
+--- a/lib/npa.js
++++ b/lib/npa.js
+@@ -5,6 +5,7 @@ const isWindows = process.platform === 'win32'
+ const { URL } = require('node:url')
+ // We need to use path/win32 so that we get consistent results in tests, but this also means we need to manually convert backslashes to forward slashes when generating file: urls with paths.
+ const path = isWindows ? require('node:path/win32') : require('node:path')
++const fs = require('node:fs')
+ const { homedir } = require('node:os')
+ const HostedGit = require('hosted-git-info')
+ const semver = require('semver')
+@@ -78,6 +79,153 @@ function isAliasSpec (spec) {
+   return spec.toLowerCase().startsWith('npm:')
+ }
+ 
++function isCatalogSpec (spec) {
++  if (!spec) {
++    return false
++  }
++  return spec.toLowerCase().startsWith('catalog:')
++}
++
++// Cache parsed catalogs by absolute pnpm-workspace.yaml path.
++const catalogCache = new Map()
++
++function findPnpmWorkspaceFile (startDir) {
++  let dir = path.resolve(startDir)
++  while (true) {
++    const candidate = path.join(dir, 'pnpm-workspace.yaml')
++    if (fs.existsSync(candidate)) {
++      return candidate
++    }
++    const parent = path.dirname(dir)
++    if (parent === dir) {
++      return null
++    }
++    dir = parent
++  }
++}
++
++// Minimal YAML extractor for the `catalog:` and `catalogs:` blocks of
++// pnpm-workspace.yaml. Only supports the flat `name: version` shape that pnpm
++// itself documents; anything exotic should be resolved by pnpm before reaching
++// this code path.
++function parseCatalogs (yamlPath) {
++  if (catalogCache.has(yamlPath)) {
++    return catalogCache.get(yamlPath)
++  }
++  const text = fs.readFileSync(yamlPath, 'utf8')
++  const lines = text.split(/\r?\n/)
++  const catalogs = { default: {} }
++  let section = null // 'default' | string | null
++  let sectionIndent = -1
++  for (const rawLine of lines) {
++    const line = rawLine.replace(/#.*$/, '').trimEnd()
++    if (line === '') {
++      continue
++    }
++    const topMatch = /^(catalog|catalogs):\s*$/.exec(line)
++    if (topMatch) {
++      section = topMatch[1] === 'catalog' ? 'default' : '__named__'
++      sectionIndent = -1
++      continue
++    }
++    if (/^\S/.test(line)) {
++      // back at the top level, leaving any catalog block
++      section = null
++      continue
++    }
++    if (section === null) {
++      continue
++    }
++    const indentMatch = /^(\s+)(\S.*)$/.exec(line)
++    if (!indentMatch) {
++      continue
++    }
++    const indent = indentMatch[1].length
++    const body = indentMatch[2]
++    if (sectionIndent === -1) {
++      sectionIndent = indent
++    }
++    if (section === 'default' && indent === sectionIndent) {
++      const entry = /^("?)([^"\s:]+)\1\s*:\s*(.+?)\s*$/.exec(body)
++      if (entry) {
++        catalogs.default[entry[2]] = stripQuotes(entry[3])
++      }
++      continue
++    }
++    if (section === '__named__') {
++      if (indent === sectionIndent) {
++        // `catalogName:` header
++        const header = /^("?)([^"\s:]+)\1\s*:\s*$/.exec(body)
++        if (header) {
++          section = header[2]
++          catalogs[section] = {}
++        }
++      }
++      continue
++    }
++    // inside a named catalog
++    if (indent > sectionIndent) {
++      const entry = /^("?)([^"\s:]+)\1\s*:\s*(.+?)\s*$/.exec(body)
++      if (entry) {
++        catalogs[section][entry[2]] = stripQuotes(entry[3])
++      }
++    } else {
++      // dedented back to the `catalogs:` level — either a new named catalog
++      // header or we've left the block entirely. Re-enter the dispatcher on
++      // the next iteration by resetting.
++      section = '__named__'
++      const header = /^("?)([^"\s:]+)\1\s*:\s*$/.exec(body)
++      if (header) {
++        section = header[2]
++        catalogs[section] = {}
++      }
++    }
++  }
++  catalogCache.set(yamlPath, catalogs)
++  return catalogs
++}
++
++function stripQuotes (value) {
++  if ((value.startsWith('"') && value.endsWith('"')) ||
++      (value.startsWith("'") && value.endsWith("'"))) {
++    return value.slice(1, -1)
++  }
++  return value
++}
++
++function resolveCatalogSpec (name, spec, where) {
++  if (!name) {
++    throw Object.assign(
++      new Error(`Cannot resolve catalog spec "${spec}" without a package name`),
++      { code: 'ECATALOGNONAME' }
++    )
++  }
++  const catalogName = spec.slice('catalog:'.length).trim() || 'default'
++  const yamlPath = findPnpmWorkspaceFile(where || process.cwd())
++  if (!yamlPath) {
++    throw Object.assign(
++      new Error(`Cannot resolve "${name}@${spec}": no pnpm-workspace.yaml found from ${where}`),
++      { code: 'ECATALOGNOWORKSPACE' }
++    )
++  }
++  const catalogs = parseCatalogs(yamlPath)
++  const catalog = catalogs[catalogName]
++  if (!catalog) {
++    throw Object.assign(
++      new Error(`Cannot resolve "${name}@${spec}": catalog "${catalogName}" not found in ${yamlPath}`),
++      { code: 'ECATALOGMISSING' }
++    )
++  }
++  const resolved = catalog[name]
++  if (!resolved) {
++    throw Object.assign(
++      new Error(`Cannot resolve "${name}@${spec}": "${name}" not listed in catalog "${catalogName}" at ${yamlPath}`),
++      { code: 'ECATALOGENTRYMISSING' }
++    )
++  }
++  return resolved
++}
++
+ function resolve (name, spec, where, arg) {
+   const res = new Result({
+     raw: arg,
+@@ -94,6 +242,12 @@ function resolve (name, spec, where, arg) {
+     where = process.cwd()
+   }
+ 
++  if (isCatalogSpec(spec)) {
++    const rewritten = resolveCatalogSpec(name, spec, where)
++    res.rawSpec = rewritten
++    spec = rewritten
++  }
++
+   if (isFileSpec(spec)) {
+     return fromFile(res, where)
+   } else if (isAliasSpec(spec)) {

--- a/patches/npm-package-arg@13.0.1.patch
+++ b/patches/npm-package-arg@13.0.1.patch
@@ -1,5 +1,5 @@
 diff --git a/lib/npa.js b/lib/npa.js
-index 50121b99efbe362de2770f97b98d8a79c327cb9e..8fba56d604d90692e58e857a3e48f37385bd5379 100644
+index 50121b99efbe362de2770f97b98d8a79c327cb9e..c86eeddbc2c4d53abaf425bdb46e2a9093daedf3 100644
 --- a/lib/npa.js
 +++ b/lib/npa.js
 @@ -5,6 +5,7 @@ const isWindows = process.platform === 'win32'
@@ -10,7 +10,7 @@ index 50121b99efbe362de2770f97b98d8a79c327cb9e..8fba56d604d90692e58e857a3e48f373
  const { homedir } = require('node:os')
  const HostedGit = require('hosted-git-info')
  const semver = require('semver')
-@@ -78,6 +79,137 @@ function isAliasSpec (spec) {
+@@ -78,6 +79,129 @@ function isAliasSpec (spec) {
    return spec.toLowerCase().startsWith('npm:')
  }
  
@@ -96,20 +96,12 @@ index 50121b99efbe362de2770f97b98d8a79c327cb9e..8fba56d604d90692e58e857a3e48f373
 +    } else if (indent === 6 && catalogName && pkgName) {
 +      const entry = /^version:\s*(.+?)\s*$/.exec(body)
 +      if (entry) {
-+        catalogs[catalogName][pkgName] = stripQuotes(entry[1])
++        catalogs[catalogName][pkgName] = entry[1]
 +      }
 +    }
 +  }
 +  catalogCache.set(lockPath, catalogs)
 +  return catalogs
-+}
-+
-+function stripQuotes (value) {
-+  if ((value.startsWith('"') && value.endsWith('"')) ||
-+      (value.startsWith("'") && value.endsWith("'"))) {
-+    return value.slice(1, -1)
-+  }
-+  return value
 +}
 +
 +function resolveCatalogSpec (name, spec, where) {
@@ -148,7 +140,7 @@ index 50121b99efbe362de2770f97b98d8a79c327cb9e..8fba56d604d90692e58e857a3e48f373
  function resolve (name, spec, where, arg) {
    const res = new Result({
      raw: arg,
-@@ -94,6 +226,12 @@ function resolve (name, spec, where, arg) {
+@@ -94,6 +218,12 @@ function resolve (name, spec, where, arg) {
      where = process.cwd()
    }
  

--- a/patches/npm-package-arg@13.0.1.patch
+++ b/patches/npm-package-arg@13.0.1.patch
@@ -1,5 +1,5 @@
 diff --git a/lib/npa.js b/lib/npa.js
-index 50121b99efbe362de2770f97b98d8a79c327cb9e..dc6f8ff84b262bbf320e30ee9d6fbb1dbe0c1854 100644
+index 50121b99efbe362de2770f97b98d8a79c327cb9e..8fba56d604d90692e58e857a3e48f37385bd5379 100644
 --- a/lib/npa.js
 +++ b/lib/npa.js
 @@ -5,6 +5,7 @@ const isWindows = process.platform === 'win32'
@@ -10,7 +10,7 @@ index 50121b99efbe362de2770f97b98d8a79c327cb9e..dc6f8ff84b262bbf320e30ee9d6fbb1d
  const { homedir } = require('node:os')
  const HostedGit = require('hosted-git-info')
  const semver = require('semver')
-@@ -78,6 +79,153 @@ function isAliasSpec (spec) {
+@@ -78,6 +79,137 @@ function isAliasSpec (spec) {
    return spec.toLowerCase().startsWith('npm:')
  }
  
@@ -21,13 +21,13 @@ index 50121b99efbe362de2770f97b98d8a79c327cb9e..dc6f8ff84b262bbf320e30ee9d6fbb1d
 +  return spec.toLowerCase().startsWith('catalog:')
 +}
 +
-+// Cache parsed catalogs by absolute pnpm-workspace.yaml path.
++// Cache parsed catalogs by absolute pnpm-lock.yaml path.
 +const catalogCache = new Map()
 +
-+function findPnpmWorkspaceFile (startDir) {
++function findPnpmLockfile (startDir) {
 +  let dir = path.resolve(startDir)
 +  while (true) {
-+    const candidate = path.join(dir, 'pnpm-workspace.yaml')
++    const candidate = path.join(dir, 'pnpm-lock.yaml')
 +    if (fs.existsSync(candidate)) {
 +      return candidate
 +    }
@@ -39,84 +39,68 @@ index 50121b99efbe362de2770f97b98d8a79c327cb9e..dc6f8ff84b262bbf320e30ee9d6fbb1d
 +  }
 +}
 +
-+// Minimal YAML extractor for the `catalog:` and `catalogs:` blocks of
-+// pnpm-workspace.yaml. Only supports the flat `name: version` shape that pnpm
-+// itself documents; anything exotic should be resolved by pnpm before reaching
-+// this code path.
-+function parseCatalogs (yamlPath) {
-+  if (catalogCache.has(yamlPath)) {
-+    return catalogCache.get(yamlPath)
++// Extract the top-level `catalogs:` block from pnpm-lock.yaml. The lockfile
++// format is strictly regular (2-space indent, no anchors/flow style under this
++// section), so a tiny line-based scanner is sufficient — dropping in a real
++// YAML dep inside npm-package-arg would be overkill.
++//
++// Shape we care about:
++//   catalogs:
++//     default:                     <- 2sp
++//       typescript:                <- 4sp
++//         specifier: 6.0.2         <- 6sp
++//         version: 6.0.2
++function parseCatalogs (lockPath) {
++  if (catalogCache.has(lockPath)) {
++    return catalogCache.get(lockPath)
 +  }
-+  const text = fs.readFileSync(yamlPath, 'utf8')
++  const text = fs.readFileSync(lockPath, 'utf8')
 +  const lines = text.split(/\r?\n/)
-+  const catalogs = { default: {} }
-+  let section = null // 'default' | string | null
-+  let sectionIndent = -1
-+  for (const rawLine of lines) {
-+    const line = rawLine.replace(/#.*$/, '').trimEnd()
-+    if (line === '') {
-+      continue
-+    }
-+    const topMatch = /^(catalog|catalogs):\s*$/.exec(line)
-+    if (topMatch) {
-+      section = topMatch[1] === 'catalog' ? 'default' : '__named__'
-+      sectionIndent = -1
++  const catalogs = Object.create(null)
++  let inCatalogs = false
++  let catalogName = null
++  let pkgName = null
++  for (const line of lines) {
++    if (!inCatalogs) {
++      if (line === 'catalogs:') {
++        inCatalogs = true
++      }
 +      continue
 +    }
 +    if (/^\S/.test(line)) {
-+      // back at the top level, leaving any catalog block
-+      section = null
++      // left the catalogs: block (next top-level key)
++      break
++    }
++    // Alternatives ordered longest-first so the regex engine picks the real
++    // indent depth rather than the first matching (shortest) alternative.
++    const match = /^( {6}| {4}| {2})(.*)$/.exec(line)
++    if (!match) {
 +      continue
 +    }
-+    if (section === null) {
-+      continue
-+    }
-+    const indentMatch = /^(\s+)(\S.*)$/.exec(line)
-+    if (!indentMatch) {
-+      continue
-+    }
-+    const indent = indentMatch[1].length
-+    const body = indentMatch[2]
-+    if (sectionIndent === -1) {
-+      sectionIndent = indent
-+    }
-+    if (section === 'default' && indent === sectionIndent) {
-+      const entry = /^("?)([^"\s:]+)\1\s*:\s*(.+?)\s*$/.exec(body)
-+      if (entry) {
-+        catalogs.default[entry[2]] = stripQuotes(entry[3])
-+      }
-+      continue
-+    }
-+    if (section === '__named__') {
-+      if (indent === sectionIndent) {
-+        // `catalogName:` header
-+        const header = /^("?)([^"\s:]+)\1\s*:\s*$/.exec(body)
-+        if (header) {
-+          section = header[2]
-+          catalogs[section] = {}
++    const indent = match[1].length
++    const body = match[2]
++    if (indent === 2) {
++      const header = /^([^\s:]+):\s*$/.exec(body)
++      if (header) {
++        catalogName = header[1]
++        pkgName = null
++        if (!catalogs[catalogName]) {
++          catalogs[catalogName] = Object.create(null)
 +        }
 +      }
-+      continue
-+    }
-+    // inside a named catalog
-+    if (indent > sectionIndent) {
-+      const entry = /^("?)([^"\s:]+)\1\s*:\s*(.+?)\s*$/.exec(body)
-+      if (entry) {
-+        catalogs[section][entry[2]] = stripQuotes(entry[3])
-+      }
-+    } else {
-+      // dedented back to the `catalogs:` level — either a new named catalog
-+      // header or we've left the block entirely. Re-enter the dispatcher on
-+      // the next iteration by resetting.
-+      section = '__named__'
-+      const header = /^("?)([^"\s:]+)\1\s*:\s*$/.exec(body)
++    } else if (indent === 4 && catalogName) {
++      const header = /^('?)([^'\s:]+)\1:\s*$/.exec(body)
 +      if (header) {
-+        section = header[2]
-+        catalogs[section] = {}
++        pkgName = header[2]
++      }
++    } else if (indent === 6 && catalogName && pkgName) {
++      const entry = /^version:\s*(.+?)\s*$/.exec(body)
++      if (entry) {
++        catalogs[catalogName][pkgName] = stripQuotes(entry[1])
 +      }
 +    }
 +  }
-+  catalogCache.set(yamlPath, catalogs)
++  catalogCache.set(lockPath, catalogs)
 +  return catalogs
 +}
 +
@@ -136,25 +120,25 @@ index 50121b99efbe362de2770f97b98d8a79c327cb9e..dc6f8ff84b262bbf320e30ee9d6fbb1d
 +    )
 +  }
 +  const catalogName = spec.slice('catalog:'.length).trim() || 'default'
-+  const yamlPath = findPnpmWorkspaceFile(where || process.cwd())
-+  if (!yamlPath) {
++  const lockPath = findPnpmLockfile(where || process.cwd())
++  if (!lockPath) {
 +    throw Object.assign(
-+      new Error(`Cannot resolve "${name}@${spec}": no pnpm-workspace.yaml found from ${where}`),
-+      { code: 'ECATALOGNOWORKSPACE' }
++      new Error(`Cannot resolve "${name}@${spec}": no pnpm-lock.yaml found from ${where}. Run \`pnpm install\` to generate one.`),
++      { code: 'ECATALOGNOLOCKFILE' }
 +    )
 +  }
-+  const catalogs = parseCatalogs(yamlPath)
++  const catalogs = parseCatalogs(lockPath)
 +  const catalog = catalogs[catalogName]
 +  if (!catalog) {
 +    throw Object.assign(
-+      new Error(`Cannot resolve "${name}@${spec}": catalog "${catalogName}" not found in ${yamlPath}`),
++      new Error(`Cannot resolve "${name}@${spec}": catalog "${catalogName}" not found in ${lockPath}`),
 +      { code: 'ECATALOGMISSING' }
 +    )
 +  }
 +  const resolved = catalog[name]
 +  if (!resolved) {
 +    throw Object.assign(
-+      new Error(`Cannot resolve "${name}@${spec}": "${name}" not listed in catalog "${catalogName}" at ${yamlPath}`),
++      new Error(`Cannot resolve "${name}@${spec}": "${name}" not listed in catalog "${catalogName}" at ${lockPath}`),
 +      { code: 'ECATALOGENTRYMISSING' }
 +    )
 +  }
@@ -164,7 +148,7 @@ index 50121b99efbe362de2770f97b98d8a79c327cb9e..dc6f8ff84b262bbf320e30ee9d6fbb1d
  function resolve (name, spec, where, arg) {
    const res = new Result({
      raw: arg,
-@@ -94,6 +242,12 @@ function resolve (name, spec, where, arg) {
+@@ -94,6 +226,12 @@ function resolve (name, spec, where, arg) {
      where = process.cwd()
    }
  

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,6 +58,9 @@ patchedDependencies:
   minizlib@3.1.0:
     hash: 587688821244aaee46680929cd869947377a284ac1b30c9ae8660a5ea7d2be67
     path: patches/minizlib@3.1.0.patch
+  npm-package-arg@13.0.1:
+    hash: 60224f312822e7432d6a6532e12d2b052cf8d1f0c9cc3a5cf7b3d00446906070
+    path: patches/npm-package-arg@13.0.1.patch
   postcss-scss:
     hash: 88893e632b3e099730dc0ffcc93cf3654b31c277da9e2796e822f6b5aeedc093
     path: patches/postcss-scss.patch
@@ -21033,7 +21036,7 @@ snapshots:
       make-fetch-happen: 15.0.2
       minimatch: 3.0.5
       multimatch: 5.0.0
-      npm-package-arg: 13.0.1
+      npm-package-arg: 13.0.1(patch_hash=60224f312822e7432d6a6532e12d2b052cf8d1f0c9cc3a5cf7b3d00446906070)
       npm-packlist: 10.0.3
       npm-registry-fetch: 19.1.0
       nx: 22.2.3(@swc/core@1.11.24(@swc/helpers@0.5.15))
@@ -21383,7 +21386,7 @@ snapshots:
       minimatch: 10.2.4
       nopt: 8.1.0
       npm-install-checks: 7.1.2
-      npm-package-arg: 13.0.1
+      npm-package-arg: 13.0.1(patch_hash=60224f312822e7432d6a6532e12d2b052cf8d1f0c9cc3a5cf7b3d00446906070)
       npm-pick-manifest: 11.0.3
       npm-registry-fetch: 19.1.0
       pacote: 21.0.4
@@ -27455,26 +27458,6 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
-  eslint-config-next@16.2.0-canary.91(eslint-plugin-import-x@4.3.1(eslint@9.37.0(jiti@2.6.1))(typescript@6.0.2))(eslint@9.37.0(jiti@2.6.1))(typescript@6.0.2):
-    dependencies:
-      '@next/eslint-plugin-next': 16.2.0-canary.91
-      eslint: 9.37.0(jiti@2.6.1)
-      eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.3.1(eslint@9.37.0(jiti@2.6.1))(typescript@6.0.2))(eslint-plugin-import@2.32.0(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.3.1(eslint@9.37.0(jiti@2.6.1))(typescript@6.0.2))(eslint-plugin-import@2.32.0(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1))
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.37.0(jiti@2.6.1))
-      eslint-plugin-react: 7.37.0(eslint@9.37.0(jiti@2.6.1))
-      eslint-plugin-react-hooks: 7.0.0(eslint@9.37.0(jiti@2.6.1))
-      globals: 16.4.0
-      typescript-eslint: 8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@6.0.2)
-    optionalDependencies:
-      typescript: 6.0.2
-    transitivePeerDependencies:
-      - '@typescript-eslint/parser'
-      - eslint-import-resolver-webpack
-      - eslint-plugin-import-x
-      - supports-color
-
   eslint-formatter-codeframe@7.32.1:
     dependencies:
       '@babel/code-frame': 7.12.11
@@ -27485,22 +27468,6 @@ snapshots:
       debug: 3.2.7
       is-core-module: 2.16.1
       resolve: 1.22.10
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.3.1(eslint@9.37.0(jiti@2.6.1))(typescript@6.0.2))(eslint-plugin-import@2.32.0(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.0
-      eslint: 9.37.0(jiti@2.6.1)
-      get-tsconfig: 4.12.0
-      is-bun-module: 2.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.15
-      unrs-resolver: 1.11.1
-    optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.3.1(eslint@9.37.0(jiti@2.6.1))(typescript@6.0.2))(eslint-plugin-import@2.32.0(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1))
-      eslint-plugin-import-x: 4.3.1(eslint@9.37.0(jiti@2.6.1))(typescript@6.0.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -27558,16 +27525,6 @@ snapshots:
       eslint: 9.37.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.3.1(eslint@9.37.0(jiti@2.6.1))(typescript@6.0.2))(eslint-plugin-import@2.32.0)(eslint@9.37.0(jiti@2.6.1))
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.3.1(eslint@9.37.0(jiti@2.6.1))(typescript@6.0.2))(eslint-plugin-import@2.32.0(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)):
-    dependencies:
-      debug: 3.2.7
-    optionalDependencies:
-      eslint: 9.37.0(jiti@2.6.1)
-      eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.3.1(eslint@9.37.0(jiti@2.6.1))(typescript@6.0.2))(eslint-plugin-import@2.32.0(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -27646,33 +27603,6 @@ snapshots:
       tsconfig-paths: 3.15.0
     optionalDependencies:
       '@typescript-eslint/parser': 8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@6.0.2)
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
-
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.3.1(eslint@9.37.0(jiti@2.6.1))(typescript@6.0.2))(eslint-plugin-import@2.32.0(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)):
-    dependencies:
-      '@rtsao/scc': 1.1.0
-      array-includes: 3.1.9
-      array.prototype.findlastindex: 1.2.6
-      array.prototype.flat: 1.3.3
-      array.prototype.flatmap: 1.3.3
-      debug: 3.2.7
-      doctrine: 2.1.0
-      eslint: 9.37.0(jiti@2.6.1)
-      eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.3.1(eslint@9.37.0(jiti@2.6.1))(typescript@6.0.2))(eslint-plugin-import@2.32.0(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1))
-      hasown: 2.0.2
-      is-core-module: 2.16.1
-      is-glob: 4.0.3
-      minimatch: 3.1.2
-      object.fromentries: 2.0.8
-      object.groupby: 1.0.3
-      object.values: 1.2.1
-      semver: 6.3.1
-      string.prototype.trimend: 1.0.9
-      tsconfig-paths: 3.15.0
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -29634,7 +29564,7 @@ snapshots:
   init-package-json@8.2.2:
     dependencies:
       '@npmcli/package-json': 7.0.2
-      npm-package-arg: 13.0.1
+      npm-package-arg: 13.0.1(patch_hash=60224f312822e7432d6a6532e12d2b052cf8d1f0c9cc3a5cf7b3d00446906070)
       promzard: 2.0.0
       read: 4.1.0
       semver: 7.7.3
@@ -31094,7 +31024,7 @@ snapshots:
       make-fetch-happen: 15.0.2
       minimatch: 3.0.5
       multimatch: 5.0.0
-      npm-package-arg: 13.0.1
+      npm-package-arg: 13.0.1(patch_hash=60224f312822e7432d6a6532e12d2b052cf8d1f0c9cc3a5cf7b3d00446906070)
       npm-packlist: 10.0.3
       npm-registry-fetch: 19.1.0
       nx: 22.2.3(@swc/core@1.11.24(@swc/helpers@0.5.15))
@@ -31153,7 +31083,7 @@ snapshots:
 
   libnpmaccess@10.0.3:
     dependencies:
-      npm-package-arg: 13.0.1
+      npm-package-arg: 13.0.1(patch_hash=60224f312822e7432d6a6532e12d2b052cf8d1f0c9cc3a5cf7b3d00446906070)
       npm-registry-fetch: 19.1.0
     transitivePeerDependencies:
       - supports-color
@@ -31168,7 +31098,7 @@ snapshots:
     dependencies:
       '@npmcli/package-json': 7.0.2
       ci-info: 4.0.0
-      npm-package-arg: 13.0.1
+      npm-package-arg: 13.0.1(patch_hash=60224f312822e7432d6a6532e12d2b052cf8d1f0c9cc3a5cf7b3d00446906070)
       npm-registry-fetch: 19.1.0
       proc-log: 5.0.0
       semver: 7.6.3
@@ -32991,7 +32921,7 @@ snapshots:
       semver: 7.6.3
       validate-npm-package-name: 6.0.2
 
-  npm-package-arg@13.0.1:
+  npm-package-arg@13.0.1(patch_hash=60224f312822e7432d6a6532e12d2b052cf8d1f0c9cc3a5cf7b3d00446906070):
     dependencies:
       hosted-git-info: 9.0.2
       proc-log: 5.0.0
@@ -33014,7 +32944,7 @@ snapshots:
     dependencies:
       npm-install-checks: 8.0.0
       npm-normalize-package-bin: 5.0.0
-      npm-package-arg: 13.0.1
+      npm-package-arg: 13.0.1(patch_hash=60224f312822e7432d6a6532e12d2b052cf8d1f0c9cc3a5cf7b3d00446906070)
       semver: 7.6.3
 
   npm-pick-manifest@9.1.0:
@@ -33032,7 +32962,7 @@ snapshots:
       minipass: 7.1.2
       minipass-fetch: 4.0.1
       minizlib: 3.1.0(patch_hash=587688821244aaee46680929cd869947377a284ac1b30c9ae8660a5ea7d2be67)
-      npm-package-arg: 13.0.1
+      npm-package-arg: 13.0.1(patch_hash=60224f312822e7432d6a6532e12d2b052cf8d1f0c9cc3a5cf7b3d00446906070)
       proc-log: 5.0.0
     transitivePeerDependencies:
       - supports-color
@@ -33524,7 +33454,7 @@ snapshots:
       cacache: 20.0.3
       fs-minipass: 3.0.3
       minipass: 7.1.2
-      npm-package-arg: 13.0.1
+      npm-package-arg: 13.0.1(patch_hash=60224f312822e7432d6a6532e12d2b052cf8d1f0c9cc3a5cf7b3d00446906070)
       npm-packlist: 10.0.3
       npm-pick-manifest: 10.0.0
       npm-registry-fetch: 19.1.0
@@ -33546,7 +33476,7 @@ snapshots:
       cacache: 20.0.3
       fs-minipass: 3.0.3
       minipass: 7.1.2
-      npm-package-arg: 13.0.1
+      npm-package-arg: 13.0.1(patch_hash=60224f312822e7432d6a6532e12d2b052cf8d1f0c9cc3a5cf7b3d00446906070)
       npm-packlist: 10.0.3
       npm-pick-manifest: 11.0.3
       npm-registry-fetch: 19.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,7 +59,7 @@ patchedDependencies:
     hash: 587688821244aaee46680929cd869947377a284ac1b30c9ae8660a5ea7d2be67
     path: patches/minizlib@3.1.0.patch
   npm-package-arg@13.0.1:
-    hash: 60224f312822e7432d6a6532e12d2b052cf8d1f0c9cc3a5cf7b3d00446906070
+    hash: 3b7c893ddbf69560f6bab04baa7d5bee64a7ae606ec8496c381833c710352013
     path: patches/npm-package-arg@13.0.1.patch
   postcss-scss:
     hash: 88893e632b3e099730dc0ffcc93cf3654b31c277da9e2796e822f6b5aeedc093
@@ -21036,7 +21036,7 @@ snapshots:
       make-fetch-happen: 15.0.2
       minimatch: 3.0.5
       multimatch: 5.0.0
-      npm-package-arg: 13.0.1(patch_hash=60224f312822e7432d6a6532e12d2b052cf8d1f0c9cc3a5cf7b3d00446906070)
+      npm-package-arg: 13.0.1(patch_hash=3b7c893ddbf69560f6bab04baa7d5bee64a7ae606ec8496c381833c710352013)
       npm-packlist: 10.0.3
       npm-registry-fetch: 19.1.0
       nx: 22.2.3(@swc/core@1.11.24(@swc/helpers@0.5.15))
@@ -21386,7 +21386,7 @@ snapshots:
       minimatch: 10.2.4
       nopt: 8.1.0
       npm-install-checks: 7.1.2
-      npm-package-arg: 13.0.1(patch_hash=60224f312822e7432d6a6532e12d2b052cf8d1f0c9cc3a5cf7b3d00446906070)
+      npm-package-arg: 13.0.1(patch_hash=3b7c893ddbf69560f6bab04baa7d5bee64a7ae606ec8496c381833c710352013)
       npm-pick-manifest: 11.0.3
       npm-registry-fetch: 19.1.0
       pacote: 21.0.4
@@ -29564,7 +29564,7 @@ snapshots:
   init-package-json@8.2.2:
     dependencies:
       '@npmcli/package-json': 7.0.2
-      npm-package-arg: 13.0.1(patch_hash=60224f312822e7432d6a6532e12d2b052cf8d1f0c9cc3a5cf7b3d00446906070)
+      npm-package-arg: 13.0.1(patch_hash=3b7c893ddbf69560f6bab04baa7d5bee64a7ae606ec8496c381833c710352013)
       promzard: 2.0.0
       read: 4.1.0
       semver: 7.7.3
@@ -31024,7 +31024,7 @@ snapshots:
       make-fetch-happen: 15.0.2
       minimatch: 3.0.5
       multimatch: 5.0.0
-      npm-package-arg: 13.0.1(patch_hash=60224f312822e7432d6a6532e12d2b052cf8d1f0c9cc3a5cf7b3d00446906070)
+      npm-package-arg: 13.0.1(patch_hash=3b7c893ddbf69560f6bab04baa7d5bee64a7ae606ec8496c381833c710352013)
       npm-packlist: 10.0.3
       npm-registry-fetch: 19.1.0
       nx: 22.2.3(@swc/core@1.11.24(@swc/helpers@0.5.15))
@@ -31083,7 +31083,7 @@ snapshots:
 
   libnpmaccess@10.0.3:
     dependencies:
-      npm-package-arg: 13.0.1(patch_hash=60224f312822e7432d6a6532e12d2b052cf8d1f0c9cc3a5cf7b3d00446906070)
+      npm-package-arg: 13.0.1(patch_hash=3b7c893ddbf69560f6bab04baa7d5bee64a7ae606ec8496c381833c710352013)
       npm-registry-fetch: 19.1.0
     transitivePeerDependencies:
       - supports-color
@@ -31098,7 +31098,7 @@ snapshots:
     dependencies:
       '@npmcli/package-json': 7.0.2
       ci-info: 4.0.0
-      npm-package-arg: 13.0.1(patch_hash=60224f312822e7432d6a6532e12d2b052cf8d1f0c9cc3a5cf7b3d00446906070)
+      npm-package-arg: 13.0.1(patch_hash=3b7c893ddbf69560f6bab04baa7d5bee64a7ae606ec8496c381833c710352013)
       npm-registry-fetch: 19.1.0
       proc-log: 5.0.0
       semver: 7.6.3
@@ -32921,7 +32921,7 @@ snapshots:
       semver: 7.6.3
       validate-npm-package-name: 6.0.2
 
-  npm-package-arg@13.0.1(patch_hash=60224f312822e7432d6a6532e12d2b052cf8d1f0c9cc3a5cf7b3d00446906070):
+  npm-package-arg@13.0.1(patch_hash=3b7c893ddbf69560f6bab04baa7d5bee64a7ae606ec8496c381833c710352013):
     dependencies:
       hosted-git-info: 9.0.2
       proc-log: 5.0.0
@@ -32944,7 +32944,7 @@ snapshots:
     dependencies:
       npm-install-checks: 8.0.0
       npm-normalize-package-bin: 5.0.0
-      npm-package-arg: 13.0.1(patch_hash=60224f312822e7432d6a6532e12d2b052cf8d1f0c9cc3a5cf7b3d00446906070)
+      npm-package-arg: 13.0.1(patch_hash=3b7c893ddbf69560f6bab04baa7d5bee64a7ae606ec8496c381833c710352013)
       semver: 7.6.3
 
   npm-pick-manifest@9.1.0:
@@ -32962,7 +32962,7 @@ snapshots:
       minipass: 7.1.2
       minipass-fetch: 4.0.1
       minizlib: 3.1.0(patch_hash=587688821244aaee46680929cd869947377a284ac1b30c9ae8660a5ea7d2be67)
-      npm-package-arg: 13.0.1(patch_hash=60224f312822e7432d6a6532e12d2b052cf8d1f0c9cc3a5cf7b3d00446906070)
+      npm-package-arg: 13.0.1(patch_hash=3b7c893ddbf69560f6bab04baa7d5bee64a7ae606ec8496c381833c710352013)
       proc-log: 5.0.0
     transitivePeerDependencies:
       - supports-color
@@ -33454,7 +33454,7 @@ snapshots:
       cacache: 20.0.3
       fs-minipass: 3.0.3
       minipass: 7.1.2
-      npm-package-arg: 13.0.1(patch_hash=60224f312822e7432d6a6532e12d2b052cf8d1f0c9cc3a5cf7b3d00446906070)
+      npm-package-arg: 13.0.1(patch_hash=3b7c893ddbf69560f6bab04baa7d5bee64a7ae606ec8496c381833c710352013)
       npm-packlist: 10.0.3
       npm-pick-manifest: 10.0.0
       npm-registry-fetch: 19.1.0
@@ -33476,7 +33476,7 @@ snapshots:
       cacache: 20.0.3
       fs-minipass: 3.0.3
       minipass: 7.1.2
-      npm-package-arg: 13.0.1(patch_hash=60224f312822e7432d6a6532e12d2b052cf8d1f0c9cc3a5cf7b3d00446906070)
+      npm-package-arg: 13.0.1(patch_hash=3b7c893ddbf69560f6bab04baa7d5bee64a7ae606ec8496c381833c710352013)
       npm-packlist: 10.0.3
       npm-pick-manifest: 11.0.3
       npm-registry-fetch: 19.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,7 +59,7 @@ patchedDependencies:
     hash: 587688821244aaee46680929cd869947377a284ac1b30c9ae8660a5ea7d2be67
     path: patches/minizlib@3.1.0.patch
   npm-package-arg@13.0.1:
-    hash: 3b7c893ddbf69560f6bab04baa7d5bee64a7ae606ec8496c381833c710352013
+    hash: b1e14ac6bd29b6f7e45fa617ac5285f1de3f105aade333525840086703f5cef9
     path: patches/npm-package-arg@13.0.1.patch
   postcss-scss:
     hash: 88893e632b3e099730dc0ffcc93cf3654b31c277da9e2796e822f6b5aeedc093
@@ -21036,7 +21036,7 @@ snapshots:
       make-fetch-happen: 15.0.2
       minimatch: 3.0.5
       multimatch: 5.0.0
-      npm-package-arg: 13.0.1(patch_hash=3b7c893ddbf69560f6bab04baa7d5bee64a7ae606ec8496c381833c710352013)
+      npm-package-arg: 13.0.1(patch_hash=b1e14ac6bd29b6f7e45fa617ac5285f1de3f105aade333525840086703f5cef9)
       npm-packlist: 10.0.3
       npm-registry-fetch: 19.1.0
       nx: 22.2.3(@swc/core@1.11.24(@swc/helpers@0.5.15))
@@ -21386,7 +21386,7 @@ snapshots:
       minimatch: 10.2.4
       nopt: 8.1.0
       npm-install-checks: 7.1.2
-      npm-package-arg: 13.0.1(patch_hash=3b7c893ddbf69560f6bab04baa7d5bee64a7ae606ec8496c381833c710352013)
+      npm-package-arg: 13.0.1(patch_hash=b1e14ac6bd29b6f7e45fa617ac5285f1de3f105aade333525840086703f5cef9)
       npm-pick-manifest: 11.0.3
       npm-registry-fetch: 19.1.0
       pacote: 21.0.4
@@ -29564,7 +29564,7 @@ snapshots:
   init-package-json@8.2.2:
     dependencies:
       '@npmcli/package-json': 7.0.2
-      npm-package-arg: 13.0.1(patch_hash=3b7c893ddbf69560f6bab04baa7d5bee64a7ae606ec8496c381833c710352013)
+      npm-package-arg: 13.0.1(patch_hash=b1e14ac6bd29b6f7e45fa617ac5285f1de3f105aade333525840086703f5cef9)
       promzard: 2.0.0
       read: 4.1.0
       semver: 7.7.3
@@ -31024,7 +31024,7 @@ snapshots:
       make-fetch-happen: 15.0.2
       minimatch: 3.0.5
       multimatch: 5.0.0
-      npm-package-arg: 13.0.1(patch_hash=3b7c893ddbf69560f6bab04baa7d5bee64a7ae606ec8496c381833c710352013)
+      npm-package-arg: 13.0.1(patch_hash=b1e14ac6bd29b6f7e45fa617ac5285f1de3f105aade333525840086703f5cef9)
       npm-packlist: 10.0.3
       npm-registry-fetch: 19.1.0
       nx: 22.2.3(@swc/core@1.11.24(@swc/helpers@0.5.15))
@@ -31083,7 +31083,7 @@ snapshots:
 
   libnpmaccess@10.0.3:
     dependencies:
-      npm-package-arg: 13.0.1(patch_hash=3b7c893ddbf69560f6bab04baa7d5bee64a7ae606ec8496c381833c710352013)
+      npm-package-arg: 13.0.1(patch_hash=b1e14ac6bd29b6f7e45fa617ac5285f1de3f105aade333525840086703f5cef9)
       npm-registry-fetch: 19.1.0
     transitivePeerDependencies:
       - supports-color
@@ -31098,7 +31098,7 @@ snapshots:
     dependencies:
       '@npmcli/package-json': 7.0.2
       ci-info: 4.0.0
-      npm-package-arg: 13.0.1(patch_hash=3b7c893ddbf69560f6bab04baa7d5bee64a7ae606ec8496c381833c710352013)
+      npm-package-arg: 13.0.1(patch_hash=b1e14ac6bd29b6f7e45fa617ac5285f1de3f105aade333525840086703f5cef9)
       npm-registry-fetch: 19.1.0
       proc-log: 5.0.0
       semver: 7.6.3
@@ -32921,7 +32921,7 @@ snapshots:
       semver: 7.6.3
       validate-npm-package-name: 6.0.2
 
-  npm-package-arg@13.0.1(patch_hash=3b7c893ddbf69560f6bab04baa7d5bee64a7ae606ec8496c381833c710352013):
+  npm-package-arg@13.0.1(patch_hash=b1e14ac6bd29b6f7e45fa617ac5285f1de3f105aade333525840086703f5cef9):
     dependencies:
       hosted-git-info: 9.0.2
       proc-log: 5.0.0
@@ -32944,7 +32944,7 @@ snapshots:
     dependencies:
       npm-install-checks: 8.0.0
       npm-normalize-package-bin: 5.0.0
-      npm-package-arg: 13.0.1(patch_hash=3b7c893ddbf69560f6bab04baa7d5bee64a7ae606ec8496c381833c710352013)
+      npm-package-arg: 13.0.1(patch_hash=b1e14ac6bd29b6f7e45fa617ac5285f1de3f105aade333525840086703f5cef9)
       semver: 7.6.3
 
   npm-pick-manifest@9.1.0:
@@ -32962,7 +32962,7 @@ snapshots:
       minipass: 7.1.2
       minipass-fetch: 4.0.1
       minizlib: 3.1.0(patch_hash=587688821244aaee46680929cd869947377a284ac1b30c9ae8660a5ea7d2be67)
-      npm-package-arg: 13.0.1(patch_hash=3b7c893ddbf69560f6bab04baa7d5bee64a7ae606ec8496c381833c710352013)
+      npm-package-arg: 13.0.1(patch_hash=b1e14ac6bd29b6f7e45fa617ac5285f1de3f105aade333525840086703f5cef9)
       proc-log: 5.0.0
     transitivePeerDependencies:
       - supports-color
@@ -33454,7 +33454,7 @@ snapshots:
       cacache: 20.0.3
       fs-minipass: 3.0.3
       minipass: 7.1.2
-      npm-package-arg: 13.0.1(patch_hash=3b7c893ddbf69560f6bab04baa7d5bee64a7ae606ec8496c381833c710352013)
+      npm-package-arg: 13.0.1(patch_hash=b1e14ac6bd29b6f7e45fa617ac5285f1de3f105aade333525840086703f5cef9)
       npm-packlist: 10.0.3
       npm-pick-manifest: 10.0.0
       npm-registry-fetch: 19.1.0
@@ -33476,7 +33476,7 @@ snapshots:
       cacache: 20.0.3
       fs-minipass: 3.0.3
       minipass: 7.1.2
-      npm-package-arg: 13.0.1(patch_hash=3b7c893ddbf69560f6bab04baa7d5bee64a7ae606ec8496c381833c710352013)
+      npm-package-arg: 13.0.1(patch_hash=b1e14ac6bd29b6f7e45fa617ac5285f1de3f105aade333525840086703f5cef9)
       npm-packlist: 10.0.3
       npm-pick-manifest: 11.0.3
       npm-registry-fetch: 19.1.0


### PR DESCRIPTION
We recently adopted pnpm catalogs to improve our turbo-repo caching (in #93071)

This however breaks lerna which we use for releases.  this is because it relies on `npm-package-arg` which parses versions directly out of `package.json` files.

This patches npm-package-arg to recover the dependency versions from the `pnpm-lock.yml` file. 