### PR TITLE
docs: single file name, without pipe divider

### DIFF
--- a/docs/01-app/03-api-reference/03-file-conventions/01-metadata/manifest.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/01-metadata/manifest.mdx
@@ -7,7 +7,9 @@ Add or generate a `manifest.(json|webmanifest)` file that matches the [Web Manif
 
 ## Static Manifest file
 
-```json filename="app/manifest.json | app/manifest.webmanifest"
+You can use a `manifest.json` file (or `manifest.webmanifest`):
+
+```json filename="app/manifest.json"
 {
   "name": "My Next.js Application",
   "short_name": "Next.js App",


### PR DESCRIPTION
In certain markdown processing engines, the pipe `|` in the fence produces _strange_ results, though it is allowed by spec.