### PR TITLE
Fix dynamic pages routes in symlinked directories

### DIFF
--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -77,6 +77,7 @@ import {
 import { getDefineEnv } from '../../../build/define-env'
 import { TurbopackInternalError } from '../../../shared/lib/turbopack/internal-error'
 import { normalizePath } from '../../../lib/normalize-path'
+import { recursiveReadDir } from '../../../lib/recursive-readdir'
 import {
   JSON_CONTENT_TYPE_HEADER,
   MIDDLEWARE_FILENAME,
@@ -452,9 +453,18 @@ async function startWatcher(
       staticMetadataFiles.clear()
       devPageFiles.clear()
 
-      const sortedKnownFiles: string[] = [...knownFiles.keys()].sort(
-        sortByPageExts(nextConfig.pageExtensions)
-      )
+      const discoveredPageFiles = pagesDir
+        ? await recursiveReadDir(pagesDir, {
+            pathnameFilter: validFileMatcher.isPageFile,
+            relativePathnames: false,
+          })
+        : []
+
+      const discoveredPageFileSet = new Set(discoveredPageFiles)
+
+      const sortedKnownFiles: string[] = [
+        ...new Set([...knownFiles.keys(), ...discoveredPageFiles]),
+      ].sort(sortByPageExts(nextConfig.pageExtensions))
 
       let proxyFilePath: string | undefined
       let middlewareFilePath: string | undefined
@@ -529,7 +539,8 @@ async function startWatcher(
         }
 
         if (
-          meta?.accuracy === undefined ||
+          (meta?.accuracy === undefined &&
+            !discoveredPageFileSet.has(fileName)) ||
           !validFileMatcher.isPageFile(fileName)
         ) {
           continue

--- a/test/e2e/pages-symlink-dynamic-routes/index.test.ts
+++ b/test/e2e/pages-symlink-dynamic-routes/index.test.ts
@@ -1,0 +1,43 @@
+import { nextTestSetup } from 'e2e-utils'
+import { rm, symlink } from 'fs/promises'
+import { join } from 'path'
+
+describe('pages symlink dynamic routes', () => {
+  const { next, skipped } = nextTestSetup({
+    files: __dirname,
+    skipStart: true,
+    skipDeployment: true,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  beforeAll(async () => {
+    const pagesDir = join(next.testDir, 'pages')
+    const linkPath = join(pagesDir, 'symlinktest')
+    const targetPath = join(pagesDir, 'nolink')
+
+    await rm(linkPath, { recursive: true, force: true })
+
+    await symlink(
+      process.platform === 'win32' ? targetPath : 'nolink',
+      linkPath,
+      process.platform === 'win32' ? 'junction' : 'dir'
+    )
+
+    await next.start()
+  })
+
+  it('should render dynamic pages through a symlinked pages directory', async () => {
+    async function getResult(pathname: string) {
+      const $ = await next.render$(pathname)
+      return $('#result').text()
+    }
+
+    expect(await getResult('/nolink')).toBe('Works')
+    expect(await getResult('/nolink/123')).toBe('Works')
+    expect(await getResult('/symlinktest')).toBe('Works')
+    expect(await getResult('/symlinktest/123')).toBe('Works')
+  })
+})

--- a/test/e2e/pages-symlink-dynamic-routes/pages/nolink/[id].js
+++ b/test/e2e/pages-symlink-dynamic-routes/pages/nolink/[id].js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p id="result">Works</p>
+}

--- a/test/e2e/pages-symlink-dynamic-routes/pages/nolink/index.js
+++ b/test/e2e/pages-symlink-dynamic-routes/pages/nolink/index.js
@@ -1,0 +1,3 @@
+export default function Index() {
+  return <p id="result">Works</p>
+}


### PR DESCRIPTION
Fixes #16660

## What?

This fixes dynamic Pages Router routes inside symlinked directories in `next dev`.

## Why?

A symlinked pages directory could render its index route, but dynamic routes inside the same symlinked directory were missing from the dev dynamic route matcher.

For example, `/symlinktest` worked, while `/symlinktest/123` returned 404 even though the target route `/nolink/123` worked.

## How?

The dev route discovery now also includes Pages Router files discovered through the existing recursive page discovery logic. This ensures symlinked route aliases are included when dev dynamic routes are rebuilt.

## Tests

- `scripts/run-jest.sh --mode=dev --bundler=webpack --headless -- test/e2e/pages-symlink-dynamic-routes/index.test.ts`
- `scripts/run-jest.sh --mode=dev --bundler=turbo --headless -- test/e2e/pages-symlink-dynamic-routes/index.test.ts`