### PR TITLE
docs: fix typos, grammar, and broken code example

### DIFF
--- a/docs/01-app/01-getting-started/02-project-structure.mdx
+++ b/docs/01-app/01-getting-started/02-project-structure.mdx
@@ -122,7 +122,7 @@ Use `@slot` for named slots rendered by a parent layout. Use intercept patterns 
 | [`favicon`](/docs/app/api-reference/file-conventions/metadata/app-icons#favicon)                                | `.ico`                              | Favicon file             |
 | [`icon`](/docs/app/api-reference/file-conventions/metadata/app-icons#icon)                                      | `.ico` `.jpg` `.jpeg` `.png` `.svg` | App Icon file            |
 | [`icon`](/docs/app/api-reference/file-conventions/metadata/app-icons#generate-icons-using-code-js-ts-tsx)       | `.js` `.ts` `.tsx`                  | Generated App Icon       |
-| [`apple-icon`](/docs/app/api-reference/file-conventions/metadata/app-icons#apple-icon)                          | `.jpg` `.jpeg`, `.png`              | Apple App Icon file      |
+| [`apple-icon`](/docs/app/api-reference/file-conventions/metadata/app-icons#apple-icon)                          | `.jpg` `.jpeg` `.png`               | Apple App Icon file      |
 | [`apple-icon`](/docs/app/api-reference/file-conventions/metadata/app-icons#generate-icons-using-code-js-ts-tsx) | `.js` `.ts` `.tsx`                  | Generated Apple App Icon |
 
 #### Open Graph and Twitter images

--- a/docs/01-app/02-guides/authentication.mdx
+++ b/docs/01-app/02-guides/authentication.mdx
@@ -348,7 +348,7 @@ export async function signup(state, formData) {
   // e.g. Hash the user's password before storing it
   const hashedPassword = await bcrypt.hash(password, 10)
 
-  // 3. Insert the user into the database or call an Library API
+  // 3. Insert the user into the database or call an Auth Library's API
   const data = await db
     .insert(users)
     .values({
@@ -681,7 +681,7 @@ export async function signup(state: FormState, formData: FormData) {
   // Previous steps:
   // 1. Validate form fields
   // 2. Prepare data for insertion into database
-  // 3. Insert the user into the database or call an Library API
+  // 3. Insert the user into the database or call an Auth Library's API
 
   // Current steps:
   // 4. Create user session
@@ -698,7 +698,7 @@ export async function signup(state, formData) {
   // Previous steps:
   // 1. Validate form fields
   // 2. Prepare data for insertion into database
-  // 3. Insert the user into the database or call an Library API
+  // 3. Insert the user into the database or call an Auth Library's API
 
   // Current steps:
   // 4. Create user session
@@ -756,9 +756,10 @@ export async function updateSession() {
     return null
   }
 
-  const expires = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000)(
-    await cookies()
-  ).set('session', session, {
+  const expires = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000)
+
+  const cookieStore = await cookies()
+  cookieStore.set('session', session, {
     httpOnly: true,
     secure: true,
     expires: expires,

--- a/docs/01-app/02-guides/mdx.mdx
+++ b/docs/01-app/02-guides/mdx.mdx
@@ -164,7 +164,7 @@ This is a list in markdown:
 - Two
 - Three
 
-Checkout my React component:
+Check out my React component:
 
 <MyComponent />
 ```
@@ -221,7 +221,7 @@ This is a list in markdown:
 - Two
 - Three
 
-Checkout my React component:
+Check out my React component:
 
 <MyComponent />
 ```

--- a/docs/01-app/02-guides/self-hosting.mdx
+++ b/docs/01-app/02-guides/self-hosting.mdx
@@ -171,7 +171,7 @@ Using a custom cache handler will allow you to ensure consistency across all pod
 
 ## Build Cache
 
-Next.js generates an ID during `next build` to identify which version of your application is being served. The same build should be used and boot up multiple containers.
+Next.js generates an ID during `next build` to identify which version of your application is being served. The same build should be used to boot up multiple containers.
 
 If you are rebuilding for each stage of your environment, you will need to generate a consistent build ID to use between containers. Use the `generateBuildId` command in `next.config.js`:
 

--- a/docs/03-architecture/fast-refresh.mdx
+++ b/docs/03-architecture/fast-refresh.mdx
@@ -3,7 +3,7 @@ title: Fast Refresh
 description: Fast Refresh is a hot module reloading experience that gives you instantaneous feedback on edits made to your React components.
 ---
 
-Fast refresh is a React feature integrated into Next.js that allows you to live reload the browser page while maintaining temporary client-side state when you save changes to a file. It's enabled by default in all Next.js applications on **9.4 or newer**. With Fast Refresh enabled, most edits should be visible within a second.
+Fast Refresh is a React feature integrated into Next.js that allows you to live reload the browser page while maintaining temporary client-side state when you save changes to a file. It's enabled by default in all Next.js applications on **9.4 or newer**. With Fast Refresh enabled, most edits should be visible within a second.
 
 ## How It Works
 
@@ -53,7 +53,7 @@ intentionally.
 ## Limitations
 
 Fast Refresh tries to preserve local React state in the component you're
-editing, but only if it's safe to do so. Here's a few reasons why you might see
+editing, but only if it's safe to do so. Here are a few reasons why you might see
 local state being reset on every edit to a file:
 
 - Local state is not preserved for class components (only function components


### PR DESCRIPTION
## For Contributors

### Improving Documentation

- [x] Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- [x] Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

---

Fixes several small issues across the docs:

| File | Issue | Fix |
| --- | --- | --- |
| `docs/03-architecture/fast-refresh.mdx` | "Fast refresh" → "Fast Refresh" (capitalisation) | Fixed |
| `docs/03-architecture/fast-refresh.mdx` | "Here's a few reasons" → "Here are a few reasons" (grammar) | Fixed |
| `docs/01-app/02-guides/mdx.mdx` | "Checkout my React component" × 2 → "Check out" (word choice) | Fixed |
| `docs/01-app/02-guides/authentication.mdx` | JS switcher tabs had "call an Library API" (missing "Auth") in 3 places; TS tabs were correct | Fixed |
| `docs/01-app/02-guides/authentication.mdx` | Broken `updateSession` JS code example — missing `const cookieStore =` assignment, making it syntactically invalid | Fixed |
| `docs/01-app/02-guides/self-hosting.mdx` | "used and boot up multiple containers" → "used to boot up" (missing word) | Fixed |
| `docs/01-app/01-getting-started/02-project-structure.mdx` | Stray comma in apple-icon extensions list: `.jpeg`, `.png` → `.jpeg` `.png` | Fixed |