### PR TITLE
Report process memory footprint (RSS) in TurboMalloc and trace samples

### DIFF
--- a/turbopack/crates/turbo-tasks-malloc/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-malloc/Cargo.toml
@@ -28,12 +28,17 @@ mimalloc = { version = "0.1.48", features = [
   "extended",
   "local_dynamic_tls",
 ], optional = true }
+libc = "0.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.60", features = ["Win32_System_SystemInformation"] }
+windows-sys = { version = "0.60", features = [
+  "Win32_System_ProcessStatus",
+  "Win32_System_SystemInformation",
+  "Win32_System_Threading",
+] }
 
 [features]
 custom_allocator = ["dep:mimalloc", "dep:libmimalloc-sys"]

--- a/turbopack/crates/turbo-tasks-malloc/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-malloc/src/lib.rs
@@ -1,4 +1,5 @@
 mod counter;
+mod memory_footprint;
 mod memory_pressure;
 
 use std::{
@@ -125,6 +126,19 @@ impl TurboMalloc {
     pub fn memory_pressure() -> Option<u8> {
         memory_pressure::memory_pressure()
     }
+
+    /// Returns the resident memory size of the current process in bytes, or
+    /// `None` when the current platform does not expose a memory footprint
+    /// signal or a query for it failed.
+    ///
+    /// - On Linux this is the resident set size from `/proc/self/statm`.
+    /// - On macOS this is `task_vm_info_data_t::phys_footprint` (what Apple calls "memory
+    ///   footprint" / Activity Monitor's "Memory" column).
+    /// - On Windows this is `PROCESS_MEMORY_COUNTERS::WorkingSetSize`.
+    /// - On other platforms this returns `None`.
+    pub fn memory_footprint() -> Option<usize> {
+        memory_footprint::memory_footprint()
+    }
 }
 
 /// Get the allocator for this platform that we should wrap with TurboMalloc.
@@ -212,6 +226,38 @@ mod tests {
         assert!(
             value <= 100,
             "memory_pressure() returned {value}, expected a value in 0..=100"
+        );
+    }
+
+    #[test]
+    fn memory_footprint_is_reported_on_supported_platforms() {
+        let value = TurboMalloc::memory_footprint();
+
+        // On all supported platforms the value must be reported.
+        #[cfg(any(
+            all(target_os = "linux", not(target_family = "wasm")),
+            target_os = "macos",
+            windows,
+        ))]
+        let value = value.expect("memory_footprint() should return Some on this platform");
+
+        // On unsupported platforms we expect None and have nothing further to assert.
+        #[cfg(not(any(
+            all(target_os = "linux", not(target_family = "wasm")),
+            target_os = "macos",
+            windows,
+        )))]
+        let Some(value) = value else {
+            return;
+        };
+
+        assert!(
+            value > 0,
+            "memory_footprint() returned {value}, expected a positive byte count"
+        );
+        assert!(
+            value < isize::MAX as usize,
+            "memory_footprint() returned {value}, which is implausibly large"
         );
     }
 }

--- a/turbopack/crates/turbo-tasks-malloc/src/memory_footprint.rs
+++ b/turbopack/crates/turbo-tasks-malloc/src/memory_footprint.rs
@@ -1,0 +1,142 @@
+//! Per-OS memory footprint detection.
+//!
+//! All implementations return the resident memory size of the current
+//! process in bytes. Platforms that do not expose a memory footprint signal
+//! (or for which the query fails) return `None`.
+
+/// See [`super::TurboMalloc::memory_footprint`].
+pub fn memory_footprint() -> Option<usize> {
+    platform::memory_footprint()
+}
+
+#[cfg(all(target_os = "linux", not(target_family = "wasm")))]
+mod platform {
+    /// Reads `/proc/self/statm` and returns the resident set size in bytes
+    /// (the second whole number, multiplied by the system page size).
+    pub fn memory_footprint() -> Option<usize> {
+        let content = std::fs::read_to_string("/proc/self/statm").ok()?;
+        let resident_pages = parse_resident_pages(&content)?;
+        let page_size = page_size()?;
+        resident_pages.checked_mul(page_size)
+    }
+
+    fn parse_resident_pages(content: &str) -> Option<usize> {
+        // Expected format: "<size> <resident> <shared> <text> 0 <data> 0"
+        // where each value is in pages.
+        let mut iter = content.split_ascii_whitespace();
+        let _size = iter.next()?;
+        let resident = iter.next()?;
+        resident.parse().ok()
+    }
+
+    fn page_size() -> Option<usize> {
+        // Safety: `sysconf` is thread-safe and never accesses memory through
+        // its argument.
+        let value = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+        if value <= 0 {
+            return None;
+        }
+        usize::try_from(value).ok()
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::parse_resident_pages;
+
+        #[test]
+        fn parses_typical_statm_content() {
+            assert_eq!(
+                parse_resident_pages("12345 6789 4321 8 0 1234 0\n"),
+                Some(6789)
+            );
+        }
+
+        #[test]
+        fn returns_none_on_malformed_statm() {
+            assert_eq!(parse_resident_pages(""), None);
+            assert_eq!(parse_resident_pages("12345"), None);
+            assert_eq!(parse_resident_pages("12345 garbage"), None);
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+mod platform {
+    use std::mem::size_of;
+
+    /// Reads `task_vm_info_data_t::phys_footprint` for the current task. This
+    /// is what Apple calls the "memory footprint" of a process and is the
+    /// value reported in Activity Monitor's "Memory" column.
+    pub fn memory_footprint() -> Option<usize> {
+        let mut info = std::mem::MaybeUninit::<libc::task_vm_info_data_t>::zeroed();
+        let mut count: libc::mach_msg_type_number_t = libc::TASK_VM_INFO_COUNT;
+        // Safety: `mach_task_self` is a thread-safe accessor for the current
+        // task port. `task_info` writes up to `count` 32-bit words into our
+        // properly sized and zero-initialized `task_vm_info_data_t` buffer.
+        let kr = unsafe {
+            libc::task_info(
+                libc::mach_task_self(),
+                libc::TASK_VM_INFO,
+                info.as_mut_ptr() as libc::task_info_t,
+                &mut count,
+            )
+        };
+        if kr != libc::KERN_SUCCESS {
+            return None;
+        }
+        // `phys_footprint` is filled in only when at least
+        // `TASK_VM_INFO_REV1_COUNT` words are returned. Guard against older
+        // kernels that return a smaller struct.
+        if (count as usize) * size_of::<libc::integer_t>()
+            < std::mem::offset_of!(libc::task_vm_info_data_t, phys_footprint) + size_of::<u64>()
+        {
+            return None;
+        }
+        // Safety: `task_info` returned `KERN_SUCCESS` and wrote at least
+        // through `phys_footprint`, so the struct is initialized through that
+        // field.
+        let info = unsafe { info.assume_init() };
+        usize::try_from(info.phys_footprint).ok()
+    }
+}
+
+#[cfg(windows)]
+mod platform {
+    use std::mem::size_of;
+
+    use windows_sys::Win32::System::{
+        ProcessStatus::{GetProcessMemoryInfo, PROCESS_MEMORY_COUNTERS},
+        Threading::GetCurrentProcess,
+    };
+
+    /// Reads `PROCESS_MEMORY_COUNTERS::WorkingSetSize`, which is the amount
+    /// of memory currently resident for the calling process in bytes.
+    pub fn memory_footprint() -> Option<usize> {
+        let mut counters: PROCESS_MEMORY_COUNTERS = unsafe { std::mem::zeroed() };
+        // Safety: `counters` is a properly sized and zero-initialized
+        // `PROCESS_MEMORY_COUNTERS`. `GetCurrentProcess` returns a
+        // pseudo-handle that does not need closing.
+        let ok = unsafe {
+            GetProcessMemoryInfo(
+                GetCurrentProcess(),
+                &mut counters,
+                size_of::<PROCESS_MEMORY_COUNTERS>() as u32,
+            )
+        };
+        if ok == 0 {
+            return None;
+        }
+        Some(counters.WorkingSetSize)
+    }
+}
+
+#[cfg(not(any(
+    all(target_os = "linux", not(target_family = "wasm")),
+    target_os = "macos",
+    windows,
+)))]
+mod platform {
+    pub fn memory_footprint() -> Option<usize> {
+        None
+    }
+}

--- a/turbopack/crates/turbo-tasks-malloc/src/memory_footprint.rs
+++ b/turbopack/crates/turbo-tasks-malloc/src/memory_footprint.rs
@@ -11,12 +11,24 @@ pub fn memory_footprint() -> Option<usize> {
 
 #[cfg(all(target_os = "linux", not(target_family = "wasm")))]
 mod platform {
+    use std::sync::LazyLock;
+
+    static PAGE_SIZE: LazyLock<Option<usize>> = LazyLock::new(|| {
+        // Safety: `sysconf` is thread-safe and never accesses memory through
+        // its argument.
+        let value = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+        if value <= 0 {
+            return None;
+        }
+        usize::try_from(value).ok()
+    });
+
     /// Reads `/proc/self/statm` and returns the resident set size in bytes
     /// (the second whole number, multiplied by the system page size).
     pub fn memory_footprint() -> Option<usize> {
         let content = std::fs::read_to_string("/proc/self/statm").ok()?;
         let resident_pages = parse_resident_pages(&content)?;
-        let page_size = page_size()?;
+        let page_size = (*PAGE_SIZE)?;
         resident_pages.checked_mul(page_size)
     }
 
@@ -27,16 +39,6 @@ mod platform {
         let _size = iter.next()?;
         let resident = iter.next()?;
         resident.parse().ok()
-    }
-
-    fn page_size() -> Option<usize> {
-        // Safety: `sysconf` is thread-safe and never accesses memory through
-        // its argument.
-        let value = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
-        if value <= 0 {
-            return None;
-        }
-        usize::try_from(value).ok()
     }
 
     #[cfg(test)]
@@ -62,41 +64,29 @@ mod platform {
 
 #[cfg(target_os = "macos")]
 mod platform {
-    use std::mem::size_of;
-
-    /// Reads `task_vm_info_data_t::phys_footprint` for the current task. This
-    /// is what Apple calls the "memory footprint" of a process and is the
-    /// value reported in Activity Monitor's "Memory" column.
+    /// Reads `rusage_info_v0::ri_phys_footprint` for the current process via
+    /// `proc_pid_rusage`. This is what Apple calls the "memory footprint" of
+    /// a process and is the value reported in Activity Monitor's "Memory"
+    /// column.
     pub fn memory_footprint() -> Option<usize> {
-        let mut info = std::mem::MaybeUninit::<libc::task_vm_info_data_t>::zeroed();
-        let mut count: libc::mach_msg_type_number_t = libc::TASK_VM_INFO_COUNT;
-        // Safety: `mach_task_self` is a thread-safe accessor for the current
-        // task port. `task_info` writes up to `count` 32-bit words into our
-        // properly sized and zero-initialized `task_vm_info_data_t` buffer.
-        let kr = unsafe {
-            libc::task_info(
-                libc::mach_task_self(),
-                libc::TASK_VM_INFO,
-                info.as_mut_ptr() as libc::task_info_t,
-                &mut count,
+        let mut info = std::mem::MaybeUninit::<libc::rusage_info_v0>::zeroed();
+        // Safety: `proc_pid_rusage` writes a `rusage_info_v0` into the buffer
+        // when called with `RUSAGE_INFO_V0`. `getpid` is always safe and
+        // returns the current process id.
+        let rc = unsafe {
+            libc::proc_pid_rusage(
+                libc::getpid(),
+                libc::RUSAGE_INFO_V0,
+                info.as_mut_ptr() as *mut libc::rusage_info_t,
             )
         };
-        if kr != libc::KERN_SUCCESS {
+        if rc != 0 {
             return None;
         }
-        // `phys_footprint` is filled in only when at least
-        // `TASK_VM_INFO_REV1_COUNT` words are returned. Guard against older
-        // kernels that return a smaller struct.
-        if (count as usize) * size_of::<libc::integer_t>()
-            < std::mem::offset_of!(libc::task_vm_info_data_t, phys_footprint) + size_of::<u64>()
-        {
-            return None;
-        }
-        // Safety: `task_info` returned `KERN_SUCCESS` and wrote at least
-        // through `phys_footprint`, so the struct is initialized through that
-        // field.
+        // Safety: `proc_pid_rusage` returned success, so the buffer is
+        // initialized.
         let info = unsafe { info.assume_init() };
-        usize::try_from(info.phys_footprint).ok()
+        usize::try_from(info.ri_phys_footprint).ok()
     }
 }
 

--- a/turbopack/crates/turbopack-trace-server/src/reader/turbopack.rs
+++ b/turbopack/crates/turbopack-trace-server/src/reader/turbopack.rs
@@ -287,9 +287,10 @@ impl TurbopackFormat {
                 ts,
                 memory,
                 memory_pressure,
+                memory_footprint,
             } => {
                 let ts = Timestamp::from_micros(ts);
-                store.add_memory_sample(ts, memory, memory_pressure);
+                store.add_memory_sample(ts, memory, memory_pressure, memory_footprint);
             }
             TraceRow::AllocationCounters {
                 ts: _,

--- a/turbopack/crates/turbopack-trace-server/src/server.rs
+++ b/turbopack/crates/turbopack-trace-server/src/server.rs
@@ -45,6 +45,7 @@ pub enum ServerToClientMessage {
         path: Vec<String>,
         memory_samples: Vec<u64>,
         memory_pressure_samples: Vec<u8>,
+        memory_footprint_samples: Vec<u64>,
     },
 }
 
@@ -297,6 +298,8 @@ fn handle_connection(
                                     store.memory_samples_for_range(span.start(), span.end());
                                 let memory_pressure_samples = store
                                     .memory_pressure_samples_for_range(span.start(), span.end());
+                                let memory_footprint_samples = store
+                                    .memory_footprint_samples_for_range(span.start(), span.end());
                                 ServerToClientMessage::QueryResult {
                                     id,
                                     is_graph,
@@ -312,6 +315,7 @@ fn handle_connection(
                                     path,
                                     memory_samples,
                                     memory_pressure_samples,
+                                    memory_footprint_samples,
                                 }
                             } else {
                                 ServerToClientMessage::QueryResult {
@@ -329,6 +333,7 @@ fn handle_connection(
                                     path: Vec::new(),
                                     memory_samples: Vec::new(),
                                     memory_pressure_samples: Vec::new(),
+                                    memory_footprint_samples: Vec::new(),
                                 }
                             }
                         };

--- a/turbopack/crates/turbopack-trace-server/src/store.rs
+++ b/turbopack/crates/turbopack-trace-server/src/store.rs
@@ -24,11 +24,12 @@ pub type SpanId = NonZeroUsize;
 /// at the cut-off depth (Flattening).
 const CUT_OFF_DEPTH: u32 = 80;
 
-/// A single memory usage sample: (timestamp, memory_bytes, memory_pressure).
-/// Sorted by timestamp. `memory_pressure` is an OS-reported pressure value in
-/// the range `0..=100`; `0` is used when the reporter platform did not expose
-/// a pressure signal.
-type MemorySample = (Timestamp, u64, u8);
+/// A single memory usage sample: (timestamp, memory_bytes, memory_pressure,
+/// memory_footprint_bytes). Sorted by timestamp. `memory_pressure` is an
+/// OS-reported pressure value in the range `0..=100`; `memory_footprint` is
+/// the process resident memory size in bytes. `0` is used when the reporter
+/// platform did not expose the corresponding signal.
+type MemorySample = (Timestamp, u64, u8, u64);
 
 /// Maximum number of memory samples returned in a query result.
 const MAX_MEMORY_SAMPLES: usize = 200;
@@ -341,11 +342,18 @@ impl Store {
         span.self_deallocation_count += count;
     }
 
-    pub fn add_memory_sample(&mut self, ts: Timestamp, memory: u64, memory_pressure: u8) {
+    pub fn add_memory_sample(
+        &mut self,
+        ts: Timestamp,
+        memory: u64,
+        memory_pressure: u8,
+        memory_footprint: u64,
+    ) {
         // Samples arrive nearly sorted (roughly chronological from the trace
         // writer), so an insertion-sort step is efficient: push to the end
         // then swap backward until the timestamp ordering is restored.
-        self.memory_samples.push((ts, memory, memory_pressure));
+        self.memory_samples
+            .push((ts, memory, memory_pressure, memory_footprint));
         let mut i = self.memory_samples.len() - 1;
         while i > 0 && self.memory_samples[i - 1].0 > ts {
             self.memory_samples.swap(i, i - 1);
@@ -364,14 +372,14 @@ impl Store {
         }
 
         if count <= MAX_MEMORY_SAMPLES {
-            return slice.iter().map(|(_, mem, _)| *mem).collect();
+            return slice.iter().map(|(_, mem, _, _)| *mem).collect();
         }
 
         // Merge groups of N samples, taking the max memory in each group.
         let n = count.div_ceil(MAX_MEMORY_SAMPLES);
         slice
             .chunks(n)
-            .map(|chunk| chunk.iter().map(|(_, mem, _)| *mem).max().unwrap())
+            .map(|chunk| chunk.iter().map(|(_, mem, _, _)| *mem).max().unwrap())
             .collect()
     }
 
@@ -388,13 +396,36 @@ impl Store {
         }
 
         if count <= MAX_MEMORY_SAMPLES {
-            return slice.iter().map(|(_, _, p)| *p).collect();
+            return slice.iter().map(|(_, _, p, _)| *p).collect();
         }
 
         let n = count.div_ceil(MAX_MEMORY_SAMPLES);
         slice
             .chunks(n)
-            .map(|chunk| chunk.iter().map(|(_, _, p)| *p).max().unwrap())
+            .map(|chunk| chunk.iter().map(|(_, _, p, _)| *p).max().unwrap())
+            .collect()
+    }
+
+    /// Returns up to `MAX_MEMORY_SAMPLES` memory footprint values in the
+    /// range `[start, end]`. The returned slice has the same length and
+    /// group boundaries as [`Self::memory_samples_for_range`] so that the
+    /// two results can be rendered in parallel. Each group is downsampled
+    /// by taking the maximum footprint value.
+    pub fn memory_footprint_samples_for_range(&self, start: Timestamp, end: Timestamp) -> Vec<u64> {
+        let slice = self.memory_samples_slice(start, end);
+        let count = slice.len();
+        if count == 0 {
+            return Vec::new();
+        }
+
+        if count <= MAX_MEMORY_SAMPLES {
+            return slice.iter().map(|(_, _, _, f)| *f).collect();
+        }
+
+        let n = count.div_ceil(MAX_MEMORY_SAMPLES);
+        slice
+            .chunks(n)
+            .map(|chunk| chunk.iter().map(|(_, _, _, f)| *f).max().unwrap())
             .collect()
     }
 
@@ -402,9 +433,11 @@ impl Store {
         // Binary search for the first sample >= start
         let lo = self
             .memory_samples
-            .partition_point(|(ts, _, _)| *ts < start);
+            .partition_point(|(ts, _, _, _)| *ts < start);
         // Binary search for the first sample > end
-        let hi = self.memory_samples.partition_point(|(ts, _, _)| *ts <= end);
+        let hi = self
+            .memory_samples
+            .partition_point(|(ts, _, _, _)| *ts <= end);
         &self.memory_samples[lo..hi]
     }
 

--- a/turbopack/crates/turbopack-trace-utils/src/raw_trace.rs
+++ b/turbopack/crates/turbopack-trace-utils/src/raw_trace.rs
@@ -103,10 +103,14 @@ impl<S: Subscriber + for<'a> LookupSpan<'a>> RawTraceLayer<S> {
                 THREAD_LOCAL_LAST_MEMORY_SAMPLE.with(|tl| tl.set(ts));
                 let memory = TurboMalloc::memory_usage() as u64;
                 let memory_pressure = TurboMalloc::memory_pressure().unwrap_or(0);
+                let memory_footprint = TurboMalloc::memory_footprint()
+                    .map(|v| v as u64)
+                    .unwrap_or(0);
                 self.write(TraceRow::MemorySample {
                     ts,
                     memory,
                     memory_pressure,
+                    memory_footprint,
                 });
             }
             Err(actual) => {

--- a/turbopack/crates/turbopack-trace-utils/src/tracing.rs
+++ b/turbopack/crates/turbopack-trace-utils/src/tracing.rs
@@ -110,6 +110,10 @@ pub enum TraceRow<'a> {
         /// `TurboMalloc::memory_pressure()`). `0` is used when the current
         /// platform does not report a pressure value.
         memory_pressure: u8,
+        /// Process memory footprint in bytes (from
+        /// `TurboMalloc::memory_footprint()`). `0` is used when the current
+        /// platform does not report a value.
+        memory_footprint: u64,
     },
 }
 


### PR DESCRIPTION
### What?
Adds the process memory footprint (RSS / "Memory" column on macOS) to TurboMalloc's trace samples, mirroring how OS memory pressure was wired up in #93333.
### Why?
The trace viewer already plots `memory` (TurboMalloc's accounted bytes) and, since #93333, OS-level `memory_pressure`. Neither captures the actual resident size of the process. Tracking the OS-reported footprint alongside the allocator's view exposes overhead from things the allocator doesn't account for (e.g. mimalloc reserves, mmap'd files, executable pages, native dependencies) and makes leaks/regressions in real RSS visible in traces.
### How?
- New `TurboMalloc::memory_footprint() -> Option<usize>` (bytes), implemented in `turbopack/crates/turbo-tasks-malloc/src/memory_footprint.rs` with one `mod platform` per OS:
  - **Linux**: parses the resident-pages field of `/proc/self/statm` and multiplies by `sysconf(_SC_PAGESIZE)`.
  - **macOS**: `task_info(mach_task_self(), TASK_VM_INFO, …).phys_footprint` — the same value Apple's Activity Monitor labels "Memory". Guards against older kernels that return a shorter struct by checking the returned `count` covers `phys_footprint`.
  - **Windows**: `GetProcessMemoryInfo(GetCurrentProcess(), …).WorkingSetSize`. New `windows-sys` features `Win32_System_ProcessStatus` and `Win32_System_Threading`.
  - Other targets (incl. wasm) return `None`.
- `TraceRow::MemorySample` gains a `memory_footprint: u64` field. `RawTraceLayer::maybe_report_memory_sample` captures it via `TurboMalloc::memory_footprint().map(|v| v as u64).unwrap_or(0)` at the same sampling point as `memory` and `memory_pressure`.
- Trace-server `Store::MemorySample` becomes `(Timestamp, u64, u8, u64)` carrying `(ts, memory, memory_pressure, memory_footprint)`. A new `memory_footprint_samples_for_range` mirrors `memory_samples_for_range` and `memory_pressure_samples_for_range`, sharing the existing `memory_samples_slice` helper so the three result vectors stay index-aligned and use the same `MAX_MEMORY_SAMPLES`-cap max-per-chunk downsampling.
- `ServerToClientMessage::QueryResult` exposes a parallel `memory_footprint_samples: Vec<u64>` next to `memory_samples` and `memory_pressure_samples`.
This is a wire-format break for the postcard-encoded raw trace (added a serde field to `TraceRow::MemorySample`); old trace files cannot be read by the new trace-server. This matches the precedent set by #93333.
### Testing
- `cargo test -p turbo-tasks-malloc` — 10 pass, including a new `parses_typical_statm_content` / `returns_none_on_malformed_statm` parser pair and a runtime `memory_footprint_is_reported_on_supported_platforms` check that asserts `Some(_)` and a positive, plausibly bounded byte count on Linux/macOS/Windows.
- `cargo build`, `cargo clippy --all-targets`, and `cargo fmt --check` clean for `turbo-tasks-malloc`, `turbopack-trace-utils`, and `turbopack-trace-server`.
<!-- NEXT_JS_LLM_PR -->