### PR TITLE
Stop ignore-listing original stack frames if source maps are disabled

### DIFF
--- a/packages/next/src/server/node-environment-extensions/error-inspect.tsx
+++ b/packages/next/src/server/node-environment-extensions/error-inspect.tsx
@@ -1,3 +1,19 @@
+import * as module from 'module'
+import * as process from 'process'
 import { patchErrorInspectNodeJS } from '../patch-error-inspect'
 
-patchErrorInspectNodeJS(globalThis.Error)
+const sourceMappingEnabled =
+  // @ts-expect-error Node.js 22+ only
+  typeof module.getSourceMapsSupport === 'function'
+    ? // @ts-expect-error Node.js 22+ only
+      module.getSourceMapsSupport().enabled
+    : process.env.NODE_OPTIONS?.includes('--enable-source-maps') ||
+      process.execArgv.includes('--enable-source-maps')
+
+if (sourceMappingEnabled) {
+  patchErrorInspectNodeJS(globalThis.Error)
+} else {
+  // leave Errors untouched if source maps are disabled.
+  // We're likely in a prod server where sourcemapping is done lazily when logs
+  // are inspected so ignore-listing would permanently hide these frames.
+}


### PR DESCRIPTION
If source maps are disabled, we're most likely running in a prod server where sourcemapping happens lazily when logs are inspected. Ignore-listing generated frames would forever hide n_m frames. 

It also avoids doing a bunch of work that just won't have any effect.

As a follow-up, I'll experiment with showing all frames during next-build if all original frames are ignore-listed since that's a one-shot process. For next-dev, we'll continue showing no frames if everything is ignore-listed since you can attach a debugger to get a high-fidelity UI to see ignore-listed frames. 