### PR TITLE
CI speed improvements

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -136,6 +136,7 @@ jobs:
     name: build-next
     uses: ./.github/workflows/build_reusable.yml
     with:
+      needsPlaywright: 'no'
       skipNativeBuild: 'yes'
       stepName: 'build-next'
     secrets: inherit
@@ -210,6 +211,7 @@ jobs:
     needs: ['build-next']
     uses: ./.github/workflows/build_reusable.yml
     with:
+      needsPlaywright: 'no'
       skipNativeBuild: 'yes'
       skipNativeInstall: 'yes'
       afterBuild: |
@@ -241,6 +243,7 @@ jobs:
 
     uses: ./.github/workflows/build_reusable.yml
     with:
+      needsPlaywright: 'no'
       afterBuild: pnpm types-and-precompiled
       stepName: 'types-and-precompiled'
     secrets: inherit
@@ -710,6 +713,7 @@ jobs:
 
     uses: ./.github/workflows/build_reusable.yml
     with:
+      needsPlaywright: 'no'
       nodeVersion: ${{ matrix.node }}
       afterBuild: node run-tests.js --type unit
       stepName: 'test-unit-${{ matrix.node }}'
@@ -772,6 +776,7 @@ jobs:
 
     uses: ./.github/workflows/build_reusable.yml
     with:
+      needsPlaywright: 'no'
       nodeVersion: ${{ matrix.node }}
       afterBuild: node run-tests.js --type unit
       stepName: 'test-unit-windows-${{ matrix.node }}'
@@ -1092,8 +1097,6 @@ jobs:
     with:
       browser: 'firefox webkit'
       afterBuild: |
-        pnpm playwright install
-
         # these all run without concurrency because they're heavier
         export TEST_CONCURRENCY=1
         export IS_TURBOPACK_TEST=1

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -162,6 +162,23 @@ jobs:
         with:
           fetch-depth: 25
 
+      # Match the reusable workflow's pnpm-store cache path so this setup-only
+      # job does not bottleneck the larger test matrix.
+      - name: Get pnpm store directory
+        if: ${{ runner.environment == 'github-hosted' }}
+        id: get-store-path
+        run: echo STORE_PATH=$(pnpm store path) >> $GITHUB_OUTPUT
+
+      - name: Cache pnpm store
+        if: ${{ runner.environment == 'github-hosted' }}
+        uses: actions/cache@v4
+        timeout-minutes: 5
+        id: cache-pnpm-store
+        with:
+          path: ${{ steps.get-store-path.outputs.STORE_PATH }}
+          key: pnpm-store-v2-${{ hashFiles('pnpm-lock.yaml') }}
+          # Do not use restore-keys since it leads to indefinite growth of the cache.
+
       - name: Install dependencies
         run: pnpm install
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -172,7 +172,7 @@ jobs:
 
       - name: Cache pnpm store
         if: ${{ runner.environment == 'github-hosted' }}
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         timeout-minutes: 5
         id: cache-pnpm-store
         with:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -168,7 +168,7 @@ jobs:
       - name: Get pnpm store directory
         if: ${{ runner.environment == 'github-hosted' }}
         id: get-store-path
-        run: echo STORE_PATH=$(pnpm store path) >> $GITHUB_OUTPUT
+        run: echo STORE_PATH="$(pnpm store path)" >> "$GITHUB_OUTPUT"
 
       - name: Cache pnpm store
         if: ${{ runner.environment == 'github-hosted' }}

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -96,6 +96,11 @@ on:
         required: false
         type: string
         default: 'chromium'
+      needsPlaywright:
+        description: 'whether Playwright browser installation is needed'
+        required: false
+        type: string
+        default: 'yes'
 env:
   NAPI_CLI_VERSION: 2.18.4
   TURBO_VERSION: 2.9.4
@@ -320,7 +325,7 @@ jobs:
         if: ${{ inputs.skipInstallBuild != 'yes' }}
 
       - name: Install Playwright browsers
-        if: ${{ inputs.skipInstallBuild != 'yes' }}
+        if: ${{ inputs.skipInstallBuild != 'yes' && inputs.needsPlaywright != 'no' }}
         run: |
           PW_VERSION=$(pnpm playwright --version 2>/dev/null || echo "unknown")
           CACHE_DIR="$HOME/.cache"


### PR DESCRIPTION
## What?

- Restore pnpm store for test timing fetch to speed up `pnpm install` in that step.
- Skip playwright install when it's not needed. Multiple steps don't need Playwright in order to run. Saves 41 seconds per step that doesn't need it.
- Removed extra playwright install on the `test-firefox-safari` as Playwright already gets installed in the reusable workflow.

### Before (canary)

<img width="1546" height="1142" alt="CleanShot 2026-05-01 at 16 17 37@2x" src="https://github.com/user-attachments/assets/7819915b-9c42-4286-b0b9-c2489b322825" />

### After (This PR)

<img width="1588" height="968" alt="CleanShot 2026-05-01 at 16 17 25@2x" src="https://github.com/user-attachments/assets/fb583831-a78c-42db-a77d-7e27af9c1f35" />

