### PR TITLE
[test] Fix broken terminal output

### DIFF
--- a/test/lib/create-next-install.js
+++ b/test/lib/create-next-install.js
@@ -90,6 +90,10 @@ async function createNextInstall({
               'pack-for-isolated-tests',
               '--output-logs',
               'new-only',
+              // Jest tui can't handle Turborepo tui. But we're cutting off stdin
+              // so Turborepo's tui isn't interactive anyway.
+              '--ui',
+              'stream',
             ],
             {
               cwd: origRepoDir,


### PR DESCRIPTION
Nesting TUIs is hard but also a bit excessive since Turborepo's TUI isn't interactive if `stdin` is ignored.