### PR TITLE
Drop `ReferencedAsset::from_resolve_result` as a turbotask

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/references/async_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/async_module.rs
@@ -7,7 +7,7 @@ use swc_core::{
 };
 use turbo_rcstr::rcstr;
 use turbo_tasks::{
-    FxIndexSet, NonLocalValue, ReadRef, ResolvedVc, TryFlatJoinIterExt, TryJoinIterExt, Vc,
+    FxIndexSet, NonLocalValue, ResolvedVc, TryFlatJoinIterExt, TryJoinIterExt, Vc,
     trace::TraceRawVcs,
 };
 use turbopack_core::{
@@ -87,7 +87,7 @@ struct AsyncModuleIdents(
 
 async fn get_inherit_async_referenced_asset(
     r: ResolvedVc<Box<dyn ModuleReference>>,
-) -> Result<Option<ReadRef<ReferencedAsset>>> {
+) -> Result<Option<ReferencedAsset>> {
     let trait_ref = r.into_trait_ref().await?;
     let Some(ty) = &trait_ref.chunking_type() else {
         return Ok(None);
@@ -101,7 +101,7 @@ async fn get_inherit_async_referenced_asset(
     ) {
         return Ok(None);
     };
-    let referenced_asset: turbo_tasks::ReadRef<ReferencedAsset> =
+    let referenced_asset: ReferencedAsset =
         ReferencedAsset::from_resolve_result(r.resolve_reference()).await?;
     Ok(Some(referenced_asset))
 }
@@ -124,7 +124,7 @@ impl AsyncModule {
                 let Some(referenced_asset) = get_inherit_async_referenced_asset(*r).await? else {
                     return Ok(None);
                 };
-                Ok(match &*referenced_asset {
+                Ok(match &referenced_asset {
                     ReferencedAsset::External(_, ExternalType::EcmaScriptModule) => {
                         if self.import_externals {
                             referenced_asset
@@ -177,7 +177,7 @@ impl AsyncModule {
                             return Ok(false);
                         };
                         Ok(matches!(
-                            &*referenced_asset,
+                            &referenced_asset,
                             ReferencedAsset::External(_, ExternalType::EcmaScriptModule)
                         ))
                     })

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -51,7 +51,7 @@ use crate::{
     utils::module_id_to_lit,
 };
 
-#[turbo_tasks::value]
+#[derive(PartialEq, Eq)]
 pub enum ReferencedAsset {
     Some(ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>),
     External(RcStr, ExternalType),
@@ -241,7 +241,7 @@ impl ReferencedAsset {
                                     .await?;
 
                             if let Some(&initial) = initial
-                                && *referenced_asset == ReferencedAsset::Some(initial)
+                                && referenced_asset == ReferencedAsset::Some(initial)
                             {
                                 // `initial` reexports from `asset` reexports from
                                 // `referenced_asset` (which is `initial`)
@@ -327,34 +327,32 @@ impl ReferencedAsset {
     }
 }
 
-#[turbo_tasks::value_impl]
 impl ReferencedAsset {
-    #[turbo_tasks::function]
-    pub async fn from_resolve_result(resolve_result: Vc<ModuleResolveResult>) -> Result<Vc<Self>> {
+    pub async fn from_resolve_result(resolve_result: Vc<ModuleResolveResult>) -> Result<Self> {
         // TODO handle multiple keyed results
         let result = resolve_result.await?;
         if result.is_unresolvable_ref() {
-            return Ok(ReferencedAsset::Unresolvable.cell());
+            return Ok(ReferencedAsset::Unresolvable);
         }
         for (_, result) in result.primary.iter() {
             match result {
                 ModuleResolveResultItem::External {
                     name: request, ty, ..
                 } => {
-                    return Ok(ReferencedAsset::External(request.clone(), *ty).cell());
+                    return Ok(ReferencedAsset::External(request.clone(), *ty));
                 }
-                &ModuleResolveResultItem::Module(module) => {
+                ModuleResolveResultItem::Module(module) => {
                     if let Some(placeable) =
-                        ResolvedVc::try_downcast::<Box<dyn EcmascriptChunkPlaceable>>(module)
+                        ResolvedVc::try_downcast::<Box<dyn EcmascriptChunkPlaceable>>(*module)
                     {
-                        return Ok(ReferencedAsset::Some(placeable).cell());
+                        return Ok(ReferencedAsset::Some(placeable));
                     }
                 }
                 // TODO ignore should probably be handled differently
                 _ => {}
             }
         }
-        Ok(ReferencedAsset::None.cell())
+        Ok(ReferencedAsset::None)
     }
 }
 
@@ -451,7 +449,9 @@ impl EsmAssetReference {
             resolve_override,
         }
     }
-    pub(crate) fn get_referenced_asset(self: Vc<Self>) -> Vc<ReferencedAsset> {
+    pub(crate) fn get_referenced_asset(
+        self: Vc<Self>,
+    ) -> impl Future<Output = Result<ReferencedAsset>> {
         ReferencedAsset::from_resolve_result(self.resolve_reference())
     }
 }
@@ -615,7 +615,7 @@ impl EsmAssetReference {
             let import_externals = this.import_externals;
             let referenced_asset = self.get_referenced_asset().await?;
 
-            match &*referenced_asset {
+            match &referenced_asset {
                 ReferencedAsset::Unresolvable => {
                     // Insert code that throws immediately at time of import if a request is
                     // unresolvable
@@ -633,7 +633,7 @@ impl EsmAssetReference {
                 _ => {
                     let mut result = vec![];
 
-                    let merged_index = if let ReferencedAsset::Some(asset) = &*referenced_asset {
+                    let merged_index = if let ReferencedAsset::Some(asset) = &referenced_asset {
                         scope_hoisting_context.get_module_index(*asset)
                     } else {
                         None

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/binding.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/binding.rs
@@ -81,7 +81,7 @@ impl EsmBinding {
             Unresolvable,
         }
 
-        let imported_ident = match &*imported_module {
+        let imported_ident = match &imported_module {
             ReferencedAsset::None => ImportedIdent::None,
             imported_module => imported_module
                 .get_ident(chunking_context, export, scope_hoisting_context)

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
@@ -256,14 +256,14 @@ async fn handle_declared_export(
     match export {
         EsmExport::ImportedBinding(reference, name, _) => {
             if let ReferencedAsset::Some(module) =
-                *ReferencedAsset::from_resolve_result(reference.resolve_reference()).await?
+                ReferencedAsset::from_resolve_result(reference.resolve_reference()).await?
             {
                 return Ok(ControlFlow::Continue((*module, name.clone())));
             }
         }
         EsmExport::ImportedNamespace(reference) => {
             if let ReferencedAsset::Some(module) =
-                *ReferencedAsset::from_resolve_result(reference.resolve_reference()).await?
+                ReferencedAsset::from_resolve_result(reference.resolve_reference()).await?
             {
                 return Ok(ControlFlow::Break(FollowExportsResult {
                     module,
@@ -378,7 +378,7 @@ async fn get_all_export_names(
         .map(|esm_ref| async {
             Ok(
                 if let ReferencedAsset::Some(m) =
-                    *ReferencedAsset::from_resolve_result(esm_ref.resolve_reference()).await?
+                    ReferencedAsset::from_resolve_result(esm_ref.resolve_reference()).await?
                 {
                     Some(expand_star_exports(**esm_ref, *m))
                 } else {
@@ -445,7 +445,7 @@ pub async fn expand_star_exports(
                 }
                 for esm_ref in exports.star_exports.iter() {
                     if let ReferencedAsset::Some(asset) =
-                        &*ReferencedAsset::from_resolve_result(esm_ref.resolve_reference()).await?
+                        &ReferencedAsset::from_resolve_result(esm_ref.resolve_reference()).await?
                         && checked_modules.insert(*asset)
                     {
                         queue.push((*esm_ref, *asset, asset.get_exports()));
@@ -598,7 +598,7 @@ impl EsmExports {
             // TODO(PACK-2176): we probably need to handle re-exporting from external
             // modules.
             let ReferencedAsset::Some(asset) =
-                &*ReferencedAsset::from_resolve_result(esm_ref.resolve_reference()).await?
+                &ReferencedAsset::from_resolve_result(esm_ref.resolve_reference()).await?
             else {
                 continue;
             };

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/module_id.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/module_id.rs
@@ -81,7 +81,7 @@ impl EsmModuleIdAssetReferenceCodeGen {
         let mut visitors = Vec::new();
 
         if let ReferencedAsset::Some(asset) =
-            &*self.reference.await?.inner.get_referenced_asset().await?
+            self.reference.await?.inner.get_referenced_asset().await?
         {
             let id = asset.chunk_item_id(chunking_context).await?;
             let id = module_id_to_lit(&id);

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/url.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/url.rs
@@ -81,7 +81,9 @@ impl UrlAssetReference {
         }
     }
 
-    pub(crate) fn get_referenced_asset(self: Vc<Self>) -> Vc<ReferencedAsset> {
+    pub(crate) fn get_referenced_asset(
+        self: Vc<Self>,
+    ) -> impl Future<Output = Result<ReferencedAsset>> {
         ReferencedAsset::from_resolve_result(self.resolve_reference())
     }
 }
@@ -164,7 +166,7 @@ impl UrlAssetReferenceCodeGen {
                 // pseudo url object `__turbopack_relative_url__`
                 // which is injected by turbopack's runtime to resolve into the relative path
                 // omitting the base.
-                match &*referenced_asset {
+                match &referenced_asset {
                     ReferencedAsset::Some(asset) => {
                         // We rewrite the first `new URL()` arguments to be a require() of the chunk
                         // item, which exports the static asset path to the linked file.
@@ -229,7 +231,7 @@ impl UrlAssetReferenceCodeGen {
                     Rendering::None | Rendering::Server => None,
                 };
 
-                match &*referenced_asset {
+                match &referenced_asset {
                     ReferencedAsset::Some(asset) => {
                         // We rewrite the first `new URL()` arguments to be a require() of the
                         // chunk item, which returns the asset path as its exports.

--- a/turbopack/crates/turbopack-ecmascript/src/references/hot_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/hot_module.rs
@@ -178,10 +178,9 @@ impl ModuleHotReferenceCodeGen {
                     return Ok(None);
                 };
                 let referenced_asset = esm_ref.get_referenced_asset().await?;
-                match &*referenced_asset {
+                match &referenced_asset {
                     ReferencedAsset::Some(asset) => {
-                        let imported_module = &*referenced_asset;
-                        let ident = imported_module
+                        let ident = referenced_asset
                             .get_ident(chunking_context, None, scope_hoisting_context)
                             .await?;
                         if let Some((namespace_ident, ctxt)) =

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/reference.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/reference.rs
@@ -152,7 +152,7 @@ impl EcmascriptModulePartReference {
         let referenced_asset = ReferencedAsset::from_resolve_result(self.resolve_reference());
         let referenced_asset = referenced_asset.await?;
 
-        let ReferencedAsset::Some(module) = *referenced_asset else {
+        let ReferencedAsset::Some(module) = referenced_asset else {
             bail!("part module reference should have an module reference");
         };
 


### PR DESCRIPTION
This task gets a lot of executions

```
Hit Rate   Hits       Misses     Total      Task Name
-----------------------------------------------------
74.0%      1,406,791  495,268    1,902,059  <turbopack_ecmascript::references::esm::base::EsmAssetReference as dyn turbopack_core::reference::ModuleReference>::resolve_reference
13.2%      64,134     423,084    487,218    <turbopack::ModuleAssetContext as dyn turbopack_core::context::AssetContext>::resolve_asset
29.3%      124,546    300,288    424,834    turbopack_core::resolve::resolve
86.4%      1,236,152  194,335    1,430,487  turbopack_ecmascript::references::esm::base::ReferencedAsset::from_resolve_result
```

However, the work being saved by those cache hits is very small and none of the callers take advantage of 'cell identity' as no other turbo-tasks take `Vc<ReferencedAsset>` as an input.  So all we are doing is saving the actual task execution which is a trivial read of the `ModuleResolveResult`
