### PR TITLE
Add compiled web-vitals types

### DIFF
--- a/packages/next/src/compiled/web-vitals/attribution/deprecated.d.ts
+++ b/packages/next/src/compiled/web-vitals/attribution/deprecated.d.ts
@@ -1,0 +1,7 @@
+export {
+/**
+ * @deprecated Use `onINP()` instead.
+ */
+onFID, } from './onFID.js';
+export { FIDThresholds } from '../onFID.js';
+export * from '../types.js';

--- a/packages/next/src/compiled/web-vitals/attribution/index.d.ts
+++ b/packages/next/src/compiled/web-vitals/attribution/index.d.ts
@@ -1,0 +1,12 @@
+export { onCLS } from './onCLS.js';
+export { onFCP } from './onFCP.js';
+export { onINP } from './onINP.js';
+export { onLCP } from './onLCP.js';
+export { onTTFB } from './onTTFB.js';
+export { CLSThresholds } from '../onCLS.js';
+export { FCPThresholds } from '../onFCP.js';
+export { INPThresholds } from '../onINP.js';
+export { LCPThresholds } from '../onLCP.js';
+export { TTFBThresholds } from '../onTTFB.js';
+export * from './deprecated.js';
+export * from '../types.js';

--- a/packages/next/src/compiled/web-vitals/attribution/onCLS.d.ts
+++ b/packages/next/src/compiled/web-vitals/attribution/onCLS.d.ts
@@ -1,0 +1,23 @@
+import { CLSMetricWithAttribution, ReportOpts } from '../types.js';
+/**
+ * Calculates the [CLS](https://web.dev/articles/cls) value for the current page and
+ * calls the `callback` function once the value is ready to be reported, along
+ * with all `layout-shift` performance entries that were used in the metric
+ * value calculation. The reported value is a `double` (corresponding to a
+ * [layout shift score](https://web.dev/articles/cls#layout_shift_score)).
+ *
+ * If the `reportAllChanges` configuration option is set to `true`, the
+ * `callback` function will be called as soon as the value is initially
+ * determined as well as any time the value changes throughout the page
+ * lifespan.
+ *
+ * _**Important:** CLS should be continually monitored for changes throughout
+ * the entire lifespan of a page—including if the user returns to the page after
+ * it's been hidden/backgrounded. However, since browsers often [will not fire
+ * additional callbacks once the user has backgrounded a
+ * page](https://developer.chrome.com/blog/page-lifecycle-api/#advice-hidden),
+ * `callback` is always called when the page's visibility state changes to
+ * hidden. As a result, the `callback` function might be called multiple times
+ * during the same page load._
+ */
+export declare const onCLS: (onReport: (metric: CLSMetricWithAttribution) => void, opts?: ReportOpts) => void;

--- a/packages/next/src/compiled/web-vitals/attribution/onFCP.d.ts
+++ b/packages/next/src/compiled/web-vitals/attribution/onFCP.d.ts
@@ -1,0 +1,8 @@
+import { FCPMetricWithAttribution, ReportOpts } from '../types.js';
+/**
+ * Calculates the [FCP](https://web.dev/articles/fcp) value for the current page and
+ * calls the `callback` function once the value is ready, along with the
+ * relevant `paint` performance entry used to determine the value. The reported
+ * value is a `DOMHighResTimeStamp`.
+ */
+export declare const onFCP: (onReport: (metric: FCPMetricWithAttribution) => void, opts?: ReportOpts) => void;

--- a/packages/next/src/compiled/web-vitals/attribution/onFID.d.ts
+++ b/packages/next/src/compiled/web-vitals/attribution/onFID.d.ts
@@ -1,0 +1,11 @@
+import { FIDMetricWithAttribution, ReportOpts } from '../types.js';
+/**
+ * Calculates the [FID](https://web.dev/articles/fid) value for the current page and
+ * calls the `callback` function once the value is ready, along with the
+ * relevant `first-input` performance entry used to determine the value. The
+ * reported value is a `DOMHighResTimeStamp`.
+ *
+ * _**Important:** since FID is only reported after the user interacts with the
+ * page, it's possible that it will not be reported for some page loads._
+ */
+export declare const onFID: (onReport: (metric: FIDMetricWithAttribution) => void, opts?: ReportOpts) => void;

--- a/packages/next/src/compiled/web-vitals/attribution/onINP.d.ts
+++ b/packages/next/src/compiled/web-vitals/attribution/onINP.d.ts
@@ -1,0 +1,30 @@
+import { INPMetricWithAttribution, ReportOpts } from '../types.js';
+export declare const interactionTargetMap: Map<number, Node>;
+/**
+ * Calculates the [INP](https://web.dev/articles/inp) value for the current
+ * page and calls the `callback` function once the value is ready, along with
+ * the `event` performance entries reported for that interaction. The reported
+ * value is a `DOMHighResTimeStamp`.
+ *
+ * A custom `durationThreshold` configuration option can optionally be passed to
+ * control what `event-timing` entries are considered for INP reporting. The
+ * default threshold is `40`, which means INP scores of less than 40 are
+ * reported as 0. Note that this will not affect your 75th percentile INP value
+ * unless that value is also less than 40 (well below the recommended
+ * [good](https://web.dev/articles/inp#what_is_a_good_inp_score) threshold).
+ *
+ * If the `reportAllChanges` configuration option is set to `true`, the
+ * `callback` function will be called as soon as the value is initially
+ * determined as well as any time the value changes throughout the page
+ * lifespan.
+ *
+ * _**Important:** INP should be continually monitored for changes throughout
+ * the entire lifespan of a page—including if the user returns to the page after
+ * it's been hidden/backgrounded. However, since browsers often [will not fire
+ * additional callbacks once the user has backgrounded a
+ * page](https://developer.chrome.com/blog/page-lifecycle-api/#advice-hidden),
+ * `callback` is always called when the page's visibility state changes to
+ * hidden. As a result, the `callback` function might be called multiple times
+ * during the same page load._
+ */
+export declare const onINP: (onReport: (metric: INPMetricWithAttribution) => void, opts?: ReportOpts) => void;

--- a/packages/next/src/compiled/web-vitals/attribution/onLCP.d.ts
+++ b/packages/next/src/compiled/web-vitals/attribution/onLCP.d.ts
@@ -1,0 +1,13 @@
+import { LCPMetricWithAttribution, ReportOpts } from '../types.js';
+/**
+ * Calculates the [LCP](https://web.dev/articles/lcp) value for the current page and
+ * calls the `callback` function once the value is ready (along with the
+ * relevant `largest-contentful-paint` performance entry used to determine the
+ * value). The reported value is a `DOMHighResTimeStamp`.
+ *
+ * If the `reportAllChanges` configuration option is set to `true`, the
+ * `callback` function will be called any time a new `largest-contentful-paint`
+ * performance entry is dispatched, or once the final value of the metric has
+ * been determined.
+ */
+export declare const onLCP: (onReport: (metric: LCPMetricWithAttribution) => void, opts?: ReportOpts) => void;

--- a/packages/next/src/compiled/web-vitals/attribution/onTTFB.d.ts
+++ b/packages/next/src/compiled/web-vitals/attribution/onTTFB.d.ts
@@ -1,0 +1,17 @@
+import { TTFBMetricWithAttribution, ReportOpts } from '../types.js';
+/**
+ * Calculates the [TTFB](https://web.dev/articles/ttfb) value for the
+ * current page and calls the `callback` function once the page has loaded,
+ * along with the relevant `navigation` performance entry used to determine the
+ * value. The reported value is a `DOMHighResTimeStamp`.
+ *
+ * Note, this function waits until after the page is loaded to call `callback`
+ * in order to ensure all properties of the `navigation` entry are populated.
+ * This is useful if you want to report on other metrics exposed by the
+ * [Navigation Timing API](https://w3c.github.io/navigation-timing/). For
+ * example, the TTFB metric starts from the page's [time
+ * origin](https://www.w3.org/TR/hr-time-2/#sec-time-origin), which means it
+ * includes time spent on DNS lookup, connection negotiation, network latency,
+ * and server processing time.
+ */
+export declare const onTTFB: (onReport: (metric: TTFBMetricWithAttribution) => void, opts?: ReportOpts) => void;

--- a/packages/next/src/compiled/web-vitals/deprecated.d.ts
+++ b/packages/next/src/compiled/web-vitals/deprecated.d.ts
@@ -1,0 +1,5 @@
+export {
+/**
+ * @deprecated Use `onINP()` instead.
+ */
+onFID, FIDThresholds, } from './onFID.js';

--- a/packages/next/src/compiled/web-vitals/index.d.ts
+++ b/packages/next/src/compiled/web-vitals/index.d.ts
@@ -1,0 +1,7 @@
+export { onCLS, CLSThresholds } from './onCLS.js';
+export { onFCP, FCPThresholds } from './onFCP.js';
+export { onINP, INPThresholds } from './onINP.js';
+export { onLCP, LCPThresholds } from './onLCP.js';
+export { onTTFB, TTFBThresholds } from './onTTFB.js';
+export * from './deprecated.js';
+export * from './types.js';

--- a/packages/next/src/compiled/web-vitals/onCLS.d.ts
+++ b/packages/next/src/compiled/web-vitals/onCLS.d.ts
@@ -1,0 +1,25 @@
+import { CLSMetric, MetricRatingThresholds, ReportOpts } from './types.js';
+/** Thresholds for CLS. See https://web.dev/articles/cls#what_is_a_good_cls_score */
+export declare const CLSThresholds: MetricRatingThresholds;
+/**
+ * Calculates the [CLS](https://web.dev/articles/cls) value for the current page and
+ * calls the `callback` function once the value is ready to be reported, along
+ * with all `layout-shift` performance entries that were used in the metric
+ * value calculation. The reported value is a `double` (corresponding to a
+ * [layout shift score](https://web.dev/articles/cls#layout_shift_score)).
+ *
+ * If the `reportAllChanges` configuration option is set to `true`, the
+ * `callback` function will be called as soon as the value is initially
+ * determined as well as any time the value changes throughout the page
+ * lifespan.
+ *
+ * _**Important:** CLS should be continually monitored for changes throughout
+ * the entire lifespan of a page—including if the user returns to the page after
+ * it's been hidden/backgrounded. However, since browsers often [will not fire
+ * additional callbacks once the user has backgrounded a
+ * page](https://developer.chrome.com/blog/page-lifecycle-api/#advice-hidden),
+ * `callback` is always called when the page's visibility state changes to
+ * hidden. As a result, the `callback` function might be called multiple times
+ * during the same page load._
+ */
+export declare const onCLS: (onReport: (metric: CLSMetric) => void, opts?: ReportOpts) => void;

--- a/packages/next/src/compiled/web-vitals/onFCP.d.ts
+++ b/packages/next/src/compiled/web-vitals/onFCP.d.ts
@@ -1,0 +1,10 @@
+import { FCPMetric, MetricRatingThresholds, ReportOpts } from './types.js';
+/** Thresholds for FCP. See https://web.dev/articles/fcp#what_is_a_good_fcp_score */
+export declare const FCPThresholds: MetricRatingThresholds;
+/**
+ * Calculates the [FCP](https://web.dev/articles/fcp) value for the current page and
+ * calls the `callback` function once the value is ready, along with the
+ * relevant `paint` performance entry used to determine the value. The reported
+ * value is a `DOMHighResTimeStamp`.
+ */
+export declare const onFCP: (onReport: (metric: FCPMetric) => void, opts?: ReportOpts) => void;

--- a/packages/next/src/compiled/web-vitals/onFID.d.ts
+++ b/packages/next/src/compiled/web-vitals/onFID.d.ts
@@ -1,0 +1,13 @@
+import { FIDMetric, MetricRatingThresholds, ReportOpts } from './types.js';
+/** Thresholds for FID. See https://web.dev/articles/fid#what_is_a_good_fid_score */
+export declare const FIDThresholds: MetricRatingThresholds;
+/**
+ * Calculates the [FID](https://web.dev/articles/fid) value for the current page and
+ * calls the `callback` function once the value is ready, along with the
+ * relevant `first-input` performance entry used to determine the value. The
+ * reported value is a `DOMHighResTimeStamp`.
+ *
+ * _**Important:** since FID is only reported after the user interacts with the
+ * page, it's possible that it will not be reported for some page loads._
+ */
+export declare const onFID: (onReport: (metric: FIDMetric) => void, opts?: ReportOpts) => void;

--- a/packages/next/src/compiled/web-vitals/onINP.d.ts
+++ b/packages/next/src/compiled/web-vitals/onINP.d.ts
@@ -1,0 +1,31 @@
+import { INPMetric, MetricRatingThresholds, ReportOpts } from './types.js';
+/** Thresholds for INP. See https://web.dev/articles/inp#what_is_a_good_inp_score */
+export declare const INPThresholds: MetricRatingThresholds;
+/**
+ * Calculates the [INP](https://web.dev/articles/inp) value for the current
+ * page and calls the `callback` function once the value is ready, along with
+ * the `event` performance entries reported for that interaction. The reported
+ * value is a `DOMHighResTimeStamp`.
+ *
+ * A custom `durationThreshold` configuration option can optionally be passed to
+ * control what `event-timing` entries are considered for INP reporting. The
+ * default threshold is `40`, which means INP scores of less than 40 are
+ * reported as 0. Note that this will not affect your 75th percentile INP value
+ * unless that value is also less than 40 (well below the recommended
+ * [good](https://web.dev/articles/inp#what_is_a_good_inp_score) threshold).
+ *
+ * If the `reportAllChanges` configuration option is set to `true`, the
+ * `callback` function will be called as soon as the value is initially
+ * determined as well as any time the value changes throughout the page
+ * lifespan.
+ *
+ * _**Important:** INP should be continually monitored for changes throughout
+ * the entire lifespan of a page—including if the user returns to the page after
+ * it's been hidden/backgrounded. However, since browsers often [will not fire
+ * additional callbacks once the user has backgrounded a
+ * page](https://developer.chrome.com/blog/page-lifecycle-api/#advice-hidden),
+ * `callback` is always called when the page's visibility state changes to
+ * hidden. As a result, the `callback` function might be called multiple times
+ * during the same page load._
+ */
+export declare const onINP: (onReport: (metric: INPMetric) => void, opts?: ReportOpts) => void;

--- a/packages/next/src/compiled/web-vitals/onLCP.d.ts
+++ b/packages/next/src/compiled/web-vitals/onLCP.d.ts
@@ -1,0 +1,15 @@
+import { LCPMetric, MetricRatingThresholds, ReportOpts } from './types.js';
+/** Thresholds for LCP. See https://web.dev/articles/lcp#what_is_a_good_lcp_score */
+export declare const LCPThresholds: MetricRatingThresholds;
+/**
+ * Calculates the [LCP](https://web.dev/articles/lcp) value for the current page and
+ * calls the `callback` function once the value is ready (along with the
+ * relevant `largest-contentful-paint` performance entry used to determine the
+ * value). The reported value is a `DOMHighResTimeStamp`.
+ *
+ * If the `reportAllChanges` configuration option is set to `true`, the
+ * `callback` function will be called any time a new `largest-contentful-paint`
+ * performance entry is dispatched, or once the final value of the metric has
+ * been determined.
+ */
+export declare const onLCP: (onReport: (metric: LCPMetric) => void, opts?: ReportOpts) => void;

--- a/packages/next/src/compiled/web-vitals/onTTFB.d.ts
+++ b/packages/next/src/compiled/web-vitals/onTTFB.d.ts
@@ -1,0 +1,19 @@
+import { MetricRatingThresholds, ReportOpts, TTFBMetric } from './types.js';
+/** Thresholds for TTFB. See https://web.dev/articles/ttfb#what_is_a_good_ttfb_score */
+export declare const TTFBThresholds: MetricRatingThresholds;
+/**
+ * Calculates the [TTFB](https://web.dev/articles/ttfb) value for the
+ * current page and calls the `callback` function once the page has loaded,
+ * along with the relevant `navigation` performance entry used to determine the
+ * value. The reported value is a `DOMHighResTimeStamp`.
+ *
+ * Note, this function waits until after the page is loaded to call `callback`
+ * in order to ensure all properties of the `navigation` entry are populated.
+ * This is useful if you want to report on other metrics exposed by the
+ * [Navigation Timing API](https://w3c.github.io/navigation-timing/). For
+ * example, the TTFB metric starts from the page's [time
+ * origin](https://www.w3.org/TR/hr-time-2/#sec-time-origin), which means it
+ * includes time spent on DNS lookup, connection negotiation, network latency,
+ * and server processing time.
+ */
+export declare const onTTFB: (onReport: (metric: TTFBMetric) => void, opts?: ReportOpts) => void;

--- a/packages/next/src/compiled/web-vitals/package.json
+++ b/packages/next/src/compiled/web-vitals/package.json
@@ -1,1 +1,1 @@
-{"name":"web-vitals","main":"web-vitals.js","author":{"name":"Philip Walton","email":"philip@philipwalton.com","url":"http://philipwalton.com"},"license":"Apache-2.0"}
+{"name":"web-vitals","main":"web-vitals.js","author":{"name":"Philip Walton","email":"philip@philipwalton.com","url":"http://philipwalton.com"},"license":"Apache-2.0","types":"./index.d.ts"}

--- a/packages/next/src/compiled/web-vitals/types.d.ts
+++ b/packages/next/src/compiled/web-vitals/types.d.ts
@@ -1,0 +1,55 @@
+export * from './types/base.js';
+export * from './types/polyfills.js';
+export * from './types/cls.js';
+export * from './types/fcp.js';
+export * from './types/fid.js';
+export * from './types/inp.js';
+export * from './types/lcp.js';
+export * from './types/ttfb.js';
+interface PerformanceEntryMap {
+    navigation: PerformanceNavigationTiming;
+    resource: PerformanceResourceTiming;
+    paint: PerformancePaintTiming;
+}
+declare global {
+    interface Document {
+        prerendering?: boolean;
+        wasDiscarded?: boolean;
+    }
+    interface Performance {
+        getEntriesByType<K extends keyof PerformanceEntryMap>(type: K): PerformanceEntryMap[K][];
+    }
+    interface PerformanceObserverInit {
+        durationThreshold?: number;
+    }
+    interface PerformanceNavigationTiming {
+        activationStart?: number;
+    }
+    interface PerformanceEventTiming extends PerformanceEntry {
+        duration: DOMHighResTimeStamp;
+        // Waiting for https://github.com/GoogleChrome/web-vitals/commit/a92f8a78bce9e400366bc29db5fc23fdf23db469
+        readonly interactionId: number;
+    }
+    interface LayoutShiftAttribution {
+        node?: Node;
+        previousRect: DOMRectReadOnly;
+        currentRect: DOMRectReadOnly;
+    }
+    interface LayoutShift extends PerformanceEntry {
+        value: number;
+        sources: LayoutShiftAttribution[];
+        hadRecentInput: boolean;
+    }
+    interface LargestContentfulPaint extends PerformanceEntry {
+        readonly renderTime: DOMHighResTimeStamp;
+        readonly loadTime: DOMHighResTimeStamp;
+        readonly size: number;
+        readonly id: string;
+        readonly url: string;
+        readonly element: Element | null;
+    }
+    interface PerformanceLongAnimationFrameTiming extends PerformanceEntry {
+        renderStart: DOMHighResTimeStamp;
+        duration: DOMHighResTimeStamp;
+    }
+}

--- a/packages/next/src/compiled/web-vitals/types/base.d.ts
+++ b/packages/next/src/compiled/web-vitals/types/base.d.ts
@@ -1,0 +1,101 @@
+import type { CLSMetric, CLSMetricWithAttribution } from './cls.js';
+import type { FCPMetric, FCPMetricWithAttribution } from './fcp.js';
+import type { FIDMetric, FIDMetricWithAttribution } from './fid.js';
+import type { INPMetric, INPMetricWithAttribution } from './inp.js';
+import type { LCPMetric, LCPMetricWithAttribution } from './lcp.js';
+import type { TTFBMetric, TTFBMetricWithAttribution } from './ttfb.js';
+export interface Metric {
+    /**
+     * The name of the metric (in acronym form).
+     */
+    name: 'CLS' | 'FCP' | 'FID' | 'INP' | 'LCP' | 'TTFB';
+    /**
+     * The current value of the metric.
+     */
+    value: number;
+    /**
+     * The rating as to whether the metric value is within the "good",
+     * "needs improvement", or "poor" thresholds of the metric.
+     */
+    rating: 'good' | 'needs-improvement' | 'poor';
+    /**
+     * The delta between the current value and the last-reported value.
+     * On the first report, `delta` and `value` will always be the same.
+     */
+    delta: number;
+    /**
+     * A unique ID representing this particular metric instance. This ID can
+     * be used by an analytics tool to dedupe multiple values sent for the same
+     * metric instance, or to group multiple deltas together and calculate a
+     * total. It can also be used to differentiate multiple different metric
+     * instances sent from the same page, which can happen if the page is
+     * restored from the back/forward cache (in that case new metrics object
+     * get created).
+     */
+    id: string;
+    /**
+     * Any performance entries relevant to the metric value calculation.
+     * The array may also be empty if the metric value was not based on any
+     * entries (e.g. a CLS value of 0 given no layout shifts).
+     */
+    entries: PerformanceEntry[];
+    /**
+     * The type of navigation.
+     *
+     * This will be the value returned by the Navigation Timing API (or
+     * `undefined` if the browser doesn't support that API), with the following
+     * exceptions:
+     * - 'back-forward-cache': for pages that are restored from the bfcache.
+     * - 'back_forward' is renamed to 'back-forward' for consistency.
+     * - 'prerender': for pages that were prerendered.
+     * - 'restore': for pages that were discarded by the browser and then
+     * restored by the user.
+     */
+    navigationType: 'navigate' | 'reload' | 'back-forward' | 'back-forward-cache' | 'prerender' | 'restore';
+}
+/** The union of supported metric types. */
+export type MetricType = CLSMetric | FCPMetric | FIDMetric | INPMetric | LCPMetric | TTFBMetric;
+/** The union of supported metric attribution types. */
+export type MetricWithAttribution = CLSMetricWithAttribution | FCPMetricWithAttribution | FIDMetricWithAttribution | INPMetricWithAttribution | LCPMetricWithAttribution | TTFBMetricWithAttribution;
+/**
+ * The thresholds of metric's "good", "needs improvement", and "poor" ratings.
+ *
+ * - Metric values up to and including [0] are rated "good"
+ * - Metric values up to and including [1] are rated "needs improvement"
+ * - Metric values above [1] are "poor"
+ *
+ * | Metric value    | Rating              |
+ * | --------------- | ------------------- |
+ * | ≦ [0]           | "good"              |
+ * | > [0] and ≦ [1] | "needs improvement" |
+ * | > [1]           | "poor"              |
+ */
+export type MetricRatingThresholds = [number, number];
+/**
+ * @deprecated Use metric-specific function types instead, such as:
+ * `(metric: LCPMetric) => void`. If a single callback type is needed for
+ * multiple metrics, use `(metric: MetricType) => void`.
+ */
+export interface ReportCallback {
+    (metric: MetricType): void;
+}
+export interface ReportOpts {
+    reportAllChanges?: boolean;
+    durationThreshold?: number;
+}
+/**
+ * The loading state of the document. Note: this value is similar to
+ * `document.readyState` but it subdivides the "interactive" state into the
+ * time before and after the DOMContentLoaded event fires.
+ *
+ * State descriptions:
+ * - `loading`: the initial document response has not yet been fully downloaded
+ *   and parsed. This is equivalent to the corresponding `readyState` value.
+ * - `dom-interactive`: the document has been fully loaded and parsed, but
+ *   scripts may not have yet finished loading and executing.
+ * - `dom-content-loaded`: the document is fully loaded and parsed, and all
+ *   scripts (except `async` scripts) have loaded and finished executing.
+ * - `complete`: the document and all of its sub-resources have finished
+ *   loading. This is equivalent to the corresponding `readyState` value.
+ */
+export type LoadState = 'loading' | 'dom-interactive' | 'dom-content-loaded' | 'complete';

--- a/packages/next/src/compiled/web-vitals/types/cls.d.ts
+++ b/packages/next/src/compiled/web-vitals/types/cls.d.ts
@@ -1,0 +1,55 @@
+import type { LoadState, Metric } from './base.js';
+/**
+ * A CLS-specific version of the Metric object.
+ */
+export interface CLSMetric extends Metric {
+    name: 'CLS';
+    entries: LayoutShift[];
+}
+/**
+ * An object containing potentially-helpful debugging information that
+ * can be sent along with the CLS value for the current page visit in order
+ * to help identify issues happening to real-users in the field.
+ */
+export interface CLSAttribution {
+    /**
+     * A selector identifying the first element (in document order) that
+     * shifted when the single largest layout shift contributing to the page's
+     * CLS score occurred.
+     */
+    largestShiftTarget?: string;
+    /**
+     * The time when the single largest layout shift contributing to the page's
+     * CLS score occurred.
+     */
+    largestShiftTime?: DOMHighResTimeStamp;
+    /**
+     * The layout shift score of the single largest layout shift contributing to
+     * the page's CLS score.
+     */
+    largestShiftValue?: number;
+    /**
+     * The `LayoutShiftEntry` representing the single largest layout shift
+     * contributing to the page's CLS score. (Useful when you need more than just
+     * `largestShiftTarget`, `largestShiftTime`, and `largestShiftValue`).
+     */
+    largestShiftEntry?: LayoutShift;
+    /**
+     * The first element source (in document order) among the `sources` list
+     * of the `largestShiftEntry` object. (Also useful when you need more than
+     * just `largestShiftTarget`, `largestShiftTime`, and `largestShiftValue`).
+     */
+    largestShiftSource?: LayoutShiftAttribution;
+    /**
+     * The loading state of the document at the time when the largest layout
+     * shift contribution to the page's CLS score occurred (see `LoadState`
+     * for details).
+     */
+    loadState?: LoadState;
+}
+/**
+ * A CLS-specific version of the Metric object with attribution.
+ */
+export interface CLSMetricWithAttribution extends CLSMetric {
+    attribution: CLSAttribution;
+}

--- a/packages/next/src/compiled/web-vitals/types/fcp.d.ts
+++ b/packages/next/src/compiled/web-vitals/types/fcp.d.ts
@@ -1,0 +1,46 @@
+import type { LoadState, Metric } from './base.js';
+/**
+ * An FCP-specific version of the Metric object.
+ */
+export interface FCPMetric extends Metric {
+    name: 'FCP';
+    entries: PerformancePaintTiming[];
+}
+/**
+ * An object containing potentially-helpful debugging information that
+ * can be sent along with the FCP value for the current page visit in order
+ * to help identify issues happening to real-users in the field.
+ */
+export interface FCPAttribution {
+    /**
+     * The time from when the user initiates loading the page until when the
+     * browser receives the first byte of the response (a.k.a. TTFB).
+     */
+    timeToFirstByte: number;
+    /**
+     * The delta between TTFB and the first contentful paint (FCP).
+     */
+    firstByteToFCP: number;
+    /**
+     * The loading state of the document at the time when FCP `occurred (see
+     * `LoadState` for details). Ideally, documents can paint before they finish
+     * loading (e.g. the `loading` or `dom-interactive` phases).
+     */
+    loadState: LoadState;
+    /**
+     * The `PerformancePaintTiming` entry corresponding to FCP.
+     */
+    fcpEntry?: PerformancePaintTiming;
+    /**
+     * The `navigation` entry of the current page, which is useful for diagnosing
+     * general page load issues. This can be used to access `serverTiming` for example:
+     * navigationEntry?.serverTiming
+     */
+    navigationEntry?: PerformanceNavigationTiming;
+}
+/**
+ * An FCP-specific version of the Metric object with attribution.
+ */
+export interface FCPMetricWithAttribution extends FCPMetric {
+    attribution: FCPAttribution;
+}

--- a/packages/next/src/compiled/web-vitals/types/fid.d.ts
+++ b/packages/next/src/compiled/web-vitals/types/fid.d.ts
@@ -1,0 +1,46 @@
+import type { LoadState, Metric } from './base.js';
+/**
+ * An FID-specific version of the Metric object.
+ */
+export interface FIDMetric extends Metric {
+    name: 'FID';
+    entries: PerformanceEventTiming[];
+}
+/**
+ * An object containing potentially-helpful debugging information that
+ * can be sent along with the FID value for the current page visit in order
+ * to help identify issues happening to real-users in the field.
+ */
+export interface FIDAttribution {
+    /**
+     * A selector identifying the element that the user interacted with. This
+     * element will be the `target` of the `event` dispatched.
+     */
+    eventTarget: string;
+    /**
+     * The time when the user interacted. This time will match the `timeStamp`
+     * value of the `event` dispatched.
+     */
+    eventTime: number;
+    /**
+     * The `type` of the `event` dispatched from the user interaction.
+     */
+    eventType: string;
+    /**
+     * The `PerformanceEventTiming` entry corresponding to FID.
+     */
+    eventEntry: PerformanceEventTiming;
+    /**
+     * The loading state of the document at the time when the first interaction
+     * occurred (see `LoadState` for details). If the first interaction occurred
+     * while the document was loading and executing script (e.g. usually in the
+     * `dom-interactive` phase) it can result in long input delays.
+     */
+    loadState: LoadState;
+}
+/**
+ * An FID-specific version of the Metric object with attribution.
+ */
+export interface FIDMetricWithAttribution extends FIDMetric {
+    attribution: FIDAttribution;
+}

--- a/packages/next/src/compiled/web-vitals/types/inp.d.ts
+++ b/packages/next/src/compiled/web-vitals/types/inp.d.ts
@@ -1,0 +1,103 @@
+import type { LoadState, Metric } from './base.js';
+/**
+ * An INP-specific version of the Metric object.
+ */
+export interface INPMetric extends Metric {
+    name: 'INP';
+    entries: PerformanceEventTiming[];
+}
+/**
+ * An object containing potentially-helpful debugging information that
+ * can be sent along with the INP value for the current page visit in order
+ * to help identify issues happening to real-users in the field.
+ */
+export interface INPAttribution {
+    /**
+     * A selector identifying the element that the user first interacted with
+     * as part of the frame where the INP candidate interaction occurred.
+     * If this value is an empty string, that generally means the element was
+     * removed from the DOM after the interaction.
+     */
+    interactionTarget: string;
+    /**
+     * A reference to the HTML element identified by `interactionTargetSelector`.
+     * NOTE: for attribution purpose, a selector identifying the element is
+     * typically more useful than the element itself. However, the element is
+     * also made available in case additional context is needed.
+     */
+    interactionTargetElement: Node | undefined;
+    /**
+     * The time when the user first interacted during the frame where the INP
+     * candidate interaction occurred (if more than one interaction occurred
+     * within the frame, only the first time is reported).
+     */
+    interactionTime: DOMHighResTimeStamp;
+    /**
+     * The best-guess timestamp of the next paint after the interaction.
+     * In general, this timestamp is the same as the `startTime + duration` of
+     * the event timing entry. However, since `duration` values are rounded to
+     * the nearest 8ms, it can sometimes appear that the paint occurred before
+     * processing ended (which cannot happen). This value clamps the paint time
+     * so it's always after `processingEnd` from the Event Timing API and
+     * `renderStart` from the Long Animation Frame API (where available).
+     * It also averages the duration values for all entries in the same
+     * animation frame, which should be closer to the "real" value.
+     */
+    nextPaintTime: DOMHighResTimeStamp;
+    /**
+     * The type of interaction, based on the event type of the `event` entry
+     * that corresponds to the interaction (i.e. the first `event` entry
+     * containing an `interactionId` dispatched in a given animation frame).
+     * For "pointerdown", "pointerup", or "click" events this will be "pointer",
+     * and for "keydown" or "keyup" events this will be "keyboard".
+     */
+    interactionType: 'pointer' | 'keyboard';
+    /**
+     * An array of Event Timing entries that were processed within the same
+     * animation frame as the INP candidate interaction.
+     */
+    processedEventEntries: PerformanceEventTiming[];
+    /**
+     * If the browser supports the Long Animation Frame API, this array will
+     * include any `long-animation-frame` entries that intersect with the INP
+     * candidate interaction's `startTime` and the `processingEnd` time of the
+     * last event processed within that animation frame. If the browser does not
+     * support the Long Animation Frame API or no `long-animation-frame` entries
+     * are detect, this array will be empty.
+     */
+    longAnimationFrameEntries: PerformanceLongAnimationFrameTiming[];
+    /**
+     * The time from when the user interacted with the page until when the
+     * browser was first able to start processing event listeners for that
+     * interaction. This time captures the delay before event processing can
+     * begin due to the main thread being busy with other work.
+     */
+    inputDelay: number;
+    /**
+     * The time from when the first event listener started running in response to
+     * the user interaction until when all event listener processing has finished.
+     */
+    processingDuration: number;
+    /**
+     * The time from when the browser finished processing all event listeners for
+     * the user interaction until the next frame is presented on the screen and
+     * visible to the user. This time includes work on the main thread (such as
+     * `requestAnimationFrame()` callbacks, `ResizeObserver` and
+     * `IntersectionObserver` callbacks, and style/layout calculation) as well
+     * as off-main-thread work (such as compositor, GPU, and raster work).
+     */
+    presentationDelay: number;
+    /**
+     * The loading state of the document at the time when the interaction
+     * corresponding to INP occurred (see `LoadState` for details). If the
+     * interaction occurred while the document was loading and executing script
+     * (e.g. usually in the `dom-interactive` phase) it can result in long delays.
+     */
+    loadState: LoadState;
+}
+/**
+ * An INP-specific version of the Metric object with attribution.
+ */
+export interface INPMetricWithAttribution extends INPMetric {
+    attribution: INPAttribution;
+}

--- a/packages/next/src/compiled/web-vitals/types/lcp.d.ts
+++ b/packages/next/src/compiled/web-vitals/types/lcp.d.ts
@@ -1,0 +1,69 @@
+import type { Metric } from './base.js';
+/**
+ * An LCP-specific version of the Metric object.
+ */
+export interface LCPMetric extends Metric {
+    name: 'LCP';
+    entries: LargestContentfulPaint[];
+}
+/**
+ * An object containing potentially-helpful debugging information that
+ * can be sent along with the LCP value for the current page visit in order
+ * to help identify issues happening to real-users in the field.
+ */
+export interface LCPAttribution {
+    /**
+     * The element corresponding to the largest contentful paint for the page.
+     */
+    element?: string;
+    /**
+     * The URL (if applicable) of the LCP image resource. If the LCP element
+     * is a text node, this value will not be set.
+     */
+    url?: string;
+    /**
+     * The time from when the user initiates loading the page until when the
+     * browser receives the first byte of the response (a.k.a. TTFB). See
+     * [Optimize LCP](https://web.dev/articles/optimize-lcp) for details.
+     */
+    timeToFirstByte: number;
+    /**
+     * The delta between TTFB and when the browser starts loading the LCP
+     * resource (if there is one, otherwise 0). See [Optimize
+     * LCP](https://web.dev/articles/optimize-lcp) for details.
+     */
+    resourceLoadDelay: number;
+    /**
+     * The total time it takes to load the LCP resource itself (if there is one,
+     * otherwise 0). See [Optimize LCP](https://web.dev/articles/optimize-lcp) for
+     * details.
+     */
+    resourceLoadDuration: number;
+    /**
+     * The delta between when the LCP resource finishes loading until the LCP
+     * element is fully rendered. See [Optimize
+     * LCP](https://web.dev/articles/optimize-lcp) for details.
+     */
+    elementRenderDelay: number;
+    /**
+     * The `navigation` entry of the current page, which is useful for diagnosing
+     * general page load issues. This can be used to access `serverTiming` for example:
+     * navigationEntry?.serverTiming
+     */
+    navigationEntry?: PerformanceNavigationTiming;
+    /**
+     * The `resource` entry for the LCP resource (if applicable), which is useful
+     * for diagnosing resource load issues.
+     */
+    lcpResourceEntry?: PerformanceResourceTiming;
+    /**
+     * The `LargestContentfulPaint` entry corresponding to LCP.
+     */
+    lcpEntry?: LargestContentfulPaint;
+}
+/**
+ * An LCP-specific version of the Metric object with attribution.
+ */
+export interface LCPMetricWithAttribution extends LCPMetric {
+    attribution: LCPAttribution;
+}

--- a/packages/next/src/compiled/web-vitals/types/polyfills.d.ts
+++ b/packages/next/src/compiled/web-vitals/types/polyfills.d.ts
@@ -1,0 +1,4 @@
+export type FirstInputPolyfillEntry = Omit<PerformanceEventTiming, 'processingEnd'>;
+export interface FirstInputPolyfillCallback {
+    (entry: FirstInputPolyfillEntry): void;
+}

--- a/packages/next/src/compiled/web-vitals/types/ttfb.d.ts
+++ b/packages/next/src/compiled/web-vitals/types/ttfb.d.ts
@@ -1,0 +1,59 @@
+import type { Metric } from './base.js';
+/**
+ * A TTFB-specific version of the Metric object.
+ */
+export interface TTFBMetric extends Metric {
+    name: 'TTFB';
+    entries: PerformanceNavigationTiming[];
+}
+/**
+ * An object containing potentially-helpful debugging information that
+ * can be sent along with the TTFB value for the current page visit in order
+ * to help identify issues happening to real-users in the field.
+ *
+ * NOTE: these values are primarily useful for page loads not handled via
+ * service worker, as browsers differ in what they report when service worker
+ * is involved, see: https://github.com/w3c/navigation-timing/issues/199
+ */
+export interface TTFBAttribution {
+    /**
+     * The total time from when the user initiates loading the page to when the
+     * page starts to handle the request. Large values here are typically due
+     * to HTTP redirects, though other browser processing contributes to this
+     * duration as well (so even without redirect it's generally not zero).
+     */
+    waitingDuration: number;
+    /**
+     * The total time spent checking the HTTP cache for a match. For navigations
+     * handled via service worker, this duration usually includes service worker
+     * start-up time as well as time processing `fetch` event listeners, with
+     * some exceptions, see: https://github.com/w3c/navigation-timing/issues/199
+     */
+    cacheDuration: number;
+    /**
+     * The total time to resolve the DNS for the requested domain.
+     */
+    dnsDuration: number;
+    /**
+     * The total time to create the connection to the requested domain.
+     */
+    connectionDuration: number;
+    /**
+     * The total time from when the request was sent until the first byte of the
+     * response was received. This includes network time as well as server
+     * processing time.
+     */
+    requestDuration: number;
+    /**
+     * The `navigation` entry of the current page, which is useful for diagnosing
+     * general page load issues. This can be used to access `serverTiming` for
+     * example: navigationEntry?.serverTiming
+     */
+    navigationEntry?: PerformanceNavigationTiming;
+}
+/**
+ * A TTFB-specific version of the Metric object with attribution.
+ */
+export interface TTFBMetricWithAttribution extends TTFBMetric {
+    attribution: TTFBAttribution;
+}

--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -1959,6 +1959,9 @@ export async function ncc_zod_validation_error(task, opts) {
 
 externals['web-vitals'] = 'next/dist/compiled/web-vitals'
 export async function ncc_web_vitals(task, opts) {
+  const compiledDir = join(__dirname, 'src/compiled/web-vitals')
+  const webVitalsDir = resolve(resolveFrom(__dirname, 'web-vitals'), '../..')
+
   await task
     .source(
       relative(
@@ -1969,6 +1972,29 @@ export async function ncc_web_vitals(task, opts) {
     // web-vitals@3.0.0 is pure ESM, compile to CJS for pre-compiled
     .ncc({ packageName: 'web-vitals', externals, target: 'es5', esm: false })
     .target('src/compiled/web-vitals')
+
+  await rmrf(join(compiledDir, 'attribution'))
+  await rmrf(join(compiledDir, 'types'))
+  for (const file of glob.sync('*.d.ts', { cwd: compiledDir })) {
+    await rmrf(join(compiledDir, file))
+  }
+
+  const typeFiles = glob.sync(
+    'dist/modules/{*.d.ts,attribution/*.d.ts,types/**/*.d.ts}',
+    { cwd: webVitalsDir }
+  )
+  for (const file of typeFiles) {
+    const outputFile = join(compiledDir, file.replace(/^dist\/modules\//, ''))
+    await fs.mkdir(dirname(outputFile), { recursive: true })
+    const content = await fs.readFile(join(webVitalsDir, file), 'utf8')
+    await fs.writeFile(outputFile, content.replace(/[ \t]+$/gm, ''))
+  }
+
+  const pkg = await readJson(join(compiledDir, 'package.json'))
+  await writeJson(join(compiledDir, 'package.json'), {
+    ...pkg,
+    types: './index.d.ts',
+  })
 }
 externals['web-vitals-attribution'] =
   'next/dist/compiled/web-vitals-attribution'

--- a/test/production/typescript-basic/typechecking/index.ts
+++ b/test/production/typescript-basic/typechecking/index.ts
@@ -19,5 +19,15 @@ import 'next/og'
 import 'next/router'
 import 'next/script'
 import 'next/server'
-// FIXME
-// import 'next/web-vitals';
+import type { useReportWebVitals } from 'next/web-vitals'
+
+type ReportWebVitalsCallback = Parameters<typeof useReportWebVitals>[0]
+type WebVitalsMetric = Parameters<ReportWebVitalsCallback>[0]
+type WebVitalsMetricName = WebVitalsMetric['name']
+
+const webVitalsMetricName: WebVitalsMetricName = 'CLS'
+// @ts-expect-error - metric.name should not allow arbitrary strings.
+const invalidWebVitalsMetricName: WebVitalsMetricName = 'custom'
+
+void webVitalsMetricName
+void invalidWebVitalsMetricName


### PR DESCRIPTION
### What?

Adds TypeScript declaration files for the compiled `web-vitals` package bundled in Next.js.

### Why?

`next/web-vitals` imports the `Metric` type from `next/dist/compiled/web-vitals`, but the compiled package did not include `.d.ts` files. This caused `useReportWebVitals` callback metrics to lose their proper type information.

### How?

- Copies `web-vitals` declaration files into `packages/next/src/compiled/web-vitals`
- Adds a `types` entry to the compiled package metadata
- Updates the `ncc_web_vitals` task so regenerated compiled output includes the declarations
- Adds a production TypeScript typechecking regression test for `useReportWebVitals`

Fixes #59903 