### PR TITLE
Stop patching error inspection if source maps are disabled

### DIFF
--- a/packages/next/src/server/node-environment-extensions/error-inspect.tsx
+++ b/packages/next/src/server/node-environment-extensions/error-inspect.tsx
@@ -1,3 +1,19 @@
+import * as module from 'module'
+import * as process from 'process'
 import { patchErrorInspectNodeJS } from '../patch-error-inspect'
 
-patchErrorInspectNodeJS(globalThis.Error)
+const sourceMappingEnabled =
+  // @ts-expect-error Node.js 22+ only
+  typeof module.getSourceMapsSupport === 'function'
+    ? // @ts-expect-error Node.js 22+ only
+      module.getSourceMapsSupport().enabled
+    : process.env.NODE_OPTIONS?.includes('--enable-source-maps') ||
+      process.execArgv.includes('--enable-source-maps')
+
+if (sourceMappingEnabled) {
+  patchErrorInspectNodeJS(globalThis.Error)
+} else {
+  // leave Errors untouched if source maps are disabled.
+  // We're likely in a prod server where sourcemapping is done lazily when logs
+  // are inspected so ignore-listing would permanently hide these frames.
+}

--- a/test/e2e/app-dir/actions/app-action-size-limit-invalid.test.ts
+++ b/test/e2e/app-dir/actions/app-action-size-limit-invalid.test.ts
@@ -9,19 +9,21 @@ const CONFIG_ERROR =
   'Server Actions Size Limit must be a valid number or filesize format larger than 1MB'
 
 describe('app-dir action size limit invalid config', () => {
-  const { next, isNextStart, isNextDeploy, skipped } = nextTestSetup({
-    files: __dirname,
-    overrideFiles: process.env.TEST_NODE_MIDDLEWARE
-      ? {
-          'middleware.js': new FileRef(join(__dirname, 'middleware-node.js')),
-        }
-      : {},
-    skipStart: true,
-    dependencies: {
-      nanoid: '4.0.1',
-      'server-only': 'latest',
-    },
-  })
+  const { next, isNextDev, isNextStart, isNextDeploy, skipped } = nextTestSetup(
+    {
+      files: __dirname,
+      overrideFiles: process.env.TEST_NODE_MIDDLEWARE
+        ? {
+            'middleware.js': new FileRef(join(__dirname, 'middleware-node.js')),
+          }
+        : {},
+      skipStart: true,
+      dependencies: {
+        nanoid: '4.0.1',
+        'server-only': 'latest',
+      },
+    }
+  )
   if (skipped) return
 
   const logs: string[] = []
@@ -123,7 +125,7 @@ describe('app-dir action size limit invalid config', () => {
           )
         )
         expect(logs).not.toContainEqual(
-          expect.stringContaining('Error: Body exceeded 2mb limit')
+          expect.stringContaining('Body exceeded 2mb limit')
         )
       }
     })
@@ -149,7 +151,12 @@ describe('app-dir action size limit invalid config', () => {
       if (!isNextDeploy) {
         await retry(() => {
           expect(logs).toContainEqual(
-            expect.stringContaining('Error: Body exceeded 2mb limit')
+            expect.stringContaining(
+              isNextDev
+                ? 'Error: Body exceeded 2mb limit'
+                : // Minified ApiError class name
+                  '[Error]: Body exceeded 2mb limit'
+            )
           )
           expect(logs).toContainEqual(
             expect.stringContaining(
@@ -187,7 +194,7 @@ describe('app-dir action size limit invalid config', () => {
           )
         )
         expect(logs).not.toContainEqual(
-          expect.stringContaining('Error: Body exceeded 2mb limit')
+          expect.stringContaining('Body exceeded 2mb limit')
         )
       }
     })
@@ -212,7 +219,7 @@ describe('app-dir action size limit invalid config', () => {
           )
         )
         expect(logs).not.toContainEqual(
-          expect.stringContaining('Error: Body exceeded 2mb limit')
+          expect.stringContaining('Body exceeded 2mb limit')
         )
       }
     })
@@ -238,7 +245,12 @@ describe('app-dir action size limit invalid config', () => {
       if (!isNextDeploy) {
         await retry(() => {
           expect(logs).toContainEqual(
-            expect.stringContaining('Error: Body exceeded 2mb limit')
+            expect.stringContaining(
+              isNextDev
+                ? 'Error: Body exceeded 2mb limit'
+                : // Minified ApiError class name
+                  '[Error]: Body exceeded 2mb limit'
+            )
           )
           expect(logs).toContainEqual(
             expect.stringContaining(

--- a/test/e2e/app-dir/cache-components-errors/utils.ts
+++ b/test/e2e/app-dir/cache-components-errors/utils.ts
@@ -109,7 +109,7 @@ export function getDeterministicOutput(
       }
 
       line = line
-        .replace(/at (.+?) \(.next[^)]+\)/, replaceNextDistStackFrame)
+        .replace(/at (.+?) \((.*?\/)?.next[^)]+\)/, replaceNextDistStackFrame)
         .replace(
           // Single-letter lower-case names are likely minified.
           /at [a-z] \((?!(<next-dist-dir>|<anonymous>))/,

--- a/test/e2e/app-dir/errors/index.test.ts
+++ b/test/e2e/app-dir/errors/index.test.ts
@@ -118,13 +118,9 @@ describe('app-dir - errors', () => {
           )
         )
       } else {
-        expect(cleanCliOutput).toMatchInlineSnapshot(`
-         "⨯ Error: undefined
-             at stringify (<anonymous>) {
-           digest: '<digest>@E394'
-         }
-         "
-        `)
+        expect(cleanCliOutput).toContain('⨯ Error: undefined')
+        // No runtime sourcemapping so the stack is just a bunch of library internals
+        expect(cleanCliOutput).toContain("digest: '<digest>@E394'")
       }
     })
 
@@ -153,13 +149,9 @@ describe('app-dir - errors', () => {
           )
         )
       } else {
-        expect(cleanCliOutput).toMatchInlineSnapshot(`
-         "⨯ Error: null
-             at stringify (<anonymous>) {
-           digest: '<digest>@E394'
-         }
-         "
-        `)
+        expect(cleanCliOutput).toContain('⨯ Error: null')
+        // No runtime sourcemapping so the stack is just a bunch of library internals
+        expect(cleanCliOutput).toContain("digest: '<digest>@E394'")
       }
     })
 
@@ -186,13 +178,9 @@ describe('app-dir - errors', () => {
           expect.stringMatching(/Error: this is a test.*digest: '<digest>'/s)
         )
       } else {
-        expect(cleanCliOutput).toMatchInlineSnapshot(`
-         "⨯ Error: this is a test
-             at stringify (<anonymous>) {
-           digest: '<digest>'
-         }
-         "
-        `)
+        expect(cleanCliOutput).toContain('⨯ Error: this is a test')
+        // No runtime sourcemapping so the stack is just a bunch of library internals
+        expect(cleanCliOutput).toContain("digest: '<digest>@E394'")
       }
     })
 


### PR DESCRIPTION
If source maps are disabled, we're most likely running in a prod server where sourcemapping happens lazily when logs are inspected. Ignore-listing generated frames would forever hide n_m frames. 

It also avoids doing a bunch of work that just won't have any effect.

As a follow-up, I'll experiment with showing all frames during next-build if all original frames are ignore-listed since that's a one-shot process. For next-dev, we'll continue showing no frames if everything is ignore-listed since you have an attached a debugger with the browser to get a high-fidelity UI to see ignore-listed frames. 