### PR TITLE
[turbopack-trace-server] optimize loading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10809,6 +10809,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "serde_json",
+ "smallvec",
  "tungstenite 0.21.0",
  "turbo-rcstr",
  "turbo-tasks-malloc",

--- a/turbopack/crates/turbopack-trace-server/Cargo.toml
+++ b/turbopack/crates/turbopack-trace-server/Cargo.toml
@@ -28,6 +28,7 @@ rustc-demangle = "0.1"
 rustc-hash = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+smallvec = { workspace = true }
 turbo-rcstr = { workspace = true }
 turbo-tasks-malloc = { workspace = true, default-features = false }
 tungstenite = { version = "0.21.0" }

--- a/turbopack/crates/turbopack-trace-server/src/lazy_sorted_vec.rs
+++ b/turbopack/crates/turbopack-trace-server/src/lazy_sorted_vec.rs
@@ -1,7 +1,15 @@
 use std::{cell::UnsafeCell, ops::Deref, sync::Once};
 
+use smallvec::SmallVec;
+
+/// Backing storage for `LazySortedVec`. Inlines a single element so that
+/// the common case (e.g. a leaf span with one self-time event) does not
+/// pay a heap allocation. With one inline slot plus the workspace's
+/// `union` smallvec feature, this is the same size as a `Vec`.
+type Inner<T> = SmallVec<[T; 1]>;
+
 pub struct LazySortedVec<T> {
-    vec: UnsafeCell<Vec<T>>,
+    vec: UnsafeCell<Inner<T>>,
     once: Once,
 }
 
@@ -11,7 +19,7 @@ unsafe impl<T> Sync for LazySortedVec<T> where T: Sync {}
 impl<T> LazySortedVec<T> {
     pub fn new() -> Self {
         Self {
-            vec: UnsafeCell::new(Vec::new()),
+            vec: UnsafeCell::new(SmallVec::new()),
             once: Once::new(),
         }
     }
@@ -21,8 +29,8 @@ impl<T> LazySortedVec<T> {
         self.vec.get_mut().push(value);
     }
 
-    pub fn retain_unordered(&mut self, f: impl FnMut(&T) -> bool) {
-        self.vec.get_mut().retain(f);
+    pub fn retain_unordered(&mut self, mut f: impl FnMut(&T) -> bool) {
+        self.vec.get_mut().retain(|t| f(t));
     }
 
     pub fn iter_mut_unordered(&mut self) -> std::slice::IterMut<'_, T> {
@@ -31,7 +39,7 @@ impl<T> LazySortedVec<T> {
 }
 
 impl<T: Ord> Deref for LazySortedVec<T> {
-    type Target = Vec<T>;
+    type Target = [T];
 
     fn deref(&self) -> &Self::Target {
         let ptr = self.vec.get();
@@ -44,7 +52,7 @@ impl<T: Ord> Deref for LazySortedVec<T> {
         // SAFETY: Returning this reference is safe because the lifetime guarantees that there is no
         // `&mut self` that could cause a simultaneous access to the `vec`, and the `Once`
         // guarantees that the sorting is complete before we return the reference.
-        unsafe { &*ptr }
+        unsafe { &*ptr }.as_slice()
     }
 }
 
@@ -54,10 +62,19 @@ impl<T> Default for LazySortedVec<T> {
     }
 }
 
+impl<T> From<Inner<T>> for LazySortedVec<T> {
+    fn from(vec: Inner<T>) -> Self {
+        Self {
+            vec: UnsafeCell::new(vec),
+            once: Once::new(),
+        }
+    }
+}
+
 impl<T> From<Vec<T>> for LazySortedVec<T> {
     fn from(vec: Vec<T>) -> Self {
         Self {
-            vec: UnsafeCell::new(vec),
+            vec: UnsafeCell::new(SmallVec::from_vec(vec)),
             once: Once::new(),
         }
     }

--- a/turbopack/crates/turbopack-trace-server/src/reader/heaptrack.rs
+++ b/turbopack/crates/turbopack-trace-server/src/reader/heaptrack.rs
@@ -7,7 +7,12 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use turbo_rcstr::{RcStr, rcstr};
 
 use super::TraceFormat;
-use crate::{FxIndexMap, span::SpanIndex, store_container::StoreContainer, timestamp::Timestamp};
+use crate::{
+    FxIndexMap,
+    span::{SpanArgs, SpanIndex},
+    store_container::StoreContainer,
+    timestamp::Timestamp,
+};
 
 #[derive(Debug, Clone, Copy)]
 struct TraceNode {
@@ -276,7 +281,7 @@ impl TraceFormat for HeaptrackFormat {
                                             self.last_timestamp,
                                             RcStr::default(),
                                             rcstr!("recursion"),
-                                            Vec::new(),
+                                            SpanArgs::new(),
                                             &mut outdated_spans,
                                         );
                                         store.complete_span(span_index);
@@ -321,7 +326,7 @@ impl TraceFormat for HeaptrackFormat {
                     } else {
                         "unknown".to_string()
                     };
-                    let mut args = Vec::new();
+                    let mut args = SpanArgs::new();
                     for Frame {
                         function_index,
                         file_index,

--- a/turbopack/crates/turbopack-trace-server/src/self_time_tree.rs
+++ b/turbopack/crates/turbopack-trace-server/src/self_time_tree.rs
@@ -90,8 +90,12 @@ impl<T> SelfTimeTree<T> {
 
     fn distribute_entries(&mut self) {
         if self.children.is_none() {
-            let start = self.entries.iter().min_by_key(|e| e.start).unwrap().start;
-            let end = self.entries.iter().max_by_key(|e| e.end).unwrap().end;
+            let (start, end) = self
+                .entries
+                .iter()
+                .fold((Timestamp::MAX, Timestamp::ZERO), |(lo, hi), e| {
+                    (lo.min(e.start), hi.max(e.end))
+                });
             let middle = (start + end) / 2;
             // Pre-allocate half the split threshold: after distributing, each child
             // typically receives ~SPLIT_COUNT / 2 entries.
@@ -235,7 +239,6 @@ impl<T> SelfTimeTree<T> {
     }
 
     pub fn lookup_range_corrected_time(&self, start: Timestamp, end: Timestamp) -> Timestamp {
-        let mut factor_times_1000 = 0u64;
         #[derive(PartialEq, Eq, PartialOrd, Ord)]
         enum Change {
             Start,
@@ -253,7 +256,18 @@ impl<T> SelfTimeTree<T> {
                 changes.push((e, Change::End));
             }
         });
+
+        // Fast path: every overlapping interval fully contains `[start, end]`, so the
+        // count is constant over the whole window. Skip the sort and the sweep.
+        if changes.is_empty() {
+            if current_count == 0 {
+                return Timestamp::ZERO;
+            }
+            return Timestamp::from_value(*(end - start) / current_count);
+        }
+
         changes.sort_unstable();
+        let mut factor_times_1000 = 0u64;
         let mut current_ts = start;
         for (ts, change) in changes {
             if current_ts < ts {
@@ -442,5 +456,54 @@ mod tests {
         );
         print_tree(&tree, 0);
         assert_balanced(&tree);
+    }
+
+    #[test]
+    fn test_corrected_time_no_overlap() {
+        // No intervals at all — corrected time of an empty range is zero.
+        let tree: SelfTimeTree<u32> = SelfTimeTree::new();
+        let r = tree
+            .lookup_range_corrected_time(Timestamp::from_micros(0), Timestamp::from_micros(100));
+        assert_eq!(r, Timestamp::ZERO);
+    }
+
+    #[test]
+    fn test_corrected_time_single_interval() {
+        // One interval matching the query window exactly: correction factor 1, returns full
+        // duration.
+        let mut tree = SelfTimeTree::new();
+        tree.insert(Timestamp::from_micros(0), Timestamp::from_micros(100), 0u32);
+        let r = tree
+            .lookup_range_corrected_time(Timestamp::from_micros(0), Timestamp::from_micros(100));
+        assert_eq!(r, Timestamp::from_micros(100));
+    }
+
+    #[test]
+    fn test_corrected_time_fast_path_full_containment() {
+        // Two intervals each fully contain [10, 20]: count is 2 throughout, answer = 10/2 = 5us.
+        let mut tree = SelfTimeTree::new();
+        tree.insert(Timestamp::from_micros(0), Timestamp::from_micros(100), 0u32);
+        tree.insert(Timestamp::from_micros(5), Timestamp::from_micros(50), 1u32);
+        let r = tree
+            .lookup_range_corrected_time(Timestamp::from_micros(10), Timestamp::from_micros(20));
+        assert_eq!(r, Timestamp::from_micros(5));
+    }
+
+    #[test]
+    fn test_corrected_time_partial_overlap() {
+        // [0, 100] is the query window. Intervals:
+        //   A: [0, 100]    (covers whole window)
+        //   B: [30, 70]    (fully inside, contributes corrections during [30, 70])
+        // Expected:
+        //   [0, 30):  count=1, time=30, corrected = 30 / 1 = 30
+        //   [30, 70): count=2, time=40, corrected = 40 / 2 = 20
+        //   [70, 100): count=1, time=30, corrected = 30 / 1 = 30
+        // Total: 80us
+        let mut tree = SelfTimeTree::new();
+        tree.insert(Timestamp::from_micros(0), Timestamp::from_micros(100), 0u32);
+        tree.insert(Timestamp::from_micros(30), Timestamp::from_micros(70), 1u32);
+        let r = tree
+            .lookup_range_corrected_time(Timestamp::from_micros(0), Timestamp::from_micros(100));
+        assert_eq!(r, Timestamp::from_micros(80));
     }
 }

--- a/turbopack/crates/turbopack-trace-server/src/span.rs
+++ b/turbopack/crates/turbopack-trace-server/src/span.rs
@@ -4,11 +4,18 @@ use std::{
 };
 
 use hashbrown::HashMap;
+use smallvec::SmallVec;
 use turbo_rcstr::RcStr;
 
 use crate::{lazy_sorted_vec::LazySortedVec, timestamp::Timestamp};
 
 pub type SpanIndex = NonZeroUsize;
+
+/// Storage for `Span::args`. Most spans have 0–1 args (typically just the
+/// `name` key for `turbo_tasks::function` spans), so inlining one entry
+/// avoids a heap allocation in the common case. With one inline slot plus
+/// the workspace's `union` feature, this is the same 24 bytes as a `Vec`.
+pub type SpanArgs = SmallVec<[(RcStr, RcStr); 1]>;
 
 pub struct Span {
     // These values won't change after creation:
@@ -17,7 +24,7 @@ pub struct Span {
     pub start: Timestamp,
     pub category: RcStr,
     pub name: RcStr,
-    pub args: Vec<(RcStr, RcStr)>,
+    pub args: SpanArgs,
 
     // This might change during writing:
     /// The list of events sorted by start time

--- a/turbopack/crates/turbopack-trace-server/src/span.rs
+++ b/turbopack/crates/turbopack-trace-server/src/span.rs
@@ -42,9 +42,12 @@ pub struct Span {
     // Bundling the subtree totals into a single OnceLock pays a small cost on
     // partial reads in exchange for a much-reduced lock count per Span.
     pub totals: OnceLock<SpanTotals>,
-    pub time_data: OnceLock<Box<SpanTimeData>>,
+    pub time_data: SpanTimeData,
     pub extra: OnceLock<Box<SpanExtra>>,
-    pub names: OnceLock<Box<SpanNames>>,
+    /// Lazy first-touch via `OnceLock`, but inline rather than boxed: ~96% of
+    /// spans get names populated after browsing, never invalidated, so the box
+    /// indirection is pure overhead.
+    pub names: OnceLock<SpanNames>,
 }
 
 #[derive(Default)]
@@ -82,35 +85,87 @@ pub struct SpanExtra {
     pub search_index: OnceLock<HashMap<RcStr, Vec<SpanIndex>>>,
 }
 
-#[derive(Default)]
+#[derive(Clone)]
+pub struct SpanName {
+    pub category: RcStr,
+    pub title: RcStr,
+}
+
 pub struct SpanNames {
-    // These values are computed when accessed (and maybe deleted during writing):
-    pub nice_name: OnceLock<(RcStr, RcStr)>,
-    pub group_name: OnceLock<(RcStr, RcStr)>,
+    pub nice_name: SpanName,
+    pub group_name: SpanName,
 }
 
 impl Span {
-    pub fn time_data(&self) -> &SpanTimeData {
-        self.time_data.get_or_init(|| {
-            Box::new(SpanTimeData {
-                self_end: self.start,
-                ignore_self_time: &self.name == "thread" || &self.name == "blocking",
-                ..Default::default()
-            })
-        })
-    }
-
-    pub fn time_data_mut(&mut self) -> &mut SpanTimeData {
-        self.time_data();
-        self.time_data.get_mut().unwrap()
-    }
-
     pub fn extra(&self) -> &SpanExtra {
         self.extra.get_or_init(Default::default)
     }
 
     pub fn names(&self) -> &SpanNames {
-        self.names.get_or_init(Default::default)
+        self.names.get_or_init(|| self.compute_names())
+    }
+
+    fn compute_names(&self) -> SpanNames {
+        // Classify the span. `turbo_tasks::function` and the resolve-call spans
+        // get special-cased rendering when they carry a `name` arg; everything
+        // else is rendered generically.
+        enum Kind {
+            Function,
+            Resolve,
+            Other,
+        }
+        let kind = match self.name.as_str() {
+            "turbo_tasks::function" => Kind::Function,
+            "turbo_tasks::resolve_call" | "turbo_tasks::resolve_trait_call" => Kind::Resolve,
+            _ => Kind::Other,
+        };
+        let arg_name = self.args.iter().find(|&(k, _)| k == "name").map(|(_, v)| v);
+
+        // Generic fallback used by both names whenever no special case applies.
+        let generic = || SpanName {
+            category: self.category.clone(),
+            title: self.name.clone(),
+        };
+
+        // Each arm constructs the full `SpanNames` so the relationship between
+        // `nice_name` and `group_name` is visible at a glance. The `Some(n)`
+        // rows handle the "this span carries a `name` arg" case; the `None`
+        // arm falls back to the generic shape for both names — including for
+        // function/resolve spans, which (in practice) always carry a name arg,
+        // so the fallback is mostly defensive.
+        match (kind, arg_name) {
+            (Kind::Function, Some(n)) => {
+                let pretty = SpanName {
+                    category: self.name.clone(),
+                    title: n.clone(),
+                };
+                SpanNames {
+                    nice_name: pretty.clone(),
+                    group_name: pretty,
+                }
+            }
+            (Kind::Resolve, Some(n)) => SpanNames {
+                nice_name: SpanName {
+                    category: self.name.clone(),
+                    title: format!("*{n}").into(),
+                },
+                group_name: SpanName {
+                    category: self.category.clone(),
+                    title: format!("{} *{n}", self.name).into(),
+                },
+            },
+            (Kind::Other, Some(n)) => SpanNames {
+                nice_name: SpanName {
+                    category: self.category.clone(),
+                    title: format!("{} {n}", self.name).into(),
+                },
+                group_name: generic(),
+            },
+            (_, None) => SpanNames {
+                nice_name: generic(),
+                group_name: generic(),
+            },
+        }
     }
 }
 

--- a/turbopack/crates/turbopack-trace-server/src/span.rs
+++ b/turbopack/crates/turbopack-trace-server/src/span.rs
@@ -1,5 +1,5 @@
 use std::{
-    num::NonZeroUsize,
+    num::{NonZeroU64, NonZeroUsize},
     sync::{Arc, OnceLock},
 };
 
@@ -101,10 +101,21 @@ impl Span {
     }
 }
 
+/// Stores `duration` as `NonZeroU64` so the variant has a niche; combined with
+/// `Child`'s `NonZeroUsize` index, this lets the compiler pack `SpanEvent`
+/// without a separate discriminant byte (saving 8 bytes per event vs. an
+/// `end: Timestamp` layout). Callers must filter zero-duration self-time
+/// events before constructing — see [`SpanEvent::self_time`].
 pub struct SpanEventSelfTime {
     pub start: Timestamp,
-    pub end: Timestamp,
+    pub duration: NonZeroU64,
     pub corrected_self_time: OnceLock<Timestamp>,
+}
+
+impl SpanEventSelfTime {
+    pub fn end(&self) -> Timestamp {
+        Timestamp::from_value(*self.start + self.duration.get())
+    }
 }
 
 pub enum SpanEvent {
@@ -112,13 +123,21 @@ pub enum SpanEvent {
     Child { start: Timestamp, index: SpanIndex },
 }
 
+// 32 bytes = 8 (start) + 8 (duration) + 16 (OnceLock<Timestamp>) for the
+// SelfTime variant; the Child variant fits in 16 and uses the niche, so no
+// extra discriminant byte is needed.
+const _: () = assert!(std::mem::size_of::<SpanEvent>() == 32);
+
 impl SpanEvent {
-    pub fn self_time(start: Timestamp, end: Timestamp) -> Self {
-        Self::SelfTime(SpanEventSelfTime {
+    /// Constructs a `SelfTime` event from start and end timestamps. Returns `None`
+    /// if `end <= start` (zero or negative duration).
+    pub fn self_time(start: Timestamp, end: Timestamp) -> Option<Self> {
+        let duration = NonZeroU64::new(*end.saturating_sub(start))?;
+        Some(SpanEvent::SelfTime(SpanEventSelfTime {
             start,
-            end,
+            duration,
             corrected_self_time: OnceLock::new(),
-        })
+        }))
     }
 
     pub fn start(&self) -> Timestamp {
@@ -150,7 +169,7 @@ impl Ord for SpanEvent {
             .then_with(|| match (self, other) {
                 (SpanEvent::SelfTime(_), SpanEvent::Child { .. }) => std::cmp::Ordering::Less,
                 (SpanEvent::Child { .. }, SpanEvent::SelfTime(_)) => std::cmp::Ordering::Greater,
-                (SpanEvent::SelfTime(a), SpanEvent::SelfTime(b)) => a.end.cmp(&b.end),
+                (SpanEvent::SelfTime(a), SpanEvent::SelfTime(b)) => a.duration.cmp(&b.duration),
                 (
                     SpanEvent::Child { start: _, index: a },
                     SpanEvent::Child { start: _, index: b },
@@ -231,5 +250,40 @@ impl SpanBottomUp {
             self_persistent_allocations: OnceLock::new(),
             self_allocation_count: OnceLock::new(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn span_event_self_time_filters_zero_duration() {
+        let t = Timestamp::from_micros(100);
+        assert!(SpanEvent::self_time(t, t).is_none());
+        // end < start should also return None (saturating_sub clamps to 0).
+        assert!(SpanEvent::self_time(t, Timestamp::from_micros(50)).is_none());
+    }
+
+    #[test]
+    fn span_event_self_time_constructs_positive_duration() {
+        let start = Timestamp::from_micros(100);
+        let end = Timestamp::from_micros(150);
+        let event = SpanEvent::self_time(start, end).unwrap();
+        match event {
+            SpanEvent::SelfTime(self_time) => {
+                assert_eq!(self_time.start, start);
+                assert_eq!(self_time.duration.get(), *end - *start);
+                assert_eq!(self_time.end(), end);
+            }
+            SpanEvent::Child { .. } => panic!("expected SelfTime"),
+        }
+    }
+
+    #[test]
+    fn span_event_size_is_packed() {
+        // Backstop for the const assert; if this fails the const assert above
+        // would also fail, but having a test gives a clearer error message.
+        assert_eq!(std::mem::size_of::<SpanEvent>(), 32);
     }
 }

--- a/turbopack/crates/turbopack-trace-server/src/span.rs
+++ b/turbopack/crates/turbopack-trace-server/src/span.rs
@@ -11,10 +11,9 @@ use crate::{lazy_sorted_vec::LazySortedVec, timestamp::Timestamp};
 
 pub type SpanIndex = NonZeroUsize;
 
-/// Storage for `Span::args`. Most spans have 0–1 args (typically just the
+/// Storage for `Span::args` ~32% of spans have <=1 arg (typically just the
 /// `name` key for `turbo_tasks::function` spans), so inlining one entry
-/// avoids a heap allocation in the common case. With one inline slot plus
-/// the workspace's `union` feature, this is the same 24 bytes as a `Vec`.
+/// avoids a heap allocation in this common case.
 pub type SpanArgs = SmallVec<[(RcStr, RcStr); 1]>;
 
 pub struct Span {
@@ -27,7 +26,9 @@ pub struct Span {
     pub args: SpanArgs,
 
     // This might change during writing:
-    /// The list of events sorted by start time
+    /// The list of events sorted by start time. Backed by a SmallVec so leaf
+    /// spans (~69%, typically just one self-time event) don't pay a heap
+    /// allocation.
     pub events: LazySortedVec<SpanEvent>,
     pub is_complete: bool,
 

--- a/turbopack/crates/turbopack-trace-server/src/span.rs
+++ b/turbopack/crates/turbopack-trace-server/src/span.rs
@@ -38,18 +38,23 @@ pub struct Span {
     pub self_deallocations: u64,
     pub self_deallocation_count: u64,
 
-    // These values are computed when accessed (and maybe deleted during writing):
-    pub max_depth: OnceLock<u32>,
-    pub total_allocations: OnceLock<u64>,
-    pub total_deallocations: OnceLock<u64>,
-    pub total_persistent_allocations: OnceLock<u64>,
-    pub total_span_count: OnceLock<u64>,
-    pub total_allocation_count: OnceLock<u64>,
-
-    // More nested fields, but memory lazily allocated
+    // These values are computed when accessed (and maybe deleted during writing).
+    // Bundling the subtree totals into a single OnceLock pays a small cost on
+    // partial reads in exchange for a much-reduced lock count per Span.
+    pub totals: OnceLock<SpanTotals>,
     pub time_data: OnceLock<Box<SpanTimeData>>,
     pub extra: OnceLock<Box<SpanExtra>>,
     pub names: OnceLock<Box<SpanNames>>,
+}
+
+#[derive(Default)]
+pub struct SpanTotals {
+    pub max_depth: u32,
+    pub allocations: u64,
+    pub deallocations: u64,
+    pub persistent_allocations: u64,
+    pub allocation_count: u64,
+    pub span_count: u64,
 }
 
 #[derive(Default)]

--- a/turbopack/crates/turbopack-trace-server/src/span_ref.rs
+++ b/turbopack/crates/turbopack-trace-server/src/span_ref.rs
@@ -603,3 +603,115 @@ impl SpanEventRef<'_> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use rustc_hash::FxHashSet;
+    use turbo_rcstr::RcStr;
+
+    use crate::{span::SpanArgs, span_ref::SpanRef, store::Store, timestamp::Timestamp};
+
+    fn span_ref<'a>(store: &'a Store, idx: crate::span::SpanIndex) -> SpanRef<'a> {
+        SpanRef {
+            span: &store.spans[idx.get()],
+            store,
+            index: idx.get(),
+        }
+    }
+
+    #[test]
+    fn totals_aggregate_subtree() {
+        let mut store = Store::new();
+        let mut outdated = FxHashSet::default();
+
+        // root → a → b
+        // root → c
+        let a = store.add_span(
+            None,
+            Timestamp::from_micros(0),
+            RcStr::default(),
+            RcStr::from("a"),
+            SpanArgs::new(),
+            &mut outdated,
+        );
+        let b = store.add_span(
+            Some(a),
+            Timestamp::from_micros(1),
+            RcStr::default(),
+            RcStr::from("b"),
+            SpanArgs::new(),
+            &mut outdated,
+        );
+        let c = store.add_span(
+            None,
+            Timestamp::from_micros(2),
+            RcStr::default(),
+            RcStr::from("c"),
+            SpanArgs::new(),
+            &mut outdated,
+        );
+
+        // Use values large enough that the 32-byte/4-allocation tracing
+        // overhead subtraction in `self_allocations()` / `self_allocation_count()`
+        // doesn't dominate.
+        store.add_allocation(a, 1000, 10, &mut outdated);
+        store.add_allocation(b, 500, 5, &mut outdated);
+        store.add_allocation(c, 200, 2, &mut outdated);
+
+        let a_ref = span_ref(&store, a);
+        let b_ref = span_ref(&store, b);
+        let c_ref = span_ref(&store, c);
+
+        // Sanity: per-span self_* values reflect the saturating overhead subtraction.
+        assert_eq!(a_ref.self_allocations(), 1000 - 32);
+        assert_eq!(b_ref.self_allocations(), 500 - 32);
+        assert_eq!(c_ref.self_allocations(), 200 - 32);
+
+        // Totals are the recursive subtree sum of self_*.
+        assert_eq!(
+            a_ref.total_allocations(),
+            a_ref.self_allocations() + b_ref.self_allocations()
+        );
+        assert_eq!(b_ref.total_allocations(), b_ref.self_allocations());
+        assert_eq!(c_ref.total_allocations(), c_ref.self_allocations());
+
+        // span_count is 1 + child count.
+        assert_eq!(a_ref.total_span_count(), 2);
+        assert_eq!(b_ref.total_span_count(), 1);
+        assert_eq!(c_ref.total_span_count(), 1);
+
+        // total_allocation_count similarly.
+        assert_eq!(
+            a_ref.total_allocation_count(),
+            a_ref.self_allocation_count() + b_ref.self_allocation_count()
+        );
+    }
+
+    #[test]
+    fn totals_invalidate_and_recompute() {
+        let mut store = Store::new();
+        let mut outdated = FxHashSet::default();
+        let s = store.add_span(
+            None,
+            Timestamp::from_micros(0),
+            RcStr::default(),
+            RcStr::from("s"),
+            SpanArgs::new(),
+            &mut outdated,
+        );
+        store.add_allocation(s, 1000, 10, &mut outdated);
+
+        // Cache the totals.
+        let before = span_ref(&store, s).total_allocations();
+        assert_eq!(before, 1000 - 32);
+
+        // Add more allocations and invalidate.
+        let mut outdated = FxHashSet::default();
+        store.add_allocation(s, 200, 2, &mut outdated);
+        store.invalidate_outdated_spans(&outdated);
+
+        // After invalidation, the cached totals must be recomputed from new self_*.
+        let after = span_ref(&store, s).total_allocations();
+        assert_eq!(after, 1200 - 32);
+    }
+}

--- a/turbopack/crates/turbopack-trace-server/src/span_ref.rs
+++ b/turbopack/crates/turbopack-trace-server/src/span_ref.rs
@@ -571,20 +571,19 @@ impl<'a> SpanEventSelfTimeRef<'a> {
     }
 
     pub fn end(&self) -> Timestamp {
-        self.self_time.end
+        self.self_time.end()
     }
 
     pub fn corrected_self_time(&self) -> Timestamp {
         *self.self_time.corrected_self_time.get_or_init(|| {
-            let duration = self.self_time.end - self.self_time.start;
-            if !duration.is_zero() {
-                self.store.set_max_self_time_lookup(self.self_time.end);
-                self.store.self_time_tree.as_ref().map_or(duration, |tree| {
-                    tree.lookup_range_corrected_time(self.self_time.start, self.self_time.end)
-                })
-            } else {
-                Timestamp::ZERO
-            }
+            // `duration` is `NonZeroU64`, so zero-duration events are filtered
+            // at construction time (see `SpanEvent::self_time`).
+            let end = self.self_time.end();
+            let duration = Timestamp::from_value(self.self_time.duration.get());
+            self.store.set_max_self_time_lookup(end);
+            self.store.self_time_tree.as_ref().map_or(duration, |tree| {
+                tree.lookup_range_corrected_time(self.self_time.start, end)
+            })
         })
     }
 }

--- a/turbopack/crates/turbopack-trace-server/src/span_ref.rs
+++ b/turbopack/crates/turbopack-trace-server/src/span_ref.rs
@@ -15,7 +15,7 @@ use crate::{
     bottom_up::build_bottom_up_graph,
     span::{
         Span, SpanEvent, SpanEventSelfTime, SpanExtra, SpanGraphEvent, SpanIndex, SpanNames,
-        SpanTimeData,
+        SpanTimeData, SpanTotals,
     },
     span_bottom_up_ref::SpanBottomUpRef,
     span_graph_ref::{SpanGraphEventRef, SpanGraphRef, event_map_to_list},
@@ -236,54 +236,52 @@ impl<'a> SpanRef<'a> {
         })
     }
 
-    pub fn total_allocations(&self) -> u64 {
-        *self.span.total_allocations.get_or_init(|| {
-            self.children()
-                .map(|child| child.total_allocations())
-                .reduce(|a, b| a + b)
-                .unwrap_or_default()
-                + self.self_allocations()
+    /// Compute (or fetch) the bundled subtree totals. All six totals share a
+    /// single `OnceLock`, so the first call walks the subtree once and fills
+    /// every field; subsequent calls return cached values. Children's bundles
+    /// are computed recursively, so depth-many calls happen once per subtree
+    /// regardless of which field is queried first.
+    fn totals(&self) -> &'a SpanTotals {
+        self.span.totals.get_or_init(|| {
+            let mut t = SpanTotals {
+                max_depth: 0,
+                allocations: self.self_allocations(),
+                deallocations: self.self_deallocations(),
+                persistent_allocations: self.self_persistent_allocations(),
+                allocation_count: self.self_allocation_count(),
+                span_count: 1,
+            };
+            for child in self.children() {
+                let c = child.totals();
+                t.max_depth = max(t.max_depth, c.max_depth + 1);
+                t.allocations += c.allocations;
+                t.deallocations += c.deallocations;
+                t.persistent_allocations += c.persistent_allocations;
+                t.allocation_count += c.allocation_count;
+                t.span_count += c.span_count;
+            }
+            t
         })
+    }
+
+    pub fn total_allocations(&self) -> u64 {
+        self.totals().allocations
     }
 
     pub fn total_deallocations(&self) -> u64 {
-        *self.span.total_deallocations.get_or_init(|| {
-            self.children()
-                .map(|child| child.total_deallocations())
-                .reduce(|a, b| a + b)
-                .unwrap_or_default()
-                + self.self_deallocations()
-        })
+        self.totals().deallocations
     }
 
     pub fn total_persistent_allocations(&self) -> u64 {
-        *self.span.total_persistent_allocations.get_or_init(|| {
-            self.children()
-                .map(|child| child.total_persistent_allocations())
-                .reduce(|a, b| a + b)
-                .unwrap_or_default()
-                + self.self_persistent_allocations()
-        })
+        self.totals().persistent_allocations
     }
 
     pub fn total_allocation_count(&self) -> u64 {
-        *self.span.total_allocation_count.get_or_init(|| {
-            self.children()
-                .map(|child| child.total_allocation_count())
-                .reduce(|a, b| a + b)
-                .unwrap_or_default()
-                + self.self_allocation_count()
-        })
+        self.totals().allocation_count
     }
 
     pub fn total_span_count(&self) -> u64 {
-        *self.span.total_span_count.get_or_init(|| {
-            self.children()
-                .map(|child| child.total_span_count())
-                .reduce(|a, b| a + b)
-                .unwrap_or_default()
-                + 1
-        })
+        self.totals().span_count
     }
 
     pub fn corrected_self_time(&self) -> Timestamp {
@@ -319,12 +317,7 @@ impl<'a> SpanRef<'a> {
     }
 
     pub fn max_depth(&self) -> u32 {
-        *self.span.max_depth.get_or_init(|| {
-            self.children()
-                .map(|child| child.max_depth() + 1)
-                .max()
-                .unwrap_or_default()
-        })
+        self.totals().max_depth
     }
 
     pub fn graph(&self) -> impl Iterator<Item = SpanGraphEventRef<'a>> + '_ {

--- a/turbopack/crates/turbopack-trace-server/src/span_ref.rs
+++ b/turbopack/crates/turbopack-trace-server/src/span_ref.rs
@@ -14,8 +14,8 @@ use crate::{
     FxIndexMap,
     bottom_up::build_bottom_up_graph,
     span::{
-        Span, SpanEvent, SpanEventSelfTime, SpanExtra, SpanGraphEvent, SpanIndex, SpanNames,
-        SpanTimeData, SpanTotals,
+        Span, SpanEvent, SpanEventSelfTime, SpanExtra, SpanGraphEvent, SpanIndex, SpanName,
+        SpanNames, SpanTimeData, SpanTotals,
     },
     span_bottom_up_ref::SpanBottomUpRef,
     span_graph_ref::{SpanGraphEventRef, SpanGraphRef, event_map_to_list},
@@ -55,7 +55,7 @@ impl<'a> SpanRef<'a> {
     }
 
     pub fn time_data(&self) -> &'a SpanTimeData {
-        self.span.time_data()
+        &self.span.time_data
     }
 
     pub fn extra(&self) -> &'a SpanExtra {
@@ -88,64 +88,12 @@ impl<'a> SpanRef<'a> {
     }
 
     pub fn nice_name(&self) -> (&'a str, &'a str) {
-        let (category, title) = self.names().nice_name.get_or_init(|| {
-            if let Some(name) = self
-                .span
-                .args
-                .iter()
-                .find(|&(k, _)| k == "name")
-                .map(|(_, v)| v)
-            {
-                if matches!(self.span.name.as_str(), "turbo_tasks::function") {
-                    (self.span.name.clone(), name.clone())
-                } else if matches!(
-                    self.span.name.as_str(),
-                    "turbo_tasks::resolve_call" | "turbo_tasks::resolve_trait_call"
-                ) {
-                    (self.span.name.clone(), format!("*{name}").into())
-                } else {
-                    (
-                        self.span.category.clone(),
-                        format!("{} {name}", self.span.name).into(),
-                    )
-                }
-            } else {
-                (self.span.category.clone(), self.span.name.clone())
-            }
-        });
+        let SpanName { category, title } = &self.names().nice_name;
         (category.as_str(), title.as_str())
     }
 
     pub fn group_name(&self) -> (&'a str, &'a str) {
-        let (category, title) = self.names().group_name.get_or_init(|| {
-            if matches!(self.span.name.as_str(), "turbo_tasks::function") {
-                let name = self
-                    .span
-                    .args
-                    .iter()
-                    .find(|&(k, _)| k == "name")
-                    .map(|(_, v)| v.clone())
-                    .unwrap_or_else(|| self.span.name.clone());
-                (self.span.name.clone(), name)
-            } else if matches!(
-                self.span.name.as_str(),
-                "turbo_tasks::resolve_call" | "turbo_tasks::resolve_trait_call"
-            ) {
-                let name = self
-                    .span
-                    .args
-                    .iter()
-                    .find(|&(k, _)| k == "name")
-                    .map(|(_, v)| RcStr::from(format!("*{v}")))
-                    .unwrap_or_else(|| self.span.name.clone());
-                (
-                    self.span.category.clone(),
-                    format!("{} {name}", self.span.name).into(),
-                )
-            } else {
-                (self.span.category.clone(), self.span.name.clone())
-            }
-        });
+        let SpanName { category, title } = &self.names().group_name;
         (category.as_str(), title.as_str())
     }
 

--- a/turbopack/crates/turbopack-trace-server/src/store.rs
+++ b/turbopack/crates/turbopack-trace-server/src/store.rs
@@ -48,16 +48,11 @@ fn new_root_span() -> Span {
         args: SpanArgs::new(),
         events: Default::default(),
         is_complete: true,
-        max_depth: OnceLock::new(),
         self_allocations: 0,
         self_allocation_count: 0,
         self_deallocations: 0,
         self_deallocation_count: 0,
-        total_allocations: OnceLock::new(),
-        total_deallocations: OnceLock::new(),
-        total_persistent_allocations: OnceLock::new(),
-        total_allocation_count: OnceLock::new(),
-        total_span_count: OnceLock::new(),
+        totals: OnceLock::new(),
         time_data: OnceLock::new(),
         extra: OnceLock::new(),
         names: OnceLock::new(),
@@ -122,16 +117,11 @@ impl Store {
             args,
             events: Default::default(),
             is_complete: false,
-            max_depth: OnceLock::new(),
             self_allocations: 0,
             self_allocation_count: 0,
             self_deallocations: 0,
             self_deallocation_count: 0,
-            total_allocations: OnceLock::new(),
-            total_deallocations: OnceLock::new(),
-            total_persistent_allocations: OnceLock::new(),
-            total_allocation_count: OnceLock::new(),
-            total_span_count: OnceLock::new(),
+            totals: OnceLock::new(),
             time_data: OnceLock::new(),
             extra: OnceLock::new(),
             names: OnceLock::new(),
@@ -399,11 +389,7 @@ impl Store {
                     self_time.corrected_self_time.take();
                 }
             }
-            span.total_allocations.take();
-            span.total_deallocations.take();
-            span.total_persistent_allocations.take();
-            span.total_allocation_count.take();
-            span.total_span_count.take();
+            span.totals.take();
             span.extra.take();
         }
 

--- a/turbopack/crates/turbopack-trace-server/src/store.rs
+++ b/turbopack/crates/turbopack-trace-server/src/store.rs
@@ -211,9 +211,7 @@ impl Store {
         end: Timestamp,
         outdated_spans: &mut FxHashSet<SpanIndex>,
     ) {
-        let Some(event) = SpanEvent::self_time(start, end) else {
-            return;
-        };
+        let event = SpanEvent::self_time(start, end);
         let span = &mut self.spans[span_index.get()];
         let time_data = &mut span.time_data;
         if time_data.ignore_self_time {
@@ -222,8 +220,10 @@ impl Store {
         outdated_spans.insert(span_index);
         time_data.self_time += end - start;
         time_data.self_end = max(time_data.self_end, end);
-        span.events.push(event);
-        self.insert_self_time(start, end, span_index, outdated_spans);
+        if let Some(event) = event {
+            span.events.push(event);
+            self.insert_self_time(start, end, span_index, outdated_spans);
+        }
     }
 
     pub fn set_total_time(

--- a/turbopack/crates/turbopack-trace-server/src/store.rs
+++ b/turbopack/crates/turbopack-trace-server/src/store.rs
@@ -120,7 +120,7 @@ impl Store {
             category,
             name,
             args,
-            events: vec![].into(),
+            events: Default::default(),
             is_complete: false,
             max_depth: OnceLock::new(),
             self_allocations: 0,

--- a/turbopack/crates/turbopack-trace-server/src/store.rs
+++ b/turbopack/crates/turbopack-trace-server/src/store.rs
@@ -10,7 +10,7 @@ use turbo_rcstr::{RcStr, rcstr};
 
 use crate::{
     self_time_tree::SelfTimeTree,
-    span::{Span, SpanEvent, SpanIndex},
+    span::{Span, SpanArgs, SpanEvent, SpanIndex},
     span_ref::SpanRef,
     timestamp::Timestamp,
 };
@@ -45,7 +45,7 @@ fn new_root_span() -> Span {
         start: Timestamp::MAX,
         category: RcStr::default(),
         name: rcstr!("(root)"),
-        args: vec![],
+        args: SpanArgs::new(),
         events: Default::default(),
         is_complete: true,
         max_depth: OnceLock::new(),
@@ -109,7 +109,7 @@ impl Store {
         start: Timestamp,
         category: RcStr,
         name: RcStr,
-        args: Vec<(RcStr, RcStr)>,
+        args: SpanArgs,
         outdated_spans: &mut FxHashSet<SpanIndex>,
     ) -> SpanIndex {
         let id = SpanIndex::new(self.spans.len()).unwrap();

--- a/turbopack/crates/turbopack-trace-server/src/store.rs
+++ b/turbopack/crates/turbopack-trace-server/src/store.rs
@@ -10,7 +10,7 @@ use turbo_rcstr::{RcStr, rcstr};
 
 use crate::{
     self_time_tree::SelfTimeTree,
-    span::{Span, SpanArgs, SpanEvent, SpanIndex},
+    span::{Span, SpanArgs, SpanEvent, SpanIndex, SpanTimeData},
     span_ref::SpanRef,
     timestamp::Timestamp,
 };
@@ -53,7 +53,10 @@ fn new_root_span() -> Span {
         self_deallocations: 0,
         self_deallocation_count: 0,
         totals: OnceLock::new(),
-        time_data: OnceLock::new(),
+        time_data: SpanTimeData {
+            self_end: Timestamp::MAX,
+            ..Default::default()
+        },
         extra: OnceLock::new(),
         names: OnceLock::new(),
     }
@@ -108,6 +111,7 @@ impl Store {
         outdated_spans: &mut FxHashSet<SpanIndex>,
     ) -> SpanIndex {
         let id = SpanIndex::new(self.spans.len()).unwrap();
+        let ignore_self_time = &name == "thread" || &name == "blocking";
         self.spans.push(Span {
             parent,
             depth: 0,
@@ -122,7 +126,11 @@ impl Store {
             self_deallocations: 0,
             self_deallocation_count: 0,
             totals: OnceLock::new(),
-            time_data: OnceLock::new(),
+            time_data: SpanTimeData {
+                self_end: start,
+                ignore_self_time,
+                ..Default::default()
+            },
             extra: OnceLock::new(),
             names: OnceLock::new(),
         });
@@ -207,7 +215,7 @@ impl Store {
             return;
         };
         let span = &mut self.spans[span_index.get()];
-        let time_data = span.time_data_mut();
+        let time_data = &mut span.time_data;
         if time_data.ignore_self_time {
             return;
         }
@@ -232,7 +240,7 @@ impl Store {
         };
         let mut children = span
             .children()
-            .map(|c| (c.span.start, c.span.time_data().self_end, c.index()))
+            .map(|c| (c.span.start, c.span.time_data.self_end, c.index()))
             .collect::<Vec<_>>();
         children.sort();
         let self_end = start_time + total_time;
@@ -270,7 +278,7 @@ impl Store {
         }
         let span = &mut self.spans[span_index.get()];
         outdated_spans.insert(span_index);
-        let time_data = span.time_data_mut();
+        let time_data = &mut span.time_data;
         time_data.self_time = self_time;
         time_data.self_end = self_end;
         span.events = events.into();
@@ -378,12 +386,10 @@ impl Store {
 
     pub fn invalidate_outdated_spans(&mut self, outdated_spans: &FxHashSet<SpanId>) {
         fn invalidate_span(span: &mut Span) {
-            if let Some(time_data) = span.time_data.get_mut() {
-                time_data.end.take();
-                time_data.total_time.take();
-                time_data.corrected_self_time.take();
-                time_data.corrected_total_time.take();
-            }
+            span.time_data.end.take();
+            span.time_data.total_time.take();
+            span.time_data.corrected_self_time.take();
+            span.time_data.corrected_total_time.take();
             for event in span.events.iter_mut_unordered() {
                 if let SpanEvent::SelfTime(self_time) = event {
                     self_time.corrected_self_time.take();

--- a/turbopack/crates/turbopack-trace-server/src/store.rs
+++ b/turbopack/crates/turbopack-trace-server/src/store.rs
@@ -213,6 +213,9 @@ impl Store {
         end: Timestamp,
         outdated_spans: &mut FxHashSet<SpanIndex>,
     ) {
+        let Some(event) = SpanEvent::self_time(start, end) else {
+            return;
+        };
         let span = &mut self.spans[span_index.get()];
         let time_data = span.time_data_mut();
         if time_data.ignore_self_time {
@@ -221,7 +224,7 @@ impl Store {
         outdated_spans.insert(span_index);
         time_data.self_time += end - start;
         time_data.self_end = max(time_data.self_end, end);
-        span.events.push(SpanEvent::self_time(start, end));
+        span.events.push(event);
         self.insert_self_time(start, end, span_index, outdated_spans);
     }
 
@@ -249,14 +252,18 @@ impl Store {
         for (start, end, index) in children {
             if start > current {
                 if start > self_end {
-                    events.push(SpanEvent::self_time(current, self_end));
-                    self.insert_self_time(current, self_end, span_index, outdated_spans);
-                    self_time += self_end - current;
+                    if let Some(event) = SpanEvent::self_time(current, self_end) {
+                        events.push(event);
+                        self.insert_self_time(current, self_end, span_index, outdated_spans);
+                        self_time += self_end - current;
+                    }
                     break;
                 }
-                events.push(SpanEvent::self_time(current, start));
-                self.insert_self_time(current, start, span_index, outdated_spans);
-                self_time += start - current;
+                if let Some(event) = SpanEvent::self_time(current, start) {
+                    events.push(event);
+                    self.insert_self_time(current, start, span_index, outdated_spans);
+                    self_time += start - current;
+                }
             }
             events.push(SpanEvent::Child { start, index });
             current = max(current, end);
@@ -264,16 +271,12 @@ impl Store {
         current -= start_time;
         if current < total_time {
             self_time += total_time - current;
-            events.push(SpanEvent::self_time(
-                current + start_time,
-                start_time + total_time,
-            ));
-            self.insert_self_time(
-                current + start_time,
-                start_time + total_time,
-                span_index,
-                outdated_spans,
-            );
+            let st = current + start_time;
+            let en = start_time + total_time;
+            if let Some(event) = SpanEvent::self_time(st, en) {
+                events.push(event);
+                self.insert_self_time(st, en, span_index, outdated_spans);
+            }
         }
         let span = &mut self.spans[span_index.get()];
         outdated_spans.insert(span_index);


### PR DESCRIPTION
Land a few optimizations to the trace server

* Change `SpanEvent` so it is 32 bytes instead of 40 bytes by triggering a `niche` optimization
* Change `args` and `events` to be a `smallvec` with inline size 1
  * for `args` it is size <=1 ~31% of the time
  * for `events` it is size <=1 69% of the time
* Compute min/max timestamps in a single pass instead of 2 when inserting into the selftimetree
* Bundle dynamically computed 'total' fields behind a single OnceLock
   * saves 40 bytes per span due to `Oncelock` overheads
* Inline SpanTimeData and SpanNames into Span
   * We get little benefit from deferring the allocations and by inlining we save time and improve memory locality.
     * post load SpanTimeData is allocated for 94% of spans, but after loading `trace.nextjs.org` it is 100%
     * post load SpanNames is allocated for 0% of spans, but after loading it is 96.2% of spans
* Remove the `inner` `OnceLocks` from `SpanNames` we can just allocate these all together


Measuring with one 10gb trace file I see loading times progress from 75.7s (33G of ram)  to 60.5s (19.5G of ram).  With loading times hitting >200mb/s occasionally 

