### PR TITLE
Speed up native postinstall script

### DIFF
--- a/scripts/install-native.mjs
+++ b/scripts/install-native.mjs
@@ -86,18 +86,24 @@ import { outdent } from 'outdent'
         `
     )
 
-    const args = [
-      'add',
-      `next@${nextVersion}`,
-      '--lockfile=false',
-      '--ignore-scripts',
-    ]
+    const args = ['install', '--lockfile=false', '--ignore-scripts']
     if (preferOffline) {
       args.push('--prefer-offline')
     }
     await execa('pnpm', args, { cwd: tmpdir })
 
-    let pkgs = fs.readdirSync(path.join(tmpdir, 'node_modules/@next'))
+    /** @type {string[]} */
+    let pkgs
+    try {
+      pkgs = fs.readdirSync(path.join(tmpdir, 'node_modules/@next'), {})
+    } catch (error) {
+      throw new Error(
+        'No binary candidate found. ' +
+          `This environment is not supported by Next.js or publish of ${nextVersion} is incomplete. ` +
+          'If binaries are built from source, set `NEXT_SKIP_NATIVE_POSTINSTALL=1`.',
+        { cause: error }
+      )
+    }
     fs.mkdirSync(path.join(cwd, 'node_modules/@next'), { recursive: true })
 
     await Promise.all(

--- a/scripts/install-native.mjs
+++ b/scripts/install-native.mjs
@@ -98,8 +98,8 @@ import { outdent } from 'outdent'
       pkgs = fs.readdirSync(path.join(tmpdir, 'node_modules/@next'), {})
     } catch (error) {
       throw new Error(
-        'No binary candidate found. ' +
-          `This environment is not supported by Next.js or publish of ${nextVersion} is incomplete. ` +
+        'No binary candidate found.\n' +
+          `This environment is not supported by Next.js or publish of ${nextVersion} is incomplete.\n` +
           'If binaries are built from source, set `NEXT_SKIP_NATIVE_POSTINSTALL=1`.',
         { cause: error }
       )


### PR DESCRIPTION
This script always installed `next` even though we just need the binaries which are already listed as optional dependencies. So it seems to me we can avoid downloading `next`.

Also improved the error message if no install candidate is found. pnpm considers non existing versions as failing compat check and ignores those dependencies just like it would ignore dependencies for a different architecture.

## test plan

1. set `version` in `packages/next/package.json` to a version that's fully published (e.g. `16.3.0-canary.2`

```terminal
$ node scripts/install-native.mjs
Installed the following binary packages: [ 'swc-darwin-arm64' ]
```