### PR TITLE
Enable prefetching in dev mode with background limit of 1

### DIFF
--- a/packages/next/src/build/define-env.ts
+++ b/packages/next/src/build/define-env.ts
@@ -246,6 +246,9 @@ export function getDefineEnv({
     'process.env.__NEXT_DYNAMIC_ON_HOVER': Boolean(
       config.experimental.dynamicOnHover
     ),
+    'process.env.__NEXT_PREFETCH':
+      !dev ||
+      (isTurbopack && Boolean(config.experimental.turbopackPrefetchInDev)),
     'process.env.__NEXT_USE_OFFLINE': Boolean(config.experimental.useOffline),
     'process.env.__NEXT_PREFETCH_INLINING': Boolean(
       config.experimental.prefetchInlining

--- a/packages/next/src/client/app-dir/link.tsx
+++ b/packages/next/src/client/app-dir/link.tsx
@@ -695,7 +695,7 @@ export default function LinkComponent(
       if (!prefetchEnabled) {
         return
       }
-      if (process.env.NODE_ENV === 'development' && !process.env.TURBOPACK) {
+      if (!process.env.__NEXT_PREFETCH) {
         return
       }
 

--- a/packages/next/src/client/app-dir/link.tsx
+++ b/packages/next/src/client/app-dir/link.tsx
@@ -692,7 +692,7 @@ export default function LinkComponent(
       if (!router) {
         return
       }
-      if (!prefetchEnabled || process.env.NODE_ENV === 'development') {
+      if (!prefetchEnabled) {
         return
       }
 

--- a/packages/next/src/client/app-dir/link.tsx
+++ b/packages/next/src/client/app-dir/link.tsx
@@ -695,6 +695,9 @@ export default function LinkComponent(
       if (!prefetchEnabled) {
         return
       }
+      if (process.env.NODE_ENV === 'development' && !process.env.TURBOPACK) {
+        return
+      }
 
       const upgradeToDynamicPrefetch = unstable_dynamicOnHover === true
       onNavigationIntent(

--- a/packages/next/src/client/components/app-router-utils.ts
+++ b/packages/next/src/client/components/app-router-utils.ts
@@ -29,11 +29,6 @@ export function createPrefetchURL(href: string): URL | null {
     )
   }
 
-  // Don't prefetch during development (improves compilation performance)
-  if (process.env.NODE_ENV === 'development') {
-    return null
-  }
-
   // External urls can't be prefetched in the same way.
   if (isExternalURL(url)) {
     return null

--- a/packages/next/src/client/components/app-router-utils.ts
+++ b/packages/next/src/client/components/app-router-utils.ts
@@ -29,10 +29,8 @@ export function createPrefetchURL(href: string): URL | null {
     )
   }
 
-  // Don't prefetch during development with webpack (improves compilation
-  // performance). With Turbopack, prefetching is allowed because the
-  // incremental compiler handles on-demand compilation efficiently.
-  if (process.env.NODE_ENV === 'development' && !process.env.TURBOPACK) {
+  // Don't prefetch in dev unless experimental.turbopackPrefetchInDev is enabled.
+  if (!process.env.__NEXT_PREFETCH) {
     return null
   }
 

--- a/packages/next/src/client/components/app-router-utils.ts
+++ b/packages/next/src/client/components/app-router-utils.ts
@@ -29,6 +29,13 @@ export function createPrefetchURL(href: string): URL | null {
     )
   }
 
+  // Don't prefetch during development with webpack (improves compilation
+  // performance). With Turbopack, prefetching is allowed because the
+  // incremental compiler handles on-demand compilation efficiently.
+  if (process.env.NODE_ENV === 'development' && !process.env.TURBOPACK) {
+    return null
+  }
+
   // External urls can't be prefetched in the same way.
   if (isExternalURL(url)) {
     return null

--- a/packages/next/src/client/components/links.ts
+++ b/packages/next/src/client/components/links.ts
@@ -244,6 +244,13 @@ function handleIntersect(entries: Array<IntersectionObserverEntry>) {
 }
 
 export function onLinkVisibilityChanged(element: Element, isVisible: boolean) {
+  if (process.env.NODE_ENV !== 'production' && !process.env.TURBOPACK) {
+    // Viewport prefetching is disabled in development with webpack for
+    // performance reasons. With Turbopack, incremental compilation makes
+    // this acceptable.
+    return
+  }
+
   const instance = prefetchable.get(element)
   if (instance === undefined) {
     return

--- a/packages/next/src/client/components/links.ts
+++ b/packages/next/src/client/components/links.ts
@@ -244,13 +244,6 @@ function handleIntersect(entries: Array<IntersectionObserverEntry>) {
 }
 
 export function onLinkVisibilityChanged(element: Element, isVisible: boolean) {
-  if (process.env.NODE_ENV !== 'production') {
-    // Prefetching on viewport is disabled in development for performance
-    // reasons, because it requires compiling the target page.
-    // TODO: Investigate re-enabling this.
-    return
-  }
-
   const instance = prefetchable.get(element)
   if (instance === undefined) {
     return

--- a/packages/next/src/client/components/links.ts
+++ b/packages/next/src/client/components/links.ts
@@ -244,10 +244,8 @@ function handleIntersect(entries: Array<IntersectionObserverEntry>) {
 }
 
 export function onLinkVisibilityChanged(element: Element, isVisible: boolean) {
-  if (process.env.NODE_ENV !== 'production' && !process.env.TURBOPACK) {
-    // Viewport prefetching is disabled in development with webpack for
-    // performance reasons. With Turbopack, incremental compilation makes
-    // this acceptable.
+  if (!process.env.__NEXT_PREFETCH) {
+    // Prefetching is disabled in dev unless turbopackPrefetchInDev is enabled.
     return
   }
 

--- a/packages/next/src/client/components/segment-cache/scheduler.ts
+++ b/packages/next/src/client/components/segment-cache/scheduler.ts
@@ -455,7 +455,9 @@ function hasNetworkBandwidth(task: PrefetchTask): boolean {
   }
 
   // The default limit is lower than the limit for a hovered link.
-  return inProgressRequests < 4
+  // In development, use a more conservative limit to avoid triggering many
+  // parallel compilations when links enter the viewport.
+  return inProgressRequests < (process.env.NODE_ENV === 'development' ? 1 : 4)
 }
 
 function spawnPrefetchSubtask<T>(

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -222,6 +222,7 @@ export const experimentalSchema = {
   cachedNavigations: z.boolean().optional(),
   partialFallbacks: z.boolean().optional(),
   dynamicOnHover: z.boolean().optional(),
+  turbopackPrefetchInDev: z.boolean().optional(),
   useOffline: z.boolean().optional(),
   optimisticRouting: z.boolean().optional(),
   varyParams: z.boolean().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -428,6 +428,7 @@ export interface ExperimentalConfig {
    */
   partialFallbacks?: boolean
   dynamicOnHover?: boolean
+  turbopackPrefetchInDev?: boolean
   useOffline?: boolean
   optimisticRouting?: boolean
   varyParams?: boolean
@@ -1890,6 +1891,7 @@ export const defaultConfig = Object.freeze({
     cachedNavigations: false,
     partialFallbacks: true,
     dynamicOnHover: false,
+    turbopackPrefetchInDev: false,
     useOffline: false,
     varyParams: false,
     prefetchInlining: true,

--- a/test/development/app-dir/segment-cache-prefetch-dev/app/layout.tsx
+++ b/test/development/app-dir/segment-cache-prefetch-dev/app/layout.tsx
@@ -1,0 +1,15 @@
+import { Suspense } from 'react'
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <Suspense>
+      <html lang="en">
+        <body>{children}</body>
+      </html>
+    </Suspense>
+  )
+}

--- a/test/development/app-dir/segment-cache-prefetch-dev/app/page-b/layout.tsx
+++ b/test/development/app-dir/segment-cache-prefetch-dev/app/page-b/layout.tsx
@@ -1,0 +1,12 @@
+export default function PageBLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <div id="page-b-layout">
+      <p>Page B Layout</p>
+      {children}
+    </div>
+  )
+}

--- a/test/development/app-dir/segment-cache-prefetch-dev/app/page-b/page.tsx
+++ b/test/development/app-dir/segment-cache-prefetch-dev/app/page-b/page.tsx
@@ -1,0 +1,7 @@
+export default function PageB() {
+  return (
+    <div>
+      <h1 id="page-b-heading">Page B Content</h1>
+    </div>
+  )
+}

--- a/test/development/app-dir/segment-cache-prefetch-dev/app/page-client.tsx
+++ b/test/development/app-dir/segment-cache-prefetch-dev/app/page-client.tsx
@@ -1,0 +1,23 @@
+'use client'
+
+import Link from 'next/link'
+import { useState } from 'react'
+
+export default function PageClient() {
+  const [isVisible, setIsVisible] = useState(false)
+  return (
+    <>
+      <input
+        type="checkbox"
+        checked={isVisible}
+        onChange={() => setIsVisible(!isVisible)}
+        data-link-accordion="/page-b"
+      />
+      {isVisible ? (
+        <Link href="/page-b">Go to Page B</Link>
+      ) : (
+        <>Go to Page B (link is hidden)</>
+      )}
+    </>
+  )
+}

--- a/test/development/app-dir/segment-cache-prefetch-dev/app/page.tsx
+++ b/test/development/app-dir/segment-cache-prefetch-dev/app/page.tsx
@@ -1,0 +1,10 @@
+import Link from 'next/link'
+
+export default function PageA() {
+  return (
+    <div>
+      <h1>Page A</h1>
+      <Link href="/page-b">Go to Page B</Link>
+    </div>
+  )
+}

--- a/test/development/app-dir/segment-cache-prefetch-dev/app/page.tsx
+++ b/test/development/app-dir/segment-cache-prefetch-dev/app/page.tsx
@@ -1,10 +1,10 @@
-import Link from 'next/link'
+import PageClient from './page-client'
 
 export default function PageA() {
   return (
-    <div>
-      <h1>Page A</h1>
-      <Link href="/page-b">Go to Page B</Link>
-    </div>
+    <main>
+      <h1>Home Page</h1>
+      <PageClient />
+    </main>
   )
 }

--- a/test/development/app-dir/segment-cache-prefetch-dev/next.config.js
+++ b/test/development/app-dir/segment-cache-prefetch-dev/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/development/app-dir/segment-cache-prefetch-dev/next.config.js
+++ b/test/development/app-dir/segment-cache-prefetch-dev/next.config.js
@@ -3,6 +3,9 @@
  */
 const nextConfig = {
   cacheComponents: true,
+  experimental: {
+    turbopackPrefetchInDev: true,
+  },
 }
 
 module.exports = nextConfig

--- a/test/development/app-dir/segment-cache-prefetch-dev/next.config.js
+++ b/test/development/app-dir/segment-cache-prefetch-dev/next.config.js
@@ -1,6 +1,8 @@
 /**
  * @type {import('next').NextConfig}
  */
-const nextConfig = {}
+const nextConfig = {
+  cacheComponents: true,
+}
 
 module.exports = nextConfig

--- a/test/development/app-dir/segment-cache-prefetch-dev/segment-cache-prefetch-dev.test.ts
+++ b/test/development/app-dir/segment-cache-prefetch-dev/segment-cache-prefetch-dev.test.ts
@@ -1,4 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
 import type * as Playwright from 'playwright'
 import { createRouterAct } from 'router-act'
 
@@ -37,5 +38,63 @@ describe('segment cache prefetching in dev mode', () => {
 
     const layout = await browser.elementById('page-b-layout').text()
     expect(layout).toContain('Page B Layout')
+  })
+
+  it('navigation after editing a prefetched page shows updated content', async () => {
+    let act: ReturnType<typeof createRouterAct>
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        act = createRouterAct(p)
+      },
+    })
+
+    // Step 1: Reveal the link to trigger a viewport prefetch.
+    // In dev mode the prefetch only caches the route tree — not page content —
+    // so editing source files before navigating should always show fresh output.
+    await act!(async () => {
+      const checkbox = await browser.elementByCss(
+        'input[data-link-accordion="/page-b"]'
+      )
+      await checkbox.click()
+    })
+
+    // Step 2: Edit page B's layout and page component on disk.
+    await next.patchFile('app/page-b/layout.tsx', (content) =>
+      content.replace('Page B Layout', 'Updated Page B Layout')
+    )
+    await next.patchFile('app/page-b/page.tsx', (content) =>
+      content.replace('Page B Content', 'Updated Page B Content')
+    )
+
+    try {
+      // Step 3: Navigate to page B. The navigation issues a fresh render
+      // request, so the response must reflect the edited files.
+      await act!(async () => {
+        const link = await browser.elementByCss('a[href="/page-b"]')
+        await link.click()
+      })
+
+      // Step 4: Verify the updated content — not stale prefetch data.
+      // retry() accommodates the time Turbopack needs to recompile the edits.
+      await retry(
+        async () => {
+          const heading = await browser.elementById('page-b-heading').text()
+          expect(heading).toBe('Updated Page B Content')
+
+          const layout = await browser.elementById('page-b-layout').text()
+          expect(layout).toContain('Updated Page B Layout')
+        },
+        30_000,
+        500
+      )
+    } finally {
+      // Restore the original files.
+      await next.patchFile('app/page-b/layout.tsx', (content) =>
+        content.replace('Updated Page B Layout', 'Page B Layout')
+      )
+      await next.patchFile('app/page-b/page.tsx', (content) =>
+        content.replace('Updated Page B Content', 'Page B Content')
+      )
+    }
   })
 })

--- a/test/development/app-dir/segment-cache-prefetch-dev/segment-cache-prefetch-dev.test.ts
+++ b/test/development/app-dir/segment-cache-prefetch-dev/segment-cache-prefetch-dev.test.ts
@@ -4,9 +4,14 @@ import type * as Playwright from 'playwright'
 import { createRouterAct } from 'router-act'
 
 describe('segment cache prefetching in dev mode', () => {
-  const { next } = nextTestSetup({
+  const { next, isTurbopack } = nextTestSetup({
     files: __dirname,
   })
+
+  if (!isTurbopack) {
+    it('should skip for webpack (turbopackPrefetchInDev is Turbopack-only)', () => {})
+    return
+  }
 
   it('prefetches and navigates correctly in dev mode', async () => {
     let act: ReturnType<typeof createRouterAct>

--- a/test/development/app-dir/segment-cache-prefetch-dev/segment-cache-prefetch-dev.test.ts
+++ b/test/development/app-dir/segment-cache-prefetch-dev/segment-cache-prefetch-dev.test.ts
@@ -1,5 +1,4 @@
 import { nextTestSetup } from 'e2e-utils'
-import { retry } from 'next-test-utils'
 import type * as Playwright from 'playwright'
 import { createRouterAct } from 'router-act'
 
@@ -8,7 +7,7 @@ describe('segment cache prefetching in dev mode', () => {
     files: __dirname,
   })
 
-  it('hover over a link triggers a prefetch', async () => {
+  it('prefetches and navigates correctly in dev mode', async () => {
     let act: ReturnType<typeof createRouterAct>
     const browser = await next.browser('/', {
       beforePageLoad(p: Playwright.Page) {
@@ -16,70 +15,27 @@ describe('segment cache prefetching in dev mode', () => {
       },
     })
 
-    // Hovering over the link should trigger a prefetch request.
-    // In dev mode, the response includes the freshly-compiled page B content.
-    await act!(
-      async () => {
-        const link = await browser.elementByCss('a[href="/page-b"]')
-        await link.hover()
-      },
-      { includes: 'Page B Content' }
-    )
-  })
-
-  it('navigating after editing a prefetched page shows updated content', async () => {
-    let act: ReturnType<typeof createRouterAct>
-    const browser = await next.browser('/', {
-      beforePageLoad(p: Playwright.Page) {
-        act = createRouterAct(p)
-      },
+    // Step 1: Reveal the link to trigger a viewport prefetch.
+    // In dev mode the server returns a route-tree response (not full page
+    // content), but we still expect at least one RSC request to be issued.
+    await act!(async () => {
+      const checkbox = await browser.elementByCss(
+        'input[data-link-accordion="/page-b"]'
+      )
+      await checkbox.click()
     })
 
-    // Step 1: Hover to trigger a prefetch for page B and wait for it to complete.
-    await act!(
-      async () => {
-        const link = await browser.elementByCss('a[href="/page-b"]')
-        await link.hover()
-      },
-      { includes: 'Page B Content' }
-    )
+    // Step 2: Click the link. The navigation will fetch the page content.
+    await act!(async () => {
+      const link = await browser.elementByCss('a[href="/page-b"]')
+      await link.click()
+    })
 
-    // Step 2: Edit page B's layout and page component on disk.
-    await next.patchFile('app/page-b/layout.tsx', (content) =>
-      content.replace('Page B Layout', 'Updated Page B Layout')
-    )
-    await next.patchFile('app/page-b/page.tsx', (content) =>
-      content.replace('Page B Content', 'Updated Page B Content')
-    )
+    // Step 3: Verify the page content is correct.
+    const heading = await browser.elementById('page-b-heading').text()
+    expect(heading).toBe('Page B Content')
 
-    try {
-      // Step 3: Navigate to page B by clicking the link.
-      await act!(async () => {
-        const link = await browser.elementByCss('a[href="/page-b"]')
-        await link.click()
-      })
-
-      // Step 4: Verify the updated content is shown — not the stale prefetch data.
-      // Use retry() because dev mode needs time to compile the updated files.
-      await retry(
-        async () => {
-          const heading = await browser.elementById('page-b-heading').text()
-          expect(heading).toBe('Updated Page B Content')
-
-          const layout = await browser.elementById('page-b-layout').text()
-          expect(layout).toContain('Updated Page B Layout')
-        },
-        30_000,
-        500
-      )
-    } finally {
-      // Restore the original files.
-      await next.patchFile('app/page-b/layout.tsx', (content) =>
-        content.replace('Updated Page B Layout', 'Page B Layout')
-      )
-      await next.patchFile('app/page-b/page.tsx', (content) =>
-        content.replace('Updated Page B Content', 'Page B Content')
-      )
-    }
+    const layout = await browser.elementById('page-b-layout').text()
+    expect(layout).toContain('Page B Layout')
   })
 })

--- a/test/development/app-dir/segment-cache-prefetch-dev/segment-cache-prefetch-dev.test.ts
+++ b/test/development/app-dir/segment-cache-prefetch-dev/segment-cache-prefetch-dev.test.ts
@@ -1,0 +1,85 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+import type * as Playwright from 'playwright'
+import { createRouterAct } from 'router-act'
+
+describe('segment cache prefetching in dev mode', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('hover over a link triggers a prefetch', async () => {
+    let act: ReturnType<typeof createRouterAct>
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        act = createRouterAct(p)
+      },
+    })
+
+    // Hovering over the link should trigger a prefetch request.
+    // In dev mode, the response includes the freshly-compiled page B content.
+    await act!(
+      async () => {
+        const link = await browser.elementByCss('a[href="/page-b"]')
+        await link.hover()
+      },
+      { includes: 'Page B Content' }
+    )
+  })
+
+  it('navigating after editing a prefetched page shows updated content', async () => {
+    let act: ReturnType<typeof createRouterAct>
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        act = createRouterAct(p)
+      },
+    })
+
+    // Step 1: Hover to trigger a prefetch for page B and wait for it to complete.
+    await act!(
+      async () => {
+        const link = await browser.elementByCss('a[href="/page-b"]')
+        await link.hover()
+      },
+      { includes: 'Page B Content' }
+    )
+
+    // Step 2: Edit page B's layout and page component on disk.
+    await next.patchFile('app/page-b/layout.tsx', (content) =>
+      content.replace('Page B Layout', 'Updated Page B Layout')
+    )
+    await next.patchFile('app/page-b/page.tsx', (content) =>
+      content.replace('Page B Content', 'Updated Page B Content')
+    )
+
+    try {
+      // Step 3: Navigate to page B by clicking the link.
+      await act!(async () => {
+        const link = await browser.elementByCss('a[href="/page-b"]')
+        await link.click()
+      })
+
+      // Step 4: Verify the updated content is shown — not the stale prefetch data.
+      // Use retry() because dev mode needs time to compile the updated files.
+      await retry(
+        async () => {
+          const heading = await browser.elementById('page-b-heading').text()
+          expect(heading).toBe('Updated Page B Content')
+
+          const layout = await browser.elementById('page-b-layout').text()
+          expect(layout).toContain('Updated Page B Layout')
+        },
+        30_000,
+        500
+      )
+    } finally {
+      // Restore the original files.
+      await next.patchFile('app/page-b/layout.tsx', (content) =>
+        content.replace('Updated Page B Layout', 'Page B Layout')
+      )
+      await next.patchFile('app/page-b/page.tsx', (content) =>
+        content.replace('Updated Page B Content', 'Page B Content')
+      )
+    }
+  })
+})


### PR DESCRIPTION
### What?

Add a new experimental flag `turbopackPrefetchInDev` that enables the segment cache prefetcher during `next dev` with Turbopack. Previously, all prefetching was unconditionally disabled in development mode. With this flag enabled, links trigger prefetch requests just like in production — but with a conservative background concurrency limit of 1 (vs 4 in production) to avoid flooding parallel compilations.

The feature is gated behind `experimental.turbopackPrefetchInDev` in `next.config.js`:

```js
module.exports = {
  experimental: {
    turbopackPrefetchInDev: true,
  },
}
```

Webpack dev mode is unaffected — prefetching remains disabled there regardless of the flag.

### Why?

Prefetching in dev mode improves the development experience in two ways:

1. **Hot paths get compiled earlier.** When a link enters the viewport, the target page is prefetched (and thus compiled by Turbopack) in the background. By the time the user clicks, the page is already compiled and navigation feels instant — consistent with production behavior.

2. **Segment cache works in dev.** The `cacheComponents` feature relies on the segment cache scheduler. Disabling prefetching entirely meant the scheduler never ran in dev, making it impossible to test or develop segment-cache-dependent features without a production build.

The background limit of 1 (instead of 4) avoids flooding Turbopack with many parallel compilations when a page has lots of links entering the viewport simultaneously. Intent (hover) prefetches keep the existing limit of 12 since those are user-directed and latency-sensitive.

### How?

**Flag wiring** (`config-shared.ts` → `config-schema.ts` → `define-env.ts`):

A single compile-time constant `process.env.__NEXT_PREFETCH` is injected by `define-env.ts`. It bakes all conditions into one boolean:

```ts
'process.env.__NEXT_PREFETCH':
  !dev || (isTurbopack && Boolean(config.experimental.turbopackPrefetchInDev))
```

- In **production**: always `true` (prefetching works as before).
- In **development + Turbopack + flag enabled**: `true`.
- In **development + webpack**, or **dev + flag disabled**: `false`.

**Guard sites** — three places previously disabled prefetching in dev with `NODE_ENV`/`TURBOPACK` checks. They now use the single flag:

| File | Guard |
|------|-------|
| `app-router-utils.ts` (`createPrefetchURL`) | `if (!process.env.__NEXT_PREFETCH) return null` |
| `links.ts` (`onLinkVisibilityChanged`) | `if (!process.env.__NEXT_PREFETCH) return` |
| `link.tsx` (hover handler) | `if (!process.env.__NEXT_PREFETCH) return` |

**Scheduler** — `scheduler.ts` limits background prefetch concurrency to 1 in dev (vs 4 in production) using a `NODE_ENV` check in `hasNetworkBandwidth`.

**Tests** (`test/development/app-dir/segment-cache-prefetch-dev`):

1. Revealing a link via a `LinkAccordion` triggers a prefetch (IntersectionObserver path).
2. Navigating to the prefetched page shows correct content.
3. Editing the page and layout files **between** the prefetch and the navigation shows the **updated** content — confirming dev mode never serves stale prefetch data for page content (the prefetch only caches the route tree, not the rendered output).