### PR TITLE
docs: remove broken error-handling overlay screenshot

### DIFF
--- a/docs/02-pages/03-building-your-application/06-configuring/12-error-handling.mdx
+++ b/docs/02-pages/03-building-your-application/06-configuring/12-error-handling.mdx
@@ -9,11 +9,6 @@ This documentation explains how you can handle development, server-side, and cli
 
 When there is a runtime error during the development phase of your Next.js application, you will encounter an **overlay**. It is a modal that covers the webpage. It is **only** visible when the development server runs using `next dev` via `pnpm dev`, `npm run dev`, `yarn dev`, or `bun dev` and will not be shown in production. Fixing the error will automatically dismiss the overlay.
 
-Here is an example of an overlay:
-
-{/* TODO UPDATE SCREENSHOT */}
-![Example of an overlay when in development mode](https://assets.vercel.com/image/upload/v1645118290/docs-assets/static/docs/error-handling/overlay.png)
-
 ## Handling Server Errors
 
 Next.js provides a static 500 page by default to handle server-side errors that occur in your application. You can also [customize this page](/docs/pages/building-your-application/routing/custom-error#customizing-the-500-page) by creating a `pages/500.js` file.


### PR DESCRIPTION
The Cloudinary URL for the overlay screenshot
(`assets.vercel.com/image/upload/v1645118290/docs-assets/static/docs/error-handling/overlay.png`)
404s. The line above it had a `{/* TODO UPDATE SCREENSHOT */}` comment, so this was already flagged as known-stale.

Removes the broken image and its `"Here is an example of an overlay:"` intro line. The paragraph above still explains what the overlay is, so the page reads cleanly without the screenshot. If someone produces a fresh screenshot later, restoring the markdown with an updated URL is a one-line change.

### Affects

- `nextjs.org/docs/pages/building-your-application/configuring/error-handling` (stable, on next stable cut)
- `nextjs.org/docs/canary/pages/building-your-application/configuring/error-handling` (canary)

### Older versions

The same broken URL is present in v13/v14/v15 of the docs (synced from the corresponding release tags). Backport is a separate call for maintainers.