### PR TITLE
Fix basePath stripping in RSC cache-busting redirect

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2117,8 +2117,9 @@ export default abstract class Server<
         // must send `_rsc` param, otherwise actualHash is null and hash check fails.
         const url = new URL(req.url || '', 'http://localhost')
         setCacheBustingSearchParamWithHash(url, expectedHash)
+        const basePath = this.nextConfig.basePath || ''
         res.statusCode = 307
-        res.setHeader('location', `${url.pathname}${url.search}`)
+        res.setHeader('location', `${basePath}${url.pathname}${url.search}`)
         res.body('').send()
         return null
       }

--- a/test/e2e/app-dir/segment-cache/cdn-cache-busting-base-path/app/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/cdn-cache-busting-base-path/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/cdn-cache-busting-base-path/app/page.tsx
+++ b/test/e2e/app-dir/segment-cache/cdn-cache-busting-base-path/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Home</div>
+}

--- a/test/e2e/app-dir/segment-cache/cdn-cache-busting-base-path/app/target-page/page.tsx
+++ b/test/e2e/app-dir/segment-cache/cdn-cache-busting-base-path/app/target-page/page.tsx
@@ -1,0 +1,3 @@
+export default function TargetPage() {
+  return <div id="target-page">Target page</div>
+}

--- a/test/e2e/app-dir/segment-cache/cdn-cache-busting-base-path/cdn-cache-busting-base-path.test.ts
+++ b/test/e2e/app-dir/segment-cache/cdn-cache-busting-base-path/cdn-cache-busting-base-path.test.ts
@@ -1,0 +1,36 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('segment cache (CDN cache busting + basePath)', () => {
+  const { next, isNextDev, isNextDeploy, skipped } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+  })
+
+  if (skipped || isNextDev || isNextDeploy) {
+    test('should not run during dev or deploy test runs', () => {})
+    return
+  }
+
+  it(
+    'preserves basePath in the Location header when redirecting to the ' +
+      'correct cache-busting search param',
+    async () => {
+      // Issue an RSC request without a `_rsc=` cache-busting search param.
+      // The server should redirect with a 307 to the same URL with `_rsc=`
+      // appended, and the Location header MUST include the configured
+      // basePath so the browser stays inside the app.
+      const res = await next.fetch('/docs/target-page', {
+        redirect: 'manual',
+        headers: {
+          rsc: '1',
+          'next-router-prefetch': '1',
+          'next-router-segment-prefetch': '/_tree',
+        },
+      })
+      expect(res.status).toBe(307)
+      const location = res.headers.get('location')
+      expect(location).not.toBeNull()
+      expect(location).toMatch(/^\/docs\/target-page\?.*_rsc=/)
+    }
+  )
+})

--- a/test/e2e/app-dir/segment-cache/cdn-cache-busting-base-path/next.config.js
+++ b/test/e2e/app-dir/segment-cache/cdn-cache-busting-base-path/next.config.js
@@ -1,0 +1,11 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  basePath: '/docs',
+  experimental: {
+    validateRSCRequestHeaders: true,
+  },
+}
+
+module.exports = nextConfig


### PR DESCRIPTION
Fixes #93435.

## Summary

When `experimental.validateRSCRequestHeaders` is enabled (the default on canary builds — `config-shared.ts` defaults to `!!(process.env.__NEXT_TEST_MODE || !isStableBuild())`), `Server.renderToResponseWithComponentsImpl` issues a 307 redirect whenever the client-supplied `_rsc` cache-busting search param does not match the hash computed from RSC request headers. This is a defense-in-depth measure against CDN cache poisoning for CDNs that ignore the `Vary` header (introduced in #80669, gated behind the flag in #80157).

The redirect's `Location` header is built from `req.url`:

```ts
// packages/next/src/server/base-server.ts (pre-fix)
const url = new URL(req.url || '', 'http://localhost')
setCacheBustingSearchParamWithHash(url, expectedHash)
res.statusCode = 307
res.setHeader('location', `${url.pathname}${url.search}`)
```

But by the time this code runs, `basePath` has already been stripped from `req.url` in `handleRequestImpl`:

```ts
// base-server.ts ~line 1055
if (pathnameInfo.basePath) {
  req.url = removePathPrefix(req.url!, this.nextConfig.basePath)
}
```

So for any app configured with `basePath: '/app'` (etc.), the redirect's `Location` is `/foo?_rsc=…` instead of `/app/foo?_rsc=…`. The browser then navigates outside the app's basePath, hitting whatever (if anything) is mounted at the bare path on the same host.

This fix re-prepends `this.nextConfig.basePath` to the `Location` header so the redirect stays within the app.

## Reproduction

1. App with `basePath: '/app'` and a route handler at `/app/api/cookie` that 307s to `/app/some-page?foo=bar` (i.e. *without* a `_rsc` query param).
2. From a client component, call `router.push('/api/cookie?…')`. The browser issues an RSC fetch (RSC headers + `_rsc=<hash>` query).
3. Cookie route 307s to `/app/some-page?foo=bar`. Browser follows in RSC mode — sends RSC headers, but the redirect target had no `_rsc=` query, so `actualHash` is null.
4. `validateRSCRequestHeaders` check fires: `expectedHash !== null`, mismatch.
5. Server emits a 307 with `Location: /some-page?foo=bar&_rsc=<expectedHash>` — note the missing `/app`.
6. Browser navigates outside the app's basePath.

The same flow also hits any user whose nginx/proxy rule routes `/app/*` to one backend and `/*` to another (a common pattern when the Next.js app shares a hostname with a marketing site or other backend mounted at `/`). In that setup, the redirect leaves the Next app entirely and lands on the wrong backend.

See #93435 for full real-world impact context.

## Fix

```diff
         const url = new URL(req.url || '', 'http://localhost')
         setCacheBustingSearchParamWithHash(url, expectedHash)
+        const basePath = this.nextConfig.basePath || ''
         res.statusCode = 307
-        res.setHeader('location', `${url.pathname}${url.search}`)
+        res.setHeader('location', `${basePath}${url.pathname}${url.search}`)
         res.body('').send()
         return null
```

`basePath` is normalized on `nextConfig` (always either an empty string or a path starting with `/`, never trailing `/`), so concatenation is safe without further normalization.

## Test

Added a regression test under `test/e2e/app-dir/segment-cache/cdn-cache-busting-base-path/` that:

- Mounts a minimal app at `basePath: '/docs'` with `validateRSCRequestHeaders: true`.
- Issues an RSC request to `/docs/target-page` with RSC headers but no `_rsc=` query param.
- Asserts the 307 `Location` header matches `/docs/target-page?…_rsc=…`.

Without this PR's fix, that assertion fails (Location would be `/target-page?_rsc=…`).

## Related

- Cache-busting check: #80669 (introduced the buggy line)
- Experimental flag: #80157 (gated the feature)
- Companion bug report: #93435

cc @acdlite (#80157 / surrounding RSC code) — happy to make any requested changes.
