### PR TITLE
[ci]: Use macOS arm runner for intel builds

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -223,7 +223,7 @@ jobs:
 
     name: stable - ${{ matrix.target }} - node@20
     runs-on: ${{ fromJSON(matrix.host) }}
-    timeout-minutes: ${{ matrix.os == 'mac' && 90 || 45 }}
+    timeout-minutes: 45
     env:
       # Disable all build caches for production/staging/force-preview deploys
       NEXT_SKIP_BUILD_CACHE: ${{ contains(fromJSON('["production","staging","force-preview"]'), needs.deploy-target.outputs.value) && '1' || '' }}

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -183,13 +183,10 @@ jobs:
             build_task: build-native-release
             os:
               mac:
+                host: "['macos-15']"
                 vendor: apple
                 sys: darwin
-                arch:
-                  x86_64:
-                    host: "['macos-15-intel']"
-                  aarch64:
-                    host: "['macos-15']"
+                arch: [x86_64, aarch64]
               windows:
                 host: "['windows-latest-8-core-oss']"
                 vendor: pc


### PR DESCRIPTION
The intel runners were quite a bit slower than the base arm runners. We were previously compiling both architectures on self-hosted arm so this just back the status quo on GH runners to improve speed. This shaves off ~10/20 mins.

Validated [here](https://github.com/vercel/next.js/actions/runs/25071926790/job/73454315459) 