### PR TITLE
Only log partytown setup error once

### DIFF
--- a/crates/next-error-code-swc-plugin/src/lib.rs
+++ b/crates/next-error-code-swc-plugin/src/lib.rs
@@ -56,7 +56,6 @@ fn is_error_class_name(name: &str) -> bool {
         || name == "DecodeError"
         || name == "DynamicServerError"
         || name == "ExportError"
-        || name == "FatalError"
         || name == "ImageError"
         || name == "InstantValidationError"
         || name == "InvariantError"

--- a/packages/next/src/lib/fatal-error.ts
+++ b/packages/next/src/lib/fatal-error.ts
@@ -1,1 +1,0 @@
-export class FatalError extends Error {}

--- a/packages/next/src/lib/typescript/getTypeScriptConfiguration.ts
+++ b/packages/next/src/lib/typescript/getTypeScriptConfiguration.ts
@@ -3,7 +3,6 @@ import os from 'os'
 import path from 'path'
 import semver from 'next/dist/compiled/semver'
 
-import { FatalError } from '../fatal-error'
 import isError from '../is-error'
 
 function resolvePathAliasTarget(baseUrl: string, target: string): string {
@@ -92,9 +91,7 @@ export async function getTypeScriptConfiguration(
       typescript.sys.readFile
     )
     if (error) {
-      throw new FatalError(
-        typescript.formatDiagnostic(error, formatDiagnosticsHost)
-      )
+      throw new Error(typescript.formatDiagnostic(error, formatDiagnosticsHost))
     }
 
     let configToParse: any = config
@@ -185,7 +182,8 @@ export async function getTypeScriptConfiguration(
     }
 
     if (result.errors?.length) {
-      throw new FatalError(
+      // TODO: Throw AggregateError for all diagnostics.
+      throw new Error(
         typescript.formatDiagnostic(result.errors[0], formatDiagnosticsHost)
       )
     }
@@ -194,7 +192,7 @@ export async function getTypeScriptConfiguration(
   } catch (err) {
     if (isError(err) && err.name === 'SyntaxError') {
       const reason = '\n' + (err.message ?? '')
-      throw new FatalError(
+      throw new Error(
         bold(
           'Could not parse' +
             cyan('tsconfig.json') +

--- a/packages/next/src/lib/typescript/missingDependencyError.ts
+++ b/packages/next/src/lib/typescript/missingDependencyError.ts
@@ -2,7 +2,6 @@ import { bold, cyan, red } from '../picocolors'
 
 import { getOxfordCommaList } from '../oxford-comma-list'
 import type { MissingDependency } from '../has-necessary-dependencies'
-import { FatalError } from '../fatal-error'
 import { getPkgManager } from '../helpers/get-pkg-manager'
 
 export function missingDepsError(
@@ -21,7 +20,7 @@ export function missingDepsError(
         ' file from your package root (and any TypeScript files in your app and pages directories).'
     )
 
-  throw new FatalError(
+  throw new Error(
     bold(
       red(
         `It looks like you're trying to use TypeScript but do not have the required package(s) installed.`

--- a/packages/next/src/lib/verify-partytown-setup.ts
+++ b/packages/next/src/lib/verify-partytown-setup.ts
@@ -5,14 +5,13 @@ import path from 'path'
 import { hasNecessaryDependencies } from './has-necessary-dependencies'
 import type { NecessaryDependencies } from './has-necessary-dependencies'
 import { fileExists, FileType } from './file-exists'
-import { FatalError } from './fatal-error'
 import * as Log from '../build/output/log'
 import { getPkgManager } from './helpers/get-pkg-manager'
 
 async function missingDependencyError(dir: string) {
   const packageManager = getPkgManager(dir)
 
-  throw new FatalError(
+  throw new Error(
     bold(
       red(
         "It looks like you're trying to use Partytown with next/script but do not have the required package(s) installed."
@@ -65,35 +64,25 @@ export async function verifyPartytownSetup(
   dir: string,
   targetDir: string
 ): Promise<void> {
-  try {
-    const partytownDeps: NecessaryDependencies = hasNecessaryDependencies(dir, [
-      {
-        file: '@builder.io/partytown',
-        pkg: '@builder.io/partytown',
-        exportsRestrict: false,
-      },
-    ])
+  const partytownDeps: NecessaryDependencies = hasNecessaryDependencies(dir, [
+    {
+      file: '@builder.io/partytown',
+      pkg: '@builder.io/partytown',
+      exportsRestrict: false,
+    },
+  ])
 
-    if (partytownDeps.missing?.length > 0) {
-      await missingDependencyError(dir)
-    } else {
-      try {
-        await copyPartytownStaticFiles(partytownDeps, targetDir)
-      } catch (err) {
-        Log.warn(
-          `Partytown library files could not be copied to the static directory. Please ensure that ${bold(
-            cyan('@builder.io/partytown')
-          )} is installed as a dependency.`
-        )
-      }
+  if (partytownDeps.missing?.length > 0) {
+    await missingDependencyError(dir)
+  } else {
+    try {
+      await copyPartytownStaticFiles(partytownDeps, targetDir)
+    } catch (err) {
+      Log.warn(
+        `Partytown library files could not be copied to the static directory. Please ensure that ${bold(
+          cyan('@builder.io/partytown')
+        )} is installed as a dependency.`
+      )
     }
-  } catch (err) {
-    // Don't show a stack trace when there is an error due to missing dependencies
-    if (err instanceof FatalError) {
-      console.error(err.message)
-      // Throw to allow finally blocks to run (e.g., telemetry flush)
-      throw err
-    }
-    throw err
   }
 }

--- a/test/production/next-server-nft/next-server-nft.test.ts
+++ b/test/production/next-server-nft/next-server-nft.test.ts
@@ -243,7 +243,6 @@ async function readNormalizedNFT(next, name) {
            "/node_modules/next/dist/lib/download-swc.js",
            "/node_modules/next/dist/lib/error-telemetry-utils.js",
            "/node_modules/next/dist/lib/fallback.js",
-           "/node_modules/next/dist/lib/fatal-error.js",
            "/node_modules/next/dist/lib/file-exists.js",
            "/node_modules/next/dist/lib/find-config.js",
            "/node_modules/next/dist/lib/find-pages-dir.js",


### PR DESCRIPTION
Which allows removing `FatalError`. There are more instances of errors that are "fatal" that aren't using this special Error subclass. We don't even document what's so special about "FatalError".