### PR TITLE
[ci]: fix permissions on comment workflow

### DIFF
--- a/.github/workflows/pr_ci_comment.yml
+++ b/.github/workflows/pr_ci_comment.yml
@@ -8,8 +8,7 @@ on:
 permissions:
   actions: read
   contents: read
-  issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   comment:


### PR DESCRIPTION
Needs write to comment on PR. x-ref: https://github.com/vercel/next.js/actions/runs/24914306362/job/72962981110