### PR TITLE
Apply sourcemaps by default during prerender in `next build`

### DIFF
--- a/docs/01-app/02-guides/memory-usage.mdx
+++ b/docs/01-app/02-guides/memory-usage.mdx
@@ -125,7 +125,7 @@ Generating source maps consumes extra memory during the build process.
 
 You can disable source map generation by adding `productionBrowserSourceMaps: false` and `experimental.serverSourceMaps: false` to your Next.js configuration.
 
-When using the `cacheComponents` feature, Next.js will use source maps by default during the prerender phase of `next build`.
+Next.js will use source maps by default during the prerender phase of `next build`.
 If you consistently encounter memory issues during that phase (after "Generating static pages"),
 you can try disabling source maps in that phase by adding `enablePrerenderSourceMaps: false` to your Next.js configuration.
 

--- a/docs/01-app/03-api-reference/06-cli/next.mdx
+++ b/docs/01-app/03-api-reference/06-cli/next.mdx
@@ -288,8 +288,6 @@ This enables several experimental options to make debugging easier:
   - `experimental.turbopackMinify = false`
 - Generates source maps for server bundles:
   - `experimental.serverSourceMaps = true`
-- Enables source map consumption in child processes used for prerendering:
-  - `enablePrerenderSourceMaps = true`
 - Continues building even after the first prerender error, so you can see all issues at once:
   - `experimental.prerenderEarlyExit = false`
 

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1635,6 +1635,7 @@ export interface NextConfig {
   /**
    * Enables source maps while generating static pages.
    * Helps with errors during the prerender phase in `next build`.
+   * Defaults to `true`. Set to `false` to disable.
    */
   enablePrerenderSourceMaps?: boolean
 
@@ -1799,8 +1800,7 @@ export const defaultConfig = Object.freeze({
   modularizeImports: undefined,
   outputFileTracingRoot: process.env.NEXT_PRIVATE_OUTPUT_TRACE_ROOT || '',
   allowedDevOrigins: undefined,
-  // Will default to cacheComponents value.
-  enablePrerenderSourceMaps: undefined,
+  enablePrerenderSourceMaps: true,
   cacheComponents: false,
   cacheLife: {
     default: {

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1459,11 +1459,6 @@ function assignDefaultsAndValidate(
   if (result.cacheComponents) {
     // TODO: remove once we've finished migrating internally to cacheComponents.
     result.experimental.ppr = true
-
-    // Prerender sourcemaps are enabled by default when using cacheComponents, unless explicitly disabled.
-    if (result.enablePrerenderSourceMaps === undefined) {
-      result.enablePrerenderSourceMaps = true
-    }
   }
 
   // "use cache" was originally implicitly enabled with the cacheComponents flag, so
@@ -2025,9 +2020,6 @@ function enforceExperimentalFeatures(
     debugPrerender &&
     (phase === PHASE_PRODUCTION_BUILD || phase === PHASE_EXPORT)
   ) {
-    // TODO: This is not an experimental feature, but should be enabled alongside other prerender debugging features.
-    config.enablePrerenderSourceMaps = true
-
     setExperimentalFeatureForDebugPrerender(
       config.experimental,
       'serverSourceMaps',

--- a/test/e2e/app-dir/root-suspense-dynamic/fixtures/default/next.config.js
+++ b/test/e2e/app-dir/root-suspense-dynamic/fixtures/default/next.config.js
@@ -2,8 +2,6 @@
  * @type {import('next').NextConfig}
  */
 const nextConfig = {
-  enablePrerenderSourceMaps: false,
-
   cacheComponents: true,
 }
 

--- a/test/e2e/app-dir/server-source-maps/fixtures/edge/next.config.js
+++ b/test/e2e/app-dir/server-source-maps/fixtures/edge/next.config.js
@@ -2,7 +2,6 @@
  * @type {import('next').NextConfig}
  */
 const nextConfig = {
-  enablePrerenderSourceMaps: true,
   experimental: {
     cpus: 1,
     serverSourceMaps: true,


### PR DESCRIPTION
This config was previously only enabled for Cache Components.

We don't expect any meaningful impact for `next build` performance. It's been on with Cache Components for a while so there's less of a chance for surprises.

Apps with default configs using Webpack will see no differenced. Those apps would need to enable `experimental.serverSourceMaps`