### PR TITLE
Turbopack: remove unused module references

### DIFF
--- a/turbopack/crates/turbopack-core/src/reference/mod.rs
+++ b/turbopack/crates/turbopack-core/src/reference/mod.rs
@@ -56,35 +56,6 @@ impl ModuleReferences {
     }
 }
 
-/// A reference that always resolves to a single module.
-#[turbo_tasks::value]
-#[derive(ValueToString)]
-#[value_to_string(self.description)]
-pub struct SingleModuleReference {
-    module: ResolvedVc<Box<dyn Module>>,
-    description: RcStr,
-}
-
-#[turbo_tasks::value_impl]
-impl ModuleReference for SingleModuleReference {
-    #[turbo_tasks::function]
-    fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
-        *ModuleResolveResult::module(self.module)
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl SingleModuleReference {
-    /// Create a new instance that resolves to the given module.
-    #[turbo_tasks::function]
-    pub fn new(module: ResolvedVc<Box<dyn Module>>, description: RcStr) -> Vc<Self> {
-        Self::cell(SingleModuleReference {
-            module,
-            description,
-        })
-    }
-}
-
 #[turbo_tasks::value]
 #[derive(ValueToString)]
 #[value_to_string(self.description)]

--- a/turbopack/crates/turbopack-core/src/reference/mod.rs
+++ b/turbopack/crates/turbopack-core/src/reference/mod.rs
@@ -16,7 +16,7 @@ use crate::{
         expand_output_assets,
     },
     raw_module::RawModule,
-    resolve::{BindingUsage, ExportUsage, ImportUsage, ModuleResolveResult, RequestKey},
+    resolve::{BindingUsage, ExportUsage, ImportUsage, ModuleResolveResult},
 };
 pub mod source_map;
 
@@ -100,38 +100,6 @@ impl ModuleReference for SingleChunkableModuleReference {
             import: ImportUsage::TopLevel,
             export: self.export.clone(),
         }
-    }
-}
-
-/// A reference that always resolves to a single module.
-#[turbo_tasks::value]
-#[derive(ValueToString)]
-#[value_to_string(self.description)]
-pub struct SingleOutputAssetReference {
-    asset: ResolvedVc<Box<dyn OutputAsset>>,
-    description: RcStr,
-}
-
-#[turbo_tasks::value_impl]
-impl ModuleReference for SingleOutputAssetReference {
-    #[turbo_tasks::function]
-    fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
-        *ModuleResolveResult::output_asset(RequestKey::default(), self.asset)
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl SingleOutputAssetReference {
-    /// Create a new `Vc<SingleOutputAssetReference>` that resolves to the given asset.
-    #[turbo_tasks::function]
-    pub fn new(asset: ResolvedVc<Box<dyn OutputAsset>>, description: RcStr) -> Vc<Self> {
-        Self::cell(SingleOutputAssetReference { asset, description })
-    }
-
-    /// The [`Vc<Box<dyn OutputAsset>>`][OutputAsset] that this reference resolves to.
-    #[turbo_tasks::function]
-    pub fn asset(&self) -> Vc<Box<dyn OutputAsset>> {
-        *self.asset
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/async_chunk/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/async_chunk/module.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Result, bail};
 use indoc::formatdoc;
 use tracing::Instrument;
 use turbo_rcstr::rcstr;
@@ -14,7 +14,7 @@ use turbopack_core::{
         ModuleGraph, chunk_group_info::ChunkGroup, module_batch::ChunkableModuleOrBatch,
     },
     output::OutputAssetsWithReferenced,
-    reference::{ModuleReferences, SingleModuleReference},
+    reference::ModuleReferences,
 };
 
 use crate::{
@@ -118,14 +118,7 @@ impl Module for AsyncLoaderModule {
 
     #[turbo_tasks::function]
     async fn references(self: Vc<Self>) -> Result<Vc<ModuleReferences>> {
-        Ok(Vc::cell(vec![ResolvedVc::upcast(
-            SingleModuleReference::new(
-                *ResolvedVc::upcast(self.await?.inner),
-                rcstr!("async module"),
-            )
-            .to_resolved()
-            .await?,
-        )]))
+        bail!("AsyncLoaderModule::references should never be called")
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
@@ -13,7 +13,6 @@ use turbopack_core::{
         ModuleGraph, chunk_group_info::ChunkGroup, module_batch::ChunkableModuleOrBatch,
     },
     output::OutputAssetsWithReferenced,
-    reference::{ModuleReferences, SingleOutputAssetReference},
 };
 
 use crate::{
@@ -143,29 +142,6 @@ impl Module for ManifestAsyncModule {
     #[turbo_tasks::function]
     fn source(&self) -> Vc<turbopack_core::source::OptionSource> {
         Vc::cell(None)
-    }
-
-    #[turbo_tasks::function]
-    async fn references(self: Vc<Self>) -> Result<Vc<ModuleReferences>> {
-        let assets = self.chunk_group().expand_all_assets().await?;
-
-        Ok(Vc::cell(
-            assets
-                .into_iter()
-                .copied()
-                .map(|chunk| async move {
-                    Ok(ResolvedVc::upcast(
-                        SingleOutputAssetReference::new(
-                            *chunk,
-                            manifest_chunk_reference_description(),
-                        )
-                        .to_resolved()
-                        .await?,
-                    ))
-                })
-                .try_join()
-                .await?,
-        ))
     }
 
     #[turbo_tasks::function]


### PR DESCRIPTION
- SingleModuleReference is dead code, never actually called
- SingleOutputAssetReference was created, but never actually did anything because of the ChunkingType being None