### PR TITLE
Fix deploy tests crashing under AI coding assistants

### DIFF
--- a/test/lib/next-modes/next-deploy.ts
+++ b/test/lib/next-modes/next-deploy.ts
@@ -295,6 +295,16 @@ export class NextDeployInstance extends NextInstance {
     }
     const vercelEnv = { ...process.env }
 
+    // The Vercel CLI uses @vercel/detect-agent to detect when it's running
+    // under an AI coding agent (Claude Code, Cursor, Codex, …) and, when it
+    // does, switches `vercel deploy` stdout from a plain URL to a JSON
+    // manifest intended for AI consumption — which breaks
+    // `new URL(deployRes.stdout)` below. The CLI honors an explicit
+    // `--non-interactive=false` as an override of the agent default, and the
+    // JSON-vs-plain decision keys off `client.nonInteractive`, so passing
+    // the flag is enough to force plain-URL output for both link and deploy.
+    vercelFlags.push('--non-interactive=false')
+
     // If the token is available in the environment, use it as the token in the
     // environment.
     if (TEST_TOKEN) {


### PR DESCRIPTION
The Vercel CLI bundles `@vercel/detect-agent`, which inspects environment variables that AI coding assistants (Claude Code, Cursor, Codex, Gemini CLI, GitHub Copilot CLI, and others) set in every shell they spawn. When the CLI detects one, `vercel deploy` writes a JSON payload to stdout instead of the plain deployment URL. The harness then crashes when `new URL(deployRes.stdout)` in `next-deploy.ts` runs, which breaks every `test-deploy*` run launched from such a shell.

The fix appends `--non-interactive=false` to `vercelFlags` so it is passed to both `vercel link` and `vercel deploy`. The CLI honors that flag as an explicit override of the agent-derived default, and the deploy command's JSON-vs-plain output decision is gated on `client.nonInteractive` (`const asJson = formatResult.jsonOutput || client.nonInteractive` in the deploy source), so a single flag is enough to restore plain-URL stdout.

The alternative considered was reading `deployment.url` out of the JSON payload at the single call site that breaks. That is a more localized change but couples the harness to an undocumented payload shape that exists only for AI agents, so a future rename of that field would silently break deploy tests again. Forcing the CLI's output mode avoids that coupling, which is why the flag won.

With this change, `pnpm test-deploy` and `pnpm test-deploy-turbo` work uniformly whether they are launched from a human's interactive terminal or from inside an AI coding assistant.