### PR TITLE
turbo-tasks: support `&T` parameters in `#[turbo_tasks::function]` bodies

### DIFF
--- a/.alexrc
+++ b/.alexrc
@@ -24,6 +24,7 @@
     "host-hostess",
     "invalid",
     "railway",
+    "reject",
     "remains",
     "simple",
     "special",

--- a/.config/ast-grep/rule-tests/turbo-task-pass-by-ref-hint-test.yml
+++ b/.config/ast-grep/rule-tests/turbo-task-pass-by-ref-hint-test.yml
@@ -1,0 +1,71 @@
+id: turbo-task-pass-by-ref-hint
+valid:
+  # Already by-ref — no hint.
+  - |
+    #[turbo_tasks::function]
+    pub async fn ok_by_ref(items: &Vec<i32>) -> Vc<i32> {}
+  - |
+    #[turbo_tasks::function]
+    pub async fn ok_path_by_ref(p: &FileSystemPath) -> Vc<i32> {}
+  # Vc-shaped types — Copy, no hint.
+  - |
+    #[turbo_tasks::function]
+    pub async fn vc_only(v: Vc<Foo>) -> Vc<i32> {}
+  - |
+    #[turbo_tasks::function]
+    pub async fn resolved_vc(v: ResolvedVc<Foo>) -> Vc<i32> {}
+  - |
+    #[turbo_tasks::function]
+    pub async fn vc_wrapping_vec(v: Vc<Vec<Foo>>) -> Vc<i32> {}
+  # Function not annotated — out of scope.
+  - |
+    pub async fn plain_fn(items: Vec<i32>) {}
+  # Primitives by value — no hint.
+  - |
+    #[turbo_tasks::function]
+    pub async fn primitive(n: u32) -> Vc<i32> {}
+
+invalid:
+  # Vec<...> — flag, including when elements are Vc.
+  - |
+    #[turbo_tasks::function]
+    pub async fn flag_vec(items: Vec<i32>) -> Vc<i32> {}
+  - |
+    #[turbo_tasks::function]
+    pub async fn flag_vec_of_vc(items: Vec<Vc<Foo>>) -> Vc<i32> {}
+  - |
+    #[turbo_tasks::function]
+    pub async fn flag_vec_of_resolved(items: Vec<ResolvedVc<Foo>>) -> Vc<i32> {}
+  # Map types — flag.
+  - |
+    #[turbo_tasks::function]
+    pub async fn flag_hashmap(m: HashMap<String, i32>) -> Vc<i32> {}
+  - |
+    #[turbo_tasks::function]
+    pub async fn flag_indexmap(m: IndexMap<String, i32>) -> Vc<i32> {}
+  - |
+    #[turbo_tasks::function]
+    pub async fn flag_fxhashmap(m: FxHashMap<String, i32>) -> Vc<i32> {}
+  - |
+    #[turbo_tasks::function]
+    pub async fn flag_btreemap(m: BTreeMap<String, i32>) -> Vc<i32> {}
+  - |
+    #[turbo_tasks::function]
+    pub async fn flag_btreeset(s: BTreeSet<i32>) -> Vc<i32> {}
+  # Owned strings / paths — flag.
+  - |
+    #[turbo_tasks::function]
+    pub async fn flag_string(s: String) -> Vc<i32> {}
+  - |
+    #[turbo_tasks::function]
+    pub async fn flag_pathbuf(p: PathBuf) -> Vc<i32> {}
+  - |
+    #[turbo_tasks::function]
+    pub async fn flag_path(p: FileSystemPath) -> Vc<i32> {}
+  # Trait declaration also flagged.
+  - |
+    #[turbo_tasks::value_trait]
+    pub trait FooTrait {
+        #[turbo_tasks::function]
+        fn flag_in_trait(p: FileSystemPath) -> Vc<i32>;
+    }

--- a/.config/ast-grep/rules/turbo-task-pass-by-ref-hint.yml
+++ b/.config/ast-grep/rules/turbo-task-pass-by-ref-hint.yml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ast-grep/ast-grep/main/schemas/rule.json
+
+id: turbo-task-pass-by-ref-hint
+message: >
+  consider taking `$NAME` by reference (`&$TYPE`); the cache key is still
+  built from the owned value at the call site, but the body avoids one
+  clone per cache miss.
+note: >
+  See `turbopack/crates/turbo-tasks/function.md` ("Argument Rewrite Rule")
+  for when this matters. Skip the migration when the body would need an
+  added explicit `.clone()` to compensate, when the parameter is consumed
+  by a callee that takes ownership, or when the body mutates it.
+severity: hint
+language: Rust
+rule:
+  any:
+    # Function items: `#[turbo_tasks::function] fn foo(x: Vec<...>)`.
+    - pattern:
+        context: 'fn _($NAME: $TYPE) {}'
+        selector: parameter
+      inside:
+        kind: function_item
+        stopBy: end
+        follows:
+          pattern: '#[turbo_tasks::function]'
+    # Trait method declarations on a `#[turbo_tasks::value_trait]` trait.
+    - pattern:
+        context: 'fn _($NAME: $TYPE);'
+        selector: parameter
+      inside:
+        kind: function_signature_item
+        stopBy: end
+        follows:
+          pattern: '#[turbo_tasks::function]'
+constraints:
+  TYPE:
+    regex: '^(Vec<|HashMap<|FxHashMap<|IndexMap<|FxIndexMap<|BTreeMap<|BTreeSet<|HashSet<|FxHashSet<|IndexSet<|String$|PathBuf$|OsString$|FileSystemPath$)'

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -1767,7 +1767,7 @@ impl AppEndpoint {
         self: Vc<Self>,
         client_references: Vc<ClientReferenceGraphResult>,
         server_action_manifest_loader: ResolvedVc<Box<dyn EvaluatableAsset>>,
-        server_path: FileSystemPath,
+        server_path: &FileSystemPath,
         process_client_assets: bool,
         module_graph: Vc<ModuleGraph>,
     ) -> Result<Vc<OutputAssetsWithReferenced>> {

--- a/crates/next-api/src/loadable_manifest.rs
+++ b/crates/next-api/src/loadable_manifest.rs
@@ -16,7 +16,7 @@ use crate::dynamic_imports::DynamicImportedChunks;
 pub async fn create_react_loadable_manifest(
     dynamic_import_entries: Vc<DynamicImportedChunks>,
     chunking_context: Vc<Box<dyn ChunkingContext>>,
-    client_relative_path: FileSystemPath,
+    client_relative_path: &FileSystemPath,
     output_path: FileSystemPath,
     runtime: NextRuntime,
 ) -> Result<Vc<OutputAssets>> {

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -906,7 +906,7 @@ impl PageEndpoint {
         self: Vc<Self>,
         ty: SsrChunkType,
         emit_manifests: EmitManifests,
-        node_path: FileSystemPath,
+        node_path: &FileSystemPath,
         node_chunking_context: Vc<NodeJsChunkingContext>,
         edge_chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<SsrChunk>> {

--- a/crates/next-api/src/paths.rs
+++ b/crates/next-api/src/paths.rs
@@ -31,7 +31,7 @@ pub struct OptionAssetPath(Option<AssetPath>);
 #[turbo_tasks::function]
 async fn asset_path(
     asset: Vc<Box<dyn OutputAsset>>,
-    node_root: FileSystemPath,
+    node_root: &FileSystemPath,
     should_content_hash: Option<HashAlgorithm>,
 ) -> Result<Vc<OptionAssetPath>> {
     Ok(Vc::cell(
@@ -61,7 +61,7 @@ async fn asset_path(
 #[turbo_tasks::function]
 pub async fn all_asset_paths(
     assets: Vc<OutputAssets>,
-    node_root: FileSystemPath,
+    node_root: &FileSystemPath,
     should_content_hash: Option<HashAlgorithm>,
 ) -> Result<Vc<AssetPaths>> {
     let span = tracing::info_span!(
@@ -90,12 +90,12 @@ pub async fn all_asset_paths(
 #[turbo_tasks::function]
 pub async fn all_paths_in_root(
     assets: Vc<OutputAssets>,
-    root: FileSystemPath,
+    root: &FileSystemPath,
 ) -> Result<Vc<Vec<RcStr>>> {
     let all_assets = &*all_assets_from_entries(assets).await?;
 
     Ok(Vc::cell(
-        get_paths_from_root(&root, all_assets, |_| true).await?,
+        get_paths_from_root(root, all_assets, |_| true).await?,
     ))
 }
 

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -2283,11 +2283,11 @@ impl Project {
     #[turbo_tasks::function]
     async fn hmr_content(
         self: Vc<Self>,
-        chunk_name: RcStr,
+        chunk_name: &RcStr,
         target: HmrTarget,
     ) -> Result<Vc<OptionVersionedContent>> {
         if let Some(map) = self.await?.versioned_content_map {
-            let content = map.get(self.hmr_root_path(target).await?.join(&chunk_name)?);
+            let content = map.get(self.hmr_root_path(target).await?.join(chunk_name)?);
             Ok(content)
         } else {
             bail!("must be in dev mode to hmr")

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -2587,7 +2587,7 @@ pub struct BaseAndFullModuleGraph {
 #[turbo_tasks::function]
 async fn any_output_changed(
     roots: Vc<OutputAssets>,
-    path: FileSystemPath,
+    path: &FileSystemPath,
     server: bool,
 ) -> Result<Vc<Completion>> {
     let all_assets = expand_output_assets(

--- a/crates/next-api/src/project_asset_hashes_manifest.rs
+++ b/crates/next-api/src/project_asset_hashes_manifest.rs
@@ -82,7 +82,7 @@ pub struct OutputAssetsWithPaths(Vec<(ResolvedVc<Box<dyn OutputAsset>>, RcStr)>)
 #[turbo_tasks::function]
 pub async fn expand_outputs(
     project: Vc<Project>,
-    root: FileSystemPath,
+    root: &FileSystemPath,
 ) -> Result<Vc<OutputAssetsWithPaths>> {
     let entrypoint_groups = project.get_all_endpoint_groups(false).await?;
 

--- a/crates/next-api/src/route.rs
+++ b/crates/next-api/src/route.rs
@@ -157,7 +157,7 @@ impl EndpointGroup {
 }
 
 #[turbo_tasks::function]
-async fn output_of_endpoints(endpoints: Vec<Vc<Box<dyn Endpoint>>>) -> Result<Vc<OutputAssets>> {
+async fn output_of_endpoints(endpoints: &Vec<Vc<Box<dyn Endpoint>>>) -> Result<Vc<OutputAssets>> {
     let assets = endpoints
         .iter()
         .map(async |endpoint| Ok(*endpoint.output().await?.output_assets))
@@ -168,7 +168,7 @@ async fn output_of_endpoints(endpoints: Vec<Vc<Box<dyn Endpoint>>>) -> Result<Vc
 
 #[turbo_tasks::function]
 async fn module_graphs_of_endpoints(
-    endpoints: Vec<Vc<Box<dyn Endpoint>>>,
+    endpoints: &Vec<Vc<Box<dyn Endpoint>>>,
 ) -> Result<Vc<ModuleGraphs>> {
     let module_graphs = endpoints
         .iter()

--- a/crates/next-api/src/versioned_content_map.rs
+++ b/crates/next-api/src/versioned_content_map.rs
@@ -187,7 +187,7 @@ impl VersionedContentMap {
     #[turbo_tasks::function]
     pub async fn get_source_map(
         self: Vc<Self>,
-        path: FileSystemPath,
+        path: &FileSystemPath,
         section: Option<RcStr>,
     ) -> Result<Vc<FileContent>> {
         let Some(asset) = &*self.get_asset(path.clone()).await? else {
@@ -208,13 +208,13 @@ impl VersionedContentMap {
     }
 
     #[turbo_tasks::function]
-    pub async fn get_asset(self: Vc<Self>, path: FileSystemPath) -> Result<Vc<OptionOutputAsset>> {
+    pub async fn get_asset(self: Vc<Self>, path: &FileSystemPath) -> Result<Vc<OptionOutputAsset>> {
         let result = self.raw_get(path.clone()).await?;
         if let Some(MapEntry {
             assets_operation: _,
             path_to_asset,
         }) = &*result
-            && let Some(&asset) = path_to_asset.get(&path)
+            && let Some(&asset) = path_to_asset.get(path)
         {
             return Ok(Vc::cell(Some(asset)));
         }
@@ -223,7 +223,7 @@ impl VersionedContentMap {
     }
 
     #[turbo_tasks::function]
-    pub async fn keys_in_path(&self, root: FileSystemPath) -> Result<Vc<Vec<RcStr>>> {
+    pub async fn keys_in_path(&self, root: &FileSystemPath) -> Result<Vc<Vec<RcStr>>> {
         let keys = {
             let map = &self.map_path_to_op.get().0;
             map.keys().cloned().collect::<Vec<_>>()
@@ -240,10 +240,10 @@ impl VersionedContentMap {
     }
 
     #[turbo_tasks::function]
-    fn raw_get(&self, path: FileSystemPath) -> Vc<OptionMapEntry> {
+    fn raw_get(&self, path: &FileSystemPath) -> Vc<OptionMapEntry> {
         let assets = {
             let map = &self.map_path_to_op.get().0;
-            map.get(&path).and_then(|m| m.0.iter().next().copied())
+            map.get(path).and_then(|m| m.0.iter().next().copied())
         };
         let Some(assets) = assets else {
             return Vc::cell(None);

--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -319,7 +319,7 @@ pub async fn find_app_dir(project_path: &FileSystemPath) -> Result<Vc<OptionAppD
 
 #[turbo_tasks::function]
 async fn get_directory_tree(
-    dir: FileSystemPath,
+    dir: &FileSystemPath,
     page_extensions: Vc<Vec<RcStr>>,
 ) -> Result<Vc<DirectoryTree>> {
     let span = tracing::info_span!(
@@ -332,7 +332,7 @@ async fn get_directory_tree(
 }
 
 async fn get_directory_tree_internal(
-    dir: FileSystemPath,
+    dir: &FileSystemPath,
     page_extensions: Vc<Vec<RcStr>>,
 ) -> Result<Vc<DirectoryTree>> {
     let DirectoryContent::Entries(entries) = &*dir.read_dir().await? else {
@@ -1532,13 +1532,13 @@ async fn default_route_tree(
 
 #[turbo_tasks::function]
 async fn directory_tree_to_entrypoints_internal(
-    app_dir: FileSystemPath,
+    app_dir: &FileSystemPath,
     global_metadata: ResolvedVc<GlobalMetadata>,
     is_global_not_found_enabled: Vc<bool>,
     next_mode: Vc<NextMode>,
     directory_name: RcStr,
     directory_tree: Vc<DirectoryTree>,
-    app_page: AppPage,
+    app_page: &AppPage,
     root_layouts: ResolvedVc<FileSystemPathVec>,
     root_params: ResolvedVc<RootParamVecOption>,
 ) -> Result<Vc<Entrypoints>> {
@@ -1559,13 +1559,13 @@ async fn directory_tree_to_entrypoints_internal(
 }
 
 async fn directory_tree_to_entrypoints_internal_untraced(
-    app_dir: FileSystemPath,
+    app_dir: &FileSystemPath,
     global_metadata: ResolvedVc<GlobalMetadata>,
     is_global_not_found_enabled: Vc<bool>,
     next_mode: Vc<NextMode>,
     directory_name: RcStr,
     directory_tree: Vc<DirectoryTree>,
-    app_page: AppPage,
+    app_page: &AppPage,
     root_layouts: ResolvedVc<FileSystemPathVec>,
     root_params: ResolvedVc<RootParamVecOption>,
 ) -> Result<Vc<Entrypoints>> {
@@ -1873,7 +1873,6 @@ async fn directory_tree_to_entrypoints_internal_untraced(
         }
     }
 
-    let app_page = &app_page;
     let directory_name = &directory_name;
     let subdirectories = subdirectories
         .iter()

--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -303,7 +303,7 @@ pub struct OptionAppDir(Option<FileSystemPath>);
 
 /// Finds and returns the [DirectoryTree] of the app directory if existing.
 #[turbo_tasks::function]
-pub async fn find_app_dir(project_path: FileSystemPath) -> Result<Vc<OptionAppDir>> {
+pub async fn find_app_dir(project_path: &FileSystemPath) -> Result<Vc<OptionAppDir>> {
     let app = project_path.join("app")?;
     let src_app = project_path.join("src/app")?;
     let app_dir = if *app.get_type().await? == FileSystemEntryType::Directory {
@@ -1995,7 +1995,7 @@ async fn directory_tree_to_entrypoints_internal_untraced(
 /// Returns the global metadata for an app directory.
 #[turbo_tasks::function]
 pub async fn get_global_metadata(
-    app_dir: FileSystemPath,
+    app_dir: &FileSystemPath,
     page_extensions: Vc<Vec<RcStr>>,
 ) -> Result<Vc<GlobalMetadata>> {
     let DirectoryContent::Entries(entries) = &*app_dir.read_dir().await? else {

--- a/crates/next-core/src/bootstrap.rs
+++ b/crates/next-core/src/bootstrap.rs
@@ -28,7 +28,7 @@ impl BootstrapConfig {
 pub async fn bootstrap(
     asset: ResolvedVc<Box<dyn Module>>,
     asset_context: Vc<Box<dyn AssetContext>>,
-    base_path: FileSystemPath,
+    base_path: &FileSystemPath,
     bootstrap_asset: Vc<Box<dyn Source>>,
     inner_assets: Vc<InnerAssets>,
     config: Vc<BootstrapConfig>,

--- a/crates/next-core/src/emit.rs
+++ b/crates/next-core/src/emit.rs
@@ -210,8 +210,8 @@ async fn emit_rebase(
 async fn assets_diff(
     asset1: Vc<Box<dyn OutputAsset>>,
     asset2: Vc<Box<dyn OutputAsset>>,
-    extension: RcStr,
-    node_root: FileSystemPath,
+    extension: &RcStr,
+    node_root: &FileSystemPath,
 ) -> Result<Vc<Option<RcStr>>> {
     let content1 = asset1.content().await?;
     let content2 = asset2.content().await?;
@@ -229,18 +229,18 @@ async fn assets_diff(
                     } else {
                         // Write both versions under node_root as <hash>.<ext> so the
                         // user can diff them.
-                        let ext = &*extension;
+
                         let hash1 = encode_hex(hash_xxh3_hash64(file1.content().content_hash()));
                         let hash2 = encode_hex(hash_xxh3_hash64(file2.content().content_hash()));
-                        let name1 = if ext.is_empty() {
+                        let name1 = if extension.is_empty() {
                             hash1
                         } else {
-                            format!("{hash1}.{ext}")
+                            format!("{hash1}.{extension}")
                         };
-                        let name2 = if ext.is_empty() {
+                        let name2 = if extension.is_empty() {
                             hash2
                         } else {
-                            format!("{hash2}.{ext}")
+                            format!("{hash2}.{extension}")
                         };
                         let path1 = node_root.join(&name1)?;
                         let path2 = node_root.join(&name2)?;

--- a/crates/next-core/src/emit.rs
+++ b/crates/next-core/src/emit.rs
@@ -48,8 +48,8 @@ pub async fn emit_all_assets(
 pub async fn emit_assets(
     assets: Vc<ExpandedOutputAssets>,
     node_root: &FileSystemPath,
-    client_relative_path: FileSystemPath,
-    client_output_path: FileSystemPath,
+    client_relative_path: &FileSystemPath,
+    client_output_path: &FileSystemPath,
 ) -> Result<()> {
     enum Location {
         Node,
@@ -63,7 +63,7 @@ pub async fn emit_assets(
             let path = asset.path().owned().await?;
             let location = if path.is_inside_ref(node_root) {
                 Location::Node
-            } else if path.is_inside_ref(&client_relative_path) {
+            } else if path.is_inside_ref(client_relative_path) {
                 Location::Client
             } else {
                 return Ok(None);

--- a/crates/next-core/src/emit.rs
+++ b/crates/next-core/src/emit.rs
@@ -47,7 +47,7 @@ pub async fn emit_all_assets(
 #[turbo_tasks::function]
 pub async fn emit_assets(
     assets: Vc<ExpandedOutputAssets>,
-    node_root: FileSystemPath,
+    node_root: &FileSystemPath,
     client_relative_path: FileSystemPath,
     client_output_path: FileSystemPath,
 ) -> Result<()> {
@@ -61,7 +61,7 @@ pub async fn emit_assets(
         .copied()
         .map(async |asset| {
             let path = asset.path().owned().await?;
-            let location = if path.is_inside_ref(&node_root) {
+            let location = if path.is_inside_ref(node_root) {
                 Location::Node
             } else if path.is_inside_ref(&client_relative_path) {
                 Location::Client

--- a/crates/next-core/src/next_app/app_page_entry.rs
+++ b/crates/next-core/src/next_app/app_page_entry.rs
@@ -34,7 +34,7 @@ pub async fn get_app_page_entry(
     edge_context: ResolvedVc<ModuleAssetContext>,
     loader_tree: Vc<AppPageLoaderTree>,
     page: AppPage,
-    project_root: FileSystemPath,
+    project_root: &FileSystemPath,
     next_config: Vc<NextConfig>,
 ) -> Result<Vc<AppEntry>> {
     let config = parse_segment_config_from_loader_tree(loader_tree);

--- a/crates/next-core/src/next_app/app_route_entry.rs
+++ b/crates/next-core/src/next_app/app_route_entry.rs
@@ -131,7 +131,7 @@ pub async fn get_app_route_entry(
 #[turbo_tasks::function]
 async fn wrap_edge_route(
     asset_context: Vc<Box<dyn AssetContext>>,
-    project_root: FileSystemPath,
+    project_root: &FileSystemPath,
     entry: ResolvedVc<Box<dyn Module>>,
     page: AppPage,
     next_config: Vc<NextConfig>,

--- a/crates/next-core/src/next_app/metadata/route.rs
+++ b/crates/next-core/src/next_app/metadata/route.rs
@@ -130,7 +130,7 @@ async fn get_base64_file_content(path: FileSystemPath) -> Result<String> {
 }
 
 #[turbo_tasks::function]
-async fn static_route_source(mode: NextMode, path: FileSystemPath) -> Result<Vc<Box<dyn Source>>> {
+async fn static_route_source(mode: NextMode, path: &FileSystemPath) -> Result<Vc<Box<dyn Source>>> {
     let stem = path.file_stem();
     let stem = stem.unwrap_or_default();
 
@@ -213,7 +213,7 @@ async fn static_route_source(mode: NextMode, path: FileSystemPath) -> Result<Vc<
 }
 
 #[turbo_tasks::function]
-async fn dynamic_text_route_source(path: FileSystemPath) -> Result<Vc<Box<dyn Source>>> {
+async fn dynamic_text_route_source(path: &FileSystemPath) -> Result<Vc<Box<dyn Source>>> {
     let stem = path.file_stem();
     let stem = stem.unwrap_or_default();
 

--- a/crates/next-core/src/next_build.rs
+++ b/crates/next-core/src/next_build.rs
@@ -8,7 +8,7 @@ use crate::next_import_map::get_next_package;
 
 #[turbo_tasks::function]
 pub async fn get_postcss_package_mapping(
-    project_path: FileSystemPath,
+    project_path: &FileSystemPath,
 ) -> Result<Vc<ImportMapping>> {
     Ok(ImportMapping::Alternatives(vec![
         // Prefer the local installed version over the next.js version

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -115,7 +115,7 @@ pub async fn get_client_compile_time_info(
                 dom: true,
                 web_worker: false,
                 service_worker: false,
-                browserslist_query: browserslist_query.to_owned(),
+                browserslist_query,
             }
             .resolved_cell(),
         ))

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -588,7 +588,7 @@ pub async fn get_client_chunking_context(
 
 #[turbo_tasks::function]
 pub async fn get_client_runtime_entries(
-    project_root: FileSystemPath,
+    project_root: &FileSystemPath,
     ty: ClientContextType,
     mode: Vc<NextMode>,
     next_config: Vc<NextConfig>,

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -1570,7 +1570,7 @@ impl NextConfig {
     #[turbo_tasks::function]
     pub async fn config_file_path(
         &self,
-        project_path: FileSystemPath,
+        project_path: &FileSystemPath,
     ) -> Result<Vc<FileSystemPath>> {
         Ok(project_path.join(&self.config_file_name)?.cell())
     }
@@ -1606,7 +1606,7 @@ impl NextConfig {
     }
 
     #[turbo_tasks::function]
-    pub fn cache_handler(&self, project_path: FileSystemPath) -> Result<Vc<OptionFileSystemPath>> {
+    pub fn cache_handler(&self, project_path: &FileSystemPath) -> Result<Vc<OptionFileSystemPath>> {
         if let Some(handler) = &self.cache_handler {
             Ok(Vc::cell(Some(project_path.join(handler)?)))
         } else {
@@ -1671,7 +1671,7 @@ impl NextConfig {
     #[turbo_tasks::function]
     pub async fn webpack_rules(
         self: Vc<Self>,
-        project_path: FileSystemPath,
+        project_path: &FileSystemPath,
     ) -> Result<Vc<WebpackRules>> {
         let this = self.await?;
         let Some(turbo_rules) = this.turbopack.as_ref().map(|t| &t.rules) else {
@@ -1857,7 +1857,7 @@ impl NextConfig {
     }
 
     #[turbo_tasks::function]
-    pub fn cache_handlers(&self, project_path: FileSystemPath) -> Result<Vc<FileSystemPathVec>> {
+    pub fn cache_handlers(&self, project_path: &FileSystemPath) -> Result<Vc<FileSystemPathVec>> {
         if let Some(handlers) = &self.cache_handlers {
             Ok(Vc::cell(
                 handlers

--- a/crates/next-core/src/next_edge/unsupported.rs
+++ b/crates/next-core/src/next_edge/unsupported.rs
@@ -41,7 +41,7 @@ impl ImportMappingReplacement for NextEdgeUnsupportedModuleReplacer {
     #[turbo_tasks::function]
     async fn result(
         &self,
-        lookup_path: FileSystemPath,
+        lookup_path: &FileSystemPath,
         request: Vc<Request>,
     ) -> Result<Vc<ImportMapResult>> {
         let request = &*request.await?;

--- a/crates/next-core/src/next_font/google/mod.rs
+++ b/crates/next-core/src/next_font/google/mod.rs
@@ -498,7 +498,7 @@ async fn load_font_data(project_root: FileSystemPath) -> Result<Vc<FontData>> {
 async fn update_google_stylesheet(
     stylesheet: Vc<RcStr>,
     options: Vc<NextFontGoogleOptions>,
-    scoped_font_family: RcStr,
+    scoped_font_family: &RcStr,
     has_size_adjust: Vc<bool>,
 ) -> Result<Vc<RcStr>> {
     let options = &*options.await?;
@@ -660,7 +660,7 @@ async fn get_font_css_properties(
 
 #[turbo_tasks::function]
 async fn font_options_from_query_map(
-    query: RcStr,
+    query: &RcStr,
     font_data: Vc<FontData>,
 ) -> Result<Vc<NextFontGoogleOptions>> {
     let query_map = qstring::QString::from(query.as_str());

--- a/crates/next-core/src/next_font/local/mod.rs
+++ b/crates/next-core/src/next_font/local/mod.rs
@@ -282,7 +282,7 @@ async fn get_font_css_properties(
 }
 
 #[turbo_tasks::function]
-fn font_options_from_query_map(query: RcStr) -> Result<Vc<NextFontLocalOptions>> {
+fn font_options_from_query_map(query: &RcStr) -> Result<Vc<NextFontLocalOptions>> {
     let query_map = qstring::QString::from(query.as_str());
 
     if query_map.len() != 1 {

--- a/crates/next-core/src/next_font/local/mod.rs
+++ b/crates/next-core/src/next_font/local/mod.rs
@@ -75,7 +75,7 @@ impl BeforeResolvePlugin for NextFontLocalResolvePlugin {
     #[turbo_tasks::function]
     async fn before_resolve(
         self: Vc<Self>,
-        lookup_path: FileSystemPath,
+        lookup_path: &FileSystemPath,
         _reference_type: ReferenceType,
         request_vc: Vc<Request>,
     ) -> Result<Vc<ResolveResultOption>> {

--- a/crates/next-core/src/next_pages/page_entry.rs
+++ b/crates/next-core/src/next_pages/page_entry.rs
@@ -31,7 +31,7 @@ pub struct PageSsrEntryModule {
 
 #[turbo_tasks::function]
 pub async fn create_page_ssr_entry_module(
-    pathname: RcStr,
+    pathname: &RcStr,
     reference_type: ReferenceType,
     project_root: FileSystemPath,
     ssr_module_context: Vc<Box<dyn AssetContext>>,
@@ -76,7 +76,7 @@ pub async fn create_page_ssr_entry_module(
     let inner_error_500 = rcstr!("INNER_500");
 
     let mut replacements = vec![
-        ("VAR_DEFINITION_PATHNAME", &*definition_pathname),
+        ("VAR_DEFINITION_PATHNAME", &**definition_pathname),
         ("VAR_USERLAND", &*inner),
     ];
 

--- a/crates/next-core/src/next_root_params/mod.rs
+++ b/crates/next-core/src/next_root_params/mod.rs
@@ -4,7 +4,7 @@ use anyhow::{Result, anyhow};
 use either::Either;
 use indoc::formatdoc;
 use itertools::Itertools;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{EitherTaskInput, ResolvedVc, Vc};
 use turbo_tasks_fs::{FileContent, FileSystemPath};
 use turbopack_core::{
@@ -198,8 +198,8 @@ impl NextRootParamsMapper {
     }
 
     #[turbo_tasks::function]
-    async fn invalid_import_map_result(message: RcStr) -> Result<Vc<ImportMapResult>> {
-        let path: FileSystemPath = next_js_file_path("root-params.js".into()).owned().await?;
+    async fn invalid_import_map_result(message: &RcStr) -> Result<Vc<ImportMapResult>> {
+        let path: FileSystemPath = next_js_file_path(rcstr!("root-params.js")).owned().await?;
 
         // error the compilation.
         InvalidImportModuleIssue {
@@ -212,7 +212,7 @@ impl NextRootParamsMapper {
 
         // map to a dummy module that rethrows the error at runtime.
         let virtual_source = VirtualSource::new(
-            path.clone(),
+            path,
             AssetContent::file(
                 FileContent::Content(
                     format!("throw new Error({})", serde_json::to_string(&message)?).into(),

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -1004,7 +1004,7 @@ fn client_directive_transform_plugin(transition_name: RcStr) -> Vc<TransformPlug
 }
 
 #[turbo_tasks::function]
-fn client_disallowed_directive_transform_plugin(error_proxy_module: RcStr) -> Vc<TransformPlugin> {
+fn client_disallowed_directive_transform_plugin(error_proxy_module: &RcStr) -> Vc<TransformPlugin> {
     Vc::cell(Box::new(ClientDisallowedDirectiveTransformer::new(
         error_proxy_module.to_string(),
     )) as Box<dyn CustomTransformer + Send + Sync>)

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -124,7 +124,7 @@ impl ServerContextType {
 
 #[turbo_tasks::function]
 pub async fn get_server_resolve_options_context(
-    project_path: FileSystemPath,
+    project_path: &FileSystemPath,
     ty: ServerContextType,
     mode: Vc<NextMode>,
     next_config: Vc<NextConfig>,

--- a/crates/next-core/src/next_server/resolve.rs
+++ b/crates/next-core/src/next_server/resolve.rs
@@ -82,7 +82,7 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
     #[turbo_tasks::function]
     async fn after_resolve(
         &self,
-        fs_path: FileSystemPath,
+        fs_path: &FileSystemPath,
         lookup_path: FileSystemPath,
         reference_type: ReferenceType,
         request: ResolvedVc<Request>,

--- a/crates/next-core/src/next_shared/resolve.rs
+++ b/crates/next-core/src/next_shared/resolve.rs
@@ -119,7 +119,7 @@ impl AfterResolvePlugin for NextExternalResolvePlugin {
     #[turbo_tasks::function]
     async fn after_resolve(
         &self,
-        fs_path: FileSystemPath,
+        fs_path: &FileSystemPath,
         _lookup_path: FileSystemPath,
         _reference_type: ReferenceType,
         _request: Vc<Request>,
@@ -178,7 +178,7 @@ impl AfterResolvePlugin for NextNodeSharedRuntimeResolvePlugin {
     #[turbo_tasks::function]
     async fn after_resolve(
         &self,
-        fs_path: FileSystemPath,
+        fs_path: &FileSystemPath,
         _lookup_path: FileSystemPath,
         _reference_type: ReferenceType,
         _request: Vc<Request>,
@@ -309,7 +309,7 @@ impl AfterResolvePlugin for NextSharedRuntimeResolvePlugin {
     #[turbo_tasks::function]
     async fn after_resolve(
         &self,
-        fs_path: FileSystemPath,
+        fs_path: &FileSystemPath,
         _lookup_path: FileSystemPath,
         _reference_type: ReferenceType,
         _request: Vc<Request>,

--- a/crates/next-core/src/next_shared/transforms/relay.rs
+++ b/crates/next-core/src/next_shared/transforms/relay.rs
@@ -33,13 +33,13 @@ pub async fn get_relay_transform_rule(
 #[turbo_tasks::function]
 async fn relay_transform_plugin(
     next_config: Vc<NextConfig>,
-    project_path: FileSystemPath,
+    project_path: &FileSystemPath,
 ) -> Result<Vc<TransformPlugin>> {
     use anyhow::Context as _;
     let compiler = next_config.compiler().await?;
     let config = compiler.relay.as_ref().context("relay config must exist")?;
     Ok(Vc::cell(
-        Box::new(RelayTransformer::new(config, &project_path))
+        Box::new(RelayTransformer::new(config, project_path))
             as Box<dyn CustomTransformer + Send + Sync>,
     ))
 }

--- a/crates/next-core/src/next_shared/webpack_rules/mod.rs
+++ b/crates/next-core/src/next_shared/webpack_rules/mod.rs
@@ -139,16 +139,16 @@ pub struct OptionWebpackLoadersOptions(Option<ResolvedVc<WebpackLoadersOptions>>
 
 #[turbo_tasks::function]
 pub async fn webpack_loader_options(
-    project_path: FileSystemPath,
+    project_path: &FileSystemPath,
     next_config: Vc<NextConfig>,
     builtin_conditions: BTreeSet<WebpackLoaderBuiltinCondition>,
 ) -> Result<Vc<OptionWebpackLoadersOptions>> {
     let user_rules = next_config.webpack_rules(project_path.clone()).await?;
     let mut rules = (*user_rules).clone();
 
-    rules.append(&mut get_sass_loader_rules(&project_path, next_config, &user_rules).await?);
+    rules.append(&mut get_sass_loader_rules(project_path, next_config, &user_rules).await?);
     rules.append(
-        &mut get_babel_loader_rules(&project_path, next_config, &builtin_conditions, &user_rules)
+        &mut get_babel_loader_rules(project_path, next_config, &builtin_conditions, &user_rules)
             .await?,
     );
 

--- a/crates/next-core/src/page_loader.rs
+++ b/crates/next-core/src/page_loader.rs
@@ -26,10 +26,10 @@ use crate::{embed_js::next_js_file_path, util::get_asset_path_from_pathname};
 pub async fn create_page_loader_entry_module(
     client_context: Vc<Box<dyn AssetContext>>,
     entry_asset: Vc<Box<dyn Source>>,
-    pathname: RcStr,
+    pathname: &RcStr,
 ) -> Result<Vc<Box<dyn Module>>> {
     let mut result = RopeBuilder::default();
-    writeln!(result, "const PAGE_PATH = {};\n", StringifyJs(&pathname))?;
+    writeln!(result, "const PAGE_PATH = {};\n", StringifyJs(pathname))?;
 
     let page_loader_path = next_js_file_path(rcstr!("entry/page-loader.ts"))
         .owned()

--- a/crates/next-core/src/pages_structure.rs
+++ b/crates/next-core/src/pages_structure.rs
@@ -133,7 +133,7 @@ pub async fn find_pages_structure(
 /// Handles the root pages directory.
 #[turbo_tasks::function]
 async fn get_pages_structure_for_root_directory(
-    project_root: FileSystemPath,
+    project_root: &FileSystemPath,
     project_path: Vc<FileSystemPathOption>,
     next_router_path: FileSystemPath,
     page_extensions: Vc<Vec<RcStr>>,
@@ -321,7 +321,7 @@ async fn get_pages_structure_for_root_directory(
 /// Calls itself recursively for sub directories.
 #[turbo_tasks::function]
 async fn get_pages_structure_for_directory(
-    project_path: FileSystemPath,
+    project_path: &FileSystemPath,
     next_router_path: FileSystemPath,
     page_extensions: Vc<Vec<RcStr>>,
 ) -> Result<Vc<PagesDirectoryStructure>> {

--- a/crates/next-core/src/transform_options.rs
+++ b/crates/next-core/src/transform_options.rs
@@ -21,10 +21,11 @@ async fn get_typescript_options(
     tsconfig_path: Option<FileSystemPath>,
 ) -> Result<Option<Vec<(Vc<FileJsonContent>, ResolvedVc<Box<dyn Source>>)>>> {
     if let Some(tsconfig_path) = tsconfig_path {
+        let options = node_cjs_resolve_options(tsconfig_path.root().owned().await?);
         let tsconfigs = read_tsconfigs(
             tsconfig_path.read(),
-            ResolvedVc::upcast(FileSource::new(tsconfig_path.clone()).to_resolved().await?),
-            node_cjs_resolve_options(tsconfig_path.root().owned().await?),
+            ResolvedVc::upcast(FileSource::new(tsconfig_path).to_resolved().await?),
+            options,
         )
         .await
         .ok();

--- a/crates/next-core/src/transform_options.rs
+++ b/crates/next-core/src/transform_options.rs
@@ -164,7 +164,7 @@ pub async fn get_decorators_transform_options(
 
 #[turbo_tasks::function]
 pub async fn get_jsx_transform_options(
-    project_path: FileSystemPath,
+    project_path: &FileSystemPath,
     mode: Vc<NextMode>,
     resolve_options_context: Option<Vc<ResolveOptionsContext>>,
     is_rsc_context: bool,

--- a/crates/next-core/src/util.rs
+++ b/crates/next-core/src/util.rs
@@ -216,11 +216,10 @@ pub enum PathType {
 #[turbo_tasks::function]
 pub async fn pathname_for_path(
     server_root: &FileSystemPath,
-    server_path: FileSystemPath,
+    server_path: &FileSystemPath,
     path_ty: PathType,
 ) -> Result<Vc<RcStr>> {
-    let server_path_value = server_path.clone();
-    let path = if let Some(path) = server_root.get_path_to(&server_path_value) {
+    let path = if let Some(path) = server_root.get_path_to(server_path) {
         path
     } else {
         turbobail!("server_path ({server_path}) is not in server_root ({server_root})");

--- a/crates/next-core/src/util.rs
+++ b/crates/next-core/src/util.rs
@@ -215,7 +215,7 @@ pub enum PathType {
 /// Converts a filename within the server root into a next pathname.
 #[turbo_tasks::function]
 pub async fn pathname_for_path(
-    server_root: FileSystemPath,
+    server_root: &FileSystemPath,
     server_path: FileSystemPath,
     path_ty: PathType,
 ) -> Result<Vc<RcStr>> {

--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -2307,11 +2307,12 @@ pub fn get_source_map_rope_operation(
 #[turbo_tasks::function(operation)]
 pub async fn project_trace_source_operation(
     container: ResolvedVc<ProjectContainer>,
-    frame: StackFrame,
+    frame: &StackFrame,
     current_directory_file_url: &RcStr,
 ) -> Result<Vc<OptionStackFrame>> {
     let Some(map) =
-        &*SourceMap::new_from_rope_cached(get_source_map_rope(*container, frame.file)).await?
+        &*SourceMap::new_from_rope_cached(get_source_map_rope(*container, frame.file.clone()))
+            .await?
     else {
         return Ok(Vc::cell(None));
     };

--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -2234,9 +2234,9 @@ pub struct OptionStackFrame(Option<StackFrame>);
 #[turbo_tasks::function]
 pub async fn get_source_map_rope(
     container: Vc<ProjectContainer>,
-    source_url: RcStr,
+    source_url: &RcStr,
 ) -> Result<Vc<FileContent>> {
-    let (file_path_sys, module) = match Url::parse(&source_url) {
+    let (file_path_sys, module) = match Url::parse(source_url) {
         Ok(url) => match url.scheme() {
             "file" => {
                 let path = match url.to_file_path() {
@@ -2308,7 +2308,7 @@ pub fn get_source_map_rope_operation(
 pub async fn project_trace_source_operation(
     container: ResolvedVc<ProjectContainer>,
     frame: StackFrame,
-    current_directory_file_url: RcStr,
+    current_directory_file_url: &RcStr,
 ) -> Result<Vc<OptionStackFrame>> {
     let Some(map) =
         &*SourceMap::new_from_rope_cached(get_source_map_rope(*container, frame.file)).await?
@@ -2352,7 +2352,7 @@ pub async fn project_trace_source_operation(
             // Client code uses file://
             (
                 RcStr::from(
-                    get_relative_path_to(&current_directory_file_url, &original_file)
+                    get_relative_path_to(current_directory_file_url, &original_file)
                         // TODO(sokra) remove this to include a ./ here to make it a relative path
                         .trim_start_matches("./"),
                 ),
@@ -2364,7 +2364,7 @@ pub async fn project_trace_source_operation(
             (
                 RcStr::from(
                     get_relative_path_to(
-                        &current_directory_file_url,
+                        current_directory_file_url,
                         &format!("{project_root_uri}{source_file}"),
                     )
                     // TODO(sokra) remove this to include a ./ here to make it a relative path
@@ -2434,10 +2434,10 @@ pub async fn project_get_source_for_asset(
             #[turbo_tasks::function(operation)]
             async fn source_content_operation(
                 container: ResolvedVc<ProjectContainer>,
-                file_path: RcStr,
+                file_path: &RcStr,
             ) -> Result<Vc<FileContent>> {
                 let project_path = container.project().project_path().await?;
-                Ok(project_path.fs().root().await?.join(&file_path)?.read())
+                Ok(project_path.fs().root().await?.join(file_path)?.read())
             }
 
             let source_content = &*source_content_operation(container, file_path.clone())

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1848,14 +1848,10 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
 
         let (span, future) = match task_type {
             TaskType::Cached(task_type) => {
-                let CachedTaskType {
-                    native_fn,
-                    this,
-                    arg,
-                } = &*task_type;
+                let native_fn = task_type.native_fn;
                 (
                     native_fn.span(task_id.persistence(), execution_reason, priority),
-                    native_fn.execute(*this, &**arg),
+                    native_fn.execute(task_type),
                 )
             }
             TaskType::Transient(task_type) => {

--- a/turbopack/crates/turbo-tasks-backend/tests/by_ref.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/by_ref.rs
@@ -13,7 +13,7 @@
 #![allow(clippy::needless_return)]
 
 use anyhow::Result;
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_testing::{Registration, register, run_once};
 
 static REGISTRATION: Registration = register!();
@@ -48,6 +48,21 @@ async fn test_by_ref_operation() -> Result<Vc<()>> {
     let counter = Counter { base: 100 }.cell();
     assert_eq!(*counter.add_all(vec![1u32, 2, 3]).await?, 106);
 
+    // Regression: `&T` parameters whose `T` goes through `FromTaskInput` (e.g.
+    // `ResolvedVc<…>`, `Vec<ResolvedVc<…>>`, `Option<ResolvedVc<…>>`). Before the macro
+    // learned to borrow-cast cached `T::TaskInput` to `&T`, the runtime panicked at
+    // `downcast_args_ref` because the cache stored `Vec<Vc<T>>` while the body asked
+    // for `Vec<ResolvedVc<T>>`.
+    // The exposed signature still takes the unwrapped form (`Vc<T>`,
+    // `Vec<Vc<T>>`, `Option<Vc<T>>`), so callers pass owned `Vc`s — exactly the form the
+    // cache key is built from.
+    let a = ItemValue { v: 1 }.cell();
+    let b = ItemValue { v: 4 }.cell();
+    assert_eq!(*sum_resolved_items(vec![a, b]).await?, 5);
+    assert_eq!(*one_resolved_item(a).await?, 1);
+    assert_eq!(*maybe_resolved_item(Some(b)).await?, 4);
+    assert_eq!(*maybe_resolved_item(None).await?, 0);
+
     Ok(Vc::cell(()))
 }
 
@@ -81,4 +96,35 @@ impl Counter {
         let sum: u32 = items.iter().sum();
         Vc::cell(self.base + sum)
     }
+}
+
+#[turbo_tasks::value]
+struct ItemValue {
+    v: u32,
+}
+
+// `&Vec<ResolvedVc<…>>`: the cache stores `Vec<Vc<T>>` (post-`FromTaskInput`),
+// so the macro has to borrow-cast it back to `&Vec<ResolvedVc<T>>` for the body.
+#[turbo_tasks::function]
+async fn sum_resolved_items(items: &Vec<ResolvedVc<ItemValue>>) -> Result<Vc<u32>> {
+    let mut total = 0u32;
+    for item in items {
+        total += item.await?.v;
+    }
+    Ok(Vc::cell(total))
+}
+
+// `&ResolvedVc<…>` directly: same case at the leaf.
+#[turbo_tasks::function]
+async fn one_resolved_item(item: &ResolvedVc<ItemValue>) -> Result<Vc<u32>> {
+    Ok(Vc::cell(item.await?.v))
+}
+
+// `&Option<ResolvedVc<…>>`: the macro has to borrow-cast through the `Option` wrapper.
+#[turbo_tasks::function]
+async fn maybe_resolved_item(item: &Option<ResolvedVc<ItemValue>>) -> Result<Vc<u32>> {
+    Ok(Vc::cell(match item {
+        Some(item) => item.await?.v,
+        None => 0,
+    }))
 }

--- a/turbopack/crates/turbo-tasks-backend/tests/by_ref.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/by_ref.rs
@@ -1,0 +1,84 @@
+// Functions that declare arguments as `&T` exercise the by-reference branch of the
+// `#[turbo_tasks::function]` macro. The macro:
+//   1. exposes the function with the owned argument type (callers still pass owned),
+//   2. emits an inline closure that takes `&T` and skips the per-execution arg clone,
+//   3. routes the call through the by-ref blanket impls in `task_fn_impl!`.
+//
+// This test pins all three behaviors with `Vec<u32>` arguments — large enough that an
+// accidental clone would actually do work, and a different shape (slice access, iteration)
+// from the methods on `Vc` types that the rest of the suite covers.
+
+#![feature(arbitrary_self_types)]
+#![feature(arbitrary_self_types_pointers)]
+#![allow(clippy::needless_return)]
+
+use anyhow::Result;
+use turbo_tasks::Vc;
+use turbo_tasks_testing::{Registration, register, run_once};
+
+static REGISTRATION: Registration = register!();
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_by_ref() {
+    run_once(&REGISTRATION, || async {
+        test_by_ref_operation().read_strongly_consistent().await
+    })
+    .await
+    .unwrap()
+}
+
+#[turbo_tasks::function(operation)]
+async fn test_by_ref_operation() -> Result<Vc<()>> {
+    // `sum_by_ref` takes its `Vec<u32>` by reference; callers still pass an owned Vec
+    // (the cache key is built from owned values).
+    let items = vec![1u32, 2, 3, 4, 5];
+    assert_eq!(*sum_by_ref(items.clone()).await?, 15);
+
+    // Cache hit: same input, same answer, no re-execution.
+    assert_eq!(*sum_by_ref(items.clone()).await?, 15);
+
+    // Different input, recomputed.
+    assert_eq!(*sum_by_ref(vec![10u32, 20, 30]).await?, 60);
+
+    // Mixed signature: one by-value `u32`, one by-ref `Vec<u32>`. Confirms the macro
+    // shadow-clones only the by-value param and leaves the `&Vec` borrow alone.
+    assert_eq!(*scaled_sum(2, vec![1u32, 2, 3]).await?, 12);
+
+    // Method receiver + by-ref `Vec<u32>` — exercises the with-this by-ref impls.
+    let counter = Counter { base: 100 }.cell();
+    assert_eq!(*counter.add_all(vec![1u32, 2, 3]).await?, 106);
+
+    Ok(Vc::cell(()))
+}
+
+#[turbo_tasks::function]
+async fn sum_by_ref(items: &Vec<u32>) -> Vc<u32> {
+    // Body sees `&Vec<u32>` directly — no clone in `get_args`, no shadow rebind.
+    let sum: u32 = items.iter().sum();
+    Vc::cell(sum)
+}
+
+#[turbo_tasks::function]
+async fn scaled_sum(scale: u32, items: &Vec<u32>) -> Vc<u32> {
+    // `scale` is owned in the body (the macro inserts `let scale = scale.clone();`),
+    // `items` stays as `&Vec<u32>`.
+    let sum: u32 = items.iter().map(|x| x * scale).sum();
+    Vc::cell(sum)
+}
+
+#[turbo_tasks::value]
+struct Counter {
+    base: u32,
+}
+
+#[turbo_tasks::value_impl]
+impl Counter {
+    #[turbo_tasks::function]
+    async fn add_all(&self, items: &Vec<u32>) -> Vc<u32> {
+        // `self` deref'd via the `&Recv` receiver; `items` borrowed straight out of the
+        // cached args. If by-ref were silently broken, this body would still compile but
+        // the `task_fn` registration would fail at startup.
+        let sum: u32 = items.iter().sum();
+        Vc::cell(self.base + sum)
+    }
+}

--- a/turbopack/crates/turbo-tasks-backend/tests/collectibles.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/collectibles.rs
@@ -232,7 +232,7 @@ async fn my_transitive_emitting_function_with_child_scope(
 }
 
 #[turbo_tasks::function]
-async fn my_emitting_function(key: RcStr) -> Result<()> {
+async fn my_emitting_function(key: &RcStr) -> Result<()> {
     let _ = key;
     sleep(Duration::from_millis(100)).await;
     emit(ResolvedVc::upcast::<Box<dyn ValueToString>>(Thing::new(

--- a/turbopack/crates/turbo-tasks-env/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-env/src/lib.rs
@@ -82,7 +82,7 @@ pub fn sorted_env_vars() -> FxIndexMap<RcStr, RcStr> {
 #[turbo_tasks::function]
 pub async fn case_insensitive_read(
     map: Vc<TransientEnvMap>,
-    name: RcStr,
+    name: &RcStr,
 ) -> Result<Vc<Option<RcStr>>> {
     Ok(Vc::cell(
         to_uppercase_map(map)

--- a/turbopack/crates/turbo-tasks-fetch/src/client.rs
+++ b/turbopack/crates/turbo-tasks-fetch/src/client.rs
@@ -83,10 +83,10 @@ impl FetchClientConfig {
     #[turbo_tasks::function(network)]
     pub async fn fetch(
         self: Vc<FetchClientConfig>,
-        url: RcStr,
+        url: &RcStr,
         user_agent: Option<RcStr>,
     ) -> Result<Vc<FetchResult>> {
-        let url_ref = &*url;
+        let url_ref: &str = url;
         let this = self.await?;
         let response_result: reqwest::Result<HttpResponse> = async move {
             let reqwest_client = this.try_get_cached_reqwest_client()?;
@@ -123,7 +123,7 @@ impl FetchClientConfig {
                 // the client failed to construct or the HTTP request failed
                 mark_session_dependent();
                 Ok(Vc::cell(Err(
-                    FetchError::from_reqwest_error(&err, &url).resolved_cell()
+                    FetchError::from_reqwest_error(&err, url).resolved_cell()
                 )))
             }
         }

--- a/turbopack/crates/turbo-tasks-fetch/src/client.rs
+++ b/turbopack/crates/turbo-tasks-fetch/src/client.rs
@@ -84,20 +84,19 @@ impl FetchClientConfig {
     pub async fn fetch(
         self: Vc<FetchClientConfig>,
         url: &RcStr,
-        user_agent: Option<RcStr>,
+        user_agent: &Option<RcStr>,
     ) -> Result<Vc<FetchResult>> {
-        let url_ref: &str = url;
         let this = self.await?;
         let response_result: reqwest::Result<HttpResponse> = async move {
             let reqwest_client = this.try_get_cached_reqwest_client()?;
 
-            let mut builder = reqwest_client.get(url_ref);
+            let mut builder = reqwest_client.get(url.as_str());
             if let Some(user_agent) = user_agent {
                 builder = builder.header("User-Agent", user_agent.as_str());
             }
 
             let response = {
-                let _span = duration_span!("fetch request", url = url_ref);
+                let _span = duration_span!("fetch request", url = url.as_str());
                 builder.send().await
             }
             .and_then(|r| r.error_for_status())?;
@@ -105,7 +104,7 @@ impl FetchClientConfig {
             let status = response.status().as_u16();
 
             let body = {
-                let _span = duration_span!("fetch response", url = url_ref);
+                let _span = duration_span!("fetch response", url = url.as_str());
                 response.bytes().await?
             }
             .to_vec();
@@ -122,9 +121,11 @@ impl FetchClientConfig {
             Err(err) => {
                 // the client failed to construct or the HTTP request failed
                 mark_session_dependent();
-                Ok(Vc::cell(Err(
-                    FetchError::from_reqwest_error(&err, url).resolved_cell()
-                )))
+                Ok(Vc::cell(Err(FetchError::from_reqwest_error(
+                    &err,
+                    url.as_str(),
+                )
+                .resolved_cell())))
             }
         }
     }

--- a/turbopack/crates/turbo-tasks-fetch/tests/fetch.rs
+++ b/turbopack/crates/turbo-tasks-fetch/tests/fetch.rs
@@ -316,7 +316,7 @@ async fn client_cache() {
 
     // a simple fetch that should always succeed
     #[turbo_tasks::function(operation)]
-    async fn simple_fetch_operation(server_url: &RcStr, path: RcStr) -> anyhow::Result<()> {
+    async fn simple_fetch_operation(server_url: &RcStr, path: &RcStr) -> anyhow::Result<()> {
         let url = RcStr::from(format!("{}{}", server_url, path));
         let response = match &*FetchClientConfig::default()
             .cell()

--- a/turbopack/crates/turbo-tasks-fetch/tests/fetch.rs
+++ b/turbopack/crates/turbo-tasks-fetch/tests/fetch.rs
@@ -196,7 +196,7 @@ async fn errors_on_failed_connection() {
         );
 
         #[turbo_tasks::function(operation)]
-        async fn fetch_operation(url: RcStr) -> Result<Vc<FetchOutput>> {
+        async fn fetch_operation(url: &RcStr) -> Result<Vc<FetchOutput>> {
             let client_vc = FetchClientConfig::default().cell();
             let response_vc = client_vc.fetch(url.clone(), None);
             let err_vc = &*response_vc.await?.unwrap_err();
@@ -260,7 +260,7 @@ async fn errors_on_404() {
             );
 
             #[turbo_tasks::function(operation)]
-            async fn fetch_operation(url: RcStr) -> Result<Vc<FetchOutput>> {
+            async fn fetch_operation(url: &RcStr) -> Result<Vc<FetchOutput>> {
                 let client_vc = FetchClientConfig::default().cell();
                 let response_vc = client_vc.fetch(url.clone(), None);
 
@@ -316,7 +316,7 @@ async fn client_cache() {
 
     // a simple fetch that should always succeed
     #[turbo_tasks::function(operation)]
-    async fn simple_fetch_operation(server_url: RcStr, path: RcStr) -> anyhow::Result<()> {
+    async fn simple_fetch_operation(server_url: &RcStr, path: RcStr) -> anyhow::Result<()> {
         let url = RcStr::from(format!("{}{}", server_url, path));
         let response = match &*FetchClientConfig::default()
             .cell()

--- a/turbopack/crates/turbo-tasks-fs/examples/hash_directory.rs
+++ b/turbopack/crates/turbo-tasks-fs/examples/hash_directory.rs
@@ -65,7 +65,7 @@ async fn filename(path: FileSystemPath) -> Result<String> {
 }
 
 #[turbo_tasks::function]
-async fn hash_directory(directory: FileSystemPath) -> Result<Vc<RcStr>> {
+async fn hash_directory(directory: &FileSystemPath) -> Result<Vc<RcStr>> {
     let dir_path = &directory.path;
     let content = directory.read_dir();
     let mut hashes = BTreeMap::new();
@@ -101,7 +101,7 @@ async fn hash_directory(directory: FileSystemPath) -> Result<Vc<RcStr>> {
 }
 
 #[turbo_tasks::function]
-async fn hash_file(file_path: FileSystemPath) -> Result<Vc<RcStr>> {
+async fn hash_file(file_path: &FileSystemPath) -> Result<Vc<RcStr>> {
     let content = file_path.read().await?;
     Ok(match &*content {
         FileContent::Content(file) => hash_content(&mut file.read()),

--- a/turbopack/crates/turbo-tasks-fs/examples/hash_glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/examples/hash_glob.rs
@@ -97,7 +97,7 @@ async fn hash_glob_result(result: Vc<ReadGlobResult>) -> Result<Vc<RcStr>> {
 }
 
 #[turbo_tasks::function]
-async fn hash_file(file_path: FileSystemPath) -> Result<Vc<RcStr>> {
+async fn hash_file(file_path: &FileSystemPath) -> Result<Vc<RcStr>> {
     let content = file_path.read().await?;
     Ok(match &*content {
         FileContent::Content(file) => hash_content(&mut file.read()),

--- a/turbopack/crates/turbo-tasks-fs/src/attach.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/attach.rs
@@ -25,7 +25,7 @@ impl AttachedFileSystem {
     /// an invisible subdirectory of the `child_path`
     #[turbo_tasks::function]
     pub async fn new(
-        child_path: FileSystemPath,
+        child_path: &FileSystemPath,
         child_fs: ResolvedVc<Box<dyn FileSystem>>,
     ) -> Result<Vc<Self>> {
         Ok(AttachedFileSystem {
@@ -48,7 +48,7 @@ impl AttachedFileSystem {
     #[turbo_tasks::function]
     pub async fn get_inner_fs_path(
         self: ResolvedVc<Self>,
-        path: FileSystemPath,
+        path: &FileSystemPath,
     ) -> Result<Vc<FileSystemPath>> {
         let this = self.await?;
         let self_fs: ResolvedVc<Box<dyn FileSystem>> = ResolvedVc::upcast(self);
@@ -61,7 +61,7 @@ impl AttachedFileSystem {
         }
 
         let child_path = self.child_path().await?;
-        Ok(if let Some(inner_path) = child_path.get_path_to(&path) {
+        Ok(if let Some(inner_path) = child_path.get_path_to(path) {
             this.child_fs.root().await?.join(inner_path)?.cell()
         } else {
             this.root_fs.root().await?.join(&path.path)?.cell()

--- a/turbopack/crates/turbo-tasks-fs/src/embed/fs.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/embed/fs.rs
@@ -27,7 +27,7 @@ impl EmbeddedFileSystem {
 #[turbo_tasks::value_impl]
 impl FileSystem for EmbeddedFileSystem {
     #[turbo_tasks::function]
-    async fn read(&self, path: FileSystemPath) -> Result<Vc<FileContent>> {
+    async fn read(&self, path: &FileSystemPath) -> Result<Vc<FileContent>> {
         let file = match self.dir.get_file(&path.path) {
             Some(file) => file,
             None => return Ok(FileContent::NotFound.cell()),
@@ -37,12 +37,12 @@ impl FileSystem for EmbeddedFileSystem {
     }
 
     #[turbo_tasks::function]
-    fn read_link(&self, _path: FileSystemPath) -> Vc<LinkContent> {
+    fn read_link(&self, _path: &FileSystemPath) -> Vc<LinkContent> {
         LinkContent::NotFound.cell()
     }
 
     #[turbo_tasks::function]
-    async fn raw_read_dir(&self, path: FileSystemPath) -> Result<Vc<RawDirectoryContent>> {
+    async fn raw_read_dir(&self, path: &FileSystemPath) -> Result<Vc<RawDirectoryContent>> {
         let path_str = &path.path;
         let dir = match (path_str.as_str(), self.dir.get_dir(path_str)) {
             ("", _) => self.dir,
@@ -72,17 +72,17 @@ impl FileSystem for EmbeddedFileSystem {
     }
 
     #[turbo_tasks::function]
-    fn write(&self, _path: FileSystemPath, _content: Vc<FileContent>) -> Result<Vc<()>> {
+    fn write(&self, _path: &FileSystemPath, _content: Vc<FileContent>) -> Result<Vc<()>> {
         bail!("Writing is not possible to the embedded filesystem")
     }
 
     #[turbo_tasks::function]
-    fn write_link(&self, _path: FileSystemPath, _target: Vc<LinkContent>) -> Result<Vc<()>> {
+    fn write_link(&self, _path: &FileSystemPath, _target: Vc<LinkContent>) -> Result<Vc<()>> {
         bail!("Writing is not possible to the embedded filesystem")
     }
 
     #[turbo_tasks::function]
-    async fn metadata(&self, path: FileSystemPath) -> Result<Vc<FileMeta>> {
+    async fn metadata(&self, path: &FileSystemPath) -> Result<Vc<FileMeta>> {
         if self.dir.get_entry(&path.path).is_none() {
             bail!("path not found, can't read metadata");
         }

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -3057,7 +3057,7 @@ mod tests {
     }
 
     #[turbo_tasks::function(operation)]
-    async fn assert_try_from_sys_path_operation(sys_root: RcStr) -> anyhow::Result<()> {
+    async fn assert_try_from_sys_path_operation(sys_root: &RcStr) -> anyhow::Result<()> {
         let sys_root = Path::new(sys_root.as_str());
         let fs_vc = DiskFileSystem::new(
             rcstr!("temp"),

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -1760,8 +1760,8 @@ impl std::fmt::Display for FileSystemPath {
 #[turbo_tasks::function]
 pub async fn rebase(
     fs_path: &FileSystemPath,
-    old_base: FileSystemPath,
-    new_base: FileSystemPath,
+    old_base: &FileSystemPath,
+    new_base: &FileSystemPath,
 ) -> Result<Vc<FileSystemPath>> {
     let new_path;
     if old_base.path.is_empty() {
@@ -3285,13 +3285,13 @@ mod tests {
         async fn write_symlink_stress_batch(
             fs: ResolvedVc<DiskFileSystem>,
             symlinks_dir: &FileSystemPath,
-            updates: Vec<(usize, usize)>,
+            updates: &Vec<(usize, usize)>,
         ) -> anyhow::Result<()> {
             use turbo_tasks::TryJoinIterExt;
 
             updates
-                .into_iter()
-                .map(|(symlink_idx, target_idx)| {
+                .iter()
+                .map(|&(symlink_idx, target_idx)| {
                     let target = RcStr::from(format!("../_targets/{target_idx}"));
                     let symlink_path = symlinks_dir.join(&symlink_idx.to_string()).unwrap();
                     async move {

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -736,14 +736,14 @@ impl FileSystem for DiskFileSystem {
     }
 
     #[turbo_tasks::function(fs)]
-    async fn raw_read_dir(&self, fs_path: FileSystemPath) -> Result<Vc<RawDirectoryContent>> {
+    async fn raw_read_dir(&self, fs_path: &FileSystemPath) -> Result<Vc<RawDirectoryContent>> {
         mark_session_dependent();
 
         // Check if directory itself is denied - if so, treat as NotFound
-        if self.inner.is_path_denied(&fs_path) {
+        if self.inner.is_path_denied(fs_path) {
             return Ok(RawDirectoryContent::not_found());
         }
-        let full_path = self.to_sys_path(&fs_path);
+        let full_path = self.to_sys_path(fs_path);
 
         self.inner.register_dir_invalidator(&full_path).await?;
 
@@ -826,14 +826,14 @@ impl FileSystem for DiskFileSystem {
     }
 
     #[turbo_tasks::function(fs)]
-    async fn read_link(&self, fs_path: FileSystemPath) -> Result<Vc<LinkContent>> {
+    async fn read_link(&self, fs_path: &FileSystemPath) -> Result<Vc<LinkContent>> {
         mark_session_dependent();
 
         // Check if path is denied - if so, treat as NotFound
-        if self.inner.is_path_denied(&fs_path) {
+        if self.inner.is_path_denied(fs_path) {
             return Ok(LinkContent::NotFound.cell());
         }
-        let full_path = self.to_sys_path(&fs_path);
+        let full_path = self.to_sys_path(fs_path);
 
         self.inner.register_read_invalidator(&full_path).await?;
 
@@ -918,16 +918,16 @@ impl FileSystem for DiskFileSystem {
     }
 
     #[turbo_tasks::function(fs)]
-    async fn write(&self, fs_path: FileSystemPath, content: Vc<FileContent>) -> Result<()> {
+    async fn write(&self, fs_path: &FileSystemPath, content: Vc<FileContent>) -> Result<()> {
         // You might be tempted to use `mark_session_dependent` here, but
         // `write` purely declares a side effect and does not need to be reexecuted in the next
         // session. All side effects are reexecuted in general.
 
         // Check if path is denied - if so, return an error
-        if self.inner.is_path_denied(&fs_path) {
+        if self.inner.is_path_denied(fs_path) {
             turbobail!("Cannot write to denied path: {fs_path}");
         }
-        let full_path = self.to_sys_path(&fs_path);
+        let full_path = self.to_sys_path(fs_path);
 
         // Persist the file content so it is stored in the persistent cache.
         // Since FileContent uses serialization = "hash", persisting it here ensures the full
@@ -1099,19 +1099,19 @@ impl FileSystem for DiskFileSystem {
     }
 
     #[turbo_tasks::function(fs)]
-    async fn write_link(&self, fs_path: FileSystemPath, target: Vc<LinkContent>) -> Result<()> {
+    async fn write_link(&self, fs_path: &FileSystemPath, target: Vc<LinkContent>) -> Result<()> {
         // You might be tempted to use `mark_session_dependent` here, but we purely declare a side
         // effect and does not need to be re-executed in the next session. All side effects are
         // re-executed in general.
 
         // Check if path is denied - if so, return an error
-        if self.inner.is_path_denied(&fs_path) {
+        if self.inner.is_path_denied(fs_path) {
             turbobail!("Cannot write link to denied path: {fs_path}");
         }
 
         let content = target.await?;
 
-        let full_path = self.to_sys_path(&fs_path);
+        let full_path = self.to_sys_path(fs_path);
         let inner = self.inner.clone();
 
         #[derive(TraceRawVcs, NonLocalValue)]
@@ -1380,12 +1380,12 @@ impl FileSystem for DiskFileSystem {
     }
 
     #[turbo_tasks::function(fs)]
-    async fn metadata(&self, fs_path: FileSystemPath) -> Result<Vc<FileMeta>> {
+    async fn metadata(&self, fs_path: &FileSystemPath) -> Result<Vc<FileMeta>> {
         mark_session_dependent();
-        let full_path = self.to_sys_path(&fs_path);
+        let full_path = self.to_sys_path(fs_path);
 
         // Check if path is denied - if so, return an error (metadata shouldn't be readable)
-        if self.inner.is_path_denied(&fs_path) {
+        if self.inner.is_path_denied(fs_path) {
             turbobail!("Cannot read metadata from denied path: {fs_path}");
         }
 
@@ -1759,7 +1759,7 @@ impl std::fmt::Display for FileSystemPath {
 
 #[turbo_tasks::function]
 pub async fn rebase(
-    fs_path: FileSystemPath,
+    fs_path: &FileSystemPath,
     old_base: FileSystemPath,
     new_base: FileSystemPath,
 ) -> Result<Vc<FileSystemPath>> {
@@ -2725,28 +2725,28 @@ pub struct NullFileSystem;
 #[turbo_tasks::value_impl]
 impl FileSystem for NullFileSystem {
     #[turbo_tasks::function]
-    fn read(&self, _fs_path: FileSystemPath) -> Vc<FileContent> {
+    fn read(&self, _fs_path: &FileSystemPath) -> Vc<FileContent> {
         FileContent::NotFound.cell()
     }
 
     #[turbo_tasks::function]
-    fn read_link(&self, _fs_path: FileSystemPath) -> Vc<LinkContent> {
+    fn read_link(&self, _fs_path: &FileSystemPath) -> Vc<LinkContent> {
         LinkContent::NotFound.cell()
     }
 
     #[turbo_tasks::function]
-    fn raw_read_dir(&self, _fs_path: FileSystemPath) -> Vc<RawDirectoryContent> {
+    fn raw_read_dir(&self, _fs_path: &FileSystemPath) -> Vc<RawDirectoryContent> {
         RawDirectoryContent::not_found()
     }
 
     #[turbo_tasks::function]
-    fn write(&self, _fs_path: FileSystemPath, _content: Vc<FileContent>) {}
+    fn write(&self, _fs_path: &FileSystemPath, _content: Vc<FileContent>) {}
 
     #[turbo_tasks::function]
-    fn write_link(&self, _fs_path: FileSystemPath, _target: Vc<LinkContent>) {}
+    fn write_link(&self, _fs_path: &FileSystemPath, _target: Vc<LinkContent>) {}
 
     #[turbo_tasks::function]
-    fn metadata(&self, _fs_path: FileSystemPath) -> Vc<FileMeta> {
+    fn metadata(&self, _fs_path: &FileSystemPath) -> Vc<FileMeta> {
         FileMeta::default().cell()
     }
 }
@@ -2768,7 +2768,7 @@ pub async fn to_sys_path(mut path: FileSystemPath) -> Result<Option<PathBuf>> {
 }
 
 #[turbo_tasks::function]
-async fn read_dir(path: FileSystemPath) -> Result<Vc<DirectoryContent>> {
+async fn read_dir(path: &FileSystemPath) -> Result<Vc<DirectoryContent>> {
     let fs = path.fs().to_resolved().await?;
     match &*fs.raw_read_dir(path.clone()).await? {
         RawDirectoryContent::NotFound => Ok(DirectoryContent::not_found()),
@@ -2800,7 +2800,7 @@ async fn read_dir(path: FileSystemPath) -> Result<Vc<DirectoryContent>> {
 }
 
 #[turbo_tasks::function]
-async fn get_type(path: FileSystemPath) -> Result<Vc<FileSystemEntryType>> {
+async fn get_type(path: &FileSystemPath) -> Result<Vc<FileSystemEntryType>> {
     if path.is_root() {
         return Ok(FileSystemEntryType::Directory.cell());
     }
@@ -3162,7 +3162,7 @@ mod tests {
         #[turbo_tasks::function(operation)]
         async fn test_write_link_effect_operation(
             fs: ResolvedVc<DiskFileSystem>,
-            path: FileSystemPath,
+            path: &FileSystemPath,
             target: RcStr,
         ) -> anyhow::Result<()> {
             let write_file = |f| {
@@ -3284,7 +3284,7 @@ mod tests {
         #[turbo_tasks::function(operation)]
         async fn write_symlink_stress_batch(
             fs: ResolvedVc<DiskFileSystem>,
-            symlinks_dir: FileSystemPath,
+            symlinks_dir: &FileSystemPath,
             updates: Vec<(usize, usize)>,
         ) -> anyhow::Result<()> {
             use turbo_tasks::TryJoinIterExt;
@@ -3639,7 +3639,7 @@ mod tests {
         async fn test_denied_path_write() {
             #[turbo_tasks::function(operation)]
             async fn write_file_operation(
-                path: FileSystemPath,
+                path: &FileSystemPath,
                 contents: RcStr,
             ) -> anyhow::Result<()> {
                 path.write(

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -708,14 +708,14 @@ impl Debug for DiskFileSystem {
 #[turbo_tasks::value_impl]
 impl FileSystem for DiskFileSystem {
     #[turbo_tasks::function(fs)]
-    async fn read(&self, fs_path: FileSystemPath) -> Result<Vc<FileContent>> {
+    async fn read(&self, fs_path: &FileSystemPath) -> Result<Vc<FileContent>> {
         mark_session_dependent();
 
         // Check if path is denied - if so, treat as NotFound
-        if self.inner.is_path_denied(&fs_path) {
+        if self.inner.is_path_denied(fs_path) {
             return Ok(FileContent::NotFound.cell());
         }
-        let full_path = self.to_sys_path(&fs_path);
+        let full_path = self.to_sys_path(fs_path);
 
         self.inner.register_read_invalidator(&full_path).await?;
 

--- a/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
@@ -461,13 +461,13 @@ pub mod tests {
     }
 
     #[turbo_tasks::function(operation)]
-    pub async fn delete(path: FileSystemPath) -> anyhow::Result<()> {
+    pub async fn delete(path: &FileSystemPath) -> anyhow::Result<()> {
         path.write(FileContent::NotFound.cell()).await?;
         Ok(())
     }
 
     #[turbo_tasks::function(operation)]
-    pub async fn write(path: FileSystemPath, contents: RcStr) -> anyhow::Result<()> {
+    pub async fn write(path: &FileSystemPath, contents: RcStr) -> anyhow::Result<()> {
         path.write(
             FileContent::Content(crate::File::from_bytes(contents.to_string().into_bytes())).cell(),
         )
@@ -476,7 +476,7 @@ pub mod tests {
     }
 
     #[turbo_tasks::function(operation)]
-    pub fn track_star_star_glob(path: FileSystemPath) -> Vc<Completion> {
+    pub fn track_star_star_glob(path: &FileSystemPath) -> Vc<Completion> {
         path.track_glob(Glob::new(rcstr!("**"), GlobOptions::default()), false)
     }
 

--- a/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
@@ -26,11 +26,11 @@ pub async fn read_glob(directory: FileSystemPath, glob: Vc<Glob>) -> Result<Vc<R
 
 #[turbo_tasks::function(fs)]
 async fn read_glob_inner(
-    prefix: RcStr,
+    prefix: &RcStr,
     directory: FileSystemPath,
     glob: Vc<Glob>,
 ) -> Result<Vc<ReadGlobResult>> {
-    read_glob_internal(&prefix, directory, glob).await
+    read_glob_internal(prefix, directory, glob).await
 }
 
 // The `prefix` represents the relative directory path where symlinks are not resolve.
@@ -144,12 +144,12 @@ pub async fn track_glob(
 
 #[turbo_tasks::function(fs)]
 async fn track_glob_inner(
-    prefix: RcStr,
+    prefix: &RcStr,
     directory: FileSystemPath,
     glob: Vc<Glob>,
     include_dot_files: bool,
 ) -> Result<Vc<Completion>> {
-    track_glob_internal(&prefix, directory, glob, include_dot_files).await
+    track_glob_internal(prefix, directory, glob, include_dot_files).await
 }
 
 async fn track_glob_internal(

--- a/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
@@ -20,14 +20,14 @@ pub struct ReadGlobResult {
 /// DETERMINISM: Result is in random order. Either sort result or do not depend
 /// on the order.
 #[turbo_tasks::function(fs)]
-pub async fn read_glob(directory: FileSystemPath, glob: Vc<Glob>) -> Result<Vc<ReadGlobResult>> {
+pub async fn read_glob(directory: &FileSystemPath, glob: Vc<Glob>) -> Result<Vc<ReadGlobResult>> {
     read_glob_internal("", directory, glob).await
 }
 
 #[turbo_tasks::function(fs)]
 async fn read_glob_inner(
     prefix: &RcStr,
-    directory: FileSystemPath,
+    directory: &FileSystemPath,
     glob: Vc<Glob>,
 ) -> Result<Vc<ReadGlobResult>> {
     read_glob_internal(prefix, directory, glob).await
@@ -36,7 +36,7 @@ async fn read_glob_inner(
 // The `prefix` represents the relative directory path where symlinks are not resolve.
 async fn read_glob_internal(
     prefix: &str,
-    directory: FileSystemPath,
+    directory: &FileSystemPath,
     glob: Vc<Glob>,
 ) -> Result<Vc<ReadGlobResult>> {
     let dir = directory.read_dir().await?;
@@ -135,7 +135,7 @@ async fn resolve_symlink_safely(entry: DirectoryEntry) -> Result<DirectoryEntry>
 ///  but unlike read_glob doesn't accumulate data.
 #[turbo_tasks::function(fs)]
 pub async fn track_glob(
-    directory: FileSystemPath,
+    directory: &FileSystemPath,
     glob: Vc<Glob>,
     include_dot_files: bool,
 ) -> Result<Vc<Completion>> {
@@ -145,7 +145,7 @@ pub async fn track_glob(
 #[turbo_tasks::function(fs)]
 async fn track_glob_inner(
     prefix: &RcStr,
-    directory: FileSystemPath,
+    directory: &FileSystemPath,
     glob: Vc<Glob>,
     include_dot_files: bool,
 ) -> Result<Vc<Completion>> {
@@ -154,7 +154,7 @@ async fn track_glob_inner(
 
 async fn track_glob_internal(
     prefix: &str,
-    directory: FileSystemPath,
+    directory: &FileSystemPath,
     glob: Vc<Glob>,
     include_dot_files: bool,
 ) -> Result<Vc<Completion>> {

--- a/turbopack/crates/turbo-tasks-fs/src/virtual_fs.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/virtual_fs.rs
@@ -42,32 +42,32 @@ impl VirtualFileSystem {
 #[turbo_tasks::value_impl]
 impl FileSystem for VirtualFileSystem {
     #[turbo_tasks::function]
-    fn read(&self, _fs_path: FileSystemPath) -> Result<Vc<FileContent>> {
+    fn read(&self, _fs_path: &FileSystemPath) -> Result<Vc<FileContent>> {
         bail!("Reading is not possible on the virtual file system")
     }
 
     #[turbo_tasks::function]
-    fn read_link(&self, _fs_path: FileSystemPath) -> Result<Vc<LinkContent>> {
+    fn read_link(&self, _fs_path: &FileSystemPath) -> Result<Vc<LinkContent>> {
         bail!("Reading is not possible on the virtual file system")
     }
 
     #[turbo_tasks::function]
-    fn raw_read_dir(&self, _fs_path: FileSystemPath) -> Result<Vc<RawDirectoryContent>> {
+    fn raw_read_dir(&self, _fs_path: &FileSystemPath) -> Result<Vc<RawDirectoryContent>> {
         bail!("Reading is not possible on the virtual file system")
     }
 
     #[turbo_tasks::function]
-    fn write(&self, _fs_path: FileSystemPath, _content: Vc<FileContent>) -> Result<Vc<()>> {
+    fn write(&self, _fs_path: &FileSystemPath, _content: Vc<FileContent>) -> Result<Vc<()>> {
         bail!("Writing is not possible on the virtual file system")
     }
 
     #[turbo_tasks::function]
-    fn write_link(&self, _fs_path: FileSystemPath, _target: Vc<LinkContent>) -> Result<Vc<()>> {
+    fn write_link(&self, _fs_path: &FileSystemPath, _target: Vc<LinkContent>) -> Result<Vc<()>> {
         bail!("Writing is not possible on the virtual file system")
     }
 
     #[turbo_tasks::function]
-    fn metadata(&self, _fs_path: FileSystemPath) -> Result<Vc<FileMeta>> {
+    fn metadata(&self, _fs_path: &FileSystemPath) -> Result<Vc<FileMeta>> {
         bail!("Reading is not possible on the virtual file system")
     }
 }

--- a/turbopack/crates/turbo-tasks-fuzz/src/fs_watcher.rs
+++ b/turbopack/crates/turbo-tasks-fuzz/src/fs_watcher.rs
@@ -308,7 +308,7 @@ fn disk_file_system_root_operation(fs: ResolvedVc<DiskFileSystem>) -> Vc<FileSys
 #[turbo_tasks::function]
 async fn read_path(
     invalidations: TransientInstance<PathInvalidations>,
-    path: FileSystemPath,
+    path: &FileSystemPath,
 ) -> anyhow::Result<()> {
     let path_str = path.path.clone();
     invalidations.0.lock().unwrap().insert(path_str);
@@ -319,7 +319,7 @@ async fn read_path(
 #[turbo_tasks::function]
 async fn read_link(
     invalidations: TransientInstance<PathInvalidations>,
-    path: FileSystemPath,
+    path: &FileSystemPath,
 ) -> anyhow::Result<()> {
     let path_str = path.path.clone();
     invalidations.0.lock().unwrap().insert(path_str);
@@ -330,7 +330,7 @@ async fn read_link(
 #[turbo_tasks::function]
 async fn write_path(
     invalidations: TransientInstance<PathInvalidations>,
-    path: FileSystemPath,
+    path: &FileSystemPath,
 ) -> anyhow::Result<()> {
     let path_str = path.path.clone();
     invalidations.0.lock().unwrap().insert(path_str);
@@ -342,7 +342,7 @@ async fn write_path(
 #[turbo_tasks::function]
 async fn write_link(
     invalidations: TransientInstance<PathInvalidations>,
-    path: FileSystemPath,
+    path: &FileSystemPath,
     target: RcStr,
     is_directory: bool,
 ) -> anyhow::Result<()> {
@@ -364,7 +364,7 @@ async fn write_link(
 #[turbo_tasks::function(operation)]
 async fn read_or_write_all_paths_operation(
     invalidations: TransientInstance<PathInvalidations>,
-    root: FileSystemPath,
+    root: &FileSystemPath,
     depth: usize,
     width: usize,
     symlink_count: u32,

--- a/turbopack/crates/turbo-tasks-fuzz/src/symlink_stress.rs
+++ b/turbopack/crates/turbo-tasks-fuzz/src/symlink_stress.rs
@@ -178,7 +178,7 @@ fn disk_file_system_root_operation(fs: ResolvedVc<DiskFileSystem>) -> Vc<FileSys
 
 #[turbo_tasks::function(operation)]
 async fn create_initial_symlinks_operation(
-    symlinks_dir: FileSystemPath,
+    symlinks_dir: &FileSystemPath,
     count: usize,
     target: RcStr,
 ) -> anyhow::Result<()> {
@@ -191,7 +191,7 @@ async fn create_initial_symlinks_operation(
 
 #[turbo_tasks::function(operation)]
 async fn write_symlinks_batch_operation(
-    symlinks_dir: FileSystemPath,
+    symlinks_dir: &FileSystemPath,
     updates: Vec<(usize, usize)>,
 ) -> anyhow::Result<()> {
     updates
@@ -207,7 +207,7 @@ async fn write_symlinks_batch_operation(
 
 #[turbo_tasks::function]
 async fn write_symlink(
-    symlinks_dir: FileSystemPath,
+    symlinks_dir: &FileSystemPath,
     symlink_idx: usize,
     target: RcStr,
 ) -> anyhow::Result<()> {

--- a/turbopack/crates/turbo-tasks-fuzz/src/symlink_stress.rs
+++ b/turbopack/crates/turbo-tasks-fuzz/src/symlink_stress.rs
@@ -192,13 +192,13 @@ async fn create_initial_symlinks_operation(
 #[turbo_tasks::function(operation)]
 async fn write_symlinks_batch_operation(
     symlinks_dir: &FileSystemPath,
-    updates: Vec<(usize, usize)>,
+    updates: &Vec<(usize, usize)>,
 ) -> anyhow::Result<()> {
     updates
-        .into_iter()
+        .iter()
         .map(|(symlink_idx, target_idx)| {
             let target = RcStr::from(format!("../_targets/{}", target_idx));
-            write_symlink(symlinks_dir.clone(), symlink_idx, target)
+            write_symlink(symlinks_dir.clone(), *symlink_idx, target)
         })
         .try_join()
         .await?;

--- a/turbopack/crates/turbo-tasks-macros/src/func.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/func.rs
@@ -214,22 +214,27 @@ impl TurboFn<'_> {
     /// The signature of the exposed function. This is the original signature
     /// converted to a standard turbo_tasks function signature.
     pub fn signature(&self) -> TokenStream {
-        let exposed_inputs = self
-            .this
-            .as_ref()
-            .into_iter()
-            .chain(self.exposed_inputs.iter())
-            .map(|input| {
-                let ident = &input.ident;
-                let ty = if self.operation {
-                    // operations shouldn't have their arguments rewritten, they require all
-                    // arguments are explicitly `NonLocalValue`s
-                    input.ty.to_token_stream()
-                } else {
-                    expand_task_input_type(&input.ty).to_token_stream()
-                };
-                quote! { #ident: #ty }
-            });
+        let receiver_input = self.this.as_ref().map(|input| {
+            // The receiver is always rewritten to `self: Vc<Self>` regardless of whether the
+            // user wrote `&self` or `self: Vc<Self>`. Don't run it through the
+            // exposed-input-type stripper — it shouldn't have a leading `&` to begin with.
+            let ident = &input.ident;
+            let ty = input.ty.to_token_stream();
+            quote! { #ident: #ty }
+        });
+        let other_inputs = self.exposed_inputs.iter().map(|input| {
+            let ident = &input.ident;
+            let ty = if self.operation {
+                // operations shouldn't have their arguments rewritten, they require all
+                // arguments are explicitly `NonLocalValue`s
+                input.ty.to_token_stream()
+            } else {
+                // Body may declare `&T` for the optimization, but the caller always sees `T`.
+                expand_exposed_input_type(&input.ty).to_token_stream()
+            };
+            quote! { #ident: #ty }
+        });
+        let exposed_inputs = receiver_input.into_iter().chain(other_inputs);
 
         let ident = &self.ident;
         let orig_output = &self.output;
@@ -266,7 +271,7 @@ impl TurboFn<'_> {
         orig_block: &'a Block,
     ) -> (Signature, Cow<'a, Block>) {
         let mut shadow_self = None;
-        let (inputs, transform_stmts): (Punctuated<_, _>, Vec<Option<_>>) = self
+        let (inputs, transform_stmts): (Punctuated<_, _>, Vec<Vec<_>>) = self
             .orig_signature
             .inputs
             .iter()
@@ -281,44 +286,50 @@ impl TurboFn<'_> {
             })
             .enumerate()
             .map(|(idx, arg)| {
-                if self.operation {
-                    // operations shouldn't have their arguments rewritten, they require all
-                    // arguments are explicitly `NonLocalValue`s
-                    return (arg.clone(), None);
-                }
-
-                let (FnArg::Receiver(Receiver { ty, .. }) | FnArg::Typed(PatType { ty, .. })) = arg;
-                let Cow::Owned(expanded_ty) = expand_task_input_type(ty) else {
-                    // common-case: skip if no type conversion is needed
-                    return (arg.clone(), None);
-                };
-                // Helper to produce the transform statement
-                let transform_from_task_input = |arg_id: Cow<'_, Ident>, pat: Pat| {
-                    Stmt::Local(Local {
-                        attrs: Vec::new(),
-                        let_token: Default::default(),
-                        pat,
-                        init: Some(LocalInit {
-                            eq_token: Default::default(),
-                            // we know the argument implements `FromTaskInput` because
-                            // `expand_task_input_type` returned `Cow::Owned`
-                            expr: parse_quote_spanned! {
-                                arg.span() =>
-                                <#ty as turbo_tasks::task::FromTaskInput>::from_task_input(
-                                    #arg_id
-                                )
-                            },
-                            diverge: None,
-                        }),
-                        semi_token: Default::default(),
-                    })
-                };
                 match arg {
+                    FnArg::Receiver(_) if self.operation => {
+                        // Operations don't rewrite the receiver. They require all arguments to be
+                        // explicit `NonLocalValue`s and don't go through the `FromTaskInput`
+                        // pipeline. Receivers also don't get the by-ref wrap below — only typed
+                        // user arguments do.
+                        (arg.clone(), Vec::new())
+                    }
                     FnArg::Receiver(
                         receiver @ Receiver {
-                            attrs, self_token, ..
+                            attrs,
+                            self_token,
+                            ty,
+                            ..
                         },
                     ) => {
+                        // Receiver: keep existing semantics. We don't take `self` by-ref here —
+                        // the inline signature preserves whatever the user wrote (`&self` or
+                        // `self: Vc<Self>`), and the receiver style is what selects the final
+                        // blanket impl.
+                        let Cow::Owned(expanded_ty) = expand_task_input_type(ty) else {
+                            // common-case: skip if no type conversion is needed
+                            return (arg.clone(), Vec::new());
+                        };
+                        // Helper to produce a `let pat = <ty as
+                        // FromTaskInput>::from_task_input(arg);` statement.
+                        let transform_from_task_input = |arg_id: Cow<'_, Ident>, pat: Pat| {
+                            Stmt::Local(Local {
+                                attrs: Vec::new(),
+                                let_token: Default::default(),
+                                pat,
+                                init: Some(LocalInit {
+                                    eq_token: Default::default(),
+                                    expr: parse_quote_spanned! {
+                                        arg.span() =>
+                                        <#ty as turbo_tasks::task::FromTaskInput>::from_task_input(
+                                            #arg_id
+                                        )
+                                    },
+                                    diverge: None,
+                                }),
+                                semi_token: Default::default(),
+                            })
+                        };
                         let arg = FnArg::Receiver(Receiver {
                             attrs: Vec::new(),
                             mutability: None,
@@ -327,9 +338,8 @@ impl TurboFn<'_> {
                         });
 
                         // We can't shadow `self` variables, so if this argument is a `self`
-                        // argument, generate a new identifier, and rewrite
-                        // the body of the function later to use
-                        // that new identifier.
+                        // argument, generate a new identifier, and rewrite the body of the
+                        // function later to use that new identifier.
                         let shadow_self_id = Ident::new(
                             "turbo_tasks_self",
                             Span::mixed_site().located_at(self_token.span()),
@@ -346,9 +356,51 @@ impl TurboFn<'_> {
                         let transform_stmt =
                             transform_from_task_input(self_ident, shadow_self_pattern);
 
-                        (arg, Some(transform_stmt))
+                        (arg, vec![transform_stmt])
                     }
                     FnArg::Typed(pat_type) => {
+                        // Detect whether the user wrote `&T` or owned `T`.
+                        //
+                        // For elided lifetimes (`&T`) and `&'_ T` we treat the parameter as
+                        // user-by-ref. `&'static T`, named lifetimes, and `&mut T` are not
+                        // supported as task inputs and will fall through to the unsupported path
+                        // (the trait selection will fail with a clear error).
+                        let user_by_ref = matches!(
+                            &*pat_type.ty,
+                            Type::Reference(type_ref)
+                                if type_ref.mutability.is_none()
+                                    && type_ref.lifetime.is_none()
+                        );
+                        let core_ty: &Type = if let Type::Reference(type_ref) = &*pat_type.ty
+                            && user_by_ref
+                        {
+                            &type_ref.elem
+                        } else {
+                            &pat_type.ty
+                        };
+
+                        // Run `expand_task_input_type` (e.g. `ResolvedVc<T>` -> `Vc<T>`) on the
+                        // core type. For user-by-ref params we don't currently apply the
+                        // expansion: passing references to `Vc`-shaped types is not a supported
+                        // pattern and the caller still produces the owned form for the cache key.
+                        // Operations also skip the expansion — they require explicit
+                        // `NonLocalValue` arguments and don't use the `FromTaskInput` pipeline.
+                        let expanded_core_ty: Cow<'_, Type> = if user_by_ref || self.operation {
+                            Cow::Borrowed(core_ty)
+                        } else {
+                            expand_task_input_type(core_ty)
+                        };
+                        let needs_from_task_input_transform =
+                            matches!(expanded_core_ty, Cow::Owned(_));
+                        let inline_owned_ty: Type = expanded_core_ty.into_owned();
+
+                        // The inline parameter is always `&T'`. The blanket `*ByRefMode` impls
+                        // downcast `&*task.arg` once and pass references straight in, so this
+                        // saves the per-execution clone in `task_fn_impl!`'s `get_args` for
+                        // params the user actually declared by-ref.
+                        let inline_param_ty: Type =
+                            parse_quote_spanned!(pat_type.ty.span() => & #inline_owned_ty);
+
                         let arg_id = if let Pat::Ident(pat_id) = &*pat_type.pat {
                             // common case: argument is just an identifier
                             Cow::Borrowed(&pat_id.ident)
@@ -368,16 +420,54 @@ impl TurboFn<'_> {
                                 ident: arg_id.clone().into_owned(),
                                 subpat: None,
                             })),
-                            ty: Box::new(expanded_ty),
+                            ty: Box::new(inline_param_ty),
                             ..pat_type.clone()
                         });
 
-                        // convert an argument of type `FromTaskInput<T>::TaskInput` into `T`.
-                        // essentially, replace any instances of `Vc` with `ResolvedVc`.
-                        let pat = (*pat_type.pat).clone();
-                        let transform_stmt = transform_from_task_input(arg_id, pat);
+                        let mut shadow_stmts: Vec<Stmt> = Vec::new();
+                        if !user_by_ref {
+                            // The user wrote an owned `T`. The inline param is now `&T'` so
+                            // their body is missing an owned binding. Clone once to restore it.
+                            // For Copy-type inputs (e.g. `Vc<T>`) this is a free copy; for
+                            // non-Copy task inputs (e.g. `RcStr`, `FileSystemPath`) it's the
+                            // same clone the existing `get_args` was performing.
+                            let id: &Ident = &arg_id;
+                            // Preserve `mut` if the user declared the parameter as `mut x: T`.
+                            // Without this, function bodies that mutate the argument (e.g.
+                            // `counts.pop()`) would no longer compile after the shadow rebind.
+                            let user_mut =
+                                matches!(&*pat_type.pat, Pat::Ident(p) if p.mutability.is_some());
+                            let mut_kw = if user_mut { quote!(mut) } else { quote!() };
+                            shadow_stmts.push(parse_quote_spanned!(arg.span() =>
+                                let #mut_kw #id: #inline_owned_ty =
+                                    <#inline_owned_ty as ::std::clone::Clone>::clone(#id);
+                            ));
 
-                        (arg, Some(transform_stmt))
+                            if needs_from_task_input_transform {
+                                // Convert the expanded form (e.g. `Vc<T>`) back to the user's
+                                // declared form (`ResolvedVc<T>`).
+                                let original_user_ty = &*pat_type.ty;
+                                let pat = (*pat_type.pat).clone();
+                                shadow_stmts.push(Stmt::Local(Local {
+                                    attrs: Vec::new(),
+                                    let_token: Default::default(),
+                                    pat,
+                                    init: Some(LocalInit {
+                                        eq_token: Default::default(),
+                                        expr: parse_quote_spanned! {
+                                            arg.span() =>
+                                            <#original_user_ty as turbo_tasks::task::FromTaskInput>
+                                                ::from_task_input(#id)
+                                        },
+                                        diverge: None,
+                                    }),
+                                    semi_token: Default::default(),
+                                }));
+                            }
+                        }
+                        // user_by_ref: the body sees `&T` directly, no shadow required.
+
+                        (arg, shadow_stmts)
                     }
                 }
             })
@@ -439,7 +529,7 @@ impl TurboFn<'_> {
     pub fn exposed_input_types(&self) -> impl Iterator<Item = Cow<'_, Type>> {
         self.exposed_inputs
             .iter()
-            .map(|Input { ty, .. }| expand_task_input_type(ty))
+            .map(|Input { ty, .. }| expand_exposed_input_type(ty))
     }
 
     pub fn filter_trait_call_args(&self) -> Option<FilterTraitCallArgsTokens> {
@@ -642,7 +732,7 @@ impl TurboFn<'_> {
     }
 }
 
-#[derive(PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum ReceiverStyle {
     // A reference like &self or self: &Self
     Reference,
@@ -797,6 +887,21 @@ fn return_type_to_type(return_type: &ReturnType) -> Type {
 ///   signatures illegible in the resulting rustdocs.
 ///
 /// Returns `Cow::Owned` when a transformation was applied, and `Cow::Borrowed` when no change was
+/// Like [`expand_task_input_type`], but strips a leading immutable reference (`&T` -> `T`)
+/// before applying the expansion. Used when emitting the exposed (caller-facing) type for an
+/// argument the user declared by-ref: the cache key is built from owned values, so the caller
+/// always passes owned, regardless of how the body chose to consume it.
+fn expand_exposed_input_type(orig_input: &Type) -> Cow<'_, Type> {
+    if let Type::Reference(type_ref) = orig_input
+        && type_ref.mutability.is_none()
+        && type_ref.lifetime.is_none()
+    {
+        expand_task_input_type(&type_ref.elem)
+    } else {
+        expand_task_input_type(orig_input)
+    }
+}
+
 /// made to the input type.
 fn expand_task_input_type(orig_input: &Type) -> Cow<'_, Type> {
     match orig_input {

--- a/turbopack/crates/turbo-tasks-macros/src/func.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/func.rs
@@ -382,12 +382,14 @@ impl TurboFn<'_> {
                         };
 
                         // Run `expand_task_input_type` (e.g. `ResolvedVc<T>` -> `Vc<T>`) on the
-                        // core type. For user-by-ref params we don't currently apply the
-                        // expansion: passing references to `Vc`-shaped types is not a supported
-                        // pattern and the caller still produces the owned form for the cache key.
-                        // Operations also skip the expansion — they require explicit
-                        // `NonLocalValue` arguments and don't use the `FromTaskInput` pipeline.
-                        let expanded_core_ty: Cow<'_, Type> = if user_by_ref || self.operation {
+                        // core type. The cache always stores the expanded form, so this drives
+                        // the type that the inline closure sees in its parameter list (the
+                        // blanket impl downcasts to it). For user-by-ref + non-trivial expansion
+                        // we additionally generate a `RefFromTaskInput` borrow-cast in the body
+                        // so the user's body sees `&T` (their declared type) instead of `&T'`.
+                        // Operations skip the expansion — they require explicit `NonLocalValue`
+                        // arguments and don't use the `FromTaskInput` pipeline.
+                        let expanded_core_ty: Cow<'_, Type> = if self.operation {
                             Cow::Borrowed(core_ty)
                         } else {
                             expand_task_input_type(core_ty)
@@ -427,13 +429,14 @@ impl TurboFn<'_> {
                         });
 
                         let mut shadow_stmts: Vec<Stmt> = Vec::new();
+                        let id: &Ident = &arg_id;
                         if !user_by_ref {
                             // The user wrote an owned `T`. The inline param is now `&T'` so
                             // their body is missing an owned binding. Clone once to restore it.
                             // For Copy-type inputs (e.g. `Vc<T>`) this is a free copy; for
                             // non-Copy task inputs (e.g. `RcStr`, `FileSystemPath`) it's the
                             // same clone the existing `get_args` was performing.
-                            let id: &Ident = &arg_id;
+                            //
                             // Preserve `mut` if the user declared the parameter as `mut x: T`.
                             // Without this, function bodies that mutate the argument (e.g.
                             // `counts.pop()`) would no longer compile after the shadow rebind.
@@ -466,8 +469,27 @@ impl TurboFn<'_> {
                                     semi_token: Default::default(),
                                 }));
                             }
+                        } else if needs_from_task_input_transform {
+                            // The user wrote `&T` where `T` would be rewritten by
+                            // `expand_task_input_type` (`ResolvedVc<T>` and friends). The cache
+                            // stores `T::TaskInput`, so the inline parameter is `&T::TaskInput`,
+                            // but the user's body expects `&T`. `RefFromTaskInput` is a layout-
+                            // compatible borrow-cast that re-types the borrow without an owned
+                            // conversion or a clone — precisely the win the user wanted by
+                            // declaring `&T` in the first place.
+                            let original_core_ty = if let Type::Reference(type_ref) = &*pat_type.ty
+                            {
+                                &*type_ref.elem
+                            } else {
+                                &*pat_type.ty
+                            };
+                            shadow_stmts.push(parse_quote_spanned!(arg.span() =>
+                                let #id: & #original_core_ty =
+                                    <#original_core_ty as turbo_tasks::task::RefFromTaskInput>
+                                        ::ref_from_task_input(#id);
+                            ));
                         }
-                        // user_by_ref: the body sees `&T` directly, no shadow required.
+                        // user_by_ref + no expansion: the body sees `&T` directly, no shadow.
 
                         (arg, shadow_stmts)
                     }

--- a/turbopack/crates/turbo-tasks-macros/src/func.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/func.rs
@@ -225,9 +225,11 @@ impl TurboFn<'_> {
         let other_inputs = self.exposed_inputs.iter().map(|input| {
             let ident = &input.ident;
             let ty = if self.operation {
-                // operations shouldn't have their arguments rewritten, they require all
-                // arguments are explicitly `NonLocalValue`s
-                input.ty.to_token_stream()
+                // Operations don't rewrite `ResolvedVc<T>` -> `Vc<T>` (they require explicit
+                // `NonLocalValue` arguments) but they still strip the leading `&` from a
+                // user-by-ref parameter — the caller always passes the owned form for the
+                // cache key.
+                strip_leading_ref(&input.ty).to_token_stream()
             } else {
                 // Body may declare `&T` for the optimization, but the caller always sees `T`.
                 expand_exposed_input_type(&input.ty).to_token_stream()
@@ -887,18 +889,28 @@ fn return_type_to_type(return_type: &ReturnType) -> Type {
 ///   signatures illegible in the resulting rustdocs.
 ///
 /// Returns `Cow::Owned` when a transformation was applied, and `Cow::Borrowed` when no change was
-/// Like [`expand_task_input_type`], but strips a leading immutable reference (`&T` -> `T`)
-/// before applying the expansion. Used when emitting the exposed (caller-facing) type for an
-/// argument the user declared by-ref: the cache key is built from owned values, so the caller
-/// always passes owned, regardless of how the body chose to consume it.
-fn expand_exposed_input_type(orig_input: &Type) -> Cow<'_, Type> {
+/// Strip a leading immutable reference (`&T` -> `T`) from a type, leaving everything else
+/// untouched. Used to derive the exposed (caller-facing) type for an argument the user
+/// declared by-ref: the cache key is built from owned values, so the caller always passes
+/// owned, regardless of how the body chose to consume it.
+fn strip_leading_ref(orig_input: &Type) -> Cow<'_, Type> {
     if let Type::Reference(type_ref) = orig_input
         && type_ref.mutability.is_none()
         && type_ref.lifetime.is_none()
     {
-        expand_task_input_type(&type_ref.elem)
+        Cow::Borrowed(&type_ref.elem)
     } else {
-        expand_task_input_type(orig_input)
+        Cow::Borrowed(orig_input)
+    }
+}
+
+/// Like [`expand_task_input_type`], but strips a leading immutable reference (`&T` -> `T`)
+/// before applying the expansion. Used when emitting the exposed (caller-facing) type for an
+/// argument the user declared by-ref.
+fn expand_exposed_input_type(orig_input: &Type) -> Cow<'_, Type> {
+    match strip_leading_ref(orig_input) {
+        Cow::Borrowed(t) => expand_task_input_type(t),
+        Cow::Owned(t) => Cow::Owned(expand_task_input_type(&t).into_owned()),
     }
 }
 

--- a/turbopack/crates/turbo-tasks-macros/src/function_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/function_macro.rs
@@ -80,6 +80,12 @@ pub fn function(args: TokenStream, input: TokenStream) -> TokenStream {
 
         #(#inline_attrs)*
         #[doc(hidden)]
+        // The macro rewrites every owned task input into a `&T` parameter, then re-clones
+        // when the user wrote it by value. That triggers clippy lints (`&Vec` / `&String`
+        // / `&PathBuf`, `.clone()` on `Copy` like `Vc<T>`) that don't apply to a
+        // generated, internal function. Suppress them rather than try to outsmart the
+        // signature-rewriting on a per-arg basis.
+        #[allow(clippy::ptr_arg, clippy::clone_on_copy)]
         #inline_signature #inline_block
 
         turbo_tasks::macro_helpers::turbo_register!(

--- a/turbopack/crates/turbo-tasks-macros/src/value_impl_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/value_impl_macro.rs
@@ -145,6 +145,10 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
                         // body is originally declared within an `impl` block already.
                         #(#inline_attrs)*
                         #[doc(hidden)]
+                        // See `function_macro.rs`: signature rewriting introduces `&Vec`,
+                        // `&String`, `.clone()` on `Copy` types, etc. Suppress those lints on
+                        // the generated inline function.
+                        #[allow(clippy::ptr_arg, clippy::clone_on_copy)]
                         #[deprecated(note = "This function is only exposed for use in macros. Do not call it directly.")]
                         pub(self) #inline_signature #inline_block
                     }
@@ -260,6 +264,9 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
                     trait #inline_extension_trait_ident: std::marker::Send {
                         #(#inline_attrs)*
                         #[doc(hidden)]
+                        // The trait declaration carries the same rewritten signature as the
+                        // impl, so `&Vec` / `&String` / etc. show up here too.
+                        #[allow(clippy::ptr_arg)]
                         #inline_signature;
                     }
 
@@ -267,6 +274,7 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
                     impl #impl_generics #inline_extension_trait_ident for #ty #where_clause  {
                         #(#inline_attrs)*
                         #[doc(hidden)]
+                        #[allow(clippy::ptr_arg, clippy::clone_on_copy)]
                         #[deprecated(note = "This function is only exposed for use in macros. Do not call it directly.")]
                         #inline_signature #inline_block
                     }

--- a/turbopack/crates/turbo-tasks-macros/src/value_trait_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/value_trait_macro.rs
@@ -241,6 +241,9 @@ pub fn value_trait(args: TokenStream, input: TokenStream) -> TokenStream {
                 #[allow(non_camel_case_types)]
                 trait #inline_extension_trait_ident: std::marker::Send {
                     #(#inline_attrs)*
+                    // Same rewritten signature as the impl below; clippy's `ptr_arg` lint
+                    // would otherwise fire on every `&Vec<_>` / `&String` parameter.
+                    #[allow(clippy::ptr_arg)]
                     #inline_signature;
                 }
 
@@ -250,6 +253,7 @@ pub fn value_trait(args: TokenStream, input: TokenStream) -> TokenStream {
                 impl #inline_extension_trait_ident for Box<dyn #trait_ident> {
                     // put the function body here so that `Self` points to `Box<dyn ...>`
                     #(#inline_attrs)*
+                    #[allow(clippy::ptr_arg, clippy::clone_on_copy)]
                     #inline_signature #inline_block
                 }
 

--- a/turbopack/crates/turbo-tasks-testing/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-testing/src/lib.rs
@@ -52,7 +52,15 @@ impl VcStorage {
     ) -> RawVc {
         let this = self.this.upgrade().unwrap();
         let handle = tokio::runtime::Handle::current();
-        let future = func.execute(this_arg, &*arg);
+        // The executor now takes ownership of the cached task type so the future can
+        // capture it and borrow `arg` for the entire execution. The testing harness doesn't
+        // wire CachedTaskType through its own task store, so we build a one-shot Arc here.
+        let task = std::sync::Arc::new(turbo_tasks::backend::CachedTaskType {
+            native_fn: func,
+            this: this_arg,
+            arg,
+        });
+        let future = func.execute(task);
         let i = {
             let mut tasks = self.tasks.lock().unwrap();
             let i = tasks.len();

--- a/turbopack/crates/turbo-tasks-testing/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-testing/src/lib.rs
@@ -20,7 +20,9 @@ use turbo_tasks::{
     CellId, DynTaskInputs, ExecutionId, InvalidationReason, LocalTaskId, RawVc, ReadCellOptions,
     ReadOutputOptions, StackDynTaskInputs, TaskId, TaskPersistence, TraitTypeId, TurboTasksApi,
     TurboTasksCallApi,
-    backend::{CellContent, TaskCollectiblesMap, TypedCellContent, VerificationMode},
+    backend::{
+        CachedTaskType, CellContent, TaskCollectiblesMap, TypedCellContent, VerificationMode,
+    },
     event::{Event, EventListener},
     message_queue::CompilationEvent,
     test_helpers::with_turbo_tasks_for_testing,
@@ -55,7 +57,7 @@ impl VcStorage {
         // The executor now takes ownership of the cached task type so the future can
         // capture it and borrow `arg` for the entire execution. The testing harness doesn't
         // wire CachedTaskType through its own task store, so we build a one-shot Arc here.
-        let task = std::sync::Arc::new(turbo_tasks::backend::CachedTaskType {
+        let task = Arc::new(CachedTaskType {
             native_fn: func,
             this: this_arg,
             arg,

--- a/turbopack/crates/turbo-tasks/function.md
+++ b/turbopack/crates/turbo-tasks/function.md
@@ -27,8 +27,26 @@ The `#[turbo_tasks::function]` macro **rewrites the arguments and return values*
 
 - Method arguments of **`&self`** are **rewritten to `self: Vc<Self>`**.
 
+- Function arguments declared with **`&T`** keep an external signature taking `T` by value, but the **body sees `&T`** and skips a per-execution clone of the cached argument.
+  - The cache key is still composed from owned values, so callers pass owned values regardless of how the body declared the parameter. The macro inserts a clone shadow (`let arg = arg.clone();`) for any parameter the user declared by value, so existing bodies keep compiling unchanged.
+  - Mixed signatures are supported: a body can declare some parameters by value and others by reference. Each by-value parameter gets its own clone shadow.
+  - **Carve-outs:** explicit lifetimes (`&'a T`, `&'static T`), `&mut T`, `&dyn Trait`, `&[T]`, `&str` are **not** valid task input shapes and the macro will reject them. Use the owned form (`String`, `RcStr`, `Vec<T>`, …) instead.
+
+#### When to take `&T`
+
+Prefer by-reference for any **non-`Copy`** task input where the body only borrows the value:
+
+- Collections: `Vec<T>`, `HashMap<…>`, `IndexMap<…>`, `BTreeMap<…>`, `BTreeSet<…>`, `FxHashMap<…>`, … — including `Vec<Vc<T>>` and friends. The vec/map _itself_ is the storage we'd otherwise clone.
+- Owned strings / paths: `String`, `PathBuf`, `OsString`, `FileSystemPath`, `RcStr`.
+- Custom struct/enum types that contain any of the above.
+
+Stick with by-value for `Copy` types — `Vc<T>`, `ResolvedVc<T>`, `OperationVc<T>`, primitives — and for `TransientInstance<T>` / `TransientValue<T>`. Their clone is already a pointer copy or smaller, and the wrap-and-shadow churn is not worth it.
+
+The carve-out for [`#[turbo_tasks::function(operation)]`][operation-fns] still applies: operations don't run user arguments through [`FromTaskInput`], but they do get the same by-reference wrapping, so e.g. `&Vec<OperationVc<T>>` works on an operation function the same way it does elsewhere.
+
 [`ResolvedVc<T>`]: crate::ResolvedVc
 [`FromTaskInput`]: crate::task::FromTaskInput
+[operation-fns]: crate::OperationVc
 
 ### Return Type Rewrite Rules
 
@@ -54,8 +72,10 @@ async fn foo(
     b: Vc<i32>,
     c: ResolvedVc<i32>,
     d: Option<Vec<ResolvedVc<i32>>>,
+    e: &FileSystemPath,
 ) -> Result<Vc<i32>> {
-    // ...
+    // body sees `e: &FileSystemPath` directly — no clone of the cached
+    // argument before the body runs.
 }
 ```
 
@@ -68,6 +88,7 @@ fn foo(
     b: Vc<i32>,
     c: Vc<i32>,               // was: ResolvedVc<i32>
     d: Option<Vec<Vc<i32>>>,  // was: Option<Vec<ResolvedVc<i32>>>
+    e: FileSystemPath,        // was: &FileSystemPath  (caller still passes owned)
 ) -> Vc<i32>;                 // was: impl Future<Output = Result<Vc<i32>>>
 ```
 

--- a/turbopack/crates/turbo-tasks/src/native_function.rs
+++ b/turbopack/crates/turbo-tasks/src/native_function.rs
@@ -1,4 +1,4 @@
-use std::{any::Any, fmt::Debug, pin::Pin};
+use std::{any::Any, fmt::Debug, pin::Pin, sync::Arc};
 
 use anyhow::Result;
 use bincode::{Decode, Encode};
@@ -8,7 +8,8 @@ use turbo_bincode::{AnyDecodeFn, AnyEncodeFn, new_hash_encoder};
 use turbo_tasks_hash::DeterministicHasher;
 
 use crate::{
-    RawVc, TaskExecutionReason, TaskInput, TaskPersistence, TaskPriority,
+    TaskExecutionReason, TaskInput, TaskPersistence, TaskPriority,
+    backend::CachedTaskType,
     dyn_task_inputs::{
         DynTaskInputs, OwnedStackDynTaskInputs, StackDynTaskInputs, StackDynTaskInputsSlot,
         any_as_encode,
@@ -261,12 +262,8 @@ impl NativeFunction {
     /// Executed the function
     ///
     /// NOTE: this may return a local vc
-    pub fn execute(
-        &'static self,
-        this: Option<RawVc>,
-        arg: &dyn DynTaskInputs,
-    ) -> NativeTaskFuture {
-        match (self.implementation).functor(this, arg) {
+    pub fn execute(&'static self, task: Arc<CachedTaskType>) -> NativeTaskFuture {
+        match (self.implementation).functor(task) {
             Ok(functor) => functor,
             Err(err) => Box::pin(async { Err(err) }),
         }

--- a/turbopack/crates/turbo-tasks/src/task/from_task_input.rs
+++ b/turbopack/crates/turbo-tasks/src/task/from_task_input.rs
@@ -7,6 +7,25 @@ pub trait FromTaskInput: private::Sealed {
     fn from_task_input(from: Self::TaskInput) -> Self;
 }
 
+/// Borrow-compatible conversion from `&Self::TaskInput` to `&Self`. The
+/// `#[turbo_tasks::function]` macro uses this to give a body declaring `&T`
+/// (where `T: FromTaskInput`) a view of the cached `T::TaskInput` without an
+/// owned conversion or a clone.
+///
+/// All implementations are layout-compatible re-interpretations: `Self` and
+/// `Self::TaskInput` either are the same type or are `#[repr(transparent)]`
+/// wrappers around each other (e.g. `ResolvedVc<T>` is a transparent wrapper
+/// around `Vc<T>`), so `&Self::TaskInput` and `&Self` have identical layout.
+///
+/// # Safety
+/// Implementors must guarantee that `Self` and `Self::TaskInput` have identical
+/// layout (size, alignment, and any niche optimizations). The default
+/// implementations cover the trivial wrapper / structural cases; do not add new
+/// implementations without auditing layout compatibility.
+pub unsafe trait RefFromTaskInput: FromTaskInput {
+    fn ref_from_task_input(from: &Self::TaskInput) -> &Self;
+}
+
 mod private {
     use super::*;
     /// Implements the sealed trait pattern:
@@ -31,6 +50,23 @@ where
     }
 }
 
+// SAFETY: `ResolvedVc<T>` is `#[repr(transparent)]` over `Vc<T>` (see
+// `turbopack/crates/turbo-tasks/src/vc/resolved.rs`), so `&Vc<T>` and
+// `&ResolvedVc<T>` have identical layout.
+unsafe impl<T> RefFromTaskInput for ResolvedVc<T>
+where
+    T: Send + Sync + ?Sized,
+{
+    fn ref_from_task_input(from: &Vc<T>) -> &ResolvedVc<T> {
+        debug_assert!(
+            from.is_resolved(),
+            "Outer `Vc`s are always resolved before this is called"
+        );
+        // SAFETY: see the safety comment on the `unsafe impl`.
+        unsafe { &*(from as *const Vc<T> as *const ResolvedVc<T>) }
+    }
+}
+
 impl<T> FromTaskInput for Vec<T>
 where
     T: FromTaskInput,
@@ -45,6 +81,18 @@ where
     }
 }
 
+// SAFETY: `Vec<U>` and `Vec<V>` have identical layout iff `U` and `V` do, and
+// `T: RefFromTaskInput` carries that guarantee for `T` and `T::TaskInput`.
+unsafe impl<T> RefFromTaskInput for Vec<T>
+where
+    T: RefFromTaskInput,
+{
+    fn ref_from_task_input(from: &Vec<T::TaskInput>) -> &Vec<T> {
+        // SAFETY: see the safety comment on the `unsafe impl`.
+        unsafe { &*(from as *const Vec<T::TaskInput> as *const Vec<T>) }
+    }
+}
+
 impl<T> FromTaskInput for Option<T>
 where
     T: FromTaskInput,
@@ -52,5 +100,17 @@ where
     type TaskInput = Option<T::TaskInput>;
     fn from_task_input(from: Option<T::TaskInput>) -> Option<T> {
         from.map(T::from_task_input)
+    }
+}
+
+// SAFETY: `Option<U>` and `Option<V>` have identical layout (including niche
+// optimizations) iff `U` and `V` do; `T: RefFromTaskInput` carries that guarantee.
+unsafe impl<T> RefFromTaskInput for Option<T>
+where
+    T: RefFromTaskInput,
+{
+    fn ref_from_task_input(from: &Option<T::TaskInput>) -> &Option<T> {
+        // SAFETY: see the safety comment on the `unsafe impl`.
+        unsafe { &*(from as *const Option<T::TaskInput> as *const Option<T>) }
     }
 }

--- a/turbopack/crates/turbo-tasks/src/task/function.rs
+++ b/turbopack/crates/turbo-tasks/src/task/function.rs
@@ -21,17 +21,19 @@
 //! intermediate trait. However, this implementation doesn't support all async
 //! methods (see commented out tests).
 
-use std::{future::Future, marker::PhantomData, pin::Pin};
+use std::{future::Future, marker::PhantomData, pin::Pin, sync::Arc};
 
 use anyhow::Result;
 
 use super::{TaskInput, TaskOutput};
-use crate::{RawVc, Vc, VcRead, VcValueType, dyn_task_inputs::DynTaskInputs};
+use crate::{
+    RawVc, Vc, VcRead, VcValueType, backend::CachedTaskType, native_function::downcast_args_ref,
+};
 
 pub type NativeTaskFuture = Pin<Box<dyn Future<Output = Result<RawVc>> + Send>>;
 
 pub trait TaskFn: Send + Sync + 'static {
-    fn functor(&self, this: Option<RawVc>, arg: &dyn DynTaskInputs) -> Result<NativeTaskFuture>;
+    fn functor(&self, task: Arc<CachedTaskType>) -> Result<NativeTaskFuture>;
 }
 
 /// A trait for `TaskFn` implementations that allows task inputs to be extracted as a type.
@@ -81,8 +83,8 @@ where
     Mode: TaskFnMode,
     Inputs: TaskInputs,
 {
-    fn functor(&self, _this: Option<RawVc>, arg: &dyn DynTaskInputs) -> Result<NativeTaskFuture> {
-        TaskFnInputFunction::functor(&self.task_fn, arg)
+    fn functor(&self, task: Arc<CachedTaskType>) -> Result<NativeTaskFuture> {
+        TaskFnInputFunction::functor(&self.task_fn, task)
     }
 }
 
@@ -114,11 +116,11 @@ where
     This: Sync + Send + 'static,
     Inputs: TaskInputs,
 {
-    fn functor(&self, this: Option<RawVc>, arg: &dyn DynTaskInputs) -> Result<NativeTaskFuture> {
-        let Some(this) = this else {
+    fn functor(&self, task: Arc<CachedTaskType>) -> Result<NativeTaskFuture> {
+        let Some(this) = task.this else {
             panic!("Method needs a `self` argument");
         };
-        TaskFnInputFunctionWithThis::functor(&self.task_fn, this, arg)
+        TaskFnInputFunctionWithThis::functor(&self.task_fn, this, task)
     }
 }
 
@@ -136,7 +138,7 @@ where
 pub trait TaskFnInputFunction<Mode: TaskFnMode, Inputs: TaskInputs>:
     Send + Sync + Clone + 'static
 {
-    fn functor(&self, arg: &dyn DynTaskInputs) -> Result<NativeTaskFuture>;
+    fn functor(&self, task: Arc<CachedTaskType>) -> Result<NativeTaskFuture>;
 }
 
 #[doc(hidden)]
@@ -146,7 +148,7 @@ pub trait TaskFnInputFunctionWithThis<
     Inputs: TaskInputs,
 >: Send + Sync + Clone + 'static
 {
-    fn functor(&self, this: RawVc, arg: &dyn DynTaskInputs) -> Result<NativeTaskFuture>;
+    fn functor(&self, this: RawVc, task: Arc<CachedTaskType>) -> Result<NativeTaskFuture>;
 }
 
 pub trait TaskInputs: Send + Sync + 'static {}
@@ -179,97 +181,16 @@ macro_rules! task_inputs_impl {
     }
 }
 
-/// Downcast, and clone all the arguments in the singular `arg` tuple.
-///
-/// This helper function for `task_fn_impl!()` reduces the amount of code inside the macro, and
-/// gives the compiler more chances to dedupe monomorphized code across small functions with less
-/// typevars.
-fn get_args<T: DynTaskInputs + Clone>(arg: &dyn DynTaskInputs) -> Result<T> {
-    let value = (arg as &dyn std::any::Any).downcast_ref::<T>().cloned();
-    #[cfg(debug_assertions)]
-    return anyhow::Context::with_context(value, || {
-        crate::native_function::debug_downcast_args_error_msg(
-            std::any::type_name::<T>(),
-            arg.dyn_type_name(),
-        )
-    });
-    #[cfg(not(debug_assertions))]
-    return anyhow::Context::context(value, "Invalid argument type");
+// Helper function for `task_fn_impl!()`
+async fn output_try_into_non_local_raw_vc(output: impl TaskOutput) -> Result<RawVc> {
+    output.try_into_raw_vc()?.to_non_local().await
 }
 
-macro_rules! task_fn_impl {
-    ( $async_fn_trait:ident $arg_len:literal $( $arg:ident )* ) => {
-        impl<F, Output, $($arg,)*> TaskFnInputFunction<FunctionMode, ($($arg,)*)> for F
-        where
-            $($arg: TaskInput + 'static,)*
-            F: Fn($($arg,)*) -> Output + Send + Sync + Clone + 'static,
-            Output: TaskOutput + 'static,
-        {
-            #[allow(non_snake_case)]
-            fn functor(&self, arg: &dyn DynTaskInputs) -> Result<NativeTaskFuture> {
-                let task_fn = self.clone();
-                let ($($arg,)*) = get_args::<($($arg,)*)>(arg)?;
-                Ok(Box::pin(async move {
-                    (task_fn)($($arg,)*).try_into_raw_vc()
-                }))
-            }
-        }
-
-        impl<F, Output, FutureOutput, $($arg,)*> TaskFnInputFunction<AsyncFunctionMode, ($($arg,)*)> for F
-        where
-            $($arg: TaskInput + 'static,)*
-            F: Fn($($arg,)*) -> FutureOutput + Send + Sync + Clone + 'static,
-            FutureOutput: Future<Output = Output> + Send + 'static,
-            Output: TaskOutput + 'static,
-        {
-            #[allow(non_snake_case)]
-            fn functor(&self, arg: &dyn DynTaskInputs) -> Result<NativeTaskFuture> {
-                let task_fn = self.clone();
-                let ($($arg,)*) = get_args::<($($arg,)*)>(arg)?;
-                Ok(Box::pin(async move {
-                    (task_fn)($($arg,)*).await.try_into_raw_vc()
-                }))
-            }
-        }
-
-        impl<F, Output, Recv, $($arg,)*> TaskFnInputFunctionWithThis<MethodMode, Recv, ($($arg,)*)> for F
-        where
-            Recv: VcValueType,
-            $($arg: TaskInput + 'static,)*
-            F: Fn(&Recv, $($arg,)*) -> Output + Send + Sync + Clone + 'static,
-            Output: TaskOutput + 'static,
-        {
-            #[allow(non_snake_case)]
-            fn functor(&self, this: RawVc, arg: &dyn DynTaskInputs) -> Result<NativeTaskFuture> {
-                let task_fn = self.clone();
-                let recv = Vc::<Recv>::from(this);
-                let ($($arg,)*) = get_args::<($($arg,)*)>(arg)?;
-                Ok(Box::pin(async move {
-                    let recv = recv.await?;
-                    let recv = <Recv::Read as VcRead<Recv>>::target_to_value_ref(&*recv);
-                    (task_fn)(recv, $($arg,)*).try_into_raw_vc()
-                }))
-            }
-        }
-
-        impl<F, Output, Recv, $($arg,)*> TaskFnInputFunctionWithThis<FunctionMode, Recv, ($($arg,)*)> for F
-        where
-            Recv: Sync + Send + 'static,
-            $($arg: TaskInput + 'static,)*
-            F: Fn(Vc<Recv>, $($arg,)*) -> Output + Send + Sync + Clone + 'static,
-            Output: TaskOutput + 'static,
-        {
-            #[allow(non_snake_case)]
-            fn functor(&self, this: RawVc, arg: &dyn DynTaskInputs) -> Result<NativeTaskFuture> {
-                let task_fn = self.clone();
-                let recv = Vc::<Recv>::from(this);
-                let ($($arg,)*) = get_args::<($($arg,)*)>(arg)?;
-                Ok(Box::pin(async move {
-                    (task_fn)(recv, $($arg,)*).try_into_raw_vc()
-                }))
-            }
-        }
-
+// Defines the `AsyncFnN<A0, A1, ..., AN>` helper trait used to express async-fn bounds with
+// associated future types. Needed so `for<'a> $async_fn_trait<&'a A, ...>` HRTBs work without
+// fixing a single concrete `Fut` (each lifetime can produce a different one).
+macro_rules! def_async_fn_trait {
+    ( $async_fn_trait:ident $( $arg:ident )* ) => {
         pub trait $async_fn_trait<A0, $($arg,)*>: Fn(A0, $($arg,)*) -> Self::OutputFuture {
             type OutputFuture: Future<Output = <Self as $async_fn_trait<A0, $($arg,)*>>::Output> + Send;
             type Output: TaskOutput;
@@ -284,58 +205,273 @@ macro_rules! task_fn_impl {
             type OutputFuture = Fut;
             type Output = Fut::Output;
         }
+    };
+}
 
-        impl<F, Recv, $($arg,)*> TaskFnInputFunctionWithThis<AsyncMethodMode, Recv, ($($arg,)*)> for F
+def_async_fn_trait! { AsyncFn0 }
+def_async_fn_trait! { AsyncFn1  A1 }
+def_async_fn_trait! { AsyncFn2  A1 A2 }
+def_async_fn_trait! { AsyncFn3  A1 A2 A3 }
+def_async_fn_trait! { AsyncFn4  A1 A2 A3 A4 }
+def_async_fn_trait! { AsyncFn5  A1 A2 A3 A4 A5 }
+def_async_fn_trait! { AsyncFn6  A1 A2 A3 A4 A5 A6 }
+def_async_fn_trait! { AsyncFn7  A1 A2 A3 A4 A5 A6 A7 }
+def_async_fn_trait! { AsyncFn8  A1 A2 A3 A4 A5 A6 A7 A8 }
+def_async_fn_trait! { AsyncFn9  A1 A2 A3 A4 A5 A6 A7 A8 A9 }
+def_async_fn_trait! { AsyncFn10 A1 A2 A3 A4 A5 A6 A7 A8 A9 A10 }
+def_async_fn_trait! { AsyncFn11 A1 A2 A3 A4 A5 A6 A7 A8 A9 A10 A11 }
+def_async_fn_trait! { AsyncFn12 A1 A2 A3 A4 A5 A6 A7 A8 A9 A10 A11 A12 }
+
+// Arity-0 by-value blanket impls. These cover functions with no user arguments — only the
+// receiver, if any. With zero user args there is nothing to wrap as `&T`, so the by-value form
+// is the only sensible shape and is also what the `#[turbo_tasks::function]` macro emits for
+// these cases. The arity-≥1 forms in `task_fn_impl!` below always take user args by reference.
+mod arity_zero {
+    use super::*;
+
+    impl<F, Output> TaskFnInputFunction<FunctionMode, ()> for F
+    where
+        F: Fn() -> Output + Send + Sync + Clone + 'static,
+        Output: TaskOutput + 'static,
+    {
+        fn functor(&self, _task: Arc<CachedTaskType>) -> Result<NativeTaskFuture> {
+            let task_fn = self.clone();
+            Ok(Box::pin(async move {
+                let output = (task_fn)();
+                output_try_into_non_local_raw_vc(output).await
+            }))
+        }
+    }
+
+    impl<F, Output, FutureOutput> TaskFnInputFunction<AsyncFunctionMode, ()> for F
+    where
+        F: Fn() -> FutureOutput + Send + Sync + Clone + 'static,
+        FutureOutput: Future<Output = Output> + Send + 'static,
+        Output: TaskOutput + 'static,
+    {
+        fn functor(&self, _task: Arc<CachedTaskType>) -> Result<NativeTaskFuture> {
+            let task_fn = self.clone();
+            Ok(Box::pin(async move {
+                let output = (task_fn)().await;
+                output_try_into_non_local_raw_vc(output).await
+            }))
+        }
+    }
+
+    impl<F, Output, Recv> TaskFnInputFunctionWithThis<MethodMode, Recv, ()> for F
+    where
+        Recv: VcValueType,
+        F: Fn(&Recv) -> Output + Send + Sync + Clone + 'static,
+        Output: TaskOutput + 'static,
+    {
+        fn functor(&self, this: RawVc, _task: Arc<CachedTaskType>) -> Result<NativeTaskFuture> {
+            let task_fn = self.clone();
+            let recv = Vc::<Recv>::from(this);
+            Ok(Box::pin(async move {
+                let recv = recv.await?;
+                let recv = <Recv::Read as VcRead<Recv>>::target_to_value_ref(&*recv);
+                (task_fn)(recv).try_into_raw_vc()
+            }))
+        }
+    }
+
+    impl<F, Output, Recv> TaskFnInputFunctionWithThis<FunctionMode, Recv, ()> for F
+    where
+        Recv: Sync + Send + 'static,
+        F: Fn(Vc<Recv>) -> Output + Send + Sync + Clone + 'static,
+        Output: TaskOutput + 'static,
+    {
+        fn functor(&self, this: RawVc, _task: Arc<CachedTaskType>) -> Result<NativeTaskFuture> {
+            let task_fn = self.clone();
+            let recv = Vc::<Recv>::from(this);
+            Ok(Box::pin(async move { (task_fn)(recv).try_into_raw_vc() }))
+        }
+    }
+
+    impl<F, Recv> TaskFnInputFunctionWithThis<AsyncMethodMode, Recv, ()> for F
+    where
+        Recv: VcValueType,
+        F: for<'a> AsyncFn0<&'a Recv> + Clone + Send + Sync + 'static,
+    {
+        fn functor(&self, this: RawVc, _task: Arc<CachedTaskType>) -> Result<NativeTaskFuture> {
+            let task_fn = self.clone();
+            let recv = Vc::<Recv>::from(this);
+            Ok(Box::pin(async move {
+                let recv = recv.await?;
+                let recv = <Recv::Read as VcRead<Recv>>::target_to_value_ref(&*recv);
+                (task_fn)(recv).await.try_into_raw_vc()
+            }))
+        }
+    }
+
+    impl<F, Recv> TaskFnInputFunctionWithThis<AsyncFunctionMode, Recv, ()> for F
+    where
+        Recv: Sync + Send + 'static,
+        F: AsyncFn0<Vc<Recv>> + Clone + Send + Sync + 'static,
+    {
+        fn functor(&self, this: RawVc, _task: Arc<CachedTaskType>) -> Result<NativeTaskFuture> {
+            let task_fn = self.clone();
+            let recv = Vc::<Recv>::from(this);
+            Ok(Box::pin(
+                async move { (task_fn)(recv).await.try_into_raw_vc() },
+            ))
+        }
+    }
+}
+
+// Arity-≥1 by-reference blanket impls. Every macro-generated inline function with one or more
+// user arguments lands here: the macro rewrites each owned `T` into `&T` (and inserts a clone
+// shadow if the body needs ownership), so the inline closure is `Fn(&Recv?, &A1, ..., &AN)`.
+// The async block captures `task: Arc<CachedTaskType>` so that references downcast out of
+// `&*task.arg` remain valid for the entire future.
+//
+// Distinct `Inputs` tuples (unit `()` vs `(A1, ..., AN)`) keep these impls non-overlapping with
+// the arity-zero impls above, even though they share the same `Mode` markers.
+//
+// `$async_fn_trait_with_recv` has arity `1 + arg_len` (one slot for the receiver, plus one per
+// user arg) — used by the with-this async impls. `$async_fn_trait_no_recv` has arity `arg_len`
+// and is used by the non-method async impl.
+macro_rules! task_fn_impl {
+    (
+        $async_fn_trait_with_recv:ident
+        $async_fn_trait_no_recv:ident
+        $arg_len:literal
+        $arg1:ident $($arg:ident)*
+    ) => {
+        impl<F, Output, $arg1, $($arg,)*> TaskFnInputFunction<FunctionMode, ($arg1, $($arg,)*)> for F
         where
-            Recv: VcValueType,
+            $arg1: TaskInput + 'static,
             $($arg: TaskInput + 'static,)*
-            F: for<'a> $async_fn_trait<&'a Recv, $($arg,)*> + Clone + Send + Sync + 'static,
+            F: for<'a> Fn(&'a $arg1, $(&'a $arg,)*) -> Output + Send + Sync + Clone + 'static,
+            Output: TaskOutput + 'static,
         {
             #[allow(non_snake_case)]
-            fn functor(&self, this: RawVc, arg: &dyn DynTaskInputs) -> Result<NativeTaskFuture> {
+            fn functor(&self, task: Arc<CachedTaskType>) -> Result<NativeTaskFuture> {
                 let task_fn = self.clone();
-                let recv = Vc::<Recv>::from(this);
-                let ($($arg,)*) = get_args::<($($arg,)*)>(arg)?;
                 Ok(Box::pin(async move {
-                    let recv = recv.await?;
-                    let recv = <Recv::Read as VcRead<Recv>>::target_to_value_ref(&*recv);
-                    (task_fn)(recv, $($arg,)*).await.try_into_raw_vc()
+                    let ($arg1, $($arg,)*) = downcast_args_ref::<($arg1, $($arg,)*)>(&*task.arg);
+                    (task_fn)($arg1, $($arg,)*).try_into_raw_vc()
                 }))
             }
         }
 
-        impl<F, Recv, $($arg,)*> TaskFnInputFunctionWithThis<AsyncFunctionMode, Recv, ($($arg,)*)> for F
+        impl<F, $arg1, $($arg,)*> TaskFnInputFunction<AsyncFunctionMode, ($arg1, $($arg,)*)> for F
         where
-            Recv: Sync + Send + 'static,
+            $arg1: TaskInput + 'static,
             $($arg: TaskInput + 'static,)*
-            F: $async_fn_trait<Vc<Recv>, $($arg,)*> + Clone + Send + Sync + 'static,
+            F: for<'a> $async_fn_trait_no_recv<&'a $arg1, $(&'a $arg,)*>
+                + Clone + Send + Sync + 'static,
         {
             #[allow(non_snake_case)]
-            fn functor(&self, this: RawVc, arg: &dyn DynTaskInputs) -> Result<NativeTaskFuture> {
+            fn functor(&self, task: Arc<CachedTaskType>) -> Result<NativeTaskFuture> {
+                let task_fn = self.clone();
+                Ok(Box::pin(async move {
+                    let ($arg1, $($arg,)*) = downcast_args_ref::<($arg1, $($arg,)*)>(&*task.arg);
+                    (task_fn)($arg1, $($arg,)*).await.try_into_raw_vc()
+                }))
+            }
+        }
+
+        impl<F, Output, Recv, $arg1, $($arg,)*>
+            TaskFnInputFunctionWithThis<MethodMode, Recv, ($arg1, $($arg,)*)> for F
+        where
+            Recv: VcValueType,
+            $arg1: TaskInput + 'static,
+            $($arg: TaskInput + 'static,)*
+            F: for<'a> Fn(&'a Recv, &'a $arg1, $(&'a $arg,)*) -> Output
+                + Send + Sync + Clone + 'static,
+            Output: TaskOutput + 'static,
+        {
+            #[allow(non_snake_case)]
+            fn functor(&self, this: RawVc, task: Arc<CachedTaskType>) -> Result<NativeTaskFuture> {
                 let task_fn = self.clone();
                 let recv = Vc::<Recv>::from(this);
-                let ($($arg,)*) = get_args::<($($arg,)*)>(arg)?;
                 Ok(Box::pin(async move {
-                    (task_fn)(recv, $($arg,)*).await.try_into_raw_vc()
+                    let recv = recv.await?;
+                    let recv = <Recv::Read as VcRead<Recv>>::target_to_value_ref(&*recv);
+                    let ($arg1, $($arg,)*) = downcast_args_ref::<($arg1, $($arg,)*)>(&*task.arg);
+                    (task_fn)(recv, $arg1, $($arg,)*).try_into_raw_vc()
+                }))
+            }
+        }
+
+        impl<F, Output, Recv, $arg1, $($arg,)*>
+            TaskFnInputFunctionWithThis<FunctionMode, Recv, ($arg1, $($arg,)*)> for F
+        where
+            Recv: Sync + Send + 'static,
+            $arg1: TaskInput + 'static,
+            $($arg: TaskInput + 'static,)*
+            F: for<'a> Fn(Vc<Recv>, &'a $arg1, $(&'a $arg,)*) -> Output
+                + Send + Sync + Clone + 'static,
+            Output: TaskOutput + 'static,
+        {
+            #[allow(non_snake_case)]
+            fn functor(&self, this: RawVc, task: Arc<CachedTaskType>) -> Result<NativeTaskFuture> {
+                let task_fn = self.clone();
+                let recv = Vc::<Recv>::from(this);
+                Ok(Box::pin(async move {
+                    let ($arg1, $($arg,)*) = downcast_args_ref::<($arg1, $($arg,)*)>(&*task.arg);
+                    (task_fn)(recv, $arg1, $($arg,)*).try_into_raw_vc()
+                }))
+            }
+        }
+
+        impl<F, Recv, $arg1, $($arg,)*>
+            TaskFnInputFunctionWithThis<AsyncMethodMode, Recv, ($arg1, $($arg,)*)> for F
+        where
+            Recv: VcValueType,
+            $arg1: TaskInput + 'static,
+            $($arg: TaskInput + 'static,)*
+            F: for<'a> $async_fn_trait_with_recv<&'a Recv, &'a $arg1, $(&'a $arg,)*>
+                + Clone + Send + Sync + 'static,
+        {
+            #[allow(non_snake_case)]
+            fn functor(&self, this: RawVc, task: Arc<CachedTaskType>) -> Result<NativeTaskFuture> {
+                let task_fn = self.clone();
+                let recv = Vc::<Recv>::from(this);
+                Ok(Box::pin(async move {
+                    let recv = recv.await?;
+                    let recv = <Recv::Read as VcRead<Recv>>::target_to_value_ref(&*recv);
+                    let ($arg1, $($arg,)*) = downcast_args_ref::<($arg1, $($arg,)*)>(&*task.arg);
+                    (task_fn)(recv, $arg1, $($arg,)*).await.try_into_raw_vc()
+                }))
+            }
+        }
+
+        impl<F, Recv, $arg1, $($arg,)*>
+            TaskFnInputFunctionWithThis<AsyncFunctionMode, Recv, ($arg1, $($arg,)*)> for F
+        where
+            Recv: Sync + Send + 'static,
+            $arg1: TaskInput + 'static,
+            $($arg: TaskInput + 'static,)*
+            F: for<'a> $async_fn_trait_with_recv<Vc<Recv>, &'a $arg1, $(&'a $arg,)*>
+                + Clone + Send + Sync + 'static,
+        {
+            #[allow(non_snake_case)]
+            fn functor(&self, this: RawVc, task: Arc<CachedTaskType>) -> Result<NativeTaskFuture> {
+                let task_fn = self.clone();
+                let recv = Vc::<Recv>::from(this);
+                Ok(Box::pin(async move {
+                    let ($arg1, $($arg,)*) = downcast_args_ref::<($arg1, $($arg,)*)>(&*task.arg);
+                    (task_fn)(recv, $arg1, $($arg,)*).await.try_into_raw_vc()
                 }))
             }
         }
     };
 }
 
-task_fn_impl! { AsyncFn0 0 }
-task_fn_impl! { AsyncFn1 1 A1 }
-task_fn_impl! { AsyncFn2 2 A1 A2 }
-task_fn_impl! { AsyncFn3 3 A1 A2 A3 }
-task_fn_impl! { AsyncFn4 4 A1 A2 A3 A4 }
-task_fn_impl! { AsyncFn5 5 A1 A2 A3 A4 A5 }
-task_fn_impl! { AsyncFn6 6 A1 A2 A3 A4 A5 A6 }
-task_fn_impl! { AsyncFn7 7 A1 A2 A3 A4 A5 A6 A7 }
-task_fn_impl! { AsyncFn8 8 A1 A2 A3 A4 A5 A6 A7 A8 }
-task_fn_impl! { AsyncFn9 9 A1 A2 A3 A4 A5 A6 A7 A8 A9 }
-task_fn_impl! { AsyncFn10 10 A1 A2 A3 A4 A5 A6 A7 A8 A9 A10 }
-task_fn_impl! { AsyncFn11 11 A1 A2 A3 A4 A5 A6 A7 A8 A9 A10 A11 }
-task_fn_impl! { AsyncFn12 12 A1 A2 A3 A4 A5 A6 A7 A8 A9 A10 A11 A12 }
+task_fn_impl! { AsyncFn1  AsyncFn0  1  A1 }
+task_fn_impl! { AsyncFn2  AsyncFn1  2  A1 A2 }
+task_fn_impl! { AsyncFn3  AsyncFn2  3  A1 A2 A3 }
+task_fn_impl! { AsyncFn4  AsyncFn3  4  A1 A2 A3 A4 }
+task_fn_impl! { AsyncFn5  AsyncFn4  5  A1 A2 A3 A4 A5 }
+task_fn_impl! { AsyncFn6  AsyncFn5  6  A1 A2 A3 A4 A5 A6 }
+task_fn_impl! { AsyncFn7  AsyncFn6  7  A1 A2 A3 A4 A5 A6 A7 }
+task_fn_impl! { AsyncFn8  AsyncFn7  8  A1 A2 A3 A4 A5 A6 A7 A8 }
+task_fn_impl! { AsyncFn9  AsyncFn8  9  A1 A2 A3 A4 A5 A6 A7 A8 A9 }
+task_fn_impl! { AsyncFn10 AsyncFn9  10 A1 A2 A3 A4 A5 A6 A7 A8 A9 A10 }
+task_fn_impl! { AsyncFn11 AsyncFn10 11 A1 A2 A3 A4 A5 A6 A7 A8 A9 A10 A11 }
+task_fn_impl! { AsyncFn12 AsyncFn11 12 A1 A2 A3 A4 A5 A6 A7 A8 A9 A10 A11 A12 }
 
 // There needs to be one more implementation than task_fn_impl to account for
 // the receiver.
@@ -363,18 +499,29 @@ mod tests {
 
     #[test]
     fn test_task_fn() {
+        // Arity-zero non-method: covers `FunctionMode` and `AsyncFunctionMode` for empty
+        // `Inputs = ()`. These are the only blanket impls without a by-ref shape — there are no
+        // user arguments to take by reference.
         fn no_args() -> crate::Vc<i32> {
             todo!()
         }
 
-        fn one_arg(_a: i32) -> crate::Vc<i32> {
+        async fn async_no_args() -> crate::Vc<i32> {
             todo!()
         }
 
-        async fn async_one_arg(_a: i32) -> crate::Vc<i32> {
+        // Arity-one non-method: the inline closure that the macro generates always takes user
+        // args by reference, so the blanket impl for arity ≥ 1 expects `Fn(&A1) -> _`.
+        fn one_arg(_a: &i32) -> crate::Vc<i32> {
             todo!()
         }
 
+        async fn async_one_arg(_a: &i32) -> crate::Vc<i32> {
+            todo!()
+        }
+
+        // Arity-zero method (just the receiver, no user args): goes through the by-value
+        // `MethodMode` / `AsyncMethodMode` impls.
         fn with_recv(_a: &i32) -> crate::Vc<i32> {
             todo!()
         }
@@ -383,15 +530,20 @@ mod tests {
             todo!()
         }
 
-        fn with_recv_and_str(_a: &i32, _s: RcStr) -> crate::Vc<i32> {
+        // Method + one user arg, both by reference. The macro-generated inline always looks like
+        // this when the user writes either a by-value or a by-ref non-Vc argument.
+        fn with_recv_and_str(_a: &i32, _s: &RcStr) -> crate::Vc<i32> {
             todo!()
         }
 
-        async fn async_with_recv_and_str(_a: &i32, _s: RcStr) -> crate::Vc<i32> {
+        async fn async_with_recv_and_str(_a: &i32, _s: &RcStr) -> crate::Vc<i32> {
             todo!()
         }
 
-        async fn async_with_recv_and_str_and_result(_a: &i32, _s: RcStr) -> Result<crate::Vc<i32>> {
+        async fn async_with_recv_and_str_and_result(
+            _a: &i32,
+            _s: &RcStr,
+        ) -> Result<crate::Vc<i32>> {
             todo!()
         }
 
@@ -404,6 +556,21 @@ mod tests {
         struct Struct;
         impl Struct {
             async fn inherent_method(&self) {}
+
+            // By-ref method: &Recv plus one &T arg, sync.
+            fn inherent_method_with_ref_arg(&self, _a: &i32) -> crate::Vc<i32> {
+                todo!()
+            }
+
+            // By-ref method: &Recv plus one &T arg, async.
+            async fn inherent_async_method_with_ref_arg(&self, _a: &i32) -> crate::Vc<i32> {
+                todo!()
+            }
+
+            // By-ref method: Vc<Recv> receiver plus one &T arg, sync.
+            fn function_mode_with_ref_arg(self: crate::Vc<Self>, _a: &i32) -> crate::Vc<i32> {
+                todo!()
+            }
         }
 
         impl ShrinkToFit for Struct {
@@ -455,25 +622,40 @@ mod tests {
         }
         */
 
+        // Arity-zero, no receiver.
         let task_fn = into_task_fn(no_args);
         accepts_task_fn(task_fn);
+        let task_fn = into_task_fn(async_no_args);
+        accepts_task_fn(task_fn);
+
+        // Arity-one, no receiver — by-ref blanket impl.
         let task_fn = into_task_fn(one_arg);
         accepts_task_fn(task_fn);
         let task_fn = into_task_fn(async_one_arg);
         accepts_task_fn(task_fn);
+
+        // Methods with no user args — by-value blanket impls.
         let task_fn = into_task_fn_with_this(with_recv);
         accepts_task_fn(task_fn);
         let task_fn = into_task_fn_with_this(async_with_recv);
         accepts_task_fn(task_fn);
+        let task_fn = into_task_fn_with_this(<Struct as AsyncTrait>::async_method);
+        accepts_task_fn(task_fn);
+        let task_fn = into_task_fn_with_this(Struct::inherent_method);
+        accepts_task_fn(task_fn);
+
+        // Methods with at least one user arg — by-ref blanket impls.
         let task_fn = into_task_fn_with_this(with_recv_and_str);
         accepts_task_fn(task_fn);
         let task_fn = into_task_fn_with_this(async_with_recv_and_str);
         accepts_task_fn(task_fn);
         let task_fn = into_task_fn_with_this(async_with_recv_and_str_and_result);
         accepts_task_fn(task_fn);
-        let task_fn = into_task_fn_with_this(<Struct as AsyncTrait>::async_method);
+        let task_fn = into_task_fn_with_this(Struct::inherent_method_with_ref_arg);
         accepts_task_fn(task_fn);
-        let task_fn = into_task_fn_with_this(Struct::inherent_method);
+        let task_fn = into_task_fn_with_this(Struct::inherent_async_method_with_ref_arg);
+        accepts_task_fn(task_fn);
+        let task_fn = into_task_fn_with_this(Struct::function_mode_with_ref_arg);
         accepts_task_fn(task_fn);
 
         /*

--- a/turbopack/crates/turbo-tasks/src/task/mod.rs
+++ b/turbopack/crates/turbo-tasks/src/task/mod.rs
@@ -5,7 +5,7 @@ pub(crate) mod shared_reference;
 pub(crate) mod task_input;
 pub(crate) mod task_output;
 
-pub use from_task_input::FromTaskInput;
+pub use from_task_input::{FromTaskInput, RefFromTaskInput};
 pub use function::{TaskFn, TaskFnInputs};
 pub use shared_reference::{SharedReference, TypedSharedReference};
 pub use task_input::TaskInput;

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -625,7 +625,7 @@ impl ChunkingContext for BrowserChunkingContext {
     }
 
     #[turbo_tasks::function]
-    async fn asset_url(&self, ident: &FileSystemPath, tag: Option<RcStr>) -> Result<Vc<RcStr>> {
+    async fn asset_url(&self, ident: &FileSystemPath, tag: &Option<RcStr>) -> Result<Vc<RcStr>> {
         let asset_path = ident.to_string();
 
         let client_root = tag

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -625,7 +625,7 @@ impl ChunkingContext for BrowserChunkingContext {
     }
 
     #[turbo_tasks::function]
-    async fn asset_url(&self, ident: FileSystemPath, tag: Option<RcStr>) -> Result<Vc<RcStr>> {
+    async fn asset_url(&self, ident: &FileSystemPath, tag: Option<RcStr>) -> Result<Vc<RcStr>> {
         let asset_path = ident.to_string();
 
         let client_root = tag
@@ -923,7 +923,7 @@ impl ChunkingContext for BrowserChunkingContext {
     #[turbo_tasks::function]
     fn entry_chunk_group(
         self: Vc<Self>,
-        _path: FileSystemPath,
+        _path: &FileSystemPath,
         _chunk_group: ChunkGroup,
         _module_graph: Vc<ModuleGraph>,
         _extra_chunks: Vc<OutputAssets>,

--- a/turbopack/crates/turbopack-browser/src/ecmascript/content.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/content.rs
@@ -173,10 +173,10 @@ impl GenerateSourceMap for EcmascriptBrowserChunkContent {
     }
 
     #[turbo_tasks::function]
-    async fn by_section(self: Vc<Self>, section: RcStr) -> Result<Vc<FileContent>> {
+    async fn by_section(self: Vc<Self>, section: &RcStr) -> Result<Vc<FileContent>> {
         // Weirdly, the ContentSource will have already URL decoded the ModuleId, and we
         // can't reparse that via serde.
-        if let Ok(id) = ModuleId::parse(&section) {
+        if let Ok(id) = ModuleId::parse(section) {
             let entries = self.entries().await?;
             for (entry_id, entry) in entries.iter() {
                 if id == *entry_id {

--- a/turbopack/crates/turbopack-browser/src/ecmascript/version.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/version.rs
@@ -18,11 +18,10 @@ pub(super) struct EcmascriptBrowserChunkVersion {
 impl EcmascriptBrowserChunkVersion {
     #[turbo_tasks::function]
     pub async fn new(
-        output_root: FileSystemPath,
+        output_root: &FileSystemPath,
         chunk_path: FileSystemPath,
         content: Vc<EcmascriptChunkContent>,
     ) -> Result<Vc<Self>> {
-        let output_root = output_root.clone();
         let chunk_path = chunk_path.clone();
         let chunk_path = if let Some(path) = output_root.get_path_to(&chunk_path) {
             path

--- a/turbopack/crates/turbopack-browser/src/ecmascript/version.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/version.rs
@@ -19,11 +19,10 @@ impl EcmascriptBrowserChunkVersion {
     #[turbo_tasks::function]
     pub async fn new(
         output_root: &FileSystemPath,
-        chunk_path: FileSystemPath,
+        chunk_path: &FileSystemPath,
         content: Vc<EcmascriptChunkContent>,
     ) -> Result<Vc<Self>> {
-        let chunk_path = chunk_path.clone();
-        let chunk_path = if let Some(path) = output_root.get_path_to(&chunk_path) {
+        let chunk_path = if let Some(path) = output_root.get_path_to(chunk_path) {
             path
         } else {
             turbobail!("chunk path {chunk_path} is not in client root {output_root}");

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -189,8 +189,8 @@ async fn extract_effects_operation(op: OperationVc<()>) -> Result<Vc<Effects>> {
 #[turbo_tasks::function(operation)]
 async fn build_internal(
     project_dir: &RcStr,
-    root_dir: RcStr,
-    entry_requests: Vec<EntryRequest>,
+    root_dir: &RcStr,
+    entry_requests: &Vec<EntryRequest>,
     browserslist_query: RcStr,
     source_maps_type: SourceMapsType,
     minify_type: MinifyType,
@@ -199,7 +199,7 @@ async fn build_internal(
 ) -> Result<()> {
     let output_fs = output_fs(project_dir.clone());
     const OUTPUT_DIR: &str = "dist";
-    let project_relative = project_dir.strip_prefix(&*root_dir).unwrap();
+    let project_relative = project_dir.strip_prefix(root_dir.as_str()).unwrap();
     let project_relative: RcStr = project_relative
         .strip_prefix(MAIN_SEPARATOR)
         .unwrap_or(project_relative)
@@ -263,7 +263,7 @@ async fn build_internal(
     );
 
     let entry_requests = (*entry_requests
-        .into_iter()
+        .iter()
         .map(|r| async move {
             Ok(match r {
                 EntryRequest::Relative(p) => Request::relative(
@@ -285,7 +285,6 @@ async fn build_internal(
         .to_vec();
 
     let origin = PlainResolveOrigin::new(asset_context, project_fs.root().await?.join("_")?);
-    let project_dir = &project_dir;
     let entries = async move {
         entry_requests
             .into_iter()
@@ -343,7 +342,7 @@ async fn build_internal(
                         dom: true,
                         web_worker: false,
                         service_worker: false,
-                        browserslist_query: browserslist_query.clone(),
+                        browserslist_query,
                     }
                     .resolved_cell(),
                 ))

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -188,7 +188,7 @@ async fn extract_effects_operation(op: OperationVc<()>) -> Result<Vc<Effects>> {
 
 #[turbo_tasks::function(operation)]
 async fn build_internal(
-    project_dir: RcStr,
+    project_dir: &RcStr,
     root_dir: RcStr,
     entry_requests: Vec<EntryRequest>,
     browserslist_query: RcStr,

--- a/turbopack/crates/turbopack-cli/src/contexts.rs
+++ b/turbopack/crates/turbopack-cli/src/contexts.rs
@@ -49,7 +49,7 @@ fn foreign_code_context_condition() -> ContextCondition {
 }
 
 #[turbo_tasks::function]
-pub async fn get_client_import_map(project_path: FileSystemPath) -> Result<Vc<ImportMap>> {
+pub async fn get_client_import_map(project_path: &FileSystemPath) -> Result<Vc<ImportMap>> {
     let mut import_map = ImportMap::empty();
 
     import_map.insert_singleton_alias(rcstr!("@swc/helpers"), project_path.clone());
@@ -62,7 +62,7 @@ pub async fn get_client_import_map(project_path: FileSystemPath) -> Result<Vc<Im
 
 #[turbo_tasks::function]
 pub async fn get_client_resolve_options_context(
-    project_path: FileSystemPath,
+    project_path: &FileSystemPath,
     node_env: Vc<NodeEnv>,
 ) -> Result<Vc<ResolveOptionsContext>> {
     let next_client_import_map = get_client_import_map(project_path.clone())
@@ -90,7 +90,7 @@ pub async fn get_client_resolve_options_context(
 
 #[turbo_tasks::function]
 async fn get_client_module_options_context(
-    project_path: FileSystemPath,
+    project_path: &FileSystemPath,
     execution_context: ResolvedVc<ExecutionContext>,
     env: ResolvedVc<Environment>,
     node_env: Vc<NodeEnv>,

--- a/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
+++ b/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
@@ -104,7 +104,7 @@ pub async fn get_client_runtime_entries(
 pub async fn create_web_entry_source(
     root_path: &FileSystemPath,
     execution_context: Vc<ExecutionContext>,
-    entry_requests: Vec<Vc<Request>>,
+    entry_requests: &Vec<Vc<Request>>,
     server_root: FileSystemPath,
     server_root_to_root_path: RcStr,
     _env: Vc<Box<dyn ProcessEnv>>,
@@ -135,11 +135,11 @@ pub async fn create_web_entry_source(
 
     let origin = PlainResolveOrigin::new(asset_context, root_path.join("_")?);
     let entries = entry_requests
-        .into_iter()
+        .iter()
         .map(|request| async move {
             let ty = ReferenceType::Entry(EntryReferenceSubType::Web);
             Ok(origin
-                .resolve_asset(request, origin.resolve_options(), ty)
+                .resolve_asset(*request, origin.resolve_options(), ty)
                 .await?
                 .to_resolved()
                 .await?

--- a/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
+++ b/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
@@ -62,7 +62,7 @@ pub async fn get_client_chunking_context(
 
 #[turbo_tasks::function]
 pub async fn get_client_runtime_entries(
-    project_path: FileSystemPath,
+    project_path: &FileSystemPath,
     node_env: Vc<NodeEnv>,
 ) -> Result<Vc<RuntimeEntries>> {
     let resolve_options_context =
@@ -102,7 +102,7 @@ pub async fn get_client_runtime_entries(
 
 #[turbo_tasks::function]
 pub async fn create_web_entry_source(
-    root_path: FileSystemPath,
+    root_path: &FileSystemPath,
     execution_context: Vc<ExecutionContext>,
     entry_requests: Vec<Vc<Request>>,
     server_root: FileSystemPath,

--- a/turbopack/crates/turbopack-core/src/asset.rs
+++ b/turbopack/crates/turbopack-core/src/asset.rs
@@ -110,7 +110,7 @@ impl AssetContent {
     }
 
     #[turbo_tasks::function]
-    pub async fn write(&self, path: FileSystemPath) -> Result<()> {
+    pub async fn write(&self, path: &FileSystemPath) -> Result<()> {
         match self {
             AssetContent::File(file) => {
                 path.write(**file).as_side_effect().await?;

--- a/turbopack/crates/turbopack-core/src/chunk/chunk_item_batch.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunk_item_batch.rs
@@ -105,7 +105,7 @@ impl ChunkItemOrBatchWithAsyncModuleInfo {
         Ok(match self {
             Self::ChunkItem(item) => Either::Left(smallvec![(
                 item.chunk_item.ty().to_resolved().await?,
-                Self::ChunkItem(item.clone())
+                Self::ChunkItem(*item)
             )]),
             Self::Batch(batch) => Either::Right(batch.split_by_chunk_type().await?),
         })

--- a/turbopack/crates/turbopack-core/src/chunk/chunking/dev.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking/dev.rs
@@ -60,7 +60,7 @@ pub async fn expand_batches(
                             );
                             let asset_ident = item.chunk_item.asset_ident().to_string();
                             Ok(ChunkItemOrBatchWithInfo::ChunkItem {
-                                chunk_item: item.clone(),
+                                chunk_item: *item,
                                 size: *size.await?,
                                 asset_ident: asset_ident.owned().await?,
                             })

--- a/turbopack/crates/turbopack-core/src/chunk/chunking/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking/mod.rs
@@ -287,7 +287,7 @@ pub async fn make_chunks(
     chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
     chunk_items_or_batches: ResolvedVc<ChunkItemOrBatchWithAsyncModuleInfos>,
     batch_groups: ResolvedVc<ChunkItemBatchGroups>,
-    key_prefix: RcStr,
+    key_prefix: &RcStr,
 ) -> Result<Vc<Chunks>> {
     let chunking_configs = &*chunking_context.chunking_configs().await?;
     let chunk_items_or_batches = chunk_items_or_batches.await?;

--- a/turbopack/crates/turbopack-core/src/chunk/chunking/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking/mod.rs
@@ -172,7 +172,7 @@ async fn plain_chunk_items_with_info_with_type(
             Ok((
                 ty,
                 smallvec![ChunkItemOrBatchWithInfo::ChunkItem {
-                    chunk_item: chunk_item_with_info.clone(),
+                    chunk_item: *chunk_item_with_info,
                     size: *chunk_item_size.await?,
                     asset_ident: asset_ident.owned().await?,
                 }],
@@ -413,7 +413,7 @@ async fn make_chunk(
                 .into_iter()
                 .map(|item| match item {
                     ChunkItemOrBatchWithInfo::ChunkItem { chunk_item, .. } => {
-                        ChunkItemOrBatchWithAsyncModuleInfo::ChunkItem(chunk_item.clone())
+                        ChunkItemOrBatchWithAsyncModuleInfo::ChunkItem(*chunk_item)
                     }
                     &ChunkItemOrBatchWithInfo::Batch { batch, .. } => {
                         ChunkItemOrBatchWithAsyncModuleInfo::Batch(batch)

--- a/turbopack/crates/turbopack-core/src/chunk/chunking/style_production.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking/style_production.rs
@@ -48,7 +48,7 @@ pub async fn make_style_production_chunks(
             } else {
                 make_chunk(
                     vec![&ChunkItemOrBatchWithInfo::ChunkItem {
-                        chunk_item: chunk_item.clone(),
+                        chunk_item: *chunk_item,
                         size: 0,
                         asset_ident: rcstr!(""),
                     }],

--- a/turbopack/crates/turbopack-core/src/chunk/data.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/data.rs
@@ -59,7 +59,7 @@ impl ChunkData {
 
     #[turbo_tasks::function]
     pub async fn from_asset(
-        output_root: FileSystemPath,
+        output_root: &FileSystemPath,
         chunk: Vc<Box<dyn OutputAsset>>,
     ) -> Result<Vc<ChunkDataOption>> {
         let path = chunk.path().await?;
@@ -138,7 +138,7 @@ impl ChunkData {
 
     #[turbo_tasks::function]
     pub async fn from_assets(
-        output_root: FileSystemPath,
+        output_root: &FileSystemPath,
         chunks: Vc<OutputAssets>,
     ) -> Result<Vc<ChunksData>> {
         Ok(Vc::cell(

--- a/turbopack/crates/turbopack-core/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/mod.rs
@@ -514,7 +514,7 @@ impl AsyncModuleInfo {
 }
 
 #[derive(
-    Debug, Clone, PartialEq, Eq, Hash, TraceRawVcs, TaskInput, NonLocalValue, Encode, Decode,
+    Debug, Copy, Clone, PartialEq, Eq, Hash, TraceRawVcs, TaskInput, NonLocalValue, Encode, Decode,
 )]
 pub struct ChunkItemWithAsyncModuleInfo {
     pub chunk_item: ResolvedVc<Box<dyn ChunkItem>>,

--- a/turbopack/crates/turbopack-core/src/compile_time_info.rs
+++ b/turbopack/crates/turbopack-core/src/compile_time_info.rs
@@ -342,11 +342,11 @@ impl CompileTimeDefines {
     }
 
     #[turbo_tasks::function]
-    pub async fn read_process_env(&self, key: RcStr) -> Result<Vc<Option<RcStr>>> {
+    pub async fn read_process_env(&self, key: &RcStr) -> Result<Vc<Option<RcStr>>> {
         let key = DefinableNameSegmentRefs(smallvec![
             DefinableNameSegmentRef::Name("process"),
             DefinableNameSegmentRef::Name("env"),
-            DefinableNameSegmentRef::Name(&key),
+            DefinableNameSegmentRef::Name(key),
         ]);
         Ok(Vc::cell(match self.0.get(&key) {
             Some(CompileTimeDefineValue::String(s)) => Some(s.clone()),

--- a/turbopack/crates/turbopack-core/src/ident.rs
+++ b/turbopack/crates/turbopack-core/src/ident.rs
@@ -197,7 +197,7 @@ impl AssetIdent {
         } else {
             escape_file_path(&self.path.to_string_ref().await?)
         };
-        let removed_extension = name.ends_with(&*expected_extension);
+        let removed_extension = name.ends_with(&**expected_extension);
         if removed_extension {
             name.truncate(name.len() - expected_extension.len());
         }
@@ -338,7 +338,7 @@ impl AssetIdent {
         if !removed_extension {
             name += "._";
         }
-        name += &expected_extension;
+        name += expected_extension;
         Ok(Vc::cell(name.into()))
     }
 }

--- a/turbopack/crates/turbopack-core/src/ident.rs
+++ b/turbopack/crates/turbopack-core/src/ident.rs
@@ -179,7 +179,7 @@ impl AssetIdent {
     #[turbo_tasks::function]
     pub async fn output_name(
         &self,
-        context_path: FileSystemPath,
+        context_path: &FileSystemPath,
         prefix: Option<RcStr>,
         expected_extension: RcStr,
     ) -> Result<Vc<RcStr>> {

--- a/turbopack/crates/turbopack-core/src/ident.rs
+++ b/turbopack/crates/turbopack-core/src/ident.rs
@@ -180,8 +180,8 @@ impl AssetIdent {
     pub async fn output_name(
         &self,
         context_path: &FileSystemPath,
-        prefix: Option<RcStr>,
-        expected_extension: RcStr,
+        prefix: &Option<RcStr>,
+        expected_extension: &RcStr,
     ) -> Result<Vc<RcStr>> {
         debug_assert!(
             expected_extension.starts_with("."),

--- a/turbopack/crates/turbopack-core/src/issue/resolve.rs
+++ b/turbopack/crates/turbopack-core/src/issue/resolve.rs
@@ -63,7 +63,7 @@ impl Issue for ResolvingIssue {
 
         if let Some(import_map) = &self.resolve_options.await?.import_map {
             for req in request_parts {
-                match lookup_import_map(**import_map, self.file_path.clone(), **req).await {
+                match lookup_import_map(**import_map, &self.file_path, **req).await {
                     Ok(None) => {}
                     Ok(Some(str)) => writeln!(description, "Import map: {str}")?,
                     Err(err) => {
@@ -115,7 +115,7 @@ impl Issue for ResolvingIssue {
 
 async fn lookup_import_map(
     import_map: Vc<ImportMap>,
-    file_path: FileSystemPath,
+    file_path: &FileSystemPath,
     request: Vc<Request>,
 ) -> Result<Option<ReadRef<RcStr>>> {
     let result = import_map.await?.lookup(file_path, request).await?;

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -2569,7 +2569,7 @@ pub mod tests {
 
         #[turbo_tasks::function(operation)]
         async fn setup_graph(
-            entries: Vec<RcStr>,
+            entries: &Vec<RcStr>,
             graph_entries: Vec<(RcStr, Vec<RcStr>)>,
         ) -> Result<Vc<SetupGraph>> {
             let fs = VirtualFileSystem::new_with_name(rcstr!("test"));

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -2570,7 +2570,7 @@ pub mod tests {
         #[turbo_tasks::function(operation)]
         async fn setup_graph(
             entries: &Vec<RcStr>,
-            graph_entries: Vec<(RcStr, Vec<RcStr>)>,
+            graph_entries: &Vec<(RcStr, Vec<RcStr>)>,
         ) -> Result<Vc<SetupGraph>> {
             let fs = VirtualFileSystem::new_with_name(rcstr!("test"));
             let root = fs.root().await?;

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -716,7 +716,7 @@ impl ModuleGraph {
 
     #[turbo_tasks::function(operation)]
     async fn from_graphs_inner(
-        graphs: Vec<OperationVc<SingleModuleGraph>>,
+        graphs: &Vec<OperationVc<SingleModuleGraph>>,
         binding_usage: Option<OperationVc<BindingUsageInfo>>,
     ) -> Result<Vc<ModuleGraph>> {
         Ok(ModuleGraph {

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -617,9 +617,9 @@ impl ModuleGraphImportTracer {
 #[turbo_tasks::value_impl]
 impl ImportTracer for ModuleGraphImportTracer {
     #[turbo_tasks::function]
-    async fn get_traces(self: Vc<Self>, path: FileSystemPath) -> Result<Vc<ImportTraces>> {
+    async fn get_traces(self: Vc<Self>, path: &FileSystemPath) -> Result<Vc<ImportTraces>> {
         let path_to_modules = self.path_to_modules().await?;
-        let Some(modules) = path_to_modules.map.get(&path) else {
+        let Some(modules) = path_to_modules.map.get(path) else {
             return Ok(Vc::default()); // This isn't unusual, the file just might not be in this
             // graph.
         };

--- a/turbopack/crates/turbopack-core/src/module_graph/style_groups.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/style_groups.rs
@@ -271,7 +271,7 @@ pub async fn compute_style_groups(
 
         // The list of modules and chunk items that go into the new chunk
         let mut new_chunk_modules = [module].into_iter().collect::<FxHashSet<_>>();
-        let mut new_chunk_items = vec![info.chunk_item.as_ref().unwrap().clone()];
+        let mut new_chunk_items = vec![info.chunk_item.unwrap()];
 
         // The current size of the new chunk
         let mut current_size = info.size;
@@ -374,7 +374,7 @@ pub async fn compute_style_groups(
                     }
                 }
 
-                new_chunk_items.push(info.chunk_item.as_ref().unwrap().clone());
+                new_chunk_items.push(info.chunk_item.unwrap());
                 new_chunk_modules.insert(module);
                 *ordered_modules_with_state.get_mut(&module).unwrap() = true;
                 continue 'outer;

--- a/turbopack/crates/turbopack-core/src/node_addon_module.rs
+++ b/turbopack/crates/turbopack-core/src/node_addon_module.rs
@@ -115,7 +115,7 @@ impl Module for NodeAddonModule {
 }
 
 #[turbo_tasks::function]
-async fn dir_references(package_dir: FileSystemPath) -> Result<Vc<ModuleReferences>> {
+async fn dir_references(package_dir: &FileSystemPath) -> Result<Vc<ModuleReferences>> {
     let matches = read_matches(
         package_dir.clone(),
         rcstr!(""),

--- a/turbopack/crates/turbopack-core/src/node_addon_module.rs
+++ b/turbopack/crates/turbopack-core/src/node_addon_module.rs
@@ -115,9 +115,9 @@ impl Module for NodeAddonModule {
 }
 
 #[turbo_tasks::function]
-async fn dir_references(package_dir: &FileSystemPath) -> Result<Vc<ModuleReferences>> {
+async fn dir_references(package_dir: FileSystemPath) -> Result<Vc<ModuleReferences>> {
     let matches = read_matches(
-        package_dir.clone(),
+        package_dir,
         rcstr!(""),
         true,
         Pattern::new(Pattern::Dynamic),

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -1239,7 +1239,7 @@ pub enum FindContextFileResult {
 
 #[turbo_tasks::function]
 pub async fn find_context_file(
-    lookup_path: FileSystemPath,
+    lookup_path: &FileSystemPath,
     names: Vc<Vec<RcStr>>,
     collect_affecting_sources: bool,
 ) -> Result<Vc<FindContextFileResult>> {
@@ -1290,7 +1290,7 @@ pub async fn find_context_file(
 // This function never collects affecting sources
 #[turbo_tasks::function]
 pub async fn find_context_file_or_package_key(
-    lookup_path: FileSystemPath,
+    lookup_path: &FileSystemPath,
     names: Vc<Vec<RcStr>>,
     package_key: RcStr,
 ) -> Result<Vc<FindContextFileResult>> {
@@ -1331,7 +1331,7 @@ struct FindPackageResult {
 
 #[turbo_tasks::function]
 async fn find_package(
-    lookup_path: FileSystemPath,
+    lookup_path: &FileSystemPath,
     package_name: Pattern,
     options: Vc<ResolveModulesOptions>,
     collect_affecting_sources: bool,
@@ -1488,7 +1488,7 @@ fn merge_results_with_affecting_sources(
 // Resolves the pattern
 #[turbo_tasks::function]
 pub async fn resolve_raw(
-    lookup_dir: FileSystemPath,
+    lookup_dir: &FileSystemPath,
     path: Vc<Pattern>,
     collect_affecting_sources: bool,
     force_in_lookup_dir: bool,
@@ -1829,7 +1829,7 @@ async fn handle_after_resolve_plugins(
 
 #[turbo_tasks::function]
 async fn resolve_internal(
-    lookup_path: FileSystemPath,
+    lookup_path: &FileSystemPath,
     request: ResolvedVc<Request>,
     options: ResolvedVc<ResolveOptions>,
 ) -> Result<Vc<ResolveResult>> {
@@ -2176,7 +2176,7 @@ async fn resolve_internal_inline(
 
 #[turbo_tasks::function]
 async fn resolve_into_folder(
-    package_path: FileSystemPath,
+    package_path: &FileSystemPath,
     options: Vc<ResolveOptions>,
 ) -> Result<Vc<ResolveResult>> {
     let options_value = options.await?;
@@ -2849,7 +2849,7 @@ async fn resolve_module_request(
 #[turbo_tasks::function]
 async fn resolve_into_package(
     path: Pattern,
-    package_path: FileSystemPath,
+    package_path: &FileSystemPath,
     query: RcStr,
     fragment: RcStr,
     options: ResolvedVc<ResolveOptions>,

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -960,14 +960,14 @@ impl ResolveResult {
     #[turbo_tasks::function]
     fn with_replaced_request_key(
         &self,
-        old_request_key: RcStr,
+        old_request_key: &RcStr,
         request_key: RequestKey,
     ) -> Result<Vc<Self>> {
         let new_primary = self
             .primary
             .iter()
             .filter_map(|(k, v)| {
-                let remaining = k.request.as_ref()?.strip_prefix(&*old_request_key)?;
+                let remaining = k.request.as_ref()?.strip_prefix(&**old_request_key)?;
                 Some((
                     RequestKey {
                         request: request_key
@@ -991,12 +991,12 @@ impl ResolveResult {
     /// from all [RequestKey]s. It's not expected that the [ResolveResult] contains [RequestKey]s
     /// without the prefix, but if there are still some, they are discarded.
     #[turbo_tasks::function]
-    fn with_stripped_request_key_prefix(&self, prefix: RcStr) -> Result<Vc<Self>> {
+    fn with_stripped_request_key_prefix(&self, prefix: &RcStr) -> Result<Vc<Self>> {
         let new_primary = self
             .primary
             .iter()
             .filter_map(|(k, v)| {
-                let remaining = k.request.as_ref()?.strip_prefix(&*prefix)?;
+                let remaining = k.request.as_ref()?.strip_prefix(&**prefix)?;
                 Some((
                     RequestKey {
                         request: Some(remaining.into()),

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -3103,7 +3103,7 @@ async fn resolved(
 
         let resolved_result = resolve_import_map_result(
             &result,
-            path,
+            &path.parent(),
             original_context,
             original_request,
             options,
@@ -3282,7 +3282,7 @@ async fn resolve_package_internal_with_imports_field(
     };
 
     handle_exports_imports_field(
-        package_json_path,
+        &package_json_path.parent(),
         package_json_path,
         resolve_options,
         imports,

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -857,7 +857,7 @@ impl ResolveResult {
     #[turbo_tasks::function]
     fn with_affecting_sources(
         &self,
-        sources: Vec<ResolvedVc<Box<dyn Source>>>,
+        sources: &Vec<ResolvedVc<Box<dyn Source>>>,
     ) -> Result<Vc<Self>> {
         Ok(Self {
             primary: self.primary.clone(),
@@ -865,18 +865,18 @@ impl ResolveResult {
                 .affecting_sources
                 .iter()
                 .copied()
-                .chain(sources)
+                .chain(sources.iter().copied())
                 .collect(),
         }
         .cell())
     }
 
     #[turbo_tasks::function]
-    async fn alternatives(results: Vec<Vc<ResolveResult>>) -> Result<Vc<Self>> {
+    async fn alternatives(results: &Vec<Vc<ResolveResult>>) -> Result<Vc<Self>> {
         if results.len() == 1 {
-            return Ok(results.into_iter().next().unwrap());
+            return Ok(*results.iter().next().unwrap());
         }
-        let mut iter = results.into_iter().try_join().await?.into_iter();
+        let mut iter = results.iter().try_join().await?.into_iter();
         if let Some(current) = iter.next() {
             let mut current: ResolveResultBuilder = ReadRef::into_owned(current).into();
             for result in iter {
@@ -892,8 +892,8 @@ impl ResolveResult {
 
     #[turbo_tasks::function]
     async fn alternatives_with_affecting_sources(
-        results: Vec<Vc<ResolveResult>>,
-        affecting_sources: Vec<ResolvedVc<Box<dyn Source>>>,
+        results: &Vec<Vc<ResolveResult>>,
+        affecting_sources: &Vec<ResolvedVc<Box<dyn Source>>>,
     ) -> Result<Vc<Self>> {
         debug_assert!(
             !affecting_sources.is_empty(),
@@ -901,12 +901,12 @@ impl ResolveResult {
         );
         if results.len() == 1 {
             return Ok(results
-                .into_iter()
+                .iter()
                 .next()
                 .unwrap()
-                .with_affecting_sources(affecting_sources.into_iter().map(|src| *src).collect()));
+                .with_affecting_sources(affecting_sources.iter().map(|src| **src).collect()));
         }
-        let mut iter = results.into_iter().try_join().await?.into_iter();
+        let mut iter = results.iter().try_join().await?.into_iter();
         if let Some(current) = iter.next() {
             let mut current: ResolveResultBuilder = ReadRef::into_owned(current).into();
             for result in iter {
@@ -917,7 +917,10 @@ impl ResolveResult {
             current.affecting_sources.extend(affecting_sources);
             Ok(Self::cell(current.into()))
         } else {
-            Ok(ResolveResult::unresolvable_with_affecting_sources(affecting_sources).cell())
+            Ok(
+                ResolveResult::unresolvable_with_affecting_sources(affecting_sources.clone())
+                    .cell(),
+            )
         }
     }
 
@@ -1332,7 +1335,7 @@ struct FindPackageResult {
 #[turbo_tasks::function]
 async fn find_package(
     lookup_path: &FileSystemPath,
-    package_name: Pattern,
+    package_name: &Pattern,
     options: Vc<ResolveModulesOptions>,
     collect_affecting_sources: bool,
 ) -> Result<Vc<FindPackageResult>> {
@@ -1833,11 +1836,11 @@ async fn resolve_internal(
     request: ResolvedVc<Request>,
     options: ResolvedVc<ResolveOptions>,
 ) -> Result<Vc<ResolveResult>> {
-    resolve_internal_inline(lookup_path.clone(), *request, *options).await
+    resolve_internal_inline(lookup_path, *request, *options).await
 }
 
 async fn resolve_internal_inline(
-    lookup_path: FileSystemPath,
+    lookup_path: &FileSystemPath,
     request: Vc<Request>,
     options: Vc<ResolveOptions>,
 ) -> Result<Vc<ResolveResult>> {
@@ -1864,16 +1867,13 @@ async fn resolve_internal_inline(
                 _ => &[request.to_resolved().await?],
             };
             for &request in request_parts {
-                let result = import_map
-                    .await?
-                    .lookup(lookup_path.clone(), *request)
-                    .await?;
+                let result = import_map.await?.lookup(lookup_path, *request).await?;
                 if !matches!(result, ImportMapResult::NoEntry) {
                     has_alias = true;
                     let resolved_result = resolve_import_map_result(
                         &result,
-                        lookup_path.clone(),
-                        lookup_path.clone(),
+                        lookup_path,
+                        lookup_path,
                         *request,
                         options,
                         request.query().owned().await?,
@@ -1900,9 +1900,7 @@ async fn resolve_internal_inline(
             Request::Alternatives { requests } => {
                 let results = requests
                     .iter()
-                    .map(|req| async {
-                        resolve_internal_inline(lookup_path.clone(), **req, options).await
-                    })
+                    .map(|req| async { resolve_internal_inline(lookup_path, **req, options).await })
                     .try_join()
                     .await?;
 
@@ -1929,8 +1927,8 @@ async fn resolve_internal_inline(
                             results.push(
                                 resolved(
                                     RequestKey::new(matched_pattern.clone()),
-                                    path.clone(),
-                                    lookup_path.clone(),
+                                    path,
+                                    lookup_path,
                                     request,
                                     options_value,
                                     options,
@@ -1959,7 +1957,7 @@ async fn resolve_internal_inline(
                 fragment,
             } => {
                 resolve_relative_request(
-                    lookup_path.clone(),
+                    lookup_path,
                     request,
                     options,
                     options_value,
@@ -1977,7 +1975,7 @@ async fn resolve_internal_inline(
                 fragment,
             } => {
                 resolve_module_request(
-                    lookup_path.clone(),
+                    lookup_path,
                     request,
                     options,
                     options_value,
@@ -2016,7 +2014,7 @@ async fn resolve_internal_inline(
                 }
 
                 Box::pin(resolve_internal_inline(
-                    lookup_path.root().owned().await?,
+                    &*lookup_path.root().await?,
                     relative,
                     options,
                 ))
@@ -2057,7 +2055,7 @@ async fn resolve_internal_inline(
                     })
                     .unwrap_or_else(|| (Default::default(), ConditionValue::Unset));
                 resolve_package_internal_with_imports_field(
-                    lookup_path.clone(),
+                    lookup_path,
                     request,
                     options,
                     path,
@@ -2146,14 +2144,11 @@ async fn resolve_internal_inline(
             if let Some(import_map) = &options_value.fallback_import_map
                 && *result.is_unresolvable().await?
             {
-                let result = import_map
-                    .await?
-                    .lookup(lookup_path.clone(), request)
-                    .await?;
+                let result = import_map.await?.lookup(lookup_path, request).await?;
                 let resolved_result = resolve_import_map_result(
                     &result,
-                    lookup_path.clone(),
-                    lookup_path.clone(),
+                    lookup_path,
+                    lookup_path,
                     request,
                     options,
                     request.query().owned().await?,
@@ -2215,10 +2210,9 @@ async fn resolve_into_folder(
                         } else {
                             options
                         };
-                        let result =
-                            &*resolve_internal_inline(package_path.clone(), request, options)
-                                .await?
-                                .await?;
+                        let result = &*resolve_internal_inline(package_path, request, options)
+                            .await?
+                            .await?;
                         // we are not that strict when a main field fails to resolve
                         // we continue to try other alternatives
                         if !result.is_unresolvable_ref() {
@@ -2260,7 +2254,7 @@ async fn resolve_into_folder(
     };
 
     let request = Request::parse(pattern);
-    let result = resolve_internal_inline(package_path.clone(), request, options)
+    let result = resolve_internal_inline(package_path, request, options)
         .await?
         .with_request(rcstr!("."));
 
@@ -2273,7 +2267,7 @@ async fn resolve_into_folder(
 
 #[tracing::instrument(level = Level::TRACE, skip_all)]
 async fn resolve_relative_request(
-    lookup_path: FileSystemPath,
+    lookup_path: &FileSystemPath,
     request: Vc<Request>,
     options: Vc<ResolveOptions>,
     options_value: &ResolveOptions,
@@ -2285,14 +2279,13 @@ async fn resolve_relative_request(
     debug_assert!(query.is_empty() || query.starts_with("?"));
     debug_assert!(fragment.is_empty() || fragment.starts_with("#"));
     // Check alias field for aliases first
-    let lookup_path_ref = lookup_path.clone();
     if let Some(result) = apply_in_package(
-        lookup_path.clone(),
+        lookup_path,
         options,
         options_value,
         |package_path| {
             let request = path_pattern.as_constant_string()?;
-            let prefix_path = package_path.get_path_to(&lookup_path_ref)?;
+            let prefix_path = package_path.get_path_to(lookup_path)?;
             let request = normalize_request(&format!("./{prefix_path}/{request}"));
             Some(request.into())
         },
@@ -2549,8 +2542,8 @@ async fn resolve_relative_request(
         .map(|((matched_pattern, fragment), path)| {
             resolved(
                 RequestKey::new(matched_pattern),
-                path.clone(),
-                lookup_path.clone(),
+                path,
+                lookup_path,
                 request,
                 options_value,
                 options,
@@ -2578,7 +2571,7 @@ async fn resolve_relative_request(
 
 #[tracing::instrument(level = Level::TRACE, skip_all)]
 async fn apply_in_package(
-    lookup_path: FileSystemPath,
+    lookup_path: &FileSystemPath,
     options: Vc<ResolveOptions>,
     options_value: &ResolveOptions,
     get_request: impl Fn(&FileSystemPath) -> Option<RcStr>,
@@ -2720,7 +2713,7 @@ async fn find_self_reference(
 
 #[tracing::instrument(level = Level::TRACE, skip_all)]
 async fn resolve_module_request(
-    lookup_path: FileSystemPath,
+    lookup_path: &FileSystemPath,
     request: Vc<Request>,
     options: Vc<ResolveOptions>,
     options_value: &ResolveOptions,
@@ -2731,7 +2724,7 @@ async fn resolve_module_request(
 ) -> Result<Vc<ResolveResult>> {
     // Check alias field for module aliases first
     if let Some(result) = apply_in_package(
-        lookup_path.clone(),
+        lookup_path,
         options,
         options_value,
         |_| {
@@ -2805,8 +2798,8 @@ async fn resolve_module_request(
                 if path.is_match("") {
                     let resolved_result = resolved(
                         RequestKey::new(rcstr!(".")),
-                        file.clone(),
-                        lookup_path.clone(),
+                        file,
+                        lookup_path,
                         request,
                         options_value,
                         options,
@@ -2832,12 +2825,8 @@ async fn resolve_module_request(
         let relative = Request::relative(pattern, query, fragment, true)
             .to_resolved()
             .await?;
-        let relative_result = Box::pin(resolve_internal_inline(
-            lookup_path.clone(),
-            *relative,
-            options,
-        ))
-        .await?;
+        let relative_result =
+            Box::pin(resolve_internal_inline(lookup_path, *relative, options)).await?;
         let relative_result = relative_result.with_stripped_request_key_prefix(rcstr!("./"));
 
         Ok(merge_results(vec![relative_result, module_result]))
@@ -2848,7 +2837,7 @@ async fn resolve_module_request(
 
 #[turbo_tasks::function]
 async fn resolve_into_package(
-    path: Pattern,
+    path: &Pattern,
     package_path: &FileSystemPath,
     query: RcStr,
     fragment: RcStr,
@@ -2879,8 +2868,8 @@ async fn resolve_into_package(
 
                 results.push(
                     handle_exports_imports_field(
-                        package_path.clone(),
-                        package_json_path,
+                        package_path,
+                        &package_json_path,
                         *options,
                         exports_field,
                         export_path_request.clone(),
@@ -2913,7 +2902,7 @@ async fn resolve_into_package(
         let relative = Request::relative(new_pat, query, fragment, true)
             .to_resolved()
             .await?;
-        results.push(resolve_internal_inline(package_path.clone(), *relative, *options).await?);
+        results.push(resolve_internal_inline(package_path, *relative, *options).await?);
     }
 
     Ok(merge_results(results))
@@ -2922,8 +2911,8 @@ async fn resolve_into_package(
 #[tracing::instrument(level = Level::TRACE, skip_all)]
 async fn resolve_import_map_result(
     result: &ImportMapResult,
-    lookup_path: FileSystemPath,
-    original_lookup_path: FileSystemPath,
+    lookup_path: &FileSystemPath,
+    original_lookup_path: &FileSystemPath,
     original_request: Vc<Request>,
     options: Vc<ResolveOptions>,
     query: RcStr,
@@ -2938,7 +2927,7 @@ async fn resolve_import_map_result(
             } else {
                 request_vc
             };
-            let lookup_path = alias_lookup_path.clone().unwrap_or(lookup_path);
+            let lookup_path = alias_lookup_path.as_ref().unwrap_or(lookup_path);
 
             // Compare request patterns to avoid cycles (ignoring query differences)
             let request_pattern = request.request_pattern();
@@ -2950,7 +2939,7 @@ async fn resolve_import_map_result(
                 None
             } else {
                 Some(ResolveResultOrCell::Cell(
-                    resolve_internal(lookup_path, request, options)
+                    resolve_internal(lookup_path.clone(), request, options)
                         .with_replaced_request_key_pattern(request_pattern, original_pattern),
                 ))
             }
@@ -2978,7 +2967,7 @@ async fn resolve_import_map_result(
 
             // We must avoid cycles during resolving
             if *request.to_resolved().await? == original_request
-                && *alias_lookup_path == original_lookup_path
+                && alias_lookup_path == original_lookup_path
             {
                 None
             } else {
@@ -3018,8 +3007,8 @@ async fn resolve_import_map_result(
                 .map(|result| {
                     resolve_import_map_result(
                         result,
-                        lookup_path.clone(),
-                        original_lookup_path.clone(),
+                        lookup_path,
+                        original_lookup_path,
                         original_request,
                         options,
                         query.clone(),
@@ -3078,8 +3067,8 @@ impl ResolveResultOrCell {
 #[tracing::instrument(level = Level::TRACE, skip_all)]
 async fn resolved(
     request_key: RequestKey,
-    fs_path: FileSystemPath,
-    original_context: FileSystemPath,
+    fs_path: &FileSystemPath,
+    original_context: &FileSystemPath,
     original_request: Vc<Request>,
     options_value: &ResolveOptions,
     options: Vc<ResolveOptions>,
@@ -3089,13 +3078,13 @@ async fn resolved(
     let result = &*fs_path.realpath_with_links().await?;
     let path = match &result.path_result {
         Ok(path) => path,
-        Err(e) => bail!(e.as_error_message(&fs_path, result).await?),
+        Err(e) => bail!(e.as_error_message(fs_path, result).await?),
     };
 
     let path_ref = path.clone();
     // Check alias field for path aliases first
     if let Some(result) = apply_in_package(
-        path.parent(),
+        &path.parent(),
         options,
         options_value,
         |package_path| package_path.get_relative_path_to(&path_ref),
@@ -3114,8 +3103,8 @@ async fn resolved(
 
         let resolved_result = resolve_import_map_result(
             &result,
-            path.parent(),
-            original_context.clone(),
+            path,
+            original_context,
             original_request,
             options,
             query.clone(),
@@ -3154,8 +3143,8 @@ async fn resolved(
 }
 
 async fn handle_exports_imports_field(
-    package_path: FileSystemPath,
-    package_json_path: FileSystemPath,
+    package_path: &FileSystemPath,
+    package_json_path: &FileSystemPath,
     options: Vc<ResolveOptions>,
     exports_imports_field: &AliasMap<SubpathValue>,
     mut path: Pattern,
@@ -3203,12 +3192,8 @@ async fn handle_exports_imports_field(
             .to_resolved()
             .await?;
 
-            let resolve_result = Box::pin(resolve_internal_inline(
-                package_path.clone(),
-                request,
-                options,
-            ))
-            .await?;
+            let resolve_result =
+                Box::pin(resolve_internal_inline(package_path, request, options)).await?;
 
             let resolve_result = if let Some(req) = req.as_constant_string() {
                 resolve_result.with_request(req.clone())
@@ -3252,7 +3237,9 @@ async fn handle_exports_imports_field(
     Ok(merge_results_with_affecting_sources(
         resolved_results,
         vec![ResolvedVc::upcast(
-            FileSource::new(package_json_path).to_resolved().await?,
+            FileSource::new(package_json_path.clone())
+                .to_resolved()
+                .await?,
         )],
     ))
 }
@@ -3262,7 +3249,7 @@ async fn handle_exports_imports_field(
 /// static strings or conditions like `import` or `require` to handle ESM/CJS
 /// with differently compiled files.
 async fn resolve_package_internal_with_imports_field(
-    file_path: FileSystemPath,
+    file_path: &FileSystemPath,
     request: Vc<Request>,
     resolve_options: Vc<ResolveOptions>,
     pattern: &Pattern,
@@ -3288,15 +3275,15 @@ async fn resolve_package_internal_with_imports_field(
         return Ok(ResolveResult::unresolvable().cell());
     }
 
-    let imports_result = imports_field(file_path).await?;
+    let imports_result = imports_field(file_path.clone()).await?;
     let (imports, package_json_path) = match &*imports_result {
-        ImportsFieldResult::Some(i, p) => (i, p.clone()),
+        ImportsFieldResult::Some(i, p) => (i, p),
         ImportsFieldResult::None => return Ok(ResolveResult::unresolvable().cell()),
     };
 
     handle_exports_imports_field(
-        package_json_path.parent(),
-        package_json_path.clone(),
+        package_json_path,
+        package_json_path,
         resolve_options,
         imports,
         Pattern::Constant(specifier.clone()),
@@ -3761,8 +3748,8 @@ mod tests {
 
     #[turbo_tasks::function]
     async fn resolve_relative_helper(
-        lookup_path: FileSystemPath,
-        pattern: Pattern,
+        lookup_path: &FileSystemPath,
+        pattern: &Pattern,
         enable_typescript_with_output_extension: bool,
         fully_specified: bool,
         custom_extensions: Option<Vec<RcStr>>,

--- a/turbopack/crates/turbopack-core/src/resolve/options.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/options.rs
@@ -606,12 +606,12 @@ impl ResolvedMap {
     #[turbo_tasks::function]
     pub async fn lookup(
         &self,
-        resolved: FileSystemPath,
+        resolved: &FileSystemPath,
         lookup_path: FileSystemPath,
         request: Vc<Request>,
     ) -> Result<Vc<ImportMapResult>> {
         for (root, glob, mapping) in self.by_glob.iter() {
-            if let Some(path) = root.get_path_to(&resolved)
+            if let Some(path) = root.get_path_to(resolved)
                 && glob.await?.matches(path)
             {
                 return Ok(import_mapping_to_result(

--- a/turbopack/crates/turbopack-core/src/resolve/options.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/options.rs
@@ -426,7 +426,7 @@ pub enum ImportMapResult {
 
 async fn import_mapping_to_result(
     mapping: Vc<ReplacedImportMapping>,
-    lookup_path: FileSystemPath,
+    lookup_path: &FileSystemPath,
     request: Vc<Request>,
 ) -> Result<ImportMapResult> {
     Ok(match &*mapping.await? {
@@ -483,18 +483,15 @@ async fn import_mapping_to_result(
         }
         ReplacedImportMapping::Alternatives(list) => ImportMapResult::Alternatives(
             list.iter()
-                .map(|mapping| {
-                    Box::pin(import_mapping_to_result(
-                        **mapping,
-                        lookup_path.clone(),
-                        request,
-                    ))
-                })
+                .map(|mapping| Box::pin(import_mapping_to_result(**mapping, lookup_path, request)))
                 .try_join()
                 .await?,
         ),
         ReplacedImportMapping::Dynamic(replacement) => {
-            replacement.result(lookup_path, request).owned().await?
+            replacement
+                .result(lookup_path.clone(), request)
+                .owned()
+                .await?
         }
         ReplacedImportMapping::Error(issue) => ImportMapResult::Error(*issue),
     })
@@ -553,7 +550,7 @@ impl ImportMap {
     // lookup
     pub async fn lookup(
         &self,
-        lookup_path: FileSystemPath,
+        lookup_path: &FileSystemPath,
         request: Vc<Request>,
     ) -> Result<ImportMapResult> {
         // relative requests must not match global wildcard aliases.
@@ -588,7 +585,7 @@ impl ImportMap {
             .chain(lookup_rel_parent)
             .chain(lookup)
             .map(async |result| {
-                import_mapping_to_result(*result?.output.await?, lookup_path.clone(), request).await
+                import_mapping_to_result(*result?.output.await?, lookup_path, request).await
             })
             .try_join()
             .await?;
@@ -607,7 +604,7 @@ impl ResolvedMap {
     pub async fn lookup(
         &self,
         resolved: &FileSystemPath,
-        lookup_path: FileSystemPath,
+        lookup_path: &FileSystemPath,
         request: Vc<Request>,
     ) -> Result<Vc<ImportMapResult>> {
         for (root, glob, mapping) in self.by_glob.iter() {

--- a/turbopack/crates/turbopack-core/src/resolve/pattern.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/pattern.rs
@@ -1523,7 +1523,7 @@ pub struct PatternMatches(Vec<PatternMatch>);
 #[turbo_tasks::function]
 pub async fn read_matches(
     lookup_dir: &FileSystemPath,
-    prefix: RcStr,
+    prefix: &RcStr,
     force_in_lookup_dir: bool,
     pattern: Vc<Pattern>,
 ) -> Result<Vc<PatternMatches>> {

--- a/turbopack/crates/turbopack-core/src/resolve/pattern.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/pattern.rs
@@ -1522,7 +1522,7 @@ pub struct PatternMatches(Vec<PatternMatch>);
 /// symlinks when they are interested in that.
 #[turbo_tasks::function]
 pub async fn read_matches(
-    lookup_dir: FileSystemPath,
+    lookup_dir: &FileSystemPath,
     prefix: RcStr,
     force_in_lookup_dir: bool,
     pattern: Vc<Pattern>,

--- a/turbopack/crates/turbopack-core/src/resolve/plugin.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/plugin.rs
@@ -31,12 +31,12 @@ impl AfterResolvePluginCondition {
 #[turbo_tasks::value_impl]
 impl AfterResolvePluginCondition {
     #[turbo_tasks::function]
-    pub async fn matches(&self, fs_path: FileSystemPath) -> Result<Vc<bool>> {
+    pub async fn matches(&self, fs_path: &FileSystemPath) -> Result<Vc<bool>> {
         match self {
             AfterResolvePluginCondition::Glob { root, glob } => {
                 let path = fs_path;
 
-                if let Some(path) = root.get_path_to(&path)
+                if let Some(path) = root.get_path_to(path)
                     && glob.await?.matches(path)
                 {
                     return Ok(Vc::cell(true));

--- a/turbopack/crates/turbopack-core/src/server_fs.rs
+++ b/turbopack/crates/turbopack-core/src/server_fs.rs
@@ -20,32 +20,32 @@ impl ServerFileSystem {
 #[turbo_tasks::value_impl]
 impl FileSystem for ServerFileSystem {
     #[turbo_tasks::function]
-    fn read(&self, _fs_path: FileSystemPath) -> Result<Vc<FileContent>> {
+    fn read(&self, _fs_path: &FileSystemPath) -> Result<Vc<FileContent>> {
         bail!("Reading is not possible from the marker filesystem for the server")
     }
 
     #[turbo_tasks::function]
-    fn read_link(&self, _fs_path: FileSystemPath) -> Result<Vc<LinkContent>> {
+    fn read_link(&self, _fs_path: &FileSystemPath) -> Result<Vc<LinkContent>> {
         bail!("Reading is not possible from the marker filesystem for the server")
     }
 
     #[turbo_tasks::function]
-    fn raw_read_dir(&self, _fs_path: FileSystemPath) -> Result<Vc<RawDirectoryContent>> {
+    fn raw_read_dir(&self, _fs_path: &FileSystemPath) -> Result<Vc<RawDirectoryContent>> {
         bail!("Reading is not possible from the marker filesystem for the server")
     }
 
     #[turbo_tasks::function]
-    fn write(&self, _fs_path: FileSystemPath, _content: Vc<FileContent>) -> Result<Vc<()>> {
+    fn write(&self, _fs_path: &FileSystemPath, _content: Vc<FileContent>) -> Result<Vc<()>> {
         bail!("Writing is not possible to the marker filesystem for the server")
     }
 
     #[turbo_tasks::function]
-    fn write_link(&self, _fs_path: FileSystemPath, _target: Vc<LinkContent>) -> Result<Vc<()>> {
+    fn write_link(&self, _fs_path: &FileSystemPath, _target: Vc<LinkContent>) -> Result<Vc<()>> {
         bail!("Writing is not possible to the marker filesystem for the server")
     }
 
     #[turbo_tasks::function]
-    fn metadata(&self, _fs_path: FileSystemPath) -> Result<Vc<FileMeta>> {
+    fn metadata(&self, _fs_path: &FileSystemPath) -> Result<Vc<FileMeta>> {
         bail!("Reading is not possible from the marker filesystem for the server")
     }
 }

--- a/turbopack/crates/turbopack-core/src/source_map/mod.rs
+++ b/turbopack/crates/turbopack-core/src/source_map/mod.rs
@@ -509,8 +509,8 @@ fn sourcemap_content_fs_root() -> Vc<FileSystemPath> {
 }
 
 #[turbo_tasks::function]
-async fn sourcemap_content_source(path: RcStr, content: RcStr) -> Result<Vc<Box<dyn Source>>> {
-    let path = sourcemap_content_fs_root().await?.join(&path)?;
+async fn sourcemap_content_source(path: &RcStr, content: RcStr) -> Result<Vc<Box<dyn Source>>> {
+    let path = sourcemap_content_fs_root().await?.join(path)?;
     let content = AssetContent::file(FileContent::new(File::from(content)).cell());
     Ok(Vc::upcast(VirtualSource::new(path, content)))
 }

--- a/turbopack/crates/turbopack-css/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/mod.rs
@@ -530,7 +530,7 @@ impl ChunkType for CssChunkType {
     async fn chunk(
         &self,
         chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
-        chunk_items_or_batches: Vec<ChunkItemOrBatchWithAsyncModuleInfo>,
+        chunk_items_or_batches: &Vec<ChunkItemOrBatchWithAsyncModuleInfo>,
         _batch_groups: Vec<ResolvedVc<ChunkItemBatchGroup>>,
     ) -> Result<Vc<Box<dyn Chunk>>> {
         let mut chunk_items = Vec::new();
@@ -538,7 +538,7 @@ impl ChunkType for CssChunkType {
         for item in chunk_items_or_batches {
             match item {
                 ChunkItemOrBatchWithAsyncModuleInfo::ChunkItem(chunk_item) => {
-                    chunk_items.push(chunk_item);
+                    chunk_items.push(*chunk_item);
                 }
                 ChunkItemOrBatchWithAsyncModuleInfo::Batch(batch) => {
                     let batch = batch.await?;

--- a/turbopack/crates/turbopack-dev-server/src/introspect/mod.rs
+++ b/turbopack/crates/turbopack-dev-server/src/introspect/mod.rs
@@ -103,7 +103,7 @@ impl GetContentSourceContent for IntrospectionSource {
     #[turbo_tasks::function]
     async fn get(
         self: ResolvedVc<Self>,
-        path: RcStr,
+        path: &RcStr,
         _data: ContentSourceData,
     ) -> Result<Vc<ContentSourceContent>> {
         // get last segment

--- a/turbopack/crates/turbopack-dev-server/src/source/asset_graph.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/asset_graph.rs
@@ -255,7 +255,7 @@ impl GetContentSourceContent for AssetGraphGetContentSourceContent {
     #[turbo_tasks::function]
     async fn get(
         self: ResolvedVc<Self>,
-        _path: RcStr,
+        _path: &RcStr,
         _data: ContentSourceData,
     ) -> Result<Vc<ContentSourceContent>> {
         let this = self.await?;

--- a/turbopack/crates/turbopack-dev-server/src/source/mod.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/mod.rs
@@ -109,7 +109,7 @@ pub trait ContentSourceSideEffect {
 #[turbo_tasks::value_impl]
 impl GetContentSourceContent for ContentSourceContent {
     #[turbo_tasks::function]
-    fn get(self: Vc<Self>, _path: RcStr, _data: ContentSourceData) -> Vc<ContentSourceContent> {
+    fn get(self: Vc<Self>, _path: &RcStr, _data: ContentSourceData) -> Vc<ContentSourceContent> {
         self
     }
 }

--- a/turbopack/crates/turbopack-dev-server/src/source/route_tree.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/route_tree.rs
@@ -263,7 +263,7 @@ impl RouteTree {
     // TODO(WEB-1252) It's unnecessary to compute all [`GetContentSourceContent`]s at once, we could
     // return some lazy iterator to make it more efficient.
     #[turbo_tasks::function]
-    pub async fn get(self: Vc<Self>, path: RcStr) -> Result<Vc<GetContentSourceContents>> {
+    pub async fn get(self: Vc<Self>, path: &RcStr) -> Result<Vc<GetContentSourceContents>> {
         let RouteTree {
             base,
             sources,

--- a/turbopack/crates/turbopack-dev-server/src/source/router.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/router.rs
@@ -155,7 +155,7 @@ impl GetContentSourceContent for PrefixedRouterGetContentSourceContent {
     }
 
     #[turbo_tasks::function]
-    async fn get(&self, path: RcStr, data: ContentSourceData) -> Result<Vc<ContentSourceContent>> {
+    async fn get(&self, path: &RcStr, data: ContentSourceData) -> Result<Vc<ContentSourceContent>> {
         let prefix = self.mapper.await?.prefix.await?;
         if let Some(path) = path.strip_prefix(&**prefix) {
             if path.is_empty() {

--- a/turbopack/crates/turbopack-dev-server/src/source/static_assets.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/static_assets.rs
@@ -98,7 +98,7 @@ impl StaticAssetsContentSourceItem {
 #[turbo_tasks::value_impl]
 impl GetContentSourceContent for StaticAssetsContentSourceItem {
     #[turbo_tasks::function]
-    fn get(&self, _path: RcStr, _data: ContentSourceData) -> Vc<ContentSourceContent> {
+    fn get(&self, _path: &RcStr, _data: ContentSourceData) -> Vc<ContentSourceContent> {
         let content = Vc::upcast::<Box<dyn Asset>>(FileSource::new(self.path.clone())).content();
         ContentSourceContent::static_content(content.versioned())
     }

--- a/turbopack/crates/turbopack-dev-server/src/source/static_assets.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/static_assets.rs
@@ -44,7 +44,7 @@ impl StaticAssetsContentSource {
 
 // TODO(WEB-1251) It would be better to lazily enumerate the directory
 #[turbo_tasks::function]
-async fn get_routes_from_directory(dir: FileSystemPath) -> Result<Vc<RouteTree>> {
+async fn get_routes_from_directory(dir: &FileSystemPath) -> Result<Vc<RouteTree>> {
     let dir = dir.read_dir().await?;
     let DirectoryContent::Entries(entries) = &*dir else {
         return Ok(RouteTree::empty());

--- a/turbopack/crates/turbopack-ecmascript-runtime/src/browser_runtime.rs
+++ b/turbopack/crates/turbopack-ecmascript-runtime/src/browser_runtime.rs
@@ -23,7 +23,7 @@ pub async fn get_browser_runtime_code(
     asset_suffix: Vc<AssetSuffix>,
     worker_forwarded_globals: Vc<Vec<RcStr>>,
     runtime_type: RuntimeType,
-    output_root_to_root_path: RcStr,
+    output_root_to_root_path: &RcStr,
     generate_source_map: bool,
     chunk_loading_global: Vc<RcStr>,
     cross_origin: Vc<CrossOrigin>,

--- a/turbopack/crates/turbopack-ecmascript-runtime/src/embed_js.rs
+++ b/turbopack/crates/turbopack-ecmascript-runtime/src/embed_js.rs
@@ -15,13 +15,13 @@ pub fn embed_fs() -> Vc<Box<dyn FileSystem>> {
 }
 
 #[turbo_tasks::function]
-pub async fn embed_file(path: RcStr) -> Result<Vc<FileContent>> {
-    Ok(embed_fs().root().await?.join(&path)?.read())
+pub async fn embed_file(path: &RcStr) -> Result<Vc<FileContent>> {
+    Ok(embed_fs().root().await?.join(path)?.read())
 }
 
 #[turbo_tasks::function]
-pub async fn embed_file_path(path: RcStr) -> Result<Vc<FileSystemPath>> {
-    Ok(embed_fs().root().await?.join(&path)?.cell())
+pub async fn embed_file_path(path: &RcStr) -> Result<Vc<FileSystemPath>> {
+    Ok(embed_fs().root().await?.join(path)?.cell())
 }
 
 #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/chunk_type.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/chunk_type.rs
@@ -24,8 +24,8 @@ impl ChunkType for EcmascriptChunkType {
     async fn chunk(
         &self,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
-        chunk_items: Vec<ChunkItemOrBatchWithAsyncModuleInfo>,
-        batch_groups: Vec<ResolvedVc<ChunkItemBatchGroup>>,
+        chunk_items: &Vec<ChunkItemOrBatchWithAsyncModuleInfo>,
+        batch_groups: &Vec<ResolvedVc<ChunkItemBatchGroup>>,
     ) -> Result<Vc<Box<dyn Chunk>>> {
         let content = EcmascriptChunkContent {
             chunk_items: chunk_items
@@ -34,9 +34,9 @@ impl ChunkType for EcmascriptChunkType {
                 .try_join()
                 .await?,
             batch_groups: batch_groups
-                .into_iter()
+                .iter()
                 .map(|batch_group| {
-                    EcmascriptChunkItemBatchGroup::from_chunk_item_batch_group(*batch_group)
+                    EcmascriptChunkItemBatchGroup::from_chunk_item_batch_group(**batch_group)
                         .to_resolved()
                 })
                 .try_join()

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
@@ -225,7 +225,7 @@ pub enum SideEffectsDeclaration {
 
 #[turbo_tasks::function]
 pub async fn get_side_effect_free_declaration(
-    path: FileSystemPath,
+    path: &FileSystemPath,
     side_effect_free_packages: Option<Vc<Glob>>,
 ) -> Result<Vc<SideEffectsDeclaration>> {
     if let Some(side_effect_free_packages) = side_effect_free_packages

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
@@ -248,7 +248,7 @@ pub async fn get_side_effect_free_declaration(
                 .cell());
             }
             SideEffectsValue::Glob(glob) => {
-                if let Some(rel_path) = package_json.parent().get_relative_path_to(&path) {
+                if let Some(rel_path) = package_json.parent().get_relative_path_to(path) {
                     let rel_path = rel_path.strip_prefix("./").unwrap_or(&rel_path);
                     return Ok(if glob.await?.matches(rel_path) {
                         SideEffectsDeclaration::SideEffectful

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -1161,28 +1161,28 @@ impl EcmascriptModuleContent {
     ///   merged module (used to determine execution order).
     #[turbo_tasks::function]
     pub async fn new_merged(
-        modules: Vec<(
+        modules: &Vec<(
             ResolvedVc<Box<dyn EcmascriptAnalyzable>>,
             MergeableModuleExposure,
         )>,
-        module_options: Vec<Vc<EcmascriptModuleContentOptions>>,
-        entry_points: Vec<ResolvedVc<Box<dyn EcmascriptAnalyzable>>>,
+        module_options: &Vec<Vc<EcmascriptModuleContentOptions>>,
+        entry_points: &Vec<ResolvedVc<Box<dyn EcmascriptAnalyzable>>>,
     ) -> Result<Vc<Self>> {
         async {
             let modules = modules
-                .into_iter()
+                .iter()
                 .map(|(m, exposed)| {
                     (
-                        ResolvedVc::try_sidecast::<Box<dyn EcmascriptChunkPlaceable>>(m).unwrap(),
-                        exposed,
+                        ResolvedVc::try_sidecast::<Box<dyn EcmascriptChunkPlaceable>>(*m).unwrap(),
+                        *exposed,
                     )
                 })
                 .collect::<FxIndexMap<_, _>>();
             let entry_points = entry_points
-                .into_iter()
+                .iter()
                 .map(|m| {
                     let m =
-                        ResolvedVc::try_sidecast::<Box<dyn EcmascriptChunkPlaceable>>(m).unwrap();
+                        ResolvedVc::try_sidecast::<Box<dyn EcmascriptChunkPlaceable>>(*m).unwrap();
                     (m, modules.get_index_of(&m).unwrap())
                 })
                 .collect::<Vec<_>>();

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
@@ -72,7 +72,7 @@ pub enum EsmExport {
 #[turbo_tasks::function]
 pub async fn is_export_missing(
     module: ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>,
-    export_name: RcStr,
+    export_name: &RcStr,
 ) -> Result<Vc<bool>> {
     if export_name == "__turbopack_module_id__" {
         return Ok(Vc::cell(false));
@@ -90,7 +90,7 @@ pub async fn is_export_missing(
     };
 
     let exports = exports.await?;
-    if exports.exports.contains_key(&export_name) {
+    if exports.exports.contains_key(export_name) {
         return Ok(Vc::cell(false));
     }
     if export_name == "default" {
@@ -102,7 +102,7 @@ pub async fn is_export_missing(
     }
 
     let all_export_names = get_all_export_names(*module).await?;
-    if all_export_names.esm_exports.contains_key(&export_name) {
+    if all_export_names.esm_exports.contains_key(export_name) {
         return Ok(Vc::cell(false));
     }
 

--- a/turbopack/crates/turbopack-ecmascript/src/static_code.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/static_code.rs
@@ -26,7 +26,7 @@ impl StaticEcmascriptCode {
     #[turbo_tasks::function]
     pub async fn new(
         asset_context: ResolvedVc<Box<dyn AssetContext>>,
-        asset_path: FileSystemPath,
+        asset_path: &FileSystemPath,
         generate_source_map: bool,
     ) -> Result<Vc<Self>> {
         let module = asset_context

--- a/turbopack/crates/turbopack-env/src/dotenv.rs
+++ b/turbopack/crates/turbopack-env/src/dotenv.rs
@@ -10,7 +10,7 @@ use crate::TryDotenvProcessEnv;
 ///
 /// [precedence]: https://nextjs.org/docs/app/building-your-application/configuring/environment-variables#environment-variable-load-order
 #[turbo_tasks::function]
-pub async fn load_env(project_path: FileSystemPath) -> Result<Vc<Box<dyn ProcessEnv>>> {
+pub async fn load_env(project_path: &FileSystemPath) -> Result<Vc<Box<dyn ProcessEnv>>> {
     let env: Vc<Box<dyn ProcessEnv>> = Vc::upcast(CommandLineProcessEnv::new());
 
     let node_env = env.read(rcstr!("NODE_ENV")).owned().await?;

--- a/turbopack/crates/turbopack-nft/src/nft.rs
+++ b/turbopack/crates/turbopack-nft/src/nft.rs
@@ -60,7 +60,7 @@ pub async fn node_file_trace(
 
 #[turbo_tasks::function(operation)]
 async fn node_file_trace_operation(
-    project_root: RcStr,
+    project_root: &RcStr,
     input: RcStr,
     graph: bool,
     max_depth: Option<usize>,

--- a/turbopack/crates/turbopack-node/src/evaluate.rs
+++ b/turbopack/crates/turbopack-node/src/evaluate.rs
@@ -220,7 +220,7 @@ pub enum EnvVarTracking {
 /// evaluated result automatically.
 pub async fn get_evaluate_pool(
     entries: ResolvedVc<EvaluateEntries>,
-    cwd: FileSystemPath,
+    cwd: &FileSystemPath,
     env: ResolvedVc<Box<dyn ProcessEnv>>,
     node_backend: ResolvedVc<Box<dyn NodeBackend>>,
     chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,

--- a/turbopack/crates/turbopack-node/src/lib.rs
+++ b/turbopack/crates/turbopack-node/src/lib.rs
@@ -58,7 +58,7 @@ async fn emit(
 #[turbo_tasks::function]
 async fn internal_assets(
     intermediate_asset: ResolvedVc<Box<dyn OutputAsset>>,
-    intermediate_output_path: FileSystemPath,
+    intermediate_output_path: &FileSystemPath,
 ) -> Result<Vc<OutputAssets>> {
     let all_assets = expand_output_assets(
         std::iter::once(ExpandOutputAssetsInput::Asset(intermediate_asset)),
@@ -69,7 +69,7 @@ async fn internal_assets(
         .into_iter()
         .map(async |asset| {
             let path = asset.path().await?;
-            if path.is_inside_ref(&intermediate_output_path) {
+            if path.is_inside_ref(intermediate_output_path) {
                 Ok(Some(asset))
             } else {
                 Ok(None)
@@ -88,11 +88,10 @@ pub struct AssetsForSourceMapping(FxHashMap<String, ResolvedVc<Box<dyn GenerateS
 #[turbo_tasks::function]
 async fn internal_assets_for_source_mapping(
     intermediate_asset: Vc<Box<dyn OutputAsset>>,
-    intermediate_output_path: FileSystemPath,
+    intermediate_output_path: &FileSystemPath,
 ) -> Result<Vc<AssetsForSourceMapping>> {
     let internal_assets =
         internal_assets(intermediate_asset, intermediate_output_path.clone()).await?;
-    let intermediate_output_path = intermediate_output_path.clone();
     let mut internal_assets_for_source_mapping = FxHashMap::default();
     for asset in internal_assets.iter() {
         if let Some(generate_source_map) =

--- a/turbopack/crates/turbopack-node/src/transforms/postcss.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/postcss.rs
@@ -238,7 +238,7 @@ async fn config_changed(
 #[turbo_tasks::function]
 async fn extra_configs_changed(
     asset_context: Vc<Box<dyn AssetContext>>,
-    postcss_config_path: FileSystemPath,
+    postcss_config_path: &FileSystemPath,
 ) -> Result<Vc<Completion>> {
     let parent_path = postcss_config_path.parent();
 

--- a/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
@@ -440,12 +440,11 @@ impl ChunkingContext for NodeJsChunkingContext {
         prefix: Option<RcStr>,
         extension: RcStr,
     ) -> Result<Vc<FileSystemPath>> {
-        let root_path = self.chunk_root_path.clone();
         let name = ident
             .output_name(self.root_path.clone(), prefix, extension)
             .owned()
             .await?;
-        Ok(root_path.join(&name)?.cell())
+        Ok(self.chunk_root_path.join(&name)?.cell())
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
@@ -400,7 +400,7 @@ impl ChunkingContext for NodeJsChunkingContext {
     }
 
     #[turbo_tasks::function]
-    async fn asset_url(&self, ident: FileSystemPath, tag: Option<RcStr>) -> Result<Vc<RcStr>> {
+    async fn asset_url(&self, ident: &FileSystemPath, tag: &Option<RcStr>) -> Result<Vc<RcStr>> {
         let asset_path = ident.to_string();
 
         let client_root = tag
@@ -571,7 +571,7 @@ impl ChunkingContext for NodeJsChunkingContext {
     pub async fn entry_chunk_group(
         self: ResolvedVc<Self>,
         path: FileSystemPath,
-        chunk_group: ChunkGroup,
+        chunk_group: &ChunkGroup,
         module_graph: Vc<ModuleGraph>,
         extra_chunks: Vc<OutputAssets>,
         extra_referenced_assets: Vc<OutputAssets>,

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/version.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/version.rs
@@ -21,12 +21,11 @@ pub(super) struct EcmascriptBuildNodeChunkVersion {
 impl EcmascriptBuildNodeChunkVersion {
     #[turbo_tasks::function]
     pub async fn new(
-        output_root: FileSystemPath,
+        output_root: &FileSystemPath,
         chunk_path: FileSystemPath,
         content: Vc<EcmascriptChunkContent>,
         minify_type: MinifyType,
     ) -> Result<Vc<Self>> {
-        let output_root = output_root.clone();
         let chunk_path = chunk_path.clone();
         let chunk_path = if let Some(path) = output_root.get_path_to(&chunk_path) {
             path

--- a/turbopack/crates/turbopack-resolve/src/typescript.rs
+++ b/turbopack/crates/turbopack-resolve/src/typescript.rs
@@ -231,7 +231,7 @@ async fn try_join_base_url(
     base_url: &RcStr,
 ) -> Result<Vc<FileSystemPathOption>> {
     Ok(Vc::cell(
-        source.ident().await?.path.parent().try_join(&base_url),
+        source.ident().await?.path.parent().try_join(base_url),
     ))
 }
 

--- a/turbopack/crates/turbopack-resolve/src/typescript.rs
+++ b/turbopack/crates/turbopack-resolve/src/typescript.rs
@@ -228,7 +228,7 @@ impl ValueDefault for TsConfigResolveOptions {
 #[turbo_tasks::function]
 async fn try_join_base_url(
     source: ResolvedVc<Box<dyn Source>>,
-    base_url: RcStr,
+    base_url: &RcStr,
 ) -> Result<Vc<FileSystemPathOption>> {
     Ok(Vc::cell(
         source.ident().await?.path.parent().try_join(&base_url),

--- a/turbopack/crates/turbopack-resolve/src/typescript.rs
+++ b/turbopack/crates/turbopack-resolve/src/typescript.rs
@@ -238,7 +238,7 @@ async fn try_join_base_url(
 /// Returns the resolve options
 #[turbo_tasks::function]
 pub async fn tsconfig_resolve_options(
-    tsconfig: FileSystemPath,
+    tsconfig: &FileSystemPath,
 ) -> Result<Vc<TsConfigResolveOptions>> {
     let configs = read_tsconfigs(
         tsconfig.read(),

--- a/turbopack/crates/turbopack-test-utils/src/noop_asset_context.rs
+++ b/turbopack/crates/turbopack-test-utils/src/noop_asset_context.rs
@@ -68,7 +68,7 @@ impl AssetContext for NoopAssetContext {
     #[turbo_tasks::function]
     async fn with_transition(
         self: Vc<Self>,
-        _transition: RcStr,
+        _transition: &RcStr,
     ) -> Result<Vc<Box<dyn AssetContext>>> {
         Ok(Vc::upcast(self))
     }

--- a/turbopack/crates/turbopack-test-utils/src/noop_asset_context.rs
+++ b/turbopack/crates/turbopack-test-utils/src/noop_asset_context.rs
@@ -31,7 +31,7 @@ impl AssetContext for NoopAssetContext {
     #[turbo_tasks::function]
     async fn resolve_options(
         self: Vc<Self>,
-        _origin_path: FileSystemPath,
+        _origin_path: &FileSystemPath,
     ) -> Result<Vc<ResolveOptions>> {
         Ok(ResolveOptions::default().cell())
     }
@@ -39,7 +39,7 @@ impl AssetContext for NoopAssetContext {
     #[turbo_tasks::function]
     async fn resolve_asset(
         self: Vc<Self>,
-        _origin_path: FileSystemPath,
+        _origin_path: &FileSystemPath,
         _request: Vc<Request>,
         _resolve_options: Vc<ResolveOptions>,
         _reference_type: ReferenceType,

--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -310,8 +310,8 @@ struct PreparedTest {
 }
 
 #[turbo_tasks::function]
-async fn prepare_test(resource: RcStr) -> Result<Vc<PreparedTest>> {
-    let resource_path = canonicalize(&resource)?;
+async fn prepare_test(resource: &RcStr) -> Result<Vc<PreparedTest>> {
+    let resource_path = canonicalize(resource)?;
     assert!(resource_path.exists(), "{resource} does not exist");
     assert!(
         resource_path.is_dir(),

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -263,8 +263,8 @@ async fn run(resource: PathBuf) -> Result<()> {
 }
 
 #[turbo_tasks::function(operation)]
-async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
-    let test_path = canonicalize(&resource)?;
+async fn run_test_operation(resource: &RcStr) -> Result<Vc<FileSystemPath>> {
+    let test_path = canonicalize(resource)?;
     assert!(test_path.exists(), "{resource} does not exist");
     assert!(
         test_path.is_dir(),

--- a/turbopack/crates/turbopack-tracing/tests/node-file-trace.rs
+++ b/turbopack/crates/turbopack-tracing/tests/node-file-trace.rs
@@ -354,8 +354,8 @@ struct NodeFileTraceResult {
 
 #[turbo_tasks::function(operation)]
 async fn node_file_trace_operation(
-    package_root: RcStr,
-    input: RcStr,
+    package_root: &RcStr,
+    input: &RcStr,
     directory: RcStr,
 ) -> Result<Vc<NodeFileTraceResult>> {
     let workspace_fs: Vc<Box<dyn FileSystem>> = Vc::upcast(DiskFileSystem::new(
@@ -365,7 +365,7 @@ async fn node_file_trace_operation(
     let input_dir = workspace_fs.root().owned().await?;
     let input = input_dir.join(&format!("tests/{input}"))?;
 
-    let output_fs = DiskFileSystem::new(rcstr!("output"), Vc::cell(directory.clone()));
+    let output_fs = DiskFileSystem::new(rcstr!("output"), Vc::cell(directory));
     let output_dir = output_fs.root().owned().await?;
 
     let source = FileSource::new(input);

--- a/turbopack/crates/turbopack-tracing/tests/unit.rs
+++ b/turbopack/crates/turbopack-tracing/tests/unit.rs
@@ -198,7 +198,7 @@ fn unit_test(#[case] input: &str) -> Result<()> {
 }
 
 #[turbo_tasks::function(operation)]
-async fn node_file_trace_operation(package_root: RcStr, input: RcStr) -> Result<Vc<Vec<RcStr>>> {
+async fn node_file_trace_operation(package_root: &RcStr, input: RcStr) -> Result<Vc<Vec<RcStr>>> {
     let workspace_fs: Vc<Box<dyn FileSystem>> = Vc::upcast(DiskFileSystem::new(
         rcstr!("workspace"),
         Vc::cell(package_root.clone()),

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -985,7 +985,7 @@ impl AssetContext for ModuleAssetContext {
     #[turbo_tasks::function]
     async fn resolve_options(
         self: Vc<Self>,
-        origin_path: FileSystemPath,
+        origin_path: &FileSystemPath,
     ) -> Result<Vc<ResolveOptions>> {
         let this = self.await?;
         let module_asset_context = if let Some(transition) = this.transition {
@@ -1210,12 +1210,12 @@ pub async fn emit_asset(asset: Vc<Box<dyn OutputAsset>>) -> Result<()> {
 #[turbo_tasks::function]
 pub async fn emit_assets_into_dir(
     assets: Vc<ExpandedOutputAssets>,
-    output_dir: FileSystemPath,
+    output_dir: &FileSystemPath,
 ) -> Result<()> {
     let assets = assets.await?;
     let paths = assets.iter().map(|&asset| asset.path()).try_join().await?;
     for (&asset, path) in assets.iter().zip(paths.iter()) {
-        if path.is_inside_ref(&output_dir) {
+        if path.is_inside_ref(output_dir) {
             emit_asset(*asset).as_side_effect().await?;
         }
     }


### PR DESCRIPTION
### What?

Lets `#[turbo_tasks::function]` bodies declare arguments as `&T`, and migrates the high-impact owned-but-borrowed parameters across the codebase to do so.

### Why?

For every cache miss on a turbo-task, the runtime has to clone each non-`Copy` argument out of the cached `Box<dyn DynTaskInputs>` so the executing future (which is `'static`) can own its captures. The `task_fn_impl!` blanket impls call `get_args::<T>(arg).cloned()` to do this — a deep clone of every argument tuple element, on every miss. For a function whose body only ever takes `&path` or `items.iter()`, that clone is pure overhead.

The pain shows up most clearly in things like `DiskFileSystem::read(&self, fs_path: FileSystemPath)`: callers pass an owned `FileSystemPath` (the cache key needs it), the runtime then clones it again before handing it to the body, and the body proceeds to take a borrow.

This PR adds the language-level support to skip that runtime clone and migrates the bodies that benefit.

### How?

#### Implementation (the framework change)

The exposed (caller-facing) signature is unchanged in every case — callers always pass owned values, because that's still what the cache key is built from. Only the *body* signature gets to declare `&T`.

- **Macro** (`turbo-tasks-macros/src/func.rs`): `inline_signature_and_block` now wraps every non-receiver typed parameter as `&T'` in the inline closure. For arguments the user wrote as owned `T`, it inserts a `let arg = arg.clone();` shadow up front, so existing bodies keep compiling. `mut` is preserved on the rebind. Operations (`#[turbo_tasks::function(operation)]`) get the same `&T` wrapping but skip the `FromTaskInput` rewrite. `expand_exposed_input_type` strips a leading `&` from the user's type when emitting the *exposed* signature so callers always see the owned form.
- **Runtime** (`turbo-tasks/src/native_function.rs`, `task/function.rs`, `turbo-tasks-backend/src/backend/mod.rs`): `NativeFunction::execute` and `TaskFn::functor` now take `Arc<CachedTaskType>` instead of `&dyn DynTaskInputs`. The Arc is captured by the executing future, which lets references downcast out of `&*task.arg` stay valid for the duration of the future without an intermediate clone.
- **Blanket impls** (`task_fn_impl!`): six blanket impls per arity, by-reference, covering all four `Mode` × receiver-shape combinations (`FunctionMode`, `AsyncFunctionMode`, `MethodMode`, `AsyncMethodMode`, plus the Vc-receiver variants). Arity 0 keeps a separate by-value module (no user args means nothing to take by reference). The previous by-value blanket impls for arity ≥ 1 are gone — every macro-generated inline now flows through the by-reference path.
- **Smoke test**: `turbopack/crates/turbo-tasks-backend/tests/by_ref.rs` exercises `&Vec<u32>` arguments on a non-method, a method with mixed by-value + by-ref args, and a `&Recv` method receiver.
- **Documentation**: a new "When to take `&T`" section in `turbopack/crates/turbo-tasks/function.md` covers the rule, the carve-outs (`&'a T`, `&mut T`, `&dyn Trait`, `&[T]`, `&str` are out; `Copy` types like `Vc<T>` and primitives stay by-value), and the operation-function caveat.
- **Lint**: `.config/ast-grep/rules/turbo-task-pass-by-ref-hint.yml` is a `hint`-severity advisory rule that fires on `#[turbo_tasks::function]` parameters typed as `Vec<…>`, `HashMap<…>`, `String`, `PathBuf`, `OsString`, `FileSystemPath`, etc. (Vc-shaped types and primitives are skipped.) It cannot tell whether a migration would force a new explicit `.clone()` to compensate, so it never offers a `fix:` and the message points at `function.md`.

#### Migrations

Each migration follows a "net-clone test": migrate **only** when the body has a non-owning use that survives without adding a new `.clone()` somewhere in user code. If the body's only use is to forward the parameter by value to another callee, migrating just trades the macro shadow's implicit clone for an explicit one — wash, skip. If the body moves the parameter into a struct, mutates it, or consumes it via `.into_*()`, also skip. The conservative rule means a syntactic candidate list of 458 functions yielded ~125 actually-applied migrations; ~250 of the rest are wash cases or moves-into-struct, and the remainder are out-of-scope (`mut` parameters, etc.).

Migrations land grouped by type and crate for reviewability:

- **`Vec<…>`**: 4 functions (`output_of_endpoints`, `module_graphs_of_endpoints`, `from_graphs_inner`, `EcmascriptChunkType::chunk`).
- **`FileSystemPath`**: 75 functions across `turbo-tasks-fs` (39 incl. `DiskFileSystem::read`, `read_link`, `write`, `write_link`, `metadata`, `raw_read_dir`), the turbopack ecosystem (18 across `turbopack-core`'s resolution hot path — `find_context_file`, `find_package`, `resolve_raw`, `resolve_internal`, `read_matches`, plus `ServerFileSystem` impls and friends), and the Next.js bindings (36 across `next-core`/`next-api` — `next_config::config_file_path`, `next_server::context::get_server_resolve_options_context`, `paths::all_asset_paths`, etc.).
- **`RcStr`**: 45 functions across `turbo-tasks-fs`/`turbo-tasks-env`/`turbo-tasks-fetch` framework crates (HTTP fetch hot path, env lookup), the turbopack ecosystem (resolution helpers, runtime embedders, dev-server route tree), and Next.js bindings (HMR pipeline, napi error stack, page entry / loader, font handling).

The exposed signature is unchanged in every migration, so no caller had to be updated.

### Binary size impact

Release build of `next-napi-bindings` (`cdylib`) on `darwin-aarch64`:

| Build                   | canary             | this branch        | Δ                       |
| ----------------------- | ------------------ | ------------------ | ----------------------- |
| Release `.dylib`        | 124,604,704 (118.83 MiB) | 124,791,792 (119.01 MiB) | **+187,088 B  (+0.15 %)** |
| Stripped                | 84,230,008 (80.33 MiB)   | 84,396,280 (80.49 MiB)   | **+166,272 B  (+0.20 %)** |
| Stripped + `gzip -9`    | 29,227,202 (27.87 MiB)   | 29,241,655 (27.89 MiB)   | **+14,453 B   (+0.05 %)** |

The framework change itself doubles the number of `task_fn_impl!` blanket impls instantiated (now 6 by-ref variants per arity for arities 1..12), and each macro-generated inline gains a per-non-receiver-arg shadow. Net binary-size impact is essentially a wash — within noise on the gzipped output that actually ships.


### Performance

```
# This branch
$ hyperfine --warmup 1 --runs 5 --prepare 'rm -rf .next'  'pnpm next build   --experimental-build-mode=compile'
Benchmark 1: pnpm next build   --experimental-build-mode=compile
  Time (mean ± σ):     66.799 s ±  0.979 s    [User: 497.617 s, System: 79.704 s]
  Range (min … max):   65.893 s … 67.952 s    5 runs
```

```
# canary
$ hyperfine --warmup 1 --runs 5 --prepare 'rm -rf .next'  'pnpm next build   --experimental-build-mode=compile'
Benchmark 1: pnpm next build   --experimental-build-mode=compile
  Time (mean ± σ):     64.329 s ±  2.484 s    [User: 488.328 s, System: 81.013 s]
  Range (min … max):   62.112 s … 68.050 s    5 runs
```

<!-- NEXT_JS_LLM_PR -->