### PR TITLE
[ci] Handle namespaced packages in preview builds

### DIFF
--- a/scripts/upload-preview-tarballs.js
+++ b/scripts/upload-preview-tarballs.js
@@ -3,6 +3,50 @@ const { put } = require('@vercel/blob')
 const fs = require('node:fs/promises')
 const path = require('node:path')
 
+/**
+ * Yields one entry per package tarball under `tarballDirectory`. Scoped
+ * packages are laid out one level deeper (e.g. `@next/env/<name>.tgz`), so the
+ * walk descends into any directory whose name starts with `@`.
+ *
+ * @param {string} tarballDirectory
+ * @returns {AsyncGenerator<{ packageName: string, tarballPath: string }>}
+ */
+async function* findTarballs(tarballDirectory) {
+  const entries = await fs.readdir(tarballDirectory, { withFileTypes: true })
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue
+    const entryPath = path.join(tarballDirectory, entry.name)
+    if (entry.name.startsWith('@')) {
+      const scopeEntries = await fs.readdir(entryPath, { withFileTypes: true })
+      for (const scopeEntry of scopeEntries) {
+        if (!scopeEntry.isDirectory()) continue
+        const tarballPath = await findTarballInDir(
+          path.join(entryPath, scopeEntry.name)
+        )
+        if (tarballPath === null) continue
+        yield {
+          packageName: `${entry.name}/${scopeEntry.name}`,
+          tarballPath,
+        }
+      }
+    } else {
+      const tarballPath = await findTarballInDir(entryPath)
+      if (tarballPath === null) continue
+      yield { packageName: entry.name, tarballPath }
+    }
+  }
+}
+
+/**
+ * @param {string} dir
+ * @returns {Promise<string | null>}
+ */
+async function findTarballInDir(dir) {
+  const files = await fs.readdir(dir)
+  const tgzFile = files.find((f) => f.endsWith('.tgz'))
+  return tgzFile ? path.join(dir, tgzFile) : null
+}
+
 async function main() {
   const [githubHeadSha, tarballDirectory] = process.argv.slice(2)
   if (!githubHeadSha || !tarballDirectory) {
@@ -15,19 +59,12 @@ async function main() {
     throw new Error('BLOB_READ_WRITE_TOKEN environment variable is required')
   }
 
-  const packageDirs = await fs.readdir(tarballDirectory)
-  for (const packageName of packageDirs) {
-    const dir = path.join(tarballDirectory, packageName)
-    const stat = await fs.stat(dir)
-    if (!stat.isDirectory()) continue
-
-    const files = await fs.readdir(dir)
-    const tgzFile = files.find((f) => f.endsWith('.tgz'))
-    if (!tgzFile) continue
-
+  for await (const { packageName, tarballPath } of findTarballs(
+    tarballDirectory
+  )) {
     const blobPathname = `next/commits/${githubHeadSha}/${packageName}.tgz`
 
-    const fileBuffer = await fs.readFile(path.join(dir, tgzFile))
+    const fileBuffer = await fs.readFile(tarballPath)
     const { url } = await put(blobPathname, fileBuffer, {
       access: 'public',
       addRandomSuffix: false,


### PR DESCRIPTION
We're currently only uploading preview builds of packages without a namespace (e.g. https://github.com/vercel/next.js/actions/runs/24929710642/job/73005395963). Namespaced packages look like nested directories so we need to handle that.