### PR TITLE
WIP repro: stylesheet preload + Suspense fallback paint

### DIFF
--- a/test/e2e/app-dir/segment-cache/stylesheet-preload-then-render-race/app/fallback-probe.tsx
+++ b/test/e2e/app-dir/segment-cache/stylesheet-preload-then-render-race/app/fallback-probe.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import { useLayoutEffect, useRef } from 'react'
+
+// Tripwire that fires when (and only when) the layout's `<Suspense>`
+// fallback is committed to the DOM. If the destination tree commits in
+// one shot, this never mounts — and the test asserts `__FALLBACK_MOUNTED`
+// is true, so the test fails when the bug is fixed (by design — this is a
+// regression repro, not a happy-path test).
+//
+// `useLayoutEffect` fires synchronously after commit, before the browser
+// paints, so it's the earliest reliable signal that the fallback was
+// committed. Recording the timestamp lets the test bound how long the
+// empty shell was visible.
+export function FallbackProbe() {
+  const fired = useRef(false)
+  useLayoutEffect(() => {
+    if (fired.current) return
+    fired.current = true
+    const w = window as unknown as {
+      __FALLBACK_MOUNTED?: boolean
+      __FALLBACK_MOUNTED_AT?: number
+    }
+    w.__FALLBACK_MOUNTED = true
+    w.__FALLBACK_MOUNTED_AT = performance.now()
+  }, [])
+  return <div id="logs-fallback">Loading…</div>
+}

--- a/test/e2e/app-dir/segment-cache/stylesheet-preload-then-render-race/app/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/stylesheet-preload-then-render-race/app/layout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from 'react'
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/stylesheet-preload-then-render-race/app/logs/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/stylesheet-preload-then-render-race/app/logs/layout.tsx
@@ -1,0 +1,20 @@
+import { Suspense } from 'react'
+import type { ReactNode } from 'react'
+import { FallbackProbe } from '../fallback-probe'
+
+// Mirrors the production wide-Suspense layout shape: a fresh
+// `<Suspense>` at LAYOUT depth (above the page). When this layout
+// mounts for the first time during navigation,
+// `pushPrimaryTreeSuspenseHandler` (line 7734 in
+// `react-dom-client.production.js`) sets `shellBoundary` to this
+// Suspense — its `current.alternate` is null. Any stylesheet rendered
+// below it whose `state.loading=0` will throw
+// `SuspenseyCommitException` on a transition lane (because
+// `shouldRemainOnPreviousScreen()` returns false when shellBoundary is
+// set), which causes this Suspense to commit its fallback for at least
+// one paint before the retry render eventually commits the children.
+//
+// `<FallbackProbe />` is a tripwire — if it ever mounts, the bug fired.
+export default function LogsLayout({ children }: { children: ReactNode }) {
+  return <Suspense fallback={<FallbackProbe />}>{children}</Suspense>
+}

--- a/test/e2e/app-dir/segment-cache/stylesheet-preload-then-render-race/app/logs/page.tsx
+++ b/test/e2e/app-dir/segment-cache/stylesheet-preload-then-render-race/app/logs/page.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+// `'use client'` so the `<link rel="stylesheet" precedence>` JSX is
+// rendered on the client during navigation, NOT walked by the Flight
+// server. Why this matters:
+//
+// Flight's dispatcher S slot (`preinitStyle`) is invoked when Flight
+// encounters a stylesheet hoistable in the SERVER tree. The S handler
+// inserts a `<link rel="stylesheet">` element AND sets
+// `state.loading |= 4` before the client's `getResource` runs, which
+// short-circuits `preloadResourceAndSuspendIfNeeded` to no throw.
+// Putting the `<link>` inside a client component bypasses Flight (which
+// only emits a Module reference for client components) — by the time
+// `getResource` runs on the client, no resource exists yet, only the
+// preload `<link>` and the `preloadPropsMap` entry from the L call on
+// `/`.
+//
+// Multiple stylesheets here mimic front's shape — production routes
+// emit many CSS chunks. Each one independently exhibits the bug.
+export default function LogsPage() {
+  return (
+    <>
+      <link rel="stylesheet" href="/test-style-a.css" precedence="default" />
+      <link rel="stylesheet" href="/test-style-b.css" precedence="default" />
+      <link rel="stylesheet" href="/test-style-c.css" precedence="default" />
+      <main id="content">
+        <h1 id="heading">/logs page</h1>
+        <p id="body">Body content for the /logs page.</p>
+      </main>
+    </>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/stylesheet-preload-then-render-race/app/page.tsx
+++ b/test/e2e/app-dir/segment-cache/stylesheet-preload-then-render-race/app/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect } from 'react'
- 
+
 import { preload } from 'react-dom'
 import Link from 'next/link'
 
@@ -41,7 +41,7 @@ export default function Home() {
   return (
     <main id="home">
       <h1>Home</h1>
-      <Link href="/logs" id="link-logs" prefetch={false}>
+      <Link href="/logs" id="link-logs">
         Go to /logs
       </Link>
     </main>

--- a/test/e2e/app-dir/segment-cache/stylesheet-preload-then-render-race/app/page.tsx
+++ b/test/e2e/app-dir/segment-cache/stylesheet-preload-then-render-race/app/page.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import { useEffect } from 'react'
+ 
+import { preload } from 'react-dom'
+import Link from 'next/link'
+
+// Hrefs the destination route will render. We preload all of them on
+// `/` mount to mimic the production scenario: Next's prefetch
+// instrumentation emits L (preload) opcodes for the destination
+// route's CSS chunks during the SOURCE page's render, populating
+// `preloadPropsMap` for each href.
+const STYLESHEET_HREFS = [
+  '/test-style-a.css',
+  '/test-style-b.css',
+  '/test-style-c.css',
+]
+
+export default function Home() {
+  // `ReactDOM.preload(href, { as: 'style' })` enters via the
+  // dispatcher's L slot (`react-dom-client.production.js:16619` —
+  // the `preload` function), which:
+  //   1. `preloadPropsMap.has(key)` → false on first call
+  //   2. `preloadPropsMap.set(key, props)`             ← the troublesome write
+  //   3. `<link rel="preload" as="style">` appended to <head>
+  //
+  // After this runs, `preloadPropsMap.has(key) === true` for the rest
+  // of the page's lifetime. No React resource record exists yet —
+  // there is no resource to update with the preload's loaded state.
+  //
+  // The bug then fires on the next navigation when `getResource`
+  // creates a fresh resource and short-circuits the
+  // `preloadStylesheet` call at line 16841 because the Map already
+  // has the key. `state.loading` stays at 0 and the throw fires.
+  useEffect(() => {
+    for (const href of STYLESHEET_HREFS) {
+      preload(href, { as: 'style' })
+    }
+  }, [])
+
+  return (
+    <main id="home">
+      <h1>Home</h1>
+      <Link href="/logs" id="link-logs" prefetch={false}>
+        Go to /logs
+      </Link>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/stylesheet-preload-then-render-race/next.config.ts
+++ b/test/e2e/app-dir/segment-cache/stylesheet-preload-then-render-race/next.config.ts
@@ -1,0 +1,5 @@
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {}
+
+export default nextConfig

--- a/test/e2e/app-dir/segment-cache/stylesheet-preload-then-render-race/public/test-style-a.css
+++ b/test/e2e/app-dir/segment-cache/stylesheet-preload-then-render-race/public/test-style-a.css
@@ -1,0 +1,3 @@
+#heading {
+  color: rgb(0, 100, 200);
+}

--- a/test/e2e/app-dir/segment-cache/stylesheet-preload-then-render-race/public/test-style-b.css
+++ b/test/e2e/app-dir/segment-cache/stylesheet-preload-then-render-race/public/test-style-b.css
@@ -1,0 +1,3 @@
+#heading {
+  color: rgb(0, 100, 200);
+}

--- a/test/e2e/app-dir/segment-cache/stylesheet-preload-then-render-race/public/test-style-c.css
+++ b/test/e2e/app-dir/segment-cache/stylesheet-preload-then-render-race/public/test-style-c.css
@@ -1,0 +1,3 @@
+#heading {
+  color: rgb(0, 100, 200);
+}

--- a/test/e2e/app-dir/segment-cache/stylesheet-preload-then-render-race/stylesheet-preload-then-render-race.test.ts
+++ b/test/e2e/app-dir/segment-cache/stylesheet-preload-then-render-race/stylesheet-preload-then-render-race.test.ts
@@ -1,0 +1,238 @@
+import { nextTestSetup } from 'e2e-utils'
+import type * as Playwright from 'playwright'
+
+// Regression repro for a React DOM preload-then-render race that causes
+// a layout-level `<Suspense>` to paint its fallback during navigation,
+// even though the destination route's stylesheets were preloaded via
+// `ReactDOM.preload(href, { as: 'style' })` and their bytes are in the
+// browser cache.
+//
+// Why this is in the Next.js test suite (vs filed upstream in React):
+// the bug fires in production traffic for any route whose stylesheets
+// are preloaded via the `L` (preload) opcode pipeline rather than the
+// `S` (preinit) opcode pipeline. Next.js's prefetch instrumentation
+// emits `L` opcodes for destination-route CSS during the source page's
+// render, so this is the production trigger.
+//
+// The test is marked `it.failing` because it asserts the EXPECTED
+// (post-fix) behavior. It currently passes because the assertions
+// fail — i.e. the bug is firing. When the bug is fixed in either
+// React DOM or Next.js, this test will start failing (because the
+// assertions will pass), at which point the maintainer should remove
+// the `.failing` modifier to convert this into a regression guard.
+//
+// Source-level trace, in
+// `next/src/compiled/react-dom/cjs/react-dom-client.production.js`:
+//
+//   On `/` mount, `<Home>` calls `ReactDOM.preload(href, {as:'style'})`
+//   for each destination stylesheet → `preload` (line 16619):
+//     1. `preloadPropsMap.has(key)` → false
+//     2. `preloadPropsMap.set(key, props)`        ← (A) the troublesome write
+//     3. `<link rel="preload" as="style">` appended to <head>
+//
+//   On click /logs, render reaches `<link rel="stylesheet" precedence>`
+//   inside the fresh `/logs/layout.tsx` Suspense (= `shellBoundary`):
+//
+//     `getResource` (line 16786):
+//        `styles.get(key)` → null
+//        create new resource `state = { loading: 0, preload: null }`
+//        `styles.set(key, resource)`
+//        `querySelector(link[rel="stylesheet"]…)` → null
+//        `preloadPropsMap.has(key)` → TRUE         ← short-circuits (B)
+//          ↓
+//        `preloadStylesheet` is NEVER CALLED. Without it, the matching
+//        `<link rel="preload">` from (A) is never consulted, so
+//        `state.loading` stays at 0.
+//
+//     `completeWork` case 26 → `preloadResourceAndSuspendIfNeeded`
+//       (line 12695-12707):
+//        `(state.loading & 4) === 0` ✓ → `flags |= 16777216`
+//        `!preloadResource(resource)` ((loading & 3) === 0) ✓
+//        `shouldRemainOnPreviousScreen()` (transition lane,
+//          `shellBoundary` set) → false
+//        → throw `SuspenseyCommitException`
+//
+//   Wide Suspense catches → fallback commits → empty-shell paint.
+//
+// The test asserts three independent signals:
+//
+//   1. `<link rel="preload" as="style">` is in <head> for each
+//      stylesheet href before click, and `<link rel="stylesheet">`
+//      for the same href is NOT (otherwise the bug wouldn't fire —
+//      `getResource` would find the stylesheet via line 16835 and set
+//      `state.loading = 5`).
+//   2. `__FALLBACK_MOUNTED` stays false after click — i.e., no
+//      empty-shell paint.
+//   3. No SuspenseComponent fiber catches `SuspenseyCommitException`
+//      (no `flags & 16384` with empty `updateQueue`).
+describe('ReactDOM.preload then <link rel="stylesheet" precedence> race', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: __dirname,
+  })
+  if (isNextDev) {
+    it('is skipped', () => {})
+    return
+  }
+
+  // Custom DevTools hook injected before any page script. React DOM's
+  // module-load-time check at `react-dom-client.production.js:18170`
+  // calls `inject(internals)`, after which `onCommitFiberRoot` fires
+  // for every commit.
+  const HOOK_SCRIPT = `
+    (function () {
+      const captures = []
+      window.__SUSPENSEY_FIBER_CAPTURES = captures
+      window.__SUSPENSEY_RESET = function () { captures.length = 0 }
+
+      const SUSPENSE_TAG = 13
+      const DID_CAPTURE = 16384
+
+      function walk(fiber, accum) {
+        if (!fiber) return
+        if (fiber.tag === SUSPENSE_TAG) {
+          const flags = fiber.flags | 0
+          const uq = fiber.updateQueue
+          let queueSize = 0
+          let queueIsNull = uq == null
+          if (uq && typeof uq.size === 'number') queueSize = uq.size
+          accum.push({
+            flags,
+            didCapture: (flags & DID_CAPTURE) !== 0,
+            queueSize,
+            queueIsNull,
+          })
+        }
+        walk(fiber.child, accum)
+        walk(fiber.sibling, accum)
+      }
+
+      window.__REACT_DEVTOOLS_GLOBAL_HOOK__ = {
+        supportsFiber: true,
+        renderers: new Map(),
+        inject(internals) {
+          const id = this.renderers.size + 1
+          this.renderers.set(id, internals)
+          return id
+        },
+        onCommitFiberRoot(_id, root) {
+          try {
+            const accum = []
+            walk(root.current, accum)
+            captures.push({ t: performance.now(), suspenseFibers: accum })
+          } catch (e) {
+            // swallow
+          }
+        },
+        onCommitFiberUnmount() {},
+        onPostCommitFiberRoot() {},
+      }
+    })()
+  `
+
+  const STYLESHEET_HREFS = [
+    '/test-style-a.css',
+    '/test-style-b.css',
+    '/test-style-c.css',
+  ]
+
+  type Fiber = {
+    flags: number
+    didCapture: boolean
+    queueSize: number
+    queueIsNull: boolean
+  }
+  type Capture = { t: number; suspenseFibers: Fiber[] }
+
+  function hasSuspenseyCommitCatch(captures: Capture[]): boolean {
+    return captures.some((c) =>
+      c.suspenseFibers.some(
+        (f) => f.didCapture && (f.queueIsNull || f.queueSize === 0)
+      )
+    )
+  }
+
+  // Marked `.failing`: asserts post-fix expected behavior. Currently
+  // passes because the bug fires. Will fail when the bug is fixed —
+  // at which point remove `.failing`.
+  it.failing(
+    'navigation to a route with preloaded stylesheets does not paint the layout Suspense fallback',
+    async () => {
+      let page: Playwright.Page
+      const browser = await next.browser('/', {
+        async beforePageLoad(p: Playwright.Page) {
+          page = p
+          await p.addInitScript(HOOK_SCRIPT)
+        },
+      })
+      await browser.waitForElementByCss('#home')
+
+      // Wait until `<Home>`'s `useEffect` has fired and all three
+      // `<link rel="preload" as="style">` elements are in <head>.
+      // This is the precondition for the bug: `preloadPropsMap` is
+      // populated for each href, and the matching preload `<link>`
+      // is in the document with bytes downloading or already cached.
+      await page!.waitForFunction(
+        (hrefs) =>
+          hrefs.every(
+            (h) =>
+              !!document.head.querySelector(
+                `link[rel="preload"][as="style"][href="${h}"]`
+              )
+          ),
+        STYLESHEET_HREFS
+      )
+
+      // Signal 1: preloads ARE in head, and stylesheets are NOT.
+      const preloadsBeforeClick = await page!.evaluate(
+        (hrefs) =>
+          hrefs.map((h) => ({
+            href: h,
+            preloadPresent: !!document.head.querySelector(
+              `link[rel="preload"][as="style"][href="${h}"]`
+            ),
+            stylesheetPresent: !!document.head.querySelector(
+              `link[rel="stylesheet"][href="${h}"]`
+            ),
+          })),
+        STYLESHEET_HREFS
+      )
+      for (const r of preloadsBeforeClick) {
+        expect(r.preloadPresent).toBe(true)
+        expect(r.stylesheetPresent).toBe(false)
+      }
+
+      // Reset the fallback tripwire and the fiber captures so that
+      // observations from initial-load hydration don't leak in.
+      await page!.evaluate(() => {
+        ;(window as any).__FALLBACK_MOUNTED = false
+        ;(window as any).__FALLBACK_MOUNTED_AT = undefined
+        ;(window as any).__SUSPENSEY_RESET()
+      })
+      const clickT = await page!.evaluate(() => performance.now())
+
+      await browser.elementById('link-logs').click()
+      await browser.waitForElementByCss('#content')
+      await page!.waitForTimeout(1500)
+
+      const fallbackMounted = await page!.evaluate(
+        () => !!(window as any).__FALLBACK_MOUNTED
+      )
+
+      const all = await page!.evaluate<Capture[]>(
+        () => (window as any).__SUSPENSEY_FIBER_CAPTURES
+      )
+      const captures = all.filter((c) => c.t >= clickT - 5)
+
+      // Signal 2 (post-fix expected): the layout-level Suspense
+      // fallback was NOT committed — i.e., the destination tree
+      // committed in one shot using the cached preload bytes.
+      // Currently fails because the bug fires.
+      expect(fallbackMounted).toBe(false)
+
+      // Signal 3 (post-fix expected): no SuspenseComponent caught
+      // `SuspenseyCommitException`. Currently fails because the bug
+      // fires.
+      expect(hasSuspenseyCommitCatch(captures)).toBe(false)
+    }
+  )
+})


### PR DESCRIPTION
## tl;dr

Adding a failing-by-design e2e test that reproduces a bug we hit on the deployment Logs tab in front: clicking the Logs link causes the wide layout `<Suspense>` fallback to paint for 100-300ms even though the destination route's stylesheets were preloaded and the bytes are sitting in cache.

This is filed as a draft / RFC — **the bug technically lives in React DOM, not Next**, but Next is what triggers it via the `L` opcode pipeline, and the fix could land in either place. Wanted to get it on your radar before deciding where to push.

## Where the bug lives

`react-dom-client.production.js` line 16841:

```js
preloadPropsMap.has(type) ||
  ((pendingProps = {...}),
   preloadPropsMap.set(type, pendingProps),
   styles$262 ||
     preloadStylesheet(...))
```

The chain:
1. On the source page, something calls `ReactDOM.preload(href, {as: 'style'})` (in production: Next's prefetch instrumentation for destination-route CSS). This goes through the `L` dispatcher slot at line 16619, which (a) inserts a `<link rel=\"preload\" as=\"style\">` into <head> and (b) does `preloadPropsMap.set(key, props)`.
2. User clicks. Render hits `<link rel=\"stylesheet\" precedence>`. \`getResource\` creates a fresh resource (`state.loading = 0`).
3. Stylesheet querySelector fails (no `<link rel=\"stylesheet\">` for this href yet).
4. **`preloadPropsMap.has(key)` returns true** (from step 1) → the entire `||` block is short-circuited → \`preloadStylesheet\` is **never called** → `state.loading` stays at 0.
5. \`preloadResourceAndSuspendIfNeeded\` sees \`(state.loading & 4) === 0\`, fresh shellBoundary on a transition lane → throws \`SuspenseyCommitException\`.
6. Wide Suspense catches → fallback paints.

\`preloadStylesheet\` (line 16907) is the only path that would have set \`state.loading = 1\` by querying for the existing preload `<link>`. Skipping it means the preload's existence is invisible to the resource state.

## What's in the PR

A single e2e fixture at \`test/e2e/app-dir/segment-cache/stylesheet-preload-then-render-race/\`. Minimal:

- \`app/page.tsx\` — \`'use client'\`, calls \`ReactDOM.preload(href, {as:'style'})\` for 3 hrefs in \`useEffect\`, then a \`<Link prefetch={false} href=\"/logs\">\`.
- \`app/logs/layout.tsx\` — \`<Suspense fallback={<FallbackProbe/>}>{children}</Suspense>\`.
- \`app/logs/page.tsx\` — \`'use client'\`, renders 3x \`<link rel=\"stylesheet\" precedence>\` for the same hrefs. (Client component so Flight emits no \`S\` opcode that would preempt the bug.)
- \`app/fallback-probe.tsx\` — \`useLayoutEffect\` tripwire that sets \`__FALLBACK_MOUNTED\` if the fallback ever commits.

Test asserts three things via standard Playwright + a custom DevTools hook:
1. \`<link rel=\"preload\" as=\"style\">\` is in head before click; \`<link rel=\"stylesheet\">\` is not.
2. \`__FALLBACK_MOUNTED\` is false after click (i.e. no empty-shell paint).
3. No SuspenseComponent fiber catches \`SuspenseyCommitException\` (no \`flags & 16384\` with empty \`updateQueue\`).

Marked \`it.failing\` — passes today because the bug fires (assertions 2 and 3 fail). When fixed, the test will start failing in CI, and whoever lands the fix can drop \`.failing\` to convert it to a regression guard.

Run:
\`\`\`
pnpm test-start-turbo --testPathPattern='stylesheet-preload-then-render-race'
\`\`\`

(Also passes on webpack — confirmed.)

## How I got here / proof this is the production trigger

I ran the same fiber-walking spec against the wide-Suspense preview (\`vercel-site-git-jude-perf-probes-wide.vercel.sh\`) with extra instrumentation — \`Document.prototype.querySelector\` patched to log every preload/stylesheet selector, and \`Map.prototype.has\`/\`set\` patched to log every call where the key starts with \`href=\"/_next/...\"\`. The captures show, for the two CSS chunks that exhibit the bug in production (\`3nkad1jveclu6.css\` and \`0yxqxnosns_0t.css\`):

- Pre-click L call (during \`/\`'s render): \`preloadPropsMap.has(key) → false\`, \`set(key, props) → ok\`, then qs for both preload selector and stylesheet selector → both miss → \`<link rel=\"preload\">\` created.
- Post-click \`getResource\`: \`styles.get(key) → null\`, \`set(key, newResource)\`, qs stylesheet → null, \`preloadPropsMap.has(key) → TRUE\` (from the pre-click L call).
- No preload-selector qs is ever logged for these hrefs in the click window — which can only happen if \`preloadStylesheet\` was skipped via the line-16841 short-circuit.

So we know it's the same bug, end-to-end, in production.

## Open questions

- **Where should the fix land?** Options I see:
  - **React DOM**: drop or rework the \`preloadPropsMap.has\` short-circuit so \`preloadStylesheet\`'s preload-lookup still runs. The check was probably an optimization to avoid duplicate \`<link rel=\"preload\">\` insertions, but it also kills the only path that updates \`state.loading\` for an existing preload. One-line fix shape: even when \`has\` is true, still query for the preload \`<link>\` and set \`state.loading = 1\` if found.
  - **Next.js**: emit \`S\` (preinit) opcodes instead of \`L\` (preload) opcodes for destination-route stylesheets in the Flight stream. Preinit creates the \`<link rel=\"stylesheet\">\` element directly and sets \`state.loading |= 4\`, so by the time \`getResource\` runs the short-circuit is harmless. Don't know how invasive that is in Next's prefetch code — haven't read it.
  - **App-level (front)**: render the destination route's stylesheets in \`/\`'s tree so they exist in head before navigation (forces \`getResource\`'s line-16835 stylesheet-querySelector to match → \`state.loading = 5\`). This is what the \"narrow Suspense\" pattern accidentally does and is why narrow doesn't repro.
- **Is this worth filing upstream in React?** I lean yes regardless of whether Next also patches around it — the React DOM behavior is genuinely surprising (calling \`preload\` makes the resource look unloaded?) and isolated.
- **Are there other apps inside Vercel that hit this?** Anywhere with a layout-level \`<Suspense>\` and CSS chunks that aren't shared with the source page should hit it on every cold navigation.

## What \"fixed\" looks like

Test assertions are written for the post-fix behavior:
- \`__FALLBACK_MOUNTED\` stays \`false\` (no fallback paint)
- No \`SuspenseyCommitException\` is thrown

Whoever lands the fix:
1. Run the test → it should fail (assertion now passes, but it's marked \`.failing\`).
2. Drop \`it.failing\` → \`it\` and the test becomes a regression guard.

## Not in this PR

- The actual fix.
- An upstream React issue.
- An app-level mitigation in front.

Putting this up first to align on locus.