### PR TITLE
[ci]: app-based release workflow

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -10,6 +10,11 @@ on:
   pull_request:
     types: [opened, synchronize]
   workflow_dispatch:
+    inputs:
+      dryRunReleasePublish:
+        description: validate release publish decisions without publishing packages or patching GitHub releases
+        default: false
+        type: boolean
 
 concurrency:
   # Limit concurrent runs to 1 per PR,
@@ -496,10 +501,10 @@ jobs:
           path: ${{ runner.temp }}/preview-tarballs/*
 
   publishRelease:
-    if: ${{ needs.deploy-target.outputs.value == 'production' }}
+    if: ${{ needs.deploy-target.outputs.value == 'production' || (github.event_name == 'workflow_dispatch' && github.event.inputs.dryRunReleasePublish == 'true') }}
     name: Potentially publish release
     runs-on: ubuntu-latest
-    environment: ${{ needs.deploy-target.outputs.release_environment }}
+    environment: ${{ needs.deploy-target.outputs.release_environment || 'release-canary' }}
     needs:
       - deploy-target
       - build
@@ -548,10 +553,27 @@ jobs:
           merge-multiple: true
           path: crates/wasm
 
+      - name: Create GitHub App token
+        id: release-app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.RELEASE_GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: next.js
+          permission-contents: write
+
       - run: ./scripts/publish-native.js
-      - run: ./scripts/publish-release.js
+        if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dryRunReleasePublish == 'true') }}
+      - run: |
+          args=()
+          if [[ "${RELEASE_DRY_RUN}" == "true" ]]; then
+            args+=(--dry-run)
+          fi
+          ./scripts/publish-release.js "${args[@]}"
         env:
-          RELEASE_BOT_GITHUB_TOKEN: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
+          RELEASE_GITHUB_TOKEN: ${{ steps.release-app-token.outputs.token }}
+          RELEASE_DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dryRunReleasePublish == 'true' }}
 
   buildPassed:
     needs: ['deploy-target', 'build', 'build-wasm', 'build-native']

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -10,11 +10,6 @@ on:
   pull_request:
     types: [opened, synchronize]
   workflow_dispatch:
-    inputs:
-      dryRunReleasePublish:
-        description: validate release publish decisions without publishing packages or patching GitHub releases
-        default: false
-        type: boolean
 
 concurrency:
   # Limit concurrent runs to 1 per PR,
@@ -501,10 +496,10 @@ jobs:
           path: ${{ runner.temp }}/preview-tarballs/*
 
   publishRelease:
-    if: ${{ needs.deploy-target.outputs.value == 'production' || (github.event_name == 'workflow_dispatch' && github.event.inputs.dryRunReleasePublish == 'true') }}
+    if: ${{ needs.deploy-target.outputs.value == 'production' }}
     name: Potentially publish release
     runs-on: ubuntu-latest
-    environment: ${{ needs.deploy-target.outputs.release_environment || 'release-canary' }}
+    environment: ${{ needs.deploy-target.outputs.release_environment }}
     needs:
       - deploy-target
       - build
@@ -564,16 +559,9 @@ jobs:
           permission-contents: write
 
       - run: ./scripts/publish-native.js
-        if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dryRunReleasePublish == 'true') }}
-      - run: |
-          args=()
-          if [[ "${RELEASE_DRY_RUN}" == "true" ]]; then
-            args+=(--dry-run)
-          fi
-          ./scripts/publish-release.js "${args[@]}"
+      - run: ./scripts/publish-release.js
         env:
           RELEASE_GITHUB_TOKEN: ${{ steps.release-app-token.outputs.token }}
-          RELEASE_DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dryRunReleasePublish == 'true' }}
 
   buildPassed:
     needs: ['deploy-target', 'build', 'build-wasm', 'build-native']

--- a/.github/workflows/create_release_branch.yml
+++ b/.github/workflows/create_release_branch.yml
@@ -43,7 +43,6 @@ jobs:
           private-key: ${{ secrets.RELEASE_GITHUB_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: next.js
-          permission-administration: write
           permission-contents: write
           permission-environments: write
           permission-workflows: write

--- a/.github/workflows/create_release_branch.yml
+++ b/.github/workflows/create_release_branch.yml
@@ -11,10 +11,6 @@ on:
         type: string
         required: true
 
-    secrets:
-      RELEASE_BOT_GITHUB_TOKEN:
-        required: true
-
 name: Create Release Branch
 
 env:
@@ -39,13 +35,34 @@ jobs:
           node-version: 20
           check-latest: true
 
+      - name: Create GitHub App token
+        id: release-app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.RELEASE_GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: next.js
+          permission-administration: write
+          permission-contents: write
+          permission-environments: write
+          permission-workflows: write
+
+      - name: Get GitHub App user ID
+        id: release-app-user
+        run: |
+          user_id="$(gh api "/users/${{ steps.release-app-token.outputs.app-slug }}[bot]" --jq .id)"
+          echo "user-id=$user_id" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.release-app-token.outputs.token }}
+
       - name: Clone Next.js repository
         run: git clone https://github.com/vercel/next.js.git --depth=25 --single-branch --branch ${GITHUB_REF_NAME:-canary} .
 
       - name: Check token
         run: gh auth status
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.release-app-token.outputs.token }}
 
       # https://github.com/actions/virtual-environments/issues/1187
       - name: tune linux network
@@ -72,6 +89,8 @@ jobs:
 
       - run: node ./scripts/create-release-branch.js --branch-name "${INPUT_BRANCHNAME}" --tag-name "${INPUT_TAGNAME}"
         env:
-          RELEASE_BOT_GITHUB_TOKEN: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
+          RELEASE_GITHUB_TOKEN: ${{ steps.release-app-token.outputs.token }}
+          RELEASE_GITHUB_APP_SLUG: ${{ steps.release-app-token.outputs.app-slug }}
+          RELEASE_GITHUB_APP_USER_ID: ${{ steps.release-app-user.outputs.user-id }}
           INPUT_BRANCHNAME: ${{ github.event.inputs.branchName }}
           INPUT_TAGNAME: ${{ github.event.inputs.tagName }}

--- a/.github/workflows/sync_backport_canary_release.yml
+++ b/.github/workflows/sync_backport_canary_release.yml
@@ -84,11 +84,23 @@ jobs:
         if: steps.precheck.outputs.should_evaluate == 'true'
         run: pnpm install --frozen-lockfile --ignore-scripts
 
+      - name: Create GitHub App token
+        id: release-app-token
+        if: steps.precheck.outputs.should_evaluate == 'true'
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.RELEASE_GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: next.js
+          permission-actions: read
+          permission-contents: read
+
       - name: Evaluate backport release
         id: evaluate
         if: steps.precheck.outputs.should_evaluate == 'true'
         env:
-          RELEASE_BOT_GITHUB_TOKEN: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
+          RELEASE_GITHUB_TOKEN: ${{ steps.release-app-token.outputs.token }}
           WORKFLOW_RUN_ID: ${{ github.event_name == 'workflow_dispatch' && inputs.workflowRunId || github.event.workflow_run.id }}
           HEAD_SHA: ${{ github.event_name == 'workflow_dispatch' && inputs.headSha || github.event.workflow_run.head_sha }}
           HEAD_COMMIT_MESSAGE: ${{ github.event_name == 'workflow_dispatch' && '' || github.event.workflow_run.head_commit.message }}
@@ -108,9 +120,19 @@ jobs:
     if: ${{ needs.evaluate.outputs.should_dispatch == 'true' && ((github.event_name == 'workflow_dispatch' && inputs.dispatch) || (github.event_name == 'workflow_run' && vars.ENABLE_BACKPORT_CANARY_SYNC == 'true')) }}
     runs-on: ubuntu-latest
     steps:
+      - name: Create GitHub App token
+        id: release-app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.RELEASE_GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: next.js
+          permission-actions: write
+
       - uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
+          github-token: ${{ steps.release-app-token.outputs.token }}
           script: |
             await github.request(
               "POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches",

--- a/.github/workflows/trigger_release.yml
+++ b/.github/workflows/trigger_release.yml
@@ -1,4 +1,13 @@
 on:
+  push:
+    branches:
+      - 'release-app-dry-run/**'
+      - 'release-app-dry-run-with-writes/**'
+    paths:
+      - '.github/workflows/trigger_release.yml'
+      - 'scripts/start-release.js'
+      - 'scripts/release-github-auth.js'
+
   schedule:
     # run every day at 23:15
     - cron: '15 23 * * *'
@@ -28,6 +37,16 @@ on:
         default: false
         type: boolean
 
+      dryRun:
+        description: validate release auth and local versioning without pushing commits, tags, or releases
+        default: false
+        type: boolean
+
+      verifyGitWrites:
+        description: create and delete disposable refs during a dry run
+        default: false
+        type: boolean
+
 name: Trigger Release
 
 env:
@@ -52,6 +71,24 @@ jobs:
           node-version: 20
           check-latest: true
 
+      - name: Create GitHub App token
+        id: release-app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.RELEASE_GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: next.js
+          permission-contents: write
+
+      - name: Get GitHub App user ID
+        id: release-app-user
+        run: |
+          user_id="$(gh api "/users/${{ steps.release-app-token.outputs.app-slug }}[bot]" --jq .id)"
+          echo "user-id=$user_id" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.release-app-token.outputs.token }}
+
       - name: Clone Next.js repository
         run: git clone https://github.com/vercel/next.js.git --depth=25 --single-branch --branch ${GITHUB_REF_NAME:-canary} .
 
@@ -61,7 +98,7 @@ jobs:
         # Ignoring failures for now to check if a failure truly implies a failed publish.
         continue-on-error: true
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.release-app-token.outputs.token }}
 
       - name: Get commit of the latest tag
         run: echo "LATEST_TAG_COMMIT=$(git rev-list -n 1 $(git describe --tags --abbrev=0))" >> $GITHUB_ENV
@@ -100,8 +137,20 @@ jobs:
 
       - run: pnpm install
 
-      - run: node ./scripts/start-release.js --release-type "${INPUT_RELEASETYPE}" --semver-type "${INPUT_SEMVERTYPE}"
+      - run: |
+          args=(--release-type "${INPUT_RELEASETYPE}" --semver-type "${INPUT_SEMVERTYPE}")
+          if [[ "${RELEASE_DRY_RUN}" == "true" ]]; then
+            args+=(--dry-run)
+          fi
+          if [[ "${VERIFY_GIT_WRITES}" == "true" ]]; then
+            args+=(--verify-git-writes)
+          fi
+          node ./scripts/start-release.js "${args[@]}"
         env:
-          RELEASE_BOT_GITHUB_TOKEN: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
+          RELEASE_GITHUB_TOKEN: ${{ steps.release-app-token.outputs.token }}
+          RELEASE_GITHUB_APP_SLUG: ${{ steps.release-app-token.outputs.app-slug }}
+          RELEASE_GITHUB_APP_USER_ID: ${{ steps.release-app-user.outputs.user-id }}
+          RELEASE_DRY_RUN: ${{ github.event_name == 'push' || github.event.inputs.dryRun == 'true' }}
+          VERIFY_GIT_WRITES: ${{ (github.event_name == 'push' && startsWith(github.ref_name, 'release-app-dry-run-with-writes/')) || (github.event_name == 'workflow_dispatch' && github.event.inputs.verifyGitWrites == 'true') }}
           INPUT_RELEASETYPE: ${{ github.event.inputs.releaseType || 'canary' }}
           INPUT_SEMVERTYPE: ${{ github.event.inputs.semverType }}

--- a/.github/workflows/trigger_release.yml
+++ b/.github/workflows/trigger_release.yml
@@ -1,13 +1,4 @@
 on:
-  push:
-    branches:
-      - 'release-app-dry-run/**'
-      - 'release-app-dry-run-with-writes/**'
-    paths:
-      - '.github/workflows/trigger_release.yml'
-      - 'scripts/start-release.js'
-      - 'scripts/release-github-auth.js'
-
   schedule:
     # run every day at 23:15
     - cron: '15 23 * * *'
@@ -34,16 +25,6 @@ on:
 
       force:
         description: create a new release even if there are no new commits
-        default: false
-        type: boolean
-
-      dryRun:
-        description: validate release auth and local versioning without pushing commits, tags, or releases
-        default: false
-        type: boolean
-
-      verifyGitWrites:
-        description: create and delete disposable refs during a dry run
         default: false
         type: boolean
 
@@ -137,20 +118,10 @@ jobs:
 
       - run: pnpm install
 
-      - run: |
-          args=(--release-type "${INPUT_RELEASETYPE}" --semver-type "${INPUT_SEMVERTYPE}")
-          if [[ "${RELEASE_DRY_RUN}" == "true" ]]; then
-            args+=(--dry-run)
-          fi
-          if [[ "${VERIFY_GIT_WRITES}" == "true" ]]; then
-            args+=(--verify-git-writes)
-          fi
-          node ./scripts/start-release.js "${args[@]}"
+      - run: node ./scripts/start-release.js --release-type "${INPUT_RELEASETYPE}" --semver-type "${INPUT_SEMVERTYPE}"
         env:
           RELEASE_GITHUB_TOKEN: ${{ steps.release-app-token.outputs.token }}
           RELEASE_GITHUB_APP_SLUG: ${{ steps.release-app-token.outputs.app-slug }}
           RELEASE_GITHUB_APP_USER_ID: ${{ steps.release-app-user.outputs.user-id }}
-          RELEASE_DRY_RUN: ${{ github.event_name == 'push' || github.event.inputs.dryRun == 'true' }}
-          VERIFY_GIT_WRITES: ${{ (github.event_name == 'push' && startsWith(github.ref_name, 'release-app-dry-run-with-writes/')) || (github.event_name == 'workflow_dispatch' && github.event.inputs.verifyGitWrites == 'true') }}
           INPUT_RELEASETYPE: ${{ github.event.inputs.releaseType || 'canary' }}
           INPUT_SEMVERTYPE: ${{ github.event.inputs.semverType }}

--- a/.github/workflows/trigger_release.yml
+++ b/.github/workflows/trigger_release.yml
@@ -82,7 +82,10 @@ jobs:
           GH_TOKEN: ${{ steps.release-app-token.outputs.token }}
 
       - name: Get commit of the latest tag
-        run: echo "LATEST_TAG_COMMIT=$(git rev-list -n 1 $(git describe --tags --abbrev=0))" >> $GITHUB_ENV
+        run: |
+          git fetch --tags --force --deepen=1000 origin
+          latest_tag="$(git describe --tags --abbrev=0)"
+          echo "LATEST_TAG_COMMIT=$(git rev-list -n 1 "$latest_tag")" >> $GITHUB_ENV
 
       - name: Get latest commit
         run: echo "LATEST_COMMIT=$(git rev-parse HEAD)" >> $GITHUB_ENV

--- a/scripts/check-backport-canary-release.js
+++ b/scripts/check-backport-canary-release.js
@@ -4,6 +4,10 @@
 const fs = require('fs/promises')
 const path = require('path')
 const semver = require('semver')
+const {
+  getGitHubToken,
+  getGitHubTokenMissingMessage,
+} = require('./release-github-auth')
 
 const PUBLISH_RELEASE_JOB_NAME = 'Potentially publish release'
 const TRIGGER_RELEASE_WORKFLOW = 'trigger_release.yml'
@@ -132,11 +136,11 @@ async function main() {
     throw new Error('Missing --head-sha')
   }
 
-  const token = process.env.RELEASE_BOT_GITHUB_TOKEN || process.env.GITHUB_TOKEN
+  const token = getGitHubToken() || process.env.GITHUB_TOKEN
   const repoFullName = process.env.GITHUB_REPOSITORY
 
   if (!token) {
-    throw new Error('Missing RELEASE_BOT_GITHUB_TOKEN or GITHUB_TOKEN')
+    throw new Error(`${getGitHubTokenMissingMessage()} or GITHUB_TOKEN`)
   }
 
   if (!repoFullName) {

--- a/scripts/create-release-branch.js
+++ b/scripts/create-release-branch.js
@@ -2,6 +2,12 @@
 const fs = require('fs')
 const path = require('path')
 const execa = require('execa')
+const {
+  configureGitHubAuth,
+  getGitHubToken,
+  getGitHubTokenMissingMessage,
+  verifyGitHubApiAccess,
+} = require('./release-github-auth')
 
 async function main() {
   const args = process.argv
@@ -16,25 +22,20 @@ async function main() {
     throw new Error('tagName value is invalid "' + tagName + '"')
   }
 
-  const githubToken = process.env.RELEASE_BOT_GITHUB_TOKEN
+  const githubToken = getGitHubToken()
 
   if (!githubToken) {
-    console.log(`Missing RELEASE_BOT_GITHUB_TOKEN`)
+    console.log(getGitHubTokenMissingMessage())
     return
   }
 
-  await execa(
-    `git remote set-url origin https://nextjs-bot:${githubToken}@github.com/vercel/next.js.git`,
-    { stdio: 'inherit', shell: true }
+  await configureGitHubAuth(githubToken)
+  await verifyGitHubApiAccess(
+    githubToken,
+    '/repos/vercel/next.js/environments/release-stable/deployment-branch-policies?per_page=1',
+    'release-stable deployment branch policies'
   )
-  await execa(`git config user.name "nextjs-bot"`, {
-    stdio: 'inherit',
-    shell: true,
-  })
-  await execa(`git config user.email "it+nextjs-bot@vercel.com"`, {
-    stdio: 'inherit',
-    shell: true,
-  })
+
   await execa(`git checkout -b "${branchName}"`, {
     stdio: 'inherit',
     shell: true,
@@ -96,6 +97,7 @@ async function main() {
     stdio: 'inherit',
     shell: true,
   })
+
   await execa(`git push origin "${branchName}"`, {
     stdio: 'inherit',
     shell: true,

--- a/scripts/publish-release.js
+++ b/scripts/publish-release.js
@@ -15,7 +15,6 @@ const {
 const cwd = process.cwd()
 
 ;(async function () {
-  const dryRun = process.argv.includes('--dry-run')
   let isCanary = true
   let isReleaseCandidate = false
   let isBeta = false
@@ -179,11 +178,6 @@ const cwd = process.cwd()
           return
         }
 
-        if (dryRun) {
-          console.log(`[dry-run] Would un-draft canary release ${version}`)
-          return
-        }
-
         const undraftRes = await fetch(release.url, {
           headers: ghHeaders,
           method: 'PATCH',
@@ -202,29 +196,6 @@ const cwd = process.cwd()
         console.error(`Failed to undraft release`, err)
       }
     }
-  }
-
-  if (dryRun) {
-    const publicPackages = []
-
-    for (const packageDir of packageDirs) {
-      const pkgJson = JSON.parse(
-        await fs.promises.readFile(
-          path.join(packagesDir, packageDir, 'package.json'),
-          'utf-8'
-        )
-      )
-
-      if (!pkgJson.private) {
-        publicPackages.push(packageDir)
-      }
-    }
-
-    console.log(
-      `[dry-run] Would publish ${publicPackages.length} packages as "${tag}" dist tag.`
-    )
-    await undraft()
-    return
   }
 
   const results = await Promise.allSettled(

--- a/scripts/publish-release.js
+++ b/scripts/publish-release.js
@@ -7,10 +7,15 @@ const semver = require('semver')
 const { Sema } = require('async-sema')
 const { execSync } = require('child_process')
 const fs = require('fs')
+const {
+  getGitHubToken,
+  getGitHubTokenMissingMessage,
+} = require('./release-github-auth')
 
 const cwd = process.cwd()
 
 ;(async function () {
+  const dryRun = process.argv.includes('--dry-run')
   let isCanary = true
   let isReleaseCandidate = false
   let isBeta = false
@@ -126,10 +131,10 @@ const cwd = process.cwd()
   }
 
   const undraft = async () => {
-    const githubToken = process.env.RELEASE_BOT_GITHUB_TOKEN
+    const githubToken = getGitHubToken()
 
     if (!githubToken) {
-      throw new Error(`Missing RELEASE_BOT_GITHUB_TOKEN`)
+      throw new Error(getGitHubTokenMissingMessage())
     }
 
     if (isCanary) {
@@ -174,6 +179,11 @@ const cwd = process.cwd()
           return
         }
 
+        if (dryRun) {
+          console.log(`[dry-run] Would un-draft canary release ${version}`)
+          return
+        }
+
         const undraftRes = await fetch(release.url, {
           headers: ghHeaders,
           method: 'PATCH',
@@ -192,6 +202,29 @@ const cwd = process.cwd()
         console.error(`Failed to undraft release`, err)
       }
     }
+  }
+
+  if (dryRun) {
+    const publicPackages = []
+
+    for (const packageDir of packageDirs) {
+      const pkgJson = JSON.parse(
+        await fs.promises.readFile(
+          path.join(packagesDir, packageDir, 'package.json'),
+          'utf-8'
+        )
+      )
+
+      if (!pkgJson.private) {
+        publicPackages.push(packageDir)
+      }
+    }
+
+    console.log(
+      `[dry-run] Would publish ${publicPackages.length} packages as "${tag}" dist tag.`
+    )
+    await undraft()
+    return
   }
 
   const results = await Promise.allSettled(

--- a/scripts/release-github-auth.js
+++ b/scripts/release-github-auth.js
@@ -48,42 +48,6 @@ async function configureGitHubAuth(token) {
   })
 }
 
-async function verifyDisposableGitWrites(
-  prefix = 'github-app-release-dry-run'
-) {
-  const runId = process.env.GITHUB_RUN_ID || String(Date.now())
-  const runAttempt = process.env.GITHUB_RUN_ATTEMPT
-    ? `-${process.env.GITHUB_RUN_ATTEMPT}`
-    : ''
-  const suffix = `${runId}${runAttempt}`
-  const branchName = `${prefix}/${suffix}`
-  const tagName = `${prefix}-${suffix}`
-
-  console.log(`Verifying disposable git branch write: ${branchName}`)
-  await execa('git', ['push', 'origin', `HEAD:refs/heads/${branchName}`], {
-    stdio: 'inherit',
-  })
-  await execa('git', ['push', 'origin', `:refs/heads/${branchName}`], {
-    stdio: 'inherit',
-  })
-
-  console.log(`Verifying disposable git tag write: ${tagName}`)
-  await execa('git', ['tag', '-f', tagName, 'HEAD'], { stdio: 'inherit' })
-  try {
-    await execa('git', ['push', 'origin', `refs/tags/${tagName}`], {
-      stdio: 'inherit',
-    })
-    await execa('git', ['push', 'origin', `:refs/tags/${tagName}`], {
-      stdio: 'inherit',
-    })
-  } finally {
-    await execa('git', ['tag', '-d', tagName], {
-      stdio: 'inherit',
-      reject: false,
-    })
-  }
-}
-
 async function verifyGitHubApiAccess(token, path, label) {
   const response = await fetch(`https://api.github.com${path}`, {
     headers: {
@@ -107,5 +71,4 @@ module.exports = {
   getGitHubToken,
   getGitHubTokenMissingMessage,
   verifyGitHubApiAccess,
-  verifyDisposableGitWrites,
 }

--- a/scripts/release-github-auth.js
+++ b/scripts/release-github-auth.js
@@ -1,0 +1,111 @@
+// @ts-check
+
+const execa = require('execa')
+
+const REPO_URL = 'github.com/vercel/next.js.git'
+
+function getGitHubToken() {
+  return (
+    process.env.RELEASE_GITHUB_TOKEN || process.env.RELEASE_BOT_GITHUB_TOKEN
+  )
+}
+
+function getGitHubTokenMissingMessage() {
+  return 'Missing RELEASE_GITHUB_TOKEN or RELEASE_BOT_GITHUB_TOKEN'
+}
+
+function getGitUser() {
+  const appSlug = process.env.RELEASE_GITHUB_APP_SLUG
+  const appUserId = process.env.RELEASE_GITHUB_APP_USER_ID
+
+  if (appSlug && appUserId) {
+    return {
+      name: `${appSlug}[bot]`,
+      email: `${appUserId}+${appSlug}[bot]@users.noreply.github.com`,
+    }
+  }
+
+  return {
+    name: process.env.RELEASE_GITHUB_USER_NAME || 'nextjs-bot',
+    email: process.env.RELEASE_GITHUB_USER_EMAIL || 'it+nextjs-bot@vercel.com',
+  }
+}
+
+async function configureGitHubAuth(token) {
+  const gitUser = getGitUser()
+  const remoteUrl = `https://x-access-token:${encodeURIComponent(
+    token
+  )}@${REPO_URL}`
+
+  await execa('git', ['remote', 'set-url', 'origin', remoteUrl], {
+    stdio: 'inherit',
+  })
+  await execa('git', ['config', 'user.name', gitUser.name], {
+    stdio: 'inherit',
+  })
+  await execa('git', ['config', 'user.email', gitUser.email], {
+    stdio: 'inherit',
+  })
+}
+
+async function verifyDisposableGitWrites(
+  prefix = 'github-app-release-dry-run'
+) {
+  const runId = process.env.GITHUB_RUN_ID || String(Date.now())
+  const runAttempt = process.env.GITHUB_RUN_ATTEMPT
+    ? `-${process.env.GITHUB_RUN_ATTEMPT}`
+    : ''
+  const suffix = `${runId}${runAttempt}`
+  const branchName = `${prefix}/${suffix}`
+  const tagName = `${prefix}-${suffix}`
+
+  console.log(`Verifying disposable git branch write: ${branchName}`)
+  await execa('git', ['push', 'origin', `HEAD:refs/heads/${branchName}`], {
+    stdio: 'inherit',
+  })
+  await execa('git', ['push', 'origin', `:refs/heads/${branchName}`], {
+    stdio: 'inherit',
+  })
+
+  console.log(`Verifying disposable git tag write: ${tagName}`)
+  await execa('git', ['tag', '-f', tagName, 'HEAD'], { stdio: 'inherit' })
+  try {
+    await execa('git', ['push', 'origin', `refs/tags/${tagName}`], {
+      stdio: 'inherit',
+    })
+    await execa('git', ['push', 'origin', `:refs/tags/${tagName}`], {
+      stdio: 'inherit',
+    })
+  } finally {
+    await execa('git', ['tag', '-d', tagName], {
+      stdio: 'inherit',
+      reject: false,
+    })
+  }
+}
+
+async function verifyGitHubApiAccess(token, path, label) {
+  const response = await fetch(`https://api.github.com${path}`, {
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${token}`,
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+  })
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to verify GitHub API access for ${label} (${response.status}): ${await response.text()}`
+    )
+  }
+
+  console.log(`Verified GitHub API access for ${label}`)
+}
+
+module.exports = {
+  configureGitHubAuth,
+  getGitHubToken,
+  getGitHubTokenMissingMessage,
+  verifyGitHubApiAccess,
+  verifyDisposableGitWrites,
+}

--- a/scripts/start-release.js
+++ b/scripts/start-release.js
@@ -2,6 +2,13 @@
 const path = require('path')
 const execa = require('execa')
 const resolveFrom = require('resolve-from')
+const {
+  configureGitHubAuth,
+  getGitHubToken,
+  getGitHubTokenMissingMessage,
+  verifyGitHubApiAccess,
+  verifyDisposableGitWrites,
+} = require('./release-github-auth')
 
 const SEMVER_TYPES = ['patch', 'minor', 'major']
 
@@ -9,6 +16,8 @@ async function main() {
   const args = process.argv
   const releaseType = args[args.indexOf('--release-type') + 1]
   const semverType = args[args.indexOf('--semver-type') + 1]
+  const dryRun = args.includes('--dry-run')
+  const verifyGitWrites = args.includes('--verify-git-writes')
   const isCanary = releaseType === 'canary'
   const isReleaseCandidate = releaseType === 'release-candidate'
   const isBeta = releaseType === 'beta'
@@ -33,10 +42,10 @@ async function main() {
     return
   }
 
-  const githubToken = process.env.RELEASE_BOT_GITHUB_TOKEN
+  const githubToken = getGitHubToken()
 
   if (!githubToken) {
-    console.log(`Missing RELEASE_BOT_GITHUB_TOKEN`)
+    console.log(getGitHubTokenMissingMessage())
     return
   }
 
@@ -49,20 +58,26 @@ async function main() {
   const config = new ConfigStore('release')
   config.set('token', githubToken)
 
-  await execa(
-    `git remote set-url origin https://nextjs-bot:${githubToken}@github.com/vercel/next.js.git`,
-    { stdio: 'inherit', shell: true }
+  await configureGitHubAuth(githubToken)
+  await verifyGitHubApiAccess(
+    githubToken,
+    '/repos/vercel/next.js/releases?per_page=1',
+    'release lookup'
   )
-  await execa(`git config user.name "nextjs-bot"`, {
-    stdio: 'inherit',
-    shell: true,
-  })
-  await execa(`git config user.email "it+nextjs-bot@vercel.com"`, {
-    stdio: 'inherit',
-    shell: true,
-  })
 
-  console.log(`Running pnpm release-${isCanary ? 'canary' : 'stable'}...`)
+  if (verifyGitWrites) {
+    if (!dryRun) {
+      console.log(`Ignoring --verify-git-writes without --dry-run`)
+    } else {
+      await verifyDisposableGitWrites()
+    }
+  }
+
+  console.log(
+    `Running pnpm release-${isCanary ? 'canary' : 'stable'}${
+      dryRun ? ' dry run' : ''
+    }...`
+  )
   const preleaseType =
     semverType === 'major'
       ? 'premajor'
@@ -70,24 +85,36 @@ async function main() {
         ? 'preminor'
         : 'prerelease'
 
-  const child = execa(
-    isCanary
-      ? `pnpm lerna version ${preleaseType} --preid canary --force-publish -y && pnpm release --pre --skip-questions --show-url`
-      : isReleaseCandidate
-        ? `pnpm lerna version ${preleaseType} --preid rc --force-publish -y && pnpm release --pre --skip-questions --show-url`
-        : isBeta
-          ? `pnpm lerna version ${preleaseType} --preid beta --force-publish -y && pnpm release --pre --skip-questions --show-url`
-          : `pnpm lerna version ${semverType} --force-publish -y`,
-    {
-      stdio: 'pipe',
-      shell: true,
-    }
-  )
+  let command = isCanary
+    ? `pnpm lerna version ${preleaseType} --preid canary --force-publish -y`
+    : isReleaseCandidate
+      ? `pnpm lerna version ${preleaseType} --preid rc --force-publish -y`
+      : isBeta
+        ? `pnpm lerna version ${preleaseType} --preid beta --force-publish -y`
+        : `pnpm lerna version ${semverType} --force-publish -y`
+
+  if (dryRun) {
+    command +=
+      ' --no-push --allow-branch release-app-dry-run/** --allow-branch release-app-dry-run-with-writes/**'
+  } else if (isCanary || isReleaseCandidate || isBeta) {
+    command += ' && pnpm release --pre --skip-questions --show-url'
+  }
+
+  const child = execa(command, {
+    stdio: 'pipe',
+    shell: true,
+  })
 
   child.stdout?.pipe(process.stdout)
   child.stderr?.pipe(process.stderr)
   await child
-  console.log('Release process is finished')
+  if (dryRun) {
+    console.log(
+      'Release dry run is finished. No release commits, tags, or GitHub releases were pushed.'
+    )
+  } else {
+    console.log('Release process is finished')
+  }
 }
 
 main()

--- a/scripts/start-release.js
+++ b/scripts/start-release.js
@@ -7,7 +7,6 @@ const {
   getGitHubToken,
   getGitHubTokenMissingMessage,
   verifyGitHubApiAccess,
-  verifyDisposableGitWrites,
 } = require('./release-github-auth')
 
 const SEMVER_TYPES = ['patch', 'minor', 'major']
@@ -16,8 +15,6 @@ async function main() {
   const args = process.argv
   const releaseType = args[args.indexOf('--release-type') + 1]
   const semverType = args[args.indexOf('--semver-type') + 1]
-  const dryRun = args.includes('--dry-run')
-  const verifyGitWrites = args.includes('--verify-git-writes')
   const isCanary = releaseType === 'canary'
   const isReleaseCandidate = releaseType === 'release-candidate'
   const isBeta = releaseType === 'beta'
@@ -65,19 +62,7 @@ async function main() {
     'release lookup'
   )
 
-  if (verifyGitWrites) {
-    if (!dryRun) {
-      console.log(`Ignoring --verify-git-writes without --dry-run`)
-    } else {
-      await verifyDisposableGitWrites()
-    }
-  }
-
-  console.log(
-    `Running pnpm release-${isCanary ? 'canary' : 'stable'}${
-      dryRun ? ' dry run' : ''
-    }...`
-  )
+  console.log(`Running pnpm release-${isCanary ? 'canary' : 'stable'}...`)
   const preleaseType =
     semverType === 'major'
       ? 'premajor'
@@ -93,10 +78,7 @@ async function main() {
         ? `pnpm lerna version ${preleaseType} --preid beta --force-publish -y`
         : `pnpm lerna version ${semverType} --force-publish -y`
 
-  if (dryRun) {
-    command +=
-      ' --no-push --allow-branch release-app-dry-run/** --allow-branch release-app-dry-run-with-writes/**'
-  } else if (isCanary || isReleaseCandidate || isBeta) {
+  if (isCanary || isReleaseCandidate || isBeta) {
     command += ' && pnpm release --pre --skip-questions --show-url'
   }
 
@@ -108,13 +90,7 @@ async function main() {
   child.stdout?.pipe(process.stdout)
   child.stderr?.pipe(process.stderr)
   await child
-  if (dryRun) {
-    console.log(
-      'Release dry run is finished. No release commits, tags, or GitHub releases were pushed.'
-    )
-  } else {
-    console.log('Release process is finished')
-  }
+  console.log('Release process is finished')
 }
 
 main()


### PR DESCRIPTION
Moves all release workflows off of a GH PAT and uses an app with a short-lived token instead.

Test Plan:
Dry run [here](https://github.com/vercel/next.js/actions/runs/24934593874).

However, this workflow is blocked until we figure out commit signing for the bot app. Some options:
- The bot account generates a signing key and we use it in CI (not great, bypasses the app)
- The org bypasses signature verification for the bot user (also not great, requires an exemption rule)
- We need to rework the commit step so Lerna does not do the push, and instead trigger it via the app + GH API. This seems like the best option, will be added in a follow-up PR.

Note: `create-release-branch` workflow is broken in its current form, as we will not be restoring administrator privileges to adjust environment settings. This will become a manual step in the future. 