### PR TITLE
[test] Preserve Playwright traces on every failure

### DIFF
--- a/run-tests.js
+++ b/run-tests.js
@@ -825,10 +825,9 @@ ${ENDGROUP}`)
           return reject(err)
         }
 
-        // If environment is CI and if this test execution is failed after retry, preserve test traces
-        // to upload into github actions artifacts for debugging purpose
+        // preserve test traces to upload into github actions artifacts for debugging purposes
         const shouldPreserveTracesOutput =
-          (process.env.CI && isRetry && isChildExitWithNonZero) ||
+          (process.env.CI && isChildExitWithNonZero) ||
           process.env.PRESERVE_TRACES_OUTPUT
         if (!shouldPreserveTracesOutput) {
           await fsp


### PR DESCRIPTION
Playwright traces were only preserved on retry but for debugging flakiness it's still
valuable to have traces on any failure.
Flaky tests are a problem even if they succeed on a retry since they negatively
impact CI performance.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>