### PR TITLE
perf(ecmascript): wrap recursive JsValue children in Arc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10410,6 +10410,7 @@ dependencies = [
  "swc_sourcemap",
  "tokio",
  "tracing",
+ "triomphe 0.1.12",
  "turbo-bincode",
  "turbo-esregex",
  "turbo-frozenmap",

--- a/crates/next-core/src/segment_config.rs
+++ b/crates/next-core/src/segment_config.rs
@@ -699,7 +699,7 @@ async fn parse_config_value(
                     .await;
                 };
 
-                if matches!(value, JsValue::Constant(ConstantValue::Undefined)) {
+                if matches!(&**value, JsValue::Constant(ConstantValue::Undefined)) {
                     continue;
                 }
                 match key {
@@ -1061,7 +1061,7 @@ async fn parse_route_matcher_from_js_value(
         let mut route_has = vec![];
         if let JsValue::Array { items, .. } = value {
             for (i, item) in items.iter().enumerate() {
-                if let JsValue::Object { parts, .. } = item {
+                if let JsValue::Object { parts, .. } = &**item {
                     let mut route_type = None;
                     let mut route_key = None;
                     let mut route_value = None;
@@ -1189,7 +1189,7 @@ async fn parse_route_matcher_from_js_value(
             for (i, item) in items.iter().enumerate() {
                 if let Some(matcher) = item.as_str() {
                     matchers.push(MiddlewareMatcherKind::Str(matcher.to_string()));
-                } else if let JsValue::Object { parts, .. } = item {
+                } else if let JsValue::Object { parts, .. } = &**item {
                     let mut matcher = ProxyMatcher::default();
                     let mut had_source = false;
                     for matcher_part in parts {
@@ -1225,7 +1225,7 @@ async fn parse_route_matcher_from_js_value(
                                     {
                                         matcher.locale = false;
                                     } else if matches!(
-                                        value,
+                                        &**value,
                                         JsValue::Constant(ConstantValue::Undefined)
                                     ) {
                                         // ignore

--- a/turbopack/crates/turbopack-ecmascript/Cargo.toml
+++ b/turbopack/crates/turbopack-ecmascript/Cargo.toml
@@ -45,6 +45,7 @@ swc_sourcemap = { workspace = true }
 smallvec = { workspace = true }
 strsim = { workspace = true }
 tokio = { workspace = true }
+triomphe = { workspace = true }
 tracing = { workspace = true }
 turbo-bincode = { workspace = true }
 turbo-esregex = { workspace = true }

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/builtin.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/builtin.rs
@@ -15,14 +15,14 @@ pub fn early_replace_builtin(value: &mut JsValue) -> bool {
         JsValue::Call(_, call) => {
             let (args, callee) = call.as_parts_mut();
             let args_have_side_effects = || args.iter().any(|arg| arg.has_side_effects());
-            match Arc::make_mut(callee) {
+            match &**callee {
                 // We don't know what the callee is, so we can early return
-                &mut JsValue::Unknown {
+                JsValue::Unknown {
                     original_value: _,
                     reason: _,
                     has_side_effects,
                 } => {
-                    let has_side_effects = has_side_effects || args_have_side_effects();
+                    let has_side_effects = *has_side_effects || args_have_side_effects();
                     value.make_unknown(has_side_effects, rcstr!("unknown callee"));
                     true
                 }
@@ -48,27 +48,27 @@ pub fn early_replace_builtin(value: &mut JsValue) -> bool {
         JsValue::MemberCall(_, call) => {
             let (args, prop, obj) = call.as_parts_mut();
             let args_have_side_effects = || args.iter().any(|arg| arg.has_side_effects());
-            match Arc::make_mut(obj) {
+            match &**obj {
                 // We don't know what the callee is, so we can early return
-                &mut JsValue::Unknown {
+                JsValue::Unknown {
                     original_value: _,
                     reason: _,
                     has_side_effects,
                 } => {
                     let side_effects =
-                        has_side_effects || prop.has_side_effects() || args_have_side_effects();
+                        *has_side_effects || prop.has_side_effects() || args_have_side_effects();
                     value.make_unknown(side_effects, rcstr!("unknown callee object"));
                     true
                 }
                 // otherwise we need to look at the property
-                _ => match Arc::make_mut(prop) {
+                _ => match &**prop {
                     // We don't know what the property is, so we can early return
-                    &mut JsValue::Unknown {
+                    JsValue::Unknown {
                         original_value: _,
                         reason: _,
                         has_side_effects,
                     } => {
-                        let side_effects = has_side_effects || args_have_side_effects();
+                        let side_effects = *has_side_effects || args_have_side_effects();
                         value.make_unknown(side_effects, rcstr!("unknown callee property"));
                         true
                     }
@@ -102,7 +102,7 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
             // numeric addition
             let mut sum = 0f64;
             for arg in list {
-                let JsValue::Constant(ConstantValue::Num(num)) = Arc::make_mut(arg) else {
+                let JsValue::Constant(ConstantValue::Num(num)) = &**arg else {
                     return false;
                 };
                 sum += *num.0;
@@ -123,10 +123,10 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
                 values,
                 logical_property: _,
             } => {
-                *value = JsValue::alternatives_arc(
+                *value = JsValue::alternatives(
                     take(values)
                         .into_iter()
-                        .map(|alt| Arc::new(JsValue::member_arc(alt, prop.clone())))
+                        .map(|alt| Arc::new(JsValue::member(alt, prop.clone())))
                         .collect(),
                 );
                 true
@@ -139,19 +139,19 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
             } => {
                 fn items_to_alternatives(
                     items: &mut Vec<Arc<JsValue>>,
-                    prop: &mut Arc<JsValue>,
+                    prop: &Arc<JsValue>,
                 ) -> JsValue {
                     items.push(Arc::new(JsValue::unknown(
-                        JsValue::member_arc(
+                        JsValue::member(
                             Arc::new(JsValue::array(Vec::new())),
-                            Arc::new(take(Arc::make_mut(prop))),
+                            prop.clone(),
                         ),
                         false,
                         rcstr!("unknown array prototype methods or values"),
                     )));
-                    JsValue::alternatives_arc(take(items))
+                    JsValue::alternatives(take(items))
                 }
-                match Arc::make_mut(prop) {
+                match &**prop {
                     // accessing a numeric property on an array like `[1,2,3][1]`
                     // We can replace this with the value at the index
                     JsValue::Constant(ConstantValue::Num(num @ ConstantNumber(_))) => {
@@ -164,7 +164,7 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
                                 true
                             } else {
                                 *value = JsValue::unknown(
-                                    JsValue::member_arc(take(obj), take(prop)),
+                                    JsValue::member(obj.clone(), prop.clone()),
                                     false,
                                     rcstr!("invalid index"),
                                 );
@@ -189,10 +189,12 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
                         logical_property: _,
                     } => {
                         let obj_arc: Arc<JsValue> = obj.clone();
-                        *value = JsValue::alternatives_arc(
-                            take(values)
-                                .into_iter()
-                                .map(|alt| Arc::new(JsValue::member_arc(obj_arc.clone(), alt)))
+                        *value = JsValue::alternatives(
+                            values
+                                .iter()
+                                .map(|alt| {
+                                    Arc::new(JsValue::member(obj_arc.clone(), alt.clone()))
+                                })
                                 .collect(),
                         );
                         true
@@ -224,7 +226,7 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
                             }
                             ObjectPart::Spread(_) => {
                                 values.push(Arc::new(JsValue::unknown(
-                                    JsValue::member_arc(
+                                    JsValue::member(
                                         Arc::new(JsValue::object(vec![take(part)])),
                                         prop.clone(),
                                     ),
@@ -236,7 +238,7 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
                     }
                     if include_unknown {
                         values.push(Arc::new(JsValue::unknown(
-                            JsValue::member_arc(
+                            JsValue::member(
                                 Arc::new(JsValue::object(Vec::new())),
                                 take(prop),
                             ),
@@ -244,7 +246,7 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
                             rcstr!("unknown object prototype methods or values"),
                         )));
                     }
-                    JsValue::alternatives_arc(values)
+                    JsValue::alternatives(values)
                 }
 
                 /// Convert a list of potential values into
@@ -274,7 +276,7 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
                     parts_to_alternatives(&mut potential_values, prop, include_unknown)
                 }
 
-                match Arc::make_mut(prop) {
+                match &**prop {
                     // matching constant string property access on an object like `{a: 1, b:
                     // 2}["a"]`
                     JsValue::Constant(ConstantValue::Str(_)) => {
@@ -333,11 +335,12 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
                         values,
                         logical_property: _,
                     } => {
-                        let obj_arc: Arc<JsValue> = obj.clone();
-                        *value = JsValue::alternatives_arc(
-                            take(values)
-                                .into_iter()
-                                .map(|alt| Arc::new(JsValue::member_arc(obj_arc.clone(), alt)))
+                        *value = JsValue::alternatives(
+                            values
+                                .iter()
+                                .map(|alt| {
+                                    Arc::new(JsValue::member(obj.clone(), alt.clone()))
+                                })
                                 .collect(),
                         );
                         true
@@ -355,10 +358,13 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
         JsValue::MemberCall(_, list) => {
             // `into_parts` pops obj + prop off the tail of the underlying `Vec`, and the
             // remaining `Vec` (owned, not reallocated) becomes `args`.
-            let (mut obj, prop, args) = take(list).into_parts();
-            match Arc::make_mut(&mut obj) {
+            let (obj, prop, args) = take(list).into_parts();
+            // Cheap variant dispatch on the borrowed inner value — branches that need to
+            // move out of `obj` call `Arc::unwrap_or_clone` themselves so the fallthrough
+            // paths skip the refcount check.
+            match &*obj {
                 // matching calls on an array like `[1,2,3].concat([4,5,6])`
-                JsValue::Array { items, mutable, .. } => {
+                JsValue::Array { .. } => {
                     // matching cases where the property is a const string
                     if let Some(str) = prop.as_str() {
                         match str {
@@ -377,6 +383,13 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
                                             | JsValue::Function(..)
                                     )
                                 }) => {
+                                    let mut obj_inner = Arc::unwrap_or_clone(obj);
+                                    let JsValue::Array {
+                                        items, mutable, ..
+                                    } = &mut obj_inner
+                                    else {
+                                        unreachable!()
+                                    };
                                     for arg in args {
                                         match Arc::unwrap_or_clone(arg) {
                                             JsValue::Array {
@@ -401,27 +414,31 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
                                             }
                                         }
                                     }
-                                    Arc::make_mut(&mut obj).update_total_nodes();
-                                    *value = Arc::unwrap_or_clone(obj);
+                                    obj_inner.update_total_nodes();
+                                    *value = obj_inner;
                                     return true;
                                 }
                             // The Array.prototype.map method
                             "map" => {
                                 if let Some(func) = args.first() {
+                                    let JsValue::Array { items, .. } = Arc::unwrap_or_clone(obj)
+                                    else {
+                                        unreachable!()
+                                    };
                                     *value = JsValue::array(
-                                        take(items)
+                                        items
                                             .into_iter()
                                             .enumerate()
                                             .map(|(i, item)| {
-                                                JsValue::call_from_iter(
-                                                    func.clone(),
+                                                Arc::new(JsValue::call_from_iter(
+                                                    (**func).clone(),
                                                     [
                                                         item,
-                                                        JsValue::Constant(ConstantValue::Num(
-                                                            (i as f64).into(),
+                                                        Arc::new(JsValue::Constant(
+                                                            ConstantValue::Num((i as f64).into()),
                                                         )),
                                                     ],
-                                                )
+                                                ))
                                             })
                                             .collect(),
                                     );
@@ -434,20 +451,19 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
                 }
                 // matching calls on multiple alternative objects like `(obj1 | obj2).prop(arg1,
                 // arg2, ...)`
-                JsValue::Alternatives {
-                    total_nodes: _,
-                    values,
-                    logical_property: _,
-                } => {
+                JsValue::Alternatives { .. } => {
+                    let JsValue::Alternatives { values, .. } = Arc::unwrap_or_clone(obj) else {
+                        unreachable!()
+                    };
                     *value = JsValue::alternatives(
-                        take(values)
+                        values
                             .into_iter()
                             .map(|alt| {
-                                JsValue::member_call_from_iter(
-                                    alt,
-                                    prop.clone(),
+                                Arc::new(JsValue::member_call_from_iter(
+                                    Arc::unwrap_or_clone(alt),
+                                    (*prop).clone(),
                                     args.iter().cloned(),
-                                )
+                                ))
                             })
                             .collect(),
                     );
@@ -465,7 +481,7 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
                     let mut values = vec![obj];
                     values.extend(args);
 
-                    *value = JsValue::concat_arc(values);
+                    *value = JsValue::concat(values);
                     return true;
                 }
             }
@@ -478,10 +494,7 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
             // into a `JsValue::Call` only needs `+1` slot, which fits in the existing slack —
             // no realloc. This is the original motivation for the `[args..., prop, obj]`
             // tail layout.
-            *value = JsValue::call_from_parts(
-                JsValue::member(Box::new(obj), Box::new(prop)),
-                args,
-            );
+            *value = JsValue::call_from_parts(JsValue::member(obj, prop), args);
             true
         }
         // match calls when the callee are multiple alternative functions like `(func1 |
@@ -494,10 +507,15 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
             let JsValue::Alternatives { values, .. } = Arc::unwrap_or_clone(callee) else {
                 unreachable!()
             };
-            *value = JsValue::alternatives_arc(
+            *value = JsValue::alternatives(
                 values
                     .into_iter()
-                    .map(|alt| JsValue::call_from_iter(alt, args.iter().cloned()))
+                    .map(|alt| {
+                        Arc::new(JsValue::call_from_iter(
+                            Arc::unwrap_or_clone(alt),
+                            args.iter().cloned(),
+                        ))
+                    })
                     .collect(),
             );
             true
@@ -645,13 +663,13 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
                     }
                 };
                 if let Some(property) = property {
-                    *value = JsValue::alternatives_with_additional_property_arc(
+                    *value = JsValue::alternatives_with_additional_property(
                         take(parts),
                         property,
                     );
                     true
                 } else {
-                    *value = JsValue::alternatives_arc(take(parts));
+                    *value = JsValue::alternatives(take(parts));
                     true
                 }
             }
@@ -697,7 +715,7 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
 
         JsValue::Iterated(_, iterable) => {
             if let JsValue::Array { items, mutable, .. } = Arc::make_mut(iterable) {
-                let mut new_value = JsValue::alternatives_arc(take(items));
+                let mut new_value = JsValue::alternatives(take(items));
                 if *mutable {
                     new_value.add_unknown_mutations(true);
                 }

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/builtin.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/builtin.rs
@@ -1,5 +1,6 @@
-use std::{mem::take, sync::Arc};
+use std::mem::take;
 
+use triomphe::Arc;
 use turbo_rcstr::rcstr;
 
 use super::{ConstantNumber, ConstantValue, JsValue, LogicalOperator, LogicalProperty, ObjectPart};

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/builtin.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/builtin.rs
@@ -3,7 +3,10 @@ use std::mem::take;
 use triomphe::Arc;
 use turbo_rcstr::rcstr;
 
-use super::{ConstantNumber, ConstantValue, JsValue, LogicalOperator, LogicalProperty, ObjectPart};
+use super::{
+    ConstantNumber, ConstantValue, JsValue, LogicalOperator, LogicalProperty, ObjectPart,
+    take_arc_slot,
+};
 use crate::analyzer::JsValueUrlKind;
 
 /// Replaces some builtin values with their resulting values. Called early
@@ -222,7 +225,7 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
                     for part in parts {
                         match part {
                             ObjectPart::KeyValue(_, value) => {
-                                values.push(take(value));
+                                values.push(take_arc_slot(value));
                             }
                             ObjectPart::Spread(_) => {
                                 values.push(Arc::new(JsValue::unknown(
@@ -240,7 +243,7 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
                         values.push(Arc::new(JsValue::unknown(
                             JsValue::member(
                                 Arc::new(JsValue::object(Vec::new())),
-                                take(prop),
+                                take_arc_slot(prop),
                             ),
                             true,
                             rcstr!("unknown object prototype methods or values"),
@@ -288,7 +291,7 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
                                     if let Some(key) = key.as_str() {
                                         if key == prop_str {
                                             if potential_values.is_empty() {
-                                                *value = Arc::unwrap_or_clone(take(val));
+                                                *value = Arc::unwrap_or_clone(take_arc_slot(val));
                                             } else {
                                                 potential_values.push(i);
                                                 *value = potential_values_to_alternatives(

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/builtin.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/builtin.rs
@@ -1,4 +1,4 @@
-use std::mem::take;
+use std::{mem::take, sync::Arc};
 
 use turbo_rcstr::rcstr;
 
@@ -14,7 +14,7 @@ pub fn early_replace_builtin(value: &mut JsValue) -> bool {
         JsValue::Call(_, call) => {
             let (args, callee) = call.as_parts_mut();
             let args_have_side_effects = || args.iter().any(|arg| arg.has_side_effects());
-            match callee {
+            match Arc::make_mut(callee) {
                 // We don't know what the callee is, so we can early return
                 &mut JsValue::Unknown {
                     original_value: _,
@@ -47,7 +47,7 @@ pub fn early_replace_builtin(value: &mut JsValue) -> bool {
         JsValue::MemberCall(_, call) => {
             let (args, prop, obj) = call.as_parts_mut();
             let args_have_side_effects = || args.iter().any(|arg| arg.has_side_effects());
-            match obj {
+            match Arc::make_mut(obj) {
                 // We don't know what the callee is, so we can early return
                 &mut JsValue::Unknown {
                     original_value: _,
@@ -60,7 +60,7 @@ pub fn early_replace_builtin(value: &mut JsValue) -> bool {
                     true
                 }
                 // otherwise we need to look at the property
-                _ => match prop {
+                _ => match Arc::make_mut(prop) {
                     // We don't know what the property is, so we can early return
                     &mut JsValue::Unknown {
                         original_value: _,
@@ -77,16 +77,14 @@ pub fn early_replace_builtin(value: &mut JsValue) -> bool {
         }
         // matching property access like `obj.prop` when we don't know what the obj is.
         // We can early return here
-        &mut JsValue::Member(
-            _,
-            box JsValue::Unknown {
-                original_value: _,
-                reason: _,
-                has_side_effects,
-            },
-            box ref mut prop,
-        ) => {
-            let side_effects = has_side_effects || prop.has_side_effects();
+        JsValue::Member(_, obj, prop) if matches!(&**obj, JsValue::Unknown { .. }) => {
+            let JsValue::Unknown {
+                has_side_effects, ..
+            } = &**obj
+            else {
+                unreachable!()
+            };
+            let side_effects = *has_side_effects || prop.has_side_effects();
             value.make_unknown(side_effects, rcstr!("unknown object"));
             true
         }
@@ -103,7 +101,7 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
             // numeric addition
             let mut sum = 0f64;
             for arg in list {
-                let JsValue::Constant(ConstantValue::Num(num)) = arg else {
+                let JsValue::Constant(ConstantValue::Num(num)) = Arc::make_mut(arg) else {
                     return false;
                 };
                 sum += *num.0;
@@ -114,7 +112,8 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
 
         // matching property access like `obj.prop`
         // Accessing a property on something can be handled in some cases
-        JsValue::Member(_, box obj, prop) => match obj {
+        JsValue::Member(_, obj, prop) => {
+            match Arc::make_mut(obj) {
             // matching property access when obj is a bunch of alternatives
             // like `(obj1 | obj2 | obj3).prop`
             // We expand these to `obj1.prop | obj2.prop | obj3.prop`
@@ -123,10 +122,10 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
                 values,
                 logical_property: _,
             } => {
-                *value = JsValue::alternatives(
+                *value = JsValue::alternatives_arc(
                     take(values)
                         .into_iter()
-                        .map(|alt| JsValue::member(Box::new(alt), prop.clone()))
+                        .map(|alt| Arc::new(JsValue::member_arc(alt, prop.clone())))
                         .collect(),
                 );
                 true
@@ -137,28 +136,34 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
                 mutable,
                 ..
             } => {
-                fn items_to_alternatives(items: &mut Vec<JsValue>, prop: &mut JsValue) -> JsValue {
-                    items.push(JsValue::unknown(
-                        JsValue::member(Box::new(JsValue::array(Vec::new())), Box::new(take(prop))),
+                fn items_to_alternatives(
+                    items: &mut Vec<Arc<JsValue>>,
+                    prop: &mut Arc<JsValue>,
+                ) -> JsValue {
+                    items.push(Arc::new(JsValue::unknown(
+                        JsValue::member_arc(
+                            Arc::new(JsValue::array(Vec::new())),
+                            Arc::new(take(Arc::make_mut(prop))),
+                        ),
                         false,
                         rcstr!("unknown array prototype methods or values"),
-                    ));
-                    JsValue::alternatives(take(items))
+                    )));
+                    JsValue::alternatives_arc(take(items))
                 }
-                match &mut **prop {
+                match Arc::make_mut(prop) {
                     // accessing a numeric property on an array like `[1,2,3][1]`
                     // We can replace this with the value at the index
                     JsValue::Constant(ConstantValue::Num(num @ ConstantNumber(_))) => {
                         if let Some(index) = num.as_u32_index() {
                             if index < items.len() {
-                                *value = items.swap_remove(index);
+                                *value = Arc::unwrap_or_clone(items.swap_remove(index));
                                 if mutable {
                                     value.add_unknown_mutations(true);
                                 }
                                 true
                             } else {
                                 *value = JsValue::unknown(
-                                    JsValue::member(Box::new(take(obj)), Box::new(take(prop))),
+                                    JsValue::member_arc(take(obj), take(prop)),
                                     false,
                                     rcstr!("invalid index"),
                                 );
@@ -182,10 +187,11 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
                         values,
                         logical_property: _,
                     } => {
-                        *value = JsValue::alternatives(
+                        let obj_arc: Arc<JsValue> = obj.clone();
+                        *value = JsValue::alternatives_arc(
                             take(values)
                                 .into_iter()
-                                .map(|alt| JsValue::member(Box::new(obj.clone()), Box::new(alt)))
+                                .map(|alt| Arc::new(JsValue::member_arc(obj_arc.clone(), alt)))
                                 .collect(),
                         );
                         true
@@ -206,38 +212,38 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
             } => {
                 fn parts_to_alternatives(
                     parts: &mut Vec<ObjectPart>,
-                    prop: &mut Box<JsValue>,
+                    prop: &mut Arc<JsValue>,
                     include_unknown: bool,
                 ) -> JsValue {
-                    let mut values = Vec::new();
+                    let mut values: Vec<Arc<JsValue>> = Vec::new();
                     for part in parts {
                         match part {
                             ObjectPart::KeyValue(_, value) => {
                                 values.push(take(value));
                             }
                             ObjectPart::Spread(_) => {
-                                values.push(JsValue::unknown(
-                                    JsValue::member(
-                                        Box::new(JsValue::object(vec![take(part)])),
+                                values.push(Arc::new(JsValue::unknown(
+                                    JsValue::member_arc(
+                                        Arc::new(JsValue::object(vec![take(part)])),
                                         prop.clone(),
                                     ),
                                     true,
                                     rcstr!("spread object"),
-                                ));
+                                )));
                             }
                         }
                     }
                     if include_unknown {
-                        values.push(JsValue::unknown(
-                            JsValue::member(
-                                Box::new(JsValue::object(Vec::new())),
-                                Box::new(take(prop)),
+                        values.push(Arc::new(JsValue::unknown(
+                            JsValue::member_arc(
+                                Arc::new(JsValue::object(Vec::new())),
+                                take(prop),
                             ),
                             true,
                             rcstr!("unknown object prototype methods or values"),
-                        ));
+                        )));
                     }
-                    JsValue::alternatives(values)
+                    JsValue::alternatives_arc(values)
                 }
 
                 /// Convert a list of potential values into
@@ -247,7 +253,7 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
                 fn potential_values_to_alternatives(
                     mut potential_values: Vec<usize>,
                     parts: &mut Vec<ObjectPart>,
-                    prop: &mut Box<JsValue>,
+                    prop: &mut Arc<JsValue>,
                     include_unknown: bool,
                 ) -> JsValue {
                     // Note: potential_values are already in reverse order
@@ -267,7 +273,7 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
                     parts_to_alternatives(&mut potential_values, prop, include_unknown)
                 }
 
-                match &mut **prop {
+                match Arc::make_mut(prop) {
                     // matching constant string property access on an object like `{a: 1, b:
                     // 2}["a"]`
                     JsValue::Constant(ConstantValue::Str(_)) => {
@@ -279,7 +285,7 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
                                     if let Some(key) = key.as_str() {
                                         if key == prop_str {
                                             if potential_values.is_empty() {
-                                                *value = take(val);
+                                                *value = Arc::unwrap_or_clone(take(val));
                                             } else {
                                                 potential_values.push(i);
                                                 *value = potential_values_to_alternatives(
@@ -326,10 +332,11 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
                         values,
                         logical_property: _,
                     } => {
-                        *value = JsValue::alternatives(
+                        let obj_arc: Arc<JsValue> = obj.clone();
+                        *value = JsValue::alternatives_arc(
                             take(values)
                                 .into_iter()
-                                .map(|alt| JsValue::member(Box::new(obj.clone()), Box::new(alt)))
+                                .map(|alt| Arc::new(JsValue::member_arc(obj_arc.clone(), alt)))
                                 .collect(),
                         );
                         true
@@ -341,13 +348,14 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
                 }
             }
             _ => false,
-        },
+            }
+        }
 
-        JsValue::MemberCall(_, call) => {
+        JsValue::MemberCall(_, list) => {
             // `into_parts` pops obj + prop off the tail of the underlying `Vec`, and the
             // remaining `Vec` (owned, not reallocated) becomes `args`.
-            let (mut obj, prop, args) = take(call).into_parts();
-            match &mut obj {
+            let (mut obj, prop, args) = take(list).into_parts();
+            match Arc::make_mut(&mut obj) {
                 // matching calls on an array like `[1,2,3].concat([4,5,6])`
                 JsValue::Array { items, mutable, .. } => {
                     // matching cases where the property is a const string
@@ -357,7 +365,7 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
                             "concat"
                                 if args.iter().all(|arg| {
                                     matches!(
-                                        arg,
+                                        &**arg,
                                         JsValue::Array { .. }
                                             | JsValue::Constant(_)
                                             | JsValue::Url(_, JsValueUrlKind::Absolute)
@@ -369,7 +377,7 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
                                     )
                                 }) => {
                                     for arg in args {
-                                        match arg {
+                                        match Arc::unwrap_or_clone(arg) {
                                             JsValue::Array {
                                                 items: inner,
                                                 mutable: inner_mutable,
@@ -385,15 +393,15 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
                                             | JsValue::WellKnownObject(_)
                                             | JsValue::WellKnownFunction(_)
                                             | JsValue::Function(..)) => {
-                                                items.push(other);
+                                                items.push(Arc::new(other));
                                             }
                                             _ => {
                                                 unreachable!();
                                             }
                                         }
                                     }
-                                    obj.update_total_nodes();
-                                    *value = obj;
+                                    Arc::make_mut(&mut obj).update_total_nodes();
+                                    *value = Arc::unwrap_or_clone(obj);
                                     return true;
                                 }
                             // The Array.prototype.map method
@@ -456,7 +464,7 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
                     let mut values = vec![obj];
                     values.extend(args);
 
-                    *value = JsValue::concat(values);
+                    *value = JsValue::concat_arc(values);
                     return true;
                 }
             }
@@ -482,10 +490,10 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
         {
             // Take ownership so we can move the alternatives `values` out of the callee.
             let (callee, args) = take(call).into_parts();
-            let JsValue::Alternatives { values, .. } = callee else {
+            let JsValue::Alternatives { values, .. } = Arc::unwrap_or_clone(callee) else {
                 unreachable!()
             };
-            *value = JsValue::alternatives(
+            *value = JsValue::alternatives_arc(
                 values
                     .into_iter()
                     .map(|alt| JsValue::call_from_iter(alt, args.iter().cloned()))
@@ -498,18 +506,46 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
             // If the object contains any spread, we might be able to flatten that
             if parts
                 .iter()
-                .any(|part| matches!(part, ObjectPart::Spread(JsValue::Object { .. })))
+                .any(|part| matches!(part, ObjectPart::Spread(s) if matches!(&**s, JsValue::Object { .. })))
             => {
                 let old_parts = take(parts);
                 for part in old_parts {
-                    if let ObjectPart::Spread(JsValue::Object {
-                        parts: inner_parts,
-                        mutable: inner_mutable,
-                        ..
-                    }) = part
+                    // If this part is a spread of an inline `Object` literal, flatten its parts
+                    // into ours. Use `try_unwrap` so we move the inner `Vec<ObjectPart>` out
+                    // when the `Arc` is uniquely owned (the common case here, since `take` just
+                    // gave us ownership of the outer slot); otherwise clone.
+                    if let ObjectPart::Spread(spread) = &part
+                        && matches!(&**spread, JsValue::Object { .. })
                     {
-                        parts.extend(inner_parts);
-                        *mutable |= inner_mutable;
+                        let ObjectPart::Spread(spread) = part else {
+                            unreachable!()
+                        };
+                        match Arc::try_unwrap(spread) {
+                            Ok(JsValue::Object {
+                                parts: inner_parts,
+                                mutable: inner_mutable,
+                                ..
+                            }) => {
+                                parts.extend(inner_parts);
+                                *mutable |= inner_mutable;
+                            }
+                            Ok(other) => {
+                                parts.push(ObjectPart::Spread(Arc::new(other)));
+                            }
+                            Err(arc) => {
+                                if let JsValue::Object {
+                                    parts: inner_parts,
+                                    mutable: inner_mutable,
+                                    ..
+                                } = &*arc
+                                {
+                                    parts.extend(inner_parts.iter().cloned());
+                                    *mutable |= *inner_mutable;
+                                } else {
+                                    parts.push(ObjectPart::Spread(arc));
+                                }
+                            }
+                        }
                     } else {
                         parts.push(part);
                     }
@@ -521,7 +557,7 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
         // Reduce logical expressions to their final value(s)
         JsValue::Logical(_, op, parts) => {
             let len = parts.len();
-            let input_parts: Vec<JsValue> = take(parts);
+            let input_parts: Vec<Arc<JsValue>> = take(parts);
             *parts = Vec::with_capacity(len);
             let mut part_properties = Vec::with_capacity(len);
             for (i, part) in input_parts.into_iter().enumerate() {
@@ -559,7 +595,7 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
             }
             // If we reduced the expression to a single value, we can replace it.
             if parts.len() == 1 {
-                *value = parts.pop().unwrap();
+                *value = Arc::unwrap_or_clone(parts.pop().unwrap());
                 true
             } else {
                 // If not, we know that it will be one of the remaining values.
@@ -608,20 +644,23 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
                     }
                 };
                 if let Some(property) = property {
-                    *value = JsValue::alternatives_with_additional_property(take(parts), property);
+                    *value = JsValue::alternatives_with_additional_property_arc(
+                        take(parts),
+                        property,
+                    );
                     true
                 } else {
-                    *value = JsValue::alternatives(take(parts));
+                    *value = JsValue::alternatives_arc(take(parts));
                     true
                 }
             }
         }
         JsValue::Tenary(_, test, cons, alt) => {
             if test.is_truthy() == Some(true) {
-                *value = take(cons);
+                *value = Arc::unwrap_or_clone(take(cons));
                 true
             } else if test.is_falsy() == Some(true) {
-                *value = take(alt);
+                *value = Arc::unwrap_or_clone(take(alt));
                 true
             } else {
                 false
@@ -656,8 +695,8 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
         },
 
         JsValue::Iterated(_, iterable) => {
-            if let JsValue::Array { items, mutable, .. } = &mut **iterable {
-                let mut new_value = JsValue::alternatives(take(items));
+            if let JsValue::Array { items, mutable, .. } = Arc::make_mut(iterable) {
+                let mut new_value = JsValue::alternatives_arc(take(items));
                 if *mutable {
                     new_value.add_unknown_mutations(true);
                 }
@@ -669,11 +708,11 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
         }
 
         JsValue::Awaited(_, operand) => {
-            if let JsValue::Promise(_, inner) = &mut **operand {
-                *value = take(inner);
+            if let JsValue::Promise(_, inner) = Arc::make_mut(operand) {
+                *value = Arc::unwrap_or_clone(take(inner));
                 true
             } else {
-                *value = take(operand);
+                *value = Arc::unwrap_or_clone(take(operand));
                 true
             }
         }

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/graph.rs
@@ -506,7 +506,7 @@ impl EvalContext {
             }) => {
                 let arg = self.eval(arg);
 
-                JsValue::logical_not(Box::new(arg))
+                JsValue::logical_not(arg)
             }
 
             Expr::Unary(UnaryExpr {
@@ -516,7 +516,7 @@ impl EvalContext {
             }) => {
                 let arg = self.eval(arg);
 
-                JsValue::type_of(Box::new(arg))
+                JsValue::type_of(arg)
             }
 
             Expr::Bin(BinExpr {
@@ -531,7 +531,7 @@ impl EvalContext {
                 match (l, r) {
                     (JsValue::Add(c, l), r) => JsValue::Add(
                         c + r.total_nodes(),
-                        l.into_iter().chain(iter::once(r)).collect(),
+                        l.into_iter().chain(iter::once(Arc::new(r))).collect(),
                     ),
                     (l, r) => JsValue::add(vec![l, r]),
                 }
@@ -563,28 +563,28 @@ impl EvalContext {
                 left,
                 right,
                 ..
-            }) => JsValue::equal(Box::new(self.eval(left)), Box::new(self.eval(right))),
+            }) => JsValue::equal(self.eval(left), self.eval(right)),
 
             Expr::Bin(BinExpr {
                 op: op!("!="),
                 left,
                 right,
                 ..
-            }) => JsValue::not_equal(Box::new(self.eval(left)), Box::new(self.eval(right))),
+            }) => JsValue::not_equal(self.eval(left), self.eval(right)),
 
             Expr::Bin(BinExpr {
                 op: op!("==="),
                 left,
                 right,
                 ..
-            }) => JsValue::strict_equal(Box::new(self.eval(left)), Box::new(self.eval(right))),
+            }) => JsValue::strict_equal(self.eval(left), self.eval(right)),
 
             Expr::Bin(BinExpr {
                 op: op!("!=="),
                 left,
                 right,
                 ..
-            }) => JsValue::strict_not_equal(Box::new(self.eval(left)), Box::new(self.eval(right))),
+            }) => JsValue::strict_not_equal(self.eval(left), self.eval(right)),
 
             &Expr::Cond(CondExpr {
                 box ref cons,
@@ -600,11 +600,7 @@ impl EvalContext {
                         self.eval(alt)
                     }
                 } else {
-                    JsValue::tenary(
-                        Box::new(test),
-                        Box::new(self.eval(cons)),
-                        Box::new(self.eval(alt)),
-                    )
+                    JsValue::tenary(test, self.eval(cons), self.eval(alt))
                 }
             }
 
@@ -648,7 +644,7 @@ impl EvalContext {
                 SyntaxContext::empty(),
             )),
 
-            Expr::Await(AwaitExpr { arg, .. }) => JsValue::awaited(Box::new(self.eval(arg))),
+            Expr::Await(AwaitExpr { arg, .. }) => JsValue::awaited(self.eval(arg)),
 
             Expr::Seq(e) => {
                 let mut seq = e.exprs.iter().map(|e| self.eval(e)).peekable();
@@ -670,7 +666,7 @@ impl EvalContext {
                 ..
             }) => {
                 let obj = self.eval(obj);
-                JsValue::member(Box::new(obj), Box::new(prop.sym.clone().into()))
+                JsValue::member(obj, prop.sym.clone().into())
             }
 
             Expr::Member(MemberExpr {
@@ -680,7 +676,7 @@ impl EvalContext {
             }) => {
                 let obj = self.eval(obj);
                 let prop = self.eval(&computed.expr);
-                JsValue::member(Box::new(obj), Box::new(prop))
+                JsValue::member(obj, prop)
             }
 
             Expr::New(NewExpr {
@@ -798,19 +794,22 @@ impl EvalContext {
                     .iter()
                     .map(|prop| match prop {
                         PropOrSpread::Spread(SpreadElement { expr, .. }) => {
-                            ObjectPart::Spread(self.eval(expr))
+                            ObjectPart::Spread(Arc::new(self.eval(expr)))
                         }
                         PropOrSpread::Prop(box Prop::KeyValue(KeyValueProp { key, box value })) => {
-                            ObjectPart::KeyValue(self.eval_prop_name(key), self.eval(value))
+                            ObjectPart::KeyValue(
+                                Arc::new(self.eval_prop_name(key)),
+                                Arc::new(self.eval(value)),
+                            )
                         }
                         PropOrSpread::Prop(box Prop::Shorthand(ident)) => ObjectPart::KeyValue(
-                            ident.sym.clone().into(),
-                            self.eval(&Expr::Ident(ident.clone())),
+                            Arc::new(ident.sym.clone().into()),
+                            Arc::new(self.eval(&Expr::Ident(ident.clone()))),
                         ),
-                        _ => ObjectPart::Spread(JsValue::unknown_empty(
+                        _ => ObjectPart::Spread(Arc::new(JsValue::unknown_empty(
                             true,
                             rcstr!("unsupported object part"),
-                        )),
+                        ))),
                     })
                     .collect(),
             ),
@@ -2347,7 +2346,7 @@ impl VisitAstPath for Analyzer<'_> {
         let iterable = self.eval_context.eval(&n.right);
 
         // TODO n.await is ignored (async interables)
-        self.with_pat_value(Some(JsValue::iterated(Box::new(iterable))), |this| {
+        self.with_pat_value(Some(JsValue::iterated(iterable)), |this| {
             let mut ast_path =
                 ast_path.with_guard(AstParentNodeRef::ForOfStmt(n, ForOfStmtField::Left));
             n.left.visit_with_ast_path(this, &mut ast_path);
@@ -3110,7 +3109,12 @@ impl Analyzer<'_> {
                     .iter()
                     // TODO: This does not handle inline spreads correctly
                     // e.g. `let [a,..b,c] = [1,2,3]`
-                    .zip(items.into_iter().map(Some).chain(iter::repeat(None)))
+                    .zip(
+                        items
+                            .into_iter()
+                            .map(|v| Some(Arc::unwrap_or_clone(v)))
+                            .chain(iter::repeat(None)),
+                    )
                     .enumerate()
                 {
                     self.with_pat_value(value_item, |this| {
@@ -3123,8 +3127,8 @@ impl Analyzer<'_> {
             value => {
                 for (idx, elem) in arr.elems.iter().enumerate() {
                     let pat_value = Some(JsValue::member(
-                        Box::new(value.clone()),
-                        Box::new(JsValue::Constant(ConstantValue::Num((idx as f64).into()))),
+                        value.clone(),
+                        JsValue::Constant(ConstantValue::Num((idx as f64).into())),
                     ));
                     self.with_pat_value(pat_value, |this| {
                         let mut ast_path = ast_path
@@ -3160,10 +3164,7 @@ impl Analyzer<'_> {
                         ));
                         key.visit_with_ast_path(self, &mut ast_path);
                     }
-                    let pat_value = Some(JsValue::member(
-                        Box::new(pat_value.clone()),
-                        Box::new(key_value),
-                    ));
+                    let pat_value = Some(JsValue::member(pat_value.clone(), key_value));
                     self.with_pat_value(pat_value, |this| {
                         let mut ast_path = ast_path.with_guard(AstParentNodeRef::KeyValuePatProp(
                             kv,
@@ -3191,11 +3192,11 @@ impl Analyzer<'_> {
                         if let Some(box value) = value {
                             let value = self.eval_context.eval(value);
                             JsValue::alternatives(vec![
-                                JsValue::member(Box::new(pat_value.clone()), Box::new(key_value)),
+                                JsValue::member(pat_value.clone(), key_value),
                                 value,
                             ])
                         } else {
-                            JsValue::member(Box::new(pat_value.clone()), Box::new(key_value))
+                            JsValue::member(pat_value.clone(), key_value)
                         },
                     );
                     {

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/graph.rs
@@ -372,7 +372,7 @@ pub struct EvalContext {
     /// Should be the same [`Mark`] used by [`swc_core::ecma::transforms::base::resolver`].
     pub(crate) top_level_mark: Mark,
     pub(crate) imports: ImportMap,
-    pub(crate) force_free_values: std::sync::Arc<FxHashSet<Id>>,
+    pub(crate) force_free_values: Arc<FxHashSet<Id>>,
 }
 
 impl EvalContext {
@@ -387,7 +387,7 @@ impl EvalContext {
         module: Option<&Program>,
         unresolved_mark: Mark,
         top_level_mark: Mark,
-        force_free_values: std::sync::Arc<FxHashSet<Id>>,
+        force_free_values: Arc<FxHashSet<Id>>,
         comments: Option<&dyn Comments>,
     ) -> Self {
         Self {
@@ -459,7 +459,7 @@ impl EvalContext {
         match values.len() {
             0 => JsValue::Constant(ConstantValue::Str(rcstr!("").into())),
             1 => values.into_iter().next().unwrap(),
-            _ => JsValue::concat(values),
+            _ => JsValue::concat(values.into_iter().map(Arc::new).collect()),
         }
     }
 
@@ -506,7 +506,7 @@ impl EvalContext {
             }) => {
                 let arg = self.eval(arg);
 
-                JsValue::logical_not(arg)
+                JsValue::logical_not(Arc::new(arg))
             }
 
             Expr::Unary(UnaryExpr {
@@ -516,7 +516,7 @@ impl EvalContext {
             }) => {
                 let arg = self.eval(arg);
 
-                JsValue::type_of(arg)
+                JsValue::type_of(Arc::new(arg))
             }
 
             Expr::Bin(BinExpr {
@@ -533,7 +533,7 @@ impl EvalContext {
                         c + r.total_nodes(),
                         l.into_iter().chain(iter::once(Arc::new(r))).collect(),
                     ),
-                    (l, r) => JsValue::add(vec![l, r]),
+                    (l, r) => JsValue::add(vec![Arc::new(l), Arc::new(r)]),
                 }
             }
 
@@ -542,49 +542,52 @@ impl EvalContext {
                 left,
                 right,
                 ..
-            }) => JsValue::logical_and(vec![self.eval(left), self.eval(right)]),
+            }) => JsValue::logical_and(vec![Arc::new(self.eval(left)), Arc::new(self.eval(right))]),
 
             Expr::Bin(BinExpr {
                 op: op!("||"),
                 left,
                 right,
                 ..
-            }) => JsValue::logical_or(vec![self.eval(left), self.eval(right)]),
+            }) => JsValue::logical_or(vec![Arc::new(self.eval(left)), Arc::new(self.eval(right))]),
 
             Expr::Bin(BinExpr {
                 op: op!("??"),
                 left,
                 right,
                 ..
-            }) => JsValue::nullish_coalescing(vec![self.eval(left), self.eval(right)]),
+            }) => JsValue::nullish_coalescing(vec![
+                Arc::new(self.eval(left)),
+                Arc::new(self.eval(right)),
+            ]),
 
             Expr::Bin(BinExpr {
                 op: op!("=="),
                 left,
                 right,
                 ..
-            }) => JsValue::equal(self.eval(left), self.eval(right)),
+            }) => JsValue::equal(Arc::new(self.eval(left)), Arc::new(self.eval(right))),
 
             Expr::Bin(BinExpr {
                 op: op!("!="),
                 left,
                 right,
                 ..
-            }) => JsValue::not_equal(self.eval(left), self.eval(right)),
+            }) => JsValue::not_equal(Arc::new(self.eval(left)), Arc::new(self.eval(right))),
 
             Expr::Bin(BinExpr {
                 op: op!("==="),
                 left,
                 right,
                 ..
-            }) => JsValue::strict_equal(self.eval(left), self.eval(right)),
+            }) => JsValue::strict_equal(Arc::new(self.eval(left)), Arc::new(self.eval(right))),
 
             Expr::Bin(BinExpr {
                 op: op!("!=="),
                 left,
                 right,
                 ..
-            }) => JsValue::strict_not_equal(self.eval(left), self.eval(right)),
+            }) => JsValue::strict_not_equal(Arc::new(self.eval(left)), Arc::new(self.eval(right))),
 
             &Expr::Cond(CondExpr {
                 box ref cons,
@@ -600,7 +603,11 @@ impl EvalContext {
                         self.eval(alt)
                     }
                 } else {
-                    JsValue::tenary(test, self.eval(cons), self.eval(alt))
+                    JsValue::tenary(
+                        Arc::new(test),
+                        Arc::new(self.eval(cons)),
+                        Arc::new(self.eval(alt)),
+                    )
                 }
             }
 
@@ -644,7 +651,7 @@ impl EvalContext {
                 SyntaxContext::empty(),
             )),
 
-            Expr::Await(AwaitExpr { arg, .. }) => JsValue::awaited(self.eval(arg)),
+            Expr::Await(AwaitExpr { arg, .. }) => JsValue::awaited(Arc::new(self.eval(arg))),
 
             Expr::Seq(e) => {
                 let mut seq = e.exprs.iter().map(|e| self.eval(e)).peekable();
@@ -666,7 +673,7 @@ impl EvalContext {
                 ..
             }) => {
                 let obj = self.eval(obj);
-                JsValue::member(obj, prop.sym.clone().into())
+                JsValue::member(Arc::new(obj), Arc::new(prop.sym.clone().into()))
             }
 
             Expr::Member(MemberExpr {
@@ -676,7 +683,7 @@ impl EvalContext {
             }) => {
                 let obj = self.eval(obj);
                 let prop = self.eval(&computed.expr);
-                JsValue::member(obj, prop)
+                JsValue::member(Arc::new(obj), Arc::new(prop))
             }
 
             Expr::New(NewExpr {
@@ -695,7 +702,7 @@ impl EvalContext {
 
                 JsValue::new_from_iter(
                     self.eval(callee),
-                    args.iter().map(|arg| self.eval(&arg.expr)),
+                    args.iter().map(|arg| Arc::new(self.eval(&arg.expr))),
                 )
             }
 
@@ -727,12 +734,12 @@ impl EvalContext {
                     JsValue::member_call_from_iter(
                         obj,
                         prop,
-                        args.iter().map(|arg| self.eval(&arg.expr)),
+                        args.iter().map(|arg| Arc::new(self.eval(&arg.expr))),
                     )
                 } else {
                     JsValue::call_from_iter(
                         self.eval(callee),
-                        args.iter().map(|arg| self.eval(&arg.expr)),
+                        args.iter().map(|arg| Arc::new(self.eval(&arg.expr))),
                     )
                 }
             }
@@ -750,7 +757,10 @@ impl EvalContext {
                     );
                 }
 
-                let args = args.iter().map(|arg| self.eval(&arg.expr)).collect();
+                let args = args
+                    .iter()
+                    .map(|arg| Arc::new(self.eval(&arg.expr)))
+                    .collect();
 
                 JsValue::super_call(args)
             }
@@ -769,7 +779,7 @@ impl EvalContext {
                 }
                 JsValue::call_from_iter(
                     JsValue::FreeVar(atom!("import")),
-                    args.iter().map(|arg| self.eval(&arg.expr)),
+                    args.iter().map(|arg| Arc::new(self.eval(&arg.expr))),
                 )
             }
 
@@ -782,8 +792,8 @@ impl EvalContext {
                     .elems
                     .iter()
                     .map(|e| match e {
-                        Some(e) => self.eval(&e.expr),
-                        _ => JsValue::Constant(ConstantValue::Undefined),
+                        Some(e) => Arc::new(self.eval(&e.expr)),
+                        _ => Arc::new(JsValue::Constant(ConstantValue::Undefined)),
                     })
                     .collect();
                 JsValue::array(arr)
@@ -1135,9 +1145,11 @@ mod analyzer_state {
                 function.is_async(),
                 function.is_generator(),
                 match return_values.len() {
-                    0 => JsValue::Constant(ConstantValue::Undefined),
-                    1 => return_values.into_iter().next().unwrap(),
-                    _ => JsValue::alternatives(return_values),
+                    0 => Arc::new(JsValue::Constant(ConstantValue::Undefined)),
+                    1 => Arc::new(return_values.into_iter().next().unwrap()),
+                    _ => Arc::new(JsValue::alternatives(
+                        return_values.into_iter().map(Arc::new).collect(),
+                    )),
                 },
             )
         }
@@ -1914,7 +1926,7 @@ impl VisitAstPath for Analyzer<'_> {
                 (AssignOp::AddAssign, Some(key)) => {
                     let left = self.eval_context.eval(&Expr::Ident(key.clone().into()));
                     let right = self.eval_context.eval(&n.right);
-                    JsValue::add(vec![left, right])
+                    JsValue::add(vec![Arc::new(left), Arc::new(right)])
                 }
                 _ => JsValue::unknown_empty(true, rcstr!("unsupported assign operation")),
             };
@@ -2271,8 +2283,8 @@ impl VisitAstPath for Analyzer<'_> {
                 let init_value = self.eval_context.eval(init);
                 let pat_value = Some(if should_include_undefined {
                     JsValue::alternatives(vec![
-                        init_value,
-                        JsValue::Constant(ConstantValue::Undefined),
+                        Arc::new(init_value),
+                        Arc::new(JsValue::Constant(ConstantValue::Undefined)),
                     ])
                 } else {
                     init_value
@@ -2346,7 +2358,7 @@ impl VisitAstPath for Analyzer<'_> {
         let iterable = self.eval_context.eval(&n.right);
 
         // TODO n.await is ignored (async interables)
-        self.with_pat_value(Some(JsValue::iterated(iterable)), |this| {
+        self.with_pat_value(Some(JsValue::iterated(Arc::new(iterable))), |this| {
             let mut ast_path =
                 ast_path.with_guard(AstParentNodeRef::ForOfStmt(n, ForOfStmtField::Left));
             n.left.visit_with_ast_path(this, &mut ast_path);
@@ -2468,14 +2480,14 @@ impl VisitAstPath for Analyzer<'_> {
                     pat,
                     AssignTargetPatField::Array,
                 ));
-                self.handle_array_pat_with_value(arr, value, &mut ast_path);
+                self.handle_array_pat_with_value(arr, Arc::new(value), &mut ast_path);
             }
             AssignTargetPat::Object(obj) => {
                 let mut ast_path = ast_path.with_guard(AstParentNodeRef::AssignTargetPat(
                     pat,
                     AssignTargetPatField::Object,
                 ));
-                self.handle_object_pat_with_value(obj, value, &mut ast_path);
+                self.handle_object_pat_with_value(obj, Arc::new(value), &mut ast_path);
             }
             AssignTargetPat::Invalid(_) => {}
         }
@@ -2506,7 +2518,7 @@ impl VisitAstPath for Analyzer<'_> {
                 let value = value.unwrap_or_else(|| {
                     JsValue::unknown_empty(false, rcstr!("pattern without value"))
                 });
-                self.handle_array_pat_with_value(arr, value, &mut ast_path);
+                self.handle_array_pat_with_value(arr, Arc::new(value), &mut ast_path);
             }
 
             Pat::Object(obj) => {
@@ -2515,7 +2527,7 @@ impl VisitAstPath for Analyzer<'_> {
                 let value = value.unwrap_or_else(|| {
                     JsValue::unknown_empty(false, rcstr!("pattern without value"))
                 });
-                self.handle_object_pat_with_value(obj, value, &mut ast_path);
+                self.handle_object_pat_with_value(obj, Arc::new(value), &mut ast_path);
             }
 
             _ => pat.visit_children_with_ast_path(self, ast_path),
@@ -3099,10 +3111,10 @@ impl Analyzer<'_> {
     fn handle_array_pat_with_value<'ast: 'r, 'r>(
         &mut self,
         arr: &'ast ArrayPat,
-        pat_value: JsValue,
+        pat_value: Arc<JsValue>,
         ast_path: &mut AstNodePath<AstParentNodeRef<'r>>,
     ) {
-        match pat_value {
+        match Arc::unwrap_or_clone(pat_value) {
             JsValue::Array { items, .. } => {
                 for (idx, (elem_pat, value_item)) in arr
                     .elems
@@ -3125,10 +3137,11 @@ impl Analyzer<'_> {
                 }
             }
             value => {
+                let value = Arc::new(value);
                 for (idx, elem) in arr.elems.iter().enumerate() {
                     let pat_value = Some(JsValue::member(
                         value.clone(),
-                        JsValue::Constant(ConstantValue::Num((idx as f64).into())),
+                        Arc::new(JsValue::Constant(ConstantValue::Num((idx as f64).into()))),
                     ));
                     self.with_pat_value(pat_value, |this| {
                         let mut ast_path = ast_path
@@ -3143,7 +3156,7 @@ impl Analyzer<'_> {
     fn handle_object_pat_with_value<'ast: 'r, 'r>(
         &mut self,
         obj: &'ast ObjectPat,
-        pat_value: JsValue,
+        pat_value: Arc<JsValue>,
         ast_path: &mut AstNodePath<AstParentNodeRef<'r>>,
     ) {
         for (i, prop) in obj.props.iter().enumerate() {
@@ -3164,7 +3177,7 @@ impl Analyzer<'_> {
                         ));
                         key.visit_with_ast_path(self, &mut ast_path);
                     }
-                    let pat_value = Some(JsValue::member(pat_value.clone(), key_value));
+                    let pat_value = Some(JsValue::member(pat_value.clone(), Arc::new(key_value)));
                     self.with_pat_value(pat_value, |this| {
                         let mut ast_path = ast_path.with_guard(AstParentNodeRef::KeyValuePatProp(
                             kv,
@@ -3192,11 +3205,11 @@ impl Analyzer<'_> {
                         if let Some(box value) = value {
                             let value = self.eval_context.eval(value);
                             JsValue::alternatives(vec![
-                                JsValue::member(pat_value.clone(), key_value),
-                                value,
+                                Arc::new(JsValue::member(pat_value.clone(), Arc::new(key_value))),
+                                Arc::new(value),
                             ])
                         } else {
-                            JsValue::member(pat_value.clone(), key_value)
+                            JsValue::member(pat_value.clone(), Arc::new(key_value))
                         },
                     );
                     {

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/graph.rs
@@ -1,7 +1,6 @@
 use std::{
     iter,
     mem::{replace, take},
-    sync::Arc,
 };
 
 use anyhow::{Ok, Result};
@@ -21,6 +20,7 @@ use swc_core::{
         visit::{fields::*, *},
     },
 };
+use triomphe::Arc;
 use turbo_rcstr::{RcStr, rcstr};
 use turbopack_core::resolve::ExportUsage;
 
@@ -372,7 +372,7 @@ pub struct EvalContext {
     /// Should be the same [`Mark`] used by [`swc_core::ecma::transforms::base::resolver`].
     pub(crate) top_level_mark: Mark,
     pub(crate) imports: ImportMap,
-    pub(crate) force_free_values: Arc<FxHashSet<Id>>,
+    pub(crate) force_free_values: std::sync::Arc<FxHashSet<Id>>,
 }
 
 impl EvalContext {
@@ -387,7 +387,7 @@ impl EvalContext {
         module: Option<&Program>,
         unresolved_mark: Mark,
         top_level_mark: Mark,
-        force_free_values: Arc<FxHashSet<Id>>,
+        force_free_values: std::sync::Arc<FxHashSet<Id>>,
         comments: Option<&dyn Comments>,
     ) -> Self {
         Self {

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
@@ -18,6 +18,7 @@ use swc_core::{
         visit::{Visit, VisitWith},
     },
 };
+use triomphe::Arc;
 use turbo_frozenmap::FrozenMap;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{FxIndexMap, FxIndexSet, ResolvedVc};

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
@@ -2,7 +2,7 @@ use std::{
     borrow::Cow,
     collections::{BTreeMap, hash_map::Entry},
     fmt::Display,
-    sync::{Arc, LazyLock},
+    sync::LazyLock,
 };
 
 use anyhow::{Context, Result};
@@ -18,6 +18,7 @@ use swc_core::{
         visit::{Visit, VisitWith},
     },
 };
+use triomphe::Arc;
 use turbo_frozenmap::FrozenMap;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{FxIndexMap, FxIndexSet, ResolvedVc};
@@ -528,11 +529,11 @@ impl ImportMap {
         if let Some((i, i_sym)) = self.imports.get(id) {
             let r = &self.references[*i];
             return Some(JsValue::member(
-                JsValue::Module(ModuleValue {
+                Arc::new(JsValue::Module(ModuleValue {
                     module: r.module_path.clone(),
                     annotations: r.annotations.clone(),
-                }),
-                i_sym.clone().into(),
+                })),
+                Arc::new(i_sym.clone().into()),
             ));
         }
         if let Some(i) = self.namespace_imports.get(id) {

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
@@ -174,7 +174,7 @@ impl ImportAnnotations {
             let (
                 JsValue::Constant(ConstantValue::Str(key)),
                 JsValue::Constant(ConstantValue::Str(value)),
-            ) = (key, value)
+            ) = (&**key, &**value)
             else {
                 continue;
             };
@@ -528,11 +528,11 @@ impl ImportMap {
         if let Some((i, i_sym)) = self.imports.get(id) {
             let r = &self.references[*i];
             return Some(JsValue::member(
-                Box::new(JsValue::Module(ModuleValue {
+                JsValue::Module(ModuleValue {
                     module: r.module_path.clone(),
                     annotations: r.annotations.clone(),
-                })),
-                Box::new(i_sym.clone().into()),
+                }),
+                i_sym.clone().into(),
             ));
         }
         if let Some(i) = self.namespace_imports.get(id) {

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
@@ -18,7 +18,6 @@ use swc_core::{
         visit::{Visit, VisitWith},
     },
 };
-use triomphe::Arc;
 use turbo_frozenmap::FrozenMap;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{FxIndexMap, FxIndexSet, ResolvedVc};

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/linker.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/linker.rs
@@ -1,4 +1,4 @@
-use std::{collections::hash_map::Entry, fmt::Display, future::Future, mem::take};
+use std::{collections::hash_map::Entry, fmt::Display, future::Future, mem::take, sync::Arc};
 
 use anyhow::Result;
 use parking_lot::Mutex;
@@ -176,7 +176,9 @@ where
                 if matches!(call.callee(), JsValue::Function(..)) =>
             {
                 let (callee, args) = call.into_parts();
-                let JsValue::Function(function_nodes, func_ident, return_value) = callee else {
+                let JsValue::Function(function_nodes, func_ident, return_value) =
+                    Arc::unwrap_or_clone(callee)
+                else {
                     unreachable!()
                 };
                 total_nodes -= 2; // Call + Function
@@ -185,19 +187,26 @@ where
                     for arg in args.iter() {
                         total_nodes -= arg.total_nodes();
                     }
-                    entry.insert(args);
+                    // Materialize back to `Vec<JsValue>` for the legacy `fun_args_values`
+                    // map signature; the Arc unwrap is cheap when each arg is uniquely
+                    // owned (the common case here).
+                    let args_owned: Vec<JsValue> =
+                        args.into_iter().map(Arc::unwrap_or_clone).collect();
+                    entry.insert(args_owned);
                     work_queue_stack.push(Step::LeaveCall(func_ident));
-                    work_queue_stack.push(Step::Enter(*return_value));
+                    work_queue_stack.push(Step::Enter(Arc::unwrap_or_clone(return_value)));
                 } else {
                     total_nodes -= return_value.total_nodes();
                     for arg in args.iter() {
                         total_nodes -= arg.total_nodes();
                     }
                     total_nodes += 1;
+                    let args_owned: Vec<JsValue> =
+                        args.into_iter().map(Arc::unwrap_or_clone).collect();
                     done.push(JsValue::unknown(
                         JsValue::call_from_parts(
                             JsValue::Function(function_nodes, func_ident, return_value),
-                            args,
+                            args_owned,
                         ),
                         true,
                         rcstr!("recursive function call"),

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/linker.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/linker.rs
@@ -1,9 +1,10 @@
-use std::{collections::hash_map::Entry, fmt::Display, future::Future, mem::take, sync::Arc};
+use std::{collections::hash_map::Entry, fmt::Display, future::Future, mem::take};
 
 use anyhow::Result;
 use parking_lot::Mutex;
 use rustc_hash::{FxHashMap, FxHashSet};
 use swc_core::ecma::ast::Id;
+use triomphe::Arc;
 use turbo_rcstr::rcstr;
 
 use super::{JsValue, graph::VarGraph};

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/linker.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/linker.rs
@@ -202,12 +202,10 @@ where
                         total_nodes -= arg.total_nodes();
                     }
                     total_nodes += 1;
-                    let args_owned: Vec<JsValue> =
-                        args.into_iter().map(Arc::unwrap_or_clone).collect();
                     done.push(JsValue::unknown(
                         JsValue::call_from_parts(
                             JsValue::Function(function_nodes, func_ident, return_value),
-                            args_owned,
+                            args,
                         ),
                         true,
                         rcstr!("recursive function call"),

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/linker.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/linker.rs
@@ -1,4 +1,4 @@
-use std::{collections::hash_map::Entry, fmt::Display, future::Future, mem::take};
+use std::{collections::hash_map::Entry, fmt::Display, future::Future};
 
 use anyhow::Result;
 use parking_lot::Mutex;
@@ -7,7 +7,7 @@ use swc_core::ecma::ast::Id;
 use triomphe::Arc;
 use turbo_rcstr::rcstr;
 
-use super::{JsValue, graph::VarGraph};
+use super::{JsValue, graph::VarGraph, take_arc_slot};
 
 pub async fn link<'a, B, RB, F, RF>(
     graph: &VarGraph,
@@ -243,14 +243,16 @@ where
                     let mut has_early_children = false;
                     val.for_each_early_children_mut(&mut |child| {
                         has_early_children = true;
-                        work_queue_stack.push(Step::Enter(take(child)));
+                        work_queue_stack
+                            .push(Step::Enter(Arc::unwrap_or_clone(take_arc_slot(child))));
                         false
                     });
                     if has_early_children {
                         work_queue_stack[i] = Step::EarlyVisit(val);
                     } else {
                         val.for_each_children_mut(&mut |child| {
-                            work_queue_stack.push(Step::Enter(take(child)));
+                            work_queue_stack
+                                .push(Step::Enter(Arc::unwrap_or_clone(take_arc_slot(child))));
                             false
                         });
                         work_queue_stack[i] = Step::Leave(val);
@@ -264,7 +266,7 @@ where
             Step::EarlyVisit(mut val) => {
                 val.for_each_early_children_mut(&mut |child| {
                     let val = done.pop().unwrap();
-                    *child = val;
+                    *child = Arc::new(val);
                     true
                 });
                 val.debug_assert_total_nodes_up_to_date();
@@ -304,7 +306,8 @@ where
                     let i = work_queue_stack.len();
                     work_queue_stack.push(Step::TemporarySlot);
                     val.for_each_late_children_mut(&mut |child| {
-                        work_queue_stack.push(Step::Enter(take(child)));
+                        work_queue_stack
+                            .push(Step::Enter(Arc::unwrap_or_clone(take_arc_slot(child))));
                         false
                     });
                     work_queue_stack[i] = Step::LeaveLate(val);
@@ -314,7 +317,7 @@ where
             Step::Leave(mut val) => {
                 val.for_each_children_mut(&mut |child| {
                     let val = done.pop().unwrap();
-                    *child = val;
+                    *child = Arc::new(val);
                     true
                 });
                 val.debug_assert_total_nodes_up_to_date();
@@ -337,7 +340,7 @@ where
             Step::LeaveLate(mut val) => {
                 val.for_each_late_children_mut(&mut |child| {
                     let val = done.pop().unwrap();
-                    *child = val;
+                    *child = Arc::new(val);
                     true
                 });
                 val.debug_assert_total_nodes_up_to_date();

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -638,10 +638,13 @@ impl MemberCallList {
     fn for_each_children(&self, visitor: &mut impl FnMut(&JsValue)) {
         self.0.iter().for_each(|child| visitor(child))
     }
-    fn for_each_children_mut(&mut self, visitor: &mut impl FnMut(&mut JsValue) -> bool) -> bool {
+    fn for_each_children_mut(
+        &mut self,
+        visitor: &mut impl FnMut(&mut Arc<JsValue>) -> bool,
+    ) -> bool {
         let mut modified = false;
         for child in self.0.iter_mut() {
-            if visitor(Arc::make_mut(child)) {
+            if visitor(child) {
                 modified = true;
             }
         }
@@ -760,10 +763,13 @@ impl CallList {
     fn for_each_children(&self, visitor: &mut impl FnMut(&JsValue)) {
         self.0.iter().for_each(|child| visitor(child))
     }
-    fn for_each_children_mut(&mut self, visitor: &mut impl FnMut(&mut JsValue) -> bool) -> bool {
+    fn for_each_children_mut(
+        &mut self,
+        visitor: &mut impl FnMut(&mut Arc<JsValue>) -> bool,
+    ) -> bool {
         let mut modified = false;
         for child in self.0.iter_mut() {
-            if visitor(Arc::make_mut(child)) {
+            if visitor(child) {
                 modified = true;
             }
         }
@@ -1147,6 +1153,20 @@ fn pretty_join(
 
 fn total_nodes(vec: &[Arc<JsValue>]) -> u32 {
     vec.iter().map(|v| v.total_nodes()).sum::<u32>()
+}
+
+/// Replace the slot with a shared placeholder and return the original `Arc<JsValue>`.
+///
+/// Use this in place of `mem::take` (or `mem::replace(slot, Arc::default())`) on
+/// `&mut Arc<JsValue>` slots that you are about to overwrite. The placeholder is a
+/// single shared `Arc` (cloning it is just an atomic refcount bump), so the take is
+/// allocation-free.
+///
+/// The slot must be overwritten before any code reads it, since the placeholder
+/// carries no useful information.
+pub fn take_arc_slot(slot: &mut Arc<JsValue>) -> Arc<JsValue> {
+    static PLACEHOLDER: LazyLock<Arc<JsValue>> = LazyLock::new(|| Arc::new(JsValue::default()));
+    std::mem::replace(slot, PLACEHOLDER.clone())
 }
 
 // Private meta methods
@@ -2300,12 +2320,21 @@ impl JsValue {
 
     /// Make all nested operations unknown when the value is an operation.
     pub fn make_nested_operations_unknown(&mut self) -> bool {
-        fn inner(this: &mut JsValue) -> bool {
+        fn inner(this: &mut Arc<JsValue>) -> bool {
             if matches!(this.meta_type(), JsValueMetaKind::Operation) {
-                this.make_unknown(false, rcstr!("nested operation"));
+                let original = take_arc_slot(this);
+                // Match the existing `make_unknown` behavior: side_effects is `false`
+                // here. (`make_unknown` reads `self.has_side_effects()` after `take(self)`
+                // has reset `self` to a default `Unknown` with `has_side_effects=false`,
+                // so that branch was always `false || false` in practice.)
+                *this = Arc::new(JsValue::unknown(
+                    original,
+                    false,
+                    rcstr!("nested operation"),
+                ));
                 true
             } else {
-                this.for_each_children_mut(&mut inner)
+                Arc::make_mut(this).for_each_children_mut(&mut inner)
             }
         }
         if matches!(self.meta_type(), JsValueMetaKind::Operation) {
@@ -2890,23 +2919,12 @@ fn shortcircuit_if_known<T: Copy>(
 
 // Visiting
 impl JsValue {
-    /// Calls a function for each child of the node. Allows mutating the node.
-    /// Updates the total nodes count after mutation.
+    /// Calls a function for each child of the node. Allows mutating the node by
+    /// replacing the child `Arc` slot. Updates the total nodes count after mutation.
     pub fn for_each_children_mut(
         &mut self,
-        visitor: &mut impl FnMut(&mut JsValue) -> bool,
+        visitor: &mut impl FnMut(&mut Arc<JsValue>) -> bool,
     ) -> bool {
-        // Helper: visit an `Arc<JsValue>` slot. The `&mut JsValue` visitor signature
-        // forces an `Arc::make_mut` here — clone-on-write happens inside `make_mut`, so
-        // shared `Arc`s are deep-cloned even if the visitor never mutates. Callers that
-        // only need read access should use `for_each_children` instead.
-        fn visit_arc(
-            slot: &mut Arc<JsValue>,
-            visitor: &mut impl FnMut(&mut JsValue) -> bool,
-        ) -> bool {
-            visitor(Arc::make_mut(slot))
-        }
-
         match self {
             JsValue::Alternatives {
                 total_nodes: _,
@@ -2919,7 +2937,7 @@ impl JsValue {
             | JsValue::Array { items: list, .. } => {
                 let mut modified = false;
                 for item in list.iter_mut() {
-                    if visit_arc(item, visitor) {
+                    if visitor(item) {
                         modified = true
                     }
                 }
@@ -2929,7 +2947,7 @@ impl JsValue {
                 modified
             }
             JsValue::Not(_, value) => {
-                let modified = visit_arc(value, visitor);
+                let modified = visitor(value);
                 if modified {
                     self.update_total_nodes();
                 }
@@ -2940,15 +2958,15 @@ impl JsValue {
                 for item in parts.iter_mut() {
                     match item {
                         ObjectPart::KeyValue(key, value) => {
-                            if visit_arc(key, visitor) {
+                            if visitor(key) {
                                 modified = true
                             }
-                            if visit_arc(value, visitor) {
+                            if visitor(value) {
                                 modified = true
                             }
                         }
                         ObjectPart::Spread(value) => {
-                            if visit_arc(value, visitor) {
+                            if visitor(value) {
                                 modified = true
                             }
                         }
@@ -2976,7 +2994,7 @@ impl JsValue {
             JsValue::SuperCall(_, args) => {
                 let mut modified = false;
                 for item in args.iter_mut() {
-                    if visit_arc(item, visitor) {
+                    if visitor(item) {
                         modified = true
                     }
                 }
@@ -2994,7 +3012,7 @@ impl JsValue {
                 modified
             }
             JsValue::Function(_, _, return_value) => {
-                let modified = visit_arc(return_value, visitor);
+                let modified = visitor(return_value);
 
                 if modified {
                     self.update_total_nodes();
@@ -3002,8 +3020,8 @@ impl JsValue {
                 modified
             }
             JsValue::Binary(_, a, _, b) => {
-                let m1 = visit_arc(a, visitor);
-                let m2 = visit_arc(b, visitor);
+                let m1 = visitor(a);
+                let m2 = visitor(b);
                 let modified = m1 || m2;
                 if modified {
                     self.update_total_nodes();
@@ -3011,9 +3029,9 @@ impl JsValue {
                 modified
             }
             JsValue::Tenary(_, test, cons, alt) => {
-                let m1 = visit_arc(test, visitor);
-                let m2 = visit_arc(cons, visitor);
-                let m3 = visit_arc(alt, visitor);
+                let m1 = visitor(test);
+                let m2 = visitor(cons);
+                let m3 = visitor(alt);
                 let modified = m1 || m2 || m3;
                 if modified {
                     self.update_total_nodes();
@@ -3021,8 +3039,8 @@ impl JsValue {
                 modified
             }
             JsValue::Member(_, obj, prop) => {
-                let m1 = visit_arc(obj, visitor);
-                let m2 = visit_arc(prop, visitor);
+                let m1 = visitor(obj);
+                let m2 = visitor(prop);
                 let modified = m1 || m2;
                 if modified {
                     self.update_total_nodes();
@@ -3034,7 +3052,7 @@ impl JsValue {
             | JsValue::TypeOf(_, operand)
             | JsValue::Promise(_, operand)
             | JsValue::Awaited(_, operand) => {
-                let modified = visit_arc(operand, visitor);
+                let modified = visitor(operand);
                 if modified {
                     self.update_total_nodes();
                 }
@@ -3054,29 +3072,30 @@ impl JsValue {
     }
 
     /// Calls a function for only early children. Allows mutating the
-    /// node. Updates the total nodes count after mutation.
+    /// node by replacing the child `Arc` slot. Updates the total nodes count after mutation.
     pub fn for_each_early_children_mut(
         &mut self,
-        visitor: &mut impl FnMut(&mut JsValue) -> bool,
+        visitor: &mut impl FnMut(&mut Arc<JsValue>) -> bool,
     ) -> bool {
         match self {
             JsValue::New(_, call) if !call.args().is_empty() => {
-                let m = visitor(call.callee_mut());
+                let m = visitor(call.callee_arc_mut());
                 if m {
                     self.update_total_nodes();
                 }
                 m
             }
             JsValue::Call(_, call) if !call.args().is_empty() => {
-                let m = visitor(call.callee_mut());
+                let m = visitor(call.callee_arc_mut());
                 if m {
                     self.update_total_nodes();
                 }
                 m
             }
             JsValue::MemberCall(_, call) if !call.args().is_empty() => {
-                let m1 = visitor(call.prop_mut());
-                let m2 = visitor(call.obj_mut());
+                let (_, prop_slot, obj_slot) = call.as_parts_mut();
+                let m1 = visitor(prop_slot);
+                let m2 = visitor(obj_slot);
                 let modified = m1 || m2;
                 if modified {
                     self.update_total_nodes();
@@ -3084,7 +3103,7 @@ impl JsValue {
                 modified
             }
             JsValue::Member(_, obj, _) => {
-                let m = visitor(Arc::make_mut(obj));
+                let m = visitor(obj);
                 if m {
                     self.update_total_nodes();
                 }
@@ -3095,16 +3114,16 @@ impl JsValue {
     }
 
     /// Calls a function for only late children. Allows mutating the
-    /// node. Updates the total nodes count after mutation.
+    /// node by replacing the child `Arc` slot. Updates the total nodes count after mutation.
     pub fn for_each_late_children_mut(
         &mut self,
-        visitor: &mut impl FnMut(&mut JsValue) -> bool,
+        visitor: &mut impl FnMut(&mut Arc<JsValue>) -> bool,
     ) -> bool {
         match self {
             JsValue::New(_, call) if !call.args().is_empty() => {
                 let mut modified = false;
                 for item in call.args_mut().iter_mut() {
-                    if visitor(Arc::make_mut(item)) {
+                    if visitor(item) {
                         modified = true
                     }
                 }
@@ -3116,7 +3135,7 @@ impl JsValue {
             JsValue::Call(_, call) if !call.args().is_empty() => {
                 let mut modified = false;
                 for item in call.args_mut().iter_mut() {
-                    if visitor(Arc::make_mut(item)) {
+                    if visitor(item) {
                         modified = true
                     }
                 }
@@ -3128,7 +3147,7 @@ impl JsValue {
             JsValue::MemberCall(_, call) if !call.args().is_empty() => {
                 let mut modified = false;
                 for item in call.args_mut().iter_mut() {
-                    if visitor(Arc::make_mut(item)) {
+                    if visitor(item) {
                         modified = true
                     }
                 }
@@ -3138,7 +3157,7 @@ impl JsValue {
                 modified
             }
             JsValue::Member(_, _, prop) => {
-                let m = visitor(Arc::make_mut(prop));
+                let m = visitor(prop);
                 if m {
                     self.update_total_nodes();
                 }
@@ -3439,7 +3458,7 @@ impl JsValue {
     /// Normalizes the current node and all nested nodes.
     pub fn normalize(&mut self) {
         self.for_each_children_mut(&mut |child| {
-            child.normalize();
+            Arc::make_mut(child).normalize();
             true
         });
         self.normalize_shallow();

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -383,8 +383,6 @@ impl Display for LogicalProperty {
     }
 }
 
-/// TODO: Use `Arc`
-///
 /// There are 4 kinds of values: Leaves, Nested, Operations, and Placeholders
 /// (see `JsValueMetaKind` for details). Values are processed in two phases:
 /// - Analyze phase: We convert AST into `JsValue`s. We don't have contextual information so we need
@@ -546,24 +544,24 @@ impl fmt::Debug for MemberCallList {
 }
 
 impl MemberCallList {
-    fn from_parts(obj: JsValue, prop: JsValue, args: Vec<JsValue>) -> Self {
+    fn from_parts(obj: JsValue, prop: JsValue, args: Vec<Arc<JsValue>>) -> Self {
         let mut list = args;
         list.reserve_exact(2);
-        list.push(prop);
-        list.push(obj);
+        list.push(Arc::new(prop));
+        list.push(Arc::new(obj));
         Self(list)
     }
 
     fn from_iter<I>(obj: JsValue, prop: JsValue, args: I) -> Self
     where
-        I: IntoIterator<Item = JsValue>,
+        I: IntoIterator<Item = Arc<JsValue>>,
         I::IntoIter: ExactSizeIterator,
     {
         let args = args.into_iter();
         let mut list = Vec::with_capacity(args.len() + 2);
         list.extend(args);
-        list.push(prop);
-        list.push(obj);
+        list.push(Arc::new(prop));
+        list.push(Arc::new(obj));
         Self(list)
     }
 
@@ -638,12 +636,12 @@ impl MemberCallList {
     }
 
     fn for_each_children(&self, visitor: &mut impl FnMut(&JsValue)) {
-        self.0.iter().for_each(visitor)
+        self.0.iter().for_each(|child| visitor(child))
     }
     fn for_each_children_mut(&mut self, visitor: &mut impl FnMut(&mut JsValue) -> bool) -> bool {
         let mut modified = false;
         for child in self.0.iter_mut() {
-            if visitor(child) {
+            if visitor(Arc::make_mut(child)) {
                 modified = true;
             }
         }
@@ -687,22 +685,22 @@ impl fmt::Debug for CallList {
 }
 
 impl CallList {
-    fn from_parts(callee: JsValue, args: Vec<JsValue>) -> Self {
+    fn from_parts(callee: JsValue, args: Vec<Arc<JsValue>>) -> Self {
         let mut list = args;
         list.reserve_exact(1);
-        list.push(callee);
+        list.push(Arc::new(callee));
         Self(list)
     }
 
     fn from_iter<I>(callee: JsValue, args: I) -> Self
     where
-        I: IntoIterator<Item = JsValue>,
+        I: IntoIterator<Item = Arc<JsValue>>,
         I::IntoIter: ExactSizeIterator,
     {
         let args = args.into_iter();
         let mut list = Vec::with_capacity(args.len() + 1);
         list.extend(args);
-        list.push(callee);
+        list.push(Arc::new(callee));
         Self(list)
     }
 
@@ -760,12 +758,12 @@ impl CallList {
     }
 
     fn for_each_children(&self, visitor: &mut impl FnMut(&JsValue)) {
-        self.0.iter().for_each(visitor)
+        self.0.iter().for_each(|child| visitor(child))
     }
     fn for_each_children_mut(&mut self, visitor: &mut impl FnMut(&mut JsValue) -> bool) -> bool {
         let mut modified = false;
         for child in self.0.iter_mut() {
-            if visitor(child) {
+            if visitor(Arc::make_mut(child)) {
                 modified = true;
             }
         }
@@ -1189,22 +1187,11 @@ impl JsValue {
 
 // Constructors
 //
-// Each list-shaped constructor has two flavors: the owned-`JsValue` form (e.g. `concat`)
-// for callers that build values from scratch, and an `_arc` variant (e.g. `concat_arc`) for
-// callers that already have `Arc<JsValue>` elements and want to avoid the per-element
-// re-wrap. Single-child constructors (`logical_not`, `tenary`, …) likewise take owned
-// `JsValue`s and wrap internally. Use the `_arc` variants in hot paths that thread
-// `Arc<JsValue>`s through.
+// All constructors that store children take `Arc<JsValue>` (or `Vec<Arc<JsValue>>`)
+// directly so that every heap allocation is visible at the call site. Callers building
+// from owned `JsValue` should wrap each child explicitly via `Arc::new(...)`.
 impl JsValue {
-    fn into_arc_vec(list: Vec<JsValue>) -> Vec<Arc<JsValue>> {
-        list.into_iter().map(Arc::new).collect()
-    }
-
-    pub fn alternatives(list: Vec<JsValue>) -> Self {
-        Self::alternatives_arc(Self::into_arc_vec(list))
-    }
-
-    pub fn alternatives_arc(list: Vec<Arc<JsValue>>) -> Self {
+    pub fn alternatives(list: Vec<Arc<JsValue>>) -> Self {
         Self::Alternatives {
             total_nodes: 1 + total_nodes(&list),
             values: list,
@@ -1213,13 +1200,6 @@ impl JsValue {
     }
 
     pub fn alternatives_with_additional_property(
-        list: Vec<JsValue>,
-        logical_property: LogicalProperty,
-    ) -> Self {
-        Self::alternatives_with_additional_property_arc(Self::into_arc_vec(list), logical_property)
-    }
-
-    pub fn alternatives_with_additional_property_arc(
         list: Vec<Arc<JsValue>>,
         logical_property: LogicalProperty,
     ) -> Self {
@@ -1230,34 +1210,23 @@ impl JsValue {
         }
     }
 
-    pub fn concat(list: Vec<JsValue>) -> Self {
-        Self::concat_arc(Self::into_arc_vec(list))
-    }
-
-    pub fn concat_arc(list: Vec<Arc<JsValue>>) -> Self {
+    pub fn concat(list: Vec<Arc<JsValue>>) -> Self {
         Self::Concat(1 + total_nodes(&list), list)
     }
 
-    pub fn add(list: Vec<JsValue>) -> Self {
-        Self::add_arc(Self::into_arc_vec(list))
-    }
-
-    pub fn add_arc(list: Vec<Arc<JsValue>>) -> Self {
+    pub fn add(list: Vec<Arc<JsValue>>) -> Self {
         Self::Add(1 + total_nodes(&list), list)
     }
 
-    pub fn logical_and(list: Vec<JsValue>) -> Self {
-        let list = Self::into_arc_vec(list);
+    pub fn logical_and(list: Vec<Arc<JsValue>>) -> Self {
         Self::Logical(1 + total_nodes(&list), LogicalOperator::And, list)
     }
 
-    pub fn logical_or(list: Vec<JsValue>) -> Self {
-        let list = Self::into_arc_vec(list);
+    pub fn logical_or(list: Vec<Arc<JsValue>>) -> Self {
         Self::Logical(1 + total_nodes(&list), LogicalOperator::Or, list)
     }
 
-    pub fn nullish_coalescing(list: Vec<JsValue>) -> Self {
-        let list = Self::into_arc_vec(list);
+    pub fn nullish_coalescing(list: Vec<Arc<JsValue>>) -> Self {
         Self::Logical(
             1 + total_nodes(&list),
             LogicalOperator::NullishCoalescing,
@@ -1265,65 +1234,64 @@ impl JsValue {
         )
     }
 
-    pub fn tenary(test: JsValue, cons: JsValue, alt: JsValue) -> Self {
+    pub fn tenary(test: Arc<JsValue>, cons: Arc<JsValue>, alt: Arc<JsValue>) -> Self {
         Self::Tenary(
             1 + test.total_nodes() + cons.total_nodes() + alt.total_nodes(),
-            Arc::new(test),
-            Arc::new(cons),
-            Arc::new(alt),
+            test,
+            cons,
+            alt,
         )
     }
 
-    pub fn iterated(iterable: JsValue) -> Self {
-        Self::Iterated(1 + iterable.total_nodes(), Arc::new(iterable))
+    pub fn iterated(iterable: Arc<JsValue>) -> Self {
+        Self::Iterated(1 + iterable.total_nodes(), iterable)
     }
 
-    pub fn equal(a: JsValue, b: JsValue) -> Self {
+    pub fn equal(a: Arc<JsValue>, b: Arc<JsValue>) -> Self {
         Self::Binary(
             1 + a.total_nodes() + b.total_nodes(),
-            Arc::new(a),
+            a,
             BinaryOperator::Equal,
-            Arc::new(b),
+            b,
         )
     }
 
-    pub fn not_equal(a: JsValue, b: JsValue) -> Self {
+    pub fn not_equal(a: Arc<JsValue>, b: Arc<JsValue>) -> Self {
         Self::Binary(
             1 + a.total_nodes() + b.total_nodes(),
-            Arc::new(a),
+            a,
             BinaryOperator::NotEqual,
-            Arc::new(b),
+            b,
         )
     }
 
-    pub fn strict_equal(a: JsValue, b: JsValue) -> Self {
+    pub fn strict_equal(a: Arc<JsValue>, b: Arc<JsValue>) -> Self {
         Self::Binary(
             1 + a.total_nodes() + b.total_nodes(),
-            Arc::new(a),
+            a,
             BinaryOperator::StrictEqual,
-            Arc::new(b),
+            b,
         )
     }
 
-    pub fn strict_not_equal(a: JsValue, b: JsValue) -> Self {
+    pub fn strict_not_equal(a: Arc<JsValue>, b: Arc<JsValue>) -> Self {
         Self::Binary(
             1 + a.total_nodes() + b.total_nodes(),
-            Arc::new(a),
+            a,
             BinaryOperator::StrictNotEqual,
-            Arc::new(b),
+            b,
         )
     }
 
-    pub fn logical_not(inner: JsValue) -> Self {
-        Self::Not(1 + inner.total_nodes(), Arc::new(inner))
+    pub fn logical_not(inner: Arc<JsValue>) -> Self {
+        Self::Not(1 + inner.total_nodes(), inner)
     }
 
-    pub fn type_of(operand: JsValue) -> Self {
-        Self::TypeOf(1 + operand.total_nodes(), Arc::new(operand))
+    pub fn type_of(operand: Arc<JsValue>) -> Self {
+        Self::TypeOf(1 + operand.total_nodes(), operand)
     }
 
-    pub fn array(items: Vec<JsValue>) -> Self {
-        let items = Self::into_arc_vec(items);
+    pub fn array(items: Vec<Arc<JsValue>>) -> Self {
         Self::Array {
             total_nodes: 1 + total_nodes(&items),
             items,
@@ -1331,8 +1299,7 @@ impl JsValue {
         }
     }
 
-    pub fn frozen_array(items: Vec<JsValue>) -> Self {
-        let items = Self::into_arc_vec(items);
+    pub fn frozen_array(items: Vec<Arc<JsValue>>) -> Self {
         Self::Array {
             total_nodes: 1 + total_nodes(&items),
             items,
@@ -1344,21 +1311,17 @@ impl JsValue {
         func_ident: u32,
         is_async: bool,
         is_generator: bool,
-        return_value: JsValue,
+        return_value: Arc<JsValue>,
     ) -> Self {
         // Check generator first to handle async generators
         let return_value = if is_generator {
-            JsValue::WellKnownObject(WellKnownObjectKind::Generator)
+            Arc::new(JsValue::WellKnownObject(WellKnownObjectKind::Generator))
         } else if is_async {
-            JsValue::promise(return_value)
+            Arc::new(JsValue::promise(return_value))
         } else {
             return_value
         };
-        Self::Function(
-            1 + return_value.total_nodes(),
-            func_ident,
-            Arc::new(return_value),
-        )
+        Self::Function(1 + return_value.total_nodes(), func_ident, return_value)
     }
 
     pub fn object(list: Vec<ObjectPart>) -> Self {
@@ -1397,7 +1360,7 @@ impl JsValue {
     /// slot (e.g. an `args` Vec returned from [`CallList::into_parts`] or
     /// [`MemberCallList::into_parts`]). For from-scratch construction use
     /// [`JsValue::new_from_iter`], which pre-sizes the underlying allocation exactly.
-    pub fn new_from_parts(f: JsValue, args: Vec<JsValue>) -> Self {
+    pub fn new_from_parts(f: JsValue, args: Vec<Arc<JsValue>>) -> Self {
         let total = 1 + f.total_nodes() + total_nodes(&args);
         Self::New(total, CallList::from_parts(f, args))
     }
@@ -1408,7 +1371,7 @@ impl JsValue {
     /// occurs.
     pub fn new_from_iter<I>(f: JsValue, args: I) -> Self
     where
-        I: IntoIterator<Item = JsValue>,
+        I: IntoIterator<Item = Arc<JsValue>>,
         I::IntoIter: ExactSizeIterator,
     {
         let list = CallList::from_iter(f, args);
@@ -1422,7 +1385,7 @@ impl JsValue {
     /// caller already has a `Vec` that is likely to be correctly sized (typically one
     /// obtained from [`CallList::into_parts`] / [`MemberCallList::into_parts`]). For
     /// from-scratch construction use [`JsValue::call_from_iter`].
-    pub fn call_from_parts(f: JsValue, args: Vec<JsValue>) -> Self {
+    pub fn call_from_parts(f: JsValue, args: Vec<Arc<JsValue>>) -> Self {
         let total = 1 + f.total_nodes() + total_nodes(&args);
         Self::Call(total, CallList::from_parts(f, args))
     }
@@ -1433,7 +1396,7 @@ impl JsValue {
     /// occurs.
     pub fn call_from_iter<I>(f: JsValue, args: I) -> Self
     where
-        I: IntoIterator<Item = JsValue>,
+        I: IntoIterator<Item = Arc<JsValue>>,
         I::IntoIter: ExactSizeIterator,
     {
         let list = CallList::from_iter(f, args);
@@ -1441,12 +1404,7 @@ impl JsValue {
         Self::Call(total, list)
     }
 
-    pub fn super_call(args: Vec<JsValue>) -> Self {
-        let args = Self::into_arc_vec(args);
-        Self::SuperCall(1 + total_nodes(&args), args)
-    }
-
-    pub fn super_call_arc(args: Vec<Arc<JsValue>>) -> Self {
+    pub fn super_call(args: Vec<Arc<JsValue>>) -> Self {
         Self::SuperCall(1 + total_nodes(&args), args)
     }
 
@@ -1456,7 +1414,7 @@ impl JsValue {
     /// caller already has a `Vec` that is likely to be correctly sized (typically one
     /// obtained from [`MemberCallList::into_parts`]). For from-scratch construction use
     /// [`JsValue::member_call_from_iter`].
-    pub fn member_call_from_parts(o: JsValue, p: JsValue, args: Vec<JsValue>) -> Self {
+    pub fn member_call_from_parts(o: JsValue, p: JsValue, args: Vec<Arc<JsValue>>) -> Self {
         let total = 1 + o.total_nodes() + p.total_nodes() + total_nodes(&args);
         Self::MemberCall(total, MemberCallList::from_parts(o, p, args))
     }
@@ -1468,7 +1426,7 @@ impl JsValue {
     /// occurs.
     pub fn member_call_from_iter<I>(o: JsValue, p: JsValue, args: I) -> Self
     where
-        I: IntoIterator<Item = JsValue>,
+        I: IntoIterator<Item = Arc<JsValue>>,
         I::IntoIter: ExactSizeIterator,
     {
         let list = MemberCallList::from_iter(o, p, args);
@@ -1476,24 +1434,20 @@ impl JsValue {
         Self::MemberCall(total, list)
     }
 
-    pub fn member(o: JsValue, p: JsValue) -> Self {
-        Self::member_arc(Arc::new(o), Arc::new(p))
-    }
-
-    pub fn member_arc(o: Arc<JsValue>, p: Arc<JsValue>) -> Self {
+    pub fn member(o: Arc<JsValue>, p: Arc<JsValue>) -> Self {
         Self::Member(1 + o.total_nodes() + p.total_nodes(), o, p)
     }
 
-    pub fn promise(operand: JsValue) -> Self {
+    pub fn promise(operand: Arc<JsValue>) -> Self {
         // In ecmascript Promise<Promise<T>> is equivalent to Promise<T>
-        if let JsValue::Promise(_, _) = operand {
-            return operand;
+        if matches!(&*operand, JsValue::Promise(_, _)) {
+            return Arc::unwrap_or_clone(operand);
         }
-        Self::Promise(1 + operand.total_nodes(), Arc::new(operand))
+        Self::Promise(1 + operand.total_nodes(), operand)
     }
 
-    pub fn awaited(operand: JsValue) -> Self {
-        Self::Awaited(1 + operand.total_nodes(), Arc::new(operand))
+    pub fn awaited(operand: Arc<JsValue>) -> Self {
+        Self::Awaited(1 + operand.total_nodes(), operand)
     }
 
     pub fn unknown(value: impl Into<Arc<JsValue>>, side_effects: bool, reason: RcStr) -> Self {
@@ -2942,9 +2896,10 @@ impl JsValue {
         &mut self,
         visitor: &mut impl FnMut(&mut JsValue) -> bool,
     ) -> bool {
-        // Helper: visit an `Arc<JsValue>` slot, calling `Arc::make_mut` only if the
-        // visitor actually modifies the value. The clone-on-write happens inside
-        // `make_mut`; siblings that aren't mutated keep their shared `Arc`.
+        // Helper: visit an `Arc<JsValue>` slot. The `&mut JsValue` visitor signature
+        // forces an `Arc::make_mut` here — clone-on-write happens inside `make_mut`, so
+        // shared `Arc`s are deep-cloned even if the visitor never mutates. Callers that
+        // only need read access should use `for_each_children` instead.
         fn visit_arc(
             slot: &mut Arc<JsValue>,
             visitor: &mut impl FnMut(&mut JsValue) -> bool,
@@ -3494,7 +3449,7 @@ impl JsValue {
 // Similarity
 // Like equality, but with depth limit
 impl JsValue {
-    fn all_similar(a: &[JsValue], b: &[JsValue], depth: usize) -> bool {
+    fn all_similar(a: &[Arc<JsValue>], b: &[Arc<JsValue>], depth: usize) -> bool {
         if a.len() != b.len() {
             return false;
         }
@@ -3975,6 +3930,7 @@ fn is_unresolved_id(i: &Id, unresolved_mark: Mark) -> bool {
 #[doc(hidden)]
 pub mod test_utils {
     use anyhow::Result;
+    use triomphe::Arc;
     use turbo_rcstr::rcstr;
     use turbo_tasks::{FxIndexMap, PrettyPrintError, Vc};
     use turbopack_core::compile_time_info::CompileTimeInfo;
@@ -4013,10 +3969,10 @@ pub mod test_utils {
             {
                 match &*call.args()[0] {
                     JsValue::Constant(ConstantValue::Str(v)) => {
-                        JsValue::promise(JsValue::Module(ModuleValue {
+                        JsValue::promise(Arc::new(JsValue::Module(ModuleValue {
                             module: v.as_atom().into_owned().into(),
                             annotations: None,
-                        }))
+                        })))
                     }
                     _ => v.into_unknown(true, rcstr!("import() non constant")),
                 }
@@ -4173,6 +4129,7 @@ mod tests {
         },
         testing::{NormalizedOutput, fixture, run_test},
     };
+    use triomphe::Arc;
     use turbo_rcstr::rcstr;
     use turbo_tasks::{ResolvedVc, util::FormatDuration};
     use turbopack_core::{
@@ -4377,12 +4334,12 @@ mod tests {
                             var_graph: &VarGraph,
                             var_cache: &Mutex<FxHashMap<Id, JsValue>>,
                             i: usize,
-                        ) -> Vec<JsValue> {
+                        ) -> Vec<Arc<JsValue>> {
                             let mut new_args = Vec::with_capacity(args.len());
                             for arg in args {
                                 match arg {
                                     EffectArg::Value(v) => {
-                                        new_args.push(
+                                        new_args.push(Arc::new(
                                             resolve(
                                                 var_graph,
                                                 v,
@@ -4391,10 +4348,10 @@ mod tests {
                                             )
                                             .await
                                             .0,
-                                        );
+                                        ));
                                     }
                                     EffectArg::Closure(v, effects) => {
-                                        new_args.push(
+                                        new_args.push(Arc::new(
                                             resolve(
                                                 var_graph,
                                                 v,
@@ -4403,14 +4360,16 @@ mod tests {
                                             )
                                             .await
                                             .0,
-                                        );
+                                        ));
                                         queue.extend(
                                             effects.effects.into_iter().rev().map(|e| (i, e)),
                                         );
                                     }
                                     EffectArg::Spread => {
-                                        new_args
-                                            .push(JsValue::unknown_empty(true, rcstr!("spread")));
+                                        new_args.push(Arc::new(JsValue::unknown_empty(
+                                            true,
+                                            rcstr!("spread"),
+                                        )));
                                     }
                                 }
                             }
@@ -4511,7 +4470,7 @@ mod tests {
                                 .await;
                                 resolved.push((
                                     format!("{parent} -> {i} typeof"),
-                                    JsValue::type_of(arg),
+                                    JsValue::type_of(Arc::new(arg)),
                                 ));
                                 steps
                             }

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -48,8 +48,8 @@ pub mod well_known;
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub enum ObjectPart {
-    KeyValue(JsValue, JsValue),
-    Spread(JsValue),
+    KeyValue(Arc<JsValue>, Arc<JsValue>),
+    Spread(Arc<JsValue>),
 }
 
 impl Default for ObjectPart {
@@ -422,7 +422,7 @@ pub enum JsValue {
     /// An array of nested values
     Array {
         total_nodes: u32,
-        items: Vec<JsValue>,
+        items: Vec<Arc<JsValue>>,
         mutable: bool,
     },
     /// An object of nested values
@@ -434,60 +434,60 @@ pub enum JsValue {
     /// A list of alternative values
     Alternatives {
         total_nodes: u32,
-        values: Vec<JsValue>,
+        values: Vec<Arc<JsValue>>,
         logical_property: Option<LogicalProperty>,
     },
     /// A function reference. The return value might contain [JsValue::Argument]
     /// placeholders that need to be replaced when calling this function.
     /// `(total_node_count, func_ident, return_value)`
-    Function(u32, u32, Box<JsValue>),
+    Function(u32, u32, Arc<JsValue>),
 
     // OPERATIONS
     // ----------------------------
     /// A string concatenation of values.
     /// `foo.${unknownVar}.js` => 'foo' + Unknown + '.js'
-    Concat(u32, Vec<JsValue>),
+    Concat(u32, Vec<Arc<JsValue>>),
     /// An addition of values.
     /// This can be converted to [JsValue::Concat] if the type of the variable
     /// is string.
-    Add(u32, Vec<JsValue>),
+    Add(u32, Vec<Arc<JsValue>>),
     /// Logical negation `!expr`
-    Not(u32, Box<JsValue>),
+    Not(u32, Arc<JsValue>),
     /// Logical operator chain e. g. `expr && expr`
-    Logical(u32, LogicalOperator, Vec<JsValue>),
+    Logical(u32, LogicalOperator, Vec<Arc<JsValue>>),
     /// Binary expression e. g. `expr == expr`
-    Binary(u32, Box<JsValue>, BinaryOperator, Box<JsValue>),
+    Binary(u32, Arc<JsValue>, BinaryOperator, Arc<JsValue>),
     /// A constructor call. `(total_node_count, list)` — see [`CallList`].
     New(u32, CallList),
     /// A function call without a `this` context. `(total_node_count, list)` — see [`CallList`].
     Call(u32, CallList),
     /// A super call to the parent constructor.
     /// `(total_node_count, args)`
-    SuperCall(u32, Vec<JsValue>),
+    SuperCall(u32, Vec<Arc<JsValue>>),
     /// A function call with a `this` context. `(total_node_count, list)` — see [`MemberCallList`].
     MemberCall(u32, MemberCallList),
     /// A member access `obj[prop]`
     /// `(total_node_count, obj, prop)`
-    Member(u32, Box<JsValue>, Box<JsValue>),
+    Member(u32, Arc<JsValue>, Arc<JsValue>),
     /// A tenary operator `test ? cons : alt`
     /// `(total_node_count, test, cons, alt)`
-    Tenary(u32, Box<JsValue>, Box<JsValue>, Box<JsValue>),
+    Tenary(u32, Arc<JsValue>, Arc<JsValue>, Arc<JsValue>),
     /// A promise resolving to some value
     /// `(total_node_count, value)`
-    Promise(u32, Box<JsValue>),
+    Promise(u32, Arc<JsValue>),
     /// An await call (potentially) unwrapping a promise.
     /// `(total_node_count, value)`
-    Awaited(u32, Box<JsValue>),
+    Awaited(u32, Arc<JsValue>),
 
     /// A for-of loop
     ///
     /// `(total_node_count, iterable)`
-    Iterated(u32, Box<JsValue>),
+    Iterated(u32, Arc<JsValue>),
 
     /// A `typeof` expression.
     ///
     /// `(total_node_count, operand)`
-    TypeOf(u32, Box<JsValue>),
+    TypeOf(u32, Arc<JsValue>),
 
     // PLACEHOLDERS
     // ----------------------------
@@ -514,7 +514,7 @@ pub enum JsValue {
 /// parent's `debug_tuple`. This keeps fixture snapshots identical to the 4-tuple-payload
 /// version without forcing a hand-written `Debug` on every `JsValue` arm.
 #[derive(Default, Clone, Hash, PartialEq, Eq)]
-pub struct MemberCallList(Vec<JsValue>);
+pub struct MemberCallList(Vec<Arc<JsValue>>);
 
 impl fmt::Debug for MemberCallList {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -527,12 +527,14 @@ impl fmt::Debug for MemberCallList {
             // The parent `debug_tuple` writes the field's leading indent for us (via
             // PadAdapter) and appends `,\n` after we return. Emitting
             // `<obj>,\n<prop>,\n<args>` with no trailing comma makes us appear as three
-            // sibling fields in the parent's pretty-print output.
-            writeln!(f, "{obj:#?},")?;
-            writeln!(f, "{prop:#?},")?;
-            write!(f, "{args:#?}")
+            // sibling fields in the parent's pretty-print output. Strip the `Arc`
+            // wrapper from each emitted child so snapshots match the pre-Arc shape.
+            writeln!(f, "{:#?},", &**obj)?;
+            writeln!(f, "{:#?},", &**prop)?;
+            f.debug_list().entries(args.iter().map(|a| &**a)).finish()
         } else {
-            write!(f, "{obj:?}, {prop:?}, {args:?}")
+            write!(f, "{:?}, {:?}, ", &**obj, &**prop)?;
+            f.debug_list().entries(args.iter().map(|a| &**a)).finish()
         }
     }
 }
@@ -564,7 +566,16 @@ impl MemberCallList {
         &self.0[self.0.len() - 1]
     }
 
+    pub fn obj_arc(&self) -> &Arc<JsValue> {
+        &self.0[self.0.len() - 1]
+    }
+
     pub fn obj_mut(&mut self) -> &mut JsValue {
+        let n = self.0.len();
+        Arc::make_mut(&mut self.0[n - 1])
+    }
+
+    pub fn obj_arc_mut(&mut self) -> &mut Arc<JsValue> {
         let n = self.0.len();
         &mut self.0[n - 1]
     }
@@ -574,25 +585,34 @@ impl MemberCallList {
         &self.0[self.0.len() - 2]
     }
 
+    pub fn prop_arc(&self) -> &Arc<JsValue> {
+        &self.0[self.0.len() - 2]
+    }
+
     pub fn prop_mut(&mut self) -> &mut JsValue {
+        let n = self.0.len();
+        Arc::make_mut(&mut self.0[n - 2])
+    }
+
+    pub fn prop_arc_mut(&mut self) -> &mut Arc<JsValue> {
         let n = self.0.len();
         &mut self.0[n - 2]
     }
 
     /// The call arguments — everything before `prop` and `obj`.
-    pub fn args(&self) -> &[JsValue] {
+    pub fn args(&self) -> &[Arc<JsValue>] {
         let n = self.0.len();
         &self.0[..n - 2]
     }
 
-    pub fn args_mut(&mut self) -> &mut [JsValue] {
+    pub fn args_mut(&mut self) -> &mut [Arc<JsValue>] {
         let n = self.0.len();
         &mut self.0[..n - 2]
     }
 
     /// Borrow `args`, `prop`, and `obj` simultaneously as mutable references. The single
     /// `Vec` storage means callers can't get these via separate accessor calls.
-    pub fn as_parts_mut(&mut self) -> (&mut [JsValue], &mut JsValue, &mut JsValue) {
+    pub fn as_parts_mut(&mut self) -> (&mut [Arc<JsValue>], &mut Arc<JsValue>, &mut Arc<JsValue>) {
         let n = self.0.len();
         let (args, tail) = self.0.split_at_mut(n - 2);
         let (prop_slot, obj_slot) = tail.split_at_mut(1);
@@ -601,7 +621,7 @@ impl MemberCallList {
 
     /// Take everything out. The returned `args` `Vec` reuses the original allocation — no
     /// copy. That's the point of storing obj/prop at the tail.
-    pub fn into_parts(mut self) -> (JsValue, JsValue, Vec<JsValue>) {
+    pub fn into_parts(mut self) -> (Arc<JsValue>, Arc<JsValue>, Vec<Arc<JsValue>>) {
         let obj = self.0.pop().unwrap();
         let prop = self.0.pop().unwrap();
         (obj, prop, self.0)
@@ -639,7 +659,7 @@ impl MemberCallList {
 /// The custom `Debug` impl re-emits the pre-refactor `(callee, [args])` shape so fixture
 /// snapshots remain identical to the 3-tuple-payload version.
 #[derive(Default, Clone, Hash, PartialEq, Eq)]
-pub struct CallList(Vec<JsValue>);
+pub struct CallList(Vec<Arc<JsValue>>);
 
 impl fmt::Debug for CallList {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -649,11 +669,13 @@ impl fmt::Debug for CallList {
         let args = &self.0[..n - 1];
         if f.alternate() {
             // Same trick as MemberCallList: emit two sibling fields inside the parent
-            // `debug_tuple`'s pretty-print output.
-            writeln!(f, "{callee:#?},")?;
-            write!(f, "{args:#?}")
+            // `debug_tuple`'s pretty-print output. Strip the `Arc` wrapper from each
+            // emitted child so snapshots match the pre-Arc shape.
+            writeln!(f, "{:#?},", &**callee)?;
+            f.debug_list().entries(args.iter().map(|a| &**a)).finish()
         } else {
-            write!(f, "{callee:?}, {args:?}")
+            write!(f, "{:?}, ", &**callee)?;
+            f.debug_list().entries(args.iter().map(|a| &**a)).finish()
         }
     }
 }
@@ -683,26 +705,38 @@ impl CallList {
         self.0.last().expect("CallList must always have a callee")
     }
 
+    pub fn callee_arc(&self) -> &Arc<JsValue> {
+        self.0.last().expect("CallList must always have a callee")
+    }
+
     pub fn callee_mut(&mut self) -> &mut JsValue {
+        Arc::make_mut(
+            self.0
+                .last_mut()
+                .expect("CallList must always have a callee"),
+        )
+    }
+
+    pub fn callee_arc_mut(&mut self) -> &mut Arc<JsValue> {
         self.0
             .last_mut()
             .expect("CallList must always have a callee")
     }
 
     /// The call arguments — everything before the callee.
-    pub fn args(&self) -> &[JsValue] {
+    pub fn args(&self) -> &[Arc<JsValue>] {
         let n = self.0.len();
         &self.0[..n - 1]
     }
 
-    pub fn args_mut(&mut self) -> &mut [JsValue] {
+    pub fn args_mut(&mut self) -> &mut [Arc<JsValue>] {
         let n = self.0.len();
         &mut self.0[..n - 1]
     }
 
     /// Borrow `args` and `callee` simultaneously as mutable references. The single `Vec`
     /// storage means callers can't get these via separate accessor calls.
-    pub fn as_parts_mut(&mut self) -> (&mut [JsValue], &mut JsValue) {
+    pub fn as_parts_mut(&mut self) -> (&mut [Arc<JsValue>], &mut Arc<JsValue>) {
         let n = self.0.len();
         let (args, callee_slot) = self.0.split_at_mut(n - 1);
         (args, &mut callee_slot[0])
@@ -710,7 +744,7 @@ impl CallList {
 
     /// Take everything out. The returned `args` `Vec` reuses the original allocation — no
     /// copy. That's the point of storing the callee at the tail.
-    pub fn into_parts(mut self) -> (JsValue, Vec<JsValue>) {
+    pub fn into_parts(mut self) -> (Arc<JsValue>, Vec<Arc<JsValue>>) {
         let callee = self.0.pop().unwrap();
         (callee, self.0)
     }
@@ -809,7 +843,10 @@ impl TryFrom<&CompileTimeDefineValue> for JsValue {
             CompileTimeDefineValue::Array(a) => {
                 let mut js_value = JsValue::Array {
                     total_nodes: a.len() as u32,
-                    items: a.iter().map(|i| i.try_into()).collect::<Result<Vec<_>>>()?,
+                    items: a
+                        .iter()
+                        .map(|i| Ok::<Arc<JsValue>, anyhow::Error>(Arc::new(i.try_into()?)))
+                        .collect::<Result<Vec<_>>>()?,
                     mutable: false,
                 };
                 js_value.update_total_nodes();
@@ -822,8 +859,8 @@ impl TryFrom<&CompileTimeDefineValue> for JsValue {
                         .iter()
                         .map(|(k, v)| {
                             Ok::<ObjectPart, anyhow::Error>(ObjectPart::KeyValue(
-                                k.clone().into(),
-                                v.try_into()?,
+                                Arc::new(k.clone().into()),
+                                Arc::new(v.try_into()?),
                             ))
                         })
                         .collect::<Result<Vec<_>>>()?,
@@ -1104,7 +1141,7 @@ fn pretty_join(
     }
 }
 
-fn total_nodes(vec: &[JsValue]) -> u32 {
+fn total_nodes(vec: &[Arc<JsValue>]) -> u32 {
     vec.iter().map(|v| v.total_nodes()).sum::<u32>()
 }
 
@@ -1145,8 +1182,23 @@ impl JsValue {
 }
 
 // Constructors
+//
+// Each list-shaped constructor has two flavors: the owned-`JsValue` form (e.g. `concat`)
+// for callers that build values from scratch, and an `_arc` variant (e.g. `concat_arc`) for
+// callers that already have `Arc<JsValue>` elements and want to avoid the per-element
+// re-wrap. Single-child constructors (`logical_not`, `tenary`, …) likewise take owned
+// `JsValue`s and wrap internally. Use the `_arc` variants in hot paths that thread
+// `Arc<JsValue>`s through.
 impl JsValue {
+    fn into_arc_vec(list: Vec<JsValue>) -> Vec<Arc<JsValue>> {
+        list.into_iter().map(Arc::new).collect()
+    }
+
     pub fn alternatives(list: Vec<JsValue>) -> Self {
+        Self::alternatives_arc(Self::into_arc_vec(list))
+    }
+
+    pub fn alternatives_arc(list: Vec<Arc<JsValue>>) -> Self {
         Self::Alternatives {
             total_nodes: 1 + total_nodes(&list),
             values: list,
@@ -1158,6 +1210,13 @@ impl JsValue {
         list: Vec<JsValue>,
         logical_property: LogicalProperty,
     ) -> Self {
+        Self::alternatives_with_additional_property_arc(Self::into_arc_vec(list), logical_property)
+    }
+
+    pub fn alternatives_with_additional_property_arc(
+        list: Vec<Arc<JsValue>>,
+        logical_property: LogicalProperty,
+    ) -> Self {
         Self::Alternatives {
             total_nodes: 1 + total_nodes(&list),
             values: list,
@@ -1166,22 +1225,33 @@ impl JsValue {
     }
 
     pub fn concat(list: Vec<JsValue>) -> Self {
+        Self::concat_arc(Self::into_arc_vec(list))
+    }
+
+    pub fn concat_arc(list: Vec<Arc<JsValue>>) -> Self {
         Self::Concat(1 + total_nodes(&list), list)
     }
 
     pub fn add(list: Vec<JsValue>) -> Self {
+        Self::add_arc(Self::into_arc_vec(list))
+    }
+
+    pub fn add_arc(list: Vec<Arc<JsValue>>) -> Self {
         Self::Add(1 + total_nodes(&list), list)
     }
 
     pub fn logical_and(list: Vec<JsValue>) -> Self {
+        let list = Self::into_arc_vec(list);
         Self::Logical(1 + total_nodes(&list), LogicalOperator::And, list)
     }
 
     pub fn logical_or(list: Vec<JsValue>) -> Self {
+        let list = Self::into_arc_vec(list);
         Self::Logical(1 + total_nodes(&list), LogicalOperator::Or, list)
     }
 
     pub fn nullish_coalescing(list: Vec<JsValue>) -> Self {
+        let list = Self::into_arc_vec(list);
         Self::Logical(
             1 + total_nodes(&list),
             LogicalOperator::NullishCoalescing,
@@ -1189,64 +1259,65 @@ impl JsValue {
         )
     }
 
-    pub fn tenary(test: Box<JsValue>, cons: Box<JsValue>, alt: Box<JsValue>) -> Self {
+    pub fn tenary(test: JsValue, cons: JsValue, alt: JsValue) -> Self {
         Self::Tenary(
             1 + test.total_nodes() + cons.total_nodes() + alt.total_nodes(),
-            test,
-            cons,
-            alt,
+            Arc::new(test),
+            Arc::new(cons),
+            Arc::new(alt),
         )
     }
 
-    pub fn iterated(iterable: Box<JsValue>) -> Self {
-        Self::Iterated(1 + iterable.total_nodes(), iterable)
+    pub fn iterated(iterable: JsValue) -> Self {
+        Self::Iterated(1 + iterable.total_nodes(), Arc::new(iterable))
     }
 
-    pub fn equal(a: Box<JsValue>, b: Box<JsValue>) -> Self {
+    pub fn equal(a: JsValue, b: JsValue) -> Self {
         Self::Binary(
             1 + a.total_nodes() + b.total_nodes(),
-            a,
+            Arc::new(a),
             BinaryOperator::Equal,
-            b,
+            Arc::new(b),
         )
     }
 
-    pub fn not_equal(a: Box<JsValue>, b: Box<JsValue>) -> Self {
+    pub fn not_equal(a: JsValue, b: JsValue) -> Self {
         Self::Binary(
             1 + a.total_nodes() + b.total_nodes(),
-            a,
+            Arc::new(a),
             BinaryOperator::NotEqual,
-            b,
+            Arc::new(b),
         )
     }
 
-    pub fn strict_equal(a: Box<JsValue>, b: Box<JsValue>) -> Self {
+    pub fn strict_equal(a: JsValue, b: JsValue) -> Self {
         Self::Binary(
             1 + a.total_nodes() + b.total_nodes(),
-            a,
+            Arc::new(a),
             BinaryOperator::StrictEqual,
-            b,
+            Arc::new(b),
         )
     }
 
-    pub fn strict_not_equal(a: Box<JsValue>, b: Box<JsValue>) -> Self {
+    pub fn strict_not_equal(a: JsValue, b: JsValue) -> Self {
         Self::Binary(
             1 + a.total_nodes() + b.total_nodes(),
-            a,
+            Arc::new(a),
             BinaryOperator::StrictNotEqual,
-            b,
+            Arc::new(b),
         )
     }
 
-    pub fn logical_not(inner: Box<JsValue>) -> Self {
-        Self::Not(1 + inner.total_nodes(), inner)
+    pub fn logical_not(inner: JsValue) -> Self {
+        Self::Not(1 + inner.total_nodes(), Arc::new(inner))
     }
 
-    pub fn type_of(operand: Box<JsValue>) -> Self {
-        Self::TypeOf(1 + operand.total_nodes(), operand)
+    pub fn type_of(operand: JsValue) -> Self {
+        Self::TypeOf(1 + operand.total_nodes(), Arc::new(operand))
     }
 
     pub fn array(items: Vec<JsValue>) -> Self {
+        let items = Self::into_arc_vec(items);
         Self::Array {
             total_nodes: 1 + total_nodes(&items),
             items,
@@ -1255,6 +1326,7 @@ impl JsValue {
     }
 
     pub fn frozen_array(items: Vec<JsValue>) -> Self {
+        let items = Self::into_arc_vec(items);
         Self::Array {
             total_nodes: 1 + total_nodes(&items),
             items,
@@ -1279,7 +1351,7 @@ impl JsValue {
         Self::Function(
             1 + return_value.total_nodes(),
             func_ident,
-            Box::new(return_value),
+            Arc::new(return_value),
         )
     }
 
@@ -1364,6 +1436,11 @@ impl JsValue {
     }
 
     pub fn super_call(args: Vec<JsValue>) -> Self {
+        let args = Self::into_arc_vec(args);
+        Self::SuperCall(1 + total_nodes(&args), args)
+    }
+
+    pub fn super_call_arc(args: Vec<Arc<JsValue>>) -> Self {
         Self::SuperCall(1 + total_nodes(&args), args)
     }
 
@@ -1393,7 +1470,11 @@ impl JsValue {
         Self::MemberCall(total, list)
     }
 
-    pub fn member(o: Box<JsValue>, p: Box<JsValue>) -> Self {
+    pub fn member(o: JsValue, p: JsValue) -> Self {
+        Self::member_arc(Arc::new(o), Arc::new(p))
+    }
+
+    pub fn member_arc(o: Arc<JsValue>, p: Arc<JsValue>) -> Self {
         Self::Member(1 + o.total_nodes() + p.total_nodes(), o, p)
     }
 
@@ -1402,11 +1483,11 @@ impl JsValue {
         if let JsValue::Promise(_, _) = operand {
             return operand;
         }
-        Self::Promise(1 + operand.total_nodes(), Box::new(operand))
+        Self::Promise(1 + operand.total_nodes(), Arc::new(operand))
     }
 
-    pub fn awaited(operand: Box<JsValue>) -> Self {
-        Self::Awaited(1 + operand.total_nodes(), operand)
+    pub fn awaited(operand: JsValue) -> Self {
+        Self::Awaited(1 + operand.total_nodes(), Arc::new(operand))
     }
 
     pub fn unknown(value: impl Into<Arc<JsValue>>, side_effects: bool, reason: RcStr) -> Self {
@@ -2396,13 +2477,15 @@ impl JsValue {
                 total_nodes: _,
                 values,
                 logical_property: _,
-            } => values.iter().any(JsValue::has_side_effects),
+            } => values.iter().any(|a: &Arc<JsValue>| a.has_side_effects()),
             JsValue::Binary(_, a, _, b) => a.has_side_effects() || b.has_side_effects(),
             JsValue::Tenary(_, test, cons, alt) => {
                 test.has_side_effects() || cons.has_side_effects() || alt.has_side_effects()
             }
             JsValue::Not(_, value) => value.has_side_effects(),
-            JsValue::Array { items, .. } => items.iter().any(JsValue::has_side_effects),
+            JsValue::Array { items, .. } => {
+                items.iter().any(|a: &Arc<JsValue>| a.has_side_effects())
+            }
             JsValue::Object { parts, .. } => parts.iter().any(|v| match v {
                 ObjectPart::KeyValue(k, v) => k.has_side_effects() || v.has_side_effects(),
                 ObjectPart::Spread(v) => v.has_side_effects(),
@@ -2411,7 +2494,8 @@ impl JsValue {
             // have sideeffects as well.
             // Otherwise it would be
             // `func_body(callee).has_side_effects() ||
-            //      callee.has_side_effects() || args.iter().any(JsValue::has_side_effects`
+            //      callee.has_side_effects() || args.iter().any(|a: &Arc<JsValue>|
+            // a.has_side_effects()`
             JsValue::New(_, _call) => true,
             JsValue::Call(_, _call) => true,
             JsValue::SuperCall(_, _args) => true,
@@ -2455,19 +2539,21 @@ impl JsValue {
                 Some(LogicalProperty::Truthy) => Some(true),
                 Some(LogicalProperty::Falsy) => Some(false),
                 Some(LogicalProperty::Nullish) => Some(false),
-                _ => merge_if_known(values, JsValue::is_truthy),
+                _ => merge_if_known(values, |a: &Arc<JsValue>| a.is_truthy()),
             },
             JsValue::Not(_, value) => value.is_truthy().map(|x| !x),
             JsValue::Logical(_, op, list) => match op {
-                LogicalOperator::And => all_if_known(list, JsValue::is_truthy),
-                LogicalOperator::Or => any_if_known(list, JsValue::is_truthy),
-                LogicalOperator::NullishCoalescing => {
-                    shortcircuit_if_known(list, JsValue::is_not_nullish, JsValue::is_truthy)
-                }
+                LogicalOperator::And => all_if_known(list, |a: &Arc<JsValue>| a.is_truthy()),
+                LogicalOperator::Or => any_if_known(list, |a: &Arc<JsValue>| a.is_truthy()),
+                LogicalOperator::NullishCoalescing => shortcircuit_if_known(
+                    list,
+                    |a: &Arc<JsValue>| a.is_not_nullish(),
+                    |a: &Arc<JsValue>| a.is_truthy(),
+                ),
             },
-            JsValue::Binary(_, box a, op, box b) => {
+            JsValue::Binary(_, a, op, b) => {
                 let (positive_op, negate) = op.positive_op();
-                match (positive_op, a, b) {
+                match (positive_op, &**a, &**b) {
                     (
                         PositiveBinaryOperator::StrictEqual,
                         JsValue::Constant(a),
@@ -2536,16 +2622,22 @@ impl JsValue {
                 logical_property,
             } => match logical_property {
                 Some(LogicalProperty::Nullish) => Some(true),
-                _ => merge_if_known(values, JsValue::is_nullish),
+                _ => merge_if_known(values, |a: &Arc<JsValue>| a.is_nullish()),
             },
             JsValue::Logical(_, op, list) => match op {
-                LogicalOperator::And => {
-                    shortcircuit_if_known(list, JsValue::is_truthy, JsValue::is_nullish)
+                LogicalOperator::And => shortcircuit_if_known(
+                    list,
+                    |a: &Arc<JsValue>| a.is_truthy(),
+                    |a: &Arc<JsValue>| a.is_nullish(),
+                ),
+                LogicalOperator::Or => shortcircuit_if_known(
+                    list,
+                    |a: &Arc<JsValue>| a.is_falsy(),
+                    |a: &Arc<JsValue>| a.is_nullish(),
+                ),
+                LogicalOperator::NullishCoalescing => {
+                    all_if_known(list, |a: &Arc<JsValue>| a.is_nullish())
                 }
-                LogicalOperator::Or => {
-                    shortcircuit_if_known(list, JsValue::is_falsy, JsValue::is_nullish)
-                }
-                LogicalOperator::NullishCoalescing => all_if_known(list, JsValue::is_nullish),
             },
             _ => None,
         }
@@ -2564,22 +2656,28 @@ impl JsValue {
     pub fn is_empty_string(&self) -> Option<bool> {
         match self {
             JsValue::Constant(c) => Some(c.is_empty_string()),
-            JsValue::Concat(_, list) => all_if_known(list, JsValue::is_empty_string),
+            JsValue::Concat(_, list) => all_if_known(list, |a: &Arc<JsValue>| a.is_empty_string()),
             JsValue::Alternatives {
                 total_nodes: _,
                 values,
                 logical_property: _,
-            } => merge_if_known(values, JsValue::is_empty_string),
+            } => merge_if_known(values, |a: &Arc<JsValue>| a.is_empty_string()),
             JsValue::Logical(_, op, list) => match op {
-                LogicalOperator::And => {
-                    shortcircuit_if_known(list, JsValue::is_truthy, JsValue::is_empty_string)
-                }
-                LogicalOperator::Or => {
-                    shortcircuit_if_known(list, JsValue::is_falsy, JsValue::is_empty_string)
-                }
-                LogicalOperator::NullishCoalescing => {
-                    shortcircuit_if_known(list, JsValue::is_not_nullish, JsValue::is_empty_string)
-                }
+                LogicalOperator::And => shortcircuit_if_known(
+                    list,
+                    |a: &Arc<JsValue>| a.is_truthy(),
+                    |a: &Arc<JsValue>| a.is_empty_string(),
+                ),
+                LogicalOperator::Or => shortcircuit_if_known(
+                    list,
+                    |a: &Arc<JsValue>| a.is_falsy(),
+                    |a: &Arc<JsValue>| a.is_empty_string(),
+                ),
+                LogicalOperator::NullishCoalescing => shortcircuit_if_known(
+                    list,
+                    |a: &Arc<JsValue>| a.is_not_nullish(),
+                    |a: &Arc<JsValue>| a.is_empty_string(),
+                ),
             },
             // Booleans are not empty strings
             JsValue::Not(..) | JsValue::Binary(..) => Some(false),
@@ -2630,24 +2728,30 @@ impl JsValue {
             // Booleans are not strings
             JsValue::Not(..) | JsValue::Binary(..) => Some(false),
 
-            JsValue::Add(_, list) => any_if_known(list, JsValue::is_string),
+            JsValue::Add(_, list) => any_if_known(list, |a: &Arc<JsValue>| a.is_string()),
             JsValue::Logical(_, op, list) => match op {
-                LogicalOperator::And => {
-                    shortcircuit_if_known(list, JsValue::is_truthy, JsValue::is_string)
-                }
-                LogicalOperator::Or => {
-                    shortcircuit_if_known(list, JsValue::is_falsy, JsValue::is_string)
-                }
-                LogicalOperator::NullishCoalescing => {
-                    shortcircuit_if_known(list, JsValue::is_not_nullish, JsValue::is_string)
-                }
+                LogicalOperator::And => shortcircuit_if_known(
+                    list,
+                    |a: &Arc<JsValue>| a.is_truthy(),
+                    |a: &Arc<JsValue>| a.is_string(),
+                ),
+                LogicalOperator::Or => shortcircuit_if_known(
+                    list,
+                    |a: &Arc<JsValue>| a.is_falsy(),
+                    |a: &Arc<JsValue>| a.is_string(),
+                ),
+                LogicalOperator::NullishCoalescing => shortcircuit_if_known(
+                    list,
+                    |a: &Arc<JsValue>| a.is_not_nullish(),
+                    |a: &Arc<JsValue>| a.is_string(),
+                ),
             },
 
             JsValue::Alternatives {
                 total_nodes: _,
                 values,
                 logical_property: _,
-            } => merge_if_known(values, JsValue::is_string),
+            } => merge_if_known(values, |a: &Arc<JsValue>| a.is_string()),
 
             JsValue::Call(_, call)
                 if matches!(
@@ -2832,6 +2936,16 @@ impl JsValue {
         &mut self,
         visitor: &mut impl FnMut(&mut JsValue) -> bool,
     ) -> bool {
+        // Helper: visit an `Arc<JsValue>` slot, calling `Arc::make_mut` only if the
+        // visitor actually modifies the value. The clone-on-write happens inside
+        // `make_mut`; siblings that aren't mutated keep their shared `Arc`.
+        fn visit_arc(
+            slot: &mut Arc<JsValue>,
+            visitor: &mut impl FnMut(&mut JsValue) -> bool,
+        ) -> bool {
+            visitor(Arc::make_mut(slot))
+        }
+
         match self {
             JsValue::Alternatives {
                 total_nodes: _,
@@ -2844,7 +2958,7 @@ impl JsValue {
             | JsValue::Array { items: list, .. } => {
                 let mut modified = false;
                 for item in list.iter_mut() {
-                    if visitor(item) {
+                    if visit_arc(item, visitor) {
                         modified = true
                     }
                 }
@@ -2854,7 +2968,7 @@ impl JsValue {
                 modified
             }
             JsValue::Not(_, value) => {
-                let modified = visitor(value);
+                let modified = visit_arc(value, visitor);
                 if modified {
                     self.update_total_nodes();
                 }
@@ -2865,15 +2979,15 @@ impl JsValue {
                 for item in parts.iter_mut() {
                     match item {
                         ObjectPart::KeyValue(key, value) => {
-                            if visitor(key) {
+                            if visit_arc(key, visitor) {
                                 modified = true
                             }
-                            if visitor(value) {
+                            if visit_arc(value, visitor) {
                                 modified = true
                             }
                         }
                         ObjectPart::Spread(value) => {
-                            if visitor(value) {
+                            if visit_arc(value, visitor) {
                                 modified = true
                             }
                         }
@@ -2901,7 +3015,7 @@ impl JsValue {
             JsValue::SuperCall(_, args) => {
                 let mut modified = false;
                 for item in args.iter_mut() {
-                    if visitor(item) {
+                    if visit_arc(item, visitor) {
                         modified = true
                     }
                 }
@@ -2919,7 +3033,7 @@ impl JsValue {
                 modified
             }
             JsValue::Function(_, _, return_value) => {
-                let modified = visitor(return_value);
+                let modified = visit_arc(return_value, visitor);
 
                 if modified {
                     self.update_total_nodes();
@@ -2927,8 +3041,8 @@ impl JsValue {
                 modified
             }
             JsValue::Binary(_, a, _, b) => {
-                let m1 = visitor(a);
-                let m2 = visitor(b);
+                let m1 = visit_arc(a, visitor);
+                let m2 = visit_arc(b, visitor);
                 let modified = m1 || m2;
                 if modified {
                     self.update_total_nodes();
@@ -2936,9 +3050,9 @@ impl JsValue {
                 modified
             }
             JsValue::Tenary(_, test, cons, alt) => {
-                let m1 = visitor(test);
-                let m2 = visitor(cons);
-                let m3 = visitor(alt);
+                let m1 = visit_arc(test, visitor);
+                let m2 = visit_arc(cons, visitor);
+                let m3 = visit_arc(alt, visitor);
                 let modified = m1 || m2 || m3;
                 if modified {
                     self.update_total_nodes();
@@ -2946,8 +3060,8 @@ impl JsValue {
                 modified
             }
             JsValue::Member(_, obj, prop) => {
-                let m1 = visitor(obj);
-                let m2 = visitor(prop);
+                let m1 = visit_arc(obj, visitor);
+                let m2 = visit_arc(prop, visitor);
                 let modified = m1 || m2;
                 if modified {
                     self.update_total_nodes();
@@ -2959,7 +3073,7 @@ impl JsValue {
             | JsValue::TypeOf(_, operand)
             | JsValue::Promise(_, operand)
             | JsValue::Awaited(_, operand) => {
-                let modified = visitor(operand);
+                let modified = visit_arc(operand, visitor);
                 if modified {
                     self.update_total_nodes();
                 }
@@ -3009,7 +3123,7 @@ impl JsValue {
                 modified
             }
             JsValue::Member(_, obj, _) => {
-                let m = visitor(obj);
+                let m = visitor(Arc::make_mut(obj));
                 if m {
                     self.update_total_nodes();
                 }
@@ -3029,7 +3143,7 @@ impl JsValue {
             JsValue::New(_, call) if !call.args().is_empty() => {
                 let mut modified = false;
                 for item in call.args_mut().iter_mut() {
-                    if visitor(item) {
+                    if visitor(Arc::make_mut(item)) {
                         modified = true
                     }
                 }
@@ -3041,7 +3155,7 @@ impl JsValue {
             JsValue::Call(_, call) if !call.args().is_empty() => {
                 let mut modified = false;
                 for item in call.args_mut().iter_mut() {
-                    if visitor(item) {
+                    if visitor(Arc::make_mut(item)) {
                         modified = true
                     }
                 }
@@ -3053,7 +3167,7 @@ impl JsValue {
             JsValue::MemberCall(_, call) if !call.args().is_empty() => {
                 let mut modified = false;
                 for item in call.args_mut().iter_mut() {
-                    if visitor(item) {
+                    if visitor(Arc::make_mut(item)) {
                         modified = true
                     }
                 }
@@ -3063,7 +3177,7 @@ impl JsValue {
                 modified
             }
             JsValue::Member(_, _, prop) => {
-                let m = visitor(prop);
+                let m = visitor(Arc::make_mut(prop));
                 if m {
                     self.update_total_nodes();
                 }
@@ -3178,15 +3292,15 @@ impl JsValue {
             logical_property: _,
         } = self
         {
-            if !values.contains(&v) {
+            if !values.iter().any(|existing| **existing == v) {
                 *c += v.total_nodes();
-                values.push(v);
+                values.push(Arc::new(v));
             }
         } else {
             let l = take(self);
             *self = JsValue::Alternatives {
                 total_nodes: 1 + l.total_nodes() + v.total_nodes(),
-                values: vec![l, v],
+                values: vec![Arc::new(l), Arc::new(v)],
                 logical_property: None,
             };
         }
@@ -3205,30 +3319,48 @@ impl JsValue {
                 logical_property: _,
             } => {
                 if values.len() == 1 {
-                    *self = take(&mut values[0]);
+                    *self = Arc::unwrap_or_clone(values.pop().unwrap());
                 } else {
                     let mut set = FxIndexSet::with_capacity_and_hasher(
                         values.len(),
                         BuildHasherDefault::<FxHasher>::default(),
                     );
                     for v in take(values) {
-                        match v {
-                            JsValue::Alternatives {
+                        // Flatten any nested `Alternatives` into the outer set. We need to
+                        // peek inside the `Arc` to inspect, and unwrap-or-clone if it turns
+                        // out to be the kind we want to flatten. The common case (refcount
+                        // == 1) avoids the deep clone.
+                        match Arc::try_unwrap(v) {
+                            Ok(JsValue::Alternatives {
                                 total_nodes: _,
-                                values,
+                                values: inner,
                                 logical_property: _,
-                            } => {
-                                for v in values {
-                                    set.insert(SimilarJsValue(v));
+                            }) => {
+                                for inner_v in inner {
+                                    set.insert(SimilarJsValue(inner_v));
                                 }
                             }
-                            v => {
-                                set.insert(SimilarJsValue(v));
+                            Ok(other) => {
+                                set.insert(SimilarJsValue(Arc::new(other)));
+                            }
+                            Err(arc) => {
+                                if let JsValue::Alternatives {
+                                    total_nodes: _,
+                                    values: inner,
+                                    logical_property: _,
+                                } = &*arc
+                                {
+                                    for inner_v in inner.iter() {
+                                        set.insert(SimilarJsValue(Arc::clone(inner_v)));
+                                    }
+                                } else {
+                                    set.insert(SimilarJsValue(arc));
+                                }
                             }
                         }
                     }
                     if set.len() == 1 {
-                        *self = set.into_iter().next().unwrap().0;
+                        *self = Arc::unwrap_or_clone(set.into_iter().next().unwrap().0);
                     } else {
                         *values = set.into_iter().map(|v| v.0).collect();
                         self.update_total_nodes();
@@ -3240,43 +3372,52 @@ impl JsValue {
                 v.retain(|v| v.as_str() != Some(""));
 
                 // TODO(kdy1): Remove duplicate
-                let mut new: Vec<JsValue> = vec![];
+                let mut new: Vec<Arc<JsValue>> = vec![];
                 for v in take(v) {
                     if let Some(str) = v.as_str() {
                         if let Some(last) = new.last_mut() {
                             if let Some(last_str) = last.as_str() {
-                                *last = [last_str, str].concat().into();
+                                *last = Arc::new([last_str, str].concat().into());
                             } else {
                                 new.push(v);
                             }
                         } else {
                             new.push(v);
                         }
-                    } else if let JsValue::Concat(_, v) = v {
-                        new.extend(v);
                     } else {
-                        new.push(v);
+                        // Flatten any nested `Concat` into the new list.
+                        match Arc::try_unwrap(v) {
+                            Ok(JsValue::Concat(_, inner)) => new.extend(inner),
+                            Ok(other) => new.push(Arc::new(other)),
+                            Err(arc) => {
+                                if let JsValue::Concat(_, inner) = &*arc {
+                                    new.extend(inner.iter().cloned());
+                                } else {
+                                    new.push(arc);
+                                }
+                            }
+                        }
                     }
                 }
                 if new.len() == 1 {
-                    *self = new.into_iter().next().unwrap();
+                    *self = Arc::unwrap_or_clone(new.into_iter().next().unwrap());
                 } else {
                     *v = new;
                     self.update_total_nodes();
                 }
             }
             JsValue::Add(_, v) => {
-                let mut added: Vec<JsValue> = Vec::new();
+                let mut added: Vec<Arc<JsValue>> = Vec::new();
                 let mut iter = take(v).into_iter();
                 while let Some(item) = iter.next() {
                     if item.is_string() == Some(true) {
-                        let mut concat = match added.len() {
+                        let mut concat: Vec<Arc<JsValue>> = match added.len() {
                             0 => Vec::new(),
                             1 => vec![added.into_iter().next().unwrap()],
-                            _ => vec![JsValue::Add(
+                            _ => vec![Arc::new(JsValue::Add(
                                 1 + added.iter().map(|v| v.total_nodes()).sum::<u32>(),
                                 added,
-                            )],
+                            ))],
                         };
                         concat.push(item);
                         for item in iter.by_ref() {
@@ -3292,7 +3433,7 @@ impl JsValue {
                     }
                 }
                 if added.len() == 1 {
-                    *self = added.into_iter().next().unwrap();
+                    *self = Arc::unwrap_or_clone(added.into_iter().next().unwrap());
                 } else {
                     *v = added;
                     self.update_total_nodes();
@@ -3302,22 +3443,30 @@ impl JsValue {
                 // Nested logical expressions can be normalized: e. g. `a && (b && c)` => `a &&
                 // b && c`
                 if list.iter().any(|v| {
-                    if let JsValue::Logical(_, inner_op, _) = v {
+                    if let JsValue::Logical(_, inner_op, _) = &**v {
                         inner_op == op
                     } else {
                         false
                     }
                 }) => {
-                    // Taking the old list and constructing a new merged list
-                    for mut v in take(list).into_iter() {
-                        if let JsValue::Logical(_, inner_op, inner_list) = &mut v {
-                            if inner_op == op {
-                                list.append(inner_list);
-                            } else {
-                                list.push(v);
+                    // Taking the old list and constructing a new merged list. When the
+                    // shared `Arc` for an inner `Logical` happens to be uniquely owned
+                    // we can move its `Vec` out; otherwise we clone.
+                    for v in take(list).into_iter() {
+                        match Arc::try_unwrap(v) {
+                            Ok(JsValue::Logical(_, inner_op, inner_list)) if inner_op == *op => {
+                                list.extend(inner_list);
                             }
-                        } else {
-                            list.push(v);
+                            Ok(other) => list.push(Arc::new(other)),
+                            Err(arc) => {
+                                if let JsValue::Logical(_, inner_op, inner_list) = &*arc
+                                    && inner_op == op
+                                {
+                                    list.extend(inner_list.iter().cloned());
+                                } else {
+                                    list.push(arc);
+                                }
+                            }
                         }
                     }
                     self.update_total_nodes();
@@ -3351,7 +3500,6 @@ impl JsValue {
         if depth == 0 {
             return false;
         }
-
         fn all_parts_similar(a: &[ObjectPart], b: &[ObjectPart], depth: usize) -> bool {
             if a.len() != b.len() {
                 return false;
@@ -3469,7 +3617,11 @@ impl JsValue {
             return;
         }
 
-        fn all_similar_hash<H: std::hash::Hasher>(slice: &[JsValue], state: &mut H, depth: usize) {
+        fn all_similar_hash<H: std::hash::Hasher>(
+            slice: &[Arc<JsValue>],
+            state: &mut H,
+            depth: usize,
+        ) {
             for item in slice {
                 item.similar_hash(state, depth);
             }
@@ -3584,7 +3736,7 @@ const SIMILAR_HASH_DEPTH: usize = 2;
 /// A wrapper around `JsValue` that implements `PartialEq` and `Hash` by
 /// comparing the values with a depth of [SIMILAR_EQ_DEPTH] and hashing values
 /// with a depth of [SIMILAR_HASH_DEPTH].
-struct SimilarJsValue(JsValue);
+struct SimilarJsValue(Arc<JsValue>);
 
 impl PartialEq for SimilarJsValue {
     fn eq(&self, other: &Self) -> bool {
@@ -3667,7 +3819,7 @@ pub struct RequireContextOptions {
 
 /// Parse the arguments passed to a require.context invocation, validate them
 /// and convert them to the appropriate rust values.
-pub fn parse_require_context(args: &[JsValue]) -> Result<RequireContextOptions> {
+pub fn parse_require_context(args: &[Arc<JsValue>]) -> Result<RequireContextOptions> {
     if !(1..=3).contains(&args.len()) {
         // https://linear.app/vercel/issue/WEB-910/add-support-for-requirecontexts-mode-argument
         bail!("require.context() only supports 1-3 arguments (mode is not supported)");
@@ -3691,7 +3843,7 @@ pub fn parse_require_context(args: &[JsValue]) -> Result<RequireContextOptions> 
     };
 
     let filter = if let Some(filter) = args.get(2) {
-        if let JsValue::Constant(ConstantValue::Regex(box (pattern, flags))) = filter {
+        if let JsValue::Constant(ConstantValue::Regex(box (pattern, flags))) = &**filter {
             EsRegex::new(pattern, flags)?
         } else {
             bail!("require.context(..., ..., filter) requires filter to be a regex");
@@ -3853,7 +4005,7 @@ pub mod test_utils {
                     JsValue::WellKnownFunction(WellKnownFunctionKind::Import)
                 ) =>
             {
-                match &call.args()[0] {
+                match &*call.args()[0] {
                     JsValue::Constant(ConstantValue::Str(v)) => {
                         JsValue::promise(JsValue::Module(ModuleValue {
                             module: v.as_atom().into_owned().into(),
@@ -3869,13 +4021,10 @@ pub mod test_utils {
                     JsValue::WellKnownFunction(WellKnownFunctionKind::CreateRequire)
                 ) =>
             {
-                if let [
-                    JsValue::Member(
-                        _,
-                        box JsValue::WellKnownObject(WellKnownObjectKind::ImportMeta),
-                        box JsValue::Constant(ConstantValue::Str(prop)),
-                    ),
-                ] = call.args()
+                if let [arg] = call.args()
+                    && let JsValue::Member(_, obj, prop) = &**arg
+                    && let JsValue::WellKnownObject(WellKnownObjectKind::ImportMeta) = &**obj
+                    && let JsValue::Constant(ConstantValue::Str(prop)) = &**prop
                     && prop.as_str() == "url"
                 {
                     JsValue::WellKnownFunction(WellKnownFunctionKind::Require)
@@ -3889,7 +4038,7 @@ pub mod test_utils {
                     JsValue::WellKnownFunction(WellKnownFunctionKind::RequireResolve)
                 ) =>
             {
-                match &call.args()[0] {
+                match &*call.args()[0] {
                     JsValue::Constant(v) => (v.to_string() + "/resolved/lib/index.js").into(),
                     _ => v.into_unknown(true, rcstr!("require.resolve non constant")),
                 }
@@ -3938,14 +4087,11 @@ pub mod test_utils {
                     JsValue::WellKnownFunction(WellKnownFunctionKind::URLConstructor)
                 ) =>
             {
-                if let [
-                    JsValue::Constant(ConstantValue::Str(url)),
-                    JsValue::Member(
-                        _,
-                        box JsValue::WellKnownObject(WellKnownObjectKind::ImportMeta),
-                        box JsValue::Constant(ConstantValue::Str(prop)),
-                    ),
-                ] = call.args()
+                if let [arg0, arg1] = call.args()
+                    && let JsValue::Constant(ConstantValue::Str(url)) = &**arg0
+                    && let JsValue::Member(_, obj, prop) = &**arg1
+                    && let JsValue::WellKnownObject(WellKnownObjectKind::ImportMeta) = &**obj
+                    && let JsValue::Constant(ConstantValue::Str(prop)) = &**prop
                 {
                     if prop.as_str() == "url" {
                         // TODO avoid clone
@@ -4359,7 +4505,7 @@ mod tests {
                                 .await;
                                 resolved.push((
                                     format!("{parent} -> {i} typeof"),
-                                    JsValue::type_of(Box::new(arg)),
+                                    JsValue::type_of(arg),
                                 ));
                                 steps
                             }

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -5,7 +5,7 @@ use std::{
     fmt::{self, Display, Formatter, Write},
     hash::{BuildHasherDefault, Hash, Hasher},
     mem::take,
-    sync::{Arc, LazyLock},
+    sync::LazyLock,
 };
 
 use anyhow::{Result, bail};
@@ -22,6 +22,12 @@ use swc_core::{
         atoms::Atom,
     },
 };
+// `triomphe::Arc` (a.k.a. `Arc` here) drops the weak refcount: the header is
+// `{ refcount: AtomicUsize }` (8 bytes) instead of `std`'s
+// `{ strong: AtomicUsize, weak: AtomicUsize }` (16 bytes). For deeply nested
+// `JsValue` trees this halves the per-allocation header overhead and skips the
+// second atomic op on drop.
+use triomphe::Arc;
 use turbo_esregex::EsRegex;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{FxIndexMap, FxIndexSet, Vc};

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/well_known.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/well_known.rs
@@ -1,4 +1,4 @@
-use std::mem::take;
+use std::{mem::take, sync::Arc};
 
 use anyhow::Result;
 use turbo_rcstr::rcstr;
@@ -16,17 +16,24 @@ pub async fn replace_well_known(
     compile_time_info: Vc<CompileTimeInfo>,
     allow_project_root_tracing: bool,
 ) -> Result<(JsValue, bool)> {
+    // Helper: unwrap a Vec<Arc<JsValue>> into Vec<JsValue>, sharing the allocation
+    // when possible. Cheap when each Arc is uniquely owned (the common case here,
+    // since `into_parts` consumes the only reference).
+    fn unwrap_args(args: Vec<Arc<JsValue>>) -> Vec<JsValue> {
+        args.into_iter().map(Arc::unwrap_or_clone).collect()
+    }
+
     Ok(match value {
         JsValue::Call(_, call) if matches!(call.callee(), JsValue::WellKnownFunction(_)) => {
             let (callee, args) = call.into_parts();
-            let JsValue::WellKnownFunction(kind) = callee else {
+            let JsValue::WellKnownFunction(kind) = Arc::unwrap_or_clone(callee) else {
                 unreachable!()
             };
             (
                 well_known_function_call(
                     kind,
                     JsValue::unknown_empty(false, rcstr!("this is not analyzed yet")),
-                    args,
+                    unwrap_args(args),
                     compile_time_info,
                     allow_project_root_tracing,
                 )
@@ -38,39 +45,48 @@ pub async fn replace_well_known(
             // var fs = require('fs'), fs = __importStar(fs);
             // TODO(WEB-552) this is not correct and has many false positives!
             if call.args().len() == 1
-                && let JsValue::WellKnownObject(_) = &call.args()[0]
+                && let JsValue::WellKnownObject(_) = &*call.args()[0]
             {
-                return Ok((call.args()[0].clone(), true));
+                return Ok(((*call.args()[0]).clone(), true));
             }
             (JsValue::Call(total, call), false)
         }
-        JsValue::Member(_, box JsValue::WellKnownObject(kind), box prop) => {
-            well_known_object_member(kind, prop, compile_time_info).await?
+        JsValue::Member(_, obj, prop) if matches!(&*obj, JsValue::WellKnownObject(_)) => {
+            let JsValue::WellKnownObject(kind) = Arc::unwrap_or_clone(obj) else {
+                unreachable!()
+            };
+            well_known_object_member(kind, Arc::unwrap_or_clone(prop), compile_time_info).await?
         }
-        JsValue::Member(_, box JsValue::WellKnownFunction(kind), box prop) => {
-            well_known_function_member(kind, prop)
+        JsValue::Member(_, obj, prop) if matches!(&*obj, JsValue::WellKnownFunction(_)) => {
+            let JsValue::WellKnownFunction(kind) = Arc::unwrap_or_clone(obj) else {
+                unreachable!()
+            };
+            well_known_function_member(kind, Arc::unwrap_or_clone(prop))
         }
-        JsValue::Member(_, box JsValue::Array { .. }, box ref prop) => match prop.as_str() {
-            Some("filter") => (
-                JsValue::WellKnownFunction(WellKnownFunctionKind::ArrayFilter),
-                true,
-            ),
-            Some("forEach") => (
-                JsValue::WellKnownFunction(WellKnownFunctionKind::ArrayForEach),
-                true,
-            ),
-            Some("map") => (
-                JsValue::WellKnownFunction(WellKnownFunctionKind::ArrayMap),
-                true,
-            ),
-            _ => (value, false),
-        },
+        JsValue::Member(c, obj, prop) if matches!(&*obj, JsValue::Array { .. }) => {
+            match prop.as_str() {
+                Some("filter") => (
+                    JsValue::WellKnownFunction(WellKnownFunctionKind::ArrayFilter),
+                    true,
+                ),
+                Some("forEach") => (
+                    JsValue::WellKnownFunction(WellKnownFunctionKind::ArrayForEach),
+                    true,
+                ),
+                Some("map") => (
+                    JsValue::WellKnownFunction(WellKnownFunctionKind::ArrayMap),
+                    true,
+                ),
+                _ => (JsValue::Member(c, obj, prop), false),
+            }
+        }
         // module.hot → WellKnownObject(ModuleHot) (only when HMR is enabled)
-        JsValue::Member(_, box JsValue::FreeVar(ref name), box ref prop)
-            if &**name == "module"
+        JsValue::Member(c, obj, prop)
+            if matches!(&*obj, JsValue::FreeVar(name) if &**name == "module")
                 && prop.as_str() == Some("hot")
                 && compile_time_info.await?.hot_module_replacement_enabled =>
         {
+            let _ = (c, obj, prop);
             (
                 JsValue::WellKnownObject(WellKnownObjectKind::ModuleHot),
                 true,
@@ -337,7 +353,9 @@ fn path_dirname(mut args: Vec<JsValue>) -> JsValue {
             && let Some(str) = last.as_str()
             && let Some(i) = str.rfind('/')
         {
-            *last = JsValue::Constant(ConstantValue::Str(str[..i].to_string().into()));
+            *last = Arc::new(JsValue::Constant(ConstantValue::Str(
+                str[..i].to_string().into(),
+            )));
             return take(arg);
         }
     }
@@ -590,7 +608,7 @@ fn well_known_function_member(kind: WellKnownFunctionKind, prop: JsValue) -> (Js
         #[allow(unreachable_patterns)]
         (kind, _) => {
             return (
-                JsValue::member(Box::new(JsValue::WellKnownFunction(kind)), Box::new(prop)),
+                JsValue::member(JsValue::WellKnownFunction(kind), prop),
                 false,
             );
         }
@@ -645,10 +663,7 @@ async fn well_known_object_member(
             // not supported. Users should migrate to import.meta.glob('...', { eager: true }).
             Some("glob") => JsValue::WellKnownFunction(WellKnownFunctionKind::ImportMetaGlob),
             _ => {
-                return Ok((
-                    JsValue::member(Box::new(JsValue::WellKnownObject(kind)), Box::new(prop)),
-                    false,
-                ));
+                return Ok((JsValue::member(JsValue::WellKnownObject(kind), prop), false));
             }
         },
         WellKnownObjectKind::ModuleHot => match prop.as_str() {
@@ -657,7 +672,7 @@ async fn well_known_object_member(
             _ => {
                 return Ok((
                     JsValue::unknown(
-                        JsValue::member(Box::new(JsValue::WellKnownObject(kind)), Box::new(prop)),
+                        JsValue::member(JsValue::WellKnownObject(kind), prop),
                         true,
                         rcstr!("unsupported property on module.hot"),
                     ),
@@ -667,10 +682,7 @@ async fn well_known_object_member(
         },
         #[allow(unreachable_patterns)]
         _ => {
-            return Ok((
-                JsValue::member(Box::new(JsValue::WellKnownObject(kind)), Box::new(prop)),
-                false,
-            ));
+            return Ok((JsValue::member(JsValue::WellKnownObject(kind), prop), false));
         }
     };
     Ok((new_value, true))
@@ -681,8 +693,8 @@ fn global_object(prop: JsValue) -> JsValue {
         Some("assign") => JsValue::WellKnownFunction(WellKnownFunctionKind::ObjectAssign),
         _ => JsValue::unknown(
             JsValue::member(
-                Box::new(JsValue::WellKnownObject(WellKnownObjectKind::GlobalObject)),
-                Box::new(prop),
+                JsValue::WellKnownObject(WellKnownObjectKind::GlobalObject),
+                prop,
             ),
             true,
             rcstr!("unsupported property on global Object"),
@@ -716,8 +728,8 @@ async fn path_module_member(
         }
         _ => JsValue::unknown(
             JsValue::member(
-                Box::new(JsValue::WellKnownObject(WellKnownObjectKind::PathModule)),
-                Box::new(prop),
+                JsValue::WellKnownObject(WellKnownObjectKind::PathModule),
+                prop,
             ),
             true,
             rcstr!("unsupported property on Node.js path module"),
@@ -751,8 +763,8 @@ fn fs_module_member(kind: WellKnownObjectKind, prop: JsValue) -> JsValue {
     }
     JsValue::unknown(
         JsValue::member(
-            Box::new(JsValue::WellKnownObject(WellKnownObjectKind::FsModule)),
-            Box::new(prop),
+            JsValue::WellKnownObject(WellKnownObjectKind::FsModule),
+            prop,
         ),
         true,
         rcstr!("unsupported property on Node.js fs module"),
@@ -790,8 +802,8 @@ fn fs_extra_module_member(kind: WellKnownObjectKind, prop: JsValue) -> JsValue {
     }
     JsValue::unknown(
         JsValue::member(
-            Box::new(JsValue::WellKnownObject(WellKnownObjectKind::FsExtraModule)),
-            Box::new(prop),
+            JsValue::WellKnownObject(WellKnownObjectKind::FsExtraModule),
+            prop,
         ),
         true,
         rcstr!("unsupported property on fs-extra module"),
@@ -808,8 +820,8 @@ fn module_module_member(kind: WellKnownObjectKind, prop: JsValue) -> JsValue {
         }
         _ => JsValue::unknown(
             JsValue::member(
-                Box::new(JsValue::WellKnownObject(WellKnownObjectKind::ModuleModule)),
-                Box::new(prop),
+                JsValue::WellKnownObject(WellKnownObjectKind::ModuleModule),
+                prop,
             ),
             true,
             rcstr!("unsupported property on Node.js `module` module"),
@@ -827,8 +839,8 @@ fn url_module_member(kind: WellKnownObjectKind, prop: JsValue) -> JsValue {
         }
         _ => JsValue::unknown(
             JsValue::member(
-                Box::new(JsValue::WellKnownObject(WellKnownObjectKind::UrlModule)),
-                Box::new(prop),
+                JsValue::WellKnownObject(WellKnownObjectKind::UrlModule),
+                prop,
             ),
             true,
             rcstr!("unsupported property on Node.js url module"),
@@ -846,10 +858,8 @@ fn worker_threads_module_member(kind: WellKnownObjectKind, prop: JsValue) -> JsV
         }
         _ => JsValue::unknown(
             JsValue::member(
-                Box::new(JsValue::WellKnownObject(
-                    WellKnownObjectKind::WorkerThreadsModule,
-                )),
-                Box::new(prop),
+                JsValue::WellKnownObject(WellKnownObjectKind::WorkerThreadsModule),
+                prop,
             ),
             true,
             rcstr!("unsupported property on Node.js worker_threads module"),
@@ -872,10 +882,8 @@ fn child_process_module_member(kind: WellKnownObjectKind, prop: JsValue) -> JsVa
 
         _ => JsValue::unknown(
             JsValue::member(
-                Box::new(JsValue::WellKnownObject(
-                    WellKnownObjectKind::ChildProcessModule,
-                )),
-                Box::new(prop),
+                JsValue::WellKnownObject(WellKnownObjectKind::ChildProcessModule),
+                prop,
             ),
             true,
             rcstr!("unsupported property on Node.js child_process module"),
@@ -893,8 +901,8 @@ fn os_module_member(kind: WellKnownObjectKind, prop: JsValue) -> JsValue {
         }
         _ => JsValue::unknown(
             JsValue::member(
-                Box::new(JsValue::WellKnownObject(WellKnownObjectKind::OsModule)),
-                Box::new(prop),
+                JsValue::WellKnownObject(WellKnownObjectKind::OsModule),
+                prop,
             ),
             true,
             rcstr!("unsupported property on Node.js os module"),
@@ -926,10 +934,8 @@ async fn node_process_member(
         Some("env") => JsValue::WellKnownObject(WellKnownObjectKind::NodeProcessEnv),
         _ => JsValue::unknown(
             JsValue::member(
-                Box::new(JsValue::WellKnownObject(
-                    WellKnownObjectKind::NodeProcessModule,
-                )),
-                Box::new(prop),
+                JsValue::WellKnownObject(WellKnownObjectKind::NodeProcessModule),
+                prop,
             ),
             true,
             rcstr!("unsupported property on Node.js process object"),
@@ -942,8 +948,8 @@ fn node_pre_gyp(prop: JsValue) -> JsValue {
         Some("find") => JsValue::WellKnownFunction(WellKnownFunctionKind::NodePreGypFind),
         _ => JsValue::unknown(
             JsValue::member(
-                Box::new(JsValue::WellKnownObject(WellKnownObjectKind::NodePreGyp)),
-                Box::new(prop),
+                JsValue::WellKnownObject(WellKnownObjectKind::NodePreGyp),
+                prop,
             ),
             true,
             rcstr!("unsupported property on @mapbox/node-pre-gyp module"),
@@ -956,10 +962,8 @@ fn express(prop: JsValue) -> JsValue {
         Some("set") => JsValue::WellKnownFunction(WellKnownFunctionKind::NodeExpressSet),
         _ => JsValue::unknown(
             JsValue::member(
-                Box::new(JsValue::WellKnownObject(
-                    WellKnownObjectKind::NodeExpressApp,
-                )),
-                Box::new(prop),
+                JsValue::WellKnownObject(WellKnownObjectKind::NodeExpressApp),
+                prop,
             ),
             true,
             rcstr!("unsupported property on require('express')() object"),
@@ -974,10 +978,8 @@ fn protobuf_loader(prop: JsValue) -> JsValue {
         }
         _ => JsValue::unknown(
             JsValue::member(
-                Box::new(JsValue::WellKnownObject(
-                    WellKnownObjectKind::NodeProtobufLoader,
-                )),
-                Box::new(prop),
+                JsValue::WellKnownObject(WellKnownObjectKind::NodeProtobufLoader),
+                prop,
             ),
             true,
             rcstr!("unsupported property on require('@grpc/proto-loader') object"),

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/well_known.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/well_known.rs
@@ -1,5 +1,3 @@
-use std::mem::take;
-
 use anyhow::Result;
 use triomphe::Arc;
 use turbo_rcstr::rcstr;
@@ -17,13 +15,6 @@ pub async fn replace_well_known(
     compile_time_info: Vc<CompileTimeInfo>,
     allow_project_root_tracing: bool,
 ) -> Result<(JsValue, bool)> {
-    // Helper: unwrap a Vec<Arc<JsValue>> into Vec<JsValue>, sharing the allocation
-    // when possible. Cheap when each Arc is uniquely owned (the common case here,
-    // since `into_parts` consumes the only reference).
-    fn unwrap_args(args: Vec<Arc<JsValue>>) -> Vec<JsValue> {
-        args.into_iter().map(Arc::unwrap_or_clone).collect()
-    }
-
     Ok(match value {
         JsValue::Call(_, call) if matches!(call.callee(), JsValue::WellKnownFunction(_)) => {
             let (callee, args) = call.into_parts();
@@ -34,7 +25,7 @@ pub async fn replace_well_known(
                 well_known_function_call(
                     kind,
                     JsValue::unknown_empty(false, rcstr!("this is not analyzed yet")),
-                    unwrap_args(args),
+                    args,
                     compile_time_info,
                     allow_project_root_tracing,
                 )
@@ -56,13 +47,13 @@ pub async fn replace_well_known(
             let JsValue::WellKnownObject(kind) = Arc::unwrap_or_clone(obj) else {
                 unreachable!()
             };
-            well_known_object_member(kind, Arc::unwrap_or_clone(prop), compile_time_info).await?
+            well_known_object_member(kind, prop, compile_time_info).await?
         }
         JsValue::Member(_, obj, prop) if matches!(&*obj, JsValue::WellKnownFunction(_)) => {
             let JsValue::WellKnownFunction(kind) = Arc::unwrap_or_clone(obj) else {
                 unreachable!()
             };
-            well_known_function_member(kind, Arc::unwrap_or_clone(prop))
+            well_known_function_member(kind, prop)
         }
         JsValue::Member(c, obj, prop) if matches!(&*obj, JsValue::Array { .. }) => {
             match prop.as_str() {
@@ -100,7 +91,7 @@ pub async fn replace_well_known(
 pub async fn well_known_function_call(
     kind: WellKnownFunctionKind,
     _this: JsValue,
-    args: Vec<JsValue>,
+    args: Vec<Arc<JsValue>>,
     compile_time_info: Vc<CompileTimeInfo>,
     allow_project_root_tracing: bool,
 ) -> Result<JsValue> {
@@ -142,7 +133,7 @@ pub async fn well_known_function_call(
                 format!("/ROOT/{}", cwd.path).into()
             } else {
                 JsValue::unknown(
-                    JsValue::call_from_parts(JsValue::WellKnownFunction(kind), args),
+                    JsValue::call_from_iter(JsValue::WellKnownFunction(kind), args),
                     true,
                     rcstr!("process.cwd is not specified in the environment"),
                 )
@@ -164,35 +155,42 @@ pub async fn well_known_function_call(
         }
 
         _ => JsValue::unknown(
-            JsValue::call_from_parts(JsValue::WellKnownFunction(kind), args),
+            JsValue::call_from_iter(JsValue::WellKnownFunction(kind), args),
             true,
             rcstr!("unsupported function"),
         ),
     })
 }
 
-fn object_assign(args: Vec<JsValue>) -> JsValue {
-    if args.iter().all(|arg| matches!(arg, JsValue::Object { .. })) {
-        if let Some(mut merged_object) = args.into_iter().reduce(|mut acc, cur| {
-            if let JsValue::Object { parts, mutable, .. } = &mut acc
-                && let JsValue::Object {
-                    parts: next_parts,
-                    mutable: next_mutable,
-                    ..
-                } = &cur
-            {
-                parts.extend_from_slice(next_parts);
-                *mutable |= *next_mutable;
-            }
-            acc
-        }) {
+fn object_assign(args: Vec<Arc<JsValue>>) -> JsValue {
+    if args
+        .iter()
+        .all(|arg| matches!(&**arg, JsValue::Object { .. }))
+    {
+        if let Some(mut merged_object) =
+            args.into_iter()
+                .map(Arc::unwrap_or_clone)
+                .reduce(|mut acc, cur| {
+                    if let JsValue::Object { parts, mutable, .. } = &mut acc
+                        && let JsValue::Object {
+                            parts: next_parts,
+                            mutable: next_mutable,
+                            ..
+                        } = &cur
+                    {
+                        parts.extend_from_slice(next_parts);
+                        *mutable |= *next_mutable;
+                    }
+                    acc
+                })
+        {
             merged_object.update_total_nodes();
             merged_object
         } else {
             JsValue::unknown(
                 JsValue::call_from_iter(
                     JsValue::WellKnownFunction(WellKnownFunctionKind::ObjectAssign),
-                    [],
+                    Vec::<Arc<JsValue>>::new(),
                 ),
                 true,
                 rcstr!("empty arguments for Object.assign"),
@@ -200,7 +198,7 @@ fn object_assign(args: Vec<JsValue>) -> JsValue {
         }
     } else {
         JsValue::unknown(
-            JsValue::call_from_parts(
+            JsValue::call_from_iter(
                 JsValue::WellKnownFunction(WellKnownFunctionKind::ObjectAssign),
                 args,
             ),
@@ -210,17 +208,17 @@ fn object_assign(args: Vec<JsValue>) -> JsValue {
     }
 }
 
-fn path_join(args: Vec<JsValue>) -> JsValue {
+fn path_join(args: Vec<Arc<JsValue>>) -> JsValue {
     if args.is_empty() {
         return rcstr!(".").into();
     }
-    let mut parts = Vec::new();
+    let mut parts: Vec<JsValue> = Vec::new();
     for item in args {
         if let Some(str) = item.as_str() {
             let split = str.split('/');
             parts.extend(split.map(|s| s.into()));
         } else {
-            parts.push(item);
+            parts.push(Arc::unwrap_or_clone(item));
         }
     }
     let mut results_final = Vec::new();
@@ -249,31 +247,31 @@ fn path_join(args: Vec<JsValue>) -> JsValue {
     let mut iter = results_final.into_iter();
     let first = iter.next().unwrap();
     let mut last_is_str = first.as_str().is_some();
-    results.push(first);
+    let mut results: Vec<Arc<JsValue>> = vec![Arc::new(first)];
     for part in iter {
         let is_str = part.as_str().is_some();
         if last_is_str && is_str {
-            results.push(rcstr!("/").into());
+            results.push(Arc::new(rcstr!("/").into()));
         } else {
-            results.push(JsValue::alternatives(vec![
-                rcstr!("/").into(),
-                rcstr!("").into(),
-            ]));
+            results.push(Arc::new(JsValue::alternatives(vec![
+                Arc::new(rcstr!("/").into()),
+                Arc::new(rcstr!("").into()),
+            ])));
         }
-        results.push(part);
+        results.push(Arc::new(part));
         last_is_str = is_str;
     }
     JsValue::concat(results)
 }
 
-fn path_resolve(cwd: JsValue, mut args: Vec<JsValue>) -> JsValue {
+fn path_resolve(cwd: JsValue, mut args: Vec<Arc<JsValue>>) -> JsValue {
     // If no path segments are passed, `path.resolve()` will return the absolute
     // path of the current working directory.
     if args.is_empty() {
         return JsValue::unknown_empty(false, rcstr!("cwd is not static analyzable"));
     }
     if args.len() == 1 {
-        return args.into_iter().next().unwrap();
+        return Arc::unwrap_or_clone(args.into_iter().next().unwrap());
     }
 
     // path.resolve stops at the string starting with `/`
@@ -307,7 +305,7 @@ fn path_resolve(cwd: JsValue, mut args: Vec<JsValue>) -> JsValue {
             }
         } else {
             results_final.append(&mut results);
-            results_final.push(item);
+            results_final.push(Arc::unwrap_or_clone(item));
         }
     }
     results_final.append(&mut results);
@@ -319,49 +317,63 @@ fn path_resolve(cwd: JsValue, mut args: Vec<JsValue>) -> JsValue {
 
     let mut last_was_str = first.as_str().is_some();
 
+    let mut results: Vec<Arc<JsValue>> = Vec::new();
     if !is_already_absolute {
-        results.push(cwd);
+        results.push(Arc::new(cwd));
     }
 
-    results.push(first);
+    results.push(Arc::new(first));
     for part in iter {
         let is_str = part.as_str().is_some();
         if last_was_str && is_str {
-            results.push(rcstr!("/").into());
+            results.push(Arc::new(rcstr!("/").into()));
         } else {
-            results.push(JsValue::alternatives(vec![
-                rcstr!("/").into(),
-                rcstr!("").into(),
-            ]));
+            results.push(Arc::new(JsValue::alternatives(vec![
+                Arc::new(rcstr!("/").into()),
+                Arc::new(rcstr!("").into()),
+            ])));
         }
-        results.push(part);
+        results.push(Arc::new(part));
         last_was_str = is_str;
     }
 
     JsValue::concat(results)
 }
 
-fn path_dirname(mut args: Vec<JsValue>) -> JsValue {
-    if let Some(arg) = args.iter_mut().next() {
+fn path_dirname(mut args: Vec<Arc<JsValue>>) -> JsValue {
+    if let Some(arg) = args.first() {
         if let Some(str) = arg.as_str() {
             if let Some(i) = str.rfind('/') {
                 return JsValue::Constant(ConstantValue::Str(str[..i].to_string().into()));
             } else {
                 return JsValue::Constant(ConstantValue::Str(rcstr!("").into()));
             }
-        } else if let JsValue::Concat(_, items) = arg
-            && let Some(last) = items.last_mut()
+        }
+        let truncate_to = if let JsValue::Concat(_, items) = &**arg
+            && let Some(last) = items.last()
             && let Some(str) = last.as_str()
-            && let Some(i) = str.rfind('/')
         {
+            str.rfind('/')
+        } else {
+            None
+        };
+        if let Some(i) = truncate_to {
+            // We're going to consume the first arg, so unwrap it to take ownership and
+            // modify in place.
+            let mut arg = Arc::unwrap_or_clone(args.swap_remove(0));
+            let JsValue::Concat(_, items) = &mut arg else {
+                unreachable!()
+            };
+            let last = items.last_mut().unwrap();
+            let str = last.as_str().unwrap();
             *last = Arc::new(JsValue::Constant(ConstantValue::Str(
                 str[..i].to_string().into(),
             )));
-            return take(arg);
+            return arg;
         }
     }
     JsValue::unknown(
-        JsValue::call_from_parts(
+        JsValue::call_from_iter(
             JsValue::WellKnownFunction(WellKnownFunctionKind::PathDirname),
             args,
         ),
@@ -372,16 +384,19 @@ fn path_dirname(mut args: Vec<JsValue>) -> JsValue {
 
 /// Resolve the contents of an import call, throwing errors
 /// if we come across any unsupported syntax.
-pub fn import(args: Vec<JsValue>) -> JsValue {
-    match &args[..] {
-        [JsValue::Constant(ConstantValue::Str(v))] => {
-            JsValue::promise(JsValue::Module(ModuleValue {
+pub fn import(args: Vec<Arc<JsValue>>) -> JsValue {
+    match args.as_slice() {
+        [arg] if matches!(&**arg, JsValue::Constant(ConstantValue::Str(_))) => {
+            let JsValue::Constant(ConstantValue::Str(v)) = &**arg else {
+                unreachable!()
+            };
+            JsValue::promise(Arc::new(JsValue::Module(ModuleValue {
                 module: v.as_atom().into_owned().into(),
                 annotations: None,
-            }))
+            })))
         }
         _ => JsValue::unknown(
-            JsValue::call_from_parts(
+            JsValue::call_from_iter(
                 JsValue::WellKnownFunction(WellKnownFunctionKind::Import),
                 args,
             ),
@@ -393,7 +408,7 @@ pub fn import(args: Vec<JsValue>) -> JsValue {
 
 /// Resolve the contents of a require call, throwing errors
 /// if we come across any unsupported syntax.
-fn require(args: Vec<JsValue>) -> JsValue {
+fn require(args: Vec<Arc<JsValue>>) -> JsValue {
     if args.len() == 1 {
         if let Some(s) = args[0].as_str() {
             JsValue::Module(ModuleValue {
@@ -402,7 +417,7 @@ fn require(args: Vec<JsValue>) -> JsValue {
             })
         } else {
             JsValue::unknown(
-                JsValue::call_from_parts(
+                JsValue::call_from_iter(
                     JsValue::WellKnownFunction(WellKnownFunctionKind::Require),
                     args,
                 ),
@@ -412,7 +427,7 @@ fn require(args: Vec<JsValue>) -> JsValue {
         }
     } else {
         JsValue::unknown(
-            JsValue::call_from_parts(
+            JsValue::call_from_iter(
                 JsValue::WellKnownFunction(WellKnownFunctionKind::Require),
                 args,
             ),
@@ -423,10 +438,13 @@ fn require(args: Vec<JsValue>) -> JsValue {
 }
 
 /// (try to) statically evaluate `require.context(...)()`
-fn require_context_require(val: Box<RequireContextValue>, args: Vec<JsValue>) -> Result<JsValue> {
+fn require_context_require(
+    val: Box<RequireContextValue>,
+    args: Vec<Arc<JsValue>>,
+) -> Result<JsValue> {
     if args.is_empty() {
         return Ok(JsValue::unknown(
-            JsValue::call_from_parts(
+            JsValue::call_from_iter(
                 JsValue::WellKnownFunction(WellKnownFunctionKind::RequireContextRequire(val)),
                 args,
             ),
@@ -439,7 +457,7 @@ fn require_context_require(val: Box<RequireContextValue>, args: Vec<JsValue>) ->
 
     let Some(s) = args[0].as_str() else {
         return Ok(JsValue::unknown(
-            JsValue::call_from_parts(
+            JsValue::call_from_iter(
                 JsValue::WellKnownFunction(WellKnownFunctionKind::RequireContextRequire(val)),
                 args,
             ),
@@ -452,7 +470,7 @@ fn require_context_require(val: Box<RequireContextValue>, args: Vec<JsValue>) ->
 
     let Some(m) = val.0.get(s) else {
         return Ok(JsValue::unknown(
-            JsValue::call_from_parts(
+            JsValue::call_from_iter(
                 JsValue::WellKnownFunction(WellKnownFunctionKind::RequireContextRequire(val)),
                 args,
             ),
@@ -473,13 +491,13 @@ fn require_context_require(val: Box<RequireContextValue>, args: Vec<JsValue>) ->
 /// (try to) statically evaluate `require.context(...).keys()`
 fn require_context_require_keys(
     val: Box<RequireContextValue>,
-    args: Vec<JsValue>,
+    args: Vec<Arc<JsValue>>,
 ) -> Result<JsValue> {
     Ok(if args.is_empty() {
-        JsValue::array(val.0.keys().cloned().map(|k| k.into()).collect())
+        JsValue::array(val.0.keys().cloned().map(|k| Arc::new(k.into())).collect())
     } else {
         JsValue::unknown(
-            JsValue::call_from_parts(
+            JsValue::call_from_iter(
                 JsValue::WellKnownFunction(WellKnownFunctionKind::RequireContextRequireKeys(val)),
                 args,
             ),
@@ -492,11 +510,11 @@ fn require_context_require_keys(
 /// (try to) statically evaluate `require.context(...).resolve()`
 fn require_context_require_resolve(
     val: Box<RequireContextValue>,
-    args: Vec<JsValue>,
+    args: Vec<Arc<JsValue>>,
 ) -> Result<JsValue> {
     if args.len() != 1 {
         return Ok(JsValue::unknown(
-            JsValue::call_from_parts(
+            JsValue::call_from_iter(
                 JsValue::WellKnownFunction(WellKnownFunctionKind::RequireContextRequireResolve(
                     val,
                 )),
@@ -511,7 +529,7 @@ fn require_context_require_resolve(
 
     let Some(s) = args[0].as_str() else {
         return Ok(JsValue::unknown(
-            JsValue::call_from_parts(
+            JsValue::call_from_iter(
                 JsValue::WellKnownFunction(WellKnownFunctionKind::RequireContextRequireResolve(
                     val,
                 )),
@@ -526,7 +544,7 @@ fn require_context_require_resolve(
 
     let Some(m) = val.0.get(s) else {
         return Ok(JsValue::unknown(
-            JsValue::call_from_parts(
+            JsValue::call_from_iter(
                 JsValue::WellKnownFunction(WellKnownFunctionKind::RequireContextRequireResolve(
                     val,
                 )),
@@ -543,14 +561,14 @@ fn require_context_require_resolve(
     Ok(m.as_str().into())
 }
 
-fn path_to_file_url(args: Vec<JsValue>) -> JsValue {
+fn path_to_file_url(args: Vec<Arc<JsValue>>) -> JsValue {
     if args.len() == 1 {
         if let Some(path) = args[0].as_str() {
             Url::from_file_path(path)
                 .map(|url| JsValue::Url(String::from(url).into(), JsValueUrlKind::Absolute))
                 .unwrap_or_else(|_| {
                     JsValue::unknown(
-                        JsValue::call_from_parts(
+                        JsValue::call_from_iter(
                             JsValue::WellKnownFunction(WellKnownFunctionKind::PathToFileUrl),
                             args,
                         ),
@@ -560,7 +578,7 @@ fn path_to_file_url(args: Vec<JsValue>) -> JsValue {
                 })
         } else {
             JsValue::unknown(
-                JsValue::call_from_parts(
+                JsValue::call_from_iter(
                     JsValue::WellKnownFunction(WellKnownFunctionKind::PathToFileUrl),
                     args,
                 ),
@@ -570,7 +588,7 @@ fn path_to_file_url(args: Vec<JsValue>) -> JsValue {
         }
     } else {
         JsValue::unknown(
-            JsValue::call_from_parts(
+            JsValue::call_from_iter(
                 JsValue::WellKnownFunction(WellKnownFunctionKind::PathToFileUrl),
                 args,
             ),
@@ -580,7 +598,7 @@ fn path_to_file_url(args: Vec<JsValue>) -> JsValue {
     }
 }
 
-fn well_known_function_member(kind: WellKnownFunctionKind, prop: JsValue) -> (JsValue, bool) {
+fn well_known_function_member(kind: WellKnownFunctionKind, prop: Arc<JsValue>) -> (JsValue, bool) {
     let new_value = match (kind, prop.as_str()) {
         (WellKnownFunctionKind::Require, Some("resolve")) => {
             JsValue::WellKnownFunction(WellKnownFunctionKind::RequireResolve)
@@ -609,7 +627,7 @@ fn well_known_function_member(kind: WellKnownFunctionKind, prop: JsValue) -> (Js
         #[allow(unreachable_patterns)]
         (kind, _) => {
             return (
-                JsValue::member(JsValue::WellKnownFunction(kind), prop),
+                JsValue::member(Arc::new(JsValue::WellKnownFunction(kind)), prop),
                 false,
             );
         }
@@ -619,7 +637,7 @@ fn well_known_function_member(kind: WellKnownFunctionKind, prop: JsValue) -> (Js
 
 async fn well_known_object_member(
     kind: WellKnownObjectKind,
-    prop: JsValue,
+    prop: Arc<JsValue>,
     compile_time_info: Vc<CompileTimeInfo>,
 ) -> Result<(JsValue, bool)> {
     let new_value = match kind {
@@ -664,7 +682,10 @@ async fn well_known_object_member(
             // not supported. Users should migrate to import.meta.glob('...', { eager: true }).
             Some("glob") => JsValue::WellKnownFunction(WellKnownFunctionKind::ImportMetaGlob),
             _ => {
-                return Ok((JsValue::member(JsValue::WellKnownObject(kind), prop), false));
+                return Ok((
+                    JsValue::member(Arc::new(JsValue::WellKnownObject(kind)), prop),
+                    false,
+                ));
             }
         },
         WellKnownObjectKind::ModuleHot => match prop.as_str() {
@@ -673,7 +694,7 @@ async fn well_known_object_member(
             _ => {
                 return Ok((
                     JsValue::unknown(
-                        JsValue::member(JsValue::WellKnownObject(kind), prop),
+                        JsValue::member(Arc::new(JsValue::WellKnownObject(kind)), prop),
                         true,
                         rcstr!("unsupported property on module.hot"),
                     ),
@@ -683,18 +704,21 @@ async fn well_known_object_member(
         },
         #[allow(unreachable_patterns)]
         _ => {
-            return Ok((JsValue::member(JsValue::WellKnownObject(kind), prop), false));
+            return Ok((
+                JsValue::member(Arc::new(JsValue::WellKnownObject(kind)), prop),
+                false,
+            ));
         }
     };
     Ok((new_value, true))
 }
 
-fn global_object(prop: JsValue) -> JsValue {
+fn global_object(prop: Arc<JsValue>) -> JsValue {
     match prop.as_str() {
         Some("assign") => JsValue::WellKnownFunction(WellKnownFunctionKind::ObjectAssign),
         _ => JsValue::unknown(
             JsValue::member(
-                JsValue::WellKnownObject(WellKnownObjectKind::GlobalObject),
+                Arc::new(JsValue::WellKnownObject(WellKnownObjectKind::GlobalObject)),
                 prop,
             ),
             true,
@@ -705,7 +729,7 @@ fn global_object(prop: JsValue) -> JsValue {
 
 async fn path_module_member(
     kind: WellKnownObjectKind,
-    prop: JsValue,
+    prop: Arc<JsValue>,
     compile_time_info: Vc<CompileTimeInfo>,
 ) -> Result<JsValue> {
     Ok(match (kind, prop.as_str()) {
@@ -729,7 +753,7 @@ async fn path_module_member(
         }
         _ => JsValue::unknown(
             JsValue::member(
-                JsValue::WellKnownObject(WellKnownObjectKind::PathModule),
+                Arc::new(JsValue::WellKnownObject(WellKnownObjectKind::PathModule)),
                 prop,
             ),
             true,
@@ -738,7 +762,7 @@ async fn path_module_member(
     })
 }
 
-fn fs_module_member(kind: WellKnownObjectKind, prop: JsValue) -> JsValue {
+fn fs_module_member(kind: WellKnownObjectKind, prop: Arc<JsValue>) -> JsValue {
     if let Some(word) = prop.as_str() {
         match (kind, word) {
             (
@@ -764,7 +788,7 @@ fn fs_module_member(kind: WellKnownObjectKind, prop: JsValue) -> JsValue {
     }
     JsValue::unknown(
         JsValue::member(
-            JsValue::WellKnownObject(WellKnownObjectKind::FsModule),
+            Arc::new(JsValue::WellKnownObject(WellKnownObjectKind::FsModule)),
             prop,
         ),
         true,
@@ -772,7 +796,7 @@ fn fs_module_member(kind: WellKnownObjectKind, prop: JsValue) -> JsValue {
     )
 }
 
-fn fs_extra_module_member(kind: WellKnownObjectKind, prop: JsValue) -> JsValue {
+fn fs_extra_module_member(kind: WellKnownObjectKind, prop: Arc<JsValue>) -> JsValue {
     if let Some(word) = prop.as_str() {
         match (kind, word) {
             // regular fs methods
@@ -803,7 +827,7 @@ fn fs_extra_module_member(kind: WellKnownObjectKind, prop: JsValue) -> JsValue {
     }
     JsValue::unknown(
         JsValue::member(
-            JsValue::WellKnownObject(WellKnownObjectKind::FsExtraModule),
+            Arc::new(JsValue::WellKnownObject(WellKnownObjectKind::FsExtraModule)),
             prop,
         ),
         true,
@@ -811,7 +835,7 @@ fn fs_extra_module_member(kind: WellKnownObjectKind, prop: JsValue) -> JsValue {
     )
 }
 
-fn module_module_member(kind: WellKnownObjectKind, prop: JsValue) -> JsValue {
+fn module_module_member(kind: WellKnownObjectKind, prop: Arc<JsValue>) -> JsValue {
     match (kind, prop.as_str()) {
         (.., Some("createRequire")) => {
             JsValue::WellKnownFunction(WellKnownFunctionKind::CreateRequire)
@@ -821,7 +845,7 @@ fn module_module_member(kind: WellKnownObjectKind, prop: JsValue) -> JsValue {
         }
         _ => JsValue::unknown(
             JsValue::member(
-                JsValue::WellKnownObject(WellKnownObjectKind::ModuleModule),
+                Arc::new(JsValue::WellKnownObject(WellKnownObjectKind::ModuleModule)),
                 prop,
             ),
             true,
@@ -830,7 +854,7 @@ fn module_module_member(kind: WellKnownObjectKind, prop: JsValue) -> JsValue {
     }
 }
 
-fn url_module_member(kind: WellKnownObjectKind, prop: JsValue) -> JsValue {
+fn url_module_member(kind: WellKnownObjectKind, prop: Arc<JsValue>) -> JsValue {
     match (kind, prop.as_str()) {
         (.., Some("pathToFileURL")) => {
             JsValue::WellKnownFunction(WellKnownFunctionKind::PathToFileUrl)
@@ -840,7 +864,7 @@ fn url_module_member(kind: WellKnownObjectKind, prop: JsValue) -> JsValue {
         }
         _ => JsValue::unknown(
             JsValue::member(
-                JsValue::WellKnownObject(WellKnownObjectKind::UrlModule),
+                Arc::new(JsValue::WellKnownObject(WellKnownObjectKind::UrlModule)),
                 prop,
             ),
             true,
@@ -849,7 +873,7 @@ fn url_module_member(kind: WellKnownObjectKind, prop: JsValue) -> JsValue {
     }
 }
 
-fn worker_threads_module_member(kind: WellKnownObjectKind, prop: JsValue) -> JsValue {
+fn worker_threads_module_member(kind: WellKnownObjectKind, prop: Arc<JsValue>) -> JsValue {
     match (kind, prop.as_str()) {
         (.., Some("Worker")) => {
             JsValue::WellKnownFunction(WellKnownFunctionKind::NodeWorkerConstructor)
@@ -859,7 +883,9 @@ fn worker_threads_module_member(kind: WellKnownObjectKind, prop: JsValue) -> JsV
         }
         _ => JsValue::unknown(
             JsValue::member(
-                JsValue::WellKnownObject(WellKnownObjectKind::WorkerThreadsModule),
+                Arc::new(JsValue::WellKnownObject(
+                    WellKnownObjectKind::WorkerThreadsModule,
+                )),
                 prop,
             ),
             true,
@@ -868,7 +894,7 @@ fn worker_threads_module_member(kind: WellKnownObjectKind, prop: JsValue) -> JsV
     }
 }
 
-fn child_process_module_member(kind: WellKnownObjectKind, prop: JsValue) -> JsValue {
+fn child_process_module_member(kind: WellKnownObjectKind, prop: Arc<JsValue>) -> JsValue {
     let prop_str = prop.as_str();
     match (kind, prop_str) {
         (.., Some("spawn" | "spawnSync" | "execFile" | "execFileSync")) => {
@@ -883,7 +909,9 @@ fn child_process_module_member(kind: WellKnownObjectKind, prop: JsValue) -> JsVa
 
         _ => JsValue::unknown(
             JsValue::member(
-                JsValue::WellKnownObject(WellKnownObjectKind::ChildProcessModule),
+                Arc::new(JsValue::WellKnownObject(
+                    WellKnownObjectKind::ChildProcessModule,
+                )),
                 prop,
             ),
             true,
@@ -892,7 +920,7 @@ fn child_process_module_member(kind: WellKnownObjectKind, prop: JsValue) -> JsVa
     }
 }
 
-fn os_module_member(kind: WellKnownObjectKind, prop: JsValue) -> JsValue {
+fn os_module_member(kind: WellKnownObjectKind, prop: Arc<JsValue>) -> JsValue {
     match (kind, prop.as_str()) {
         (.., Some("platform")) => JsValue::WellKnownFunction(WellKnownFunctionKind::OsPlatform),
         (.., Some("arch")) => JsValue::WellKnownFunction(WellKnownFunctionKind::OsArch),
@@ -902,7 +930,7 @@ fn os_module_member(kind: WellKnownObjectKind, prop: JsValue) -> JsValue {
         }
         _ => JsValue::unknown(
             JsValue::member(
-                JsValue::WellKnownObject(WellKnownObjectKind::OsModule),
+                Arc::new(JsValue::WellKnownObject(WellKnownObjectKind::OsModule)),
                 prop,
             ),
             true,
@@ -912,7 +940,7 @@ fn os_module_member(kind: WellKnownObjectKind, prop: JsValue) -> JsValue {
 }
 
 async fn node_process_member(
-    prop: JsValue,
+    prop: Arc<JsValue>,
     compile_time_info: Vc<CompileTimeInfo>,
 ) -> Result<JsValue> {
     Ok(match prop.as_str() {
@@ -935,7 +963,9 @@ async fn node_process_member(
         Some("env") => JsValue::WellKnownObject(WellKnownObjectKind::NodeProcessEnv),
         _ => JsValue::unknown(
             JsValue::member(
-                JsValue::WellKnownObject(WellKnownObjectKind::NodeProcessModule),
+                Arc::new(JsValue::WellKnownObject(
+                    WellKnownObjectKind::NodeProcessModule,
+                )),
                 prop,
             ),
             true,
@@ -944,12 +974,12 @@ async fn node_process_member(
     })
 }
 
-fn node_pre_gyp(prop: JsValue) -> JsValue {
+fn node_pre_gyp(prop: Arc<JsValue>) -> JsValue {
     match prop.as_str() {
         Some("find") => JsValue::WellKnownFunction(WellKnownFunctionKind::NodePreGypFind),
         _ => JsValue::unknown(
             JsValue::member(
-                JsValue::WellKnownObject(WellKnownObjectKind::NodePreGyp),
+                Arc::new(JsValue::WellKnownObject(WellKnownObjectKind::NodePreGyp)),
                 prop,
             ),
             true,
@@ -958,12 +988,14 @@ fn node_pre_gyp(prop: JsValue) -> JsValue {
     }
 }
 
-fn express(prop: JsValue) -> JsValue {
+fn express(prop: Arc<JsValue>) -> JsValue {
     match prop.as_str() {
         Some("set") => JsValue::WellKnownFunction(WellKnownFunctionKind::NodeExpressSet),
         _ => JsValue::unknown(
             JsValue::member(
-                JsValue::WellKnownObject(WellKnownObjectKind::NodeExpressApp),
+                Arc::new(JsValue::WellKnownObject(
+                    WellKnownObjectKind::NodeExpressApp,
+                )),
                 prop,
             ),
             true,
@@ -972,14 +1004,16 @@ fn express(prop: JsValue) -> JsValue {
     }
 }
 
-fn protobuf_loader(prop: JsValue) -> JsValue {
+fn protobuf_loader(prop: Arc<JsValue>) -> JsValue {
     match prop.as_str() {
         Some("load") | Some("loadSync") => {
             JsValue::WellKnownFunction(WellKnownFunctionKind::NodeProtobufLoad)
         }
         _ => JsValue::unknown(
             JsValue::member(
-                JsValue::WellKnownObject(WellKnownObjectKind::NodeProtobufLoader),
+                Arc::new(JsValue::WellKnownObject(
+                    WellKnownObjectKind::NodeProtobufLoader,
+                )),
                 prop,
             ),
             true,

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/well_known.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/well_known.rs
@@ -1,6 +1,7 @@
-use std::{mem::take, sync::Arc};
+use std::mem::take;
 
 use anyhow::Result;
+use triomphe::Arc;
 use turbo_rcstr::rcstr;
 use turbo_tasks::Vc;
 use turbopack_core::compile_time_info::CompileTimeInfo;

--- a/turbopack/crates/turbopack-ecmascript/src/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/parse.rs
@@ -604,7 +604,7 @@ async fn parse_file_content(
                 Some(&parsed_program),
                 unresolved_mark,
                 top_level_mark,
-                Arc::new(var_with_ts_declare),
+                triomphe::Arc::new(var_with_ts_declare),
                 Some(&comments),
             );
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/import_meta_glob.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/import_meta_glob.rs
@@ -195,7 +195,7 @@ pub fn parse_import_meta_glob(
                                         format!("?{s}").into()
                                     };
                                     query = Some(q);
-                                } else if let JsValue::Object { parts, .. } = val {
+                                } else if let JsValue::Object { parts, .. } = &**val {
                                     // Support object form: { query: { bar: 'foo', raw: true } }
                                     // Serializes to "?bar=foo&raw=true" with URL-encoding.
                                     use crate::analyzer::ObjectPart;

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -1095,7 +1095,7 @@ async fn analyze_ecmascript_module_internal(
                 } => {
                     let func = analysis_state
                         .link_value(
-                            JsValue::member(obj.clone(), prop),
+                            JsValue::member((*obj).clone(), *prop),
                             eval_context.imports.get_attributes(span),
                         )
                         .await?;
@@ -1122,7 +1122,7 @@ async fn analyze_ecmascript_module_internal(
                             .link_value(take(value), ImportAttributes::empty_ref())
                             .await?;
                         if let JsValue::Function(_, func_ident, _) = value {
-                            let mut closure_arg = JsValue::alternatives(take(values));
+                            let mut closure_arg = JsValue::alternatives_arc(take(values));
                             if mutable {
                                 closure_arg.add_unknown_mutations(true);
                             }
@@ -1535,7 +1535,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
             logical_property: _,
         } => {
             for alt in values {
-                if let JsValue::WellKnownFunction(wkf) = alt {
+                if let JsValue::WellKnownFunction(wkf) = Arc::unwrap_or_clone(alt) {
                     handle_well_known_function_call(
                         wkf,
                         new,
@@ -1680,13 +1680,12 @@ async fn handle_dynamic_import_with_linked_args(
             .and_then(|options| {
                 if let JsValue::Object { parts, .. } = options {
                     parts.iter().find_map(|part| {
-                        if let ObjectPart::KeyValue(
-                            JsValue::Constant(super::analyzer::ConstantValue::Str(key)),
-                            value,
-                        ) = part
+                        if let ObjectPart::KeyValue(key, value) = part
+                            && let JsValue::Constant(super::analyzer::ConstantValue::Str(key)) =
+                                &**key
                             && key.as_str() == "with"
                         {
-                            return Some(value);
+                            return Some(&**value);
                         }
                         None
                     })
@@ -1806,14 +1805,11 @@ where
         match func {
             WellKnownFunctionKind::URLConstructor => {
                 let args = linked_args().await?;
-                if let [
-                    url,
-                    JsValue::Member(
-                        _,
-                        box JsValue::WellKnownObject(WellKnownObjectKind::ImportMeta),
-                        box JsValue::Constant(super::analyzer::ConstantValue::Str(meta_prop)),
-                    ),
-                ] = &args[..]
+                if let [url, member] = &args[..]
+                    && let JsValue::Member(_, member_obj, member_prop) = member
+                    && let JsValue::WellKnownObject(WellKnownObjectKind::ImportMeta) = &**member_obj
+                    && let JsValue::Constant(super::analyzer::ConstantValue::Str(meta_prop)) =
+                        &**member_prop
                     && meta_prop.as_str() == "url"
                 {
                     let pat = js_value_to_pattern(url);
@@ -1908,12 +1904,15 @@ where
                     if let Some(opts) = args.get(1) {
                         match opts {
                             JsValue::Object { parts, .. } => {
-                                let eval_value = parts.iter().find_map(|part| match part {
-                                    ObjectPart::KeyValue(
-                                        JsValue::Constant(JsConstantValue::Str(key)),
-                                        value,
-                                    ) if key.as_str() == "eval" => Some(value),
-                                    _ => None,
+                                let eval_value = parts.iter().find_map(|part| {
+                                    if let ObjectPart::KeyValue(key, value) = part
+                                        && let JsValue::Constant(JsConstantValue::Str(key)) = &**key
+                                        && key.as_str() == "eval"
+                                    {
+                                        Some(&**value)
+                                    } else {
+                                        None
+                                    }
                                 });
                                 if let Some(eval_value) = eval_value {
                                     match eval_value {
@@ -2131,15 +2130,11 @@ where
             )
         }
         WellKnownFunctionKind::Define => {
+            // analyze_amd_define expects `&[Arc<JsValue>]`; rewrap inline.
+            let args_arc: Vec<Arc<JsValue>> =
+                linked_args().await?.iter().cloned().map(Arc::new).collect();
             analyze_amd_define(
-                source,
-                analysis,
-                origin,
-                handler,
-                span,
-                ast_path,
-                linked_args().await?,
-                error_mode,
+                source, analysis, origin, handler, span, ast_path, &args_arc, error_mode,
             )
             .await?;
         }
@@ -2228,7 +2223,9 @@ where
 
         WellKnownFunctionKind::RequireContext => {
             let args = linked_args().await?;
-            let options = match parse_require_context(args) {
+            // parse_require_context expects `&[Arc<JsValue>]`; rewrap inline.
+            let args_arc: Vec<Arc<JsValue>> = args.iter().cloned().map(Arc::new).collect();
+            let options = match parse_require_context(&args_arc) {
                 Ok(options) => options,
                 Err(err) => {
                     let (args, hints) = explain_args(args);
@@ -2433,8 +2430,7 @@ where
                 let mut show_dynamic_warning = false;
                 let pat = js_value_to_pattern(&args[0]);
                 if pat.is_match_ignore_dynamic("node") && args.len() >= 2 {
-                    let first_arg =
-                        JsValue::member(Box::new(args[1].clone()), Box::new(0_f64.into()));
+                    let first_arg = JsValue::member(args[1].clone(), 0_f64.into());
                     let first_arg = state
                         .link_value(first_arg, ImportAttributes::empty_ref())
                         .await?;
@@ -2829,14 +2825,16 @@ where
                 let context_dir = get_traced_project_dir().await?;
                 let resolved_dirs = parts
                     .iter()
-                    .filter_map(|object_part| match object_part {
-                        ObjectPart::KeyValue(
-                            JsValue::Constant(key),
-                            JsValue::Array { items: dirs, .. },
-                        ) if key.as_str() == Some("includeDirs") => {
+                    .filter_map(|object_part| {
+                        if let ObjectPart::KeyValue(key, value) = object_part
+                            && let JsValue::Constant(key_const) = &**key
+                            && key_const.as_str() == Some("includeDirs")
+                            && let JsValue::Array { items: dirs, .. } = &**value
+                        {
                             Some(dirs.iter().filter_map(|dir| dir.as_str()))
+                        } else {
+                            None
                         }
-                        _ => None,
                     })
                     .flatten()
                     .map(|dir| {
@@ -3195,10 +3193,14 @@ async fn analyze_amd_define(
     handler: &Handler,
     span: Span,
     ast_path: &[AstParentKind],
-    args: &[JsValue],
+    args: &[Arc<JsValue>],
     error_mode: ResolveErrorMode,
 ) -> Result<()> {
-    match args {
+    // Pre-deref the arms via a slice of `&JsValue`. This avoids having to write `&**arg`
+    // in each pattern and keeps the existing match shape. `args` slot count is at most a
+    // small fixed handful, so the borrow vec is cheap.
+    let derefed: Vec<&JsValue> = args.iter().map(|a| &**a).collect();
+    match derefed.as_slice() {
         [JsValue::Constant(id), JsValue::Array { items: deps, .. }, _] if id.as_str().is_some() => {
             analyze_amd_define_with_deps(
                 source,
@@ -3305,7 +3307,7 @@ async fn analyze_amd_define_with_deps(
     span: Span,
     ast_path: &[AstParentKind],
     id: Option<&str>,
-    deps: &[JsValue],
+    deps: &[Arc<JsValue>],
     error_mode: ResolveErrorMode,
 ) -> Result<()> {
     let mut requests = Vec::new();
@@ -3461,6 +3463,7 @@ async fn value_visitor_inner(
             ) =>
         {
             let (_, args) = call.into_parts();
+            let args: Vec<JsValue> = args.into_iter().map(Arc::unwrap_or_clone).collect();
             require_context_visitor(origin, args).await?
         }
         JsValue::Call(_, ref call)
@@ -3486,18 +3489,17 @@ async fn value_visitor_inner(
                 JsValue::WellKnownFunction(WellKnownFunctionKind::CreateRequire)
             ) =>
         {
-            if let [
-                JsValue::Member(
-                    _,
-                    box JsValue::WellKnownObject(WellKnownObjectKind::ImportMeta),
-                    box JsValue::Constant(super::analyzer::ConstantValue::Str(prop)),
-                ),
-            ] = call.args()
+            if let [arg] = call.args()
+                && let JsValue::Member(_, member_obj, member_prop) = &**arg
+                && let JsValue::WellKnownObject(WellKnownObjectKind::ImportMeta) = &**member_obj
+                && let JsValue::Constant(super::analyzer::ConstantValue::Str(prop)) = &**member_prop
                 && prop.as_str() == "url"
             {
                 // `createRequire(import.meta.url)`
                 JsValue::WellKnownFunction(WellKnownFunctionKind::Require)
-            } else if let [JsValue::Url(rel, JsValueUrlKind::Relative)] = call.args() {
+            } else if let [arg] = call.args()
+                && let JsValue::Url(rel, JsValueUrlKind::Relative) = &**arg
+            {
                 // `createRequire(new URL("<rel>", import.meta.url))`
                 JsValue::WellKnownFunction(WellKnownFunctionKind::RequireFrom(Box::new(
                     rel.clone(),
@@ -3512,14 +3514,11 @@ async fn value_visitor_inner(
                 JsValue::WellKnownFunction(WellKnownFunctionKind::URLConstructor)
             ) =>
         {
-            if let [
-                JsValue::Constant(super::analyzer::ConstantValue::Str(url)),
-                JsValue::Member(
-                    _,
-                    box JsValue::WellKnownObject(WellKnownObjectKind::ImportMeta),
-                    box JsValue::Constant(super::analyzer::ConstantValue::Str(prop)),
-                ),
-            ] = call.args()
+            if let [arg0, arg1] = call.args()
+                && let JsValue::Constant(super::analyzer::ConstantValue::Str(url)) = &**arg0
+                && let JsValue::Member(_, member_obj, member_prop) = &**arg1
+                && let JsValue::WellKnownObject(WellKnownObjectKind::ImportMeta) = &**member_obj
+                && let JsValue::Constant(super::analyzer::ConstantValue::Str(prop)) = &**member_prop
             {
                 if prop.as_str() == "url" {
                     JsValue::Url(url.clone(), JsValueUrlKind::Relative)
@@ -3606,7 +3605,7 @@ async fn value_visitor_inner(
 
 async fn require_resolve_visitor(
     origin: Vc<Box<dyn ResolveOrigin>>,
-    args: Vec<JsValue>,
+    args: Vec<Arc<JsValue>>,
 ) -> Result<JsValue> {
     Ok(if args.len() == 1 {
         let pat = js_value_to_pattern(&args[0]);
@@ -3659,7 +3658,9 @@ async fn require_context_visitor(
     origin: Vc<Box<dyn ResolveOrigin>>,
     args: Vec<JsValue>,
 ) -> Result<JsValue> {
-    let options = match parse_require_context(&args) {
+    // parse_require_context expects `&[Arc<JsValue>]`; rewrap inline.
+    let args_arc: Vec<Arc<JsValue>> = args.iter().cloned().map(Arc::new).collect();
+    let options = match parse_require_context(&args_arc) {
         Ok(options) => options,
         Err(err) => {
             return Ok(JsValue::unknown(
@@ -3737,33 +3738,29 @@ fn is_invoking_node_process_eval(args: &[JsValue]) -> bool {
         return false;
     }
 
-    if let JsValue::Member(_, obj, constant) = &args[0] {
-        // Is the first argument to spawn `process.argv[]`?
-        if let (
-            &box JsValue::WellKnownObject(WellKnownObjectKind::NodeProcessArgv),
-            &box JsValue::Constant(JsConstantValue::Num(ConstantNumber(num))),
-        ) = (obj, constant)
+    if let JsValue::Member(_, obj, constant) = &args[0]
+        && let JsValue::WellKnownObject(WellKnownObjectKind::NodeProcessArgv) = &**obj
+        && let JsValue::Constant(JsConstantValue::Num(ConstantNumber(num))) = &**constant
+    {
+        // Is it specifically `process.argv[0]`?
+        if num.is_zero()
+            && let JsValue::Array {
+                total_nodes: _,
+                items,
+                mutable: _,
+            } = &args[1]
         {
-            // Is it specifically `process.argv[0]`?
-            if num.is_zero()
-                && let JsValue::Array {
-                    total_nodes: _,
-                    items,
-                    mutable: _,
-                } = &args[1]
-            {
-                // Is `-e` one of the arguments passed to the program?
-                if items.iter().any(|e| {
-                    if let JsValue::Constant(JsConstantValue::Str(ConstantString::Atom(arg))) = e {
-                        arg == "-e"
-                    } else {
-                        false
-                    }
-                }) {
-                    // If so, this is likely spawning node to evaluate a string, and
-                    // does not need to be statically analyzed.
-                    return true;
+            // Is `-e` one of the arguments passed to the program?
+            if items.iter().any(|e| {
+                if let JsValue::Constant(JsConstantValue::Str(ConstantString::Atom(arg))) = &**e {
+                    arg == "-e"
+                } else {
+                    false
                 }
+            }) {
+                // If so, this is likely spawning node to evaluate a string, and
+                // does not need to be statically analyzed.
+                return true;
             }
         }
     }

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -1099,7 +1099,7 @@ async fn analyze_ecmascript_module_internal(
                 } => {
                     let func = analysis_state
                         .link_value(
-                            JsValue::member((*obj).clone(), *prop),
+                            JsValue::member(Arc::new((*obj).clone()), Arc::new(*prop)),
                             eval_context.imports.get_attributes(span),
                         )
                         .await?;
@@ -1126,7 +1126,7 @@ async fn analyze_ecmascript_module_internal(
                             .link_value(take(value), ImportAttributes::empty_ref())
                             .await?;
                         if let JsValue::Function(_, func_ident, _) = value {
-                            let mut closure_arg = JsValue::alternatives_arc(take(values));
+                            let mut closure_arg = JsValue::alternatives(take(values));
                             if mutable {
                                 closure_arg.add_unknown_mutations(true);
                             }
@@ -2339,11 +2339,11 @@ where
 
             let linked_func_call = state
                 .link_value(
-                    JsValue::call_from_parts(
+                    JsValue::call_from_iter(
                         JsValue::WellKnownFunction(WellKnownFunctionKind::PathResolve(Box::new(
                             parent_path.path.as_str().into(),
                         ))),
-                        args.clone(),
+                        args.iter().cloned().map(Arc::new),
                     ),
                     ImportAttributes::empty_ref(),
                 )
@@ -2388,9 +2388,9 @@ where
             let args = linked_args().await?;
             let linked_func_call = state
                 .link_value(
-                    JsValue::call_from_parts(
+                    JsValue::call_from_iter(
                         JsValue::WellKnownFunction(WellKnownFunctionKind::PathJoin),
-                        args.clone(),
+                        args.iter().cloned().map(Arc::new),
                     ),
                     ImportAttributes::empty_ref(),
                 )
@@ -2434,7 +2434,8 @@ where
                 let mut show_dynamic_warning = false;
                 let pat = js_value_to_pattern(&args[0]);
                 if pat.is_match_ignore_dynamic("node") && args.len() >= 2 {
-                    let first_arg = JsValue::member(args[1].clone(), 0_f64.into());
+                    let first_arg =
+                        JsValue::member(Arc::new(args[1].clone()), Arc::new(0_f64.into()));
                     let first_arg = state
                         .link_value(first_arg, ImportAttributes::empty_ref())
                         .await?;
@@ -2685,13 +2686,13 @@ where
                             } else {
                                 let linked_func_call = state
                                     .link_value(
-                                        JsValue::call_from_parts(
+                                        JsValue::call_from_iter(
                                             JsValue::WellKnownFunction(
                                                 WellKnownFunctionKind::PathJoin,
                                             ),
-                                            vec![
-                                                JsValue::FreeVar(atom!("__dirname")),
-                                                pkg_or_dir.clone(),
+                                            [
+                                                Arc::new(JsValue::FreeVar(atom!("__dirname"))),
+                                                Arc::new(pkg_or_dir.clone()),
                                             ],
                                         ),
                                         ImportAttributes::empty_ref(),
@@ -2756,12 +2757,12 @@ where
                 } else {
                     let linked_func_call = state
                         .link_value(
-                            JsValue::call_from_parts(
+                            JsValue::call_from_iter(
                                 JsValue::WellKnownFunction(WellKnownFunctionKind::PathJoin),
-                                vec![
-                                    JsValue::FreeVar(atom!("__dirname")),
-                                    p.into(),
-                                    atom!("intl").into(),
+                                [
+                                    Arc::new(JsValue::FreeVar(atom!("__dirname"))),
+                                    Arc::new(p.into()),
+                                    Arc::new(atom!("intl").into()),
                                 ],
                             ),
                             ImportAttributes::empty_ref(),
@@ -3467,7 +3468,6 @@ async fn value_visitor_inner(
             ) =>
         {
             let (_, args) = call.into_parts();
-            let args: Vec<JsValue> = args.into_iter().map(Arc::unwrap_or_clone).collect();
             require_context_visitor(origin, args).await?
         }
         JsValue::Call(_, ref call)
@@ -3623,16 +3623,17 @@ async fn require_resolve_visitor(
         )
         .to_resolved()
         .await?;
-        let mut values =
-            resolved
-                .primary_sources()
-                .await?
-                .iter()
-                .map(|&source| async move {
-                    Ok(require_resolve(source.ident().await?.path.clone()).into())
-                })
-                .try_join()
-                .await?;
+        let mut values: Vec<Arc<JsValue>> = resolved
+            .primary_sources()
+            .await?
+            .iter()
+            .map(|&source| async move {
+                Ok(Arc::new(
+                    require_resolve(source.ident().await?.path.clone()).into(),
+                ))
+            })
+            .try_join()
+            .await?;
 
         match values.len() {
             0 => JsValue::unknown(
@@ -3643,7 +3644,7 @@ async fn require_resolve_visitor(
                 false,
                 rcstr!("unresolvable request"),
             ),
-            1 => values.pop().unwrap(),
+            1 => Arc::unwrap_or_clone(values.pop().unwrap()),
             _ => JsValue::alternatives(values),
         }
     } else {
@@ -3660,15 +3661,13 @@ async fn require_resolve_visitor(
 
 async fn require_context_visitor(
     origin: Vc<Box<dyn ResolveOrigin>>,
-    args: Vec<JsValue>,
+    args: Vec<Arc<JsValue>>,
 ) -> Result<JsValue> {
-    // parse_require_context expects `&[Arc<JsValue>]`; rewrap inline.
-    let args_arc: Vec<Arc<JsValue>> = args.iter().cloned().map(Arc::new).collect();
-    let options = match parse_require_context(&args_arc) {
+    let options = match parse_require_context(&args) {
         Ok(options) => options,
         Err(err) => {
             return Ok(JsValue::unknown(
-                JsValue::call_from_parts(
+                JsValue::call_from_iter(
                     JsValue::WellKnownFunction(WellKnownFunctionKind::RequireContext),
                     args,
                 ),

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -26,7 +26,7 @@ use std::{
     future::Future,
     mem::take,
     ops::Deref,
-    sync::{Arc, LazyLock},
+    sync::{Arc as StdArc, LazyLock},
 };
 
 use anyhow::Result;
@@ -60,6 +60,10 @@ use swc_core::{
 };
 use tokio::sync::OnceCell;
 use tracing::Instrument;
+// `triomphe::Arc` is preferred for `JsValue` because of its smaller header
+// (no weak refcount). `std::sync::Arc` is still imported as `StdArc` above for
+// types that interoperate with `Arc<Globals>` etc.
+use triomphe::Arc;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     FxIndexMap, FxIndexSet, NonLocalValue, PrettyPrintError, ReadRef, ResolvedVc, TaskInput,
@@ -499,7 +503,7 @@ impl AnalysisState<'_> {
     }
 }
 
-fn set_handler_and_globals<F, R>(handler: &Handler, globals: &Arc<Globals>, f: F) -> R
+fn set_handler_and_globals<F, R>(handler: &Handler, globals: &StdArc<Globals>, f: F) -> R
 where
     F: FnOnce() -> R,
 {

--- a/turbopack/crates/turbopack-ecmascript/src/utils.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/utils.rs
@@ -55,13 +55,14 @@ pub fn js_value_to_pattern(value: &JsValue) -> Pattern {
             values,
             logical_property: _,
         } => {
-            let mut alts = Pattern::Alternatives(values.iter().map(js_value_to_pattern).collect());
+            let mut alts =
+                Pattern::Alternatives(values.iter().map(|v| js_value_to_pattern(v)).collect());
             alts.normalize();
             alts
         }
         JsValue::Concat(_, parts) => {
             let mut concats =
-                Pattern::Concatenation(parts.iter().map(js_value_to_pattern).collect());
+                Pattern::Concatenation(parts.iter().map(|v| js_value_to_pattern(v)).collect());
             concats.normalize();
             concats
         }
@@ -296,6 +297,8 @@ pub fn inline_source_map_comment(original_path: &str, original_content: &str) ->
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use turbo_rcstr::rcstr;
     use turbopack_core::resolve::pattern::Pattern;
 
@@ -318,9 +321,9 @@ mod tests {
             js_value_to_pattern(&JsValue::Concat(
                 1,
                 vec![
-                    rcstr!("hello").into(),
-                    rcstr!("\\").into(),
-                    rcstr!("world").into()
+                    Arc::new(rcstr!("hello").into()),
+                    Arc::new(rcstr!("\\").into()),
+                    Arc::new(rcstr!("world").into()),
                 ]
             ))
         );

--- a/turbopack/crates/turbopack-ecmascript/src/utils.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/utils.rs
@@ -297,8 +297,7 @@ pub fn inline_source_map_comment(original_path: &str, original_content: &str) ->
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
+    use triomphe::Arc;
     use turbo_rcstr::rcstr;
     use turbopack_core::resolve::pattern::Pattern;
 

--- a/turbopack/crates/turbopack-ecmascript/src/webpack/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/webpack/parse.rs
@@ -12,6 +12,7 @@ use swc_core::{
         visit::{Visit, VisitWith},
     },
 };
+use triomphe::Arc;
 use turbo_rcstr::rcstr;
 use turbo_tasks::Vc;
 use turbo_tasks_fs::FileSystemPath;
@@ -227,8 +228,8 @@ pub async fn webpack_runtime(
 
                 if let (Some(chunk_filename), Some(prefix_path)) = (chunk_filename, prefix_path) {
                     let value = JsValue::concat(vec![
-                        JsValue::Constant(prefix_path.into()),
-                        chunk_filename,
+                        Arc::new(JsValue::Constant(prefix_path.into())),
+                        Arc::new(chunk_filename),
                     ]);
 
                     return Ok(WebpackRuntime::Webpack5 {


### PR DESCRIPTION
WIP: benchmark results are not compelling.

## What this branch does

Wrap recursive `JsValue` children in `triomphe::Arc` and remove a number of follow-on clones. The intent was to eliminate the per-argument `Box<JsValue>` allocations the analyzer was doing for `Call` / `MemberCall` argument lists and reduce make-mut clones in the visitor APIs.

Changes layered on top of the original commit:

- `triomphe::Arc<JsValue>` for all recursive children, replacing `Box<JsValue>` and `std::sync::Arc<JsValue>` mixed usage.
- `Vec<Arc<JsValue>>` for argument lists, with `[args..., callee]` and `[args..., prop, obj]` tail layouts so `into_parts` / `from_parts` can round-trip without re-allocating.
- Constructor surface forced to take `Arc<JsValue>` directly so heap allocations are visible at the call site (no JsValue-wrapping convenience overloads). Renamed the surviving `_arc` variants to drop the suffix.
- Pushed `Arc<JsValue>` down through `well_known_function_call`, the prop-dispatch helpers (`*_module_member`), and `require_context_visitor` so we don't unwrap-and-rewrap at the boundary.
- `for_each_children_mut` (and the `_early` / `_late` siblings) now take `&mut Arc<JsValue>` instead of `&mut JsValue`, letting the visitor decide whether to replace the slot, mutate the inner via `Arc::make_mut`, or just read.
- Pushed `Arc::make_mut` audit through `builtin.rs` — match on `&*obj` for variant dispatch, then `Arc::unwrap_or_clone` only inside the matched branch.
- `take_arc_slot` helper with a shared `PLACEHOLDER` static, used in linker.rs and builtin.rs to swap out a child without paying for `Arc::default()`'s per-call allocation.

## Benchmark results

Compared against canary using the in-tree `analyzer` criterion benches (`create_graph` and `link` on every fixture in `tests/analyzer/graph/`).

### Headline (full run, 87 benchmarks)

|        | n  | median Δ | mean Δ | worst |
|---|---:|---:|---:|---|
| create_graph | 57 | **+8.8%** | +9.7% | process-and-os: +34.2% |
| link         | 30 | **+4.0%** | +4.2% | member-call: +15.8% |
| **All**      | 87 | **+6.7%** | +7.8% | |

62 regressed (criterion p < 0.05), 8 improved, 17 noise/no-change.

### Worst regressions (full run)

```
create_graph/process-and-os       +34.2%
create_graph/logical              +29.9%
create_graph/member-call          +29.7%
create_graph/md5-reduced          +27.2%
create_graph/cycle-cache          +25.1%
create_graph/md5_2                +24.9%
create_graph/md5                  +23.0%
create_graph/assign               +22.0%
create_graph/esbuild              +18.5%
create_graph/peg                  +16.4%
link/esbuild                      +17.4%
link/member-call                  +15.8%
link/cycle-cache                  +15.7%
link/peg                          +13.5%
link/md5-reduced                  +13.6%
link/pack-2521                    +11.8%
```

Top improvements were small (1–6%) and inconsistent: `arrow`, `iife`, `nested`, `declarations`, `class_super`, `webpack-target-node`, `unreachable`, `import-meta-prop`.

### Re-measurement

Reran a targeted subset (large Δ, non-trivial absolute time) against a freshly-saved canary baseline to check for system interference. Canary's own absolute times drifted 1–4% between baseline runs (system noise floor); the regression sizes were stable within ~3pp.

| Benchmark | 1st Δ | 2nd Δ |
|---|---:|---:|
| create_graph/process-and-os | +34.2% | +33.9% |
| create_graph/md5-reduced    | +27.2% | +28.8% |
| create_graph/cycle-cache    | +25.1% | +26.6% |
| create_graph/assign         | +22.0% | +25.3% |
| create_graph/md5_2          | +24.9% | +23.0% |
| create_graph/esbuild        | +18.5% | +20.9% |
| link/cycle-cache            | +15.7% | +21.1% |
| link/esbuild                | +17.4% | +18.8% |
| create_graph/peg            | +16.4% | +13.6% |
| link/peg                    | +13.5% | +10.6% |
| link/md5-reduced            | +13.6% | +16.0% |
| link/process-and-os         |  +8.2% | +10.4% |

The regressions are reproducible.

### Note about the canary baseline

Between the two measurement runs, canary picked up `ed1c6ccbdb perf(ecmascript): shrink JsValue 64→32 bytes (#93106)` and a couple of other turbopack commits. The branch was rebased onto that newer canary before the second measurement, so both rounds compare like-for-like — but the gap is being measured against a faster canary than the first round. The fact that regression sizes still match across rounds means those canary changes didn't shift the comparison.

## Why probably

`create_graph` regresses harder than `link` (median 8.8% vs 4.0%), but `create_graph` doesn't go through the linker at all, so the `&mut Arc<JsValue>` visitor API and the `take_arc_slot` work aren't the cause. `create_graph` is dominated by JsValue construction — `call_from_iter`, `member`, `tenary`, `equal`, etc. — which is exactly the surface where this branch forced explicit `Arc::new(...)` at every call site instead of wrapping inside the constructor.

Suspected sources of extra allocations:

1. `linked_args` and similar in `references/mod.rs` now do `args.iter().cloned().map(Arc::new)` — Arc-allocs per arg per call.
2. `graph.rs` builds alternatives/concat lists with `.into_iter().map(Arc::new).collect()` — Arc-allocs per element.
3. Constructors that previously consumed `JsValue` (already-flat, no inner Arc) now demand `Arc<JsValue>`, so callers Arc-wrap eagerly even when the value would have been immediately destructured.
4. linker.rs leave-phase: every `*child = Arc::new(val)` is a fresh alloc — `done` would need to be `Vec<Arc<JsValue>>` for that allocation to be avoidable.

## Things still worth exploring

- **Bisect the branch.** Several commits' worth of changes are layered here. Running the bench at intermediate commits would tell us whether the storage change (Arc child layout) is itself fine and the regression is concentrated in the constructor-surface change, the visitor-API change, or something else. Cheapest next step.
- **Push `Arc<JsValue>` further into the linker.** `Step::Enter`/`Leave`/`Visit` and `done` currently hold `JsValue`; flipping them to `Arc<JsValue>` lets the original Arc allocation flow back into a child slot when the visitor doesn't modify it. That's the only path I see to recovering the leave-phase `Arc::new(val)` cost.
- **Profile the worst case.** `create_graph/process-and-os` (+34%) on a flame graph would tell us where the extra time is going. If it's `Arc::new` / `alloc::alloc`, that confirms the alloc-count theory; if it's `Arc::clone` / `Drop`, we're paying refcount overhead instead.
- **Selectively un-revert convenience constructors.** The "callers wrap Arcs explicitly" rule catches us at every leaf JsValue construction. We could keep that rule for the list-shaped constructors (where the `_arc` form is the natural one) and restore the JsValue-taking variants for the small fixed-arity ones (`tenary`, `equal`, etc.) where there's no real ambiguity to surface.

Raw criterion logs for the runs in this PR are at `/tmp/bench-canary.log`, `/tmp/bench-feature.log`, `/tmp/bench-canary-rerun.log`, `/tmp/bench-feature-rerun.log` on my machine.

<!-- NEXT_JS_LLM_PR -->