### PR TITLE
Fix MQTT client cleanup in example

### DIFF
--- a/examples/with-mqtt-js/README.md
+++ b/examples/with-mqtt-js/README.md
@@ -30,9 +30,9 @@ cp .env.local.example .env.local
 
 Then set each variable on `.env.local`:
 
-- `NEXT_MQTT_URI`: The URI of the broker. For example `wss://test.mosquitto.org:8081/mqtt`
-- `NEXT_MQTT_CLIENTID`: An arbitrary string of max. 23 characters.
-- `NEXT_MQTT_USERNAME`: The username for the connection to the broker.
-- `NEXT_MQTT_PASSWORD`: The password for the connection to the broker.
+- `NEXT_PUBLIC_MQTT_URI`: The URI of the broker. For example `wss://test.mosquitto.org:8081/mqtt`
+- `NEXT_PUBLIC_MQTT_CLIENTID`: An arbitrary string of max. 23 characters.
+- `NEXT_PUBLIC_MQTT_USERNAME`: The username for the connection to the broker.
+- `NEXT_PUBLIC_MQTT_PASSWORD`: The password for the connection to the broker.
 
 Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).

--- a/examples/with-mqtt-js/app/layout.tsx
+++ b/examples/with-mqtt-js/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { MqttProvider } from "@/lib/mqttProvider";
 
 export const metadata: Metadata = {
   title: "Next.js",
@@ -12,7 +13,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <MqttProvider>{children}</MqttProvider>
+      </body>
     </html>
   );
 }

--- a/examples/with-mqtt-js/app/page.tsx
+++ b/examples/with-mqtt-js/app/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState, useRef } from "react";
-import type { MqttClient } from "mqtt";
 import useMqtt from "@/lib/useMqtt";
 
 export default function Home() {
@@ -22,19 +21,8 @@ export default function Home() {
     },
   ]);
 
-  const mqttClientRef = useRef<MqttClient | null>(null);
-  const setMqttClient = (client: MqttClient) => {
-    mqttClientRef.current = client;
-  };
-  useMqtt({
-    uri: process.env.NEXT_PUBLIC_MQTT_URI,
-    options: {
-      username: process.env.NEXT_PUBLIC_MQTT_USERNAME,
-      password: process.env.NEXT_PUBLIC_MQTT_PASSWORD,
-      clientId: process.env.NEXT_PUBLIC_MQTT_CLIENTID,
-    },
+  const mqttClient = useMqtt({
     topicHandlers: incomingMessageHandlers.current,
-    onConnectedHandler: (client) => setMqttClient(client),
   });
 
   const publishMessages = (client: any) => {
@@ -56,7 +44,7 @@ export default function Home() {
       {incomingMessages.map((m) => (
         <p key={Math.random()}>{m.payload.toString()}</p>
       ))}
-      <button onClick={() => publishMessages(mqttClientRef.current)}>
+      <button onClick={() => publishMessages(mqttClient)}>
         Publish Test Messages
       </button>
       <button onClick={() => clearMessages()}>Clear Test Messages</button>

--- a/examples/with-mqtt-js/lib/mqttProvider.tsx
+++ b/examples/with-mqtt-js/lib/mqttProvider.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import type { MqttClient } from "mqtt";
+import MQTT from "mqtt";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+
+interface MqttContextValue {
+  client: MqttClient | null;
+  subscribeToTopic: (topic: string) => void;
+  unsubscribeFromTopic: (topic: string) => void;
+}
+
+const MqttContext = createContext<MqttContextValue | null>(null);
+
+export function MqttProvider({ children }: { children: ReactNode }) {
+  const clientRef = useRef<MqttClient | null>(null);
+  const topicSubscriptionsRef = useRef<Map<string, number>>(new Map());
+  const [client, setClient] = useState<MqttClient | null>(null);
+
+  useEffect(() => {
+    if (clientRef.current) return;
+
+    const topicSubscriptions = topicSubscriptionsRef.current;
+
+    try {
+      const mqttClient = MQTT.connect(process.env.NEXT_PUBLIC_MQTT_URI, {
+        username: process.env.NEXT_PUBLIC_MQTT_USERNAME,
+        password: process.env.NEXT_PUBLIC_MQTT_PASSWORD,
+        clientId: process.env.NEXT_PUBLIC_MQTT_CLIENTID,
+      });
+
+      clientRef.current = mqttClient;
+      setClient(mqttClient);
+    } catch (error) {
+      console.error("error", error);
+    }
+
+    return () => {
+      clientRef.current?.end();
+      clientRef.current = null;
+      topicSubscriptions.clear();
+    };
+  }, []);
+
+  const subscribeToTopic = useCallback((topic: string) => {
+    const subscriptionCount = topicSubscriptionsRef.current.get(topic) ?? 0;
+
+    if (subscriptionCount === 0) {
+      clientRef.current?.subscribe(topic);
+    }
+
+    topicSubscriptionsRef.current.set(topic, subscriptionCount + 1);
+  }, []);
+
+  const unsubscribeFromTopic = useCallback((topic: string) => {
+    const subscriptionCount = topicSubscriptionsRef.current.get(topic) ?? 0;
+
+    if (subscriptionCount <= 1) {
+      clientRef.current?.unsubscribe(topic);
+      topicSubscriptionsRef.current.delete(topic);
+      return;
+    }
+
+    topicSubscriptionsRef.current.set(topic, subscriptionCount - 1);
+  }, []);
+
+  const contextValue = useMemo(
+    () => ({ client, subscribeToTopic, unsubscribeFromTopic }),
+    [client, subscribeToTopic, unsubscribeFromTopic],
+  );
+
+  return (
+    <MqttContext.Provider value={contextValue}>{children}</MqttContext.Provider>
+  );
+}
+
+export function useMqttContext() {
+  return useContext(MqttContext);
+}

--- a/examples/with-mqtt-js/lib/useMqtt.ts
+++ b/examples/with-mqtt-js/lib/useMqtt.ts
@@ -1,63 +1,47 @@
-import type { MqttClient, IClientOptions } from "mqtt";
-import MQTT from "mqtt";
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
+import { useMqttContext } from "@/lib/mqttProvider";
 
 interface useMqttProps {
-  uri: string;
-  options?: IClientOptions;
   topicHandlers?: { topic: string; handler: (payload: any) => void }[];
-  onConnectedHandler?: (client: MqttClient) => void;
 }
 
-function useMqtt({
-  uri,
-  options = {},
-  topicHandlers = [{ topic: "", handler: ({ topic, payload, packet }) => {} }],
-  onConnectedHandler = (client) => {},
-}: useMqttProps) {
-  const clientRef = useRef<MqttClient | null>(null);
+function useMqtt({ topicHandlers = [] }: useMqttProps) {
+  const mqttContext = useMqttContext();
 
   useEffect(() => {
-    if (clientRef.current) return;
     if (!topicHandlers || topicHandlers.length === 0) return () => {};
+    if (!mqttContext?.client) return;
 
-    try {
-      clientRef.current = options
-        ? MQTT.connect(uri, options)
-        : MQTT.connect(uri);
-    } catch (error) {
-      console.error("error", error);
-    }
+    const { client, subscribeToTopic, unsubscribeFromTopic } = mqttContext;
 
-    const client = clientRef.current;
     topicHandlers.forEach((th) => {
-      client?.subscribe(th.topic);
+      subscribeToTopic(th.topic);
     });
-    client?.on("message", (topic: string, rawPayload: any, packet: any) => {
+
+    const handleMessage = (topic: string, rawPayload: any, packet: any) => {
       const th = topicHandlers.find((t) => t.topic === topic);
       let payload;
+
       try {
         payload = JSON.parse(rawPayload);
       } catch {
         payload = rawPayload;
       }
-      if (th) th.handler({ topic, payload, packet });
-    });
 
-    client?.on("connect", () => {
-      if (onConnectedHandler) onConnectedHandler(client);
-    });
+      if (th) th.handler({ topic, payload, packet });
+    };
+
+    client.on("message", handleMessage);
 
     return () => {
-      if (client) {
-        topicHandlers.forEach((th) => {
-          client.unsubscribe(th.topic);
-        });
-        client.end();
-      }
+      topicHandlers.forEach((th) => {
+        unsubscribeFromTopic(th.topic);
+      });
+      client.removeListener("message", handleMessage);
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [mqttContext, topicHandlers]);
+
+  return mqttContext?.client ?? null;
 }
 
 export default useMqtt;


### PR DESCRIPTION
### What?

Fixes the MQTT example so the MQTT client is shared through a provider instead of being created and closed by each `useMqtt` hook instance.

### Why?

The previous cleanup closed the MQTT client when a page using `useMqtt` unmounted, which could break MQTT usage from other pages or components.

### How?

Moves the client connection into `MqttProvider`, updates `useMqtt` to use the shared client, and reference-counts topic subscriptions so shared topics are not unsubscribed while another consumer still needs them.

Also updates the README to use the existing `NEXT_PUBLIC_MQTT_*` environment variable names.

Fixes #69109