### PR TITLE
[test] Stop building fresh packages for every test

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -20,6 +20,7 @@
       "dependsOn": ["^test-storybook"]
     },
     "pack-for-isolated-tests": {
+      "inputs": ["$TURBO_DEFAULT$", "dist/**"],
       "outputs": ["packed.tgz"]
     },
     "typescript": {},

--- a/turbo.json
+++ b/turbo.json
@@ -20,7 +20,6 @@
       "dependsOn": ["^test-storybook"]
     },
     "pack-for-isolated-tests": {
-      "dependsOn": ["build"],
       "outputs": ["packed.tgz"]
     },
     "typescript": {},


### PR DESCRIPTION
Added in https://github.com/vercel/next.js/pull/92575 but this means you can't have build running in watchmode in parallel. https://github.com/vercel/next.js/pull/92575 was also not concerned with ensuring a fresh build for each test which would churn existing DX.