### PR TITLE
fix(typescript): set pathsBasePath after deleting baseUrl for TS6 compat

### DIFF
--- a/packages/next/src/lib/typescript/getTypeScriptConfiguration.test.ts
+++ b/packages/next/src/lib/typescript/getTypeScriptConfiguration.test.ts
@@ -1,0 +1,84 @@
+import { mkdtemp, writeFile, mkdir } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, dirname } from 'node:path'
+// eslint-disable-next-line import/no-extraneous-dependencies
+import ts from 'typescript'
+import { getTypeScriptConfiguration } from './getTypeScriptConfiguration'
+
+describe('getTypeScriptConfiguration()', () => {
+  let tmpDir: string
+  let tsConfigPath: string
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'nextjs-ts-config-test-'))
+    tsConfigPath = join(tmpDir, 'tsconfig.json')
+  })
+
+  describe('TypeScript 6 compat — pathsBasePath', () => {
+    it('removes baseUrl and sets pathsBasePath to tsconfig dir for TS6 compat', async () => {
+      // The scenario not addressed by #92277 (which handled paths-without-baseUrl):
+      // when a tsconfig HAS baseUrl, the TS6 compat code rewrites paths to
+      // relative form and deletes baseUrl. TypeScript then needs pathsBasePath
+      // to determine the root for resolving those rewritten aliases. Without
+      // setting pathsBasePath, TypeScript falls back to the repo root (or CWD)
+      // which breaks monorepo setups where the app lives in a subdirectory.
+      await writeFile(
+        tsConfigPath,
+        JSON.stringify({
+          compilerOptions: {
+            baseUrl: '.',
+            paths: {
+              '@lib/*': ['./src/lib/*'],
+            },
+          },
+        }),
+        { encoding: 'utf8' }
+      )
+
+      const result = await getTypeScriptConfiguration(ts, tsConfigPath, true)
+
+      // baseUrl must be removed so TS6 deprecation checks don't fail type checking
+      expect(result.options.baseUrl).toBeUndefined()
+      // pathsBasePath must be set to the tsconfig directory so the rewritten
+      // ../../... aliases resolve relative to the app dir, not the repo root
+      expect(result.options.pathsBasePath).toBe(dirname(tsConfigPath))
+    })
+
+    it('sets pathsBasePath to the app tsconfig dir when baseUrl is inherited from an extended root tsconfig', async () => {
+      // Monorepo scenario: root tsconfig defines baseUrl/paths, app tsconfig extends it.
+      // The pathsBasePath must point to the *app* tsconfig dir so that rewritten
+      // relative aliases (../../packages/...) resolve from the app, not the root.
+      const rootTsConfigPath = join(tmpDir, 'tsconfig.base.json')
+      await writeFile(
+        rootTsConfigPath,
+        JSON.stringify({
+          compilerOptions: {
+            baseUrl: '.',
+            paths: {
+              '@shared/*': ['./packages/shared/src/*'],
+            },
+          },
+        }),
+        { encoding: 'utf8' }
+      )
+
+      const appDir = join(tmpDir, 'apps', 'web')
+      await mkdir(appDir, { recursive: true })
+      const appTsConfigPath = join(appDir, 'tsconfig.json')
+      await writeFile(
+        appTsConfigPath,
+        JSON.stringify({
+          extends: '../../tsconfig.base.json',
+          compilerOptions: {},
+        }),
+        { encoding: 'utf8' }
+      )
+
+      const result = await getTypeScriptConfiguration(ts, appTsConfigPath, true)
+
+      expect(result.options.baseUrl).toBeUndefined()
+      // Must be the app dir, not the root dir where tsconfig.base.json lives
+      expect(result.options.pathsBasePath).toBe(dirname(appTsConfigPath))
+    })
+  })
+})

--- a/packages/next/src/lib/typescript/getTypeScriptConfiguration.ts
+++ b/packages/next/src/lib/typescript/getTypeScriptConfiguration.ts
@@ -173,6 +173,11 @@ export async function getTypeScriptConfiguration(
           result.options.paths
         ) as import('typescript').MapLike<string[]>
         delete (result.options as { baseUrl?: unknown }).baseUrl
+        // After removing baseUrl, TypeScript uses pathsBasePath to determine the
+        // base directory for resolving rewritten path aliases. Set it to the
+        // tsconfig directory so the rewritten ../../... aliases resolve relative
+        // to the app dir, matching webpack's JsConfigPathsPlugin behavior.
+        result.options.pathsBasePath = path.dirname(path.resolve(tsConfigPath))
       }
     }
 

--- a/test/production/typescript-paths-base-path/typescript-paths-base-path.test.ts
+++ b/test/production/typescript-paths-base-path/typescript-paths-base-path.test.ts
@@ -1,0 +1,124 @@
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { createNext } from 'e2e-utils'
+import type { NextInstance } from 'e2e-utils'
+
+// Reproduces https://github.com/vercel/next.js/issues/93336
+// When path aliases are inherited from a parent tsconfig (monorepo setup),
+// getTypeScriptConfiguration deletes baseUrl for TS6 compat and must set
+// pathsBasePath to the app tsconfig directory so that rewritten aliases
+// (e.g. ../../packages/shared/src/*) resolve relative to the app dir.
+describe('TypeScript pathsBasePath fix for TS6 monorepo path aliases', () => {
+  let next: NextInstance
+  let baseTsConfigDir: string
+
+  beforeAll(async () => {
+    // Create a "repo root" directory outside the Next.js project that holds
+    // the shared base tsconfig and packages — simulating a monorepo layout.
+    baseTsConfigDir = await mkdtemp(join(tmpdir(), 'nextjs-test-ts-base-'))
+
+    // Root tsconfig: defines baseUrl and paths (the classic monorepo pattern)
+    await writeFile(
+      join(baseTsConfigDir, 'tsconfig.base.json'),
+      JSON.stringify({
+        compilerOptions: {
+          baseUrl: '.',
+          paths: {
+            '@shared/*': ['packages/shared/src/*'],
+          },
+        },
+      })
+    )
+
+    // Shared package that will be imported via path alias
+    await mkdir(join(baseTsConfigDir, 'packages', 'shared', 'src'), {
+      recursive: true,
+    })
+    await writeFile(
+      join(baseTsConfigDir, 'packages', 'shared', 'src', 'index.ts'),
+      'export const greet = (name: string): string => "Hello, " + name + "!"'
+    )
+
+    next = await createNext({
+      files: {
+        'next.config.js': `module.exports = {}`,
+        // App-level tsconfig extends the root tsconfig via absolute path.
+        // This is the scenario from #93336: aliases are defined in the root
+        // tsconfig, so TypeScript sets pathsBasePath to the root dir —
+        // which means our fix (setting pathsBasePath = app tsconfig dir)
+        // is required for the rewritten paths to resolve correctly.
+        'tsconfig.json': JSON.stringify({
+          extends: join(baseTsConfigDir, 'tsconfig.base.json'),
+          compilerOptions: {
+            target: 'ES2020',
+            lib: ['dom', 'dom.iterable', 'esnext'],
+            allowJs: true,
+            skipLibCheck: true,
+            strict: true,
+            noEmit: true,
+            esModuleInterop: true,
+            module: 'esnext',
+            moduleResolution: 'bundler',
+            resolveJsonModule: true,
+            isolatedModules: true,
+            jsx: 'preserve',
+            incremental: true,
+            plugins: [{ name: 'next' }],
+          },
+          include: ['next-env.d.ts', '**/*.ts', '**/*.tsx'],
+          exclude: ['node_modules'],
+        }),
+        'app/layout.tsx': `
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}
+`,
+        // Page that imports from the @shared/* path alias defined in the base tsconfig.
+        // Without the pathsBasePath fix, TypeScript would fail with:
+        //   Type error: Cannot find module '@shared/index' or its corresponding type declarations.
+        'app/page.tsx': `
+import { greet } from '@shared/index'
+
+export default function Page() {
+  return <p>{greet('world')}</p>
+}
+`,
+      },
+      dependencies: {
+        // Use TypeScript 6+ to trigger the TS6 compat code path in getTypeScriptConfiguration.
+        // The baseUrl-to-pathsBasePath migration only runs for semver >= 6.0.0.
+        typescript: '^6.0.0',
+        '@types/node': 'latest',
+        '@types/react': 'latest',
+        '@types/react-dom': 'latest',
+      },
+    })
+  })
+
+  afterAll(async () => {
+    await next?.destroy()
+  })
+
+  it('should build successfully without "Cannot find module" type errors', async () => {
+    // If pathsBasePath is not set after deleting baseUrl, TypeScript resolves
+    // the rewritten relative aliases (e.g. ../../packages/shared/src/*) from
+    // the repo root dir instead of the app dir — producing paths that don't exist.
+    expect(next.cliOutput).not.toContain('Cannot find module')
+    expect(next.cliOutput).not.toContain('Type error')
+    expect(next.cliOutput).not.toContain('Failed to compile')
+  })
+
+  it('should render the page that uses the aliased module', async () => {
+    const html = await next.render('/')
+    expect(html).toContain('Hello, world!')
+  })
+})


### PR DESCRIPTION
## What?

When the TypeScript 6 compatibility code deletes `baseUrl` and rewrites path aliases to relative form (e.g. `../../libs/shared-lib/src/*`), TypeScript's module resolver falls back to `pathsBasePath` to determine the base directory for resolving those aliases.

In a monorepo, `paths` is typically defined in a shared base tsconfig at the repo root, so `pathsBasePath` points to the repo root. TypeScript then resolves the rewritten `../../...` paths **relative to the repo root** instead of the app dir, producing paths that don't exist.

## Why?

`JsConfigPathsPlugin` (webpack) always resolves rewritten paths from `path.dirname(tsConfigPath)` (the app dir) — making compilation succeed. The TypeScript checker goes through the same `getTypeScriptConfiguration` call but uses `pathsBasePath` instead, which points at the wrong base directory — causing type checking to fail with `Cannot find module`.

## How?

After deleting `baseUrl`, set `pathsBasePath` to `path.dirname(path.resolve(tsConfigPath))` so TypeScript uses the same resolution base as webpack.

```diff
 result.options.paths = rewritePathAliasesWithoutBaseUrl(...)
 delete (result.options as { baseUrl?: unknown }).baseUrl
+result.options.pathsBasePath = path.dirname(path.resolve(tsConfigPath))
```

Fixes #93336