### PR TITLE
Turbopack: remove ModuleResolveResultItem::OutputAsset

### DIFF
--- a/turbopack/crates/turbopack-core/src/chunk/chunk_group.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunk_group.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, sync::atomic::AtomicBool};
+use std::sync::atomic::AtomicBool;
 
 use anyhow::{Context, Result};
 use rustc_hash::FxHashMap;
@@ -26,11 +26,7 @@ use crate::{
         },
         module_batches::{BatchingConfig, ModuleBatchesGraphEdge},
     },
-    output::{
-        OutputAsset, OutputAssets, OutputAssetsReference, OutputAssetsReferences,
-        OutputAssetsWithReferenced,
-    },
-    reference::ModuleReference,
+    output::{OutputAsset, OutputAssetsReference},
     traced_asset::TracedAsset,
 };
 
@@ -168,29 +164,6 @@ pub async fn make_chunk_group(
         references: ResolvedVc::upcast_vec(async_loaders),
         availability_info: new_availability_info,
     })
-}
-
-pub async fn references_to_output_assets(
-    references: impl IntoIterator<Item = &ResolvedVc<Box<dyn ModuleReference>>>,
-) -> Result<Vc<OutputAssetsWithReferenced>> {
-    let output_assets = references
-        .into_iter()
-        .map(|reference| reference.resolve_reference().primary_output_assets())
-        .try_join()
-        .await?;
-    let mut set = HashSet::new();
-    let output_assets = output_assets
-        .iter()
-        .flatten()
-        .copied()
-        .filter(|&asset| set.insert(asset))
-        .collect::<Vec<_>>();
-    Ok(OutputAssetsWithReferenced {
-        assets: ResolvedVc::cell(output_assets),
-        referenced_assets: OutputAssets::empty_resolved(),
-        references: OutputAssetsReferences::empty_resolved(),
-    }
-    .cell())
 }
 
 pub struct ChunkGroupContentOptions {

--- a/turbopack/crates/turbopack-core/src/introspect/utils.rs
+++ b/turbopack/crates/turbopack-core/src/introspect/utils.rs
@@ -97,19 +97,6 @@ pub async fn children_from_module_references(
                 IntrospectableModule::new(*module).to_resolved().await?,
             ));
         }
-        for &output_asset in reference
-            .resolve_reference()
-            .primary_output_assets()
-            .await?
-            .iter()
-        {
-            children.insert((
-                key.clone(),
-                IntrospectableOutputAsset::new(*output_asset)
-                    .to_resolved()
-                    .await?,
-            ));
-        }
     }
     Ok(Vc::cell(children))
 }

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -32,7 +32,6 @@ use crate::{
         resolve::ResolvingIssue,
     },
     module::{Module, Modules, OptionModule},
-    output::{OutputAsset, OutputAssets},
     package_json::{PackageJsonIssue, read_package_json},
     raw_module::RawModule,
     reference_type::ReferenceType,
@@ -91,7 +90,6 @@ type AfterResolvePluginWithCondition = (
 #[derive(Clone, Debug)]
 pub enum ModuleResolveResultItem {
     Module(ResolvedVc<Box<dyn Module>>),
-    OutputAsset(ResolvedVc<Box<dyn OutputAsset>>),
     External {
         /// uri, path, reference, etc.
         name: RcStr,
@@ -237,21 +235,6 @@ impl ModuleResolveResult {
         ModuleResolveResult {
             primary: vec![(request_key, ModuleResolveResultItem::Module(module))]
                 .into_boxed_slice(),
-            affecting_sources: Default::default(),
-        }
-        .resolved_cell()
-    }
-
-    pub fn output_asset(
-        request_key: RequestKey,
-        output_asset: ResolvedVc<Box<dyn OutputAsset>>,
-    ) -> ResolvedVc<Self> {
-        ModuleResolveResult {
-            primary: vec![(
-                request_key,
-                ModuleResolveResultItem::OutputAsset(output_asset),
-            )]
-            .into_boxed_slice(),
             affecting_sources: Default::default(),
         }
         .resolved_cell()
@@ -413,19 +396,6 @@ impl ModuleResolveResult {
             }
         }
         Ok(Vc::cell(set.into_iter().collect()))
-    }
-
-    #[turbo_tasks::function]
-    pub fn primary_output_assets(&self) -> Vc<OutputAssets> {
-        Vc::cell(
-            self.primary
-                .iter()
-                .filter_map(|(_, item)| match item {
-                    &ModuleResolveResultItem::OutputAsset(a) => Some(a),
-                    _ => None,
-                })
-                .collect(),
-        )
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
@@ -328,9 +328,7 @@ async fn to_single_pattern_mapping(
                     .to_unstyled_string(),
             ));
         }
-        ModuleResolveResultItem::OutputAsset(_)
-        | ModuleResolveResultItem::Empty
-        | ModuleResolveResultItem::Custom(_) => {
+        ModuleResolveResultItem::Empty | ModuleResolveResultItem::Custom(_) => {
             // TODO implement mapping
             CodeGenerationIssue {
                 severity: IssueSeverity::Bug,

--- a/turbopack/crates/turbopack-wasm/src/module_asset.rs
+++ b/turbopack/crates/turbopack-wasm/src/module_asset.rs
@@ -3,9 +3,7 @@ use turbo_rcstr::rcstr;
 use turbo_tasks::{ResolvedVc, Vc, fxindexmap};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
-    chunk::{
-        AsyncModuleInfo, ChunkableModule, ChunkingContext, chunk_group::references_to_output_assets,
-    },
+    chunk::{AsyncModuleInfo, ChunkableModule, ChunkingContext},
     context::AssetContext,
     ident::AssetIdent,
     module::{Module, ModuleSideEffects},
@@ -196,11 +194,13 @@ impl EcmascriptChunkPlaceable for WebAssemblyModuleAsset {
     #[turbo_tasks::function]
     async fn chunk_item_output_assets(
         self: Vc<Self>,
-        _chunking_context: Vc<Box<dyn ChunkingContext>>,
+        chunking_context: Vc<Box<dyn ChunkingContext>>,
         _module_graph: Vc<ModuleGraph>,
     ) -> Result<Vc<OutputAssetsWithReferenced>> {
-        let loader_references = self.loader().references().await?;
-        references_to_output_assets(&*loader_references).await
+        let wasm_asset = self.wasm_asset(chunking_context).to_resolved().await?;
+        Ok(OutputAssetsWithReferenced::from_assets(Vc::cell(vec![
+            ResolvedVc::upcast(wasm_asset),
+        ])))
     }
 }
 


### PR DESCRIPTION
It never made sense to have module references that point to an output asset, and the `ChunkingType` value on those made even less sense. We had already migrated almost everything off anyway