### PR TITLE
Update upload trace url

### DIFF
--- a/packages/next/src/cli/internal/upload-trace.ts
+++ b/packages/next/src/cli/internal/upload-trace.ts
@@ -1,7 +1,7 @@
 import path from 'path'
 import fs from 'fs/promises'
 
-const UPLOAD_TRACE_URL = 'https://api.nextjs.org/api/upload-trace'
+const UPLOAD_TRACE_URL = 'https://nextjs.org/api/upload-trace'
 
 // V8 CPU profiles are JSON objects starting with {"nodes":
 const CPUPROFILE_HEADER = Buffer.from('{"nodes":')


### PR DESCRIPTION
## What?

Updates the trace upload url as it has been moved.

Since this subcommand is only available on canary currently the previous API url will not be preserved.