### PR TITLE
Turbopack: allow global CSS in transformed custom app

### DIFF
--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -776,6 +776,7 @@ async fn validate_pages_css_imports_individual(
 ) -> Result<()> {
     let graph = graph.await?;
     let entry = entry.to_resolved().await?;
+    let app_path = app_module.ident().path().owned().await?;
 
     let entries = if !is_single_page {
         if !graph.graphs.first().unwrap().has_entry_module(entry) {
@@ -839,19 +840,28 @@ async fn validate_pages_css_imports_individual(
 
     candidates
         .into_iter()
-        .map(async |issue| {
-            let ident = issue.module.ident().await?;
-            let path = &ident.path;
-            // We allow imports of global CSS files which are inside of `node_modules`.
-            // We also allow data URL CSS imports (e.g. `data:text/css,...`) since they
-            // are mostly tooling-generated and co-located with the importing components
-            Ok(
-                if !path.is_in_node_modules() && !path.file_name().starts_with("data:") {
-                    Some(issue)
-                } else {
-                    None
-                },
-            )
+        .map(|issue| {
+            let app_path = app_path.clone();
+            async move {
+                let parent_ident = issue.parent_module.ident().await?;
+                // The app file can appear as a distinct module instance after transforms.
+                if &parent_ident.path == &app_path {
+                    return Ok(None);
+                }
+
+                let ident = issue.module.ident().await?;
+                let path = &ident.path;
+                // We allow imports of global CSS files which are inside of `node_modules`.
+                // We also allow data URL CSS imports (e.g. `data:text/css,...`) since they
+                // are mostly tooling-generated and co-located with the importing components
+                Ok(
+                    if !path.is_in_node_modules() && !path.file_name().starts_with("data:") {
+                        Some(issue)
+                    } else {
+                        None
+                    },
+                )
+            }
         })
         .try_flat_join()
         .await?

--- a/test/integration/css-fixtures/next-font-global-css/pages/_app.js
+++ b/test/integration/css-fixtures/next-font-global-css/pages/_app.js
@@ -1,0 +1,12 @@
+import '../styles/global.css'
+import { Abel } from 'next/font/google'
+
+const abel = Abel({ weight: '400', display: 'optional', preload: false })
+
+export default function App({ Component, pageProps }) {
+  return (
+    <main className={abel.className}>
+      <Component {...pageProps} />
+    </main>
+  )
+}

--- a/test/integration/css-fixtures/next-font-global-css/pages/index.js
+++ b/test/integration/css-fixtures/next-font-global-css/pages/index.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/integration/css-fixtures/next-font-global-css/styles/global.css
+++ b/test/integration/css-fixtures/next-font-global-css/styles/global.css
@@ -1,0 +1,4 @@
+html,
+body {
+  margin: 0;
+}

--- a/test/integration/css/test/valid-invalid-css.test.ts
+++ b/test/integration/css/test/valid-invalid-css.test.ts
@@ -12,6 +12,9 @@ import cheerio from 'cheerio'
 import { join } from 'path'
 
 const fixturesDir = join(__dirname, '../..', 'css-fixtures')
+const mockedGoogleFontResponses = require.resolve(
+  '../../../e2e/next-font/google-font-mocked-responses.js'
+)
 
 // Importing module CSS in _document is allowed in Turbopack
 ;(process.env.IS_TURBOPACK_TEST ? describe.skip : describe)(
@@ -114,6 +117,32 @@ describe('Valid Global CSS from npm', () => {
           .trim()
 
         expect(cssContent).toMatchInlineSnapshot(`".red-text{color:"red"}"`)
+      })
+    }
+  )
+})
+
+describe('Valid Global CSS with next/font in Custom App', () => {
+  ;(process.env.TURBOPACK_DEV ? describe.skip : describe)(
+    'production mode',
+    () => {
+      const appDir = join(fixturesDir, 'next-font-global-css')
+
+      beforeAll(async () => {
+        await remove(join(appDir, '.next'))
+      })
+
+      it('should build successfully', async () => {
+        const { code, stderr } = await nextBuild(appDir, [], {
+          stderr: true,
+          env: {
+            NEXT_DEPLOYMENT_ID: 'test-dpl-id-1234',
+            NEXT_FONT_GOOGLE_MOCKED_RESPONSES: mockedGoogleFontResponses,
+            __NEXT_SUPPORTS_IMMUTABLE_ASSETS: '1',
+          },
+        })
+        expect(code).toBe(0)
+        expect(stderr).not.toContain('Global CSS cannot be imported')
       })
     }
   )


### PR DESCRIPTION
Fixes #93162

`next/font` can cause the Pages Router custom app to appear as a transformed module instance in Turbopack's module graph. The global CSS validator only compared module identity, so it rejected `pages/_app` even though the import came from the custom app file.

This also compares the importer path with the known custom app path before emitting the global CSS error. The existing identity check still handles the normal path, and the path check covers transformed `_app` modules.

Added a Turbopack production regression fixture that imports both global CSS and `next/font/google` from `pages/_app`.

Tests:
- `cargo fmt -- --check`
- `pnpm prettier --check` on changed JS/TS/CSS files
- `pnpm --filter=@next/swc build-native`
- `pnpm --filter=next... build`
- `pnpm test-start-turbo test/integration/css/test/valid-invalid-css.test.ts -t "Valid Global CSS with next/font"`
- `pnpm test-start-turbo test/integration/css/test/valid-invalid-css.test.ts -t "Invalid Global CSS with Custom App"`

<!-- NEXT_JS_LLM_PR -->
