### PR TITLE
ci: Fix caching of test-cargo-unit

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -238,6 +238,7 @@ jobs:
       needsRust: 'yes'
       needsNextest: 'yes'
       skipNativeBuild: 'yes'
+      skipInstallBuild: 'yes'
       afterBuild: pnpm dlx turbo@${TURBO_VERSION} run test-cargo-unit ${TURBO_ARGS}
       stepName: 'test-cargo-unit'
     secrets: inherit

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -309,7 +309,7 @@ jobs:
         if: ${{ inputs.skipInstallBuild != 'yes' }}
 
       - run: pnpm install
-        if: ${{ inputs.skipInstallBuild != 'yes' }}
+        if: ${{ inputs.skipInstallBuild != 'yes' || inputs.needsNextest == 'yes' }}
 
       - name: Install node-file-trace test dependencies
         if: ${{ inputs.needsNextest == 'yes' }}

--- a/packages/next-swc/turbo.jsonc
+++ b/packages/next-swc/turbo.jsonc
@@ -84,7 +84,12 @@
     },
     "test-cargo-unit": {
       "dependsOn": ["rust-fingerprint"],
-      "inputs": ["../../target/.rust-fingerprint"],
+      "inputs": [
+        "../../target/.rust-fingerprint",
+        "../../crates/*/tests/**",
+        "../../turbopack/crates/*/tests/**",
+        "!../../turbopack/crates/turbopack-tests/tests/execution/**/output/*",
+      ],
     },
   },
 }


### PR DESCRIPTION
Previously, it only used the rust files as the cache key via `rust-fingerprint`.
So changing fixtures didn't invalidate the turborepo run.