### PR TITLE
Turbopack: iter_reachable_modules

### DIFF
--- a/crates/next-api/src/client_references.rs
+++ b/crates/next-api/src/client_references.rs
@@ -31,9 +31,9 @@ pub struct ClientReferenceData(FxHashMap<ResolvedVc<Box<dyn Module>>, ClientMani
 pub async fn map_client_references(
     graph: ResolvedVc<ModuleGraphLayer>,
 ) -> Result<Vc<ClientReferenceData>> {
-    let graph = graph.await?;
     let manifest = graph
-        .iter_nodes()
+        .await?
+        .iter_reachable_modules()?
         .map(|module| async move {
             if let Some(client_reference_module) =
                 ResolvedVc::try_downcast_type::<EcmascriptClientReferenceModule>(module)

--- a/crates/next-api/src/dynamic_imports.rs
+++ b/crates/next-api/src/dynamic_imports.rs
@@ -123,7 +123,7 @@ pub async fn map_next_dynamic(
     let actions =
         graph
             .await?
-            .iter_nodes()
+            .iter_reachable_modules()?
             .map(|module| async move {
                 if let Some(dynamic_entry_module) =
                     ResolvedVc::try_downcast_type::<NextDynamicEntryModule>(module)

--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -527,7 +527,7 @@ pub async fn map_server_actions(
 ) -> Result<Vc<AllModuleActions>> {
     let actions = graph
         .await?
-        .iter_nodes()
+        .iter_reachable_modules()?
         .map(async |module| {
             // TODO: compare module contexts instead?
             let layer = match module.ident().await?.layer.as_ref() {

--- a/turbopack/crates/turbopack-core/src/module_graph/async_module_info.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/async_module_info.rs
@@ -4,7 +4,7 @@ use turbo_tasks::{OperationVc, ResolvedVc, TryFlatJoinIterExt, Vc};
 
 use crate::{
     module::Module,
-    module_graph::{GraphTraversalAction, ModuleGraph, ModuleGraphLayer},
+    module_graph::{GraphTraversalAction, ModuleGraph, ModuleGraphLayer, SingleModuleGraphNode},
 };
 
 /// This lists all the modules that are async (self or transitively because they reference another
@@ -44,13 +44,11 @@ async fn compute_async_module_info_single(
     };
     let graph = graph.read_strongly_consistent().await?;
     let self_async_modules = graph
-        .enumerate_nodes()
-        .map(async |(_, node)| {
+        .iter_reachable_nodes()?
+        .map(async |node| {
             Ok(match node {
-                super::SingleModuleGraphNode::Module(node) => {
-                    node.is_self_async().await?.then_some(*node)
-                }
-                super::SingleModuleGraphNode::VisitedModule { idx: _, module } => {
+                SingleModuleGraphNode::Module(node) => node.is_self_async().await?.then_some(*node),
+                SingleModuleGraphNode::VisitedModule { idx: _, module } => {
                     // If a module is async in the parent then we need to mark reverse dependencies
                     // async in this graph as well.
                     parent_async_modules

--- a/turbopack/crates/turbopack-core/src/module_graph/merged_modules.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/merged_modules.rs
@@ -140,7 +140,7 @@ pub async fn compute_merged_modules(module_graph: Vc<ModuleGraph>) -> Result<Vc<
 
         let inner_span = tracing::info_span!("collect mergeable modules");
         let mergeable = module_graph
-            .iter_nodes()
+            .iter_reachable_modules()?
             .map(async |module| {
                 if let Some(mergeable) =
                     ResolvedVc::try_downcast::<Box<dyn MergeableModule>>(module)

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::{BinaryHeap, VecDeque},
     future::Future,
+    iter::FusedIterator,
     ops::Deref,
 };
 
@@ -425,7 +426,8 @@ impl SingleModuleGraph {
         Ok(graph)
     }
 
-    /// Iterate over all nodes in the graph
+    /// WARNING: using this is discouraged, as it doesn't filter out unused or traced references.
+    /// Use iter_reachable_modules or one of the .traverse_* functions instead.
     pub fn iter_nodes(&self) -> impl Iterator<Item = ResolvedVc<Box<dyn Module>>> + '_ {
         self.graph.node_weights().filter_map(|n| match n {
             SingleModuleGraphNode::Module(node) => Some(*node),
@@ -450,7 +452,8 @@ impl SingleModuleGraph {
         self.entries.iter().flat_map(|e| e.entries())
     }
 
-    /// Enumerate all nodes in the graph
+    /// WARNING: using this is discouraged, as it doesn't filter out unused or traced references.
+    /// Use iter_reachable_modules or one of the .traverse_* functions instead.
     pub fn enumerate_nodes(
         &self,
     ) -> impl Iterator<Item = (NodeIndex, &'_ SingleModuleGraphNode)> + '_ {
@@ -933,12 +936,16 @@ impl ModuleGraphSnapshot {
         }
     }
 
+    /// WARNING: using this is discouraged, as it doesn't filter out unused or traced references.
+    /// Use iter_reachable_modules or one of the .traverse_* functions instead.
     pub fn enumerate_nodes(
         &self,
     ) -> impl Iterator<Item = (NodeIndex, &'_ SingleModuleGraphNode)> + '_ {
         self.graphs.iter().flat_map(|g| g.enumerate_nodes())
     }
 
+    /// WARNING: using this is discouraged, as it doesn't filter out unused or traced references.
+    /// Use iter_reachable_modules or one of the .traverse_* functions instead.
     pub fn iter_nodes(&self) -> impl Iterator<Item = ResolvedVc<Box<dyn Module>>> + '_ {
         self.graphs.iter().flat_map(|g| g.iter_nodes())
     }
@@ -1419,7 +1426,65 @@ impl ModuleGraphSnapshot {
 
         Ok(visit_count)
     }
+
+    pub fn iter_reachable_modules(
+        &self,
+    ) -> Result<impl Iterator<Item = ResolvedVc<Box<dyn Module>>>> {
+        ModuleGraphSnapshotNodeIterator::new(self)
+    }
 }
+
+struct ModuleGraphSnapshotNodeIterator<'a> {
+    graph: &'a ModuleGraphSnapshot,
+    visited: FxHashSet<GraphNodeIndex>,
+    visit_queue: VecDeque<GraphNodeIndex>,
+}
+
+impl<'a> ModuleGraphSnapshotNodeIterator<'a> {
+    fn new(graph: &'a ModuleGraphSnapshot) -> Result<Self> {
+        let entries = graph
+            .graphs
+            .iter()
+            .flat_map(|g| g.entry_modules())
+            .map(|e| graph.get_entry(e))
+            .collect::<Result<VecDeque<_>>>()?;
+
+        Ok(Self {
+            graph,
+            visited: FxHashSet::default(),
+            visit_queue: entries,
+        })
+    }
+}
+impl Iterator for ModuleGraphSnapshotNodeIterator<'_> {
+    type Item = ResolvedVc<Box<dyn Module>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(node_idx) = self.visit_queue.pop_front() {
+            if self.visited.insert(node_idx)
+                && let node_weight = self.graph.get_node(node_idx).unwrap()
+                && let SingleModuleGraphNode::Module(module) = node_weight
+                && self
+                    .graph
+                    .should_visit_node(node_weight, Direction::Outgoing)
+            {
+                for (_, succ) in self
+                    .graph
+                    .iter_graphs_neighbors_rev(node_idx, Direction::Outgoing)
+                {
+                    self.visit_queue.push_back(succ);
+                }
+                Some(*module)
+            } else {
+                // Continue to next node
+                self.next()
+            }
+        } else {
+            None
+        }
+    }
+}
+impl FusedIterator for ModuleGraphSnapshotNodeIterator<'_> {}
 
 #[turbo_tasks::value_impl]
 impl SingleModuleGraph {

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -1427,9 +1427,21 @@ impl ModuleGraphSnapshot {
         Ok(visit_count)
     }
 
+    /// Iterates all reachable modules in the graph, ignoring unused and traced references.
     pub fn iter_reachable_modules(
         &self,
     ) -> Result<impl Iterator<Item = ResolvedVc<Box<dyn Module>>>> {
+        Ok(self.iter_reachable_nodes()?.filter_map(|n| match n {
+            SingleModuleGraphNode::Module(m) => Some(*m),
+            SingleModuleGraphNode::VisitedModule { .. } => None,
+        }))
+    }
+
+    /// Iterates all reachable nodes in the graph, ignoring unused and traced references.
+    /// This includes VisitedModule nodes (which means that some modules are returned twice).
+    pub fn iter_reachable_nodes<'a>(
+        &'a self,
+    ) -> Result<impl Iterator<Item = &'a SingleModuleGraphNode> + 'a> {
         ModuleGraphSnapshotNodeIterator::new(self)
     }
 }
@@ -1456,25 +1468,27 @@ impl<'a> ModuleGraphSnapshotNodeIterator<'a> {
         })
     }
 }
-impl Iterator for ModuleGraphSnapshotNodeIterator<'_> {
-    type Item = ResolvedVc<Box<dyn Module>>;
+impl<'a> Iterator for ModuleGraphSnapshotNodeIterator<'a> {
+    type Item = &'a SingleModuleGraphNode;
 
     fn next(&mut self) -> Option<Self::Item> {
         if let Some(node_idx) = self.visit_queue.pop_front() {
-            if self.visited.insert(node_idx)
-                && let node_weight = self.graph.get_node(node_idx).unwrap()
-                && let SingleModuleGraphNode::Module(module) = node_weight
-                && self
+            if self.visited.insert(node_idx) {
+                let node_weight = self.graph.get_node(node_idx).unwrap();
+                if self
                     .graph
                     .should_visit_node(node_weight, Direction::Outgoing)
-            {
-                for (_, succ) in self
-                    .graph
-                    .iter_graphs_neighbors_rev(node_idx, Direction::Outgoing)
                 {
-                    self.visit_queue.push_back(succ);
+                    let node = node_weight
+                        .target_idx(Direction::Outgoing)
+                        .unwrap_or(node_idx);
+                    self.visit_queue.extend(
+                        self.graph
+                            .iter_graphs_neighbors_rev(node, Direction::Outgoing)
+                            .map(|(_, succ)| succ),
+                    );
                 }
-                Some(*module)
+                Some(node_weight)
             } else {
                 // Continue to next node
                 self.next()
@@ -2242,6 +2256,209 @@ pub mod tests {
             assert_eq!(
                 traversal_results.reverse_from_b,
                 vec![rcstr!("[test]/b.js"), rcstr!("[test]/a.js")]
+            );
+
+            Ok(())
+        })
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_iter_nodes_modules_through_layered_graph() {
+        let tt = turbo_tasks::TurboTasks::new(TurboTasksBackend::new(
+            BackendOptions::default(),
+            noop_backing_storage(),
+        ));
+        tt.run_once(async move {
+            #[turbo_tasks::value]
+            struct Results {
+                iter_nodes: Vec<RcStr>,
+                iter_modules: Vec<RcStr>,
+                iter_nodes_single: Vec<Vec<RcStr>>,
+                iter_modules_single: Vec<Vec<RcStr>>,
+            }
+
+            #[turbo_tasks::function(operation)]
+            async fn reverse_traversal_results_operation() -> Result<Vc<Results>> {
+                let fs = VirtualFileSystem::new_with_name(rcstr!("test"));
+                let root = fs.root().await?;
+
+                // a simple linear graph a -> b -> c -> x -> y -> z
+                // but x -> y -> z is in a parent graph
+                let graph = {
+                    let mut deps = FxHashMap::default();
+
+                    deps.insert(rcstr!("a.js"), vec![rcstr!("b.js")]);
+                    deps.insert(rcstr!("b.js"), vec![rcstr!("c.js")]);
+                    deps.insert(rcstr!("c.js"), vec![rcstr!("x.js")]);
+                    deps.insert(rcstr!("x.js"), vec![rcstr!("y.js")]);
+                    deps.insert(rcstr!("y.js"), vec![rcstr!("z.js")]);
+                    deps
+                };
+                let repo = TestRepo {
+                    repo: graph
+                        .iter()
+                        .map(|(k, v)| {
+                            (
+                                root.join(k).unwrap(),
+                                v.iter().map(|f| root.join(f).unwrap()).collect(),
+                            )
+                        })
+                        .collect(),
+                }
+                .cell();
+                let make_module = |name| {
+                    Vc::upcast::<Box<dyn Module>>(MockModule::new(root.join(name).unwrap(), repo))
+                        .to_resolved()
+                };
+                let x_module = make_module("x.js").await?;
+                let a_module = make_module("a.js").await?;
+
+                let parent_graph = SingleModuleGraph::new_with_entries(
+                    ResolvedVc::cell(vec![ChunkGroupEntry::Entry(vec![x_module])]),
+                    false,
+                    false,
+                );
+
+                let module_graph = ModuleGraph::from_graphs(
+                    vec![
+                        parent_graph,
+                        SingleModuleGraph::new_with_entries_visited(
+                            ResolvedVc::cell(vec![ChunkGroupEntry::Entry(vec![a_module])]),
+                            VisitedModules::from_graph(parent_graph),
+                            false,
+                            false,
+                        ),
+                    ],
+                    None,
+                )
+                .connect();
+                let graph_layers = module_graph.iter_graphs().await?;
+
+                Ok(Results {
+                    iter_nodes: module_graph
+                        .await?
+                        .iter_reachable_nodes()?
+                        .map(async |node| {
+                            Ok(match node {
+                                SingleModuleGraphNode::Module(module) => {
+                                    module.ident_string().owned().await?
+                                }
+                                SingleModuleGraphNode::VisitedModule { module, .. } => {
+                                    format!("visited {}", module.ident_string().owned().await?)
+                                        .into()
+                                }
+                            })
+                        })
+                        .try_join()
+                        .await?,
+                    iter_modules: module_graph
+                        .await?
+                        .iter_reachable_modules()?
+                        .map(|m| m.ident_string().owned())
+                        .try_join()
+                        .await?,
+                    iter_nodes_single: graph_layers
+                        .iter()
+                        .map(async |layer| {
+                            layer
+                                .connect()
+                                .await?
+                                .iter_reachable_nodes()?
+                                .map(async |node| {
+                                    Ok(match node {
+                                        SingleModuleGraphNode::Module(module) => {
+                                            module.ident_string().owned().await?
+                                        }
+                                        SingleModuleGraphNode::VisitedModule { module, .. } => {
+                                            format!(
+                                                "visited {}",
+                                                module.ident_string().owned().await?
+                                            )
+                                            .into()
+                                        }
+                                    })
+                                })
+                                .try_join()
+                                .await
+                        })
+                        .try_join()
+                        .await?,
+                    iter_modules_single: graph_layers
+                        .iter()
+                        .map(async |layer| {
+                            layer
+                                .connect()
+                                .await?
+                                .iter_reachable_modules()?
+                                .map(|m| m.ident_string().owned())
+                                .try_join()
+                                .await
+                        })
+                        .try_join()
+                        .await?,
+                }
+                .cell())
+            }
+
+            let traversal_results = reverse_traversal_results_operation()
+                .read_strongly_consistent()
+                .await?;
+
+            assert_eq!(
+                traversal_results.iter_nodes,
+                vec![
+                    rcstr!("[test]/x.js"),
+                    rcstr!("[test]/a.js"),
+                    rcstr!("[test]/y.js"),
+                    rcstr!("[test]/b.js"),
+                    rcstr!("[test]/z.js"),
+                    rcstr!("[test]/c.js"),
+                    rcstr!("visited [test]/x.js")
+                ]
+            );
+            assert_eq!(
+                traversal_results.iter_modules,
+                vec![
+                    rcstr!("[test]/x.js"),
+                    rcstr!("[test]/a.js"),
+                    rcstr!("[test]/y.js"),
+                    rcstr!("[test]/b.js"),
+                    rcstr!("[test]/z.js"),
+                    rcstr!("[test]/c.js")
+                ]
+            );
+            assert_eq!(
+                traversal_results.iter_nodes_single,
+                vec![
+                    vec![
+                        rcstr!("[test]/x.js"),
+                        rcstr!("[test]/y.js"),
+                        rcstr!("[test]/z.js")
+                    ],
+                    vec![
+                        rcstr!("[test]/a.js"),
+                        rcstr!("[test]/b.js"),
+                        rcstr!("[test]/c.js"),
+                        rcstr!("visited [test]/x.js")
+                    ]
+                ]
+            );
+            assert_eq!(
+                traversal_results.iter_modules_single,
+                vec![
+                    vec![
+                        rcstr!("[test]/x.js"),
+                        rcstr!("[test]/y.js"),
+                        rcstr!("[test]/z.js")
+                    ],
+                    vec![
+                        rcstr!("[test]/a.js"),
+                        rcstr!("[test]/b.js"),
+                        rcstr!("[test]/c.js")
+                    ]
+                ]
             );
 
             Ok(())

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -1472,7 +1472,7 @@ impl<'a> Iterator for ModuleGraphSnapshotNodeIterator<'a> {
     type Item = &'a SingleModuleGraphNode;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if let Some(node_idx) = self.visit_queue.pop_front() {
+        while let Some(node_idx) = self.visit_queue.pop_front() {
             if self.visited.insert(node_idx) {
                 let node_weight = self.graph.get_node(node_idx).unwrap();
                 if self
@@ -1485,17 +1485,14 @@ impl<'a> Iterator for ModuleGraphSnapshotNodeIterator<'a> {
                     self.visit_queue.extend(
                         self.graph
                             .iter_graphs_neighbors_rev(node, Direction::Outgoing)
-                            .map(|(_, succ)| succ),
+                            .map(|(_, succ)| succ)
+                            .filter(|succ| !self.visited.contains(succ)),
                     );
                 }
-                Some(node_weight)
-            } else {
-                // Continue to next node
-                self.next()
+                return Some(node_weight);
             }
-        } else {
-            None
         }
+        None
     }
 }
 impl FusedIterator for ModuleGraphSnapshotNodeIterator<'_> {}

--- a/turbopack/crates/turbopack-core/src/module_graph/side_effect_module_info.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/side_effect_module_info.rs
@@ -4,7 +4,7 @@ use turbo_tasks::{ResolvedVc, TryJoinIterExt, Vc};
 
 use crate::{
     module::{Module, ModuleSideEffects},
-    module_graph::{GraphTraversalAction, ModuleGraph, ModuleGraphLayer},
+    module_graph::{GraphTraversalAction, ModuleGraph, ModuleGraphLayer, SingleModuleGraphNode},
 };
 
 /// This lists all the modules that are side effect free
@@ -43,16 +43,16 @@ async fn compute_side_effect_free_module_info_single(
     let parent_side_effect_free_modules = parent_side_effect_free_modules.await?;
     let graph = graph.await?;
     let module_side_effects = graph
-        .enumerate_nodes()
-        .map(async |(_, node)| {
+        .iter_reachable_nodes()?
+        .map(async |node| {
             Ok(match node {
-                super::SingleModuleGraphNode::Module(module) => {
+                SingleModuleGraphNode::Module(module) => {
                     // This turbo task always has a cache hit since it is called when building the
                     // module graph. we could consider moving this information
                     // into to the module graph, but then changes would invalidate the whole graph.
                     (*module, *module.side_effects().await?)
                 }
-                super::SingleModuleGraphNode::VisitedModule { idx: _, module } => (
+                SingleModuleGraphNode::VisitedModule { idx: _, module } => (
                     *module,
                     if parent_side_effect_free_modules.contains(module) {
                         ModuleSideEffects::SideEffectFree


### PR DESCRIPTION
Add `iter_reachable_modules` and `iter_reachable_nodes`. They actually respect unused references