### PR TITLE
[turbo-trace-server] optimize loading even more

### DIFF
--- a/turbopack/crates/turbopack-trace-server/src/chunked_vec.rs
+++ b/turbopack/crates/turbopack-trace-server/src/chunked_vec.rs
@@ -1,0 +1,320 @@
+//! A push-only vector that grows in fixed-size chunks instead of one
+//! contiguous reallocating buffer.
+//!
+//! `Vec<T>` doubles its backing buffer on overflow, which is fine for
+//! small workloads but expensive when the per-element size is large and
+//! the element count is huge. The trace server pushes ~47M `Span`s of
+//! ~376 bytes each during a load — every doubling copies gigabytes of
+//! span data. `ChunkedVec` instead allocates a fresh chunk of `CHUNK_SIZE`
+//! elements on overflow, so growth cost is constant per chunk and there
+//! are no copies of existing elements.
+//!
+//! The trade-off vs. `Vec`:
+//! - One pointer indirection per indexed access (chunk lookup → element).
+//! - Slightly larger per-element overhead from chunk pointers (negligible at 64K elements/chunk ×
+//!   376 bytes = 24 MB/chunk).
+//! - References returned by `index`/`index_mut` are stable across `push` (a future-useful property;
+//!   not currently relied on).
+//!
+//! Each chunk is a `Box<[MaybeUninit<T>; CHUNK_SIZE]>` rather than a
+//! `Vec<T>` because chunks are fixed-size and never reallocate — the
+//! per-chunk `len`/`capacity` fields a `Vec` would carry are pure
+//! redundancy when `ChunkedVec::len` is the sole source of truth for the
+//! init/uninit cutoff.
+//!
+//! API is intentionally minimal — only the operations the trace server
+//! needs (`push`, `len`, indexed access, `get`, `truncate`).
+
+use std::{
+    mem::MaybeUninit,
+    ops::{Index, IndexMut},
+};
+
+/// Number of elements per chunk. Power of two so `idx / CHUNK_SIZE` and
+/// `idx % CHUNK_SIZE` compile to a shift and a mask. 64K elements ×
+/// 376-byte `Span` = 24 MB per chunk; large allocations like this are
+/// served via `mmap`, so they're naturally page-aligned.
+const CHUNK_SIZE: usize = 1 << 16;
+
+/// Returns the chunk index and intra-chunk offset for an element index.
+#[inline]
+fn split_index(idx: usize) -> (usize, usize) {
+    (idx / CHUNK_SIZE, idx % CHUNK_SIZE)
+}
+
+type Chunk<T> = Box<[MaybeUninit<T>; CHUNK_SIZE]>;
+
+/// Allocate a fresh chunk on the heap without ever materializing a
+/// `CHUNK_SIZE`-element array on the stack.
+fn new_chunk<T>() -> Chunk<T> {
+    // SAFETY: `Box<MaybeUninit<[MaybeUninit<T>; N]>>` and
+    // `Box<[MaybeUninit<T>; N]>` have identical layout; the outer
+    // `MaybeUninit` is just deferring initialization of the array of
+    // uninitialized slots, which trivially satisfies "init".
+    unsafe {
+        let raw: Box<MaybeUninit<[MaybeUninit<T>; CHUNK_SIZE]>> = Box::new_uninit();
+        raw.assume_init()
+    }
+}
+
+pub struct ChunkedVec<T> {
+    chunks: Vec<Chunk<T>>,
+    len: usize,
+}
+
+impl<T> ChunkedVec<T> {
+    pub fn new() -> Self {
+        Self {
+            chunks: Vec::new(),
+            len: 0,
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Append an element. Returns the index it was placed at.
+    pub fn push(&mut self, value: T) -> usize {
+        let idx = self.len;
+        let (chunk_idx, off) = split_index(idx);
+        if off == 0 {
+            // Crossing into a new chunk — allocate it.
+            debug_assert_eq!(chunk_idx, self.chunks.len());
+            self.chunks.push(new_chunk());
+        }
+        self.chunks[chunk_idx][off].write(value);
+        self.len += 1;
+        idx
+    }
+
+    pub fn get(&self, idx: usize) -> Option<&T> {
+        if idx >= self.len {
+            return None;
+        }
+        let (chunk_idx, off) = split_index(idx);
+        // SAFETY: `idx < self.len` ⇒ slot was previously written by
+        // `push` and not freed by `truncate`.
+        Some(unsafe { self.chunks[chunk_idx][off].assume_init_ref() })
+    }
+
+    /// Drop all elements after `new_len`. Used by `Store::reset` with
+    /// `new_len = 1` to keep the root span and discard everything else.
+    pub fn truncate(&mut self, new_len: usize) {
+        if new_len >= self.len {
+            return;
+        }
+        let old_len = self.len;
+        // Set len early so any panic in element drops doesn't leave us
+        // with a `len` that points at already-dropped slots.
+        self.len = new_len;
+
+        // Drop every initialized slot in [new_len, old_len). Walk the
+        // chunks one by one so we visit each `MaybeUninit<T>` exactly
+        // once.
+        let (first_chunk, first_off) = split_index(new_len);
+        // `old_len > new_len >= 0` here, so `old_len > 0` and the last
+        // populated chunk is `(old_len - 1) / CHUNK_SIZE`. The number
+        // of initialized slots in that chunk is `((old_len - 1) %
+        // CHUNK_SIZE) + 1` — which is `CHUNK_SIZE` when `old_len` lands
+        // exactly on a chunk boundary.
+        let last_chunk = (old_len - 1) / CHUNK_SIZE;
+        let last_chunk_end = ((old_len - 1) % CHUNK_SIZE) + 1;
+
+        for chunk_idx in first_chunk..=last_chunk {
+            let chunk = &mut self.chunks[chunk_idx];
+            let start = if chunk_idx == first_chunk {
+                first_off
+            } else {
+                0
+            };
+            let end = if chunk_idx == last_chunk {
+                last_chunk_end
+            } else {
+                CHUNK_SIZE
+            };
+            for slot in &mut chunk[start..end] {
+                // SAFETY: the slot was initialized by a prior `push`
+                // and has not yet been dropped by `truncate`.
+                unsafe { slot.assume_init_drop() };
+            }
+        }
+
+        // Free chunks that no longer hold any initialized slots.
+        let chunks_to_keep = if first_off == 0 {
+            first_chunk
+        } else {
+            first_chunk + 1
+        };
+        self.chunks.truncate(chunks_to_keep);
+    }
+}
+
+impl<T> Default for ChunkedVec<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T> Drop for ChunkedVec<T> {
+    fn drop(&mut self) {
+        // Drops every initialized slot; the `Vec<Chunk<T>>` then frees
+        // the chunk allocations themselves on its own drop.
+        self.truncate(0);
+    }
+}
+
+impl<T> Index<usize> for ChunkedVec<T> {
+    type Output = T;
+
+    #[inline]
+    fn index(&self, idx: usize) -> &T {
+        assert!(idx < self.len, "index out of bounds: {idx} >= {}", self.len);
+        let (chunk_idx, off) = split_index(idx);
+        // SAFETY: `idx < self.len` ⇒ slot is initialized.
+        unsafe { self.chunks[chunk_idx][off].assume_init_ref() }
+    }
+}
+
+impl<T> IndexMut<usize> for ChunkedVec<T> {
+    #[inline]
+    fn index_mut(&mut self, idx: usize) -> &mut T {
+        assert!(idx < self.len, "index out of bounds: {idx} >= {}", self.len);
+        let (chunk_idx, off) = split_index(idx);
+        // SAFETY: `idx < self.len` ⇒ slot is initialized.
+        unsafe { self.chunks[chunk_idx][off].assume_init_mut() }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty() {
+        let v: ChunkedVec<u32> = ChunkedVec::new();
+        assert_eq!(v.len(), 0);
+        assert!(v.get(0).is_none());
+    }
+
+    #[test]
+    fn push_within_first_chunk() {
+        let mut v = ChunkedVec::new();
+        for i in 0..1000u32 {
+            assert_eq!(v.push(i), i as usize);
+        }
+        assert_eq!(v.len(), 1000);
+        assert_eq!(v[0], 0);
+        assert_eq!(v[999], 999);
+        assert_eq!(v.get(1000), None);
+    }
+
+    #[test]
+    fn push_across_chunk_boundary() {
+        let mut v = ChunkedVec::new();
+        // Push enough to span three chunks.
+        let total = 3 * CHUNK_SIZE + 17;
+        for i in 0..total {
+            v.push(i);
+        }
+        assert_eq!(v.len(), total);
+        assert_eq!(v[0], 0);
+        assert_eq!(v[CHUNK_SIZE - 1], CHUNK_SIZE - 1);
+        assert_eq!(v[CHUNK_SIZE], CHUNK_SIZE);
+        assert_eq!(v[2 * CHUNK_SIZE], 2 * CHUNK_SIZE);
+        assert_eq!(v[total - 1], total - 1);
+    }
+
+    #[test]
+    fn index_mut_writes_through() {
+        let mut v = ChunkedVec::new();
+        for i in 0..(CHUNK_SIZE + 5) {
+            v.push(i);
+        }
+        v[CHUNK_SIZE + 3] = 9999;
+        assert_eq!(v[CHUNK_SIZE + 3], 9999);
+    }
+
+    #[test]
+    fn truncate_within_first_chunk() {
+        let mut v = ChunkedVec::new();
+        for i in 0..100 {
+            v.push(i);
+        }
+        v.truncate(1);
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0], 0);
+        assert!(v.get(1).is_none());
+    }
+
+    #[test]
+    fn truncate_across_chunks() {
+        let mut v = ChunkedVec::new();
+        for i in 0..(2 * CHUNK_SIZE + 10) {
+            v.push(i);
+        }
+        // Truncate to a length that lands on a chunk boundary.
+        v.truncate(CHUNK_SIZE);
+        assert_eq!(v.len(), CHUNK_SIZE);
+        assert_eq!(v[CHUNK_SIZE - 1], CHUNK_SIZE - 1);
+        assert!(v.get(CHUNK_SIZE).is_none());
+        // Truncate further into the first chunk.
+        v.truncate(50);
+        assert_eq!(v.len(), 50);
+        assert_eq!(v[49], 49);
+        assert!(v.get(50).is_none());
+    }
+
+    #[test]
+    fn truncate_to_or_above_len_is_noop() {
+        let mut v = ChunkedVec::new();
+        for i in 0..10 {
+            v.push(i);
+        }
+        v.truncate(10);
+        assert_eq!(v.len(), 10);
+        v.truncate(100);
+        assert_eq!(v.len(), 10);
+    }
+
+    #[test]
+    fn push_after_truncate_continues_at_correct_index() {
+        let mut v = ChunkedVec::new();
+        for i in 0..(CHUNK_SIZE + 5) {
+            v.push(i);
+        }
+        v.truncate(3);
+        assert_eq!(v.push(42), 3);
+        assert_eq!(v.len(), 4);
+        assert_eq!(v[3], 42);
+    }
+
+    #[test]
+    fn drops_elements_on_truncate_and_drop() {
+        use std::rc::Rc;
+        let counter = Rc::new(());
+        {
+            let mut v: ChunkedVec<Rc<()>> = ChunkedVec::new();
+            // Span multiple chunks so we exercise the multi-chunk drop path.
+            let total = 2 * CHUNK_SIZE + 5;
+            for _ in 0..total {
+                v.push(counter.clone());
+            }
+            assert_eq!(Rc::strong_count(&counter), total + 1);
+            // Truncate into the first chunk; should drop everything except
+            // the first 10 clones.
+            v.truncate(10);
+            assert_eq!(Rc::strong_count(&counter), 10 + 1);
+            // Truncate to a chunk boundary after pushing more; verify the
+            // boundary case (off == 0) drops the whole trailing chunk.
+            for _ in 0..(CHUNK_SIZE - 10) {
+                v.push(counter.clone());
+            }
+            assert_eq!(v.len(), CHUNK_SIZE);
+            assert_eq!(Rc::strong_count(&counter), CHUNK_SIZE + 1);
+            v.truncate(CHUNK_SIZE);
+            assert_eq!(Rc::strong_count(&counter), CHUNK_SIZE + 1);
+        } // ChunkedVec drop runs here, dropping the remaining CHUNK_SIZE clones.
+        assert_eq!(Rc::strong_count(&counter), 1);
+    }
+}

--- a/turbopack/crates/turbopack-trace-server/src/chunked_vec.rs
+++ b/turbopack/crates/turbopack-trace-server/src/chunked_vec.rs
@@ -1,26 +1,11 @@
 //! A push-only vector that grows in fixed-size chunks instead of one
 //! contiguous reallocating buffer.
 //!
-//! `Vec<T>` doubles its backing buffer on overflow, which is fine for
-//! small workloads but expensive when the per-element size is large and
-//! the element count is huge. The trace server pushes ~47M `Span`s of
-//! ~376 bytes each during a load — every doubling copies gigabytes of
-//! span data. `ChunkedVec` instead allocates a fresh chunk of `CHUNK_SIZE`
-//! elements on overflow, so growth cost is constant per chunk and there
-//! are no copies of existing elements.
-//!
 //! The trade-off vs. `Vec`:
 //! - One pointer indirection per indexed access (chunk lookup → element).
-//! - Slightly larger per-element overhead from chunk pointers (negligible at 64K elements/chunk ×
-//!   376 bytes = 24 MB/chunk).
+//! - Slightly larger per-element overhead from chunk pointers (negligible at 64K elements/chunk).
 //! - References returned by `index`/`index_mut` are stable across `push` (a future-useful property;
 //!   not currently relied on).
-//!
-//! Each chunk is a `Box<[MaybeUninit<T>; CHUNK_SIZE]>` rather than a
-//! `Vec<T>` because chunks are fixed-size and never reallocate — the
-//! per-chunk `len`/`capacity` fields a `Vec` would carry are pure
-//! redundancy when `ChunkedVec::len` is the sole source of truth for the
-//! init/uninit cutoff.
 //!
 //! API is intentionally minimal — only the operations the trace server
 //! needs (`push`, `len`, indexed access, `get`, `truncate`).
@@ -31,9 +16,7 @@ use std::{
 };
 
 /// Number of elements per chunk. Power of two so `idx / CHUNK_SIZE` and
-/// `idx % CHUNK_SIZE` compile to a shift and a mask. 64K elements ×
-/// 376-byte `Span` = 24 MB per chunk; large allocations like this are
-/// served via `mmap`, so they're naturally page-aligned.
+/// `idx % CHUNK_SIZE` compile to a shift and a mask.
 const CHUNK_SIZE: usize = 1 << 16;
 
 /// Returns the chunk index and intra-chunk offset for an element index.

--- a/turbopack/crates/turbopack-trace-server/src/chunked_vec.rs
+++ b/turbopack/crates/turbopack-trace-server/src/chunked_vec.rs
@@ -97,57 +97,6 @@ impl<T> ChunkedVec<T> {
         // `push` and not freed by `truncate`.
         Some(unsafe { self.chunks[chunk_idx][off].assume_init_ref() })
     }
-
-    /// Drop all elements after `new_len`. Used by `Store::reset` with
-    /// `new_len = 1` to keep the root span and discard everything else.
-    pub fn truncate(&mut self, new_len: usize) {
-        if new_len >= self.len {
-            return;
-        }
-        let old_len = self.len;
-        // Set len early so any panic in element drops doesn't leave us
-        // with a `len` that points at already-dropped slots.
-        self.len = new_len;
-
-        // Drop every initialized slot in [new_len, old_len). Walk the
-        // chunks one by one so we visit each `MaybeUninit<T>` exactly
-        // once.
-        let (first_chunk, first_off) = split_index(new_len);
-        // `old_len > new_len >= 0` here, so `old_len > 0` and the last
-        // populated chunk is `(old_len - 1) / CHUNK_SIZE`. The number
-        // of initialized slots in that chunk is `((old_len - 1) %
-        // CHUNK_SIZE) + 1` — which is `CHUNK_SIZE` when `old_len` lands
-        // exactly on a chunk boundary.
-        let last_chunk = (old_len - 1) / CHUNK_SIZE;
-        let last_chunk_end = ((old_len - 1) % CHUNK_SIZE) + 1;
-
-        for chunk_idx in first_chunk..=last_chunk {
-            let chunk = &mut self.chunks[chunk_idx];
-            let start = if chunk_idx == first_chunk {
-                first_off
-            } else {
-                0
-            };
-            let end = if chunk_idx == last_chunk {
-                last_chunk_end
-            } else {
-                CHUNK_SIZE
-            };
-            for slot in &mut chunk[start..end] {
-                // SAFETY: the slot was initialized by a prior `push`
-                // and has not yet been dropped by `truncate`.
-                unsafe { slot.assume_init_drop() };
-            }
-        }
-
-        // Free chunks that no longer hold any initialized slots.
-        let chunks_to_keep = if first_off == 0 {
-            first_chunk
-        } else {
-            first_chunk + 1
-        };
-        self.chunks.truncate(chunks_to_keep);
-    }
 }
 
 impl<T> Default for ChunkedVec<T> {
@@ -158,9 +107,23 @@ impl<T> Default for ChunkedVec<T> {
 
 impl<T> Drop for ChunkedVec<T> {
     fn drop(&mut self) {
-        // Drops every initialized slot; the `Vec<Chunk<T>>` then frees
-        // the chunk allocations themselves on its own drop.
-        self.truncate(0);
+        // Drop every initialized slot in [new_len, old_len). Walk the
+        // chunks one by one so we visit each `MaybeUninit<T>` exactly
+        // once.
+        let (last_chunk, last_chunk_len) = split_index(self.len);
+
+        for (chunk_index, chunk) in self.chunks.iter_mut().enumerate() {
+            let chunk_end = if chunk_index == last_chunk {
+                last_chunk_len
+            } else {
+                CHUNK_SIZE
+            };
+            for slot in &mut chunk[0..chunk_end] {
+                // SAFETY: the slot was initialized by a prior `push`
+                // and has not yet been dropped by `truncate`.
+                unsafe { slot.assume_init_drop() };
+            }
+        }
     }
 }
 
@@ -236,61 +199,7 @@ mod tests {
     }
 
     #[test]
-    fn truncate_within_first_chunk() {
-        let mut v = ChunkedVec::new();
-        for i in 0..100 {
-            v.push(i);
-        }
-        v.truncate(1);
-        assert_eq!(v.len(), 1);
-        assert_eq!(v[0], 0);
-        assert!(v.get(1).is_none());
-    }
-
-    #[test]
-    fn truncate_across_chunks() {
-        let mut v = ChunkedVec::new();
-        for i in 0..(2 * CHUNK_SIZE + 10) {
-            v.push(i);
-        }
-        // Truncate to a length that lands on a chunk boundary.
-        v.truncate(CHUNK_SIZE);
-        assert_eq!(v.len(), CHUNK_SIZE);
-        assert_eq!(v[CHUNK_SIZE - 1], CHUNK_SIZE - 1);
-        assert!(v.get(CHUNK_SIZE).is_none());
-        // Truncate further into the first chunk.
-        v.truncate(50);
-        assert_eq!(v.len(), 50);
-        assert_eq!(v[49], 49);
-        assert!(v.get(50).is_none());
-    }
-
-    #[test]
-    fn truncate_to_or_above_len_is_noop() {
-        let mut v = ChunkedVec::new();
-        for i in 0..10 {
-            v.push(i);
-        }
-        v.truncate(10);
-        assert_eq!(v.len(), 10);
-        v.truncate(100);
-        assert_eq!(v.len(), 10);
-    }
-
-    #[test]
-    fn push_after_truncate_continues_at_correct_index() {
-        let mut v = ChunkedVec::new();
-        for i in 0..(CHUNK_SIZE + 5) {
-            v.push(i);
-        }
-        v.truncate(3);
-        assert_eq!(v.push(42), 3);
-        assert_eq!(v.len(), 4);
-        assert_eq!(v[3], 42);
-    }
-
-    #[test]
-    fn drops_elements_on_truncate_and_drop() {
+    fn drops_elements_on_drop() {
         use std::rc::Rc;
         let counter = Rc::new(());
         {
@@ -301,19 +210,6 @@ mod tests {
                 v.push(counter.clone());
             }
             assert_eq!(Rc::strong_count(&counter), total + 1);
-            // Truncate into the first chunk; should drop everything except
-            // the first 10 clones.
-            v.truncate(10);
-            assert_eq!(Rc::strong_count(&counter), 10 + 1);
-            // Truncate to a chunk boundary after pushing more; verify the
-            // boundary case (off == 0) drops the whole trailing chunk.
-            for _ in 0..(CHUNK_SIZE - 10) {
-                v.push(counter.clone());
-            }
-            assert_eq!(v.len(), CHUNK_SIZE);
-            assert_eq!(Rc::strong_count(&counter), CHUNK_SIZE + 1);
-            v.truncate(CHUNK_SIZE);
-            assert_eq!(Rc::strong_count(&counter), CHUNK_SIZE + 1);
         } // ChunkedVec drop runs here, dropping the remaining CHUNK_SIZE clones.
         assert_eq!(Rc::strong_count(&counter), 1);
     }

--- a/turbopack/crates/turbopack-trace-server/src/lib.rs
+++ b/turbopack/crates/turbopack-trace-server/src/lib.rs
@@ -17,6 +17,7 @@ use self::{
 };
 
 mod bottom_up;
+mod chunked_vec;
 mod lazy_sorted_vec;
 mod reader;
 mod self_time_tree;

--- a/turbopack/crates/turbopack-trace-server/src/main.rs
+++ b/turbopack/crates/turbopack-trace-server/src/main.rs
@@ -12,6 +12,7 @@ use rustc_hash::FxHasher;
 use self::{reader::TraceReader, server::serve, store_container::StoreContainer};
 
 mod bottom_up;
+mod chunked_vec;
 mod lazy_sorted_vec;
 mod reader;
 mod self_time_tree;

--- a/turbopack/crates/turbopack-trace-server/src/reader/turbopack.rs
+++ b/turbopack/crates/turbopack-trace-server/src/reader/turbopack.rs
@@ -100,12 +100,6 @@ impl TurbopackFormat {
         }
     }
 
-    /// Eagerly intern a list of `(key, value)` pairs from a parsed trace row
-    /// into the same `SpanArgs` (`SmallVec<[(RcStr, RcStr); 1]>`) shape that
-    /// `Span::args` uses, so the queued/Start path and the final stored args
-    /// share one allocation. Both keys and values become `RcStr`s up front:
-    /// string variants are interned directly, non-string variants are
-    /// rendered via `Display` and interned.
     fn intern_span_args(&mut self, values: Vec<(Cow<'_, str>, TraceValue<'_>)>) -> SpanArgs {
         values
             .into_iter()
@@ -216,9 +210,7 @@ impl TurbopackFormat {
             TraceRow::Event { ts, parent, values } => {
                 let ts = Timestamp::from_micros(ts);
                 // Pull `duration` and `name` out of the typed values during
-                // interning, so the runtime `values` vec is uniformly
-                // `Vec<(RcStr, RcStr)>` and the Event arm of
-                // `process_internal_row` doesn't need a hashmap detour.
+                // interning
                 let mut duration = Timestamp::ZERO;
                 let mut name = rcstr!("event");
                 let mut interned_values: SpanArgs = SpanArgs::with_capacity(values.len());

--- a/turbopack/crates/turbopack-trace-server/src/reader/turbopack.rs
+++ b/turbopack/crates/turbopack-trace-server/src/reader/turbopack.rs
@@ -1,20 +1,19 @@
 use std::{
     borrow::Cow,
     collections::hash_map::Entry,
-    mem::{take, transmute},
+    mem::transmute,
     ops::{Deref, DerefMut},
     sync::Arc,
 };
 
 use anyhow::Result;
 use rustc_hash::{FxHashMap, FxHashSet};
-use turbo_rcstr::{RcStr, RcStrInterning};
+use turbo_rcstr::{RcStr, RcStrInterning, rcstr};
 use turbopack_trace_utils::tracing::{TraceRow, TraceValue};
 
 use super::TraceFormat;
 use crate::{
-    FxIndexMap,
-    span::SpanIndex,
+    span::{SpanArgs, SpanIndex},
     store_container::{StoreContainer, StoreWriteGuard},
     timestamp::Timestamp,
 };
@@ -27,41 +26,36 @@ struct AllocationInfo {
     deallocation_count: u64,
 }
 
-struct InternalRow<'a> {
+struct InternalRow {
     id: Option<u64>,
-    ty: InternalRowType<'a>,
+    ty: InternalRowType,
 }
 
-impl InternalRow<'_> {
-    fn into_static(self) -> InternalRow<'static> {
-        InternalRow {
-            id: self.id,
-            ty: self.ty.into_static(),
-        }
-    }
-}
-
-enum InternalRowType<'a> {
+enum InternalRowType {
     Start {
         new_id: u64,
         ts: Timestamp,
-        name: Cow<'a, str>,
-        target: Cow<'a, str>,
-        values: Vec<(Cow<'a, str>, TraceValue<'a>)>,
+        name: RcStr,
+        target: RcStr,
+        values: SpanArgs,
     },
-    End {
-        ts: Timestamp,
-    },
+    End,
     SelfTime {
         start: Timestamp,
         end: Timestamp,
     },
     Event {
         ts: Timestamp,
-        values: Vec<(Cow<'a, str>, TraceValue<'a>)>,
+        /// Pre-extracted at parse time from the typed `TraceValue::UInt`;
+        /// the runtime `values` vec no longer carries it.
+        duration: Timestamp,
+        /// Pre-extracted at parse time from the typed `TraceValue::String`;
+        /// defaults to `"event"` when not present.
+        name: RcStr,
+        values: SpanArgs,
     },
     Record {
-        values: Vec<(Cow<'a, str>, TraceValue<'a>)>,
+        values: SpanArgs,
     },
     Allocation {
         allocations: u64,
@@ -73,71 +67,16 @@ enum InternalRowType<'a> {
     },
 }
 
-impl InternalRowType<'_> {
-    fn into_static(self) -> InternalRowType<'static> {
-        match self {
-            InternalRowType::Start {
-                ts,
-                new_id,
-                name,
-                target,
-                values,
-            } => InternalRowType::Start {
-                ts,
-                new_id,
-                name: name.into_owned().into(),
-                target: target.into_owned().into(),
-                values: values
-                    .into_iter()
-                    .map(|(k, v)| (k.into_owned().into(), v.into_static()))
-                    .collect(),
-            },
-            InternalRowType::End { ts } => InternalRowType::End { ts },
-            InternalRowType::SelfTime { start, end } => InternalRowType::SelfTime { start, end },
-            InternalRowType::Event { ts, values } => InternalRowType::Event {
-                ts,
-                values: values
-                    .into_iter()
-                    .map(|(k, v)| (k.into_owned().into(), v.into_static()))
-                    .collect(),
-            },
-            InternalRowType::Record { values } => InternalRowType::Record {
-                values: values
-                    .into_iter()
-                    .map(|(k, v)| (k.into_owned().into(), v.into_static()))
-                    .collect(),
-            },
-            InternalRowType::Allocation {
-                allocations,
-                allocation_count,
-            } => InternalRowType::Allocation {
-                allocations,
-                allocation_count,
-            },
-            InternalRowType::Deallocation {
-                deallocations,
-                deallocation_count,
-            } => InternalRowType::Deallocation {
-                deallocations,
-                deallocation_count,
-            },
-        }
-    }
-}
-
 pub struct TurbopackFormat {
     store: Arc<StoreContainer>,
     id_mapping: FxHashMap<u64, SpanIndex>,
     dropped_ids: FxHashSet<u64>,
     remaining_ids_to_drop: usize,
-    queued_rows: FxHashMap<u64, Vec<InternalRow<'static>>>,
+    queued_rows: FxHashMap<u64, Vec<InternalRow>>,
     outdated_spans: FxHashSet<SpanIndex>,
     thread_stacks: FxHashMap<u64, Vec<u64>>,
     thread_allocation_counters: FxHashMap<u64, AllocationInfo>,
     self_time_started: FxHashMap<(u64, u64), Timestamp>,
-    /// Scratch buffer reused across `process_internal_row` calls to avoid
-    /// per-call allocation. Always empty between calls.
-    row_queue: Vec<InternalRow<'static>>,
     interner: RcStrInterning,
 }
 
@@ -157,9 +96,28 @@ impl TurbopackFormat {
             thread_stacks: FxHashMap::with_capacity_and_hasher(64, Default::default()),
             thread_allocation_counters: FxHashMap::with_capacity_and_hasher(64, Default::default()),
             self_time_started: FxHashMap::with_capacity_and_hasher(256, Default::default()),
-            row_queue: Vec::new(),
             interner: RcStrInterning::new(),
         }
+    }
+
+    /// Eagerly intern a list of `(key, value)` pairs from a parsed trace row
+    /// into the same `SpanArgs` (`SmallVec<[(RcStr, RcStr); 1]>`) shape that
+    /// `Span::args` uses, so the queued/Start path and the final stored args
+    /// share one allocation. Both keys and values become `RcStr`s up front:
+    /// string variants are interned directly, non-string variants are
+    /// rendered via `Display` and interned.
+    fn intern_span_args(&mut self, values: Vec<(Cow<'_, str>, TraceValue<'_>)>) -> SpanArgs {
+        values
+            .into_iter()
+            .map(|(k, v)| {
+                let k = self.interner.intern_cow(k);
+                let v = match v {
+                    TraceValue::String(s) => self.interner.intern_cow(s),
+                    other => self.interner.intern_display(&other),
+                };
+                (k, v)
+            })
+            .collect()
     }
 
     fn process(&mut self, store: &mut StoreWriteGuard, row: TraceRow<'_>) {
@@ -173,6 +131,9 @@ impl TurbopackFormat {
                 values,
             } => {
                 let ts = Timestamp::from_micros(ts);
+                let name = self.interner.intern_cow(name);
+                let target = self.interner.intern_cow(target);
+                let values = self.intern_span_args(values);
                 self.process_internal_row(
                     store,
                     InternalRow {
@@ -188,6 +149,7 @@ impl TurbopackFormat {
                 );
             }
             TraceRow::Record { id, values } => {
+                let values = self.intern_span_args(values);
                 self.process_internal_row(
                     store,
                     InternalRow {
@@ -196,13 +158,12 @@ impl TurbopackFormat {
                     },
                 );
             }
-            TraceRow::End { ts, id } => {
-                let ts = Timestamp::from_micros(ts);
+            TraceRow::End { ts: _, id } => {
                 self.process_internal_row(
                     store,
                     InternalRow {
                         id: Some(id),
-                        ty: InternalRowType::End { ts },
+                        ty: InternalRowType::End,
                     },
                 );
             }
@@ -254,11 +215,43 @@ impl TurbopackFormat {
             }
             TraceRow::Event { ts, parent, values } => {
                 let ts = Timestamp::from_micros(ts);
+                // Pull `duration` and `name` out of the typed values during
+                // interning, so the runtime `values` vec is uniformly
+                // `Vec<(RcStr, RcStr)>` and the Event arm of
+                // `process_internal_row` doesn't need a hashmap detour.
+                let mut duration = Timestamp::ZERO;
+                let mut name = rcstr!("event");
+                let mut interned_values: SpanArgs = SpanArgs::with_capacity(values.len());
+                for (k, v) in values {
+                    match k.as_ref() {
+                        "duration" => {
+                            duration = Timestamp::from_micros(v.as_u64().unwrap_or(0));
+                        }
+                        "name" => {
+                            if let TraceValue::String(s) = v {
+                                name = self.interner.intern_cow(s);
+                            }
+                        }
+                        _ => {
+                            let k = self.interner.intern_cow(k);
+                            let v = match v {
+                                TraceValue::String(s) => self.interner.intern_cow(s),
+                                other => self.interner.intern_display(&other),
+                            };
+                            interned_values.push((k, v));
+                        }
+                    }
+                }
                 self.process_internal_row(
                     store,
                     InternalRow {
                         id: parent,
-                        ty: InternalRowType::Event { ts, values },
+                        ty: InternalRowType::Event {
+                            ts,
+                            duration,
+                            name,
+                            values: interned_values,
+                        },
                     },
                 );
             }
@@ -365,29 +358,11 @@ impl TurbopackFormat {
         }
     }
 
-    fn process_internal_row(&mut self, store: &mut StoreWriteGuard, row: InternalRow<'_>) {
-        // Reclaim capacity from the previous call; the field is always empty between calls.
-        let mut queue = take(&mut self.row_queue);
-        self.process_internal_row_queue(store, row, &mut queue);
-        while !queue.is_empty() {
-            let batch = take(&mut queue);
-            for row in batch {
-                self.process_internal_row_queue(store, row, &mut queue);
-            }
-        }
-        self.row_queue = queue; // save capacity for next call
-    }
-
-    fn process_internal_row_queue(
-        &mut self,
-        store: &mut StoreWriteGuard,
-        row: InternalRow<'_>,
-        queue: &mut Vec<InternalRow<'static>>,
-    ) {
+    fn process_internal_row(&mut self, store: &mut StoreWriteGuard, row: InternalRow) {
         let id = if let Some(id) = row.id {
             if matches!(
                 row.ty,
-                InternalRowType::End { .. }
+                InternalRowType::End
                     | InternalRowType::Event { .. }
                     | InternalRowType::Record { .. }
                     | InternalRowType::SelfTime { .. }
@@ -398,10 +373,11 @@ impl TurbopackFormat {
             if let Some(id) = self.id_mapping.get(&id) {
                 Some(*id)
             } else {
-                self.queued_rows
-                    .entry(id)
-                    .or_default()
-                    .push(row.into_static());
+                // Parent hasn't been seen yet; queue this row to be processed
+                // when the parent arrives. The row is already lifetime-free
+                // (strings interned eagerly at parse time) so no allocation
+                // is needed to extend its lifetime here.
+                self.queued_rows.entry(id).or_default().push(row);
                 return;
             }
         } else {
@@ -422,71 +398,46 @@ impl TurbopackFormat {
                     self.dropped_ids.insert(new_id);
                     self.id_mapping.insert(new_id, id);
                 } else {
-                    let span_id = store.add_span(
-                        id,
-                        ts,
-                        self.interner.intern_cow(target),
-                        self.interner.intern_cow(name),
-                        values
-                            .iter()
-                            .map(|(k, v)| {
-                                (self.interner.intern(k), self.interner.intern_display(v))
-                            })
-                            .collect(),
-                        &mut self.outdated_spans,
-                    );
+                    let span_id =
+                        store.add_span(id, ts, target, name, values, &mut self.outdated_spans);
                     self.id_mapping.insert(new_id, span_id);
                 }
+                // Inline-flush any rows that were waiting on this parent.
+                // Processing them now keeps the just-added Span (and its
+                // surrounding Store state) hot in cache, and avoids the
+                // memcpy of a working-queue extend. Recursion depth is
+                // bounded by the depth of orphan chains in the trace.
                 if let Some(rows) = self.queued_rows.remove(&new_id) {
-                    queue.extend(rows);
+                    for row in rows {
+                        self.process_internal_row(store, row);
+                    }
                 }
             }
-            InternalRowType::Record { ref values } => {
-                store.add_args(
-                    id.unwrap(),
-                    values
-                        .iter()
-                        .map(|(k, v)| (self.interner.intern(k), self.interner.intern_display(v)))
-                        .collect(),
-                    &mut self.outdated_spans,
-                );
+            InternalRowType::Record { values } => {
+                store.add_args(id.unwrap(), values, &mut self.outdated_spans);
             }
-            InternalRowType::End { ts: _ } => {
+            InternalRowType::End => {
                 store.complete_span(id.unwrap());
             }
             InternalRowType::SelfTime { start, end } => {
                 store.add_self_time(id.unwrap(), start, end, &mut self.outdated_spans);
             }
-            InternalRowType::Event { ts, values } => {
-                let mut values = values.into_iter().collect::<FxIndexMap<_, _>>();
-                let duration = Timestamp::from_micros(
-                    values
-                        .swap_remove("duration")
-                        .and_then(|v| v.as_u64())
-                        .unwrap_or(0),
-                );
-                let name = values
-                    .swap_remove("name")
-                    .and_then(|v| v.as_str().map(|s| self.interner.intern(s)))
-                    .unwrap_or_else(|| RcStr::from("event"));
-
+            InternalRowType::Event {
+                ts,
+                duration,
+                name,
+                values,
+            } => {
+                let start = ts.saturating_sub(duration);
                 let id = store.add_span(
                     id,
-                    ts.saturating_sub(duration),
-                    RcStr::from("event"),
+                    start,
+                    rcstr!("event"),
                     name,
-                    values
-                        .iter()
-                        .map(|(k, v)| (self.interner.intern(k), self.interner.intern_display(v)))
-                        .collect(),
+                    values,
                     &mut self.outdated_spans,
                 );
-                store.add_self_time(
-                    id,
-                    ts.saturating_sub(duration),
-                    ts,
-                    &mut self.outdated_spans,
-                );
+                store.add_self_time(id, start, ts, &mut self.outdated_spans);
                 store.complete_span(id);
             }
             InternalRowType::Allocation {

--- a/turbopack/crates/turbopack-trace-server/src/store.rs
+++ b/turbopack/crates/turbopack-trace-server/src/store.rs
@@ -79,11 +79,9 @@ impl Store {
     }
 
     pub fn reset(&mut self) {
-        self.spans.truncate(1);
-        self.spans[0] = new_root_span();
-        if let Some(tree) = self.self_time_tree.as_mut() {
-            *tree = SelfTimeTree::new();
-        }
+        self.spans = ChunkedVec::new();
+        self.spans.push(new_root_span());
+        self.self_time_tree.take();
         *self.max_self_time_lookup_time.get_mut() = 0;
         self.memory_samples.clear();
     }

--- a/turbopack/crates/turbopack-trace-server/src/store.rs
+++ b/turbopack/crates/turbopack-trace-server/src/store.rs
@@ -9,6 +9,7 @@ use rustc_hash::FxHashSet;
 use turbo_rcstr::{RcStr, rcstr};
 
 use crate::{
+    chunked_vec::ChunkedVec,
     self_time_tree::SelfTimeTree,
     span::{Span, SpanArgs, SpanEvent, SpanIndex, SpanTimeData},
     span_ref::SpanRef,
@@ -31,7 +32,7 @@ type MemorySample = (Timestamp, u64);
 const MAX_MEMORY_SAMPLES: usize = 200;
 
 pub struct Store {
-    pub(crate) spans: Vec<Span>,
+    pub(crate) spans: ChunkedVec<Span>,
     pub(crate) self_time_tree: Option<SelfTimeTree<SpanIndex>>,
     max_self_time_lookup_time: AtomicU64,
     /// Global sorted list of memory samples (timestamp, memory_bytes).
@@ -64,12 +65,10 @@ fn new_root_span() -> Span {
 
 impl Store {
     pub fn new() -> Self {
+        let mut spans = ChunkedVec::new();
+        spans.push(new_root_span());
         Self {
-            spans: {
-                let mut v = Vec::with_capacity(131_072);
-                v.push(new_root_span());
-                v
-            },
+            spans,
             self_time_tree: env::var("NO_CORRECTED_TIME")
                 .ok()
                 .is_none()
@@ -161,7 +160,7 @@ impl Store {
     pub fn add_args(
         &mut self,
         span_index: SpanIndex,
-        args: Vec<(RcStr, RcStr)>,
+        args: SpanArgs,
         outdated_spans: &mut FxHashSet<SpanIndex>,
     ) {
         let span = &mut self.spans[span_index.get()];

--- a/turbopack/crates/turbopack-trace-server/src/store.rs
+++ b/turbopack/crates/turbopack-trace-server/src/store.rs
@@ -81,7 +81,9 @@ impl Store {
     pub fn reset(&mut self) {
         self.spans = ChunkedVec::new();
         self.spans.push(new_root_span());
-        self.self_time_tree.take();
+        if let Some(tree) = self.self_time_tree.as_mut() {
+            *tree = SelfTimeTree::new();
+        }
         *self.max_self_time_lookup_time.get_mut() = 0;
         self.memory_samples.clear();
     }


### PR DESCRIPTION
## What

Reduce time and memory spent loading large traces in `turbopack-trace-server`, focused on the row-ingestion hot path (`reader/turbopack.rs`).

**Eager interning at parse time**
- New `OwnedTraceValue` enum (lifetime-free) and `SpanArgs` reuse for `InternalRow` value lists. All borrowed `Cow<str>` keys/values are interned to `RcStr` once, at parse time, via a single `intern_span_args` helper.
- `InternalRow`/`InternalRowType` shed their `'a` parameter. The `into_static` path is gone — previously, every row that had to be queued waiting for its parent allocated a fresh `String` for each Cow field, then the eventual processor re-interned those strings. Now both costs are gone: one intern, no String allocation.
- `Event` rows pre-extract `duration` (from `TraceValue::UInt`) and `name` (from `TraceValue::String`) at parse time, so the per-event `FxIndexMap` `swap_remove` lookup goes away entirely.

**Inline queue flush instead of working-queue extend**
- `process_internal_row` and `process_internal_row_queue` collapsed into a single recursive method. When a `Start` row flushes queued children (i.e. orphaned rows whose parent has now appeared), those rows are processed inline via direct recursion instead of being `extend`ed into a working queue and re-driven. Eliminates the `Vec<InternalRow>::extend` memcpy that showed up as a top memmove site, and keeps the just-added `Span` hot in cache while its child events are applied.
- `row_queue` field and the `take`/swap driver loop on `TurbopackFormat` removed.

**New ChunkedVec storage for Span**
- reduces costs when adding Span objects, since they are large and expensive to move
- reduces peak heap due to resizing (in exchange for larger min sizes)

## Result

Loading a 10 GB trace: **53s → 45s** wall clock, **21.5 GB → 18.8 GB** peak heap. Hitting 220mb/s loading speed

<!-- NEXT_JS_LLM_PR -->