### PR TITLE
Preserve error sublcass constructor names after mangling

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -401,6 +401,7 @@ export default defineConfig([
     },
     rules: {
       '@next/internal/typechecked-require': 'error',
+      '@next/internal/error-subclass-static-name': 'error',
       'jsdoc/no-types': 'error',
       'jsdoc/no-undefined-types': 'error',
     },

--- a/packages/create-next-app/create-app.ts
+++ b/packages/create-next-app/create-app.ts
@@ -23,7 +23,9 @@ import { runTypegen } from './helpers/typegen'
 import type { Bundler, TemplateMode, TemplateType } from './templates'
 import { getTemplateFile, installTemplate } from './templates'
 
-export class DownloadError extends Error {}
+export class DownloadError extends Error {
+  static name = 'DownloadError'
+}
 
 export async function createApp({
   appPath,

--- a/packages/create-next-app/tsconfig.json
+++ b/packages/create-next-app/tsconfig.json
@@ -7,7 +7,8 @@
     "esModuleInterop": true,
     "outDir": "dist",
     "rootDir": ".",
-    "skipLibCheck": false
+    "skipLibCheck": false,
+    "useDefineForClassFields": true
   },
   "exclude": ["templates", "dist"],
   "files": ["index.ts"]

--- a/packages/eslint-plugin-internal/src/eslint-error-subclass-static-name.js
+++ b/packages/eslint-plugin-internal/src/eslint-error-subclass-static-name.js
@@ -1,0 +1,107 @@
+/**
+ * ESLint rule: error-subclass-static-name
+ *
+ * Requires every named class whose superclass identifier ends with `Error`
+ * to declare `static name = '<ClassName>'`. Without this, SWC's class
+ * minification renames the constructor and logged error instances appear
+ * with a mangled name instead of the original class name.
+ */
+
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
+const plugin = {
+  name: 'error-subclass-static-name',
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Require a `static name` declaration on classes extending an Error so the class name survives SWC minification in logs.',
+      recommended: true,
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      missingStaticName:
+        '`{{className}}` extends an Error but is missing `static name = "{{className}}"`. ' +
+        'This is required so the class name survives SWC minification in logs.',
+      mismatchedName:
+        '`static name` on `{{className}}` should equal "{{className}}" so the original ' +
+        'class name is preserved in logs after SWC minification.',
+    },
+  },
+
+  create(context) {
+    function checkClass(node) {
+      if (!node.id || !node.superClass) {
+        return
+      }
+      if (
+        node.superClass.type !== 'Identifier' ||
+        !node.superClass.name.endsWith('Error')
+      ) {
+        return
+      }
+
+      const className = node.id.name
+      const existing = node.body.body.find(
+        (member) =>
+          member.type === 'PropertyDefinition' &&
+          member.static === true &&
+          member.computed === false &&
+          member.key &&
+          member.key.type === 'Identifier' &&
+          member.key.name === 'name'
+      )
+
+      if (existing) {
+        const init = existing.value
+        if (
+          init &&
+          init.type === 'Literal' &&
+          typeof init.value === 'string' &&
+          init.value === className
+        ) {
+          return
+        }
+
+        context.report({
+          node: existing,
+          messageId: 'mismatchedName',
+          data: { className },
+          fix(fixer) {
+            if (init) {
+              return fixer.replaceText(init, `'${className}'`)
+            }
+            // No initializer at all: rewrite the whole property.
+            return fixer.replaceText(
+              existing,
+              `static name = '${className}'`
+            )
+          },
+        })
+        return
+      }
+
+      context.report({
+        node: node.id,
+        messageId: 'missingStaticName',
+        data: { className },
+        fix(fixer) {
+          const openBrace = node.body.range[0]
+          return fixer.insertTextAfterRange(
+            [openBrace, openBrace + 1],
+            `\n  static name = '${className}'\n`
+          )
+        },
+      })
+    }
+
+    return {
+      ClassDeclaration: checkClass,
+      ClassExpression: checkClass,
+    }
+  },
+}
+
+module.exports = plugin

--- a/packages/eslint-plugin-internal/src/eslint-error-subclass-static-name.test.js
+++ b/packages/eslint-plugin-internal/src/eslint-error-subclass-static-name.test.js
@@ -1,0 +1,153 @@
+const { RuleTester } = require('eslint')
+const rule = require('./eslint-error-subclass-static-name')
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parser: require('@typescript-eslint/parser'),
+    parserOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module',
+    },
+  },
+})
+
+describe('error-subclass-static-name ESLint rule', () => {
+  ruleTester.run('error-subclass-static-name', rule, {
+    valid: [
+      // Not extending anything.
+      {
+        code: `class Foo {}`,
+        filename: 'test.ts',
+      },
+      // Parent name does not end with Error.
+      {
+        code: `class Foo extends Bar {}`,
+        filename: 'test.ts',
+      },
+      // Direct extends Error with matching static name.
+      {
+        code: `class FooError extends Error { static name = 'FooError' }`,
+        filename: 'test.ts',
+      },
+      // Annotated form is also accepted — rule only checks the literal value.
+      {
+        code: `class FooError extends Error { static name: string = 'FooError' }`,
+        filename: 'test.ts',
+      },
+      // Chained subclass with matching static name.
+      {
+        code: `class FooError extends BaseError { static name = 'FooError' }`,
+        filename: 'test.ts',
+      },
+      // Anonymous class — no id to preserve.
+      {
+        code: `const X = class extends Error {}`,
+        filename: 'test.ts',
+      },
+      // Static name with other members already present.
+      {
+        code: `class FooError extends Error {
+  static name = 'FooError'
+  message = 'boom'
+}`,
+        filename: 'test.ts',
+      },
+      // Non-identifier superclass (e.g. member expression) — skipped.
+      {
+        code: `class FooError extends ns.Error {}`,
+        filename: 'test.ts',
+      },
+    ],
+
+    invalid: [
+      // Direct Error subclass missing static name.
+      {
+        code: `class FooError extends Error {}`,
+        filename: 'test.ts',
+        errors: [
+          {
+            messageId: 'missingStaticName',
+            data: { className: 'FooError' },
+          },
+        ],
+        output: `class FooError extends Error {\n  static name = 'FooError'\n}`,
+      },
+      // Chained *Error parent, missing static name.
+      {
+        code: `class FooError extends BaseError {}`,
+        filename: 'test.ts',
+        errors: [
+          {
+            messageId: 'missingStaticName',
+            data: { className: 'FooError' },
+          },
+        ],
+        output: `class FooError extends BaseError {\n  static name = 'FooError'\n}`,
+      },
+      // Child name doesn't end with Error; parent is Error — still flagged.
+      {
+        code: `class Foo extends Error {}`,
+        filename: 'test.ts',
+        errors: [
+          {
+            messageId: 'missingStaticName',
+            data: { className: 'Foo' },
+          },
+        ],
+        output: `class Foo extends Error {\n  static name = 'Foo'\n}`,
+      },
+      // Wrong static name literal.
+      {
+        code: `class FooError extends Error { static name = 'Wrong' }`,
+        filename: 'test.ts',
+        errors: [
+          {
+            messageId: 'mismatchedName',
+            data: { className: 'FooError' },
+          },
+        ],
+        output: `class FooError extends Error { static name = 'FooError' }`,
+      },
+      // Static name with no initializer.
+      {
+        code: `class FooError extends Error { static name }`,
+        filename: 'test.ts',
+        errors: [
+          {
+            messageId: 'mismatchedName',
+            data: { className: 'FooError' },
+          },
+        ],
+        output: `class FooError extends Error { static name = 'FooError' }`,
+      },
+      // Existing members — fixer inserts at top.
+      {
+        code: `class FooError extends Error {
+  message = 'boom'
+}`,
+        filename: 'test.ts',
+        errors: [
+          {
+            messageId: 'missingStaticName',
+            data: { className: 'FooError' },
+          },
+        ],
+        output: `class FooError extends Error {\n  static name = 'FooError'\n
+  message = 'boom'
+}`,
+      },
+      // Class expression with a name.
+      {
+        code: `const X = class FooError extends Error {}`,
+        filename: 'test.ts',
+        errors: [
+          {
+            messageId: 'missingStaticName',
+            data: { className: 'FooError' },
+          },
+        ],
+        output: `const X = class FooError extends Error {\n  static name = 'FooError'\n}`,
+      },
+    ],
+  })
+})

--- a/packages/eslint-plugin-internal/src/eslint-plugin-internal.js
+++ b/packages/eslint-plugin-internal/src/eslint-plugin-internal.js
@@ -1,9 +1,11 @@
 const typecheckedRequire = require('./eslint-typechecked-require')
 const noAmbiguousJSX = require('./eslint-no-ambiguous-jsx')
+const errorSubclassStaticName = require('./eslint-error-subclass-static-name')
 
 module.exports = {
   rules: {
     'no-ambiguous-jsx': noAmbiguousJSX,
     'typechecked-require': typecheckedRequire,
+    'error-subclass-static-name': errorSubclassStaticName,
   },
 }

--- a/packages/next-codemod/bin/shared.ts
+++ b/packages/next-codemod/bin/shared.ts
@@ -1,1 +1,3 @@
-export class BadInput extends Error {}
+export class BadInput extends Error {
+  static name = 'BadInput'
+}

--- a/packages/next-codemod/tsconfig.json
+++ b/packages/next-codemod/tsconfig.json
@@ -9,7 +9,8 @@
     "strictFunctionTypes": false,
     "strictNullChecks": false,
     "types": ["node"],
-    "useUnknownInCatchVariables": false
+    "useUnknownInCatchVariables": false,
+    "useDefineForClassFields": true
   },
   "include": ["**/*.ts"],
   "exclude": ["node_modules", "transforms/__testfixtures__/**"]

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -562,7 +562,9 @@ function bindingToApi(
       }
   )
 
-  const cancel = new (class Cancel extends Error {})()
+  const cancel = new (class Cancel extends Error {
+    static name = 'Cancel'
+  })()
 
   /**
    * Utility function to ensure all variants of an enum are handled.

--- a/packages/next/src/build/templates/middleware.ts
+++ b/packages/next/src/build/templates/middleware.ts
@@ -21,6 +21,8 @@ const isProxy = page === '/proxy' || page === '/src/proxy'
 const handlerUserland = (isProxy ? mod.proxy : mod.middleware) || mod.default
 
 class ProxyMissingExportError extends Error {
+  static name = 'ProxyMissingExportError'
+
   constructor(message: string) {
     super(message)
     // Stack isn't useful here, remove it considering it spams logs during development.

--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -1505,6 +1505,8 @@ export function getPossibleMiddlewareFilenames(
 }
 
 export class NestedMiddlewareError extends Error {
+  static name = 'NestedMiddlewareError'
+
   constructor(
     nestedFileNames: string[],
     mainDir: string,

--- a/packages/next/src/build/webpack/loaders/css-loader/src/CssSyntaxError.ts
+++ b/packages/next/src/build/webpack/loaders/css-loader/src/CssSyntaxError.ts
@@ -1,4 +1,6 @@
 export default class CssSyntaxError extends Error {
+  static name = 'CssSyntaxError'
+
   stack: any
   constructor(error: any) {
     super(error)

--- a/packages/next/src/build/webpack/loaders/postcss-loader/src/Error.ts
+++ b/packages/next/src/build/webpack/loaders/postcss-loader/src/Error.ts
@@ -9,6 +9,8 @@
  * @param {Object} err CssSyntaxError
  */
 export default class PostCSSSyntaxError extends Error {
+  static name = 'PostCSSSyntaxError'
+
   stack: any
   constructor(error: any) {
     super(error)

--- a/packages/next/src/build/webpack/loaders/postcss-loader/src/Warning.ts
+++ b/packages/next/src/build/webpack/loaders/postcss-loader/src/Warning.ts
@@ -9,6 +9,8 @@
  * @param {Object} warning PostCSS Warning
  */
 export default class Warning extends Error {
+  static name = 'Warning'
+
   stack: any
   constructor(warning: any) {
     super(warning)

--- a/packages/next/src/client/components/hooks-server-context.ts
+++ b/packages/next/src/client/components/hooks-server-context.ts
@@ -1,6 +1,8 @@
 const DYNAMIC_ERROR_CODE = 'DYNAMIC_SERVER_USAGE'
 
 export class DynamicServerError extends Error {
+  static name = 'DynamicServerError'
+
   digest: typeof DYNAMIC_ERROR_CODE = DYNAMIC_ERROR_CODE
 
   constructor(public readonly description: string) {

--- a/packages/next/src/client/components/readonly-url-search-params.ts
+++ b/packages/next/src/client/components/readonly-url-search-params.ts
@@ -6,6 +6,8 @@
 
 /** @internal */
 class ReadonlyURLSearchParamsError extends Error {
+  static name = 'ReadonlyURLSearchParamsError'
+
   constructor() {
     super(
       'Method unavailable on `ReadonlyURLSearchParams`. Read more: https://nextjs.org/docs/app/api-reference/functions/use-search-params#updating-searchparams'

--- a/packages/next/src/client/components/static-generation-bailout.ts
+++ b/packages/next/src/client/components/static-generation-bailout.ts
@@ -1,6 +1,8 @@
 const NEXT_STATIC_GEN_BAILOUT = 'NEXT_STATIC_GEN_BAILOUT'
 
 export class StaticGenBailoutError extends Error {
+  static name = 'StaticGenBailoutError'
+
   public readonly code = NEXT_STATIC_GEN_BAILOUT
 }
 

--- a/packages/next/src/client/components/unrecognized-action-error.ts
+++ b/packages/next/src/client/components/unrecognized-action-error.ts
@@ -1,4 +1,6 @@
 export class UnrecognizedActionError extends Error {
+  static name = 'UnrecognizedActionError'
+
   constructor(...args: ConstructorParameters<typeof Error>) {
     super(...args)
     this.name = 'UnrecognizedActionError'

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -76,6 +76,8 @@ import type { Params } from '../server/request/params'
 import { Bundler } from '../lib/bundler'
 
 export class ExportError extends Error {
+  static name = 'ExportError'
+
   code = 'NEXT_EXPORT_ERROR'
 }
 

--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -61,10 +61,14 @@ import { installGlobalBehaviors } from '../server/node-environment-extensions/gl
 }
 
 class TimeoutError extends Error {
+  static name = 'TimeoutError'
+
   code = 'NEXT_EXPORT_TIMEOUT_ERROR'
 }
 
 class ExportPageError extends Error {
+  static name = 'ExportPageError'
+
   code = 'NEXT_EXPORT_PAGE_ERROR'
 }
 

--- a/packages/next/src/lib/compile-error.ts
+++ b/packages/next/src/lib/compile-error.ts
@@ -1,1 +1,3 @@
-export class CompileError extends Error {}
+export class CompileError extends Error {
+  static name = 'CompileError'
+}

--- a/packages/next/src/lib/fatal-error.ts
+++ b/packages/next/src/lib/fatal-error.ts
@@ -1,1 +1,3 @@
-export class FatalError extends Error {}
+export class FatalError extends Error {
+  static name = 'FatalError'
+}

--- a/packages/next/src/lib/is-serializable-props.ts
+++ b/packages/next/src/lib/is-serializable-props.ts
@@ -6,6 +6,8 @@ import {
 const regexpPlainIdentifier = /^[A-Za-z_$][A-Za-z0-9_$]*$/
 
 export class SerializableError extends Error {
+  static name = 'SerializableError'
+
   constructor(page: string, method: string, path: string, message: string) {
     super(
       path

--- a/packages/next/src/pages/_document.tsx
+++ b/packages/next/src/pages/_document.tsx
@@ -379,7 +379,7 @@ function getNextFontLinkTags(
 export class Head extends React.Component<HeadProps> {
   static contextType = HtmlContext
 
-  context!: HtmlProps
+  declare context: HtmlProps
 
   getCssLinks(files: DocumentFiles): JSX.Element[] | null {
     const {
@@ -801,7 +801,7 @@ function handleDocumentScriptLoaderItems(
 export class NextScript extends React.Component<OriginProps> {
   static contextType = HtmlContext
 
-  context!: HtmlProps
+  declare context: HtmlProps
 
   getDynamicChunks(files: DocumentFiles) {
     return getDynamicChunks(this.context, this.props, files)

--- a/packages/next/src/server/api-utils/index.ts
+++ b/packages/next/src/server/api-utils/index.ts
@@ -175,6 +175,8 @@ export function clearPreviewData<T>(
  * Custom error class
  */
 export class ApiError extends Error {
+  static name = 'ApiError'
+
   readonly statusCode: number
 
   constructor(statusCode: number, message: string) {

--- a/packages/next/src/server/app-render/instant-validation/instant-validation-error.ts
+++ b/packages/next/src/server/app-render/instant-validation/instant-validation-error.ts
@@ -13,5 +13,7 @@ export function isInstantValidationError(
 }
 
 export class InstantValidationError extends Error {
+  static name = 'InstantValidationError'
+
   digest = INSTANT_VALIDATION_ERROR_DIGEST
 }

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -295,6 +295,8 @@ export type RequestContext<
 // Internal wrapper around build errors at development
 // time, to prevent us from propagating or logging them
 export class WrappedBuildError extends Error {
+  static name = 'WrappedBuildError'
+
   innerError: Error
 
   constructor(innerError: Error) {

--- a/packages/next/src/server/dynamic-rendering-utils.ts
+++ b/packages/next/src/server/dynamic-rendering-utils.ts
@@ -23,6 +23,8 @@ export function isHangingPromiseRejectionError(
 const HANGING_PROMISE_REJECTION = 'HANGING_PROMISE_REJECTION'
 
 class HangingPromiseRejectionError extends Error {
+  static name = 'HangingPromiseRejectionError'
+
   public readonly digest = HANGING_PROMISE_REJECTION
 
   constructor(

--- a/packages/next/src/server/image-optimizer.ts
+++ b/packages/next/src/server/image-optimizer.ts
@@ -736,6 +736,8 @@ export class ImageOptimizerCache {
   }
 }
 export class ImageError extends Error {
+  static name = 'ImageError'
+
   statusCode: number
 
   constructor(statusCode: number, message: string) {

--- a/packages/next/src/server/lib/trace/tracer.ts
+++ b/packages/next/src/server/lib/trace/tracer.ts
@@ -39,6 +39,8 @@ const { context, propagation, trace, SpanStatusCode, SpanKind, ROOT_CONTEXT } =
   api
 
 export class BubbledError extends Error {
+  static name = 'BubbledError'
+
   constructor(
     public readonly bubble?: boolean,
     public readonly result?: FetchEventResult

--- a/packages/next/src/server/node-environment-extensions/unhandled-rejection.external.tsx
+++ b/packages/next/src/server/node-environment-extensions/unhandled-rejection.external.tsx
@@ -88,6 +88,8 @@ switch (UHR_FILTER_LOG_LEVEL) {
 }
 
 class DebugWithStack extends Error {
+  static name = 'DebugWithStack'
+
   constructor(message: string) {
     super(message)
     this.name = '[Next.js Unhandled Rejection Filter]'
@@ -95,6 +97,8 @@ class DebugWithStack extends Error {
 }
 
 class WarnWithStack extends Error {
+  static name = 'WarnWithStack'
+
   constructor(message: string) {
     super(message)
     this.name = '[Next.js Unhandled Rejection Filter]'

--- a/packages/next/src/server/use-cache/use-cache-errors.ts
+++ b/packages/next/src/server/use-cache/use-cache-errors.ts
@@ -1,6 +1,8 @@
 const USE_CACHE_TIMEOUT_ERROR_CODE = 'USE_CACHE_TIMEOUT'
 
 export class UseCacheTimeoutError extends Error {
+  static name = 'UseCacheTimeoutError'
+
   digest: typeof USE_CACHE_TIMEOUT_ERROR_CODE = USE_CACHE_TIMEOUT_ERROR_CODE
 
   constructor() {

--- a/packages/next/src/server/web/error.ts
+++ b/packages/next/src/server/web/error.ts
@@ -1,4 +1,6 @@
 export class PageSignatureError extends Error {
+  static name = 'PageSignatureError'
+
   constructor({ page }: { page: string }) {
     super(`The middleware "${page}" accepts an async API directly with the form:
   
@@ -12,6 +14,8 @@ export class PageSignatureError extends Error {
 }
 
 export class RemovedPageError extends Error {
+  static name = 'RemovedPageError'
+
   constructor() {
     super(`The request.page has been deprecated in favour of \`URLPattern\`.
   Read more: https://nextjs.org/docs/messages/middleware-request-page
@@ -20,6 +24,8 @@ export class RemovedPageError extends Error {
 }
 
 export class RemovedUAError extends Error {
+  static name = 'RemovedUAError'
+
   constructor() {
     super(`The request.ua has been removed in favour of \`userAgent\` function.
   Read more: https://nextjs.org/docs/messages/middleware-parse-user-agent

--- a/packages/next/src/server/web/spec-extension/adapters/headers.ts
+++ b/packages/next/src/server/web/spec-extension/adapters/headers.ts
@@ -6,6 +6,8 @@ import { ReflectAdapter } from './reflect'
  * @internal
  */
 export class ReadonlyHeadersError extends Error {
+  static name = 'ReadonlyHeadersError'
+
   constructor() {
     super(
       'Headers cannot be modified. Read more: https://nextjs.org/docs/app/api-reference/functions/headers'

--- a/packages/next/src/server/web/spec-extension/adapters/next-request.ts
+++ b/packages/next/src/server/web/spec-extension/adapters/next-request.ts
@@ -10,6 +10,8 @@ import { isNodeNextRequest, isWebNextRequest } from '../../../base-http/helpers'
 
 export const ResponseAbortedName = 'ResponseAborted'
 export class ResponseAborted extends Error {
+  static name = 'ResponseAborted'
+
   public readonly name = ResponseAbortedName
 }
 

--- a/packages/next/src/server/web/spec-extension/adapters/request-cookies.ts
+++ b/packages/next/src/server/web/spec-extension/adapters/request-cookies.ts
@@ -10,6 +10,8 @@ import { ActionDidRevalidateStaticAndDynamic } from '../../../../shared/lib/acti
  * @internal
  */
 export class ReadonlyRequestCookiesError extends Error {
+  static name = 'ReadonlyRequestCookiesError'
+
   constructor() {
     super(
       'Cookies can only be modified in a Server Action or Route Handler. Read more: https://nextjs.org/docs/app/api-reference/functions/cookies#options'

--- a/packages/next/src/shared/lib/errors/canary-only-config-error.ts
+++ b/packages/next/src/shared/lib/errors/canary-only-config-error.ts
@@ -7,6 +7,8 @@ export function isStableBuild() {
 }
 
 export class CanaryOnlyConfigError extends Error {
+  static name = 'CanaryOnlyConfigError'
+
   constructor(arg: { feature: string } | string) {
     if (typeof arg === 'object' && 'feature' in arg) {
       super(

--- a/packages/next/src/shared/lib/errors/hard-deprecated-config-error.ts
+++ b/packages/next/src/shared/lib/errors/hard-deprecated-config-error.ts
@@ -1,4 +1,6 @@
 export class HardDeprecatedConfigError extends Error {
+  static name = 'HardDeprecatedConfigError'
+
   constructor(message: string) {
     super(message)
 

--- a/packages/next/src/shared/lib/errors/missing-default-parallel-route-error.ts
+++ b/packages/next/src/shared/lib/errors/missing-default-parallel-route-error.ts
@@ -1,6 +1,8 @@
 import { UsageError } from './usage-error'
 
 export class MissingDefaultParallelRouteError extends UsageError {
+  static name = 'MissingDefaultParallelRouteError'
+
   constructor(fullSegmentPath: string, slotName: string) {
     super(
       `Missing required default.js file for parallel route at ${fullSegmentPath}\n` +

--- a/packages/next/src/shared/lib/errors/usage-error.ts
+++ b/packages/next/src/shared/lib/errors/usage-error.ts
@@ -1,4 +1,6 @@
 export class UsageError extends Error {
+  static name = 'UsageError'
+
   constructor(message: string, docUrl: string) {
     super(`${message}\n\nLearn more: ${docUrl}`)
     this.name = 'UsageError'

--- a/packages/next/src/shared/lib/invariant-error.ts
+++ b/packages/next/src/shared/lib/invariant-error.ts
@@ -1,4 +1,6 @@
 export class InvariantError extends Error {
+  static name = 'InvariantError'
+
   constructor(message: string, options?: ErrorOptions) {
     super(
       `Invariant: ${message.endsWith('.') ? message : message + '.'} This is a bug in Next.js.`,

--- a/packages/next/src/shared/lib/lazy-dynamic/bailout-to-csr.ts
+++ b/packages/next/src/shared/lib/lazy-dynamic/bailout-to-csr.ts
@@ -3,6 +3,8 @@ const BAILOUT_TO_CSR = 'BAILOUT_TO_CLIENT_SIDE_RENDERING'
 
 /** An error that should be thrown when we want to bail out to client-side rendering. */
 export class BailoutToCSRError extends Error {
+  static name = 'BailoutToCSRError'
+
   public readonly digest = BAILOUT_TO_CSR
 
   constructor(public readonly reason: string) {

--- a/packages/next/src/shared/lib/no-fallback-error.external.ts
+++ b/packages/next/src/shared/lib/no-fallback-error.external.ts
@@ -1,4 +1,6 @@
 export class NoFallbackError extends Error {
+  static name = 'NoFallbackError'
+
   constructor() {
     super()
     this.message = 'Internal: NoFallbackError'

--- a/packages/next/src/shared/lib/turbopack/internal-error.ts
+++ b/packages/next/src/shared/lib/turbopack/internal-error.ts
@@ -9,6 +9,8 @@ import { traceGlobals } from '../../../trace/shared'
  * These are constructed in Turbopack by calling `throwTurbopackInternalError`.
  */
 export class TurbopackInternalError extends Error {
+  static name = 'TurbopackInternalError'
+
   name = 'TurbopackInternalError'
   location: string | undefined
 

--- a/packages/next/src/shared/lib/turbopack/utils.ts
+++ b/packages/next/src/shared/lib/turbopack/utils.ts
@@ -23,6 +23,7 @@ const VERBOSE_ISSUES = !!process.env.NEXT_TURBOPACK_VERBOSE_ISSUES
  * errors caused by issues with user code.
  */
 export class ModuleBuildError extends Error {
+  static name = 'ModuleBuildError'
   name = 'ModuleBuildError'
 }
 

--- a/packages/next/src/shared/lib/utils.ts
+++ b/packages/next/src/shared/lib/utils.ts
@@ -430,9 +430,15 @@ export const ST =
     (method) => typeof performance[method] === 'function'
   )
 
-export class DecodeError extends Error {}
-export class NormalizeError extends Error {}
+export class DecodeError extends Error {
+  static name = 'DecodeError'
+}
+export class NormalizeError extends Error {
+  static name = 'NormalizeError'
+}
 export class PageNotFoundError extends Error {
+  static name = 'PageNotFoundError'
+
   code: string
 
   constructor(page: string) {
@@ -444,6 +450,8 @@ export class PageNotFoundError extends Error {
 }
 
 export class MissingStaticPage extends Error {
+  static name = 'MissingStaticPage'
+
   constructor(page: string, message: string) {
     super()
     this.message = `Failed to load static file for page: ${page} ${message}`
@@ -451,6 +459,8 @@ export class MissingStaticPage extends Error {
 }
 
 export class MiddlewareNotFoundError extends Error {
+  static name = 'MiddlewareNotFoundError'
+
   code: string
   constructor() {
     super()

--- a/packages/next/tsconfig.json
+++ b/packages/next/tsconfig.json
@@ -10,6 +10,7 @@
     "target": "ES2018",
     "moduleResolution": "bundler",
     "types": ["trusted-types", "jest", "node"],
+    "useDefineForClassFields": true,
     "paths": {
       // Required absolute paths.
       // We rewrite these here so that they aren't also input files which would fail tsc with


### PR DESCRIPTION
SWC mangles constructor names by default when minification is enabled (i.e. in prod).
For example `class ApiError extends Error {}` will end up as `class y extends Error {}`.

The problem with that is that Error constructor names appear in Node.js' default error inspection i.e. `console.log(new ApiError('message'))` will log `y [Error]: message`.
We patch Node.js error inspection to avoid that but I want to stop patching error inspection if sourcemapping is disabled (for performance reasons). It also ensure nice error inspection for other runtimes.

We could stop mangling Error subclasses to preseve the constructor name. However, this negatively impacts parsed size if Error subclasses have multiple callsites. E.g. instead of `new z(); new z()`, we'd emit `new ApiError(); new ApiError()`. For gzip size it largely doesn't matter.

So instead we enforce emitting a `static name` class property repeating the constructor name. This ensures equivalent inspection display. We could've done this automatically. Instead, we're doing an explicit opt-in. This avoids compiler magic and leaking constructor names that aren't meant to be leaked (React Flight doesn't transport Error names either in prod). It's not a strong concern since I'm not even sure that you can 100% rely on error subclass constructor name minification but better be safe than sorry.

Missing `static name` on Error subclasses are caught with a lint rule. Like any other Lint rule, this can be disabled in situations where you don't want to leak the constructor name.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>