### PR TITLE
Fix streaming in draft mode for cache components

### DIFF
--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -535,6 +535,8 @@ export async function handler(
     // If we're in development, we always support dynamic HTML, unless it's
     // a data request, in which case we only produce static HTML.
     routeModule.isDev === true ||
+    // If this is a draft mode request, it supports dynamic HTML.
+    isDraftMode ||
     // If this is not SSG or does not have static paths, then it supports
     // dynamic HTML.
     !isSSG ||

--- a/test/e2e/app-dir/cache-components/app/draftmode/streaming/layout.tsx
+++ b/test/e2e/app-dir/cache-components/app/draftmode/streaming/layout.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from 'react'
+import { draftMode } from 'next/headers'
+
+export default async function Layout({ children }: { children: ReactNode }) {
+  const { isEnabled } = await draftMode()
+
+  return (
+    <>
+      <div id="draft-mode">{String(isEnabled)}</div>
+      {children}
+    </>
+  )
+}

--- a/test/e2e/app-dir/cache-components/app/draftmode/streaming/loading.tsx
+++ b/test/e2e/app-dir/cache-components/app/draftmode/streaming/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <div id="delayed-runtime-fallback">Loading draft content...</div>
+}

--- a/test/e2e/app-dir/cache-components/app/draftmode/streaming/page.tsx
+++ b/test/e2e/app-dir/cache-components/app/draftmode/streaming/page.tsx
@@ -1,0 +1,5 @@
+export default async function Page() {
+  await new Promise((resolve) => setTimeout(resolve, 100))
+
+  return <div id="delayed-runtime-content">Draft runtime content</div>
+}

--- a/test/e2e/app-dir/cache-components/cache-components.draft-mode.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.draft-mode.test.ts
@@ -39,4 +39,23 @@ describe('cache-components', () => {
       expect(getLines('Route "/draftmode')).toEqual([])
     }
   })
+
+  if (!isNextDev) {
+    it('should stream Suspense fallbacks when draft mode is enabled', async () => {
+      const draftRes = await next.fetch('/draftmode/toggle')
+      const setCookie = draftRes.headers.get('set-cookie')
+      const cookieHeader = { Cookie: setCookie?.split(';', 1)[0] }
+
+      expect(cookieHeader.Cookie).toBeTruthy()
+
+      const $ = await next.render$('/draftmode/streaming', undefined, {
+        headers: cookieHeader,
+      })
+
+      expect($('#draft-mode').text()).toBe('true')
+      expect($('#delayed-runtime-fallback').text()).toBe(
+        'Loading draft content...'
+      )
+    })
+  }
 })


### PR DESCRIPTION
Even though Next doesn't generate PPR shells for draftMode.enabled versions of pages, it should still stream any Suspense fallbacks those pages happen to render. Currently, when draftMode is enabled, pages fully block on all IO.

This behavior is unintentional and this PR fixes this so that draftMode.enabled pages can still stream.