### PR TITLE
[test] Suppress build when preparing next for cache hits

### DIFF
--- a/test/lib/create-next-install.js
+++ b/test/lib/create-next-install.js
@@ -82,10 +82,20 @@ async function createNextInstall({
         require('console').log('using provided pkg paths')
       } else {
         await rootSpan.traceChild('turbo-run-pack').traceAsyncFn(() =>
-          execa('pnpm', ['turbo', 'run', 'pack-for-isolated-tests'], {
-            cwd: origRepoDir,
-            stdio: ['ignore', 'inherit', 'inherit'],
-          })
+          execa(
+            'pnpm',
+            [
+              'turbo',
+              'run',
+              'pack-for-isolated-tests',
+              '--output-logs',
+              'new-only',
+            ],
+            {
+              cwd: origRepoDir,
+              stdio: ['ignore', 'inherit', 'inherit'],
+            }
+          )
         )
 
         if (process.env.NEXT_TEST_WASM) {


### PR DESCRIPTION
In https://github.com/vercel/next.js/pull/92575 we started using Turborepo to build a fresh copy of Next.js before each test. This can become quite noisy IMO since Turborepo replays logs by default. Now we hide logs for cache hits. 

If you want to debug logs from cached builds, you should use `pnpm build` directly.


```terminal
@next/polyfill-nomodule#build > cache hit, suppressing logs 951e3e04258a486d 
 @next/playwright#build > cache hit, suppressing logs a37fc1279a93411b 
 @next/routing#build > cache hit, suppressing logs e29bf8207712d9ea 
 @next/env#build > cache hit, suppressing logs 6f68cdf7c8f202f6 
 @next/bundle-analyzer-ui#build > cache hit, suppressing logs 5dbf9112c4f7029e 
 @next/polyfill-module#build > cache hit, suppressing logs 601b6f5afa47853d 
 @vercel/devlow-bench#build > cache hit, suppressing logs dfd1c037ef4e8100 
 @next/codemod#build > cache hit, suppressing logs a5eac293134b4263 
 @next/react-refresh-utils#build > cache hit, suppressing logs 51d64c1f7e8e5cfb 
 @next/eslint-plugin-next#build > cache hit, suppressing logs 74ec27fec9910c71 
 create-next-app#build > cache hit, suppressing logs 0c4c9d38e0e0913e 
 @next/font#build > cache hit, suppressing logs d1d057c5ffe70285 
 @next/bundle-analyzer#pack-for-isolated-tests > cache hit, suppressing logs 867b1e9082440087 
 @next/env#pack-for-isolated-tests > cache hit, suppressing logs 50d7a018277cafb8 
 next-rspack#pack-for-isolated-tests > cache hit, suppressing logs 1046e9cfa3ba6879 
 @next/mdx#pack-for-isolated-tests > cache hit, suppressing logs 6da45b672b5b081a 
 eslint-config-next#build > cache hit, suppressing logs fcf529c5b1428c5d 
 @next/font#pack-for-isolated-tests > cache hit, suppressing logs 9675f7ed199b9841 
 next#build > cache hit, suppressing logs 8c62df3806949bad 
 @vercel/turbopack-next#build > cache hit, suppressing logs 94890b06e4b937bf 
 @next/third-parties#build > cache hit, suppressing logs f1da8c56f9222a0c 
 next#pack-for-isolated-tests > cache hit, suppressing logs f11a5a11e2584c14 
 @next/third-parties#pack-for-isolated-tests > cache hit, suppressing logs 988b5be9471a943e
```