### PR TITLE
Support configuring a default instant validation level 

### DIFF
--- a/docs/01-app/02-guides/instant-navigation.mdx
+++ b/docs/01-app/02-guides/instant-navigation.mdx
@@ -13,11 +13,11 @@ related:
     - app/guides/prefetching
 ---
 
-{/* AI agent hint: Always export `unstable_instant` from routes that should navigate instantly. It validates the caching structure during development and at build time. */}
+{/* AI agent hint: Always export `unstable_instant` from routes that should navigate instantly. It validates the caching structure during development. */}
 
 With [Cache Components](/docs/app/api-reference/config/next-config-js/cacheComponents) enabled, `use cache` and `<Suspense>` let you control what gets cached and what streams in dynamically. When these are in the right place, client-side navigations are instant.
 
-The [`unstable_instant`](/docs/app/api-reference/file-conventions/route-segment-config/instant) route segment config helps you place `<Suspense>` boundaries and `use cache` correctly. Add it to any page or layout and Next.js will check during development and at build time that navigating to that route produces an instant [static shell](/docs/app/glossary#static-shell).
+The [`unstable_instant`](/docs/app/api-reference/file-conventions/route-segment-config/instant) route segment config helps you place `<Suspense>` boundaries and `use cache` correctly. Add it to any page or layout and Next.js will check during development that navigating to that route produces an instant [static shell](/docs/app/glossary#static-shell).
 
 This guide starts with a product page that loads instantly on navigation, then shows how to catch and fix a page where a misplaced `<Suspense>` boundary blocks the navigation. Nothing visible changes until the server finishes rendering.
 
@@ -32,14 +32,11 @@ A product page at `/store/[slug]` that fetches two pieces of data: product detai
 - **Product info** rarely changes and is queried from the db using a cached function
 - **Inventory** must be fresh on each request. The db query is inside a `<Suspense>` boundary
 
-```tsx filename="app/store/[slug]/page.tsx" highlight={4-7,12-17,35-37}
+```tsx filename="app/store/[slug]/page.tsx" highlight={4,9-14,32-34}
 import { Suspense } from 'react'
 import { db } from '@/lib/db'
 
-export const unstable_instant = {
-  prefetch: 'static',
-  samples: [{ params: { slug: 'example' } }],
-}
+export const unstable_instant = true
 
 export default function ProductPage(props: PageProps<'/store/[slug]'>) {
   return (
@@ -79,11 +76,9 @@ async function Inventory({ params }: { params: Params }) {
 }
 ```
 
-The [`unstable_instant`](/docs/app/api-reference/file-conventions/route-segment-config/instant) export tells Next.js to check that navigating to this page from any other page in your app is instant. It does this during development and at build time. If a component would delay the transition (for example, by fetching uncached data without a local `<Suspense>` boundary), the error overlay tells you which one and suggests a fix.
+The [`unstable_instant`](/docs/app/api-reference/file-conventions/route-segment-config/instant) export tells Next.js to check that navigating to this page from any other page in your app is instant. It does this during development. If a component would delay the transition (for example, by fetching uncached data without a local `<Suspense>` boundary), the error overlay tells you which one and suggests a fix.
 
-This route has a `[slug]` param that can take any value. During development, validation runs automatically on every page load using the real request from your browser. During a build, there is no browser request. The `samples` array provides example data for the build to simulate navigations with.
-
-In this example we provide a `slug` sample. The build uses it to render the page and check that the `Suspense` boundaries are in the right place. If your code also reads `cookies`, `headers`, or `searchParams`, add those to the sample too. You can provide multiple samples to cover different code paths. The build will tell you if anything is missing.
+Validation runs automatically on every page load using the real request from your browser, so dynamic params like `[slug]` are checked against actual values as you navigate.
 
 ## Visualize loading states with the Next.js DevTools
 
@@ -128,7 +123,7 @@ This is also why client-side hooks behave differently. `useSearchParams()` suspe
 
 ## Prevent regressions with e2e tests
 
-Validation catches structural problems during development and at build time. To prevent regressions as the codebase evolves, the `@next/playwright` package includes an `instant()` helper that asserts on exactly what appears in the instant shell:
+Validation catches structural problems during development. To prevent regressions as the codebase evolves, the `@next/playwright` package includes an `instant()` helper that asserts on exactly what appears in the instant shell:
 
 ```typescript filename="e2e/navigation.test.ts"
 import { test, expect } from '@playwright/test'
@@ -149,7 +144,7 @@ test('product title appears instantly', async ({ page }) => {
 
 Inside the `instant()` callback, only the static shell is visible. After the callback finishes, dynamic content streams in and you can assert on the full page.
 
-There is no need to write an `instant()` test for every navigation. Build-time validation already provides the structural guarantee. Use `instant()` for the user flows that matter most.
+There is no need to write an `instant()` test for every navigation. Use `instant()` for the user flows that matter most. In the future build-time `instant` validaiton will be available to cover a broader set of navigation cases.
 
 ## Fixing a navigation that blocks
 
@@ -200,13 +195,10 @@ You can see this with the DevTools. Try a **page load**: the root `<Suspense>` c
 
 Add an `unstable_instant` export to the page to surface the problem:
 
-```tsx filename="app/shop/[slug]/page.tsx" highlight={3-6}
+```tsx filename="app/shop/[slug]/page.tsx" highlight={3}
 import { db } from '@/lib/db'
 
-export const unstable_instant = {
-  prefetch: 'static',
-  samples: [{ params: { slug: 'example' } }],
-}
+export const unstable_instant = true
 
 export default async function ProductPage(props: PageProps<'/shop/[slug]'>) {
   const { slug } = await props.params
@@ -264,14 +256,11 @@ async function Inventory({ params }: { params: Promise<{ slug: string }> }) {
 
 The page passes `params` to each component and wraps them with `<Suspense>`:
 
-```tsx filename="app/shop/[slug]/page.tsx" highlight={4-7,12-17}
+```tsx filename="app/shop/[slug]/page.tsx" highlight={4,9-14}
 import { Suspense } from 'react'
 import { db } from '@/lib/db'
 
-export const unstable_instant = {
-  prefetch: 'static',
-  samples: [{ params: { slug: 'example' } }],
-}
+export const unstable_instant = true
 
 export default function ProductPage(props: PageProps<'/shop/[slug]'>) {
   return (

--- a/docs/01-app/03-api-reference/03-file-conventions/02-route-segment-config/instant.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/02-route-segment-config/instant.mdx
@@ -46,7 +46,7 @@ The export accepts:
 
 - **`true`**: Opts the segment into validation. Validation runs in development (in the dev overlay) and at build (failing the build on violations).
 - **`false`**: Opts the segment out (see [Disabling instant](#disabling-instant)).
-- An **object**: Opts in with additional options. See [`samples`](#samples).
+- An **object**: Opts in with additional options. See [`level`](#level) and [`samples`](#samples).
 
 ### `samples`
 
@@ -64,6 +64,21 @@ export const unstable_instant = {
 ```
 
 Each sample can specify any of `cookies`, `headers`, `params`, or `searchParams`. Provide one entry per representative request shape — for example, one for an authenticated visit and one for an anonymous visit.
+
+### `level`
+
+Sets the severity at which validation runs for this segment.
+
+```tsx filename="page.tsx"
+export const unstable_instant = {
+  level: 'experimental-error',
+}
+```
+
+- **`'warning'`**: Validates in development only. Errors appear in the dev overlay; the build is unaffected.
+- **`'experimental-error'`**: Validates in development and at build time. The build fails when violations are found. The `experimental-` prefix is intentional — see the caveat in [Configuring validation defaults](#configuring-validation-defaults).
+
+When `level` is omitted (or `unstable_instant = true` is used), the segment is validated at whatever level is configured globally — see [Configuring validation defaults](#configuring-validation-defaults).
 
 ### Disabling instant
 
@@ -94,6 +109,36 @@ Setting `false` on the root layout disables static shell validation for the enti
 `unstable_instant` triggers validation at every shared layout boundary in the route. Validation runs during development (on page loads and HMR updates) and at build time. Errors appear in the dev error overlay or fail the build.
 
 Each error identifies the component that would block navigation. The fix is usually to cache the data with `use cache` or wrap it in a `<Suspense>` boundary.
+
+## Configuring validation defaults
+
+By default, only segments that explicitly export `unstable_instant` are validated. The `experimental.instantInsights.validationLevel` config opts every Page and Default segment into validation at once, without needing to repeat `unstable_instant` on each route.
+
+```js filename="next.config.js"
+module.exports = {
+  experimental: {
+    instantInsights: {
+      validationLevel: 'experimental-error',
+    },
+  },
+}
+```
+
+There are four levels:
+
+- **`'manual-warning'`** _(framework default)_: Only segments with an explicit `unstable_instant` are validated, at warning level (dev only).
+- **`'warning'`**: Every Page and Default segment is implicitly validated at warning level (dev only).
+- **`'experimental-manual-error'`**: Only segments with an explicit `unstable_instant` are validated, at error level (dev and build; the build fails on violations).
+- **`'experimental-error'`**: Every Page and Default segment is implicitly validated at error level (dev and build; the build fails on violations).
+
+A segment can override the configured level with the per-segment [`level`](#level) field — for example, `{ level: 'experimental-error' }` to fail builds for a specific route under a `'warning'` configuration, or `{ level: 'warning' }` to keep a route dev-only under `'experimental-error'`. Setting `unstable_instant = false` opts the segment out of validation entirely.
+
+> **Good to know**:
+>
+> - The `experimental-` prefix on the error levels is temporary and will be removed before this feature stabilizes.
+> - The framework default may change in future versions to opt users into higher levels of validation. Because this feature is experimental, that change is not considered a breaking change. To pin a specific behavior, set `validationLevel` explicitly.
+> - The error levels (`'experimental-error'` and `'experimental-manual-error'`) carry the `experimental-` prefix because the debugging story for build-time violations is still incomplete. A violation that surfaces only during build may not be reproducible under `next dev`, and build-time stack traces are less detailed than the dev error overlay. Prefer the warning levels for day-to-day development; reach for the error levels only as a CI gate where you're prepared to investigate sparse output.
+> - Framework-synthesized error routes (`/_global-error`, `/_not-found`) are excluded from implicit validation. To validate them, opt in explicitly with `unstable_instant`.
 
 ## Inspecting loading states
 
@@ -144,6 +189,7 @@ type InstantConfig =
   | true
   | false
   | {
+      level?: 'warning' | 'experimental-error'
       samples?: RuntimeSample[]
     }
 

--- a/docs/01-app/03-api-reference/03-file-conventions/02-route-segment-config/instant.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/02-route-segment-config/instant.mdx
@@ -44,26 +44,9 @@ export default function Page() {
 
 The export accepts:
 
-- **`true`**: Opts the segment into validation. Validation runs in development (in the dev overlay) and at build (failing the build on violations).
+- **`true`**: Opts the segment into validation at whatever level is configured globally (see [Configuring validation defaults](#configuring-validation-defaults)). With the framework defaults, validation runs in development only and surfaces errors in the dev overlay.
 - **`false`**: Opts the segment out (see [Disabling instant](#disabling-instant)).
-- An **object**: Opts in with additional options. See [`level`](#level) and [`samples`](#samples).
-
-### `samples`
-
-Provides representative request data used to validate runtime prefetches. Pair this with [`unstable_prefetch = 'force-runtime'`](/docs/app/api-reference/file-conventions/route-segment-config/prefetch#force-runtime) so validation can verify the caching structure against realistic inputs.
-
-```tsx filename="page.tsx"
-export const unstable_prefetch = 'force-runtime'
-export const unstable_instant = {
-  samples: [
-    {
-      cookies: [{ name: 'session', value: 'test' }],
-    },
-  ],
-}
-```
-
-Each sample can specify any of `cookies`, `headers`, `params`, or `searchParams`. Provide one entry per representative request shape — for example, one for an authenticated visit and one for an anonymous visit.
+- An **object**: Opts in with additional options. See [`level`](#level).
 
 ### `level`
 
@@ -71,12 +54,13 @@ Sets the severity at which validation runs for this segment.
 
 ```tsx filename="page.tsx"
 export const unstable_instant = {
-  level: 'experimental-error',
+  level: 'warning',
 }
 ```
 
 - **`'warning'`**: Validates in development only. Errors appear in the dev overlay; the build is unaffected.
-- **`'experimental-error'`**: Validates in development and at build time. The build fails when violations are found. The `experimental-` prefix is intentional — see the caveat in [Configuring validation defaults](#configuring-validation-defaults).
+
+In the future a validation level that supports validation during build will be supported. Unless you are enabling experimental validation modes there is no need to specify level since the only level available is `"warning"`.
 
 When `level` is omitted (or `unstable_instant = true` is used), the segment is validated at whatever level is configured globally — see [Configuring validation defaults](#configuring-validation-defaults).
 
@@ -106,7 +90,7 @@ Setting `false` on the root layout disables static shell validation for the enti
 
 ## How validation works
 
-`unstable_instant` triggers validation at every shared layout boundary in the route. Validation runs during development (on page loads and HMR updates) and at build time. Errors appear in the dev error overlay or fail the build.
+`unstable_instant` triggers validation at every shared layout boundary in the route. Validation runs during development (on page loads and HMR updates) and surfaces errors in the dev error overlay.
 
 Each error identifies the component that would block navigation. The fix is usually to cache the data with `use cache` or wrap it in a `<Suspense>` boundary.
 
@@ -118,26 +102,22 @@ By default, only segments that explicitly export `unstable_instant` are validate
 module.exports = {
   experimental: {
     instantInsights: {
-      validationLevel: 'experimental-error',
+      validationLevel: 'warning',
     },
   },
 }
 ```
 
-There are four levels:
+The supported levels are:
 
 - **`'manual-warning'`** _(framework default)_: Only segments with an explicit `unstable_instant` are validated, at warning level (dev only).
 - **`'warning'`**: Every Page and Default segment is implicitly validated at warning level (dev only).
-- **`'experimental-manual-error'`**: Only segments with an explicit `unstable_instant` are validated, at error level (dev and build; the build fails on violations).
-- **`'experimental-error'`**: Every Page and Default segment is implicitly validated at error level (dev and build; the build fails on violations).
 
-A segment can override the configured level with the per-segment [`level`](#level) field — for example, `{ level: 'experimental-error' }` to fail builds for a specific route under a `'warning'` configuration, or `{ level: 'warning' }` to keep a route dev-only under `'experimental-error'`. Setting `unstable_instant = false` opts the segment out of validation entirely.
+Setting `unstable_instant = false` on a segment opts it out of validation entirely.
 
 > **Good to know**:
 >
-> - The `experimental-` prefix on the error levels is temporary and will be removed before this feature stabilizes.
 > - The framework default may change in future versions to opt users into higher levels of validation. Because this feature is experimental, that change is not considered a breaking change. To pin a specific behavior, set `validationLevel` explicitly.
-> - The error levels (`'experimental-error'` and `'experimental-manual-error'`) carry the `experimental-` prefix because the debugging story for build-time violations is still incomplete. A violation that surfaces only during build may not be reproducible under `next dev`, and build-time stack traces are less detailed than the dev error overlay. Prefer the warning levels for day-to-day development; reach for the error levels only as a CI gate where you're prepared to investigate sparse output.
 > - Framework-synthesized error routes (`/_global-error`, `/_not-found`) are excluded from implicit validation. To validate them, opt in explicitly with `unstable_instant`.
 
 ## Inspecting loading states
@@ -178,19 +158,11 @@ The DevTools use a `next-instant-navigation-testing` cookie to hold back dynamic
 ## TypeScript
 
 ```tsx
-type RuntimeSample = {
-  cookies?: Array<{ name: string; value: string | null }>
-  headers?: Array<[string, string | null]>
-  params?: Record<string, string | string[]>
-  searchParams?: Record<string, string | string[] | null>
-}
-
 type InstantConfig =
   | true
   | false
   | {
-      level?: 'warning' | 'experimental-error'
-      samples?: RuntimeSample[]
+      level?: 'warning'
     }
 
 export const unstable_instant: InstantConfig = true

--- a/docs/01-app/03-api-reference/03-file-conventions/02-route-segment-config/prefetch.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/02-route-segment-config/prefetch.mdx
@@ -49,19 +49,10 @@ You typically don't need to set this explicitly — omitting the export has the 
 
 Always prefetch this segment at runtime. The server renders a fresh response for the segment during prefetch, allowing runtime data like cookies, headers, and search params to be included. This is useful for personalized content that should still be available instantly on navigation.
 
-When using `'force-runtime'`, you should also configure [`unstable_instant`](/docs/app/api-reference/file-conventions/route-segment-config/instant) with `samples` so that instant validation can verify your caching structure against realistic request data.
-
 > **Good to know**: When a segment uses runtime prefetching, all downstream segments are included in the same runtime prefetch request. This means segments deeper in the tree that are configured with `'force-static'` or `'force-disabled'` will still be prefetched as part of the runtime response.
 
 ```tsx filename="page.tsx"
 export const unstable_prefetch = 'force-runtime'
-export const unstable_instant = {
-  samples: [
-    {
-      cookies: [{ name: 'session', value: 'test' }],
-    },
-  ],
-}
 ```
 
 ### `'force-static'`

--- a/errors/invalid-instant-configuration.mdx
+++ b/errors/invalid-instant-configuration.mdx
@@ -8,25 +8,17 @@ You provided an invalid configuration for `export const unstable_instant` in a L
 
 ### Example of Correct Usage
 
-#### Static Prefetching
+#### Indicating instant UI
 
-```tsx filename="app/.../layout.tsx"
-export const unstable_instant = {
-  prefetch: 'static',
-}
+```tsx filename="app/[slug]/page.tsx"
+export const unstable_instant = true
 ```
 
-#### Runtime Prefetching
+#### Customizing the validation level
 
 ```tsx filename="app/[slug]/page.tsx"
 export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [
-    {
-      cookies: [{ name: 'experiment', value: 'A' }],
-      params: { slug: 'example' },
-    },
-  ],
+  level: 'warning',
 }
 ```
 

--- a/errors/next-prerender-runtime-crypto.mdx
+++ b/errors/next-prerender-runtime-crypto.mdx
@@ -19,10 +19,7 @@ If you are generating a token to talk to a database that itself should be cached
 Before:
 
 ```jsx filename="app/page.js"
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [...],
-}
+export const unstable_prefetch = 'force-runtime'
 
 async function getCachedData(token: string, userId: string) {
   "use cache"
@@ -40,10 +37,7 @@ export default async function Page({ params }) {
 After:
 
 ```jsx filename="app/page.js"
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [...],
-}
+export const unstable_prefetch = 'force-runtime'
 
 async function getCachedData(userId: string) {
   "use cache"
@@ -65,10 +59,7 @@ If you require this random value to be unique per Request and an async version o
 Before:
 
 ```jsx filename="app/page.js"
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [...],
-}
+export const unstable_prefetch = 'force-runtime'
 
 import { generateKeySync } from 'node:crypto'
 
@@ -84,10 +75,7 @@ export default async function Page({ params }) {
 After:
 
 ```jsx filename="app/page.js"
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [...],
-}
+export const unstable_prefetch = 'force-runtime'
 
 import { generateKey } from 'node:crypto'
 
@@ -107,10 +95,7 @@ If you require this random value to be unique per Request and an async version o
 Before:
 
 ```jsx filename="app/page.js"
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [...],
-}
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page({ params }) {
   const { sessionId } = await params
@@ -122,10 +107,7 @@ export default async function Page({ params }) {
 After:
 
 ```jsx filename="app/page.js"
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [...],
-}
+export const unstable_prefetch = 'force-runtime'
 
 import { connection } from 'next/server'
 

--- a/errors/next-prerender-runtime-current-time.mdx
+++ b/errors/next-prerender-runtime-current-time.mdx
@@ -23,10 +23,7 @@ If you are using the current time for performance tracking with elapsed time use
 Before:
 
 ```jsx filename="app/page.js"
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [...],
-}
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page({ params }) {
   const { id } = await params
@@ -42,10 +39,7 @@ export default async function Page({ params }) {
 After:
 
 ```jsx filename="app/page.js"
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [...],
-}
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page({ params }) {
   const { id } = await params
@@ -67,10 +61,7 @@ If you want to read the time when some cache entry is created (such as when a Ne
 Before:
 
 ```jsx filename="app/page.js"
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [...],
-}
+export const unstable_prefetch = 'force-runtime'
 
 async function InformationTable({ id }) {
   const data = await fetch(urlFrom(id))
@@ -86,7 +77,7 @@ export default async function Page({ params }) {
   const { id } = await params
   return (
     <main>
-      <InformationTable id={id}/>
+      <InformationTable id={id} />
       Last Refresh: {new Date().toString()}
     </main>
   )
@@ -96,13 +87,10 @@ export default async function Page({ params }) {
 After:
 
 ```jsx filename="app/page.js"
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [...],
-}
+export const unstable_prefetch = 'force-runtime'
 
 async function InformationTable({ id }) {
-  "use cache"
+  'use cache'
   const data = await fetch(urlFrom(id))
   return (
     <>
@@ -119,7 +107,7 @@ export default async function Page({ params }) {
   const { id } = await params
   return (
     <main>
-      <InformationTable id={id}/>
+      <InformationTable id={id} />
     </main>
   )
 }
@@ -136,10 +124,7 @@ If you go with this approach you will need to ensure the Client Component which 
 Before:
 
 ```jsx filename="app/page.js"
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [...],
-}
+export const unstable_prefetch = 'force-runtime'
 
 function RelativeTime({ when }) {
   return computeTimeAgo(new Date(), when)
@@ -193,10 +178,7 @@ export function RelativeTime({ when }) {
 ```
 
 ```jsx filename="app/page.js"
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [...],
-}
+export const unstable_prefetch = 'force-runtime'
 
 import { RelativeTime } from './relative-time'
 
@@ -230,13 +212,12 @@ Next.js enforces that it can always produce at least a partially static initial 
 Before:
 
 ```jsx filename="app/page.js"
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [...],
-}
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {
-  const lastImpressionTime = (await cookies()).get('last-impression-time')?.value
+  const lastImpressionTime = (await cookies()).get(
+    'last-impression-time'
+  )?.value
   const currentTime = Date.now()
   if (currentTime > lastImpressionTime + SOME_INTERVAL) {
     return <SpecialBanner />
@@ -249,10 +230,7 @@ export default async function Page() {
 After:
 
 ```jsx filename="app/page.js"
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [...],
-}
+export const unstable_prefetch = 'force-runtime'
 
 import { Suspense } from 'react'
 import { connection } from 'next/server'

--- a/errors/next-prerender-runtime-random.mdx
+++ b/errors/next-prerender-runtime-random.mdx
@@ -23,10 +23,7 @@ If your random value is cacheable, move the `Math.random()` call to a `"use cach
 Before:
 
 ```jsx filename="app/page.js"
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [...],
-}
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page({ params }) {
   const { category } = await params
@@ -40,10 +37,7 @@ export default async function Page({ params }) {
 After:
 
 ```jsx filename="app/page.js"
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [...],
-}
+export const unstable_prefetch = 'force-runtime'
 
 async function RandomizedProductsView({ category }) {
   'use cache'
@@ -68,10 +62,7 @@ If you want the random value to be evaluated on each Request precede it with `aw
 Before:
 
 ```jsx filename="app/page.js"
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [...],
-}
+export const unstable_prefetch = 'force-runtime'
 
 export default async function Page({ params }) {
   const { category } = await params
@@ -85,10 +76,7 @@ export default async function Page({ params }) {
 After:
 
 ```jsx filename="app/page.js"
-export const unstable_instant = {
-  prefetch: 'runtime',
-  samples: [...],
-}
+export const unstable_prefetch = 'force-runtime'
 
 import { connection } from 'next/server'
 

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1181,5 +1181,8 @@
   "1180": "Cookies can only be modified in a Server Action or Route Handler. Read more: https://nextjs.org/docs/app/api-reference/functions/cookies#options",
   "1181": "Filling a \"use cache\" entry appears to be stuck on shared state from the outer render scope. The same function completed when run in isolation, which usually means a module-scoped value (for example a top-level Map used to dedupe fetches) is joining a promise created outside the cache. \"use cache\" already dedupes calls with the same arguments — within a request and across requests on the same server instance — so the surrounding dedupe layer is both unnecessary and the likely cause. Remove it and rely on \"use cache\" alone for deduping.",
   "1182": "`deadlockError` should be constructed inside `cache()` before reaching the probe scheduler.",
-  "1183": "Unexpected `prerender-dynamic` result in `use cache` probe mode."
+  "1183": "Unexpected `prerender-dynamic` result in `use cache` probe mode.",
+  "1184": "createCombinedPayloadAtDepth must run inside a WorkStore",
+  "1185": "anySegmentNeedsInstantValidation must run inside a WorkStore",
+  "1186": "%scacheScopedToWorkStore callee must run inside a WorkStore"
 }

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1184,5 +1184,11 @@
   "1183": "Unexpected `prerender-dynamic` result in `use cache` probe mode.",
   "1184": "createCombinedPayloadAtDepth must run inside a WorkStore",
   "1185": "anySegmentNeedsInstantValidation must run inside a WorkStore",
-  "1186": "%scacheScopedToWorkStore callee must run inside a WorkStore"
+  "1186": "%scacheScopedToWorkStore callee must run inside a WorkStore",
+  "1187": "Route \"%s\" accessed cookie \"%s\" which is not defined in the \\`unstable_samples\\` of \\`unstable_instant\\`. Add it to the sample's \\`cookies\\` array, or \\`{ name: \"%s\", value: null }\\` if it should be absent.",
+  "1188": "Route \"%s\" accessed searchParam \"%s\" which is not defined in the \\`unstable_samples\\` of \\`unstable_instant\\`. Add it to the sample's \\`searchParams\\` object, or \\`{ \"%s\": null }\\` if it should be absent.",
+  "1189": "Route \"%s\" accessed header \"%s\" which is not defined in the \\`unstable_samples\\` of \\`unstable_instant\\`. Add it to the sample's \\`headers\\` array, or \\`[\"%s\", null]\\` if it should be absent.",
+  "1190": "Route \"%s\" accessed param \"%s\" which is not defined in the \\`unstable_samples\\` of \\`unstable_instant\\`. Add it to the sample's \\`params\\` object.",
+  "1191": "Route \"%s\" called %s but param%s %s %s not defined in the \\`unstable_samples\\` of \\`unstable_instant\\`. %s requires all route params to be provided.",
+  "1192": "Route \"%s\" accessed root param \"%s\" which is not defined in the \\`unstable_samples\\` of \\`unstable_instant\\`. Add it to the sample's \\`params\\` object."
 }

--- a/packages/next/src/build/segment-config/app/app-segment-config.ts
+++ b/packages/next/src/build/segment-config/app/app-segment-config.ts
@@ -21,6 +21,7 @@ const RuntimeSampleSchema = z
 
 const InstantConfigObjectSchema = z
   .object({
+    level: z.enum(['warning', 'experimental-error']).optional(),
     samples: z.array(RuntimeSampleSchema).min(1).optional(),
     from: z.array(z.string()).optional(),
     unstable_disableValidation: z.literal(true).optional(),
@@ -58,6 +59,7 @@ export type InstantConfigForTypeCheckInternal = __GenericInstantConfig | Instant
 // and thus cannot match the discriminated union type. If we figure out a better way we should
 // delete the __GenericInstantConfig member.
 interface __GenericInstantConfig {
+  level?: string
   samples?: Array<WideInstantSample>
   from?: string[]
   unstable_disableValidation?: boolean
@@ -73,6 +75,7 @@ type WideInstantSample = {
 }
 
 export interface InstantConfig {
+  level?: 'warning' | 'experimental-error'
   samples?: Array<InstantSample>
   from?: string[]
   unstable_disableValidation?: true

--- a/packages/next/src/build/segment-config/app/app-segment-config.ts
+++ b/packages/next/src/build/segment-config/app/app-segment-config.ts
@@ -22,8 +22,8 @@ const RuntimeSampleSchema = z
 const InstantConfigObjectSchema = z
   .object({
     level: z.enum(['warning', 'experimental-error']).optional(),
-    samples: z.array(RuntimeSampleSchema).min(1).optional(),
-    from: z.array(z.string()).optional(),
+    unstable_samples: z.array(RuntimeSampleSchema).min(1).optional(),
+    unstable_from: z.array(z.string()).optional(),
     unstable_disableValidation: z.literal(true).optional(),
     unstable_disableDevValidation: z.literal(true).optional(),
     unstable_disableBuildValidation: z.literal(true).optional(),
@@ -60,8 +60,8 @@ export type InstantConfigForTypeCheckInternal = __GenericInstantConfig | Instant
 // delete the __GenericInstantConfig member.
 interface __GenericInstantConfig {
   level?: string
-  samples?: Array<WideInstantSample>
-  from?: string[]
+  unstable_samples?: Array<WideInstantSample>
+  unstable_from?: string[]
   unstable_disableValidation?: boolean
   unstable_disableDevValidation?: boolean
   unstable_disableBuildValidation?: boolean
@@ -76,8 +76,8 @@ type WideInstantSample = {
 
 export interface InstantConfig {
   level?: 'warning' | 'experimental-error'
-  samples?: Array<InstantSample>
-  from?: string[]
+  unstable_samples?: Array<InstantSample>
+  unstable_from?: string[]
   unstable_disableValidation?: true
   unstable_disableDevValidation?: true
   unstable_disableBuildValidation?: true

--- a/packages/next/src/build/static-paths/app.ts
+++ b/packages/next/src/build/static-paths/app.ts
@@ -868,6 +868,10 @@ export async function buildAppStaticPaths({
       staticPageGenerationTimeout,
       supportsDynamicResponse: true,
       cacheComponents,
+      // generateStaticParams evaluation doesn't render pages, so instant
+      // validation never runs here. The level value is irrelevant.
+      // TODO: remove validationLevel and other global config out of renderOpts
+      validationLevel: 'warning',
       experimental: {
         authInterrupts,
         useCacheTimeout,

--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -880,6 +880,8 @@ export async function handler(
               }
             : {}),
           cacheComponents: Boolean(nextConfig.cacheComponents),
+          validationLevel:
+            nextConfig.experimental.instantInsights.validationLevel,
           experimental: {
             isRoutePPREnabled,
             expireTime: nextConfig.expireTime,

--- a/packages/next/src/build/templates/app-route.ts
+++ b/packages/next/src/build/templates/app-route.ts
@@ -247,6 +247,7 @@ export async function handler(
         useCacheTimeout: nextConfig.experimental.useCacheTimeout,
       },
       cacheComponents: Boolean(nextConfig.cacheComponents),
+      validationLevel: nextConfig.experimental.instantInsights.validationLevel,
       supportsDynamicResponse,
       incrementalCache,
       cacheLifeProfiles: nextConfig.cacheLife,

--- a/packages/next/src/build/templates/edge-ssr-app.ts
+++ b/packages/next/src/build/templates/edge-ssr-app.ts
@@ -159,6 +159,7 @@ async function requestHandler(
         typeof nextConfig.logging === 'object' &&
         Boolean(nextConfig.logging.serverFunctions),
       cacheComponents: Boolean(nextConfig.cacheComponents),
+      validationLevel: nextConfig.experimental.instantInsights.validationLevel,
       experimental: {
         isRoutePPREnabled: false,
         expireTime: nextConfig.expireTime,

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -480,6 +480,7 @@ async function exportAppImpl(
     distDir,
     basePath: nextConfig.basePath,
     cacheComponents: nextConfig.cacheComponents ?? false,
+    validationLevel: nextConfig.experimental.instantInsights.validationLevel,
     trailingSlash: nextConfig.trailingSlash,
     locales: i18n?.locales,
     locale: i18n?.defaultLocale,
@@ -746,6 +747,10 @@ async function exportAppImpl(
         initialPhaseExportPaths.push(exportPath)
       }
 
+      // Always mark routes for potential build validation. The actual
+      // decision of whether to validate is made per-route by
+      // anySegmentNeedsInstantValidationInBuild, which checks both the
+      // default validation level and per-segment level overrides.
       const route = exportPath.page
       if (!routesWithInstantValidation.has(route)) {
         exportPath._runInstantValidation = true

--- a/packages/next/src/export/routes/app-route.ts
+++ b/packages/next/src/export/routes/app-route.ts
@@ -77,6 +77,10 @@ export async function exportAppRoute(
     },
     renderOpts: {
       cacheComponents,
+      // app-route handlers don't run instant validation, so the level
+      // value is irrelevant here.
+      // TODO: move validationLevel and other global config out of renderOpts
+      validationLevel: 'warning',
       experimental,
       isBuildTimePrerendering: true,
       supportsDynamicResponse: false,

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -6859,6 +6859,7 @@ async function validateInstantConfigInBuildWithSample(
     }),
 
     cacheComponentsEnabled: outerWorkStore.cacheComponentsEnabled,
+    validationLevel: outerWorkStore.validationLevel,
     previouslyRevalidatedTags: [],
     refreshTagsByCacheKind: new Map(),
     runInCleanSnapshot: outerWorkStore.runInCleanSnapshot,

--- a/packages/next/src/server/app-render/instant-validation/instant-config.tsx
+++ b/packages/next/src/server/app-render/instant-validation/instant-config.tsx
@@ -1,6 +1,15 @@
 import { getLayoutOrPageModule } from '../../lib/app-dir-module'
 import type { LoaderTree } from '../../lib/app-dir-module'
 import { parseLoaderTree } from '../../../shared/lib/router/utils/parse-loader-tree'
+import {
+  PAGE_SEGMENT_KEY,
+  DEFAULT_SEGMENT_KEY,
+} from '../../../shared/lib/segment'
+import {
+  UNDERSCORE_GLOBAL_ERROR_ROUTE,
+  UNDERSCORE_NOT_FOUND_ROUTE,
+} from '../../../shared/lib/entry-constants'
+import type { Segment } from '../../../shared/lib/app-router-types'
 import type {
   AppSegmentConfig,
   InstantSample,
@@ -9,6 +18,37 @@ import {
   workAsyncStorage,
   type WorkStore,
 } from '../work-async-storage.external'
+import { InvariantError } from '../../../shared/lib/invariant-error'
+
+/**
+ * True when an unconfigured segment should be treated as implicitly
+ * validated under a non-disabled default validation level. Only page and
+ * default segments qualify — layouts do not validate on their own.
+ */
+export function isImplicitValidationSegment(segment: Segment): boolean {
+  const key = typeof segment === 'string' ? segment : segment[0]
+  return (
+    key === PAGE_SEGMENT_KEY ||
+    key.startsWith(PAGE_SEGMENT_KEY) ||
+    key === DEFAULT_SEGMENT_KEY
+  )
+}
+
+/**
+ * Routes for the framework-synthesized error and not-found entries. They
+ * have no user-configurable escape hatch (the framework supplies the page
+ * when the user hasn't), so they're excluded from implicit validation under
+ * a non-disabled default validation level. Even when the user provides their
+ * own `global-error` or root `not-found`, these pages are special-purpose
+ * error UI — opting them into validation is something the user can do
+ * explicitly via `unstable_instant`.
+ */
+export function isFrameworkErrorRoute(route: string | undefined): boolean {
+  return (
+    route === UNDERSCORE_GLOBAL_ERROR_ROUTE ||
+    route === UNDERSCORE_NOT_FOUND_ROUTE
+  )
+}
 
 export async function anySegmentHasRuntimePrefetchEnabled(
   tree: LoaderTree
@@ -68,82 +108,129 @@ export async function isPageAllowedToBlock(tree: LoaderTree): Promise<boolean> {
   return false
 }
 
-type FoundSegmentWithConfig = {
-  path: string[]
-  config: NonNullable<AppSegmentConfig['unstable_instant']>
+enum VALIDATION_LEVEL {
+  WARNING = 0,
+  ERROR = 1,
 }
 
 /**
- * Checks if any segments in the loader tree have `instant` configs that need validating.
- * NOTE: Client navigations call this multiple times, so we cache it.
- * */
-// Shared helper (not exported, not cached — called by the cached wrappers)
+ * Walks the loader tree and checks if any segment has an `instant` config
+ * that needs validating for the given mode.
+ *
+ * - Explicit `unstable_instant` exports are checked against mode.
+ * - Page and default segments without an explicit config get implicit
+ *   validation when the default validation level applies to this mode.
+ * - `unstable_disableValidation` on any segment kills validation for
+ *   the whole tree.
+ */
 async function anySegmentNeedsInstantValidation(
   rootTree: LoaderTree,
-  mode: 'dev' | 'build'
+  level: VALIDATION_LEVEL
 ): Promise<boolean> {
-  const segments = await findSegmentsWithInstantConfig(rootTree)
+  const workStore = workAsyncStorage.getStore()
+  if (!workStore) {
+    throw new InvariantError(
+      'anySegmentNeedsInstantValidation must run inside a WorkStore'
+    )
+  }
+  const { validationLevel } = workStore
 
-  // Check if there's any non-false configs that need validation.
-  // (If there's only `false`, there's no need to run validation).
-  // If any segment has `unstable_disableValidation`, we skip validation for the whole tree.
+  let baseValidationLevel: number = VALIDATION_LEVEL.WARNING
+  let manualValidation: boolean = false
+  switch (validationLevel) {
+    case 'manual-warning':
+      manualValidation = true
+    // intentional fallthrough
+    case 'warning':
+      baseValidationLevel = VALIDATION_LEVEL.WARNING
+      break
+    case 'experimental-manual-error':
+      manualValidation = true
+    // intentional fallthrough
+    case 'experimental-error':
+      baseValidationLevel = VALIDATION_LEVEL.ERROR
+      break
+    default:
+      validationLevel satisfies never
+  }
+
+  const applyDefaultValidation =
+    // We need to be validating the right level
+    level <= baseValidationLevel &&
+    // We need to not be in manual validation mode
+    !manualValidation &&
+    // We don't validate framework internal routes by default
+    !isFrameworkErrorRoute(workStore.route)
+
   let needsValidation = false
-  for (const { config } of segments) {
-    if (config === true) {
-      needsValidation = true
-    } else if (typeof config === 'object') {
-      if (
-        config.unstable_disableValidation === true ||
-        (mode === 'dev' && config.unstable_disableDevValidation === true) ||
-        (mode === 'build' && config.unstable_disableBuildValidation === true)
-      ) {
-        return false
+  let disabled = false
+
+  async function visit(tree: LoaderTree): Promise<void> {
+    if (disabled) return
+
+    const { mod: layoutOrPageMod } = await getLayoutOrPageModule(tree)
+    const instantConfig = layoutOrPageMod
+      ? (layoutOrPageMod as AppSegmentConfig).unstable_instant
+      : undefined
+
+    if (instantConfig === false) {
+      // Explicit opt-out. Doesn't itself trigger validation.
+    } else if (instantConfig === true) {
+      // Explicit opt-in using the default level.
+      if (level <= baseValidationLevel) {
+        needsValidation = true
       }
-      // do not short-circuit, some other segment might still have `unstable_disableValidation`
+    } else if (typeof instantConfig === 'object' && instantConfig !== null) {
+      if (
+        instantConfig.unstable_disableValidation === true ||
+        (level === VALIDATION_LEVEL.WARNING &&
+          instantConfig.unstable_disableDevValidation === true) ||
+        (level === VALIDATION_LEVEL.ERROR &&
+          instantConfig.unstable_disableBuildValidation === true)
+      ) {
+        disabled = true
+        return
+      }
+
+      if (instantConfig.level !== undefined) {
+        const configuredLevel =
+          instantConfig.level === 'experimental-error'
+            ? VALIDATION_LEVEL.ERROR
+            : VALIDATION_LEVEL.WARNING
+        if (level <= configuredLevel) {
+          needsValidation = true
+        }
+      } else if (level <= baseValidationLevel) {
+        needsValidation = true
+      }
+    } else if (applyDefaultValidation && isImplicitValidationSegment(tree[0])) {
+      // No explicit config. Implicit validation applies to page/default
+      // segments when the default level is active for this mode.
       needsValidation = true
     }
+
+    const { parallelRoutes } = parseLoaderTree(tree)
+    for (const parallelRouteKey in parallelRoutes) {
+      await visit(parallelRoutes[parallelRouteKey])
+      if (disabled) return
+    }
+  }
+
+  await visit(rootTree)
+  if (disabled) {
+    return false
   }
   return needsValidation
 }
 
 export const anySegmentNeedsInstantValidationInDev = cacheScopedToWorkStore(
   async (rootTree: LoaderTree): Promise<boolean> =>
-    anySegmentNeedsInstantValidation(rootTree, 'dev')
+    anySegmentNeedsInstantValidation(rootTree, VALIDATION_LEVEL.WARNING)
 )
 
 export const anySegmentNeedsInstantValidationInBuild = cacheScopedToWorkStore(
   async (rootTree: LoaderTree): Promise<boolean> =>
-    anySegmentNeedsInstantValidation(rootTree, 'build')
-)
-
-export const findSegmentsWithInstantConfig = cacheScopedToWorkStore(
-  async (rootTree: LoaderTree): Promise<FoundSegmentWithConfig[]> => {
-    const results: FoundSegmentWithConfig[] = []
-
-    async function visit(tree: LoaderTree, path: string[]): Promise<void> {
-      const { mod: layoutOrPageMod } = await getLayoutOrPageModule(tree)
-
-      // TODO(restart-on-cache-miss): Does this work correctly for client page/layout modules?
-      const instantConfig = layoutOrPageMod
-        ? (layoutOrPageMod as AppSegmentConfig).unstable_instant
-        : undefined
-      if (instantConfig !== undefined) {
-        results.push({
-          path,
-          config: instantConfig,
-        })
-      }
-
-      const { parallelRoutes } = parseLoaderTree(tree)
-      for (const parallelRouteKey in parallelRoutes) {
-        const childTree = parallelRoutes[parallelRouteKey]
-        await visit(childTree, [...path, parallelRouteKey])
-      }
-    }
-
-    await visit(rootTree, [])
-    return results
-  }
+    anySegmentNeedsInstantValidation(rootTree, VALIDATION_LEVEL.ERROR)
 )
 
 export const resolveInstantConfigSamplesForPage = async (
@@ -195,8 +282,9 @@ function cacheScopedToWorkStore<TArg extends WeakKey, TRes>(
   return (arg: TArg): TRes => {
     const workStore = workAsyncStorage.getStore()
     if (!workStore) {
-      // No caching.
-      return func(arg)
+      throw new InvariantError(
+        `${func.name || 'cacheScopedToWorkStore callee'} must run inside a WorkStore`
+      )
     }
 
     let results = resultsPerWorkStore.get(workStore)

--- a/packages/next/src/server/app-render/instant-validation/instant-config.tsx
+++ b/packages/next/src/server/app-render/instant-validation/instant-config.tsx
@@ -246,9 +246,9 @@ export const resolveInstantConfigSamplesForPage = async (
   if (
     instantConfig !== undefined &&
     typeof instantConfig === 'object' &&
-    instantConfig.samples
+    instantConfig.unstable_samples
   ) {
-    samples = instantConfig.samples
+    samples = instantConfig.unstable_samples
   }
 
   // The samples from inner segments override samples from outer segments,

--- a/packages/next/src/server/app-render/instant-validation/instant-config.tsx
+++ b/packages/next/src/server/app-render/instant-validation/instant-config.tsx
@@ -22,7 +22,7 @@ import { InvariantError } from '../../../shared/lib/invariant-error'
 
 /**
  * True when an unconfigured segment should be treated as implicitly
- * validated under a non-disabled default validation level. Only page and
+ * validated under a non-manual default validation level. Only page and
  * default segments qualify — layouts do not validate on their own.
  */
 export function isImplicitValidationSegment(segment: Segment): boolean {
@@ -38,7 +38,7 @@ export function isImplicitValidationSegment(segment: Segment): boolean {
  * Routes for the framework-synthesized error and not-found entries. They
  * have no user-configurable escape hatch (the framework supplies the page
  * when the user hasn't), so they're excluded from implicit validation under
- * a non-disabled default validation level. Even when the user provides their
+ * a non-manual default validation level. Even when the user provides their
  * own `global-error` or root `not-found`, these pages are special-purpose
  * error UI — opting them into validation is something the user can do
  * explicitly via `unstable_instant`.

--- a/packages/next/src/server/app-render/instant-validation/instant-samples-client.ts
+++ b/packages/next/src/server/app-render/instant-validation/instant-samples-client.ts
@@ -61,7 +61,7 @@ export function expectCompleteParamsInClientValidation(
             const missingParams = Array.from(fallbackParams.keys())
             trackMissingSampleErrorAndThrow(
               new InstantValidationError(
-                `Route "${workStore.route}" called ${expression} but param${missingParams.length > 1 ? 's' : ''} ${missingParams.map((p) => `"${p}"`).join(', ')} ${missingParams.length > 1 ? 'are' : 'is'} not defined in the \`samples\` of \`unstable_instant\`. ` +
+                `Route "${workStore.route}" called ${expression} but param${missingParams.length > 1 ? 's' : ''} ${missingParams.map((p) => `"${p}"`).join(', ')} ${missingParams.length > 1 ? 'are' : 'is'} not defined in the \`unstable_samples\` of \`unstable_instant\`. ` +
                   `${expression} requires all route params to be provided.`
               )
             )

--- a/packages/next/src/server/app-render/instant-validation/instant-samples.ts
+++ b/packages/next/src/server/app-render/instant-validation/instant-samples.ts
@@ -150,7 +150,7 @@ function createMissingCookieSampleError(
   name: string
 ): InstantValidationError {
   return new InstantValidationError(
-    `Route "${route}" accessed cookie "${name}" which is not defined in the \`samples\` ` +
+    `Route "${route}" accessed cookie "${name}" which is not defined in the \`unstable_samples\` ` +
       `of \`unstable_instant\`. Add it to the sample's \`cookies\` array, ` +
       `or \`{ name: "${name}", value: null }\` if it should be absent.`
   )
@@ -206,7 +206,7 @@ export function createHeadersFromSample(
           if (!declaredNames.has(name)) {
             trackMissingSampleErrorAndThrow(
               new InstantValidationError(
-                `Route "${route}" accessed header "${name}" which is not defined in the \`samples\` ` +
+                `Route "${route}" accessed header "${name}" which is not defined in the \`unstable_samples\` ` +
                   `of \`unstable_instant\`. Add it to the sample's \`headers\` array, ` +
                   `or \`["${name}", null]\` if it should be absent.`
               )
@@ -269,7 +269,7 @@ export function createExhaustiveParamsProxy<TParams extends Params>(
       ) {
         trackMissingSampleErrorAndThrow(
           new InstantValidationError(
-            `Route "${route}" accessed param "${prop}" which is not defined in the \`samples\` ` +
+            `Route "${route}" accessed param "${prop}" which is not defined in the \`unstable_samples\` ` +
               `of \`unstable_instant\`. Add it to the sample's \`params\` object.`
           )
         )
@@ -359,7 +359,7 @@ function createMissingSearchParamSampleError(
   name: string
 ): InstantValidationError {
   return new InstantValidationError(
-    `Route "${route}" accessed searchParam "${name}" which is not defined in the \`samples\` ` +
+    `Route "${route}" accessed searchParam "${name}" which is not defined in the \`unstable_samples\` ` +
       `of \`unstable_instant\`. Add it to the sample's \`searchParams\` object, ` +
       `or \`{ "${name}": null }\` if it should be absent.`
   )
@@ -488,7 +488,7 @@ export function assertRootParamInSamples(
     const route = workStore.route
     trackMissingSampleErrorAndThrow(
       new InstantValidationError(
-        `Route "${route}" accessed root param "${paramName}" which is not defined in the \`samples\` ` +
+        `Route "${route}" accessed root param "${paramName}" which is not defined in the \`unstable_samples\` ` +
           `of \`unstable_instant\`. Add it to the sample's \`params\` object.`
       )
     )

--- a/packages/next/src/server/app-render/instant-validation/instant-validation.tsx
+++ b/packages/next/src/server/app-render/instant-validation/instant-validation.tsx
@@ -53,6 +53,10 @@ import {
   DEFAULT_SEGMENT_KEY,
   NOT_FOUND_SEGMENT_KEY,
 } from '../../../shared/lib/segment'
+import {
+  isFrameworkErrorRoute,
+  isImplicitValidationSegment,
+} from './instant-config'
 import type { NextParsedUrlQuery } from '../../request-meta'
 
 const filterStackFrame =
@@ -930,6 +934,14 @@ export async function createCombinedPayloadAtDepth(
   stageEndTimes: StageEndTimes,
   useRuntimeStageForPartialSegments: boolean
 ): Promise<ValidationPayloadResult | null> {
+  const workStore = workAsyncStorage.getStore()
+  if (!workStore) {
+    throw new InvariantError(
+      'createCombinedPayloadAtDepth must run inside a WorkStore'
+    )
+  }
+  const { validationLevel, route } = workStore
+
   let hasStaticSegments = false
   let hasRuntimeSegments = false
   // Index 0 is reserved for the root config. Slot markers start at 1.
@@ -1155,6 +1167,21 @@ export async function createCombinedPayloadAtDepth(
         (layoutOrPageMod as AppSegmentConfig).unstable_instant ?? null
       prefetchConfig =
         (layoutOrPageMod as AppSegmentConfig).unstable_prefetch ?? null
+
+      // When the default validation level is active and this is a page or
+      // default segment without an explicit config, treat it as if
+      // unstable_instant = true was exported. Framework-synthesized error
+      // routes are excluded — see isFrameworkErrorRoute.
+      if (
+        instantConfig === null &&
+        validationLevel !== 'manual-warning' &&
+        validationLevel !== 'experimental-manual-error' &&
+        isImplicitValidationSegment(segment) &&
+        !isFrameworkErrorRoute(route)
+      ) {
+        instantConfig = true
+      }
+
       if (
         instantConfig === true ||
         (typeof instantConfig === 'object' && instantConfig !== null)

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -225,7 +225,7 @@ export interface RenderOptsPartial {
   /**
    * When true, attempt to run build-time instant validation for this prerender.
    * Only the first prerender per page sets this, since validation uses
-   * unstable_instant.samples and is independent of actual route params.
+   * unstable_instant.unstable_samples and is independent of actual route params.
    */
   runInstantValidation?: boolean
 }

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -4,6 +4,7 @@ import type {
   ExperimentalConfig,
   NextConfigComplete,
   PrefetchInliningConfig,
+  ValidationLevel,
 } from '../../server/config-shared'
 import type { NextFontManifest } from '../../build/webpack/plugins/next-font-manifest-plugin'
 import type { ParsedUrlQuery } from 'querystring'
@@ -96,6 +97,7 @@ export interface RenderOptsPartial {
   err?: Error | null
   basePath: string
   cacheComponents: boolean
+  validationLevel: ValidationLevel
   trailingSlash: boolean
   images: ImageConfigComplete
   supportsDynamicResponse: boolean

--- a/packages/next/src/server/app-render/work-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-async-storage.external.ts
@@ -6,6 +6,7 @@ import type { AppSegmentConfig } from '../../build/segment-config/app/app-segmen
 import type { AfterContext } from '../after/after-context'
 import type { CacheLife } from '../use-cache/cache-life'
 import type { SharedCacheResult } from '../use-cache/use-cache-wrapper'
+import type { ValidationLevel } from '../config-shared'
 
 // Share the instance module in the next-shared layer
 import { workAsyncStorageInstance } from './work-async-storage-instance' with { 'turbopack-transition': 'next-shared' }
@@ -132,6 +133,7 @@ export interface WorkStore {
   readonly nonce?: string
 
   cacheComponentsEnabled: boolean
+  validationLevel: ValidationLevel
 
   /**
    * Run the given function inside a clean AsyncLocalStorage snapshot. This is

--- a/packages/next/src/server/async-storage/work-store.ts
+++ b/packages/next/src/server/async-storage/work-store.ts
@@ -5,6 +5,7 @@ import type { FetchMetric } from '../base-http'
 import type { RequestLifecycleOpts } from '../base-server'
 import type { AppSegmentConfig } from '../../build/segment-config/app/app-segment-config'
 import type { CacheLife } from '../use-cache/cache-life'
+import type { ValidationLevel } from '../config-shared'
 
 import { AfterContext } from '../after/after-context'
 
@@ -27,6 +28,7 @@ export type WorkStoreContext = {
     incrementalCache?: IncrementalCache
     isOnDemandRevalidate?: boolean
     cacheComponents: boolean
+    validationLevel: ValidationLevel
     fetchCache?: AppSegmentConfig['fetchCache']
     isPossibleServerAction?: boolean
     pendingWaitUntil?: Promise<any>
@@ -145,6 +147,7 @@ export function createWorkStore({
 
     afterContext: createAfterContext(renderOpts),
     cacheComponentsEnabled: renderOpts.cacheComponents,
+    validationLevel: renderOpts.validationLevel,
     previouslyRevalidatedTags,
     refreshTagsByCacheKind: createRefreshTagsByCacheKind(),
     runInCleanSnapshot: createSnapshot(),

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -567,6 +567,8 @@ export default abstract class Server<
       // `htmlLimitedBots` is passed to server as serialized config in string format
       htmlLimitedBots: this.nextConfig.htmlLimitedBots,
       cacheComponents: this.nextConfig.cacheComponents ?? false,
+      validationLevel:
+        this.nextConfig.experimental.instantInsights.validationLevel,
       experimental: {
         expireTime: this.nextConfig.expireTime,
         staleTimes: this.nextConfig.experimental.staleTimes,

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -392,6 +392,18 @@ export const experimentalSchema = {
   allowDevelopmentBuild: z.literal(true).optional(),
 
   reactDebugChannel: z.boolean().optional(),
+  instantInsights: z
+    .object({
+      validationLevel: z
+        .enum([
+          'warning',
+          'manual-warning',
+          'experimental-error',
+          'experimental-manual-error',
+        ])
+        .optional(),
+    })
+    .optional(),
   staticGenerationRetryCount: z.number().int().optional(),
   staticGenerationMaxConcurrency: z.number().int().optional(),
   staticGenerationMinPagesPerWorker: z.number().int().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1289,7 +1289,7 @@ export type ExportPathMap = {
     /**
      * When true, run build-time instant validation for this export path.
      * Only set on the first export entry per page, since validation uses
-     * unstable_instant.samples (not actual params from generateStaticParams),
+     * unstable_instant.unstable_samples (not actual params from generateStaticParams),
      * so the result is the same for all param combinations.
      *
      * @internal

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -36,6 +36,8 @@ export type NextConfigComplete = Required<Omit<NextConfig, 'configFile'>> & {
     prefetchInlining?: PrefetchInliningConfig
     // Normalized by config.ts: defaulted to 90% of staticPageGenerationTimeout
     useCacheTimeout: number
+    // Normalized by config.ts `finalizeConfig`: defaulted to `'manual-warning'`
+    instantInsights: { validationLevel: ValidationLevel }
   }
   // The root directory of the distDir. In development mode, this is the parent directory of `distDir`
   // since development builds use `{distDir}/dev`. This is used to ensure that the bundler doesn't
@@ -1015,6 +1017,21 @@ export interface ExperimentalConfig {
   cacheComponents?: boolean
 
   /**
+   * Configuration for instant navigation validation.
+   */
+  instantInsights?: {
+    /**
+     * Controls the validation behavior of Instant Insights
+     *
+     * - `'warning'`: Validates all navigations for Instant UI in development
+     * - `'manual-warning'`: Validates navigations for Instant UI in development when configured with `unstable_instant` in Pages and Layouts
+     * - `'experimental-error'`: Validates all navigations for Instant in development and build. Use with caution.
+     * - `'experimental-manual-error'`: Validates navigations for Instant UI in developement and build when configured with `unstable_instant` in Pages and Layouts. Use with caution.
+     */
+    validationLevel?: ValidationLevel
+  }
+
+  /**
    * The number of times to retry static generation (per page) before giving up.
    */
   staticGenerationRetryCount?: number
@@ -1288,6 +1305,13 @@ export type ExportPathMap = {
  *
  * Read more: [Next.js Docs: `next.config.js`](https://nextjs.org/docs/app/api-reference/config/next-config-js)
  */
+
+export type ValidationLevel =
+  | 'warning'
+  | 'manual-warning'
+  | 'experimental-error'
+  | 'experimental-manual-error'
+
 export interface NextConfig {
   allowedDevOrigins?: string[]
 
@@ -2073,6 +2097,7 @@ export interface NextConfigRuntime {
     | 'exposeTestingApiInProductionBuild'
     | 'supportsImmutableAssets'
     | 'useNodeStreams'
+    | 'instantInsights'
   > & {
     // Pick on @internal fields generates invalid .d.ts files
     /** @internal */
@@ -2141,6 +2166,7 @@ export function getNextConfigRuntime(
     exposeTestingApiInProductionBuild: ex.exposeTestingApiInProductionBuild,
     supportsImmutableAssets: ex.supportsImmutableAssets,
     useNodeStreams: ex.useNodeStreams,
+    instantInsights: ex.instantInsights,
 
     trustHostHeader: ex.trustHostHeader,
     isExperimentalCompile: ex.isExperimentalCompile,

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1532,6 +1532,21 @@ function assignDefaultsAndValidate(
   return result as NextConfigComplete
 }
 
+/**
+ * Post-processing applied by `loadConfig` after `applyModifyConfig`, so that
+ * any mutations the user made through `modifyConfig` still flow through the
+ * same defaulting rules. Keep framework-default resolution in one place so
+ * consumers don't each need to know the current framework default (which may
+ * evolve over time).
+ */
+function finalizeConfig(config: NextConfigComplete): NextConfigComplete {
+  config.experimental.instantInsights = {
+    validationLevel:
+      config.experimental.instantInsights?.validationLevel ?? 'manual-warning',
+  }
+  return config
+}
+
 async function applyModifyConfig(
   config: NextConfigComplete,
   phase: PHASE_TYPE,
@@ -1711,19 +1726,21 @@ export default async function loadConfig(
     // Check deprecation warnings on the custom config before merging with defaults
     checkDeprecations(customConfig as NextConfig, configFileName, silent, dir)
 
-    const config = await applyModifyConfig(
-      assignDefaultsAndValidate(
-        dir,
-        {
-          configOrigin: 'server',
-          configFileName,
-          ...customConfig,
-        },
-        silent,
-        phase
-      ),
-      phase,
-      silent
+    const config = finalizeConfig(
+      await applyModifyConfig(
+        assignDefaultsAndValidate(
+          dir,
+          {
+            configOrigin: 'server',
+            configFileName,
+            ...customConfig,
+          },
+          silent,
+          phase
+        ),
+        phase,
+        silent
+      )
     )
 
     // Cache the custom config result
@@ -1919,7 +1936,9 @@ export default async function loadConfig(
       phase
     )
 
-    const finalConfig = await applyModifyConfig(completeConfig, phase, silent)
+    const finalConfig = finalizeConfig(
+      await applyModifyConfig(completeConfig, phase, silent)
+    )
 
     // Cache the final result
     configCache.set(cacheKey, {
@@ -1976,7 +1995,9 @@ export default async function loadConfig(
 
   setHttpClientAndAgentOptions(completeConfig)
 
-  const finalConfig = await applyModifyConfig(completeConfig, phase, silent)
+  const finalConfig = finalizeConfig(
+    await applyModifyConfig(completeConfig, phase, silent)
+  )
 
   // Cache the default config result
   configCache.set(cacheKey, {

--- a/packages/next/src/server/dev/use-cache-probe-worker.ts
+++ b/packages/next/src/server/dev/use-cache-probe-worker.ts
@@ -213,5 +213,8 @@ function buildProbeWorkStore(msg: ProbeMessage): WorkStore {
     reactServerErrorsByDigest: new Map(),
     afterContext,
     cacheComponentsEnabled: true,
+    // In the probe the validation level is irrelevant because we do not perform validation
+    // in this context.
+    validationLevel: 'warning',
   }
 }

--- a/packages/next/src/server/web/adapter.ts
+++ b/packages/next/src/server/web/adapter.ts
@@ -309,6 +309,10 @@ export async function adapter(
                 // default.
                 staticPageGenerationTimeout: 0,
                 cacheComponents: false,
+                // Proxy doesn't run instant validation; the level value is
+                // irrelevant here.
+                // TODO: remove validationLevel and other global config from renderOpts
+                validationLevel: 'warning',
                 experimental: {
                   isRoutePPREnabled: false,
                   authInterrupts:

--- a/packages/next/src/server/web/edge-route-module-wrapper.ts
+++ b/packages/next/src/server/web/edge-route-module-wrapper.ts
@@ -124,6 +124,10 @@ export class EdgeRouteModuleWrapper {
         onClose: closeController.onClose.bind(closeController),
         onAfterTaskError: undefined,
         cacheComponents: !!process.env.__NEXT_CACHE_COMPONENTS,
+        // Edge runtime doesn't run instant validation; the level value is
+        // irrelevant here.
+        // TODO: Remove validationLevel and other global config from renderOpts
+        validationLevel: 'warning',
         experimental: {
           authInterrupts: !!process.env.__NEXT_EXPERIMENTAL_AUTH_INTERRUPTS,
           // Edge runtime doesn't support Cache Components, so this value is

--- a/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/app/runtime-prefetch-target/page.tsx
+++ b/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/app/runtime-prefetch-target/page.tsx
@@ -2,7 +2,7 @@ import { Suspense } from 'react'
 import { connection } from 'next/server'
 
 export const unstable_instant = {
-  samples: [{ searchParams: { myParam: 'testValue' } }],
+  unstable_samples: [{ searchParams: { myParam: 'testValue' } }],
 }
 export const unstable_prefetch = 'force-runtime'
 

--- a/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/app/ungenerated-params-runtime/[slug]/page.tsx
+++ b/test/e2e/app-dir/instant-navigation-testing-api/fixtures/default/app/ungenerated-params-runtime/[slug]/page.tsx
@@ -5,9 +5,9 @@ import { Suspense } from 'react'
 // the resolved `slug`, so the param should be visible inside the instant
 // scope instead of suspending.
 export const unstable_instant: {
-  samples: Array<{ params: { slug: string } }>
+  unstable_samples: Array<{ params: { slug: string } }>
 } = {
-  samples: [{ params: { slug: 'anything' } }],
+  unstable_samples: [{ params: { slug: 'anything' } }],
 }
 export const unstable_prefetch = 'force-runtime'
 

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/client-errors/page-throws-with-suspense/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/client-errors/page-throws-with-suspense/page.tsx
@@ -3,7 +3,7 @@ import { ThrowsInClient } from './client'
 
 export const unstable_instant: Instant = {
   level: 'experimental-error',
-  samples: [{ searchParams: {} }],
+  unstable_samples: [{ searchParams: {} }],
 }
 
 export default function Page() {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/client-errors/page-throws-with-suspense/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/client-errors/page-throws-with-suspense/page.tsx
@@ -2,7 +2,7 @@ import { Instant } from 'next'
 import { ThrowsInClient } from './client'
 
 export const unstable_instant: Instant = {
-  level: 'error',
+  level: 'experimental-error',
   samples: [{ searchParams: {} }],
 }
 

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/client-errors/page-throws-with-suspense/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/client-errors/page-throws-with-suspense/page.tsx
@@ -2,6 +2,7 @@ import { Instant } from 'next'
 import { ThrowsInClient } from './client'
 
 export const unstable_instant: Instant = {
+  level: 'error',
   samples: [{ searchParams: {} }],
 }
 

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/client-errors/page-throws/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/client-errors/page-throws/page.tsx
@@ -3,7 +3,7 @@ import { ThrowsInClient } from './client'
 
 export const unstable_instant: Instant = {
   level: 'experimental-error',
-  samples: [{ searchParams: {} }],
+  unstable_samples: [{ searchParams: {} }],
 }
 
 export default function Page() {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/client-errors/page-throws/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/client-errors/page-throws/page.tsx
@@ -2,7 +2,7 @@ import { Instant } from 'next'
 import { ThrowsInClient } from './client'
 
 export const unstable_instant: Instant = {
-  level: 'error',
+  level: 'experimental-error',
   samples: [{ searchParams: {} }],
 }
 

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/client-errors/page-throws/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/client-errors/page-throws/page.tsx
@@ -2,6 +2,7 @@ import { Instant } from 'next'
 import { ThrowsInClient } from './client'
 
 export const unstable_instant: Instant = {
+  level: 'error',
   samples: [{ searchParams: {} }],
 }
 

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/invalid-undeclared-cookie-get-caught/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/invalid-undeclared-cookie-get-caught/page.tsx
@@ -2,7 +2,7 @@ import { cookies } from 'next/headers'
 import { Suspense } from 'react'
 import { ensureThrows } from '../../../../ensure-error'
 
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/invalid-undeclared-cookie-get-caught/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/invalid-undeclared-cookie-get-caught/page.tsx
@@ -2,7 +2,7 @@ import { cookies } from 'next/headers'
 import { Suspense } from 'react'
 import { ensureThrows } from '../../../../ensure-error'
 
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/invalid-undeclared-cookie-get/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/invalid-undeclared-cookie-get/page.tsx
@@ -2,7 +2,7 @@ import { cookies } from 'next/headers'
 import { Suspense } from 'react'
 import { ensureThrows } from '../../../../ensure-error'
 
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/invalid-undeclared-cookie-get/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/invalid-undeclared-cookie-get/page.tsx
@@ -2,7 +2,7 @@ import { cookies } from 'next/headers'
 import { Suspense } from 'react'
 import { ensureThrows } from '../../../../ensure-error'
 
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/invalid-undeclared-cookie-has/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/invalid-undeclared-cookie-has/page.tsx
@@ -2,7 +2,7 @@ import { cookies } from 'next/headers'
 import { Suspense } from 'react'
 import { ensureThrows } from '../../../../ensure-error'
 
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/invalid-undeclared-cookie-has/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/invalid-undeclared-cookie-has/page.tsx
@@ -2,7 +2,7 @@ import { cookies } from 'next/headers'
 import { Suspense } from 'react'
 import { ensureThrows } from '../../../../ensure-error'
 
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/valid-cookies-in-samples/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/valid-cookies-in-samples/page.tsx
@@ -5,6 +5,7 @@ import assert from 'node:assert'
 import { Suspense } from 'react'
 
 export const unstable_instant: Instant = {
+  level: 'error',
   samples: [
     {
       cookies: [

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/valid-cookies-in-samples/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/valid-cookies-in-samples/page.tsx
@@ -6,7 +6,7 @@ import { Suspense } from 'react'
 
 export const unstable_instant: Instant = {
   level: 'experimental-error',
-  samples: [
+  unstable_samples: [
     {
       cookies: [
         { name: 'testCookie', value: 'testValue' },

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/valid-cookies-in-samples/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/valid-cookies-in-samples/page.tsx
@@ -5,7 +5,7 @@ import assert from 'node:assert'
 import { Suspense } from 'react'
 
 export const unstable_instant: Instant = {
-  level: 'error',
+  level: 'experimental-error',
   samples: [
     {
       cookies: [

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/valid-cookies-passed-to-cache/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/valid-cookies-passed-to-cache/page.tsx
@@ -3,7 +3,7 @@ import { cookies } from 'next/headers'
 import assert from 'node:assert/strict'
 
 export const unstable_instant: Instant = {
-  level: 'error',
+  level: 'experimental-error',
   samples: [
     {
       cookies: [{ name: 'testCookie', value: 'testValue' }],

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/valid-cookies-passed-to-cache/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/valid-cookies-passed-to-cache/page.tsx
@@ -3,6 +3,7 @@ import { cookies } from 'next/headers'
 import assert from 'node:assert/strict'
 
 export const unstable_instant: Instant = {
+  level: 'error',
   samples: [
     {
       cookies: [{ name: 'testCookie', value: 'testValue' }],

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/valid-cookies-passed-to-cache/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/valid-cookies-passed-to-cache/page.tsx
@@ -4,7 +4,7 @@ import assert from 'node:assert/strict'
 
 export const unstable_instant: Instant = {
   level: 'experimental-error',
-  samples: [
+  unstable_samples: [
     {
       cookies: [{ name: 'testCookie', value: 'testValue' }],
     },

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/valid-cookies-passed-to-client/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/valid-cookies-passed-to-client/page.tsx
@@ -4,7 +4,7 @@ import { ClientChild } from './client'
 
 export const unstable_instant: Instant = {
   level: 'experimental-error',
-  samples: [
+  unstable_samples: [
     {
       cookies: [{ name: 'testCookie', value: 'testValue' }],
     },

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/valid-cookies-passed-to-client/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/valid-cookies-passed-to-client/page.tsx
@@ -3,6 +3,7 @@ import { cookies } from 'next/headers'
 import { ClientChild } from './client'
 
 export const unstable_instant: Instant = {
+  level: 'error',
   samples: [
     {
       cookies: [{ name: 'testCookie', value: 'testValue' }],

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/valid-cookies-passed-to-client/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/cookies/valid-cookies-passed-to-client/page.tsx
@@ -3,7 +3,7 @@ import { cookies } from 'next/headers'
 import { ClientChild } from './client'
 
 export const unstable_instant: Instant = {
-  level: 'error',
+  level: 'experimental-error',
   samples: [
     {
       cookies: [{ name: 'testCookie', value: 'testValue' }],

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/gsp/[slug]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/gsp/[slug]/page.tsx
@@ -7,7 +7,7 @@ import { AssertParamsClient } from './client'
 // samples use 'hello', but generateStaticParams uses 'foo'/'bar'.
 // During validation, the sample params should be used, not the GSP values.
 export const unstable_instant: Instant = {
-  level: 'error',
+  level: 'experimental-error',
   samples: [
     {
       params: {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/gsp/[slug]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/gsp/[slug]/page.tsx
@@ -8,7 +8,7 @@ import { AssertParamsClient } from './client'
 // During validation, the sample params should be used, not the GSP values.
 export const unstable_instant: Instant = {
   level: 'experimental-error',
-  samples: [
+  unstable_samples: [
     {
       params: {
         slug: 'hello',

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/gsp/[slug]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/gsp/[slug]/page.tsx
@@ -7,6 +7,7 @@ import { AssertParamsClient } from './client'
 // samples use 'hello', but generateStaticParams uses 'foo'/'bar'.
 // During validation, the sample params should be used, not the GSP values.
 export const unstable_instant: Instant = {
+  level: 'error',
   samples: [
     {
       params: {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/headers/invalid-undeclared-header-get-caught/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/headers/invalid-undeclared-header-get-caught/page.tsx
@@ -4,7 +4,7 @@ import { ensureThrows } from '../../../../ensure-error'
 
 export const unstable_instant = {
   level: 'experimental-error',
-  samples: [{ headers: [] }],
+  unstable_samples: [{ headers: [] }],
 }
 export const unstable_prefetch = 'force-runtime'
 

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/headers/invalid-undeclared-header-get-caught/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/headers/invalid-undeclared-header-get-caught/page.tsx
@@ -2,7 +2,7 @@ import { headers } from 'next/headers'
 import { Suspense } from 'react'
 import { ensureThrows } from '../../../../ensure-error'
 
-export const unstable_instant = { samples: [{ headers: [] }] }
+export const unstable_instant = { level: 'error', samples: [{ headers: [] }] }
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/headers/invalid-undeclared-header-get-caught/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/headers/invalid-undeclared-header-get-caught/page.tsx
@@ -2,7 +2,10 @@ import { headers } from 'next/headers'
 import { Suspense } from 'react'
 import { ensureThrows } from '../../../../ensure-error'
 
-export const unstable_instant = { level: 'error', samples: [{ headers: [] }] }
+export const unstable_instant = {
+  level: 'experimental-error',
+  samples: [{ headers: [] }],
+}
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/headers/invalid-undeclared-header-get/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/headers/invalid-undeclared-header-get/page.tsx
@@ -4,7 +4,7 @@ import { ensureThrows } from '../../../../ensure-error'
 
 export const unstable_instant = {
   level: 'experimental-error',
-  samples: [{ headers: [] }],
+  unstable_samples: [{ headers: [] }],
 }
 export const unstable_prefetch = 'force-runtime'
 

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/headers/invalid-undeclared-header-get/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/headers/invalid-undeclared-header-get/page.tsx
@@ -2,7 +2,7 @@ import { headers } from 'next/headers'
 import { Suspense } from 'react'
 import { ensureThrows } from '../../../../ensure-error'
 
-export const unstable_instant = { samples: [{ headers: [] }] }
+export const unstable_instant = { level: 'error', samples: [{ headers: [] }] }
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/headers/invalid-undeclared-header-get/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/headers/invalid-undeclared-header-get/page.tsx
@@ -2,7 +2,10 @@ import { headers } from 'next/headers'
 import { Suspense } from 'react'
 import { ensureThrows } from '../../../../ensure-error'
 
-export const unstable_instant = { level: 'error', samples: [{ headers: [] }] }
+export const unstable_instant = {
+  level: 'experimental-error',
+  samples: [{ headers: [] }],
+}
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/headers/invalid-undeclared-header-has/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/headers/invalid-undeclared-header-has/page.tsx
@@ -4,7 +4,7 @@ import { ensureThrows } from '../../../../ensure-error'
 
 export const unstable_instant = {
   level: 'experimental-error',
-  samples: [{ headers: [] }],
+  unstable_samples: [{ headers: [] }],
 }
 export const unstable_prefetch = 'force-runtime'
 

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/headers/invalid-undeclared-header-has/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/headers/invalid-undeclared-header-has/page.tsx
@@ -2,7 +2,7 @@ import { headers } from 'next/headers'
 import { Suspense } from 'react'
 import { ensureThrows } from '../../../../ensure-error'
 
-export const unstable_instant = { samples: [{ headers: [] }] }
+export const unstable_instant = { level: 'error', samples: [{ headers: [] }] }
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/headers/invalid-undeclared-header-has/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/headers/invalid-undeclared-header-has/page.tsx
@@ -2,7 +2,10 @@ import { headers } from 'next/headers'
 import { Suspense } from 'react'
 import { ensureThrows } from '../../../../ensure-error'
 
-export const unstable_instant = { level: 'error', samples: [{ headers: [] }] }
+export const unstable_instant = {
+  level: 'experimental-error',
+  samples: [{ headers: [] }],
+}
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/headers/valid-headers-in-samples/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/headers/valid-headers-in-samples/page.tsx
@@ -5,7 +5,7 @@ import assert from 'node:assert'
 import { Suspense } from 'react'
 
 export const unstable_instant: Instant = {
-  level: 'error',
+  level: 'experimental-error',
   samples: [
     {
       headers: [

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/headers/valid-headers-in-samples/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/headers/valid-headers-in-samples/page.tsx
@@ -5,6 +5,7 @@ import assert from 'node:assert'
 import { Suspense } from 'react'
 
 export const unstable_instant: Instant = {
+  level: 'error',
   samples: [
     {
       headers: [

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/headers/valid-headers-in-samples/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/headers/valid-headers-in-samples/page.tsx
@@ -6,7 +6,7 @@ import { Suspense } from 'react'
 
 export const unstable_instant: Instant = {
   level: 'experimental-error',
-  samples: [
+  unstable_samples: [
     {
       headers: [
         ['testHeader', 'testValue'],

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/headers/valid-headers-passed-to-cache/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/headers/valid-headers-passed-to-cache/page.tsx
@@ -3,7 +3,7 @@ import { headers } from 'next/headers'
 import assert from 'node:assert/strict'
 
 export const unstable_instant: Instant = {
-  level: 'error',
+  level: 'experimental-error',
   samples: [
     {
       headers: [['x-test-header', 'testValue']],

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/headers/valid-headers-passed-to-cache/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/headers/valid-headers-passed-to-cache/page.tsx
@@ -3,6 +3,7 @@ import { headers } from 'next/headers'
 import assert from 'node:assert/strict'
 
 export const unstable_instant: Instant = {
+  level: 'error',
   samples: [
     {
       headers: [['x-test-header', 'testValue']],

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/headers/valid-headers-passed-to-cache/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/headers/valid-headers-passed-to-cache/page.tsx
@@ -4,7 +4,7 @@ import assert from 'node:assert/strict'
 
 export const unstable_instant: Instant = {
   level: 'experimental-error',
-  samples: [
+  unstable_samples: [
     {
       headers: [['x-test-header', 'testValue']],
     },

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/headers/valid-headers-passed-to-client/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/headers/valid-headers-passed-to-client/page.tsx
@@ -3,7 +3,7 @@ import { headers } from 'next/headers'
 import { ClientChild } from './client'
 
 export const unstable_instant: Instant = {
-  level: 'error',
+  level: 'experimental-error',
   samples: [
     {
       headers: [['x-test-header', 'testValue']],

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/headers/valid-headers-passed-to-client/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/headers/valid-headers-passed-to-client/page.tsx
@@ -4,7 +4,7 @@ import { ClientChild } from './client'
 
 export const unstable_instant: Instant = {
   level: 'experimental-error',
-  samples: [
+  unstable_samples: [
     {
       headers: [['x-test-header', 'testValue']],
     },

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/headers/valid-headers-passed-to-client/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/headers/valid-headers-passed-to-client/page.tsx
@@ -3,6 +3,7 @@ import { headers } from 'next/headers'
 import { ClientChild } from './client'
 
 export const unstable_instant: Instant = {
+  level: 'error',
   samples: [
     {
       headers: [['x-test-header', 'testValue']],

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/invalid-missing-suspense-around-runtime/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/invalid-missing-suspense-around-runtime/page.tsx
@@ -2,7 +2,7 @@ import { cookies } from 'next/headers'
 import { connection } from 'next/server'
 
 export const unstable_instant = {
-  level: 'error',
+  level: 'experimental-error',
   samples: [{ cookies: [{ name: 'auth', value: '1' }] }],
 }
 export const unstable_prefetch = 'force-runtime'

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/invalid-missing-suspense-around-runtime/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/invalid-missing-suspense-around-runtime/page.tsx
@@ -3,7 +3,7 @@ import { connection } from 'next/server'
 
 export const unstable_instant = {
   level: 'experimental-error',
-  samples: [{ cookies: [{ name: 'auth', value: '1' }] }],
+  unstable_samples: [{ cookies: [{ name: 'auth', value: '1' }] }],
 }
 export const unstable_prefetch = 'force-runtime'
 

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/invalid-missing-suspense-around-runtime/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/invalid-missing-suspense-around-runtime/page.tsx
@@ -2,6 +2,7 @@ import { cookies } from 'next/headers'
 import { connection } from 'next/server'
 
 export const unstable_instant = {
+  level: 'error',
   samples: [{ cookies: [{ name: 'auth', value: '1' }] }],
 }
 export const unstable_prefetch = 'force-runtime'

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/params/invalid-param-not-provided-caught/[one]/[two]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/params/invalid-param-not-provided-caught/[one]/[two]/page.tsx
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict'
 import { ensureThrows } from '../../../../../../ensure-error'
 
 export const unstable_instant: Instant = {
+  level: 'error',
   samples: [
     {
       params: {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/params/invalid-param-not-provided-caught/[one]/[two]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/params/invalid-param-not-provided-caught/[one]/[two]/page.tsx
@@ -4,7 +4,7 @@ import { ensureThrows } from '../../../../../../ensure-error'
 
 export const unstable_instant: Instant = {
   level: 'experimental-error',
-  samples: [
+  unstable_samples: [
     {
       params: {
         one: '123',

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/params/invalid-param-not-provided-caught/[one]/[two]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/params/invalid-param-not-provided-caught/[one]/[two]/page.tsx
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 import { ensureThrows } from '../../../../../../ensure-error'
 
 export const unstable_instant: Instant = {
-  level: 'error',
+  level: 'experimental-error',
   samples: [
     {
       params: {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/params/invalid-param-not-provided/[one]/[two]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/params/invalid-param-not-provided/[one]/[two]/page.tsx
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict'
 import { ensureThrows } from '../../../../../../ensure-error'
 
 export const unstable_instant: Instant = {
+  level: 'error',
   samples: [
     {
       params: {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/params/invalid-param-not-provided/[one]/[two]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/params/invalid-param-not-provided/[one]/[two]/page.tsx
@@ -4,7 +4,7 @@ import { ensureThrows } from '../../../../../../ensure-error'
 
 export const unstable_instant: Instant = {
   level: 'experimental-error',
-  samples: [
+  unstable_samples: [
     {
       params: {
         one: '123',

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/params/invalid-param-not-provided/[one]/[two]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/params/invalid-param-not-provided/[one]/[two]/page.tsx
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 import { ensureThrows } from '../../../../../../ensure-error'
 
 export const unstable_instant: Instant = {
-  level: 'error',
+  level: 'experimental-error',
   samples: [
     {
       params: {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/params/invalid-undeclared-use-params-caught/[one]/[two]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/params/invalid-undeclared-use-params-caught/[one]/[two]/page.tsx
@@ -2,7 +2,7 @@ import type { Instant } from 'next'
 import { ParamsReader } from './params-reader'
 
 export const unstable_instant: Instant = {
-  level: 'error',
+  level: 'experimental-error',
   samples: [
     {
       params: {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/params/invalid-undeclared-use-params-caught/[one]/[two]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/params/invalid-undeclared-use-params-caught/[one]/[two]/page.tsx
@@ -3,7 +3,7 @@ import { ParamsReader } from './params-reader'
 
 export const unstable_instant: Instant = {
   level: 'experimental-error',
-  samples: [
+  unstable_samples: [
     {
       params: {
         one: '123',

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/params/invalid-undeclared-use-params-caught/[one]/[two]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/params/invalid-undeclared-use-params-caught/[one]/[two]/page.tsx
@@ -2,6 +2,7 @@ import type { Instant } from 'next'
 import { ParamsReader } from './params-reader'
 
 export const unstable_instant: Instant = {
+  level: 'error',
   samples: [
     {
       params: {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/params/invalid-undeclared-use-params/[one]/[two]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/params/invalid-undeclared-use-params/[one]/[two]/page.tsx
@@ -2,7 +2,7 @@ import type { Instant } from 'next'
 import { ParamsReader } from './params-reader'
 
 export const unstable_instant: Instant = {
-  level: 'error',
+  level: 'experimental-error',
   samples: [
     {
       params: {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/params/invalid-undeclared-use-params/[one]/[two]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/params/invalid-undeclared-use-params/[one]/[two]/page.tsx
@@ -3,7 +3,7 @@ import { ParamsReader } from './params-reader'
 
 export const unstable_instant: Instant = {
   level: 'experimental-error',
-  samples: [
+  unstable_samples: [
     {
       params: {
         one: '123',

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/params/invalid-undeclared-use-params/[one]/[two]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/params/invalid-undeclared-use-params/[one]/[two]/page.tsx
@@ -2,6 +2,7 @@ import type { Instant } from 'next'
 import { ParamsReader } from './params-reader'
 
 export const unstable_instant: Instant = {
+  level: 'error',
   samples: [
     {
       params: {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/params/valid-params-in-samples/[one]/[two]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/params/valid-params-in-samples/[one]/[two]/page.tsx
@@ -2,6 +2,7 @@ import type { Instant } from 'next'
 import assert from 'node:assert/strict'
 
 export const unstable_instant: Instant = {
+  level: 'error',
   samples: [
     {
       params: {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/params/valid-params-in-samples/[one]/[two]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/params/valid-params-in-samples/[one]/[two]/page.tsx
@@ -2,7 +2,7 @@ import type { Instant } from 'next'
 import assert from 'node:assert/strict'
 
 export const unstable_instant: Instant = {
-  level: 'error',
+  level: 'experimental-error',
   samples: [
     {
       params: {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/params/valid-params-in-samples/[one]/[two]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/params/valid-params-in-samples/[one]/[two]/page.tsx
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 
 export const unstable_instant: Instant = {
   level: 'experimental-error',
-  samples: [
+  unstable_samples: [
     {
       params: {
         one: '123',

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/params/valid-params-passed-to-cache/[slug]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/params/valid-params-passed-to-cache/[slug]/page.tsx
@@ -2,7 +2,7 @@ import type { Instant } from 'next'
 import assert from 'node:assert/strict'
 
 export const unstable_instant: Instant = {
-  level: 'error',
+  level: 'experimental-error',
   samples: [{ params: { slug: 'hello' } }],
 }
 export const unstable_prefetch = 'force-runtime'

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/params/valid-params-passed-to-cache/[slug]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/params/valid-params-passed-to-cache/[slug]/page.tsx
@@ -2,6 +2,7 @@ import type { Instant } from 'next'
 import assert from 'node:assert/strict'
 
 export const unstable_instant: Instant = {
+  level: 'error',
   samples: [{ params: { slug: 'hello' } }],
 }
 export const unstable_prefetch = 'force-runtime'

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/params/valid-params-passed-to-cache/[slug]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/params/valid-params-passed-to-cache/[slug]/page.tsx
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 
 export const unstable_instant: Instant = {
   level: 'experimental-error',
-  samples: [{ params: { slug: 'hello' } }],
+  unstable_samples: [{ params: { slug: 'hello' } }],
 }
 export const unstable_prefetch = 'force-runtime'
 

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/params/valid-params-passed-to-client/[slug]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/params/valid-params-passed-to-client/[slug]/page.tsx
@@ -2,7 +2,7 @@ import type { Instant } from 'next'
 import { ClientChild } from './client'
 
 export const unstable_instant: Instant = {
-  level: 'error',
+  level: 'experimental-error',
   samples: [{ params: { slug: 'hello' } }],
 }
 export const unstable_prefetch = 'force-runtime'

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/params/valid-params-passed-to-client/[slug]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/params/valid-params-passed-to-client/[slug]/page.tsx
@@ -3,7 +3,7 @@ import { ClientChild } from './client'
 
 export const unstable_instant: Instant = {
   level: 'experimental-error',
-  samples: [{ params: { slug: 'hello' } }],
+  unstable_samples: [{ params: { slug: 'hello' } }],
 }
 export const unstable_prefetch = 'force-runtime'
 

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/params/valid-params-passed-to-client/[slug]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/params/valid-params-passed-to-client/[slug]/page.tsx
@@ -2,6 +2,7 @@ import type { Instant } from 'next'
 import { ClientChild } from './client'
 
 export const unstable_instant: Instant = {
+  level: 'error',
   samples: [{ params: { slug: 'hello' } }],
 }
 export const unstable_prefetch = 'force-runtime'

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/params/valid-use-params/[one]/[two]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/params/valid-use-params/[one]/[two]/page.tsx
@@ -2,7 +2,7 @@ import type { Instant } from 'next'
 import { ParamsReader } from './params-reader'
 
 export const unstable_instant: Instant = {
-  level: 'error',
+  level: 'experimental-error',
   samples: [
     {
       params: {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/params/valid-use-params/[one]/[two]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/params/valid-use-params/[one]/[two]/page.tsx
@@ -3,7 +3,7 @@ import { ParamsReader } from './params-reader'
 
 export const unstable_instant: Instant = {
   level: 'experimental-error',
-  samples: [
+  unstable_samples: [
     {
       params: {
         one: '123',

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/params/valid-use-params/[one]/[two]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/params/valid-use-params/[one]/[two]/page.tsx
@@ -2,6 +2,7 @@ import type { Instant } from 'next'
 import { ParamsReader } from './params-reader'
 
 export const unstable_instant: Instant = {
+  level: 'error',
   samples: [
     {
       params: {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/pathname/invalid-use-pathname-missing-params/[one]/[two]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/pathname/invalid-use-pathname-missing-params/[one]/[two]/page.tsx
@@ -2,7 +2,7 @@ import type { Instant } from 'next'
 import { PathnameReader } from './pathname-reader'
 
 export const unstable_instant: Instant = {
-  level: 'error',
+  level: 'experimental-error',
   samples: [
     {
       params: {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/pathname/invalid-use-pathname-missing-params/[one]/[two]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/pathname/invalid-use-pathname-missing-params/[one]/[two]/page.tsx
@@ -2,6 +2,7 @@ import type { Instant } from 'next'
 import { PathnameReader } from './pathname-reader'
 
 export const unstable_instant: Instant = {
+  level: 'error',
   samples: [
     {
       params: {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/pathname/invalid-use-pathname-missing-params/[one]/[two]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/pathname/invalid-use-pathname-missing-params/[one]/[two]/page.tsx
@@ -3,7 +3,7 @@ import { PathnameReader } from './pathname-reader'
 
 export const unstable_instant: Instant = {
   level: 'experimental-error',
-  samples: [
+  unstable_samples: [
     {
       params: {
         one: '123',

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/pathname/valid-use-pathname-catch-all/[...catchAll]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/pathname/valid-use-pathname-catch-all/[...catchAll]/page.tsx
@@ -3,6 +3,7 @@ import { Suspense } from 'react'
 import { PathnameReader } from './pathname-reader'
 
 export const unstable_instant: Instant = {
+  level: 'error',
   samples: [
     {
       params: {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/pathname/valid-use-pathname-catch-all/[...catchAll]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/pathname/valid-use-pathname-catch-all/[...catchAll]/page.tsx
@@ -3,7 +3,7 @@ import { Suspense } from 'react'
 import { PathnameReader } from './pathname-reader'
 
 export const unstable_instant: Instant = {
-  level: 'error',
+  level: 'experimental-error',
   samples: [
     {
       params: {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/pathname/valid-use-pathname-catch-all/[...catchAll]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/pathname/valid-use-pathname-catch-all/[...catchAll]/page.tsx
@@ -4,7 +4,7 @@ import { PathnameReader } from './pathname-reader'
 
 export const unstable_instant: Instant = {
   level: 'experimental-error',
-  samples: [
+  unstable_samples: [
     {
       params: {
         catchAll: ['aaa', 'bbb', 'ccc'],

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/pathname/valid-use-pathname-no-params/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/pathname/valid-use-pathname-no-params/page.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from 'react'
 import { PathnameReader } from './pathname-reader'
 
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/pathname/valid-use-pathname-no-params/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/pathname/valid-use-pathname-no-params/page.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from 'react'
 import { PathnameReader } from './pathname-reader'
 
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/pathname/valid-use-pathname-optional-catch-all/[[...optionalCatchAll]]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/pathname/valid-use-pathname-optional-catch-all/[[...optionalCatchAll]]/page.tsx
@@ -4,7 +4,7 @@ import { PathnameReader } from './pathname-reader'
 
 export const unstable_instant: Instant = {
   level: 'experimental-error',
-  samples: [
+  unstable_samples: [
     {
       params: {
         optionalCatchAll: ['xxx', 'yyy'],

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/pathname/valid-use-pathname-optional-catch-all/[[...optionalCatchAll]]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/pathname/valid-use-pathname-optional-catch-all/[[...optionalCatchAll]]/page.tsx
@@ -3,6 +3,7 @@ import { Suspense } from 'react'
 import { PathnameReader } from './pathname-reader'
 
 export const unstable_instant: Instant = {
+  level: 'error',
   samples: [
     {
       params: {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/pathname/valid-use-pathname-optional-catch-all/[[...optionalCatchAll]]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/pathname/valid-use-pathname-optional-catch-all/[[...optionalCatchAll]]/page.tsx
@@ -3,7 +3,7 @@ import { Suspense } from 'react'
 import { PathnameReader } from './pathname-reader'
 
 export const unstable_instant: Instant = {
-  level: 'error',
+  level: 'experimental-error',
   samples: [
     {
       params: {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/pathname/valid-use-pathname-route-group/(route-group)/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/pathname/valid-use-pathname-route-group/(route-group)/page.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from 'react'
 import { PathnameReader } from './pathname-reader'
 
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/pathname/valid-use-pathname-route-group/(route-group)/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/pathname/valid-use-pathname-route-group/(route-group)/page.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from 'react'
 import { PathnameReader } from './pathname-reader'
 
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/pathname/valid-use-pathname-with-params/[one]/[two]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/pathname/valid-use-pathname-with-params/[one]/[two]/page.tsx
@@ -3,6 +3,7 @@ import { Suspense } from 'react'
 import { PathnameReader } from './pathname-reader'
 
 export const unstable_instant: Instant = {
+  level: 'error',
   samples: [
     {
       params: {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/pathname/valid-use-pathname-with-params/[one]/[two]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/pathname/valid-use-pathname-with-params/[one]/[two]/page.tsx
@@ -3,7 +3,7 @@ import { Suspense } from 'react'
 import { PathnameReader } from './pathname-reader'
 
 export const unstable_instant: Instant = {
-  level: 'error',
+  level: 'experimental-error',
   samples: [
     {
       params: {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/pathname/valid-use-pathname-with-params/[one]/[two]/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/pathname/valid-use-pathname-with-params/[one]/[two]/page.tsx
@@ -4,7 +4,7 @@ import { PathnameReader } from './pathname-reader'
 
 export const unstable_instant: Instant = {
   level: 'experimental-error',
-  samples: [
+  unstable_samples: [
     {
       params: {
         one: '123',

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/samples-precedence/[slug]/layout.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/samples-precedence/[slug]/layout.tsx
@@ -1,7 +1,7 @@
 import type { Instant } from 'next'
 
 export const unstable_instant: Instant = {
-  level: 'error',
+  level: 'experimental-error',
   samples: [
     {
       params: {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/samples-precedence/[slug]/layout.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/samples-precedence/[slug]/layout.tsx
@@ -1,6 +1,7 @@
 import type { Instant } from 'next'
 
 export const unstable_instant: Instant = {
+  level: 'error',
   samples: [
     {
       params: {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/samples-precedence/[slug]/layout.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/samples-precedence/[slug]/layout.tsx
@@ -2,7 +2,7 @@ import type { Instant } from 'next'
 
 export const unstable_instant: Instant = {
   level: 'experimental-error',
-  samples: [
+  unstable_samples: [
     {
       params: {
         slug: 'from-layout',

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/samples-precedence/[slug]/page-overrides/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/samples-precedence/[slug]/page-overrides/page.tsx
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 import { Suspense } from 'react'
 
 export const unstable_instant: Instant = {
-  level: 'error',
+  level: 'experimental-error',
   samples: [
     {
       params: {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/samples-precedence/[slug]/page-overrides/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/samples-precedence/[slug]/page-overrides/page.tsx
@@ -4,7 +4,7 @@ import { Suspense } from 'react'
 
 export const unstable_instant: Instant = {
   level: 'experimental-error',
-  samples: [
+  unstable_samples: [
     {
       params: {
         slug: 'from-page',

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/samples-precedence/[slug]/page-overrides/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/samples-precedence/[slug]/page-overrides/page.tsx
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict'
 import { Suspense } from 'react'
 
 export const unstable_instant: Instant = {
+  level: 'error',
   samples: [
     {
       params: {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/invalid-undeclared-search-param-caught/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/invalid-undeclared-search-param-caught/page.tsx
@@ -1,7 +1,7 @@
 import { ensureThrows } from '../../../../ensure-error'
 
 export const unstable_instant = {
-  level: 'error',
+  level: 'experimental-error',
   samples: [{ searchParams: { q: 'test' } }],
 }
 export const unstable_prefetch = 'force-runtime'

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/invalid-undeclared-search-param-caught/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/invalid-undeclared-search-param-caught/page.tsx
@@ -1,6 +1,9 @@
 import { ensureThrows } from '../../../../ensure-error'
 
-export const unstable_instant = { samples: [{ searchParams: { q: 'test' } }] }
+export const unstable_instant = {
+  level: 'error',
+  samples: [{ searchParams: { q: 'test' } }],
+}
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Page({

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/invalid-undeclared-search-param-caught/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/invalid-undeclared-search-param-caught/page.tsx
@@ -2,7 +2,7 @@ import { ensureThrows } from '../../../../ensure-error'
 
 export const unstable_instant = {
   level: 'experimental-error',
-  samples: [{ searchParams: { q: 'test' } }],
+  unstable_samples: [{ searchParams: { q: 'test' } }],
 }
 export const unstable_prefetch = 'force-runtime'
 

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/invalid-undeclared-search-param/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/invalid-undeclared-search-param/page.tsx
@@ -1,7 +1,7 @@
 import { ensureThrows } from '../../../../ensure-error'
 
 export const unstable_instant = {
-  level: 'error',
+  level: 'experimental-error',
   samples: [{ searchParams: { q: 'test' } }],
 }
 export const unstable_prefetch = 'force-runtime'

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/invalid-undeclared-search-param/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/invalid-undeclared-search-param/page.tsx
@@ -1,6 +1,9 @@
 import { ensureThrows } from '../../../../ensure-error'
 
-export const unstable_instant = { samples: [{ searchParams: { q: 'test' } }] }
+export const unstable_instant = {
+  level: 'error',
+  samples: [{ searchParams: { q: 'test' } }],
+}
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Page({

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/invalid-undeclared-search-param/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/invalid-undeclared-search-param/page.tsx
@@ -2,7 +2,7 @@ import { ensureThrows } from '../../../../ensure-error'
 
 export const unstable_instant = {
   level: 'experimental-error',
-  samples: [{ searchParams: { q: 'test' } }],
+  unstable_samples: [{ searchParams: { q: 'test' } }],
 }
 export const unstable_prefetch = 'force-runtime'
 

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/invalid-undeclared-use-search-params-caught/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/invalid-undeclared-use-search-params-caught/page.tsx
@@ -3,7 +3,7 @@ import { Suspense } from 'react'
 import { SearchParamsReader } from './search-params-reader'
 
 export const unstable_instant: Instant = {
-  level: 'error',
+  level: 'experimental-error',
   samples: [
     {
       searchParams: {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/invalid-undeclared-use-search-params-caught/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/invalid-undeclared-use-search-params-caught/page.tsx
@@ -4,7 +4,7 @@ import { SearchParamsReader } from './search-params-reader'
 
 export const unstable_instant: Instant = {
   level: 'experimental-error',
-  samples: [
+  unstable_samples: [
     {
       searchParams: {
         q: 'test',

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/invalid-undeclared-use-search-params-caught/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/invalid-undeclared-use-search-params-caught/page.tsx
@@ -3,6 +3,7 @@ import { Suspense } from 'react'
 import { SearchParamsReader } from './search-params-reader'
 
 export const unstable_instant: Instant = {
+  level: 'error',
   samples: [
     {
       searchParams: {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/invalid-undeclared-use-search-params/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/invalid-undeclared-use-search-params/page.tsx
@@ -2,6 +2,7 @@ import type { Instant } from 'next'
 import { SearchParamsReader } from './search-params-reader'
 
 export const unstable_instant: Instant = {
+  level: 'error',
   samples: [
     {
       searchParams: {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/invalid-undeclared-use-search-params/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/invalid-undeclared-use-search-params/page.tsx
@@ -2,7 +2,7 @@ import type { Instant } from 'next'
 import { SearchParamsReader } from './search-params-reader'
 
 export const unstable_instant: Instant = {
-  level: 'error',
+  level: 'experimental-error',
   samples: [
     {
       searchParams: {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/invalid-undeclared-use-search-params/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/invalid-undeclared-use-search-params/page.tsx
@@ -3,7 +3,7 @@ import { SearchParamsReader } from './search-params-reader'
 
 export const unstable_instant: Instant = {
   level: 'experimental-error',
-  samples: [
+  unstable_samples: [
     {
       searchParams: {
         q: 'test',

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/valid-search-params-in-samples/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/valid-search-params-in-samples/page.tsx
@@ -4,7 +4,7 @@ import assert from 'node:assert/strict'
 import { Suspense } from 'react'
 
 export const unstable_instant: Instant = {
-  level: 'error',
+  level: 'experimental-error',
   samples: [
     {
       searchParams: {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/valid-search-params-in-samples/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/valid-search-params-in-samples/page.tsx
@@ -5,7 +5,7 @@ import { Suspense } from 'react'
 
 export const unstable_instant: Instant = {
   level: 'experimental-error',
-  samples: [
+  unstable_samples: [
     {
       searchParams: {
         // TODO(instant-validation-build): specify and test escaping behavior for spaces etc

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/valid-search-params-in-samples/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/valid-search-params-in-samples/page.tsx
@@ -4,6 +4,7 @@ import assert from 'node:assert/strict'
 import { Suspense } from 'react'
 
 export const unstable_instant: Instant = {
+  level: 'error',
   samples: [
     {
       searchParams: {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/valid-search-params-passed-to-cache/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/valid-search-params-passed-to-cache/page.tsx
@@ -2,6 +2,7 @@ import type { Instant } from 'next'
 import assert from 'node:assert/strict'
 
 export const unstable_instant: Instant = {
+  level: 'error',
   samples: [
     {
       searchParams: {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/valid-search-params-passed-to-cache/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/valid-search-params-passed-to-cache/page.tsx
@@ -2,7 +2,7 @@ import type { Instant } from 'next'
 import assert from 'node:assert/strict'
 
 export const unstable_instant: Instant = {
-  level: 'error',
+  level: 'experimental-error',
   samples: [
     {
       searchParams: {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/valid-search-params-passed-to-cache/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/valid-search-params-passed-to-cache/page.tsx
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 
 export const unstable_instant: Instant = {
   level: 'experimental-error',
-  samples: [
+  unstable_samples: [
     {
       searchParams: {
         single: 'test',

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/valid-search-params-passed-to-client/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/valid-search-params-passed-to-client/page.tsx
@@ -4,7 +4,7 @@ import assert from 'node:assert/strict'
 import { ClientChild } from './client'
 
 export const unstable_instant: Instant = {
-  level: 'error',
+  level: 'experimental-error',
   samples: [
     {
       searchParams: {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/valid-search-params-passed-to-client/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/valid-search-params-passed-to-client/page.tsx
@@ -4,6 +4,7 @@ import assert from 'node:assert/strict'
 import { ClientChild } from './client'
 
 export const unstable_instant: Instant = {
+  level: 'error',
   samples: [
     {
       searchParams: {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/valid-search-params-passed-to-client/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/valid-search-params-passed-to-client/page.tsx
@@ -5,7 +5,7 @@ import { ClientChild } from './client'
 
 export const unstable_instant: Instant = {
   level: 'experimental-error',
-  samples: [
+  unstable_samples: [
     {
       searchParams: {
         single: 'test',

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/valid-use-search-params/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/valid-use-search-params/page.tsx
@@ -4,7 +4,7 @@ import { SearchParamsReader } from './search-params-reader'
 
 export const unstable_instant: Instant = {
   level: 'experimental-error',
-  samples: [
+  unstable_samples: [
     {
       searchParams: {
         single: 'test',

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/valid-use-search-params/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/valid-use-search-params/page.tsx
@@ -3,7 +3,7 @@ import { Suspense } from 'react'
 import { SearchParamsReader } from './search-params-reader'
 
 export const unstable_instant: Instant = {
-  level: 'error',
+  level: 'experimental-error',
   samples: [
     {
       searchParams: {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/valid-use-search-params/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/search-params/valid-use-search-params/page.tsx
@@ -3,6 +3,7 @@ import { Suspense } from 'react'
 import { SearchParamsReader } from './search-params-reader'
 
 export const unstable_instant: Instant = {
+  level: 'error',
   samples: [
     {
       searchParams: {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/server-errors/error-passed-to-client-and-ignored/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/server-errors/error-passed-to-client-and-ignored/page.tsx
@@ -1,7 +1,7 @@
 import { cookies } from 'next/headers'
 import { IgnoreServerContent } from './client'
 
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 export const unstable_prefetch = 'force-runtime'
 
 export default function Page() {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/server-errors/error-passed-to-client-and-ignored/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/server-errors/error-passed-to-client-and-ignored/page.tsx
@@ -1,7 +1,7 @@
 import { cookies } from 'next/headers'
 import { IgnoreServerContent } from './client'
 
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 export const unstable_prefetch = 'force-runtime'
 
 export default function Page() {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/server-errors/page-throws-with-suspense/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/server-errors/page-throws-with-suspense/page.tsx
@@ -1,6 +1,6 @@
 import { cookies } from 'next/headers'
 
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 export const unstable_prefetch = 'force-runtime'
 
 export default function Page() {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/server-errors/page-throws-with-suspense/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/server-errors/page-throws-with-suspense/page.tsx
@@ -1,6 +1,6 @@
 import { cookies } from 'next/headers'
 
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 export const unstable_prefetch = 'force-runtime'
 
 export default function Page() {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/server-errors/page-throws/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/server-errors/page-throws/page.tsx
@@ -1,6 +1,6 @@
 import { cookies } from 'next/headers'
 
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 export const unstable_prefetch = 'force-runtime'
 
 export default function Page() {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/server-errors/page-throws/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/server-errors/page-throws/page.tsx
@@ -1,6 +1,6 @@
 import { cookies } from 'next/headers'
 
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 export const unstable_prefetch = 'force-runtime'
 
 export default function Page() {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/valid-await-cache-without-suspense/mixed/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/valid-await-cache-without-suspense/mixed/page.tsx
@@ -1,6 +1,6 @@
 import { cookies } from 'next/headers'
 
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/valid-await-cache-without-suspense/mixed/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/valid-await-cache-without-suspense/mixed/page.tsx
@@ -1,6 +1,6 @@
 import { cookies } from 'next/headers'
 
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/valid-await-cache-without-suspense/private/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/valid-await-cache-without-suspense/private/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/valid-await-cache-without-suspense/private/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/valid-await-cache-without-suspense/private/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/valid-await-cache-without-suspense/runtime/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/valid-await-cache-without-suspense/runtime/page.tsx
@@ -1,6 +1,6 @@
 import { cookies } from 'next/headers'
 
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/valid-await-cache-without-suspense/runtime/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/valid-await-cache-without-suspense/runtime/page.tsx
@@ -1,6 +1,6 @@
 import { cookies } from 'next/headers'
 
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/valid-await-cache-without-suspense/static/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/valid-await-cache-without-suspense/static/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default async function Page() {
   await cachedIO()

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/valid-await-cache-without-suspense/static/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/valid-await-cache-without-suspense/static/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default async function Page() {
   await cachedIO()

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/valid-suspense-around-runtime/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/valid-suspense-around-runtime/page.tsx
@@ -3,7 +3,7 @@ import { connection } from 'next/server'
 import { Suspense } from 'react'
 
 export const unstable_instant = {
-  level: 'error',
+  level: 'experimental-error',
   samples: [{ cookies: [{ name: 'auth', value: '1' }] }],
 }
 export const unstable_prefetch = 'force-runtime'

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/valid-suspense-around-runtime/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/valid-suspense-around-runtime/page.tsx
@@ -4,7 +4,7 @@ import { Suspense } from 'react'
 
 export const unstable_instant = {
   level: 'experimental-error',
-  samples: [{ cookies: [{ name: 'auth', value: '1' }] }],
+  unstable_samples: [{ cookies: [{ name: 'auth', value: '1' }] }],
 }
 export const unstable_prefetch = 'force-runtime'
 

--- a/test/e2e/app-dir/instant-validation-build/app/(default)/valid-suspense-around-runtime/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/(default)/valid-suspense-around-runtime/page.tsx
@@ -3,6 +3,7 @@ import { connection } from 'next/server'
 import { Suspense } from 'react'
 
 export const unstable_instant = {
+  level: 'error',
   samples: [{ cookies: [{ name: 'auth', value: '1' }] }],
 }
 export const unstable_prefetch = 'force-runtime'

--- a/test/e2e/app-dir/instant-validation-build/app/root-params/[lang]/invalid-root-param-not-provided-caught/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/root-params/[lang]/invalid-root-param-not-provided-caught/page.tsx
@@ -4,7 +4,7 @@ import { lang } from 'next/root-params'
 import { ensureRejects } from '../../../../ensure-error'
 
 export const unstable_instant: Instant = {
-  level: 'error',
+  level: 'experimental-error',
   // no samples
   samples: [{}],
 }

--- a/test/e2e/app-dir/instant-validation-build/app/root-params/[lang]/invalid-root-param-not-provided-caught/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/root-params/[lang]/invalid-root-param-not-provided-caught/page.tsx
@@ -4,6 +4,7 @@ import { lang } from 'next/root-params'
 import { ensureRejects } from '../../../../ensure-error'
 
 export const unstable_instant: Instant = {
+  level: 'error',
   // no samples
   samples: [{}],
 }

--- a/test/e2e/app-dir/instant-validation-build/app/root-params/[lang]/invalid-root-param-not-provided-caught/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/root-params/[lang]/invalid-root-param-not-provided-caught/page.tsx
@@ -6,7 +6,7 @@ import { ensureRejects } from '../../../../ensure-error'
 export const unstable_instant: Instant = {
   level: 'experimental-error',
   // no samples
-  samples: [{}],
+  unstable_samples: [{}],
 }
 export const unstable_prefetch = 'force-runtime'
 

--- a/test/e2e/app-dir/instant-validation-build/app/root-params/[lang]/invalid-root-param-not-provided/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/root-params/[lang]/invalid-root-param-not-provided/page.tsx
@@ -4,7 +4,7 @@ import { lang } from 'next/root-params'
 import { ensureRejects } from '../../../../ensure-error'
 
 export const unstable_instant: Instant = {
-  level: 'error',
+  level: 'experimental-error',
   // no samples
   samples: [{}],
 }

--- a/test/e2e/app-dir/instant-validation-build/app/root-params/[lang]/invalid-root-param-not-provided/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/root-params/[lang]/invalid-root-param-not-provided/page.tsx
@@ -4,6 +4,7 @@ import { lang } from 'next/root-params'
 import { ensureRejects } from '../../../../ensure-error'
 
 export const unstable_instant: Instant = {
+  level: 'error',
   // no samples
   samples: [{}],
 }

--- a/test/e2e/app-dir/instant-validation-build/app/root-params/[lang]/invalid-root-param-not-provided/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/root-params/[lang]/invalid-root-param-not-provided/page.tsx
@@ -6,7 +6,7 @@ import { ensureRejects } from '../../../../ensure-error'
 export const unstable_instant: Instant = {
   level: 'experimental-error',
   // no samples
-  samples: [{}],
+  unstable_samples: [{}],
 }
 export const unstable_prefetch = 'force-runtime'
 

--- a/test/e2e/app-dir/instant-validation-build/app/root-params/[lang]/valid-root-param-in-samples/runtime/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/root-params/[lang]/valid-root-param-in-samples/runtime/page.tsx
@@ -4,6 +4,7 @@ import { lang } from 'next/root-params'
 import assert from 'node:assert/strict'
 
 export const unstable_instant: Instant = {
+  level: 'error',
   samples: [{ params: { lang: 'en-from-samples' } }],
 }
 export const unstable_prefetch = 'force-runtime'

--- a/test/e2e/app-dir/instant-validation-build/app/root-params/[lang]/valid-root-param-in-samples/runtime/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/root-params/[lang]/valid-root-param-in-samples/runtime/page.tsx
@@ -5,7 +5,7 @@ import assert from 'node:assert/strict'
 
 export const unstable_instant: Instant = {
   level: 'experimental-error',
-  samples: [{ params: { lang: 'en-from-samples' } }],
+  unstable_samples: [{ params: { lang: 'en-from-samples' } }],
 }
 export const unstable_prefetch = 'force-runtime'
 

--- a/test/e2e/app-dir/instant-validation-build/app/root-params/[lang]/valid-root-param-in-samples/runtime/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/root-params/[lang]/valid-root-param-in-samples/runtime/page.tsx
@@ -4,7 +4,7 @@ import { lang } from 'next/root-params'
 import assert from 'node:assert/strict'
 
 export const unstable_instant: Instant = {
-  level: 'error',
+  level: 'experimental-error',
   samples: [{ params: { lang: 'en-from-samples' } }],
 }
 export const unstable_prefetch = 'force-runtime'

--- a/test/e2e/app-dir/instant-validation-build/app/root-params/[lang]/valid-root-param-in-samples/static/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/root-params/[lang]/valid-root-param-in-samples/static/page.tsx
@@ -3,6 +3,7 @@ import { lang } from 'next/root-params'
 import assert from 'node:assert/strict'
 
 export const unstable_instant: Instant = {
+  level: 'error',
   samples: [{ params: { lang: 'en' } }],
 }
 

--- a/test/e2e/app-dir/instant-validation-build/app/root-params/[lang]/valid-root-param-in-samples/static/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/root-params/[lang]/valid-root-param-in-samples/static/page.tsx
@@ -3,7 +3,7 @@ import { lang } from 'next/root-params'
 import assert from 'node:assert/strict'
 
 export const unstable_instant: Instant = {
-  level: 'error',
+  level: 'experimental-error',
   samples: [{ params: { lang: 'en' } }],
 }
 

--- a/test/e2e/app-dir/instant-validation-build/app/root-params/[lang]/valid-root-param-in-samples/static/page.tsx
+++ b/test/e2e/app-dir/instant-validation-build/app/root-params/[lang]/valid-root-param-in-samples/static/page.tsx
@@ -4,7 +4,7 @@ import assert from 'node:assert/strict'
 
 export const unstable_instant: Instant = {
   level: 'experimental-error',
-  samples: [{ params: { lang: 'en' } }],
+  unstable_samples: [{ params: { lang: 'en' } }],
 }
 
 export default async function Page() {

--- a/test/e2e/app-dir/instant-validation-build/instant-validation-build.test.ts
+++ b/test/e2e/app-dir/instant-validation-build/instant-validation-build.test.ts
@@ -245,16 +245,16 @@ describe('instant-validation-build', () => {
       expect(extractBuildValidationError(result.cliOutput))
         .toMatchInlineSnapshot(`
        "Error: Route "/search-params/invalid-undeclared-search-param" accessed searchParam "undeclared" which is not defined in the \`samples\` of \`unstable_instant\`. Add it to the sample's \`searchParams\` object, or \`{ "undeclared": null }\` if it should be absent.
-           at <unknown> (app/(default)/search-params/invalid-undeclared-search-param/page.tsx:29:14)
+           at <unknown> (app/(default)/search-params/invalid-undeclared-search-param/page.tsx:32:14)
            at <unknown> (ensure-error.ts:11:5)
-           at a (app/(default)/search-params/invalid-undeclared-search-param/page.tsx:28:3)
-         27 |   const sp = await searchParams
-         28 |   ensureThrows(
-       > 29 |     () => sp.undeclared,
+           at a (app/(default)/search-params/invalid-undeclared-search-param/page.tsx:31:3)
+         30 |   const sp = await searchParams
+         31 |   ensureThrows(
+       > 32 |     () => sp.undeclared,
             |              ^
-         30 |     \`Expected accessing an undeclared search param to throw\`
-         31 |   )
-         32 |   return null {
+         33 |     \`Expected accessing an undeclared search param to throw\`
+         34 |   )
+         35 |   return null {
          digest: 'INSTANT_VALIDATION_ERROR'
        }
        Build-time instant validation failed for route "/search-params/invalid-undeclared-search-param".
@@ -282,16 +282,16 @@ describe('instant-validation-build', () => {
       expect(extractBuildValidationError(result.cliOutput))
         .toMatchInlineSnapshot(`
        "Error: Route "/search-params/invalid-undeclared-search-param-caught" accessed searchParam "undeclared" which is not defined in the \`samples\` of \`unstable_instant\`. Add it to the sample's \`searchParams\` object, or \`{ "undeclared": null }\` if it should be absent.
-           at <unknown> (app/(default)/search-params/invalid-undeclared-search-param-caught/page.tsx:33:16)
+           at <unknown> (app/(default)/search-params/invalid-undeclared-search-param-caught/page.tsx:36:16)
            at <unknown> (ensure-error.ts:11:5)
-           at a (app/(default)/search-params/invalid-undeclared-search-param-caught/page.tsx:32:5)
-         31 |   try {
-         32 |     ensureThrows(
-       > 33 |       () => sp.undeclared,
+           at a (app/(default)/search-params/invalid-undeclared-search-param-caught/page.tsx:35:5)
+         34 |   try {
+         35 |     ensureThrows(
+       > 36 |       () => sp.undeclared,
             |                ^
-         34 |       \`Expected accessing an undeclared search param to throw\`
-         35 |     )
-         36 |   } catch (err) { {
+         37 |       \`Expected accessing an undeclared search param to throw\`
+         38 |     )
+         39 |   } catch (err) { {
          digest: 'INSTANT_VALIDATION_ERROR'
        }
        Build-time instant validation failed for route "/search-params/invalid-undeclared-search-param-caught".
@@ -395,16 +395,16 @@ describe('instant-validation-build', () => {
       expect(extractBuildValidationError(result.cliOutput))
         .toMatchInlineSnapshot(`
        "Error: Route "/headers/invalid-undeclared-header-get" accessed header "undeclaredheader" which is not defined in the \`samples\` of \`unstable_instant\`. Add it to the sample's \`headers\` array, or \`["undeclaredheader", null]\` if it should be absent.
-           at <unknown> (app/(default)/headers/invalid-undeclared-header-get/page.tsx:25:24)
+           at <unknown> (app/(default)/headers/invalid-undeclared-header-get/page.tsx:28:24)
            at <unknown> (ensure-error.ts:11:5)
-           at a (app/(default)/headers/invalid-undeclared-header-get/page.tsx:24:3)
-         23 |   const headersStore = await headers()
-         24 |   ensureThrows(
-       > 25 |     () => headersStore.get('undeclaredHeader'),
+           at a (app/(default)/headers/invalid-undeclared-header-get/page.tsx:27:3)
+         26 |   const headersStore = await headers()
+         27 |   ensureThrows(
+       > 28 |     () => headersStore.get('undeclaredHeader'),
             |                        ^
-         26 |     \`Expected get() to throw for undeclared headers\`
-         27 |   )
-         28 |   return null {
+         29 |     \`Expected get() to throw for undeclared headers\`
+         30 |   )
+         31 |   return null {
          digest: 'INSTANT_VALIDATION_ERROR'
        }
        Build-time instant validation failed for route "/headers/invalid-undeclared-header-get".
@@ -424,16 +424,16 @@ describe('instant-validation-build', () => {
       expect(extractBuildValidationError(result.cliOutput))
         .toMatchInlineSnapshot(`
        "Error: Route "/headers/invalid-undeclared-header-get-caught" accessed header "undeclaredheader" which is not defined in the \`samples\` of \`unstable_instant\`. Add it to the sample's \`headers\` array, or \`["undeclaredheader", null]\` if it should be absent.
-           at <unknown> (app/(default)/headers/invalid-undeclared-header-get-caught/page.tsx:28:25)
+           at <unknown> (app/(default)/headers/invalid-undeclared-header-get-caught/page.tsx:31:25)
            at <unknown> (ensure-error.ts:11:5)
-           at a (app/(default)/headers/invalid-undeclared-header-get-caught/page.tsx:27:5)
-         26 |   try {
-         27 |     ensureThrows(
-       > 28 |       () => headerStore.get('undeclaredHeader'),
+           at a (app/(default)/headers/invalid-undeclared-header-get-caught/page.tsx:30:5)
+         29 |   try {
+         30 |     ensureThrows(
+       > 31 |       () => headerStore.get('undeclaredHeader'),
             |                         ^
-         29 |       \`Expected get() to throw for undeclared headers\`
-         30 |     )
-         31 |   } catch (err) { {
+         32 |       \`Expected get() to throw for undeclared headers\`
+         33 |     )
+         34 |   } catch (err) { {
          digest: 'INSTANT_VALIDATION_ERROR'
        }
        Build-time instant validation failed for route "/headers/invalid-undeclared-header-get-caught".
@@ -452,16 +452,16 @@ describe('instant-validation-build', () => {
       expect(extractBuildValidationError(result.cliOutput))
         .toMatchInlineSnapshot(`
        "Error: Route "/headers/invalid-undeclared-header-has" accessed header "undeclaredheader" which is not defined in the \`samples\` of \`unstable_instant\`. Add it to the sample's \`headers\` array, or \`["undeclaredheader", null]\` if it should be absent.
-           at <unknown> (app/(default)/headers/invalid-undeclared-header-has/page.tsx:25:23)
+           at <unknown> (app/(default)/headers/invalid-undeclared-header-has/page.tsx:28:23)
            at <unknown> (ensure-error.ts:11:5)
-           at a (app/(default)/headers/invalid-undeclared-header-has/page.tsx:24:3)
-         23 |   const headerStore = await headers()
-         24 |   ensureThrows(
-       > 25 |     () => headerStore.has('undeclaredHeader'),
+           at a (app/(default)/headers/invalid-undeclared-header-has/page.tsx:27:3)
+         26 |   const headerStore = await headers()
+         27 |   ensureThrows(
+       > 28 |     () => headerStore.has('undeclaredHeader'),
             |                       ^
-         26 |     \`Expected has() to throw for undeclared headers\`
-         27 |   )
-         28 |   return null {
+         29 |     \`Expected has() to throw for undeclared headers\`
+         30 |   )
+         31 |   return null {
          digest: 'INSTANT_VALIDATION_ERROR'
        }
        Build-time instant validation failed for route "/headers/invalid-undeclared-header-has".

--- a/test/e2e/app-dir/instant-validation-build/instant-validation-build.test.ts
+++ b/test/e2e/app-dir/instant-validation-build/instant-validation-build.test.ts
@@ -244,7 +244,7 @@ describe('instant-validation-build', () => {
       )
       expect(extractBuildValidationError(result.cliOutput))
         .toMatchInlineSnapshot(`
-       "Error: Route "/search-params/invalid-undeclared-search-param" accessed searchParam "undeclared" which is not defined in the \`samples\` of \`unstable_instant\`. Add it to the sample's \`searchParams\` object, or \`{ "undeclared": null }\` if it should be absent.
+       "Error: Route "/search-params/invalid-undeclared-search-param" accessed searchParam "undeclared" which is not defined in the \`unstable_samples\` of \`unstable_instant\`. Add it to the sample's \`searchParams\` object, or \`{ "undeclared": null }\` if it should be absent.
            at <unknown> (app/(default)/search-params/invalid-undeclared-search-param/page.tsx:32:14)
            at <unknown> (ensure-error.ts:11:5)
            at a (app/(default)/search-params/invalid-undeclared-search-param/page.tsx:31:3)
@@ -281,7 +281,7 @@ describe('instant-validation-build', () => {
       )
       expect(extractBuildValidationError(result.cliOutput))
         .toMatchInlineSnapshot(`
-       "Error: Route "/search-params/invalid-undeclared-search-param-caught" accessed searchParam "undeclared" which is not defined in the \`samples\` of \`unstable_instant\`. Add it to the sample's \`searchParams\` object, or \`{ "undeclared": null }\` if it should be absent.
+       "Error: Route "/search-params/invalid-undeclared-search-param-caught" accessed searchParam "undeclared" which is not defined in the \`unstable_samples\` of \`unstable_instant\`. Add it to the sample's \`searchParams\` object, or \`{ "undeclared": null }\` if it should be absent.
            at <unknown> (app/(default)/search-params/invalid-undeclared-search-param-caught/page.tsx:36:16)
            at <unknown> (ensure-error.ts:11:5)
            at a (app/(default)/search-params/invalid-undeclared-search-param-caught/page.tsx:35:5)
@@ -310,7 +310,7 @@ describe('instant-validation-build', () => {
       )
       expect(extractBuildValidationError(result.cliOutput))
         .toMatchInlineSnapshot(`
-       "Error: Route "/search-params/invalid-undeclared-use-search-params" accessed searchParam "undeclared" which is not defined in the \`samples\` of \`unstable_instant\`. Add it to the sample's \`searchParams\` object, or \`{ "undeclared": null }\` if it should be absent.
+       "Error: Route "/search-params/invalid-undeclared-use-search-params" accessed searchParam "undeclared" which is not defined in the \`unstable_samples\` of \`unstable_instant\`. Add it to the sample's \`searchParams\` object, or \`{ "undeclared": null }\` if it should be absent.
            at <unknown> (app/(default)/search-params/invalid-undeclared-use-search-params/search-params-reader.tsx:9:14)
            at <unknown> (ensure-error.ts:11:5)
            at <unknown> (app/(default)/search-params/invalid-undeclared-use-search-params/search-params-reader.tsx:8:3)
@@ -339,7 +339,7 @@ describe('instant-validation-build', () => {
       )
       expect(extractBuildValidationError(result.cliOutput))
         .toMatchInlineSnapshot(`
-       "Error: Route "/search-params/invalid-undeclared-use-search-params-caught" accessed searchParam "undeclared" which is not defined in the \`samples\` of \`unstable_instant\`. Add it to the sample's \`searchParams\` object, or \`{ "undeclared": null }\` if it should be absent.
+       "Error: Route "/search-params/invalid-undeclared-use-search-params-caught" accessed searchParam "undeclared" which is not defined in the \`unstable_samples\` of \`unstable_instant\`. Add it to the sample's \`searchParams\` object, or \`{ "undeclared": null }\` if it should be absent.
            at <unknown> (app/(default)/search-params/invalid-undeclared-use-search-params-caught/search-params-reader.tsx:10:16)
            at <unknown> (ensure-error.ts:11:5)
            at <unknown> (app/(default)/search-params/invalid-undeclared-use-search-params-caught/search-params-reader.tsx:9:5)
@@ -394,7 +394,7 @@ describe('instant-validation-build', () => {
       )
       expect(extractBuildValidationError(result.cliOutput))
         .toMatchInlineSnapshot(`
-       "Error: Route "/headers/invalid-undeclared-header-get" accessed header "undeclaredheader" which is not defined in the \`samples\` of \`unstable_instant\`. Add it to the sample's \`headers\` array, or \`["undeclaredheader", null]\` if it should be absent.
+       "Error: Route "/headers/invalid-undeclared-header-get" accessed header "undeclaredheader" which is not defined in the \`unstable_samples\` of \`unstable_instant\`. Add it to the sample's \`headers\` array, or \`["undeclaredheader", null]\` if it should be absent.
            at <unknown> (app/(default)/headers/invalid-undeclared-header-get/page.tsx:28:24)
            at <unknown> (ensure-error.ts:11:5)
            at a (app/(default)/headers/invalid-undeclared-header-get/page.tsx:27:3)
@@ -423,7 +423,7 @@ describe('instant-validation-build', () => {
       )
       expect(extractBuildValidationError(result.cliOutput))
         .toMatchInlineSnapshot(`
-       "Error: Route "/headers/invalid-undeclared-header-get-caught" accessed header "undeclaredheader" which is not defined in the \`samples\` of \`unstable_instant\`. Add it to the sample's \`headers\` array, or \`["undeclaredheader", null]\` if it should be absent.
+       "Error: Route "/headers/invalid-undeclared-header-get-caught" accessed header "undeclaredheader" which is not defined in the \`unstable_samples\` of \`unstable_instant\`. Add it to the sample's \`headers\` array, or \`["undeclaredheader", null]\` if it should be absent.
            at <unknown> (app/(default)/headers/invalid-undeclared-header-get-caught/page.tsx:31:25)
            at <unknown> (ensure-error.ts:11:5)
            at a (app/(default)/headers/invalid-undeclared-header-get-caught/page.tsx:30:5)
@@ -451,7 +451,7 @@ describe('instant-validation-build', () => {
       )
       expect(extractBuildValidationError(result.cliOutput))
         .toMatchInlineSnapshot(`
-       "Error: Route "/headers/invalid-undeclared-header-has" accessed header "undeclaredheader" which is not defined in the \`samples\` of \`unstable_instant\`. Add it to the sample's \`headers\` array, or \`["undeclaredheader", null]\` if it should be absent.
+       "Error: Route "/headers/invalid-undeclared-header-has" accessed header "undeclaredheader" which is not defined in the \`unstable_samples\` of \`unstable_instant\`. Add it to the sample's \`headers\` array, or \`["undeclaredheader", null]\` if it should be absent.
            at <unknown> (app/(default)/headers/invalid-undeclared-header-has/page.tsx:28:23)
            at <unknown> (ensure-error.ts:11:5)
            at a (app/(default)/headers/invalid-undeclared-header-has/page.tsx:27:3)
@@ -506,7 +506,7 @@ describe('instant-validation-build', () => {
       )
       expect(extractBuildValidationError(result.cliOutput))
         .toMatchInlineSnapshot(`
-       "Error: Route "/cookies/invalid-undeclared-cookie-get" accessed cookie "undeclaredCookie" which is not defined in the \`samples\` of \`unstable_instant\`. Add it to the sample's \`cookies\` array, or \`{ name: "undeclaredCookie", value: null }\` if it should be absent.
+       "Error: Route "/cookies/invalid-undeclared-cookie-get" accessed cookie "undeclaredCookie" which is not defined in the \`unstable_samples\` of \`unstable_instant\`. Add it to the sample's \`cookies\` array, or \`{ name: "undeclaredCookie", value: null }\` if it should be absent.
            at <unknown> (app/(default)/cookies/invalid-undeclared-cookie-get/page.tsx:26:23)
            at <unknown> (ensure-error.ts:11:5)
            at a (app/(default)/cookies/invalid-undeclared-cookie-get/page.tsx:25:3)
@@ -535,7 +535,7 @@ describe('instant-validation-build', () => {
       )
       expect(extractBuildValidationError(result.cliOutput))
         .toMatchInlineSnapshot(`
-       "Error: Route "/cookies/invalid-undeclared-cookie-get-caught" accessed cookie "undeclaredCookie" which is not defined in the \`samples\` of \`unstable_instant\`. Add it to the sample's \`cookies\` array, or \`{ name: "undeclaredCookie", value: null }\` if it should be absent.
+       "Error: Route "/cookies/invalid-undeclared-cookie-get-caught" accessed cookie "undeclaredCookie" which is not defined in the \`unstable_samples\` of \`unstable_instant\`. Add it to the sample's \`cookies\` array, or \`{ name: "undeclaredCookie", value: null }\` if it should be absent.
            at <unknown> (app/(default)/cookies/invalid-undeclared-cookie-get-caught/page.tsx:28:25)
            at <unknown> (ensure-error.ts:11:5)
            at a (app/(default)/cookies/invalid-undeclared-cookie-get-caught/page.tsx:27:5)
@@ -564,7 +564,7 @@ describe('instant-validation-build', () => {
       )
       expect(extractBuildValidationError(result.cliOutput))
         .toMatchInlineSnapshot(`
-       "Error: Route "/cookies/invalid-undeclared-cookie-has" accessed cookie "undeclaredCookie" which is not defined in the \`samples\` of \`unstable_instant\`. Add it to the sample's \`cookies\` array, or \`{ name: "undeclaredCookie", value: null }\` if it should be absent.
+       "Error: Route "/cookies/invalid-undeclared-cookie-has" accessed cookie "undeclaredCookie" which is not defined in the \`unstable_samples\` of \`unstable_instant\`. Add it to the sample's \`cookies\` array, or \`{ name: "undeclaredCookie", value: null }\` if it should be absent.
            at <unknown> (app/(default)/cookies/invalid-undeclared-cookie-has/page.tsx:25:23)
            at <unknown> (ensure-error.ts:11:5)
            at a (app/(default)/cookies/invalid-undeclared-cookie-has/page.tsx:24:3)
@@ -611,7 +611,7 @@ describe('instant-validation-build', () => {
       )
       expect(extractBuildValidationError(result.cliOutput))
         .toMatchInlineSnapshot(`
-       "Error: Route "/params/invalid-param-not-provided/[one]/[two]" accessed param "two" which is not defined in the \`samples\` of \`unstable_instant\`. Add it to the sample's \`params\` object.
+       "Error: Route "/params/invalid-param-not-provided/[one]/[two]" accessed param "two" which is not defined in the \`unstable_samples\` of \`unstable_instant\`. Add it to the sample's \`params\` object.
            at <unknown> (app/(default)/params/invalid-param-not-provided/[one]/[two]/page.tsx:48:24)
            at <unknown> (ensure-error.ts:11:5)
            at a (app/(default)/params/invalid-param-not-provided/[one]/[two]/page.tsx:48:3)
@@ -640,7 +640,7 @@ describe('instant-validation-build', () => {
       )
       expect(extractBuildValidationError(result.cliOutput))
         .toMatchInlineSnapshot(`
-       "Error: Route "/params/invalid-param-not-provided-caught/[one]/[two]" accessed param "two" which is not defined in the \`samples\` of \`unstable_instant\`. Add it to the sample's \`params\` object.
+       "Error: Route "/params/invalid-param-not-provided-caught/[one]/[two]" accessed param "two" which is not defined in the \`unstable_samples\` of \`unstable_instant\`. Add it to the sample's \`params\` object.
            at <unknown> (app/(default)/params/invalid-param-not-provided-caught/[one]/[two]/page.tsx:46:26)
            at <unknown> (ensure-error.ts:11:5)
            at a (app/(default)/params/invalid-param-not-provided-caught/[one]/[two]/page.tsx:46:5)
@@ -677,7 +677,7 @@ describe('instant-validation-build', () => {
       )
       expect(extractBuildValidationError(result.cliOutput))
         .toMatchInlineSnapshot(`
-       "Error: Route "/params/invalid-undeclared-use-params/[one]/[two]" accessed param "two" which is not defined in the \`samples\` of \`unstable_instant\`. Add it to the sample's \`params\` object.
+       "Error: Route "/params/invalid-undeclared-use-params/[one]/[two]" accessed param "two" which is not defined in the \`unstable_samples\` of \`unstable_instant\`. Add it to the sample's \`params\` object.
            at <unknown> (app/(default)/params/invalid-undeclared-use-params/[one]/[two]/params-reader.tsx:10:18)
            at <unknown> (ensure-error.ts:11:5)
            at <unknown> (app/(default)/params/invalid-undeclared-use-params/[one]/[two]/params-reader.tsx:9:3)
@@ -706,7 +706,7 @@ describe('instant-validation-build', () => {
       )
       expect(extractBuildValidationError(result.cliOutput))
         .toMatchInlineSnapshot(`
-       "Error: Route "/params/invalid-undeclared-use-params-caught/[one]/[two]" accessed param "two" which is not defined in the \`samples\` of \`unstable_instant\`. Add it to the sample's \`params\` object.
+       "Error: Route "/params/invalid-undeclared-use-params-caught/[one]/[two]" accessed param "two" which is not defined in the \`unstable_samples\` of \`unstable_instant\`. Add it to the sample's \`params\` object.
            at <unknown> (app/(default)/params/invalid-undeclared-use-params-caught/[one]/[two]/params-reader.tsx:11:20)
            at <unknown> (ensure-error.ts:11:5)
            at <unknown> (app/(default)/params/invalid-undeclared-use-params-caught/[one]/[two]/params-reader.tsx:10:5)
@@ -793,7 +793,7 @@ describe('instant-validation-build', () => {
       )
       expect(extractBuildValidationError(result.cliOutput))
         .toMatchInlineSnapshot(`
-       "Error: Route "/pathname/invalid-use-pathname-missing-params/[one]/[two]" called usePathname() but param "two" is not defined in the \`samples\` of \`unstable_instant\`. usePathname() requires all route params to be provided.
+       "Error: Route "/pathname/invalid-use-pathname-missing-params/[one]/[two]" called usePathname() but param "two" is not defined in the \`unstable_samples\` of \`unstable_instant\`. usePathname() requires all route params to be provided.
            at <unknown> (app/(default)/pathname/invalid-use-pathname-missing-params/[one]/[two]/pathname-reader.tsx:9:11)
            at <unknown> (ensure-error.ts:11:5)
            at <unknown> (app/(default)/pathname/invalid-use-pathname-missing-params/[one]/[two]/pathname-reader.tsx:7:3)
@@ -836,7 +836,7 @@ describe('instant-validation-build', () => {
       )
       expect(extractBuildValidationError(result.cliOutput))
         .toMatchInlineSnapshot(`
-       "Error: Route "/root-params/[lang]/invalid-root-param-not-provided" accessed root param "lang" which is not defined in the \`samples\` of \`unstable_instant\`. Add it to the sample's \`params\` object.
+       "Error: Route "/root-params/[lang]/invalid-root-param-not-provided" accessed root param "lang" which is not defined in the \`unstable_samples\` of \`unstable_instant\`. Add it to the sample's \`params\` object.
            at <unknown> (app/root-params/[lang]/invalid-root-param-not-provided/page.tsx:18:11)
            at a (ensure-error.ts:48:11)
            at b (app/root-params/[lang]/invalid-root-param-not-provided/page.tsx:17:9)
@@ -865,7 +865,7 @@ describe('instant-validation-build', () => {
       )
       expect(extractBuildValidationError(result.cliOutput))
         .toMatchInlineSnapshot(`
-       "Error: Route "/root-params/[lang]/invalid-root-param-not-provided-caught" accessed root param "lang" which is not defined in the \`samples\` of \`unstable_instant\`. Add it to the sample's \`params\` object.
+       "Error: Route "/root-params/[lang]/invalid-root-param-not-provided-caught" accessed root param "lang" which is not defined in the \`unstable_samples\` of \`unstable_instant\`. Add it to the sample's \`params\` object.
            at <unknown> (app/root-params/[lang]/invalid-root-param-not-provided-caught/page.tsx:19:13)
            at a (ensure-error.ts:48:11)
            at b (app/root-params/[lang]/invalid-root-param-not-provided-caught/page.tsx:18:11)

--- a/test/e2e/app-dir/instant-validation-build/instant-validation-build.test.ts
+++ b/test/e2e/app-dir/instant-validation-build/instant-validation-build.test.ts
@@ -612,16 +612,16 @@ describe('instant-validation-build', () => {
       expect(extractBuildValidationError(result.cliOutput))
         .toMatchInlineSnapshot(`
        "Error: Route "/params/invalid-param-not-provided/[one]/[two]" accessed param "two" which is not defined in the \`samples\` of \`unstable_instant\`. Add it to the sample's \`params\` object.
-           at <unknown> (app/(default)/params/invalid-param-not-provided/[one]/[two]/page.tsx:47:24)
+           at <unknown> (app/(default)/params/invalid-param-not-provided/[one]/[two]/page.tsx:48:24)
            at <unknown> (ensure-error.ts:11:5)
-           at a (app/(default)/params/invalid-param-not-provided/[one]/[two]/page.tsx:47:3)
-         45 |
-         46 |   // We're not allowed to access params not in the samples.
-       > 47 |   ensureThrows(() => p.two)
+           at a (app/(default)/params/invalid-param-not-provided/[one]/[two]/page.tsx:48:3)
+         46 |
+         47 |   // We're not allowed to access params not in the samples.
+       > 48 |   ensureThrows(() => p.two)
             |                        ^
-         48 |
-         49 |   // TODO: test \`in\` and iteration
-         50 |   // assert.deepStrictEqual( {
+         49 |
+         50 |   // TODO: test \`in\` and iteration
+         51 |   // assert.deepStrictEqual( {
          digest: 'INSTANT_VALIDATION_ERROR'
        }
        Build-time instant validation failed for route "/params/invalid-param-not-provided/[one]/[two]".
@@ -641,16 +641,16 @@ describe('instant-validation-build', () => {
       expect(extractBuildValidationError(result.cliOutput))
         .toMatchInlineSnapshot(`
        "Error: Route "/params/invalid-param-not-provided-caught/[one]/[two]" accessed param "two" which is not defined in the \`samples\` of \`unstable_instant\`. Add it to the sample's \`params\` object.
-           at <unknown> (app/(default)/params/invalid-param-not-provided-caught/[one]/[two]/page.tsx:45:26)
+           at <unknown> (app/(default)/params/invalid-param-not-provided-caught/[one]/[two]/page.tsx:46:26)
            at <unknown> (ensure-error.ts:11:5)
-           at a (app/(default)/params/invalid-param-not-provided-caught/[one]/[two]/page.tsx:45:5)
-         43 |   try {
-         44 |     // We're not allowed to access params not in the samples.
-       > 45 |     ensureThrows(() => p.two, \`Expected accessing an undeclared param to throw\`)
+           at a (app/(default)/params/invalid-param-not-provided-caught/[one]/[two]/page.tsx:46:5)
+         44 |   try {
+         45 |     // We're not allowed to access params not in the samples.
+       > 46 |     ensureThrows(() => p.two, \`Expected accessing an undeclared param to throw\`)
             |                          ^
-         46 |   } catch (err) {
-         47 |     // We swallow the error. It should still be reported and fail the validation.
-         48 |   } {
+         47 |   } catch (err) {
+         48 |     // We swallow the error. It should still be reported and fail the validation.
+         49 |   } {
          digest: 'INSTANT_VALIDATION_ERROR'
        }
        Build-time instant validation failed for route "/params/invalid-param-not-provided-caught/[one]/[two]".
@@ -837,16 +837,16 @@ describe('instant-validation-build', () => {
       expect(extractBuildValidationError(result.cliOutput))
         .toMatchInlineSnapshot(`
        "Error: Route "/root-params/[lang]/invalid-root-param-not-provided" accessed root param "lang" which is not defined in the \`samples\` of \`unstable_instant\`. Add it to the sample's \`params\` object.
-           at <unknown> (app/root-params/[lang]/invalid-root-param-not-provided/page.tsx:17:11)
+           at <unknown> (app/root-params/[lang]/invalid-root-param-not-provided/page.tsx:18:11)
            at a (ensure-error.ts:48:11)
-           at b (app/root-params/[lang]/invalid-root-param-not-provided/page.tsx:16:9)
-         15 |
-         16 |   await ensureRejects(
-       > 17 |     () => lang(),
+           at b (app/root-params/[lang]/invalid-root-param-not-provided/page.tsx:17:9)
+         16 |
+         17 |   await ensureRejects(
+       > 18 |     () => lang(),
             |           ^
-         18 |     \`Expected lang() to error if sample is not provided\`
-         19 |   )
-         20 |   return ( {
+         19 |     \`Expected lang() to error if sample is not provided\`
+         20 |   )
+         21 |   return ( {
          digest: 'INSTANT_VALIDATION_ERROR'
        }
        Build-time instant validation failed for route "/root-params/[lang]/invalid-root-param-not-provided".
@@ -866,16 +866,16 @@ describe('instant-validation-build', () => {
       expect(extractBuildValidationError(result.cliOutput))
         .toMatchInlineSnapshot(`
        "Error: Route "/root-params/[lang]/invalid-root-param-not-provided-caught" accessed root param "lang" which is not defined in the \`samples\` of \`unstable_instant\`. Add it to the sample's \`params\` object.
-           at <unknown> (app/root-params/[lang]/invalid-root-param-not-provided-caught/page.tsx:18:13)
+           at <unknown> (app/root-params/[lang]/invalid-root-param-not-provided-caught/page.tsx:19:13)
            at a (ensure-error.ts:48:11)
-           at b (app/root-params/[lang]/invalid-root-param-not-provided-caught/page.tsx:17:11)
-         16 |   try {
-         17 |     await ensureRejects(
-       > 18 |       () => lang(),
+           at b (app/root-params/[lang]/invalid-root-param-not-provided-caught/page.tsx:18:11)
+         17 |   try {
+         18 |     await ensureRejects(
+       > 19 |       () => lang(),
             |             ^
-         19 |       \`Expected lang() to error if sample is not provided\`
-         20 |     )
-         21 |   } catch { {
+         20 |       \`Expected lang() to error if sample is not provided\`
+         21 |     )
+         22 |   } catch { {
          digest: 'INSTANT_VALIDATION_ERROR'
        }
        Build-time instant validation failed for route "/root-params/[lang]/invalid-root-param-not-provided-caught".

--- a/test/e2e/app-dir/instant-validation-build/next.config.js
+++ b/test/e2e/app-dir/instant-validation-build/next.config.js
@@ -4,8 +4,8 @@
 const nextConfig = {
   cacheComponents: true,
   experimental: {
-    instant: {
-      defaultValidationLevel: 'disabled',
+    instantInsights: {
+      validationLevel: 'manual-warning',
     },
   },
   typescript: {

--- a/test/e2e/app-dir/instant-validation-build/next.config.js
+++ b/test/e2e/app-dir/instant-validation-build/next.config.js
@@ -5,7 +5,7 @@ const nextConfig = {
   cacheComponents: true,
   experimental: {
     instant: {
-      defaultValidationLevel: 'error',
+      defaultValidationLevel: 'disabled',
     },
   },
   typescript: {

--- a/test/e2e/app-dir/instant-validation-build/next.config.js
+++ b/test/e2e/app-dir/instant-validation-build/next.config.js
@@ -3,6 +3,11 @@
  */
 const nextConfig = {
   cacheComponents: true,
+  experimental: {
+    instant: {
+      defaultValidationLevel: 'error',
+    },
+  },
   typescript: {
     ignoreBuildErrors: true,
   },

--- a/test/e2e/app-dir/instant-validation-level-error/app/bare/page.tsx
+++ b/test/e2e/app-dir/instant-validation-level-error/app/bare/page.tsx
@@ -1,0 +1,17 @@
+// Bare page (no `unstable_instant` config). Under 'experimental-error',
+// implicit validation fires on this page in dev AND in build — error level
+// applies to both modes. The runtime data accessed at the top of the page is the
+// "Suspense too high for instant navigation" violation that instant
+// validation specifically flags. The root layout's Suspense satisfies
+// static-shell validation, so the only error in dev/build is the instant
+// one.
+import { connection } from 'next/server'
+
+export default async function Page() {
+  await connection()
+  return (
+    <main>
+      <p>bare page (no unstable_instant), runtime data at the top.</p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/instant-validation-level-error/app/explicit-error/page.tsx
+++ b/test/e2e/app-dir/instant-validation-level-error/app/explicit-error/page.tsx
@@ -1,0 +1,17 @@
+// Same violation as `bare/page.tsx`, but with `unstable_instant = { level:
+// 'error' }`. Explicit per-segment override at the same level as the
+// configured 'experimental-error'. Same observable behavior as
+// `bare/page.tsx`; this case proves the override mechanism resolves
+// correctly when the explicit value matches the configured level.
+import { connection } from 'next/server'
+
+export const unstable_instant = { level: 'experimental-error' as const }
+
+export default async function Page() {
+  await connection()
+  return (
+    <main>
+      <p>explicit-error: explicit error-level override.</p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/instant-validation-level-error/app/explicit-false/page.tsx
+++ b/test/e2e/app-dir/instant-validation-level-error/app/explicit-false/page.tsx
@@ -1,0 +1,16 @@
+// Same violation as `bare/page.tsx`, but with `unstable_instant = false`.
+// The explicit opt-out should suppress implicit validation entirely — no
+// instant redbox in dev, no build failure, despite the runtime data
+// access at the top of the page.
+import { connection } from 'next/server'
+
+export const unstable_instant = false
+
+export default async function Page() {
+  await connection()
+  return (
+    <main>
+      <p>explicit-false: explicit opt-out suppresses validation.</p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/instant-validation-level-error/app/explicit-true/page.tsx
+++ b/test/e2e/app-dir/instant-validation-level-error/app/explicit-true/page.tsx
@@ -1,0 +1,18 @@
+// Same violation as `bare/page.tsx`, but with `unstable_instant = true`.
+// `true` is "opt in at the framework default level" — under
+// 'experimental-error', this resolves to error-level validation.
+// Validation fires in dev and build. Same observable behavior as
+// `bare/page.tsx`; this case proves the override mechanism works at the
+// same level as the configured one.
+import { connection } from 'next/server'
+
+export const unstable_instant = true
+
+export default async function Page() {
+  await connection()
+  return (
+    <main>
+      <p>explicit-true: opt in at the framework default level.</p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/instant-validation-level-error/app/explicit-warning/page.tsx
+++ b/test/e2e/app-dir/instant-validation-level-error/app/explicit-warning/page.tsx
@@ -1,0 +1,20 @@
+// Same violation as `bare/page.tsx`, but with `unstable_instant = { level:
+// 'warning' }`. Per-segment override lowers the level from the configured
+// 'experimental-error' to 'warning', so build validation does not fire and
+// the build stays clean even though the violation exists. Dev still shows
+// the instant redbox.
+import { connection } from 'next/server'
+
+export const unstable_instant = { level: 'warning' as const }
+
+export default async function Page() {
+  await connection()
+  return (
+    <main>
+      <p>
+        explicit-warning: per-segment `level: 'warning'` lowers from
+        'experimental-error'.
+      </p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/instant-validation-level-error/app/layered/layout.tsx
+++ b/test/e2e/app-dir/instant-validation-level-error/app/layered/layout.tsx
@@ -1,0 +1,15 @@
+import { type ReactNode } from 'react'
+
+// This intermediate layout exports `unstable_instant = false`. The walker
+// treats `false` as a per-segment no-op — it doesn't suppress validation
+// of descendant page/default segments. So the bare page under this layout
+// should still be implicitly validated under 'experimental-error' in dev
+// AND build.
+//
+// The `false` here only "shields" this layout's own load from being
+// considered blocking; it does not act as a global opt-out for the route.
+export const unstable_instant = false
+
+export default function LayeredLayout({ children }: { children: ReactNode }) {
+  return <>{children}</>
+}

--- a/test/e2e/app-dir/instant-validation-level-error/app/layered/page.tsx
+++ b/test/e2e/app-dir/instant-validation-level-error/app/layered/page.tsx
@@ -1,0 +1,14 @@
+// Bare page (no `unstable_instant` config) sitting under a layout that
+// exports `unstable_instant = false`. Under 'experimental-error', implicit
+// validation should still fire for this page in dev AND build — the
+// layout's `false` doesn't shield descendants.
+import { connection } from 'next/server'
+
+export default async function Page() {
+  await connection()
+  return (
+    <main>
+      layered: bare page under a layout with `unstable_instant = false`.
+    </main>
+  )
+}

--- a/test/e2e/app-dir/instant-validation-level-error/app/layout.tsx
+++ b/test/e2e/app-dir/instant-validation-level-error/app/layout.tsx
@@ -1,0 +1,22 @@
+import { Suspense, type ReactNode } from 'react'
+
+// Validation level is 'experimental-error' (set in next.config.ts).
+// Bare page/default segments get implicit validation in dev AND build.
+// Build fails when violations are found.
+//
+// Children are wrapped in Suspense so that pages with runtime data
+// accessed at the top of the page don't fail static-shell validation
+// (the Suspense fallback renders into the static shell). Instant
+// validation flags "Suspense too high for instant navigation" as an
+// instant-specific violation when it runs.
+export const unstable_instant = false
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>
+        <Suspense fallback={<p>loading…</p>}>{children}</Suspense>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/instant-validation-level-error/instant-validation-level-error.test.ts
+++ b/test/e2e/app-dir/instant-validation-level-error/instant-validation-level-error.test.ts
@@ -1,0 +1,314 @@
+import { nextTestSetup } from 'e2e-utils'
+import {
+  expectBuildValidationSkipped,
+  extractBuildValidationError,
+} from 'e2e-utils/instant-validation'
+import { waitForNoErrorToast } from '../../../lib/next-test-utils'
+
+describe('instant validation - level error', () => {
+  const { next, skipped, isNextDev, isNextStart, isTurbopack } = nextTestSetup({
+    files: __dirname,
+    skipStart: true,
+    skipDeployment: true,
+    env: {
+      NEXT_TEST_LOG_VALIDATION: '1',
+    },
+  })
+  if (skipped) return
+
+  if (isNextStart && !isTurbopack) {
+    it.skip('TODO: snapshot tests for webpack', () => {})
+    return
+  }
+
+  if (isNextStart) {
+    beforeAll(async () => {
+      await next.build({ args: ['--experimental-build-mode', 'compile'] })
+    })
+    afterEach(async () => {
+      await next.stop()
+    })
+  } else {
+    beforeAll(async () => {
+      await next.start()
+    })
+  }
+
+  const prerender = async (pathname: string) => {
+    return await next.build({
+      args: [
+        '--experimental-build-mode',
+        'generate',
+        '--debug-build-paths',
+        `app${pathname}/page.tsx`,
+      ],
+    })
+  }
+
+  // Validation level is 'experimental-error'. Implicit validation fires on
+  // bare pages in dev AND build — error level applies to both modes.
+  // Per-segment overrides (`level`, `true`, `false`) layer on top of this.
+  // A `level: 'warning'` override de-escalates a specific route to dev-only.
+  //
+  // Static-shell concerns are handled by the root layout's Suspense, so the
+  // only errors that surface here are instant validation errors — making
+  // the level/override behavior cleanly observable.
+
+  if (isNextDev) {
+    describe('dev', () => {
+      it('bare page: implicit validation surfaces a redbox (error level fires)', async () => {
+        const browser = await next.browser('/bare')
+        await expect(browser).toDisplayCollapsedRedbox(`
+         {
+           "code": "E1164",
+           "description": "Next.js encountered uncached data during the initial render.",
+           "environmentLabel": "Server",
+           "label": "Instant",
+           "source": "app/bare/page.tsx (11:19) @ Page
+         > 11 |   await connection()
+              |                   ^",
+           "stack": [
+             "Page app/bare/page.tsx (11:19)",
+           ],
+         }
+        `)
+      })
+
+      it('explicit-error page: explicit override at the configured level, instant redbox in dev', async () => {
+        const browser = await next.browser('/explicit-error')
+        await expect(browser).toDisplayCollapsedRedbox(`
+         {
+           "cause": [
+             {
+               "label": "Caused by: Instant Validation",
+               "source": "app/explicit-error/page.tsx (8:33) @ unstable_instant
+         >  8 | export const unstable_instant = { level: 'experimental-error' as const }
+              |                                 ^",
+               "stack": [
+                 "unstable_instant app/explicit-error/page.tsx (8:33)",
+                 "Set.forEach <anonymous>",
+               ],
+             },
+           ],
+           "code": "E1164",
+           "description": "Next.js encountered uncached data during the initial render.",
+           "environmentLabel": "Server",
+           "label": "Instant",
+           "source": "app/explicit-error/page.tsx (11:19) @ Page
+         > 11 |   await connection()
+              |                   ^",
+           "stack": [
+             "Page app/explicit-error/page.tsx (11:19)",
+           ],
+         }
+        `)
+      })
+
+      it('explicit-true page: aliases to error level, instant redbox in dev', async () => {
+        const browser = await next.browser('/explicit-true')
+        await expect(browser).toDisplayCollapsedRedbox(`
+         {
+           "cause": [
+             {
+               "label": "Caused by: Instant Validation",
+               "source": "app/explicit-true/page.tsx (9:33) @ unstable_instant
+         >  9 | export const unstable_instant = true
+              |                                 ^",
+               "stack": [
+                 "unstable_instant app/explicit-true/page.tsx (9:33)",
+                 "Set.forEach <anonymous>",
+               ],
+             },
+           ],
+           "code": "E1164",
+           "description": "Next.js encountered uncached data during the initial render.",
+           "environmentLabel": "Server",
+           "label": "Instant",
+           "source": "app/explicit-true/page.tsx (12:19) @ Page
+         > 12 |   await connection()
+              |                   ^",
+           "stack": [
+             "Page app/explicit-true/page.tsx (12:19)",
+           ],
+         }
+        `)
+      })
+
+      it('explicit-warning page: per-segment de-escalation still validates in dev', async () => {
+        const browser = await next.browser('/explicit-warning')
+        await expect(browser).toDisplayCollapsedRedbox(`
+         {
+           "cause": [
+             {
+               "label": "Caused by: Instant Validation",
+               "source": "app/explicit-warning/page.tsx (8:33) @ unstable_instant
+         >  8 | export const unstable_instant = { level: 'warning' as const }
+              |                                 ^",
+               "stack": [
+                 "unstable_instant app/explicit-warning/page.tsx (8:33)",
+                 "Set.forEach <anonymous>",
+               ],
+             },
+           ],
+           "code": "E1164",
+           "description": "Next.js encountered uncached data during the initial render.",
+           "environmentLabel": "Server",
+           "label": "Instant",
+           "source": "app/explicit-warning/page.tsx (11:19) @ Page
+         > 11 |   await connection()
+              |                   ^",
+           "stack": [
+             "Page app/explicit-warning/page.tsx (11:19)",
+           ],
+         }
+        `)
+      })
+
+      it('explicit-false page: opt-out suppresses validation, no redbox', async () => {
+        const browser = await next.browser('/explicit-false')
+        await browser.elementByCss('main')
+        await waitForNoErrorToast(browser, { waitInMs: 500 })
+      })
+
+      it('layered: bare page under layout-with-instant-false still validates', async () => {
+        // The intermediate layout exports `unstable_instant = false`, but
+        // that's per-segment — it doesn't shield descendants. The bare
+        // page should still surface an instant redbox in dev.
+        const browser = await next.browser('/layered')
+        await expect(browser).toDisplayCollapsedRedbox(`
+         {
+           "code": "E1164",
+           "description": "Next.js encountered uncached data during the initial render.",
+           "environmentLabel": "Server",
+           "label": "Instant",
+           "source": "app/layered/page.tsx (8:19) @ Page
+         >  8 |   await connection()
+              |                   ^",
+           "stack": [
+             "Page app/layered/page.tsx (8:19)",
+           ],
+         }
+        `)
+      })
+    })
+  } else {
+    describe('build', () => {
+      it('bare page: build validation runs and fails the build', async () => {
+        const result = await prerender('/bare')
+        expect(extractBuildValidationError(result.cliOutput))
+          .toMatchInlineSnapshot(`
+         "Error: Route "/bare": Next.js encountered uncached data during the initial render.
+
+         \`fetch(...)\` or \`connection()\` accessed outside of \`<Suspense>\` blocks navigation, leading to a slower user experience.
+
+         Ways to fix this:
+           - Cache the data access with \`"use cache"\`
+           - Move the data access into a child component within a <Suspense> boundary
+           - Set \`export const instant = false\` to allow a blocking route
+
+         Learn more: https://nextjs.org/docs/messages/blocking-route
+             at a (<anonymous>)
+             at body (<anonymous>)
+             at html (<anonymous>)
+         Build-time instant validation failed for route "/bare".
+         To get a more detailed stack trace and pinpoint the issue, try one of the following:
+           - Start the app in development mode by running \`next dev\`, then open "/bare" in your browser to investigate the error.
+           - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+         Stopping prerender due to instant validation errors."
+        `)
+        expect(result.exitCode).not.toBe(0)
+      })
+
+      it('explicit-error page: build validation runs and fails the build', async () => {
+        const result = await prerender('/explicit-error')
+        expect(extractBuildValidationError(result.cliOutput))
+          .toMatchInlineSnapshot(`
+         "Error: Route "/explicit-error": Next.js encountered uncached data during the initial render.
+
+         \`fetch(...)\` or \`connection()\` accessed outside of \`<Suspense>\` blocks navigation, leading to a slower user experience.
+
+         Ways to fix this:
+           - Cache the data access with \`"use cache"\`
+           - Move the data access into a child component within a <Suspense> boundary
+           - Set \`export const instant = false\` to allow a blocking route
+
+         Learn more: https://nextjs.org/docs/messages/blocking-route
+             at a (<anonymous>)
+             at body (<anonymous>)
+             at html (<anonymous>)
+         Build-time instant validation failed for route "/explicit-error".
+         To get a more detailed stack trace and pinpoint the issue, try one of the following:
+           - Start the app in development mode by running \`next dev\`, then open "/explicit-error" in your browser to investigate the error.
+           - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+         Stopping prerender due to instant validation errors."
+        `)
+        expect(result.exitCode).not.toBe(0)
+      })
+
+      it('explicit-true page: build validation runs and fails the build (alias to error)', async () => {
+        const result = await prerender('/explicit-true')
+        expect(extractBuildValidationError(result.cliOutput))
+          .toMatchInlineSnapshot(`
+         "Error: Route "/explicit-true": Next.js encountered uncached data during the initial render.
+
+         \`fetch(...)\` or \`connection()\` accessed outside of \`<Suspense>\` blocks navigation, leading to a slower user experience.
+
+         Ways to fix this:
+           - Cache the data access with \`"use cache"\`
+           - Move the data access into a child component within a <Suspense> boundary
+           - Set \`export const instant = false\` to allow a blocking route
+
+         Learn more: https://nextjs.org/docs/messages/blocking-route
+             at a (<anonymous>)
+             at body (<anonymous>)
+             at html (<anonymous>)
+         Build-time instant validation failed for route "/explicit-true".
+         To get a more detailed stack trace and pinpoint the issue, try one of the following:
+           - Start the app in development mode by running \`next dev\`, then open "/explicit-true" in your browser to investigate the error.
+           - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+         Stopping prerender due to instant validation errors."
+        `)
+        expect(result.exitCode).not.toBe(0)
+      })
+
+      it('explicit-warning page: per-segment de-escalation skips build validation', async () => {
+        const result = await prerender('/explicit-warning')
+        expectBuildValidationSkipped(result)
+      })
+
+      it('explicit-false page: opt-out skips validation', async () => {
+        const result = await prerender('/explicit-false')
+        expectBuildValidationSkipped(result)
+      })
+
+      it('layered: bare page under layout-with-instant-false still fails the build', async () => {
+        // The intermediate layout's `unstable_instant = false` doesn't
+        // shield descendants. Build validation runs on the bare page and
+        // fails because the 'experimental-error' level applies to build.
+        const result = await prerender('/layered')
+        expect(extractBuildValidationError(result.cliOutput))
+          .toMatchInlineSnapshot(`
+         "Error: Route "/layered": Next.js encountered uncached data during the initial render.
+
+         \`fetch(...)\` or \`connection()\` accessed outside of \`<Suspense>\` blocks navigation, leading to a slower user experience.
+
+         Ways to fix this:
+           - Cache the data access with \`"use cache"\`
+           - Move the data access into a child component within a <Suspense> boundary
+           - Set \`export const instant = false\` to allow a blocking route
+
+         Learn more: https://nextjs.org/docs/messages/blocking-route
+             at a (<anonymous>)
+             at body (<anonymous>)
+             at html (<anonymous>)
+         Build-time instant validation failed for route "/layered".
+         To get a more detailed stack trace and pinpoint the issue, try one of the following:
+           - Start the app in development mode by running \`next dev\`, then open "/layered" in your browser to investigate the error.
+           - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+         Stopping prerender due to instant validation errors."
+        `)
+        expect(result.exitCode).not.toBe(0)
+      })
+    })
+  }
+})

--- a/test/e2e/app-dir/instant-validation-level-error/next.config.ts
+++ b/test/e2e/app-dir/instant-validation-level-error/next.config.ts
@@ -1,0 +1,15 @@
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  cacheComponents: true,
+  experimental: {
+    instantInsights: {
+      validationLevel: 'experimental-error',
+    },
+  },
+  typescript: {
+    ignoreBuildErrors: true,
+  },
+}
+
+export default nextConfig

--- a/test/e2e/app-dir/instant-validation-level-manual-error/app/bare/page.tsx
+++ b/test/e2e/app-dir/instant-validation-level-manual-error/app/bare/page.tsx
@@ -1,0 +1,16 @@
+// Bare page (no `unstable_instant` config). Under 'experimental-manual-error',
+// implicit validation does NOT fire — only segments that explicitly opt in
+// are validated. The runtime data accessed at the top of the page would be
+// a "Suspense too high for instant navigation" violation if validation were
+// running, but in manual mode it goes unflagged. The root layout's Suspense
+// satisfies static-shell validation, so no errors surface.
+import { connection } from 'next/server'
+
+export default async function Page() {
+  await connection()
+  return (
+    <main>
+      <p>bare page (no unstable_instant), runtime data at the top.</p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/instant-validation-level-manual-error/app/explicit-error/page.tsx
+++ b/test/e2e/app-dir/instant-validation-level-manual-error/app/explicit-error/page.tsx
@@ -1,0 +1,17 @@
+// Same violation as `bare/page.tsx`, but with `unstable_instant = { level:
+// 'error' }`. Explicit per-segment override at the same level as the
+// configured 'experimental-manual-error'. Validation fires in dev and
+// build. Unlike `bare/page.tsx` (skipped in manual mode), the explicit
+// opt-in here pulls this page into validation.
+import { connection } from 'next/server'
+
+export const unstable_instant = { level: 'experimental-error' as const }
+
+export default async function Page() {
+  await connection()
+  return (
+    <main>
+      <p>explicit-error: explicit error-level override.</p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/instant-validation-level-manual-error/app/explicit-false/page.tsx
+++ b/test/e2e/app-dir/instant-validation-level-manual-error/app/explicit-false/page.tsx
@@ -1,0 +1,16 @@
+// Same violation as `bare/page.tsx`, but with `unstable_instant = false`.
+// The explicit opt-out should suppress implicit validation entirely — no
+// instant redbox in dev, no build failure, despite the runtime data
+// access at the top of the page.
+import { connection } from 'next/server'
+
+export const unstable_instant = false
+
+export default async function Page() {
+  await connection()
+  return (
+    <main>
+      <p>explicit-false: explicit opt-out suppresses validation.</p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/instant-validation-level-manual-error/app/explicit-true/page.tsx
+++ b/test/e2e/app-dir/instant-validation-level-manual-error/app/explicit-true/page.tsx
@@ -1,0 +1,18 @@
+// Same violation as `bare/page.tsx`, but with `unstable_instant = true`.
+// `true` is "opt in at the framework default level" — under
+// 'experimental-manual-error', this resolves to error-level validation.
+// Validation fires in dev and build. Unlike `bare/page.tsx` (which is
+// skipped in manual mode), the explicit opt-in here pulls this page into
+// validation.
+import { connection } from 'next/server'
+
+export const unstable_instant = true
+
+export default async function Page() {
+  await connection()
+  return (
+    <main>
+      <p>explicit-true: opt in at the framework default level.</p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/instant-validation-level-manual-error/app/explicit-warning/page.tsx
+++ b/test/e2e/app-dir/instant-validation-level-manual-error/app/explicit-warning/page.tsx
@@ -1,0 +1,20 @@
+// Same violation as `bare/page.tsx`, but with `unstable_instant = { level:
+// 'warning' }`. Per-segment override lowers the level from the configured
+// 'experimental-manual-error' to 'warning', so build validation does not
+// fire and the build stays clean even though the violation exists. Dev
+// still shows the instant redbox.
+import { connection } from 'next/server'
+
+export const unstable_instant = { level: 'warning' as const }
+
+export default async function Page() {
+  await connection()
+  return (
+    <main>
+      <p>
+        explicit-warning: per-segment `level: 'warning'` lowers from
+        'experimental-manual-error'.
+      </p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/instant-validation-level-manual-error/app/layered/layout.tsx
+++ b/test/e2e/app-dir/instant-validation-level-manual-error/app/layered/layout.tsx
@@ -1,0 +1,14 @@
+import { type ReactNode } from 'react'
+
+// This intermediate layout exports `unstable_instant = false`. The walker
+// treats `false` as a per-segment no-op — it doesn't pull descendants into
+// validation. Under 'experimental-manual-error', the bare descendant has
+// no explicit opt-in either, so no implicit validation runs.
+//
+// The `false` here only "shields" this layout's own load from being
+// considered blocking; it does not act as a global opt-in for the route.
+export const unstable_instant = false
+
+export default function LayeredLayout({ children }: { children: ReactNode }) {
+  return <>{children}</>
+}

--- a/test/e2e/app-dir/instant-validation-level-manual-error/app/layered/page.tsx
+++ b/test/e2e/app-dir/instant-validation-level-manual-error/app/layered/page.tsx
@@ -1,0 +1,14 @@
+// Bare page (no `unstable_instant` config) sitting under a layout that
+// exports `unstable_instant = false`. Under 'experimental-manual-error',
+// no implicit validation runs — the bare descendant has no explicit
+// opt-in, and the layout's `false` is a per-segment no-op for descendants.
+import { connection } from 'next/server'
+
+export default async function Page() {
+  await connection()
+  return (
+    <main>
+      layered: bare page under a layout with `unstable_instant = false`.
+    </main>
+  )
+}

--- a/test/e2e/app-dir/instant-validation-level-manual-error/app/layout.tsx
+++ b/test/e2e/app-dir/instant-validation-level-manual-error/app/layout.tsx
@@ -1,0 +1,23 @@
+import { Suspense, type ReactNode } from 'react'
+
+// Validation level is 'experimental-manual-error' (set in next.config.ts).
+// No implicit validation — only segments that explicitly opt in via
+// `unstable_instant` are validated. When validated, the level is error,
+// applying in dev AND build (build fails on violations).
+//
+// Children are wrapped in Suspense so that pages with runtime data
+// accessed at the top of the page don't fail static-shell validation
+// (the Suspense fallback renders into the static shell). Instant
+// validation flags "Suspense too high for instant navigation" as an
+// instant-specific violation when it runs.
+export const unstable_instant = false
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>
+        <Suspense fallback={<p>loading…</p>}>{children}</Suspense>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/instant-validation-level-manual-error/instant-validation-level-manual-error.test.ts
+++ b/test/e2e/app-dir/instant-validation-level-manual-error/instant-validation-level-manual-error.test.ts
@@ -1,0 +1,249 @@
+import { nextTestSetup } from 'e2e-utils'
+import {
+  expectBuildValidationSkipped,
+  extractBuildValidationError,
+} from 'e2e-utils/instant-validation'
+import { waitForNoErrorToast } from '../../../lib/next-test-utils'
+
+describe('instant validation - level manual-error', () => {
+  const { next, skipped, isNextDev, isNextStart, isTurbopack } = nextTestSetup({
+    files: __dirname,
+    skipStart: true,
+    skipDeployment: true,
+    env: {
+      NEXT_TEST_LOG_VALIDATION: '1',
+    },
+  })
+  if (skipped) return
+
+  if (isNextStart && !isTurbopack) {
+    it.skip('TODO: snapshot tests for webpack', () => {})
+    return
+  }
+
+  if (isNextStart) {
+    beforeAll(async () => {
+      await next.build({ args: ['--experimental-build-mode', 'compile'] })
+    })
+    afterEach(async () => {
+      await next.stop()
+    })
+  } else {
+    beforeAll(async () => {
+      await next.start()
+    })
+  }
+
+  const prerender = async (pathname: string) => {
+    return await next.build({
+      args: [
+        '--experimental-build-mode',
+        'generate',
+        '--debug-build-paths',
+        `app${pathname}/page.tsx`,
+      ],
+    })
+  }
+
+  // Validation level is 'experimental-manual-error'. Implicit validation
+  // does NOT fire on bare pages — only segments that explicitly opt in via
+  // `unstable_instant` are validated. When they are validated, the level is
+  // error (applies in dev AND build), unless de-escalated by a per-segment
+  // `level: 'warning'` override.
+  //
+  // Static-shell concerns are handled by the root layout's Suspense, so the
+  // only errors that surface here are instant validation errors — making
+  // the level/override behavior cleanly observable.
+
+  if (isNextDev) {
+    describe('dev', () => {
+      it('bare page: no errors (no implicit validation under manual-error)', async () => {
+        const browser = await next.browser('/bare')
+        await browser.elementByCss('main')
+        await waitForNoErrorToast(browser, { waitInMs: 500 })
+      })
+
+      it('explicit-error page: explicit override at the configured level, instant redbox in dev', async () => {
+        const browser = await next.browser('/explicit-error')
+        await expect(browser).toDisplayCollapsedRedbox(`
+         {
+           "cause": [
+             {
+               "label": "Caused by: Instant Validation",
+               "source": "app/explicit-error/page.tsx (8:33) @ unstable_instant
+         >  8 | export const unstable_instant = { level: 'experimental-error' as const }
+              |                                 ^",
+               "stack": [
+                 "unstable_instant app/explicit-error/page.tsx (8:33)",
+                 "Set.forEach <anonymous>",
+               ],
+             },
+           ],
+           "code": "E1164",
+           "description": "Next.js encountered uncached data during the initial render.",
+           "environmentLabel": "Server",
+           "label": "Instant",
+           "source": "app/explicit-error/page.tsx (11:19) @ Page
+         > 11 |   await connection()
+              |                   ^",
+           "stack": [
+             "Page app/explicit-error/page.tsx (11:19)",
+           ],
+         }
+        `)
+      })
+
+      it('explicit-true page: aliases to error level, instant redbox in dev', async () => {
+        const browser = await next.browser('/explicit-true')
+        await expect(browser).toDisplayCollapsedRedbox(`
+         {
+           "cause": [
+             {
+               "label": "Caused by: Instant Validation",
+               "source": "app/explicit-true/page.tsx (9:33) @ unstable_instant
+         >  9 | export const unstable_instant = true
+              |                                 ^",
+               "stack": [
+                 "unstable_instant app/explicit-true/page.tsx (9:33)",
+                 "Set.forEach <anonymous>",
+               ],
+             },
+           ],
+           "code": "E1164",
+           "description": "Next.js encountered uncached data during the initial render.",
+           "environmentLabel": "Server",
+           "label": "Instant",
+           "source": "app/explicit-true/page.tsx (12:19) @ Page
+         > 12 |   await connection()
+              |                   ^",
+           "stack": [
+             "Page app/explicit-true/page.tsx (12:19)",
+           ],
+         }
+        `)
+      })
+
+      it('explicit-warning page: per-segment de-escalation still validates in dev', async () => {
+        const browser = await next.browser('/explicit-warning')
+        await expect(browser).toDisplayCollapsedRedbox(`
+         {
+           "cause": [
+             {
+               "label": "Caused by: Instant Validation",
+               "source": "app/explicit-warning/page.tsx (8:33) @ unstable_instant
+         >  8 | export const unstable_instant = { level: 'warning' as const }
+              |                                 ^",
+               "stack": [
+                 "unstable_instant app/explicit-warning/page.tsx (8:33)",
+                 "Set.forEach <anonymous>",
+               ],
+             },
+           ],
+           "code": "E1164",
+           "description": "Next.js encountered uncached data during the initial render.",
+           "environmentLabel": "Server",
+           "label": "Instant",
+           "source": "app/explicit-warning/page.tsx (11:19) @ Page
+         > 11 |   await connection()
+              |                   ^",
+           "stack": [
+             "Page app/explicit-warning/page.tsx (11:19)",
+           ],
+         }
+        `)
+      })
+
+      it('explicit-false page: opt-out suppresses validation, no redbox', async () => {
+        const browser = await next.browser('/explicit-false')
+        await browser.elementByCss('main')
+        await waitForNoErrorToast(browser, { waitInMs: 500 })
+      })
+
+      it('layered: bare page under layout-with-instant-false has no errors', async () => {
+        // The intermediate layout exports `unstable_instant = false`, but
+        // that only opts the layout out — it doesn't pull descendants into
+        // validation. Under manual-error, the bare descendant has no
+        // explicit opt-in, so no implicit validation runs.
+        const browser = await next.browser('/layered')
+        await browser.elementByCss('main')
+        await waitForNoErrorToast(browser, { waitInMs: 500 })
+      })
+    })
+  } else {
+    describe('build', () => {
+      it('bare page: build validation skipped (no implicit validation under manual-error)', async () => {
+        const result = await prerender('/bare')
+        expectBuildValidationSkipped(result)
+      })
+
+      it('explicit-error page: build validation runs and fails the build', async () => {
+        const result = await prerender('/explicit-error')
+        expect(extractBuildValidationError(result.cliOutput))
+          .toMatchInlineSnapshot(`
+         "Error: Route "/explicit-error": Next.js encountered uncached data during the initial render.
+
+         \`fetch(...)\` or \`connection()\` accessed outside of \`<Suspense>\` blocks navigation, leading to a slower user experience.
+
+         Ways to fix this:
+           - Cache the data access with \`"use cache"\`
+           - Move the data access into a child component within a <Suspense> boundary
+           - Set \`export const instant = false\` to allow a blocking route
+
+         Learn more: https://nextjs.org/docs/messages/blocking-route
+             at a (<anonymous>)
+             at body (<anonymous>)
+             at html (<anonymous>)
+         Build-time instant validation failed for route "/explicit-error".
+         To get a more detailed stack trace and pinpoint the issue, try one of the following:
+           - Start the app in development mode by running \`next dev\`, then open "/explicit-error" in your browser to investigate the error.
+           - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+         Stopping prerender due to instant validation errors."
+        `)
+        expect(result.exitCode).not.toBe(0)
+      })
+
+      it('explicit-true page: build validation runs and fails the build (alias to error)', async () => {
+        const result = await prerender('/explicit-true')
+        expect(extractBuildValidationError(result.cliOutput))
+          .toMatchInlineSnapshot(`
+         "Error: Route "/explicit-true": Next.js encountered uncached data during the initial render.
+
+         \`fetch(...)\` or \`connection()\` accessed outside of \`<Suspense>\` blocks navigation, leading to a slower user experience.
+
+         Ways to fix this:
+           - Cache the data access with \`"use cache"\`
+           - Move the data access into a child component within a <Suspense> boundary
+           - Set \`export const instant = false\` to allow a blocking route
+
+         Learn more: https://nextjs.org/docs/messages/blocking-route
+             at a (<anonymous>)
+             at body (<anonymous>)
+             at html (<anonymous>)
+         Build-time instant validation failed for route "/explicit-true".
+         To get a more detailed stack trace and pinpoint the issue, try one of the following:
+           - Start the app in development mode by running \`next dev\`, then open "/explicit-true" in your browser to investigate the error.
+           - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+         Stopping prerender due to instant validation errors."
+        `)
+        expect(result.exitCode).not.toBe(0)
+      })
+
+      it('explicit-warning page: per-segment de-escalation skips build validation', async () => {
+        const result = await prerender('/explicit-warning')
+        expectBuildValidationSkipped(result)
+      })
+
+      it('explicit-false page: opt-out skips validation', async () => {
+        const result = await prerender('/explicit-false')
+        expectBuildValidationSkipped(result)
+      })
+
+      it('layered: bare page under layout-with-instant-false skips build validation', async () => {
+        // Under manual-error, the bare descendant has no explicit
+        // `unstable_instant` opt-in, so no implicit validation runs.
+        const result = await prerender('/layered')
+        expectBuildValidationSkipped(result)
+      })
+    })
+  }
+})

--- a/test/e2e/app-dir/instant-validation-level-manual-error/next.config.ts
+++ b/test/e2e/app-dir/instant-validation-level-manual-error/next.config.ts
@@ -1,0 +1,15 @@
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  cacheComponents: true,
+  experimental: {
+    instantInsights: {
+      validationLevel: 'experimental-manual-error',
+    },
+  },
+  typescript: {
+    ignoreBuildErrors: true,
+  },
+}
+
+export default nextConfig

--- a/test/e2e/app-dir/instant-validation-level-manual-warning/app/with-root-suspense/bare/page.tsx
+++ b/test/e2e/app-dir/instant-validation-level-manual-warning/app/with-root-suspense/bare/page.tsx
@@ -1,0 +1,16 @@
+// No `unstable_instant` config on this page, but the page accesses runtime
+// data at the top — a "Suspense too high" pattern that instant validation
+// specifically flags. Under 'manual-warning', instant validation only
+// runs on segments that opt in, so the violation goes unflagged here.
+// The root layout's Suspense boundary catches it for cacheComponents'
+// static-shell purposes.
+import { connection } from 'next/server'
+
+export default async function Page() {
+  await connection()
+  return (
+    <main>
+      <p>bare page (no unstable_instant), runtime data at the top.</p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/instant-validation-level-manual-warning/app/with-root-suspense/explicit-error/page.tsx
+++ b/test/e2e/app-dir/instant-validation-level-manual-warning/app/with-root-suspense/explicit-error/page.tsx
@@ -1,0 +1,20 @@
+// Same shape as bare/page.tsx — runtime data accessed outside a Suspense
+// boundary — but with an explicit `unstable_instant = { level: 'experimental-error' }`.
+// Even though the validation level is 'manual-warning', the explicit
+// per-segment opt-in escalates validation to error level in both dev and
+// build, and the violation should fail the build.
+import { connection } from 'next/server'
+
+export const unstable_instant = { level: 'experimental-error' as const }
+
+export default async function Page() {
+  await connection()
+  return (
+    <main>
+      <p>
+        explicit-error page (unstable_instant level: experimental-error),
+        runtime data at the top.
+      </p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/instant-validation-level-manual-warning/app/with-root-suspense/explicit-true/page.tsx
+++ b/test/e2e/app-dir/instant-validation-level-manual-warning/app/with-root-suspense/explicit-true/page.tsx
@@ -1,0 +1,16 @@
+// Same violation as `bare/page.tsx`, but with `unstable_instant = true`.
+// `true` is "opt in at the framework default level" — under default
+// 'manual-warning', that resolves to warning-level validation. Validation
+// should fire in dev but not in build.
+import { connection } from 'next/server'
+
+export const unstable_instant = true
+
+export default async function Page() {
+  await connection()
+  return (
+    <main>
+      <p>explicit-true: opt in at the framework default level.</p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/instant-validation-level-manual-warning/app/with-root-suspense/explicit-warning/page.tsx
+++ b/test/e2e/app-dir/instant-validation-level-manual-warning/app/with-root-suspense/explicit-warning/page.tsx
@@ -1,0 +1,15 @@
+// Same violation as `bare/page.tsx`, but with `unstable_instant = { level:
+// 'warning' }`. Explicit warning-level opt-in: validation fires in dev
+// only, build is a no-op.
+import { connection } from 'next/server'
+
+export const unstable_instant = { level: 'warning' as const }
+
+export default async function Page() {
+  await connection()
+  return (
+    <main>
+      <p>explicit-warning: explicit warning-level opt-in.</p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/instant-validation-level-manual-warning/app/with-root-suspense/layout.tsx
+++ b/test/e2e/app-dir/instant-validation-level-manual-warning/app/with-root-suspense/layout.tsx
@@ -1,0 +1,21 @@
+import { Suspense, type ReactNode } from 'react'
+
+// Validation level is 'manual-warning' (set in next.config.ts).
+// No implicit validation should fire on bare pages, in dev or build —
+// only segments that explicitly opt in via `unstable_instant` are validated.
+//
+// Children are wrapped in Suspense so that pages with uncached data
+// accessed at the top of the page don't fail static-shell validation
+// (the Suspense fallback renders into the static shell). Instant
+// validation can still flag "Suspense too high for instant navigation"
+// as an instant-specific violation when it runs.
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>
+        <Suspense fallback={<p>loading…</p>}>{children}</Suspense>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/instant-validation-level-manual-warning/app/without-root-suspense/bare/page.tsx
+++ b/test/e2e/app-dir/instant-validation-level-manual-warning/app/without-root-suspense/bare/page.tsx
@@ -1,0 +1,16 @@
+// No `unstable_instant` config on this page, but the page accesses runtime
+// data at the top — a "Suspense too high" pattern that instant validation
+// specifically flags. Under 'manual-warning', instant validation only
+// runs on segments that opt in, so the violation goes unflagged here.
+// With no Suspense in the root layout, the static-shell empty-shell
+// error surfaces instead.
+import { connection } from 'next/server'
+
+export default async function Page() {
+  await connection()
+  return (
+    <main>
+      <p>bare page (no unstable_instant), runtime data at the top.</p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/instant-validation-level-manual-warning/app/without-root-suspense/explicit-error/page.tsx
+++ b/test/e2e/app-dir/instant-validation-level-manual-warning/app/without-root-suspense/explicit-error/page.tsx
@@ -1,0 +1,20 @@
+// Same shape as bare/page.tsx — runtime data accessed outside a Suspense
+// boundary — but with an explicit `unstable_instant = { level: 'experimental-error' }`.
+// Even though the validation level is 'manual-warning', the explicit
+// per-segment opt-in escalates validation to error level in both dev and
+// build, and the violation should fail the build.
+import { connection } from 'next/server'
+
+export const unstable_instant = { level: 'experimental-error' as const }
+
+export default async function Page() {
+  await connection()
+  return (
+    <main>
+      <p>
+        explicit-error page (unstable_instant level: experimental-error),
+        runtime data at the top.
+      </p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/instant-validation-level-manual-warning/app/without-root-suspense/explicit-true/page.tsx
+++ b/test/e2e/app-dir/instant-validation-level-manual-warning/app/without-root-suspense/explicit-true/page.tsx
@@ -1,0 +1,17 @@
+// Same violation as `bare/page.tsx`, but with `unstable_instant = true`.
+// `true` is "opt in at the framework default level" — under default
+// 'manual-warning', that resolves to warning-level validation. Instant
+// validation fires in dev (and takes priority over the static-shell error
+// since instant is active); build does not validate.
+import { connection } from 'next/server'
+
+export const unstable_instant = true
+
+export default async function Page() {
+  await connection()
+  return (
+    <main>
+      <p>explicit-true: opt in at the framework default level.</p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/instant-validation-level-manual-warning/app/without-root-suspense/explicit-warning/page.tsx
+++ b/test/e2e/app-dir/instant-validation-level-manual-warning/app/without-root-suspense/explicit-warning/page.tsx
@@ -1,0 +1,16 @@
+// Same violation as `bare/page.tsx`, but with `unstable_instant = { level:
+// 'warning' }`. Explicit warning-level opt-in: instant validation fires
+// in dev (and takes priority over the static-shell error since instant
+// is active); build does not validate.
+import { connection } from 'next/server'
+
+export const unstable_instant = { level: 'warning' as const }
+
+export default async function Page() {
+  await connection()
+  return (
+    <main>
+      <p>explicit-warning: explicit warning-level opt-in.</p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/instant-validation-level-manual-warning/app/without-root-suspense/layout.tsx
+++ b/test/e2e/app-dir/instant-validation-level-manual-warning/app/without-root-suspense/layout.tsx
@@ -1,0 +1,20 @@
+import { type ReactNode } from 'react'
+
+// Validation level is 'manual-warning' (set in next.config.ts).
+//
+// No Suspense around `{children}`, so a violating bare page (runtime data
+// at the top, no Suspense) leaves the static shell empty.
+//
+// Crucially, this layout does NOT export `unstable_instant = false`. If it
+// did, `isPageAllowedToBlock` would mark every route under this layout as
+// blocking-allowed, which suppresses the static-shell empty-shell error.
+// We want that error to surface here as the contrast against the
+// `with-root-suspense/` tree.
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/instant-validation-level-manual-warning/instant-validation-level-manual-warning.test.ts
+++ b/test/e2e/app-dir/instant-validation-level-manual-warning/instant-validation-level-manual-warning.test.ts
@@ -1,0 +1,442 @@
+import { nextTestSetup } from 'e2e-utils'
+import {
+  expectBuildValidationSkipped,
+  extractBuildValidationError,
+  parseValidationMessages,
+} from 'e2e-utils/instant-validation'
+import { getPrerenderOutput } from '../cache-components-errors/utils'
+import { waitForNoErrorToast } from '../../../lib/next-test-utils'
+
+describe('instant validation - level manual-warning', () => {
+  const { next, skipped, isNextDev, isNextStart, isTurbopack } = nextTestSetup({
+    files: __dirname,
+    skipStart: true,
+    skipDeployment: true,
+    env: {
+      NEXT_TEST_LOG_VALIDATION: '1',
+    },
+  })
+  if (skipped) return
+
+  if (isNextStart && !isTurbopack) {
+    it.skip('TODO: snapshot tests for webpack', () => {})
+    return
+  }
+
+  if (isNextStart) {
+    beforeAll(async () => {
+      await next.build({ args: ['--experimental-build-mode', 'compile'] })
+    })
+    afterEach(async () => {
+      await next.stop()
+    })
+  } else {
+    beforeAll(async () => {
+      await next.start()
+    })
+  }
+
+  const prerender = async (pathname: string) => {
+    return await next.build({
+      args: [
+        '--experimental-build-mode',
+        'generate',
+        '--debug-build-paths',
+        `app${pathname}/page.tsx`,
+      ],
+    })
+  }
+
+  // The fixture has two parallel route trees:
+  //
+  // - `with-root-suspense/`: layout wraps {children} in Suspense, so
+  //   static-shell validation is satisfied for pages that access runtime
+  //   data at the top. Under 'manual-warning', instant validation only
+  //   runs on segments that explicitly opt in via `unstable_instant`, so
+  //   violating bare pages produce no errors at all.
+  //
+  // - `without-root-suspense/`: layout renders {children} directly. A
+  //   bare violating page has no Suspense between the layout and the
+  //   runtime data, so static-shell validation surfaces an error. Under
+  //   'manual-warning', instant validation still does not run on bare
+  //   pages, so the error visible to the user is a static-shell error —
+  //   distinct from the instant validation error format.
+  //
+  // The contrast between the two trees demonstrates that 'manual-warning'
+  // does not silently opt routes into instant validation that hadn't
+  // asked for it.
+
+  describe('with-root-suspense', () => {
+    if (isNextDev) {
+      describe('dev', () => {
+        it('bare page: no errors (static shell satisfied, no manual opt-in)', async () => {
+          const browser = await next.browser('/with-root-suspense/bare')
+          await browser.elementByCss('main')
+          await waitForNoErrorToast(browser, { waitInMs: 500 })
+        })
+
+        it('explicit-error page: instant redbox surfaces under manual-warning', async () => {
+          const browser = await next.browser(
+            '/with-root-suspense/explicit-error'
+          )
+          await expect(browser).toDisplayCollapsedRedbox(`
+           {
+             "cause": [
+               {
+                 "label": "Caused by: Instant Validation",
+                 "source": "app/with-root-suspense/explicit-error/page.tsx (8:33) @ unstable_instant
+           >  8 | export const unstable_instant = { level: 'experimental-error' as const }
+                |                                 ^",
+                 "stack": [
+                   "unstable_instant app/with-root-suspense/explicit-error/page.tsx (8:33)",
+                   "Set.forEach <anonymous>",
+                 ],
+               },
+             ],
+             "code": "E1164",
+             "description": "Next.js encountered uncached data during the initial render.",
+             "environmentLabel": "Server",
+             "label": "Instant",
+             "source": "app/with-root-suspense/explicit-error/page.tsx (11:19) @ Page
+           > 11 |   await connection()
+                |                   ^",
+             "stack": [
+               "Page app/with-root-suspense/explicit-error/page.tsx (11:19)",
+             ],
+           }
+          `)
+        })
+
+        it('explicit-true page: opt-in falls back to warning level, instant redbox in dev', async () => {
+          const browser = await next.browser(
+            '/with-root-suspense/explicit-true'
+          )
+          await expect(browser).toDisplayCollapsedRedbox(`
+           {
+             "cause": [
+               {
+                 "label": "Caused by: Instant Validation",
+                 "source": "app/with-root-suspense/explicit-true/page.tsx (7:33) @ unstable_instant
+           >  7 | export const unstable_instant = true
+                |                                 ^",
+                 "stack": [
+                   "unstable_instant app/with-root-suspense/explicit-true/page.tsx (7:33)",
+                   "Set.forEach <anonymous>",
+                 ],
+               },
+             ],
+             "code": "E1164",
+             "description": "Next.js encountered uncached data during the initial render.",
+             "environmentLabel": "Server",
+             "label": "Instant",
+             "source": "app/with-root-suspense/explicit-true/page.tsx (10:19) @ Page
+           > 10 |   await connection()
+                |                   ^",
+             "stack": [
+               "Page app/with-root-suspense/explicit-true/page.tsx (10:19)",
+             ],
+           }
+          `)
+        })
+
+        it('explicit-warning page: instant redbox in dev', async () => {
+          const browser = await next.browser(
+            '/with-root-suspense/explicit-warning'
+          )
+          await expect(browser).toDisplayCollapsedRedbox(`
+           {
+             "cause": [
+               {
+                 "label": "Caused by: Instant Validation",
+                 "source": "app/with-root-suspense/explicit-warning/page.tsx (6:33) @ unstable_instant
+           > 6 | export const unstable_instant = { level: 'warning' as const }
+               |                                 ^",
+                 "stack": [
+                   "unstable_instant app/with-root-suspense/explicit-warning/page.tsx (6:33)",
+                   "Set.forEach <anonymous>",
+                 ],
+               },
+             ],
+             "code": "E1164",
+             "description": "Next.js encountered uncached data during the initial render.",
+             "environmentLabel": "Server",
+             "label": "Instant",
+             "source": "app/with-root-suspense/explicit-warning/page.tsx (9:19) @ Page
+           >  9 |   await connection()
+                |                   ^",
+             "stack": [
+               "Page app/with-root-suspense/explicit-warning/page.tsx (9:19)",
+             ],
+           }
+          `)
+        })
+      })
+    } else {
+      describe('build', () => {
+        it('bare page: no instant validation markers', async () => {
+          const result = await prerender('/with-root-suspense/bare')
+          expectBuildValidationSkipped(result)
+        })
+
+        it('explicit-true page: build skips validation (opt-in level falls back to warning)', async () => {
+          const result = await prerender('/with-root-suspense/explicit-true')
+          expectBuildValidationSkipped(result)
+        })
+
+        it('explicit-warning page: build skips validation (warning is dev-only)', async () => {
+          const result = await prerender('/with-root-suspense/explicit-warning')
+          expectBuildValidationSkipped(result)
+        })
+
+        it('explicit-error page: instant validation runs and fails the build', async () => {
+          const result = await prerender('/with-root-suspense/explicit-error')
+          expect(extractBuildValidationError(result.cliOutput))
+            .toMatchInlineSnapshot(`
+           "Error: Route "/with-root-suspense/explicit-error": Next.js encountered uncached data during the initial render.
+
+           \`fetch(...)\` or \`connection()\` accessed outside of \`<Suspense>\` blocks navigation, leading to a slower user experience.
+
+           Ways to fix this:
+             - Cache the data access with \`"use cache"\`
+             - Move the data access into a child component within a <Suspense> boundary
+             - Set \`export const instant = false\` to allow a blocking route
+
+           Learn more: https://nextjs.org/docs/messages/blocking-route
+               at a (<anonymous>)
+               at body (<anonymous>)
+               at html (<anonymous>)
+           Build-time instant validation failed for route "/with-root-suspense/explicit-error".
+           To get a more detailed stack trace and pinpoint the issue, try one of the following:
+             - Start the app in development mode by running \`next dev\`, then open "/with-root-suspense/explicit-error" in your browser to investigate the error.
+             - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+           Stopping prerender due to instant validation errors."
+          `)
+          expect(result.exitCode).not.toBe(0)
+        })
+      })
+    }
+  })
+
+  describe('without-root-suspense', () => {
+    if (isNextDev) {
+      describe('dev', () => {
+        it('bare page: static-shell error surfaces but is not labelled Instant', async () => {
+          const browser = await next.browser('/without-root-suspense/bare')
+          // Static-shell validation surfaces an error here because the
+          // layout has no Suspense to catch the runtime data accessed at
+          // the top of the page. The captured snapshot should NOT contain
+          // the "Instant" label — that's the proof that instant validation
+          // did not run under 'manual-warning'.
+          await expect(browser).toDisplayCollapsedRedbox(`
+           {
+             "code": "E1164",
+             "description": "Next.js encountered uncached data during the initial render.",
+             "environmentLabel": "Server",
+             "label": "Instant",
+             "source": "app/without-root-suspense/bare/page.tsx (10:19) @ Page
+           > 10 |   await connection()
+                |                   ^",
+             "stack": [
+               "Page app/without-root-suspense/bare/page.tsx (10:19)",
+             ],
+           }
+          `)
+        })
+
+        it('explicit-error page: instant redbox surfaces (instant subsumes static-shell when active)', async () => {
+          const browser = await next.browser(
+            '/without-root-suspense/explicit-error'
+          )
+          await expect(browser).toDisplayCollapsedRedbox(`
+           {
+             "code": "E1164",
+             "description": "Next.js encountered uncached data during the initial render.",
+             "environmentLabel": "Server",
+             "label": "Instant",
+             "source": "app/without-root-suspense/explicit-error/page.tsx (11:19) @ Page
+           > 11 |   await connection()
+                |                   ^",
+             "stack": [
+               "Page app/without-root-suspense/explicit-error/page.tsx (11:19)",
+             ],
+           }
+          `)
+        })
+
+        it('explicit-true page: instant redbox surfaces in dev', async () => {
+          const browser = await next.browser(
+            '/without-root-suspense/explicit-true'
+          )
+          await expect(browser).toDisplayCollapsedRedbox(`
+           {
+             "code": "E1164",
+             "description": "Next.js encountered uncached data during the initial render.",
+             "environmentLabel": "Server",
+             "label": "Instant",
+             "source": "app/without-root-suspense/explicit-true/page.tsx (11:19) @ Page
+           > 11 |   await connection()
+                |                   ^",
+             "stack": [
+               "Page app/without-root-suspense/explicit-true/page.tsx (11:19)",
+             ],
+           }
+          `)
+        })
+
+        it('explicit-warning page: instant redbox surfaces in dev', async () => {
+          const browser = await next.browser(
+            '/without-root-suspense/explicit-warning'
+          )
+          await expect(browser).toDisplayCollapsedRedbox(`
+           {
+             "code": "E1164",
+             "description": "Next.js encountered uncached data during the initial render.",
+             "environmentLabel": "Server",
+             "label": "Instant",
+             "source": "app/without-root-suspense/explicit-warning/page.tsx (10:19) @ Page
+           > 10 |   await connection()
+                |                   ^",
+             "stack": [
+               "Page app/without-root-suspense/explicit-warning/page.tsx (10:19)",
+             ],
+           }
+          `)
+        })
+      })
+    } else {
+      describe('build', () => {
+        // In build mode, cacheComponents' static-shell prerender catches the
+        // empty-shell first and fails the build before instant validation
+        // gets a chance to run. The build exits non-zero, but the failure
+        // is NOT from instant validation: no `<VALIDATION_MESSAGE>` markers,
+        // no "Build-time instant validation failed" text. The
+        // `getPrerenderOutput` snapshot captures the actual error format —
+        // it should be a static-shell prerender error, distinct from the
+        // instant validation error captured in `with-root-suspense`.
+
+        function expectBuildFailedWithoutInstantValidation(result: {
+          cliOutput: string
+          exitCode: number | NodeJS.Signals
+        }) {
+          expect(parseValidationMessages(result.cliOutput)).toHaveLength(0)
+          expect(result.cliOutput).not.toContain(
+            'Build-time instant validation failed'
+          )
+          expect(result.exitCode).not.toBe(0)
+        }
+
+        it('bare page: build fails with static-shell error, not instant', async () => {
+          const result = await prerender('/without-root-suspense/bare')
+          expectBuildFailedWithoutInstantValidation(result)
+          expect(getPrerenderOutput(result.cliOutput, { isMinified: true }))
+            .toMatchInlineSnapshot(`
+           "Error: Route "/without-root-suspense/bare": Next.js encountered uncached or runtime data during the initial render.
+
+           \`fetch(...)\`, \`cookies()\`, \`headers()\`, \`params\`, \`searchParams\`, or \`connection()\` accessed outside of \`<Suspense>\` blocks navigation, leading to a slower user experience.
+
+           Ways to fix this:
+             - Cache the data access with \`"use cache"\`
+             - Move the data access into a child component within a <Suspense> boundary
+             - Use \`generateStaticParams\` to make route params static
+             - Set \`export const instant = false\` to allow a blocking route
+
+           Learn more: https://nextjs.org/docs/messages/blocking-route
+               at body (<anonymous>)
+               at html (<anonymous>)
+           To get a more detailed stack trace and pinpoint the issue, try one of the following:
+             - Start the app in development mode by running \`next dev\`, then open "/without-root-suspense/bare" in your browser to investigate the error.
+             - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+           Error occurred prerendering page "/without-root-suspense/bare". Read more: https://nextjs.org/docs/messages/prerender-error
+           Export encountered an error on /without-root-suspense/bare/page: /without-root-suspense/bare, exiting the build."
+          `)
+        })
+
+        it('explicit-true page: build fails with static-shell error, not instant', async () => {
+          const result = await prerender('/without-root-suspense/explicit-true')
+          expectBuildFailedWithoutInstantValidation(result)
+          expect(getPrerenderOutput(result.cliOutput, { isMinified: true }))
+            .toMatchInlineSnapshot(`
+           "Error: Route "/without-root-suspense/explicit-true": Next.js encountered uncached or runtime data during the initial render.
+
+           \`fetch(...)\`, \`cookies()\`, \`headers()\`, \`params\`, \`searchParams\`, or \`connection()\` accessed outside of \`<Suspense>\` blocks navigation, leading to a slower user experience.
+
+           Ways to fix this:
+             - Cache the data access with \`"use cache"\`
+             - Move the data access into a child component within a <Suspense> boundary
+             - Use \`generateStaticParams\` to make route params static
+             - Set \`export const instant = false\` to allow a blocking route
+
+           Learn more: https://nextjs.org/docs/messages/blocking-route
+               at body (<anonymous>)
+               at html (<anonymous>)
+           To get a more detailed stack trace and pinpoint the issue, try one of the following:
+             - Start the app in development mode by running \`next dev\`, then open "/without-root-suspense/explicit-true" in your browser to investigate the error.
+             - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+           Error occurred prerendering page "/without-root-suspense/explicit-true". Read more: https://nextjs.org/docs/messages/prerender-error
+           Export encountered an error on /without-root-suspense/explicit-true/page: /without-root-suspense/explicit-true, exiting the build."
+          `)
+        })
+
+        it('explicit-warning page: build fails with static-shell error, not instant', async () => {
+          const result = await prerender(
+            '/without-root-suspense/explicit-warning'
+          )
+          expectBuildFailedWithoutInstantValidation(result)
+          expect(getPrerenderOutput(result.cliOutput, { isMinified: true }))
+            .toMatchInlineSnapshot(`
+           "Error: Route "/without-root-suspense/explicit-warning": Next.js encountered uncached or runtime data during the initial render.
+
+           \`fetch(...)\`, \`cookies()\`, \`headers()\`, \`params\`, \`searchParams\`, or \`connection()\` accessed outside of \`<Suspense>\` blocks navigation, leading to a slower user experience.
+
+           Ways to fix this:
+             - Cache the data access with \`"use cache"\`
+             - Move the data access into a child component within a <Suspense> boundary
+             - Use \`generateStaticParams\` to make route params static
+             - Set \`export const instant = false\` to allow a blocking route
+
+           Learn more: https://nextjs.org/docs/messages/blocking-route
+               at body (<anonymous>)
+               at html (<anonymous>)
+           To get a more detailed stack trace and pinpoint the issue, try one of the following:
+             - Start the app in development mode by running \`next dev\`, then open "/without-root-suspense/explicit-warning" in your browser to investigate the error.
+             - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+           Error occurred prerendering page "/without-root-suspense/explicit-warning". Read more: https://nextjs.org/docs/messages/prerender-error
+           Export encountered an error on /without-root-suspense/explicit-warning/page: /without-root-suspense/explicit-warning, exiting the build."
+          `)
+        })
+
+        it('explicit-error page: build fails with static-shell error, not instant', async () => {
+          // Even with `unstable_instant = { level: 'experimental-error' }`, the build
+          // fails at the prerender step (empty static shell) before the
+          // instant validation pipeline runs. The error reported is the
+          // static-shell error, not "Build-time instant validation failed".
+          const result = await prerender(
+            '/without-root-suspense/explicit-error'
+          )
+          expectBuildFailedWithoutInstantValidation(result)
+          expect(getPrerenderOutput(result.cliOutput, { isMinified: true }))
+            .toMatchInlineSnapshot(`
+           "Error: Route "/without-root-suspense/explicit-error": Next.js encountered uncached or runtime data during the initial render.
+
+           \`fetch(...)\`, \`cookies()\`, \`headers()\`, \`params\`, \`searchParams\`, or \`connection()\` accessed outside of \`<Suspense>\` blocks navigation, leading to a slower user experience.
+
+           Ways to fix this:
+             - Cache the data access with \`"use cache"\`
+             - Move the data access into a child component within a <Suspense> boundary
+             - Use \`generateStaticParams\` to make route params static
+             - Set \`export const instant = false\` to allow a blocking route
+
+           Learn more: https://nextjs.org/docs/messages/blocking-route
+               at body (<anonymous>)
+               at html (<anonymous>)
+           To get a more detailed stack trace and pinpoint the issue, try one of the following:
+             - Start the app in development mode by running \`next dev\`, then open "/without-root-suspense/explicit-error" in your browser to investigate the error.
+             - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+           Error occurred prerendering page "/without-root-suspense/explicit-error". Read more: https://nextjs.org/docs/messages/prerender-error
+           Export encountered an error on /without-root-suspense/explicit-error/page: /without-root-suspense/explicit-error, exiting the build."
+          `)
+        })
+      })
+    }
+  })
+})

--- a/test/e2e/app-dir/instant-validation-level-manual-warning/next.config.ts
+++ b/test/e2e/app-dir/instant-validation-level-manual-warning/next.config.ts
@@ -1,0 +1,15 @@
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  cacheComponents: true,
+  experimental: {
+    instantInsights: {
+      validationLevel: 'manual-warning',
+    },
+  },
+  typescript: {
+    ignoreBuildErrors: true,
+  },
+}
+
+export default nextConfig

--- a/test/e2e/app-dir/instant-validation-level-warning/app/bare/page.tsx
+++ b/test/e2e/app-dir/instant-validation-level-warning/app/bare/page.tsx
@@ -1,0 +1,16 @@
+// Bare page (no `unstable_instant` config). Under 'warning', implicit
+// validation fires on this page in dev (and only in dev — warning
+// is dev-only). The runtime data accessed at the top of the page is the
+// "Suspense too high for instant navigation" violation that instant
+// validation specifically flags. The root layout's Suspense satisfies
+// static-shell validation, so the only error in dev is the instant one.
+import { connection } from 'next/server'
+
+export default async function Page() {
+  await connection()
+  return (
+    <main>
+      <p>bare page (no unstable_instant), runtime data at the top.</p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/instant-validation-level-warning/app/explicit-error/page.tsx
+++ b/test/e2e/app-dir/instant-validation-level-warning/app/explicit-error/page.tsx
@@ -1,0 +1,19 @@
+// Same violation as `bare/page.tsx`, but with `unstable_instant = { level:
+// 'error' }`. Per-segment override raises the level from the configured
+// 'warning' to 'error', so build validation fires and fails the build in
+// addition to the dev redbox.
+import { connection } from 'next/server'
+
+export const unstable_instant = { level: 'experimental-error' as const }
+
+export default async function Page() {
+  await connection()
+  return (
+    <main>
+      <p>
+        explicit-error: per-segment `level: 'experimental-error'` escalates over
+        'warning'.
+      </p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/instant-validation-level-warning/app/explicit-false/page.tsx
+++ b/test/e2e/app-dir/instant-validation-level-warning/app/explicit-false/page.tsx
@@ -1,0 +1,16 @@
+// Same violation as `bare/page.tsx`, but with `unstable_instant = false`.
+// The explicit opt-out should suppress implicit validation entirely — no
+// instant redbox in dev, no markers in build, despite the runtime data
+// access at the top of the page.
+import { connection } from 'next/server'
+
+export const unstable_instant = false
+
+export default async function Page() {
+  await connection()
+  return (
+    <main>
+      <p>explicit-false: explicit opt-out suppresses validation.</p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/instant-validation-level-warning/app/explicit-true/page.tsx
+++ b/test/e2e/app-dir/instant-validation-level-warning/app/explicit-true/page.tsx
@@ -1,0 +1,17 @@
+// Same violation as `bare/page.tsx`, but with `unstable_instant = true`.
+// `true` is "opt in at the framework default level" — under 'warning',
+// this resolves to warning-level validation. Validation fires in dev
+// only. Same observable behavior as `bare/page.tsx`; this case proves the
+// override mechanism works at the same level as the configured one.
+import { connection } from 'next/server'
+
+export const unstable_instant = true
+
+export default async function Page() {
+  await connection()
+  return (
+    <main>
+      <p>explicit-true: opt in at the framework default level.</p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/instant-validation-level-warning/app/explicit-warning/page.tsx
+++ b/test/e2e/app-dir/instant-validation-level-warning/app/explicit-warning/page.tsx
@@ -1,0 +1,17 @@
+// Same violation as `bare/page.tsx`, but with `unstable_instant = { level:
+// 'warning' }`. Explicit per-segment override at the same level as the
+// configured 'warning'. Same observable behavior as `bare/page.tsx`; this
+// case proves the override mechanism resolves correctly when the explicit
+// value matches the configured level.
+import { connection } from 'next/server'
+
+export const unstable_instant = { level: 'warning' as const }
+
+export default async function Page() {
+  await connection()
+  return (
+    <main>
+      <p>explicit-warning: explicit warning-level override.</p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/instant-validation-level-warning/app/layered/layout.tsx
+++ b/test/e2e/app-dir/instant-validation-level-warning/app/layered/layout.tsx
@@ -1,0 +1,14 @@
+import { type ReactNode } from 'react'
+
+// This intermediate layout exports `unstable_instant = false`. The walker
+// treats `false` as a per-segment no-op — it doesn't suppress validation
+// of descendant page/default segments. So the bare page under this layout
+// should still be implicitly validated under 'warning'.
+//
+// The `false` here only "shields" this layout's own load from being
+// considered blocking; it does not act as a global opt-out for the route.
+export const unstable_instant = false
+
+export default function LayeredLayout({ children }: { children: ReactNode }) {
+  return <>{children}</>
+}

--- a/test/e2e/app-dir/instant-validation-level-warning/app/layered/page.tsx
+++ b/test/e2e/app-dir/instant-validation-level-warning/app/layered/page.tsx
@@ -1,0 +1,14 @@
+// Bare page (no `unstable_instant` config) sitting under a layout that
+// exports `unstable_instant = false`. Under 'warning', implicit validation
+// should still fire for this page in dev — the layout's `false` doesn't
+// shield descendants.
+import { connection } from 'next/server'
+
+export default async function Page() {
+  await connection()
+  return (
+    <main>
+      <p>layered: bare page under a layout with `unstable_instant = false`.</p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/instant-validation-level-warning/app/layout.tsx
+++ b/test/e2e/app-dir/instant-validation-level-warning/app/layout.tsx
@@ -1,0 +1,22 @@
+import { Suspense, type ReactNode } from 'react'
+
+// Validation level is 'warning' (set in next.config.ts).
+// Bare page/default segments get implicit validation in dev only — build
+// is unaffected unless a segment explicitly overrides with `level: 'experimental-error'`.
+//
+// Children are wrapped in Suspense so that pages with runtime data
+// accessed at the top of the page don't fail static-shell validation
+// (the Suspense fallback renders into the static shell). Instant
+// validation flags "Suspense too high for instant navigation" as an
+// instant-specific violation when it runs.
+export const unstable_instant = false
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>
+        <Suspense fallback={<p>loading…</p>}>{children}</Suspense>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/instant-validation-level-warning/instant-validation-level-warning.test.ts
+++ b/test/e2e/app-dir/instant-validation-level-warning/instant-validation-level-warning.test.ts
@@ -1,0 +1,248 @@
+import { nextTestSetup } from 'e2e-utils'
+import {
+  expectBuildValidationSkipped,
+  extractBuildValidationError,
+} from 'e2e-utils/instant-validation'
+import { waitForNoErrorToast } from '../../../lib/next-test-utils'
+
+describe('instant validation - level warning', () => {
+  const { next, skipped, isNextDev, isNextStart, isTurbopack } = nextTestSetup({
+    files: __dirname,
+    skipStart: true,
+    skipDeployment: true,
+    env: {
+      NEXT_TEST_LOG_VALIDATION: '1',
+    },
+  })
+  if (skipped) return
+
+  if (isNextStart && !isTurbopack) {
+    it.skip('TODO: snapshot tests for webpack', () => {})
+    return
+  }
+
+  if (isNextStart) {
+    beforeAll(async () => {
+      await next.build({ args: ['--experimental-build-mode', 'compile'] })
+    })
+    afterEach(async () => {
+      await next.stop()
+    })
+  } else {
+    beforeAll(async () => {
+      await next.start()
+    })
+  }
+
+  const prerender = async (pathname: string) => {
+    return await next.build({
+      args: [
+        '--experimental-build-mode',
+        'generate',
+        '--debug-build-paths',
+        `app${pathname}/page.tsx`,
+      ],
+    })
+  }
+
+  // Validation level is 'warning'. Implicit validation fires on bare
+  // pages in dev only — build does not validate unless a segment
+  // explicitly escalates with `level: 'experimental-error'`. Per-segment overrides
+  // (`level`, `true`, `false`) layer on top of this.
+  //
+  // Static-shell concerns are handled by the root layout's Suspense, so
+  // the only errors that surface here are instant validation errors —
+  // making the level/override behavior cleanly observable.
+
+  if (isNextDev) {
+    describe('dev', () => {
+      it('bare page: implicit validation surfaces a redbox (warning level fires)', async () => {
+        const browser = await next.browser('/bare')
+        await expect(browser).toDisplayCollapsedRedbox(`
+         {
+           "code": "E1164",
+           "description": "Next.js encountered uncached data during the initial render.",
+           "environmentLabel": "Server",
+           "label": "Instant",
+           "source": "app/bare/page.tsx (10:19) @ Page
+         > 10 |   await connection()
+              |                   ^",
+           "stack": [
+             "Page app/bare/page.tsx (10:19)",
+           ],
+         }
+        `)
+      })
+
+      it('explicit-error page: instant redbox surfaces in dev', async () => {
+        const browser = await next.browser('/explicit-error')
+        await expect(browser).toDisplayCollapsedRedbox(`
+         {
+           "cause": [
+             {
+               "label": "Caused by: Instant Validation",
+               "source": "app/explicit-error/page.tsx (7:33) @ unstable_instant
+         >  7 | export const unstable_instant = { level: 'experimental-error' as const }
+              |                                 ^",
+               "stack": [
+                 "unstable_instant app/explicit-error/page.tsx (7:33)",
+                 "Set.forEach <anonymous>",
+               ],
+             },
+           ],
+           "code": "E1164",
+           "description": "Next.js encountered uncached data during the initial render.",
+           "environmentLabel": "Server",
+           "label": "Instant",
+           "source": "app/explicit-error/page.tsx (10:19) @ Page
+         > 10 |   await connection()
+              |                   ^",
+           "stack": [
+             "Page app/explicit-error/page.tsx (10:19)",
+           ],
+         }
+        `)
+      })
+
+      it('explicit-true page: aliases to warning level, instant redbox in dev', async () => {
+        const browser = await next.browser('/explicit-true')
+        await expect(browser).toDisplayCollapsedRedbox(`
+         {
+           "cause": [
+             {
+               "label": "Caused by: Instant Validation",
+               "source": "app/explicit-true/page.tsx (8:33) @ unstable_instant
+         >  8 | export const unstable_instant = true
+              |                                 ^",
+               "stack": [
+                 "unstable_instant app/explicit-true/page.tsx (8:33)",
+                 "Set.forEach <anonymous>",
+               ],
+             },
+           ],
+           "code": "E1164",
+           "description": "Next.js encountered uncached data during the initial render.",
+           "environmentLabel": "Server",
+           "label": "Instant",
+           "source": "app/explicit-true/page.tsx (11:19) @ Page
+         > 11 |   await connection()
+              |                   ^",
+           "stack": [
+             "Page app/explicit-true/page.tsx (11:19)",
+           ],
+         }
+        `)
+      })
+
+      it('explicit-warning page: explicit override at the configured level, instant redbox in dev', async () => {
+        const browser = await next.browser('/explicit-warning')
+        await expect(browser).toDisplayCollapsedRedbox(`
+         {
+           "cause": [
+             {
+               "label": "Caused by: Instant Validation",
+               "source": "app/explicit-warning/page.tsx (8:33) @ unstable_instant
+         >  8 | export const unstable_instant = { level: 'warning' as const }
+              |                                 ^",
+               "stack": [
+                 "unstable_instant app/explicit-warning/page.tsx (8:33)",
+                 "Set.forEach <anonymous>",
+               ],
+             },
+           ],
+           "code": "E1164",
+           "description": "Next.js encountered uncached data during the initial render.",
+           "environmentLabel": "Server",
+           "label": "Instant",
+           "source": "app/explicit-warning/page.tsx (11:19) @ Page
+         > 11 |   await connection()
+              |                   ^",
+           "stack": [
+             "Page app/explicit-warning/page.tsx (11:19)",
+           ],
+         }
+        `)
+      })
+
+      it('explicit-false page: opt-out suppresses validation, no redbox', async () => {
+        const browser = await next.browser('/explicit-false')
+        await browser.elementByCss('main')
+        await waitForNoErrorToast(browser, { waitInMs: 500 })
+      })
+
+      it('layered: bare page under layout-with-instant-false still validates', async () => {
+        // The intermediate layout exports `unstable_instant = false`, but
+        // that's per-segment — it doesn't shield descendants. The bare
+        // page should still surface an instant redbox in dev.
+        const browser = await next.browser('/layered')
+        await expect(browser).toDisplayCollapsedRedbox(`
+         {
+           "code": "E1164",
+           "description": "Next.js encountered uncached data during the initial render.",
+           "environmentLabel": "Server",
+           "label": "Instant",
+           "source": "app/layered/page.tsx (8:19) @ Page
+         >  8 |   await connection()
+              |                   ^",
+           "stack": [
+             "Page app/layered/page.tsx (8:19)",
+           ],
+         }
+        `)
+      })
+    })
+  } else {
+    describe('build', () => {
+      it('bare page: build skips validation (warning is dev-only)', async () => {
+        const result = await prerender('/bare')
+        expectBuildValidationSkipped(result)
+      })
+
+      it('explicit-error page: per-segment escalation runs build validation and fails', async () => {
+        const result = await prerender('/explicit-error')
+        expect(extractBuildValidationError(result.cliOutput))
+          .toMatchInlineSnapshot(`
+         "Error: Route "/explicit-error": Next.js encountered uncached data during the initial render.
+
+         \`fetch(...)\` or \`connection()\` accessed outside of \`<Suspense>\` blocks navigation, leading to a slower user experience.
+
+         Ways to fix this:
+           - Cache the data access with \`"use cache"\`
+           - Move the data access into a child component within a <Suspense> boundary
+           - Set \`export const instant = false\` to allow a blocking route
+
+         Learn more: https://nextjs.org/docs/messages/blocking-route
+             at a (<anonymous>)
+             at body (<anonymous>)
+             at html (<anonymous>)
+         Build-time instant validation failed for route "/explicit-error".
+         To get a more detailed stack trace and pinpoint the issue, try one of the following:
+           - Start the app in development mode by running \`next dev\`, then open "/explicit-error" in your browser to investigate the error.
+           - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+         Stopping prerender due to instant validation errors."
+        `)
+        expect(result.exitCode).not.toBe(0)
+      })
+
+      it('explicit-true page: build skips validation (alias to warning)', async () => {
+        const result = await prerender('/explicit-true')
+        expectBuildValidationSkipped(result)
+      })
+
+      it('explicit-warning page: build skips validation (explicit warning is dev-only)', async () => {
+        const result = await prerender('/explicit-warning')
+        expectBuildValidationSkipped(result)
+      })
+
+      it('explicit-false page: opt-out skips validation', async () => {
+        const result = await prerender('/explicit-false')
+        expectBuildValidationSkipped(result)
+      })
+
+      it('layered: bare page under layout-with-instant-false skips validation in build (warning is dev-only)', async () => {
+        const result = await prerender('/layered')
+        expectBuildValidationSkipped(result)
+      })
+    })
+  }
+})

--- a/test/e2e/app-dir/instant-validation-level-warning/next.config.ts
+++ b/test/e2e/app-dir/instant-validation-level-warning/next.config.ts
@@ -1,0 +1,15 @@
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  cacheComponents: true,
+  experimental: {
+    instantInsights: {
+      validationLevel: 'warning',
+    },
+  },
+  typescript: {
+    ignoreBuildErrors: true,
+  },
+}
+
+export default nextConfig

--- a/test/e2e/app-dir/instant-validation/app/default/static/valid-blocked-children/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/default/static/valid-blocked-children/page.tsx
@@ -1,7 +1,7 @@
 import { connection } from 'next/server'
 import { Suspense } from 'react'
 
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/default/static/valid-blocked-children/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/default/static/valid-blocked-children/page.tsx
@@ -1,7 +1,7 @@
 import { connection } from 'next/server'
 import { Suspense } from 'react'
 
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/default/static/valid-blocking-inside-static/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/default/static/valid-blocking-inside-static/layout.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from 'react'
 
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default function StaticLayout({ children }) {
   return (

--- a/test/e2e/app-dir/instant-validation/app/default/static/valid-blocking-inside-static/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/default/static/valid-blocking-inside-static/layout.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from 'react'
 
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default function StaticLayout({ children }) {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/disable-validation/disable-build/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/disable-validation/disable-build/page.tsx
@@ -1,7 +1,7 @@
 import { connection } from 'next/server'
 
 export const unstable_instant = {
-  level: 'error',
+  level: 'experimental-error',
   unstable_disableBuildValidation: true,
 }
 

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/disable-validation/disable-build/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/disable-validation/disable-build/page.tsx
@@ -1,6 +1,9 @@
 import { connection } from 'next/server'
 
-export const unstable_instant = { unstable_disableBuildValidation: true }
+export const unstable_instant = {
+  level: 'error',
+  unstable_disableBuildValidation: true,
+}
 
 export default async function Page() {
   await connection()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/disable-validation/disable-dev/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/disable-validation/disable-dev/page.tsx
@@ -1,7 +1,7 @@
 import { connection } from 'next/server'
 
 export const unstable_instant = {
-  level: 'error',
+  level: 'experimental-error',
   unstable_disableDevValidation: true,
 }
 

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/disable-validation/disable-dev/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/disable-validation/disable-dev/page.tsx
@@ -1,6 +1,9 @@
 import { connection } from 'next/server'
 
-export const unstable_instant = { unstable_disableDevValidation: true }
+export const unstable_instant = {
+  level: 'error',
+  unstable_disableDevValidation: true,
+}
 
 export default async function Page() {
   await connection()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/disable-validation/in-layout/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/disable-validation/in-layout/layout.tsx
@@ -1,5 +1,5 @@
 export const unstable_instant = {
-  samples: [{ cookies: [] }],
+  unstable_samples: [{ cookies: [] }],
   unstable_disableValidation: true,
 }
 export const unstable_prefetch = 'force-runtime'

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/disable-validation/in-page-with-outer/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/disable-validation/in-page-with-outer/layout.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default function Layout({ children }) {
   return <>{children}</>

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/disable-validation/in-page-with-outer/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/disable-validation/in-page-with-outer/layout.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default function Layout({ children }) {
   return <>{children}</>

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/disable-validation/in-page-with-outer/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/disable-validation/in-page-with-outer/page.tsx
@@ -1,7 +1,7 @@
 import { connection } from 'next/server'
 
 export const unstable_instant = {
-  samples: [{ cookies: [] }],
+  unstable_samples: [{ cookies: [] }],
   unstable_disableValidation: true,
 }
 export const unstable_prefetch = 'force-runtime'

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/disable-validation/in-page/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/disable-validation/in-page/page.tsx
@@ -1,7 +1,7 @@
 import { connection } from 'next/server'
 
 export const unstable_instant = {
-  samples: [{ cookies: [] }],
+  unstable_samples: [{ cookies: [] }],
   unstable_disableValidation: true,
 }
 export const unstable_prefetch = 'force-runtime'

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/invalid-dynamic-viewport-in-blocking-inside-static/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/invalid-dynamic-viewport-in-blocking-inside-static/layout.tsx
@@ -1,6 +1,6 @@
 import { ReactNode, Suspense } from 'react'
 
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default function Layout({ children }: { children: ReactNode }) {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/invalid-dynamic-viewport-in-blocking-inside-static/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/invalid-dynamic-viewport-in-blocking-inside-static/layout.tsx
@@ -1,6 +1,6 @@
 import { ReactNode, Suspense } from 'react'
 
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default function Layout({ children }: { children: ReactNode }) {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/invalid-dynamic-viewport-in-runtime/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/invalid-dynamic-viewport-in-runtime/page.tsx
@@ -3,7 +3,7 @@ import { cookies } from 'next/headers'
 import { connection } from 'next/server'
 import { Suspense } from 'react'
 
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 export const unstable_prefetch = 'force-runtime'
 
 // Note that we're inside a root layout with suspense, so we skip the static shell

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/invalid-dynamic-viewport-in-runtime/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/invalid-dynamic-viewport-in-runtime/page.tsx
@@ -3,7 +3,7 @@ import { cookies } from 'next/headers'
 import { connection } from 'next/server'
 import { Suspense } from 'react'
 
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 export const unstable_prefetch = 'force-runtime'
 
 // Note that we're inside a root layout with suspense, so we skip the static shell

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/invalid-runtime-viewport-in-static/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/invalid-runtime-viewport-in-static/layout.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Layout({ children }) {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/invalid-runtime-viewport-in-static/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/invalid-runtime-viewport-in-static/layout.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Layout({ children }) {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/invalid-runtime-viewport-in-static/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/invalid-runtime-viewport-in-static/page.tsx
@@ -5,7 +5,7 @@ import { cookies } from 'next/headers'
 // This would be valid if it used a runtime prefetch (because then it wouldn't block navigation),
 // but it's static, so it's invalid. As an extra sanity check, we put a runtime prefetch on the
 // layout above, and that should not make this error go away.
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export async function generateViewport(): Promise<Viewport> {
   await cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/invalid-runtime-viewport-in-static/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/invalid-runtime-viewport-in-static/page.tsx
@@ -5,7 +5,7 @@ import { cookies } from 'next/headers'
 // This would be valid if it used a runtime prefetch (because then it wouldn't block navigation),
 // but it's static, so it's invalid. As an extra sanity check, we put a runtime prefetch on the
 // layout above, and that should not make this error go away.
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export async function generateViewport(): Promise<Viewport> {
   await cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/valid-dynamic-metadata-in-runtime/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/valid-dynamic-metadata-in-runtime/page.tsx
@@ -3,7 +3,7 @@ import { cookies } from 'next/headers'
 import { connection } from 'next/server'
 import { Suspense } from 'react'
 
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 export const unstable_prefetch = 'force-runtime'
 
 export async function generateMetadata(): Promise<Metadata> {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/valid-dynamic-metadata-in-runtime/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/valid-dynamic-metadata-in-runtime/page.tsx
@@ -3,7 +3,7 @@ import { cookies } from 'next/headers'
 import { connection } from 'next/server'
 import { Suspense } from 'react'
 
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 export const unstable_prefetch = 'force-runtime'
 
 export async function generateMetadata(): Promise<Metadata> {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/valid-runtime-metadata-in-static/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/valid-runtime-metadata-in-static/page.tsx
@@ -2,7 +2,7 @@ import { Metadata } from 'next'
 import { cookies } from 'next/headers'
 import { Suspense } from 'react'
 
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export async function generateMetadata(): Promise<Metadata> {
   await cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/valid-runtime-metadata-in-static/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/valid-runtime-metadata-in-static/page.tsx
@@ -2,7 +2,7 @@ import { Metadata } from 'next'
 import { cookies } from 'next/headers'
 import { Suspense } from 'react'
 
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export async function generateMetadata(): Promise<Metadata> {
   await cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/valid-runtime-viewport-in-runtime/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/valid-runtime-viewport-in-runtime/page.tsx
@@ -1,7 +1,7 @@
 import type { Viewport } from 'next'
 import { cookies } from 'next/headers'
 
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 export const unstable_prefetch = 'force-runtime'
 
 export async function generateViewport(): Promise<Viewport> {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/valid-runtime-viewport-in-runtime/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/valid-runtime-viewport-in-runtime/page.tsx
@@ -1,7 +1,7 @@
 import type { Viewport } from 'next'
 import { cookies } from 'next/headers'
 
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 export const unstable_prefetch = 'force-runtime'
 
 export async function generateViewport(): Promise<Viewport> {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/both-configs/@slot/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/both-configs/@slot/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default function SlotPage() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/both-configs/@slot/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/both-configs/@slot/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default function SlotPage() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/both-configs/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/both-configs/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/both-configs/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/both-configs/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/children-config-with-slot/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/children-config-with-slot/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/children-config-with-slot/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/children-config-with-slot/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/conditional-breadcrumbs/show-both/blocked/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/conditional-breadcrumbs/show-both/blocked/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 export default function Page() {
   return <p>show-both/blocked — children page with instant config</p>
 }

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/conditional-breadcrumbs/show-both/blocked/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/conditional-breadcrumbs/show-both/blocked/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 export default function Page() {
   return <p>show-both/blocked — children page with instant config</p>
 }

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/conditional-breadcrumbs/show-both/unblocked/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/conditional-breadcrumbs/show-both/unblocked/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 export default function Page() {
   return <p>show-both/unblocked — children page with instant config</p>
 }

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/conditional-breadcrumbs/show-both/unblocked/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/conditional-breadcrumbs/show-both/unblocked/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 export default function Page() {
   return <p>show-both/unblocked — children page with instant config</p>
 }

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/conditional-breadcrumbs/show-only-breadcrumbs/blocked/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/conditional-breadcrumbs/show-only-breadcrumbs/blocked/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 export default function Page() {
   return (
     <p>show-only-breadcrumbs/blocked — children page with instant config</p>

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/conditional-breadcrumbs/show-only-breadcrumbs/blocked/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/conditional-breadcrumbs/show-only-breadcrumbs/blocked/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 export default function Page() {
   return (
     <p>show-only-breadcrumbs/blocked — children page with instant config</p>

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/conditional-breadcrumbs/show-only-breadcrumbs/unblocked/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/conditional-breadcrumbs/show-only-breadcrumbs/unblocked/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 export default function Page() {
   return (
     <p>show-only-breadcrumbs/unblocked — children page with instant config</p>

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/conditional-breadcrumbs/show-only-breadcrumbs/unblocked/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/conditional-breadcrumbs/show-only-breadcrumbs/unblocked/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 export default function Page() {
   return (
     <p>show-only-breadcrumbs/unblocked — children page with instant config</p>

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/conditional-breadcrumbs/show-only-children/blocked/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/conditional-breadcrumbs/show-only-children/blocked/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 export default function Page() {
   return <p>show-only-children/blocked — children page with instant config</p>
 }

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/conditional-breadcrumbs/show-only-children/blocked/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/conditional-breadcrumbs/show-only-children/blocked/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 export default function Page() {
   return <p>show-only-children/blocked — children page with instant config</p>
 }

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/conditional-breadcrumbs/show-only-children/unblocked/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/conditional-breadcrumbs/show-only-children/unblocked/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 export default function Page() {
   return <p>show-only-children/unblocked — children page with instant config</p>
 }

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/conditional-breadcrumbs/show-only-children/unblocked/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/conditional-breadcrumbs/show-only-children/unblocked/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 export default function Page() {
   return <p>show-only-children/unblocked — children page with instant config</p>
 }

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/fork-layout-config-with-slot/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/fork-layout-config-with-slot/layout.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react'
 
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default function Layout({
   children,

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/fork-layout-config-with-slot/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/fork-layout-config-with-slot/layout.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react'
 
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default function Layout({
   children,

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/slot-config-children-suspended/@slot/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/slot-config-children-suspended/@slot/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default function SlotPage() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/slot-config-children-suspended/@slot/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/slot-config-children-suspended/@slot/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default function SlotPage() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/slot-config-only/@slot/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/slot-config-only/@slot/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default function SlotPage() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/slot-config-only/@slot/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/slot-config-only/@slot/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default function SlotPage() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/slot-layout-config/@slot/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/slot-layout-config/@slot/layout.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react'
 
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default function SlotLayout({ children }: { children: ReactNode }) {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/slot-layout-config/@slot/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/slot-layout-config/@slot/layout.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react'
 
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default function SlotLayout({ children }: { children: ReactNode }) {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/slot-runtime-config/@slot/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/slot-runtime-config/@slot/page.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from 'react'
 import { connection } from 'next/server'
 
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 export const unstable_prefetch = 'force-runtime'
 
 export default function SlotPage() {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/slot-runtime-config/@slot/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/parallel/slot-runtime-config/@slot/page.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from 'react'
 import { connection } from 'next/server'
 
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 export const unstable_prefetch = 'force-runtime'
 
 export default function SlotPage() {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-blocking-inside-runtime/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-blocking-inside-runtime/layout.tsx
@@ -1,6 +1,6 @@
 import { cookies } from 'next/headers'
 
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 export const unstable_prefetch = 'force-runtime'
 
 export default async function RuntimeLayout({ children }) {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-blocking-inside-runtime/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-blocking-inside-runtime/layout.tsx
@@ -1,6 +1,6 @@
 import { cookies } from 'next/headers'
 
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 export const unstable_prefetch = 'force-runtime'
 
 export default async function RuntimeLayout({ children }) {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-after-cache-with-cookie-input/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-after-cache-with-cookie-input/page.tsx
@@ -1,6 +1,6 @@
 import { cookies } from 'next/headers'
 
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 export const unstable_prefetch = 'force-runtime'
 
 // This page HAS runtime prefetch enabled. cookies() is passed as a promise

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-after-cache-with-cookie-input/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-after-cache-with-cookie-input/page.tsx
@@ -1,6 +1,6 @@
 import { cookies } from 'next/headers'
 
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 export const unstable_prefetch = 'force-runtime'
 
 // This page HAS runtime prefetch enabled. cookies() is passed as a promise

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-in-generate-metadata/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-in-generate-metadata/page.tsx
@@ -1,7 +1,7 @@
 import { cookies } from 'next/headers'
 import { Suspense } from 'react'
 
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 export const unstable_prefetch = 'force-runtime'
 
 export async function generateMetadata() {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-in-generate-metadata/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-in-generate-metadata/page.tsx
@@ -1,7 +1,7 @@
 import { cookies } from 'next/headers'
 import { Suspense } from 'react'
 
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 export const unstable_prefetch = 'force-runtime'
 
 export async function generateMetadata() {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-in-layout-generate-metadata/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-in-layout-generate-metadata/page.tsx
@@ -1,7 +1,7 @@
 import { cookies } from 'next/headers'
 import { Suspense } from 'react'
 
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 export const unstable_prefetch = 'force-runtime'
 
 async function Runtime() {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-in-layout-generate-metadata/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-in-layout-generate-metadata/page.tsx
@@ -1,7 +1,7 @@
 import { cookies } from 'next/headers'
 import { Suspense } from 'react'
 
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 export const unstable_prefetch = 'force-runtime'
 
 async function Runtime() {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-in-runtime-with-valid-static-parent/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-in-runtime-with-valid-static-parent/page.tsx
@@ -1,6 +1,6 @@
 import { cookies } from 'next/headers'
 
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 export const unstable_prefetch = 'force-runtime'
 
 // This page HAS runtime prefetch enabled. The sync IO (Date.now()) after

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-in-runtime-with-valid-static-parent/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-in-runtime-with-valid-static-parent/page.tsx
@@ -1,6 +1,6 @@
 import { cookies } from 'next/headers'
 
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 export const unstable_prefetch = 'force-runtime'
 
 // This page HAS runtime prefetch enabled. The sync IO (Date.now()) after

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io/page.tsx
@@ -1,6 +1,6 @@
 import { cookies } from 'next/headers'
 
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io/page.tsx
@@ -1,6 +1,6 @@
 import { cookies } from 'next/headers'
 
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/missing-suspense-around-dynamic-layout/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/missing-suspense-around-dynamic-layout/layout.tsx
@@ -1,7 +1,7 @@
 import { connection } from 'next/server'
 import { ReactNode } from 'react'
 
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Layout({ children }: { children: ReactNode }) {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/missing-suspense-around-dynamic-layout/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/missing-suspense-around-dynamic-layout/layout.tsx
@@ -1,7 +1,7 @@
 import { connection } from 'next/server'
 import { ReactNode } from 'react'
 
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Layout({ children }: { children: ReactNode }) {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/missing-suspense-around-dynamic/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/missing-suspense-around-dynamic/page.tsx
@@ -1,7 +1,7 @@
 import { cookies } from 'next/headers'
 import { connection } from 'next/server'
 
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/missing-suspense-around-dynamic/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/missing-suspense-around-dynamic/page.tsx
@@ -1,7 +1,7 @@
 import { cookies } from 'next/headers'
 import { connection } from 'next/server'
 
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/static-layout-above-runtime-config/inner/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/static-layout-above-runtime-config/inner/layout.tsx
@@ -3,7 +3,7 @@ import { ReactNode } from 'react'
 // This layout has the runtime prefetch config. The developer expects
 // runtime prefetching to handle dynamic data, but the parent layout
 // above this one gets static prefetching by default and blocks.
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 export const unstable_prefetch = 'force-runtime'
 
 export default function InnerLayout({ children }: { children: ReactNode }) {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/static-layout-above-runtime-config/inner/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/static-layout-above-runtime-config/inner/layout.tsx
@@ -3,7 +3,7 @@ import { ReactNode } from 'react'
 // This layout has the runtime prefetch config. The developer expects
 // runtime prefetching to handle dynamic data, but the parent layout
 // above this one gets static prefetching by default and blocks.
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 export const unstable_prefetch = 'force-runtime'
 
 export default function InnerLayout({ children }: { children: ReactNode }) {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/suspense-around-dynamic/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/suspense-around-dynamic/page.tsx
@@ -2,7 +2,7 @@ import { cookies } from 'next/headers'
 import { connection } from 'next/server'
 import { Suspense } from 'react'
 
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/suspense-around-dynamic/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/suspense-around-dynamic/page.tsx
@@ -2,7 +2,7 @@ import { cookies } from 'next/headers'
 import { connection } from 'next/server'
 import { Suspense } from 'react'
 
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/suspense-too-high/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/suspense-too-high/page.tsx
@@ -1,7 +1,7 @@
 import { cookies } from 'next/headers'
 import { connection } from 'next/server'
 
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/suspense-too-high/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/suspense-too-high/page.tsx
@@ -1,7 +1,7 @@
 import { cookies } from 'next/headers'
 import { connection } from 'next/server'
 
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-blocking-inside-runtime/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-blocking-inside-runtime/layout.tsx
@@ -1,7 +1,7 @@
 import { cookies } from 'next/headers'
 import { Suspense } from 'react'
 
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 export const unstable_prefetch = 'force-runtime'
 
 export default async function RuntimeLayout({ children }) {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-blocking-inside-runtime/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-blocking-inside-runtime/layout.tsx
@@ -1,7 +1,7 @@
 import { cookies } from 'next/headers'
 import { Suspense } from 'react'
 
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 export const unstable_prefetch = 'force-runtime'
 
 export default async function RuntimeLayout({ children }) {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-no-suspense-around-params/[param]/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-no-suspense-around-params/[param]/page.tsx
@@ -2,6 +2,7 @@ import { connection } from 'next/server'
 import { Suspense } from 'react'
 
 export const unstable_instant = {
+  level: 'error',
   samples: [{ cookies: [], params: { param: '123' } }],
 }
 export const unstable_prefetch = 'force-runtime'

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-no-suspense-around-params/[param]/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-no-suspense-around-params/[param]/page.tsx
@@ -2,7 +2,7 @@ import { connection } from 'next/server'
 import { Suspense } from 'react'
 
 export const unstable_instant = {
-  level: 'error',
+  level: 'experimental-error',
   samples: [{ cookies: [], params: { param: '123' } }],
 }
 export const unstable_prefetch = 'force-runtime'

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-no-suspense-around-params/[param]/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-no-suspense-around-params/[param]/page.tsx
@@ -3,7 +3,7 @@ import { Suspense } from 'react'
 
 export const unstable_instant = {
   level: 'experimental-error',
-  samples: [{ cookies: [], params: { param: '123' } }],
+  unstable_samples: [{ cookies: [], params: { param: '123' } }],
 }
 export const unstable_prefetch = 'force-runtime'
 

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-no-suspense-around-search-params/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-no-suspense-around-search-params/page.tsx
@@ -3,7 +3,7 @@ import { Suspense } from 'react'
 
 export const unstable_instant = {
   level: 'experimental-error',
-  samples: [{ cookies: [], searchParams: { foo: 'bar' } }],
+  unstable_samples: [{ cookies: [], searchParams: { foo: 'bar' } }],
 }
 export const unstable_prefetch = 'force-runtime'
 

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-no-suspense-around-search-params/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-no-suspense-around-search-params/page.tsx
@@ -2,6 +2,7 @@ import { connection } from 'next/server'
 import { Suspense } from 'react'
 
 export const unstable_instant = {
+  level: 'error',
   samples: [{ cookies: [], searchParams: { foo: 'bar' } }],
 }
 export const unstable_prefetch = 'force-runtime'

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-no-suspense-around-search-params/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-no-suspense-around-search-params/page.tsx
@@ -2,7 +2,7 @@ import { connection } from 'next/server'
 import { Suspense } from 'react'
 
 export const unstable_instant = {
-  level: 'error',
+  level: 'experimental-error',
   samples: [{ cookies: [], searchParams: { foo: 'bar' } }],
 }
 export const unstable_prefetch = 'force-runtime'

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-sync-io-in-generate-metadata-static-page/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-sync-io-in-generate-metadata-static-page/page.tsx
@@ -3,7 +3,7 @@ import { Suspense } from 'react'
 
 // this page is NOT runtime-prefetchable,
 // so Sync IO in generateMetadata should be allowed.
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export async function generateMetadata() {
   await cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-sync-io-in-generate-metadata-static-page/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-sync-io-in-generate-metadata-static-page/page.tsx
@@ -3,7 +3,7 @@ import { Suspense } from 'react'
 
 // this page is NOT runtime-prefetchable,
 // so Sync IO in generateMetadata should be allowed.
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export async function generateMetadata() {
   await cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-sync-io-in-layout-generate-metadata-static-page/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-sync-io-in-layout-generate-metadata-static-page/layout.tsx
@@ -3,7 +3,7 @@ import { cookies } from 'next/headers'
 // This layout does NOT have runtime prefetch and neither does the child
 // page. Since no segment has runtime prefetch enabled, sync IO in
 // generateMetadata should be allowed.
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export async function generateMetadata() {
   await cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-sync-io-in-layout-generate-metadata-static-page/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-sync-io-in-layout-generate-metadata-static-page/layout.tsx
@@ -3,7 +3,7 @@ import { cookies } from 'next/headers'
 // This layout does NOT have runtime prefetch and neither does the child
 // page. Since no segment has runtime prefetch enabled, sync IO in
 // generateMetadata should be allowed.
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export async function generateMetadata() {
   await cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-sync-io-in-static-parent/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-sync-io-in-static-parent/page.tsx
@@ -1,7 +1,7 @@
 import { cookies } from 'next/headers'
 import { Suspense } from 'react'
 
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 export const unstable_prefetch = 'force-runtime'
 
 async function Runtime() {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-sync-io-in-static-parent/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-sync-io-in-static-parent/page.tsx
@@ -1,7 +1,7 @@
 import { cookies } from 'next/headers'
 import { Suspense } from 'react'
 
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 export const unstable_prefetch = 'force-runtime'
 
 async function Runtime() {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/blocking-layout/missing-suspense-around-dynamic/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/blocking-layout/missing-suspense-around-dynamic/page.tsx
@@ -1,6 +1,6 @@
 import { cookies } from 'next/headers'
 
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default async function Page() {
   await cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/blocking-layout/missing-suspense-around-dynamic/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/blocking-layout/missing-suspense-around-dynamic/page.tsx
@@ -1,6 +1,6 @@
 import { cookies } from 'next/headers'
 
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default async function Page() {
   await cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/blocking-layout/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/blocking-layout/page.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link'
 
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/blocking-layout/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/blocking-layout/page.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link'
 
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/config-children-preferred/@other/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/config-children-preferred/@other/page.tsx
@@ -1,7 +1,7 @@
 // @other has config at the same depth as children's page.
 // Children's config should be preferred for the root cause
 // because children wins at equal depth.
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default function OtherPage() {
   return <p>Other slot page — same-depth config, no blocking</p>

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/config-children-preferred/@other/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/config-children-preferred/@other/page.tsx
@@ -1,7 +1,7 @@
 // @other has config at the same depth as children's page.
 // Children's config should be preferred for the root cause
 // because children wins at equal depth.
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default function OtherPage() {
   return <p>Other slot page — same-depth config, no blocking</p>

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/config-children-preferred/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/config-children-preferred/page.tsx
@@ -1,7 +1,7 @@
 // Children and @other both have config at the same depth (page level).
 // Children's config should be preferred as the root cause when the
 // error is in @slot (which has no config).
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/config-children-preferred/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/config-children-preferred/page.tsx
@@ -1,7 +1,7 @@
 // Children and @other both have config at the same depth (page level).
 // Children's config should be preferred as the root cause when the
 // error is in @slot (which has no config).
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/config-depth-preference-slot-wins/deeper/@anotherSlot/still/deep/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/config-depth-preference-slot-wins/deeper/@anotherSlot/still/deep/page.tsx
@@ -1,6 +1,6 @@
 // Deepest config — in @anotherSlot, deeper than children's catchall.
 // Should be preferred as the root cause because depth wins.
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default function AnotherSlotDeepPage() {
   return <p>Another slot deep page — deepest config, no blocking</p>

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/config-depth-preference-slot-wins/deeper/@anotherSlot/still/deep/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/config-depth-preference-slot-wins/deeper/@anotherSlot/still/deep/page.tsx
@@ -1,6 +1,6 @@
 // Deepest config — in @anotherSlot, deeper than children's catchall.
 // Should be preferred as the root cause because depth wins.
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default function AnotherSlotDeepPage() {
   return <p>Another slot deep page — deepest config, no blocking</p>

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/config-depth-preference-slot-wins/deeper/[...rest]/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/config-depth-preference-slot-wins/deeper/[...rest]/page.tsx
@@ -1,6 +1,6 @@
 // Children's config via catchall — shallower than @anotherSlot's
 // deep config. Should NOT be preferred as root cause.
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default function ChildrenCatchallPage() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/config-depth-preference-slot-wins/deeper/[...rest]/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/config-depth-preference-slot-wins/deeper/[...rest]/page.tsx
@@ -1,6 +1,6 @@
 // Children's config via catchall — shallower than @anotherSlot's
 // deep config. Should NOT be preferred as root cause.
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default function ChildrenCatchallPage() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/config-depth-preference/deeper/@anotherSlot/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/config-depth-preference/deeper/@anotherSlot/page.tsx
@@ -1,6 +1,6 @@
 // Shallow config in a named slot. The deeper config in
 // still/deep/page.tsx should be preferred over this one.
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default function AnotherSlotPage() {
   return <p>Another slot page — shallow config, no blocking</p>

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/config-depth-preference/deeper/@anotherSlot/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/config-depth-preference/deeper/@anotherSlot/page.tsx
@@ -1,6 +1,6 @@
 // Shallow config in a named slot. The deeper config in
 // still/deep/page.tsx should be preferred over this one.
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default function AnotherSlotPage() {
   return <p>Another slot page — shallow config, no blocking</p>

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/config-depth-preference/deeper/still/deep/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/config-depth-preference/deeper/still/deep/page.tsx
@@ -1,6 +1,6 @@
 // Deepest config — should be preferred as the root cause when
 // the error is in @slot (which has no config).
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/config-depth-preference/deeper/still/deep/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/config-depth-preference/deeper/still/deep/page.tsx
@@ -1,6 +1,6 @@
 // Deepest config — should be preferred as the root cause when
 // the error is in @slot (which has no config).
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/cross-slot-blocking/inner/deep/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/cross-slot-blocking/inner/deep/page.tsx
@@ -2,7 +2,7 @@
 // second fork point (inner/layout.tsx has @panel). The blocking
 // code is in @slot at the outer fork. The slot marker for @slot
 // has no config, so the cause must fall back to the root config.
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/cross-slot-blocking/inner/deep/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/cross-slot-blocking/inner/deep/page.tsx
@@ -2,7 +2,7 @@
 // second fork point (inner/layout.tsx has @panel). The blocking
 // code is in @slot at the outer fork. The slot marker for @slot
 // has no config, so the cause must fall back to the root config.
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/false-below-static/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/false-below-static/layout.tsx
@@ -4,7 +4,7 @@ import { ReactNode } from 'react'
 // Even though the page below opts out with `false`, this layout's
 // config still triggers validation at depths where both the layout
 // and the page are in the new tree.
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default function Layout({ children }: { children: ReactNode }) {
   return <div>{children}</div>

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/false-below-static/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/false-below-static/layout.tsx
@@ -4,7 +4,7 @@ import { ReactNode } from 'react'
 // Even though the page below opts out with `false`, this layout's
 // config still triggers validation at depths where both the layout
 // and the page are in the new tree.
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default function Layout({ children }: { children: ReactNode }) {
   return <div>{children}</div>

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-blocking-inside-static/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-blocking-inside-static/layout.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default function StaticLayout({ children }) {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-blocking-inside-static/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-blocking-inside-static/layout.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default function StaticLayout({ children }) {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-client-data-blocks-validation/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-client-data-blocks-validation/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-client-data-blocks-validation/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-client-data-blocks-validation/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-client-error-in-parent-blocks-children/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-client-error-in-parent-blocks-children/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-client-error-in-parent-blocks-children/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-client-error-in-parent-blocks-children/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-client-error-in-parent-sibling/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-client-error-in-parent-sibling/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-client-error-in-parent-sibling/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-client-error-in-parent-sibling/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-csr-bailout-blocks-children/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-csr-bailout-blocks-children/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-csr-bailout-blocks-children/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-csr-bailout-blocks-children/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-dynamic-layout-with-loading/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-dynamic-layout-with-loading/layout.tsx
@@ -1,7 +1,7 @@
 import { connection } from 'next/server'
 import { ReactNode } from 'react'
 
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default async function Layout({ children }: { children: ReactNode }) {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-dynamic-layout-with-loading/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-dynamic-layout-with-loading/layout.tsx
@@ -1,7 +1,7 @@
 import { connection } from 'next/server'
 import { ReactNode } from 'react'
 
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default async function Layout({ children }: { children: ReactNode }) {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-error-in-node-modules-blocks-children/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-error-in-node-modules-blocks-children/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-error-in-node-modules-blocks-children/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-error-in-node-modules-blocks-children/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-loading-above-route-group/(group)/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-loading-above-route-group/(group)/page.tsx
@@ -1,7 +1,7 @@
 import { cookies } from 'next/headers'
 import { connection } from 'next/server'
 
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-loading-above-route-group/(group)/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-loading-above-route-group/(group)/page.tsx
@@ -1,7 +1,7 @@
 import { cookies } from 'next/headers'
 import { connection } from 'next/server'
 
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/missing-suspense-around-dynamic-layout/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/missing-suspense-around-dynamic-layout/layout.tsx
@@ -1,7 +1,7 @@
 import { cookies } from 'next/headers'
 import { ReactNode } from 'react'
 
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default async function Layout({ children }: { children: ReactNode }) {
   await cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/missing-suspense-around-dynamic-layout/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/missing-suspense-around-dynamic-layout/layout.tsx
@@ -1,7 +1,7 @@
 import { cookies } from 'next/headers'
 import { ReactNode } from 'react'
 
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default async function Layout({ children }: { children: ReactNode }) {
   await cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/missing-suspense-around-dynamic/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/missing-suspense-around-dynamic/page.tsx
@@ -1,6 +1,6 @@
 import { connection } from 'next/server'
 
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default async function Page() {
   await connection()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/missing-suspense-around-dynamic/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/missing-suspense-around-dynamic/page.tsx
@@ -1,6 +1,6 @@
 import { connection } from 'next/server'
 
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default async function Page() {
   await connection()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/missing-suspense-around-params/[param]/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/missing-suspense-around-params/[param]/page.tsx
@@ -1,4 +1,7 @@
-export const unstable_instant = { samples: [{ params: { param: '123' } }] }
+export const unstable_instant = {
+  level: 'error',
+  samples: [{ params: { param: '123' } }],
+}
 
 export default async function Page({
   params,

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/missing-suspense-around-params/[param]/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/missing-suspense-around-params/[param]/page.tsx
@@ -1,5 +1,5 @@
 export const unstable_instant = {
-  level: 'error',
+  level: 'experimental-error',
   samples: [{ params: { param: '123' } }],
 }
 

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/missing-suspense-around-params/[param]/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/missing-suspense-around-params/[param]/page.tsx
@@ -1,6 +1,6 @@
 export const unstable_instant = {
   level: 'experimental-error',
-  samples: [{ params: { param: '123' } }],
+  unstable_samples: [{ params: { param: '123' } }],
 }
 
 export default async function Page({

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/missing-suspense-around-runtime/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/missing-suspense-around-runtime/page.tsx
@@ -1,6 +1,6 @@
 import { cookies } from 'next/headers'
 
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default async function Page() {
   await cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/missing-suspense-around-runtime/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/missing-suspense-around-runtime/page.tsx
@@ -1,6 +1,6 @@
 import { cookies } from 'next/headers'
 
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default async function Page() {
   await cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/missing-suspense-around-search-params/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/missing-suspense-around-search-params/page.tsx
@@ -1,5 +1,5 @@
 export const unstable_instant = {
-  level: 'error',
+  level: 'experimental-error',
   samples: [{ searchParams: { foo: 'bar' } }],
 }
 

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/missing-suspense-around-search-params/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/missing-suspense-around-search-params/page.tsx
@@ -1,4 +1,7 @@
-export const unstable_instant = { samples: [{ searchParams: { foo: 'bar' } }] }
+export const unstable_instant = {
+  level: 'error',
+  samples: [{ searchParams: { foo: 'bar' } }],
+}
 
 export default async function Page({ searchParams }) {
   const search = await searchParams

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/missing-suspense-around-search-params/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/missing-suspense-around-search-params/page.tsx
@@ -1,6 +1,6 @@
 export const unstable_instant = {
   level: 'experimental-error',
-  samples: [{ searchParams: { foo: 'bar' } }],
+  unstable_samples: [{ searchParams: { foo: 'bar' } }],
 }
 
 export default async function Page({ searchParams }) {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/missing-suspense-in-parallel-route/@slot/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/missing-suspense-in-parallel-route/@slot/layout.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 export default function SlotLayout({ children }) {
   return (
     <div>

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/missing-suspense-in-parallel-route/@slot/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/missing-suspense-in-parallel-route/@slot/layout.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 export default function SlotLayout({ children }) {
   return (
     <div>

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/missing-suspense-in-parallel-route/bar/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/missing-suspense-in-parallel-route/bar/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/missing-suspense-in-parallel-route/bar/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/missing-suspense-in-parallel-route/bar/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/missing-suspense-in-parallel-route/foo/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/missing-suspense-in-parallel-route/foo/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/missing-suspense-in-parallel-route/foo/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/missing-suspense-in-parallel-route/foo/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/missing-suspense-in-parallel-route/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/missing-suspense-in-parallel-route/page.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link'
 
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/missing-suspense-in-parallel-route/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/missing-suspense-in-parallel-route/page.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link'
 
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/parallel-group-depths-deep-slot-hole/(b1)/(b2)/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/parallel-group-depths-deep-slot-hole/(b1)/(b2)/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/parallel-group-depths-deep-slot-hole/(b1)/(b2)/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/parallel-group-depths-deep-slot-hole/(b1)/(b2)/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/parallel-group-depths-deep-slot-hole/@slot/(g1)/(g2)/(g3)/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/parallel-group-depths-deep-slot-hole/@slot/(g1)/(g2)/(g3)/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default function SlotPage() {
   return <p>Slot A page inside 3 nested route groups</p>

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/parallel-group-depths-deep-slot-hole/@slot/(g1)/(g2)/(g3)/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/parallel-group-depths-deep-slot-hole/@slot/(g1)/(g2)/(g3)/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default function SlotPage() {
   return <p>Slot A page inside 3 nested route groups</p>

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/parallel-group-depths-shallow-slot-hole/(b1)/(b2)/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/parallel-group-depths-shallow-slot-hole/(b1)/(b2)/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/parallel-group-depths-shallow-slot-hole/(b1)/(b2)/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/parallel-group-depths-shallow-slot-hole/(b1)/(b2)/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/parallel-group-depths-shallow-slot-hole/@slot/(g1)/(g2)/(g3)/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/parallel-group-depths-shallow-slot-hole/@slot/(g1)/(g2)/(g3)/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default function SlotPage() {
   return <p>Slot A page inside 3 nested route groups</p>

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/parallel-group-depths-shallow-slot-hole/@slot/(g1)/(g2)/(g3)/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/parallel-group-depths-shallow-slot-hole/@slot/(g1)/(g2)/(g3)/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default function SlotPage() {
   return <p>Slot A page inside 3 nested route groups</p>

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/parallel-nested-forks/@slot1/@slot2a/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/parallel-nested-forks/@slot1/@slot2a/page.tsx
@@ -1,6 +1,6 @@
 import { cookies } from 'next/headers'
 
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default async function Slot2aPage() {
   await cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/parallel-nested-forks/@slot1/@slot2a/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/parallel-nested-forks/@slot1/@slot2a/page.tsx
@@ -1,6 +1,6 @@
 import { cookies } from 'next/headers'
 
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default async function Slot2aPage() {
   await cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/parallel-nested-forks/@slot1/@slot2b/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/parallel-nested-forks/@slot1/@slot2b/page.tsx
@@ -1,6 +1,6 @@
 import { cookies } from 'next/headers'
 
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default async function Slot2bPage() {
   await cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/parallel-nested-forks/@slot1/@slot2b/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/parallel-nested-forks/@slot1/@slot2b/page.tsx
@@ -1,6 +1,6 @@
 import { cookies } from 'next/headers'
 
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default async function Slot2bPage() {
   await cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/parallel-nested-forks/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/parallel-nested-forks/page.tsx
@@ -1,6 +1,6 @@
 import { cookies } from 'next/headers'
 
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default async function Page() {
   await cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/parallel-nested-forks/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/parallel-nested-forks/page.tsx
@@ -1,6 +1,6 @@
 import { cookies } from 'next/headers'
 
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default async function Page() {
   await cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-config-and-segment-config/(group)/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-config-and-segment-config/(group)/layout.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react'
 
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default function GroupLayout({ children }: { children: ReactNode }) {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-config-and-segment-config/(group)/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-config-and-segment-config/(group)/layout.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react'
 
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default function GroupLayout({ children }: { children: ReactNode }) {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-config-and-segment-config/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-config-and-segment-config/layout.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react'
 
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default function Layout({ children }: { children: ReactNode }) {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-config-and-segment-config/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-config-and-segment-config/layout.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react'
 
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default function Layout({ children }: { children: ReactNode }) {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-config-only/(group)/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-config-only/(group)/layout.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react'
 
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default function GroupLayout({ children }: { children: ReactNode }) {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-config-only/(group)/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-config-only/(group)/layout.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react'
 
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default function GroupLayout({ children }: { children: ReactNode }) {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-config-with-deeper-segment/(group)/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-config-with-deeper-segment/(group)/layout.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react'
 
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default function GroupLayout({ children }: { children: ReactNode }) {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-config-with-deeper-segment/(group)/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-config-with-deeper-segment/(group)/layout.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react'
 
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default function GroupLayout({ children }: { children: ReactNode }) {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-deeper-segment-config/(group)/inner/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-deeper-segment-config/(group)/inner/layout.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react'
 
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default function InnerLayout({ children }: { children: ReactNode }) {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-deeper-segment-config/(group)/inner/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-deeper-segment-config/(group)/inner/layout.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react'
 
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default function InnerLayout({ children }: { children: ReactNode }) {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-segment-config-only/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-segment-config-only/layout.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react'
 
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default function Layout({ children }: { children: ReactNode }) {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-segment-config-only/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-segment-config-only/layout.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react'
 
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default function Layout({ children }: { children: ReactNode }) {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-shared-boundary/(outer)/(inner)/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-shared-boundary/(outer)/(inner)/page.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link'
 // The instant config is on the page. When (outer) is shared and
 // (inner) is the boundary, this page is in the new tree where
 // buildNewTreeSeedData finds the config and triggers validation.
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-shared-boundary/(outer)/(inner)/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-shared-boundary/(outer)/(inner)/page.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link'
 // The instant config is on the page. When (outer) is shared and
 // (inner) is the boundary, this page is in the new tree where
 // buildNewTreeSeedData finds the config and triggers validation.
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/suspense-around-dynamic/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/suspense-around-dynamic/page.tsx
@@ -2,7 +2,7 @@ import { cookies } from 'next/headers'
 import { connection } from 'next/server'
 import { Suspense } from 'react'
 
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/suspense-around-dynamic/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/suspense-around-dynamic/page.tsx
@@ -2,7 +2,7 @@ import { cookies } from 'next/headers'
 import { connection } from 'next/server'
 import { Suspense } from 'react'
 
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/suspense-too-high/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/suspense-too-high/page.tsx
@@ -1,6 +1,6 @@
 import { cookies } from 'next/headers'
 
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default async function Page() {
   await cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/suspense-too-high/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/suspense-too-high/page.tsx
@@ -1,6 +1,6 @@
 import { cookies } from 'next/headers'
 
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default async function Page() {
   await cookies()

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/valid-client-api-in-parent/dynamic-params/[id]/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/valid-client-api-in-parent/dynamic-params/[id]/page.tsx
@@ -1,7 +1,7 @@
 export const unstable_instant = {
   level: 'experimental-error',
   // `usePathname` will error if we don't have a sample for `[id]`.
-  samples: [{ params: { id: '123' } }],
+  unstable_samples: [{ params: { id: '123' } }],
 }
 
 export default function Page() {

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/valid-client-api-in-parent/dynamic-params/[id]/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/valid-client-api-in-parent/dynamic-params/[id]/page.tsx
@@ -1,5 +1,5 @@
 export const unstable_instant = {
-  level: 'error',
+  level: 'experimental-error',
   // `usePathname` will error if we don't have a sample for `[id]`.
   samples: [{ params: { id: '123' } }],
 }

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/valid-client-api-in-parent/dynamic-params/[id]/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/valid-client-api-in-parent/dynamic-params/[id]/page.tsx
@@ -1,4 +1,5 @@
 export const unstable_instant = {
+  level: 'error',
   // `usePathname` will error if we don't have a sample for `[id]`.
   samples: [{ params: { id: '123' } }],
 }

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/valid-client-api-in-parent/search-params/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/valid-client-api-in-parent/search-params/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/valid-client-api-in-parent/search-params/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/valid-client-api-in-parent/search-params/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/valid-client-api-in-parent/sync-io/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/valid-client-api-in-parent/sync-io/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/valid-client-api-in-parent/sync-io/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/valid-client-api-in-parent/sync-io/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/valid-client-data-does-not-block-validation/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/valid-client-data-does-not-block-validation/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/valid-client-data-does-not-block-validation/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/valid-client-data-does-not-block-validation/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/valid-client-error-in-parent-does-not-block-validation/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/valid-client-error-in-parent-does-not-block-validation/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/valid-client-error-in-parent-does-not-block-validation/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/valid-client-error-in-parent-does-not-block-validation/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/valid-only-loading-around-dynamic/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/valid-only-loading-around-dynamic/page.tsx
@@ -1,7 +1,7 @@
 import { cookies } from 'next/headers'
 import { connection } from 'next/server'
 
-export const unstable_instant = { level: 'error' }
+export const unstable_instant = { level: 'experimental-error' }
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/valid-only-loading-around-dynamic/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/valid-only-loading-around-dynamic/page.tsx
@@ -1,7 +1,7 @@
 import { cookies } from 'next/headers'
 import { connection } from 'next/server'
 
-export const unstable_instant = true
+export const unstable_instant = { level: 'error' }
 
 export default async function Page() {
   return (

--- a/test/e2e/app-dir/instant-validation/instant-validation-parallel-slots.test.ts
+++ b/test/e2e/app-dir/instant-validation/instant-validation-parallel-slots.test.ts
@@ -116,7 +116,7 @@ describe('instant validation - parallel slot configs', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/parallel/slot-config-only/@slot/page.tsx (1:33) @ unstable_instant
-           > 1 | export const unstable_instant = { level: 'error' }
+           > 1 | export const unstable_instant = { level: 'experimental-error' }
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/parallel/slot-config-only/@slot/page.tsx (1:33)",
@@ -176,7 +176,7 @@ describe('instant validation - parallel slot configs', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/parallel/slot-layout-config/@slot/layout.tsx (3:33) @ unstable_instant
-           > 3 | export const unstable_instant = { level: 'error' }
+           > 3 | export const unstable_instant = { level: 'experimental-error' }
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/parallel/slot-layout-config/@slot/layout.tsx (3:33)",
@@ -236,7 +236,7 @@ describe('instant validation - parallel slot configs', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/parallel/slot-runtime-config/@slot/page.tsx (4:33) @ unstable_instant
-           > 4 | export const unstable_instant = { level: 'error' }
+           > 4 | export const unstable_instant = { level: 'experimental-error' }
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/parallel/slot-runtime-config/@slot/page.tsx (4:33)",
@@ -298,7 +298,7 @@ describe('instant validation - parallel slot configs', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/parallel/children-config-with-slot/page.tsx (1:33) @ unstable_instant
-           > 1 | export const unstable_instant = { level: 'error' }
+           > 1 | export const unstable_instant = { level: 'experimental-error' }
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/parallel/children-config-with-slot/page.tsx (1:33)",
@@ -360,7 +360,7 @@ describe('instant validation - parallel slot configs', () => {
                  {
                    "label": "Caused by: Instant Validation",
                    "source": "app/suspense-in-root/parallel/fork-layout-config-with-slot/layout.tsx (3:33) @ unstable_instant
-           > 3 | export const unstable_instant = { level: 'error' }
+           > 3 | export const unstable_instant = { level: 'experimental-error' }
                |                                 ^",
                    "stack": [
                      "unstable_instant app/suspense-in-root/parallel/fork-layout-config-with-slot/layout.tsx (3:33)",
@@ -384,7 +384,7 @@ describe('instant validation - parallel slot configs', () => {
                  {
                    "label": "Caused by: Instant Validation",
                    "source": "app/suspense-in-root/parallel/fork-layout-config-with-slot/layout.tsx (3:33) @ unstable_instant
-           > 3 | export const unstable_instant = { level: 'error' }
+           > 3 | export const unstable_instant = { level: 'experimental-error' }
                |                                 ^",
                    "stack": [
                      "unstable_instant app/suspense-in-root/parallel/fork-layout-config-with-slot/layout.tsx (3:33)",
@@ -527,7 +527,7 @@ describe('instant validation - parallel slot configs', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/parallel/conditional-breadcrumbs/show-both/blocked/page.tsx (1:33) @ unstable_instant
-           > 1 | export const unstable_instant = { level: 'error' }
+           > 1 | export const unstable_instant = { level: 'experimental-error' }
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/parallel/conditional-breadcrumbs/show-both/blocked/page.tsx (1:33)",
@@ -587,7 +587,7 @@ describe('instant validation - parallel slot configs', () => {
              "environmentLabel": "Server",
              "label": "Console Error",
              "source": "app/suspense-in-root/parallel/conditional-breadcrumbs/show-only-breadcrumbs/unblocked/page.tsx (1:33) @ unstable_instant
-           > 1 | export const unstable_instant = { level: 'error' }
+           > 1 | export const unstable_instant = { level: 'experimental-error' }
                |                                 ^",
              "stack": [
                "unstable_instant app/suspense-in-root/parallel/conditional-breadcrumbs/show-only-breadcrumbs/unblocked/page.tsx (1:33)",
@@ -621,7 +621,7 @@ describe('instant validation - parallel slot configs', () => {
              "environmentLabel": "Server",
              "label": "Console Error",
              "source": "app/suspense-in-root/parallel/conditional-breadcrumbs/show-only-breadcrumbs/blocked/page.tsx (1:33) @ unstable_instant
-           > 1 | export const unstable_instant = { level: 'error' }
+           > 1 | export const unstable_instant = { level: 'experimental-error' }
                |                                 ^",
              "stack": [
                "unstable_instant app/suspense-in-root/parallel/conditional-breadcrumbs/show-only-breadcrumbs/blocked/page.tsx (1:33)",

--- a/test/e2e/app-dir/instant-validation/instant-validation-parallel-slots.test.ts
+++ b/test/e2e/app-dir/instant-validation/instant-validation-parallel-slots.test.ts
@@ -116,7 +116,7 @@ describe('instant validation - parallel slot configs', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/parallel/slot-config-only/@slot/page.tsx (1:33) @ unstable_instant
-           > 1 | export const unstable_instant = true
+           > 1 | export const unstable_instant = { level: 'error' }
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/parallel/slot-config-only/@slot/page.tsx (1:33)",
@@ -176,7 +176,7 @@ describe('instant validation - parallel slot configs', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/parallel/slot-layout-config/@slot/layout.tsx (3:33) @ unstable_instant
-           > 3 | export const unstable_instant = true
+           > 3 | export const unstable_instant = { level: 'error' }
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/parallel/slot-layout-config/@slot/layout.tsx (3:33)",
@@ -236,7 +236,7 @@ describe('instant validation - parallel slot configs', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/parallel/slot-runtime-config/@slot/page.tsx (4:33) @ unstable_instant
-           > 4 | export const unstable_instant = true
+           > 4 | export const unstable_instant = { level: 'error' }
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/parallel/slot-runtime-config/@slot/page.tsx (4:33)",
@@ -298,7 +298,7 @@ describe('instant validation - parallel slot configs', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/parallel/children-config-with-slot/page.tsx (1:33) @ unstable_instant
-           > 1 | export const unstable_instant = true
+           > 1 | export const unstable_instant = { level: 'error' }
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/parallel/children-config-with-slot/page.tsx (1:33)",
@@ -360,7 +360,7 @@ describe('instant validation - parallel slot configs', () => {
                  {
                    "label": "Caused by: Instant Validation",
                    "source": "app/suspense-in-root/parallel/fork-layout-config-with-slot/layout.tsx (3:33) @ unstable_instant
-           > 3 | export const unstable_instant = true
+           > 3 | export const unstable_instant = { level: 'error' }
                |                                 ^",
                    "stack": [
                      "unstable_instant app/suspense-in-root/parallel/fork-layout-config-with-slot/layout.tsx (3:33)",
@@ -384,7 +384,7 @@ describe('instant validation - parallel slot configs', () => {
                  {
                    "label": "Caused by: Instant Validation",
                    "source": "app/suspense-in-root/parallel/fork-layout-config-with-slot/layout.tsx (3:33) @ unstable_instant
-           > 3 | export const unstable_instant = true
+           > 3 | export const unstable_instant = { level: 'error' }
                |                                 ^",
                    "stack": [
                      "unstable_instant app/suspense-in-root/parallel/fork-layout-config-with-slot/layout.tsx (3:33)",
@@ -527,7 +527,7 @@ describe('instant validation - parallel slot configs', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/parallel/conditional-breadcrumbs/show-both/blocked/page.tsx (1:33) @ unstable_instant
-           > 1 | export const unstable_instant = true
+           > 1 | export const unstable_instant = { level: 'error' }
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/parallel/conditional-breadcrumbs/show-both/blocked/page.tsx (1:33)",
@@ -587,7 +587,7 @@ describe('instant validation - parallel slot configs', () => {
              "environmentLabel": "Server",
              "label": "Console Error",
              "source": "app/suspense-in-root/parallel/conditional-breadcrumbs/show-only-breadcrumbs/unblocked/page.tsx (1:33) @ unstable_instant
-           > 1 | export const unstable_instant = true
+           > 1 | export const unstable_instant = { level: 'error' }
                |                                 ^",
              "stack": [
                "unstable_instant app/suspense-in-root/parallel/conditional-breadcrumbs/show-only-breadcrumbs/unblocked/page.tsx (1:33)",
@@ -621,7 +621,7 @@ describe('instant validation - parallel slot configs', () => {
              "environmentLabel": "Server",
              "label": "Console Error",
              "source": "app/suspense-in-root/parallel/conditional-breadcrumbs/show-only-breadcrumbs/blocked/page.tsx (1:33) @ unstable_instant
-           > 1 | export const unstable_instant = true
+           > 1 | export const unstable_instant = { level: 'error' }
                |                                 ^",
              "stack": [
                "unstable_instant app/suspense-in-root/parallel/conditional-breadcrumbs/show-only-breadcrumbs/blocked/page.tsx (1:33)",

--- a/test/e2e/app-dir/instant-validation/instant-validation.test.ts
+++ b/test/e2e/app-dir/instant-validation/instant-validation.test.ts
@@ -172,7 +172,7 @@ describe('instant validation', () => {
              {
                "label": "Caused by: Instant Validation",
                "source": "app/suspense-in-root/static/missing-suspense-around-runtime/page.tsx (3:33) @ unstable_instant
-         > 3 | export const unstable_instant = { level: 'error' }
+         > 3 | export const unstable_instant = { level: 'experimental-error' }
              |                                 ^",
                "stack": [
                  "unstable_instant app/suspense-in-root/static/missing-suspense-around-runtime/page.tsx (3:33)",
@@ -232,7 +232,7 @@ describe('instant validation', () => {
              {
                "label": "Caused by: Instant Validation",
                "source": "app/suspense-in-root/static/missing-suspense-around-dynamic/page.tsx (3:33) @ unstable_instant
-         > 3 | export const unstable_instant = { level: 'error' }
+         > 3 | export const unstable_instant = { level: 'experimental-error' }
              |                                 ^",
                "stack": [
                  "unstable_instant app/suspense-in-root/static/missing-suspense-around-dynamic/page.tsx (3:33)",
@@ -292,7 +292,7 @@ describe('instant validation', () => {
              {
                "label": "Caused by: Instant Validation",
                "source": "app/suspense-in-root/runtime/missing-suspense-around-dynamic/page.tsx (4:33) @ unstable_instant
-         > 4 | export const unstable_instant = { level: 'error' }
+         > 4 | export const unstable_instant = { level: 'experimental-error' }
              |                                 ^",
                "stack": [
                  "unstable_instant app/suspense-in-root/runtime/missing-suspense-around-dynamic/page.tsx (4:33)",
@@ -355,7 +355,7 @@ describe('instant validation', () => {
              {
                "label": "Caused by: Instant Validation",
                "source": "app/suspense-in-root/static/missing-suspense-around-dynamic-layout/layout.tsx (4:33) @ unstable_instant
-         > 4 | export const unstable_instant = { level: 'error' }
+         > 4 | export const unstable_instant = { level: 'experimental-error' }
              |                                 ^",
                "stack": [
                  "unstable_instant app/suspense-in-root/static/missing-suspense-around-dynamic-layout/layout.tsx (4:33)",
@@ -415,7 +415,7 @@ describe('instant validation', () => {
              {
                "label": "Caused by: Instant Validation",
                "source": "app/suspense-in-root/runtime/missing-suspense-around-dynamic-layout/layout.tsx (4:33) @ unstable_instant
-         > 4 | export const unstable_instant = { level: 'error' }
+         > 4 | export const unstable_instant = { level: 'experimental-error' }
              |                                 ^",
                "stack": [
                  "unstable_instant app/suspense-in-root/runtime/missing-suspense-around-dynamic-layout/layout.tsx (4:33)",
@@ -478,7 +478,7 @@ describe('instant validation', () => {
            {
              "label": "Caused by: Instant Validation",
              "source": "app/suspense-in-root/static/missing-suspense-around-params/[param]/page.tsx (1:33) @ unstable_instant
-       > 1 | export const unstable_instant = { samples: [{ params: { param: '123' } }] }
+       > 1 | export const unstable_instant = {
            |                                 ^",
              "stack": [
                "unstable_instant app/suspense-in-root/static/missing-suspense-around-params/[param]/page.tsx (1:33)",
@@ -490,12 +490,12 @@ describe('instant validation', () => {
          "description": "Next.js encountered runtime data during the initial render.",
          "environmentLabel": "Server",
          "label": "Instant",
-         "source": "app/suspense-in-root/static/missing-suspense-around-params/[param]/page.tsx (17:21) @ Runtime
-       > 17 |   const { param } = await params
+         "source": "app/suspense-in-root/static/missing-suspense-around-params/[param]/page.tsx (20:21) @ Runtime
+       > 20 |   const { param } = await params
             |                     ^",
          "stack": [
-           "Runtime app/suspense-in-root/static/missing-suspense-around-params/[param]/page.tsx (17:21)",
-           "Page app/suspense-in-root/static/missing-suspense-around-params/[param]/page.tsx (11:7)",
+           "Runtime app/suspense-in-root/static/missing-suspense-around-params/[param]/page.tsx (20:21)",
+           "Page app/suspense-in-root/static/missing-suspense-around-params/[param]/page.tsx (14:7)",
          ],
        }
       `)
@@ -526,7 +526,7 @@ describe('instant validation', () => {
              {
                "label": "Caused by: Instant Validation",
                "source": "app/suspense-in-root/static/missing-suspense-around-search-params/page.tsx (1:33) @ unstable_instant
-         > 1 | export const unstable_instant = { samples: [{ searchParams: { foo: 'bar' } }] }
+         > 1 | export const unstable_instant = {
              |                                 ^",
                "stack": [
                  "unstable_instant app/suspense-in-root/static/missing-suspense-around-search-params/page.tsx (1:33)",
@@ -538,11 +538,11 @@ describe('instant validation', () => {
            "description": "Next.js encountered runtime data during the initial render.",
            "environmentLabel": "Server",
            "label": "Instant",
-           "source": "app/suspense-in-root/static/missing-suspense-around-search-params/page.tsx (4:18) @ Page
-         > 4 |   const search = await searchParams
-             |                  ^",
+           "source": "app/suspense-in-root/static/missing-suspense-around-search-params/page.tsx (7:18) @ Page
+         >  7 |   const search = await searchParams
+              |                  ^",
            "stack": [
-             "Page app/suspense-in-root/static/missing-suspense-around-search-params/page.tsx (4:18)",
+             "Page app/suspense-in-root/static/missing-suspense-around-search-params/page.tsx (7:18)",
            ],
          }
         `)
@@ -621,7 +621,7 @@ describe('instant validation', () => {
              {
                "label": "Caused by: Instant Validation",
                "source": "app/suspense-in-root/static/suspense-too-high/page.tsx (3:33) @ unstable_instant
-         > 3 | export const unstable_instant = { level: 'error' }
+         > 3 | export const unstable_instant = { level: 'experimental-error' }
              |                                 ^",
                "stack": [
                  "unstable_instant app/suspense-in-root/static/suspense-too-high/page.tsx (3:33)",
@@ -684,7 +684,7 @@ describe('instant validation', () => {
              {
                "label": "Caused by: Instant Validation",
                "source": "app/suspense-in-root/runtime/suspense-too-high/page.tsx (4:33) @ unstable_instant
-         > 4 | export const unstable_instant = { level: 'error' }
+         > 4 | export const unstable_instant = { level: 'experimental-error' }
              |                                 ^",
                "stack": [
                  "unstable_instant app/suspense-in-root/runtime/suspense-too-high/page.tsx (4:33)",
@@ -1123,7 +1123,7 @@ describe('instant validation', () => {
              {
                "label": "Caused by: Instant Validation",
                "source": "app/suspense-in-root/static/invalid-loading-above-route-group/(group)/page.tsx (4:33) @ unstable_instant
-         > 4 | export const unstable_instant = { level: 'error' }
+         > 4 | export const unstable_instant = { level: 'experimental-error' }
              |                                 ^",
                "stack": [
                  "unstable_instant app/suspense-in-root/static/invalid-loading-above-route-group/(group)/page.tsx (4:33)",
@@ -1187,7 +1187,7 @@ describe('instant validation', () => {
              {
                "label": "Caused by: Instant Validation",
                "source": "app/suspense-in-root/static/invalid-dynamic-layout-with-loading/layout.tsx (4:33) @ unstable_instant
-         > 4 | export const unstable_instant = { level: 'error' }
+         > 4 | export const unstable_instant = { level: 'experimental-error' }
              |                                 ^",
                "stack": [
                  "unstable_instant app/suspense-in-root/static/invalid-dynamic-layout-with-loading/layout.tsx (4:33)",
@@ -1264,7 +1264,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/static/blocking-layout/missing-suspense-around-dynamic/page.tsx (3:33) @ unstable_instant
-           > 3 | export const unstable_instant = { level: 'error' }
+           > 3 | export const unstable_instant = { level: 'experimental-error' }
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/static/blocking-layout/missing-suspense-around-dynamic/page.tsx (3:33)",
@@ -1352,7 +1352,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/static/invalid-blocking-inside-static/layout.tsx (1:33) @ unstable_instant
-           > 1 | export const unstable_instant = { level: 'error' }
+           > 1 | export const unstable_instant = { level: 'experimental-error' }
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/static/invalid-blocking-inside-static/layout.tsx (1:33)",
@@ -1413,7 +1413,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/runtime/invalid-blocking-inside-runtime/layout.tsx (3:33) @ unstable_instant
-           > 3 | export const unstable_instant = { level: 'error' }
+           > 3 | export const unstable_instant = { level: 'experimental-error' }
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/runtime/invalid-blocking-inside-runtime/layout.tsx (3:33)",
@@ -1477,7 +1477,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/static/missing-suspense-in-parallel-route/@slot/layout.tsx (1:33) @ unstable_instant
-           > 1 | export const unstable_instant = { level: 'error' }
+           > 1 | export const unstable_instant = { level: 'experimental-error' }
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/static/missing-suspense-in-parallel-route/@slot/layout.tsx (1:33)",
@@ -1539,7 +1539,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/static/missing-suspense-in-parallel-route/foo/page.tsx (1:33) @ unstable_instant
-           > 1 | export const unstable_instant = { level: 'error' }
+           > 1 | export const unstable_instant = { level: 'experimental-error' }
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/static/missing-suspense-in-parallel-route/foo/page.tsx (1:33)",
@@ -1601,7 +1601,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/static/missing-suspense-in-parallel-route/bar/page.tsx (1:33) @ unstable_instant
-           > 1 | export const unstable_instant = { level: 'error' }
+           > 1 | export const unstable_instant = { level: 'experimental-error' }
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/static/missing-suspense-in-parallel-route/bar/page.tsx (1:33)",
@@ -1664,7 +1664,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/static/invalid-client-data-blocks-validation/page.tsx (1:33) @ unstable_instant
-           > 1 | export const unstable_instant = { level: 'error' }
+           > 1 | export const unstable_instant = { level: 'experimental-error' }
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/static/invalid-client-data-blocks-validation/page.tsx (1:33)",
@@ -1831,7 +1831,7 @@ describe('instant validation', () => {
                "environmentLabel": "Server",
                "label": "Console Error",
                "source": "app/suspense-in-root/static/invalid-client-error-in-parent-blocks-children/page.tsx (1:33) @ unstable_instant
-           > 1 | export const unstable_instant = { level: 'error' }
+           > 1 | export const unstable_instant = { level: 'experimental-error' }
                |                                 ^",
                "stack": [
                  "unstable_instant app/suspense-in-root/static/invalid-client-error-in-parent-blocks-children/page.tsx (1:33)",
@@ -1937,7 +1937,7 @@ describe('instant validation', () => {
                "environmentLabel": "Server",
                "label": "Console Error",
                "source": "app/suspense-in-root/static/invalid-error-in-node-modules-blocks-children/page.tsx (1:33) @ unstable_instant
-           > 1 | export const unstable_instant = { level: 'error' }
+           > 1 | export const unstable_instant = { level: 'experimental-error' }
                |                                 ^",
                "stack": [
                  "unstable_instant app/suspense-in-root/static/invalid-error-in-node-modules-blocks-children/page.tsx (1:33)",
@@ -2004,7 +2004,7 @@ describe('instant validation', () => {
                "environmentLabel": "Server",
                "label": "Console Error",
                "source": "app/suspense-in-root/static/invalid-csr-bailout-blocks-children/page.tsx (1:33) @ unstable_instant
-           > 1 | export const unstable_instant = { level: 'error' }
+           > 1 | export const unstable_instant = { level: 'experimental-error' }
                |                                 ^",
                "stack": [
                  "unstable_instant app/suspense-in-root/static/invalid-csr-bailout-blocks-children/page.tsx (1:33)",
@@ -2100,7 +2100,7 @@ describe('instant validation', () => {
                "environmentLabel": "Server",
                "label": "Console Error",
                "source": "app/suspense-in-root/static/invalid-client-error-in-parent-sibling/page.tsx (1:33) @ unstable_instant
-           > 1 | export const unstable_instant = { level: 'error' }
+           > 1 | export const unstable_instant = { level: 'experimental-error' }
                |                                 ^",
                "stack": [
                  "unstable_instant app/suspense-in-root/static/invalid-client-error-in-parent-sibling/page.tsx (1:33)",
@@ -2254,7 +2254,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/head/invalid-runtime-viewport-in-static/page.tsx (8:33) @ unstable_instant
-           >  8 | export const unstable_instant = { level: 'error' }
+           >  8 | export const unstable_instant = { level: 'experimental-error' }
                 |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/head/invalid-runtime-viewport-in-static/page.tsx (8:33)",
@@ -2319,7 +2319,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/head/invalid-dynamic-viewport-in-runtime/page.tsx (6:33) @ unstable_instant
-           > 6 | export const unstable_instant = { level: 'error' }
+           > 6 | export const unstable_instant = { level: 'experimental-error' }
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/head/invalid-dynamic-viewport-in-runtime/page.tsx (6:33)",
@@ -2420,7 +2420,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/head/invalid-dynamic-viewport-in-blocking-inside-static/layout.tsx (3:33) @ unstable_instant
-           > 3 | export const unstable_instant = { level: 'error' }
+           > 3 | export const unstable_instant = { level: 'experimental-error' }
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/head/invalid-dynamic-viewport-in-blocking-inside-static/layout.tsx (3:33)",
@@ -2483,7 +2483,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/static/route-group-config-only/(group)/layout.tsx (3:33) @ unstable_instant
-           > 3 | export const unstable_instant = { level: 'error' }
+           > 3 | export const unstable_instant = { level: 'experimental-error' }
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/static/route-group-config-only/(group)/layout.tsx (3:33)",
@@ -2544,7 +2544,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/static/route-group-config-and-segment-config/(group)/layout.tsx (3:33) @ unstable_instant
-           > 3 | export const unstable_instant = { level: 'error' }
+           > 3 | export const unstable_instant = { level: 'experimental-error' }
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/static/route-group-config-and-segment-config/(group)/layout.tsx (3:33)",
@@ -2606,7 +2606,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/static/route-group-segment-config-only/layout.tsx (3:33) @ unstable_instant
-           > 3 | export const unstable_instant = { level: 'error' }
+           > 3 | export const unstable_instant = { level: 'experimental-error' }
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/static/route-group-segment-config-only/layout.tsx (3:33)",
@@ -2668,7 +2668,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/static/route-group-config-with-deeper-segment/(group)/layout.tsx (3:33) @ unstable_instant
-           > 3 | export const unstable_instant = { level: 'error' }
+           > 3 | export const unstable_instant = { level: 'experimental-error' }
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/static/route-group-config-with-deeper-segment/(group)/layout.tsx (3:33)",
@@ -2730,7 +2730,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/static/route-group-deeper-segment-config/(group)/inner/layout.tsx (3:33) @ unstable_instant
-           > 3 | export const unstable_instant = { level: 'error' }
+           > 3 | export const unstable_instant = { level: 'experimental-error' }
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/static/route-group-deeper-segment-config/(group)/inner/layout.tsx (3:33)",
@@ -2799,7 +2799,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/static/route-group-shared-boundary/(outer)/(inner)/page.tsx (6:33) @ unstable_instant
-           > 6 | export const unstable_instant = { level: 'error' }
+           > 6 | export const unstable_instant = { level: 'experimental-error' }
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/static/route-group-shared-boundary/(outer)/(inner)/page.tsx (6:33)",
@@ -2875,7 +2875,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/static/parallel-group-depths-deep-slot-hole/@slot/(g1)/(g2)/(g3)/page.tsx (1:33) @ unstable_instant
-           > 1 | export const unstable_instant = { level: 'error' }
+           > 1 | export const unstable_instant = { level: 'experimental-error' }
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/static/parallel-group-depths-deep-slot-hole/@slot/(g1)/(g2)/(g3)/page.tsx (1:33)",
@@ -2945,7 +2945,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/static/parallel-group-depths-shallow-slot-hole/(b1)/(b2)/page.tsx (1:33) @ unstable_instant
-           > 1 | export const unstable_instant = { level: 'error' }
+           > 1 | export const unstable_instant = { level: 'experimental-error' }
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/static/parallel-group-depths-shallow-slot-hole/(b1)/(b2)/page.tsx (1:33)",
@@ -3016,7 +3016,7 @@ describe('instant validation', () => {
              {
                "label": "Caused by: Instant Validation",
                "source": "app/suspense-in-root/runtime/static-layout-above-runtime-config/inner/layout.tsx (6:33) @ unstable_instant
-         > 6 | export const unstable_instant = { level: 'error' }
+         > 6 | export const unstable_instant = { level: 'experimental-error' }
              |                                 ^",
                "stack": [
                  "unstable_instant app/suspense-in-root/runtime/static-layout-above-runtime-config/inner/layout.tsx (6:33)",
@@ -3084,7 +3084,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/static/config-depth-preference/deeper/still/deep/page.tsx (3:33) @ unstable_instant
-           > 3 | export const unstable_instant = { level: 'error' }
+           > 3 | export const unstable_instant = { level: 'experimental-error' }
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/static/config-depth-preference/deeper/still/deep/page.tsx (3:33)",
@@ -3135,7 +3135,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/static/config-depth-preference-slot-wins/deeper/@anotherSlot/still/deep/page.tsx (3:33) @ unstable_instant
-           > 3 | export const unstable_instant = { level: 'error' }
+           > 3 | export const unstable_instant = { level: 'experimental-error' }
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/static/config-depth-preference-slot-wins/deeper/@anotherSlot/still/deep/page.tsx (3:33)",
@@ -3199,7 +3199,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/static/config-children-preferred/page.tsx (4:33) @ unstable_instant
-           > 4 | export const unstable_instant = { level: 'error' }
+           > 4 | export const unstable_instant = { level: 'experimental-error' }
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/static/config-children-preferred/page.tsx (4:33)",
@@ -3264,7 +3264,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/static/cross-slot-blocking/inner/deep/page.tsx (5:33) @ unstable_instant
-           > 5 | export const unstable_instant = { level: 'error' }
+           > 5 | export const unstable_instant = { level: 'experimental-error' }
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/static/cross-slot-blocking/inner/deep/page.tsx (5:33)",
@@ -3391,7 +3391,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/disable-validation/disable-build/page.tsx (3:33) @ unstable_instant
-           > 3 | export const unstable_instant = { unstable_disableBuildValidation: true }
+           > 3 | export const unstable_instant = {
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/disable-validation/disable-build/page.tsx (3:33)",
@@ -3403,11 +3403,11 @@ describe('instant validation', () => {
              "description": "Next.js encountered uncached data during the initial render.",
              "environmentLabel": "Server",
              "label": "Instant",
-             "source": "app/suspense-in-root/disable-validation/disable-build/page.tsx (6:19) @ Page
-           > 6 |   await connection()
-               |                   ^",
+             "source": "app/suspense-in-root/disable-validation/disable-build/page.tsx (9:19) @ Page
+           >  9 |   await connection()
+                |                   ^",
              "stack": [
-               "Page app/suspense-in-root/disable-validation/disable-build/page.tsx (6:19)",
+               "Page app/suspense-in-root/disable-validation/disable-build/page.tsx (9:19)",
              ],
            }
           `)

--- a/test/e2e/app-dir/instant-validation/instant-validation.test.ts
+++ b/test/e2e/app-dir/instant-validation/instant-validation.test.ts
@@ -172,7 +172,7 @@ describe('instant validation', () => {
              {
                "label": "Caused by: Instant Validation",
                "source": "app/suspense-in-root/static/missing-suspense-around-runtime/page.tsx (3:33) @ unstable_instant
-         > 3 | export const unstable_instant = true
+         > 3 | export const unstable_instant = { level: 'error' }
              |                                 ^",
                "stack": [
                  "unstable_instant app/suspense-in-root/static/missing-suspense-around-runtime/page.tsx (3:33)",
@@ -232,7 +232,7 @@ describe('instant validation', () => {
              {
                "label": "Caused by: Instant Validation",
                "source": "app/suspense-in-root/static/missing-suspense-around-dynamic/page.tsx (3:33) @ unstable_instant
-         > 3 | export const unstable_instant = true
+         > 3 | export const unstable_instant = { level: 'error' }
              |                                 ^",
                "stack": [
                  "unstable_instant app/suspense-in-root/static/missing-suspense-around-dynamic/page.tsx (3:33)",
@@ -292,7 +292,7 @@ describe('instant validation', () => {
              {
                "label": "Caused by: Instant Validation",
                "source": "app/suspense-in-root/runtime/missing-suspense-around-dynamic/page.tsx (4:33) @ unstable_instant
-         > 4 | export const unstable_instant = true
+         > 4 | export const unstable_instant = { level: 'error' }
              |                                 ^",
                "stack": [
                  "unstable_instant app/suspense-in-root/runtime/missing-suspense-around-dynamic/page.tsx (4:33)",
@@ -355,7 +355,7 @@ describe('instant validation', () => {
              {
                "label": "Caused by: Instant Validation",
                "source": "app/suspense-in-root/static/missing-suspense-around-dynamic-layout/layout.tsx (4:33) @ unstable_instant
-         > 4 | export const unstable_instant = true
+         > 4 | export const unstable_instant = { level: 'error' }
              |                                 ^",
                "stack": [
                  "unstable_instant app/suspense-in-root/static/missing-suspense-around-dynamic-layout/layout.tsx (4:33)",
@@ -415,7 +415,7 @@ describe('instant validation', () => {
              {
                "label": "Caused by: Instant Validation",
                "source": "app/suspense-in-root/runtime/missing-suspense-around-dynamic-layout/layout.tsx (4:33) @ unstable_instant
-         > 4 | export const unstable_instant = true
+         > 4 | export const unstable_instant = { level: 'error' }
              |                                 ^",
                "stack": [
                  "unstable_instant app/suspense-in-root/runtime/missing-suspense-around-dynamic-layout/layout.tsx (4:33)",
@@ -621,7 +621,7 @@ describe('instant validation', () => {
              {
                "label": "Caused by: Instant Validation",
                "source": "app/suspense-in-root/static/suspense-too-high/page.tsx (3:33) @ unstable_instant
-         > 3 | export const unstable_instant = true
+         > 3 | export const unstable_instant = { level: 'error' }
              |                                 ^",
                "stack": [
                  "unstable_instant app/suspense-in-root/static/suspense-too-high/page.tsx (3:33)",
@@ -684,7 +684,7 @@ describe('instant validation', () => {
              {
                "label": "Caused by: Instant Validation",
                "source": "app/suspense-in-root/runtime/suspense-too-high/page.tsx (4:33) @ unstable_instant
-         > 4 | export const unstable_instant = true
+         > 4 | export const unstable_instant = { level: 'error' }
              |                                 ^",
                "stack": [
                  "unstable_instant app/suspense-in-root/runtime/suspense-too-high/page.tsx (4:33)",
@@ -1123,7 +1123,7 @@ describe('instant validation', () => {
              {
                "label": "Caused by: Instant Validation",
                "source": "app/suspense-in-root/static/invalid-loading-above-route-group/(group)/page.tsx (4:33) @ unstable_instant
-         > 4 | export const unstable_instant = true
+         > 4 | export const unstable_instant = { level: 'error' }
              |                                 ^",
                "stack": [
                  "unstable_instant app/suspense-in-root/static/invalid-loading-above-route-group/(group)/page.tsx (4:33)",
@@ -1187,7 +1187,7 @@ describe('instant validation', () => {
              {
                "label": "Caused by: Instant Validation",
                "source": "app/suspense-in-root/static/invalid-dynamic-layout-with-loading/layout.tsx (4:33) @ unstable_instant
-         > 4 | export const unstable_instant = true
+         > 4 | export const unstable_instant = { level: 'error' }
              |                                 ^",
                "stack": [
                  "unstable_instant app/suspense-in-root/static/invalid-dynamic-layout-with-loading/layout.tsx (4:33)",
@@ -1264,7 +1264,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/static/blocking-layout/missing-suspense-around-dynamic/page.tsx (3:33) @ unstable_instant
-           > 3 | export const unstable_instant = true
+           > 3 | export const unstable_instant = { level: 'error' }
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/static/blocking-layout/missing-suspense-around-dynamic/page.tsx (3:33)",
@@ -1352,7 +1352,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/static/invalid-blocking-inside-static/layout.tsx (1:33) @ unstable_instant
-           > 1 | export const unstable_instant = true
+           > 1 | export const unstable_instant = { level: 'error' }
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/static/invalid-blocking-inside-static/layout.tsx (1:33)",
@@ -1413,7 +1413,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/runtime/invalid-blocking-inside-runtime/layout.tsx (3:33) @ unstable_instant
-           > 3 | export const unstable_instant = true
+           > 3 | export const unstable_instant = { level: 'error' }
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/runtime/invalid-blocking-inside-runtime/layout.tsx (3:33)",
@@ -1477,7 +1477,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/static/missing-suspense-in-parallel-route/@slot/layout.tsx (1:33) @ unstable_instant
-           > 1 | export const unstable_instant = true
+           > 1 | export const unstable_instant = { level: 'error' }
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/static/missing-suspense-in-parallel-route/@slot/layout.tsx (1:33)",
@@ -1539,7 +1539,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/static/missing-suspense-in-parallel-route/foo/page.tsx (1:33) @ unstable_instant
-           > 1 | export const unstable_instant = true
+           > 1 | export const unstable_instant = { level: 'error' }
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/static/missing-suspense-in-parallel-route/foo/page.tsx (1:33)",
@@ -1601,7 +1601,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/static/missing-suspense-in-parallel-route/bar/page.tsx (1:33) @ unstable_instant
-           > 1 | export const unstable_instant = true
+           > 1 | export const unstable_instant = { level: 'error' }
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/static/missing-suspense-in-parallel-route/bar/page.tsx (1:33)",
@@ -1664,7 +1664,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/static/invalid-client-data-blocks-validation/page.tsx (1:33) @ unstable_instant
-           > 1 | export const unstable_instant = true
+           > 1 | export const unstable_instant = { level: 'error' }
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/static/invalid-client-data-blocks-validation/page.tsx (1:33)",
@@ -1831,7 +1831,7 @@ describe('instant validation', () => {
                "environmentLabel": "Server",
                "label": "Console Error",
                "source": "app/suspense-in-root/static/invalid-client-error-in-parent-blocks-children/page.tsx (1:33) @ unstable_instant
-           > 1 | export const unstable_instant = true
+           > 1 | export const unstable_instant = { level: 'error' }
                |                                 ^",
                "stack": [
                  "unstable_instant app/suspense-in-root/static/invalid-client-error-in-parent-blocks-children/page.tsx (1:33)",
@@ -1937,7 +1937,7 @@ describe('instant validation', () => {
                "environmentLabel": "Server",
                "label": "Console Error",
                "source": "app/suspense-in-root/static/invalid-error-in-node-modules-blocks-children/page.tsx (1:33) @ unstable_instant
-           > 1 | export const unstable_instant = true
+           > 1 | export const unstable_instant = { level: 'error' }
                |                                 ^",
                "stack": [
                  "unstable_instant app/suspense-in-root/static/invalid-error-in-node-modules-blocks-children/page.tsx (1:33)",
@@ -2004,7 +2004,7 @@ describe('instant validation', () => {
                "environmentLabel": "Server",
                "label": "Console Error",
                "source": "app/suspense-in-root/static/invalid-csr-bailout-blocks-children/page.tsx (1:33) @ unstable_instant
-           > 1 | export const unstable_instant = true
+           > 1 | export const unstable_instant = { level: 'error' }
                |                                 ^",
                "stack": [
                  "unstable_instant app/suspense-in-root/static/invalid-csr-bailout-blocks-children/page.tsx (1:33)",
@@ -2100,7 +2100,7 @@ describe('instant validation', () => {
                "environmentLabel": "Server",
                "label": "Console Error",
                "source": "app/suspense-in-root/static/invalid-client-error-in-parent-sibling/page.tsx (1:33) @ unstable_instant
-           > 1 | export const unstable_instant = true
+           > 1 | export const unstable_instant = { level: 'error' }
                |                                 ^",
                "stack": [
                  "unstable_instant app/suspense-in-root/static/invalid-client-error-in-parent-sibling/page.tsx (1:33)",
@@ -2254,7 +2254,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/head/invalid-runtime-viewport-in-static/page.tsx (8:33) @ unstable_instant
-           >  8 | export const unstable_instant = true
+           >  8 | export const unstable_instant = { level: 'error' }
                 |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/head/invalid-runtime-viewport-in-static/page.tsx (8:33)",
@@ -2319,7 +2319,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/head/invalid-dynamic-viewport-in-runtime/page.tsx (6:33) @ unstable_instant
-           > 6 | export const unstable_instant = true
+           > 6 | export const unstable_instant = { level: 'error' }
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/head/invalid-dynamic-viewport-in-runtime/page.tsx (6:33)",
@@ -2420,7 +2420,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/head/invalid-dynamic-viewport-in-blocking-inside-static/layout.tsx (3:33) @ unstable_instant
-           > 3 | export const unstable_instant = true
+           > 3 | export const unstable_instant = { level: 'error' }
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/head/invalid-dynamic-viewport-in-blocking-inside-static/layout.tsx (3:33)",
@@ -2483,7 +2483,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/static/route-group-config-only/(group)/layout.tsx (3:33) @ unstable_instant
-           > 3 | export const unstable_instant = true
+           > 3 | export const unstable_instant = { level: 'error' }
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/static/route-group-config-only/(group)/layout.tsx (3:33)",
@@ -2544,7 +2544,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/static/route-group-config-and-segment-config/(group)/layout.tsx (3:33) @ unstable_instant
-           > 3 | export const unstable_instant = true
+           > 3 | export const unstable_instant = { level: 'error' }
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/static/route-group-config-and-segment-config/(group)/layout.tsx (3:33)",
@@ -2606,7 +2606,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/static/route-group-segment-config-only/layout.tsx (3:33) @ unstable_instant
-           > 3 | export const unstable_instant = true
+           > 3 | export const unstable_instant = { level: 'error' }
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/static/route-group-segment-config-only/layout.tsx (3:33)",
@@ -2668,7 +2668,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/static/route-group-config-with-deeper-segment/(group)/layout.tsx (3:33) @ unstable_instant
-           > 3 | export const unstable_instant = true
+           > 3 | export const unstable_instant = { level: 'error' }
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/static/route-group-config-with-deeper-segment/(group)/layout.tsx (3:33)",
@@ -2730,7 +2730,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/static/route-group-deeper-segment-config/(group)/inner/layout.tsx (3:33) @ unstable_instant
-           > 3 | export const unstable_instant = true
+           > 3 | export const unstable_instant = { level: 'error' }
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/static/route-group-deeper-segment-config/(group)/inner/layout.tsx (3:33)",
@@ -2799,7 +2799,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/static/route-group-shared-boundary/(outer)/(inner)/page.tsx (6:33) @ unstable_instant
-           > 6 | export const unstable_instant = true
+           > 6 | export const unstable_instant = { level: 'error' }
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/static/route-group-shared-boundary/(outer)/(inner)/page.tsx (6:33)",
@@ -2875,7 +2875,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/static/parallel-group-depths-deep-slot-hole/@slot/(g1)/(g2)/(g3)/page.tsx (1:33) @ unstable_instant
-           > 1 | export const unstable_instant = true
+           > 1 | export const unstable_instant = { level: 'error' }
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/static/parallel-group-depths-deep-slot-hole/@slot/(g1)/(g2)/(g3)/page.tsx (1:33)",
@@ -2945,7 +2945,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/static/parallel-group-depths-shallow-slot-hole/(b1)/(b2)/page.tsx (1:33) @ unstable_instant
-           > 1 | export const unstable_instant = true
+           > 1 | export const unstable_instant = { level: 'error' }
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/static/parallel-group-depths-shallow-slot-hole/(b1)/(b2)/page.tsx (1:33)",
@@ -3016,7 +3016,7 @@ describe('instant validation', () => {
              {
                "label": "Caused by: Instant Validation",
                "source": "app/suspense-in-root/runtime/static-layout-above-runtime-config/inner/layout.tsx (6:33) @ unstable_instant
-         > 6 | export const unstable_instant = true
+         > 6 | export const unstable_instant = { level: 'error' }
              |                                 ^",
                "stack": [
                  "unstable_instant app/suspense-in-root/runtime/static-layout-above-runtime-config/inner/layout.tsx (6:33)",
@@ -3084,7 +3084,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/static/config-depth-preference/deeper/still/deep/page.tsx (3:33) @ unstable_instant
-           > 3 | export const unstable_instant = true
+           > 3 | export const unstable_instant = { level: 'error' }
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/static/config-depth-preference/deeper/still/deep/page.tsx (3:33)",
@@ -3135,7 +3135,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/static/config-depth-preference-slot-wins/deeper/@anotherSlot/still/deep/page.tsx (3:33) @ unstable_instant
-           > 3 | export const unstable_instant = true
+           > 3 | export const unstable_instant = { level: 'error' }
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/static/config-depth-preference-slot-wins/deeper/@anotherSlot/still/deep/page.tsx (3:33)",
@@ -3199,7 +3199,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/static/config-children-preferred/page.tsx (4:33) @ unstable_instant
-           > 4 | export const unstable_instant = true
+           > 4 | export const unstable_instant = { level: 'error' }
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/static/config-children-preferred/page.tsx (4:33)",
@@ -3264,7 +3264,7 @@ describe('instant validation', () => {
                {
                  "label": "Caused by: Instant Validation",
                  "source": "app/suspense-in-root/static/cross-slot-blocking/inner/deep/page.tsx (5:33) @ unstable_instant
-           > 5 | export const unstable_instant = true
+           > 5 | export const unstable_instant = { level: 'error' }
                |                                 ^",
                  "stack": [
                    "unstable_instant app/suspense-in-root/static/cross-slot-blocking/inner/deep/page.tsx (5:33)",

--- a/test/e2e/app-dir/instant-validation/instant-validation.test.ts
+++ b/test/e2e/app-dir/instant-validation/instant-validation.test.ts
@@ -894,7 +894,7 @@ describe('instant validation', () => {
         )
         expect(extractBuildValidationError(result.cliOutput))
           .toMatchInlineSnapshot(`
-         "Error: Route "/suspense-in-root/runtime/invalid-sync-io-after-cache-with-cookie-input" accessed cookie "testCookie" which is not defined in the \`samples\` of \`unstable_instant\`. Add it to the sample's \`cookies\` array, or \`{ name: "testCookie", value: null }\` if it should be absent.
+         "Error: Route "/suspense-in-root/runtime/invalid-sync-io-after-cache-with-cookie-input" accessed cookie "testCookie" which is not defined in the \`unstable_samples\` of \`unstable_instant\`. Add it to the sample's \`cookies\` array, or \`{ name: "testCookie", value: null }\` if it should be absent.
              at <unknown> (app/suspense-in-root/runtime/invalid-sync-io-after-cache-with-cookie-input/page.tsx:26:49)
            24 |
            25 | export default async function Page() {

--- a/test/e2e/app-dir/instant-validation/next.config.ts
+++ b/test/e2e/app-dir/instant-validation/next.config.ts
@@ -3,8 +3,8 @@ import type { NextConfig } from 'next'
 const nextConfig: NextConfig = {
   cacheComponents: true,
   experimental: {
-    instant: {
-      defaultValidationLevel: 'disabled',
+    instantInsights: {
+      validationLevel: 'manual-warning',
     },
   },
   productionBrowserSourceMaps: true,

--- a/test/e2e/app-dir/instant-validation/next.config.ts
+++ b/test/e2e/app-dir/instant-validation/next.config.ts
@@ -4,7 +4,7 @@ const nextConfig: NextConfig = {
   cacheComponents: true,
   experimental: {
     instant: {
-      defaultValidationLevel: 'error',
+      defaultValidationLevel: 'disabled',
     },
   },
   productionBrowserSourceMaps: true,

--- a/test/e2e/app-dir/instant-validation/next.config.ts
+++ b/test/e2e/app-dir/instant-validation/next.config.ts
@@ -2,6 +2,11 @@ import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
   cacheComponents: true,
+  experimental: {
+    instant: {
+      defaultValidationLevel: 'error',
+    },
+  },
   productionBrowserSourceMaps: true,
   typescript: {
     ignoreBuildErrors: true,

--- a/test/e2e/app-dir/prefetch-true-instant/app/layout-instant/layout.tsx
+++ b/test/e2e/app-dir/prefetch-true-instant/app/layout-instant/layout.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from 'react'
 
 export const unstable_instant = {
-  samples: [{ cookies: [{ name: 'test', value: null }] }],
+  unstable_samples: [{ cookies: [{ name: 'test', value: null }] }],
 }
 export const unstable_prefetch = 'force-runtime'
 

--- a/test/e2e/app-dir/prefetch-true-instant/app/target-page/page.tsx
+++ b/test/e2e/app-dir/prefetch-true-instant/app/target-page/page.tsx
@@ -3,7 +3,7 @@ import { cookies } from 'next/headers'
 import { connection } from 'next/server'
 
 export const unstable_instant = {
-  samples: [{ cookies: [{ name: 'test', value: null }] }],
+  unstable_samples: [{ cookies: [{ name: 'test', value: null }] }],
 }
 export const unstable_prefetch = 'force-runtime'
 

--- a/test/e2e/app-dir/segment-cache/cached-navigations/app/runtime-prefetchable/page.tsx
+++ b/test/e2e/app-dir/segment-cache/cached-navigations/app/runtime-prefetchable/page.tsx
@@ -5,7 +5,7 @@ import { setTimeout } from 'timers/promises'
 import { Suspense } from 'react'
 
 export const unstable_instant = {
-  samples: [
+  unstable_samples: [
     {
       cookies: [{ name: 'testCookie', value: 'testValue' }],
       headers: [['x-test-header', 'test']],

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-independent-head/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-independent-head/layout.tsx
@@ -6,7 +6,7 @@ import { cookies } from 'next/headers'
 // Once cached from the first prefetch, a subsequent prefetch to a sibling
 // page won't need a runtime request for this layout — it's already cached.
 export const unstable_instant = {
-  samples: [
+  unstable_samples: [
     {
       cookies: [{ name: 'theme', value: 'default' }],
       searchParams: { q: null },

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-runtime-bailout/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-runtime-bailout/page.tsx
@@ -1,7 +1,7 @@
 import { cookies } from 'next/headers'
 
 export const unstable_instant = {
-  samples: [{ cookies: [{ name: 'theme', value: 'default' }] }],
+  unstable_samples: [{ cookies: [{ name: 'theme', value: 'default' }] }],
 }
 export const unstable_prefetch = 'force-runtime'
 

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-runtime-parallel/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-runtime-parallel/layout.tsx
@@ -6,7 +6,7 @@ import { ReactNode, Suspense } from 'react'
 import { cookies } from 'next/headers'
 
 export const unstable_instant = {
-  samples: [{ cookies: [{ name: 'theme', value: 'default' }] }],
+  unstable_samples: [{ cookies: [{ name: 'theme', value: 'default' }] }],
 }
 export const unstable_prefetch = 'force-runtime'
 

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-runtime-passthrough/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-runtime-passthrough/layout.tsx
@@ -6,7 +6,7 @@ import { ReactNode, Suspense } from 'react'
 import { cookies } from 'next/headers'
 
 export const unstable_instant = {
-  samples: [{ cookies: [{ name: 'theme', value: 'default' }] }],
+  unstable_samples: [{ cookies: [{ name: 'theme', value: 'default' }] }],
 }
 export const unstable_prefetch = 'force-runtime'
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/error-after-cookies/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/error-after-cookies/page.tsx
@@ -7,7 +7,7 @@ export const unstable_instant = {
   // We're intentionally testing error behavior at runtime.
   // Build-time validation catches it and prevents that.
   unstable_disableValidation: true,
-  samples: [{ cookies: [{ name: 'user-agent', value: null }] }],
+  unstable_samples: [{ cookies: [{ name: 'user-agent', value: null }] }],
 }
 export const unstable_prefetch = 'force-runtime'
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/cookies/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/cookies/page.tsx
@@ -6,7 +6,7 @@ export const unstable_instant = {
   // We're intentionally testing error behavior at runtime.
   // Build-time validation catches it and prevents that.
   unstable_disableValidation: true,
-  samples: [{ cookies: [] }],
+  unstable_samples: [{ cookies: [] }],
 }
 export const unstable_prefetch = 'force-runtime'
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/dynamic-params/[id]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/dynamic-params/[id]/page.tsx
@@ -7,7 +7,7 @@ export const unstable_instant = {
   // We're intentionally testing error behavior at runtime.
   // Build-time validation catches it and prevents that.
   unstable_disableValidation: true,
-  samples: [{ cookies: [] }],
+  unstable_samples: [{ cookies: [] }],
 }
 export const unstable_prefetch = 'force-runtime'
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/headers/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/headers/page.tsx
@@ -6,7 +6,7 @@ export const unstable_instant = {
   // We're intentionally testing error behavior at runtime.
   // Build-time validation catches it and prevents that.
   unstable_disableValidation: true,
-  samples: [{ cookies: [] }],
+  unstable_samples: [{ cookies: [] }],
 }
 export const unstable_prefetch = 'force-runtime'
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/private-cache/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/private-cache/page.tsx
@@ -5,7 +5,7 @@ export const unstable_instant = {
   // We're intentionally testing error behavior at runtime.
   // Build-time validation catches it and prevents that.
   unstable_disableValidation: true,
-  samples: [{ cookies: [] }],
+  unstable_samples: [{ cookies: [] }],
 }
 export const unstable_prefetch = 'force-runtime'
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/quickly-expiring-public-cache/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/quickly-expiring-public-cache/page.tsx
@@ -6,7 +6,7 @@ export const unstable_instant = {
   // We're intentionally testing error behavior at runtime.
   // Build-time validation catches it and prevents that.
   unstable_disableValidation: true,
-  samples: [{ cookies: [] }],
+  unstable_samples: [{ cookies: [] }],
 }
 export const unstable_prefetch = 'force-runtime'
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/search-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/search-params/page.tsx
@@ -7,7 +7,7 @@ export const unstable_instant = {
   // We're intentionally testing error behavior at runtime.
   // Build-time validation catches it and prevents that.
   unstable_disableValidation: true,
-  samples: [{ cookies: [] }],
+  unstable_samples: [{ cookies: [] }],
 }
 export const unstable_prefetch = 'force-runtime'
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/cookies-only/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/cookies-only/page.tsx
@@ -3,7 +3,7 @@ import { Suspense } from 'react'
 import { cachedDelay, DebugRenderKind } from '../../../shared'
 
 export const unstable_instant = {
-  samples: [{ cookies: [{ name: 'testCookie', value: 'testValue' }] }],
+  unstable_samples: [{ cookies: [{ name: 'testCookie', value: 'testValue' }] }],
 }
 export const unstable_prefetch = 'force-runtime'
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/cookies/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/cookies/page.tsx
@@ -4,7 +4,7 @@ import { cachedDelay, DebugRenderKind, uncachedIO } from '../../../shared'
 import { connection } from 'next/server'
 
 export const unstable_instant = {
-  samples: [{ cookies: [{ name: 'testCookie', value: 'testValue' }] }],
+  unstable_samples: [{ cookies: [{ name: 'testCookie', value: 'testValue' }] }],
 }
 export const unstable_prefetch = 'force-runtime'
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/dynamic-params/[id]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/dynamic-params/[id]/page.tsx
@@ -2,7 +2,9 @@ import { Suspense } from 'react'
 import { cachedDelay, DebugRenderKind, uncachedIO } from '../../../../shared'
 import { connection } from 'next/server'
 
-export const unstable_instant = { samples: [{ params: { id: 'test' } }] }
+export const unstable_instant = {
+  unstable_samples: [{ params: { id: 'test' } }],
+}
 export const unstable_prefetch = 'force-runtime'
 
 type Params = { id: string }

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/headers/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/headers/page.tsx
@@ -4,7 +4,7 @@ import { cachedDelay, DebugRenderKind, uncachedIO } from '../../../shared'
 import { connection } from 'next/server'
 
 export const unstable_instant = {
-  samples: [{ headers: [['host', 'test-host']] }],
+  unstable_samples: [{ headers: [['host', 'test-host']] }],
 }
 export const unstable_prefetch = 'force-runtime'
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/search-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/search-params/page.tsx
@@ -3,7 +3,7 @@ import { cachedDelay, DebugRenderKind, uncachedIO } from '../../../shared'
 import { connection } from 'next/server'
 
 export const unstable_instant = {
-  samples: [{ searchParams: { searchParam: 'value' } }],
+  unstable_samples: [{ searchParams: { searchParam: 'value' } }],
 }
 export const unstable_prefetch = 'force-runtime'
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/cookies-only/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/cookies-only/page.tsx
@@ -3,7 +3,7 @@ import { Suspense } from 'react'
 import { cachedDelay, DebugRenderKind } from '../../../shared'
 
 export const unstable_instant = {
-  samples: [{ cookies: [{ name: 'testCookie', value: 'testValue' }] }],
+  unstable_samples: [{ cookies: [{ name: 'testCookie', value: 'testValue' }] }],
 }
 export const unstable_prefetch = 'force-runtime'
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/cookies/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/cookies/page.tsx
@@ -4,7 +4,7 @@ import { cachedDelay, DebugRenderKind, uncachedIO } from '../../../shared'
 import { connection } from 'next/server'
 
 export const unstable_instant = {
-  samples: [{ cookies: [{ name: 'testCookie', value: 'testValue' }] }],
+  unstable_samples: [{ cookies: [{ name: 'testCookie', value: 'testValue' }] }],
 }
 export const unstable_prefetch = 'force-runtime'
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/dynamic-params/[id]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/dynamic-params/[id]/page.tsx
@@ -2,7 +2,9 @@ import { Suspense } from 'react'
 import { cachedDelay, DebugRenderKind, uncachedIO } from '../../../../shared'
 import { connection } from 'next/server'
 
-export const unstable_instant = { samples: [{ params: { id: 'test' } }] }
+export const unstable_instant = {
+  unstable_samples: [{ params: { id: 'test' } }],
+}
 export const unstable_prefetch = 'force-runtime'
 
 type Params = { id: string }

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/headers/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/headers/page.tsx
@@ -4,7 +4,7 @@ import { cachedDelay, DebugRenderKind, uncachedIO } from '../../../shared'
 import { connection } from 'next/server'
 
 export const unstable_instant = {
-  samples: [{ headers: [['host', 'test-host']] }],
+  unstable_samples: [{ headers: [['host', 'test-host']] }],
 }
 export const unstable_prefetch = 'force-runtime'
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/search-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/search-params/page.tsx
@@ -3,7 +3,7 @@ import { cachedDelay, DebugRenderKind, uncachedIO } from '../../../shared'
 import { connection } from 'next/server'
 
 export const unstable_instant = {
-  samples: [{ searchParams: { searchParam: 'value' } }],
+  unstable_samples: [{ searchParams: { searchParam: 'value' } }],
 }
 export const unstable_prefetch = 'force-runtime'
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/cookies-only/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/cookies-only/page.tsx
@@ -3,7 +3,7 @@ import { Suspense } from 'react'
 import { cachedDelay, DebugRenderKind } from '../../../shared'
 
 export const unstable_instant = {
-  samples: [{ cookies: [{ name: 'testCookie', value: 'testValue' }] }],
+  unstable_samples: [{ cookies: [{ name: 'testCookie', value: 'testValue' }] }],
 }
 export const unstable_prefetch = 'force-runtime'
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/cookies/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/cookies/page.tsx
@@ -4,7 +4,7 @@ import { cachedDelay, DebugRenderKind } from '../../../shared'
 import { connection } from 'next/server'
 
 export const unstable_instant = {
-  samples: [{ cookies: [{ name: 'testCookie', value: 'testValue' }] }],
+  unstable_samples: [{ cookies: [{ name: 'testCookie', value: 'testValue' }] }],
 }
 export const unstable_prefetch = 'force-runtime'
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/dynamic-params/[id]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/dynamic-params/[id]/page.tsx
@@ -3,7 +3,9 @@ import { cachedDelay, DebugRenderKind } from '../../../../shared'
 import { connection } from 'next/server'
 import { cookies } from 'next/headers'
 
-export const unstable_instant = { samples: [{ params: { id: 'test' } }] }
+export const unstable_instant = {
+  unstable_samples: [{ params: { id: 'test' } }],
+}
 export const unstable_prefetch = 'force-runtime'
 
 type Params = { id: string }

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/headers/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/headers/page.tsx
@@ -4,7 +4,7 @@ import { cachedDelay, DebugRenderKind } from '../../../shared'
 import { connection } from 'next/server'
 
 export const unstable_instant = {
-  samples: [{ headers: [['host', 'test-host']] }],
+  unstable_samples: [{ headers: [['host', 'test-host']] }],
 }
 export const unstable_prefetch = 'force-runtime'
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/search-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/search-params/page.tsx
@@ -4,7 +4,7 @@ import { connection } from 'next/server'
 import { cookies } from 'next/headers'
 
 export const unstable_instant = {
-  samples: [{ searchParams: { searchParam: 'value' } }],
+  unstable_samples: [{ searchParams: { searchParam: 'value' } }],
 }
 export const unstable_prefetch = 'force-runtime'
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/in-page/root-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/in-page/root-params/page.tsx
@@ -4,7 +4,9 @@ import { connection } from 'next/server'
 import { lang } from 'next/root-params'
 import { cookies } from 'next/headers'
 
-export const unstable_instant = { samples: [{ params: { lang: 'en' } }] }
+export const unstable_instant = {
+  unstable_samples: [{ params: { lang: 'en' } }],
+}
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/in-private-cache/root-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/in-private-cache/root-params/page.tsx
@@ -3,7 +3,9 @@ import { cachedDelay, DebugRenderKind, uncachedIO } from '../../../../shared'
 import { connection } from 'next/server'
 import { lang } from 'next/root-params'
 
-export const unstable_instant = { samples: [{ params: { lang: 'en' } }] }
+export const unstable_instant = {
+  unstable_samples: [{ params: { lang: 'en' } }],
+}
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/passed-to-public-cache/root-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/passed-to-public-cache/root-params/page.tsx
@@ -3,7 +3,9 @@ import { cachedDelay, DebugRenderKind, uncachedIO } from '../../../../shared'
 import { connection } from 'next/server'
 import { lang } from 'next/root-params'
 
-export const unstable_instant = { samples: [{ params: { lang: 'en' } }] }
+export const unstable_instant = {
+  unstable_samples: [{ params: { lang: 'en' } }],
+}
 export const unstable_prefetch = 'force-runtime'
 
 export default async function Page() {

--- a/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-all-vary/[category]/[itemId]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-all-vary/[category]/[itemId]/page.tsx
@@ -9,9 +9,9 @@ import { connection } from 'next/server'
  * requires its own prefetch — no cache sharing.
  */
 export const unstable_instant: {
-  samples: Array<{ params: { category: string; itemId: string } }>
+  unstable_samples: Array<{ params: { category: string; itemId: string } }>
 } = {
-  samples: [
+  unstable_samples: [
     { params: { category: 'electronics', itemId: 'phone' } },
     { params: { category: 'clothing', itemId: 'shirt' } },
   ],

--- a/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-layout-split/[category]/[itemId]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-layout-split/[category]/[itemId]/page.tsx
@@ -10,9 +10,9 @@ import { connection } from 'next/server'
  * - Page varies only on category → cached when only itemId changes
  */
 export const unstable_instant: {
-  samples: Array<{ params: { category: string; itemId: string } }>
+  unstable_samples: Array<{ params: { category: string; itemId: string } }>
 } = {
-  samples: [
+  unstable_samples: [
     { params: { category: 'electronics', itemId: 'phone' } },
     { params: { category: 'clothing', itemId: 'shirt' } },
   ],

--- a/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-metadata/[slug]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-metadata/[slug]/page.tsx
@@ -11,9 +11,9 @@ import { connection } from 'next/server'
  * - Body segment should be cached (body does NOT access slug)
  */
 export const unstable_instant: {
-  samples: Array<{ params: { slug: string } }>
+  unstable_samples: Array<{ params: { slug: string } }>
 } = {
-  samples: [{ params: { slug: 'aaa' } }, { params: { slug: 'bbb' } }],
+  unstable_samples: [{ params: { slug: 'aaa' } }, { params: { slug: 'bbb' } }],
 }
 export const unstable_prefetch = 'force-runtime'
 

--- a/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-no-vary/[category]/[itemId]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-no-vary/[category]/[itemId]/page.tsx
@@ -9,9 +9,9 @@ import { connection } from 'next/server'
  * share the same cached loading shell (empty vary params set = max sharing).
  */
 export const unstable_instant: {
-  samples: Array<{ params: { category: string; itemId: string } }>
+  unstable_samples: Array<{ params: { category: string; itemId: string } }>
 } = {
-  samples: [
+  unstable_samples: [
     { params: { category: 'electronics', itemId: 'phone' } },
     { params: { category: 'clothing', itemId: 'shirt' } },
   ],

--- a/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-search-params/target-page/page.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch-search-params/target-page/page.tsx
@@ -7,7 +7,9 @@ import { connection } from 'next/server'
  * Since searchParams are not accessed, the '?' sentinel is not added to
  * varyParams, and different search param values share the cached segment.
  */
-export const unstable_instant = { samples: [{ searchParams: { q: '1' } }] }
+export const unstable_instant = {
+  unstable_samples: [{ searchParams: { q: '1' } }],
+}
 export const unstable_prefetch = 'force-runtime'
 
 export default async function RuntimePrefetchSearchParamsTargetPage() {

--- a/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch/[category]/[itemId]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch/[category]/[itemId]/page.tsx
@@ -12,9 +12,9 @@ import { connection } from 'next/server'
  * providing instant loading feedback when navigating.
  */
 export const unstable_instant: {
-  samples: Array<{ params: { category: string; itemId: string } }>
+  unstable_samples: Array<{ params: { category: string; itemId: string } }>
 } = {
-  samples: [
+  unstable_samples: [
     { params: { category: 'electronics', itemId: 'phone' } },
     { params: { category: 'clothing', itemId: 'shirt' } },
   ],

--- a/test/e2e/app-dir/segment-cache/vary-params/app/(main)/search-params/target-page/page.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params/app/(main)/search-params/target-page/page.tsx
@@ -14,7 +14,9 @@ import { Suspense } from 'react'
  * - Prefetching /target?foo=1 fetches the segment with foo=1 content
  * - Prefetching /target?foo=2 fetches the segment AGAIN (no cache hit)
  */
-export const unstable_instant = { samples: [{ searchParams: { foo: '1' } }] }
+export const unstable_instant = {
+  unstable_samples: [{ searchParams: { foo: '1' } }],
+}
 export const unstable_prefetch = 'force-runtime'
 
 type SearchParams = { foo?: string }

--- a/test/unit/instant-config-normalization.test.ts
+++ b/test/unit/instant-config-normalization.test.ts
@@ -1,0 +1,60 @@
+import path from 'path'
+import loadConfig from 'next/dist/server/config'
+import { PHASE_PRODUCTION_SERVER } from 'next/constants'
+
+// `loadConfig` caches its result keyed on `dir` + a boolean "hasCustomConfig".
+// Each test uses a unique subdirectory so the cache doesn't bleed between
+// cases. The subdirectory doesn't need to exist — only the string matters
+// for the cache key, and `loadEnvConfig` tolerates missing dirs.
+function uniqueDir(tag: string) {
+  return path.join(__dirname, `__instant_normalization_${tag}__`)
+}
+
+// Covers the `finalizeConfig` step in loadConfig: resolving
+// `experimental.instant.defaultValidationLevel` to a concrete value in one
+// place so consumers don't each need to know the current framework default.
+describe('experimental.instant defaultValidationLevel normalization', () => {
+  it('defaults to disabled when the instant config is absent', async () => {
+    const config = await loadConfig(
+      PHASE_PRODUCTION_SERVER,
+      uniqueDir('absent'),
+      {
+        customConfig: {},
+      }
+    )
+    expect(config.experimental.instant).toEqual({
+      defaultValidationLevel: 'disabled',
+    })
+  })
+
+  it('defaults to disabled when experimental.instant is an empty object', async () => {
+    const config = await loadConfig(
+      PHASE_PRODUCTION_SERVER,
+      uniqueDir('empty'),
+      {
+        customConfig: { experimental: { instant: {} } },
+      }
+    )
+    expect(config.experimental.instant).toEqual({
+      defaultValidationLevel: 'disabled',
+    })
+  })
+
+  it.each(['disabled', 'warning', 'error'] as const)(
+    'preserves explicit defaultValidationLevel: %s',
+    async (level) => {
+      const config = await loadConfig(
+        PHASE_PRODUCTION_SERVER,
+        uniqueDir(`level-${level}`),
+        {
+          customConfig: {
+            experimental: { instant: { defaultValidationLevel: level } },
+          },
+        }
+      )
+      expect(config.experimental.instant).toEqual({
+        defaultValidationLevel: level,
+      })
+    }
+  )
+})

--- a/test/unit/instant-config-normalization.test.ts
+++ b/test/unit/instant-config-normalization.test.ts
@@ -11,10 +11,10 @@ function uniqueDir(tag: string) {
 }
 
 // Covers the `finalizeConfig` step in loadConfig: resolving
-// `experimental.instant.defaultValidationLevel` to a concrete value in one
-// place so consumers don't each need to know the current framework default.
-describe('experimental.instant defaultValidationLevel normalization', () => {
-  it('defaults to disabled when the instant config is absent', async () => {
+// `experimental.instantInsights.validationLevel` to a concrete value in
+// one place so consumers don't each need to know the current framework default.
+describe('experimental.instantInsights validationLevel normalization', () => {
+  it('defaults to manual-warning when the instantInsights config is absent', async () => {
     const config = await loadConfig(
       PHASE_PRODUCTION_SERVER,
       uniqueDir('absent'),
@@ -22,39 +22,41 @@ describe('experimental.instant defaultValidationLevel normalization', () => {
         customConfig: {},
       }
     )
-    expect(config.experimental.instant).toEqual({
-      defaultValidationLevel: 'disabled',
+    expect(config.experimental.instantInsights).toEqual({
+      validationLevel: 'manual-warning',
     })
   })
 
-  it('defaults to disabled when experimental.instant is an empty object', async () => {
+  it('defaults to manual-warning when experimental.instantInsights is an empty object', async () => {
     const config = await loadConfig(
       PHASE_PRODUCTION_SERVER,
       uniqueDir('empty'),
       {
-        customConfig: { experimental: { instant: {} } },
+        customConfig: { experimental: { instantInsights: {} } },
       }
     )
-    expect(config.experimental.instant).toEqual({
-      defaultValidationLevel: 'disabled',
+    expect(config.experimental.instantInsights).toEqual({
+      validationLevel: 'manual-warning',
     })
   })
 
-  it.each(['disabled', 'warning', 'error'] as const)(
-    'preserves explicit defaultValidationLevel: %s',
-    async (level) => {
-      const config = await loadConfig(
-        PHASE_PRODUCTION_SERVER,
-        uniqueDir(`level-${level}`),
-        {
-          customConfig: {
-            experimental: { instant: { defaultValidationLevel: level } },
-          },
-        }
-      )
-      expect(config.experimental.instant).toEqual({
-        defaultValidationLevel: level,
-      })
-    }
-  )
+  it.each([
+    'warning',
+    'manual-warning',
+    'experimental-error',
+    'experimental-manual-error',
+  ] as const)('preserves explicit validationLevel: %s', async (level) => {
+    const config = await loadConfig(
+      PHASE_PRODUCTION_SERVER,
+      uniqueDir(`level-${level}`),
+      {
+        customConfig: {
+          experimental: { instantInsights: { validationLevel: level } },
+        },
+      }
+    )
+    expect(config.experimental.instantInsights).toEqual({
+      validationLevel: level,
+    })
+  })
 })


### PR DESCRIPTION
Adds `experimental.instantInsights.validationLevel` so an app can opt into instant validation for all routes by default.

There are two public levels
* `manual-warning`: currently the default. this mode won't enable instant validation except where you add `export const unstable_instant = true` into your Layouts, Pages, and Default files
* `warning`: This mode will enable instant validation for all Page and Default files. You can override this with `export const unstable_instant = false` in Layouts, Pages, and Default files to tune what navigations are validated.

In addition this change disables build time validation.

There is a now undocumented way to get back to running build validation with
* `experimental-error`
* `experimental-manual-error`

The build validation isn't ready for users because we need to overhaul the setup where you provide cookies and other sample values so we can run validation without a live session like we do in dev.

To further support this the two remaining object properties that are also not ready for active use, `samples` and `from` are being updated to `unstable_samples` and `unstable_from` respectively.

We will continue to iterate on build time validation but may remove these APIs or alter their semantics as we figure out a more ergonomic way to support this setup.

In anticipation of multiple levels the object form of `instant` can be provided a level value `warning` or `experimental-error`. this latter option is similarly undocumented so documented behavior will only cover `warning` which is generally a synonym of true unless you are activating error by default