### PR TITLE
[turbopack-trace-server] Add memory samples to the mcp tool results

### DIFF
--- a/crates/next-napi-bindings/src/turbo_trace_server.rs
+++ b/crates/next-napi-bindings/src/turbo_trace_server.rs
@@ -62,6 +62,14 @@ pub struct TraceSpanInfo {
     pub avg_corrected_duration: Option<i64>,
     /// Raw span ID for aggregated groups (the index of the first span).
     pub first_span_id: Option<String>,
+    /// TurboMalloc memory-usage samples recorded while this span
+    /// (or its example span, for aggregated groups) was live.
+    ///
+    /// Each entry is `[ts_offset_from_span_start_in_ticks, bytes, pressure]`,
+    /// where `pressure` is the memory-pressure byte (0 = no pressure, higher
+    /// = more pressure). `100 ticks = 1 µs`. The offset is always `>= 0` and
+    /// `<= span_duration`. Capped and downsampled by the store.
+    pub memory_samples: Vec<Vec<i64>>,
 }
 
 /// The result of a `query_trace_spans` call.
@@ -125,6 +133,11 @@ pub fn query_trace_spans(
                 total_corrected_duration: s.total_corrected_duration.map(|v| v as i64),
                 avg_corrected_duration: s.avg_corrected_duration.map(|v| v as i64),
                 first_span_id: s.first_span_id,
+                memory_samples: s
+                    .memory_samples
+                    .into_iter()
+                    .map(|(ts, mem, pressure)| vec![ts, mem as i64, pressure as i64])
+                    .collect(),
             })
             .collect(),
         page: result.page as u32,

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -670,6 +670,16 @@ export interface TraceSpanInfo {
   avgCorrectedDuration?: number
   /** Raw span ID for aggregated groups (the index of the first span). */
   firstSpanId?: string
+  /**
+   * TurboMalloc memory-usage samples recorded while this span
+   * (or its example span, for aggregated groups) was live.
+   *
+   * Each entry is `[ts_offset_from_span_start_in_ticks, bytes, pressure]`,
+   * where `pressure` is the memory-pressure byte (0 = no pressure, higher
+   * = more pressure). `100 ticks = 1 µs`. The offset is always `>= 0` and
+   * `<= span_duration`. Capped and downsampled by the store.
+   */
+  memorySamples: Array<Array<number>>
 }
 /** The result of a `query_trace_spans` call. */
 export interface TraceQueryResult {

--- a/packages/next/src/cli/internal/turbo-trace-server.ts
+++ b/packages/next/src/cli/internal/turbo-trace-server.ts
@@ -34,6 +34,34 @@ function formatRelative(ticks: number): string {
   return prefix + formatDuration(Math.abs(ticks))
 }
 
+function formatBytes(bytes: number): string {
+  const KB = 1024
+  const MB = KB * 1024
+  const GB = MB * 1024
+  if (bytes >= GB) return `${(bytes / GB).toFixed(2)} GB`
+  if (bytes >= MB) return `${(bytes / MB).toFixed(2)} MB`
+  if (bytes >= KB) return `${(bytes / KB).toFixed(2)} KB`
+  return `${bytes} B`
+}
+
+function summarizeMemorySamples(samples: number[][]): string | null {
+  if (!samples || samples.length === 0) return null
+  const bytes = samples.map((s) => s[1])
+  const pressures = samples.map((s) => s[2] ?? 0)
+  const min = Math.min(...bytes)
+  const max = Math.max(...bytes)
+  const first = bytes[0]
+  const last = bytes[bytes.length - 1]
+  const delta = last - first
+  const deltaSign = delta >= 0 ? '+' : '-'
+  const maxPressure = Math.max(...pressures)
+  return (
+    `samples=${samples.length}, min=${formatBytes(min)}, max=${formatBytes(max)}, ` +
+    `start=${formatBytes(first)}, end=${formatBytes(last)}, ` +
+    `Δ=${deltaSign}${formatBytes(Math.abs(delta))}, maxPressure=${maxPressure}`
+  )
+}
+
 /**
  * Render a single span (or aggregated span group) as a markdown section.
  */
@@ -72,6 +100,11 @@ function renderSpanMarkdown(span: TraceSpanInfo): string {
     for (const [k, v] of span.args) {
       md += `- \`${k}\`: ${v}\n`
     }
+  }
+
+  const memSummary = summarizeMemorySamples(span.memorySamples)
+  if (memSummary) {
+    md += `\n**Memory (TurboMalloc live bytes):** ${memSummary}\n`
   }
 
   md += '\n---\n\n'
@@ -121,7 +154,7 @@ export async function startTurboTraceServerCli(
     'query_spans',
     {
       description:
-        'Query spans from a turbopack trace file. Returns spans with timing, CPU usage, and attribute details. Set `outputType` to "json" for machine-readable output or "markdown" (default) for human-readable output. Use the `parent` parameter (with an ID from a previous result) to drill into children. Results are paginated to 20 spans per page.',
+        'Query spans from a turbopack trace file. Returns spans with timing, CPU usage, attribute details, and TurboMalloc live-memory samples recorded while each span was active. Set `outputType` to "json" for machine-readable output (including the raw `memorySamples` array of `[ts_offset_ticks, bytes, pressure]` triples per span — pressure is 0 = none, higher = more memory pressure) or "markdown" (default) for a human-readable summary. Use the `parent` parameter (with an ID from a previous result) to drill into children. Results are paginated to 20 spans per page.',
       inputSchema: {
         parent: z
           .string()

--- a/turbopack/crates/turbopack-trace-server/src/lib.rs
+++ b/turbopack/crates/turbopack-trace-server/src/lib.rs
@@ -129,6 +129,19 @@ pub struct SpanInfo {
     pub avg_corrected_duration: Option<u64>,
     /// Raw span ID for aggregated groups (the index of the first span).
     pub first_span_id: Option<String>,
+    /// TurboMalloc memory-usage samples recorded while this span (or its
+    /// example span, for aggregated groups) was live.
+    ///
+    /// Each tuple is `(ts_offset_from_span_start_in_ticks, bytes, pressure)`,
+    /// where `pressure` is the memory-pressure byte recorded with the sample
+    /// (0 = no pressure, higher = more pressure). `100 ticks = 1 µs`. The
+    /// offset is always `>= 0` and `<= span_duration`.
+    ///
+    /// The store caps the series at `MAX_MEMORY_SAMPLES`; when more samples
+    /// exist in the range, consecutive groups are merged by picking the
+    /// group's max-memory sample (timestamp, value, and pressure kept
+    /// together).
+    pub memory_samples: Vec<(i64, u64, u8)>,
 }
 
 /// Result of a `query_spans` call.
@@ -283,6 +296,15 @@ pub fn query_spans(store: &Arc<StoreContainer>, options: QueryOptions) -> QueryR
                 let rel_start = (span_start as i64) - (parent_start as i64);
                 let rel_end = (span_end as i64) - (parent_start as i64);
 
+                let first_start_ticks = *first.start();
+                let memory_samples: Vec<(i64, u64, u8)> = store_ref
+                    .memory_samples_for_range_with_ts(first.start(), first.end())
+                    .into_iter()
+                    .map(|(ts, mem, pressure)| {
+                        ((*ts as i64) - (first_start_ticks as i64), mem, pressure)
+                    })
+                    .collect();
+
                 SpanInfo {
                     id: graph_id,
                     name,
@@ -301,6 +323,7 @@ pub fn query_spans(store: &Arc<StoreContainer>, options: QueryOptions) -> QueryR
                     total_corrected_duration: Some(total_corrected),
                     avg_corrected_duration: Some(avg_corrected),
                     first_span_id: Some(first_index.to_string()),
+                    memory_samples,
                 }
             })
             .collect();
@@ -361,6 +384,15 @@ pub fn query_spans(store: &Arc<StoreContainer>, options: QueryOptions) -> QueryR
                 let rel_start = (span_start as i64) - (parent_start as i64);
                 let rel_end = (span_end as i64) - (parent_start as i64);
 
+                let raw_span_start = span_start;
+                let memory_samples: Vec<(i64, u64, u8)> = store_ref
+                    .memory_samples_for_range_with_ts(span.start(), span.end())
+                    .into_iter()
+                    .map(|(ts, mem, pressure)| {
+                        ((*ts as i64) - (raw_span_start as i64), mem, pressure)
+                    })
+                    .collect();
+
                 SpanInfo {
                     id: build_span_id(options.parent.as_deref(), &span.index.to_string()),
                     name,
@@ -379,6 +411,7 @@ pub fn query_spans(store: &Arc<StoreContainer>, options: QueryOptions) -> QueryR
                     total_corrected_duration: None,
                     avg_corrected_duration: None,
                     first_span_id: None,
+                    memory_samples,
                 }
             })
             .collect();

--- a/turbopack/crates/turbopack-trace-server/src/store.rs
+++ b/turbopack/crates/turbopack-trace-server/src/store.rs
@@ -357,6 +357,23 @@ impl Store {
     /// `[start, end]`. When more samples exist, groups of N consecutive
     /// samples are merged by taking the maximum memory value in each group.
     pub fn memory_samples_for_range(&self, start: Timestamp, end: Timestamp) -> Vec<u64> {
+        self.memory_samples_for_range_with_ts(start, end)
+            .into_iter()
+            .map(|(_, mem, _)| mem)
+            .collect()
+    }
+
+    /// Like `memory_samples_for_range` but keeps the timestamps and the
+    /// memory-pressure byte. Timestamps are absolute store timestamps (same
+    /// reference frame as span start/end). When the raw slice exceeds
+    /// `MAX_MEMORY_SAMPLES`, each merged group is represented by the sample
+    /// whose memory value was the group's max (its timestamp and pressure
+    /// byte are kept alongside it).
+    pub fn memory_samples_for_range_with_ts(
+        &self,
+        start: Timestamp,
+        end: Timestamp,
+    ) -> Vec<MemorySample> {
         let slice = self.memory_samples_slice(start, end);
         let count = slice.len();
         if count == 0 {
@@ -364,14 +381,15 @@ impl Store {
         }
 
         if count <= MAX_MEMORY_SAMPLES {
-            return slice.iter().map(|(_, mem, _)| *mem).collect();
+            return slice.to_vec();
         }
 
-        // Merge groups of N samples, taking the max memory in each group.
+        // Merge groups of N samples, taking the max memory in each group and
+        // keeping the timestamp and pressure of that max sample.
         let n = count.div_ceil(MAX_MEMORY_SAMPLES);
         slice
             .chunks(n)
-            .map(|chunk| chunk.iter().map(|(_, mem, _)| *mem).max().unwrap())
+            .map(|chunk| *chunk.iter().max_by_key(|(_, mem, _)| *mem).unwrap())
             .collect()
     }
 


### PR DESCRIPTION
Expose memory data to the MCP tool for the turbo trace server