### PR TITLE
fix(swc): apply swcEnvOptions to server-side env

### DIFF
--- a/packages/next/src/build/swc/options.ts
+++ b/packages/next/src/build/swc/options.ts
@@ -519,6 +519,8 @@ export function getLoaderSWCOptions({
       }
     : {}
 
+  const { targets: userTargets, ...restEnvOptions } = swcEnvOptions ?? {}
+
   let options: any
   if (isServer) {
     options = {
@@ -533,9 +535,11 @@ export function getLoaderSWCOptions({
       preferEsm: !!esm,
       isPageFile,
       env: {
+        ...restEnvOptions,
         targets: {
           // Targets the current version of Node.js
           node: process.versions.node,
+          ...(userTargets ?? {}),
         },
       },
     }


### PR DESCRIPTION
## What?

Apply `experimental.swcEnvOptions` to the server-side SWC configuration in `getLoaderSWCOptions`.

## Why?

Currently, `swcEnvOptions` are only applied to client-side compilation, leading to inconsistent behavior between client and server builds.

This PR ensures that server-side SWC compilation respects the same configuration, while preserving the existing Node target behavior.

## How?

- Extract `targets` from `swcEnvOptions`
- Merge remaining fields into the server `env` configuration
- Safely merge `targets` to preserve the default Node target

## Notes

- Scope is intentionally limited to the webpack SWC loader path
- Jest and other SWC configuration paths are unchanged
- No tests added since this is a small, isolated configuration fix and existing SWC behavior is covered indirectly through integration tests

Fixes #93372