### PR TITLE
Use strict class fields in transpiled library code

### DIFF
--- a/packages/next/taskfile-swc.js
+++ b/packages/next/taskfile-swc.js
@@ -47,7 +47,7 @@ module.exports = function (task) {
           targets: MODERN_BROWSERSLIST_TARGET,
         },
         jsc: {
-          loose: true,
+          loose: false,
           externalHelpers: true,
           parser: {
             syntax: 'typescript',
@@ -67,6 +67,7 @@ module.exports = function (task) {
               development: false,
               useBuiltins: true,
             },
+            useDefineForClassFields: true,
           },
         },
       }
@@ -91,7 +92,7 @@ module.exports = function (task) {
           },
         },
         jsc: {
-          loose: true,
+          loose: false,
           // Do not enable external helpers on server-side files build
           // _is_native_function helper is not compatible with edge runtime (need investigate)
           externalHelpers: false,
@@ -113,6 +114,7 @@ module.exports = function (task) {
               development: false,
               useBuiltins: true,
             },
+            useDefineForClassFields: true,
           },
         },
       }


### PR DESCRIPTION
This is required to allow authoring `static name = ''` in classes. Otherwise SWC transpiles this to `static { this.name = '' }` which throws as runtime because `Function.name` is read-only.

Overall bundle size impact is a wash. Classes with a lot of properties get a bit larger since
```js
class Foo {
  constructor() {
    this.name = ''
  }
}
```

will be transpiled into
```js
class Foo {
  name;
  constructor(name) {
    this.name = name
  }
}
```

but on the flip-side we'll transpile less for static class property initializations e.g.

```js
class Foo {
  name = ''
}
```
will be fully preserved now instead of creating a useless constructor like before
```js
class Foo {
  constructor() {
    this.name =''
  }
}
```
---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>