### PR TITLE
[ci] Create test summary comment if job immediately passes

### DIFF
--- a/scripts/pr-ci-comment.mjs
+++ b/scripts/pr-ci-comment.mjs
@@ -130,13 +130,7 @@ class GitHubClient {
     )
   }
 
-  async upsertIssueComment(
-    issueNumber,
-    marker,
-    body,
-    fallbackHeadings = [],
-    { createIfMissing = true } = {}
-  ) {
+  async upsertIssueComment(issueNumber, marker, body, fallbackHeadings = []) {
     body = fitComment(body)
 
     const comments = await this.listIssueComments(issueNumber)
@@ -152,19 +146,10 @@ class GitHubClient {
     })
 
     if (this.dryRun) {
-      if (!existing && !createIfMissing) {
-        console.log(`[dry-run] No existing comment found for #${issueNumber}`)
-        return
-      }
       console.log(
         `[dry-run] ${existing ? 'Would update' : 'Would create'} comment for #${issueNumber}`
       )
       console.log(body)
-      return
-    }
-
-    if (!existing && !createIfMissing) {
-      console.log(`No existing comment found for #${issueNumber}, skipping`)
       return
     }
 
@@ -479,15 +464,10 @@ async function handleBuildAndTestWorkflow({
       '',
     ].join('\n')
 
-    await github.upsertIssueComment(
-      pr.number,
-      TEST_COMMENT_MARKER,
-      body,
-      ['## Failing test suites', '## Failing CI jobs'],
-      {
-        createIfMissing: false,
-      }
-    )
+    await github.upsertIssueComment(pr.number, TEST_COMMENT_MARKER, body, [
+      '## Failing test suites',
+      '## Failing CI jobs',
+    ])
     return
   }
 


### PR DESCRIPTION
Not sure if this was intentional or just very pessimistic about our test flakiness 😄 E.g. https://github.com/vercel/next.js/pull/93235 passed immediately and no comment was posted: https://github.com/vercel/next.js/actions/runs/24928412554/job/73002141215#step:4:7

Two reasons to always post the comment:
1. confusing if the comment is absent when it would appear when we go from failing -> passing
2. Means the comment may be pushed further down in the conversation if your initial push is passing, a review is posted, new code is pushed with a failing build. Now the comment is further down when it's usually way up.