### PR TITLE
New ESLint rule: `no-credential-shape-in-config-env`

### DIFF
--- a/errors/no-credential-shape-in-config-env.mdx
+++ b/errors/no-credential-shape-in-config-env.mdx
@@ -1,0 +1,54 @@
+---
+title: No credential-shaped values in next.config.js env
+---
+
+> Disallow string literals matching the shape of Tier-1 credentials in `next.config.js`'s `env` object, since values listed there are inlined into the client bundle.
+
+## Why This Error Occurred
+
+A string literal under `env` in `next.config.js` matched the shape of a known credential (for example a Stripe `sk_live_` key, an AWS `AKIA` key ID, a GitHub `ghp_` token, an OpenAI `sk-proj-` key, or a Supabase `service_role` JWT).
+
+Values listed under `env` in `next.config.js` are bundled into client-side JavaScript and shipped to every site visitor. Hard-coding a credential there exposes it in the browser bundle.
+
+## Possible Ways to Fix It
+
+### Read the value from `process.env` at runtime
+
+If the value is meant to stay on the server, do not list it under `env` in `next.config.js`. Read it directly from `process.env` in server code:
+
+```js filename="next.config.js"
+// Before — value is inlined into the client bundle
+module.exports = {
+  env: {
+    STRIPE_SECRET_KEY: 'sk_live_...',
+  },
+}
+```
+
+```js filename="next.config.js"
+// After — entry removed; the secret stays on the server
+module.exports = {}
+```
+
+```ts filename="app/api/charge/route.ts"
+import Stripe from 'stripe'
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!)
+```
+
+### Use a public-by-design identifier instead
+
+Some vendor keys are designed to be public (Stripe publishable keys, Firebase `apiKey`, PostHog project keys, Supabase `anon` JWT, Sentry DSN). If the intent is to use one of those, swap the value for the public variant.
+
+```js filename="next.config.js"
+module.exports = {
+  env: {
+    NEXT_PUBLIC_STRIPE_KEY: 'pk_live_...',
+  },
+}
+```
+
+## Useful Links
+
+- [`next.config.js` `env` reference](/docs/app/api-reference/config/next-config-js/env)
+- [Environment variables](/docs/app/guides/environment-variables)

--- a/packages/eslint-plugin-next/src/index.ts
+++ b/packages/eslint-plugin-next/src/index.ts
@@ -7,6 +7,7 @@ import nextScriptForGa from './rules/next-script-for-ga'
 import noAssignModuleVariable from './rules/no-assign-module-variable'
 import noAsyncClientComponent from './rules/no-async-client-component'
 import noBeforeInteractiveScriptOutsideDocument from './rules/no-before-interactive-script-outside-document'
+import noCredentialShapeInConfigEnv from './rules/no-credential-shape-in-config-env'
 import noCssTags from './rules/no-css-tags'
 import noDocumentImportInPage from './rules/no-document-import-in-page'
 import noDuplicateHead from './rules/no-duplicate-head'
@@ -68,6 +69,7 @@ const plugin = {
     'no-async-client-component': noAsyncClientComponent,
     'no-before-interactive-script-outside-document':
       noBeforeInteractiveScriptOutsideDocument,
+    'no-credential-shape-in-config-env': noCredentialShapeInConfigEnv,
     'no-css-tags': noCssTags,
     'no-document-import-in-page': noDocumentImportInPage,
     'no-duplicate-head': noDuplicateHead,

--- a/packages/eslint-plugin-next/src/rules/no-credential-shape-in-config-env.ts
+++ b/packages/eslint-plugin-next/src/rules/no-credential-shape-in-config-env.ts
@@ -1,0 +1,123 @@
+import { defineRule } from '../utils/define-rule'
+
+const url = 'https://nextjs.org/docs/messages/no-credential-shape-in-config-env'
+
+// Anchored prefixes plus minimum-length floors. Public-by-design identifiers
+// (Stripe pk_, Firebase apiKey, PostHog phc_, Supabase anon JWT, Sentry DSN,
+// Mapbox pk., Google Maps AIzaSy, Algolia search keys) must NOT match.
+const SECRET_SHAPES = [
+  { name: 'Stripe live secret key', re: /^sk_live_[A-Za-z0-9]{24,}$/ },
+  { name: 'Stripe test secret key', re: /^sk_test_[A-Za-z0-9]{24,}$/ },
+  { name: 'Stripe restricted key', re: /^rk_(?:live|test)_[A-Za-z0-9]{24,}$/ },
+  { name: 'AWS access key ID', re: /^AKIA[A-Z0-9]{16}$/ },
+  { name: 'GitHub personal access token', re: /^ghp_[A-Za-z0-9]{36}$/ },
+  { name: 'GitHub OAuth token', re: /^gho_[A-Za-z0-9]{36}$/ },
+  { name: 'GitHub fine-grained PAT', re: /^github_pat_[A-Za-z0-9_]{82,}$/ },
+  { name: 'GitHub App installation token', re: /^ghs_[A-Za-z0-9]{36}$/ },
+  { name: 'OpenAI API key', re: /^sk-(?:proj|svcacct|admin)-[A-Za-z0-9_-]{40,}$/ },
+  { name: 'OpenAI legacy API key', re: /^sk-[A-Za-z0-9]{20}T3BlbkFJ[A-Za-z0-9]{20}$/ },
+  { name: 'Anthropic API key', re: /^sk-ant-api03-[A-Za-z0-9_-]{40,}$/ },
+  { name: 'Slack bot token', re: /^xoxb-[A-Za-z0-9-]{10,}$/ },
+  { name: 'Slack user token', re: /^xoxp-[A-Za-z0-9-]{10,}$/ },
+  { name: 'SendGrid API key', re: /^SG\.[A-Za-z0-9_-]{22}\.[A-Za-z0-9_-]{43}$/ },
+  { name: 'npm access token', re: /^npm_[A-Za-z0-9]{36}$/ },
+  { name: 'PEM private key', re: /^-----BEGIN (?:RSA |EC |OPENSSH |PGP )?PRIVATE KEY-----/ },
+  // Supabase keys are JWTs. anon role is intentionally public; service_role bypasses RLS.
+  { name: 'Supabase service_role JWT', test: (v) => decodeJwtRole(v) === 'service_role' },
+]
+
+function decodeJwtRole(v) {
+  if (!v.startsWith('eyJ')) return null
+  const parts = v.split('.')
+  if (parts.length !== 3) return null
+  try {
+    const payload = JSON.parse(
+      Buffer.from(parts[1], 'base64url').toString('utf8')
+    )
+    return typeof payload?.role === 'string' ? payload.role : null
+  } catch {
+    return null
+  }
+}
+
+function matchShape(v) {
+  if (v.length < 16) return null
+  for (const shape of SECRET_SHAPES) {
+    const hit = shape.re ? shape.re.test(v) : shape.test(v)
+    if (hit) return shape.name
+  }
+  return null
+}
+
+function maskValue(v) {
+  if (v.startsWith('-----BEGIN')) return '-----BEGIN ... PRIVATE KEY-----'
+  return v.slice(0, 8) + '***'
+}
+
+function isNextConfigFile(filename) {
+  if (!filename) return false
+  const base = filename.replace(/\\/g, '/').split('/').pop() || ''
+  return /^next\.config\.(js|mjs|cjs|ts|mts|cts)$/.test(base)
+}
+
+function keyName(node) {
+  if (node.computed) return null
+  if (node.key.type === 'Identifier') return node.key.name
+  if (node.key.type === 'Literal' && typeof node.key.value === 'string') {
+    return node.key.value
+  }
+  return null
+}
+
+export default defineRule({
+  meta: {
+    docs: {
+      description:
+        'Warn when a string literal under `env` in `next.config.js` has the shape of a server-only credential.',
+      recommended: false,
+      url,
+    },
+    type: 'problem',
+    schema: [],
+    messages: {
+      credentialShape:
+        '`env.{{key}}` value ({{masked}}) matches the shape of a {{shape}}. Values under `env` in `next.config.js` are inlined into the client bundle. See: ' +
+        url,
+    },
+  },
+
+  create(context) {
+    if (!isNextConfigFile(context.filename)) {
+      return {}
+    }
+
+    return {
+      Property(node) {
+        if (node.value.type !== 'Literal') return
+        if (typeof node.value.value !== 'string') return
+
+        // Parent ObjectExpression must be the value of an outer `env: {...}` Property.
+        const parentObject = node.parent
+        if (parentObject?.type !== 'ObjectExpression') return
+        const envProperty = parentObject.parent
+        if (envProperty?.type !== 'Property') return
+        const envKey = keyName(envProperty)
+        if (envKey !== 'env') return
+
+        const value = node.value.value
+        const shape = matchShape(value)
+        if (!shape) return
+
+        context.report({
+          node,
+          messageId: 'credentialShape',
+          data: {
+            key: keyName(node) ?? '?',
+            shape,
+            masked: maskValue(value),
+          },
+        })
+      },
+    }
+  },
+})

--- a/test/unit/eslint-plugin-next/no-credential-shape-in-config-env.test.ts
+++ b/test/unit/eslint-plugin-next/no-credential-shape-in-config-env.test.ts
@@ -1,0 +1,112 @@
+import { RuleTester } from 'eslint'
+import { rules } from '@next/eslint-plugin-next'
+
+const NextESLintRule = rules['no-credential-shape-in-config-env']
+
+const err = (key, shape, masked) => ({
+  messageId: 'credentialShape',
+  data: { key, shape, masked },
+})
+
+const NEXT_CONFIG = '/repo/next.config.js'
+const NEXT_CONFIG_TS = '/repo/next.config.ts'
+const NOT_CONFIG = '/repo/pages/index.js'
+
+const stripeSk = 'sk_live_51' + 'A'.repeat(40)
+const stripePk = 'pk_live_' + 'A'.repeat(40)
+const ghPat = 'ghp_' + 'a'.repeat(36)
+const awsKey = 'AKIA' + 'A'.repeat(16)
+const anthropicKey = 'sk-ant-api03-' + 'A'.repeat(50)
+const firebaseKey = 'AIzaSy' + 'A'.repeat(33)
+
+function fakeJwt(payload) {
+  const h = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64url')
+  const p = Buffer.from(JSON.stringify(payload)).toString('base64url')
+  return `${h}.${p}.${'a'.repeat(43)}`
+}
+const supabaseServiceRole = fakeJwt({ iss: 'supabase', role: 'service_role' })
+const supabaseAnon = fakeJwt({ iss: 'supabase', role: 'anon' })
+
+const tests = {
+  valid: [
+    // Public-by-design values: never warn
+    { filename: NEXT_CONFIG, code: `module.exports = { env: { K: ${JSON.stringify(stripePk)} } }` },
+    { filename: NEXT_CONFIG, code: `module.exports = { env: { K: ${JSON.stringify(firebaseKey)} } }` },
+    { filename: NEXT_CONFIG, code: `module.exports = { env: { K: ${JSON.stringify(supabaseAnon)} } }` },
+    // Sentinel values
+    { filename: NEXT_CONFIG, code: `module.exports = { env: { F: 'true', M: 'production' } }` },
+    // Dynamic value, not a Literal
+    { filename: NEXT_CONFIG, code: `module.exports = { env: { K: process.env.K } }` },
+    // Same shape but in a non-config file
+    { filename: NOT_CONFIG, code: `const c = { env: { K: ${JSON.stringify(stripeSk)} } }` },
+    // Same shape but under a non-`env` property
+    { filename: NEXT_CONFIG, code: `module.exports = { publicRuntimeConfig: { K: ${JSON.stringify(stripeSk)} } }` },
+    // ESM default export form
+    { filename: NEXT_CONFIG, code: `export default { env: { K: ${JSON.stringify(stripePk)} } }` },
+    // .ts config file
+    { filename: NEXT_CONFIG_TS, code: `export default { env: { K: ${JSON.stringify(stripePk)} } }` },
+    // Computed `env` wrapper key: skip (we cannot statically resolve the key name)
+    { filename: NEXT_CONFIG, code: `const E = 'env'; module.exports = { [E]: { K: ${JSON.stringify(stripeSk)} } }` },
+    // Shorthand and method properties under `env`
+    { filename: NEXT_CONFIG, code: `const K = 'x'; module.exports = { env: { K } }` },
+    { filename: NEXT_CONFIG, code: `module.exports = { env: { K() { return 'sk_live_xxx' } } }` },
+  ],
+  invalid: [
+    {
+      filename: NEXT_CONFIG,
+      code: `module.exports = { env: { STRIPE: ${JSON.stringify(stripeSk)} } }`,
+      errors: [err('STRIPE', 'Stripe live secret key', 'sk_live_***')],
+    },
+    {
+      filename: NEXT_CONFIG,
+      code: `export default { env: { GH: ${JSON.stringify(ghPat)} } }`,
+      errors: [err('GH', 'GitHub personal access token', 'ghp_aaaa***')],
+    },
+    {
+      filename: NEXT_CONFIG,
+      code: `module.exports = { env: { AWS: ${JSON.stringify(awsKey)} } }`,
+      errors: [err('AWS', 'AWS access key ID', 'AKIAAAAA***')],
+    },
+    {
+      filename: NEXT_CONFIG,
+      code: `module.exports = { env: { ANT: ${JSON.stringify(anthropicKey)} } }`,
+      errors: [err('ANT', 'Anthropic API key', 'sk-ant-a***')],
+    },
+    // Supabase service_role JWT — NOT anon
+    {
+      filename: NEXT_CONFIG,
+      code: `module.exports = { env: { S: ${JSON.stringify(supabaseServiceRole)} } }`,
+      errors: [err('S', 'Supabase service_role JWT', supabaseServiceRole.slice(0, 8) + '***')],
+    },
+    // Quoted key
+    {
+      filename: NEXT_CONFIG,
+      code: `module.exports = { env: { 'X-API': ${JSON.stringify(stripeSk)} } }`,
+      errors: [err('X-API', 'Stripe live secret key', 'sk_live_***')],
+    },
+    // Multiple offenders → multiple errors
+    {
+      filename: NEXT_CONFIG,
+      code: `module.exports = { env: { A: ${JSON.stringify(stripeSk)}, B: ${JSON.stringify(awsKey)} } }`,
+      errors: [
+        err('A', 'Stripe live secret key', 'sk_live_***'),
+        err('B', 'AWS access key ID', 'AKIAAAAA***'),
+      ],
+    },
+    // Computed inner key: still detected, key reported as '?'
+    {
+      filename: NEXT_CONFIG,
+      code: `const N = 'X'; module.exports = { env: { [N]: ${JSON.stringify(stripeSk)} } }`,
+      errors: [err('?', 'Stripe live secret key', 'sk_live_***')],
+    },
+  ],
+}
+
+describe('no-credential-shape-in-config-env', () => {
+  new RuleTester({
+    languageOptions: {
+      ecmaVersion: 2020,
+      sourceType: 'module',
+    },
+  }).run('eslint', NextESLintRule, tests)
+})


### PR DESCRIPTION
### Adding a feature

Adds a new ESLint rule, `no-credential-shape-in-config-env`, that reports string literals under the `env` property of `next.config.{js,mjs,cjs,ts,mts,cts}` whose value matches a known credential shape (Stripe `sk_live_`/`sk_test_`/`rk_`, AWS `AKIA`, GitHub `ghp_`/`gho_`/`github_pat_`/`ghs_`, OpenAI `sk-(proj|svcacct|admin)-` and the legacy `T3BlbkFJ` form, Anthropic `sk-ant-api03-`, Slack `xoxb-`/`xoxp-`, SendGrid, npm, PEM private key header, Supabase JWT with `role: service_role`).

Values listed under `env` in `next.config.js` are inlined into the client bundle by design, so a hard-coded credential there ships to every visitor. Public-by-design identifiers (Stripe `pk_`, Firebase `apiKey`, PostHog, Supabase anon JWT, Sentry DSN, Mapbox `pk.`, Google Maps `AIzaSy`, Algolia search keys) are not matched. Supabase JWTs are discriminated by decoding the payload's `role` claim.

The rule is shipped as opt-in (`recommended: false`); users enable it in their ESLint config. Dynamic values (`process.env.X`) and other config properties are not inspected. Discussion #33386 has tracked sustained interest in this class of warning. The error documentation and unit test cases are also added.

<!-- NEXT_JS_LLM_PR -->
