### PR TITLE
docs: add Thinking in Next.js guide

### DIFF
--- a/docs/01-app/02-guides/thinking-in-nextjs.mdx
+++ b/docs/01-app/02-guides/thinking-in-nextjs.mdx
@@ -24,8 +24,8 @@ The designer hands over mockups for three routes.
 
 <Image
   alt="Three route cards labeled /projects, /projects/compass, and /projects/compass/deployments/compass-jx9q3, each split into top bar, sidebar, and content regions."
-  srcLight="/docs/guides/thinking-in-nextjs/route-mockups-light.png"
-  srcDark="/docs/guides/thinking-in-nextjs/route-mockups-dark.png"
+  srcLight="/docs/guides/thinking-in-nextjs/route-mockups-light-3.png"
+  srcDark="/docs/guides/thinking-in-nextjs/route-mockups-dark-3.png"
   width={1088}
   height={386}
 />

--- a/docs/01-app/02-guides/thinking-in-nextjs.mdx
+++ b/docs/01-app/02-guides/thinking-in-nextjs.mdx
@@ -332,7 +332,7 @@ The mutation pattern is uniform across the app. The write touches the underlying
 Submit the deploy form, then pin and unpin a project. Watch the new deployment show up in the list and the pin state flip.
 
 <Demo
-  src="https://thinking-in-nextjs-05-mutations.labs.vercel.dev/projects"
+  src="https://thinking-in-nextjs-05.labs.vercel.dev/projects"
   title="Step 5: Mutate data"
 />
 
@@ -478,7 +478,7 @@ App Router runs `router.push` inside a [transition](https://react.dev/reference/
 Try the demo. Pin and unpin a project, type in the search bar, and submit a deploy. Watch the pin flip before the server confirms, the URL update on each keystroke, and the deploy button stay in its pending state until the Server Function returns.
 
 <Demo
-  src="https://thinking-in-nextjs-06-client-boundaries.labs.vercel.dev/projects"
+  src="https://thinking-in-nextjs-06.labs.vercel.dev/projects"
   title="Step 6: Add client interactivity"
 />
 
@@ -684,7 +684,7 @@ You could have skipped [Step 4: Stream async work](#step-4-stream-async-work) if
 Click into a project and into a deployment, then back. Watch which sections paint instantly and which still show a fallback before resolving.
 
 <Demo
-  src="https://thinking-in-nextjs-07-caching.labs.vercel.dev/projects"
+  src="https://thinking-in-nextjs-07.labs.vercel.dev/projects"
   title="Step 7: Cache reusable work"
 />
 

--- a/docs/01-app/02-guides/thinking-in-nextjs.mdx
+++ b/docs/01-app/02-guides/thinking-in-nextjs.mdx
@@ -253,11 +253,9 @@ The `◐` is [Partial Prerendering](/docs/app/glossary#partial-prerendering-ppr)
 
 When an async read isn't behind a boundary and isn't cached, the dev overlay points at the call site and lists three ways out:
 
-{/* TODO: Update the three `error-overhaul` links below once the Error Overhaul guide ships and the anchor names are finalized. */}
-
-- [Provide a `<Suspense>` placeholder](/docs/app/guides/error-overhaul#move-within-suspense) around the read — what the Sidebar above already does.
-- [Cache the data access with `'use cache'`](/docs/app/guides/error-overhaul#cache-dynamic-data) — the move when the result can be reused, covered later.
-- [Allow blocking route](/docs/app/guides/error-overhaul#allow-blocking-route) — an escape hatch when you knowingly want the whole route to wait.
+- [Provide a `<Suspense>` placeholder](/patterns/provide-placeholder-with-suspense) around the read — what the Sidebar above already does.
+- [Cache the data access with `'use cache'`](/patterns/prerender-and-cache) — the move when the result can be reused, covered later.
+- [Allow blocking route](/patterns/allow-blocking-route) — an escape hatch when you knowingly want the whole route to wait.
 
 Those checks fire on every server render. [Instant navigation](/docs/app/guides/instant-navigation) extends the same family to client navigations, failing `next dev` and `next build` when a route can't paint instantly on click. Wire it on once through `experimental.instant.defaultValidationLevel` in [`next.config`](/docs/app/api-reference/config/next-config-js).
 
@@ -737,8 +735,6 @@ Only the recent-deploys list paints with the static shell, since it's the one ca
 Source: [`steps/07-caching`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/07-caching).
 
 ## Step 8: Optimize prefetching
-
-{/* TODO: Add `unstable_instant` link once vercel/next.js#93204 lands. Likely target: /docs/app/api-reference/file-conventions/route-segment-config/instant (paired with the overhauled /docs/app/guides/instant-navigation). */}
 
 The cache is set up, but each navigation still waits. The cached entries on this route key on `params`, cookies, or `searchParams`, values that only arrive with a real request, so nothing fills them until the request lands. The static shell paints fast on its own. The data behind it is what's still missing.
 

--- a/docs/01-app/02-guides/thinking-in-nextjs.mdx
+++ b/docs/01-app/02-guides/thinking-in-nextjs.mdx
@@ -24,8 +24,8 @@ The designer hands over mockups for three routes.
 
 <Image
   alt="Three route cards labeled /projects, /projects/compass, and /projects/compass/deployments/compass-jx9q3, each split into top bar, sidebar, and content regions."
-  srcLight="/docs/guides/thinking-in-nextjs/mockups-light.png"
-  srcDark="/docs/guides/thinking-in-nextjs/mockups-dark.png"
+  srcLight="/docs/guides/thinking-in-nextjs/designer-mockups-light.png"
+  srcDark="/docs/guides/thinking-in-nextjs/designer-mockups-dark.png"
   width={1600}
   height={567}
 />
@@ -201,8 +201,8 @@ With it on, the prerender expects every async read to either be cached or sit be
 
 <Image
   alt="Next.js dev overlay reading 'Next.js encountered uncached data during the initial render.' A code preview highlights the uncached `await` inside a data-access function. Three fix cards follow. 'Cache dynamic data' shows `'use cache'` at the top of a data function. 'Move within Suspense' wraps the async child in `<Suspense fallback={…}>`. 'Allow blocking route' shows `export const instant = false`."
-  srcLight="/docs/guides/thinking-in-nextjs/overlay-light.png"
-  srcDark="/docs/guides/thinking-in-nextjs/overlay-dark.png"
+  srcLight="/docs/guides/thinking-in-nextjs/instant-overlay-light.png"
+  srcDark="/docs/guides/thinking-in-nextjs/instant-overlay-dark.png"
   width={984}
   height={779}
 />
@@ -234,7 +234,7 @@ function Sidebar() {
 
 The same move repeats anywhere else in the route an async read shows up, with the boundary sitting at the smallest scope that needs it.
 
-A _fallback_ is the UI that ships with the shell. It gets replaced with the real output once the async component finishes. For this route:
+A _fallback_ is the UI that renders in the static shell while the async child is still resolving. It's replaced with the real output once the child finishes. For this route:
 
 - **0 ms**: Shell sent. The header and search form land immediately, with fallbacks rendered for the avatar, pinned section, recent deploys, and grid.
 - **500 ms**: Avatar resolves.
@@ -408,7 +408,7 @@ What stays wrapped is what still resolves per request. The project grid reads `?
 
 Inside `BuildLogs`, the live stream still has its boundary. That part is live by definition.
 
-Could you have skipped [Step 4: Stream async work](#step-4-stream-async-work) if you'd known the cache plan up front? Sure. But the question was sharper when you asked it of each component on its own.
+You could have skipped [Step 4: Stream async work](#step-4-stream-async-work) if you'd known the cache plan up front. The question was sharper when you asked it of each component on its own.
 
 Click into a project and into a deployment, then back. Watch which sections paint instantly and which still show a fallback before resolving.
 
@@ -425,15 +425,9 @@ Source: [`steps/05-caching`](https://github.com/vercel-labs/thinking-in-nextjs/t
 
 A cache stores reusable output. A mutation invalidates the entries that stopped being true.
 
-In the App Router, mutations live in [Server Functions](/docs/app/glossary#server-function) marked with `'use server'`. Each one does two things in the same call.
+In the App Router, mutations live in [Server Functions](/docs/app/glossary#server-function) marked with `'use server'`. Each one does two things in the same call. It changes the underlying state, then it invalidates every cached read that stopped being true.
 
-It changes the underlying state, then tells the cache the write happened.
-
-Triggering a deploy is the cleanest version of that. The write hits the upstream, then tag calls invalidate every cached read that stopped being true.
-
-The project's deployments list is one. The sidebar's recent-deploys list is another.
-
-Each one has its own tag, and the Server Function calls them by name:
+Triggering a deploy is the cleanest version of that. The write hits the upstream, and two cached reads go stale alongside it. The project's deployments list is one, and the sidebar's recent-deploys list is the other. Each has its own tag, and the Server Function calls them by name:
 
 ```tsx
 'use server'
@@ -447,11 +441,7 @@ async function triggerDeploy(projectId) {
 
 The tag names match the ones the cached reads applied earlier, so one Server Function call lines up with the cache entries it touched. Any route that reads through `deployments-${projectId}` or `recent-deployments` picks up the change.
 
-[`updateTag`](/docs/app/api-reference/functions/updateTag) and [`revalidateTag`](/docs/app/api-reference/functions/revalidateTag) differ in how they treat the response that contains the mutation.
-
-`updateTag` handles read-your-writes. The new value shows up in the same response that triggered it.
-
-`revalidateTag` handles stale-while-revalidate. The previous value keeps serving while the next read fetches a fresh one.
+[`updateTag`](/docs/app/api-reference/functions/updateTag) and [`revalidateTag`](/docs/app/api-reference/functions/revalidateTag) differ in how they treat the response that contains the mutation. `updateTag` handles read-your-writes, so the new value shows up in the same response that triggered it. `revalidateTag` handles stale-while-revalidate, so the previous value keeps serving while the next read fetches a fresh one.
 
 Wired up to a button, the smallest version is a `<form action>` with no `'use client'` boundary in the path:
 
@@ -504,7 +494,7 @@ Pending state has the same options. You can put `triggerDeploy` inside a `useTra
 
 So how wide does that boundary actually need to be? Often one prop, even before it resolves.
 
-`ProjectPin` was a server form in [Step 6](#step-6-mutate-data). In this step it crosses into the client, takes the per-viewer promise as a prop, and calls [`use`](https://react.dev/reference/react/use) to resolve it on the other side, suspending at the nearest Suspense boundary above until the read lands.
+`ProjectPin` was a server form in [Step 6](#step-6-mutate-data). In this step it crosses into the client, takes the per-viewer promise as a prop, and calls [`use`](https://react.dev/reference/react/use) to resolve it on the other side, suspending at the nearest Suspense boundary above until the read resolves.
 
 The same form action from [Step 6](#step-6-mutate-data) wraps the optimistic flip:
 
@@ -618,24 +608,24 @@ App Router runs `router.push` inside a [transition](https://react.dev/reference/
 
 [`useTransition`](https://react.dev/reference/react/useTransition) adds `isPending`, a value the input can read to show a hint while the new render resolves. [`useLinkStatus`](/docs/app/api-reference/functions/use-link-status) gives the same signal for `<Link>` navigations.
 
-Try the demo. Pinning flips before the server confirms, search edits the URL on each keystroke, and the deploy button stays in a pending state until the Server Function returns.
-
-Everything else around them stays a Server Component.
+Try the demo. Pin and unpin a project, type in the search bar, and submit a deploy. Watch the pin flip before the server confirms, the URL update on each keystroke, and the deploy button stay in its pending state until the Server Function returns.
 
 <Demo
   src="https://thinking-in-nextjs-07.labs.vercel.dev/projects"
   title="Step 7: Add client interactivity"
 />
 
+Three small Client leaves (`ProjectPin`, `SearchBar`, and the deploy button) handle the moments where the request-response loop runs out of room. Everything else around them stays a Server Component.
+
 Source: [`steps/07-client-boundaries`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/07-client-boundaries).
 
 ## Step 8: Optimize prefetching
 
-By now the tree knows what to render and what to reuse. The last question is timing. When can that work happen?
+By now you know what to render and what to reuse. The last question is timing. When can that work happen?
 
-Not at click time. When a [`<Link>`](/docs/app/api-reference/components/link) enters the viewport, Next.js takes that as a hint and renders its destination in the background. By the time the click lands, the tree is already there.
+Not at click time. When a [`<Link>`](/docs/app/api-reference/components/link) enters the viewport, Next.js uses that as a hint and renders its destination in the background. By the time the click lands, the tree is already there.
 
-There's a wrinkle. The destination might depend on the viewer, and there's no real request at prefetch time. What session does that render see?
+There's a wrinkle. The destination might depend on the viewer, and there's no real request at prefetch time, so the prefetch has to choose which session it renders against.
 
 The default is [**static**](/docs/app/guides/prefetching). The prefetch renders against build-time inputs, with no cookies, headers, or search string in scope. That's enough for the shared layout and any cached read that doesn't key on the viewer.
 
@@ -675,22 +665,22 @@ Every route is in the loop, with no per-route opt-in to chase. The dev validator
 
 Try the demo. Click between projects, into deployments, and back. Everything lands instantly except the live build log on an in-progress deployment, which is live by definition.
 
-The shift the demo highlights is which sections are already populated when the click resolves. The projects grid keyed on `?q=`, the avatar, and the pinned section all used to stream on first visit. Runtime prefetch now fills those request-dependent reads in parallel during the prefetch pass, so they're served from cache instead of streaming.
-
-Whatever the prefetch pass touched, static or runtime, is cached in the browser and works offline. The only parts that need an active connection are the live-streamed sections, so flaky networks stop being a meaningful problem for most of the app.
-
 <Demo
   src="https://thinking-in-nextjs.labs.vercel.dev/projects"
   title="Step 8: Optimize prefetching"
 />
 
+The shift the demo highlights is which sections are already populated when the click resolves. The projects grid keyed on `?q=`, the avatar, and the pinned section all used to stream on first visit. Runtime prefetch now fills those request-dependent reads in parallel during the prefetch pass, so they're served from cache instead of streaming.
+
+Whatever the prefetch pass touched, static or runtime, is cached in the browser and works offline. The only parts that need an active connection are the live-streamed sections, so flaky networks stop being a meaningful problem for most of the app.
+
 Source: [`steps/08-prefetching`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/08-prefetching).
 
 ## Where to go from here
 
-Look back at the route. You didn't redesign it. You asked each component the same question. _What kind of work is this?_ A read here, a Suspense boundary there, a cache where the work repeats, a tag where it doesn't, a Client leaf where input lives. The route got more honest about what each piece was doing. One model carries the whole thing. The decisions it asks for are the ones that scale, and most routes never need a different shape.
+Look back at the route. You didn't redesign it. You asked each component the same question. _What kind of work is this?_ A read here, a Suspense boundary there, a cache where the work repeats, a tag where it doesn't, a Client leaf where input lives. The route got more honest about what each piece was doing. One model carries the whole thing, and the decisions it surfaces are the ones that scale.
 
-Try it on a route in your own codebase. Name the regions, then label each one as static, dynamic, cached, or a Client leaf. The decisions usually fall out once each component answers what kind of work it is.
+Try it on a route in your own codebase. Name the regions, then label each one as static, dynamic, cached, or a Client leaf. The decisions usually fall out once you've labeled what each piece is doing.
 
 The docs go deeper on each piece used here.
 

--- a/docs/01-app/02-guides/thinking-in-nextjs.mdx
+++ b/docs/01-app/02-guides/thinking-in-nextjs.mdx
@@ -492,29 +492,27 @@ Source: [`steps/06-client-boundaries`](https://github.com/vercel-labs/thinking-i
 
 The route works end-to-end now, but moving between routes still feels server-y. Click into a project, click back, click into another, and every read runs from scratch on each navigation. The shell paints fast, the fallbacks reappear, and the new section streams in.
 
-Caching is the move that gets the rest of the way to the instant feel of a Single Page App (SPA), without giving up the server-component model. Data lives next to the read, there's no client cache to hand-maintain across viewers, and there's no API contract to keep in sync.
+Caching is the move that gets the rest of the way to the instant feel of a [Single Page App (SPA)](/docs/app/guides/single-page-applications), without giving up the server-component model. Data lives next to the read, there's no client cache to hand-maintain across viewers, and there's no API contract to keep in sync.
 
-Walk the reads on the route. Most of them produce the same output for every visitor. The project list, project header, and deployments list look the same for one viewer as the next.
+Walk the reads on the route. Most of them are reusable. The same render can serve the next request instead of running again, even when "the next request" only means the same viewer's next click.
 
 The natural question:
 
-> Would the next viewer see the same thing?
+> Could this read be reused?
 
-If yes, the result can be reused instead of recomputed on every request, and the section can join the static shell instead of streaming behind a fallback.
-
-| UI piece                          | Same for every viewer? |
-| --------------------------------- | ---------------------- |
-| `ProjectGrid`, `ProjectHeader`    | Yes                    |
-| `Deployments`, `DeploymentHeader` | Yes                    |
-| `RecentDeploysSection`            | Yes                    |
-| `BuildLogs`, completed build      | Yes                    |
-| `BuildLogs`, in-progress build    | No, live               |
-| `ViewerAvatar`                    | No, per viewer         |
-| `PinnedSection`                   | No, per viewer         |
+| UI piece                          | Reusable?       |
+| --------------------------------- | --------------- |
+| `ProjectGrid`, `ProjectHeader`    | Yes             |
+| `Deployments`, `DeploymentHeader` | Yes             |
+| `RecentDeploysSection`            | Yes             |
+| `BuildLogs`, completed build      | Yes             |
+| `BuildLogs`, in-progress build    | No, live        |
+| `ViewerAvatar`                    | Yes, per viewer |
+| `PinnedSection`                   | Yes, per viewer |
 
 {/* TODO: The `caches the data access` link below points at the not-yet-shipped Error Overhaul guide; update once it lands. */}
 
-[`'use cache'`](/docs/app/glossary#use-cache-directive) is the directive that [caches the data access](/docs/app/guides/error-overhaul#cache-dynamic-data). Add it at the top of a data function or a Server Component, and the result is reused across requests. On a project read, the directive sits next to a [`cacheLife`](/docs/app/api-reference/functions/cacheLife) for how long entries stay around and a [`cacheTag`](/docs/app/api-reference/functions/cacheTag) for invalidation later:
+If the answer is yes, [`'use cache'`](/docs/app/glossary#use-cache-directive) is the one primitive. The same directive covers reads reused across every visitor, reads reused per viewer, and reads reused only for the current session. The variant tweaks where the entry lives, not whether to cache. Add it at the top of a data function or a Server Component, and the result joins the static shell instead of streaming behind a fallback. On a project read, the directive sits next to a [`cacheLife`](/docs/app/api-reference/functions/cacheLife) for how long entries stay around and a [`cacheTag`](/docs/app/api-reference/functions/cacheTag) for invalidation later:
 
 ```tsx filename="data/queries/projects.ts" highlight={2,4}
 async function getProject(id) {
@@ -673,7 +671,7 @@ Source: [`steps/07-caching`](https://github.com/vercel-labs/thinking-in-nextjs/t
 
 The cache is set up, but each navigation still waits. The cached entries on this route key on `params`, cookies, or `searchParams`, values that only arrive with a real request, so nothing fills them until the request lands. Instant validation keeps the shell ready at navigation; the data behind it is what's still missing.
 
-Prefetch is the timing answer. When a [`<Link>`](/docs/app/api-reference/components/link) enters the viewport, Next.js renders its destination in the background, so the tree is already there by the time of the click.
+Prefetching fills those entries before the click. When a [`<Link>`](/docs/app/api-reference/components/link) enters the viewport, Next.js renders its destination in the background, so the tree is already cached by the time of the click.
 
 The prefetch renders against one of two shapes, and each route declares which. The default is [static](/docs/app/guides/prefetching), with no cookies, headers, or search string in scope. That covers the shared layout and any cached read keyed on build-time inputs. [Runtime](/docs/app/api-reference/file-conventions/route-segment-config/prefetch) is opt-in, and it renders with the same cookies, headers, and search string the navigation would send, so per-viewer reads run against the real session before the click.
 
@@ -697,7 +695,7 @@ export default function ProjectsPage({ searchParams }) {
 
 Each page declares its own choice. We can add the export to every page whose reads depend on per-request inputs. On this app that's `/projects` (cookies for the avatar and pinned section, `?q=` for the grid), `/projects/[id]` (cookies and `params`), and `/projects/[id]/deployments/[deployId]` (cookies and `params`). The other pages on the route stay on static prefetch.
 
-Open the browser's network panel as `<Link>`s scroll into view, and the prefetch requests show up as their own rows:
+Open the browser's network panel as `<Link>` elements scroll into view, and the prefetch requests show up as their own rows:
 
 ```txt
 Name                                          Status  Type   Size      Time

--- a/docs/01-app/02-guides/thinking-in-nextjs.mdx
+++ b/docs/01-app/02-guides/thinking-in-nextjs.mdx
@@ -18,7 +18,7 @@ This tutorial builds one small app one decision at a time, the way you would in 
 
 ## Start with the mockup
 
-Picture a small projects dashboard. Each viewer sees their projects, opens one to see its deployments, and opens a deployment to read its build log. They can search the list, pin favorites, and trigger a redeploy from the project page.
+Picture a mini Vercel, a small projects dashboard. Each viewer sees their projects, opens one to see its deployments, and opens a deployment to read its build log. They can search the list, pin favorites, and trigger a redeploy from the project page.
 
 The designer hands over mockups for three routes.
 

--- a/docs/01-app/02-guides/thinking-in-nextjs.mdx
+++ b/docs/01-app/02-guides/thinking-in-nextjs.mdx
@@ -49,7 +49,7 @@ The build happens one decision at a time:
 7. Add client interactivity.
 8. Optimize prefetching.
 
-The order is not arbitrary. It is hard to think about caching before knowing what data is being fetched, and hard to think about prefetching before knowing what's cached. Each step earns the next one.
+The order is not arbitrary. It is hard to think about caching before knowing what data is being fetched, and hard to think about [prefetching](/docs/app/glossary#prefetching) before knowing what's cached. Each step earns the next one.
 
 ## Step 1: Break the UI into a component hierarchy
 
@@ -106,7 +106,11 @@ function ProjectCard({ project }) {
 }
 ```
 
-Layouts and pages are [Server Components](/docs/app/glossary#server-component) by default. They run on the server and never run again in the browser. Since this version only renders JSX from local data, no [Client Component](/docs/app/glossary#client-component) is needed yet. Running `next build` [prerenders](/docs/app/glossary#prerendering) the route as static HTML:
+[Layouts](/docs/app/glossary#layout) and [pages](/docs/app/glossary#page) are [Server Components](/docs/app/glossary#server-component) by default. They run on the server and never run again in the browser.
+
+Since this version only renders JSX from local data, no [Client Component](/docs/app/glossary#client-component) is needed yet.
+
+Running `next build` [prerenders](/docs/app/glossary#prerendering) the route as static HTML:
 
 ```txt
 Route (app)
@@ -116,9 +120,13 @@ Route (app)
 ○  (Static)  prerendered as static content
 ```
 
-The `○` next to `/projects` is what to look for: every value the route needs is known at build time, so the HTML is produced once and reused on every request. This is the App Router version of "build a static version" from Thinking in React. The UI is visible before any decision about where the real data comes from.
+The `○` next to `/projects` is what to look for: every value the route needs is known at [build time](/docs/app/glossary#build-time), so the HTML is produced once and reused on every request.
 
-Notice that the deployed route paints in one shot, with nothing to wait for. The HTML comes back from a static prerender, since every value the components need is already in the file. This is the route's flat baseline.
+This is the [App Router](/docs/app/glossary#app-router) version of "build a static version" from Thinking in React. The UI is visible before any decision about where the real data comes from.
+
+Notice that the deployed route paints in one shot, with nothing to wait for. The HTML comes back from a static prerender, since every value the components need is already in the file.
+
+This is the route's flat baseline.
 
 Each demo throughout this guide embeds the deployed lab. The refresh button in the browser chrome replays the load.
 
@@ -131,7 +139,9 @@ Source: [`steps/02-static-jsx`](https://github.com/vercel-labs/thinking-in-nextj
 
 ## Step 3: Fetch data where it is used
 
-Now the mock array has to go. The data lives in a database (or behind an API), and the page needs a function to ask for it. Each read becomes a small async function (`getProjects()`, `getProject(id)`, `getDeployments(projectId)`), and the collection of those functions is the route's data layer.
+The static version got us through [Step 2: Build a static version with JSX](#step-2-build-a-static-version-with-jsx), but real apps don't ship with their data baked into the component file. The mock array has to go. The data lives in a database (or behind an API), and the page needs a function to ask for it.
+
+Each read becomes a small async function (`getProjects()`, `getProject(id)`, `getDeployments(projectId)`), and the collection of those functions is the route's data layer.
 
 Where in the tree should those reads happen?
 
@@ -147,7 +157,7 @@ async function ProjectGrid({ searchParams }) {
 }
 ```
 
-Each section stays independent, and unrelated reads run in parallel. Co-locating the read with the JSX that uses it is the same instinct as `useEffect` or a query library, except a [Server Component](/docs/app/glossary#server-component) can `await` the read directly, without the loading-state boilerplate.
+Each section stays independent, and unrelated reads run in parallel. Co-locating the read with the JSX that uses it is the same instinct as `useEffect` or a query library, except a Server Component can `await` the read directly, without the loading-state boilerplate.
 
 The reads themselves stay thin. Each one calls into a small `db` module that stands in for the real data source (a Postgres ORM, a remote API client, whatever the app uses):
 
@@ -160,11 +170,15 @@ async function getProjects({ query }) {
 
 Caching, formatting, and retries live around the wrapper, not inside.
 
-Search is the first place where a [Client Component](/docs/app/glossary#client-component) would feel natural, but it doesn't have to be. The first cut is a plain HTML form. Submitting it navigates to `/projects?q=...`, and `ProjectGrid` reads `?q=` from `searchParams` to render the right list. No `'use client'` yet.
+Search is the first place where a Client Component would feel natural, but it doesn't have to be.
+
+The first cut is a plain HTML form. Submitting it navigates to `/projects?q=...`, and `ProjectGrid` reads `?q=` from `searchParams` to render the right list.
+
+No `'use client'` yet.
 
 By now every region has a read attached to it. The route works, but every request runs every read, and the build no longer tries to prerender.
 
-Notice that the deployed route now waits on the slowest read before it paints. Nothing on the page shows until every section's data is ready, even the parts that don't depend on it.
+Refresh the demo and notice the route now waits on the slowest read before it paints. Nothing on the page shows until every section's data is ready, even the parts that don't depend on it.
 
 <Demo
   src="https://thinking-in-nextjs-03.labs.vercel.dev/projects"
@@ -199,7 +213,13 @@ With it on, the prerender expects every async read to either be cached or sit be
   height={779}
 />
 
-The overlay lists three ways out. One lets the route block as before, an escape hatch for cases where you knowingly want that. The other two are the design conversation the rest of this guide is about. Stream the read, or cache it. Streaming first, because it's the smaller commitment. A Suspense boundary only says "this part can paint later," not "this output is reusable." Reusability is the next question, and it lands more cleanly once every async read has its own place to be asked about. Wrap each async section in its own boundary so the [static shell](/docs/app/glossary#static-shell) (the parts that don't need to wait) ships first:
+The overlay lists three ways out. One lets the route block as before, an escape hatch for cases where you knowingly want that. The other two are the design conversation the rest of this guide is about.
+
+Stream the read, or cache it. [Streaming](/docs/app/glossary#streaming) first, because it's the smaller commitment.
+
+A Suspense boundary only says "this part can paint later," not "this output is reusable." Reusability is the next question, and it lands more cleanly once every async read has its own place to be asked about.
+
+Wrap each async section in its own boundary so the [static shell](/docs/app/glossary#static-shell) (the parts that don't need to wait) ships first:
 
 ```tsx
 function Sidebar() {
@@ -216,7 +236,9 @@ function Sidebar() {
 }
 ```
 
-`Sidebar` itself is synchronous now. The two async sections it contains each sit behind their own boundary, and each fallback is shaped like the section it stands in for. The same move repeats anywhere else in the route an async read shows up, with the boundary sitting at the smallest scope that needs it.
+`Sidebar` itself is synchronous now. The two async sections it contains each sit behind their own boundary, and each fallback is shaped like the section it stands in for.
+
+The same move repeats anywhere else in the route an async read shows up, with the boundary sitting at the smallest scope that needs it.
 
 A _fallback_ is the UI that ships with the shell. It gets replaced with the real output once the async component finishes. For this route:
 
@@ -225,11 +247,15 @@ A _fallback_ is the UI that ships with the shell. It gets replaced with the real
 - **1000 ms**: Pinned and grid resolve.
 - **1500 ms**: Recent deploys resolves last.
 
-The fallback's shape matters. A skeleton matching the streamed result's width, height, and row count keeps the shell stable. A wrong-sized fallback pushes the page around when the content arrives.
+The fallback's shape matters. A skeleton matching the streamed result's width, height, and row count keeps the shell stable.
+
+A wrong-sized fallback pushes the page around when the content arrives.
 
 A boundary does not have to wrap an entire region. It can wrap a single nested child while the rest of the surrounding layout already has its props: the outer tree paints from data the parent resolved, and only the inner subtree shows a fallback while something inside awaits.
 
-What about output that arrives bit by bit, like log lines on an in-progress build, LLM tokens, or paginated work? Suspense boundaries can nest. Each piece wraps the next in its own boundary so each one streams independently:
+What about output that arrives bit by bit, like log lines on an in-progress build, LLM tokens, or paginated work? Suspense boundaries can nest.
+
+Each piece wraps the next in its own boundary so each one streams independently:
 
 ```tsx
 function LiveLines({ lines, index }) {
@@ -247,7 +273,7 @@ function LiveLines({ lines, index }) {
 
 For feeds that arrive outside the request (a real build log streamed from the platform, telemetry, chat), the typical pattern is a Client Component that polls or subscribes.
 
-Notice that the projects route paints the shell immediately, then swaps in the sidebar and grid as each Suspense boundary resolves. A deployment that's still building shows the same primitive nested, with each log line streaming in on its own.
+Notice that the projects route paints the shell immediately, then swaps in the sidebar and grid as each Suspense boundary resolves. Click into a project, then into a still-building deployment, to see the same primitive nested with each log line streaming in on its own.
 
 <Demo
   src="https://thinking-in-nextjs-04.labs.vercel.dev/projects"
@@ -258,41 +284,27 @@ Source: [`steps/04-streaming`](https://github.com/vercel-labs/thinking-in-nextjs
 
 ## Step 5: Cache reusable work
 
-Streaming hides slow reads behind fallbacks, but most of those reads aren't actually different per visitor. The project list, project header, and deployments list don't change between viewers from one second to the next. The natural question:
+Streaming hides slow reads behind fallbacks, and that gets the page paint moving. What kept coming back, though, was that most of those reads aren't actually different per visitor. The project list, project header, and deployments list don't change between viewers from one second to the next.
+
+The natural question:
 
 > Would the next viewer see the same thing?
 
-If yes, the work doesn't need to run on every request. The result can be reused, and the section can join the [static shell](/docs/app/glossary#static-shell) instead of streaming behind a fallback.
+If yes, the work doesn't need to run on every request. The result can be reused, and the section can join the static shell instead of streaming behind a fallback.
 
 Walk down the tree once and answer the question for each piece:
 
-| UI piece                          | Same for every viewer? | Becomes            |
-| --------------------------------- | ---------------------- | ------------------ |
-| `ProjectGrid`, `ProjectHeader`    | Yes                    | `'use cache'`      |
-| `Deployments`, `DeploymentHeader` | Yes                    | `'use cache'`      |
-| `RecentDeploysSection`            | Yes                    | `'use cache'`      |
-| `BuildLogs`, completed build      | Yes                    | `'use cache'`      |
-| `BuildLogs`, in-progress build    | No, live               | uncached, streamed |
-| `ViewerAvatar`                    | No, per viewer         | per-viewer cache   |
-| `PinnedSection`                   | No, per viewer         | per-viewer cache   |
+| UI piece                          | Same for every viewer? | Becomes                         |
+| --------------------------------- | ---------------------- | ------------------------------- |
+| `ProjectGrid`, `ProjectHeader`    | Yes                    | `'use cache'`                   |
+| `Deployments`, `DeploymentHeader` | Yes                    | `'use cache'`                   |
+| `RecentDeploysSection`            | Yes                    | `'use cache'`                   |
+| `BuildLogs`, completed build      | Yes                    | `'use cache'`                   |
+| `BuildLogs`, in-progress build    | No, live               | uncached, streamed              |
+| `ViewerAvatar`                    | No, per viewer         | per-viewer cache                |
+| `PinnedSection`                   | No, per viewer         | `'use cache'` keyed by `userId` |
 
 A directive at the top of the function flips a read into the shared cache:
-
-```tsx
-async function getProjects({ query }) {
-  'use cache'
-  cacheLife('hours')
-  cacheTag('projects')
-
-  return db.project.findMany({ where: matches(query) })
-}
-```
-
-[`'use cache'`](/docs/app/api-reference/directives/use-cache) marks the function as cacheable. Different arguments (and any closed-over values) become different entries, so a search for `?q=foo` and `?q=bar` are stored separately. [`cacheLife`](/docs/app/api-reference/functions/cacheLife) sets how long an entry stays valid. [`cacheTag`](/docs/app/api-reference/functions/cacheTag) labels the entry so that other code can refer to it by name, usually from a Server Function that calls [`updateTag`](/docs/app/api-reference/functions/updateTag) after a write.
-
-There's a subtlety on this route. The directive on `getProjects` says the read is cached, but the page also awaits `searchParams` to pick the query, and `searchParams` only resolves at request time. So the static prerender can't bake the cards in. The cache still applies once the request lands: the entry for that exact `?q=` is reused across viewers, and the cards swap in as soon as the param resolves. That is **extract-and-pass** in the wild. The param isn't read inside `getProjects`; it arrives as `query`. A plain `'use cache'` function can't read [`cookies()`](/docs/app/api-reference/functions/cookies) or [`headers()`](/docs/app/api-reference/functions/headers) inside itself for the same reason; the pattern is to resolve those at the edge of the tree and pass what you need down. The cache key follows the arguments.
-
-What about a read keyed to one project? `cacheTag` accepts more than one tag, so a per-id read can carry both a broad label and an entry-specific one:
 
 ```tsx
 async function getProject(id) {
@@ -304,23 +316,72 @@ async function getProject(id) {
 }
 ```
 
-The per-id tag gives a single project entry its own handle, separate from the all-projects entry. A mutation can invalidate one project without touching the rest of the list.
+[`'use cache'`](/docs/app/api-reference/directives/use-cache) marks the function as cacheable. The arguments (and any closed-over values) form the cache key, so `getProject('compass')` and `getProject('feather')` are stored as separate entries.
 
-That leaves the per-viewer reads (avatar and pinned ids). Sharing those between viewers would leak one person's data to the next, so they aren't candidates for plain `'use cache'`. They want a different variant: [`'use cache: private'`](/docs/app/api-reference/directives/use-cache-private). Same directive shape, but the entry is scoped to the viewer and stored in the browser cache instead of being shared on the server. Inside it, `cookies()` and `headers()` are allowed. That's the whole point.
+[`cacheLife`](/docs/app/api-reference/functions/cacheLife) sets how long an entry stays valid.
+
+[`cacheTag`](/docs/app/api-reference/functions/cacheTag) labels the entry so other code can refer to it by name, usually from a Server Function that calls [`updateTag`](/docs/app/api-reference/functions/updateTag) after a write. `cacheTag` accepts more than one tag, so the per-id tag (`project-${id}`) gives a single project its own handle while the broader `projects` tag still covers the list. A mutation can invalidate one project without touching the rest.
+
+A list read works the same way, keyed by whatever inputs the call takes:
 
 ```tsx
-async function getPinnedIds() {
-  'use cache: private'
+async function getProjects({ query }) {
+  'use cache'
+  cacheLife('hours')
+  cacheTag('projects')
+
+  return db.project.findMany({ where: matches(query) })
+}
+```
+
+There's a subtlety on this route. The directive on `getProjects` says the read is cached, but the page also awaits `searchParams` to pick the query, and `searchParams` only resolves at request time. So the static prerender can't bake the cards in.
+
+The cache still applies once the request lands. The entry for that exact `?q=` is reused across viewers, and the cards swap in as soon as the param resolves.
+
+The param isn't read inside `getProjects`; it arrives as `query`. The cache key follows the arguments.
+
+A plain `'use cache'` function can't read [`cookies()`](/docs/app/api-reference/functions/cookies) or [`headers()`](/docs/app/api-reference/functions/headers) inside itself for the same reason. Resolve those at the edge of the tree and pass what you need down.
+
+That leaves the per-viewer reads, like the avatar and the pinned ids. Both want different output for each viewer, but the shape of the work is different.
+
+Take pinned ids first. They're a database read keyed on the user's id, so the cache key the read needs is the id itself. The same `'use cache'` primitive works, with `userId` taken as an argument so the per-viewer entry falls out of the cache key:
+
+```tsx
+async function getPinnedIds(userId) {
+  'use cache'
   cacheLife({ stale: 60 })
-  cacheTag('pinned')
+  cacheTag(`pinned-${userId}`)
 
   return db.pin.list({ userId })
 }
 ```
 
-The tag works the same way as the shared cache: a Server Function that mutates pins calls `updateTag('pinned')` and the next read on that viewer's device sees the new value. The cache is browser-scoped, so a single tag is enough. There's no risk of one viewer's invalidation reaching another.
+The store is shared. The argument is what makes the entry per-viewer. `getPinnedIds('aurora')` and `getPinnedIds('lee')` are stored as separate entries, the same way `getProject('compass')` and `getProject('feather')` are.
 
-There's a third variant ([`'use cache: remote'`](/docs/app/api-reference/directives/use-cache-remote)) for durable shared cache across server instances when the default in-memory store isn't enough. The hosting layer usually wires the handler. The [Cache Components](/docs/app/getting-started/caching) introduction compares all three; this guide uses plain `'use cache'` for project data and `'use cache: private'` for the viewer's avatar and pinned ids.
+But the lookup needs a `userId` to start with. That comes from the session cookie, and a plain `'use cache'` can't read [`cookies()`](/docs/app/api-reference/functions/cookies) inside itself. The viewer-identity read is the case where the cache scope IS the viewer, so it gets a different variant: [`'use cache: private'`](/docs/app/api-reference/directives/use-cache-private). Same directive shape, but the entry is scoped to the viewer and stored in the browser cache instead of being shared on the server. Inside it, `cookies()` and `headers()` are allowed. That's the whole point.
+
+```tsx
+async function getCurrentUser() {
+  'use cache: private'
+  cacheLife({ stale: 60 })
+
+  const session = (await cookies()).get('session')?.value
+  return session ? JSON.parse(session) : DEFAULT_USER
+}
+```
+
+The two reads compose. Read the viewer once, hand the id down:
+
+```tsx
+const user = await getCurrentUser()
+const pinnedIds = await getPinnedIds(user.id)
+```
+
+Both reads are per-viewer, but the mechanism is different. A plain `'use cache'` keyed on `userId` for the lookup that depends on it, and `'use cache: private'` for the cookie read where the viewer is the cache scope.
+
+There's a third variant ([`'use cache: remote'`](/docs/app/api-reference/directives/use-cache-remote)) for durable shared cache across server instances when the default in-memory store isn't enough. The hosting layer usually wires the handler.
+
+The [Cache Components](/docs/app/getting-started/caching) introduction compares all three. This guide uses plain `'use cache'` for project data and pinned ids, with `'use cache: private'` reserved for the viewer's identity behind the avatar.
 
 The tree now carries a decision per node:
 
@@ -330,7 +391,7 @@ ProjectsLayout
 ├── HeaderBar
 │   └── ViewerAvatar            use cache: private
 └── Sidebar
-    ├── PinnedSection           use cache: private
+    ├── PinnedSection           use cache (keyed by userId)
     └── RecentDeploysSection    use cache
 
 /projects
@@ -345,11 +406,21 @@ ProjectsLayout
 └── BuildLogs                   use cache when complete, live while building
 ```
 
-What does this do to the Suspense boundaries from Step 4? They start coming out. A cached read joins the static shell, and the wrapper around it doesn't have a job anymore. The boundaries around `RecentDeploys`, `ProjectHeader`, `Deployments`, and `BuildLogs` come out with it. What stays wrapped is what still resolves per request. The project grid reads `?q=` from the URL. The avatar and the pinned ids still suspend on first visit, because the per-viewer cache lives in the browser and a fresh device hasn't filled it yet. Inside `BuildLogs`, the live stream still has its boundary. That part is live by definition.
+What does this do to the Suspense boundaries from [Step 4: Stream async work](#step-4-stream-async-work)? Most come off.
 
-Could you have skipped Step 4 if you'd known the cache plan up front? Sure. But the question was sharper when each component had to answer it on its own.
+A cached read joins the static shell, and the wrapper around it doesn't have a job anymore. The boundaries around `RecentDeploys`, `ProjectHeader`, `Deployments`, and `BuildLogs` come out with it.
 
-Notice the new shape. The shared cached sections paint with no fallback because they're in the prerendered shell. The avatar and pinned section still flash once on a cold visit, then stay warm in the browser for the rest of the session. Navigating around the app reuses them without another round-trip. Reload the tab and they go cold again.
+What stays wrapped is what still resolves per request. The project grid reads `?q=` from the URL. The avatar and the pinned ids still suspend on first visit, because both lean on the session cookie and the static prerender doesn't have one to read.
+
+Inside `BuildLogs`, the live stream still has its boundary. That part is live by definition.
+
+Could you have skipped [Step 4: Stream async work](#step-4-stream-async-work) if you'd known the cache plan up front? Sure. But the question was sharper when each component had to answer it on its own.
+
+Notice the new shape. The shared cached sections paint with no fallback because they're in the prerendered shell.
+
+The avatar and pinned section still flash once on a cold visit, then stay warm for the rest of the session. Click into a project and into a deployment to see the cached sections land instantly with no fallback this time.
+
+Reload the tab and the per-viewer ones go cold again.
 
 <Demo
   src="https://thinking-in-nextjs-05.labs.vercel.dev/projects"
@@ -362,9 +433,15 @@ Source: [`steps/05-caching`](https://github.com/vercel-labs/thinking-in-nextjs/t
 
 Caching decides what output gets reused. Mutations decide when that output stops being true.
 
-In the App Router, mutations live in [Server Functions](/docs/app/glossary#server-function) marked with `'use server'`. Each one does two things in the same call. It changes the underlying state, then tells the cache the write happened.
+In the App Router, mutations live in [Server Functions](/docs/app/glossary#server-function) marked with `'use server'`. Each one does two things in the same call.
 
-Triggering a deploy is the cleanest version of that. The write hits the upstream, then tag calls invalidate every cached read that stopped being true. The project's deployments list is one. The sidebar's recent-deploys list is another. Each one carries its own tag, and the Server Function calls them by name:
+It changes the underlying state, then tells the cache the write happened.
+
+Triggering a deploy is the cleanest version of that. The write hits the upstream, then tag calls invalidate every cached read that stopped being true.
+
+The project's deployments list is one. The sidebar's recent-deploys list is another.
+
+Each one carries its own tag, and the Server Function calls them by name:
 
 ```tsx
 'use server'
@@ -378,7 +455,11 @@ async function triggerDeploy(projectId) {
 
 The tag names match the ones the cached reads applied earlier, so one Server Function call lines up with the cache entries it touched. Any route that reads through `deployments-${projectId}` or `recent-deployments` picks up the change.
 
-[`updateTag`](/docs/app/api-reference/functions/updateTag) and [`revalidateTag`](/docs/app/api-reference/functions/revalidateTag) differ in how they treat the response that contains the mutation. `updateTag` handles read-your-writes: the new value shows up in the same response that triggered it. `revalidateTag` handles stale-while-revalidate: the previous value keeps serving while the next read fetches a fresh one.
+[`updateTag`](/docs/app/api-reference/functions/updateTag) and [`revalidateTag`](/docs/app/api-reference/functions/revalidateTag) differ in how they treat the response that contains the mutation.
+
+`updateTag` handles read-your-writes: the new value shows up in the same response that triggered it.
+
+`revalidateTag` handles stale-while-revalidate: the previous value keeps serving while the next read fetches a fresh one.
 
 What does that look like wired up to a button? The smallest version is a `<form action>`, with no `'use client'` boundary in the path:
 
@@ -390,20 +471,23 @@ What does that look like wired up to a button? The smallest version is a `<form 
 
 This is the same request-response loop PHP and Rails apps ran on. The browser posts a form, the server runs a function, and the server re-renders the page. The difference is that React produces the response.
 
-Pinning has the same shape. `getPinnedIds` was tagged in the previous step with `cacheTag('pinned')`, so the pin actions invalidate the same tag:
+Pinning has the same shape. `getPinnedIds` was tagged in the previous step with ``cacheTag(`pinned-${userId}`)``, so the pin actions invalidate that viewer's tag:
 
 ```tsx
 'use server'
 
 async function addPin(projectId) {
+  const { id: userId } = await getCurrentUser()
   await db.pin.add({ userId, projectId })
-  updateTag('pinned')
+  updateTag(`pinned-${userId}`)
 }
 ```
 
-The mutation pattern is now uniform across the app: the write touches the underlying state, then `updateTag` calls out the cache entries that stopped being true. The shared cache and the per-viewer cache use the same call. The difference is only in where the entry lives.
+The mutation pattern is now uniform across the app. The write touches the underlying state, then `updateTag` calls out the cache entries that stopped being true.
 
-Notice that submitting the deploy form runs the Server Function and re-renders the route with the new deployments list. Pinning runs through the same path: `updateTag('pinned')` invalidates that viewer's cache entry, and the next render shows the new state.
+The same call works against either cache. A `'use cache: private'` entry responds to `updateTag` the same way the shared cache does. The only difference is where the entry lives.
+
+Notice that submitting the deploy form runs the Server Function and re-renders the route with the new deployments list. Pinning runs through the same path. ``updateTag(`pinned-${userId}`)`` invalidates that viewer's entry, and the next render shows the new state.
 
 <Demo
   src="https://thinking-in-nextjs-06.labs.vercel.dev/projects"
@@ -414,13 +498,19 @@ Source: [`steps/06-mutations`](https://github.com/vercel-labs/thinking-in-nextjs
 
 ## Step 7: Add client interactivity
 
-So far Server Components handle every read, Server Functions handle every write, and an HTML form is enough to get from input to mutation. What's a [Client Component](/docs/app/glossary#client-component) actually for?
+For most of the route so far, the work has lived on the server. Reads happen in Server Components, writes happen in Server Functions, and a plain HTML form has been enough to wire a button to a mutation. What kept surprising me as I built the route this way was how much of an app that already covers, and how late the moment shows up where the request-response loop runs out of room.
 
-The moments the request-response loop can't answer in time. Instant feedback before the server confirms. A pending state while a request is in flight. A URL update on every keystroke instead of one per submit. Inside a [`'use client'`](/docs/app/glossary#use-client-directive) boundary the full React API is back, including `onClick`, `useState`, hooks, and refs. Server Functions stay callable from any of them, so the form pattern from Step 6 is one option among many once a Client Component is in the picture.
+That moment is real, though. The pin button should flip the second it's clicked, before the server has acknowledged the write. The search input should update the URL on every keystroke instead of waiting for a submit. The deploy button should look pending while the Server Function is still working. None of those want to wait for a round trip, and that's where a Client Component earns its place.
 
-That's also why the boundary is open-ended. A Client Component can host anything React can host, from a chart library to drag-and-drop to your own keyboard handler. For a lot of routes you won't reach that far. The URL, a form, a Server Function, and a transition cover most of what an app needs, and the rest stays on the server where it belongs. The boundary is there when you want more.
+Inside a [`'use client'`](/docs/app/glossary#use-client-directive) boundary the full React API is back, including `onClick`, `useState`, hooks, and refs. Server Functions stay callable from any of it, so the form pattern from [Step 6: Mutate data](#step-6-mutate-data) becomes one option among many, and the boundary itself is open-ended enough to host anything React can host, from a chart library to drag-and-drop to your own keyboard handler.
 
-How wide does the boundary between server and client need to be? One prop, even before it resolves. `ProjectPin` was a server form in Step 6. Step 7 moves it into the client, takes the per-viewer promise as a prop, and calls [`use`](https://react.dev/reference/react/use) to resolve it on the other side, suspending at the nearest [Suspense boundary](/docs/app/glossary#suspense-boundary) above until the read lands. The same form action from Step 6 wraps the optimistic flip:
+In practice, a lot of routes never reach that far. The URL, a form, a Server Function, and a transition cover most of what an app needs, and the rest stays on the server where it belongs. The boundary is there for the moments that ask for more.
+
+So how wide does that boundary actually need to be? Often one prop, even before it resolves.
+
+`ProjectPin` was a server form in [Step 6](#step-6-mutate-data). In this step it crosses into the client, takes the per-viewer promise as a prop, and calls [`use`](https://react.dev/reference/react/use) to resolve it on the other side, suspending at the nearest Suspense boundary above until the read lands.
+
+The same form action from [Step 6](#step-6-mutate-data) wraps the optimistic flip:
 
 ```tsx
 'use client'
@@ -450,7 +540,11 @@ function ProjectPin({ projectId, pinnedIdsPromise }) {
 }
 ```
 
-[`useOptimistic`](https://react.dev/reference/react/useOptimistic) gives the button its temporary value to display while the Server Function is in flight; React reverts to the server-confirmed value once the response lands. The flip uses `wasPinned` so the Server Function always matches the state **before** the optimistic update. That way, two fast clicks don't accidentally cancel each other out. Nothing else is needed: the `updateTag('pinned')` call inside `addPin` / `removePin` invalidates the cached read, the framework re-renders the route with fresh data, and the optimistic state hands off to the real one.
+[`useOptimistic`](https://react.dev/reference/react/useOptimistic) gives the button its temporary value to display while the Server Function is in flight; React reverts to the server-confirmed value once the response lands.
+
+The flip uses `wasPinned` so the Server Function always matches the state **before** the optimistic update. That way, two fast clicks don't accidentally cancel each other out.
+
+Nothing else is needed: the `updateTag('pinned')` call inside `addPin` / `removePin` invalidates the cached read, the framework re-renders the route with fresh data, and the optimistic state hands off to the real one.
 
 The read still runs on the server. `ProjectGrid` calls `getPinnedIds` once, hands the same promise reference to every card, and each `ProjectPin` waits on it through `use()`:
 
@@ -470,7 +564,7 @@ async function ProjectGrid({ searchParams }) {
 }
 ```
 
-In `ProjectCard`, the icon, title, framework line, description, and status all come from the `project` object the grid already loaded. Only the pin needs `getPinnedIds`, so only that control sits behind [`<Suspense>`](/docs/app/glossary#suspense-boundary): the rest of the card is not blocked by the per-viewer read, and the fallback is a pin-shaped skeleton, not a skeleton for the whole card.
+In `ProjectCard`, the icon, title, framework line, description, and status all come from the `project` object the grid already loaded. Only the pin needs `getPinnedIds`, so only that control sits behind `<Suspense>`: the rest of the card is not blocked by the per-viewer read, and the fallback is a pin-shaped skeleton, not a skeleton for the whole card.
 
 ```tsx
 <header className="flex …">
@@ -481,9 +575,13 @@ In `ProjectCard`, the icon, title, framework line, description, and status all c
 </header>
 ```
 
-It might look like marking `ProjectPin` with `'use client'` would pull `ProjectGrid` into the client too. It doesn't. `'use client'` is a _boundary_, not a whole-tree switch. The `getPinnedIds` call runs on the server where the grid lives; only the promise crosses into the client, and `use()` reads it from there.
+It might look like marking `ProjectPin` with `'use client'` would pull `ProjectGrid` into the client too. It doesn't.
 
-Search shows up again here. The plain HTML form from Step 3 worked because a single submit was all the page needed. Per-keystroke updates need a `'use client'` boundary anyway, and once that's there the input can call `router.push` from `onChange` directly. The previous page stays visible while the new one resolves:
+`'use client'` is a _boundary_, not a whole-tree switch. The `getPinnedIds` call runs on the server where the grid lives; only the promise crosses into the client, and `use()` reads it from there.
+
+Search shows up again here. The plain HTML form from [Step 3: Fetch data where it is used](#step-3-fetch-data-where-it-is-used) worked because a single submit was all the page needed.
+
+Per-keystroke updates need a `'use client'` boundary anyway, and once that's there the input can call `router.push` from `onChange` directly. The previous page stays visible while the new one resolves:
 
 ```tsx
 'use client'
@@ -520,9 +618,13 @@ function SearchBar() {
 }
 ```
 
-App Router runs `router.push` inside a [transition](https://react.dev/reference/react/useTransition) by default. The input stays responsive and the previous page stays visible whether or not the call is wrapped. [`useTransition`](https://react.dev/reference/react/useTransition) adds `isPending`, a value the input can read to show a hint while the new render resolves. [`useLinkStatus`](/docs/app/api-reference/functions/use-link-status) gives the same signal for `<Link>` navigations.
+App Router runs `router.push` inside a [transition](https://react.dev/reference/react/useTransition) by default. The input stays responsive and the previous page stays visible whether or not the call is wrapped.
 
-Notice that the leaves react directly to input on the deployed route. Pinning flips before the server confirms, search edits the URL on each keystroke, and the deploy button stays in a pending state until the Server Function returns. Everything else around them stays a Server Component.
+[`useTransition`](https://react.dev/reference/react/useTransition) adds `isPending`, a value the input can read to show a hint while the new render resolves. [`useLinkStatus`](/docs/app/api-reference/functions/use-link-status) gives the same signal for `<Link>` navigations.
+
+Try the demo. Pinning flips before the server confirms, search edits the URL on each keystroke, and the deploy button stays in a pending state until the Server Function returns.
+
+Everything else around them stays a Server Component.
 
 <Demo
   src="https://thinking-in-nextjs-07.labs.vercel.dev/projects"
@@ -535,17 +637,27 @@ Source: [`steps/07-client-boundaries`](https://github.com/vercel-labs/thinking-i
 
 By now the tree knows what to render and what to reuse. The last question is timing. When can that work happen?
 
-It doesn't have to wait for the click. When a `<Link>` is visible on the page, the runtime takes that as a hint that a navigation is likely and renders the destination ahead of time, so the click lands on a tree that's already there.
+Not at click time. When a [`<Link>`](/docs/app/api-reference/components/link) enters the viewport, Next.js takes that as a hint and renders its destination in the background. By the time the click lands, the tree is already there.
 
-Every visible link gets the same treatment. What changes is the flavor of prefetch the destination route asks for. The default is **static**. It renders the destination against build-time inputs, useful for shared chrome but blind to anything that depends on the request. **Runtime** prefetch is opt-in. It's a real render with the same cookies, headers, and search string the navigation would send. That second flavor is what makes the per-viewer cache pay off across navigations. `getPinnedIds` was already cached in Step 5, but a static prefetch couldn't see the session, so it couldn't fill that entry. Runtime prefetch can.
+There's a wrinkle. The destination might depend on the viewer, and there's no real request at prefetch time. What session does that render see?
+
+The default is [**static**](/docs/app/guides/prefetching). The prefetch renders against build-time inputs, with no cookies, headers, or search string in scope. That's enough for the shared layout and any cached read that doesn't key on the viewer.
+
+[**Runtime**](/docs/app/api-reference/file-conventions/route-segment-config/prefetch) prefetch is opt-in. It renders with the same cookies, headers, and search string the navigation would send, so per-viewer reads see the real session before the click.
+
+That's what unlocks every cached read whose key depends on the request. Static prefetch already fills the request-independent slice (the shared layout, project data, anything keyed on build-time inputs). Runtime prefetch fills the rest.
+
+The per-viewer reads from [Step 5: Cache reusable work](#step-5-cache-reusable-work) are one case. `getCurrentUser` reads cookies, and `getPinnedIds(userId)` keys on the id it returns. The projects grid is another, keyed on `?q=`, a value a static prefetch can't see.
+
+Runtime prefetch handles them all in the same pass, so the full cache graph for the route lands warm before the click resolves.
 
 Opting into runtime prefetch is one segment-config line:
 
 ```tsx
-export const unstable_prefetch = 'force-runtime'
+export const prefetch = 'force-runtime'
 ```
 
-The companion job is **instant validation**, a check that every path into the route still exposes an instant shell. Shared chrome stays in the static part of the prerender, anything dynamic sits behind a Suspense boundary, and the navigation never tears the frame apart mid-transition.
+The companion job is [**instant validation**](/docs/app/guides/instant-navigation), a check that every path into the route still exposes an instant shell. The shared layout stays in the static part of the prerender, anything dynamic sits behind a Suspense boundary, and the navigation never tears the frame apart mid-transition.
 
 Validation is a development-time check you turn on once. A single line in `next.config.ts` puts every route in the loop:
 
@@ -561,11 +673,15 @@ const nextConfig: NextConfig = {
 export default nextConfig
 ```
 
-`'warning'` runs the validator as you click through the app and surfaces violations in the dev overlay, without blocking anything. It's the pragmatic on-ramp. Every route is in the loop, with no per-route opt-in to chase. The dev validator renders against the request you're already making, so cookies, headers, and search params come from real navigation rather than declared inputs.
+`'warning'` runs the validator as you click through the app and surfaces violations in the dev overlay, without blocking anything. It's the pragmatic on-ramp.
 
-Prefetch never widens what you cached. It only moves eligible work earlier. Clicks land reconciled when the cache lines up, back navigation picks up what the forward pass stashed, and underneath it's still the same server-rendered tree.
+Every route is in the loop, with no per-route opt-in to chase. The dev validator renders against the request you're already making, so cookies, headers, and search params come from real navigation rather than declared inputs.
 
-The project header and deployments already painted without a fallback in earlier steps. What's new is the projects list. Its grid reads `?q=` and used to stream behind a skeleton on every visit. Now the runtime prefetch warms it against the current session, so the cards land with the click. Avatar and pinned state ride along because that prefetch carries the same cookies the navigation will. From there those entries live on the device, so subsequent navigations resolve them from cache rather than the network and keep working offline or over a flaky connection. The live build log on an in-progress deployment is the one read that still streams.
+Try the demo. Click between projects, into deployments, and back. Everything lands instantly except the live build log on an in-progress deployment, which is live by definition.
+
+The shift the demo highlights is what lands warm. The projects grid keyed on `?q=`, the avatar, and the pinned section all used to stream on first visit. Now they land in the prefetched shell, because runtime prefetch fills the request-dependent reads in parallel during the prefetch pass.
+
+The avatar and pinned section also live on the device after the first prefetch. Subsequent navigations read them from cache and keep working offline or over a flaky connection.
 
 <Demo
   src="https://thinking-in-nextjs.labs.vercel.dev/projects"
@@ -592,7 +708,7 @@ For the parts this route didn't ask about, the docs cover those too.
 - [Authentication](/docs/app/guides/authentication) for knowing who's reading.
 - [Proxy](/docs/app/getting-started/proxy) for intercepting requests before they reach a page.
 - [Route Handlers](/docs/app/getting-started/route-handlers) for endpoints that return data instead of a page.
-- Parallel and intercepting routes for layouts that share a URL.
+- [Parallel](/docs/app/api-reference/file-conventions/parallel-routes) and [intercepting](/docs/app/api-reference/file-conventions/intercepting-routes) routes for layouts that share a URL.
 - [Internationalization](/docs/app/guides/internationalization) for apps that speak more than one language.
 
 ## Browse the source
@@ -606,7 +722,7 @@ Jump to a step on GitHub:
 - [`steps/02-static-jsx`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/02-static-jsx). Static JSX with mock data.
 - [`steps/03-fetch-data`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/03-fetch-data). Server Components reading from a data layer.
 - [`steps/04-streaming`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/04-streaming). Suspense around async sections.
-- [`steps/05-caching`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/05-caching). `'use cache'` and tags on shared reads; `'use cache: private'` for the per-viewer reads (avatar, pinned ids).
+- [`steps/05-caching`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/05-caching). `'use cache'` and tags on shared reads, including pinned ids keyed by `userId`; `'use cache: private'` reserved for the viewer's identity behind the avatar.
 - [`steps/06-mutations`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/06-mutations). Server Functions; `updateTag` for every cached read.
 - [`steps/07-client-boundaries`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/07-client-boundaries). Client leaves; optimistic `ProjectPin` reading the per-viewer promise with `use`; URL-driven `SearchBar` with `useTransition`.
-- [`steps/08-prefetching`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/08-prefetching). Runtime prefetch and instant validation; real session model.
+- [`steps/08-prefetching`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/08-prefetching). Runtime prefetch with the navigation's cookies and search; instant validation for the static shell.

--- a/docs/01-app/02-guides/thinking-in-nextjs.mdx
+++ b/docs/01-app/02-guides/thinking-in-nextjs.mdx
@@ -10,11 +10,9 @@ related:
     - app/guides/streaming
 ---
 
-{/* The demo URLs and source links in Steps 5-7 target the post-restructure lab naming (mutations / client-boundaries / caching). They will 404 until the labs are renamed to match. */}
+In React, you break a UI into components and let data flow through the tree. [Thinking in React](https://react.dev/learn/thinking-in-react) walks through that model in five steps, from naming the parts to layering state on top.
 
-In React, you break a UI into components and let data flow through the tree. [Thinking in React](https://react.dev/learn/thinking-in-react) walks through the model in five steps. Name the parts, render them from mock data, and layer state on top.
-
-In Next.js, the same tree carries a few more decisions. Where does the data come from? What can render ahead of the request, what waits for it, and what gets reused for the next visitor? The pieces are still components, some running on the server and some in the browser, and they compose like any other React tree. Each one runs where it belongs.
+In Next.js, the same tree carries a few more decisions. Where does the data come from? What can render before a request, what needs the request, and what gets reused for the next visitor? The pieces are still components, some running on the server and some in the browser, and they compose like any other React tree. Each one runs where it belongs.
 
 This guide builds one small app one decision at a time, the way you would in your own codebase.
 
@@ -51,9 +49,9 @@ The build happens one decision at a time:
 7. Cache reusable work.
 8. Optimize prefetching.
 
-The order isn't arbitrary. You can't plan caching before you know what data each region reads, and you can't plan [prefetching](/docs/app/glossary#prefetching) before you know what's cached. Each step earns the next.
+The order isn't arbitrary. Caching depends on knowing what data each region reads, and [prefetching](/docs/app/glossary#prefetching) depends on knowing what's cached. Each step earns the next.
 
-These steps split into two passes. The first pass builds the route, going from static JSX through server-side reads with Suspense around the async ones, then mutations, then a client boundary for what the request-response loop can't cover. The second pass optimizes how it loads, with caching for the work that repeats and runtime prefetch for what can move before the click.
+These steps split into two halves. The first half builds the route, going from static JSX through server-side reads with Suspense around the async ones, then mutations, then a client boundary for what the request-response loop can't cover. The second half optimizes how it loads, with caching for the work that repeats and runtime prefetch for what can move before the click.
 
 ## Step 1: Break the UI into a component hierarchy
 
@@ -126,13 +124,13 @@ Route (app)
 
 The `○` next to `/projects` is what to look for. Every value the route renders is known at [build time](/docs/app/glossary#build-time), so the HTML is produced once and reused on every request.
 
-This is the [App Router](/docs/app/glossary#app-router) version of "build a static version" from Thinking in React. The UI is visible before any decision about where the real data comes from.
+This is the [App Router](/docs/app/glossary#app-router) version of "build a static version" from Thinking in React. The UI is visible before you decide where the real data comes from.
 
 Try the demo. Each demo throughout this guide embeds the deployed lab, and the refresh button in the browser chrome replays the load. Notice the route paints in one shot, with nothing to wait for.
 
 <Demo
   src="https://thinking-in-nextjs-02-static-jsx.labs.vercel.dev/projects"
-  title="Step 2: Static JSX"
+  title="Step 2: Build a static version with JSX"
 />
 
 The HTML comes back from a static prerender, since every value the components need is already in the file. This is the route's flat baseline.
@@ -141,9 +139,11 @@ Source: [`steps/02-static-jsx`](https://github.com/vercel-labs/thinking-in-nextj
 
 ## Step 3: Fetch data where it is used
 
-The static version got you through [Step 2: Build a static version with JSX](#step-2-build-a-static-version-with-jsx), but real apps don't ship with their data baked into the component file. The mock array has to go. The data lives in a database (or behind an API), and each region needs a function to read what it shows.
+The static version got you through [Step 2: Build a static version with JSX](#step-2-build-a-static-version-with-jsx). Next, you move the data to a database (or behind an API): the mock array goes, and each region needs a function to read what it shows.
 
 Each region gets its own async read, and the collection of those reads is the route's [data access layer](/docs/app/guides/data-security#data-access-layer). On this app that's `getProjects()`, `getProject(id)`, and `getDeployments(projectId)`, with the same shape for the recent deployments, the build log, the current viewer, and the viewer's pinned ids.
+
+Every query opens with a single `await` of [`connection()`](/docs/app/api-reference/functions/connection) before the database, so live data stays off the build-time path from Step 2. The snippet below shows the shape; the API reference covers the rest.
 
 Where in the tree should those reads happen?
 
@@ -161,22 +161,30 @@ async function ProjectGrid({ searchParams }) {
 
 Co-locating the read with the JSX that uses it is the same instinct as `useEffect` or a query library, except a Server Component can `await` the read directly, with no client state to plumb through.
 
-Each read calls into a small `db` module that stands in for the real data source (a Postgres ORM, a remote API client, whatever the app uses). The reads here are thin, but the data access layer is also where API calls, retries, validation, and shaping live in a real app — kept out of the components that render the result:
+Each read calls into a small `db` module that stands in for the real data source (a Postgres ORM, a remote API client, whatever the app uses). The reads here are thin, but the data access layer is also where API calls, retries, validation, and shaping live in a real app, kept out of the components that render the result:
 
 ```tsx
 // data/queries/projects.ts
+import { connection } from 'next/server'
+
 async function getProjects({ query }) {
+  await connection()
+  await delay(1000)
   return db.project.findMany({ where: matches(query) })
 }
 ```
 
+The individual project and deployment reads keep the missing-row case in the same layer. If the row isn't found, the query calls [`notFound`](/docs/app/api-reference/functions/not-found), and Next.js renders the matching `not-found.tsx` for that route segment.
+
+The `delay()` call comes from `lib/utils.ts`. A real local database read resolves in milliseconds; these demos add a small artificial delay on every read so loading and pending states stay visible.
+
 That `query` argument has to come from somewhere. Search is the first place a Client Component would feel natural, but it doesn't have to be one. A plain HTML form pointing at `/projects?q=...` lets the browser do the navigation, and `ProjectGrid` reads `?q=` from `searchParams` to render the right list. No `'use client'` yet.
 
-Refresh the demo and notice the route waits on the slowest read before any of it paints. Nothing shows until every section's data is ready, even the parts that don't depend on it. Try the search too, and the grid filters via `?q=` in the URL with no `'use client'` involved.
+Refresh the demo and notice the route waits on the slowest read before any of it paints. Nothing shows until every section's data is ready, even the parts that don't depend on it. Try the search too, and the grid filters via `?q=` in the URL without crossing into a Client Component.
 
 <Demo
   src="https://thinking-in-nextjs-03-fetch-data.labs.vercel.dev/projects"
-  title="Step 3: Fetch data"
+  title="Step 3: Fetch data where it is used"
 />
 
 By now every region has a read attached to it. The route works, but the slowest read still holds up the paint, every request runs every read, and `next build` can no longer prerender the route.
@@ -185,9 +193,9 @@ Source: [`steps/03-fetch-data`](https://github.com/vercel-labs/thinking-in-nextj
 
 ## Step 4: Stream async work
 
-Why should the rest of the page wait for the slowest read? It shouldn't. React's [`<Suspense>`](https://react.dev/reference/react/Suspense) is how you say so. Render this part when it's ready, render the rest now.
+Why should the rest of the page wait for the slowest read? React's [`<Suspense>`](https://react.dev/reference/react/Suspense) lets you split the wait. Render this part when it's ready, render the rest now.
 
-[`cacheComponents`](/docs/app/glossary#cache-components) is the app-wide switch that makes the framework hold you to that:
+[`cacheComponents`](/docs/app/glossary#cache-components) is the app-wide switch that turns that expectation into a dev and build check:
 
 ```ts filename="next.config.ts"
 import type { NextConfig } from 'next'
@@ -199,51 +207,29 @@ const nextConfig: NextConfig = {
 export default nextConfig
 ```
 
-Cache Components is the refined version of the App Router. Making the cache-or-stream decision explicit at every async read catches the common mistakes (uncached fetches blocking the prerender, per-request work hidden inside what looks like static content, accidental coupling between routes that share a slow read), so routes built under it ship in better shape by default.
+Cache Components is the stricter version of the App Router. Every async read needs a choice: cache it, or put it behind a Suspense boundary. That catches uncached fetches that block the prerender, per-request work hidden inside static-looking content, and routes coupled to a slow read they could have streamed.
 
-With it on, the prerender expects every async read to either be cached or sit behind a [Suspense boundary](/docs/app/glossary#suspense-boundary). That split is what enables [Partial Prerendering](/docs/app/glossary#partial-prerendering-ppr) (PPR). The route's static parts ship as HTML on the first paint, and the dynamic parts stream in behind their boundaries when they resolve. The reader sees the layout immediately, instead of a blank page while the slow read finishes.
+With it on, the prerender expects every async read to either be cached or sit behind a [Suspense boundary](/docs/app/glossary#suspense-boundary). That split is what enables [Partial Prerendering](/docs/app/glossary#partial-prerendering-ppr) (PPR). The route's static parts ship as HTML on the first paint, and the dynamic parts stream in behind their boundaries when they resolve. You see the layout immediately, instead of a blank page while the slow read finishes.
+
+The data access layer from [Step 3: Fetch data where it is used](#step-3-fetch-data-where-it-is-used) mostly stays the same. The diff in this step is structural: wrap each async slice of UI in React's `<Suspense>`, give each boundary a skeleton [loading UI](/docs/app/glossary#loading-ui) that matches what will stream in, and let the queries keep living next to the JSX that calls them.
 
 Anything else, an async read with no cache and no boundary, surfaces in `next dev` and `next build` as [`Next.js encountered uncached data during the initial render`](https://nextjs.org/docs/messages/blocking-route), pointing at the call site:
 
-{/* TODO: Replace `instant-overlay-{light,dark}.png` with the new dev overlay screenshots once they ship. Update the alt text and the inline message quoted in the paragraph above to match the final overlay copy. */}
+{/* TODO: Replace `instant-overlay-{light,dark}.png` with the new dev overlay screenshots once they ship. The uncached-data overlay has three cards: "Prerender and cache", "Provide a placeholder with Suspense", and "Allow blocking route". */}
 
 <Image
-  alt="Next.js dev overlay reading 'Next.js encountered uncached data during the initial render.' A code preview highlights the uncached `await` inside a data-access function. Three fix cards follow. 'Cache dynamic data' shows `'use cache'` at the top of a data function. 'Move within Suspense' wraps the async child in `<Suspense fallback={…}>`. 'Allow blocking route' shows `export const instant = false`."
+  alt="Next.js dev overlay reading 'Next.js encountered uncached data during the initial render.' A code preview highlights the uncached `await` inside a data-access function. Three fix cards follow: 'Prerender and cache', 'Provide a placeholder with Suspense', and 'Allow blocking route'."
   srcLight="/docs/guides/thinking-in-nextjs/instant-overlay-light.png"
   srcDark="/docs/guides/thinking-in-nextjs/instant-overlay-dark.png"
   width={984}
   height={779}
 />
 
-The overlay lists three ways out. One lets the route block as before, an escape hatch for cases where you knowingly want that. The other two are [streaming](/docs/app/glossary#loading-ui) the read and caching it. Together they're the design conversation the rest of this guide is about. Streaming is the smaller commitment, so start there.
-
-The overlay only catches the initial render. Every navigation after that needs the same guarantee, and [instant validation](/docs/app/guides/instant-navigation) extends the check to all of them.
-
-Turn it on with one config line:
-
-```ts filename="next.config.ts"
-import type { NextConfig } from 'next'
-
-const nextConfig: NextConfig = {
-  instant: {
-    defaultValidationLevel: 'warning',
-  },
-}
-
-export default nextConfig
-```
-
-`'warning'` runs the validator as you click through the app and surfaces violations in the dev overlay without blocking. It uses the real cookies, headers, and search params from each request, so there's nothing extra to declare.
-
-`'error'` runs the validator at build time. The build fails if any reachable path doesn't expose an instant shell, the same shape as the Cache Components check that blocks uncached reads outside `<Suspense>`. Sample inputs are declared per route since the build can't issue real requests.
+The overlay lists three ways out. One [allows a blocking route](/docs/app/guides/error-overhaul#allow-blocking-route), an escape hatch for cases where you knowingly want that. The other two are [providing a `<Suspense>` placeholder](/docs/app/guides/error-overhaul#move-within-suspense) around the read and [caching the data access with `'use cache'`](/docs/app/guides/error-overhaul#cache-dynamic-data). Together they're the design conversation the rest of this guide is about.
 
 A Suspense boundary only says "this part can paint later," not "this output is reusable." Boundary-by-boundary streaming is the move for now.
 
-`params` and `searchParams` count the same way. They're per-request inputs, so awaiting them at the top of a page raises the same prerender error as an uncached fetch. Pass them down to a child behind a `<Suspense>` and let the `await` happen inside the boundary.
-
-[`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params) is another option for `params`-driven routes. Enumerate the ids at build time and the per-id reads can join the static shell. That fits when the id list is fixed and the data behind it is too. Neither holds here. Projects come and go, the per-id reads stream this step and cache later, so a Suspense boundary is the cleaner fit.
-
-Wrap each async section in its own boundary so the [static shell](/docs/app/glossary#static-shell) (the parts that don't need to wait) is sent immediately:
+Streaming is the smaller commitment, so let's pick it first. We can [provide a `<Suspense>` placeholder](/docs/app/guides/error-overhaul#move-within-suspense) around each async section so the [static shell](/docs/app/glossary#static-shell) (the parts that don't need to wait) is sent immediately:
 
 ```tsx
 function Sidebar() {
@@ -262,13 +248,33 @@ function Sidebar() {
 
 `Sidebar` itself is synchronous now. The two async sections it contains each sit behind their own boundary, and each fallback is shaped like the section it stands in for.
 
-The same move repeats anywhere else in the route an async read shows up. Where to draw the boundary is a design choice. Suspense catches any async work below it that doesn't have its own boundary, so a small boundary around each read lets sections stream independently, and a higher one groups several sections under a single fallback.
+The fallback is the [loading UI](/docs/app/glossary#loading-ui) that renders in the static shell while the async child is still resolving. It's replaced with the real output once the child finishes. The fallback's shape matters: a skeleton that matches the streamed result's width, height, and row count keeps the shell stable; a mismatched one pushes the page around when content arrives.
 
-A _fallback_ is the UI that renders in the static shell while the async child is still resolving. It's replaced with the real output once the child finishes. The fallback's shape matters. A skeleton that matches the streamed result's width, height, and row count keeps the shell stable; a mismatched one pushes the page around when content arrives.
+The overlay only catches the initial render. Every navigation after that needs the same guarantee, and [instant validation](/docs/app/guides/instant-navigation) extends the check across all of them. One config line in `next.config.ts` turns it on:
+
+```ts filename="next.config.ts"
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  instant: {
+    defaultValidationLevel: 'warning',
+  },
+}
+
+export default nextConfig
+```
+
+`'warning'` surfaces violations in the dev overlay as you click through the app. `'error'` fails the build when any reachable path doesn't expose an instant shell. Same idea as the Cache Components check, broadened to every navigation.
+
+Route inputs need the same boundary treatment. `params` and `searchParams` are per-request values, so awaiting them at the top of a page raises a prerender error. Pass them down to a child behind a `<Suspense>` and let the `await` happen inside the boundary.
+
+[`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params) is another option for `params`-driven routes. It [makes route params static](/docs/app/guides/error-overhaul#make-params-static): enumerate the ids at build time so the per-id reads can join the static shell. That fits when the id list is fixed and the data behind it is too. Neither holds here. Projects come and go, so a Suspense boundary is the cleaner fit.
+
+The same move repeats anywhere else in the route an async read shows up. Where to draw the boundary is a design choice. Suspense catches any async work below it that doesn't have its own boundary, so a small boundary around each read lets sections stream independently, and a higher one groups several sections under a single fallback.
 
 A boundary does not have to wrap an entire region. It can wrap a single nested child while the rest of the surrounding layout already has its props. The outer tree paints from data the parent resolved, and only the inner subtree shows a fallback while something inside awaits.
 
-Output that arrives in pieces (log lines on an in-progress build, LLM tokens, or paginated work) follows the same pattern. Suspense boundaries nest, with each piece wrapping the next in its own boundary so each one streams independently:
+Output that arrives in pieces (log lines on an in-progress build, large language model (LLM) tokens, or paginated work) follows the same pattern. The build log read splits in two for that reason. `getCompletedBuildLog` returns all the lines at once and renders the whole list, while `getInProgressBuildLog` feeds each line through a nested Suspense boundary so the page paints them as they arrive. Suspense boundaries nest, with each piece wrapping the next in its own boundary so each one streams independently:
 
 ```tsx
 function LiveLines({ lines, index }) {
@@ -284,9 +290,7 @@ function LiveLines({ lines, index }) {
 }
 ```
 
-For feeds that arrive outside the request (a real build log streamed from the platform, telemetry, chat), the typical pattern is a Client Component that polls or subscribes.
-
-Try the demo. Refresh `/projects` first and watch the shell paint immediately, with each section swapping in as its boundary resolves. Then click into a project and into a deployment — pick a still-building one to see the smaller pieces stream in too — and the same pattern repeats on the nested routes. On `/projects`:
+Try the demo. Refresh `/projects` first and watch the shell paint immediately, with each section swapping in as its boundary resolves. Then click into a project and into a deployment. Pick a still-building one to see the smaller pieces stream in too. The same pattern repeats on the nested routes. On `/projects`:
 
 - **0 ms**: Shell sent. The header and search form land immediately, with fallbacks rendered for the avatar, pinned section, recent deploys, and grid.
 - **500 ms**: Avatar resolves.
@@ -298,19 +302,21 @@ Try the demo. Refresh `/projects` first and watch the shell paint immediately, w
   title="Step 4: Stream async work"
 />
 
-Each section's fallback hides one slow read at a time, and the shell renders around it with the parts that don't have to wait. The reader sees the layout and the search bar on the first paint, with skeleton fallbacks where the slow reads are still resolving. The route still runs every read on every request; what changed is that no read blocks any other.
+Each section's fallback hides one slow read at a time, and the shell renders around it with the parts that don't have to wait. You see the layout and the search bar on the first paint, with skeleton fallbacks where the slow reads are still resolving. The route still runs every read on every request; what changed is that no read blocks any other.
 
 Source: [`steps/04-streaming`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/04-streaming).
 
 ## Step 5: Mutate data
 
-Reads cover the route. The other half is writes — on this app, the deploy button and the pin button.
+Reads cover the route. The other half is writes. On this app, that's the deploy button and the pin button.
 
-So far the work has lived in Server Components, and their output is what crosses to the browser. Writes go the other way, so a write needs a primitive that runs on the server but is callable from the client.
+In client-side React, the first reach might be an `onClick` handler. That would move this button into the browser before it needs to be there. Let's keep the first version smaller. An HTML form submits the intent, and the write still runs on the server.
 
-You'd usually reach for a [Route Handler](/docs/app/glossary#route-handler) or an API endpoint the client calls over HTTP. The App Router adopts [React Server Functions](/docs/app/glossary#server-function), marked with `'use server'`. The client calls them like a function, and they run on the server. The endpoint exists under the hood, with arguments and return values crossing a serialization boundary as a [Remote Procedure Call (RPC)](https://en.wikipedia.org/wiki/Remote_procedure_call). Plain data passes through; functions and class instances don't.
+You could write a [Route Handler](/docs/app/glossary#route-handler) or API endpoint and post to it over HTTP. A [React Server Function](/docs/app/glossary#server-function), marked with `'use server'`, keeps the write on this route without hand-rolling a separate HTTP handler. The function still runs on the server, and the endpoint still exists under the hood.
 
-A Server Function is an exposed endpoint, so anything it touches needs the same auth checks and input validation a public API would get. The labs skip that to keep the focus on the data flow. [How to Think About Security in Next.js](https://nextjs.org/blog/security-nextjs-server-components-actions) is the reference to read before shipping.
+The form is the smallest call site. Set the form's `action` to the Server Function, submit it, and the arguments and return values cross a serialization boundary as a [Remote Procedure Call (RPC)](https://en.wikipedia.org/wiki/Remote_procedure_call). Plain data passes through; functions and class instances don't.
+
+A Server Function is an exposed endpoint, so anything it touches needs the same auth checks and input validation a public API would get. This walkthrough skips that to keep the focus on the data flow. [How to Think About Security in Next.js](https://nextjs.org/blog/security-nextjs-server-components-actions) is the reference to read before shipping.
 
 So how do we get the new state to the page? We can call [`refresh`](/docs/app/api-reference/functions/refresh) from `next/cache` inside the Server Function, and Next.js re-runs the dynamic reads on the current route. The new deployment lands in the list and the recent-deploys section updates alongside it.
 
@@ -351,6 +357,8 @@ async function addPin(projectId) {
 
 The mutation pattern is uniform across the app. The write touches the underlying state, then `refresh()` re-renders the route so the dynamic reads pick up the new value.
 
+For this walkthrough, a **building** deployment flips to **ready** on a staggered server timer, not when the next read runs. The lab adds a little extra revalidation from the caching step onward so the demo keeps updating tidily—you can dig into the source later.
+
 Submit the deploy form, then pin and unpin a project. Watch the new deployment show up in the list and the pin state flip.
 
 <Demo
@@ -374,11 +382,9 @@ Inside a [`'use client'`](/docs/app/glossary#use-client-directive) boundary the 
 
 In practice, a lot of routes never reach that far. The URL, a form, a Server Function, and a [React transition](https://react.dev/reference/react/useTransition) (React's way of running an update in the background and coordinating its async work without blocking the UI) cover most CRUD apps. The App Router uses transitions by default for navigations and form actions, so most of this happens without an explicit hook. The rest stays on the server where it belongs, and the boundary is there for the moments where input lives in the client.
 
-Pending state has two options. Wrap `triggerDeploy` in a [`useTransition`](https://react.dev/reference/react/useTransition) and read the hook's `pending` value for the spinner. React's [`useFormStatus`](https://react.dev/reference/react-dom/hooks/useFormStatus) does the same from inside a `<form>`.
+The deploy button needs to show that the Server Function is still running. Let's use [`useTransition`](https://react.dev/reference/react/useTransition) here: `DeployButton` can wrap `triggerDeploy` and read the hook's pending value for the spinner. React's [`useFormStatus`](https://react.dev/reference/react-dom/hooks/useFormStatus) gives the same signal from inside a `<form>`.
 
-So how wide does that boundary actually need to be? Often one prop, even before it resolves.
-
-The pin button was a server form in [Step 5: Mutate data](#step-5-mutate-data). In this step it crosses into the client as `ProjectPin`, takes the per-viewer promise as a prop, and calls React's [`use`](https://react.dev/reference/react/use) to resolve it on the other side, suspending at the nearest Suspense boundary above until the read resolves.
+The pin button was a server form in [Step 5: Mutate data](#step-5-mutate-data). In this step it becomes the Client Component `ProjectPin`. The server still starts the per-viewer work, but it doesn't await it before rendering the card. It passes the promise as a prop, and `ProjectPin` calls React's [`use`](https://react.dev/reference/react/use) to resolve it in the browser. While that promise is unresolved, the nearest Suspense boundary above the pin renders its fallback.
 
 The same form action from [Step 5: Mutate data](#step-5-mutate-data) wraps the optimistic flip:
 
@@ -397,7 +403,7 @@ function ProjectPin({ projectId, pinnedIdsPromise }) {
     <form
       action={async () => {
         const wasPinned = optimistic
-        setOptimistic((p) => !p)
+        setOptimistic(!wasPinned)
         await (wasPinned ? removePin(projectId) : addPin(projectId))
       }}
     >
@@ -411,17 +417,17 @@ React's [`useOptimistic`](https://react.dev/reference/react/useOptimistic) gives
 
 The flip uses `wasPinned` so the Server Function always matches the state **before** the optimistic update. That way, two fast clicks don't accidentally cancel each other out.
 
-Nothing else is needed. The `refresh()` call inside `addPin` and `removePin` re-runs the dynamic reads, the framework re-renders the route with the fresh pinned ids, and the optimistic state is replaced by the real one.
+Nothing else is needed. The `refresh()` call inside `addPin` and `removePin` re-runs the dynamic reads, Next.js re-renders the route with the fresh pinned ids, and the optimistic state is replaced by the real one.
 
-The read still runs on the server. `ProjectGrid` resolves the current user, calls `getPinnedIds` once, hands the same promise reference to every card, and each `ProjectPin` waits on it through `use()`:
+The read still starts on the server. `ProjectGrid` loads the projects, creates one promise for the viewer's pinned ids, and hands the same promise reference to every card. Each `ProjectPin` waits on it through `use()`:
 
 ```tsx
 async function ProjectGrid({ searchParams }) {
   const { q } = await searchParams
   const projects = await getProjects({ query: q })
-  const user = await getCurrentUser()
-  const pinnedIdsPromise = getPinnedIds(user.id)
-
+  const pinnedIdsPromise = getCurrentUser().then((user) =>
+    getPinnedIds(user.id)
+  )
   return projects.map((project) => (
     <ProjectCard
       key={project.id}
@@ -432,7 +438,7 @@ async function ProjectGrid({ searchParams }) {
 }
 ```
 
-In `ProjectCard`, the icon, title, framework line, description, and status all come from the `project` object the grid already loaded. Only the pin needs `getPinnedIds`, so only that control sits behind `<Suspense>`. The rest of the card is not blocked by the per-viewer read, and the fallback is a pin-shaped skeleton, not a skeleton for the whole card.
+Only the pin needs the pinned-ids promise, so only that control sits behind `<Suspense>`. The rest of the card is not blocked by the per-viewer lookup, and the fallback is a pin-shaped skeleton, not a skeleton for the whole card.
 
 ```tsx
 <header className="flex …">
@@ -443,7 +449,7 @@ In `ProjectCard`, the icon, title, framework line, description, and status all c
 </header>
 ```
 
-`'use client'` marks a [boundary](/docs/app/glossary#use-client-directive). The marked component, and anything it imports, runs in the browser. Everything above it stays on the server. `getPinnedIds` runs on the server where the grid lives, the promise crosses into the client, and `use()` reads it from there.
+`'use client'` marks a [boundary](/docs/app/glossary#use-client-directive). The marked component, and anything it imports, runs in the browser. Everything above it stays on the server. The per-viewer read still runs on the server where the grid builds the promise; the promise crosses into the client, and `use()` reads it from there.
 
 Search shows up again here. The plain HTML form from [Step 3: Fetch data where it is used](#step-3-fetch-data-where-it-is-used) worked because a single submit was all the page needed.
 
@@ -484,20 +490,22 @@ function SearchBar() {
 }
 ```
 
+This is the client-side version of the `searchParams` read from [Step 3](#step-3-fetch-data-where-it-is-used). [`useSearchParams`](/docs/app/api-reference/functions/use-search-params) still reads a per-request input, so `SearchBar` sits behind a `<Suspense>` boundary in `HeaderBar`, with a skeleton sized to the input it stands in for.
+
 App Router runs `router.push` inside a transition by default. The input stays responsive and the previous page stays visible whether or not the call is wrapped.
 
 [`useTransition`](https://react.dev/reference/react/useTransition) adds `isPending`, a value the input can read to show a hint while the new render resolves. [`useLinkStatus`](/docs/app/api-reference/functions/use-link-status) gives the same signal for `<Link>` navigations.
 
-Try the demo. Pin and unpin a project, type in the search bar, and submit a deploy. Watch the pin flip before the server confirms, the URL update on each keystroke, and the deploy button stay in its pending state until the Server Function returns.
+Try the demo. Pin a project and the button flips immediately, while the sidebar's pinned section catches up a beat later, after the Server Function settles and the dynamic reads re-run. Type in the search bar to watch the URL update on each keystroke, and submit a deploy to see the button stay in its pending state until the Server Function returns.
 
 <Demo
   src="https://thinking-in-nextjs-06-client-boundaries.labs.vercel.dev/projects"
   title="Step 6: Add client interactivity"
 />
 
-Three Client leaves cover the moments that can't wait for a round trip. Everything else around them stays a Server Component. In practice, client boundaries open at the leaves where they earn a hook, and Server Components stay the default.
+Three Client leaves cover the moments that need input before a server round trip finishes. Everything else around them stays a Server Component. Client boundaries open at the leaves where they earn a hook, and Server Components stay the default.
 
-The route is already a complete app. Streaming SSR for reads, Server Functions for writes, and a few interactive leaves for input cover most of what apps need. The JavaScript you ship stays small because only those leaves cross into the client.
+The route is already a complete app. Streaming server-side rendering (SSR) for reads, Server Functions for writes, and a few interactive leaves for input cover most of what apps need. The JavaScript you ship stays small because only those leaves cross into the client.
 
 Source: [`steps/06-client-boundaries`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/06-client-boundaries).
 
@@ -507,7 +515,7 @@ The route works end-to-end now, but moving between routes still feels server-y. 
 
 Caching is the move that gets the rest of the way to the instant feel of a Single Page App (SPA), without giving up the server-component model. Data lives next to the read, there's no client cache to hand-maintain across viewers, and no API contract to keep in sync. The reads stay where the JSX uses them, and the server keeps doing the work.
 
-Walk the reads on the route. Most of them aren't actually different per visitor. The project list, project header, and deployments list don't change between viewers from one second to the next.
+Walk the reads on the route. Most of them read the same for every visitor. The project list, project header, and deployments list look the same for one viewer as the next.
 
 The natural question:
 
@@ -527,7 +535,7 @@ Walk down the tree once and answer the question for each piece:
 | `ViewerAvatar`                    | No, per viewer         | reused per viewer       |
 | `PinnedSection`                   | No, per viewer         | reused per viewer       |
 
-[`'use cache'`](/docs/app/glossary#use-cache-directive) is the directive that marks a function as cacheable. Add it at the top of a data function or a Server Component, and the result is reused across requests:
+[`'use cache'`](/docs/app/glossary#use-cache-directive) is the directive that [caches the data access](/docs/app/guides/error-overhaul#cache-dynamic-data). Add it at the top of a data function or a Server Component, and the result is reused across requests:
 
 ```tsx
 async function getProject(id) {
@@ -557,13 +565,13 @@ async function getProjects({ query }) {
 
 The other cached reads on the route follow the same shape, with a `cacheTag` named after what each one covers.
 
-Search is the case that doesn't fit the prerender. The `q` value lives in the URL: `/projects?q=react`. The page reads it from `searchParams` and passes it down as the `query` argument to `getProjects(query)`. The function is still keyable on `query`, but `searchParams` only resolves at request time, so the prerender doesn't know which `q` to bake in. The cards don't join the static shell. The search box paints with the rest of it, and the cards arrive once the request lands.
+Search is the case that doesn't fit the prerender. The `q` value lives in the URL as `/projects?q=react`. The page reads it from `searchParams` and passes it down as the `query` argument to `getProjects(query)`. The function is still keyable on `query`, but `searchParams` only resolves at request time, so the prerender doesn't know which `q` to bake in. The cards don't join the static shell. The search box paints with the rest of it, and the cards arrive once the request lands.
 
 Per-request inputs stay outside the cached function and arrive as arguments. The argument list is the cache key.
 
 The same rule covers [`cookies()`](/docs/app/api-reference/functions/cookies) and [`headers()`](/docs/app/api-reference/functions/headers). They're per-request inputs, and a plain `'use cache'` function can't read them inline. Lift them above the cached call and pass in what you need.
 
-That leaves the per-viewer reads, the avatar and the pinned ids. Both produce different output for each viewer, but they fit the rule differently.
+The avatar and the pinned ids both produce different output for each viewer, but they fit the rule differently.
 
 Pinned ids are a database read keyed on the user's id. The cookie read can be lifted out of the cached function and `userId` passed in as an argument:
 
@@ -577,11 +585,11 @@ async function getPinnedIds(userId) {
 }
 ```
 
-The store is shared. The argument is what makes the entry per-viewer. `getPinnedIds('aurora')` and `getPinnedIds('sam')` are stored as separate entries, the same way `getProject('compass')` and `getProject('feather')` are.
+The store is shared. The argument is what makes the entry per-viewer. Two different `userId` values become two entries, the same way `getProject('compass')` and `getProject('feather')` do.
 
 The current user is the limit case. The cookie _is_ the input. There's nothing further to lift out. A plain `'use cache'` can't read cookies inline, so this read needs a primitive that's explicitly viewer-scoped.
 
-[`'use cache: private'`](/docs/app/api-reference/directives/use-cache-private) keeps the same directive shape but scopes the entry to the viewer and stores it in the browser cache instead of sharing it on the server. Inside it, `cookies()` and `headers()` are allowed:
+[`'use cache: private'`](/docs/app/api-reference/directives/use-cache-private) keeps the same directive shape but caches per viewer: the entry lives in the browser cache instead of being shared on the server. Inside it, `cookies()` and `headers()` are allowed:
 
 ```tsx
 async function getCurrentUser() {
@@ -631,7 +639,7 @@ ProjectsLayout
 
 The Suspense rule sharpens with caching in place. A boundary is needed wherever the render touches a per-request input — cookies, `searchParams`, `params`, or live output. Those reads can be cached too, but the cache key isn't known until the request lands, so the boundary stays.
 
-Cached reads with no per-request input join the prerendered shell. On this route that's `RecentDeploysSection`, the only one whose read doesn't depend on the request. Its Suspense boundary from [Step 4: Stream async work](#step-4-stream-async-work) can be removed.
+Cached reads with no per-request input join the prerendered shell. On this route that's `RecentDeploysSection`, the only one whose read doesn't depend on the request. Its Suspense boundary and `RecentDeploysSkeleton` fallback from [Step 4: Stream async work](#step-4-stream-async-work) can both be removed: the section paints with the static shell, so there's nothing to stand in for.
 
 Adding the cache layer changes the picture for the mutations from [Step 5: Mutate data](#step-5-mutate-data). `refresh()` re-runs the dynamic reads on the route, but it doesn't move cached entries. After a deploy, the cached deployments list still serves the old value. After a pin, the cached `getPinnedIds` still returns the old set.
 
@@ -686,9 +694,7 @@ The mutation pattern is now uniform across the app. Each Server Function runs th
 
 The same `updateTag` call works against either cache. `updateTag` invalidates a `'use cache: private'` entry the same way it invalidates a shared entry. The only difference is where the entry is stored.
 
-You could have skipped [Step 4: Stream async work](#step-4-stream-async-work) if you'd known the cache plan up front. The question was sharper when you asked it of each component on its own.
-
-Click into a project and into a deployment, then back. Watch which sections paint instantly and which still show a fallback before resolving.
+Click into a project and into a deployment, then back. Watch which sections paint with the shell and which still show a fallback before resolving.
 
 <Demo
   src="https://thinking-in-nextjs-07-caching.labs.vercel.dev/projects"
@@ -697,7 +703,7 @@ Click into a project and into a deployment, then back. Watch which sections pain
 
 Only the recent-deploys list paints with the static shell. It's the one cached read with no per-request input, so it joined the prerender and lost its boundary.
 
-Everything else still flashes its fallback. The reads still resolve at request time, so the static shell ships with a skeleton in those slots, and the browser swaps to the real content as the request comes back. The cache is set up, but the visible paint hasn't changed.
+Everything else still paints a fallback first. The reads still resolve at request time, so the static shell ships with a skeleton in those slots, and the browser swaps to the real content as the request comes back. The cache is set up, but the visible paint hasn't changed.
 
 Source: [`steps/07-caching`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/07-caching).
 
@@ -707,19 +713,34 @@ The cache from [Step 7: Cache reusable work](#step-7-cache-reusable-work) is in 
 
 The validator from [Step 4: Stream async work](#step-4-stream-async-work) already keeps the shell instant at navigation. The data behind it is what's still missing.
 
-Prefetch is the timing answer. When a [`<Link>`](/docs/app/api-reference/components/link) enters the viewport, Next.js renders its destination in the background, so by the time the click lands the tree is already there.
+Prefetch is the timing answer. When a [`<Link>`](/docs/app/api-reference/components/link) enters the viewport, Next.js renders its destination in the background, so the tree is already there by the time the user clicks.
 
 The prefetch renders against one of two shapes, and the route declares which. The default is [**static**](/docs/app/guides/prefetching), with no cookies, headers, or search string in scope. That covers the shared layout and any cached read keyed on build-time inputs. [**Runtime**](/docs/app/api-reference/file-conventions/route-segment-config/prefetch) is opt-in, and it renders with the same cookies, headers, and search string the navigation would send, so per-viewer reads run against the real session before the click.
 
-We can opt a page into runtime prefetch with one segment-config line, so its prefetch runs against the same cookies, headers, and search string the navigation would carry:
+Without the same session cookies the click would send, personalized prefetch can target the wrong viewer. We add minimal session wiring in the companion source so the demo prefetches match the click; [Authentication](/docs/app/guides/authentication) is the production reference.
+
+We can opt a page into runtime prefetch with one segment-config export, so its prefetch runs against the same cookies, headers, and search string the navigation would send.
 
 ```tsx
 export const prefetch = 'force-runtime'
 ```
 
-Each page declares its own choice. Add the directive to every page whose reads depend on per-request inputs. The other pages on the route stay on static prefetch.
+Each page declares its own choice. We can add the export to every page whose reads depend on per-request inputs. On this app that's `/projects` (cookies for the avatar and pinned section, `?q=` for the grid), `/projects/[id]` (cookies and `params`), and `/projects/[id]/deployments/[deployId]` (cookies and `params`). The other pages on the route stay on static prefetch.
 
-Try the demo. The first paint still flashes skeletons in the per-request slots — no `<Link>` has been seen yet, so nothing has been prefetched. Then click between projects, into deployments, and back. Each link runs its prefetch as it enters the viewport, so the click lands on already-rendered output and the fallbacks are gone. The live build log on an in-progress deployment is the one exception, since it's live by definition. Once the build finishes, that log appears instantly too, served from the cached entry until its `cacheLife` runs out.
+Open the browser's network panel as `<Link>`s scroll into view, and the prefetch requests show up as their own rows:
+
+```txt
+Name                                          Status  Type   Size      Time
+projects/compass                              200     fetch  12.4 KB    84 ms
+projects/feather                              200     fetch  11.8 KB    79 ms
+projects/compass/deployments/compass-jx9q3    200     fetch  18.2 KB   112 ms
+projects/aurora                               200     fetch  12.1 KB    81 ms
+projects/aurora/deployments/aurora-7k8h1      200     fetch  17.6 KB   108 ms
+```
+
+Each row is a real per-request render of the destination, and the result populates the cache from [Step 7: Cache reusable work](#step-7-cache-reusable-work). Every page that opted in fires its prefetch as its `<Link>` enters the viewport, so the project list, the project detail, and the deployment page each render in the background ahead of the click.
+
+Click between projects fast and the fallback paints. Wait a beat before clicking, and the section is already prefetched and shows instantly. Open the devtools network panel to watch prefetch requests fire as links enter the viewport, then the navigation reads from cache.
 
 <Demo
   src="https://thinking-in-nextjs.labs.vercel.dev/projects"
@@ -727,6 +748,10 @@ Try the demo. The first paint still flashes skeletons in the per-request slots �
 />
 
 The shift the demo highlights is which sections are already populated by the time the user clicks. Every Suspense boundary on this route is there because the read inside it resolves at request time, keyed on cookies, `?q=`, or `params`. Static prefetch couldn't fill any of them. Runtime prefetch fills them all in the same pass, so the boundaries stay in the source but stop painting a fallback at navigation time.
+
+The live build log on an in-progress deployment is the one exception, since it's live by definition. Once the build finishes, that log appears instantly too, served from the cached entry until its `cacheLife` runs out.
+
+That completion still runs on the same staggered timer as in [Step 5: Mutate data](#step-5-mutate-data), not something a prefetch or navigation read triggers.
 
 Runtime prefetch isn't free. Each visible `<Link>` triggers a real per-request render in the background, more server work than static prefetch, which renders against build-time inputs only. The cache layer from [Step 7: Cache reusable work](#step-7-cache-reusable-work) absorbs most of the cost. Each prefetched render populates an entry, and subsequent prefetches and navigations within the cache lifetime read it instead of re-rendering. The trade-off is fine for typical apps but worth knowing about.
 
@@ -736,7 +761,7 @@ Source: [`steps/08-prefetching`](https://github.com/vercel-labs/thinking-in-next
 
 ## Where to go from here
 
-React's model is declarative. Components describe the output, and React renders them when the inputs change. The App Router extends that model past the browser. React Server Components, React Server Functions, `<Suspense>`, `'use cache'`, and prefetch are each a declarative way to tell the framework where the work runs, what it reads, what it caches, and when it ships. The component stays the unit of decision the whole way down.
+React's model is declarative. Components describe the output, and React renders them when the inputs change. The App Router extends that model past the browser, with the component as the unit of decision the whole way down.
 
 The server-component model carries the reads and the scaling. Caching and prefetching are how you got the SPA feel on top, without leaving that model behind.
 
@@ -766,9 +791,9 @@ A few App Router pieces didn't fit this route, but they show up in real apps:
 Jump to a step on GitHub:
 
 - [`steps/02-static-jsx`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/02-static-jsx). Static JSX with mock data.
-- [`steps/03-fetch-data`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/03-fetch-data). Server Components reading from a data access layer.
-- [`steps/04-streaming`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/04-streaming). Suspense around async sections.
+- [`steps/03-fetch-data`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/03-fetch-data). Server Components and a data access layer; `notFound()` for missing rows.
+- [`steps/04-streaming`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/04-streaming). Suspense boundaries and skeleton fallbacks around async UI; data queries mostly unchanged from [Step 3: Fetch data where it is used](#step-3-fetch-data-where-it-is-used).
 - [`steps/05-mutations`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/05-mutations). Server Functions; `refresh()` to re-run dynamic reads after a write.
 - [`steps/06-client-boundaries`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/06-client-boundaries). Client leaves; optimistic `ProjectPin` reading the per-viewer promise with `use`; URL-driven `SearchBar` with `useTransition`.
 - [`steps/07-caching`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/07-caching). `'use cache'` and tags on shared reads, including pinned ids keyed by `userId`; `'use cache: private'` reserved for the viewer's identity behind the avatar; `updateTag` to invalidate cached entries on a write.
-- [`steps/08-prefetching`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/08-prefetching). Runtime prefetch with the navigation's cookies and search; instant validation for the static shell.
+- [`steps/08-prefetching`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/08-prefetching). `prefetch = 'force-runtime'`; instant validation for the static shell; minimal session wiring in source for the demo.

--- a/docs/01-app/02-guides/thinking-in-nextjs.mdx
+++ b/docs/01-app/02-guides/thinking-in-nextjs.mdx
@@ -217,7 +217,31 @@ The overlay lists three ways out. One lets the route block as before, an escape 
 
 Stream the read, or cache it. [Streaming](/docs/app/glossary#streaming) first, because it's the smaller commitment. Caching shows up later in the guide.
 
+The overlay catches the initial render. Every navigation after that needs the same guarantee, and [instant validation](/docs/app/guides/instant-navigation) is the dev-time check that enforces it. Cache it, stream it, or let the route block.
+
+Turn it on with one config line:
+
+```ts filename="next.config.ts"
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  instant: {
+    defaultValidationLevel: 'warning',
+  },
+}
+
+export default nextConfig
+```
+
+`'warning'` runs the validator as you click through the app and surfaces violations in the dev overlay without blocking. It uses the real cookies, headers, and search params from each request, so there's nothing extra to declare.
+
+`'error'` runs the validator at build time. The build fails if any reachable path doesn't expose an instant shell, the same shape as the Cache Components check that blocks uncached reads outside `<Suspense>`. Sample inputs are declared per route since the build can't issue real requests.
+
 A Suspense boundary only says "this part can paint later," not "this output is reusable." Boundary-by-boundary streaming is the move for now.
+
+`params` and `searchParams` count the same way. They're per-request inputs, so awaiting them at the top of a page lands the same prerender error as an uncached fetch. Pass them down to a child behind a `<Suspense>` and let the `await` happen inside the boundary.
+
+[`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params) is another option for `params`-driven routes. Enumerate the ids at build time and the per-id reads can join the static shell. That fits when the id list is fixed and the data behind it is too. Neither holds here. Projects come and go, the per-id reads stream this step and cache later, so a Suspense boundary is the cleaner fit.
 
 Wrap each async section in its own boundary so the [static shell](/docs/app/glossary#static-shell) (the parts that don't need to wait) is sent immediately:
 
@@ -238,7 +262,7 @@ function Sidebar() {
 
 `Sidebar` itself is synchronous now. The two async sections it contains each sit behind their own boundary, and each fallback is shaped like the section it stands in for.
 
-The same move repeats anywhere else in the route an async read shows up, with the boundary placed at the smallest scope that wraps the read. On this route, that's `ProjectGrid` on the projects index, `ViewerAvatar` in the header, `ProjectHeader` and `Deployments` on the project page, and `DeploymentHeader` and `BuildLogs` on the deployment page.
+The same move repeats anywhere else in the route an async read shows up, with the boundary placed at the smallest scope that wraps the read.
 
 A _fallback_ is the UI that renders in the static shell while the async child is still resolving. It's replaced with the real output once the child finishes. For this route:
 
@@ -289,6 +313,8 @@ Reads cover the route. The other half is writes, and on this app that means the 
 In the App Router, mutations live in [Server Functions](/docs/app/glossary#server-function) marked with `'use server'`. The function runs on the server, hits the underlying state, and the route re-renders so the new output replaces the old.
 
 In practice, Server Functions are how you talk to the server without writing an API endpoint by hand. The endpoint exists under the hood, but the developer experience is Remote Procedure Call (RPC), with arguments and return values crossing a serialization boundary. Plain data passes through; functions and class instances don't.
+
+Crossing that boundary is where the security work starts. The labs skip those concerns to keep the focus on the Next.js story. Production code needs the full picture, and [How to Think About Security in Next.js](https://nextjs.org/blog/security-nextjs-server-components-actions) is the canonical reference.
 
 So how does the new state get to the page? Without a cache layer yet, the answer is [`refresh`](/docs/app/api-reference/functions/refresh) from `next/cache`. Called inside a Server Function, it re-runs the dynamic reads on the current route, so the new deployment lands in the list and the recent-deploys section updates alongside it.
 
@@ -346,7 +372,7 @@ Source: [`steps/05-mutations`](https://github.com/vercel-labs/thinking-in-nextjs
 
 The mutations from [Step 5: Mutate data](#step-5-mutate-data) all worked, and they were all visibly slow. Every click paid for itself with a full server round trip, the streaming fallbacks reappeared on each re-render, and the buttons sat without feedback while the Server Function ran.
 
-For most of the route so far, the work has lived on the server. Reads happen in Server Components, writes happen in Server Functions, and a plain HTML form has been enough to wire a button to a mutation. What kept surprising me as I built the route this way was how much of an app that already covers, and how late the moment shows up where the request-response loop runs out of room.
+For most of the route so far, the work has lived on the server. Reads happen in Server Components, writes happen in Server Functions, and a plain HTML form has been enough to wire a button to a mutation. That model covers a lot of an app, and the moment where the request-response loop runs out of room shows up late.
 
 The pin button should flip the second it's clicked, before the server has acknowledged the write. The search input should update the URL on every keystroke instead of waiting for a submit. The deploy button should look pending while the Server Function is still working. None of these can wait for a round trip, and that's where a Client Component earns its place.
 
@@ -428,7 +454,7 @@ In `ProjectCard`, the icon, title, framework line, description, and status all c
 
 It might look like marking `ProjectPin` with `'use client'` would pull `ProjectGrid` into the client too. It doesn't.
 
-`'use client'` marks a [boundary](/docs/app/glossary#boundary), not a switch for everything above it. The `getPinnedIds` call runs on the server where the grid lives; only the promise crosses into the client, and `use()` reads it from there.
+`'use client'` marks a [boundary](/docs/app/glossary#use-client-directive), not a switch for everything above it. The `getPinnedIds` call runs on the server where the grid lives; only the promise crosses into the client, and `use()` reads it from there.
 
 Even when the boundary needs to be wider than a leaf (a modal wrapping a form, an interactive chrome around a server-rendered list), the server work can stay on the server. A Client Component takes Server Components as `children`, a [composition pattern](/docs/app/getting-started/server-and-client-components#interleaving-server-and-client-components) sometimes called the donut, so server-only reads, secrets, and database access stay nested inside while the interactive shell sits at the boundary.
 
@@ -482,7 +508,7 @@ Try the demo. Pin and unpin a project, type in the search bar, and submit a depl
   title="Step 6: Add client interactivity"
 />
 
-Three small Client leaves (`ProjectPin`, `SearchBar`, and the deploy button) handle the moments where the request-response loop runs out of room. Everything else around them stays a Server Component. In practice, client boundaries open at the leaves where they earn a hook, and Server Components stay the default.
+Three Client leaves handle the moments where the request-response loop runs out of room. Everything else around them stays a Server Component. In practice, client boundaries open at the leaves where they earn a hook, and Server Components stay the default.
 
 The route is already a complete app. Streaming SSR for reads, Server Functions for writes, and a few interactive leaves for input cover most of what apps need. The JavaScript you ship stays small because only those leaves cross into the client.
 
@@ -494,7 +520,7 @@ The route works end-to-end now, but moving between routes still feels server-y. 
 
 Caching is the move that gets the rest of the way to the instant feel of a Single Page App (SPA), without giving up the server-component model. Data lives next to the read, there's no client cache to hand-maintain across viewers, and no API contract to keep in sync. The reads stay where the JSX uses them, the server keeps doing the work, but most of those reads don't have to run again for the next viewer.
 
-What kept coming back was that most of these reads aren't actually different per visitor. The project list, project header, and deployments list don't change between viewers from one second to the next.
+Most of these reads aren't actually different per visitor. The project list, project header, and deployments list don't change between viewers from one second to the next.
 
 The natural question:
 
@@ -542,19 +568,19 @@ async function getProjects({ query }) {
 }
 ```
 
-The other cached reads on the route follow the same shape, with a `cacheTag` named after what each one covers (`getDeployments`, `getDeployment`, `getRecentDeployments`, and `getCompletedBuildLog`).
+The other cached reads on the route follow the same shape, with a `cacheTag` named after what each one covers.
 
-There's a subtlety on this route. `getProjects` is cached, but the page also awaits `searchParams` to pick the query, and `searchParams` only resolves at request time. So the static prerender can't bake the cards in.
+The `?q=` case is interesting. `getProjects` is cached, but the page also awaits `searchParams` to pick the query, and `searchParams` only resolves at request time. So the static prerender can't bake the cards in. The search box paints with the rest of the static shell, and the cards arrive once the request resolves.
 
-The cache still applies once the request lands. The entry for that exact `?q=` is reused across viewers, and the cards swap in as soon as the param resolves.
+The cache still earns its place. `'use cache'` keys entries on the cached function's arguments, and `getProjects(query)` is the cached call. Two viewers searching `?q=react` hit the same entry.
 
-The param isn't read inside `getProjects`; it arrives as `query`. The cache key follows the arguments.
+That's the pattern. Per-request inputs stay outside the cached function and arrive as arguments. The argument list is the cache key.
 
-A plain `'use cache'` function can't read [`cookies()`](/docs/app/api-reference/functions/cookies) or [`headers()`](/docs/app/api-reference/functions/headers) inside itself for the same reason. Resolve those at the edge of the tree and pass what you need down.
+For the same reason, a plain `'use cache'` function can't call [`cookies()`](/docs/app/api-reference/functions/cookies) or [`headers()`](/docs/app/api-reference/functions/headers) from inside itself. Anything the cached function reads has to live in its argument list, and an inline `cookies()` call doesn't. Resolve those above the cached call and pass in what you need.
 
 That leaves the per-viewer reads, the avatar and the pinned ids. Both produce different output for each viewer, but they need different caching primitives.
 
-Take pinned ids first. They're a database read keyed on the user's id, so the cache key for the read is the id itself. The same `'use cache'` primitive works, with `userId` taken as an argument so the per-viewer entry falls out of the cache key:
+Pinned ids are a database read keyed on the user's id. With `userId` as the argument, `'use cache'` stores each viewer's entry separately:
 
 ```tsx
 async function getPinnedIds(userId) {
@@ -568,11 +594,9 @@ async function getPinnedIds(userId) {
 
 The store is shared. The argument is what makes the entry per-viewer. `getPinnedIds('aurora')` and `getPinnedIds('sam')` are stored as separate entries, the same way `getProject('compass')` and `getProject('feather')` are.
 
-But the lookup needs a `userId` to start with. That comes from the session cookie, and a plain `'use cache'` can't read [`cookies()`](/docs/app/api-reference/functions/cookies) inside itself.
+But the lookup needs a `userId` to start with. That comes from the session cookie, and a plain `'use cache'` can't read it inline by the rule above. The cookie read needs a different primitive, one that's explicitly viewer-scoped.
 
-For the viewer-identity read, the entry's scope is the viewer's session, so it uses a different variant. [`'use cache: private'`](/docs/app/api-reference/directives/use-cache-private) keeps the same directive shape, but the entry is scoped to the viewer and stored in the browser cache instead of being shared on the server.
-
-Inside it, `cookies()` and `headers()` are allowed. That's the whole point.
+[`'use cache: private'`](/docs/app/api-reference/directives/use-cache-private) keeps the same directive shape but scopes the entry to the viewer and stores it in the browser cache instead of sharing it on the server. Inside it, `cookies()` and `headers()` are allowed.
 
 This shape takes a beat to internalize. That's normal.
 
@@ -624,11 +648,13 @@ ProjectsLayout
 
 The Suspense rule sharpens with caching in place. A boundary is needed wherever the render touches runtime data. Anything else (a `'use cache'` read with no per-request inputs) joins the static shell, and the wrapper around it has nothing to defer. `RecentDeploys` is the cleanest example.
 
-What stays wrapped is what still resolves per request. The avatar and pinned section depend on cookies via `'use cache: private'`, `ProjectGrid` reads `?q=` from `searchParams`, and the per-viewer `ProjectPin` keeps its boundary inside each project card and project header. Inside `BuildLogs`, the live stream stays wrapped because it's live by definition.
+What stays wrapped is what still resolves per request. That covers cookies, `searchParams`, `params`, and any live output. Those reads are cached too, but the cache key isn't known until the request lands, so the boundary stays in the source.
+
+Cached reads that don't depend on a per-request input join the prerendered shell. On this route that's `getRecentDeployments`, the sidebar's recent-deploys list. Its Suspense boundary from [Step 4: Stream async work](#step-4-stream-async-work) can be removed.
 
 Adding the cache layer changes the picture for the mutations from [Step 5: Mutate data](#step-5-mutate-data). `refresh()` re-runs the dynamic reads on the route, but it doesn't move cached entries. After a deploy, the cached deployments list still serves the old value. After a pin, the cached `getPinnedIds` still returns the old set.
 
-[`updateTag`](/docs/app/api-reference/functions/updateTag) is the surgical answer for cached entries. From inside a Server Function, it invalidates a cached read by name, so the same write that touched the underlying state can call out the entries that stopped being true. The route re-renders with the fresh values, which is what `refresh()` was doing before. Calling both is the wrong shape, so the Server Function calls `updateTag` in place of `refresh()`.
+[`updateTag`](/docs/app/api-reference/functions/updateTag) is the surgical answer for cached entries. From inside a Server Function, it invalidates a cached read by name, so the same write that changed the underlying data names the entries that just went stale. The route re-renders with the fresh values, which is what `refresh()` was doing before. Calling both is the wrong shape, so the Server Function calls `updateTag` in place of `refresh()`.
 
 The deploy mutation from [Step 5](#step-5-mutate-data) was a write plus `refresh()`:
 
@@ -657,7 +683,7 @@ async function triggerDeploy(projectId) {
 }
 ```
 
-The tag names match the cached reads. `deployments-${projectId}` is the per-project tag from `getDeployments`, and `recent-deployments` is the tag the sidebar's recent-deploys list applied. One Server Function call lines up with the cache entries it touched, and the route re-renders against the fresh values.
+The tag names match the cached reads they invalidate. Each Server Function call lines up with the cache entries the write touched, and the route re-renders against the fresh values.
 
 `updateTag` and [`revalidateTag`](/docs/app/api-reference/functions/revalidateTag) differ in how they treat the response that contains the mutation. `updateTag` handles read-your-writes, so the new value shows up in the same response that triggered it. `revalidateTag` handles stale-while-revalidate, so the previous value keeps serving while the next read fetches a fresh one.
 
@@ -688,33 +714,21 @@ Click into a project and into a deployment, then back. Watch which sections pain
   title="Step 7: Cache reusable work"
 />
 
-The shared cached sections paint with no fallback because they're already in the prerendered shell. The avatar and pinned section still show their fallback on the first visit, then stay cached in the browser for the rest of the session. Reload the tab and the per-viewer reads run again from scratch.
+Only the recent-deploys list paints with the static shell. It's the one cached read that doesn't depend on a per-request input, so it joined the prerender and lost its boundary.
+
+Everything else still shows its fallback on first visit, because the cache key isn't known until the click resolves. The per-viewer reads cache in the browser after that, so they don't reappear within the session. The shared cached reads keyed on `params` or `searchParams` paint a fallback on every navigation. The cache speeds up the response, not the paint. Step 8 closes that gap.
 
 Source: [`steps/07-caching`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/07-caching).
 
 ## Step 8: Optimize prefetching
 
-By now you know what to render and what to reuse. The last question is timing. When can that work happen?
+The cached reads from [Step 7: Cache reusable work](#step-7-cache-reusable-work) key on `params`, cookies, or `searchParams`. Those keys don't exist at prefetch time without a real request behind them, so the boundaries still paint a fallback at click time even though the data is technically cached.
 
-Not at click time. When a [`<Link>`](/docs/app/api-reference/components/link) enters the viewport, Next.js uses that as a hint and renders its destination in the background. By the time the click lands, the tree is already there.
+The validator from [Step 4: Stream async work](#step-4-stream-async-work) already keeps the shell instant at navigation. The data behind it is what's still missing.
 
-There's a wrinkle. The destination might depend on the viewer, and there's no real request at prefetch time. The prefetch renders against one of two shapes, and the route declares which.
+Prefetch is the timing answer. When a [`<Link>`](/docs/app/api-reference/components/link) enters the viewport, Next.js renders its destination in the background, so by the time the click lands the tree is already there.
 
-The default is [**static**](/docs/app/guides/prefetching). The prefetch renders against build-time inputs, with no cookies, headers, or search string in scope. That's enough for the shared layout and any cached read that doesn't key on the viewer.
-
-[**Runtime**](/docs/app/api-reference/file-conventions/route-segment-config/prefetch) prefetch is opt-in. It renders with the same cookies, headers, and search string the navigation would send, so per-viewer reads run against the real session before the click.
-
-That's what unlocks every cached read whose key depends on the request. Static prefetch already fills the request-independent slice (the shared layout and any cached read keyed on build-time inputs). Runtime prefetch fills the rest.
-
-Most of [Step 7: Cache reusable work](#step-7-cache-reusable-work)'s cached reads sit on this side:
-
-- `getProject` and `getDeployments` key on `params`.
-- `getCurrentUser` reads cookies, and `getPinnedIds(userId)` keys on the id it returns.
-- The projects grid keys on `?q=` from `searchParams`.
-
-None of those keys exist at prefetch time without a real request behind them.
-
-Runtime prefetch handles them all in the same pass, so the full cache graph for the route is populated before the click resolves.
+The prefetch renders against one of two shapes, and the route declares which. The default is [**static**](/docs/app/guides/prefetching), with no cookies, headers, or search string in scope. That covers the shared layout and any cached read keyed on build-time inputs. [**Runtime**](/docs/app/api-reference/file-conventions/route-segment-config/prefetch) is opt-in, and it renders with the same cookies, headers, and search string the navigation would send, so per-viewer reads run against the real session before the click.
 
 Opting into runtime prefetch is one segment-config line:
 
@@ -722,27 +736,11 @@ Opting into runtime prefetch is one segment-config line:
 export const prefetch = 'force-runtime'
 ```
 
-On this route, every page with per-request reads carries the directive (the projects index, each project page, and each deployment page).
+Each page declares its own choice. Add the directive to every page whose reads depend on per-request inputs. The other pages on the route stay on static prefetch.
 
-The companion job is [**instant validation**](/docs/app/guides/instant-navigation), a check that every path into the route still exposes an instant shell. The shared layout stays in the static part of the prerender, and anything dynamic sits behind a Suspense boundary so the navigation can paint the shell before the runtime work resolves.
+Runtime prefetch isn't free. Each visible `<Link>` triggers a real per-request render in the background, more server work than static prefetch, which renders against build-time inputs only.
 
-Validation is a development-time check you turn on once. A single line in `next.config.ts` puts every route in the loop:
-
-```ts filename="next.config.ts"
-import type { NextConfig } from 'next'
-
-const nextConfig: NextConfig = {
-  instant: {
-    defaultValidationLevel: 'warning',
-  },
-}
-
-export default nextConfig
-```
-
-`'warning'` runs the validator as you click through the app and surfaces violations in the dev overlay, without blocking anything. It's the pragmatic on-ramp.
-
-Every route is in the loop, with no per-route opt-in to chase. The dev validator renders against the request you're already making, so cookies, headers, and search params come from real navigation rather than declared inputs.
+The cost amortizes against the cache layer from [Step 7](#step-7-cache-reusable-work). Each prefetched render populates an entry, and subsequent prefetches and navigations within the cache lifetime read it instead of re-rendering. The trade-off is fine for typical apps but worth knowing about.
 
 Try the demo. Click between projects, into deployments, and back. Everything lands instantly except the live build log on an in-progress deployment, which is live by definition.
 
@@ -751,7 +749,7 @@ Try the demo. Click between projects, into deployments, and back. Everything lan
   title="Step 8: Optimize prefetching"
 />
 
-The shift the demo highlights is which sections are already populated when the click resolves. Every Suspense boundary on this route is there because the read inside it resolves at request time, whether that's cookies (avatar, pinned section, the per-viewer `ProjectPin`), `?q=` (projects grid, search bar), or `params` (`DeploymentHeader` and `BuildLogs`). Static prefetch couldn't fill any of them. Runtime prefetch fills them all in the same pass, so the boundaries stay in the source but stop painting a fallback at navigation time.
+The shift the demo highlights is which sections are already populated when the click resolves. Every Suspense boundary on this route is there because the read inside it resolves at request time, keyed on cookies, `?q=`, or `params`. Static prefetch couldn't fill any of them. Runtime prefetch fills them all in the same pass, so the boundaries stay in the source but stop painting a fallback at navigation time.
 
 Whatever the prefetch pass touched, static or runtime, is cached in the browser and works offline. The only parts that need an active connection are the live-streamed sections, so flaky networks stop being a meaningful problem for most of the app.
 
@@ -759,9 +757,9 @@ Source: [`steps/08-prefetching`](https://github.com/vercel-labs/thinking-in-next
 
 ## Where to go from here
 
-Look back at the route. You didn't redesign it. You asked each component the same question. _What kind of work is this?_ A read here, a Suspense boundary there, a cache where the work repeats, a tag where it doesn't, a Client leaf where input lives. The route got more honest about what each piece was doing. One model carries the whole thing, and the decisions you made along the way are the ones that scale.
+Look back at the route. You didn't redesign it. You asked each component the same question. _What kind of work is this?_ The shape stayed the same. Each component picked up the primitive that matched its answer, and the route got more honest about what each piece was doing. One model carried the whole thing, and the decisions you made along the way are the ones that scale.
 
-The arc was short. Each step added a single primitive to the tree (a `<Suspense>` boundary, a Server Function, a Client leaf, a `'use cache'` directive, a runtime prefetch), and each one answered a question the previous step had made concrete.
+The arc was short. Each step added one primitive, and each one answered a question the previous step had made concrete.
 
 The server-component model carries the reads and the scaling. Caching and prefetching are how you got the SPA feel on top, without leaving that model behind.
 

--- a/docs/01-app/02-guides/thinking-in-nextjs.mdx
+++ b/docs/01-app/02-guides/thinking-in-nextjs.mdx
@@ -12,9 +12,9 @@ related:
 
 In React, you break a UI into components and let data flow through the tree. [Thinking in React](https://react.dev/learn/thinking-in-react) walks through that model in five steps, from naming the parts to layering state on top.
 
-In Next.js, the same tree carries a few more decisions. Where does the data come from? What can render before a request, what needs the request, and what gets reused for the next visitor? The pieces are still components, some running on the server and some in the browser, and they compose like any other React tree. Each component runs where that component belongs.
+In Next.js, the same tree carries a few more decisions. Where does the data come from? What can render before a request, what depends on the request, and what gets reused for the next visitor? The pieces are still components, some running on the server and some in the browser, and they compose like any other React tree. Each component runs where that component belongs.
 
-This guide builds one small app one decision at a time, the way you would in your own codebase.
+This tutorial builds one small app one decision at a time, the way you would in your own codebase.
 
 ## Start with the mockup
 
@@ -32,11 +32,11 @@ The designer hands over mockups for three routes.
 
 The data has three shapes:
 
-| Type         | Notes                                                                                                                                             |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Project`    | One per project. Status is `production`, `building`, `paused`, or `failed`.                                                                       |
-| `Deployment` | Newest first. Status is `ready`, `building`, `failed`, `queued`, or `cancelled`.                                                                  |
-| `LogLine`    | A timestamped line with a message and a level (`info`, `warn`, `error`, `success`, `dim`) for styling. The build log is an ordered list of these. |
+| Type         | Notes                                                                            |
+| ------------ | -------------------------------------------------------------------------------- |
+| `Project`    | One per project. Status is `production`, `building`, `paused`, or `failed`.      |
+| `Deployment` | Newest first. Status is `ready`, `building`, `failed`, `queued`, or `cancelled`. |
+| `LogLine`    | A timestamped line with a message. The build log is an ordered list of these.    |
 
 The build happens one decision at a time:
 
@@ -49,9 +49,7 @@ The build happens one decision at a time:
 7. Cache reusable work.
 8. Optimize prefetching.
 
-The order isn't arbitrary. Caching depends on knowing what data each region reads, and [prefetching](/docs/app/glossary#prefetching) depends on knowing what's cached. Each step earns the next.
-
-These steps split into two halves. The first half builds the route, going from static JSX through server-side reads with Suspense around the async ones, then mutations, then a client boundary for what the request-response loop can't cover. The second half optimizes how the route loads, with caching for the work that repeats and runtime prefetch for what can move before the click.
+Caching depends on knowing what data each region reads, and [prefetching](/docs/app/glossary#prefetching) depends on knowing what's cached. Each step earns the next.
 
 ## Step 1: Break the UI into a component hierarchy
 
@@ -80,13 +78,13 @@ app/projects/
 │       └── page.tsx                    ← DeploymentDetailPage
 ```
 
-Two file conventions split the work. [`layout.tsx`](/docs/app/api-reference/file-conventions/layout) wraps every URL under `/projects` and holds the chrome that survives navigation: the top bar, the sidebar, the layout grid. [`page.tsx`](/docs/app/api-reference/file-conventions/page) owns the main column for one URL, and the layout renders it as `{children}`. The decision the convention asks of you is: what should stay mounted across the route, and what should swap with the URL?
+Two file conventions split the work. [`layout.tsx`](/docs/app/api-reference/file-conventions/layout) wraps every URL under `/projects` and holds the chrome that survives navigation — the top bar, the sidebar, and the layout grid. [`page.tsx`](/docs/app/api-reference/file-conventions/page) owns the main column for one URL, and the layout renders it as `{children}`. On each layout/page pair, the choice is what stays mounted across the route and what swaps with the URL.
 
-You haven't decided yet how the data arrives, what's reused, or where each component runs. Naming and grouping is enough for now.
+We haven't decided where the data comes from yet. Let's get the page on the screen first.
 
 ## Step 2: Build a static version with JSX
 
-With the regions named, where their values come from can wait. Render them as JSX from inline mock data, with values that already sit in the component file:
+Render each region as JSX from inline mock data — values that already sit in the component file:
 
 ```tsx
 const projects = [
@@ -117,7 +115,7 @@ function ProjectCard({ project }) {
 
 Since this version only renders JSX from local data, no Client Component is needed yet.
 
-Running `next build` [prerenders](/docs/app/glossary#prerendering) the route as static HTML:
+Run `next build`. Every value is known up front, so the route [prerenders](/docs/app/glossary#prerendering) as static HTML:
 
 ```txt
 Route (app)
@@ -127,38 +125,28 @@ Route (app)
 ○  (Static)  prerendered as static content
 ```
 
-The `○` next to `/projects` is what to look for. Every value the route renders is known at [build time](/docs/app/glossary#build-time), so the HTML is produced once and reused on every request.
+The `○` next to `/projects` is what to look for. The HTML is produced once at [build time](/docs/app/glossary#build-time) and reused on every request.
 
-This is the [App Router](/docs/app/glossary#app-router) version of "build a static version" from Thinking in React. The UI is visible before you decide where the real data comes from.
-
-Try the demo. Each demo throughout this guide embeds the deployed tutorial, and the refresh button in the browser chrome replays the load. Notice the route paints in one shot, with nothing to wait for.
+Try the demo. Each demo throughout this tutorial embeds the deployed app for that step, and the refresh button in the browser chrome replays the load. Notice the route paints in one shot — there's nothing to wait for.
 
 <Demo
   src="https://thinking-in-nextjs-02-static-jsx.labs.vercel.dev/projects"
   title="Step 2: Build a static version with JSX"
 />
 
-The HTML comes back from a static prerender, since every value the components need is already in the file. This is the route's flat baseline.
+This is the route's flat baseline. Now let's swap the inline arrays for real data.
 
 Source: [`steps/02-static-jsx`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/02-static-jsx).
 
 ## Step 3: Fetch data where it is used
 
-Real apps don't ship with data baked into the component file. The mock arrays from [Step 2: Build a static version with JSX](#step-2-build-a-static-version-with-jsx) come out and a real read takes their place. The regions stay the same; what changes is where each one gets its values.
+The mock arrays come out, real reads go in. Where in the tree should those reads happen?
 
-The tutorial sets that up in three layers:
+Each region needs a function to read what it shows. The collection of those reads is the route's [data access layer](/docs/app/guides/data-security#data-access-layer): `getProjects()`, `getProject(id)`, `getDeployments(projectId)`, and the same shape for the build log, the current viewer, and pinned ids. The schema and seed live under [`lib/db`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/03-fetch-data/lib/db); the queries themselves live under [`data/queries/`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/03-fetch-data/data/queries), one file per concern.
 
-1. **Database.** Schema and client under [`lib/db`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/03-fetch-data/lib/db), plus seed data, so there are real rows to query. The tutorial picks one stack; the same shape works with any DB module.
-2. **Query modules.** One file per concern under [`data/queries/`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/03-fetch-data/data/queries) — projects, deployments, auth, pins, build logs. Together they form the route's [data access layer](/docs/app/guides/data-security#data-access-layer). The functions you'll see are `getProjects()`, `getProject(id)`, `getDeployments(projectId)`, and the same shape for the build log, the current viewer, and pinned ids.
-3. **Server Components.** Each region imports the query for that region and `await`s it next to the JSX that paints the result.
+The page could fetch everything at the top and pass values down with a `Promise.all`. That works, but it couples independent sections — the deployments list waits on the same parent as the sidebar, and the parent has to know what every region reads.
 
-Each query opens with a single `await connection()` from [`next/server`](/docs/app/api-reference/functions/connection) before running the underlying read. That keeps live data off the build-time path from Step 2.
-
-Where in the tree should those reads happen?
-
-The page could fetch everything at the top and pass values down with a `Promise.all`. That works, but it couples independent sections. The deployments list waits on the same parent as the sidebar, and the parent has to know what every region reads.
-
-Each component owning its own read works better. The `/projects` page demonstrates the pattern for the project list: an async Server Component reads `searchParams`, passes the search string into `getProjects`, and renders one row per project. No props-from-parent fetch orchestration, only a local `await` next to the JSX that uses the result.
+The other option is for each component to read what it needs, right next to the JSX that uses it:
 
 ```tsx
 async function ProjectGrid({ searchParams }) {
@@ -170,69 +158,49 @@ async function ProjectGrid({ searchParams }) {
 
 Co-locating the read with the JSX that uses it is the same instinct as `useEffect` or a query library, except a Server Component can `await` the read directly, with no client state to plumb through.
 
-Then implement the function the component imports. In [`data/queries/projects.ts`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/03-fetch-data/data/queries/projects.ts), `getProjects` calls `connection()`, optionally applies a small demo `delay` so slow sections stay visible in the recordings, and returns rows from the database. Other regions follow the same layout in their own `data/queries/*` files.
+Each query function calls into a small `db` module — the real data source for this tutorial. Swap it for whatever your app uses: a Postgres ORM, a remote API client, anything that returns data. The data access layer is also where retries, validation, and shaping live, kept out of the components that render the result:
 
 ```tsx
 // data/queries/projects.ts
-import { connection } from 'next/server'
+import { cache } from 'react'
 
-async function getProjects({ query }) {
-  await connection()
+export const getProjects = cache(async ({ query }) => {
   await delay(1000)
   return db.project.findMany({ where: matches(query) })
-}
+})
 ```
 
-Missing rows stay in the same layer. Project and deployment queries call [`notFound`](/docs/app/api-reference/functions/not-found) when a `findFirst` (or equivalent) returns nothing, and Next.js renders the matching `not-found.tsx` next to that segment instead of you branching on `null` in every parent.
+React's [`cache`](https://react.dev/reference/react/cache) dedupes the read across one render. Two components calling `getProjects({ query: q })` share a single database round trip, so co-location costs nothing extra. If a row isn't found, the query calls [`notFound`](/docs/app/api-reference/functions/not-found) and the matching `not-found.tsx` next to that segment renders in its place. The [`delay()`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/03-fetch-data/lib/utils.ts) is a fixture that keeps loading and pending states visible in the recording — a real local read resolves in milliseconds.
 
-A normal database round trip is fast. The [`delay()`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/03-fetch-data/lib/utils.ts) helper adds a small artificial delay on these reads so loading and pending states stay obvious in the demos.
+Search stays on the server too, no Client Component needed. A plain HTML form posts to `/projects?q=...`, the browser navigates, and `ProjectGrid` reads `?q=` from [`searchParams`](/docs/app/api-reference/file-conventions/page#searchparams-optional) to render the filtered list.
 
-The `query` argument has to come from somewhere. Search is the first place a Client Component would feel natural, but search doesn't need one. A plain HTML form pointing at `/projects?q=...` lets the browser do the navigation, and the page reads `?q=` from `searchParams` and passes it into `getProjects`. No `'use client'` yet.
-
-Refresh the demo. Watch how the route only paints once every section's data is ready, and try the search to see the grid filter via `?q=` in the URL without crossing into a Client Component.
+Refresh the demo. Notice the route waits on the slowest read before any of it paints, even the parts that don't depend on it. Try the search bar, and the grid filters via `?q=` in the URL without crossing into a Client Component.
 
 <Demo
   src="https://thinking-in-nextjs-03-fetch-data.labs.vercel.dev/projects"
   title="Step 3: Fetch data where it is used"
 />
 
-Every region has a read attached to it now. The route works, but the slowest read still holds up the paint, every request runs every read, and `next build` can no longer prerender the route.
+`next build` no longer prerenders the route. The `ƒ` marker shows it's gone dynamic now that every render runs server-side reads:
+
+```txt
+Route (app)
+┌ ○ /
+└ ƒ /projects
+
+○  (Static)   prerendered as static content
+ƒ  (Dynamic)  server-rendered on demand
+```
+
+Every region has a read attached. The slowest read holds up the paint. Let's break that next.
 
 Source: [`steps/03-fetch-data`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/03-fetch-data).
 
 ## Step 4: Stream async work
 
-Why should the rest of the page wait for the slowest read? It shouldn't. React's [`<Suspense>`](https://react.dev/reference/react/Suspense) draws the line: ship the surrounding tree right away, swap in deferred children when their data resolves.
+Why should the rest of the page wait for the slowest read? It shouldn't. React's [`<Suspense>`](https://react.dev/reference/react/Suspense) lets you split the wait — render this part when it's ready, render the rest now.
 
-[`cacheComponents`](/docs/app/glossary#cache-components) is the app-wide switch:
-
-```ts filename="next.config.ts"
-import type { NextConfig } from 'next'
-
-const nextConfig: NextConfig = {
-  cacheComponents: true,
-}
-
-export default nextConfig
-```
-
-With `cacheComponents` enabled, every async read must either be cached (for example with [`'use cache'`](/docs/app/glossary#use-cache-directive)) or sit behind a [Suspense boundary](/docs/app/glossary#suspense-boundary). `next dev` and `next build` enforce that split. The cacheable tree gets [prerendered](/docs/app/glossary#prerendering) into a [static shell](/docs/app/glossary#static-shell) you can reuse, and only the Suspense-deferred slices run at request time and [stream](/docs/app/glossary#streaming) when ready. That mix is [Partial Prerendering](/docs/app/glossary#partial-prerendering-ppr) (PPR). The same rule surfaces mistakes early: uncached reads blocking the shell, request-only data hiding in static-looking trees, or one slow read stalling the rest of the route.
-
-The queries from [Step 3: Fetch data where it is used](#step-3-fetch-data-where-it-is-used) stay put. This step adds `<Suspense>` around the async UI and pairs each boundary with a [loading UI](/docs/app/glossary#loading-ui) that matches the streamed content.
-
-Break the rule with an async read that has neither a cache nor a boundary, and `next dev` reports [`Next.js encountered uncached data during the initial render`](https://nextjs.org/docs/messages/blocking-route). The overlay highlights the call site and offers the same three moves this guide uses: [allow a blocking route](/docs/app/guides/error-overhaul#allow-blocking-route) when you mean it, [move the read behind Suspense](/docs/app/guides/error-overhaul#move-within-suspense), or [cache it with `'use cache'`](/docs/app/guides/error-overhaul#cache-dynamic-data).
-
-{/* TODO: Replace `instant-overlay-{light,dark}.png` with the new dev overlay screenshots once they ship. The uncached-data overlay has three cards: "Prerender and cache", "Provide a placeholder with Suspense", and "Allow blocking route". */}
-
-<Image
-  alt="Next.js dev overlay reading 'Next.js encountered uncached data during the initial render.' A code preview highlights the uncached `await` inside a data-access function. Three fix cards follow. One is labeled 'Prerender and cache', one is labeled 'Provide a placeholder with Suspense', and one is labeled 'Allow blocking route'."
-  srcLight="/docs/guides/thinking-in-nextjs/instant-overlay-light.png"
-  srcDark="/docs/guides/thinking-in-nextjs/instant-overlay-dark.png"
-  width={984}
-  height={779}
-/>
-
-Suspense defers paint; Suspense doesn't mark output as reusable. Wrap each slow section in its own boundary so the shell can paint around it. In the sidebar, the pinned section and the recent deploys each get their own:
+Wrap each async section behind its own boundary. In the sidebar, the pinned section and the recent deploys each get one:
 
 ```tsx
 function Sidebar() {
@@ -249,47 +217,9 @@ function Sidebar() {
 }
 ```
 
-The wrapper is synchronous now. Each async child has its own boundary and a fallback shaped like the section it stands in for. That fallback is the loading UI: the skeleton occupies the slot in the shell until the real markup replaces it, so a layout that matches width, height, and row count stays steady.
+`Sidebar` itself is synchronous now. Each async child has its own boundary, and the fallback occupies the slot until the real markup replaces it. That fallback is the [loading UI](/docs/app/glossary#loading-ui) — a skeleton matching the streamed result's width, height, and row count keeps the surrounding layout steady when content arrives.
 
-The overlay only catches the initial render. Every navigation after that needs the same guarantee, and [instant validation](/docs/app/guides/instant-validation) extends the check across all of them. Add this next block to `next.config.ts` beside `cacheComponents`:
-
-```ts filename="next.config.ts"
-import type { NextConfig } from 'next'
-
-const nextConfig: NextConfig = {
-  instant: {
-    defaultValidationLevel: 'warning',
-  },
-}
-
-export default nextConfig
-```
-
-`'warning'` surfaces violations in the dev overlay as you click through the app. `'error'` fails the build when any reachable path doesn't expose an instant shell. Same idea as the Cache Components check, broadened to every navigation.
-
-Route inputs need the same treatment. `params` and `searchParams` are per-request values, so awaiting them at the top of a page raises a prerender error. Pass them down to a child behind a `<Suspense>` and let the `await` happen inside the boundary.
-
-[`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params) is another option for `params`-driven routes. It [makes route params static](/docs/app/guides/error-overhaul#make-params-static) by enumerating the ids at build time so the per-id reads can join the static shell. That fits when the id list is fixed and the data behind each id is too. Neither holds here. Projects come and go, so a Suspense boundary is the cleaner fit.
-
-Wherever else an async read appears, the pattern is the same. Suspense covers everything below it that doesn't get its own boundary, so you choose the grain. Tight boundaries per read let each section stream on its own. A higher boundary uses one fallback for several sections. A narrow wrap around a single nested child lets the parent keep its props and only the inner subtree wait.
-
-Suspense can nest, so smaller pieces inside a section can stream one after another. The in-progress build log is wired that way on purpose: the completed-log query returns every line at once, while the in-progress version yields one line per nested boundary so the recording makes row-by-row streaming obvious. That wiring is a teaching shape for fine-grained boundaries, not advice on how to design build views in general.
-
-```tsx
-function LiveLines({ lines, index }) {
-  if (index >= lines.length) return <CursorRow />
-  return (
-    <>
-      <LogRow line={lines[index]} />
-      <Suspense fallback={<CursorRow />}>
-        <DelayedNextLine lines={lines} nextIndex={index + 1} />
-      </Suspense>
-    </>
-  )
-}
-```
-
-Try the demo. Refresh `/projects` and watch the shell paint immediately, with each section swapping in as its boundary resolves. Then click into a project, and into a still-building deployment to see the smaller pieces stream in too.
+Try the demo. The header and search form land immediately. Each section fills in as its read resolves.
 
 <Demo
   src="https://thinking-in-nextjs-04-streaming.labs.vercel.dev/projects"
@@ -298,35 +228,76 @@ Try the demo. Refresh `/projects` and watch the shell paint immediately, with ea
 
 On `/projects`, the timing reads roughly:
 
-- **0ms:** Shell sent. The header and search form land immediately, with fallbacks rendered for the avatar, pinned section, recent deploys, and grid.
-- **500ms:** Avatar resolves.
-- **1000ms:** Pinned and grid resolve.
-- **1500ms:** Recent deploys resolves last.
+- **0 ms**: Shell sent. The header and search form land immediately, with fallbacks rendered for the avatar, pinned section, recent deploys, and grid.
+- **500 ms**: Avatar resolves.
+- **1000 ms**: Pinned and grid resolve.
+- **1500 ms**: Recent deploys resolves last.
 
-Each fallback hides one slow read at a time, and the shell renders around it with the parts that don't have to wait. The route still runs every read on every request; what changed is that no read blocks any other.
+The route still runs every read on every request; what changed is that no read blocks any other.
+
+Now that every async read is behind a boundary, Next.js can do more with the route. Turn on [`cacheComponents`](/docs/app/glossary#cache-components):
+
+```ts filename="next.config.ts"
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  cacheComponents: true,
+}
+
+export default nextConfig
+```
+
+This flips on a small rule: every async read either sits behind Suspense or carries a `'use cache'` directive. When the rule holds, `next build` splits the route in two — the parts that don't depend on a request prerender as a [static shell](/docs/app/glossary#static-shell), and the parts behind Suspense stream in at request time. The build output picks up a new marker:
+
+```txt
+Route (app)
+┌ ○ /
+└ ◐ /projects
+
+○  (Static)             prerendered as static content
+◐  (Partial Prerender)  prerendered as static HTML with dynamic server-streamed content
+```
+
+The `◐` is [Partial Prerendering](/docs/app/glossary#partial-prerendering-ppr) (PPR), the optimization that lets the static shell sit on a CDN. The dynamic split keeps working without it, but every visitor would re-render the shell. PPR keeps that work off the path.
+
+When an async read isn't behind a boundary and isn't cached, the dev overlay points at the call site and lists three ways out:
+
+- [Provide a `<Suspense>` placeholder](/docs/app/guides/error-overhaul#move-within-suspense) around the read — what the Sidebar above already does.
+- [Cache the data access with `'use cache'`](/docs/app/guides/error-overhaul#cache-dynamic-data) — the move when the result can be reused, covered later.
+- [Allow blocking route](/docs/app/guides/error-overhaul#allow-blocking-route) — an escape hatch when you knowingly want the whole route to wait.
+
+Suspense decides when a section paints. Caching decides whether its output is reused — that comes next. Streaming is the smaller commitment, so we picked it first.
+
+> **Note**: Suspense boundaries nest. Output that arrives in pieces — log lines on an in-progress build, LLM tokens, paginated work — can wrap each piece in its own boundary so each one streams independently. See [`BuildLogs.tsx`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/04-streaming/app/projects/%5Bid%5D/deployments/%5BdeployId%5D/_components/BuildLogs.tsx) in the lab for an example — `LiveLines` recurses through the log and wraps each next line in its own `<Suspense>`.
+
+> **Note**: A read that doesn't touch a per-request API (cookies, headers, `searchParams`, `params`) needs [`await connection()`](/docs/app/api-reference/functions/connection) at the top so Next.js excludes it from prerendering. The lab's database queries do this — without it, a sync-feeling read like `db.select(...)` resolves at build time and the Suspense boundary above it never gets to stream.
+
+> **Note**: [Instant validation](/docs/app/guides/instant-validation) extends the same boundary check from the initial render to every navigation. [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params) is the alternative for `params`-driven routes whose id list is known at build time.
+
+The page reads are covered. Let's add the writes.
 
 Source: [`steps/04-streaming`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/04-streaming).
 
 ## Step 5: Mutate data
 
-Reads cover the route. The other half is writes — on this app, the deploy button and the pin button.
+Reads are covered. Now the writes — the deploy button and the pin button.
 
-In client-side React, the first reach might be an `onClick` handler. That would pull a Client Component in before this route needs one. Stay on the server with a plain form instead. Set the form's `action` to a [React Server Function](/docs/app/glossary#server-function) (`'use server'`), and the browser posts the intent while the write runs on the server. A [Route Handler](/docs/app/glossary#route-handler) would work too, but a Server Function skips hand-rolling the endpoint while the runtime treats the call site like an endpoint under the hood. Arguments and return values cross a serialization boundary as a [Remote Procedure Call (RPC)](https://en.wikipedia.org/wiki/Remote_procedure_call); plain data passes through, not functions or class instances.
+The first reach in client-side React might be an `onClick` handler, but that would pull a Client Component into the route for the button alone. An HTML form submits the intent and the write still runs on the server. A [Route Handler](/docs/app/glossary#route-handler) would also work, but you'd hand-roll a separate HTTP endpoint to do it.
 
-A Server Function is an exposed endpoint, so anything it touches needs the same auth checks and input validation a public API would get. This walkthrough skips that to keep the focus on the data flow. [How to Think About Security in Next.js](https://nextjs.org/blog/security-nextjs-server-components-actions) is the reference to read before shipping.
-
-So how do we get the new state to the page? We can call [`refresh`](/docs/app/api-reference/functions/refresh) from `next/cache` inside the Server Function, and Next.js re-runs the dynamic reads on the current route.
+A [React Server Function](/docs/app/glossary#server-function), marked with `'use server'`, keeps the write on this route. Pass it to React's [`<form action>`](https://react.dev/reference/react-dom/components/form#form) prop, submit the form, and the arguments and return values cross a serialization boundary as a [Remote Procedure Call (RPC)](https://en.wikipedia.org/wiki/Remote_procedure_call). Plain data passes through; functions and class instances don't.
 
 ```tsx
 'use server'
 
 import { refresh } from 'next/cache'
 
-async function triggerDeploy(projectId) {
+export async function triggerDeploy(projectId) {
   await db.deployment.create({ projectId })
   refresh()
 }
 ```
+
+The matching call site is an old-school HTML form, no `'use client'` in the path:
 
 ```tsx
 <form action={triggerDeploy.bind(null, projectId)}>
@@ -334,25 +305,25 @@ async function triggerDeploy(projectId) {
 </form>
 ```
 
-The form submits, the write runs on the server, and `refresh()` tells Next.js to re-render the route with React instead of you wiring a redirect by hand. The new deployment shows up in the list and the recent-deploys section catches up alongside it.
+This is the same request-response loop PHP and Rails apps ran on. The browser posts a form, the server runs a function, the server re-renders the page. The difference is that React produces the response. [`refresh`](/docs/app/api-reference/functions/refresh) from `next/cache` re-runs the dynamic reads on the current route, so the new deployment shows up in the list and the recent-deploys section updates alongside it.
 
-Pinning has the same shape. `addPin` and `removePin` each read the current user from the session, write to (or delete from) the pins table, and call `refresh()` so the read picks up the new state:
+> **Note**: A Server Function is an exposed endpoint, so anything it touches needs the same auth checks and input validation a public API would get. The lab gates every write with `requireSession()` — a small helper that reads the session cookie and throws if it's missing or invalid. [How to Think About Security in Next.js](https://nextjs.org/blog/security-nextjs-server-components-actions) is the broader reference to read before shipping.
+
+Pinning takes the same shape. `addPin` and `removePin` each require a session, write to (or delete from) the pins table, and call `refresh()`:
 
 ```tsx
 'use server'
 
 import { refresh } from 'next/cache'
 
-async function addPin(projectId) {
-  const { id: userId } = await getCurrentUser()
+export async function addPin(projectId) {
+  const { id: userId } = await requireSession()
   await db.pin.add({ userId, projectId })
   refresh()
 }
 ```
 
 The mutation pattern stays uniform across the app. The write touches the underlying state, then `refresh()` re-renders the route so the dynamic reads pick up the new value.
-
-A building deployment flips to ready on a staggered timer in the tutorial code so the UI moves without modeling a real CI pipeline.
 
 Submit the deploy form, then pin and unpin a project. Watch the new deployment show up in the list and the pin state flip.
 
@@ -361,21 +332,23 @@ Submit the deploy form, then pin and unpin a project. Watch the new deployment s
   title="Step 5: Mutate data"
 />
 
-The deploy form runs the Server Function, `refresh()` re-renders the route, and pinning runs through the same path. Every click pays the full server round trip, and the page sits unresponsive until the new state lands. The result feels like a traditional server-rendered app.
-
-Functional, but visibly slow. The button has no pending state, the pin doesn't flip until the server confirms, and search still requires a submit. None of these can wait for a round trip.
+Functional, but visibly slow. The deploy button has no pending state, the pin doesn't flip until the server confirms, and search still requires a submit. None of these can wait for a round trip — let's fix that next.
 
 Source: [`steps/05-mutations`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/05-mutations).
 
 ## Step 6: Add client interactivity
 
-[Step 5: Mutate data](#step-5-mutate-data) closed on what still waits on the round trip. The fix is the same shape for each control. Move the pin, the search field, and the deploy button into [`'use client'`](/docs/app/glossary#use-client-directive) leaves so the UI updates in the same beat as the gesture.
+What still waits on the round trip? The deploy button has no spinner, the pin doesn't flip until the server confirms, and search requires a submit. Three controls in the mockup, three places where the gesture has to update the UI before the response lands.
 
-Inside a `'use client'` boundary the full React API is available again, including `onClick`, `useState`, hooks, and refs. Server Functions stay callable from client code, so the form pattern from [Step 5](#step-5-mutate-data) becomes one option among many.
+| Control       | Updates on     | Needs client |
+| ------------- | -------------- | ------------ |
+| Pin button    | click          | yes          |
+| Search field  | each keystroke | yes          |
+| Deploy button | click          | yes          |
 
-For the deploy button, we can wrap `triggerDeploy` in [`useTransition`](https://react.dev/reference/react/useTransition) inside an `onClick` handler and read `pending` for the spinner. The `<form action={triggerDeploy}>` shape from [Step 5](#step-5-mutate-data) is different: the App Router runs that post in a transition for you, and [`useFormStatus`](https://react.dev/reference/react-dom/hooks/useFormStatus) reads `pending` from inside the `<form>` if you keep the form shape. For more on forms and Server Functions, see [Mutating data](/docs/app/getting-started/mutating-data).
+Move each one into a [`'use client'`](/docs/app/glossary#use-client-directive) leaf. Inside the boundary the full React API is back — `onClick`, `useState`, hooks, and refs — and Server Functions stay callable from client code, so `triggerDeploy`, `addPin`, and `removePin` keep working without rewrites.
 
-The pin button was a server form in [Step 5](#step-5-mutate-data). Now it becomes a Client Component. The `/projects` page starts the per-viewer pinned-ids read once and forwards the promise down to each card without an `await` in between. The pin button calls React's [`use`](https://react.dev/reference/react/use) in the browser to read the ids. Until the promise resolves, the `<Suspense>` wrapper around the pin shows a pin-shaped skeleton.
+The pin used to be a server form. Now it becomes a Client Component so the toggle can be optimistic. The `/projects` page starts the per-viewer pinned-ids read once and forwards the promise down to each card without an `await` in between. The pin button calls React's [`use`](https://react.dev/reference/react/use) in the browser to read the ids, and the `<Suspense>` wrapper around the pin shows a pin-shaped skeleton until the promise resolves.
 
 ```tsx
 'use client'
@@ -402,20 +375,19 @@ function ProjectPin({ projectId, pinnedIdsPromise }) {
 }
 ```
 
-[`useOptimistic`](https://react.dev/reference/react/useOptimistic) supplies the temporary label while the Server Function is in flight, and React reverts to the server-confirmed value once the response lands.
+React's [`useOptimistic`](https://react.dev/reference/react/useOptimistic) supplies the temporary label while the Server Function is in flight, and React reverts to the server-confirmed value once the response lands.
 
 The form action captures `wasPinned` before the optimistic update so the Server Function always matches the state before the click. Two fast clicks then can't accidentally cancel each other out.
 
 Nothing else is needed. The `refresh()` call inside `addPin` and `removePin` re-runs the dynamic reads, Next.js re-renders the route with the fresh pinned ids, and the optimistic state is replaced by the real one.
 
-The `/projects` page awaits the projects list, starts the per-viewer pinned-ids promise, and passes the same reference into every card:
+The `/projects` page awaits the projects list, starts the per-viewer pinned-ids promise, and passes the same reference into every card. `getPinnedIds()` reads the current viewer inside its own implementation, so the call site doesn't have to thread `userId` through:
 
 ```tsx
 async function ProjectGrid({ searchParams }) {
   const { q } = await searchParams
   const projects = await getProjects({ query: q })
-  const user = await getCurrentUser()
-  const pinnedIdsPromise = getPinnedIds(user.id)
+  const pinnedIdsPromise = getPinnedIds()
   return projects.map((project) => (
     <ProjectCard
       key={project.id}
@@ -439,7 +411,7 @@ Only the pin button consumes the promise, so only that control sits behind `<Sus
 
 `'use client'` marks a [boundary](/docs/app/glossary#use-client-directive). That file and its imports run in the browser, ancestors stay on the server. The page still constructs the promise on the server, the promise crosses the boundary as a prop, and the pin button calls `use()` on the client to read it.
 
-Search picks back up from [Step 3: Fetch data where it is used](#step-3-fetch-data-where-it-is-used). The GET form there matched what you had so far: submit once, let the browser navigate to `/projects?q=…`, and let the page read `searchParams` on the server.
+Search is the third leaf. The plain GET form from earlier worked: submit once, the browser navigates to `/projects?q=…`, and the page reads `searchParams` on the server.
 
 Per-keystroke updates need a `'use client'` boundary anyway, and once that's there the input can call `router.push` from `onChange` directly:
 
@@ -461,11 +433,11 @@ function SearchBar() {
       role="search"
       onSubmit={(event) => event.preventDefault()}
     >
+      {isPending ? <Spinner /> : <SearchIcon />}
       <input
         type="search"
         name="q"
         defaultValue={searchParams.get('q') ?? ''}
-        className={isPending ? 'opacity-80' : undefined}
         onChange={(event) => {
           const next = event.target.value
           startTransition(() => {
@@ -478,9 +450,29 @@ function SearchBar() {
 }
 ```
 
-This is the client-side twin of the `searchParams` read from [Step 3](#step-3-fetch-data-where-it-is-used). [`useSearchParams`](/docs/app/api-reference/functions/use-search-params) still binds the field to the request's `?q=`, which means the static shell defers that subtree. Wrap the search bar in `<Suspense>` with a fallback shaped like the field.
+This is the client-side twin of the same `searchParams` read on the server. [`useSearchParams`](/docs/app/api-reference/functions/use-search-params) reads the request's `?q=`, which is a per-request input. Wrap the search bar in `<Suspense>` so the rest of the route can prerender as a static shell, with a fallback shaped like the field. React's [`useTransition`](https://react.dev/reference/react/useTransition) supplies `isPending`, and the field's leading search icon swaps to a spinner for the duration of the navigation.
 
-`useTransition` supplies `isPending` for the dimmed-input hint while the navigation runs. [`useLinkStatus`](/docs/app/api-reference/functions/use-link-status) gives the same signal for `<Link>` navigations.
+The deploy button stays a `<form action={triggerDeploy.bind(null, projectId)}>`, just hoisted into a `'use client'` boundary so the same [`useTransition`](https://react.dev/reference/react/useTransition) hook can drive its spinner. Triggering the action from inside `startTransition` makes `pending` observable on the button itself, the same way `isPending` swaps the search input's icon for its spinner:
+
+```tsx
+'use client'
+
+import { useTransition } from 'react'
+
+function DeployButton({ projectId }) {
+  const [pending, startTransition] = useTransition()
+
+  return (
+    <form action={() => startTransition(() => triggerDeploy(projectId))}>
+      <button type="submit" disabled={pending}>
+        {pending ? <Spinner /> : 'Deploy'}
+      </button>
+    </form>
+  )
+}
+```
+
+Nothing about React requires a form here. A `<button onClick={...}>` from inside the same `useTransition` would render the same UI. The form keeps the Enter-to-submit affordance and lets the gesture work even before the JavaScript loads, which is reason enough to keep it.
 
 Try the demo. Pin a project and watch the button flip immediately, then type in the search bar to see the URL update on each keystroke. Open a project and click Deploy.
 
@@ -489,9 +481,9 @@ Try the demo. Pin a project and watch the button flip immediately, then type in 
   title="Step 6: Add client interactivity"
 />
 
-The pin flips before the server answers, the sidebar's pinned section catches up a beat later when the Server Function settles and the dynamic reads re-run, and the search bar pushes the new URL on each keystroke without a submit. Three Client leaves cover pin, search, and deploy. Everything else stays a Server Component.
+The pin flips before the server answers, the sidebar's pinned section catches up a beat later when the Server Function settles and the dynamic reads re-run, and the search bar pushes the new URL on each keystroke without a submit. Three Client leaves cover pin, search, and deploy. Everything else stays a Server Component, and the JavaScript shipped to the browser stays small because only those leaves cross into the client.
 
-The route is already a complete app. Streaming server-side rendering (SSR) for reads, Server Functions for writes, and a few interactive leaves for input cover most of what apps need. The JavaScript that ships stays small because only those leaves cross into the client.
+The route is a complete app. Navigation between routes still feels server-y, though — let's make repeat reads instant.
 
 Source: [`steps/06-client-boundaries`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/06-client-boundaries).
 
@@ -509,17 +501,17 @@ The natural question:
 
 If yes, the result can be reused instead of recomputed on every request, and the section can join the static shell instead of streaming behind a fallback.
 
-| UI piece                          | Same for every viewer? | Becomes                 |
-| --------------------------------- | ---------------------- | ----------------------- |
-| `ProjectGrid`, `ProjectHeader`    | Yes                    | reused for every viewer |
-| `Deployments`, `DeploymentHeader` | Yes                    | reused for every viewer |
-| `RecentDeploysSection`            | Yes                    | reused for every viewer |
-| `BuildLogs`, completed build      | Yes                    | reused for every viewer |
-| `BuildLogs`, in-progress build    | No, live               | rerun every request     |
-| `ViewerAvatar`                    | No, per viewer         | reused per viewer       |
-| `PinnedSection`                   | No, per viewer         | reused per viewer       |
+| UI piece                          | Same for every viewer? |
+| --------------------------------- | ---------------------- |
+| `ProjectGrid`, `ProjectHeader`    | Yes                    |
+| `Deployments`, `DeploymentHeader` | Yes                    |
+| `RecentDeploysSection`            | Yes                    |
+| `BuildLogs`, completed build      | Yes                    |
+| `BuildLogs`, in-progress build    | No, live               |
+| `ViewerAvatar`                    | No, per viewer         |
+| `PinnedSection`                   | No, per viewer         |
 
-[`'use cache'`](/docs/app/glossary#use-cache-directive) is the directive that [caches the data access](/docs/app/guides/error-overhaul#cache-dynamic-data). Add it at the top of a data function or a Server Component, and the result is reused across requests. On a project read, the directive carries a [`cacheLife`](/docs/app/api-reference/functions/cacheLife) for how long entries stay around and a [`cacheTag`](/docs/app/api-reference/functions/cacheTag) for invalidation later:
+[`'use cache'`](/docs/app/glossary#use-cache-directive) is the directive that [caches the data access](/docs/app/guides/error-overhaul#cache-dynamic-data). Add it at the top of a data function or a Server Component, and the result is reused across requests. On a project read, the directive sits next to a [`cacheLife`](/docs/app/api-reference/functions/cacheLife) for how long entries stay around and a [`cacheTag`](/docs/app/api-reference/functions/cacheTag) for invalidation later:
 
 ```tsx
 async function getProject(id) {
@@ -547,50 +539,48 @@ async function getProjects({ query }) {
 }
 ```
 
-Every other cached read on this route follows the same pattern: `'use cache'`, `cacheLife`, and a `cacheTag` that names what the entry covers.
+Every other cached read follows the same shape, with a `'use cache'` directive, a `cacheLife`, and a `cacheTag` that names what the entry covers. Per-request inputs (`searchParams`, [`cookies()`](/docs/app/api-reference/functions/cookies), [`headers()`](/docs/app/api-reference/functions/headers)) stay outside the cached function and arrive as arguments — the argument list is the cache key. That's why the page resolves `q` from `searchParams` in the parent and passes it into `getProjects({ query: q })`. Caching keys on `query`, but `q` only arrives with a real request, so the cards stream in behind the search bar instead of joining the static shell.
 
-Inside a plain `'use cache'` function, don't read `searchParams`, [`cookies()`](/docs/app/api-reference/functions/cookies), or [`headers()`](/docs/app/api-reference/functions/headers) directly. Resolve those in the parent and pass plain values as arguments. Those arguments join the cache key, which is the same pattern `getProject(id)` and `getProjects({ query })` already use.
-
-For the project list, the page still awaits `searchParams`, pulls `q`, and calls `getProjects({ query: q })`. Caching keys on `query`, but `q` only exists on a real request, so the prerender has no default list to ship for every visitor. That's why the cards don't join the static shell. The list waits for that request, then streams in after the surrounding layout. The search UI can paint with the shell; the cards fill in once the request lands.
-
-Per-viewer data splits into two patterns. Pinned ids stay on plain `'use cache'` keyed on `userId`. Read the viewer above the cache, pass the id into the helper, and the cache entry narrows on that value:
+Per-viewer data splits into two patterns. Pinned ids stay on plain `'use cache'` keyed on `userId`. The cached function takes the id as an argument so the entry narrows on that value, while the public `getPinnedIds` reads the viewer once and delegates to it — consumers don't have to thread the user through:
 
 ```tsx
-async function getPinnedIds(userId) {
+const getPinnedIdsForUser = cache(async (userId) => {
   'use cache'
   cacheLife({ stale: 60 })
   cacheTag(`pinned-${userId}`)
 
   return db.pin.list({ userId })
-}
+})
+
+export const getPinnedIds = cache(async () => {
+  const { id: userId } = await getCurrentUser()
+  return getPinnedIdsForUser(userId)
+})
 ```
 
-The store is shared. The `userId` argument is what makes the entry per-viewer. Two different ids become two entries, the same way `getProject('compass')` and `getProject('feather')` do.
+The store is shared; the `userId` argument is what makes each entry per-viewer. Two different ids become two entries, the same way `getProject('compass')` and `getProject('feather')` do.
 
-The current viewer is the limit case. The cookie is the input, and there's nothing further to lift out. A plain `'use cache'` can't read cookies inline, so `getCurrentUser` uses [`'use cache: private'`](/docs/app/api-reference/directives/use-cache-private) instead. Same directive shape, but per-viewer entries live in the browser cache instead of the shared server store, with `cookies()` and `headers()` allowed inside the function.
+The current viewer is the limit case. The cookie is the input, and there's nothing further to lift out. A plain `'use cache'` can't read cookies inline, so `getCurrentUser` uses [`'use cache: private'`](/docs/app/api-reference/directives/use-cache-private) instead — same directive shape, but the function runs every render on the server and the result is held only in the browser's memory for the rest of the session, with `cookies()` and `headers()` allowed inside:
 
 ```tsx
-async function getCurrentUser() {
+export const getCurrentUser = cache(async () => {
   'use cache: private'
   cacheLife({ stale: 60 })
 
   const session = (await cookies()).get('session')?.value
   return session ? JSON.parse(session) : DEFAULT_USER
-}
+})
 ```
 
-The two reads compose. Resolve the viewer first, then pass `user.id` into `getPinnedIds`. From [Step 6: Add client interactivity](#step-6-add-client-interactivity) on, `getPinnedIds(user.id)` stays unawaited so the promise can pass down to every pin button and resolve with `use()` on the client:
+The page can start the read once and pass the unawaited promise to every pin button so they each resolve with `use()` on the client:
 
 ```tsx
-const user = await getCurrentUser()
-const pinnedIdsPromise = getPinnedIds(user.id)
+const pinnedIdsPromise = getPinnedIds()
 ```
 
-When a Server Component needs the array before it renders (the pinned section in the sidebar, for example), `await` that call too and `pinnedIds` is available inline alongside `getProjects()`.
+When a Server Component needs the array before it renders (the pinned section in the sidebar, for example), `await` the same call and `pinnedIds` is available inline alongside `getProjects()`.
 
-Both reads are per-viewer, but the mechanism is different. `getPinnedIds` uses plain `'use cache'` with a `userId` argument, since the lookup is safe to share server-side and the ids alone aren't sensitive. `getCurrentUser` uses `'use cache: private'`, because the entry's scope has to follow the viewer's session.
-
-There's a third variant ([`'use cache: remote'`](/docs/app/api-reference/directives/use-cache-remote)) for a durable shared cache across server instances when the default in-memory store isn't enough. The hosting layer usually wires the handler. The [Cache Components](/docs/app/getting-started/caching) introduction compares all three.
+> **Note**: A third variant, [`'use cache: remote'`](/docs/app/api-reference/directives/use-cache-remote), backs a durable shared cache across server instances when the default in-memory store isn't enough. The [Cache Components](/docs/app/getting-started/caching) introduction compares all three.
 
 The tree now carries a decision per node, split between the shared layout and the per-route pages:
 
@@ -614,9 +604,9 @@ app/projects/[id]/deployments/[deployId]/page.tsx
 └── BuildLogs                   use cache (complete) / streamed (building)
 ```
 
-The Suspense rule sharpens with caching in place. Add a boundary wherever the subtree still reads a per-request input: cookies, `searchParams`, `params`, or live output. Those reads can be cached too, but the cache key isn't known until the request lands, so the boundary stays.
+The Suspense rule sharpens with caching in place. Add a boundary wherever the subtree still reads a per-request input — cookies, `searchParams`, `params`, or live output. Those reads can be cached too, but the cache key isn't known until the request lands, so the boundary stays.
 
-Cached reads with no per-request input join the prerendered shell. On this route that's the recent-deploys section, the only cached read whose key doesn't depend on the request. Its Suspense boundary and skeleton fallback from [Step 4: Stream async work](#step-4-stream-async-work) can both come out, since the section paints with the static shell:
+Cached reads with no per-request input join the prerendered shell. On this route that's the recent-deploys section, the only cached read whose key doesn't depend on the request. Its earlier Suspense boundary and skeleton fallback can both come out, since the section paints with the static shell:
 
 ```tsx
 export function Sidebar() {
@@ -631,7 +621,7 @@ export function Sidebar() {
 }
 ```
 
-Adding the cache layer changes the picture for the mutations from [Step 5: Mutate data](#step-5-mutate-data). `refresh()` re-runs the dynamic reads on the route, but `refresh()` doesn't move cached entries. After a deploy, the cached deployments list still serves the old value. After a pin, the cached `getPinnedIds` still returns the old set.
+Adding the cache layer changes the picture for mutations. `refresh()` re-runs the dynamic reads on the route, but it doesn't move cached entries. After a deploy, the cached deployments list still serves the old value. After a pin, the cached `getPinnedIds` still returns the old set.
 
 [`updateTag`](/docs/app/api-reference/functions/updateTag) is the surgical answer for cached entries. From inside a Server Function, it invalidates a cached read by name, so the same write that changed the underlying data names the entries that went stale. The route re-renders with the fresh values, which is what `refresh()` was doing before. Calling both is the wrong shape, so the Server Function calls `updateTag` in place of `refresh()`:
 
@@ -647,9 +637,7 @@ async function triggerDeploy(projectId) {
 }
 ```
 
-The tag names match the cached reads they invalidate. Each `updateTag` call lines up with the cache entries the write touched, and the route re-renders against the fresh values.
-
-`updateTag` and [`revalidateTag`](/docs/app/api-reference/functions/revalidateTag) differ in how they treat the response that contains the mutation. `updateTag` handles read-your-writes, so the new value shows up in the same response that triggered it. `revalidateTag` handles stale-while-revalidate, so the previous value keeps serving while the next read fetches a fresh one.
+The tag names match the cached reads they invalidate. Each `updateTag` call lines up with the cache entries the write touched, and the route re-renders against the fresh values. (For stale-while-revalidate semantics — keep serving the old value while a fresh one fetches — use [`revalidateTag`](/docs/app/api-reference/functions/revalidateTag) instead.)
 
 Pinning takes the same shape. `getPinnedIds` was tagged earlier with ``cacheTag(`pinned-${userId}`)``, so `addPin` and `removePin` each invalidate that viewer's tag:
 
@@ -659,13 +647,13 @@ Pinning takes the same shape. `getPinnedIds` was tagged earlier with ``cacheTag(
 import { updateTag } from 'next/cache'
 
 async function addPin(projectId) {
-  const { id: userId } = await getCurrentUser()
+  const { id: userId } = await requireSession()
   await db.pin.add({ userId, projectId })
   updateTag(`pinned-${userId}`)
 }
 ```
 
-The mutation pattern stays uniform across the app. Each Server Function runs the write and calls `updateTag` for any cached read it touched. The same call works against either store: `updateTag` invalidates a `'use cache: private'` entry the same way it invalidates a shared one.
+The mutation pattern stays uniform across the app. Each Server Function runs the write and calls `updateTag` for any cached read it touched. Tagged shared entries get invalidated; the per-viewer avatar runs every render anyway so it doesn't need a tag.
 
 Click into a project and into a deployment, then back. Watch which sections paint with the shell and which still show a fallback before resolving.
 
@@ -674,15 +662,13 @@ Click into a project and into a deployment, then back. Watch which sections pain
   title="Step 7: Cache reusable work"
 />
 
-Only the recent-deploys list paints with the static shell, since it's the one cached read with no per-request input. Everything else still paints a fallback first. The reads still resolve at request time, so the static shell ships with a skeleton in those slots, and the browser swaps to the real content as the request comes back. The cache is set up, but the visible paint hasn't changed.
+Only the recent-deploys list paints with the static shell, since it's the one cached read with no per-request input. Everything else still paints a fallback first. The reads resolve at request time, so the static shell ships with a skeleton in those slots, and the browser swaps to the real content as the request comes back. The cache is in place, but the visible paint hasn't changed yet. Let's get the dynamic reads to render before the click.
 
 Source: [`steps/07-caching`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/07-caching).
 
 ## Step 8: Optimize prefetching
 
-The cache from [Step 7: Cache reusable work](#step-7-cache-reusable-work) is in place, but the visible paint is the same as before. Cached entries for this route still key on `params`, cookies, or `searchParams`. Those values only arrive with a real request, so nothing fills the entries until the request lands.
-
-The validator from [Step 4: Stream async work](#step-4-stream-async-work) already keeps the shell instant at navigation. The data behind it is what's still missing.
+The cache is set up, but each navigation still waits. The cached entries on this route key on `params`, cookies, or `searchParams` — values that only arrive with a real request, so nothing fills them until the request lands. Instant validation keeps the shell ready at navigation; the data behind it is what's still missing.
 
 Prefetch is the timing answer. When a [`<Link>`](/docs/app/api-reference/components/link) enters the viewport, Next.js renders its destination in the background, so the tree is already there by the time of the click.
 
@@ -719,7 +705,7 @@ projects/aurora                               200     fetch  12.1 KB    81 ms
 projects/aurora/deployments/aurora-7k8h1      200     fetch  17.6 KB   108 ms
 ```
 
-Each row is a real per-request render of the destination, and the result populates the cache from [Step 7: Cache reusable work](#step-7-cache-reusable-work). Every page that opted in fires its prefetch as its `<Link>` enters the viewport, so the project list, the project detail, and the deployment page each render in the background ahead of the click.
+Each row is a real per-request render of the destination, and the result populates the cache. Every page that opted in fires its prefetch as its `<Link>` enters the viewport, so the project list, the project detail, and the deployment page each render in the background ahead of the click.
 
 Click between projects fast and the fallback paints. Wait a beat before clicking, and the section is already prefetched and shows instantly.
 
@@ -732,7 +718,7 @@ When prefetch finishes before the click, large pieces of the destination render 
 
 The live build log on an in-progress deployment is the one exception, since it's live by definition. Once the build finishes, that log appears instantly too, served from the cached entry until its `cacheLife` runs out.
 
-Runtime prefetch isn't free. Each visible `<Link>` triggers a real per-request render in the background, more server work than static prefetch, which renders against build-time inputs only. The cache layer from [Step 7: Cache reusable work](#step-7-cache-reusable-work) absorbs most of the cost. Each prefetched render populates an entry, and subsequent prefetches and navigations within the cache lifetime read from it instead of re-rendering. The trade-off is fine for typical apps but worth knowing about.
+Runtime prefetch isn't free. Each visible `<Link>` triggers a real per-request render in the background, more server work than static prefetch, which renders against build-time inputs only. The cache absorbs most of the cost: each prefetched render populates an entry, and subsequent prefetches and navigations within the cache lifetime read from it instead of re-rendering. The trade-off is fine for typical apps but worth knowing about.
 
 Whatever the prefetch pass touched, static or runtime, is cached in the browser and works offline. The only parts that need an active connection are the live-streamed sections, so flaky networks stop being a meaningful problem for most of the app.
 
@@ -740,9 +726,7 @@ Source: [`steps/08-prefetching`](https://github.com/vercel-labs/thinking-in-next
 
 ## Where to go from here
 
-React's model is declarative. Components describe the output, and React renders them when the inputs change. The App Router extends that model past the browser, with the component as the unit of decision the whole way down.
-
-The server-component model carries the reads and the scaling. Caching and prefetching are how you get the SPA feel on top, without leaving that model behind.
+React's model is declarative. Components describe the output, and React renders them when the inputs change. The App Router extends that model past the browser — the component is the unit of decision the whole way down, with caching and prefetching layered on top to give the route an SPA feel without leaving the server-component model behind.
 
 Try it on a route in your own codebase. Name the regions, then label each one as static, dynamic, cached, or a Client leaf. The decisions usually fall out once you've labeled what each piece is doing.
 
@@ -750,7 +734,7 @@ The docs go deeper on each piece used here.
 
 - [Cache Components](/docs/app/getting-started/caching) covers what `cacheComponents: true` changes and what each `'use cache'` variant is for.
 - [Streaming](/docs/app/guides/streaming) covers `loading.tsx`, nested Suspense, and where to place `<Suspense>`.
-- [Server and Client Components](/docs/app/getting-started/server-and-client-components) goes further on the prop boundary, including the donut pattern (Client Components receiving Server Components as `children`) for cases this guide didn't run into.
+- [Server and Client Components](/docs/app/getting-started/server-and-client-components) goes further on the prop boundary, including the donut pattern (Client Components receiving Server Components as `children`) for cases this tutorial didn't run into.
 - [Prefetching](/docs/app/guides/prefetching) and [instant navigation](/docs/app/guides/instant-navigation) cover runtime prefetch and shell validation in more depth.
 
 A few App Router pieces didn't fit this route, but they show up in real apps:
@@ -763,7 +747,7 @@ A few App Router pieces didn't fit this route, but they show up in real apps:
 
 ## Browse the source
 
-The [thinking-in-nextjs tutorial repo](https://github.com/vercel-labs/thinking-in-nextjs) holds one folder per guide step under `steps/`, each runnable on its own. The last step is also live at [the tutorial deployment](https://thinking-in-nextjs.labs.vercel.dev/).
+The [thinking-in-nextjs tutorial repo](https://github.com/vercel-labs/thinking-in-nextjs) holds one folder per tutorial step under `steps/`, each runnable on its own. The last step is also live at [the tutorial deployment](https://thinking-in-nextjs.labs.vercel.dev/).
 
 {/* TODO: restore the DemoExplorer block here once vercel/front#67624 lands on main and vercel-labs/thinking-in-nextjs is public. Intended config: repo "vercel-labs/thinking-in-nextjs", gitRef "main", path "steps", include "steps/**", exclude "node_modules,.next,.turbo,dist,build,*.lock,pnpm-lock.yaml", defaultFile "steps/07-static-jsx/app/projects/page.tsx". Source: https://github.com/vercel-labs/thinking-in-nextjs */}
 
@@ -771,7 +755,7 @@ Jump to a step on GitHub:
 
 - [`steps/02-static-jsx`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/02-static-jsx). Static JSX with mock data.
 - [`steps/03-fetch-data`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/03-fetch-data). Server Components and a data access layer; `notFound()` for missing rows.
-- [`steps/04-streaming`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/04-streaming). Suspense boundaries and skeleton fallbacks around async UI; data queries unchanged from [Step 3: Fetch data where it is used](#step-3-fetch-data-where-it-is-used).
+- [`steps/04-streaming`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/04-streaming). Suspense boundaries and skeleton fallbacks around async UI; data queries unchanged.
 - [`steps/05-mutations`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/05-mutations). Server Functions; `refresh()` to re-run dynamic reads after a write.
 - [`steps/06-client-boundaries`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/06-client-boundaries). Client leaves; optimistic `ProjectPin` reading the per-viewer promise with `use`; URL-driven `SearchBar` with `useTransition`.
 - [`steps/07-caching`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/07-caching). `'use cache'` and tags on shared reads, including pinned ids keyed by `userId`; `'use cache: private'` reserved for the viewer's identity behind the avatar; `updateTag` to invalidate cached entries on a write.

--- a/docs/01-app/02-guides/thinking-in-nextjs.mdx
+++ b/docs/01-app/02-guides/thinking-in-nextjs.mdx
@@ -226,7 +226,7 @@ function Sidebar() {
 
 What about the rest of the route? The avatar in `HeaderBar` reads the session. `ProjectGrid` reads the project list on `/projects`. The project detail page loads `ProjectHeader` and `Deployments`, and the deployment page loads `DeploymentHeader` and `BuildLogs`. Each one needs its own `<Suspense>` boundary and skeleton fallback alongside the JSX that uses it.
 
-This gets brittle to manage by hand. Every new async read needs a matching boundary, and missing one quietly stalls the first chunk. [`cacheComponents`](/docs/app/glossary#cache-components) is the rule that catches what we missed. Every async read of dynamic data either sits behind `<Suspense>` or carries a `'use cache'` directive, checked at `next dev` and `next build`:
+This gets brittle to manage by hand. Every new async read needs a matching boundary, and missing one quietly stalls the first chunk. [`cacheComponents`](/docs/app/glossary#cache-components) is the rule that catches what we missed. Every async read of dynamic data needs a decision, checked at `next dev` and `next build`:
 
 ```ts filename="next.config.ts" highlight={4}
 import type { NextConfig } from 'next'
@@ -258,6 +258,8 @@ When an async read isn't behind a boundary and isn't cached, the dev overlay poi
 - [Provide a `<Suspense>` placeholder](/docs/app/guides/error-overhaul#move-within-suspense) around the read — what the Sidebar above already does.
 - [Cache the data access with `'use cache'`](/docs/app/guides/error-overhaul#cache-dynamic-data) — the move when the result can be reused, covered later.
 - [Allow blocking route](/docs/app/guides/error-overhaul#allow-blocking-route) — an escape hatch when you knowingly want the whole route to wait.
+
+Those checks fire on every server render. [Instant navigation](/docs/app/guides/instant-navigation) extends the same family to client navigations, failing `next dev` and `next build` when a route can't paint instantly on click. Wire it on once through `experimental.instant.defaultValidationLevel` in [`next.config`](/docs/app/api-reference/config/next-config-js).
 
 Try the demo. The static shell ships from a CDN at 0 ms, and each async section fills in as its read resolves.
 

--- a/docs/01-app/02-guides/thinking-in-nextjs.mdx
+++ b/docs/01-app/02-guides/thinking-in-nextjs.mdx
@@ -558,8 +558,6 @@ The natural question:
 | `ViewerAvatar`                    | Yes, per viewer |
 | `PinnedSection`                   | Yes, per viewer |
 
-{/* TODO: The `caches the data access` link below points at the not-yet-shipped Error Overhaul guide; update once it lands. */}
-
 If the answer is yes, [`'use cache'`](/docs/app/glossary#use-cache-directive) is the one primitive. The same directive covers reads reused across every visitor, reads reused per viewer, and reads reused only for the current session. The variant tweaks where the entry lives, not whether to cache. Add it at the top of a data function or a Server Component. On a project read, the directive sits next to a [`cacheLife`](/docs/app/api-reference/functions/cacheLife) for how long entries stay around and a [`cacheTag`](/docs/app/api-reference/functions/cacheTag) for invalidation later:
 
 ```tsx filename="data/queries/projects.ts" highlight={2,4}
@@ -738,7 +736,7 @@ Source: [`steps/07-caching`](https://github.com/vercel-labs/thinking-in-nextjs/t
 
 ## Step 8: Optimize prefetching
 
-{/* TODO: link target pending Joseph's instant-validation PR. */}
+{/* TODO: Add `unstable_instant` link once vercel/next.js#93204 lands. Likely target: /docs/app/api-reference/file-conventions/route-segment-config/instant (paired with the overhauled /docs/app/guides/instant-navigation). */}
 
 The cache is set up, but each navigation still waits. The cached entries on this route key on `params`, cookies, or `searchParams`, values that only arrive with a real request, so nothing fills them until the request lands. The static shell paints fast on its own. The data behind it is what's still missing.
 

--- a/docs/01-app/02-guides/thinking-in-nextjs.mdx
+++ b/docs/01-app/02-guides/thinking-in-nextjs.mdx
@@ -481,7 +481,7 @@ function SearchBar() {
 
 This is the client-side twin of the same `searchParams` read on the server. [`useSearchParams`](/docs/app/api-reference/functions/use-search-params) reads the request's `?q=`, which is a per-request input. Wrap the search bar in `<Suspense>` so the rest of the route can prerender as a static shell, with a fallback shaped like the field. [`useTransition`](https://react.dev/reference/react/useTransition) supplies `isPending` for the icon swap.
 
-The deploy button is the third leaf. It keeps its form shape from [Step 5: Mutate data](#step-5-mutate-data), now hoisted into a `'use client'` boundary so `useTransition` can drive its spinner. The form's action wraps the call to `triggerDeploy` in `startTransition`, which makes `pending` observable on the button itself, the same way `isPending` swaps the search input's icon for its spinner:
+The deploy button is the third leaf. The same form as before, now hoisted into a `'use client'` boundary so `useTransition` can drive its spinner. The form's action wraps the call to `triggerDeploy` in `startTransition`, which makes `pending` observable on the button itself, the same way `isPending` swaps the search input's icon for its spinner:
 
 ```tsx filename="app/projects/[id]/_components/DeployButton.tsx" highlight={9-10}
 'use client'
@@ -500,6 +500,8 @@ function DeployButton({ projectId }) {
   )
 }
 ```
+
+The form isn't strictly required now that we're on the client. A `<button onClick={() => startTransition(() => triggerDeploy(projectId))}>` would render the same UI. The form carries over because nothing about it needed to change.
 
 The fourth leaf doesn't take a click. The in-progress log slice grows with `Date.now() - createdAt` on each render, so the route only needs to re-render every few seconds while a build is running. We can drop a small Client Component next to `<LiveLogStream>` that calls [`router.refresh()`](/docs/app/api-reference/functions/use-router) on an interval:
 
@@ -685,6 +687,8 @@ export function Sidebar() {
   )
 }
 ```
+
+With `'use cache'` in place, that boundary could have been skipped from the start. Reaching it through Suspense first makes the pattern easier to see.
 
 Adding the cache layer changes the picture for mutations. `refresh()` re-runs the dynamic reads on the route, but it doesn't move cached entries. After a deploy, the cached deployments list still serves the old value. After a pin, the cached `getPinnedIds` still returns the old set.
 

--- a/docs/01-app/02-guides/thinking-in-nextjs.mdx
+++ b/docs/01-app/02-guides/thinking-in-nextjs.mdx
@@ -32,7 +32,7 @@ The designer hands over mockups for three routes.
   height={452}
 />
 
-The data layer returns three shapes:
+The data has three shapes:
 
 | Type         | Notes                                                                                                                                             |
 | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -110,7 +110,7 @@ function ProjectCard({ project }) {
 }
 ```
 
-[Layouts](/docs/app/glossary#layout) and [pages](/docs/app/glossary#page) are [Server Components](/docs/app/glossary#server-component) by default. They run on the server and never run again in the browser. Their JavaScript doesn't ship to the client, a different shape from [Client Components](/docs/app/glossary#client-component), which render on the server first and then hydrate in the browser to attach event handlers.
+[Layouts](/docs/app/glossary#layout) and [pages](/docs/app/glossary#page) are [React Server Components](/docs/app/glossary#server-component) by default. They run on the server and never run again in the browser. Their JavaScript doesn't ship to the client, a different shape from [React Client Components](/docs/app/glossary#client-component), which render on the server first and then hydrate in the browser to attach event handlers.
 
 Since this version only renders JSX from local data, no Client Component is needed yet.
 
@@ -131,7 +131,7 @@ This is the [App Router](/docs/app/glossary#app-router) version of "build a stat
 Try the demo. Each demo throughout this guide embeds the deployed lab, and the refresh button in the browser chrome replays the load. Notice the route paints in one shot, with nothing to wait for.
 
 <Demo
-  src="https://thinking-in-nextjs-02.labs.vercel.dev/projects"
+  src="https://thinking-in-nextjs-02-static-jsx.labs.vercel.dev/projects"
   title="Step 2: Static JSX"
 />
 
@@ -141,13 +141,13 @@ Source: [`steps/02-static-jsx`](https://github.com/vercel-labs/thinking-in-nextj
 
 ## Step 3: Fetch data where it is used
 
-The static version got us through [Step 2: Build a static version with JSX](#step-2-build-a-static-version-with-jsx), but real apps don't ship with their data baked into the component file. The mock array has to go. The data lives in a database (or behind an API), and each region needs a function to read what it shows.
+The static version got you through [Step 2: Build a static version with JSX](#step-2-build-a-static-version-with-jsx), but real apps don't ship with their data baked into the component file. The mock array has to go. The data lives in a database (or behind an API), and each region needs a function to read what it shows.
 
-Each region gets its own async read, and the collection of those reads is the route's data layer. On this app that's `getProjects()`, `getProject(id)`, and `getDeployments(projectId)`, with the same shape for the recent deployments, the build log, the current viewer, and the viewer's pinned ids.
+Each region gets its own async read, and the collection of those reads is the route's [data access layer](/docs/app/guides/data-security#data-access-layer). On this app that's `getProjects()`, `getProject(id)`, and `getDeployments(projectId)`, with the same shape for the recent deployments, the build log, the current viewer, and the viewer's pinned ids.
 
 Where in the tree should those reads happen?
 
-The page could do all the fetching at the top and pass values down. That works, but it couples independent sections (the deployments list waits on the same parent as the sidebar), and each `await` at the top blocks the next, so the reads run in sequence rather than in parallel.
+The page could do all the fetching at the top and pass values down — with `Promise.all` to run the reads in parallel. That works, but it couples independent sections (the deployments list waits on the same parent as the sidebar) and the parent has to know what every region needs.
 
 The other option is for each component to read what it needs, right next to the JSX that uses it:
 
@@ -159,9 +159,9 @@ async function ProjectGrid({ searchParams }) {
 }
 ```
 
-Co-locating the read with the JSX that uses it is the same instinct as `useEffect` or a query library, except a Server Component can `await` the read directly, without the loading-state boilerplate.
+Co-locating the read with the JSX that uses it is the same instinct as `useEffect` or a query library, except a Server Component can `await` the read directly, with no client state to plumb through.
 
-The reads themselves stay thin. Each one calls into a small `db` module that stands in for the real data source (a Postgres ORM, a remote API client, whatever the app uses), with caching, formatting, and retries handled around the wrapper, not inside:
+Each read calls into a small `db` module that stands in for the real data source (a Postgres ORM, a remote API client, whatever the app uses). The reads here are thin, but the data access layer is also where API calls, retries, validation, and shaping live in a real app — kept out of the components that render the result:
 
 ```tsx
 // data/queries/projects.ts
@@ -170,24 +170,24 @@ async function getProjects({ query }) {
 }
 ```
 
-Search is the first place a Client Component would feel natural, but it doesn't have to be one. A plain HTML form pointing at `/projects?q=...` lets the browser do the navigation, and `ProjectGrid` reads `?q=` from `searchParams` to render the right list. No `'use client'` yet.
+That `query` argument has to come from somewhere. Search is the first place a Client Component would feel natural, but it doesn't have to be one. A plain HTML form pointing at `/projects?q=...` lets the browser do the navigation, and `ProjectGrid` reads `?q=` from `searchParams` to render the right list. No `'use client'` yet.
 
-Refresh the demo and notice the route now waits on the slowest read before it paints. Nothing on the page shows until every section's data is ready, even the parts that don't depend on it.
+Refresh the demo and notice the route waits on the slowest read before any of it paints. Nothing shows until every section's data is ready, even the parts that don't depend on it. Try the search too, and the grid filters via `?q=` in the URL with no `'use client'` involved.
 
 <Demo
-  src="https://thinking-in-nextjs-03.labs.vercel.dev/projects"
+  src="https://thinking-in-nextjs-03-fetch-data.labs.vercel.dev/projects"
   title="Step 3: Fetch data"
 />
 
-By now every region has a read attached to it. The route works, but every request runs every read, and `next build` can no longer prerender the route.
+By now every region has a read attached to it. The route works, but the slowest read still holds up the paint, every request runs every read, and `next build` can no longer prerender the route.
 
 Source: [`steps/03-fetch-data`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/03-fetch-data).
 
 ## Step 4: Stream async work
 
-Why should the rest of the page wait for the slowest read? It shouldn't. [`<Suspense>`](https://react.dev/reference/react/Suspense) is how you say so. Render this part when it's ready, render the rest now.
+Why should the rest of the page wait for the slowest read? It shouldn't. React's [`<Suspense>`](https://react.dev/reference/react/Suspense) is how you say so. Render this part when it's ready, render the rest now.
 
-[`cacheComponents`](/docs/app/getting-started/caching) is the app-wide switch that makes the framework hold you to that:
+[`cacheComponents`](/docs/app/glossary#cache-components) is the app-wide switch that makes the framework hold you to that:
 
 ```ts filename="next.config.ts"
 import type { NextConfig } from 'next'
@@ -199,11 +199,13 @@ const nextConfig: NextConfig = {
 export default nextConfig
 ```
 
-Cache Components is the refined version of the App Router, and the constraint is the feature. Making the cache-or-stream decision explicit at every async read catches the common mistakes (uncached fetches blocking the prerender, per-request work hidden inside what looks like static content, accidental coupling between routes that share a slow read), so routes built under it ship in better shape by default.
+Cache Components is the refined version of the App Router. Making the cache-or-stream decision explicit at every async read catches the common mistakes (uncached fetches blocking the prerender, per-request work hidden inside what looks like static content, accidental coupling between routes that share a slow read), so routes built under it ship in better shape by default.
 
 With it on, the prerender expects every async read to either be cached or sit behind a [Suspense boundary](/docs/app/glossary#suspense-boundary). That split is what enables [Partial Prerendering](/docs/app/glossary#partial-prerendering-ppr) (PPR). The route's static parts ship as HTML on the first paint, and the dynamic parts stream in behind their boundaries when they resolve. The reader sees the layout immediately, instead of a blank page while the slow read finishes.
 
-Anything else, an async read with no cache and no boundary, surfaces in `next dev` and `next build` as [`Uncached data was accessed outside of <Suspense>`](https://nextjs.org/docs/messages/blocking-route), pointing at the call site:
+Anything else, an async read with no cache and no boundary, surfaces in `next dev` and `next build` as [`Next.js encountered uncached data during the initial render`](https://nextjs.org/docs/messages/blocking-route), pointing at the call site:
+
+{/* TODO: Replace `instant-overlay-{light,dark}.png` with the new dev overlay screenshots once they ship. Update the alt text and the inline message quoted in the paragraph above to match the final overlay copy. */}
 
 <Image
   alt="Next.js dev overlay reading 'Next.js encountered uncached data during the initial render.' A code preview highlights the uncached `await` inside a data-access function. Three fix cards follow. 'Cache dynamic data' shows `'use cache'` at the top of a data function. 'Move within Suspense' wraps the async child in `<Suspense fallback={…}>`. 'Allow blocking route' shows `export const instant = false`."
@@ -213,11 +215,9 @@ Anything else, an async read with no cache and no boundary, surfaces in `next de
   height={779}
 />
 
-The overlay lists three ways out. One lets the route block as before, an escape hatch for cases where you knowingly want that. The other two are the design conversation the rest of this guide is about.
+The overlay lists three ways out. One lets the route block as before, an escape hatch for cases where you knowingly want that. The other two are [streaming](/docs/app/glossary#loading-ui) the read and caching it. Together they're the design conversation the rest of this guide is about. Streaming is the smaller commitment, so start there.
 
-Stream the read, or cache it. [Streaming](/docs/app/glossary#streaming) first, because it's the smaller commitment. Caching shows up later in the guide.
-
-The overlay catches the initial render. Every navigation after that needs the same guarantee, and [instant validation](/docs/app/guides/instant-navigation) is the dev-time check that enforces it. Cache it, stream it, or let the route block.
+The overlay only catches the initial render. Every navigation after that needs the same guarantee, and [instant validation](/docs/app/guides/instant-navigation) extends the check to all of them.
 
 Turn it on with one config line:
 
@@ -239,7 +239,7 @@ export default nextConfig
 
 A Suspense boundary only says "this part can paint later," not "this output is reusable." Boundary-by-boundary streaming is the move for now.
 
-`params` and `searchParams` count the same way. They're per-request inputs, so awaiting them at the top of a page lands the same prerender error as an uncached fetch. Pass them down to a child behind a `<Suspense>` and let the `await` happen inside the boundary.
+`params` and `searchParams` count the same way. They're per-request inputs, so awaiting them at the top of a page raises the same prerender error as an uncached fetch. Pass them down to a child behind a `<Suspense>` and let the `await` happen inside the boundary.
 
 [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params) is another option for `params`-driven routes. Enumerate the ids at build time and the per-id reads can join the static shell. That fits when the id list is fixed and the data behind it is too. Neither holds here. Projects come and go, the per-id reads stream this step and cache later, so a Suspense boundary is the cleaner fit.
 
@@ -262,16 +262,9 @@ function Sidebar() {
 
 `Sidebar` itself is synchronous now. The two async sections it contains each sit behind their own boundary, and each fallback is shaped like the section it stands in for.
 
-The same move repeats anywhere else in the route an async read shows up, with the boundary placed at the smallest scope that wraps the read.
+The same move repeats anywhere else in the route an async read shows up. Where to draw the boundary is a design choice. Suspense catches any async work below it that doesn't have its own boundary, so a small boundary around each read lets sections stream independently, and a higher one groups several sections under a single fallback.
 
-A _fallback_ is the UI that renders in the static shell while the async child is still resolving. It's replaced with the real output once the child finishes. For this route:
-
-- **0 ms**: Shell sent. The header and search form land immediately, with fallbacks rendered for the avatar, pinned section, recent deploys, and grid.
-- **500 ms**: Avatar resolves.
-- **1000 ms**: Pinned and grid resolve.
-- **1500 ms**: Recent deploys resolves last.
-
-The fallback's shape matters. A skeleton that matches the streamed result's width, height, and row count keeps the shell stable; a mismatched one pushes the page around when content arrives.
+A _fallback_ is the UI that renders in the static shell while the async child is still resolving. It's replaced with the real output once the child finishes. The fallback's shape matters. A skeleton that matches the streamed result's width, height, and row count keeps the shell stable; a mismatched one pushes the page around when content arrives.
 
 A boundary does not have to wrap an entire region. It can wrap a single nested child while the rest of the surrounding layout already has its props. The outer tree paints from data the parent resolved, and only the inner subtree shows a fallback while something inside awaits.
 
@@ -293,30 +286,33 @@ function LiveLines({ lines, index }) {
 
 For feeds that arrive outside the request (a real build log streamed from the platform, telemetry, chat), the typical pattern is a Client Component that polls or subscribes.
 
-Try the demo. Click into projects, then into a still-building deployment. Watch the shell paint immediately and each section swap in as its boundary resolves.
+Try the demo. Refresh `/projects` first and watch the shell paint immediately, with each section swapping in as its boundary resolves. Then click into a project and into a deployment — pick a still-building one to see the smaller pieces stream in too — and the same pattern repeats on the nested routes. On `/projects`:
+
+- **0 ms**: Shell sent. The header and search form land immediately, with fallbacks rendered for the avatar, pinned section, recent deploys, and grid.
+- **500 ms**: Avatar resolves.
+- **1000 ms**: Pinned and grid resolve.
+- **1500 ms**: Recent deploys resolves last.
 
 <Demo
-  src="https://thinking-in-nextjs-04.labs.vercel.dev/projects"
+  src="https://thinking-in-nextjs-04-streaming.labs.vercel.dev/projects"
   title="Step 4: Stream async work"
 />
 
 Each section's fallback hides one slow read at a time, and the shell renders around it with the parts that don't have to wait. The reader sees the layout and the search bar on the first paint, with skeleton fallbacks where the slow reads are still resolving. The route still runs every read on every request; what changed is that no read blocks any other.
 
-Reads work end-to-end. The next question is what happens when the reader writes.
-
 Source: [`steps/04-streaming`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/04-streaming).
 
 ## Step 5: Mutate data
 
-Reads cover the route. The other half is writes, and on this app that means the deploy button, the pin button, and any other place the page changes the underlying state.
+Reads cover the route. The other half is writes — on this app, the deploy button and the pin button.
 
-In the App Router, mutations live in [Server Functions](/docs/app/glossary#server-function) marked with `'use server'`. The function runs on the server, hits the underlying state, and the route re-renders so the new output replaces the old.
+So far the work has lived in Server Components, and their output is what crosses to the browser. Writes go the other way, so a write needs a primitive that runs on the server but is callable from the client.
 
-In practice, Server Functions are how you talk to the server without writing an API endpoint by hand. The endpoint exists under the hood, but the developer experience is Remote Procedure Call (RPC), with arguments and return values crossing a serialization boundary. Plain data passes through; functions and class instances don't.
+You'd usually reach for a [Route Handler](/docs/app/glossary#route-handler) or an API endpoint the client calls over HTTP. The App Router adopts [React Server Functions](/docs/app/glossary#server-function), marked with `'use server'`. The client calls them like a function, and they run on the server. The endpoint exists under the hood, with arguments and return values crossing a serialization boundary as a [Remote Procedure Call (RPC)](https://en.wikipedia.org/wiki/Remote_procedure_call). Plain data passes through; functions and class instances don't.
 
-Crossing that boundary is where the security work starts. The labs skip those concerns to keep the focus on the Next.js story. Production code needs the full picture, and [How to Think About Security in Next.js](https://nextjs.org/blog/security-nextjs-server-components-actions) is the canonical reference.
+A Server Function is an exposed endpoint, so anything it touches needs the same auth checks and input validation a public API would get. The labs skip that to keep the focus on the data flow. [How to Think About Security in Next.js](https://nextjs.org/blog/security-nextjs-server-components-actions) is the reference to read before shipping.
 
-So how does the new state get to the page? Without a cache layer yet, the answer is [`refresh`](/docs/app/api-reference/functions/refresh) from `next/cache`. Called inside a Server Function, it re-runs the dynamic reads on the current route, so the new deployment lands in the list and the recent-deploys section updates alongside it.
+So how do we get the new state to the page? We can call [`refresh`](/docs/app/api-reference/functions/refresh) from `next/cache` inside the Server Function, and Next.js re-runs the dynamic reads on the current route. The new deployment lands in the list and the recent-deploys section updates alongside it.
 
 ```tsx
 'use server'
@@ -329,7 +325,7 @@ async function triggerDeploy(projectId) {
 }
 ```
 
-Wired up to a button, the smallest version is a `<form action>` with no `'use client'` boundary in the path:
+The minimal way to call it is an old-school HTML form, no `'use client'` in the path:
 
 ```tsx
 <form action={triggerDeploy.bind(null, projectId)}>
@@ -358,11 +354,11 @@ The mutation pattern is uniform across the app. The write touches the underlying
 Submit the deploy form, then pin and unpin a project. Watch the new deployment show up in the list and the pin state flip.
 
 <Demo
-  src="https://thinking-in-nextjs-05.labs.vercel.dev/projects"
+  src="https://thinking-in-nextjs-05-mutations.labs.vercel.dev/projects"
   title="Step 5: Mutate data"
 />
 
-The deploy form runs the Server Function and `refresh()` re-renders the route. Pinning runs through the same path. Every click pays the full server round trip, the streaming fallbacks from [Step 4: Stream async work](#step-4-stream-async-work) reappear on each mutation, and the new state lands once the read finishes.
+The deploy form runs the Server Function and `refresh()` re-renders the route. Pinning runs through the same path. Every click pays the full server round trip, and the page sits unresponsive until the new state lands. It feels like a traditional server-rendered app.
 
 Functional, but visibly slow. The button has no pending state, the pin doesn't flip until the server confirms, and search still requires a submit. None of these can wait for a round trip.
 
@@ -370,44 +366,39 @@ Source: [`steps/05-mutations`](https://github.com/vercel-labs/thinking-in-nextjs
 
 ## Step 6: Add client interactivity
 
-The mutations from [Step 5: Mutate data](#step-5-mutate-data) all worked, and they were all visibly slow. Every click paid for itself with a full server round trip, the streaming fallbacks reappeared on each re-render, and the buttons sat without feedback while the Server Function ran.
-
-For most of the route so far, the work has lived on the server. Reads happen in Server Components, writes happen in Server Functions, and a plain HTML form has been enough to wire a button to a mutation. That model covers a lot of an app, and the moment where the request-response loop runs out of room shows up late.
+For most of the route so far, the work has lived on the server. Reads happen in Server Components, writes happen in Server Functions, and a plain HTML form has been enough to wire a button to a mutation. That model covers a lot of an app. The places it isn't enough come up later than you'd think.
 
 The pin button should flip the second it's clicked, before the server has acknowledged the write. The search input should update the URL on every keystroke instead of waiting for a submit. The deploy button should look pending while the Server Function is still working. None of these can wait for a round trip, and that's where a Client Component earns its place.
 
-Inside a [`'use client'`](/docs/app/glossary#use-client-directive) boundary the full React API is back, including `onClick`, `useState`, hooks, and refs. Server Functions stay callable from any of it, so the form pattern from [Step 5](#step-5-mutate-data) becomes one option among many, and the boundary itself is open-ended enough to host anything React can host, from a chart library to drag-and-drop to your own keyboard handler.
+Inside a [`'use client'`](/docs/app/glossary#use-client-directive) boundary the full React API is back, including `onClick`, `useState`, hooks, and refs. Server Functions stay callable from any of it, so the form pattern from [Step 5: Mutate data](#step-5-mutate-data) becomes one option among many, and the boundary itself is open-ended enough to host anything React can host, from a chart library to drag-and-drop to your own keyboard handler.
 
-In practice, a lot of routes never reach that far. The URL, a form, a Server Function, and a transition cover most of what an app needs, and the rest stays on the server where it belongs. The boundary is there for the moments where input lives in the client.
+In practice, a lot of routes never reach that far. The URL, a form, a Server Function, and a [React transition](https://react.dev/reference/react/useTransition) (React's way of running an update in the background and coordinating its async work without blocking the UI) cover most CRUD apps. The App Router uses transitions by default for navigations and form actions, so most of this happens without an explicit hook. The rest stays on the server where it belongs, and the boundary is there for the moments where input lives in the client.
 
-Pending state has the same options. You can put `triggerDeploy` inside a `useTransition` and read `pending` from the hook for the spinner. React's [`useFormStatus`](https://react.dev/reference/react-dom/hooks/useFormStatus) would surface the same state from inside a `<form>`.
+Pending state has two options. Wrap `triggerDeploy` in a [`useTransition`](https://react.dev/reference/react/useTransition) and read the hook's `pending` value for the spinner. React's [`useFormStatus`](https://react.dev/reference/react-dom/hooks/useFormStatus) does the same from inside a `<form>`.
 
 So how wide does that boundary actually need to be? Often one prop, even before it resolves.
 
-`ProjectPin` was a server form in [Step 5](#step-5-mutate-data). In this step it crosses into the client, takes the per-viewer promise as a prop, and calls [`use`](https://react.dev/reference/react/use) to resolve it on the other side, suspending at the nearest Suspense boundary above until the read resolves.
+The pin button was a server form in [Step 5: Mutate data](#step-5-mutate-data). In this step it crosses into the client as `ProjectPin`, takes the per-viewer promise as a prop, and calls React's [`use`](https://react.dev/reference/react/use) to resolve it on the other side, suspending at the nearest Suspense boundary above until the read resolves.
 
-The same form action from [Step 5](#step-5-mutate-data) wraps the optimistic flip:
+The same form action from [Step 5: Mutate data](#step-5-mutate-data) wraps the optimistic flip:
 
 ```tsx
 'use client'
 
-import { use, useOptimistic, useTransition } from 'react'
+import { use, useOptimistic } from 'react'
 
 function ProjectPin({ projectId, pinnedIdsPromise }) {
   const pinnedIds = use(pinnedIdsPromise)
   const isPinned = pinnedIds.includes(projectId)
 
   const [optimistic, setOptimistic] = useOptimistic(isPinned)
-  const [, startTransition] = useTransition()
 
   return (
     <form
-      action={() => {
-        startTransition(async () => {
-          const wasPinned = optimistic
-          setOptimistic((p) => !p)
-          await (wasPinned ? removePin(projectId) : addPin(projectId))
-        })
+      action={async () => {
+        const wasPinned = optimistic
+        setOptimistic((p) => !p)
+        await (wasPinned ? removePin(projectId) : addPin(projectId))
       }}
     >
       <button type="submit">{optimistic ? 'Pinned' : 'Pin'}</button>
@@ -416,7 +407,7 @@ function ProjectPin({ projectId, pinnedIdsPromise }) {
 }
 ```
 
-[`useOptimistic`](https://react.dev/reference/react/useOptimistic) gives the button its temporary value to display while the Server Function is in flight; React reverts to the server-confirmed value once the response lands.
+React's [`useOptimistic`](https://react.dev/reference/react/useOptimistic) gives the button its temporary value to display while the Server Function is in flight; React reverts to the server-confirmed value once the response lands.
 
 The flip uses `wasPinned` so the Server Function always matches the state **before** the optimistic update. That way, two fast clicks don't accidentally cancel each other out.
 
@@ -452,15 +443,11 @@ In `ProjectCard`, the icon, title, framework line, description, and status all c
 </header>
 ```
 
-It might look like marking `ProjectPin` with `'use client'` would pull `ProjectGrid` into the client too. It doesn't.
-
-`'use client'` marks a [boundary](/docs/app/glossary#use-client-directive), not a switch for everything above it. The `getPinnedIds` call runs on the server where the grid lives; only the promise crosses into the client, and `use()` reads it from there.
-
-Even when the boundary needs to be wider than a leaf (a modal wrapping a form, an interactive chrome around a server-rendered list), the server work can stay on the server. A Client Component takes Server Components as `children`, a [composition pattern](/docs/app/getting-started/server-and-client-components#interleaving-server-and-client-components) sometimes called the donut, so server-only reads, secrets, and database access stay nested inside while the interactive shell sits at the boundary.
+`'use client'` marks a [boundary](/docs/app/glossary#use-client-directive). The marked component, and anything it imports, runs in the browser. Everything above it stays on the server. `getPinnedIds` runs on the server where the grid lives, the promise crosses into the client, and `use()` reads it from there.
 
 Search shows up again here. The plain HTML form from [Step 3: Fetch data where it is used](#step-3-fetch-data-where-it-is-used) worked because a single submit was all the page needed.
 
-Per-keystroke updates need a `'use client'` boundary anyway, and once that's there the input can call `router.push` from `onChange` directly. The previous page stays visible while the new one resolves:
+Per-keystroke updates need a `'use client'` boundary anyway, and once that's there the input can call `router.push` from `onChange` directly:
 
 ```tsx
 'use client'
@@ -497,18 +484,18 @@ function SearchBar() {
 }
 ```
 
-App Router runs `router.push` inside a [transition](https://react.dev/reference/react/useTransition) by default. The input stays responsive and the previous page stays visible whether or not the call is wrapped.
+App Router runs `router.push` inside a transition by default. The input stays responsive and the previous page stays visible whether or not the call is wrapped.
 
 [`useTransition`](https://react.dev/reference/react/useTransition) adds `isPending`, a value the input can read to show a hint while the new render resolves. [`useLinkStatus`](/docs/app/api-reference/functions/use-link-status) gives the same signal for `<Link>` navigations.
 
 Try the demo. Pin and unpin a project, type in the search bar, and submit a deploy. Watch the pin flip before the server confirms, the URL update on each keystroke, and the deploy button stay in its pending state until the Server Function returns.
 
 <Demo
-  src="https://thinking-in-nextjs-06.labs.vercel.dev/projects"
+  src="https://thinking-in-nextjs-06-client-boundaries.labs.vercel.dev/projects"
   title="Step 6: Add client interactivity"
 />
 
-Three Client leaves handle the moments where the request-response loop runs out of room. Everything else around them stays a Server Component. In practice, client boundaries open at the leaves where they earn a hook, and Server Components stay the default.
+Three Client leaves cover the moments that can't wait for a round trip. Everything else around them stays a Server Component. In practice, client boundaries open at the leaves where they earn a hook, and Server Components stay the default.
 
 The route is already a complete app. Streaming SSR for reads, Server Functions for writes, and a few interactive leaves for input cover most of what apps need. The JavaScript you ship stays small because only those leaves cross into the client.
 
@@ -518,9 +505,9 @@ Source: [`steps/06-client-boundaries`](https://github.com/vercel-labs/thinking-i
 
 The route works end-to-end now, but moving between routes still feels server-y. Click into a project, click back, click into another, and every read runs from scratch on each navigation. The shell paints fast, the fallbacks reappear, and the new section streams in.
 
-Caching is the move that gets the rest of the way to the instant feel of a Single Page App (SPA), without giving up the server-component model. Data lives next to the read, there's no client cache to hand-maintain across viewers, and no API contract to keep in sync. The reads stay where the JSX uses them, the server keeps doing the work, but most of those reads don't have to run again for the next viewer.
+Caching is the move that gets the rest of the way to the instant feel of a Single Page App (SPA), without giving up the server-component model. Data lives next to the read, there's no client cache to hand-maintain across viewers, and no API contract to keep in sync. The reads stay where the JSX uses them, and the server keeps doing the work.
 
-Most of these reads aren't actually different per visitor. The project list, project header, and deployments list don't change between viewers from one second to the next.
+Walk the reads on the route. Most of them aren't actually different per visitor. The project list, project header, and deployments list don't change between viewers from one second to the next.
 
 The natural question:
 
@@ -530,17 +517,17 @@ If yes, the work doesn't need to run on every request. The result can be reused,
 
 Walk down the tree once and answer the question for each piece:
 
-| UI piece                          | Same for every viewer? | Becomes                         |
-| --------------------------------- | ---------------------- | ------------------------------- |
-| `ProjectGrid`, `ProjectHeader`    | Yes                    | `'use cache'`                   |
-| `Deployments`, `DeploymentHeader` | Yes                    | `'use cache'`                   |
-| `RecentDeploysSection`            | Yes                    | `'use cache'`                   |
-| `BuildLogs`, completed build      | Yes                    | `'use cache'`                   |
-| `BuildLogs`, in-progress build    | No, live               | uncached, streamed              |
-| `ViewerAvatar`                    | No, per viewer         | per-viewer cache                |
-| `PinnedSection`                   | No, per viewer         | `'use cache'` keyed by `userId` |
+| UI piece                          | Same for every viewer? | Becomes                 |
+| --------------------------------- | ---------------------- | ----------------------- |
+| `ProjectGrid`, `ProjectHeader`    | Yes                    | reused for every viewer |
+| `Deployments`, `DeploymentHeader` | Yes                    | reused for every viewer |
+| `RecentDeploysSection`            | Yes                    | reused for every viewer |
+| `BuildLogs`, completed build      | Yes                    | reused for every viewer |
+| `BuildLogs`, in-progress build    | No, live               | rerun every request     |
+| `ViewerAvatar`                    | No, per viewer         | reused per viewer       |
+| `PinnedSection`                   | No, per viewer         | reused per viewer       |
 
-A directive at the top of the function flips a read into the shared cache:
+[`'use cache'`](/docs/app/glossary#use-cache-directive) is the directive that marks a function as cacheable. Add it at the top of a data function or a Server Component, and the result is reused across requests:
 
 ```tsx
 async function getProject(id) {
@@ -552,11 +539,11 @@ async function getProject(id) {
 }
 ```
 
-[`'use cache'`](/docs/app/api-reference/directives/use-cache) at the top of `getProject` marks the function as cacheable, and its arguments (together with any closed-over values) form the cache key. `getProject('compass')` and `getProject('feather')` end up as separate entries, each one kept for as long as [`cacheLife`](/docs/app/api-reference/functions/cacheLife) declares (`'hours'` on this read).
+The function's arguments (together with any closed-over values) form the cache key. `getProject('compass')` and `getProject('feather')` end up as separate entries, each one kept for as long as [`cacheLife`](/docs/app/api-reference/functions/cacheLife) declares (`'hours'` on this read).
 
 [`cacheTag`](/docs/app/api-reference/functions/cacheTag) labels each entry by name so a mutation can invalidate it later. The per-id tag `project-${id}` gives a single project its own handle, and the broader `projects` tag still covers the list, so a rename on `compass` invalidates one entry without touching `feather`.
 
-A list read works the same way, keyed by whatever inputs the call takes:
+We can add `'use cache'` to the list read the same way, with the query as the key:
 
 ```tsx
 async function getProjects({ query }) {
@@ -570,17 +557,15 @@ async function getProjects({ query }) {
 
 The other cached reads on the route follow the same shape, with a `cacheTag` named after what each one covers.
 
-The `?q=` case is interesting. `getProjects` is cached, but the page also awaits `searchParams` to pick the query, and `searchParams` only resolves at request time. So the static prerender can't bake the cards in. The search box paints with the rest of the static shell, and the cards arrive once the request resolves.
+Search is the case that doesn't fit the prerender. The `q` value lives in the URL: `/projects?q=react`. The page reads it from `searchParams` and passes it down as the `query` argument to `getProjects(query)`. The function is still keyable on `query`, but `searchParams` only resolves at request time, so the prerender doesn't know which `q` to bake in. The cards don't join the static shell. The search box paints with the rest of it, and the cards arrive once the request lands.
 
-The cache still earns its place. `'use cache'` keys entries on the cached function's arguments, and `getProjects(query)` is the cached call. Two viewers searching `?q=react` hit the same entry.
+Per-request inputs stay outside the cached function and arrive as arguments. The argument list is the cache key.
 
-That's the pattern. Per-request inputs stay outside the cached function and arrive as arguments. The argument list is the cache key.
+The same rule covers [`cookies()`](/docs/app/api-reference/functions/cookies) and [`headers()`](/docs/app/api-reference/functions/headers). They're per-request inputs, and a plain `'use cache'` function can't read them inline. Lift them above the cached call and pass in what you need.
 
-For the same reason, a plain `'use cache'` function can't call [`cookies()`](/docs/app/api-reference/functions/cookies) or [`headers()`](/docs/app/api-reference/functions/headers) from inside itself. Anything the cached function reads has to live in its argument list, and an inline `cookies()` call doesn't. Resolve those above the cached call and pass in what you need.
+That leaves the per-viewer reads, the avatar and the pinned ids. Both produce different output for each viewer, but they fit the rule differently.
 
-That leaves the per-viewer reads, the avatar and the pinned ids. Both produce different output for each viewer, but they need different caching primitives.
-
-Pinned ids are a database read keyed on the user's id. With `userId` as the argument, `'use cache'` stores each viewer's entry separately:
+Pinned ids are a database read keyed on the user's id. The cookie read can be lifted out of the cached function and `userId` passed in as an argument:
 
 ```tsx
 async function getPinnedIds(userId) {
@@ -594,11 +579,9 @@ async function getPinnedIds(userId) {
 
 The store is shared. The argument is what makes the entry per-viewer. `getPinnedIds('aurora')` and `getPinnedIds('sam')` are stored as separate entries, the same way `getProject('compass')` and `getProject('feather')` are.
 
-But the lookup needs a `userId` to start with. That comes from the session cookie, and a plain `'use cache'` can't read it inline by the rule above. The cookie read needs a different primitive, one that's explicitly viewer-scoped.
+The current user is the limit case. The cookie _is_ the input. There's nothing further to lift out. A plain `'use cache'` can't read cookies inline, so this read needs a primitive that's explicitly viewer-scoped.
 
-[`'use cache: private'`](/docs/app/api-reference/directives/use-cache-private) keeps the same directive shape but scopes the entry to the viewer and stores it in the browser cache instead of sharing it on the server. Inside it, `cookies()` and `headers()` are allowed.
-
-This shape takes a beat to internalize. That's normal.
+[`'use cache: private'`](/docs/app/api-reference/directives/use-cache-private) keeps the same directive shape but scopes the entry to the viewer and stores it in the browser cache instead of sharing it on the server. Inside it, `cookies()` and `headers()` are allowed:
 
 ```tsx
 async function getCurrentUser() {
@@ -617,7 +600,7 @@ const user = await getCurrentUser()
 const pinnedIds = await getPinnedIds(user.id)
 ```
 
-Both reads are per-viewer, but the mechanism is different. The lookup uses a plain `'use cache'` keyed on `userId`, because the id is the only input the read needs. The cookie read uses `'use cache: private'`, because the entry's scope is the viewer's session.
+Both reads are per-viewer, but the mechanism is different. The lookup uses a plain `'use cache'` keyed on `userId`, because the id is the only input the read needs and pinned ids aren't sensitive enough to keep off a shared store. The cookie read uses `'use cache: private'`, because the entry's scope is the viewer's session.
 
 There's a third variant ([`'use cache: remote'`](/docs/app/api-reference/directives/use-cache-remote)) for durable shared cache across server instances when the default in-memory store isn't enough. The hosting layer usually wires the handler.
 
@@ -643,20 +626,18 @@ ProjectsLayout
 
 /projects/[id]/deployments/[deployId]
 ├── DeploymentHeader            use cache
-└── BuildLogs                   use cache when complete, live while building
+└── BuildLogs                   use cache (complete) / streamed (building)
 ```
 
-The Suspense rule sharpens with caching in place. A boundary is needed wherever the render touches runtime data. Anything else (a `'use cache'` read with no per-request inputs) joins the static shell, and the wrapper around it has nothing to defer. `RecentDeploys` is the cleanest example.
+The Suspense rule sharpens with caching in place. A boundary is needed wherever the render touches a per-request input — cookies, `searchParams`, `params`, or live output. Those reads can be cached too, but the cache key isn't known until the request lands, so the boundary stays.
 
-What stays wrapped is what still resolves per request. That covers cookies, `searchParams`, `params`, and any live output. Those reads are cached too, but the cache key isn't known until the request lands, so the boundary stays in the source.
-
-Cached reads that don't depend on a per-request input join the prerendered shell. On this route that's `getRecentDeployments`, the sidebar's recent-deploys list. Its Suspense boundary from [Step 4: Stream async work](#step-4-stream-async-work) can be removed.
+Cached reads with no per-request input join the prerendered shell. On this route that's `RecentDeploysSection`, the only one whose read doesn't depend on the request. Its Suspense boundary from [Step 4: Stream async work](#step-4-stream-async-work) can be removed.
 
 Adding the cache layer changes the picture for the mutations from [Step 5: Mutate data](#step-5-mutate-data). `refresh()` re-runs the dynamic reads on the route, but it doesn't move cached entries. After a deploy, the cached deployments list still serves the old value. After a pin, the cached `getPinnedIds` still returns the old set.
 
-[`updateTag`](/docs/app/api-reference/functions/updateTag) is the surgical answer for cached entries. From inside a Server Function, it invalidates a cached read by name, so the same write that changed the underlying data names the entries that just went stale. The route re-renders with the fresh values, which is what `refresh()` was doing before. Calling both is the wrong shape, so the Server Function calls `updateTag` in place of `refresh()`.
+[`updateTag`](/docs/app/api-reference/functions/updateTag) is the surgical answer for cached entries. From inside a Server Function, it invalidates a cached read by name, so the same write that changed the underlying data names the entries that went stale. The route re-renders with the fresh values, which is what `refresh()` was doing before. Calling both is the wrong shape, so the Server Function calls `updateTag` in place of `refresh()`.
 
-The deploy mutation from [Step 5](#step-5-mutate-data) was a write plus `refresh()`:
+The deploy mutation from [Step 5: Mutate data](#step-5-mutate-data) was a write plus `refresh()`:
 
 ```tsx
 'use server'
@@ -710,19 +691,19 @@ You could have skipped [Step 4: Stream async work](#step-4-stream-async-work) if
 Click into a project and into a deployment, then back. Watch which sections paint instantly and which still show a fallback before resolving.
 
 <Demo
-  src="https://thinking-in-nextjs-07.labs.vercel.dev/projects"
+  src="https://thinking-in-nextjs-07-caching.labs.vercel.dev/projects"
   title="Step 7: Cache reusable work"
 />
 
-Only the recent-deploys list paints with the static shell. It's the one cached read that doesn't depend on a per-request input, so it joined the prerender and lost its boundary.
+Only the recent-deploys list paints with the static shell. It's the one cached read with no per-request input, so it joined the prerender and lost its boundary.
 
-Everything else still shows its fallback on first visit, because the cache key isn't known until the click resolves. The per-viewer reads cache in the browser after that, so they don't reappear within the session. The shared cached reads keyed on `params` or `searchParams` paint a fallback on every navigation. The cache speeds up the response, not the paint. Step 8 closes that gap.
+Everything else still flashes its fallback. The reads still resolve at request time, so the static shell ships with a skeleton in those slots, and the browser swaps to the real content as the request comes back. The cache is set up, but the visible paint hasn't changed.
 
 Source: [`steps/07-caching`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/07-caching).
 
 ## Step 8: Optimize prefetching
 
-The cached reads from [Step 7: Cache reusable work](#step-7-cache-reusable-work) key on `params`, cookies, or `searchParams`. Those keys don't exist at prefetch time without a real request behind them, so the boundaries still paint a fallback at click time even though the data is technically cached.
+The cache from [Step 7: Cache reusable work](#step-7-cache-reusable-work) is in place, but the visible paint is the same as before. The reads it covers key on `params`, cookies, or `searchParams`. Those values only arrive with a real request, so nothing fills the entries until the request lands.
 
 The validator from [Step 4: Stream async work](#step-4-stream-async-work) already keeps the shell instant at navigation. The data behind it is what's still missing.
 
@@ -730,7 +711,7 @@ Prefetch is the timing answer. When a [`<Link>`](/docs/app/api-reference/compone
 
 The prefetch renders against one of two shapes, and the route declares which. The default is [**static**](/docs/app/guides/prefetching), with no cookies, headers, or search string in scope. That covers the shared layout and any cached read keyed on build-time inputs. [**Runtime**](/docs/app/api-reference/file-conventions/route-segment-config/prefetch) is opt-in, and it renders with the same cookies, headers, and search string the navigation would send, so per-viewer reads run against the real session before the click.
 
-Opting into runtime prefetch is one segment-config line:
+We can opt a page into runtime prefetch with one segment-config line, so its prefetch runs against the same cookies, headers, and search string the navigation would carry:
 
 ```tsx
 export const prefetch = 'force-runtime'
@@ -738,18 +719,16 @@ export const prefetch = 'force-runtime'
 
 Each page declares its own choice. Add the directive to every page whose reads depend on per-request inputs. The other pages on the route stay on static prefetch.
 
-Runtime prefetch isn't free. Each visible `<Link>` triggers a real per-request render in the background, more server work than static prefetch, which renders against build-time inputs only.
-
-The cost amortizes against the cache layer from [Step 7](#step-7-cache-reusable-work). Each prefetched render populates an entry, and subsequent prefetches and navigations within the cache lifetime read it instead of re-rendering. The trade-off is fine for typical apps but worth knowing about.
-
-Try the demo. Click between projects, into deployments, and back. Everything lands instantly except the live build log on an in-progress deployment, which is live by definition.
+Try the demo. The first paint still flashes skeletons in the per-request slots — no `<Link>` has been seen yet, so nothing has been prefetched. Then click between projects, into deployments, and back. Each link runs its prefetch as it enters the viewport, so the click lands on already-rendered output and the fallbacks are gone. The live build log on an in-progress deployment is the one exception, since it's live by definition. Once the build finishes, that log appears instantly too, served from the cached entry until its `cacheLife` runs out.
 
 <Demo
   src="https://thinking-in-nextjs.labs.vercel.dev/projects"
   title="Step 8: Optimize prefetching"
 />
 
-The shift the demo highlights is which sections are already populated when the click resolves. Every Suspense boundary on this route is there because the read inside it resolves at request time, keyed on cookies, `?q=`, or `params`. Static prefetch couldn't fill any of them. Runtime prefetch fills them all in the same pass, so the boundaries stay in the source but stop painting a fallback at navigation time.
+The shift the demo highlights is which sections are already populated by the time the user clicks. Every Suspense boundary on this route is there because the read inside it resolves at request time, keyed on cookies, `?q=`, or `params`. Static prefetch couldn't fill any of them. Runtime prefetch fills them all in the same pass, so the boundaries stay in the source but stop painting a fallback at navigation time.
+
+Runtime prefetch isn't free. Each visible `<Link>` triggers a real per-request render in the background, more server work than static prefetch, which renders against build-time inputs only. The cache layer from [Step 7: Cache reusable work](#step-7-cache-reusable-work) absorbs most of the cost. Each prefetched render populates an entry, and subsequent prefetches and navigations within the cache lifetime read it instead of re-rendering. The trade-off is fine for typical apps but worth knowing about.
 
 Whatever the prefetch pass touched, static or runtime, is cached in the browser and works offline. The only parts that need an active connection are the live-streamed sections, so flaky networks stop being a meaningful problem for most of the app.
 
@@ -757,9 +736,7 @@ Source: [`steps/08-prefetching`](https://github.com/vercel-labs/thinking-in-next
 
 ## Where to go from here
 
-Look back at the route. You didn't redesign it. You asked each component the same question. _What kind of work is this?_ The shape stayed the same. Each component picked up the primitive that matched its answer, and the route got more honest about what each piece was doing. One model carried the whole thing, and the decisions you made along the way are the ones that scale.
-
-The arc was short. Each step added one primitive, and each one answered a question the previous step had made concrete.
+React's model is declarative. Components describe the output, and React renders them when the inputs change. The App Router extends that model past the browser. React Server Components, React Server Functions, `<Suspense>`, `'use cache'`, and prefetch are each a declarative way to tell the framework where the work runs, what it reads, what it caches, and when it ships. The component stays the unit of decision the whole way down.
 
 The server-component model carries the reads and the scaling. Caching and prefetching are how you got the SPA feel on top, without leaving that model behind.
 
@@ -772,7 +749,7 @@ The docs go deeper on each piece used here.
 - [Server and Client Components](/docs/app/getting-started/server-and-client-components) goes further on the prop boundary, including the donut pattern (Client Components receiving Server Components as `children`) for cases this guide didn't run into.
 - [Prefetching](/docs/app/guides/prefetching) and [instant navigation](/docs/app/guides/instant-navigation) cover runtime prefetch and shell validation in more depth.
 
-The guide didn't reach all of the App Router. The docs cover the rest.
+A few App Router pieces didn't fit this route, but they show up in real apps:
 
 - [Authentication](/docs/app/guides/authentication) for knowing who's reading.
 - [Proxy](/docs/app/getting-started/proxy) for intercepting requests before they reach a page.
@@ -789,7 +766,7 @@ The guide didn't reach all of the App Router. The docs cover the rest.
 Jump to a step on GitHub:
 
 - [`steps/02-static-jsx`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/02-static-jsx). Static JSX with mock data.
-- [`steps/03-fetch-data`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/03-fetch-data). Server Components reading from a data layer.
+- [`steps/03-fetch-data`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/03-fetch-data). Server Components reading from a data access layer.
 - [`steps/04-streaming`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/04-streaming). Suspense around async sections.
 - [`steps/05-mutations`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/05-mutations). Server Functions; `refresh()` to re-run dynamic reads after a write.
 - [`steps/06-client-boundaries`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/06-client-boundaries). Client leaves; optimistic `ProjectPin` reading the per-viewer promise with `use`; URL-driven `SearchBar` with `useTransition`.

--- a/docs/01-app/02-guides/thinking-in-nextjs.mdx
+++ b/docs/01-app/02-guides/thinking-in-nextjs.mdx
@@ -12,7 +12,7 @@ related:
 
 In React, you break a UI into components and let data flow through the tree. [Thinking in React](https://react.dev/learn/thinking-in-react) walks through that model in five steps, from naming the parts to layering state on top.
 
-In Next.js, the same tree carries a few more decisions. Where does the data come from? What can render before a request, what needs the request, and what gets reused for the next visitor? The pieces are still components, some running on the server and some in the browser, and they compose like any other React tree. Each one runs where it belongs.
+In Next.js, the same tree carries a few more decisions. Where does the data come from? What can render before a request, what needs the request, and what gets reused for the next visitor? The pieces are still components, some running on the server and some in the browser, and they compose like any other React tree. Each component runs where that component belongs.
 
 This guide builds one small app one decision at a time, the way you would in your own codebase.
 
@@ -51,7 +51,7 @@ The build happens one decision at a time:
 
 The order isn't arbitrary. Caching depends on knowing what data each region reads, and [prefetching](/docs/app/glossary#prefetching) depends on knowing what's cached. Each step earns the next.
 
-These steps split into two halves. The first half builds the route, going from static JSX through server-side reads with Suspense around the async ones, then mutations, then a client boundary for what the request-response loop can't cover. The second half optimizes how it loads, with caching for the work that repeats and runtime prefetch for what can move before the click.
+These steps split into two halves. The first half builds the route, going from static JSX through server-side reads with Suspense around the async ones, then mutations, then a client boundary for what the request-response loop can't cover. The second half optimizes how the route loads, with caching for the work that repeats and runtime prefetch for what can move before the click.
 
 ## Step 1: Break the UI into a component hierarchy
 
@@ -68,14 +68,19 @@ Draw a box around each region of the mockup and give it a name. Each repeating p
 | Build page header       | `DeploymentHeader`                                               |
 | Build logs              | `BuildLogs`                                                      |
 
-The route shape lines up with the table:
+The route shape lines up with the table and with the App Router file tree:
 
 ```txt
-ProjectsLayout                      ← persistent: HeaderBar + Sidebar
-├── /projects                       → ProjectGrid of ProjectCards
-├── /projects/[id]                  → ProjectHeader + Deployments
-└── /…/deployments/[deployId]       → DeploymentHeader + BuildLogs
+app/projects/
+├── layout.tsx                          ← ProjectsLayout
+├── page.tsx                            ← ProjectsPage
+├── [id]/
+│   ├── page.tsx                        ← ProjectDetailPage
+│   └── deployments/[deployId]/
+│       └── page.tsx                    ← DeploymentDetailPage
 ```
+
+Two file conventions split the work. [`layout.tsx`](/docs/app/api-reference/file-conventions/layout) wraps every URL under `/projects` and holds the chrome that survives navigation: the top bar, the sidebar, the layout grid. [`page.tsx`](/docs/app/api-reference/file-conventions/page) owns the main column for one URL, and the layout renders it as `{children}`. The decision the convention asks of you is: what should stay mounted across the route, and what should swap with the URL?
 
 You haven't decided yet how the data arrives, what's reused, or where each component runs. Naming and grouping is enough for now.
 
@@ -139,17 +144,21 @@ Source: [`steps/02-static-jsx`](https://github.com/vercel-labs/thinking-in-nextj
 
 ## Step 3: Fetch data where it is used
 
-The static version got you through [Step 2: Build a static version with JSX](#step-2-build-a-static-version-with-jsx). Next, you move the data to a database (or behind an API): the mock array goes, and each region needs a function to read what it shows.
+Real apps don't ship with data baked into the component file. The mock arrays from [Step 2: Build a static version with JSX](#step-2-build-a-static-version-with-jsx) come out and a real read takes their place. The regions stay the same; what changes is where each one gets its values.
 
-Each region gets its own async read, and the collection of those reads is the route's [data access layer](/docs/app/guides/data-security#data-access-layer). On this app that's `getProjects()`, `getProject(id)`, and `getDeployments(projectId)`, with the same shape for the recent deployments, the build log, the current viewer, and the viewer's pinned ids.
+The tutorial sets that up in three layers:
 
-Every query opens with a single `await` of [`connection()`](/docs/app/api-reference/functions/connection) before the database, so live data stays off the build-time path from Step 2. The snippet below shows the shape; the API reference covers the rest.
+1. **Database.** Schema and client under [`lib/db`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/03-fetch-data/lib/db), plus seed data, so there are real rows to query. The tutorial picks one stack; the same shape works with any DB module.
+2. **Query modules.** One file per concern under [`data/queries/`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/03-fetch-data/data/queries) — projects, deployments, auth, pins, build logs. Together they form the route's [data access layer](/docs/app/guides/data-security#data-access-layer). The functions you'll see are `getProjects()`, `getProject(id)`, `getDeployments(projectId)`, and the same shape for the build log, the current viewer, and pinned ids.
+3. **Server Components.** Each region imports the query for that region and `await`s it next to the JSX that paints the result.
+
+Each query opens with a single `await connection()` from [`next/server`](/docs/app/api-reference/functions/connection) before running the underlying read. That keeps live data off the build-time path from Step 2.
 
 Where in the tree should those reads happen?
 
-The page could do all the fetching at the top and pass values down — with `Promise.all` to run the reads in parallel. That works, but it couples independent sections (the deployments list waits on the same parent as the sidebar) and the parent has to know what every region needs.
+The page could fetch everything at the top and pass values down with a `Promise.all`. That works, but it couples independent sections. The deployments list waits on the same parent as the sidebar, and the parent has to know what every region reads.
 
-The other option is for each component to read what it needs, right next to the JSX that uses it:
+Each component owning its own read works better. The `/projects` page demonstrates the pattern for the project list: an async Server Component reads `searchParams`, passes the search string into `getProjects`, and renders one row per project. No props-from-parent fetch orchestration, only a local `await` next to the JSX that uses the result.
 
 ```tsx
 async function ProjectGrid({ searchParams }) {
@@ -161,7 +170,7 @@ async function ProjectGrid({ searchParams }) {
 
 Co-locating the read with the JSX that uses it is the same instinct as `useEffect` or a query library, except a Server Component can `await` the read directly, with no client state to plumb through.
 
-Each read calls into a small `db` module that stands in for the real data source (a Postgres ORM, a remote API client, whatever the app uses). The reads here are thin, but the data access layer is also where API calls, retries, validation, and shaping live in a real app, kept out of the components that render the result:
+Then implement the function the component imports. In [`data/queries/projects.ts`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/03-fetch-data/data/queries/projects.ts), `getProjects` calls `connection()`, optionally applies a small demo `delay` so slow sections stay visible in the recordings, and returns rows from the database. Other regions follow the same layout in their own `data/queries/*` files.
 
 ```tsx
 // data/queries/projects.ts
@@ -174,28 +183,28 @@ async function getProjects({ query }) {
 }
 ```
 
-The individual project and deployment reads keep the missing-row case in the same layer. If the row isn't found, the query calls [`notFound`](/docs/app/api-reference/functions/not-found), and Next.js renders the matching `not-found.tsx` for that route segment.
+Missing rows stay in the same layer. Project and deployment queries call [`notFound`](/docs/app/api-reference/functions/not-found) when a `findFirst` (or equivalent) returns nothing, and Next.js renders the matching `not-found.tsx` next to that segment instead of you branching on `null` in every parent.
 
-The `delay()` call comes from `lib/utils.ts`. A real local database read resolves in milliseconds; these demos add a small artificial delay on every read so loading and pending states stay visible.
+A normal database round trip is fast. The [`delay()`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/03-fetch-data/lib/utils.ts) helper adds a small artificial delay on these reads so loading and pending states stay obvious in the demos.
 
-That `query` argument has to come from somewhere. Search is the first place a Client Component would feel natural, but it doesn't have to be one. A plain HTML form pointing at `/projects?q=...` lets the browser do the navigation, and `ProjectGrid` reads `?q=` from `searchParams` to render the right list. No `'use client'` yet.
+The `query` argument has to come from somewhere. Search is the first place a Client Component would feel natural, but search doesn't need one. A plain HTML form pointing at `/projects?q=...` lets the browser do the navigation, and the page reads `?q=` from `searchParams` and passes it into `getProjects`. No `'use client'` yet.
 
-Refresh the demo and notice the route waits on the slowest read before any of it paints. Nothing shows until every section's data is ready, even the parts that don't depend on it. Try the search too, and the grid filters via `?q=` in the URL without crossing into a Client Component.
+Refresh the demo. Watch how the route only paints once every section's data is ready, and try the search to see the grid filter via `?q=` in the URL without crossing into a Client Component.
 
 <Demo
   src="https://thinking-in-nextjs-03-fetch-data.labs.vercel.dev/projects"
   title="Step 3: Fetch data where it is used"
 />
 
-By now every region has a read attached to it. The route works, but the slowest read still holds up the paint, every request runs every read, and `next build` can no longer prerender the route.
+Every region has a read attached to it now. The route works, but the slowest read still holds up the paint, every request runs every read, and `next build` can no longer prerender the route.
 
 Source: [`steps/03-fetch-data`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/03-fetch-data).
 
 ## Step 4: Stream async work
 
-Why should the rest of the page wait for the slowest read? React's [`<Suspense>`](https://react.dev/reference/react/Suspense) lets you split the wait. Render this part when it's ready, render the rest now.
+Why should the rest of the page wait for the slowest read? It shouldn't. React's [`<Suspense>`](https://react.dev/reference/react/Suspense) draws the line: ship the surrounding tree right away, swap in deferred children when their data resolves.
 
-[`cacheComponents`](/docs/app/glossary#cache-components) is the app-wide switch that turns that expectation into a dev and build check:
+[`cacheComponents`](/docs/app/glossary#cache-components) is the app-wide switch:
 
 ```ts filename="next.config.ts"
 import type { NextConfig } from 'next'
@@ -207,29 +216,23 @@ const nextConfig: NextConfig = {
 export default nextConfig
 ```
 
-Cache Components is the stricter version of the App Router. Every async read needs a choice: cache it, or put it behind a Suspense boundary. That catches uncached fetches that block the prerender, per-request work hidden inside static-looking content, and routes coupled to a slow read they could have streamed.
+With `cacheComponents` enabled, every async read must either be cached (for example with [`'use cache'`](/docs/app/glossary#use-cache-directive)) or sit behind a [Suspense boundary](/docs/app/glossary#suspense-boundary). `next dev` and `next build` enforce that split. The cacheable tree gets [prerendered](/docs/app/glossary#prerendering) into a [static shell](/docs/app/glossary#static-shell) you can reuse, and only the Suspense-deferred slices run at request time and [stream](/docs/app/glossary#streaming) when ready. That mix is [Partial Prerendering](/docs/app/glossary#partial-prerendering-ppr) (PPR). The same rule surfaces mistakes early: uncached reads blocking the shell, request-only data hiding in static-looking trees, or one slow read stalling the rest of the route.
 
-With it on, the prerender expects every async read to either be cached or sit behind a [Suspense boundary](/docs/app/glossary#suspense-boundary). That split is what enables [Partial Prerendering](/docs/app/glossary#partial-prerendering-ppr) (PPR). The route's static parts ship as HTML on the first paint, and the dynamic parts stream in behind their boundaries when they resolve. You see the layout immediately, instead of a blank page while the slow read finishes.
+The queries from [Step 3: Fetch data where it is used](#step-3-fetch-data-where-it-is-used) stay put. This step adds `<Suspense>` around the async UI and pairs each boundary with a [loading UI](/docs/app/glossary#loading-ui) that matches the streamed content.
 
-The data access layer from [Step 3: Fetch data where it is used](#step-3-fetch-data-where-it-is-used) mostly stays the same. The diff in this step is structural: wrap each async slice of UI in React's `<Suspense>`, give each boundary a skeleton [loading UI](/docs/app/glossary#loading-ui) that matches what will stream in, and let the queries keep living next to the JSX that calls them.
-
-Anything else, an async read with no cache and no boundary, surfaces in `next dev` and `next build` as [`Next.js encountered uncached data during the initial render`](https://nextjs.org/docs/messages/blocking-route), pointing at the call site:
+Break the rule with an async read that has neither a cache nor a boundary, and `next dev` reports [`Next.js encountered uncached data during the initial render`](https://nextjs.org/docs/messages/blocking-route). The overlay highlights the call site and offers the same three moves this guide uses: [allow a blocking route](/docs/app/guides/error-overhaul#allow-blocking-route) when you mean it, [move the read behind Suspense](/docs/app/guides/error-overhaul#move-within-suspense), or [cache it with `'use cache'`](/docs/app/guides/error-overhaul#cache-dynamic-data).
 
 {/* TODO: Replace `instant-overlay-{light,dark}.png` with the new dev overlay screenshots once they ship. The uncached-data overlay has three cards: "Prerender and cache", "Provide a placeholder with Suspense", and "Allow blocking route". */}
 
 <Image
-  alt="Next.js dev overlay reading 'Next.js encountered uncached data during the initial render.' A code preview highlights the uncached `await` inside a data-access function. Three fix cards follow: 'Prerender and cache', 'Provide a placeholder with Suspense', and 'Allow blocking route'."
+  alt="Next.js dev overlay reading 'Next.js encountered uncached data during the initial render.' A code preview highlights the uncached `await` inside a data-access function. Three fix cards follow. One is labeled 'Prerender and cache', one is labeled 'Provide a placeholder with Suspense', and one is labeled 'Allow blocking route'."
   srcLight="/docs/guides/thinking-in-nextjs/instant-overlay-light.png"
   srcDark="/docs/guides/thinking-in-nextjs/instant-overlay-dark.png"
   width={984}
   height={779}
 />
 
-The overlay lists three ways out. One [allows a blocking route](/docs/app/guides/error-overhaul#allow-blocking-route), an escape hatch for cases where you knowingly want that. The other two are [providing a `<Suspense>` placeholder](/docs/app/guides/error-overhaul#move-within-suspense) around the read and [caching the data access with `'use cache'`](/docs/app/guides/error-overhaul#cache-dynamic-data). Together they're the design conversation the rest of this guide is about.
-
-A Suspense boundary only says "this part can paint later," not "this output is reusable." Boundary-by-boundary streaming is the move for now.
-
-Streaming is the smaller commitment, so let's pick it first. We can [provide a `<Suspense>` placeholder](/docs/app/guides/error-overhaul#move-within-suspense) around each async section so the [static shell](/docs/app/glossary#static-shell) (the parts that don't need to wait) is sent immediately:
+Suspense defers paint; Suspense doesn't mark output as reusable. Wrap each slow section in its own boundary so the shell can paint around it. In the sidebar, the pinned section and the recent deploys each get their own:
 
 ```tsx
 function Sidebar() {
@@ -246,11 +249,9 @@ function Sidebar() {
 }
 ```
 
-`Sidebar` itself is synchronous now. The two async sections it contains each sit behind their own boundary, and each fallback is shaped like the section it stands in for.
+The wrapper is synchronous now. Each async child has its own boundary and a fallback shaped like the section it stands in for. That fallback is the loading UI: the skeleton occupies the slot in the shell until the real markup replaces it, so a layout that matches width, height, and row count stays steady.
 
-The fallback is the [loading UI](/docs/app/glossary#loading-ui) that renders in the static shell while the async child is still resolving. It's replaced with the real output once the child finishes. The fallback's shape matters: a skeleton that matches the streamed result's width, height, and row count keeps the shell stable; a mismatched one pushes the page around when content arrives.
-
-The overlay only catches the initial render. Every navigation after that needs the same guarantee, and [instant validation](/docs/app/guides/instant-validation) extends the check across all of them. One config line in `next.config.ts` turns it on:
+The overlay only catches the initial render. Every navigation after that needs the same guarantee, and [instant validation](/docs/app/guides/instant-validation) extends the check across all of them. Add this next block to `next.config.ts` beside `cacheComponents`:
 
 ```ts filename="next.config.ts"
 import type { NextConfig } from 'next'
@@ -266,15 +267,13 @@ export default nextConfig
 
 `'warning'` surfaces violations in the dev overlay as you click through the app. `'error'` fails the build when any reachable path doesn't expose an instant shell. Same idea as the Cache Components check, broadened to every navigation.
 
-Route inputs need the same boundary treatment. `params` and `searchParams` are per-request values, so awaiting them at the top of a page raises a prerender error. Pass them down to a child behind a `<Suspense>` and let the `await` happen inside the boundary.
+Route inputs need the same treatment. `params` and `searchParams` are per-request values, so awaiting them at the top of a page raises a prerender error. Pass them down to a child behind a `<Suspense>` and let the `await` happen inside the boundary.
 
-[`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params) is another option for `params`-driven routes. It [makes route params static](/docs/app/guides/error-overhaul#make-params-static): enumerate the ids at build time so the per-id reads can join the static shell. That fits when the id list is fixed and the data behind it is too. Neither holds here. Projects come and go, so a Suspense boundary is the cleaner fit.
+[`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params) is another option for `params`-driven routes. It [makes route params static](/docs/app/guides/error-overhaul#make-params-static) by enumerating the ids at build time so the per-id reads can join the static shell. That fits when the id list is fixed and the data behind each id is too. Neither holds here. Projects come and go, so a Suspense boundary is the cleaner fit.
 
-The same move repeats anywhere else in the route an async read shows up. Where to draw the boundary is a design choice. Suspense catches any async work below it that doesn't have its own boundary, so a small boundary around each read lets sections stream independently, and a higher one groups several sections under a single fallback.
+Wherever else an async read appears, the pattern is the same. Suspense covers everything below it that doesn't get its own boundary, so you choose the grain. Tight boundaries per read let each section stream on its own. A higher boundary uses one fallback for several sections. A narrow wrap around a single nested child lets the parent keep its props and only the inner subtree wait.
 
-A boundary does not have to wrap an entire region. It can wrap a single nested child while the rest of the surrounding layout already has its props. The outer tree paints from data the parent resolved, and only the inner subtree shows a fallback while something inside awaits.
-
-Output that arrives in pieces (log lines on an in-progress build, large language model (LLM) tokens, or paginated work) follows the same pattern. The build log read splits in two for that reason. `getCompletedBuildLog` returns all the lines at once and renders the whole list, while `getInProgressBuildLog` feeds each line through a nested Suspense boundary so the page paints them as they arrive. Suspense boundaries nest, with each piece wrapping the next in its own boundary so each one streams independently:
+Suspense can nest, so smaller pieces inside a section can stream one after another. The in-progress build log is wired that way on purpose: the completed-log query returns every line at once, while the in-progress version yields one line per nested boundary so the recording makes row-by-row streaming obvious. That wiring is a teaching shape for fine-grained boundaries, not advice on how to design build views in general.
 
 ```tsx
 function LiveLines({ lines, index }) {
@@ -290,35 +289,33 @@ function LiveLines({ lines, index }) {
 }
 ```
 
-Try the demo. Refresh `/projects` first and watch the shell paint immediately, with each section swapping in as its boundary resolves. Then click into a project and into a deployment. Pick a still-building one to see the smaller pieces stream in too. The same pattern repeats on the nested routes. On `/projects`:
-
-- **0 ms**: Shell sent. The header and search form land immediately, with fallbacks rendered for the avatar, pinned section, recent deploys, and grid.
-- **500 ms**: Avatar resolves.
-- **1000 ms**: Pinned and grid resolve.
-- **1500 ms**: Recent deploys resolves last.
+Try the demo. Refresh `/projects` and watch the shell paint immediately, with each section swapping in as its boundary resolves. Then click into a project, and into a still-building deployment to see the smaller pieces stream in too.
 
 <Demo
   src="https://thinking-in-nextjs-04-streaming.labs.vercel.dev/projects"
   title="Step 4: Stream async work"
 />
 
-Each section's fallback hides one slow read at a time, and the shell renders around it with the parts that don't have to wait. You see the layout and the search bar on the first paint, with skeleton fallbacks where the slow reads are still resolving. The route still runs every read on every request; what changed is that no read blocks any other.
+On `/projects`, the timing reads roughly:
+
+- **0ms:** Shell sent. The header and search form land immediately, with fallbacks rendered for the avatar, pinned section, recent deploys, and grid.
+- **500ms:** Avatar resolves.
+- **1000ms:** Pinned and grid resolve.
+- **1500ms:** Recent deploys resolves last.
+
+Each fallback hides one slow read at a time, and the shell renders around it with the parts that don't have to wait. The route still runs every read on every request; what changed is that no read blocks any other.
 
 Source: [`steps/04-streaming`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/04-streaming).
 
 ## Step 5: Mutate data
 
-Reads cover the route. The other half is writes. On this app, that's the deploy button and the pin button.
+Reads cover the route. The other half is writes — on this app, the deploy button and the pin button.
 
-In client-side React, the first reach might be an `onClick` handler. That would move this button into the browser before it needs to be there. Let's keep the first version smaller. An HTML form submits the intent, and the write still runs on the server.
-
-You could write a [Route Handler](/docs/app/glossary#route-handler) or API endpoint and post to it over HTTP. A [React Server Function](/docs/app/glossary#server-function), marked with `'use server'`, keeps the write on this route without hand-rolling a separate HTTP handler. The function still runs on the server, and the endpoint still exists under the hood.
-
-The form is the smallest call site. Set the form's `action` to the Server Function, submit it, and the arguments and return values cross a serialization boundary as a [Remote Procedure Call (RPC)](https://en.wikipedia.org/wiki/Remote_procedure_call). Plain data passes through; functions and class instances don't.
+In client-side React, the first reach might be an `onClick` handler. That would pull a Client Component in before this route needs one. Stay on the server with a plain form instead. Set the form's `action` to a [React Server Function](/docs/app/glossary#server-function) (`'use server'`), and the browser posts the intent while the write runs on the server. A [Route Handler](/docs/app/glossary#route-handler) would work too, but a Server Function skips hand-rolling the endpoint while the runtime treats the call site like an endpoint under the hood. Arguments and return values cross a serialization boundary as a [Remote Procedure Call (RPC)](https://en.wikipedia.org/wiki/Remote_procedure_call); plain data passes through, not functions or class instances.
 
 A Server Function is an exposed endpoint, so anything it touches needs the same auth checks and input validation a public API would get. This walkthrough skips that to keep the focus on the data flow. [How to Think About Security in Next.js](https://nextjs.org/blog/security-nextjs-server-components-actions) is the reference to read before shipping.
 
-So how do we get the new state to the page? We can call [`refresh`](/docs/app/api-reference/functions/refresh) from `next/cache` inside the Server Function, and Next.js re-runs the dynamic reads on the current route. The new deployment lands in the list and the recent-deploys section updates alongside it.
+So how do we get the new state to the page? We can call [`refresh`](/docs/app/api-reference/functions/refresh) from `next/cache` inside the Server Function, and Next.js re-runs the dynamic reads on the current route.
 
 ```tsx
 'use server'
@@ -331,15 +328,13 @@ async function triggerDeploy(projectId) {
 }
 ```
 
-The minimal way to call it is an old-school HTML form, no `'use client'` in the path:
-
 ```tsx
 <form action={triggerDeploy.bind(null, projectId)}>
   <button type="submit">Deploy</button>
 </form>
 ```
 
-This is the same request-response loop PHP and Rails apps ran on. The browser posts a form, the server runs a function, and the server re-renders the page. The difference is that React produces the response.
+The form submits, the write runs on the server, and `refresh()` tells Next.js to re-render the route with React instead of you wiring a redirect by hand. The new deployment shows up in the list and the recent-deploys section catches up alongside it.
 
 Pinning has the same shape. `addPin` and `removePin` each read the current user from the session, write to (or delete from) the pins table, and call `refresh()` so the read picks up the new state:
 
@@ -355,9 +350,9 @@ async function addPin(projectId) {
 }
 ```
 
-The mutation pattern is uniform across the app. The write touches the underlying state, then `refresh()` re-renders the route so the dynamic reads pick up the new value.
+The mutation pattern stays uniform across the app. The write touches the underlying state, then `refresh()` re-renders the route so the dynamic reads pick up the new value.
 
-For this walkthrough, a **building** deployment flips to **ready** on a staggered server timer, not when the next read runs. The tutorial adds a little extra revalidation from the caching step onward so the demo keeps updating tidily—you can dig into the source later.
+A building deployment flips to ready on a staggered timer in the tutorial code so the UI moves without modeling a real CI pipeline.
 
 Submit the deploy form, then pin and unpin a project. Watch the new deployment show up in the list and the pin state flip.
 
@@ -366,7 +361,7 @@ Submit the deploy form, then pin and unpin a project. Watch the new deployment s
   title="Step 5: Mutate data"
 />
 
-The deploy form runs the Server Function and `refresh()` re-renders the route. Pinning runs through the same path. Every click pays the full server round trip, and the page sits unresponsive until the new state lands. It feels like a traditional server-rendered app.
+The deploy form runs the Server Function, `refresh()` re-renders the route, and pinning runs through the same path. Every click pays the full server round trip, and the page sits unresponsive until the new state lands. The result feels like a traditional server-rendered app.
 
 Functional, but visibly slow. The button has no pending state, the pin doesn't flip until the server confirms, and search still requires a submit. None of these can wait for a round trip.
 
@@ -374,19 +369,13 @@ Source: [`steps/05-mutations`](https://github.com/vercel-labs/thinking-in-nextjs
 
 ## Step 6: Add client interactivity
 
-For most of the route so far, the work has lived on the server. Reads happen in Server Components, writes happen in Server Functions, and a plain HTML form has been enough to wire a button to a mutation. That model covers a lot of an app. The places it isn't enough come up later than you'd think.
+[Step 5: Mutate data](#step-5-mutate-data) closed on what still waits on the round trip. The fix is the same shape for each control. Move the pin, the search field, and the deploy button into [`'use client'`](/docs/app/glossary#use-client-directive) leaves so the UI updates in the same beat as the gesture.
 
-The pin button should flip the second it's clicked, before the server has acknowledged the write. The search input should update the URL on every keystroke instead of waiting for a submit. The deploy button should look pending while the Server Function is still working. None of these can wait for a round trip, and that's where a Client Component earns its place.
+Inside a `'use client'` boundary the full React API is available again, including `onClick`, `useState`, hooks, and refs. Server Functions stay callable from client code, so the form pattern from [Step 5](#step-5-mutate-data) becomes one option among many.
 
-Inside a [`'use client'`](/docs/app/glossary#use-client-directive) boundary the full React API is back, including `onClick`, `useState`, hooks, and refs. Server Functions stay callable from any of it, so the form pattern from [Step 5: Mutate data](#step-5-mutate-data) becomes one option among many, and the boundary itself is open-ended enough to host anything React can host, from a chart library to drag-and-drop to your own keyboard handler.
+For the deploy button, we can wrap `triggerDeploy` in [`useTransition`](https://react.dev/reference/react/useTransition) inside an `onClick` handler and read `pending` for the spinner. The `<form action={triggerDeploy}>` shape from [Step 5](#step-5-mutate-data) is different: the App Router runs that post in a transition for you, and [`useFormStatus`](https://react.dev/reference/react-dom/hooks/useFormStatus) reads `pending` from inside the `<form>` if you keep the form shape. For more on forms and Server Functions, see [Mutating data](/docs/app/getting-started/mutating-data).
 
-In practice, a lot of routes never reach that far. The URL, a form, a Server Function, and a [React transition](https://react.dev/reference/react/useTransition) (React's way of running an update in the background and coordinating its async work without blocking the UI) cover most CRUD apps. The App Router uses transitions by default for navigations and form actions, so most of this happens without an explicit hook. The rest stays on the server where it belongs, and the boundary is there for the moments where input lives in the client.
-
-The deploy button needs to show that the Server Function is still running. Let's use [`useTransition`](https://react.dev/reference/react/useTransition) here: `DeployButton` can wrap `triggerDeploy` and read the hook's pending value for the spinner. React's [`useFormStatus`](https://react.dev/reference/react-dom/hooks/useFormStatus) gives the same signal from inside a `<form>`.
-
-The pin button was a server form in [Step 5: Mutate data](#step-5-mutate-data). In this step it becomes the Client Component `ProjectPin`. The server still starts the per-viewer work, but it doesn't await it before rendering the card. It passes the promise as a prop, and `ProjectPin` calls React's [`use`](https://react.dev/reference/react/use) to resolve it in the browser. While that promise is unresolved, the nearest Suspense boundary above the pin renders its fallback.
-
-The same form action from [Step 5: Mutate data](#step-5-mutate-data) wraps the optimistic flip:
+The pin button was a server form in [Step 5](#step-5-mutate-data). Now it becomes a Client Component. The `/projects` page starts the per-viewer pinned-ids read once and forwards the promise down to each card without an `await` in between. The pin button calls React's [`use`](https://react.dev/reference/react/use) in the browser to read the ids. Until the promise resolves, the `<Suspense>` wrapper around the pin shows a pin-shaped skeleton.
 
 ```tsx
 'use client'
@@ -413,21 +402,20 @@ function ProjectPin({ projectId, pinnedIdsPromise }) {
 }
 ```
 
-React's [`useOptimistic`](https://react.dev/reference/react/useOptimistic) gives the button its temporary value to display while the Server Function is in flight; React reverts to the server-confirmed value once the response lands.
+[`useOptimistic`](https://react.dev/reference/react/useOptimistic) supplies the temporary label while the Server Function is in flight, and React reverts to the server-confirmed value once the response lands.
 
-The flip uses `wasPinned` so the Server Function always matches the state **before** the optimistic update. That way, two fast clicks don't accidentally cancel each other out.
+The form action captures `wasPinned` before the optimistic update so the Server Function always matches the state before the click. Two fast clicks then can't accidentally cancel each other out.
 
 Nothing else is needed. The `refresh()` call inside `addPin` and `removePin` re-runs the dynamic reads, Next.js re-renders the route with the fresh pinned ids, and the optimistic state is replaced by the real one.
 
-The read still starts on the server. `ProjectGrid` loads the projects, creates one promise for the viewer's pinned ids, and hands the same promise reference to every card. Each `ProjectPin` waits on it through `use()`:
+The `/projects` page awaits the projects list, starts the per-viewer pinned-ids promise, and passes the same reference into every card:
 
 ```tsx
 async function ProjectGrid({ searchParams }) {
   const { q } = await searchParams
   const projects = await getProjects({ query: q })
-  const pinnedIdsPromise = getCurrentUser().then((user) =>
-    getPinnedIds(user.id)
-  )
+  const user = await getCurrentUser()
+  const pinnedIdsPromise = getPinnedIds(user.id)
   return projects.map((project) => (
     <ProjectCard
       key={project.id}
@@ -438,7 +426,7 @@ async function ProjectGrid({ searchParams }) {
 }
 ```
 
-Only the pin needs the pinned-ids promise, so only that control sits behind `<Suspense>`. The rest of the card is not blocked by the per-viewer lookup, and the fallback is a pin-shaped skeleton, not a skeleton for the whole card.
+Only the pin button consumes the promise, so only that control sits behind `<Suspense>`. The rest of the card isn't blocked by the per-viewer lookup, and the fallback is a pin-shaped skeleton, not a skeleton for the whole card.
 
 ```tsx
 <header className="flex …">
@@ -449,9 +437,9 @@ Only the pin needs the pinned-ids promise, so only that control sits behind `<Su
 </header>
 ```
 
-`'use client'` marks a [boundary](/docs/app/glossary#use-client-directive). The marked component, and anything it imports, runs in the browser. Everything above it stays on the server. The per-viewer read still runs on the server where the grid builds the promise; the promise crosses into the client, and `use()` reads it from there.
+`'use client'` marks a [boundary](/docs/app/glossary#use-client-directive). That file and its imports run in the browser, ancestors stay on the server. The page still constructs the promise on the server, the promise crosses the boundary as a prop, and the pin button calls `use()` on the client to read it.
 
-Search shows up again here. The plain HTML form from [Step 3: Fetch data where it is used](#step-3-fetch-data-where-it-is-used) worked because a single submit was all the page needed.
+Search picks back up from [Step 3: Fetch data where it is used](#step-3-fetch-data-where-it-is-used). The GET form there matched what you had so far: submit once, let the browser navigate to `/projects?q=…`, and let the page read `searchParams` on the server.
 
 Per-keystroke updates need a `'use client'` boundary anyway, and once that's there the input can call `router.push` from `onChange` directly:
 
@@ -490,22 +478,20 @@ function SearchBar() {
 }
 ```
 
-This is the client-side version of the `searchParams` read from [Step 3](#step-3-fetch-data-where-it-is-used). [`useSearchParams`](/docs/app/api-reference/functions/use-search-params) still reads a per-request input, so `SearchBar` sits behind a `<Suspense>` boundary in `HeaderBar`, with a skeleton sized to the input it stands in for.
+This is the client-side twin of the `searchParams` read from [Step 3](#step-3-fetch-data-where-it-is-used). [`useSearchParams`](/docs/app/api-reference/functions/use-search-params) still binds the field to the request's `?q=`, which means the static shell defers that subtree. Wrap the search bar in `<Suspense>` with a fallback shaped like the field.
 
-App Router runs `router.push` inside a transition by default. The input stays responsive and the previous page stays visible whether or not the call is wrapped.
+`useTransition` supplies `isPending` for the dimmed-input hint while the navigation runs. [`useLinkStatus`](/docs/app/api-reference/functions/use-link-status) gives the same signal for `<Link>` navigations.
 
-[`useTransition`](https://react.dev/reference/react/useTransition) adds `isPending`, a value the input can read to show a hint while the new render resolves. [`useLinkStatus`](/docs/app/api-reference/functions/use-link-status) gives the same signal for `<Link>` navigations.
-
-Try the demo. Pin a project and the button flips immediately, while the sidebar's pinned section catches up a beat later, after the Server Function settles and the dynamic reads re-run. Type in the search bar to watch the URL update on each keystroke, and submit a deploy to see the button stay in its pending state until the Server Function returns.
+Try the demo. Pin a project and watch the button flip immediately, then type in the search bar to see the URL update on each keystroke. Open a project and click Deploy.
 
 <Demo
   src="https://thinking-in-nextjs-06-client-boundaries.labs.vercel.dev/projects"
   title="Step 6: Add client interactivity"
 />
 
-Three Client leaves cover the moments that need input before a server round trip finishes. Everything else around them stays a Server Component. Client boundaries open at the leaves where they earn a hook, and Server Components stay the default.
+The pin flips before the server answers, the sidebar's pinned section catches up a beat later when the Server Function settles and the dynamic reads re-run, and the search bar pushes the new URL on each keystroke without a submit. Three Client leaves cover pin, search, and deploy. Everything else stays a Server Component.
 
-The route is already a complete app. Streaming server-side rendering (SSR) for reads, Server Functions for writes, and a few interactive leaves for input cover most of what apps need. The JavaScript you ship stays small because only those leaves cross into the client.
+The route is already a complete app. Streaming server-side rendering (SSR) for reads, Server Functions for writes, and a few interactive leaves for input cover most of what apps need. The JavaScript that ships stays small because only those leaves cross into the client.
 
 Source: [`steps/06-client-boundaries`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/06-client-boundaries).
 
@@ -513,17 +499,15 @@ Source: [`steps/06-client-boundaries`](https://github.com/vercel-labs/thinking-i
 
 The route works end-to-end now, but moving between routes still feels server-y. Click into a project, click back, click into another, and every read runs from scratch on each navigation. The shell paints fast, the fallbacks reappear, and the new section streams in.
 
-Caching is the move that gets the rest of the way to the instant feel of a Single Page App (SPA), without giving up the server-component model. Data lives next to the read, there's no client cache to hand-maintain across viewers, and no API contract to keep in sync. The reads stay where the JSX uses them, and the server keeps doing the work.
+Caching is the move that gets the rest of the way to the instant feel of a Single Page App (SPA), without giving up the server-component model. Data lives next to the read, there's no client cache to hand-maintain across viewers, and there's no API contract to keep in sync.
 
-Walk the reads on the route. Most of them read the same for every visitor. The project list, project header, and deployments list look the same for one viewer as the next.
+Walk the reads on the route. Most of them produce the same output for every visitor. The project list, project header, and deployments list look the same for one viewer as the next.
 
 The natural question:
 
 > Would the next viewer see the same thing?
 
-If yes, the work doesn't need to run on every request. The result can be reused, and the section can join the static shell instead of streaming behind a fallback.
-
-Walk down the tree once and answer the question for each piece:
+If yes, the result can be reused instead of recomputed on every request, and the section can join the static shell instead of streaming behind a fallback.
 
 | UI piece                          | Same for every viewer? | Becomes                 |
 | --------------------------------- | ---------------------- | ----------------------- |
@@ -535,7 +519,7 @@ Walk down the tree once and answer the question for each piece:
 | `ViewerAvatar`                    | No, per viewer         | reused per viewer       |
 | `PinnedSection`                   | No, per viewer         | reused per viewer       |
 
-[`'use cache'`](/docs/app/glossary#use-cache-directive) is the directive that [caches the data access](/docs/app/guides/error-overhaul#cache-dynamic-data). Add it at the top of a data function or a Server Component, and the result is reused across requests:
+[`'use cache'`](/docs/app/glossary#use-cache-directive) is the directive that [caches the data access](/docs/app/guides/error-overhaul#cache-dynamic-data). Add it at the top of a data function or a Server Component, and the result is reused across requests. On a project read, the directive carries a [`cacheLife`](/docs/app/api-reference/functions/cacheLife) for how long entries stay around and a [`cacheTag`](/docs/app/api-reference/functions/cacheTag) for invalidation later:
 
 ```tsx
 async function getProject(id) {
@@ -547,11 +531,11 @@ async function getProject(id) {
 }
 ```
 
-The function's arguments (together with any closed-over values) form the cache key. `getProject('compass')` and `getProject('feather')` end up as separate entries, each one kept for as long as [`cacheLife`](/docs/app/api-reference/functions/cacheLife) declares (`'hours'` on this read).
+The function's arguments (together with any closed-over values) form the cache key. `getProject('compass')` and `getProject('feather')` end up as separate entries, each one kept for as long as `cacheLife` declares (`'hours'` on this read).
 
-[`cacheTag`](/docs/app/api-reference/functions/cacheTag) labels each entry by name so a mutation can invalidate it later. The per-id tag `project-${id}` gives a single project its own handle, and the broader `projects` tag still covers the list, so a rename on `compass` invalidates one entry without touching `feather`.
+`cacheTag` labels each entry by name so a mutation can invalidate it later. The per-id tag `project-${id}` gives a single project its own handle, and the broader `projects` tag still covers the list. A rename on `compass` invalidates one entry without touching `feather`.
 
-We can add `'use cache'` to the list read the same way, with the query as the key:
+The list read takes the same shape, with the query as the key:
 
 ```tsx
 async function getProjects({ query }) {
@@ -563,17 +547,13 @@ async function getProjects({ query }) {
 }
 ```
 
-The other cached reads on the route follow the same shape, with a `cacheTag` named after what each one covers.
+Every other cached read on this route follows the same pattern: `'use cache'`, `cacheLife`, and a `cacheTag` that names what the entry covers.
 
-Search is the case that doesn't fit the prerender. The `q` value lives in the URL as `/projects?q=react`. The page reads it from `searchParams` and passes it down as the `query` argument to `getProjects(query)`. The function is still keyable on `query`, but `searchParams` only resolves at request time, so the prerender doesn't know which `q` to bake in. The cards don't join the static shell. The search box paints with the rest of it, and the cards arrive once the request lands.
+Inside a plain `'use cache'` function, don't read `searchParams`, [`cookies()`](/docs/app/api-reference/functions/cookies), or [`headers()`](/docs/app/api-reference/functions/headers) directly. Resolve those in the parent and pass plain values as arguments. Those arguments join the cache key, which is the same pattern `getProject(id)` and `getProjects({ query })` already use.
 
-Per-request inputs stay outside the cached function and arrive as arguments. The argument list is the cache key.
+For the project list, the page still awaits `searchParams`, pulls `q`, and calls `getProjects({ query: q })`. Caching keys on `query`, but `q` only exists on a real request, so the prerender has no default list to ship for every visitor. That's why the cards don't join the static shell. The list waits for that request, then streams in after the surrounding layout. The search UI can paint with the shell; the cards fill in once the request lands.
 
-The same rule covers [`cookies()`](/docs/app/api-reference/functions/cookies) and [`headers()`](/docs/app/api-reference/functions/headers). They're per-request inputs, and a plain `'use cache'` function can't read them inline. Lift them above the cached call and pass in what you need.
-
-The avatar and the pinned ids both produce different output for each viewer, but they fit the rule differently.
-
-Pinned ids are a database read keyed on the user's id. The cookie read can be lifted out of the cached function and `userId` passed in as an argument:
+Per-viewer data splits into two patterns. Pinned ids stay on plain `'use cache'` keyed on `userId`. Read the viewer above the cache, pass the id into the helper, and the cache entry narrows on that value:
 
 ```tsx
 async function getPinnedIds(userId) {
@@ -585,11 +565,9 @@ async function getPinnedIds(userId) {
 }
 ```
 
-The store is shared. The argument is what makes the entry per-viewer. Two different `userId` values become two entries, the same way `getProject('compass')` and `getProject('feather')` do.
+The store is shared. The `userId` argument is what makes the entry per-viewer. Two different ids become two entries, the same way `getProject('compass')` and `getProject('feather')` do.
 
-The current user is the limit case. The cookie _is_ the input. There's nothing further to lift out. A plain `'use cache'` can't read cookies inline, so this read needs a primitive that's explicitly viewer-scoped.
-
-[`'use cache: private'`](/docs/app/api-reference/directives/use-cache-private) keeps the same directive shape but caches per viewer: the entry lives in the browser cache instead of being shared on the server. Inside it, `cookies()` and `headers()` are allowed:
+The current viewer is the limit case. The cookie is the input, and there's nothing further to lift out. A plain `'use cache'` can't read cookies inline, so `getCurrentUser` uses [`'use cache: private'`](/docs/app/api-reference/directives/use-cache-private) instead. Same directive shape, but per-viewer entries live in the browser cache instead of the shared server store, with `cookies()` and `headers()` allowed inside the function.
 
 ```tsx
 async function getCurrentUser() {
@@ -601,64 +579,61 @@ async function getCurrentUser() {
 }
 ```
 
-The two reads compose. Read the viewer once, hand the id down:
+The two reads compose. Resolve the viewer first, then pass `user.id` into `getPinnedIds`. From [Step 6: Add client interactivity](#step-6-add-client-interactivity) on, `getPinnedIds(user.id)` stays unawaited so the promise can pass down to every pin button and resolve with `use()` on the client:
 
 ```tsx
 const user = await getCurrentUser()
-const pinnedIds = await getPinnedIds(user.id)
+const pinnedIdsPromise = getPinnedIds(user.id)
 ```
 
-Both reads are per-viewer, but the mechanism is different. The lookup uses a plain `'use cache'` keyed on `userId`, because the id is the only input the read needs and pinned ids aren't sensitive enough to keep off a shared store. The cookie read uses `'use cache: private'`, because the entry's scope is the viewer's session.
+When a Server Component needs the array before it renders (the pinned section in the sidebar, for example), `await` that call too and `pinnedIds` is available inline alongside `getProjects()`.
 
-There's a third variant ([`'use cache: remote'`](/docs/app/api-reference/directives/use-cache-remote)) for durable shared cache across server instances when the default in-memory store isn't enough. The hosting layer usually wires the handler.
+Both reads are per-viewer, but the mechanism is different. `getPinnedIds` uses plain `'use cache'` with a `userId` argument, since the lookup is safe to share server-side and the ids alone aren't sensitive. `getCurrentUser` uses `'use cache: private'`, because the entry's scope has to follow the viewer's session.
 
-The [Cache Components](/docs/app/getting-started/caching) introduction compares all three. This guide uses plain `'use cache'` for project data and pinned ids, with `'use cache: private'` reserved for the viewer's identity behind the avatar.
+There's a third variant ([`'use cache: remote'`](/docs/app/api-reference/directives/use-cache-remote)) for a durable shared cache across server instances when the default in-memory store isn't enough. The hosting layer usually wires the handler. The [Cache Components](/docs/app/getting-started/caching) introduction compares all three.
 
-The tree now carries a decision per node:
+The tree now carries a decision per node, split between the shared layout and the per-route pages:
 
 ```txt
-persistent shell
-ProjectsLayout
+persistent shell (app/projects/layout.tsx)
 ├── HeaderBar
 │   └── ViewerAvatar            use cache: private
 └── Sidebar
     ├── PinnedSection           use cache (keyed by userId)
     └── RecentDeploysSection    use cache
 
-/projects
+app/projects/page.tsx
 └── ProjectGrid                 use cache
 
-/projects/[id]
+app/projects/[id]/page.tsx
 ├── ProjectHeader               use cache
 └── Deployments                 use cache
 
-/projects/[id]/deployments/[deployId]
+app/projects/[id]/deployments/[deployId]/page.tsx
 ├── DeploymentHeader            use cache
 └── BuildLogs                   use cache (complete) / streamed (building)
 ```
 
-The Suspense rule sharpens with caching in place. A boundary is needed wherever the render touches a per-request input — cookies, `searchParams`, `params`, or live output. Those reads can be cached too, but the cache key isn't known until the request lands, so the boundary stays.
+The Suspense rule sharpens with caching in place. Add a boundary wherever the subtree still reads a per-request input: cookies, `searchParams`, `params`, or live output. Those reads can be cached too, but the cache key isn't known until the request lands, so the boundary stays.
 
-Cached reads with no per-request input join the prerendered shell. On this route that's `RecentDeploysSection`, the only one whose read doesn't depend on the request. Its Suspense boundary and `RecentDeploysSkeleton` fallback from [Step 4: Stream async work](#step-4-stream-async-work) can both be removed: the section paints with the static shell, so there's nothing to stand in for.
-
-Adding the cache layer changes the picture for the mutations from [Step 5: Mutate data](#step-5-mutate-data). `refresh()` re-runs the dynamic reads on the route, but it doesn't move cached entries. After a deploy, the cached deployments list still serves the old value. After a pin, the cached `getPinnedIds` still returns the old set.
-
-[`updateTag`](/docs/app/api-reference/functions/updateTag) is the surgical answer for cached entries. From inside a Server Function, it invalidates a cached read by name, so the same write that changed the underlying data names the entries that went stale. The route re-renders with the fresh values, which is what `refresh()` was doing before. Calling both is the wrong shape, so the Server Function calls `updateTag` in place of `refresh()`.
-
-The deploy mutation from [Step 5: Mutate data](#step-5-mutate-data) was a write plus `refresh()`:
+Cached reads with no per-request input join the prerendered shell. On this route that's the recent-deploys section, the only cached read whose key doesn't depend on the request. Its Suspense boundary and skeleton fallback from [Step 4: Stream async work](#step-4-stream-async-work) can both come out, since the section paints with the static shell:
 
 ```tsx
-'use server'
-
-import { refresh } from 'next/cache'
-
-async function triggerDeploy(projectId) {
-  await db.deployment.create({ projectId })
-  refresh()
+export function Sidebar() {
+  return (
+    <div className="space-y-6">
+      <Suspense fallback={<PinnedSkeleton />}>
+        <PinnedSection />
+      </Suspense>
+      <RecentDeploysSection />
+    </div>
+  )
 }
 ```
 
-With the cached deployments list and the cached recent-deploys list in the picture, the same Server Function calls `updateTag` for each one:
+Adding the cache layer changes the picture for the mutations from [Step 5: Mutate data](#step-5-mutate-data). `refresh()` re-runs the dynamic reads on the route, but `refresh()` doesn't move cached entries. After a deploy, the cached deployments list still serves the old value. After a pin, the cached `getPinnedIds` still returns the old set.
+
+[`updateTag`](/docs/app/api-reference/functions/updateTag) is the surgical answer for cached entries. From inside a Server Function, it invalidates a cached read by name, so the same write that changed the underlying data names the entries that went stale. The route re-renders with the fresh values, which is what `refresh()` was doing before. Calling both is the wrong shape, so the Server Function calls `updateTag` in place of `refresh()`:
 
 ```tsx
 'use server'
@@ -672,7 +647,7 @@ async function triggerDeploy(projectId) {
 }
 ```
 
-The tag names match the cached reads they invalidate. Each Server Function call lines up with the cache entries the write touched, and the route re-renders against the fresh values.
+The tag names match the cached reads they invalidate. Each `updateTag` call lines up with the cache entries the write touched, and the route re-renders against the fresh values.
 
 `updateTag` and [`revalidateTag`](/docs/app/api-reference/functions/revalidateTag) differ in how they treat the response that contains the mutation. `updateTag` handles read-your-writes, so the new value shows up in the same response that triggered it. `revalidateTag` handles stale-while-revalidate, so the previous value keeps serving while the next read fetches a fresh one.
 
@@ -690,9 +665,7 @@ async function addPin(projectId) {
 }
 ```
 
-The mutation pattern is now uniform across the app. Each Server Function runs the write and calls `updateTag` for any cached read it touched.
-
-The same `updateTag` call works against either cache. `updateTag` invalidates a `'use cache: private'` entry the same way it invalidates a shared entry. The only difference is where the entry is stored.
+The mutation pattern stays uniform across the app. Each Server Function runs the write and calls `updateTag` for any cached read it touched. The same call works against either store: `updateTag` invalidates a `'use cache: private'` entry the same way it invalidates a shared one.
 
 Click into a project and into a deployment, then back. Watch which sections paint with the shell and which still show a fallback before resolving.
 
@@ -701,26 +674,36 @@ Click into a project and into a deployment, then back. Watch which sections pain
   title="Step 7: Cache reusable work"
 />
 
-Only the recent-deploys list paints with the static shell. It's the one cached read with no per-request input, so it joined the prerender and lost its boundary.
-
-Everything else still paints a fallback first. The reads still resolve at request time, so the static shell ships with a skeleton in those slots, and the browser swaps to the real content as the request comes back. The cache is set up, but the visible paint hasn't changed.
+Only the recent-deploys list paints with the static shell, since it's the one cached read with no per-request input. Everything else still paints a fallback first. The reads still resolve at request time, so the static shell ships with a skeleton in those slots, and the browser swaps to the real content as the request comes back. The cache is set up, but the visible paint hasn't changed.
 
 Source: [`steps/07-caching`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/07-caching).
 
 ## Step 8: Optimize prefetching
 
-The cache from [Step 7: Cache reusable work](#step-7-cache-reusable-work) is in place, but the visible paint is the same as before. The reads it covers key on `params`, cookies, or `searchParams`. Those values only arrive with a real request, so nothing fills the entries until the request lands.
+The cache from [Step 7: Cache reusable work](#step-7-cache-reusable-work) is in place, but the visible paint is the same as before. Cached entries for this route still key on `params`, cookies, or `searchParams`. Those values only arrive with a real request, so nothing fills the entries until the request lands.
 
 The validator from [Step 4: Stream async work](#step-4-stream-async-work) already keeps the shell instant at navigation. The data behind it is what's still missing.
 
-Prefetch is the timing answer. When a [`<Link>`](/docs/app/api-reference/components/link) enters the viewport, Next.js renders its destination in the background, so the tree is already there by the time the user clicks.
+Prefetch is the timing answer. When a [`<Link>`](/docs/app/api-reference/components/link) enters the viewport, Next.js renders its destination in the background, so the tree is already there by the time of the click.
 
-The prefetch renders against one of two shapes, and the route declares which. The default is [**static**](/docs/app/guides/prefetching), with no cookies, headers, or search string in scope. That covers the shared layout and any cached read keyed on build-time inputs. [**Runtime**](/docs/app/api-reference/file-conventions/route-segment-config/prefetch) is opt-in, and it renders with the same cookies, headers, and search string the navigation would send, so per-viewer reads run against the real session before the click.
+The prefetch renders against one of two shapes, and each route declares which. The default is [static](/docs/app/guides/prefetching), with no cookies, headers, or search string in scope. That covers the shared layout and any cached read keyed on build-time inputs. [Runtime](/docs/app/api-reference/file-conventions/route-segment-config/prefetch) is opt-in, and it renders with the same cookies, headers, and search string the navigation would send, so per-viewer reads run against the real session before the click.
 
-We can opt a page into runtime prefetch with one segment-config export, so its prefetch runs against the same cookies, headers, and search string the navigation would send.
+We can opt a page into runtime prefetch with the [`prefetch`](/docs/app/api-reference/file-conventions/route-segment-config/prefetch) segment export:
 
-```tsx
+```tsx filename="app/projects/page.tsx"
+import { Suspense } from 'react'
+
 export const prefetch = 'force-runtime'
+
+export default function ProjectsPage({ searchParams }) {
+  return (
+    <section>
+      <Suspense fallback={<ProjectGridSkeleton />}>
+        <ProjectGrid searchParams={searchParams} />
+      </Suspense>
+    </section>
+  )
+}
 ```
 
 Each page declares its own choice. We can add the export to every page whose reads depend on per-request inputs. On this app that's `/projects` (cookies for the avatar and pinned section, `?q=` for the grid), `/projects/[id]` (cookies and `params`), and `/projects/[id]/deployments/[deployId]` (cookies and `params`). The other pages on the route stay on static prefetch.
@@ -738,20 +721,18 @@ projects/aurora/deployments/aurora-7k8h1      200     fetch  17.6 KB   108 ms
 
 Each row is a real per-request render of the destination, and the result populates the cache from [Step 7: Cache reusable work](#step-7-cache-reusable-work). Every page that opted in fires its prefetch as its `<Link>` enters the viewport, so the project list, the project detail, and the deployment page each render in the background ahead of the click.
 
-Click between projects fast and the fallback paints. Wait a beat before clicking, and the section is already prefetched and shows instantly. Open the devtools network panel to watch prefetch requests fire as links enter the viewport, then the navigation reads from cache.
+Click between projects fast and the fallback paints. Wait a beat before clicking, and the section is already prefetched and shows instantly.
 
 <Demo
   src="https://thinking-in-nextjs.labs.vercel.dev/projects"
   title="Step 8: Optimize prefetching"
 />
 
-The shift the demo highlights is which sections are already populated by the time the user clicks. Every Suspense boundary on this route is there because the read inside it resolves at request time, keyed on cookies, `?q=`, or `params`. Static prefetch couldn't fill any of them. Runtime prefetch fills them all in the same pass, so the boundaries stay in the source but stop painting a fallback at navigation time.
+When prefetch finishes before the click, large pieces of the destination render as real markup instead of skeletons. Each `<Suspense>` boundary on the route still marks a read keyed on cookies, `?q=`, or `params`, so static prefetch never had enough context to fill it. Runtime prefetch runs those reads in the background, which is why the fallback stops showing on navigation even though the boundary stays in the tree.
 
 The live build log on an in-progress deployment is the one exception, since it's live by definition. Once the build finishes, that log appears instantly too, served from the cached entry until its `cacheLife` runs out.
 
-That completion still runs on the same staggered timer as in [Step 5: Mutate data](#step-5-mutate-data), not something a prefetch or navigation read triggers.
-
-Runtime prefetch isn't free. Each visible `<Link>` triggers a real per-request render in the background, more server work than static prefetch, which renders against build-time inputs only. The cache layer from [Step 7: Cache reusable work](#step-7-cache-reusable-work) absorbs most of the cost. Each prefetched render populates an entry, and subsequent prefetches and navigations within the cache lifetime read it instead of re-rendering. The trade-off is fine for typical apps but worth knowing about.
+Runtime prefetch isn't free. Each visible `<Link>` triggers a real per-request render in the background, more server work than static prefetch, which renders against build-time inputs only. The cache layer from [Step 7: Cache reusable work](#step-7-cache-reusable-work) absorbs most of the cost. Each prefetched render populates an entry, and subsequent prefetches and navigations within the cache lifetime read from it instead of re-rendering. The trade-off is fine for typical apps but worth knowing about.
 
 Whatever the prefetch pass touched, static or runtime, is cached in the browser and works offline. The only parts that need an active connection are the live-streamed sections, so flaky networks stop being a meaningful problem for most of the app.
 
@@ -761,7 +742,7 @@ Source: [`steps/08-prefetching`](https://github.com/vercel-labs/thinking-in-next
 
 React's model is declarative. Components describe the output, and React renders them when the inputs change. The App Router extends that model past the browser, with the component as the unit of decision the whole way down.
 
-The server-component model carries the reads and the scaling. Caching and prefetching are how you got the SPA feel on top, without leaving that model behind.
+The server-component model carries the reads and the scaling. Caching and prefetching are how you get the SPA feel on top, without leaving that model behind.
 
 Try it on a route in your own codebase. Name the regions, then label each one as static, dynamic, cached, or a Client leaf. The decisions usually fall out once you've labeled what each piece is doing.
 
@@ -790,7 +771,7 @@ Jump to a step on GitHub:
 
 - [`steps/02-static-jsx`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/02-static-jsx). Static JSX with mock data.
 - [`steps/03-fetch-data`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/03-fetch-data). Server Components and a data access layer; `notFound()` for missing rows.
-- [`steps/04-streaming`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/04-streaming). Suspense boundaries and skeleton fallbacks around async UI; data queries mostly unchanged from [Step 3: Fetch data where it is used](#step-3-fetch-data-where-it-is-used).
+- [`steps/04-streaming`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/04-streaming). Suspense boundaries and skeleton fallbacks around async UI; data queries unchanged from [Step 3: Fetch data where it is used](#step-3-fetch-data-where-it-is-used).
 - [`steps/05-mutations`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/05-mutations). Server Functions; `refresh()` to re-run dynamic reads after a write.
 - [`steps/06-client-boundaries`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/06-client-boundaries). Client leaves; optimistic `ProjectPin` reading the per-viewer promise with `use`; URL-driven `SearchBar` with `useTransition`.
 - [`steps/07-caching`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/07-caching). `'use cache'` and tags on shared reads, including pinned ids keyed by `userId`; `'use cache: private'` reserved for the viewer's identity behind the avatar; `updateTag` to invalidate cached entries on a write.

--- a/docs/01-app/02-guides/thinking-in-nextjs.mdx
+++ b/docs/01-app/02-guides/thinking-in-nextjs.mdx
@@ -12,13 +12,13 @@ related:
 
 In React, you build a UI by breaking the screen into components and letting data flow through the tree. The original [Thinking in React](https://react.dev/learn/thinking-in-react) walks through that mental model. Break it down, build it static, then add state.
 
-In Next.js, the same component tree also says where data comes from, what renders immediately, what streams later, and what can be reused across navigations. Each component picks up an extra responsibility along with its rendering. It decides what kind of work it is.
+In Next.js, the same component tree also says where data comes from, what renders immediately, what streams later, and what can be reused across navigations. You compose server and client work as plain components, with each piece running where it belongs. React's [Server Components](https://react.dev/reference/rsc/server-components), [Suspense](https://react.dev/reference/react/Suspense), and [Transitions](https://react.dev/reference/react/useTransition) coordinate the result.
 
 ## Start with the mockup
 
 The brief: a small projects dashboard. Each viewer sees their projects, opens one to see its deployments, and opens a deployment to read its build log. They can search the list, pin favorites, and trigger a redeploy from the project page.
 
-The designer hands over mockups for three routes.
+Imagine the designer hands you mockups for three routes.
 
 <Image
   alt="Three route cards labeled /projects, /projects/compass, and /projects/compass/deployments/compass-jx9q3, each split into top bar, sidebar, and content regions."
@@ -55,7 +55,7 @@ The order matters. It's hard to think about caching before knowing what data is 
 Start by drawing boxes around each region and naming them.
 
 <Image
-  alt="A /projects mockup with four numbered regions next to a legend: 1 ProjectsLayout (frame around every page), 2 HeaderBar and SearchBar (top bar across every route), 3 Sidebar (Pinned and Recent deploys), 4 ProjectCard, ProjectPin, and PinButton (one project tile in the list)."
+  alt="A /projects mockup with four numbered regions next to a legend: 1 ProjectsLayout (frame around every page), 2 HeaderBar (top bar across every route), 3 Sidebar (Pinned and Recent deploys), 4 ProjectCard (one project tile in the list)."
   srcLight="/docs/guides/thinking-in-nextjs/component-legend-light.png"
   srcDark="/docs/guides/thinking-in-nextjs/component-legend-dark.png"
   width={1088}
@@ -64,16 +64,16 @@ Start by drawing boxes around each region and naming them.
 
 The full table fills in the project and build pages:
 
-| Region                  | Component                                |
-| ----------------------- | ---------------------------------------- |
-| Frame around every page | `ProjectsLayout`                         |
-| Top bar                 | `HeaderBar` and `SearchBar`              |
-| Sidebar                 | `Sidebar` (Pinned and Recent deploys)    |
-| Project tile            | `ProjectCard`, `ProjectPin`, `PinButton` |
-| Project page header     | `ProjectHeader` and `DeployButton`       |
-| Deployments list        | `Deployments`                            |
-| Build page header       | `DeploymentHeader`                       |
-| Build logs              | `BuildLogs`                              |
+| Region                  | Component                             |
+| ----------------------- | ------------------------------------- |
+| Frame around every page | `ProjectsLayout`                      |
+| Top bar                 | `HeaderBar`                           |
+| Sidebar                 | `Sidebar` (Pinned and Recent deploys) |
+| Project tile            | `ProjectCard`                         |
+| Project page header     | `ProjectHeader`                       |
+| Deployments list        | `Deployments`                         |
+| Build page header       | `DeploymentHeader`                    |
+| Build logs              | `BuildLogs`                           |
 
 The route shape lines up with the table:
 
@@ -84,13 +84,13 @@ ProjectsLayout                      ← persistent: HeaderBar + Sidebar
 └── /…/deployments/[deployId]       → DeploymentHeader + BuildLogs
 ```
 
-A few pairs (`HeaderBar` and `SearchBar`, `ProjectPin` and `PinButton`) are split because one side reads cookies or talks to the database, and the other handles user input. Server work and client work end up in separate files because they run in separate environments.
+The split mirrors the data. Each repeating piece of data gets one component: one `ProjectCard` per `Project`, one row per `Deployment`, one row per `LogLine`. [Thinking in React](https://react.dev/learn/thinking-in-react#step-1-break-the-ui-into-a-component-hierarchy) calls this matching the component structure to the data model — UI and data tend to share the same shape.
 
-At this stage, no decisions about caching, streaming, or client-side rendering. Start with what each component is responsible for. The other choices follow from there.
+At this stage, no decisions about how the data arrives, what's reused, or where components run. Naming and grouping is enough.
 
 ## Step 2: Build a static version with JSX
 
-Build it from mock data, with no database, actions, or client state.
+Now that the regions are named, render them as JSX from inline mock data. The database, Server Functions, and client state come later. It's easier to see the UI before any of those decisions come in.
 
 ```tsx
 function ProjectsPage() {
@@ -111,7 +111,7 @@ Layouts and pages are [Server Components](/docs/app/getting-started/server-and-c
 
 This is the App Router version of "build a static version" from Thinking in React. The UI is visible before any decision about where the real data comes from.
 
-Notice that the deployed route paints in one shot, with nothing to wait for. The HTML comes back from a static prerender, since every value the components need is inline mock data.
+Notice that the deployed route paints in one shot, with nothing to wait for. The HTML comes back from a static prerender, since every value the components need is inline mock data. Think of it as the route's flat baseline. Every later step adds shape only where the route needs it.
 
 <Demo
   src="https://thinking-in-nextjs-02.labs.vercel.dev/projects"
@@ -122,7 +122,7 @@ Source: [`steps/02-static-jsx`](https://github.com/vercel-labs/thinking-in-nextj
 
 ## Step 3: Fetch data where it is used
 
-Replace the mock data with reads from the data layer (the small set of functions that talk to the database or an upstream API). In Server Components, the component that displays the data reads it directly:
+With the static version painting, each region is ready to read from the real data layer. The data layer is the small set of functions that talk to the database or an upstream API. In Server Components, the component that displays the data reads it directly:
 
 ```tsx
 async function ProjectGrid({ searchParams }) {
@@ -133,6 +133,8 @@ async function ProjectGrid({ searchParams }) {
 ```
 
 Each component owns its read, kept close to the JSX that uses it. Lifting every fetch into a single parent and passing data down through props couples otherwise independent components, and tends to run their reads one after another instead of in parallel.
+
+Search uses a plain HTML form. Submitting it navigates to `/projects?q=...`, which `ProjectGrid` reads from `searchParams`. Step 7 layers a Client Component on top for live URL updates.
 
 Walking the tree from this angle, every piece of UI shows what it depends on:
 
@@ -147,9 +149,20 @@ Walking the tree from this angle, every piece of UI shows what it depends on:
 | `PinnedList`, `ProjectPin` | The viewer's pinned ids, stored in a cookie.    |
 | `ViewerAvatar`             | The current viewer, also from a cookie.         |
 
-Each component now reads its own data, but the prerender can't tell which of those reads will block. Earlier versions of App Router built the route either way, and finding the read that kept it from being static meant reading the build output or the request waterfall.
+Each component now reads its own data, but every read is dynamic. The route works, but every request runs every read, and the build doesn't try to prerender. Step 4 takes this further.
 
-[Cache Components](/docs/app/getting-started/caching) surfaces this. Opt in:
+Notice that the deployed route waits on the slowest read before it paints. Nothing on the page shows until every section's data is ready, even the parts that don't depend on it. Hit the refresh button in the demo's browser chrome to load it again.
+
+<Demo
+  src="https://thinking-in-nextjs-03.labs.vercel.dev/projects"
+  title="Step 3: Fetch data"
+/>
+
+Source: [`steps/03-fetch-data`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/03-fetch-data).
+
+## Step 4: Stream async work
+
+Earlier versions of App Router built the route either way. Finding the read that kept it from being static meant reading the build output or watching the request waterfall by hand. The refined model surfaces it for you. [`cacheComponents`](/docs/app/getting-started/caching) is the app-wide switch in `next.config.ts`:
 
 ```ts filename="next.config.ts"
 import type { NextConfig } from 'next'
@@ -161,29 +174,17 @@ const nextConfig: NextConfig = {
 export default nextConfig
 ```
 
-With it on, the prerender expects every async read to either be cached or sit behind a Suspense boundary. Anything else surfaces in both `next dev` and `next build` as [`Uncached data was accessed outside of <Suspense>`](https://nextjs.org/docs/messages/blocking-route), pointing at the call site.
+With it on, the prerender expects every async read to either be cached or sit behind a Suspense boundary. Anything else surfaces in both `next dev` and `next build` as [`Uncached data was accessed outside of <Suspense>`](https://nextjs.org/docs/messages/blocking-route), pointing at the call site:
 
-{/* TODO: add a real screenshot of the dev overlay via <Image src="..." /> once available. */}
-
-There are two ways to answer that:
-
-- `'use cache'`. Reuse the read so it can sit in the static shell.
-- `<Suspense>`. Provide a placeholder so the read can stream at request time.
-
-The component is correct, but the rendering structure isn't finished. Each async read picks one of the next two steps.
-
-Open the deployed route. The dashboard looks the same, now backed by the data layer instead of mock data.
-
-<Demo
-  src="https://thinking-in-nextjs-03.labs.vercel.dev/projects"
-  title="Step 3: Fetch data"
+<Image
+  alt="Next.js dev overlay reading 'Next.js encountered uncached data during the initial render.' A code preview highlights an uncached fetch call inside a Page component. Below, three fix cards are listed: 'Prerender and cache' with a 'use cache' snippet, 'Provide a placeholder with Suspense', and 'Allow blocking route' with `export const instant = false`."
+  srcLight="/docs/guides/thinking-in-nextjs/dev-overlay-light.png"
+  srcDark="/docs/guides/thinking-in-nextjs/dev-overlay-dark.png"
+  width={1024}
+  height={600}
 />
 
-Source: [`steps/03-fetch-data`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/03-fetch-data).
-
-## Step 4: Stream async work
-
-Wrap the sections that load data in [`<Suspense>`](https://react.dev/reference/react/Suspense) so the [static shell](/docs/app/glossary#static-shell) (the parts that don't need to wait) can render first:
+Each error gives you two options: stream the read (this step) or cache it (Step 5). Wrap the sections that load data in [`<Suspense>`](https://react.dev/reference/react/Suspense) so the [static shell](/docs/app/glossary#static-shell) (the parts that don't need to wait) can render first:
 
 ```tsx
 <HeaderBar />
@@ -223,7 +224,7 @@ For feeds that arrive outside the request (a real build log from the platform, t
 
 From here on, cached output is shell content and uncached output streams. Suspense marks the streaming part. A `'use cache'` read doesn't need a Suspense wrapper, because the cached output is already there.
 
-Notice that the projects route paints the shell immediately, then swaps in the sidebar and grid as each Suspense boundary resolves. Open a deployment that's still building to see the same primitive nested: each log line streams in on its own.
+Notice that the projects route paints the shell immediately, then swaps in the sidebar and grid as each Suspense boundary resolves. Open a deployment that's still building to see the same primitive nested: each log line streams in on its own. Hit the refresh button to replay the reveal.
 
 <Demo
   src="https://thinking-in-nextjs-04.labs.vercel.dev/projects"
@@ -234,7 +235,7 @@ Source: [`steps/04-streaming`](https://github.com/vercel-labs/thinking-in-nextjs
 
 ## Step 5: Cache reusable work
 
-Now consider which streamed sections are stable enough to reuse. The question to ask of each piece:
+Some of the streamed sections are stable enough to share between viewers. A cached read joins the shell, so the section behind it stops needing a Suspense boundary. Ask of each piece:
 
 > Would the next viewer see the same thing?
 
@@ -301,7 +302,7 @@ ProjectsLayout                  (persistent shell)
 
 Cached output also moves when the underlying data changes. The next step covers how mutations mark cached entries stale.
 
-Notice that the cached sections (project list, project header, deployment list) are already painted on first load, with no fallback. The only thing that still streams is the live build log on an in-progress build, the one read that changes per request.
+Notice that the cached sections (project list, project header, deployment list) are already painted on first load, with no fallback. The only thing that still streams is the live build log on an in-progress build, the one read that changes per request. Hit the refresh button to load it again.
 
 <Demo
   src="https://thinking-in-nextjs-05.labs.vercel.dev/projects"
@@ -355,11 +356,11 @@ The next step keeps the form action and wraps the buttons in Client Components f
 
 ## Step 7: Add client boundaries
 
-Component state still works the same as in any React app. Many things that would be component state in a typical SPA fit other patterns: updating the URL, calling a Server Function, showing optimistic state until server-rendered data catches up.
+Inside a Client Component, the full React API is back. Many things that would be component state in a typical SPA fit other patterns in App Router: updating the URL, calling a Server Function, showing optimistic state until server-rendered data catches up. The components that do need React state become Client Components.
 
-The form action from Step 6 already lets a click reach the server. What's still missing is anything only the client can do: instant feedback before the server confirms, pending state while a request is in flight. Push the components that own those into Client Components and leave the rest of the tree on the server.
+The form action from Step 6 already lets a click reach the server. What's still missing is anything only the client can do: instant feedback before the server confirms, pending state while a request is in flight, URL updates without a full submit.
 
-A client leaf wraps the existing form action and adds whatever the client owns on top:
+A client leaf wraps the form action from Step 6 with whatever the client owns on top. `onClick` and React state would work the same once the component is `'use client'`:
 
 ```tsx
 'use client'
@@ -392,19 +393,34 @@ async function ProjectPin({ projectId }) {
 
 The cookie read happens on the server and never reaches the browser. Server Components can render Client Components directly, so the wrapper sits right above the leaf.
 
-Pending state has a related shape. A small client leaf reads the pending status of the surrounding context, with no state of its own:
+Search follows the same pattern. A Client Component reads the URL on render and pushes it on each keystroke, with pending state while the new page renders:
 
 ```tsx
 'use client'
-import { useLinkStatus } from 'next/link'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useTransition } from 'react'
 
-function NavSpinner() {
-  const { pending } = useLinkStatus()
-  return pending ? <Spinner /> : null
+function SearchBar() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const [, startTransition] = useTransition()
+
+  return (
+    <input
+      type="search"
+      defaultValue={searchParams.get('q') ?? ''}
+      onChange={(event) => {
+        const next = event.target.value
+        startTransition(() => {
+          router.push(next ? `/projects?q=${next}` : '/projects')
+        })
+      }}
+    />
+  )
 }
 ```
 
-Place that leaf inside any `<Link>` and it activates for that link's navigation. The same idea works inside a form via `useFormStatus` for submission state.
+[`useTransition`](https://react.dev/reference/react/useTransition) keeps the input responsive and holds the rest of the page on the previous render until the new one is ready. There's no half-rendered intermediate to look at while the keystroke is in flight.
 
 Notice that the leaves react directly to input on the deployed route. Pinning flips before the server confirms, search edits the URL on each keystroke, and the deploy button stays in a pending state until the Server Function returns. Everything else around them stays a Server Component.
 
@@ -416,6 +432,8 @@ Notice that the leaves react directly to input on the deployed route. Pinning fl
 Source: [`steps/07-client-boundaries`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/07-client-boundaries).
 
 ## Step 8: Configure prefetching
+
+The cached pieces from Step 5 don't have to wait until the click. The router can fetch them ahead of time and have them ready in the client cache when the navigation happens. The route opts in with one line:
 
 ```tsx
 export const prefetch = 'force-runtime'
@@ -439,6 +457,8 @@ Notice that clicking a project card lands on the project route with the header a
 Source: [`steps/08-prefetching`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/08-prefetching).
 
 ## Where to go from here
+
+The route grew in layers from a flat baseline: Suspense boundaries around dynamic reads, caching for the reusable parts, client islands where input lives. Each one was added because the route needed it.
 
 Try the same exercise on a route in your own codebase. Name the regions, then label each one as static, dynamic, cached, or a Client leaf. The decisions usually fall out once each component answers what kind of work it is.
 

--- a/docs/01-app/02-guides/thinking-in-nextjs.mdx
+++ b/docs/01-app/02-guides/thinking-in-nextjs.mdx
@@ -275,25 +275,29 @@ On `/projects`, the timing reads roughly:
 
 Suspense controls when a section paints. Reusing the output is a separate decision, and that comes later.
 
-Suspense boundaries nest. A `<Suspense>` inside another lets the outer section paint without waiting on the inner one, so each level reveals as soon as its own data is ready. We can use this in `BuildLogs`. `LiveLines` renders the current line and wraps the next one in its own boundary, so the lines already resolved stay on screen while the next one is still pending.
+The shell stays interactive while sections fill in. Click into a project before recent deploys finishes loading, and the navigation runs immediately. App Router renders every navigation inside a [React transition](https://react.dev/reference/react/useTransition), so an in-flight render never holds up the next click.
+
+Suspense boundaries can nest, too. `BuildLogs` already sits behind the page's `<Suspense fallback={<BuildLogsSkeleton />}>`, but the in-progress branch reads its own slow query for the live log. We can wrap that branch in its own `<Suspense>` so the empty log frame paints as soon as the deployment status is known, and a cursor skeleton fills the frame while the live query resolves:
 
 ```tsx filename="app/projects/[id]/deployments/[deployId]/_components/BuildLogs.tsx" highlight={6-8}
-function LiveLines({ lines, index }) {
-  if (index >= lines.length) return <CursorRow />
+export async function BuildLogs({ params }) {
+  const { deployId } = await params
+  const deployment = await getDeployment(deployId)
   return (
-    <>
-      <LogRow line={lines[index]} />
-      <Suspense fallback={<CursorRow />}>
-        <DelayedNextLine lines={lines} nextIndex={index + 1} />
-      </Suspense>
-    </>
+    <BuildLogsShell>
+      {deployment.status === 'building' ? (
+        <Suspense fallback={<LiveLogSkeleton />}>
+          <LiveLogStream deployId={deployId} />
+        </Suspense>
+      ) : (
+        <CompletedLogStream deployId={deployId} />
+      )}
+    </BuildLogsShell>
   )
 }
 ```
 
-The behavior only becomes visible once mutations are added and you can trigger a deployment of your own, but the structure is in place from the start.
-
-The page reads are covered. Let's add the writes.
+The page reads are covered. You can't actually see the `building` branch yet, because nothing in the app starts a deploy. Let's add the writes next.
 
 Source: [`steps/04-streaming`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/04-streaming).
 
@@ -329,6 +333,8 @@ This is the same request-response loop PHP and Rails apps ran on. The browser po
 
 > **Note**: A Server Function is an exposed endpoint, so anything it touches needs the same auth checks and input validation a public API would get. This tutorial gates every write with `requireSession()`, a small helper that reads the session cookie and throws if it's missing or invalid. [How to Think About Security in Next.js](https://nextjs.org/blog/security-nextjs-server-components-actions) is the broader reference to read before shipping.
 
+> **Note**: The real `triggerDeploy` does a bit more than the snippet shows. It bumps the project's patch version, generates a fake commit sha, and schedules the new `building` row to flip to `ready` or `failed` after a random delay between 45 seconds and 5 minutes. None of that changes the shape of the Server Function. See [`data/actions/deployments.ts`](https://github.com/vercel-labs/thinking-in-nextjs/blob/main/steps/05-mutations/data/actions/deployments.ts) and [`lib/deployment-lifecycle.ts`](https://github.com/vercel-labs/thinking-in-nextjs/blob/main/steps/05-mutations/lib/deployment-lifecycle.ts) for the whole thing.
+
 Pinning takes the same shape. `addPin` and `removePin` each require a session, write to (or delete from) the pins table, and call `refresh()`:
 
 ```tsx filename="data/actions/pinned.ts" highlight={8}
@@ -345,26 +351,29 @@ export async function addPin(projectId) {
 
 The mutation pattern stays uniform across the app. The write touches the underlying state, then `refresh()` re-renders the route so the dynamic reads pick up the new value.
 
-Submit the deploy form, then pin and unpin a project. Watch the new deployment show up in the list and the pin state flip.
+Submit the deploy form, then open the new `building` row to see the build log fill in the lines that have run so far. Refresh a few seconds later and a few more have arrived. Pin and unpin a project to see the pin state flip after each round trip.
 
 <Demo
   src="https://thinking-in-nextjs-05-mutations.labs.vercel.dev/projects"
   title="Step 5: Mutate data"
 />
 
-Functional, but visibly slow. The deploy button has no pending state, the pin doesn't flip until the server confirms, and search still requires a submit. None of these can wait for a round trip. Let's fix that next.
+The server reads feel responsive. Open the page mid-build and the log catches up to that moment as it streams in. The mutations don't.
+
+The deploy button has no pending state, the pin doesn't flip until the server confirms, search still needs a submit, and nothing pulls new log lines in without a manual refresh. None of these can wait for a round trip. Let's fix that next.
 
 Source: [`steps/05-mutations`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/05-mutations).
 
 ## Step 6: Add client interactivity
 
-What still waits on the round trip? The deploy button has no spinner, the pin doesn't flip until the server confirms, and search requires a submit. Three controls in the mockup, three places where the gesture has to update the UI before the response lands.
+What still waits on the round trip? The deploy button has no spinner, the pin doesn't flip until the server confirms, search requires a submit, and the in-progress build log only grows when the page reloads. Four places where the UI has to update without a navigation.
 
-| Control       | Updates on     | Needs client |
-| ------------- | -------------- | ------------ |
-| Pin button    | click          | yes          |
-| Search field  | each keystroke | yes          |
-| Deploy button | click          | yes          |
+| Control         | Should update on  | Needs client |
+| --------------- | ----------------- | ------------ |
+| Pin button      | click             | yes          |
+| Search field    | each keystroke    | yes          |
+| Deploy button   | click             | yes          |
+| In-progress log | every few seconds | yes          |
 
 Move each one into a [`'use client'`](/docs/app/glossary#use-client-directive) leaf. Inside the boundary the full React API is back, including `onClick`, `useState`, hooks, and refs. Server Functions stay callable from client code, so `triggerDeploy`, `addPin`, and `removePin` keep working without rewrites.
 
@@ -470,9 +479,9 @@ function SearchBar() {
 }
 ```
 
-This is the client-side twin of the same `searchParams` read on the server. [`useSearchParams`](/docs/app/api-reference/functions/use-search-params) reads the request's `?q=`, which is a per-request input. Wrap the search bar in `<Suspense>` so the rest of the route can prerender as a static shell, with a fallback shaped like the field. React's [`useTransition`](https://react.dev/reference/react/useTransition) supplies `isPending`, and the field's leading search icon swaps to a spinner for the duration of the navigation.
+This is the client-side twin of the same `searchParams` read on the server. [`useSearchParams`](/docs/app/api-reference/functions/use-search-params) reads the request's `?q=`, which is a per-request input. Wrap the search bar in `<Suspense>` so the rest of the route can prerender as a static shell, with a fallback shaped like the field. [`useTransition`](https://react.dev/reference/react/useTransition) supplies `isPending` for the icon swap.
 
-The deploy button keeps its form shape, now hoisted into a `'use client'` boundary so React's [`useTransition`](https://react.dev/reference/react/useTransition) hook can drive its spinner. The form's action wraps the call to `triggerDeploy` in `startTransition`, which makes `pending` observable on the button itself, the same way `isPending` swaps the search input's icon for its spinner:
+The deploy button is the third leaf. It keeps its form shape from [Step 5: Mutate data](#step-5-mutate-data), now hoisted into a `'use client'` boundary so `useTransition` can drive its spinner. The form's action wraps the call to `triggerDeploy` in `startTransition`, which makes `pending` observable on the button itself, the same way `isPending` swaps the search input's icon for its spinner:
 
 ```tsx filename="app/projects/[id]/_components/DeployButton.tsx" highlight={9-10}
 'use client'
@@ -492,14 +501,34 @@ function DeployButton({ projectId }) {
 }
 ```
 
-Try the demo. Pin a project and watch the button flip immediately, then type in the search bar to see the URL update on each keystroke. Open a project and click Deploy.
+The fourth leaf doesn't take a click. The in-progress log slice grows with `Date.now() - createdAt` on each render, so the route only needs to re-render every few seconds while a build is running. We can drop a small Client Component next to `<LiveLogStream>` that calls [`router.refresh()`](/docs/app/api-reference/functions/use-router) on an interval:
+
+```tsx filename="app/projects/[id]/deployments/[deployId]/_components/BuildLogPoller.tsx" highlight={1,9}
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { useEffect } from 'react'
+
+export function BuildLogPoller({ intervalMs = 4000 }) {
+  const router = useRouter()
+  useEffect(() => {
+    const id = setInterval(() => router.refresh(), intervalMs)
+    return () => clearInterval(id)
+  }, [router, intervalMs])
+  return null
+}
+```
+
+`BuildLogPoller` renders nothing. It sits in the tree while the deployment is `building` and ticks the route. Each refresh re-runs `getInProgressBuildLog` with a fresh `Date.now()`, the slice grows by a line or two, and the new rows render under the cursor. When the row's status changes to `ready` or `failed`, the next tick re-renders the route as `<CompletedLogStream>`, and `BuildLogPoller` unmounts with it.
+
+Try the demo. Pin a project and watch the button flip immediately, then type in the search bar to see the URL update on each keystroke. Open a project, click Deploy, and open the new deployment to watch the build log grow on its own as time passes.
 
 <Demo
   src="https://thinking-in-nextjs-06-client-boundaries.labs.vercel.dev/projects"
   title="Step 6: Add client interactivity"
 />
 
-The pin flips before the server answers, the sidebar's pinned section catches up a beat later when the Server Function settles and the dynamic reads re-run, and the search bar pushes the new URL on each keystroke without a submit. Three Client leaves cover pin, search, and deploy, and the JavaScript shipped to the browser stays small because only those leaves cross into the client.
+The pin flips before the server answers, the sidebar's pinned section catches up a beat later when the Server Function settles and the dynamic reads re-run, the search bar pushes the new URL on each keystroke without a submit, and the build log keeps growing on its own. Four Client leaves cover pin, search, deploy, and the log poller, and the JavaScript shipped to the browser stays small because only those leaves cross into the client.
 
 The route is a complete app. Navigation between routes still feels server-y, though. Let's make repeat reads instant.
 
@@ -558,6 +587,22 @@ async function getProjects({ query }) {
 ```
 
 `q` comes in from `searchParams` in the page and passes through as `getProjects({ query: q })`, so the cards stream in behind the search bar instead of joining the static shell.
+
+The directive sits on the function, so two reads in the same file can carry different decisions. `getCompletedBuildLog` returns the final log of a finished build and carries `'use cache'`. `getInProgressBuildLog` returns more of the log on each call and doesn't:
+
+```tsx filename="data/queries/build-logs.ts" highlight={2-4,8}
+export const getCompletedBuildLog = cache(async (deployId) => {
+  'use cache'
+  cacheLife('minutes')
+  cacheTag(`build-log-${deployId}`)
+  // … read and return
+})
+
+export const getInProgressBuildLog = cache(async (deployId) => {
+  await connection()
+  // … read and return
+})
+```
 
 Per-viewer data splits into two patterns. Pinned ids stay on plain `'use cache'` keyed on `userId`. The cached function takes the id as an argument so the entry narrows on that value, while the public `getPinnedIds` reads the viewer once and delegates to it, so consumers don't have to thread the user through:
 
@@ -780,6 +825,6 @@ Jump to a step on GitHub:
 - [`steps/03-fetch-data`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/03-fetch-data). Server Components and a data access layer; `notFound()` for missing rows.
 - [`steps/04-streaming`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/04-streaming). Suspense boundaries and skeleton fallbacks around async UI; data queries unchanged.
 - [`steps/05-mutations`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/05-mutations). Server Functions; `refresh()` to re-run dynamic reads after a write.
-- [`steps/06-client-boundaries`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/06-client-boundaries). Three Client leaves: optimistic `ProjectPin` reading the per-viewer promise with `use`, URL-driven `SearchBar` with `useTransition`, and `DeployButton` with `useTransition` for the pending spinner.
+- [`steps/06-client-boundaries`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/06-client-boundaries). Four Client leaves: optimistic `ProjectPin` reading the per-viewer promise with `use`, URL-driven `SearchBar` with `useTransition`, `DeployButton` with `useTransition` for the pending spinner, and `BuildLogPoller` calling `router.refresh()` on an interval to grow the in-progress log.
 - [`steps/07-caching`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/07-caching). `'use cache'` and tags on shared reads, including pinned ids keyed by `userId`; `'use cache: private'` reserved for the viewer's identity behind the avatar; `updateTag` to invalidate cached entries on a write.
 - [`steps/08-prefetching`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/08-prefetching). `prefetch = 'force-runtime'`; instant validation for the static shell; minimal session wiring in the tutorial source for the demo.

--- a/docs/01-app/02-guides/thinking-in-nextjs.mdx
+++ b/docs/01-app/02-guides/thinking-in-nextjs.mdx
@@ -60,6 +60,7 @@ Draw a box around each region of the mockup and give it a name. Each repeating p
 | Frame around every page | `ProjectsLayout`                                                 |
 | Top bar                 | `HeaderBar`                                                      |
 | Sidebar                 | `Sidebar`, containing `PinnedSection` and `RecentDeploysSection` |
+| Project list            | `ProjectGrid`, containing one `ProjectCard` per project          |
 | Project tile            | `ProjectCard`                                                    |
 | Project page header     | `ProjectHeader`                                                  |
 | Deployments list        | `Deployments`                                                    |
@@ -169,7 +170,7 @@ export const getProjects = cache(async ({ query }) => {
 })
 ```
 
-React's [`cache`](https://react.dev/reference/react/cache) dedupes the read across one render. Two components calling `getProjects({ query: q })` share a single database round trip, so co-location costs nothing extra. If a row isn't found, the query calls [`notFound`](/docs/app/api-reference/functions/not-found) and the matching `not-found.tsx` next to that segment renders in its place. The `delay()` helper is a fixture that keeps loading and pending states visible in the recording. A real local read resolves in milliseconds.
+React's [`cache`](https://react.dev/reference/react/cache) dedupes the read across one server request. Two components calling `getProjects({ query: q })` share a single database round trip, so co-location costs nothing extra. If a row isn't found, the query calls [`notFound`](/docs/app/api-reference/functions/not-found) and the matching `not-found.tsx` next to that segment renders in its place. The `delay()` helper is a fixture that keeps loading and pending states visible in the recording. A real local read resolves in milliseconds.
 
 Every other region works the same way. The header reads the current viewer, the sidebar reads pinned ids and recent deploys, and the detail pages read what their JSX shows next to it.
 
@@ -222,7 +223,7 @@ function Sidebar() {
 
 What about the rest of the route? The avatar in `HeaderBar` reads the session. `ProjectGrid` reads the project list on `/projects`. The project detail page loads `ProjectHeader` and `Deployments`, and the deployment page loads `DeploymentHeader` and `BuildLogs`. Each one needs its own `<Suspense>` boundary and skeleton fallback alongside the JSX that uses it.
 
-This gets brittle to manage by hand. Every new async read needs a matching boundary, and missing one quietly stalls the first chunk. [`cacheComponents`](/docs/app/glossary#cache-components) is the rule that catches what we missed. Every async read either sits behind `<Suspense>` or carries a `'use cache'` directive, enforced at `next dev` and `next build`:
+This gets brittle to manage by hand. Every new async read needs a matching boundary, and missing one quietly stalls the first chunk. [`cacheComponents`](/docs/app/glossary#cache-components) is the rule that catches what we missed. Every async read of dynamic data either sits behind `<Suspense>` or carries a `'use cache'` directive, checked at `next dev` and `next build`:
 
 ```ts filename="next.config.ts" highlight={4}
 import type { NextConfig } from 'next'
@@ -245,14 +246,14 @@ Route (app)
 ◐  (Partial Prerender)  prerendered as static HTML with dynamic server-streamed content
 ```
 
-The `◐` is [Partial Prerendering](/docs/app/glossary#partial-prerendering-ppr) (PPR), the optimization that lets the static shell sit on a CDN. The dynamic split keeps working without it, but every visitor would re-render the shell. PPR keeps that work off the path.
+The `◐` is [Partial Prerendering](/docs/app/glossary#partial-prerendering-ppr) (PPR), the optimization that lets the static shell sit on a CDN. Without it the dynamic split keeps working, but every visitor would re-render the shell.
 
 When an async read isn't behind a boundary and isn't cached, the dev overlay points at the call site and lists three ways out:
 
 {/* TODO: Update the three `error-overhaul` links below once the Error Overhaul guide ships and the anchor names are finalized. */}
 
-- [Provide a `<Suspense>` placeholder](/docs/app/guides/error-overhaul#move-within-suspense) around the read — what the Sidebar above already does.
-- [Cache the data access with `'use cache'`](/docs/app/guides/error-overhaul#cache-dynamic-data) — the move when the result can be reused, covered later.
+- [Move within Suspense](/docs/app/guides/error-overhaul#move-within-suspense) — what the Sidebar above already does.
+- [Cache dynamic data](/docs/app/guides/error-overhaul#cache-dynamic-data) with `'use cache'` — the move when the result can be reused, covered later.
 - [Allow blocking route](/docs/app/guides/error-overhaul#allow-blocking-route) — an escape hatch when you knowingly want the whole route to wait.
 
 Try the demo. The static shell ships from a CDN at 0 ms, and each async section fills in as its read resolves.
@@ -273,6 +274,8 @@ Suspense controls when a section paints. Reusing the output is a separate decisi
 
 > **Note**: Suspense boundaries nest. Output that arrives in pieces, like log lines on an in-progress build, LLM tokens, or paginated work, can wrap each piece in its own boundary so each one streams independently. `BuildLogs.tsx` in the lab is one example: `LiveLines` recurses through the log and wraps each next line in its own `<Suspense>`.
 
+{/* TODO: The `instant-validation` link below points at a not-yet-shipped guide; update once the PR lands. The same link is used at line 672. */}
+
 > **Note**: A read that doesn't touch a per-request API (cookies, headers, `searchParams`, `params`) needs [`await connection()`](/docs/app/api-reference/functions/connection) at the top so Next.js excludes it from prerendering. The lab's database queries do this. Without it, a sync-feeling read like `db.select(...)` resolves at build time and the Suspense boundary above it never gets to stream. [Instant validation](/docs/app/guides/instant-validation) extends the same boundary check from the initial render to every navigation.
 
 The page reads are covered. Let's add the writes.
@@ -287,12 +290,13 @@ The first reach in client-side React might be an `onClick` handler, but that wou
 
 A [React Server Function](/docs/app/glossary#server-function), marked with `'use server'`, keeps the write on this route. Pass it to React's [`<form action>`](https://react.dev/reference/react-dom/components/form#form) prop, submit the form, and the arguments and return values cross a serialization boundary as a [Remote Procedure Call (RPC)](https://en.wikipedia.org/wiki/Remote_procedure_call). Plain data passes through; functions and class instances don't.
 
-```tsx filename="data/actions/deployments.ts" highlight={1,7}
+```tsx filename="data/actions/deployments.ts" highlight={1,6,8}
 'use server'
 
 import { refresh } from 'next/cache'
 
 export async function triggerDeploy(projectId) {
+  await requireSession()
   await db.deployment.create({ projectId })
   refresh()
 }
@@ -512,7 +516,7 @@ The natural question:
 
 {/* TODO: The `caches the data access` link below points at the not-yet-shipped Error Overhaul guide; update once it lands. */}
 
-If the answer is yes, [`'use cache'`](/docs/app/glossary#use-cache-directive) is the one primitive. The same directive covers reads reused across every visitor, reads reused per viewer, and reads reused only for the current session. The variant tweaks where the entry lives, not whether to cache. Add it at the top of a data function or a Server Component, and the result joins the static shell instead of streaming behind a fallback. On a project read, the directive sits next to a [`cacheLife`](/docs/app/api-reference/functions/cacheLife) for how long entries stay around and a [`cacheTag`](/docs/app/api-reference/functions/cacheTag) for invalidation later:
+If the answer is yes, [`'use cache'`](/docs/app/glossary#use-cache-directive) is the one primitive. The same directive covers reads reused across every visitor, reads reused per viewer, and reads reused only for the current session. The variant tweaks where the entry lives, not whether to cache. Add it at the top of a data function or a Server Component. On a project read, the directive sits next to a [`cacheLife`](/docs/app/api-reference/functions/cacheLife) for how long entries stay around and a [`cacheTag`](/docs/app/api-reference/functions/cacheTag) for invalidation later:
 
 ```tsx filename="data/queries/projects.ts" highlight={2,4}
 async function getProject(id) {
@@ -561,7 +565,7 @@ export const getPinnedIds = cache(async () => {
 
 The store is shared; the `userId` argument is what makes each entry per-viewer. Two different ids become two entries, the same way `getProject('compass')` and `getProject('feather')` do.
 
-The current viewer is the limit case. The cookie is the input, and there's nothing further to lift out. A plain `'use cache'` can't read cookies inline, so `getCurrentUser` uses [`'use cache: private'`](/docs/app/api-reference/directives/use-cache-private) instead. The directive shape is the same, but the function runs every render on the server and the result is held only in the browser's memory for the rest of the session, with `cookies()` and `headers()` allowed inside:
+The current viewer is the limit case. The cookie is the input, and there's nothing further to lift out. A plain `'use cache'` can't read cookies inline, so `getCurrentUser` uses [`'use cache: private'`](/docs/app/api-reference/directives/use-cache-private) instead. The directive shape is the same, but the function runs every server render and the result is held only in the browser's memory until the next reload, with `cookies()` and `headers()` allowed inside:
 
 ```tsx filename="data/queries/auth.ts" highlight={2-3}
 export const getCurrentUser = cache(async () => {
@@ -583,7 +587,7 @@ A Server Component that needs the resolved array, like `PinnedSection` in the si
 
 > **Note**: A third variant, [`'use cache: remote'`](/docs/app/api-reference/directives/use-cache-remote), backs a durable shared cache across server instances when the default in-memory store isn't enough. The [Cache Components](/docs/app/getting-started/caching) introduction compares all three.
 
-The tree now carries a decision per node, split between the shared layout and the per-route pages:
+Every read on the route now carries its own caching decision, split between the shared layout and the per-route pages:
 
 ```txt
 persistent shell (app/projects/layout.tsx)
@@ -626,19 +630,20 @@ Adding the cache layer changes the picture for mutations. `refresh()` re-runs th
 
 [`updateTag`](/docs/app/api-reference/functions/updateTag) is the surgical answer for cached entries. From inside a Server Function, it invalidates a cached read by name, so the same write that changed the underlying data names the entries that went stale. The route re-renders with the fresh values, which is what `refresh()` was doing before. Calling both is the wrong shape, so the Server Function calls `updateTag` in place of `refresh()`:
 
-```tsx filename="data/actions/deployments.ts" highlight={7-8}
+```tsx filename="data/actions/deployments.ts" highlight={6,8-9}
 'use server'
 
 import { updateTag } from 'next/cache'
 
 async function triggerDeploy(projectId) {
+  await requireSession()
   await db.deployment.create({ projectId })
   updateTag(`deployments-${projectId}`)
   updateTag('recent-deployments')
 }
 ```
 
-The tag names match the cached reads they invalidate. Each `updateTag` call lines up with the cache entries the write touched, and the route re-renders against the fresh values. ([`revalidateTag`](/docs/app/api-reference/functions/revalidateTag) is the alternative when you want stale-while-revalidate semantics, where the old value keeps serving until a fresh one finishes fetching.)
+The tag names match the cached reads they invalidate. Each `updateTag` call lines up with the cache entries the write touched, and the route re-renders against the fresh values. ([`revalidateTag(name, 'max')`](/docs/app/api-reference/functions/revalidateTag) is the alternative when you want stale-while-revalidate semantics, where the old value keeps serving until a fresh one finishes fetching.)
 
 Pinning takes the same shape. `getPinnedIds` was tagged earlier with ``cacheTag(`pinned-${userId}`)``, so `addPin` and `removePin` each invalidate that viewer's tag:
 
@@ -669,7 +674,9 @@ Source: [`steps/07-caching`](https://github.com/vercel-labs/thinking-in-nextjs/t
 
 ## Step 8: Optimize prefetching
 
-The cache is set up, but each navigation still waits. The cached entries on this route key on `params`, cookies, or `searchParams`, values that only arrive with a real request, so nothing fills them until the request lands. Instant validation keeps the shell ready at navigation; the data behind it is what's still missing.
+{/* TODO: link target pending Joseph's instant-validation PR. */}
+
+The cache is set up, but each navigation still waits. The cached entries on this route key on `params`, cookies, or `searchParams`, values that only arrive with a real request, so nothing fills them until the request lands. The static shell paints fast on its own. The data behind it is what's still missing.
 
 Prefetching fills those entries before the click. When a [`<Link>`](/docs/app/api-reference/components/link) enters the viewport, Next.js renders its destination in the background, so the tree is already cached by the time of the click.
 

--- a/docs/01-app/02-guides/thinking-in-nextjs.mdx
+++ b/docs/01-app/02-guides/thinking-in-nextjs.mdx
@@ -126,7 +126,7 @@ The `○` next to `/projects` is what to look for. Every value the route renders
 
 This is the [App Router](/docs/app/glossary#app-router) version of "build a static version" from Thinking in React. The UI is visible before you decide where the real data comes from.
 
-Try the demo. Each demo throughout this guide embeds the deployed lab, and the refresh button in the browser chrome replays the load. Notice the route paints in one shot, with nothing to wait for.
+Try the demo. Each demo throughout this guide embeds the deployed tutorial, and the refresh button in the browser chrome replays the load. Notice the route paints in one shot, with nothing to wait for.
 
 <Demo
   src="https://thinking-in-nextjs-02-static-jsx.labs.vercel.dev/projects"
@@ -250,7 +250,7 @@ function Sidebar() {
 
 The fallback is the [loading UI](/docs/app/glossary#loading-ui) that renders in the static shell while the async child is still resolving. It's replaced with the real output once the child finishes. The fallback's shape matters: a skeleton that matches the streamed result's width, height, and row count keeps the shell stable; a mismatched one pushes the page around when content arrives.
 
-The overlay only catches the initial render. Every navigation after that needs the same guarantee, and [instant validation](/docs/app/guides/instant-navigation) extends the check across all of them. One config line in `next.config.ts` turns it on:
+The overlay only catches the initial render. Every navigation after that needs the same guarantee, and [instant validation](/docs/app/guides/instant-validation) extends the check across all of them. One config line in `next.config.ts` turns it on:
 
 ```ts filename="next.config.ts"
 import type { NextConfig } from 'next'
@@ -357,7 +357,7 @@ async function addPin(projectId) {
 
 The mutation pattern is uniform across the app. The write touches the underlying state, then `refresh()` re-renders the route so the dynamic reads pick up the new value.
 
-For this walkthrough, a **building** deployment flips to **ready** on a staggered server timer, not when the next read runs. The lab adds a little extra revalidation from the caching step onward so the demo keeps updating tidily—you can dig into the source later.
+For this walkthrough, a **building** deployment flips to **ready** on a staggered server timer, not when the next read runs. The tutorial adds a little extra revalidation from the caching step onward so the demo keeps updating tidily—you can dig into the source later.
 
 Submit the deploy form, then pin and unpin a project. Watch the new deployment show up in the list and the pin state flip.
 
@@ -717,8 +717,6 @@ Prefetch is the timing answer. When a [`<Link>`](/docs/app/api-reference/compone
 
 The prefetch renders against one of two shapes, and the route declares which. The default is [**static**](/docs/app/guides/prefetching), with no cookies, headers, or search string in scope. That covers the shared layout and any cached read keyed on build-time inputs. [**Runtime**](/docs/app/api-reference/file-conventions/route-segment-config/prefetch) is opt-in, and it renders with the same cookies, headers, and search string the navigation would send, so per-viewer reads run against the real session before the click.
 
-Without the same session cookies the click would send, personalized prefetch can target the wrong viewer. We add minimal session wiring in the companion source so the demo prefetches match the click; [Authentication](/docs/app/guides/authentication) is the production reference.
-
 We can opt a page into runtime prefetch with one segment-config export, so its prefetch runs against the same cookies, headers, and search string the navigation would send.
 
 ```tsx
@@ -784,7 +782,7 @@ A few App Router pieces didn't fit this route, but they show up in real apps:
 
 ## Browse the source
 
-[`vercel-labs/thinking-in-nextjs`](https://github.com/vercel-labs/thinking-in-nextjs) holds one folder per guide step under `steps/`, each runnable on its own. The full app is also deployed at [thinking-in-nextjs.labs.vercel.dev](https://thinking-in-nextjs.labs.vercel.dev/).
+The [thinking-in-nextjs tutorial repo](https://github.com/vercel-labs/thinking-in-nextjs) holds one folder per guide step under `steps/`, each runnable on its own. The last step is also live at [the tutorial deployment](https://thinking-in-nextjs.labs.vercel.dev/).
 
 {/* TODO: restore the DemoExplorer block here once vercel/front#67624 lands on main and vercel-labs/thinking-in-nextjs is public. Intended config: repo "vercel-labs/thinking-in-nextjs", gitRef "main", path "steps", include "steps/**", exclude "node_modules,.next,.turbo,dist,build,*.lock,pnpm-lock.yaml", defaultFile "steps/07-static-jsx/app/projects/page.tsx". Source: https://github.com/vercel-labs/thinking-in-nextjs */}
 
@@ -796,4 +794,4 @@ Jump to a step on GitHub:
 - [`steps/05-mutations`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/05-mutations). Server Functions; `refresh()` to re-run dynamic reads after a write.
 - [`steps/06-client-boundaries`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/06-client-boundaries). Client leaves; optimistic `ProjectPin` reading the per-viewer promise with `use`; URL-driven `SearchBar` with `useTransition`.
 - [`steps/07-caching`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/07-caching). `'use cache'` and tags on shared reads, including pinned ids keyed by `userId`; `'use cache: private'` reserved for the viewer's identity behind the avatar; `updateTag` to invalidate cached entries on a write.
-- [`steps/08-prefetching`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/08-prefetching). `prefetch = 'force-runtime'`; instant validation for the static shell; minimal session wiring in source for the demo.
+- [`steps/08-prefetching`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/08-prefetching). `prefetch = 'force-runtime'`; instant validation for the static shell; minimal session wiring in the tutorial source for the demo.

--- a/docs/01-app/02-guides/thinking-in-nextjs.mdx
+++ b/docs/01-app/02-guides/thinking-in-nextjs.mdx
@@ -120,20 +120,20 @@ Route (app)
 ○  (Static)  prerendered as static content
 ```
 
-The `○` next to `/projects` is what to look for: every value the route needs is known at [build time](/docs/app/glossary#build-time), so the HTML is produced once and reused on every request.
+The `○` next to `/projects` is what to look for. Every value the route renders is known at [build time](/docs/app/glossary#build-time), so the HTML is produced once and reused on every request.
 
 This is the [App Router](/docs/app/glossary#app-router) version of "build a static version" from Thinking in React. The UI is visible before any decision about where the real data comes from.
 
-Notice that the deployed route paints in one shot, with nothing to wait for. The HTML comes back from a static prerender, since every value the components need is already in the file.
-
-This is the route's flat baseline.
-
 Each demo throughout this guide embeds the deployed lab. The refresh button in the browser chrome replays the load.
+
+Notice that the deployed route paints in one shot, with nothing to wait for.
 
 <Demo
   src="https://thinking-in-nextjs-02.labs.vercel.dev/projects"
   title="Step 2: Static JSX"
 />
+
+The HTML comes back from a static prerender, since every value the components need is already in the file. This is the route's flat baseline.
 
 Source: [`steps/02-static-jsx`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/02-static-jsx).
 
@@ -157,9 +157,9 @@ async function ProjectGrid({ searchParams }) {
 }
 ```
 
-Each section stays independent, and unrelated reads run in parallel. Co-locating the read with the JSX that uses it is the same instinct as `useEffect` or a query library, except a Server Component can `await` the read directly, without the loading-state boilerplate.
+Co-locating the read with the JSX that uses it is the same instinct as `useEffect` or a query library, except a Server Component can `await` the read directly, without the loading-state boilerplate.
 
-The reads themselves stay thin. Each one calls into a small `db` module that stands in for the real data source (a Postgres ORM, a remote API client, whatever the app uses):
+The reads themselves stay thin. Each one calls into a small `db` module that stands in for the real data source (a Postgres ORM, a remote API client, whatever the app uses), with caching, formatting, and retries handled around the wrapper, not inside:
 
 ```tsx
 // data/queries/projects.ts
@@ -168,15 +168,7 @@ async function getProjects({ query }) {
 }
 ```
 
-Caching, formatting, and retries live around the wrapper, not inside.
-
-Search is the first place where a Client Component would feel natural, but it doesn't have to be.
-
-The first cut is a plain HTML form. Submitting it navigates to `/projects?q=...`, and `ProjectGrid` reads `?q=` from `searchParams` to render the right list.
-
-No `'use client'` yet.
-
-By now every region has a read attached to it. The route works, but every request runs every read, and the build no longer tries to prerender.
+Search is the first place a Client Component would feel natural, but it doesn't have to be one. A plain HTML form pointing at `/projects?q=...` lets the browser do the navigation, and `ProjectGrid` reads `?q=` from `searchParams` to render the right list. No `'use client'` yet.
 
 Refresh the demo and notice the route now waits on the slowest read before it paints. Nothing on the page shows until every section's data is ready, even the parts that don't depend on it.
 
@@ -184,6 +176,8 @@ Refresh the demo and notice the route now waits on the slowest read before it pa
   src="https://thinking-in-nextjs-03.labs.vercel.dev/projects"
   title="Step 3: Fetch data"
 />
+
+By now every region has a read attached to it. The route works, but every request runs every read, and the build no longer tries to prerender.
 
 Source: [`steps/03-fetch-data`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/03-fetch-data).
 
@@ -217,9 +211,9 @@ The overlay lists three ways out. One lets the route block as before, an escape 
 
 Stream the read, or cache it. [Streaming](/docs/app/glossary#streaming) first, because it's the smaller commitment.
 
-A Suspense boundary only says "this part can paint later," not "this output is reusable." Reusability is the next question, and it lands more cleanly once every async read has its own place to be asked about.
+A Suspense boundary only says "this part can paint later," not "this output is reusable." Reusability is the next question, and it's easier to answer once every async read has its own boundary.
 
-Wrap each async section in its own boundary so the [static shell](/docs/app/glossary#static-shell) (the parts that don't need to wait) ships first:
+Wrap each async section in its own boundary so the [static shell](/docs/app/glossary#static-shell) (the parts that don't need to wait) is sent immediately:
 
 ```tsx
 function Sidebar() {
@@ -251,11 +245,9 @@ The fallback's shape matters. A skeleton matching the streamed result's width, h
 
 A wrong-sized fallback pushes the page around when the content arrives.
 
-A boundary does not have to wrap an entire region. It can wrap a single nested child while the rest of the surrounding layout already has its props: the outer tree paints from data the parent resolved, and only the inner subtree shows a fallback while something inside awaits.
+A boundary does not have to wrap an entire region. It can wrap a single nested child while the rest of the surrounding layout already has its props. The outer tree paints from data the parent resolved, and only the inner subtree shows a fallback while something inside awaits.
 
-What about output that arrives bit by bit, like log lines on an in-progress build, LLM tokens, or paginated work? Suspense boundaries can nest.
-
-Each piece wraps the next in its own boundary so each one streams independently:
+Output that arrives bit by bit, like log lines on an in-progress build, LLM tokens, or paginated work, reaches for the same primitive. Suspense boundaries nest, with each piece wrapping the next in its own boundary so each one streams independently:
 
 ```tsx
 function LiveLines({ lines, index }) {
@@ -273,12 +265,14 @@ function LiveLines({ lines, index }) {
 
 For feeds that arrive outside the request (a real build log streamed from the platform, telemetry, chat), the typical pattern is a Client Component that polls or subscribes.
 
-Notice that the projects route paints the shell immediately, then swaps in the sidebar and grid as each Suspense boundary resolves. Click into a project, then into a still-building deployment, to see the same primitive nested with each log line streaming in on its own.
+Click into the projects route. The shell paints immediately, and the sidebar and grid swap in as each Suspense boundary resolves. Click into a project, then into a still-building deployment, to see the same primitive nested with each log line streaming in on its own.
 
 <Demo
   src="https://thinking-in-nextjs-04.labs.vercel.dev/projects"
   title="Step 4: Stream async work"
 />
+
+Each section's fallback hides one slow read at a time, and the shell renders around it with the parts that don't have to wait. The route still runs every read on every request; what changed is that no read blocks any other.
 
 Source: [`steps/04-streaming`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/04-streaming).
 
@@ -342,9 +336,9 @@ The param isn't read inside `getProjects`; it arrives as `query`. The cache key 
 
 A plain `'use cache'` function can't read [`cookies()`](/docs/app/api-reference/functions/cookies) or [`headers()`](/docs/app/api-reference/functions/headers) inside itself for the same reason. Resolve those at the edge of the tree and pass what you need down.
 
-That leaves the per-viewer reads, like the avatar and the pinned ids. Both want different output for each viewer, but the shape of the work is different.
+That leaves the per-viewer reads, like the avatar and the pinned ids. Both produce different output for each viewer, but the shape of the work is different.
 
-Take pinned ids first. They're a database read keyed on the user's id, so the cache key the read needs is the id itself. The same `'use cache'` primitive works, with `userId` taken as an argument so the per-viewer entry falls out of the cache key:
+Take pinned ids first. They're a database read keyed on the user's id, so the cache key for the read is the id itself. The same `'use cache'` primitive works, with `userId` taken as an argument so the per-viewer entry falls out of the cache key:
 
 ```tsx
 async function getPinnedIds(userId) {
@@ -356,9 +350,11 @@ async function getPinnedIds(userId) {
 }
 ```
 
-The store is shared. The argument is what makes the entry per-viewer. `getPinnedIds('aurora')` and `getPinnedIds('lee')` are stored as separate entries, the same way `getProject('compass')` and `getProject('feather')` are.
+The store is shared. The argument is what makes the entry per-viewer. `getPinnedIds('aurora')` and `getPinnedIds('sam')` are stored as separate entries, the same way `getProject('compass')` and `getProject('feather')` are.
 
-But the lookup needs a `userId` to start with. That comes from the session cookie, and a plain `'use cache'` can't read [`cookies()`](/docs/app/api-reference/functions/cookies) inside itself. The viewer-identity read is the case where the cache scope IS the viewer, so it gets a different variant: [`'use cache: private'`](/docs/app/api-reference/directives/use-cache-private). Same directive shape, but the entry is scoped to the viewer and stored in the browser cache instead of being shared on the server. Inside it, `cookies()` and `headers()` are allowed. That's the whole point.
+But the lookup needs a `userId` to start with. That comes from the session cookie, and a plain `'use cache'` can't read [`cookies()`](/docs/app/api-reference/functions/cookies) inside itself. For the viewer-identity read, the entry's scope is the viewer's session, so it uses a different variant. [`'use cache: private'`](/docs/app/api-reference/directives/use-cache-private) keeps the same directive shape, but the entry is scoped to the viewer and stored in the browser cache instead of being shared on the server. Inside it, `cookies()` and `headers()` are allowed. That's the whole point.
+
+This shape takes a beat to internalize. That's normal.
 
 ```tsx
 async function getCurrentUser() {
@@ -377,7 +373,7 @@ const user = await getCurrentUser()
 const pinnedIds = await getPinnedIds(user.id)
 ```
 
-Both reads are per-viewer, but the mechanism is different. A plain `'use cache'` keyed on `userId` for the lookup that depends on it, and `'use cache: private'` for the cookie read where the viewer is the cache scope.
+Both reads are per-viewer, but the mechanism is different. A plain `'use cache'` keyed on `userId` for the lookup that depends on it, and `'use cache: private'` for the cookie read where the entry's scope is the viewer's session.
 
 There's a third variant ([`'use cache: remote'`](/docs/app/api-reference/directives/use-cache-remote)) for durable shared cache across server instances when the default in-memory store isn't enough. The hosting layer usually wires the handler.
 
@@ -406,32 +402,28 @@ ProjectsLayout
 └── BuildLogs                   use cache when complete, live while building
 ```
 
-What does this do to the Suspense boundaries from [Step 4: Stream async work](#step-4-stream-async-work)? Most come off.
-
-A cached read joins the static shell, and the wrapper around it doesn't have a job anymore. The boundaries around `RecentDeploys`, `ProjectHeader`, `Deployments`, and `BuildLogs` come out with it.
+Most of the Suspense boundaries from [Step 4: Stream async work](#step-4-stream-async-work) can be removed. Once a cached read joins the static shell, the Suspense wrapper around it has nothing to wait for. The boundaries around `RecentDeploys`, `ProjectHeader`, `Deployments`, and `BuildLogs` are no longer needed.
 
 What stays wrapped is what still resolves per request. The project grid reads `?q=` from the URL. The avatar and the pinned ids still suspend on first visit, because both lean on the session cookie and the static prerender doesn't have one to read.
 
 Inside `BuildLogs`, the live stream still has its boundary. That part is live by definition.
 
-Could you have skipped [Step 4: Stream async work](#step-4-stream-async-work) if you'd known the cache plan up front? Sure. But the question was sharper when each component had to answer it on its own.
+Could you have skipped [Step 4: Stream async work](#step-4-stream-async-work) if you'd known the cache plan up front? Sure. But the question was sharper when you asked it of each component on its own.
 
-Notice the new shape. The shared cached sections paint with no fallback because they're in the prerendered shell.
-
-The avatar and pinned section still flash once on a cold visit, then stay warm for the rest of the session. Click into a project and into a deployment to see the cached sections land instantly with no fallback this time.
-
-Reload the tab and the per-viewer ones go cold again.
+Click into a project and into a deployment, then back. Watch which sections paint instantly and which still show a fallback before resolving.
 
 <Demo
   src="https://thinking-in-nextjs-05.labs.vercel.dev/projects"
   title="Step 5: Cache reusable work"
 />
 
+The shared cached sections paint with no fallback because they're already in the prerendered shell. The avatar and pinned section still show their fallback on the first visit, then stay cached in the browser for the rest of the session. Reload the tab and the per-viewer reads run again from scratch.
+
 Source: [`steps/05-caching`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/05-caching).
 
 ## Step 6: Mutate data
 
-Caching decides what output gets reused. Mutations decide when that output stops being true.
+A cache stores reusable output. A mutation invalidates the entries that stopped being true.
 
 In the App Router, mutations live in [Server Functions](/docs/app/glossary#server-function) marked with `'use server'`. Each one does two things in the same call.
 
@@ -441,7 +433,7 @@ Triggering a deploy is the cleanest version of that. The write hits the upstream
 
 The project's deployments list is one. The sidebar's recent-deploys list is another.
 
-Each one carries its own tag, and the Server Function calls them by name:
+Each one has its own tag, and the Server Function calls them by name:
 
 ```tsx
 'use server'
@@ -457,11 +449,11 @@ The tag names match the ones the cached reads applied earlier, so one Server Fun
 
 [`updateTag`](/docs/app/api-reference/functions/updateTag) and [`revalidateTag`](/docs/app/api-reference/functions/revalidateTag) differ in how they treat the response that contains the mutation.
 
-`updateTag` handles read-your-writes: the new value shows up in the same response that triggered it.
+`updateTag` handles read-your-writes. The new value shows up in the same response that triggered it.
 
-`revalidateTag` handles stale-while-revalidate: the previous value keeps serving while the next read fetches a fresh one.
+`revalidateTag` handles stale-while-revalidate. The previous value keeps serving while the next read fetches a fresh one.
 
-What does that look like wired up to a button? The smallest version is a `<form action>`, with no `'use client'` boundary in the path:
+Wired up to a button, the smallest version is a `<form action>` with no `'use client'` boundary in the path:
 
 ```tsx
 <form action={triggerDeploy.bind(null, projectId)}>
@@ -487,12 +479,14 @@ The mutation pattern is now uniform across the app. The write touches the underl
 
 The same call works against either cache. A `'use cache: private'` entry responds to `updateTag` the same way the shared cache does. The only difference is where the entry lives.
 
-Notice that submitting the deploy form runs the Server Function and re-renders the route with the new deployments list. Pinning runs through the same path. ``updateTag(`pinned-${userId}`)`` invalidates that viewer's entry, and the next render shows the new state.
+Submit the deploy form, then pin and unpin a project. Watch the new deployment show up in the list and the pin state flip.
 
 <Demo
   src="https://thinking-in-nextjs-06.labs.vercel.dev/projects"
   title="Step 6: Mutate data"
 />
+
+Submitting the deploy form runs the Server Function and re-renders the route with the new deployments list. Pinning runs through the same path. ``updateTag(`pinned-${userId}`)`` invalidates that viewer's entry, and the next render shows the new state.
 
 Source: [`steps/06-mutations`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/06-mutations).
 
@@ -505,6 +499,8 @@ That moment is real, though. The pin button should flip the second it's clicked,
 Inside a [`'use client'`](/docs/app/glossary#use-client-directive) boundary the full React API is back, including `onClick`, `useState`, hooks, and refs. Server Functions stay callable from any of it, so the form pattern from [Step 6: Mutate data](#step-6-mutate-data) becomes one option among many, and the boundary itself is open-ended enough to host anything React can host, from a chart library to drag-and-drop to your own keyboard handler.
 
 In practice, a lot of routes never reach that far. The URL, a form, a Server Function, and a transition cover most of what an app needs, and the rest stays on the server where it belongs. The boundary is there for the moments that ask for more.
+
+Pending state has the same options. You can put `triggerDeploy` inside a `useTransition` and read `pending` from the hook for the spinner. React's [`useFormStatus`](https://react.dev/reference/react-dom/hooks/useFormStatus) would surface the same state from inside a `<form>`.
 
 So how wide does that boundary actually need to be? Often one prop, even before it resolves.
 
@@ -649,7 +645,7 @@ That's what unlocks every cached read whose key depends on the request. Static p
 
 The per-viewer reads from [Step 5: Cache reusable work](#step-5-cache-reusable-work) are one case. `getCurrentUser` reads cookies, and `getPinnedIds(userId)` keys on the id it returns. The projects grid is another, keyed on `?q=`, a value a static prefetch can't see.
 
-Runtime prefetch handles them all in the same pass, so the full cache graph for the route lands warm before the click resolves.
+Runtime prefetch handles them all in the same pass, so the full cache graph for the route is populated before the click resolves.
 
 Opting into runtime prefetch is one segment-config line:
 
@@ -679,9 +675,9 @@ Every route is in the loop, with no per-route opt-in to chase. The dev validator
 
 Try the demo. Click between projects, into deployments, and back. Everything lands instantly except the live build log on an in-progress deployment, which is live by definition.
 
-The shift the demo highlights is what lands warm. The projects grid keyed on `?q=`, the avatar, and the pinned section all used to stream on first visit. Now they land in the prefetched shell, because runtime prefetch fills the request-dependent reads in parallel during the prefetch pass.
+The shift the demo highlights is which sections are already populated when the click resolves. The projects grid keyed on `?q=`, the avatar, and the pinned section all used to stream on first visit. Runtime prefetch now fills those request-dependent reads in parallel during the prefetch pass, so they're served from cache instead of streaming.
 
-The avatar and pinned section also live on the device after the first prefetch. Subsequent navigations read them from cache and keep working offline or over a flaky connection.
+Whatever the prefetch pass touched, static or runtime, is cached in the browser and works offline. The only parts that need an active connection are the live-streamed sections, so flaky networks stop being a meaningful problem for most of the app.
 
 <Demo
   src="https://thinking-in-nextjs.labs.vercel.dev/projects"

--- a/docs/01-app/02-guides/thinking-in-nextjs.mdx
+++ b/docs/01-app/02-guides/thinking-in-nextjs.mdx
@@ -253,9 +253,11 @@ The `◐` is [Partial Prerendering](/docs/app/glossary#partial-prerendering-ppr)
 
 When an async read isn't behind a boundary and isn't cached, the dev overlay points at the call site and lists three ways out:
 
-- [Provide a `<Suspense>` placeholder](/patterns/provide-placeholder-with-suspense) around the read — what the Sidebar above already does.
-- [Cache the data access with `'use cache'`](/patterns/prerender-and-cache) — the move when the result can be reused, covered later.
-- [Allow blocking route](/patterns/allow-blocking-route) — an escape hatch when you knowingly want the whole route to wait.
+{/* TODO: add back ](/patterns/allow-blocking-route) links when pattern pages exist */}
+
+- Provide a `<Suspense>` placeholder — what the Sidebar above already does.
+- Cache the data access with `'use cache'` — the move when the result can be reused, covered later.
+- Allow blocking route — an escape hatch when you knowingly want the whole route to wait.
 
 Those checks fire on every server render. [Instant navigation](/docs/app/guides/instant-navigation) extends the same family to client navigations, failing `next dev` and `next build` when a route can't paint instantly on click. Wire it on once through `experimental.instant.defaultValidationLevel` in [`next.config`](/docs/app/api-reference/config/next-config-js).
 
@@ -747,7 +749,7 @@ We can opt a page into runtime prefetch with the [`prefetch`](/docs/app/api-refe
 ```tsx filename="app/projects/page.tsx" highlight={3}
 import { Suspense } from 'react'
 
-export const prefetch = 'force-runtime'
+export const unstable_prefetch = 'force-runtime'
 
 export default function ProjectsPage({ searchParams }) {
   return (

--- a/docs/01-app/02-guides/thinking-in-nextjs.mdx
+++ b/docs/01-app/02-guides/thinking-in-nextjs.mdx
@@ -8,22 +8,28 @@ related:
   links:
     - app/getting-started/caching
     - app/guides/streaming
+    - app/getting-started/server-and-client-components
+    - app/guides/server-actions
+    - app/guides/prefetching
+    - app/guides/runtime-prefetching
+    - app/guides/instant-navigation
+    - app/guides/offline-support
 ---
 
-In React, you break a UI into components and let data flow through the tree. [Thinking in React](https://react.dev/learn/thinking-in-react) walks through that model in five steps, from naming the parts to layering state on top.
+In React, you break a UI into components and let data flow through the tree. [Thinking in React](https://react.dev/learn/thinking-in-react) builds that habit by starting from a mockup, rendering a static version, then adding the changing pieces.
 
-In Next.js, the same tree carries a few more decisions. Where does the data come from? What can render before a request, what depends on the request, and what gets reused for the next visitor? The pieces are still components, some running on the server and some in the browser, and they compose into one tree across the boundary. Each component runs where that component belongs.
+In Next.js, the same tree carries a parallel set of questions. Where does the data come from? What can render before the request, what depends on the request, and what gets reused for the next visitor or the next click? The work still happens in one component tree, but that tree now crosses server and client boundaries.
 
-This tutorial builds one small app one decision at a time, the way you would in your own codebase. The same handful of pieces can build most App Router apps.
+When those decisions line up, the app gets the features of a [single-page app](https://developer.mozilla.org/en-US/docs/Glossary/SPA) that make navigation feel instant. Content is ready on click, and work is reused instead of recomputed.
 
 ## Start with the mockup
 
-Picture a mini Vercel, a small projects dashboard. Each viewer sees their projects, opens one to see its deployments, and opens a deployment to read its build log. They can search the list, pin favorites, and trigger a redeploy from the project page.
+The mock app is a tiny projects dashboard. Each viewer starts on a project list, opens a project, then opens a deployment log. They can also search, pin favorites, and trigger a redeploy from the project page.
 
 The designer hands over mockups for three routes.
 
 <Image
-  alt="Three route cards labeled /projects, /projects/compass, and /projects/compass/deployments/compass-jx9q3, each split into top bar, sidebar, and content regions."
+  alt="Three route cards labeled /projects, /projects/compass, and /projects/compass/deployments/compass-jx9q3, each split into top bar, sidebar, and content sections."
   srcLight="/docs/guides/thinking-in-nextjs/designer-mockups-light-cropped.png"
   srcDark="/docs/guides/thinking-in-nextjs/designer-mockups-dark-cropped.png"
   width={1600}
@@ -38,24 +44,21 @@ The data has three shapes:
 | `Deployment` | Newest first. Status is `ready`, `building`, `failed`, `queued`, or `cancelled`. |
 | `LogLine`    | A timestamped line with a message. The build log is an ordered list of these.    |
 
-The build happens one decision at a time:
+The breakdown follows one decision at a time:
 
 1. Break the UI into a component hierarchy.
 2. Build a static version with JSX.
 3. Fetch data where it is used.
-4. Stream async work.
+4. Stream dynamic content.
 5. Mutate data.
 6. Add client interactivity.
 7. Cache reusable work.
-8. Optimize prefetching.
-
-Caching depends on knowing what data each region reads, and [prefetching](/docs/app/glossary#prefetching) depends on knowing what's cached. Each step earns the next.
 
 ## Step 1: Break the UI into a component hierarchy
 
-Draw a box around each region of the mockup and give it a name. Each repeating piece of data becomes one component, with one `ProjectCard` per `Project`, one row per `Deployment`, and one row per `LogLine`. [Thinking in React](https://react.dev/learn/thinking-in-react#step-1-break-the-ui-into-a-component-hierarchy) calls this matching the component structure to the data model. UI and data tend to share the same shape.
+Draw a box around each section of the mockup and give it a name. Each repeating piece of data becomes one component, with one `ProjectCard` per `Project`, one row per `Deployment`, and one row per `LogLine`.
 
-| Region                  | Component                                                        |
+| Section                 | Component                                                        |
 | ----------------------- | ---------------------------------------------------------------- |
 | Frame around every page | `ProjectsLayout`                                                 |
 | Top bar                 | `HeaderBar`                                                      |
@@ -79,13 +82,13 @@ app/projects/
 │       └── page.tsx                    ← DeploymentDetailPage
 ```
 
-Two file conventions split the work. [`layout.tsx`](/docs/app/api-reference/file-conventions/layout) wraps every URL under `/projects` and holds the chrome that survives navigation — the top bar, the sidebar, and the layout grid. [`page.tsx`](/docs/app/api-reference/file-conventions/page) owns the main column for one URL, and the layout renders it as `{children}`. On each layout/page pair, the choice is what stays mounted across the route and what swaps with the URL.
+[`layout.tsx`](/docs/app/api-reference/file-conventions/layout) wraps every URL under `/projects` and keeps the top bar, sidebar, and layout grid mounted across navigations. [`page.tsx`](/docs/app/api-reference/file-conventions/page) renders the main column for one URL, and the layout inserts it as `{children}`. On each layout/page pair, the choice is what stays mounted across the route and what swaps with the URL.
 
-We haven't decided where the data comes from yet. Let's get the page on the screen first.
+The route now has names and boundaries. Before data enters the picture, those boxes can render from plain JSX.
 
 ## Step 2: Build a static version with JSX
 
-Render each region as JSX from inline mock data — values that already sit in the component file:
+Render each section from inline mock data:
 
 ```tsx filename="app/projects/page.tsx"
 const projects = [
@@ -112,11 +115,9 @@ function ProjectCard({ project }) {
 }
 ```
 
-[Layouts](/docs/app/glossary#layout) and [pages](/docs/app/glossary#page) are [React Server Components](/docs/app/glossary#server-component) by default. They run on the server and never run again in the browser. Their JavaScript doesn't ship to the client, a different shape from [React Client Components](/docs/app/glossary#client-component), which render on the server first and then hydrate in the browser to attach event handlers.
+With only local JSX and no browser-only behavior, [`layout.tsx`](/docs/app/api-reference/file-conventions/layout) and [`page.tsx`](/docs/app/api-reference/file-conventions/page) can stay as [React Server Components](/docs/app/glossary#server-component). They render the HTML without shipping component JavaScript for these sections.
 
-Since this version only renders JSX from local data, no Client Component is needed yet.
-
-Run `next build`. Every value is known up front, so the route [prerenders](/docs/app/glossary#prerendering) as static HTML:
+Because every value is known up front, `next build` can [prerender](/docs/app/glossary#prerendering) the route as static HTML:
 
 ```txt
 Route (app)
@@ -128,24 +129,22 @@ Route (app)
 
 The `○` next to `/projects` is what to look for. The HTML is produced once at [build time](/docs/app/glossary#build-time) and reused on every request.
 
-Try the demo. Each demo throughout this tutorial embeds the deployed app for that step, and the refresh button in the browser chrome replays the load. Notice the route paints in one shot — there's nothing to wait for.
+Try the demo. The refresh button replays the load. The route paints in one shot, with nothing to wait for.
 
 <Demo
   src="https://thinking-in-nextjs-02-static-jsx.labs.vercel.dev/projects"
   title="Step 2: Build a static version with JSX"
 />
 
-This is the route's flat baseline. Now let's swap the inline arrays for real data.
+The same HTML serves every viewer.
 
 Source: [`steps/02-static-jsx`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/02-static-jsx).
 
 ## Step 3: Fetch data where it is used
 
-The mock arrays come out, real reads go in. Where in the tree should those reads happen?
+Replace the mock arrays with real reads. Where in the tree should those reads happen?
 
-Each region needs a function to read what it shows. The collection of those reads is the route's [data access layer](/docs/app/guides/data-security#data-access-layer): `getProjects()`, `getProject(id)`, `getDeployments(projectId)`, and the same shape for the build log, the current viewer, and pinned ids. The schema and seed live under `lib/db`; the queries themselves live under `data/queries/`, one file per concern.
-
-The page could fetch everything at the top and pass values down with a `Promise.all`. That works, but it couples independent sections. The deployments list waits on the same parent as the sidebar, and the parent has to know what every region reads.
+One option is to fetch everything at the top with `Promise.all` and pass values down. That works, but it couples unrelated sections. The deployments list waits on the same parent as the sidebar, and the parent has to know what every child reads.
 
 The other option is for each component to read what it needs, right next to the JSX that uses it:
 
@@ -159,7 +158,7 @@ async function ProjectGrid({ searchParams }) {
 
 Co-locating the read with the JSX that uses it is the same instinct as `useEffect` or a query library, except a Server Component can `await` the read directly, with no client state to plumb through.
 
-Each query function calls into a small `db` module, the real data source for this tutorial. Swap it for whatever your app uses, whether a Postgres ORM, a remote API client, or anything else that returns data. The data access layer is also where retries, validation, and shaping live, kept out of the components that render the result:
+The read runs on the server, and the component gets the data back before it renders. The query itself can stay in the route's [data access layer](/docs/app/guides/data-security#data-access-layer) under `data/queries/`, away from the JSX that renders the result:
 
 ```tsx filename="data/queries/projects.ts" highlight={3}
 import { cache } from 'react'
@@ -171,15 +170,13 @@ export const getProjects = cache(async ({ query }) => {
 })
 ```
 
-> **Note**: Reads that already touch per-request data opt out of prerendering on their own. That includes [`cookies()`](/docs/app/api-reference/functions/cookies), [`headers()`](/docs/app/api-reference/functions/headers), `searchParams`, and an uncached `fetch()`. Reads like a synchronous database driver, `Math.random()`, or `new Date()` don't, so they need [`await connection()`](/docs/app/api-reference/functions/connection) at the top. This tutorial's database queries call it for this reason.
+> **Note**: [Request-time APIs](/docs/app/glossary#request-time-apis) like `cookies()`, `headers()`, `searchParams`, and uncached `fetch()` mark a component as dynamic on their own. Other reads like a database query, `Math.random()`, or `new Date()` don't, so add [`await connection()`](/docs/app/api-reference/functions/connection) at the top to make the read dynamic explicitly. The example database queries call it for this reason.
 
-React's [`cache`](https://react.dev/reference/react/cache) dedupes the read across one render, so two components calling `getProjects({ query: q })` share a single database round trip. Co-location costs nothing extra.
+React's [`cache`](https://react.dev/reference/react/cache) runs each call once per render, so two components asking for the same data share one read.
 
-Every other region follows the same shape, with the read sitting next to the JSX that uses it. The header reads the current viewer, the sidebar reads pinned ids and recent deploys, and the detail pages read what their JSX shows. The single-row variant `getProject(id)` calls [`notFound()`](/docs/app/api-reference/functions/not-found) when the id doesn't match, and the matching `not-found.tsx` segment renders in its place.
+For search, a plain GET form posts to `/projects?q=…`, and `ProjectGrid` reads [`searchParams`](/docs/app/api-reference/file-conventions/page#searchparams-optional) to render the filtered list.
 
-Search stays on the server too. A plain HTML form posts to `/projects?q=...`, the browser navigates, and `ProjectGrid` reads `?q=` from [`searchParams`](/docs/app/api-reference/file-conventions/page#searchparams-optional) to render the filtered list.
-
-Refresh the demo. Notice the route waits on the slowest read before any of it paints, even the parts that don't depend on it. Try the search bar, and the grid filters via `?q=` in the URL on each submit.
+Refresh the demo. The route waits on the slowest read before any of it paints, even the parts that don't depend on it. Try the search bar, and the grid filters via `?q=` in the URL on each submit.
 
 <Demo
   src="https://thinking-in-nextjs-03-fetch-data.labs.vercel.dev/projects"
@@ -197,15 +194,15 @@ Route (app)
 ƒ  (Dynamic)  server-rendered on demand
 ```
 
-Every region has a read attached. The slowest read holds up the paint. Let's break that next.
+Every section has something it waits on now. The slowest one blocks the initial render. That's what comes next.
 
 Source: [`steps/03-fetch-data`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/03-fetch-data).
 
-## Step 4: Stream async work
+## Step 4: Stream dynamic content
 
-Why should the rest of the page wait for the slowest read? It shouldn't. Next.js already streams the response by default; what changes is which reads block the first chunk. React's [`<Suspense>`](https://react.dev/reference/react/Suspense) lets you split the wait. Render this part when it's ready, render the rest now.
+Why should the rest of the page wait for the slowest read? It shouldn't. Next.js already streams the response by default, and React's [`<Suspense>`](https://react.dev/reference/react/Suspense) is how you mark each section that can wait behind a fallback.
 
-Wrap each async section behind its own boundary. In the sidebar, the pinned section and the recent deploys each get one:
+Wrap each section with dynamic content in its own boundary. In the sidebar, the pinned section and the recent deploys each get one:
 
 ```tsx filename="app/projects/_components/Sidebar.tsx" highlight={4,7}
 function Sidebar() {
@@ -222,11 +219,13 @@ function Sidebar() {
 }
 ```
 
-`Sidebar` itself is synchronous now. Each async child has its own boundary, and the fallback occupies the slot until the real markup replaces it. That fallback is the [loading UI](/docs/app/glossary#loading-ui). A skeleton matching the streamed result's width, height, and row count keeps the surrounding layout steady when content arrives.
+`Sidebar` itself stays synchronous. Each child gets [loading UI](/docs/app/glossary#loading-ui) shaped like the section that will replace it.
 
-What about the rest of the route? The avatar in `HeaderBar` reads the session. `ProjectGrid` reads the project list on `/projects`. The project detail page loads `ProjectHeader` and `Deployments`, and the deployment page loads `DeploymentHeader` and `BuildLogs`. Each one needs its own `<Suspense>` boundary and skeleton fallback alongside the JSX that uses it.
+The same pass covers the rest of the route. Avatar, grid, project header, deployments list, deployment header, and build logs each need something to show while their content is still resolving.
 
-This gets brittle to manage by hand. Every new async read needs a matching boundary, and missing one quietly stalls the first chunk. [`cacheComponents`](/docs/app/glossary#cache-components) is the rule that catches what we missed. Every async read of dynamic data needs a decision, checked at `next dev` and `next build`:
+This gets brittle to manage by hand. Every new async read needs a matching boundary, and missing one quietly stalls the first chunk.
+
+We can turn on [`cacheComponents`](/docs/app/glossary#cache-components) to make the choice explicit. With it enabled, every uncached read or Request-time API has to be marked, and `next dev` and `next build` flag the ones that aren't.
 
 ```ts filename="next.config.ts" highlight={4}
 import type { NextConfig } from 'next'
@@ -238,7 +237,7 @@ const nextConfig: NextConfig = {
 export default nextConfig
 ```
 
-When the rule holds, `next build` splits the route in two. The parts that don't depend on a request prerender as a [static shell](/docs/app/glossary#static-shell), and the parts behind Suspense stream in at request time. The build output picks up a new marker:
+With `cacheComponents` enabled, `next build` separates a [static shell](/docs/app/glossary#static-shell) from sections that still stream at request time:
 
 ```txt
 Route (app)
@@ -249,37 +248,35 @@ Route (app)
 ◐  (Partial Prerender)  prerendered as static HTML with dynamic server-streamed content
 ```
 
-The `◐` is [Partial Prerendering](/docs/app/glossary#partial-prerendering-ppr) (PPR). The static shell ships from the edge while the dynamic sections stream from the server.
+The `◐` is [Partial Prerendering](/docs/app/glossary#partial-prerendering-ppr) (PPR): a prerendered shell with dynamic content that streams from the server.
 
-When an async read isn't behind a boundary and isn't cached, the dev overlay points at the call site and lists three ways out:
+If a read is still uncached and outside a boundary, the overlay points at it and lists three choices:
 
-{/* TODO: add back ](/patterns/allow-blocking-route) links when pattern pages exist */}
+- **Stream** it by adding a `<Suspense>` fallback, like the sidebar above.
+- **Cache** it when the result can be reused, covered later.
+- **Block** the route when you knowingly want the whole route to wait.
 
-- Provide a `<Suspense>` placeholder — what the Sidebar above already does.
-- Cache the data access with `'use cache'` — the move when the result can be reused, covered later.
-- Allow blocking route — an escape hatch when you knowingly want the whole route to wait.
+For these sections, the decision is **Stream**. They need fresh or request-specific values, but the rest of the page can render without them. Each `<Suspense>` boundary fixes when its subtree replaces the fallback; it does not make the underlying reads reusable. Those reads still rerun on each request until they're cached.
 
-Those checks fire on every server render. [Instant navigation](/docs/app/guides/instant-navigation) extends the same family to client navigations, failing `next dev` and `next build` when a route can't paint instantly on click. Wire it on once through `experimental.instant.defaultValidationLevel` in [`next.config`](/docs/app/api-reference/config/next-config-js).
+`cacheComponents` runs these checks on every server render. [Instant validation](/docs/app/guides/instant-navigation) is the same kind of check for navigations, catching reads that would still block a click even when they sit behind `<Suspense>`.
 
-Try the demo. The static shell ships from a CDN at 0 ms, and each async section fills in as its read resolves.
+Try the demo. The static shell ships immediately, and each section fills in as its read resolves.
 
 <Demo
   src="https://thinking-in-nextjs-04-streaming.labs.vercel.dev/projects"
-  title="Step 4: Stream async work"
+  title="Step 4: Stream dynamic content"
 />
 
 On `/projects`, the timing reads roughly:
 
-- **0 ms**: Shell sent. The header and search form land immediately, with fallbacks rendered for the avatar, pinned section, recent deploys, and grid.
+- **0 ms**: Shell sent. The header and search form land immediately, with fallbacks for the avatar, pinned section, recent deploys, and grid.
 - **500 ms**: Avatar resolves.
-- **1000 ms**: Pinned and grid resolve.
+- **1000 ms**: Pinned section and grid resolve.
 - **1500 ms**: Recent deploys resolves last.
 
-Suspense controls when a section paints. Reusing the output is a separate decision, and that comes later.
+Streaming fixes the initial render but doesn't make later navigations reuse work. While sections stream, the shared layout UI stays interactive, so a click can start the next navigation even while another section is still filling in.
 
-The shell stays interactive while sections fill in. Click into a project before recent deploys finishes loading, and the navigation runs immediately. App Router renders every navigation inside a [React transition](https://react.dev/reference/react/useTransition), so an in-flight render never holds up the next click.
-
-Suspense boundaries can nest, too. `BuildLogs` already sits behind the page's `<Suspense fallback={<BuildLogsSkeleton />}>`, but the in-progress branch reads its own slow query for the live log. We can wrap that branch in its own `<Suspense>` so the empty log frame paints as soon as the deployment status is known, and a cursor skeleton fills the frame while the live query resolves:
+Nested reads follow the same rule. `BuildLogs` already sits behind the page's `<Suspense fallback={<BuildLogsSkeleton />}>`, but the in-progress branch has its own live read. We can wrap that branch in its own `<Suspense>` so the log frame can render first and the live rows can stream behind it:
 
 ```tsx filename="app/projects/[id]/deployments/[deployId]/_components/BuildLogs.tsx" highlight={6-8}
 export async function BuildLogs({ params }) {
@@ -299,17 +296,17 @@ export async function BuildLogs({ params }) {
 }
 ```
 
-The page reads are covered. You can't actually see the `building` branch yet, because nothing in the app starts a deploy. Let's add the writes next.
+The reads are covered. The `building` branch becomes visible once the app can start a deploy.
 
 Source: [`steps/04-streaming`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/04-streaming).
 
 ## Step 5: Mutate data
 
-Reads are covered. Now the writes — the deploy button and the pin button.
+Reads are covered. Now deploy and pin change data.
 
-The first reach in client-side React might be an `onClick` handler, but that would pull a Client Component into the route for the button alone. An HTML form submits the intent and the write still runs on the server. A [Route Handler](/docs/app/glossary#route-handler) would also work, but you'd hand-roll a separate HTTP endpoint to do it.
+An HTML form is the natural shape. The browser already knows how to submit one over the network, and the write can run on the server with no extra wiring. A [Route Handler](/docs/app/glossary#route-handler) would work too, but the route ends up with a separate endpoint for one button.
 
-A [React Server Function](/docs/app/glossary#server-function), marked with `'use server'`, keeps the write on this route. Pass it to React's [`<form action>`](https://react.dev/reference/react-dom/components/form#form) prop, submit the form, and the arguments and return values cross a serialization boundary as a [Remote Procedure Call (RPC)](https://en.wikipedia.org/wiki/Remote_procedure_call). Plain data passes through; functions and class instances don't.
+We can keep the write with the route by adding a colocated React [Server Function](/docs/app/glossary#server-function), marked with `'use server'`:
 
 ```tsx filename="data/actions/deployments.ts" highlight={1,7}
 'use server'
@@ -323,7 +320,7 @@ export async function triggerDeploy(projectId) {
 }
 ```
 
-The matching call site is an old-school HTML form, no `'use client'` in the path:
+React's [`<form action>`](https://react.dev/reference/react-dom/components/form#form) connects the form to the Server Function. Submitting it makes a [Remote Procedure Call (RPC)](https://en.wikipedia.org/wiki/Remote_procedure_call) to the server, so the arguments and return values have to be serializable. Strings, numbers, arrays, and plain objects can cross. Functions and class instances cannot.
 
 ```tsx highlight={1}
 <form action={triggerDeploy.bind(null, projectId)}>
@@ -331,13 +328,11 @@ The matching call site is an old-school HTML form, no `'use client'` in the path
 </form>
 ```
 
-This is the same request-response loop PHP and Rails apps ran on. The browser posts a form, the server runs a function, the server re-renders the page. The difference is that React produces the response. [`refresh`](/docs/app/api-reference/functions/refresh) from `next/cache` re-runs the dynamic reads on the current route, so the new deployment shows up in the list and the recent-deploys section updates alongside it.
+The browser posts the form, the server runs the write, and React renders the response. [`refresh`](/docs/app/api-reference/functions/refresh) reruns the route's dynamic reads so the new deployment shows up in the list and recent-deploys section.
 
-> **Note**: A Server Function is an exposed endpoint, so anything it touches needs the same auth checks and input validation a public API would get. This tutorial gates every write with `requireSession()`, a small helper that reads the session cookie and throws if it's missing or invalid. [How to Think About Security in Next.js](https://nextjs.org/blog/security-nextjs-server-components-actions) is the broader reference to read before shipping.
+> **Note**: A Server Function is an exposed endpoint, so anything it touches needs the same auth checks and input validation a public API would get. The labs gate every write with `requireSession()` and skip the broader story to keep the focus on the data flow. The [Server Actions guide](/docs/app/guides/server-actions) covers the broader API, and [How to Think About Security in Next.js](https://nextjs.org/blog/security-nextjs-server-components-actions) is the reference to read before shipping.
 
-> **Note**: The real `triggerDeploy` does a bit more than the snippet shows. It bumps the project's patch version, generates a fake commit sha, and schedules the new `building` row to flip to `ready` or `failed` after a random delay between 45 seconds and 5 minutes. None of that changes the shape of the Server Function. See [`data/actions/deployments.ts`](https://github.com/vercel-labs/thinking-in-nextjs/blob/main/steps/05-mutations/data/actions/deployments.ts) and [`lib/deployment-lifecycle.ts`](https://github.com/vercel-labs/thinking-in-nextjs/blob/main/steps/05-mutations/lib/deployment-lifecycle.ts) for the whole thing.
-
-Pinning takes the same shape. `addPin` and `removePin` each require a session, write to (or delete from) the pins table, and call `refresh()`:
+The pin write follows the same shape:
 
 ```tsx filename="data/actions/pinned.ts" highlight={8}
 'use server'
@@ -351,8 +346,6 @@ export async function addPin(projectId) {
 }
 ```
 
-The mutation pattern stays uniform across the app. The write touches the underlying state, then `refresh()` re-renders the route so the dynamic reads pick up the new value.
-
 Submit the deploy form, then open the new `building` row to see the build log fill in the lines that have run so far. Refresh a few seconds later and a few more have arrived. Pin and unpin a project to see the pin state flip after each round trip.
 
 <Demo
@@ -360,15 +353,15 @@ Submit the deploy form, then open the new `building` row to see the build log fi
   title="Step 5: Mutate data"
 />
 
-The server reads feel responsive. Open the page mid-build and the log catches up to that moment as it streams in. The mutations don't.
-
-The deploy button has no pending state, the pin doesn't flip until the server confirms, search still needs a submit, and nothing pulls new log lines in without a manual refresh. None of these can wait for a round trip. Let's fix that next.
+The server-side flow works. The buttons and search field still feel slow.
 
 Source: [`steps/05-mutations`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/05-mutations).
 
 ## Step 6: Add client interactivity
 
-What still waits on the round trip? The deploy button has no spinner, the pin doesn't flip until the server confirms, search requires a submit, and the in-progress build log only grows when the page reloads. Four places where the UI has to update without a navigation.
+The writes stay on the server. The browser still needs to react immediately in a few places.
+
+Four pieces still wait on a round trip. Each one needs a different kind of immediate feedback:
 
 | Control         | Should update on  | Needs client |
 | --------------- | ----------------- | ------------ |
@@ -377,9 +370,9 @@ What still waits on the round trip? The deploy button has no spinner, the pin do
 | Deploy button   | click             | yes          |
 | In-progress log | every few seconds | yes          |
 
-Move each one into a [`'use client'`](/docs/app/glossary#use-client-directive) leaf. Inside the boundary the full React API is back, including `onClick`, `useState`, hooks, and refs. Server Functions stay callable from client code, so `triggerDeploy`, `addPin`, and `removePin` keep working without rewrites.
+Only those controls become Client Components, marked with [`'use client'`](/docs/app/glossary#use-client-directive). The browser handles the immediate feedback; the server still handles the data changes.
 
-The pin used to be a server form. Now it becomes a Client Component so the toggle can be optimistic. The `/projects` page starts the per-viewer pinned-ids read once and forwards the promise down to each card without an `await` in between. The pin button calls React's [`use`](https://react.dev/reference/react/use) in the browser to read the ids, and the `<Suspense>` wrapper around the pin shows a pin-shaped skeleton until the promise resolves.
+The pin is the clearest case. The label can flip the moment the user clicks, then settle on the server's confirmed value. React calls this an [optimistic update](https://react.dev/reference/react/useOptimistic). We can start `getPinnedIds()` once on the page and pass the promise into each card, and the button reads that promise in the browser:
 
 ```tsx filename="app/projects/_components/ProjectPin.tsx" highlight={1,6,9}
 'use client'
@@ -406,13 +399,9 @@ function ProjectPin({ projectId, pinnedIdsPromise }) {
 }
 ```
 
-React's [`useOptimistic`](https://react.dev/reference/react/useOptimistic) supplies the temporary label while the Server Function is in flight, and React reverts to the server-confirmed value once the response lands.
+The label changes immediately. When the server response lands, the confirmed pinned ids replace the optimistic value.
 
-The form action captures `wasPinned` before the optimistic update so the Server Function always matches the state before the click. Two fast clicks then can't accidentally cancel each other out.
-
-Nothing else is needed. The `refresh()` call inside `addPin` and `removePin` re-runs the dynamic reads, Next.js re-renders the route with the fresh pinned ids, and the optimistic state is replaced by the real one.
-
-The `/projects` page awaits the projects list, starts the per-viewer pinned-ids promise, and passes the same reference into every card. `getPinnedIds()` reads the current viewer inside its own implementation, so the call site doesn't have to thread `userId` through:
+On the server, we can start the read once and pass the same promise to each card:
 
 ```tsx filename="app/projects/page.tsx" highlight={4,9}
 async function ProjectGrid({ searchParams }) {
@@ -429,7 +418,7 @@ async function ProjectGrid({ searchParams }) {
 }
 ```
 
-Only the pin button consumes the promise, so only that control sits behind `<Suspense>`. The rest of the card isn't blocked by the per-viewer lookup, and the fallback is a pin-shaped skeleton, not a skeleton for the whole card.
+The boundary can be placed around the button alone:
 
 ```tsx
 <header className="flex …">
@@ -440,11 +429,7 @@ Only the pin button consumes the promise, so only that control sits behind `<Sus
 </header>
 ```
 
-That file and its imports run in the browser, ancestors stay on the server. The page constructs the promise on the server, the promise crosses the boundary as a prop, and the pin button calls `use()` on the client to read it.
-
-Search is the next leaf. The plain GET form from earlier worked. Submit once, the browser navigates to `/projects?q=…`, and the page reads `searchParams` on the server.
-
-Per-keystroke updates need a `'use client'` boundary anyway, and once that's there the input can call `router.push` from `onChange` directly:
+Search can keep the same server read from `searchParams`. The client input pushes the next URL as the user types:
 
 ```tsx filename="app/projects/_components/SearchBar.tsx" highlight={9,18}
 'use client'
@@ -481,9 +466,7 @@ function SearchBar() {
 }
 ```
 
-This is the client-side twin of the same `searchParams` read on the server. [`useSearchParams`](/docs/app/api-reference/functions/use-search-params) reads the request's `?q=`, which is a per-request input. Wrap the search bar in `<Suspense>` so the rest of the route can prerender as a static shell, with a fallback shaped like the field. [`useTransition`](https://react.dev/reference/react/useTransition) supplies `isPending` for the icon swap.
-
-The deploy button is the third leaf. The same form as before, now hoisted into a `'use client'` boundary so `useTransition` can drive its spinner. The form's action wraps the call to `triggerDeploy` in `startTransition`, which makes `pending` observable on the button itself, the same way `isPending` swaps the search input's icon for its spinner:
+Deploy can use the same Server Function as before, wrapped in a [React transition](https://react.dev/reference/react/useTransition) so the button can show pending state:
 
 ```tsx filename="app/projects/[id]/_components/DeployButton.tsx" highlight={9-10}
 'use client'
@@ -503,9 +486,9 @@ function DeployButton({ projectId }) {
 }
 ```
 
-The form isn't strictly required now that we're on the client. A `<button onClick={() => startTransition(() => triggerDeploy(projectId))}>` would render the same UI. The form carries over because nothing about it needed to change.
+The form stays. Nothing about the server write needs to change.
 
-The fourth leaf doesn't take a click. The in-progress log slice grows with `Date.now() - createdAt` on each render, so the route only needs to re-render every few seconds while a build is running. We can drop a small Client Component next to `<LiveLogStream>` that calls [`router.refresh()`](/docs/app/api-reference/functions/use-router) on an interval:
+The live log needs a timer instead of a click. We can drop a small poller beside `<LiveLogStream>` that refreshes the route every few seconds while the deployment is building:
 
 ```tsx filename="app/projects/[id]/deployments/[deployId]/_components/BuildLogPoller.tsx" highlight={1,9}
 'use client'
@@ -523,32 +506,24 @@ export function BuildLogPoller({ intervalMs = 4000 }) {
 }
 ```
 
-`BuildLogPoller` renders nothing. It sits in the tree while the deployment is `building` and ticks the route. Each refresh re-runs `getInProgressBuildLog` with a fresh `Date.now()`, the slice grows by a line or two, and the new rows render under the cursor. When the row's status changes to `ready` or `failed`, the next tick re-renders the route as `<CompletedLogStream>`, and `BuildLogPoller` unmounts with it.
+Each refresh re-runs the live log read, and the new rows render under the cursor.
 
-Try the demo. Pin a project and watch the button flip immediately, then type in the search bar to see the URL update on each keystroke. Open a project, click Deploy, and open the new deployment to watch the build log grow on its own as time passes.
+Try the demo. Pin a project and watch the button flip immediately, then type in the search bar to see the URL update on each keystroke. Open a project, click Deploy, and watch the build log grow on its own.
 
 <Demo
   src="https://thinking-in-nextjs-06-client-boundaries.labs.vercel.dev/projects"
   title="Step 6: Add client interactivity"
 />
 
-The pin flips before the server answers, the sidebar's pinned section catches up a beat later when the Server Function settles and the dynamic reads re-run, the search bar pushes the new URL on each keystroke without a submit, and the build log keeps growing on its own. Four Client leaves cover pin, search, deploy, and the log poller, and the JavaScript shipped to the browser stays small because only those leaves cross into the client.
-
-The route is a complete app. Navigation between routes still feels server-y, though. Let's make repeat reads instant.
+The sidebar catches up once the server confirms the pin, and Client JavaScript stays small because only these four controls run in the browser; the rest of the route stays as Server Components. The app responds quickly to input now, but navigation still reruns the same server reads.
 
 Source: [`steps/06-client-boundaries`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/06-client-boundaries).
 
 ## Step 7: Cache reusable work
 
-The route works end-to-end now, but moving between routes still feels server-y. Click into a project, click back, click into another, and every read runs from scratch on each navigation. The shell paints fast, the fallbacks reappear, and the new section streams in.
+Client Components fixed input feedback, not navigation. Between project pages, the same reads still rerun and the same fallbacks still paint. Caching closes that gap without moving the data model into the browser.
 
-Caching is the move that gets the rest of the way to the instant feel of a [Single Page App (SPA)](/docs/app/guides/single-page-applications), without giving up the server-component model. Data lives next to the read, there's no client cache to hand-maintain across viewers, and there's no API contract to keep in sync.
-
-Walk the reads on the route. Most of them are reusable. The same render can serve the next request instead of running again, even when "the next request" only means the same viewer's next click.
-
-The natural question:
-
-> Could this read be reused?
+For each read, ask one question. _Would the next viewer see the same thing?_ Most of these reads do.
 
 | UI piece                          | Reusable?       |
 | --------------------------------- | --------------- |
@@ -560,7 +535,7 @@ The natural question:
 | `ViewerAvatar`                    | Yes, per viewer |
 | `PinnedSection`                   | Yes, per viewer |
 
-If the answer is yes, [`'use cache'`](/docs/app/glossary#use-cache-directive) is the one primitive. The same directive covers reads reused across every visitor, reads reused per viewer, and reads reused only for the current session. The variant tweaks where the entry lives, not whether to cache. Add it at the top of a data function or a Server Component. On a project read, the directive sits next to a [`cacheLife`](/docs/app/api-reference/functions/cacheLife) for how long entries stay around and a [`cacheTag`](/docs/app/api-reference/functions/cacheTag) for invalidation later:
+We can mark a reusable read with [`'use cache'`](/docs/app/glossary#use-cache-directive), plus a lifetime and tags so mutations can refresh the right entries later:
 
 ```tsx filename="data/queries/projects.ts" highlight={2,4}
 async function getProject(id) {
@@ -572,11 +547,11 @@ async function getProject(id) {
 }
 ```
 
-The function's arguments (together with any closed-over values) form the cache key. `getProject('compass')` and `getProject('feather')` end up as separate entries, each one kept for as long as `cacheLife` declares (`'hours'` on this read).
+The function's arguments form the cache key. `getProject('compass')` and `getProject('feather')` end up as separate entries, each kept for as long as `cacheLife` declares (`'hours'` here).
 
-`cacheTag` labels each entry by name so a mutation can invalidate it later. The per-id tag `project-${id}` gives a single project its own handle, and the broader `projects` tag still covers the list. A rename on `compass` invalidates one entry without touching `feather`.
+`cacheTag` labels each entry by name so a mutation can invalidate it later. The per-id tag `project-${id}` gives a single project its own handle, and the broader `projects` tag covers the list.
 
-The list read takes the same shape, with the query as the key:
+The project list can cache too. Pass the search value as an argument so each query gets its own entry:
 
 ```tsx filename="data/queries/projects.ts" highlight={2,4}
 async function getProjects({ query }) {
@@ -588,9 +563,7 @@ async function getProjects({ query }) {
 }
 ```
 
-`q` comes in from `searchParams` in the page and passes through as `getProjects({ query: q })`, so the cards stream in behind the search bar instead of joining the static shell.
-
-The directive sits on the function, so two reads in the same file can carry different decisions. `getCompletedBuildLog` returns the final log of a finished build and carries `'use cache'`. `getInProgressBuildLog` returns more of the log on each call and doesn't:
+Logs split by status. A finished build log can be cached, but an in-progress log is live, so it stays uncached:
 
 ```tsx filename="data/queries/build-logs.ts" highlight={2-4,8}
 export const getCompletedBuildLog = cache(async (deployId) => {
@@ -606,7 +579,7 @@ export const getInProgressBuildLog = cache(async (deployId) => {
 })
 ```
 
-Per-viewer data splits into two patterns. Pinned ids stay on plain `'use cache'` keyed on `userId`. The cached function takes the id as an argument so the entry narrows on that value, while the public `getPinnedIds` reads the viewer once and delegates to it, so consumers don't have to thread the user through:
+Pinned ids are reusable too, but only for one viewer. Split the read in two. The outer one finds the viewer; the inner one caches by `userId`:
 
 ```tsx filename="data/queries/pinned.ts" highlight={2,4}
 const getPinnedIdsForUser = cache(async (userId) => {
@@ -625,9 +598,9 @@ export const getPinnedIds = cache(async () => {
 
 The store is shared; the `userId` argument is what makes each entry per-viewer. Two different ids become two entries, the same way `getProject('compass')` and `getProject('feather')` do.
 
-Per-request inputs ([`cookies()`](/docs/app/api-reference/functions/cookies), [`headers()`](/docs/app/api-reference/functions/headers), `searchParams`) can't be read inside a plain `'use cache'` function. Lift them out at the call site and pass them as arguments, the way `getPinnedIds` reads `userId` from the viewer and hands it to `getPinnedIdsForUser`. The argument list is what becomes the cache key.
+Request values like [`cookies()`](/docs/app/api-reference/functions/cookies), [`headers()`](/docs/app/api-reference/functions/headers), and `searchParams` stay outside plain `'use cache'` functions. Read them first, then pass values in as arguments.
 
-How does this pattern work for `getCurrentUser`? It doesn't. The cookie is the input, with nothing further to lift out. `getCurrentUser` can use [`'use cache: private'`](/docs/app/api-reference/directives/use-cache-private) instead. The directive shape is the same, but the function runs every server render and the result is held only in the browser's memory until the next reload, with `cookies()` and `headers()` allowed inside:
+For `getCurrentUser`, the cookie is the input. There's nothing to lift out, so we can reach for [`'use cache: private'`](/docs/app/api-reference/directives/use-cache-private) instead. It's the variant that runs per viewer and can read request values directly:
 
 ```tsx filename="data/queries/auth.ts" highlight={2-3}
 export const getCurrentUser = cache(async () => {
@@ -639,20 +612,20 @@ export const getCurrentUser = cache(async () => {
 })
 ```
 
-The page can start the read once and pass the unawaited promise to every pin button so they each resolve with `use()` on the client:
+The page can still start the pinned-id read once:
 
 ```tsx
 const pinnedIdsPromise = getPinnedIds()
 ```
 
-A Server Component that needs the resolved array, like `PinnedSection` in the sidebar, can `await getPinnedIds()` directly. React's `cache()` returns the same in-flight promise the page already started, so the second call is free.
+The pin button can still call `use` on that promise, and sidebar segments can still `await getPinnedIds()` directly. The render shares the same in-flight work.
 
-> **Note**: A third variant, [`'use cache: remote'`](/docs/app/api-reference/directives/use-cache-remote), backs a durable shared cache across server instances when the default in-memory store isn't enough. The [Cache Components](/docs/app/getting-started/caching) introduction compares all three.
+> **Note**: A third variant, [`'use cache: remote'`](/docs/app/api-reference/directives/use-cache-remote), backs a durable shared cache across server instances. See the [Cache Components](/docs/app/getting-started/caching) intro for the full comparison.
 
-Every read on the route now carries its own caching decision, split between the shared layout and the per-route pages:
+After the pass, the route looks like this:
 
 ```txt
-persistent shell (app/projects/layout.tsx)
+shared layout (app/projects/layout.tsx)
 ├── HeaderBar
 │   └── ViewerAvatar            use cache: private
 └── Sidebar
@@ -671,9 +644,9 @@ app/projects/[id]/deployments/[deployId]/page.tsx
 └── BuildLogs                   use cache (complete) / streamed (building)
 ```
 
-The Suspense rule sharpens with caching in place. Add a boundary wherever the subtree still reads a per-request input — cookies, `searchParams`, `params`, or live output. Those reads can be cached too, but the cache key isn't known until the request lands, so the boundary stays.
+Sections whose keys come from the request, like `cookies()`, `searchParams`, `params`, or live output, keep `<Suspense>`.
 
-Cached reads with no per-request input join the prerendered shell. On this route that's the recent-deploys section, the only cached read whose key doesn't depend on the request. Its earlier Suspense boundary and skeleton fallback can both come out, since the section paints with the static shell. `Sidebar` collapses to one Suspense boundary around the per-viewer `PinnedSection`, with `RecentDeploysSection` rendered inline:
+Cached slices with no request input can join the static shell. On this route, `RecentDeploysSection` is the example, so its boundary can be removed:
 
 ```tsx filename="app/projects/_components/Sidebar.tsx" highlight={7}
 export function Sidebar() {
@@ -688,11 +661,11 @@ export function Sidebar() {
 }
 ```
 
-With `'use cache'` in place, that boundary could have been skipped from the start. Reaching it through Suspense first makes the pattern easier to see.
+After `'use cache'` backs those reads, calling [`refresh()`](/docs/app/api-reference/functions/refresh) reruns dynamic work but leaves cached entries in place until something invalidates them. Lists can stay stale after a deploy or pin.
 
-Adding the cache layer changes the picture for mutations. `refresh()` re-runs the dynamic reads on the route, but it doesn't move cached entries. After a deploy, the cached deployments list still serves the old value. After a pin, the cached `getPinnedIds` still returns the old set.
+[`updateTag`](/docs/app/api-reference/functions/updateTag) names the entries the write touched so the next render pulls fresh values. Use it from the Server Function instead of `refresh()` (or alongside [`revalidateTag`](/docs/app/api-reference/functions/revalidateTag) for stale-while-revalidate).
 
-[`updateTag`](/docs/app/api-reference/functions/updateTag) is the surgical answer for cached entries. From inside a Server Function, it invalidates a cached read by name, so the same write that changed the underlying data names the entries that went stale. The route re-renders with the fresh values, which is what `refresh()` was doing before. Calling both is the wrong shape, so the Server Function can call `updateTag` in place of `refresh()`:
+Each Server Function can call `updateTag` for the entries its write touched:
 
 ```tsx filename="data/actions/deployments.ts" highlight={6,8-9}
 'use server'
@@ -707,9 +680,7 @@ async function triggerDeploy(projectId) {
 }
 ```
 
-The tag names match the cached reads they invalidate. Each `updateTag` call lines up with the cache entries the write touched, and the route re-renders against the fresh values. ([`revalidateTag`](/docs/app/api-reference/functions/revalidateTag) is the alternative when you want stale-while-revalidate semantics, where the old value keeps serving until a fresh one finishes fetching.)
-
-Pinning takes the same shape. `getPinnedIds` was tagged earlier with ``cacheTag(`pinned-${userId}`)``, so `addPin` and `removePin` each invalidate that viewer's tag:
+Pins use the same pattern. `getPinnedIdsForUser` has a `pinned-${userId}` tag, so pin mutations invalidate that viewer's entry:
 
 ```tsx filename="data/actions/pinned.ts" highlight={8}
 'use server'
@@ -723,26 +694,26 @@ async function addPin(projectId) {
 }
 ```
 
-The mutation pattern stays uniform across the app. Each Server Function runs the write and calls `updateTag` for any cached read it touched. Tagged shared entries get invalidated; the per-viewer avatar runs every render anyway so it doesn't need a tag.
+Each write follows the same shape. Run the write, then call `updateTag` for whichever cached reads changed.
 
-Click into a project and into a deployment, then back. Watch which sections paint with the shell and which still show a fallback before resolving.
+Click into a project, then back to the list, then into a deployment. The sidebar's recent-deploys list paints with the static shell on every click. The other sections still flash a fallback before resolving.
 
 <Demo
   src="https://thinking-in-nextjs-07-caching.labs.vercel.dev/projects"
   title="Step 7: Cache reusable work"
 />
 
-Only the recent-deploys list paints with the static shell, since it's the one cached read with no per-request input. Everything else still paints a fallback first. The reads resolve at request time, so the static shell ships with a skeleton in those slots, and the browser swaps to the real content as the request comes back. The cache is in place, but the visible paint hasn't changed yet. Let's get the dynamic reads to render before the click.
+`RecentDeploysSection` is the one cached read with no per-request input, so it joins the static shell. The others are keyed by cookies, `params`, or [`searchParams`](/docs/app/api-reference/file-conventions/page#searchparams-optional). Those values only arrive with a real request, so the cache slots stay empty until the user clicks.
 
-Source: [`steps/07-caching`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/07-caching).
+The cache is set up, but the visible paint hasn't changed for sections waiting on a request. The missing piece is filling those entries before the click.
 
-## Step 8: Optimize prefetching
+### Cache reads that depend on the request
 
-The cache is set up, but each navigation still waits. The cached entries on this route key on `params`, cookies, or `searchParams`, values that only arrive with a real request, so nothing fills them until the request lands. The static shell paints fast on its own. The data behind it is what's still missing.
+Prefetching is what fills cache entries before the click. By default, [`<Link>`](/docs/app/api-reference/components/link) prefetches its destinations against build-time inputs only when they enter the viewport, which covers the static shell and any cached read keyed on build-time inputs.
 
-Prefetching fills those entries before the click. When a [`<Link>`](/docs/app/api-reference/components/link) enters the viewport, Next.js renders its destination in the background, so the tree is already cached by the time of the click.
+[Runtime prefetch](/docs/app/guides/runtime-prefetching) does the render with the real cookies, headers, and `searchParams` the navigation would carry, then stores the result in the [Client Cache](/docs/app/glossary#client-cache). It's the same skip-recomputation goal as the server cache, only filled before the click instead of during it.
 
-The prefetch renders against one of two shapes, and each route declares which. The default is [static](/docs/app/guides/prefetching), with no cookies, headers, or search string in scope. That covers the shared layout and any cached read keyed on build-time inputs. [Runtime](/docs/app/api-reference/file-conventions/route-segment-config/prefetch) is opt-in, and it renders with the same cookies, headers, and search string the navigation would send, so per-viewer reads run against the real session before the click.
+Prefetch only sticks if the destination reads are cached. Without `'use cache'` and tags on those reads, the prefetched output has no entry to reuse, and the next click rerenders from scratch. The reads above already carry tags and lifetimes, so prefetched output has a stable slot.
 
 We can opt a page into runtime prefetch with the [`unstable_prefetch`](/docs/app/api-reference/file-conventions/route-segment-config/prefetch) segment export:
 
@@ -762,9 +733,9 @@ export default function ProjectsPage({ searchParams }) {
 }
 ```
 
-Each page declares its own choice. We can add the export to every page whose reads depend on per-request inputs. On this app that's `/projects` (cookies for the avatar and pinned section, `?q=` for the grid), `/projects/[id]` (cookies and `params`), and `/projects/[id]/deployments/[deployId]` (cookies and `params`). The other pages on the route stay on static prefetch.
+Each page declares its own choice. On this app, `/projects` opts in for the avatar and pinned section (cookies) and the grid (`?q=`). `/projects/[id]` and `/projects/[id]/deployments/[deployId]` opt in for cookies and `params`. Other pages stay on static prefetch.
 
-Open the browser's network panel as `<Link>` elements scroll into view, and the prefetch requests show up as their own rows:
+As links scroll into view, the prefetches show up as ordinary fetches:
 
 ```txt
 Name                                          Status  Type   Size      Time
@@ -775,58 +746,27 @@ projects/aurora                               200     fetch  12.1 KB    81 ms
 projects/aurora/deployments/aurora-7k8h1      200     fetch  17.6 KB   108 ms
 ```
 
-Each row is a real per-request render of the destination, and the result populates the cache. Every page that opted in fires its prefetch as its `<Link>` enters the viewport, so the project list, the project detail, and the deployment page each render in the background ahead of the click.
+Each row is a per-request render of the destination, and the result is stored in the Client Cache. Before prefetch finishes, the fallback still appears. After it finishes, the section is already in the Client Cache.
 
-Click between projects fast and the fallback paints. Wait a beat before clicking, and the section is already prefetched and shows instantly.
+Click between projects fast and the fallback paints. Wait a beat before clicking, and the section is already prefetched.
 
 <Demo
   src="https://thinking-in-nextjs.labs.vercel.dev/projects"
-  title="Step 8: Optimize prefetching"
+  title="Step 7: Cache reusable work"
 />
 
-When prefetch finishes before the click, large pieces of the destination render as real markup instead of skeletons. Each `<Suspense>` boundary on the route still marks a read keyed on cookies, `?q=`, or `params`, so static prefetch never had enough context to fill it. Runtime prefetch runs those reads in the background, which is why the fallback stops showing on navigation even though the boundary stays in the tree.
+When prefetch finishes before the click, the destination renders real markup instead of skeletons. The `<Suspense>` boundaries stay in place because they still guard reads that need a real request.
 
-The live build log on an in-progress deployment is the one exception, since it's live by definition. Once the build finishes, that log appears instantly too, served from the cached entry until its `cacheLife` runs out.
+Every route the prefetch pass touched, static or runtime, is cached in the browser, so subsequent navigations work even over a flaky connection. [Offline support](/docs/app/guides/offline-support) covers the broader story for apps that go fully offline.
 
-Runtime prefetch isn't free. Each visible `<Link>` triggers a real per-request render in the background, more server work than static prefetch, which renders against build-time inputs only. The cache absorbs most of the cost. Each prefetched render populates an entry, and subsequent prefetches and navigations within the cache lifetime read from it instead of re-rendering. The trade-off is fine for typical apps but worth knowing about.
+Three layers combine for instant repeat navigation. `<Suspense>` handles the first visit, `'use cache'` gives prefetched output a stable entry, and runtime prefetch fills that entry before the click. Each layer has a cost, so apply them where smoother repeat navigation is worth the server work and the browser memory.
 
-Whatever the prefetch pass touched, static or runtime, is cached in the browser and works offline. The only parts that need an active connection are the live-streamed sections, so flaky networks stop being a meaningful problem for most of the app.
-
-Source: [`steps/08-prefetching`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/08-prefetching).
+Source: [`steps/07-caching`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/07-caching) and [`steps/08-prefetching`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/08-prefetching).
 
 ## Where to go from here
 
-React's model is declarative. Components describe the output, and React renders them when the inputs change. The App Router extends that model past the browser. The component is the unit of decision the whole way down, with caching and prefetching layered on top to give the route an SPA feel without leaving the server-component model behind.
+React's model is declarative: components describe the output, and React renders them when inputs change. The App Router extends that model past the browser. The route stayed one component tree; each part now declares where to read, what to stream, what to mutate, what runs in the browser, and what can be reused.
 
-Try it on a route in your own codebase. Name the regions, then label each one as static, dynamic, cached, or a Client leaf. The decisions usually fall out once you've labeled what each piece is doing.
+Try it on a route in your own codebase. Name the regions, then label each one as static, dynamic, cached, or a Client leaf.
 
-The docs go deeper on each piece used here.
-
-- [Cache Components](/docs/app/getting-started/caching) covers what `cacheComponents: true` changes and what each `'use cache'` variant is for.
-- [Streaming](/docs/app/guides/streaming) covers `loading.tsx`, nested Suspense, and where to place `<Suspense>`.
-- [Server and Client Components](/docs/app/getting-started/server-and-client-components) goes further on the prop boundary, including the donut pattern (Client Components receiving Server Components as `children`) for cases this tutorial didn't run into.
-- [Prefetching](/docs/app/guides/prefetching) and [instant navigation](/docs/app/guides/instant-navigation) cover runtime prefetch and shell validation in more depth.
-
-A few App Router pieces didn't fit this route, but they show up in real apps:
-
-- [Authentication](/docs/app/guides/authentication) for knowing who's reading.
-- [Proxy](/docs/app/getting-started/proxy) for intercepting requests before they reach a page.
-- [Route Handlers](/docs/app/getting-started/route-handlers) for endpoints that return data instead of a page.
-- [Parallel](/docs/app/api-reference/file-conventions/parallel-routes) and [intercepting](/docs/app/api-reference/file-conventions/intercepting-routes) routes for layouts that share a URL.
-- [Internationalization](/docs/app/guides/internationalization) for apps that speak more than one language.
-
-## Browse the source
-
-Each step you worked through is its own folder under `steps/` in the [tutorial repo](https://github.com/vercel-labs/thinking-in-nextjs), so jump back to revisit the diff for any one decision. The final state is also live at [the tutorial deployment](https://thinking-in-nextjs.labs.vercel.dev/).
-
-{/* TODO: restore the DemoExplorer block here once vercel/front#67624 lands on main and vercel-labs/thinking-in-nextjs is public. Intended config: repo "vercel-labs/thinking-in-nextjs", gitRef "main", path "steps", include "steps/**", exclude "node_modules,.next,.turbo,dist,build,*.lock,pnpm-lock.yaml", defaultFile "steps/07-static-jsx/app/projects/page.tsx". Source: https://github.com/vercel-labs/thinking-in-nextjs */}
-
-Jump to a step on GitHub:
-
-- [`steps/02-static-jsx`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/02-static-jsx). Static JSX with mock data.
-- [`steps/03-fetch-data`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/03-fetch-data). Server Components and a data access layer; `notFound()` for missing rows.
-- [`steps/04-streaming`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/04-streaming). Suspense boundaries and skeleton fallbacks around async UI; data queries unchanged.
-- [`steps/05-mutations`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/05-mutations). Server Functions; `refresh()` to re-run dynamic reads after a write.
-- [`steps/06-client-boundaries`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/06-client-boundaries). Four Client leaves: optimistic `ProjectPin` reading the per-viewer promise with `use`, URL-driven `SearchBar` with `useTransition`, `DeployButton` with `useTransition` for the pending spinner, and `BuildLogPoller` calling `router.refresh()` on an interval to grow the in-progress log.
-- [`steps/07-caching`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/07-caching). `'use cache'` and tags on shared reads, including pinned ids keyed by `userId`; `'use cache: private'` reserved for the viewer's identity behind the avatar; `updateTag` to invalidate cached entries on a write.
-- [`steps/08-prefetching`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/08-prefetching). `prefetch = 'force-runtime'`; instant validation for the static shell; minimal session wiring in the tutorial source for the demo.
+Each step's source is under `steps/` in the [example repo](https://github.com/vercel-labs/thinking-in-nextjs). The production mirror is at [thinking-in-nextjs.labs.vercel.dev](https://thinking-in-nextjs.labs.vercel.dev/).

--- a/docs/01-app/02-guides/thinking-in-nextjs.mdx
+++ b/docs/01-app/02-guides/thinking-in-nextjs.mdx
@@ -14,7 +14,7 @@ In React, you break a UI into components and let data flow through the tree. [Th
 
 In Next.js, the same tree carries a few more decisions. Where does the data come from? What can render before a request, what depends on the request, and what gets reused for the next visitor? The pieces are still components, some running on the server and some in the browser, and they compose into one tree across the boundary. Each component runs where that component belongs.
 
-This tutorial builds one small app one decision at a time, the way you would in your own codebase.
+This tutorial builds one small app one decision at a time, the way you would in your own codebase. The same handful of pieces can build most App Router apps.
 
 ## Start with the mockup
 
@@ -165,14 +165,17 @@ Each query function calls into a small `db` module, the real data source for thi
 import { cache } from 'react'
 
 export const getProjects = cache(async ({ query }) => {
+  await connection()
   await delay(1000)
   return db.project.findMany({ where: matches(query) })
 })
 ```
 
-React's [`cache`](https://react.dev/reference/react/cache) dedupes the read across one server request. Two components calling `getProjects({ query: q })` share a single database round trip, so co-location costs nothing extra. If a row isn't found, the query calls [`notFound`](/docs/app/api-reference/functions/not-found) and the matching `not-found.tsx` next to that segment renders in its place. The `delay()` helper is a fixture that keeps loading and pending states visible in the recording. A real local read resolves in milliseconds.
+> **Note**: Reads that already touch per-request data opt out of prerendering on their own. That includes [`cookies()`](/docs/app/api-reference/functions/cookies), [`headers()`](/docs/app/api-reference/functions/headers), `searchParams`, and an uncached `fetch()`. Reads like a synchronous database driver, `Math.random()`, or `new Date()` don't, so they need [`await connection()`](/docs/app/api-reference/functions/connection) at the top. This tutorial's database queries call it for this reason.
 
-Every other region works the same way. The header reads the current viewer, the sidebar reads pinned ids and recent deploys, and the detail pages read what their JSX shows next to it.
+React's [`cache`](https://react.dev/reference/react/cache) dedupes the read across one render, so two components calling `getProjects({ query: q })` share a single database round trip. Co-location costs nothing extra.
+
+Every other region follows the same shape, with the read sitting next to the JSX that uses it. The header reads the current viewer, the sidebar reads pinned ids and recent deploys, and the detail pages read what their JSX shows. The single-row variant `getProject(id)` calls [`notFound()`](/docs/app/api-reference/functions/not-found) when the id doesn't match, and the matching `not-found.tsx` segment renders in its place.
 
 Search stays on the server too. A plain HTML form posts to `/projects?q=...`, the browser navigates, and `ProjectGrid` reads `?q=` from [`searchParams`](/docs/app/api-reference/file-conventions/page#searchparams-optional) to render the filtered list.
 
@@ -246,14 +249,14 @@ Route (app)
 ◐  (Partial Prerender)  prerendered as static HTML with dynamic server-streamed content
 ```
 
-The `◐` is [Partial Prerendering](/docs/app/glossary#partial-prerendering-ppr) (PPR), the optimization that lets the static shell sit on a CDN. Without it the dynamic split keeps working, but every visitor would re-render the shell.
+The `◐` is [Partial Prerendering](/docs/app/glossary#partial-prerendering-ppr) (PPR). The static shell ships from the edge while the dynamic sections stream from the server.
 
 When an async read isn't behind a boundary and isn't cached, the dev overlay points at the call site and lists three ways out:
 
 {/* TODO: Update the three `error-overhaul` links below once the Error Overhaul guide ships and the anchor names are finalized. */}
 
-- [Move within Suspense](/docs/app/guides/error-overhaul#move-within-suspense) — what the Sidebar above already does.
-- [Cache dynamic data](/docs/app/guides/error-overhaul#cache-dynamic-data) with `'use cache'` — the move when the result can be reused, covered later.
+- [Provide a `<Suspense>` placeholder](/docs/app/guides/error-overhaul#move-within-suspense) around the read — what the Sidebar above already does.
+- [Cache the data access with `'use cache'`](/docs/app/guides/error-overhaul#cache-dynamic-data) — the move when the result can be reused, covered later.
 - [Allow blocking route](/docs/app/guides/error-overhaul#allow-blocking-route) — an escape hatch when you knowingly want the whole route to wait.
 
 Try the demo. The static shell ships from a CDN at 0 ms, and each async section fills in as its read resolves.
@@ -272,11 +275,23 @@ On `/projects`, the timing reads roughly:
 
 Suspense controls when a section paints. Reusing the output is a separate decision, and that comes later.
 
-> **Note**: Suspense boundaries nest. Output that arrives in pieces, like log lines on an in-progress build, LLM tokens, or paginated work, can wrap each piece in its own boundary so each one streams independently. `BuildLogs.tsx` in the lab is one example: `LiveLines` recurses through the log and wraps each next line in its own `<Suspense>`.
+Suspense boundaries nest. A `<Suspense>` inside another lets the outer section paint without waiting on the inner one, so each level reveals as soon as its own data is ready. We can use this in `BuildLogs`. `LiveLines` renders the current line and wraps the next one in its own boundary, so the lines already resolved stay on screen while the next one is still pending.
 
-{/* TODO: The `instant-validation` link below points at a not-yet-shipped guide; update once the PR lands. The same link is used at line 672. */}
+```tsx filename="app/projects/[id]/deployments/[deployId]/_components/BuildLogs.tsx" highlight={6-8}
+function LiveLines({ lines, index }) {
+  if (index >= lines.length) return <CursorRow />
+  return (
+    <>
+      <LogRow line={lines[index]} />
+      <Suspense fallback={<CursorRow />}>
+        <DelayedNextLine lines={lines} nextIndex={index + 1} />
+      </Suspense>
+    </>
+  )
+}
+```
 
-> **Note**: A read that doesn't touch a per-request API (cookies, headers, `searchParams`, `params`) needs [`await connection()`](/docs/app/api-reference/functions/connection) at the top so Next.js excludes it from prerendering. The lab's database queries do this. Without it, a sync-feeling read like `db.select(...)` resolves at build time and the Suspense boundary above it never gets to stream. [Instant validation](/docs/app/guides/instant-validation) extends the same boundary check from the initial render to every navigation.
+The behavior only becomes visible once mutations are added and you can trigger a deployment of your own, but the structure is in place from the start.
 
 The page reads are covered. Let's add the writes.
 
@@ -290,7 +305,7 @@ The first reach in client-side React might be an `onClick` handler, but that wou
 
 A [React Server Function](/docs/app/glossary#server-function), marked with `'use server'`, keeps the write on this route. Pass it to React's [`<form action>`](https://react.dev/reference/react-dom/components/form#form) prop, submit the form, and the arguments and return values cross a serialization boundary as a [Remote Procedure Call (RPC)](https://en.wikipedia.org/wiki/Remote_procedure_call). Plain data passes through; functions and class instances don't.
 
-```tsx filename="data/actions/deployments.ts" highlight={1,6,8}
+```tsx filename="data/actions/deployments.ts" highlight={1,7}
 'use server'
 
 import { refresh } from 'next/cache'
@@ -312,7 +327,7 @@ The matching call site is an old-school HTML form, no `'use client'` in the path
 
 This is the same request-response loop PHP and Rails apps ran on. The browser posts a form, the server runs a function, the server re-renders the page. The difference is that React produces the response. [`refresh`](/docs/app/api-reference/functions/refresh) from `next/cache` re-runs the dynamic reads on the current route, so the new deployment shows up in the list and the recent-deploys section updates alongside it.
 
-> **Note**: A Server Function is an exposed endpoint, so anything it touches needs the same auth checks and input validation a public API would get. The lab gates every write with `requireSession()`, a small helper that reads the session cookie and throws if it's missing or invalid. [How to Think About Security in Next.js](https://nextjs.org/blog/security-nextjs-server-components-actions) is the broader reference to read before shipping.
+> **Note**: A Server Function is an exposed endpoint, so anything it touches needs the same auth checks and input validation a public API would get. This tutorial gates every write with `requireSession()`, a small helper that reads the session cookie and throws if it's missing or invalid. [How to Think About Security in Next.js](https://nextjs.org/blog/security-nextjs-server-components-actions) is the broader reference to read before shipping.
 
 Pinning takes the same shape. `addPin` and `removePin` each require a session, write to (or delete from) the pins table, and call `refresh()`:
 
@@ -337,7 +352,7 @@ Submit the deploy form, then pin and unpin a project. Watch the new deployment s
   title="Step 5: Mutate data"
 />
 
-Functional, but visibly slow. The deploy button has no pending state, the pin doesn't flip until the server confirms, and search still requires a submit. None of these can wait for a round trip — let's fix that next.
+Functional, but visibly slow. The deploy button has no pending state, the pin doesn't flip until the server confirms, and search still requires a submit. None of these can wait for a round trip. Let's fix that next.
 
 Source: [`steps/05-mutations`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/05-mutations).
 
@@ -414,9 +429,9 @@ Only the pin button consumes the promise, so only that control sits behind `<Sus
 </header>
 ```
 
-`'use client'` marks a [boundary](/docs/app/glossary#use-client-directive). That file and its imports run in the browser, ancestors stay on the server. The page still constructs the promise on the server, the promise crosses the boundary as a prop, and the pin button calls `use()` on the client to read it.
+That file and its imports run in the browser, ancestors stay on the server. The page constructs the promise on the server, the promise crosses the boundary as a prop, and the pin button calls `use()` on the client to read it.
 
-Search is the third leaf. The plain GET form from earlier worked. Submit once, the browser navigates to `/projects?q=…`, and the page reads `searchParams` on the server.
+Search is the next leaf. The plain GET form from earlier worked. Submit once, the browser navigates to `/projects?q=…`, and the page reads `searchParams` on the server.
 
 Per-keystroke updates need a `'use client'` boundary anyway, and once that's there the input can call `router.push` from `onChange` directly:
 
@@ -477,8 +492,6 @@ function DeployButton({ projectId }) {
 }
 ```
 
-Nothing about React requires a form here. A `<button onClick={...}>` from inside the same `useTransition` would render the same UI.
-
 Try the demo. Pin a project and watch the button flip immediately, then type in the search bar to see the URL update on each keystroke. Open a project and click Deploy.
 
 <Demo
@@ -486,9 +499,9 @@ Try the demo. Pin a project and watch the button flip immediately, then type in 
   title="Step 6: Add client interactivity"
 />
 
-The pin flips before the server answers, the sidebar's pinned section catches up a beat later when the Server Function settles and the dynamic reads re-run, and the search bar pushes the new URL on each keystroke without a submit. Three Client leaves cover pin, search, and deploy. Everything else stays a Server Component, and the JavaScript shipped to the browser stays small because only those leaves cross into the client.
+The pin flips before the server answers, the sidebar's pinned section catches up a beat later when the Server Function settles and the dynamic reads re-run, and the search bar pushes the new URL on each keystroke without a submit. Three Client leaves cover pin, search, and deploy, and the JavaScript shipped to the browser stays small because only those leaves cross into the client.
 
-The route is a complete app. Navigation between routes still feels server-y, though — let's make repeat reads instant.
+The route is a complete app. Navigation between routes still feels server-y, though. Let's make repeat reads instant.
 
 Source: [`steps/06-client-boundaries`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/06-client-boundaries).
 
@@ -544,7 +557,7 @@ async function getProjects({ query }) {
 }
 ```
 
-Every other cached read follows the same shape, with a `'use cache'` directive, a `cacheLife`, and a `cacheTag` that names what the entry covers. Per-request inputs (`searchParams`, [`cookies()`](/docs/app/api-reference/functions/cookies), [`headers()`](/docs/app/api-reference/functions/headers)) stay outside the cached function and arrive as arguments. The argument list is the cache key. That's why the page resolves `q` from `searchParams` in the parent and passes it into `getProjects({ query: q })`. Caching keys on `query`, but `q` only arrives with a real request, so the cards stream in behind the search bar instead of joining the static shell.
+`q` comes in from `searchParams` in the page and passes through as `getProjects({ query: q })`, so the cards stream in behind the search bar instead of joining the static shell.
 
 Per-viewer data splits into two patterns. Pinned ids stay on plain `'use cache'` keyed on `userId`. The cached function takes the id as an argument so the entry narrows on that value, while the public `getPinnedIds` reads the viewer once and delegates to it, so consumers don't have to thread the user through:
 
@@ -565,7 +578,9 @@ export const getPinnedIds = cache(async () => {
 
 The store is shared; the `userId` argument is what makes each entry per-viewer. Two different ids become two entries, the same way `getProject('compass')` and `getProject('feather')` do.
 
-The current viewer is the limit case. The cookie is the input, and there's nothing further to lift out. A plain `'use cache'` can't read cookies inline, so `getCurrentUser` uses [`'use cache: private'`](/docs/app/api-reference/directives/use-cache-private) instead. The directive shape is the same, but the function runs every server render and the result is held only in the browser's memory until the next reload, with `cookies()` and `headers()` allowed inside:
+Per-request inputs ([`cookies()`](/docs/app/api-reference/functions/cookies), [`headers()`](/docs/app/api-reference/functions/headers), `searchParams`) can't be read inside a plain `'use cache'` function. Lift them out at the call site and pass them as arguments, the way `getPinnedIds` reads `userId` from the viewer and hands it to `getPinnedIdsForUser`. The argument list is what becomes the cache key.
+
+How does this pattern work for `getCurrentUser`? It doesn't. The cookie is the input, with nothing further to lift out. `getCurrentUser` can use [`'use cache: private'`](/docs/app/api-reference/directives/use-cache-private) instead. The directive shape is the same, but the function runs every server render and the result is held only in the browser's memory until the next reload, with `cookies()` and `headers()` allowed inside:
 
 ```tsx filename="data/queries/auth.ts" highlight={2-3}
 export const getCurrentUser = cache(async () => {
@@ -628,7 +643,7 @@ export function Sidebar() {
 
 Adding the cache layer changes the picture for mutations. `refresh()` re-runs the dynamic reads on the route, but it doesn't move cached entries. After a deploy, the cached deployments list still serves the old value. After a pin, the cached `getPinnedIds` still returns the old set.
 
-[`updateTag`](/docs/app/api-reference/functions/updateTag) is the surgical answer for cached entries. From inside a Server Function, it invalidates a cached read by name, so the same write that changed the underlying data names the entries that went stale. The route re-renders with the fresh values, which is what `refresh()` was doing before. Calling both is the wrong shape, so the Server Function calls `updateTag` in place of `refresh()`:
+[`updateTag`](/docs/app/api-reference/functions/updateTag) is the surgical answer for cached entries. From inside a Server Function, it invalidates a cached read by name, so the same write that changed the underlying data names the entries that went stale. The route re-renders with the fresh values, which is what `refresh()` was doing before. Calling both is the wrong shape, so the Server Function can call `updateTag` in place of `refresh()`:
 
 ```tsx filename="data/actions/deployments.ts" highlight={6,8-9}
 'use server'
@@ -643,7 +658,7 @@ async function triggerDeploy(projectId) {
 }
 ```
 
-The tag names match the cached reads they invalidate. Each `updateTag` call lines up with the cache entries the write touched, and the route re-renders against the fresh values. ([`revalidateTag(name, 'max')`](/docs/app/api-reference/functions/revalidateTag) is the alternative when you want stale-while-revalidate semantics, where the old value keeps serving until a fresh one finishes fetching.)
+The tag names match the cached reads they invalidate. Each `updateTag` call lines up with the cache entries the write touched, and the route re-renders against the fresh values. ([`revalidateTag`](/docs/app/api-reference/functions/revalidateTag) is the alternative when you want stale-while-revalidate semantics, where the old value keeps serving until a fresh one finishes fetching.)
 
 Pinning takes the same shape. `getPinnedIds` was tagged earlier with ``cacheTag(`pinned-${userId}`)``, so `addPin` and `removePin` each invalidate that viewer's tag:
 
@@ -765,6 +780,6 @@ Jump to a step on GitHub:
 - [`steps/03-fetch-data`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/03-fetch-data). Server Components and a data access layer; `notFound()` for missing rows.
 - [`steps/04-streaming`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/04-streaming). Suspense boundaries and skeleton fallbacks around async UI; data queries unchanged.
 - [`steps/05-mutations`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/05-mutations). Server Functions; `refresh()` to re-run dynamic reads after a write.
-- [`steps/06-client-boundaries`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/06-client-boundaries). Client leaves; optimistic `ProjectPin` reading the per-viewer promise with `use`; URL-driven `SearchBar` with `useTransition`.
+- [`steps/06-client-boundaries`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/06-client-boundaries). Three Client leaves: optimistic `ProjectPin` reading the per-viewer promise with `use`, URL-driven `SearchBar` with `useTransition`, and `DeployButton` with `useTransition` for the pending spinner.
 - [`steps/07-caching`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/07-caching). `'use cache'` and tags on shared reads, including pinned ids keyed by `userId`; `'use cache: private'` reserved for the viewer's identity behind the avatar; `updateTag` to invalidate cached entries on a write.
 - [`steps/08-prefetching`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/08-prefetching). `prefetch = 'force-runtime'`; instant validation for the static shell; minimal session wiring in the tutorial source for the demo.

--- a/docs/01-app/02-guides/thinking-in-nextjs.mdx
+++ b/docs/01-app/02-guides/thinking-in-nextjs.mdx
@@ -12,7 +12,7 @@ related:
 
 In React, you break a UI into components and let data flow through the tree. [Thinking in React](https://react.dev/learn/thinking-in-react) walks through that model in five steps, from naming the parts to layering state on top.
 
-In Next.js, the same tree carries a few more decisions. Where does the data come from? What can render before a request, what depends on the request, and what gets reused for the next visitor? The pieces are still components, some running on the server and some in the browser, and they compose like any other React tree. Each component runs where that component belongs.
+In Next.js, the same tree carries a few more decisions. Where does the data come from? What can render before a request, what depends on the request, and what gets reused for the next visitor? The pieces are still components, some running on the server and some in the browser, and they compose into one tree across the boundary. Each component runs where that component belongs.
 
 This tutorial builds one small app one decision at a time, the way you would in your own codebase.
 
@@ -86,7 +86,7 @@ We haven't decided where the data comes from yet. Let's get the page on the scre
 
 Render each region as JSX from inline mock data — values that already sit in the component file:
 
-```tsx
+```tsx filename="app/projects/page.tsx"
 const projects = [
   {
     id: 'compass',
@@ -142,13 +142,13 @@ Source: [`steps/02-static-jsx`](https://github.com/vercel-labs/thinking-in-nextj
 
 The mock arrays come out, real reads go in. Where in the tree should those reads happen?
 
-Each region needs a function to read what it shows. The collection of those reads is the route's [data access layer](/docs/app/guides/data-security#data-access-layer): `getProjects()`, `getProject(id)`, `getDeployments(projectId)`, and the same shape for the build log, the current viewer, and pinned ids. The schema and seed live under [`lib/db`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/03-fetch-data/lib/db); the queries themselves live under [`data/queries/`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/03-fetch-data/data/queries), one file per concern.
+Each region needs a function to read what it shows. The collection of those reads is the route's [data access layer](/docs/app/guides/data-security#data-access-layer): `getProjects()`, `getProject(id)`, `getDeployments(projectId)`, and the same shape for the build log, the current viewer, and pinned ids. The schema and seed live under `lib/db`; the queries themselves live under `data/queries/`, one file per concern.
 
-The page could fetch everything at the top and pass values down with a `Promise.all`. That works, but it couples independent sections — the deployments list waits on the same parent as the sidebar, and the parent has to know what every region reads.
+The page could fetch everything at the top and pass values down with a `Promise.all`. That works, but it couples independent sections. The deployments list waits on the same parent as the sidebar, and the parent has to know what every region reads.
 
 The other option is for each component to read what it needs, right next to the JSX that uses it:
 
-```tsx
+```tsx filename="app/projects/page.tsx" highlight={3-4}
 async function ProjectGrid({ searchParams }) {
   const { q } = await searchParams
   const projects = await getProjects({ query: q })
@@ -158,10 +158,9 @@ async function ProjectGrid({ searchParams }) {
 
 Co-locating the read with the JSX that uses it is the same instinct as `useEffect` or a query library, except a Server Component can `await` the read directly, with no client state to plumb through.
 
-Each query function calls into a small `db` module — the real data source for this tutorial. Swap it for whatever your app uses: a Postgres ORM, a remote API client, anything that returns data. The data access layer is also where retries, validation, and shaping live, kept out of the components that render the result:
+Each query function calls into a small `db` module, the real data source for this tutorial. Swap it for whatever your app uses, whether a Postgres ORM, a remote API client, or anything else that returns data. The data access layer is also where retries, validation, and shaping live, kept out of the components that render the result:
 
-```tsx
-// data/queries/projects.ts
+```tsx filename="data/queries/projects.ts" highlight={3}
 import { cache } from 'react'
 
 export const getProjects = cache(async ({ query }) => {
@@ -170,11 +169,13 @@ export const getProjects = cache(async ({ query }) => {
 })
 ```
 
-React's [`cache`](https://react.dev/reference/react/cache) dedupes the read across one render. Two components calling `getProjects({ query: q })` share a single database round trip, so co-location costs nothing extra. If a row isn't found, the query calls [`notFound`](/docs/app/api-reference/functions/not-found) and the matching `not-found.tsx` next to that segment renders in its place. The [`delay()`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/03-fetch-data/lib/utils.ts) is a fixture that keeps loading and pending states visible in the recording — a real local read resolves in milliseconds.
+React's [`cache`](https://react.dev/reference/react/cache) dedupes the read across one render. Two components calling `getProjects({ query: q })` share a single database round trip, so co-location costs nothing extra. If a row isn't found, the query calls [`notFound`](/docs/app/api-reference/functions/not-found) and the matching `not-found.tsx` next to that segment renders in its place. The `delay()` helper is a fixture that keeps loading and pending states visible in the recording. A real local read resolves in milliseconds.
 
-Search stays on the server too, no Client Component needed. A plain HTML form posts to `/projects?q=...`, the browser navigates, and `ProjectGrid` reads `?q=` from [`searchParams`](/docs/app/api-reference/file-conventions/page#searchparams-optional) to render the filtered list.
+Every other region works the same way. The header reads the current viewer, the sidebar reads pinned ids and recent deploys, and the detail pages read what their JSX shows next to it.
 
-Refresh the demo. Notice the route waits on the slowest read before any of it paints, even the parts that don't depend on it. Try the search bar, and the grid filters via `?q=` in the URL without crossing into a Client Component.
+Search stays on the server too. A plain HTML form posts to `/projects?q=...`, the browser navigates, and `ProjectGrid` reads `?q=` from [`searchParams`](/docs/app/api-reference/file-conventions/page#searchparams-optional) to render the filtered list.
+
+Refresh the demo. Notice the route waits on the slowest read before any of it paints, even the parts that don't depend on it. Try the search bar, and the grid filters via `?q=` in the URL on each submit.
 
 <Demo
   src="https://thinking-in-nextjs-03-fetch-data.labs.vercel.dev/projects"
@@ -198,11 +199,11 @@ Source: [`steps/03-fetch-data`](https://github.com/vercel-labs/thinking-in-nextj
 
 ## Step 4: Stream async work
 
-Why should the rest of the page wait for the slowest read? It shouldn't. React's [`<Suspense>`](https://react.dev/reference/react/Suspense) lets you split the wait — render this part when it's ready, render the rest now.
+Why should the rest of the page wait for the slowest read? It shouldn't. Next.js already streams the response by default; what changes is which reads block the first chunk. React's [`<Suspense>`](https://react.dev/reference/react/Suspense) lets you split the wait. Render this part when it's ready, render the rest now.
 
 Wrap each async section behind its own boundary. In the sidebar, the pinned section and the recent deploys each get one:
 
-```tsx
+```tsx filename="app/projects/_components/Sidebar.tsx" highlight={4,7}
 function Sidebar() {
   return (
     <>
@@ -217,27 +218,13 @@ function Sidebar() {
 }
 ```
 
-`Sidebar` itself is synchronous now. Each async child has its own boundary, and the fallback occupies the slot until the real markup replaces it. That fallback is the [loading UI](/docs/app/glossary#loading-ui) — a skeleton matching the streamed result's width, height, and row count keeps the surrounding layout steady when content arrives.
+`Sidebar` itself is synchronous now. Each async child has its own boundary, and the fallback occupies the slot until the real markup replaces it. That fallback is the [loading UI](/docs/app/glossary#loading-ui). A skeleton matching the streamed result's width, height, and row count keeps the surrounding layout steady when content arrives.
 
-Try the demo. The header and search form land immediately. Each section fills in as its read resolves.
+What about the rest of the route? The avatar in `HeaderBar` reads the session. `ProjectGrid` reads the project list on `/projects`. The project detail page loads `ProjectHeader` and `Deployments`, and the deployment page loads `DeploymentHeader` and `BuildLogs`. Each one needs its own `<Suspense>` boundary and skeleton fallback alongside the JSX that uses it.
 
-<Demo
-  src="https://thinking-in-nextjs-04-streaming.labs.vercel.dev/projects"
-  title="Step 4: Stream async work"
-/>
+This gets brittle to manage by hand. Every new async read needs a matching boundary, and missing one quietly stalls the first chunk. [`cacheComponents`](/docs/app/glossary#cache-components) is the rule that catches what we missed. Every async read either sits behind `<Suspense>` or carries a `'use cache'` directive, enforced at `next dev` and `next build`:
 
-On `/projects`, the timing reads roughly:
-
-- **0 ms**: Shell sent. The header and search form land immediately, with fallbacks rendered for the avatar, pinned section, recent deploys, and grid.
-- **500 ms**: Avatar resolves.
-- **1000 ms**: Pinned and grid resolve.
-- **1500 ms**: Recent deploys resolves last.
-
-The route still runs every read on every request; what changed is that no read blocks any other.
-
-Now that every async read is behind a boundary, Next.js can do more with the route. Turn on [`cacheComponents`](/docs/app/glossary#cache-components):
-
-```ts filename="next.config.ts"
+```ts filename="next.config.ts" highlight={4}
 import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
@@ -247,7 +234,7 @@ const nextConfig: NextConfig = {
 export default nextConfig
 ```
 
-This flips on a small rule: every async read either sits behind Suspense or carries a `'use cache'` directive. When the rule holds, `next build` splits the route in two — the parts that don't depend on a request prerender as a [static shell](/docs/app/glossary#static-shell), and the parts behind Suspense stream in at request time. The build output picks up a new marker:
+When the rule holds, `next build` splits the route in two. The parts that don't depend on a request prerender as a [static shell](/docs/app/glossary#static-shell), and the parts behind Suspense stream in at request time. The build output picks up a new marker:
 
 ```txt
 Route (app)
@@ -262,17 +249,31 @@ The `◐` is [Partial Prerendering](/docs/app/glossary#partial-prerendering-ppr)
 
 When an async read isn't behind a boundary and isn't cached, the dev overlay points at the call site and lists three ways out:
 
+{/* TODO: Update the three `error-overhaul` links below once the Error Overhaul guide ships and the anchor names are finalized. */}
+
 - [Provide a `<Suspense>` placeholder](/docs/app/guides/error-overhaul#move-within-suspense) around the read — what the Sidebar above already does.
 - [Cache the data access with `'use cache'`](/docs/app/guides/error-overhaul#cache-dynamic-data) — the move when the result can be reused, covered later.
 - [Allow blocking route](/docs/app/guides/error-overhaul#allow-blocking-route) — an escape hatch when you knowingly want the whole route to wait.
 
-Suspense decides when a section paints. Caching decides whether its output is reused — that comes next. Streaming is the smaller commitment, so we picked it first.
+Try the demo. The static shell ships from a CDN at 0 ms, and each async section fills in as its read resolves.
 
-> **Note**: Suspense boundaries nest. Output that arrives in pieces — log lines on an in-progress build, LLM tokens, paginated work — can wrap each piece in its own boundary so each one streams independently. See [`BuildLogs.tsx`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/04-streaming/app/projects/%5Bid%5D/deployments/%5BdeployId%5D/_components/BuildLogs.tsx) in the lab for an example — `LiveLines` recurses through the log and wraps each next line in its own `<Suspense>`.
+<Demo
+  src="https://thinking-in-nextjs-04-streaming.labs.vercel.dev/projects"
+  title="Step 4: Stream async work"
+/>
 
-> **Note**: A read that doesn't touch a per-request API (cookies, headers, `searchParams`, `params`) needs [`await connection()`](/docs/app/api-reference/functions/connection) at the top so Next.js excludes it from prerendering. The lab's database queries do this — without it, a sync-feeling read like `db.select(...)` resolves at build time and the Suspense boundary above it never gets to stream.
+On `/projects`, the timing reads roughly:
 
-> **Note**: [Instant validation](/docs/app/guides/instant-validation) extends the same boundary check from the initial render to every navigation. [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params) is the alternative for `params`-driven routes whose id list is known at build time.
+- **0 ms**: Shell sent. The header and search form land immediately, with fallbacks rendered for the avatar, pinned section, recent deploys, and grid.
+- **500 ms**: Avatar resolves.
+- **1000 ms**: Pinned and grid resolve.
+- **1500 ms**: Recent deploys resolves last.
+
+Suspense controls when a section paints. Reusing the output is a separate decision, and that comes later.
+
+> **Note**: Suspense boundaries nest. Output that arrives in pieces, like log lines on an in-progress build, LLM tokens, or paginated work, can wrap each piece in its own boundary so each one streams independently. `BuildLogs.tsx` in the lab is one example: `LiveLines` recurses through the log and wraps each next line in its own `<Suspense>`.
+
+> **Note**: A read that doesn't touch a per-request API (cookies, headers, `searchParams`, `params`) needs [`await connection()`](/docs/app/api-reference/functions/connection) at the top so Next.js excludes it from prerendering. The lab's database queries do this. Without it, a sync-feeling read like `db.select(...)` resolves at build time and the Suspense boundary above it never gets to stream. [Instant validation](/docs/app/guides/instant-validation) extends the same boundary check from the initial render to every navigation.
 
 The page reads are covered. Let's add the writes.
 
@@ -286,7 +287,7 @@ The first reach in client-side React might be an `onClick` handler, but that wou
 
 A [React Server Function](/docs/app/glossary#server-function), marked with `'use server'`, keeps the write on this route. Pass it to React's [`<form action>`](https://react.dev/reference/react-dom/components/form#form) prop, submit the form, and the arguments and return values cross a serialization boundary as a [Remote Procedure Call (RPC)](https://en.wikipedia.org/wiki/Remote_procedure_call). Plain data passes through; functions and class instances don't.
 
-```tsx
+```tsx filename="data/actions/deployments.ts" highlight={1,7}
 'use server'
 
 import { refresh } from 'next/cache'
@@ -299,7 +300,7 @@ export async function triggerDeploy(projectId) {
 
 The matching call site is an old-school HTML form, no `'use client'` in the path:
 
-```tsx
+```tsx highlight={1}
 <form action={triggerDeploy.bind(null, projectId)}>
   <button type="submit">Deploy</button>
 </form>
@@ -307,11 +308,11 @@ The matching call site is an old-school HTML form, no `'use client'` in the path
 
 This is the same request-response loop PHP and Rails apps ran on. The browser posts a form, the server runs a function, the server re-renders the page. The difference is that React produces the response. [`refresh`](/docs/app/api-reference/functions/refresh) from `next/cache` re-runs the dynamic reads on the current route, so the new deployment shows up in the list and the recent-deploys section updates alongside it.
 
-> **Note**: A Server Function is an exposed endpoint, so anything it touches needs the same auth checks and input validation a public API would get. The lab gates every write with `requireSession()` — a small helper that reads the session cookie and throws if it's missing or invalid. [How to Think About Security in Next.js](https://nextjs.org/blog/security-nextjs-server-components-actions) is the broader reference to read before shipping.
+> **Note**: A Server Function is an exposed endpoint, so anything it touches needs the same auth checks and input validation a public API would get. The lab gates every write with `requireSession()`, a small helper that reads the session cookie and throws if it's missing or invalid. [How to Think About Security in Next.js](https://nextjs.org/blog/security-nextjs-server-components-actions) is the broader reference to read before shipping.
 
 Pinning takes the same shape. `addPin` and `removePin` each require a session, write to (or delete from) the pins table, and call `refresh()`:
 
-```tsx
+```tsx filename="data/actions/pinned.ts" highlight={8}
 'use server'
 
 import { refresh } from 'next/cache'
@@ -346,11 +347,11 @@ What still waits on the round trip? The deploy button has no spinner, the pin do
 | Search field  | each keystroke | yes          |
 | Deploy button | click          | yes          |
 
-Move each one into a [`'use client'`](/docs/app/glossary#use-client-directive) leaf. Inside the boundary the full React API is back — `onClick`, `useState`, hooks, and refs — and Server Functions stay callable from client code, so `triggerDeploy`, `addPin`, and `removePin` keep working without rewrites.
+Move each one into a [`'use client'`](/docs/app/glossary#use-client-directive) leaf. Inside the boundary the full React API is back, including `onClick`, `useState`, hooks, and refs. Server Functions stay callable from client code, so `triggerDeploy`, `addPin`, and `removePin` keep working without rewrites.
 
 The pin used to be a server form. Now it becomes a Client Component so the toggle can be optimistic. The `/projects` page starts the per-viewer pinned-ids read once and forwards the promise down to each card without an `await` in between. The pin button calls React's [`use`](https://react.dev/reference/react/use) in the browser to read the ids, and the `<Suspense>` wrapper around the pin shows a pin-shaped skeleton until the promise resolves.
 
-```tsx
+```tsx filename="app/projects/_components/ProjectPin.tsx" highlight={1,6,9}
 'use client'
 
 import { use, useOptimistic } from 'react'
@@ -383,7 +384,7 @@ Nothing else is needed. The `refresh()` call inside `addPin` and `removePin` re-
 
 The `/projects` page awaits the projects list, starts the per-viewer pinned-ids promise, and passes the same reference into every card. `getPinnedIds()` reads the current viewer inside its own implementation, so the call site doesn't have to thread `userId` through:
 
-```tsx
+```tsx filename="app/projects/page.tsx" highlight={4,9}
 async function ProjectGrid({ searchParams }) {
   const { q } = await searchParams
   const projects = await getProjects({ query: q })
@@ -411,11 +412,11 @@ Only the pin button consumes the promise, so only that control sits behind `<Sus
 
 `'use client'` marks a [boundary](/docs/app/glossary#use-client-directive). That file and its imports run in the browser, ancestors stay on the server. The page still constructs the promise on the server, the promise crosses the boundary as a prop, and the pin button calls `use()` on the client to read it.
 
-Search is the third leaf. The plain GET form from earlier worked: submit once, the browser navigates to `/projects?q=…`, and the page reads `searchParams` on the server.
+Search is the third leaf. The plain GET form from earlier worked. Submit once, the browser navigates to `/projects?q=…`, and the page reads `searchParams` on the server.
 
 Per-keystroke updates need a `'use client'` boundary anyway, and once that's there the input can call `router.push` from `onChange` directly:
 
-```tsx
+```tsx filename="app/projects/_components/SearchBar.tsx" highlight={9,18}
 'use client'
 
 import { useRouter, useSearchParams } from 'next/navigation'
@@ -452,9 +453,9 @@ function SearchBar() {
 
 This is the client-side twin of the same `searchParams` read on the server. [`useSearchParams`](/docs/app/api-reference/functions/use-search-params) reads the request's `?q=`, which is a per-request input. Wrap the search bar in `<Suspense>` so the rest of the route can prerender as a static shell, with a fallback shaped like the field. React's [`useTransition`](https://react.dev/reference/react/useTransition) supplies `isPending`, and the field's leading search icon swaps to a spinner for the duration of the navigation.
 
-The deploy button stays a `<form action={triggerDeploy.bind(null, projectId)}>`, just hoisted into a `'use client'` boundary so the same [`useTransition`](https://react.dev/reference/react/useTransition) hook can drive its spinner. Triggering the action from inside `startTransition` makes `pending` observable on the button itself, the same way `isPending` swaps the search input's icon for its spinner:
+The deploy button keeps its form shape, now hoisted into a `'use client'` boundary so React's [`useTransition`](https://react.dev/reference/react/useTransition) hook can drive its spinner. The form's action wraps the call to `triggerDeploy` in `startTransition`, which makes `pending` observable on the button itself, the same way `isPending` swaps the search input's icon for its spinner:
 
-```tsx
+```tsx filename="app/projects/[id]/_components/DeployButton.tsx" highlight={9-10}
 'use client'
 
 import { useTransition } from 'react'
@@ -472,7 +473,7 @@ function DeployButton({ projectId }) {
 }
 ```
 
-Nothing about React requires a form here. A `<button onClick={...}>` from inside the same `useTransition` would render the same UI. The form keeps the Enter-to-submit affordance and lets the gesture work even before the JavaScript loads, which is reason enough to keep it.
+Nothing about React requires a form here. A `<button onClick={...}>` from inside the same `useTransition` would render the same UI.
 
 Try the demo. Pin a project and watch the button flip immediately, then type in the search bar to see the URL update on each keystroke. Open a project and click Deploy.
 
@@ -511,9 +512,11 @@ If yes, the result can be reused instead of recomputed on every request, and the
 | `ViewerAvatar`                    | No, per viewer         |
 | `PinnedSection`                   | No, per viewer         |
 
+{/* TODO: The `caches the data access` link below points at the not-yet-shipped Error Overhaul guide; update once it lands. */}
+
 [`'use cache'`](/docs/app/glossary#use-cache-directive) is the directive that [caches the data access](/docs/app/guides/error-overhaul#cache-dynamic-data). Add it at the top of a data function or a Server Component, and the result is reused across requests. On a project read, the directive sits next to a [`cacheLife`](/docs/app/api-reference/functions/cacheLife) for how long entries stay around and a [`cacheTag`](/docs/app/api-reference/functions/cacheTag) for invalidation later:
 
-```tsx
+```tsx filename="data/queries/projects.ts" highlight={2,4}
 async function getProject(id) {
   'use cache'
   cacheLife('hours')
@@ -529,7 +532,7 @@ The function's arguments (together with any closed-over values) form the cache k
 
 The list read takes the same shape, with the query as the key:
 
-```tsx
+```tsx filename="data/queries/projects.ts" highlight={2,4}
 async function getProjects({ query }) {
   'use cache'
   cacheLife('hours')
@@ -539,11 +542,11 @@ async function getProjects({ query }) {
 }
 ```
 
-Every other cached read follows the same shape, with a `'use cache'` directive, a `cacheLife`, and a `cacheTag` that names what the entry covers. Per-request inputs (`searchParams`, [`cookies()`](/docs/app/api-reference/functions/cookies), [`headers()`](/docs/app/api-reference/functions/headers)) stay outside the cached function and arrive as arguments — the argument list is the cache key. That's why the page resolves `q` from `searchParams` in the parent and passes it into `getProjects({ query: q })`. Caching keys on `query`, but `q` only arrives with a real request, so the cards stream in behind the search bar instead of joining the static shell.
+Every other cached read follows the same shape, with a `'use cache'` directive, a `cacheLife`, and a `cacheTag` that names what the entry covers. Per-request inputs (`searchParams`, [`cookies()`](/docs/app/api-reference/functions/cookies), [`headers()`](/docs/app/api-reference/functions/headers)) stay outside the cached function and arrive as arguments. The argument list is the cache key. That's why the page resolves `q` from `searchParams` in the parent and passes it into `getProjects({ query: q })`. Caching keys on `query`, but `q` only arrives with a real request, so the cards stream in behind the search bar instead of joining the static shell.
 
-Per-viewer data splits into two patterns. Pinned ids stay on plain `'use cache'` keyed on `userId`. The cached function takes the id as an argument so the entry narrows on that value, while the public `getPinnedIds` reads the viewer once and delegates to it — consumers don't have to thread the user through:
+Per-viewer data splits into two patterns. Pinned ids stay on plain `'use cache'` keyed on `userId`. The cached function takes the id as an argument so the entry narrows on that value, while the public `getPinnedIds` reads the viewer once and delegates to it, so consumers don't have to thread the user through:
 
-```tsx
+```tsx filename="data/queries/pinned.ts" highlight={2,4}
 const getPinnedIdsForUser = cache(async (userId) => {
   'use cache'
   cacheLife({ stale: 60 })
@@ -560,9 +563,9 @@ export const getPinnedIds = cache(async () => {
 
 The store is shared; the `userId` argument is what makes each entry per-viewer. Two different ids become two entries, the same way `getProject('compass')` and `getProject('feather')` do.
 
-The current viewer is the limit case. The cookie is the input, and there's nothing further to lift out. A plain `'use cache'` can't read cookies inline, so `getCurrentUser` uses [`'use cache: private'`](/docs/app/api-reference/directives/use-cache-private) instead — same directive shape, but the function runs every render on the server and the result is held only in the browser's memory for the rest of the session, with `cookies()` and `headers()` allowed inside:
+The current viewer is the limit case. The cookie is the input, and there's nothing further to lift out. A plain `'use cache'` can't read cookies inline, so `getCurrentUser` uses [`'use cache: private'`](/docs/app/api-reference/directives/use-cache-private) instead. The directive shape is the same, but the function runs every render on the server and the result is held only in the browser's memory for the rest of the session, with `cookies()` and `headers()` allowed inside:
 
-```tsx
+```tsx filename="data/queries/auth.ts" highlight={2-3}
 export const getCurrentUser = cache(async () => {
   'use cache: private'
   cacheLife({ stale: 60 })
@@ -578,7 +581,7 @@ The page can start the read once and pass the unawaited promise to every pin but
 const pinnedIdsPromise = getPinnedIds()
 ```
 
-When a Server Component needs the array before it renders (the pinned section in the sidebar, for example), `await` the same call and `pinnedIds` is available inline alongside `getProjects()`.
+A Server Component that needs the resolved array, like `PinnedSection` in the sidebar, can `await getPinnedIds()` directly. React's `cache()` returns the same in-flight promise the page already started, so the second call is free.
 
 > **Note**: A third variant, [`'use cache: remote'`](/docs/app/api-reference/directives/use-cache-remote), backs a durable shared cache across server instances when the default in-memory store isn't enough. The [Cache Components](/docs/app/getting-started/caching) introduction compares all three.
 
@@ -606,9 +609,9 @@ app/projects/[id]/deployments/[deployId]/page.tsx
 
 The Suspense rule sharpens with caching in place. Add a boundary wherever the subtree still reads a per-request input — cookies, `searchParams`, `params`, or live output. Those reads can be cached too, but the cache key isn't known until the request lands, so the boundary stays.
 
-Cached reads with no per-request input join the prerendered shell. On this route that's the recent-deploys section, the only cached read whose key doesn't depend on the request. Its earlier Suspense boundary and skeleton fallback can both come out, since the section paints with the static shell:
+Cached reads with no per-request input join the prerendered shell. On this route that's the recent-deploys section, the only cached read whose key doesn't depend on the request. Its earlier Suspense boundary and skeleton fallback can both come out, since the section paints with the static shell. `Sidebar` collapses to one Suspense boundary around the per-viewer `PinnedSection`, with `RecentDeploysSection` rendered inline:
 
-```tsx
+```tsx filename="app/projects/_components/Sidebar.tsx" highlight={7}
 export function Sidebar() {
   return (
     <div className="space-y-6">
@@ -625,7 +628,7 @@ Adding the cache layer changes the picture for mutations. `refresh()` re-runs th
 
 [`updateTag`](/docs/app/api-reference/functions/updateTag) is the surgical answer for cached entries. From inside a Server Function, it invalidates a cached read by name, so the same write that changed the underlying data names the entries that went stale. The route re-renders with the fresh values, which is what `refresh()` was doing before. Calling both is the wrong shape, so the Server Function calls `updateTag` in place of `refresh()`:
 
-```tsx
+```tsx filename="data/actions/deployments.ts" highlight={7-8}
 'use server'
 
 import { updateTag } from 'next/cache'
@@ -637,11 +640,11 @@ async function triggerDeploy(projectId) {
 }
 ```
 
-The tag names match the cached reads they invalidate. Each `updateTag` call lines up with the cache entries the write touched, and the route re-renders against the fresh values. (For stale-while-revalidate semantics — keep serving the old value while a fresh one fetches — use [`revalidateTag`](/docs/app/api-reference/functions/revalidateTag) instead.)
+The tag names match the cached reads they invalidate. Each `updateTag` call lines up with the cache entries the write touched, and the route re-renders against the fresh values. ([`revalidateTag`](/docs/app/api-reference/functions/revalidateTag) is the alternative when you want stale-while-revalidate semantics, where the old value keeps serving until a fresh one finishes fetching.)
 
 Pinning takes the same shape. `getPinnedIds` was tagged earlier with ``cacheTag(`pinned-${userId}`)``, so `addPin` and `removePin` each invalidate that viewer's tag:
 
-```tsx
+```tsx filename="data/actions/pinned.ts" highlight={8}
 'use server'
 
 import { updateTag } from 'next/cache'
@@ -668,7 +671,7 @@ Source: [`steps/07-caching`](https://github.com/vercel-labs/thinking-in-nextjs/t
 
 ## Step 8: Optimize prefetching
 
-The cache is set up, but each navigation still waits. The cached entries on this route key on `params`, cookies, or `searchParams` — values that only arrive with a real request, so nothing fills them until the request lands. Instant validation keeps the shell ready at navigation; the data behind it is what's still missing.
+The cache is set up, but each navigation still waits. The cached entries on this route key on `params`, cookies, or `searchParams`, values that only arrive with a real request, so nothing fills them until the request lands. Instant validation keeps the shell ready at navigation; the data behind it is what's still missing.
 
 Prefetch is the timing answer. When a [`<Link>`](/docs/app/api-reference/components/link) enters the viewport, Next.js renders its destination in the background, so the tree is already there by the time of the click.
 
@@ -676,7 +679,7 @@ The prefetch renders against one of two shapes, and each route declares which. T
 
 We can opt a page into runtime prefetch with the [`prefetch`](/docs/app/api-reference/file-conventions/route-segment-config/prefetch) segment export:
 
-```tsx filename="app/projects/page.tsx"
+```tsx filename="app/projects/page.tsx" highlight={3}
 import { Suspense } from 'react'
 
 export const prefetch = 'force-runtime'
@@ -718,7 +721,7 @@ When prefetch finishes before the click, large pieces of the destination render 
 
 The live build log on an in-progress deployment is the one exception, since it's live by definition. Once the build finishes, that log appears instantly too, served from the cached entry until its `cacheLife` runs out.
 
-Runtime prefetch isn't free. Each visible `<Link>` triggers a real per-request render in the background, more server work than static prefetch, which renders against build-time inputs only. The cache absorbs most of the cost: each prefetched render populates an entry, and subsequent prefetches and navigations within the cache lifetime read from it instead of re-rendering. The trade-off is fine for typical apps but worth knowing about.
+Runtime prefetch isn't free. Each visible `<Link>` triggers a real per-request render in the background, more server work than static prefetch, which renders against build-time inputs only. The cache absorbs most of the cost. Each prefetched render populates an entry, and subsequent prefetches and navigations within the cache lifetime read from it instead of re-rendering. The trade-off is fine for typical apps but worth knowing about.
 
 Whatever the prefetch pass touched, static or runtime, is cached in the browser and works offline. The only parts that need an active connection are the live-streamed sections, so flaky networks stop being a meaningful problem for most of the app.
 
@@ -726,7 +729,7 @@ Source: [`steps/08-prefetching`](https://github.com/vercel-labs/thinking-in-next
 
 ## Where to go from here
 
-React's model is declarative. Components describe the output, and React renders them when the inputs change. The App Router extends that model past the browser — the component is the unit of decision the whole way down, with caching and prefetching layered on top to give the route an SPA feel without leaving the server-component model behind.
+React's model is declarative. Components describe the output, and React renders them when the inputs change. The App Router extends that model past the browser. The component is the unit of decision the whole way down, with caching and prefetching layered on top to give the route an SPA feel without leaving the server-component model behind.
 
 Try it on a route in your own codebase. Name the regions, then label each one as static, dynamic, cached, or a Client leaf. The decisions usually fall out once you've labeled what each piece is doing.
 
@@ -747,7 +750,7 @@ A few App Router pieces didn't fit this route, but they show up in real apps:
 
 ## Browse the source
 
-The [thinking-in-nextjs tutorial repo](https://github.com/vercel-labs/thinking-in-nextjs) holds one folder per tutorial step under `steps/`, each runnable on its own. The last step is also live at [the tutorial deployment](https://thinking-in-nextjs.labs.vercel.dev/).
+Each step you worked through is its own folder under `steps/` in the [tutorial repo](https://github.com/vercel-labs/thinking-in-nextjs), so jump back to revisit the diff for any one decision. The final state is also live at [the tutorial deployment](https://thinking-in-nextjs.labs.vercel.dev/).
 
 {/* TODO: restore the DemoExplorer block here once vercel/front#67624 lands on main and vercel-labs/thinking-in-nextjs is public. Intended config: repo "vercel-labs/thinking-in-nextjs", gitRef "main", path "steps", include "steps/**", exclude "node_modules,.next,.turbo,dist,build,*.lock,pnpm-lock.yaml", defaultFile "steps/07-static-jsx/app/projects/page.tsx". Source: https://github.com/vercel-labs/thinking-in-nextjs */}
 

--- a/docs/01-app/02-guides/thinking-in-nextjs.mdx
+++ b/docs/01-app/02-guides/thinking-in-nextjs.mdx
@@ -744,7 +744,7 @@ Prefetching fills those entries before the click. When a [`<Link>`](/docs/app/ap
 
 The prefetch renders against one of two shapes, and each route declares which. The default is [static](/docs/app/guides/prefetching), with no cookies, headers, or search string in scope. That covers the shared layout and any cached read keyed on build-time inputs. [Runtime](/docs/app/api-reference/file-conventions/route-segment-config/prefetch) is opt-in, and it renders with the same cookies, headers, and search string the navigation would send, so per-viewer reads run against the real session before the click.
 
-We can opt a page into runtime prefetch with the [`prefetch`](/docs/app/api-reference/file-conventions/route-segment-config/prefetch) segment export:
+We can opt a page into runtime prefetch with the [`unstable_prefetch`](/docs/app/api-reference/file-conventions/route-segment-config/prefetch) segment export:
 
 ```tsx filename="app/projects/page.tsx" highlight={3}
 import { Suspense } from 'react'

--- a/docs/01-app/02-guides/thinking-in-nextjs.mdx
+++ b/docs/01-app/02-guides/thinking-in-nextjs.mdx
@@ -10,9 +10,9 @@ related:
     - app/guides/streaming
 ---
 
-In React, you build a UI by breaking the screen into components and letting data flow through the tree. The original [Thinking in React](https://react.dev/learn/thinking-in-react) walks through that model in three moves: name the parts, render them static from mock data, then layer state on top.
+In React, you build a UI by breaking the screen into components and letting data flow through the tree. The original [Thinking in React](https://react.dev/learn/thinking-in-react) walks through that model in three moves. First name the parts, then render them static from mock data, then layer state on top.
 
-In Next.js, the same component tree carries a few more decisions. Where does the data come from? What can render right away? What waits, and what gets reused for the next visitor? The pieces are still components — some run on the server, some run in the browser, and they compose like any other React tree. Each one runs where it belongs.
+In Next.js, the same component tree carries a few more decisions. Where does the data come from? What can render right away? What waits, and what gets reused for the next visitor? The pieces are still components (some run on the server, some run in the browser), and they compose like any other React tree. Each one runs where it belongs.
 
 This guide builds one small app one decision at a time, the same way you would in your own codebase.
 
@@ -24,20 +24,19 @@ The designer hands over mockups for three routes.
 
 <Image
   alt="Three route cards labeled /projects, /projects/compass, and /projects/compass/deployments/compass-jx9q3, each split into top bar, sidebar, and content regions."
-  srcLight="/docs/guides/thinking-in-nextjs/route-mockups-light-3.png"
-  srcDark="/docs/guides/thinking-in-nextjs/route-mockups-dark-3.png"
-  width={1088}
-  height={386}
+  srcLight="/docs/guides/thinking-in-nextjs/mockups-light.png"
+  srcDark="/docs/guides/thinking-in-nextjs/mockups-dark.png"
+  width={1600}
+  height={567}
 />
 
-The data layer returns four shapes:
+The data layer returns three shapes:
 
-| Type                  | Notes                                                                                                                                             |
-| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Project`             | One per project. Status is `production`, `building`, `paused`, or `failed`.                                                                       |
-| `Deployment`          | Newest first. Status is `ready`, `building`, `failed`, `queued`, or `cancelled`.                                                                  |
-| `LogLine`             | A timestamped line with a message and a level (`info`, `warn`, `error`, `success`, `dim`) for styling. The build log is an ordered list of these. |
-| `pinnedIds: string[]` | The project ids the current viewer has pinned.                                                                                                    |
+| Type         | Notes                                                                                                                                             |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Project`    | One per project. Status is `production`, `building`, `paused`, or `failed`.                                                                       |
+| `Deployment` | Newest first. Status is `ready`, `building`, `failed`, `queued`, or `cancelled`.                                                                  |
+| `LogLine`    | A timestamped line with a message and a level (`info`, `warn`, `error`, `success`, `dim`) for styling. The build log is an ordered list of these. |
 
 The build happens one decision at a time:
 
@@ -54,7 +53,7 @@ The order is not arbitrary. It is hard to think about caching before knowing wha
 
 ## Step 1: Break the UI into a component hierarchy
 
-The first pass draws a box around each region of the mockup and gives it a name. Each repeating piece of data turns into one component: one `ProjectCard` per `Project`, one row per `Deployment`, one row per `LogLine`. [Thinking in React](https://react.dev/learn/thinking-in-react#step-1-break-the-ui-into-a-component-hierarchy) calls this matching the component structure to the data model. UI and data tend to share the same shape.
+The first pass draws a box around each region of the mockup and gives it a name. Each repeating piece of data turns into one component, with one `ProjectCard` per `Project`, one row per `Deployment`, and one row per `LogLine`. [Thinking in React](https://react.dev/learn/thinking-in-react#step-1-break-the-ui-into-a-component-hierarchy) calls this matching the component structure to the data model. UI and data tend to share the same shape.
 
 | Region                  | Component                                                        |
 | ----------------------- | ---------------------------------------------------------------- |
@@ -121,6 +120,8 @@ The `○` next to `/projects` is what to look for: every value the route needs i
 
 Notice that the deployed route paints in one shot, with nothing to wait for. The HTML comes back from a static prerender, since every value the components need is already in the file. This is the route's flat baseline.
 
+Each demo throughout this guide embeds the deployed lab. The refresh button in the browser chrome replays the load.
+
 <Demo
   src="https://thinking-in-nextjs-02.labs.vercel.dev/projects"
   title="Step 2: Static JSX"
@@ -130,11 +131,11 @@ Source: [`steps/02-static-jsx`](https://github.com/vercel-labs/thinking-in-nextj
 
 ## Step 3: Fetch data where it is used
 
-Now the mock array has to go. The data lives in a database (or behind an API), and the page needs a function to ask for it. Each read becomes a small async function — `getProjects()`, `getProject(id)`, `getDeployments(projectId)` — and the collection of those functions is the route's data layer.
+Now the mock array has to go. The data lives in a database (or behind an API), and the page needs a function to ask for it. Each read becomes a small async function (`getProjects()`, `getProject(id)`, `getDeployments(projectId)`), and the collection of those functions is the route's data layer.
 
 Where in the tree should those reads happen?
 
-The page could do all the fetching at the top and pass values down. That works, but it couples otherwise-independent sections — the deployments list ends up waiting on the same parent as the sidebar — and the reads tend to run in sequence rather than in parallel.
+The page could do all the fetching at the top and pass values down. That works, but it couples otherwise-independent sections (the deployments list ends up waiting on the same parent as the sidebar), and the reads tend to run in sequence rather than in parallel.
 
 The other option is for each component to read what it needs, right next to the JSX that uses it:
 
@@ -146,9 +147,9 @@ async function ProjectGrid({ searchParams }) {
 }
 ```
 
-Each section stays independent, and unrelated reads run in parallel. Co-locating the read with the JSX that uses it is the same instinct as `useEffect` or a query library — except a [Server Component](/docs/app/glossary#server-component) can `await` the read directly, without the loading-state boilerplate.
+Each section stays independent, and unrelated reads run in parallel. Co-locating the read with the JSX that uses it is the same instinct as `useEffect` or a query library, except a [Server Component](/docs/app/glossary#server-component) can `await` the read directly, without the loading-state boilerplate.
 
-The reads themselves stay thin. Each one calls into a small `db` module that stands in for the real data source — a Postgres ORM, a remote API client, whatever the app uses:
+The reads themselves stay thin. Each one calls into a small `db` module that stands in for the real data source (a Postgres ORM, a remote API client, whatever the app uses):
 
 ```tsx
 // data/queries/projects.ts
@@ -157,13 +158,13 @@ async function getProjects({ query }) {
 }
 ```
 
-Caching, formatting, retries — those concerns live around the wrapper, not inside.
+Caching, formatting, and retries live around the wrapper, not inside.
 
 Search is the first place where a [Client Component](/docs/app/glossary#client-component) would feel natural, but it doesn't have to be. The first cut is a plain HTML form. Submitting it navigates to `/projects?q=...`, and `ProjectGrid` reads `?q=` from `searchParams` to render the right list. No `'use client'` yet.
 
-By now every region has a read attached to it. The route works — but every request runs every read, and the build no longer tries to prerender.
+By now every region has a read attached to it. The route works, but every request runs every read, and the build no longer tries to prerender.
 
-Notice that the deployed route now waits on the slowest read before it paints. Nothing on the page shows until every section's data is ready, even the parts that don't depend on it. The refresh button in the demo's browser chrome replays the load.
+Notice that the deployed route now waits on the slowest read before it paints. Nothing on the page shows until every section's data is ready, even the parts that don't depend on it.
 
 <Demo
   src="https://thinking-in-nextjs-03.labs.vercel.dev/projects"
@@ -191,30 +192,38 @@ export default nextConfig
 With it on, the prerender expects every async read to either be cached or sit behind a [Suspense boundary](/docs/app/glossary#suspense-boundary). Anything else surfaces in `next dev` and `next build` as [`Uncached data was accessed outside of <Suspense>`](https://nextjs.org/docs/messages/blocking-route), pointing at the call site:
 
 <Image
-  alt="Next.js dev overlay reading 'Next.js encountered uncached data during the initial render.' A code preview highlights an uncached fetch call inside a Page component. Below, three fix cards are listed: 'Prerender and cache' with a 'use cache' snippet, 'Provide a placeholder with Suspense', and 'Allow blocking route' with `export const instant = false`."
-  srcLight="/docs/guides/thinking-in-nextjs/dev-overlay-light.png"
-  srcDark="/docs/guides/thinking-in-nextjs/dev-overlay-dark.png"
-  width={1024}
-  height={600}
+  alt="Next.js dev overlay reading 'Next.js encountered uncached data during the initial render.' A code preview highlights the uncached `await` inside a data-access function. Three fix cards follow. 'Cache dynamic data' shows `'use cache'` at the top of a data function. 'Move within Suspense' wraps the async child in `<Suspense fallback={…}>`. 'Allow blocking route' shows `export const instant = false`."
+  srcLight="/docs/guides/thinking-in-nextjs/overlay-light.png"
+  srcDark="/docs/guides/thinking-in-nextjs/overlay-dark.png"
+  width={984}
+  height={779}
 />
 
-Each error offers two ways out: stream the read or cache it. Streaming first. Wrap each async section in its own boundary, and the [static shell](/docs/app/glossary#static-shell) — the parts that don't need to wait — ships first:
+The overlay lists three ways out. One lets the route block as before, an escape hatch for cases where you knowingly want that. The other two are the design conversation the rest of this guide is about. Stream the read, or cache it. Streaming first, because it's the smaller commitment. A Suspense boundary only says "this part can paint later," not "this output is reusable." Reusability is the next question, and it lands more cleanly once every async read has its own place to be asked about. Wrap each async section in its own boundary so the [static shell](/docs/app/glossary#static-shell) (the parts that don't need to wait) ships first:
 
 ```tsx
-<HeaderBar />
-<Suspense fallback={<SidebarSkeleton />}>
-  <Sidebar />
-</Suspense>
-<Suspense fallback={<ProjectGridSkeleton />}>
-  <ProjectGrid searchParams={searchParams} />
-</Suspense>
+function Sidebar() {
+  return (
+    <>
+      <Suspense fallback={<PinnedSkeleton />}>
+        <PinnedSection />
+      </Suspense>
+      <Suspense fallback={<RecentDeploysSkeleton />}>
+        <RecentDeploysSection />
+      </Suspense>
+    </>
+  )
+}
 ```
+
+`Sidebar` itself is synchronous now. The two async sections it contains each sit behind their own boundary, and each fallback is shaped like the section it stands in for. The same move repeats anywhere else in the route an async read shows up, with the boundary sitting at the smallest scope that needs it.
 
 A _fallback_ is the UI that ships with the shell. It gets replaced with the real output once the async component finishes. For this route:
 
-- **0 ms.** Shell sent. Header, sidebar fallback, grid fallback.
-- **400 ms.** Sidebar resolves. Its fallback is replaced with the real output.
-- **900 ms.** Grid resolves. Last fallback replaced.
+- **0 ms**: Shell sent. The header and search form land immediately, with fallbacks rendered for the avatar, pinned section, recent deploys, and grid.
+- **500 ms**: Avatar resolves.
+- **1000 ms**: Pinned and grid resolve.
+- **1500 ms**: Recent deploys resolves last.
 
 The fallback's shape matters. A skeleton matching the streamed result's width, height, and row count keeps the shell stable. A wrong-sized fallback pushes the page around when the content arrives.
 
@@ -236,9 +245,9 @@ function LiveLines({ lines, index }) {
 }
 ```
 
-For feeds that arrive outside the request — a real build log streamed from the platform, telemetry, chat — the typical pattern is a Client Component that polls or subscribes.
+For feeds that arrive outside the request (a real build log streamed from the platform, telemetry, chat), the typical pattern is a Client Component that polls or subscribes.
 
-Notice that the projects route paints the shell immediately, then swaps in the sidebar and grid as each Suspense boundary resolves. A deployment that's still building shows the same primitive nested, with each log line streaming in on its own. The refresh button replays the reveal.
+Notice that the projects route paints the shell immediately, then swaps in the sidebar and grid as each Suspense boundary resolves. A deployment that's still building shows the same primitive nested, with each log line streaming in on its own.
 
 <Demo
   src="https://thinking-in-nextjs-04.labs.vercel.dev/projects"
@@ -249,7 +258,7 @@ Source: [`steps/04-streaming`](https://github.com/vercel-labs/thinking-in-nextjs
 
 ## Step 5: Cache reusable work
 
-Streaming hides slow reads behind fallbacks, but most of those reads aren't actually different per visitor. The project list, the project header, the deployments list — none of that changes between viewers from one second to the next. The natural question:
+Streaming hides slow reads behind fallbacks, but most of those reads aren't actually different per visitor. The project list, project header, and deployments list don't change between viewers from one second to the next. The natural question:
 
 > Would the next viewer see the same thing?
 
@@ -265,7 +274,7 @@ Walk down the tree once and answer the question for each piece:
 | `BuildLogs`, completed build      | Yes                    | `'use cache'`      |
 | `BuildLogs`, in-progress build    | No, live               | uncached, streamed |
 | `ViewerAvatar`                    | No, per viewer         | per-viewer cache   |
-| `PinnedSection`, `ProjectPin`     | No, per viewer         | per-viewer cache   |
+| `PinnedSection`                   | No, per viewer         | per-viewer cache   |
 
 A directive at the top of the function flips a read into the shared cache:
 
@@ -279,9 +288,9 @@ async function getProjects({ query }) {
 }
 ```
 
-[`'use cache'`](/docs/app/api-reference/directives/use-cache) marks the function as cacheable. Different arguments — and any closed-over values — become different entries, so a search for `?q=foo` and `?q=bar` are stored separately. [`cacheLife`](/docs/app/api-reference/functions/cacheLife) sets how long an entry stays valid. [`cacheTag`](/docs/app/api-reference/functions/cacheTag) labels the entry so that other code can refer to it by name — usually from a Server Function that calls [`updateTag`](/docs/app/api-reference/functions/updateTag) after a write.
+[`'use cache'`](/docs/app/api-reference/directives/use-cache) marks the function as cacheable. Different arguments (and any closed-over values) become different entries, so a search for `?q=foo` and `?q=bar` are stored separately. [`cacheLife`](/docs/app/api-reference/functions/cacheLife) sets how long an entry stays valid. [`cacheTag`](/docs/app/api-reference/functions/cacheTag) labels the entry so that other code can refer to it by name, usually from a Server Function that calls [`updateTag`](/docs/app/api-reference/functions/updateTag) after a write.
 
-There's a subtlety on this route. The directive on `getProjects` says the read is cached, but the page also awaits `searchParams` to pick the query, and `searchParams` only resolves at request time. So the static prerender can't bake the cards in. The cache still applies once the request lands: the entry for that exact `?q=` is reused across viewers, and the cards swap in as soon as the param resolves. That is **extract-and-pass** in the wild — the param is not read inside `getProjects`, it arrives as `query`. A plain `'use cache'` function can't read [`cookies()`](/docs/app/api-reference/functions/cookies) or [`headers()`](/docs/app/api-reference/functions/headers) inside itself for the same reason; the pattern is to resolve those at the edge of the tree and pass what you need down. The cache key follows the arguments.
+There's a subtlety on this route. The directive on `getProjects` says the read is cached, but the page also awaits `searchParams` to pick the query, and `searchParams` only resolves at request time. So the static prerender can't bake the cards in. The cache still applies once the request lands: the entry for that exact `?q=` is reused across viewers, and the cards swap in as soon as the param resolves. That is **extract-and-pass** in the wild. The param isn't read inside `getProjects`; it arrives as `query`. A plain `'use cache'` function can't read [`cookies()`](/docs/app/api-reference/functions/cookies) or [`headers()`](/docs/app/api-reference/functions/headers) inside itself for the same reason; the pattern is to resolve those at the edge of the tree and pass what you need down. The cache key follows the arguments.
 
 What about a read keyed to one project? `cacheTag` accepts more than one tag, so a per-id read can carry both a broad label and an entry-specific one:
 
@@ -297,7 +306,7 @@ async function getProject(id) {
 
 The per-id tag gives a single project entry its own handle, separate from the all-projects entry. A mutation can invalidate one project without touching the rest of the list.
 
-That leaves the per-viewer reads — avatar, pinned ids. Sharing those between viewers would leak one person's data to the next, so they aren't candidates for plain `'use cache'`. They want a different variant: [`'use cache: private'`](/docs/app/api-reference/directives/use-cache-private). Same directive shape, but the entry is scoped to the viewer and stored in the browser cache instead of being shared on the server. Inside it, `cookies()` and `headers()` are allowed — that's the whole point.
+That leaves the per-viewer reads (avatar and pinned ids). Sharing those between viewers would leak one person's data to the next, so they aren't candidates for plain `'use cache'`. They want a different variant: [`'use cache: private'`](/docs/app/api-reference/directives/use-cache-private). Same directive shape, but the entry is scoped to the viewer and stored in the browser cache instead of being shared on the server. Inside it, `cookies()` and `headers()` are allowed. That's the whole point.
 
 ```tsx
 async function getPinnedIds() {
@@ -309,14 +318,15 @@ async function getPinnedIds() {
 }
 ```
 
-The tag works the same way as the shared cache: a Server Function that mutates pins calls `updateTag('pinned')` and the next read on that viewer's device sees the new value. The cache is browser-scoped, so a single tag is enough — there's no risk of one viewer's invalidation reaching another.
+The tag works the same way as the shared cache: a Server Function that mutates pins calls `updateTag('pinned')` and the next read on that viewer's device sees the new value. The cache is browser-scoped, so a single tag is enough. There's no risk of one viewer's invalidation reaching another.
 
-There's a third variant — [`'use cache: remote'`](/docs/app/api-reference/directives/use-cache-remote) — for durable shared cache across server instances when the default in-memory store is not enough. The hosting layer usually wires the handler. The [Cache Components](/docs/app/getting-started/caching) introduction compares all three; this guide uses plain `'use cache'` for project data and `'use cache: private'` for the viewer's avatar and pinned ids.
+There's a third variant ([`'use cache: remote'`](/docs/app/api-reference/directives/use-cache-remote)) for durable shared cache across server instances when the default in-memory store isn't enough. The hosting layer usually wires the handler. The [Cache Components](/docs/app/getting-started/caching) introduction compares all three; this guide uses plain `'use cache'` for project data and `'use cache: private'` for the viewer's avatar and pinned ids.
 
 The tree now carries a decision per node:
 
 ```txt
-ProjectsLayout                  (persistent shell)
+persistent shell
+ProjectsLayout
 ├── HeaderBar
 │   └── ViewerAvatar            use cache: private
 └── Sidebar
@@ -325,8 +335,6 @@ ProjectsLayout                  (persistent shell)
 
 /projects
 └── ProjectGrid                 use cache
-    └── ProjectCard             server
-        └── ProjectPin          use cache: private
 
 /projects/[id]
 ├── ProjectHeader               use cache
@@ -334,10 +342,14 @@ ProjectsLayout                  (persistent shell)
 
 /projects/[id]/deployments/[deployId]
 ├── DeploymentHeader            use cache
-└── BuildLogs                   use cache (completed) / uncached, streamed (building)
+└── BuildLogs                   use cache when complete, live while building
 ```
 
-Notice that the cached sections — sidebar's recent deploys, project header, deployments list — are already painted on first load, with no fallback. The project grid still streams behind its Suspense boundary because it reads `?q=` from search params. The per-viewer reads (avatar, pinned ids) still suspend on first load too, since the private cache lives in the browser and a fresh visit has nothing in it yet — but every subsequent render on that device pulls from cache. The live build log on an in-progress build is the one read that genuinely changes per request. The refresh button reloads the route.
+What does this do to the Suspense boundaries from Step 4? They start coming out. A cached read joins the static shell, and the wrapper around it doesn't have a job anymore. The boundaries around `RecentDeploys`, `ProjectHeader`, `Deployments`, and `BuildLogs` come out with it. What stays wrapped is what still resolves per request. The project grid reads `?q=` from the URL. The avatar and the pinned ids still suspend on first visit, because the per-viewer cache lives in the browser and a fresh device hasn't filled it yet. Inside `BuildLogs`, the live stream still has its boundary. That part is live by definition.
+
+Could you have skipped Step 4 if you'd known the cache plan up front? Sure. But the question was sharper when each component had to answer it on its own.
+
+Notice the new shape. The shared cached sections paint with no fallback because they're in the prerendered shell. The avatar and pinned section still flash once on a cold visit, then stay warm in the browser for the rest of the session. Navigating around the app reuses them without another round-trip. Reload the tab and they go cold again.
 
 <Demo
   src="https://thinking-in-nextjs-05.labs.vercel.dev/projects"
@@ -350,9 +362,9 @@ Source: [`steps/05-caching`](https://github.com/vercel-labs/thinking-in-nextjs/t
 
 Caching decides what output gets reused. Mutations decide when that output stops being true.
 
-In the App Router, mutations live in [Server Functions](/docs/app/glossary#server-function) marked with `'use server'`. Each one does two things in the same call: change the underlying state, then tell the cache the write happened.
+In the App Router, mutations live in [Server Functions](/docs/app/glossary#server-function) marked with `'use server'`. Each one does two things in the same call. It changes the underlying state, then tells the cache the write happened.
 
-Triggering a deploy is the cleanest version of that. The write hits the upstream, then a tag call invalidates the cached deployments list so the next read sees the new row:
+Triggering a deploy is the cleanest version of that. The write hits the upstream, then tag calls invalidate every cached read that stopped being true. The project's deployments list is one. The sidebar's recent-deploys list is another. Each one carries its own tag, and the Server Function calls them by name:
 
 ```tsx
 'use server'
@@ -360,14 +372,15 @@ Triggering a deploy is the cleanest version of that. The write hits the upstream
 async function triggerDeploy(projectId) {
   await db.deployment.create({ projectId })
   updateTag(`deployments-${projectId}`)
+  updateTag('recent-deployments')
 }
 ```
 
-The tag name matches the one the cached read applied earlier, so one Server Function call lines up with one set of cached entries. Any route that reads through `deployments-${projectId}` picks up the change.
+The tag names match the ones the cached reads applied earlier, so one Server Function call lines up with the cache entries it touched. Any route that reads through `deployments-${projectId}` or `recent-deployments` picks up the change.
 
 [`updateTag`](/docs/app/api-reference/functions/updateTag) and [`revalidateTag`](/docs/app/api-reference/functions/revalidateTag) differ in how they treat the response that contains the mutation. `updateTag` handles read-your-writes: the new value shows up in the same response that triggered it. `revalidateTag` handles stale-while-revalidate: the previous value keeps serving while the next read fetches a fresh one.
 
-What does that look like wired up to a button? Calling a Server Function from input doesn't have to mean shipping a Client Component. An HTML form posts to the server, the function runs, and React re-renders the active route with the new state. The button stays a Server Component:
+What does that look like wired up to a button? The smallest version is a `<form action>`, with no `'use client'` boundary in the path:
 
 ```tsx
 <form action={triggerDeploy.bind(null, projectId)}>
@@ -375,7 +388,7 @@ What does that look like wired up to a button? Calling a Server Function from in
 </form>
 ```
 
-This is the same request-response loop PHP and Rails apps ran on: the browser posts a form, the server runs a function, the server re-renders the page. The difference is that React produces the response.
+This is the same request-response loop PHP and Rails apps ran on. The browser posts a form, the server runs a function, and the server re-renders the page. The difference is that React produces the response.
 
 Pinning has the same shape. `getPinnedIds` was tagged in the previous step with `cacheTag('pinned')`, so the pin actions invalidate the same tag:
 
@@ -388,7 +401,7 @@ async function addPin(projectId) {
 }
 ```
 
-The mutation pattern is now uniform across the app: the write touches the underlying state, then `updateTag` calls out the cache entries that just stopped being true. The shared cache and the per-viewer cache use the same call — the difference is only in where the entry lives.
+The mutation pattern is now uniform across the app: the write touches the underlying state, then `updateTag` calls out the cache entries that stopped being true. The shared cache and the per-viewer cache use the same call. The difference is only in where the entry lives.
 
 Notice that submitting the deploy form runs the Server Function and re-renders the route with the new deployments list. Pinning runs through the same path: `updateTag('pinned')` invalidates that viewer's cache entry, and the next render shows the new state.
 
@@ -403,17 +416,22 @@ Source: [`steps/06-mutations`](https://github.com/vercel-labs/thinking-in-nextjs
 
 So far Server Components handle every read, Server Functions handle every write, and an HTML form is enough to get from input to mutation. What's a [Client Component](/docs/app/glossary#client-component) actually for?
 
-The moments the request-response loop can't answer in time. Instant feedback before the server confirms. A pending state while a request is in flight. A URL update on every keystroke instead of one per submit. Inside a [`'use client'`](/docs/app/glossary#use-client-directive) boundary the full React API is back: `onClick`, `useState`, hooks, refs — all of it.
+The moments the request-response loop can't answer in time. Instant feedback before the server confirms. A pending state while a request is in flight. A URL update on every keystroke instead of one per submit. Inside a [`'use client'`](/docs/app/glossary#use-client-directive) boundary the full React API is back, including `onClick`, `useState`, hooks, and refs. Server Functions stay callable from any of them, so the form pattern from Step 6 is one option among many once a Client Component is in the picture.
 
-`PinButton` is the smallest version. The same form action from Step 6, wrapped in a Client Component that owns the optimistic flip:
+That's also why the boundary is open-ended. A Client Component can host anything React can host, from a chart library to drag-and-drop to your own keyboard handler. For a lot of routes you won't reach that far. The URL, a form, a Server Function, and a transition cover most of what an app needs, and the rest stays on the server where it belongs. The boundary is there when you want more.
+
+How wide does the boundary between server and client need to be? One prop, even before it resolves. `ProjectPin` was a server form in Step 6. Step 7 moves it into the client, takes the per-viewer promise as a prop, and calls [`use`](https://react.dev/reference/react/use) to resolve it on the other side, suspending at the nearest [Suspense boundary](/docs/app/glossary#suspense-boundary) above until the read lands. The same form action from Step 6 wraps the optimistic flip:
 
 ```tsx
 'use client'
 
-import { useOptimistic, useTransition } from 'react'
+import { use, useOptimistic, useTransition } from 'react'
 
-function PinButton({ projectId, pinned }) {
-  const [optimistic, setOptimistic] = useOptimistic(pinned)
+function ProjectPin({ projectId, pinnedIdsPromise }) {
+  const pinnedIds = use(pinnedIdsPromise)
+  const isPinned = pinnedIds.includes(projectId)
+
+  const [optimistic, setOptimistic] = useOptimistic(isPinned)
   const [, startTransition] = useTransition()
 
   return (
@@ -432,16 +450,23 @@ function PinButton({ projectId, pinned }) {
 }
 ```
 
-[`useOptimistic`](https://react.dev/reference/react/useOptimistic) gives the button its temporary value to display while the Server Function is in flight; React reverts to the server-confirmed value once the response lands. The flip uses `wasPinned` so the Server Function always matches the state **before** the optimistic update — that way, two fast clicks don't accidentally cancel each other out. Nothing else is needed: the `updateTag('pinned')` call inside `addPin` / `removePin` invalidates the cached read, the framework re-renders the route with fresh data, and the optimistic state hands off to the real one.
+[`useOptimistic`](https://react.dev/reference/react/useOptimistic) gives the button its temporary value to display while the Server Function is in flight; React reverts to the server-confirmed value once the response lands. The flip uses `wasPinned` so the Server Function always matches the state **before** the optimistic update. That way, two fast clicks don't accidentally cancel each other out. Nothing else is needed: the `updateTag('pinned')` call inside `addPin` / `removePin` invalidates the cached read, the framework re-renders the route with fresh data, and the optimistic state hands off to the real one.
 
-How wide does the boundary between server and client need to be? One prop. A Server Component computes the value and hands it down:
+The read still runs on the server. `ProjectGrid` calls `getPinnedIds` once, hands the same promise reference to every card, and each `ProjectPin` waits on it through `use()`:
 
 ```tsx
-async function ProjectPin({ projectId }) {
-  const pinnedIds = await getPinnedIds()
-  return (
-    <PinButton projectId={projectId} pinned={pinnedIds.includes(projectId)} />
-  )
+async function ProjectGrid({ searchParams }) {
+  const { q } = await searchParams
+  const projects = await getProjects({ query: q })
+  const pinnedIdsPromise = getPinnedIds()
+
+  return projects.map((project) => (
+    <ProjectCard
+      key={project.id}
+      project={project}
+      pinnedIdsPromise={pinnedIdsPromise}
+    />
+  ))
 }
 ```
 
@@ -449,16 +474,16 @@ In `ProjectCard`, the icon, title, framework line, description, and status all c
 
 ```tsx
 <header className="flex …">
-  {/* icon, title, meta from `project` — synchronous */}
+  {/* icon, title, meta from `project` (synchronous) */}
   <Suspense fallback={<ProjectPinSkeleton />}>
-    <ProjectPin projectId={project.id} />
+    <ProjectPin projectId={project.id} pinnedIdsPromise={pinnedIdsPromise} />
   </Suspense>
 </header>
 ```
 
-It might look like marking `PinButton` with `'use client'` would pull its parent into the client too. It doesn't. `'use client'` is a _boundary_, not a whole-tree switch. The `getPinnedIds` read stays in `ProjectPin`, the Server Component wrapper; only the boolean it computes crosses into the client. Server Components can render Client Components directly, so the wrapper sits right above the leaf.
+It might look like marking `ProjectPin` with `'use client'` would pull `ProjectGrid` into the client too. It doesn't. `'use client'` is a _boundary_, not a whole-tree switch. The `getPinnedIds` call runs on the server where the grid lives; only the promise crosses into the client, and `use()` reads it from there.
 
-Search shows up again here. The plain HTML form from Step 3 handled a single submit. Updating the URL on every keystroke needs more — the input reads the URL on render, pushes the next one on each change, and holds the previous page visible while the new one resolves:
+Search shows up again here. The plain HTML form from Step 3 worked because a single submit was all the page needed. Per-keystroke updates need a `'use client'` boundary anyway, and once that's there the input can call `router.push` from `onChange` directly. The previous page stays visible while the new one resolves:
 
 ```tsx
 'use client'
@@ -472,22 +497,30 @@ function SearchBar() {
   const [isPending, startTransition] = useTransition()
 
   return (
-    <input
-      type="search"
-      defaultValue={searchParams.get('q') ?? ''}
-      className={isPending ? 'opacity-80' : undefined}
-      onChange={(event) => {
-        const next = event.target.value
-        startTransition(() => {
-          router.push(next ? `/projects?q=${next}` : '/projects')
-        })
-      }}
-    />
+    <form
+      action="/projects"
+      method="get"
+      role="search"
+      onSubmit={(event) => event.preventDefault()}
+    >
+      <input
+        type="search"
+        name="q"
+        defaultValue={searchParams.get('q') ?? ''}
+        className={isPending ? 'opacity-80' : undefined}
+        onChange={(event) => {
+          const next = event.target.value
+          startTransition(() => {
+            router.push(next ? `/projects?q=${next}` : '/projects')
+          })
+        }}
+      />
+    </form>
   )
 }
 ```
 
-App Router runs `router.push` inside a [transition](https://react.dev/reference/react/useTransition) by default — the input stays responsive and the previous page stays visible whether or not the call is wrapped. What [`useTransition`](https://react.dev/reference/react/useTransition) adds is `isPending`: a value the input can read to show a hint while the new render resolves. [`useLinkStatus`](/docs/app/api-reference/functions/use-link-status) gives the same signal for `<Link>` navigations.
+App Router runs `router.push` inside a [transition](https://react.dev/reference/react/useTransition) by default. The input stays responsive and the previous page stays visible whether or not the call is wrapped. [`useTransition`](https://react.dev/reference/react/useTransition) adds `isPending`, a value the input can read to show a hint while the new render resolves. [`useLinkStatus`](/docs/app/api-reference/functions/use-link-status) gives the same signal for `<Link>` navigations.
 
 Notice that the leaves react directly to input on the deployed route. Pinning flips before the server confirms, search edits the URL on each keystroke, and the deploy button stays in a pending state until the Server Function returns. Everything else around them stays a Server Component.
 
@@ -500,11 +533,11 @@ Source: [`steps/07-client-boundaries`](https://github.com/vercel-labs/thinking-i
 
 ## Step 8: Optimize prefetching
 
-By now the tree knows what to render and what to reuse. The last question is one of timing: when can that work happen?
+By now the tree knows what to render and what to reuse. The last question is timing. When can that work happen?
 
-It doesn't have to wait for the click. A `<Link>` that's been on the page long enough — sitting in the viewport, hovered, idle — is a hint that a navigation is likely. The runtime can use that hint to render the destination ahead of time, so the click lands on a tree that's already there.
+It doesn't have to wait for the click. When a `<Link>` is visible on the page, the runtime takes that as a hint that a navigation is likely and renders the destination ahead of time, so the click lands on a tree that's already there.
 
-There are two flavors. A **static** prefetch renders the destination against build-time inputs: useful for shared content, but blind to anything that depends on the request. A **runtime** prefetch is a real render with the same cookies, headers, and search string the navigation would send. That second flavor is what makes the per-viewer cache pay off across navigations — `getPinnedIds` was already cached in Step 5, but a static prefetch couldn't see the session, so it couldn't fill that entry. Runtime prefetch can.
+Every visible link gets the same treatment. What changes is the flavor of prefetch the destination route asks for. The default is **static**. It renders the destination against build-time inputs, useful for shared chrome but blind to anything that depends on the request. **Runtime** prefetch is opt-in. It's a real render with the same cookies, headers, and search string the navigation would send. That second flavor is what makes the per-viewer cache pay off across navigations. `getPinnedIds` was already cached in Step 5, but a static prefetch couldn't see the session, so it couldn't fill that entry. Runtime prefetch can.
 
 Opting into runtime prefetch is one segment-config line:
 
@@ -512,24 +545,27 @@ Opting into runtime prefetch is one segment-config line:
 export const unstable_prefetch = 'force-runtime'
 ```
 
-The companion job is **instant validation**: a check that every path into the route still exposes an instant shell. Shared chrome stays in the static part of the prerender, anything dynamic sits behind a Suspense boundary, and the navigation never tears the frame apart mid-transition. Validation needs a believable example to work against, and that's what `samples` provides:
+The companion job is **instant validation**, a check that every path into the route still exposes an instant shell. Shared chrome stays in the static part of the prerender, anything dynamic sits behind a Suspense boundary, and the navigation never tears the frame apart mid-transition.
 
-```tsx
-export const unstable_instant = {
-  samples: [
-    {
-      searchParams: { q: null },
-      cookies: [{ name: 'session', value: null }],
-    },
-  ],
+Validation is a development-time check you turn on once. A single line in `next.config.ts` puts every route in the loop:
+
+```ts filename="next.config.ts"
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  instant: {
+    defaultValidationLevel: 'warning',
+  },
 }
+
+export default nextConfig
 ```
 
-The source may still prefix these exports with `unstable_`; the docs call them prefetch and instant navigation validation.
+`'warning'` runs the validator as you click through the app and surfaces violations in the dev overlay, without blocking anything. It's the pragmatic on-ramp. Every route is in the loop, with no per-route opt-in to chase. The dev validator renders against the request you're already making, so cookies, headers, and search params come from real navigation rather than declared inputs.
 
-Prefetch never widens what you cached — it only moves eligible work earlier. What you feel is simpler. Clicks land reconciled when the cache lines up. Back navigation picks up what the forward pass stashed. Underneath it is still the same server-rendered tree.
+Prefetch never widens what you cached. It only moves eligible work earlier. Clicks land reconciled when the cache lines up, back navigation picks up what the forward pass stashed, and underneath it's still the same server-rendered tree.
 
-Notice that opening a project shows the header and deployments without a blank beat; only the live build log on an in-progress deployment still streams. Pins and avatar ride along because the prefetch pass sees the same session the navigation will, and the cached entries from earlier steps are already on the device when the click happens.
+The project header and deployments already painted without a fallback in earlier steps. What's new is the projects list. Its grid reads `?q=` and used to stream behind a skeleton on every visit. Now the runtime prefetch warms it against the current session, so the cards land with the click. Avatar and pinned state ride along because that prefetch carries the same cookies the navigation will. From there those entries live on the device, so subsequent navigations resolve them from cache rather than the network and keep working offline or over a flaky connection. The live build log on an in-progress deployment is the one read that still streams.
 
 <Demo
   src="https://thinking-in-nextjs.labs.vercel.dev/projects"
@@ -540,18 +576,24 @@ Source: [`steps/08-prefetching`](https://github.com/vercel-labs/thinking-in-next
 
 ## Where to go from here
 
-The route grew in layers. A flat baseline. Reads next to the JSX that uses them. Suspense around the slow ones. Caching for the parts that repeat. Mutations that invalidate by tag. Client islands where input lives. Prefetch and validation so navigations land already painted.
+Look back at the route. You didn't redesign it. You asked each component the same question. _What kind of work is this?_ A read here, a Suspense boundary there, a cache where the work repeats, a tag where it doesn't, a Client leaf where input lives. The route got more honest about what each piece was doing. One model carries the whole thing. The decisions it asks for are the ones that scale, and most routes never need a different shape.
 
-None of those steps needed a new framework. Each one was the next question the route asked.
-
-Try the same exercise on a route in your own codebase. Name the regions, then label each one as static, dynamic, cached, or a Client leaf. The decisions usually fall out once each component answers what kind of work it is.
+Try it on a route in your own codebase. Name the regions, then label each one as static, dynamic, cached, or a Client leaf. The decisions usually fall out once each component answers what kind of work it is.
 
 The docs go deeper on each piece used here.
 
 - [Cache Components](/docs/app/getting-started/caching) covers what `cacheComponents: true` changes and what each `'use cache'` variant is for.
 - [Streaming](/docs/app/guides/streaming) covers `loading.tsx`, nested Suspense, and where to place `<Suspense>`.
 - [Server and Client Components](/docs/app/getting-started/server-and-client-components) goes further on the prop boundary, including the donut pattern (Client Components receiving Server Components as `children`) for cases this guide didn't run into.
-- [Prefetch](/docs/app/api-reference/file-conventions/route-segment-config/prefetch) and [instant](/docs/app/api-reference/file-conventions/route-segment-config/instant) segment config: runtime prefetch and shell validation. Other options sit in the [route segment config](/docs/app/api-reference/file-conventions/route-segment-config) reference.
+- [Prefetching](/docs/app/guides/prefetching) and [instant navigation](/docs/app/guides/instant-navigation) cover runtime prefetch and shell validation in more depth.
+
+For the parts this route didn't ask about, the docs cover those too.
+
+- [Authentication](/docs/app/guides/authentication) for knowing who's reading.
+- [Proxy](/docs/app/getting-started/proxy) for intercepting requests before they reach a page.
+- [Route Handlers](/docs/app/getting-started/route-handlers) for endpoints that return data instead of a page.
+- Parallel and intercepting routes for layouts that share a URL.
+- [Internationalization](/docs/app/guides/internationalization) for apps that speak more than one language.
 
 ## Browse the source
 
@@ -566,5 +608,5 @@ Jump to a step on GitHub:
 - [`steps/04-streaming`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/04-streaming). Suspense around async sections.
 - [`steps/05-caching`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/05-caching). `'use cache'` and tags on shared reads; `'use cache: private'` for the per-viewer reads (avatar, pinned ids).
 - [`steps/06-mutations`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/06-mutations). Server Functions; `updateTag` for every cached read.
-- [`steps/07-client-boundaries`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/07-client-boundaries). Client leaves; optimistic `PinButton`; URL-driven `SearchBar` with `useTransition`.
-- [`steps/08-prefetching`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/08-prefetching). Runtime prefetch and instant samples; real session model.
+- [`steps/07-client-boundaries`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/07-client-boundaries). Client leaves; optimistic `ProjectPin` reading the per-viewer promise with `use`; URL-driven `SearchBar` with `useTransition`.
+- [`steps/08-prefetching`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/08-prefetching). Runtime prefetch and instant validation; real session model.

--- a/docs/01-app/02-guides/thinking-in-nextjs.mdx
+++ b/docs/01-app/02-guides/thinking-in-nextjs.mdx
@@ -1,0 +1,466 @@
+---
+title: Thinking in Next.js
+nav_title: Thinking in Next.js
+description: A way of thinking about App Router apps as components that decide where their data comes from, what gets reused, and what stays in the browser.
+related:
+  title: Related
+  description: Continue learning about the App Router model.
+  links:
+    - app/getting-started/caching
+    - app/guides/streaming
+---
+
+In React, you build a UI by breaking the screen into components and letting data flow through the tree. The original [Thinking in React](https://react.dev/learn/thinking-in-react) walks through that mental model. Break it down, build it static, then add state.
+
+In Next.js, the same component tree also says where data comes from, what renders immediately, what streams later, and what can be reused across navigations. Each component picks up an extra responsibility along with its rendering. It decides what kind of work it is.
+
+## Start with the mockup
+
+The brief: a small projects dashboard. Each viewer sees their projects, opens one to see its deployments, and opens a deployment to read its build log. They can search the list, pin favorites, and trigger a redeploy from the project page.
+
+The designer hands over mockups for three routes.
+
+<Image
+  alt="Three route cards labeled /projects, /projects/compass, and /projects/compass/deployments/compass-jx9q3, each split into top bar, sidebar, and content regions."
+  srcLight="/docs/guides/thinking-in-nextjs/route-mockups-light.png"
+  srcDark="/docs/guides/thinking-in-nextjs/route-mockups-dark.png"
+  width={1088}
+  height={386}
+/>
+
+The data layer returns four shapes:
+
+| Type                  | Notes                                                                            |
+| --------------------- | -------------------------------------------------------------------------------- |
+| `Project`             | One per project. Status is `production`, `building`, `paused`, or `failed`.      |
+| `Deployment`          | Newest first. Status is `ready`, `building`, `failed`, `queued`, or `cancelled`. |
+| `LogLine`             | The build log is one ordered list of these.                                      |
+| `pinnedIds: string[]` | The project ids the current viewer has pinned.                                   |
+
+Building this happens one decision at a time:
+
+1. Break the UI into a component hierarchy.
+2. Build a static version with JSX.
+3. Fetch data where it is used.
+4. Stream async work.
+5. Cache reusable work.
+6. Add mutations.
+7. Add client boundaries.
+8. Configure prefetching.
+
+The order matters. It's hard to think about caching before knowing what data is being fetched, and hard to think about prefetching before knowing what's cached.
+
+## Step 1: Break the UI into a component hierarchy
+
+Start by drawing boxes around each region and naming them.
+
+<Image
+  alt="A /projects mockup with four numbered regions next to a legend: 1 ProjectsLayout (frame around every page), 2 HeaderBar and SearchBar (top bar across every route), 3 Sidebar (Pinned and Recent deploys), 4 ProjectCard, ProjectPin, and PinButton (one project tile in the list)."
+  srcLight="/docs/guides/thinking-in-nextjs/component-legend-light.png"
+  srcDark="/docs/guides/thinking-in-nextjs/component-legend-dark.png"
+  width={1088}
+  height={636}
+/>
+
+The full table fills in the project and build pages:
+
+| Region                  | Component                                |
+| ----------------------- | ---------------------------------------- |
+| Frame around every page | `ProjectsLayout`                         |
+| Top bar                 | `HeaderBar` and `SearchBar`              |
+| Sidebar                 | `Sidebar` (Pinned and Recent deploys)    |
+| Project tile            | `ProjectCard`, `ProjectPin`, `PinButton` |
+| Project page header     | `ProjectHeader` and `DeployButton`       |
+| Deployments list        | `Deployments`                            |
+| Build page header       | `DeploymentHeader`                       |
+| Build logs              | `BuildLogs`                              |
+
+The route shape lines up with the table:
+
+```txt
+ProjectsLayout                      ← persistent: HeaderBar + Sidebar
+├── /projects                       → ProjectGrid of ProjectCards
+├── /projects/[id]                  → ProjectHeader + Deployments
+└── /…/deployments/[deployId]       → DeploymentHeader + BuildLogs
+```
+
+A few pairs (`HeaderBar` and `SearchBar`, `ProjectPin` and `PinButton`) are split because one side reads cookies or talks to the database, and the other handles user input. Server work and client work end up in separate files because they run in separate environments.
+
+At this stage, no decisions about caching, streaming, or client-side rendering. Start with what each component is responsible for. The other choices follow from there.
+
+## Step 2: Build a static version with JSX
+
+Build it from mock data, with no database, actions, or client state.
+
+```tsx
+function ProjectsPage() {
+  return projects.map((p) => <ProjectCard key={p.id} project={p} />)
+}
+
+function ProjectCard({ project }) {
+  return (
+    <article>
+      <h3>{project.name}</h3>
+      <p>{project.description}</p>
+    </article>
+  )
+}
+```
+
+Layouts and pages are [Server Components](/docs/app/getting-started/server-and-client-components) by default. They run on the server and never run again in the browser. Since this version only renders JSX from local data, no [Client Component](/docs/app/getting-started/server-and-client-components#using-client-components) is needed yet. Running `next build` prerenders the route as static HTML.
+
+This is the App Router version of "build a static version" from Thinking in React. The UI is visible before any decision about where the real data comes from.
+
+Notice that the deployed route paints in one shot, with nothing to wait for. The HTML comes back from a static prerender, since every value the components need is inline mock data.
+
+<Demo
+  src="https://thinking-in-nextjs-02.labs.vercel.dev/projects"
+  title="Step 2: Static JSX"
+/>
+
+Source: [`steps/02-static-jsx`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/02-static-jsx).
+
+## Step 3: Fetch data where it is used
+
+Replace the mock data with reads from the data layer (the small set of functions that talk to the database or an upstream API). In Server Components, the component that displays the data reads it directly:
+
+```tsx
+async function ProjectGrid({ searchParams }) {
+  const { q } = await searchParams
+  const projects = await getProjects({ query: q })
+  return projects.map((p) => <ProjectCard key={p.id} project={p} />)
+}
+```
+
+Each component owns its read, kept close to the JSX that uses it. Lifting every fetch into a single parent and passing data down through props couples otherwise independent components, and tends to run their reads one after another instead of in parallel.
+
+Walking the tree from this angle, every piece of UI shows what it depends on:
+
+| UI piece                   | What it shows                                   |
+| -------------------------- | ----------------------------------------------- |
+| `ProjectGrid`              | The project list, optionally filtered by `?q=`. |
+| `ProjectHeader`            | One project's name, status, and metadata.       |
+| `Deployments`              | The deployments for one project.                |
+| `DeploymentHeader`         | One deployment's status and commit.             |
+| `BuildLogs`                | The log for one deployment.                     |
+| `RecentDeploys`            | The latest deployments across all projects.     |
+| `PinnedList`, `ProjectPin` | The viewer's pinned ids, stored in a cookie.    |
+| `ViewerAvatar`             | The current viewer, also from a cookie.         |
+
+Each component now reads its own data, but the prerender can't tell which of those reads will block. Earlier versions of App Router built the route either way, and finding the read that kept it from being static meant reading the build output or the request waterfall.
+
+[Cache Components](/docs/app/getting-started/caching) surfaces this. Opt in:
+
+```ts filename="next.config.ts"
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  cacheComponents: true,
+}
+
+export default nextConfig
+```
+
+With it on, the prerender expects every async read to either be cached or sit behind a Suspense boundary. Anything else surfaces in both `next dev` and `next build` as [`Uncached data was accessed outside of <Suspense>`](https://nextjs.org/docs/messages/blocking-route), pointing at the call site.
+
+{/* TODO: add a real screenshot of the dev overlay via <Image src="..." /> once available. */}
+
+There are two ways to answer that:
+
+- `'use cache'`. Reuse the read so it can sit in the static shell.
+- `<Suspense>`. Provide a placeholder so the read can stream at request time.
+
+The component is correct, but the rendering structure isn't finished. Each async read picks one of the next two steps.
+
+Open the deployed route. The dashboard looks the same, now backed by the data layer instead of mock data.
+
+<Demo
+  src="https://thinking-in-nextjs-03.labs.vercel.dev/projects"
+  title="Step 3: Fetch data"
+/>
+
+Source: [`steps/03-fetch-data`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/03-fetch-data).
+
+## Step 4: Stream async work
+
+Wrap the sections that load data in [`<Suspense>`](https://react.dev/reference/react/Suspense) so the [static shell](/docs/app/glossary#static-shell) (the parts that don't need to wait) can render first:
+
+```tsx
+<HeaderBar />
+<Suspense fallback={<SidebarSkeleton />}>
+  <Sidebar />
+</Suspense>
+<Suspense fallback={<ProjectGridSkeleton />}>
+  <ProjectGrid searchParams={searchParams} />
+</Suspense>
+```
+
+A _fallback_ is the UI that ships with the shell. It gets replaced with the real output once the async component finishes. For this route:
+
+- **0 ms.** Shell sent. Header, sidebar fallback, grid fallback.
+- **400 ms.** Sidebar resolves. Its fallback is replaced with the real output.
+- **900 ms.** Grid resolves. Last fallback replaced.
+
+Size each fallback to match the shape of what's coming. A skeleton with the same width, height, and number of rows as the streamed result keeps the shell stable. A wrong-sized fallback pushes the page around when content arrives.
+
+Suspense boundaries can nest. When the server produces output as it goes (log lines on an in-progress build, LLM tokens, paginated work), each piece wraps the next in its own boundary so each one streams independently:
+
+```tsx
+function LiveLines({ lines, index }) {
+  if (index >= lines.length) return null
+  return (
+    <>
+      <LogRow line={lines[index]} />
+      <Suspense fallback={<Cursor />}>
+        <DelayedNextLine lines={lines} nextIndex={index + 1} />
+      </Suspense>
+    </>
+  )
+}
+```
+
+For feeds that arrive outside the request (a real build log from the platform, telemetry, chat), the typical pattern is a Client Component that polls or subscribes to a stream.
+
+From here on, cached output is shell content and uncached output streams. Suspense marks the streaming part. A `'use cache'` read doesn't need a Suspense wrapper, because the cached output is already there.
+
+Notice that the projects route paints the shell immediately, then swaps in the sidebar and grid as each Suspense boundary resolves. Open a deployment that's still building to see the same primitive nested: each log line streams in on its own.
+
+<Demo
+  src="https://thinking-in-nextjs-04.labs.vercel.dev/projects"
+  title="Step 4: Stream async work"
+/>
+
+Source: [`steps/04-streaming`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/04-streaming).
+
+## Step 5: Cache reusable work
+
+Now consider which streamed sections are stable enough to reuse. The question to ask of each piece:
+
+> Would the next viewer see the same thing?
+
+| UI piece                          | Same for every viewer? | Becomes                  |
+| --------------------------------- | ---------------------- | ------------------------ |
+| `ProjectGrid`, `ProjectHeader`    | Yes                    | `'use cache'`            |
+| `Deployments`, `DeploymentHeader` | Yes                    | `'use cache'`            |
+| `RecentDeploys`                   | Yes                    | `'use cache'`            |
+| `BuildLogs`, completed build      | Yes                    | `'use cache'`            |
+| `BuildLogs`, in-progress build    | No, live               | uncached, streamed       |
+| `ViewerAvatar`                    | No, per viewer         | uncached, runtime cookie |
+| `PinnedList`, `ProjectPin`        | No, per viewer         | uncached, runtime cookie |
+
+A directive enters the picture when the read is worth reusing. The shape:
+
+```tsx
+async function getProjects({ query }) {
+  'use cache'
+  cacheLife('hours')
+  cacheTag('projects')
+
+  return db.project.findMany({ where: matches(query) })
+}
+```
+
+[`'use cache'`](/docs/app/api-reference/directives/use-cache) marks the function as cacheable. Different arguments (and any closed-over values) become different entries, so a search for `?q=foo` and `?q=bar` are stored separately. [`cacheLife`](/docs/app/api-reference/functions/cacheLife) sets how long an entry stays valid. [`cacheTag`](/docs/app/api-reference/functions/cacheTag) labels the entry, which gives mutations a way to refer to it by name later.
+
+Cookies, headers, and `searchParams` are request inputs, not external data. The pinned list is a cookie read:
+
+```tsx
+async function getPinnedIds() {
+  return (await cookies()).get('pinned')?.value?.split(',') ?? []
+}
+```
+
+There isn't much for plain `'use cache'` to share here, since the answer changes per viewer. The read stays uncached, with the component that needs it sitting behind a Suspense boundary.
+
+`'use cache'` covers most of what this app needs to share. Two related directives, [`'use cache: remote'`](/docs/app/api-reference/directives/use-cache-remote) and [`'use cache: private'`](/docs/app/api-reference/directives/use-cache-private), handle cases where the default in-memory, shared-across-viewers cache isn't the right fit. Check them before deciding a read can't be cached.
+
+The tree now carries a decision per node:
+
+```txt
+ProjectsLayout                  (persistent shell)
+├── HeaderBar
+│   ├── SearchBar               Client · URL state
+│   └── ViewerAvatar            runtime (cookie)
+└── Sidebar
+    ├── PinnedList              runtime (cookie)
+    └── RecentDeploys           use cache
+
+/projects
+└── ProjectGrid                 use cache
+    └── ProjectCard             server
+        └── ProjectPin          runtime (cookie) · wraps PinButton (Client)
+
+/projects/[id]
+├── ProjectHeader               use cache · wraps ProjectPin + DeployButton (Client)
+└── Deployments                 use cache
+
+/projects/[id]/deployments/[deployId]
+├── DeploymentHeader            use cache
+└── BuildLogs                   use cache (completed) / uncached, streamed (building)
+```
+
+Cached output also moves when the underlying data changes. The next step covers how mutations mark cached entries stale.
+
+Notice that the cached sections (project list, project header, deployment list) are already painted on first load, with no fallback. The only thing that still streams is the live build log on an in-progress build, the one read that changes per request.
+
+<Demo
+  src="https://thinking-in-nextjs-05.labs.vercel.dev/projects"
+  title="Step 5: Cache reusable work"
+/>
+
+Source: [`steps/05-caching`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/05-caching).
+
+## Step 6: Add mutations
+
+Caching decides what output gets reused; mutations decide when that output stops being true. In the App Router, mutations live in [Server Functions](/docs/app/getting-started/updating-data) marked with `'use server'`. They can be called from anywhere on the server, and from a Client Component once the next step introduces one. Every mutation does two jobs in one call:
+
+- Change the underlying state in a database, a cookie, or an external service.
+- Tell the cache which tagged entries the change made stale.
+
+Deploying a project is the clearest example. The write goes to an upstream API, then a tag call invalidates the cached deployments list so the next read sees the new row:
+
+```tsx
+'use server'
+
+async function triggerDeploy(projectId) {
+  await pushNewDeployment(projectId)
+  updateTag(`deployments-${projectId}`)
+}
+```
+
+The tag name matches the one the cached read applied in Step 5, so one Server Function call lines up with one set of cached entries. Any route that reads through `deployments-${projectId}` picks up the change.
+
+[`updateTag`](/docs/app/api-reference/functions/updateTag) and [`revalidateTag`](/docs/app/api-reference/functions/revalidateTag) differ in how they treat the response that contains the mutation. `updateTag` handles read-your-writes, so the new value shows up in the same response that triggered it. `revalidateTag` handles stale-while-revalidate, so the previous value keeps serving while the next read fetches a fresh one.
+
+Not every mutation invalidates something. A toggle that only writes a cookie (like `togglePinned`) has no cached read standing in for it. [Server Actions](/docs/app/getting-started/updating-data#server-functions) automatically re-render the active route after the call, and the next cookie read picks up the new value. No tag call is needed because nothing was cached on the way in.
+
+Calling a Server Function from input doesn't need any client code. A plain HTML form posts to the server, runs the function, and re-renders the active route with the new state. The button stays a Server Component.
+
+```tsx
+<form action={triggerDeploy.bind(null, projectId)}>
+  <button type="submit">Deploy</button>
+</form>
+```
+
+Notice that submitting the deploy form runs the Server Function and re-renders the route with the new deployments list, without shipping any Client Component.
+
+<Demo
+  src="https://thinking-in-nextjs-06.labs.vercel.dev/projects"
+  title="Step 6: Add mutations"
+/>
+
+Source: [`steps/06-mutations`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/06-mutations).
+
+The next step keeps the form action and wraps the buttons in Client Components for optimistic state and pending state.
+
+## Step 7: Add client boundaries
+
+Component state still works the same as in any React app. Many things that would be component state in a typical SPA fit other patterns: updating the URL, calling a Server Function, showing optimistic state until server-rendered data catches up.
+
+The form action from Step 6 already lets a click reach the server. What's still missing is anything only the client can do: instant feedback before the server confirms, pending state while a request is in flight. Push the components that own those into Client Components and leave the rest of the tree on the server.
+
+A client leaf wraps the existing form action and adds whatever the client owns on top:
+
+```tsx
+'use client'
+
+function PinButton({ projectId, pinned }) {
+  const [optimistic, setOptimistic] = useOptimistic(pinned)
+  return (
+    <form
+      action={async () => {
+        setOptimistic(!optimistic)
+        await togglePinned(projectId)
+      }}
+    >
+      <button type="submit">{optimistic ? 'Pinned' : 'Pin'}</button>
+    </form>
+  )
+}
+```
+
+The boundary between server and client is one prop wide. A Server Component computes a value and hands it down:
+
+```tsx
+async function ProjectPin({ projectId }) {
+  const pinnedIds = await getPinnedIds()
+  return (
+    <PinButton projectId={projectId} pinned={pinnedIds.includes(projectId)} />
+  )
+}
+```
+
+The cookie read happens on the server and never reaches the browser. Server Components can render Client Components directly, so the wrapper sits right above the leaf.
+
+Pending state has a related shape. A small client leaf reads the pending status of the surrounding context, with no state of its own:
+
+```tsx
+'use client'
+import { useLinkStatus } from 'next/link'
+
+function NavSpinner() {
+  const { pending } = useLinkStatus()
+  return pending ? <Spinner /> : null
+}
+```
+
+Place that leaf inside any `<Link>` and it activates for that link's navigation. The same idea works inside a form via `useFormStatus` for submission state.
+
+Notice that the leaves react directly to input on the deployed route. Pinning flips before the server confirms, search edits the URL on each keystroke, and the deploy button stays in a pending state until the Server Function returns. Everything else around them stays a Server Component.
+
+<Demo
+  src="https://thinking-in-nextjs-07.labs.vercel.dev/projects"
+  title="Step 7: Add client boundaries"
+/>
+
+Source: [`steps/07-client-boundaries`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/07-client-boundaries).
+
+## Step 8: Configure prefetching
+
+```tsx
+export const prefetch = 'force-runtime'
+```
+
+`prefetch = 'force-runtime'` tells the router to prefetch this route at runtime, so the cached parts land in the client cache before the click.
+
+What the router prefetches is decided by the cache boundaries from Step 5. Push more reads into `'use cache'` to prefetch more, leave a section uncached behind Suspense to prefetch less. There's no separate "what to prefetch" knob.
+
+`prefetch` is the explicit step. [`instant`](/docs/app/api-reference/file-conventions/route-segment-config/instant) runs in the background as a default validator, checking that the caching structure on each route produces an instant static shell, so a `force-runtime` prefetch has something cached to land.
+
+The same cache also lets the route render without a network. Cached output sits on the device; only the dynamic sections behind Suspense have to wait for a request.
+
+Notice that clicking a project card lands on the project route with the header and deployment list already painted, while the per-viewer and live sections stream in after. The cached shell prefetched as the cards came into view, so the click has nothing to wait on.
+
+<Demo
+  src="https://thinking-in-nextjs.labs.vercel.dev/projects"
+  title="Step 8: Configure prefetching"
+/>
+
+Source: [`steps/08-prefetching`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/08-prefetching).
+
+## Where to go from here
+
+Try the same exercise on a route in your own codebase. Name the regions, then label each one as static, dynamic, cached, or a Client leaf. The decisions usually fall out once each component answers what kind of work it is.
+
+The docs go deeper on each piece used here.
+
+- [Cache Components](/docs/app/getting-started/caching) covers what `cacheComponents: true` changes and what each `'use cache'` variant is for.
+- [Streaming](/docs/app/guides/streaming) covers `loading.tsx`, nested Suspense, and where to place `<Suspense>`.
+- [Server and Client Components](/docs/app/getting-started/server-and-client-components) goes further on the prop boundary, including the donut pattern (Client Components receiving Server Components as `children`) for cases this guide didn't run into.
+- [`prefetch`](/docs/app/api-reference/file-conventions/route-segment-config/prefetch) is the route segment config used in this guide to tell the router to prefetch a route at runtime. [`instant`](/docs/app/api-reference/file-conventions/route-segment-config/instant) is the default validator that keeps the static shell honest. The other per-route options live next to them in the [route segment config](/docs/app/api-reference/file-conventions/route-segment-config) reference.
+
+## Browse the source
+
+[`vercel-labs/thinking-in-nextjs`](https://github.com/vercel-labs/thinking-in-nextjs) holds one folder per guide step under `steps/`, each runnable on its own. The full app is also deployed at [thinking-in-nextjs.labs.vercel.dev](https://thinking-in-nextjs.labs.vercel.dev/).
+
+{/* TODO: restore the DemoExplorer block here once vercel/front#67624 lands on main and vercel-labs/thinking-in-nextjs is public. Intended config: repo "vercel-labs/thinking-in-nextjs", gitRef "main", path "steps", include "steps/**", exclude "node_modules,.next,.turbo,dist,build,*.lock,pnpm-lock.yaml", defaultFile "steps/07-static-jsx/app/projects/page.tsx". Source: https://github.com/vercel-labs/thinking-in-nextjs */}
+
+Jump to a step on GitHub:
+
+- [`steps/02-static-jsx`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/02-static-jsx). Static JSX with mock data.
+- [`steps/03-fetch-data`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/03-fetch-data). Server Components reading from a data layer.
+- [`steps/04-streaming`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/04-streaming). Suspense around async sections.
+- [`steps/05-caching`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/05-caching). `'use cache'` on stable reads.
+- [`steps/06-mutations`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/06-mutations). Server Functions and `updateTag` called from a plain form.
+- [`steps/07-client-boundaries`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/07-client-boundaries). Client leaves and server actions.
+- [`steps/08-prefetching`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/08-prefetching). `prefetch` and `instant` route configs.

--- a/docs/01-app/02-guides/thinking-in-nextjs.mdx
+++ b/docs/01-app/02-guides/thinking-in-nextjs.mdx
@@ -1,7 +1,7 @@
 ---
 title: Thinking in Next.js
 nav_title: Thinking in Next.js
-description: A way of thinking about App Router apps as one component tree that decides where its data comes from, what gets reused, and what stays in the browser.
+description: A way of thinking about App Router apps as one component tree where each piece declares where its data comes from, what gets reused, and what stays in the browser.
 related:
   title: Related
   description: Continue learning about the App Router model.
@@ -10,24 +10,26 @@ related:
     - app/guides/streaming
 ---
 
-In React, you build a UI by breaking the screen into components and letting data flow through the tree. The original [Thinking in React](https://react.dev/learn/thinking-in-react) walks through that model in three moves. First name the parts, then render them static from mock data, then layer state on top.
+{/* The demo URLs and source links in Steps 5-7 target the post-restructure lab naming (mutations / client-boundaries / caching). They will 404 until the labs are renamed to match. */}
 
-In Next.js, the same component tree carries a few more decisions. Where does the data come from? What can render right away? What waits, and what gets reused for the next visitor? The pieces are still components (some run on the server, some run in the browser), and they compose like any other React tree. Each one runs where it belongs.
+In React, you break a UI into components and let data flow through the tree. [Thinking in React](https://react.dev/learn/thinking-in-react) walks through the model in five steps. Name the parts, render them from mock data, and layer state on top.
 
-This guide builds one small app one decision at a time, the same way you would in your own codebase.
+In Next.js, the same tree carries a few more decisions. Where does the data come from? What can render ahead of the request, what waits for it, and what gets reused for the next visitor? The pieces are still components, some running on the server and some in the browser, and they compose like any other React tree. Each one runs where it belongs.
+
+This guide builds one small app one decision at a time, the way you would in your own codebase.
 
 ## Start with the mockup
 
-The brief: a small projects dashboard. Each viewer sees their projects, opens one to see its deployments, and opens a deployment to read its build log. They can search the list, pin favorites, and trigger a redeploy from the project page.
+Picture a small projects dashboard. Each viewer sees their projects, opens one to see its deployments, and opens a deployment to read its build log. They can search the list, pin favorites, and trigger a redeploy from the project page.
 
 The designer hands over mockups for three routes.
 
 <Image
   alt="Three route cards labeled /projects, /projects/compass, and /projects/compass/deployments/compass-jx9q3, each split into top bar, sidebar, and content regions."
-  srcLight="/docs/guides/thinking-in-nextjs/designer-mockups-light.png"
-  srcDark="/docs/guides/thinking-in-nextjs/designer-mockups-dark.png"
+  srcLight="/docs/guides/thinking-in-nextjs/designer-mockups-light-cropped.png"
+  srcDark="/docs/guides/thinking-in-nextjs/designer-mockups-dark-cropped.png"
   width={1600}
-  height={567}
+  height={452}
 />
 
 The data layer returns three shapes:
@@ -44,16 +46,18 @@ The build happens one decision at a time:
 2. Build a static version with JSX.
 3. Fetch data where it is used.
 4. Stream async work.
-5. Cache reusable work.
-6. Mutate data.
-7. Add client interactivity.
+5. Mutate data.
+6. Add client interactivity.
+7. Cache reusable work.
 8. Optimize prefetching.
 
-The order is not arbitrary. It is hard to think about caching before knowing what data is being fetched, and hard to think about [prefetching](/docs/app/glossary#prefetching) before knowing what's cached. Each step earns the next one.
+The order isn't arbitrary. You can't plan caching before you know what data each region reads, and you can't plan [prefetching](/docs/app/glossary#prefetching) before you know what's cached. Each step earns the next.
+
+These steps split into two passes. The first pass builds the route, going from static JSX through server-side reads with Suspense around the async ones, then mutations, then a client boundary for what the request-response loop can't cover. The second pass optimizes how it loads, with caching for the work that repeats and runtime prefetch for what can move before the click.
 
 ## Step 1: Break the UI into a component hierarchy
 
-The first pass draws a box around each region of the mockup and gives it a name. Each repeating piece of data turns into one component, with one `ProjectCard` per `Project`, one row per `Deployment`, and one row per `LogLine`. [Thinking in React](https://react.dev/learn/thinking-in-react#step-1-break-the-ui-into-a-component-hierarchy) calls this matching the component structure to the data model. UI and data tend to share the same shape.
+Draw a box around each region of the mockup and give it a name. Each repeating piece of data becomes one component, with one `ProjectCard` per `Project`, one row per `Deployment`, and one row per `LogLine`. [Thinking in React](https://react.dev/learn/thinking-in-react#step-1-break-the-ui-into-a-component-hierarchy) calls this matching the component structure to the data model. UI and data tend to share the same shape.
 
 | Region                  | Component                                                        |
 | ----------------------- | ---------------------------------------------------------------- |
@@ -75,11 +79,11 @@ ProjectsLayout                      ← persistent: HeaderBar + Sidebar
 └── /…/deployments/[deployId]       → DeploymentHeader + BuildLogs
 ```
 
-Nothing decided yet about how the data arrives, what's reused, or where each component runs. Naming and grouping is enough.
+You haven't decided yet how the data arrives, what's reused, or where each component runs. Naming and grouping is enough for now.
 
 ## Step 2: Build a static version with JSX
 
-With the regions named, the question of where their values come from can wait. A first pass renders them as JSX from inline mock data, with values that already sit in the component file:
+With the regions named, where their values come from can wait. Render them as JSX from inline mock data, with values that already sit in the component file:
 
 ```tsx
 const projects = [
@@ -106,9 +110,9 @@ function ProjectCard({ project }) {
 }
 ```
 
-[Layouts](/docs/app/glossary#layout) and [pages](/docs/app/glossary#page) are [Server Components](/docs/app/glossary#server-component) by default. They run on the server and never run again in the browser.
+[Layouts](/docs/app/glossary#layout) and [pages](/docs/app/glossary#page) are [Server Components](/docs/app/glossary#server-component) by default. They run on the server and never run again in the browser. Their JavaScript doesn't ship to the client, a different shape from [Client Components](/docs/app/glossary#client-component), which render on the server first and then hydrate in the browser to attach event handlers.
 
-Since this version only renders JSX from local data, no [Client Component](/docs/app/glossary#client-component) is needed yet.
+Since this version only renders JSX from local data, no Client Component is needed yet.
 
 Running `next build` [prerenders](/docs/app/glossary#prerendering) the route as static HTML:
 
@@ -124,9 +128,7 @@ The `○` next to `/projects` is what to look for. Every value the route renders
 
 This is the [App Router](/docs/app/glossary#app-router) version of "build a static version" from Thinking in React. The UI is visible before any decision about where the real data comes from.
 
-Each demo throughout this guide embeds the deployed lab. The refresh button in the browser chrome replays the load.
-
-Notice that the deployed route paints in one shot, with nothing to wait for.
+Try the demo. Each demo throughout this guide embeds the deployed lab, and the refresh button in the browser chrome replays the load. Notice the route paints in one shot, with nothing to wait for.
 
 <Demo
   src="https://thinking-in-nextjs-02.labs.vercel.dev/projects"
@@ -139,13 +141,13 @@ Source: [`steps/02-static-jsx`](https://github.com/vercel-labs/thinking-in-nextj
 
 ## Step 3: Fetch data where it is used
 
-The static version got us through [Step 2: Build a static version with JSX](#step-2-build-a-static-version-with-jsx), but real apps don't ship with their data baked into the component file. The mock array has to go. The data lives in a database (or behind an API), and the page needs a function to ask for it.
+The static version got us through [Step 2: Build a static version with JSX](#step-2-build-a-static-version-with-jsx), but real apps don't ship with their data baked into the component file. The mock array has to go. The data lives in a database (or behind an API), and each region needs a function to read what it shows.
 
-Each read becomes a small async function (`getProjects()`, `getProject(id)`, `getDeployments(projectId)`), and the collection of those functions is the route's data layer.
+Each region gets its own async read, and the collection of those reads is the route's data layer. On this app that's `getProjects()`, `getProject(id)`, and `getDeployments(projectId)`, with the same shape for the recent deployments, the build log, the current viewer, and the viewer's pinned ids.
 
 Where in the tree should those reads happen?
 
-The page could do all the fetching at the top and pass values down. That works, but it couples otherwise-independent sections (the deployments list ends up waiting on the same parent as the sidebar), and the reads tend to run in sequence rather than in parallel.
+The page could do all the fetching at the top and pass values down. That works, but it couples independent sections (the deployments list waits on the same parent as the sidebar), and each `await` at the top blocks the next, so the reads run in sequence rather than in parallel.
 
 The other option is for each component to read what it needs, right next to the JSX that uses it:
 
@@ -177,13 +179,13 @@ Refresh the demo and notice the route now waits on the slowest read before it pa
   title="Step 3: Fetch data"
 />
 
-By now every region has a read attached to it. The route works, but every request runs every read, and the build no longer tries to prerender.
+By now every region has a read attached to it. The route works, but every request runs every read, and `next build` can no longer prerender the route.
 
 Source: [`steps/03-fetch-data`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/03-fetch-data).
 
 ## Step 4: Stream async work
 
-Why should the rest of the page wait for the slowest read? It shouldn't. [`<Suspense>`](https://react.dev/reference/react/Suspense) is how you say so: render this part when it's ready, render the rest now.
+Why should the rest of the page wait for the slowest read? It shouldn't. [`<Suspense>`](https://react.dev/reference/react/Suspense) is how you say so. Render this part when it's ready, render the rest now.
 
 [`cacheComponents`](/docs/app/getting-started/caching) is the app-wide switch that makes the framework hold you to that:
 
@@ -197,7 +199,11 @@ const nextConfig: NextConfig = {
 export default nextConfig
 ```
 
-With it on, the prerender expects every async read to either be cached or sit behind a [Suspense boundary](/docs/app/glossary#suspense-boundary). Anything else surfaces in `next dev` and `next build` as [`Uncached data was accessed outside of <Suspense>`](https://nextjs.org/docs/messages/blocking-route), pointing at the call site:
+Cache Components is the refined version of the App Router, and the constraint is the feature. Making the cache-or-stream decision explicit at every async read catches the common mistakes (uncached fetches blocking the prerender, per-request work hidden inside what looks like static content, accidental coupling between routes that share a slow read), so routes built under it ship in better shape by default.
+
+With it on, the prerender expects every async read to either be cached or sit behind a [Suspense boundary](/docs/app/glossary#suspense-boundary). That split is what enables [Partial Prerendering](/docs/app/glossary#partial-prerendering-ppr) (PPR). The route's static parts ship as HTML on the first paint, and the dynamic parts stream in behind their boundaries when they resolve. The reader sees the layout immediately, instead of a blank page while the slow read finishes.
+
+Anything else, an async read with no cache and no boundary, surfaces in `next dev` and `next build` as [`Uncached data was accessed outside of <Suspense>`](https://nextjs.org/docs/messages/blocking-route), pointing at the call site:
 
 <Image
   alt="Next.js dev overlay reading 'Next.js encountered uncached data during the initial render.' A code preview highlights the uncached `await` inside a data-access function. Three fix cards follow. 'Cache dynamic data' shows `'use cache'` at the top of a data function. 'Move within Suspense' wraps the async child in `<Suspense fallback={…}>`. 'Allow blocking route' shows `export const instant = false`."
@@ -209,9 +215,9 @@ With it on, the prerender expects every async read to either be cached or sit be
 
 The overlay lists three ways out. One lets the route block as before, an escape hatch for cases where you knowingly want that. The other two are the design conversation the rest of this guide is about.
 
-Stream the read, or cache it. [Streaming](/docs/app/glossary#streaming) first, because it's the smaller commitment.
+Stream the read, or cache it. [Streaming](/docs/app/glossary#streaming) first, because it's the smaller commitment. Caching shows up later in the guide.
 
-A Suspense boundary only says "this part can paint later," not "this output is reusable." Reusability is the next question, and it's easier to answer once every async read has its own boundary.
+A Suspense boundary only says "this part can paint later," not "this output is reusable." Boundary-by-boundary streaming is the move for now.
 
 Wrap each async section in its own boundary so the [static shell](/docs/app/glossary#static-shell) (the parts that don't need to wait) is sent immediately:
 
@@ -232,7 +238,7 @@ function Sidebar() {
 
 `Sidebar` itself is synchronous now. The two async sections it contains each sit behind their own boundary, and each fallback is shaped like the section it stands in for.
 
-The same move repeats anywhere else in the route an async read shows up, with the boundary sitting at the smallest scope that needs it.
+The same move repeats anywhere else in the route an async read shows up, with the boundary placed at the smallest scope that wraps the read. On this route, that's `ProjectGrid` on the projects index, `ViewerAvatar` in the header, `ProjectHeader` and `Deployments` on the project page, and `DeploymentHeader` and `BuildLogs` on the deployment page.
 
 A _fallback_ is the UI that renders in the static shell while the async child is still resolving. It's replaced with the real output once the child finishes. For this route:
 
@@ -241,21 +247,19 @@ A _fallback_ is the UI that renders in the static shell while the async child is
 - **1000 ms**: Pinned and grid resolve.
 - **1500 ms**: Recent deploys resolves last.
 
-The fallback's shape matters. A skeleton matching the streamed result's width, height, and row count keeps the shell stable.
-
-A wrong-sized fallback pushes the page around when the content arrives.
+The fallback's shape matters. A skeleton that matches the streamed result's width, height, and row count keeps the shell stable; a mismatched one pushes the page around when content arrives.
 
 A boundary does not have to wrap an entire region. It can wrap a single nested child while the rest of the surrounding layout already has its props. The outer tree paints from data the parent resolved, and only the inner subtree shows a fallback while something inside awaits.
 
-Output that arrives bit by bit, like log lines on an in-progress build, LLM tokens, or paginated work, reaches for the same primitive. Suspense boundaries nest, with each piece wrapping the next in its own boundary so each one streams independently:
+Output that arrives in pieces (log lines on an in-progress build, LLM tokens, or paginated work) follows the same pattern. Suspense boundaries nest, with each piece wrapping the next in its own boundary so each one streams independently:
 
 ```tsx
 function LiveLines({ lines, index }) {
-  if (index >= lines.length) return null
+  if (index >= lines.length) return <CursorRow />
   return (
     <>
       <LogRow line={lines[index]} />
-      <Suspense fallback={<Cursor />}>
+      <Suspense fallback={<CursorRow />}>
         <DelayedNextLine lines={lines} nextIndex={index + 1} />
       </Suspense>
     </>
@@ -265,183 +269,39 @@ function LiveLines({ lines, index }) {
 
 For feeds that arrive outside the request (a real build log streamed from the platform, telemetry, chat), the typical pattern is a Client Component that polls or subscribes.
 
-Click into the projects route. The shell paints immediately, and the sidebar and grid swap in as each Suspense boundary resolves. Click into a project, then into a still-building deployment, to see the same primitive nested with each log line streaming in on its own.
+Try the demo. Click into projects, then into a still-building deployment. Watch the shell paint immediately and each section swap in as its boundary resolves.
 
 <Demo
   src="https://thinking-in-nextjs-04.labs.vercel.dev/projects"
   title="Step 4: Stream async work"
 />
 
-Each section's fallback hides one slow read at a time, and the shell renders around it with the parts that don't have to wait. The route still runs every read on every request; what changed is that no read blocks any other.
+Each section's fallback hides one slow read at a time, and the shell renders around it with the parts that don't have to wait. The reader sees the layout and the search bar on the first paint, with skeleton fallbacks where the slow reads are still resolving. The route still runs every read on every request; what changed is that no read blocks any other.
+
+Reads work end-to-end. The next question is what happens when the reader writes.
 
 Source: [`steps/04-streaming`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/04-streaming).
 
-## Step 5: Cache reusable work
+## Step 5: Mutate data
 
-Streaming hides slow reads behind fallbacks, and that gets the page paint moving. What kept coming back, though, was that most of those reads aren't actually different per visitor. The project list, project header, and deployments list don't change between viewers from one second to the next.
+Reads cover the route. The other half is writes, and on this app that means the deploy button, the pin button, and any other place the page changes the underlying state.
 
-The natural question:
+In the App Router, mutations live in [Server Functions](/docs/app/glossary#server-function) marked with `'use server'`. The function runs on the server, hits the underlying state, and the route re-renders so the new output replaces the old.
 
-> Would the next viewer see the same thing?
+In practice, Server Functions are how you talk to the server without writing an API endpoint by hand. The endpoint exists under the hood, but the developer experience is Remote Procedure Call (RPC), with arguments and return values crossing a serialization boundary. Plain data passes through; functions and class instances don't.
 
-If yes, the work doesn't need to run on every request. The result can be reused, and the section can join the static shell instead of streaming behind a fallback.
-
-Walk down the tree once and answer the question for each piece:
-
-| UI piece                          | Same for every viewer? | Becomes                         |
-| --------------------------------- | ---------------------- | ------------------------------- |
-| `ProjectGrid`, `ProjectHeader`    | Yes                    | `'use cache'`                   |
-| `Deployments`, `DeploymentHeader` | Yes                    | `'use cache'`                   |
-| `RecentDeploysSection`            | Yes                    | `'use cache'`                   |
-| `BuildLogs`, completed build      | Yes                    | `'use cache'`                   |
-| `BuildLogs`, in-progress build    | No, live               | uncached, streamed              |
-| `ViewerAvatar`                    | No, per viewer         | per-viewer cache                |
-| `PinnedSection`                   | No, per viewer         | `'use cache'` keyed by `userId` |
-
-A directive at the top of the function flips a read into the shared cache:
-
-```tsx
-async function getProject(id) {
-  'use cache'
-  cacheLife('hours')
-  cacheTag('projects', `project-${id}`)
-
-  return db.project.find({ where: byId(id) })
-}
-```
-
-[`'use cache'`](/docs/app/api-reference/directives/use-cache) marks the function as cacheable. The arguments (and any closed-over values) form the cache key, so `getProject('compass')` and `getProject('feather')` are stored as separate entries.
-
-[`cacheLife`](/docs/app/api-reference/functions/cacheLife) sets how long an entry stays valid.
-
-[`cacheTag`](/docs/app/api-reference/functions/cacheTag) labels the entry so other code can refer to it by name, usually from a Server Function that calls [`updateTag`](/docs/app/api-reference/functions/updateTag) after a write. `cacheTag` accepts more than one tag, so the per-id tag (`project-${id}`) gives a single project its own handle while the broader `projects` tag still covers the list. A mutation can invalidate one project without touching the rest.
-
-A list read works the same way, keyed by whatever inputs the call takes:
-
-```tsx
-async function getProjects({ query }) {
-  'use cache'
-  cacheLife('hours')
-  cacheTag('projects')
-
-  return db.project.findMany({ where: matches(query) })
-}
-```
-
-There's a subtlety on this route. The directive on `getProjects` says the read is cached, but the page also awaits `searchParams` to pick the query, and `searchParams` only resolves at request time. So the static prerender can't bake the cards in.
-
-The cache still applies once the request lands. The entry for that exact `?q=` is reused across viewers, and the cards swap in as soon as the param resolves.
-
-The param isn't read inside `getProjects`; it arrives as `query`. The cache key follows the arguments.
-
-A plain `'use cache'` function can't read [`cookies()`](/docs/app/api-reference/functions/cookies) or [`headers()`](/docs/app/api-reference/functions/headers) inside itself for the same reason. Resolve those at the edge of the tree and pass what you need down.
-
-That leaves the per-viewer reads, like the avatar and the pinned ids. Both produce different output for each viewer, but the shape of the work is different.
-
-Take pinned ids first. They're a database read keyed on the user's id, so the cache key for the read is the id itself. The same `'use cache'` primitive works, with `userId` taken as an argument so the per-viewer entry falls out of the cache key:
-
-```tsx
-async function getPinnedIds(userId) {
-  'use cache'
-  cacheLife({ stale: 60 })
-  cacheTag(`pinned-${userId}`)
-
-  return db.pin.list({ userId })
-}
-```
-
-The store is shared. The argument is what makes the entry per-viewer. `getPinnedIds('aurora')` and `getPinnedIds('sam')` are stored as separate entries, the same way `getProject('compass')` and `getProject('feather')` are.
-
-But the lookup needs a `userId` to start with. That comes from the session cookie, and a plain `'use cache'` can't read [`cookies()`](/docs/app/api-reference/functions/cookies) inside itself. For the viewer-identity read, the entry's scope is the viewer's session, so it uses a different variant. [`'use cache: private'`](/docs/app/api-reference/directives/use-cache-private) keeps the same directive shape, but the entry is scoped to the viewer and stored in the browser cache instead of being shared on the server. Inside it, `cookies()` and `headers()` are allowed. That's the whole point.
-
-This shape takes a beat to internalize. That's normal.
-
-```tsx
-async function getCurrentUser() {
-  'use cache: private'
-  cacheLife({ stale: 60 })
-
-  const session = (await cookies()).get('session')?.value
-  return session ? JSON.parse(session) : DEFAULT_USER
-}
-```
-
-The two reads compose. Read the viewer once, hand the id down:
-
-```tsx
-const user = await getCurrentUser()
-const pinnedIds = await getPinnedIds(user.id)
-```
-
-Both reads are per-viewer, but the mechanism is different. A plain `'use cache'` keyed on `userId` for the lookup that depends on it, and `'use cache: private'` for the cookie read where the entry's scope is the viewer's session.
-
-There's a third variant ([`'use cache: remote'`](/docs/app/api-reference/directives/use-cache-remote)) for durable shared cache across server instances when the default in-memory store isn't enough. The hosting layer usually wires the handler.
-
-The [Cache Components](/docs/app/getting-started/caching) introduction compares all three. This guide uses plain `'use cache'` for project data and pinned ids, with `'use cache: private'` reserved for the viewer's identity behind the avatar.
-
-The tree now carries a decision per node:
-
-```txt
-persistent shell
-ProjectsLayout
-├── HeaderBar
-│   └── ViewerAvatar            use cache: private
-└── Sidebar
-    ├── PinnedSection           use cache (keyed by userId)
-    └── RecentDeploysSection    use cache
-
-/projects
-└── ProjectGrid                 use cache
-
-/projects/[id]
-├── ProjectHeader               use cache
-└── Deployments                 use cache
-
-/projects/[id]/deployments/[deployId]
-├── DeploymentHeader            use cache
-└── BuildLogs                   use cache when complete, live while building
-```
-
-Most of the Suspense boundaries from [Step 4: Stream async work](#step-4-stream-async-work) can be removed. Once a cached read joins the static shell, the Suspense wrapper around it has nothing to wait for. The boundaries around `RecentDeploys`, `ProjectHeader`, `Deployments`, and `BuildLogs` are no longer needed.
-
-What stays wrapped is what still resolves per request. The project grid reads `?q=` from the URL. The avatar and the pinned ids still suspend on first visit, because both lean on the session cookie and the static prerender doesn't have one to read.
-
-Inside `BuildLogs`, the live stream still has its boundary. That part is live by definition.
-
-You could have skipped [Step 4: Stream async work](#step-4-stream-async-work) if you'd known the cache plan up front. The question was sharper when you asked it of each component on its own.
-
-Click into a project and into a deployment, then back. Watch which sections paint instantly and which still show a fallback before resolving.
-
-<Demo
-  src="https://thinking-in-nextjs-05.labs.vercel.dev/projects"
-  title="Step 5: Cache reusable work"
-/>
-
-The shared cached sections paint with no fallback because they're already in the prerendered shell. The avatar and pinned section still show their fallback on the first visit, then stay cached in the browser for the rest of the session. Reload the tab and the per-viewer reads run again from scratch.
-
-Source: [`steps/05-caching`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/05-caching).
-
-## Step 6: Mutate data
-
-A cache stores reusable output. A mutation invalidates the entries that stopped being true.
-
-In the App Router, mutations live in [Server Functions](/docs/app/glossary#server-function) marked with `'use server'`. Each one does two things in the same call. It changes the underlying state, then it invalidates every cached read that stopped being true.
-
-Triggering a deploy is the cleanest version of that. The write hits the upstream, and two cached reads go stale alongside it. The project's deployments list is one, and the sidebar's recent-deploys list is the other. Each has its own tag, and the Server Function calls them by name:
+So how does the new state get to the page? Without a cache layer yet, the answer is [`refresh`](/docs/app/api-reference/functions/refresh) from `next/cache`. Called inside a Server Function, it re-runs the dynamic reads on the current route, so the new deployment lands in the list and the recent-deploys section updates alongside it.
 
 ```tsx
 'use server'
 
+import { refresh } from 'next/cache'
+
 async function triggerDeploy(projectId) {
   await db.deployment.create({ projectId })
-  updateTag(`deployments-${projectId}`)
-  updateTag('recent-deployments')
+  refresh()
 }
 ```
-
-The tag names match the ones the cached reads applied earlier, so one Server Function call lines up with the cache entries it touched. Any route that reads through `deployments-${projectId}` or `recent-deployments` picks up the change.
-
-[`updateTag`](/docs/app/api-reference/functions/updateTag) and [`revalidateTag`](/docs/app/api-reference/functions/revalidateTag) differ in how they treat the response that contains the mutation. `updateTag` handles read-your-writes, so the new value shows up in the same response that triggered it. `revalidateTag` handles stale-while-revalidate, so the previous value keeps serving while the next read fetches a fresh one.
 
 Wired up to a button, the smallest version is a `<form action>` with no `'use client'` boundary in the path:
 
@@ -453,50 +313,54 @@ Wired up to a button, the smallest version is a `<form action>` with no `'use cl
 
 This is the same request-response loop PHP and Rails apps ran on. The browser posts a form, the server runs a function, and the server re-renders the page. The difference is that React produces the response.
 
-Pinning has the same shape. `getPinnedIds` was tagged in the previous step with ``cacheTag(`pinned-${userId}`)``, so the pin actions invalidate that viewer's tag:
+Pinning has the same shape. `addPin` and `removePin` each read the current user from the session, write to (or delete from) the pins table, and call `refresh()` so the read picks up the new state:
 
 ```tsx
 'use server'
 
+import { refresh } from 'next/cache'
+
 async function addPin(projectId) {
   const { id: userId } = await getCurrentUser()
   await db.pin.add({ userId, projectId })
-  updateTag(`pinned-${userId}`)
+  refresh()
 }
 ```
 
-The mutation pattern is now uniform across the app. The write touches the underlying state, then `updateTag` calls out the cache entries that stopped being true.
-
-The same call works against either cache. A `'use cache: private'` entry responds to `updateTag` the same way the shared cache does. The only difference is where the entry lives.
+The mutation pattern is uniform across the app. The write touches the underlying state, then `refresh()` re-renders the route so the dynamic reads pick up the new value.
 
 Submit the deploy form, then pin and unpin a project. Watch the new deployment show up in the list and the pin state flip.
 
 <Demo
-  src="https://thinking-in-nextjs-06.labs.vercel.dev/projects"
-  title="Step 6: Mutate data"
+  src="https://thinking-in-nextjs-05-mutations.labs.vercel.dev/projects"
+  title="Step 5: Mutate data"
 />
 
-Submitting the deploy form runs the Server Function and re-renders the route with the new deployments list. Pinning runs through the same path. ``updateTag(`pinned-${userId}`)`` invalidates that viewer's entry, and the next render shows the new state.
+The deploy form runs the Server Function and `refresh()` re-renders the route. Pinning runs through the same path. Every click pays the full server round trip, the streaming fallbacks from [Step 4: Stream async work](#step-4-stream-async-work) reappear on each mutation, and the new state lands once the read finishes.
 
-Source: [`steps/06-mutations`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/06-mutations).
+Functional, but visibly slow. The button has no pending state, the pin doesn't flip until the server confirms, and search still requires a submit. None of these can wait for a round trip.
 
-## Step 7: Add client interactivity
+Source: [`steps/05-mutations`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/05-mutations).
+
+## Step 6: Add client interactivity
+
+The mutations from [Step 5: Mutate data](#step-5-mutate-data) all worked, and they were all visibly slow. Every click paid for itself with a full server round trip, the streaming fallbacks reappeared on each re-render, and the buttons sat without feedback while the Server Function ran.
 
 For most of the route so far, the work has lived on the server. Reads happen in Server Components, writes happen in Server Functions, and a plain HTML form has been enough to wire a button to a mutation. What kept surprising me as I built the route this way was how much of an app that already covers, and how late the moment shows up where the request-response loop runs out of room.
 
-That moment is real, though. The pin button should flip the second it's clicked, before the server has acknowledged the write. The search input should update the URL on every keystroke instead of waiting for a submit. The deploy button should look pending while the Server Function is still working. None of those want to wait for a round trip, and that's where a Client Component earns its place.
+The pin button should flip the second it's clicked, before the server has acknowledged the write. The search input should update the URL on every keystroke instead of waiting for a submit. The deploy button should look pending while the Server Function is still working. None of these can wait for a round trip, and that's where a Client Component earns its place.
 
-Inside a [`'use client'`](/docs/app/glossary#use-client-directive) boundary the full React API is back, including `onClick`, `useState`, hooks, and refs. Server Functions stay callable from any of it, so the form pattern from [Step 6: Mutate data](#step-6-mutate-data) becomes one option among many, and the boundary itself is open-ended enough to host anything React can host, from a chart library to drag-and-drop to your own keyboard handler.
+Inside a [`'use client'`](/docs/app/glossary#use-client-directive) boundary the full React API is back, including `onClick`, `useState`, hooks, and refs. Server Functions stay callable from any of it, so the form pattern from [Step 5](#step-5-mutate-data) becomes one option among many, and the boundary itself is open-ended enough to host anything React can host, from a chart library to drag-and-drop to your own keyboard handler.
 
-In practice, a lot of routes never reach that far. The URL, a form, a Server Function, and a transition cover most of what an app needs, and the rest stays on the server where it belongs. The boundary is there for the moments that ask for more.
+In practice, a lot of routes never reach that far. The URL, a form, a Server Function, and a transition cover most of what an app needs, and the rest stays on the server where it belongs. The boundary is there for the moments where input lives in the client.
 
 Pending state has the same options. You can put `triggerDeploy` inside a `useTransition` and read `pending` from the hook for the spinner. React's [`useFormStatus`](https://react.dev/reference/react-dom/hooks/useFormStatus) would surface the same state from inside a `<form>`.
 
 So how wide does that boundary actually need to be? Often one prop, even before it resolves.
 
-`ProjectPin` was a server form in [Step 6](#step-6-mutate-data). In this step it crosses into the client, takes the per-viewer promise as a prop, and calls [`use`](https://react.dev/reference/react/use) to resolve it on the other side, suspending at the nearest Suspense boundary above until the read resolves.
+`ProjectPin` was a server form in [Step 5](#step-5-mutate-data). In this step it crosses into the client, takes the per-viewer promise as a prop, and calls [`use`](https://react.dev/reference/react/use) to resolve it on the other side, suspending at the nearest Suspense boundary above until the read resolves.
 
-The same form action from [Step 6](#step-6-mutate-data) wraps the optimistic flip:
+The same form action from [Step 5](#step-5-mutate-data) wraps the optimistic flip:
 
 ```tsx
 'use client'
@@ -530,15 +394,16 @@ function ProjectPin({ projectId, pinnedIdsPromise }) {
 
 The flip uses `wasPinned` so the Server Function always matches the state **before** the optimistic update. That way, two fast clicks don't accidentally cancel each other out.
 
-Nothing else is needed: the `updateTag('pinned')` call inside `addPin` / `removePin` invalidates the cached read, the framework re-renders the route with fresh data, and the optimistic state hands off to the real one.
+Nothing else is needed. The `refresh()` call inside `addPin` and `removePin` re-runs the dynamic reads, the framework re-renders the route with the fresh pinned ids, and the optimistic state is replaced by the real one.
 
-The read still runs on the server. `ProjectGrid` calls `getPinnedIds` once, hands the same promise reference to every card, and each `ProjectPin` waits on it through `use()`:
+The read still runs on the server. `ProjectGrid` resolves the current user, calls `getPinnedIds` once, hands the same promise reference to every card, and each `ProjectPin` waits on it through `use()`:
 
 ```tsx
 async function ProjectGrid({ searchParams }) {
   const { q } = await searchParams
   const projects = await getProjects({ query: q })
-  const pinnedIdsPromise = getPinnedIds()
+  const user = await getCurrentUser()
+  const pinnedIdsPromise = getPinnedIds(user.id)
 
   return projects.map((project) => (
     <ProjectCard
@@ -550,7 +415,7 @@ async function ProjectGrid({ searchParams }) {
 }
 ```
 
-In `ProjectCard`, the icon, title, framework line, description, and status all come from the `project` object the grid already loaded. Only the pin needs `getPinnedIds`, so only that control sits behind `<Suspense>`: the rest of the card is not blocked by the per-viewer read, and the fallback is a pin-shaped skeleton, not a skeleton for the whole card.
+In `ProjectCard`, the icon, title, framework line, description, and status all come from the `project` object the grid already loaded. Only the pin needs `getPinnedIds`, so only that control sits behind `<Suspense>`. The rest of the card is not blocked by the per-viewer read, and the fallback is a pin-shaped skeleton, not a skeleton for the whole card.
 
 ```tsx
 <header className="flex …">
@@ -563,7 +428,9 @@ In `ProjectCard`, the icon, title, framework line, description, and status all c
 
 It might look like marking `ProjectPin` with `'use client'` would pull `ProjectGrid` into the client too. It doesn't.
 
-`'use client'` is a _boundary_, not a whole-tree switch. The `getPinnedIds` call runs on the server where the grid lives; only the promise crosses into the client, and `use()` reads it from there.
+`'use client'` marks a [boundary](/docs/app/glossary#boundary), not a switch for everything above it. The `getPinnedIds` call runs on the server where the grid lives; only the promise crosses into the client, and `use()` reads it from there.
+
+Even when the boundary needs to be wider than a leaf (a modal wrapping a form, an interactive chrome around a server-rendered list), the server work can stay on the server. A Client Component takes Server Components as `children`, a [composition pattern](/docs/app/getting-started/server-and-client-components#interleaving-server-and-client-components) sometimes called the donut, so server-only reads, secrets, and database access stay nested inside while the interactive shell sits at the boundary.
 
 Search shows up again here. The plain HTML form from [Step 3: Fetch data where it is used](#step-3-fetch-data-where-it-is-used) worked because a single submit was all the page needed.
 
@@ -611,13 +478,219 @@ App Router runs `router.push` inside a [transition](https://react.dev/reference/
 Try the demo. Pin and unpin a project, type in the search bar, and submit a deploy. Watch the pin flip before the server confirms, the URL update on each keystroke, and the deploy button stay in its pending state until the Server Function returns.
 
 <Demo
-  src="https://thinking-in-nextjs-07.labs.vercel.dev/projects"
-  title="Step 7: Add client interactivity"
+  src="https://thinking-in-nextjs-06-client-boundaries.labs.vercel.dev/projects"
+  title="Step 6: Add client interactivity"
 />
 
-Three small Client leaves (`ProjectPin`, `SearchBar`, and the deploy button) handle the moments where the request-response loop runs out of room. Everything else around them stays a Server Component.
+Three small Client leaves (`ProjectPin`, `SearchBar`, and the deploy button) handle the moments where the request-response loop runs out of room. Everything else around them stays a Server Component. In practice, client boundaries open at the leaves where they earn a hook, and Server Components stay the default.
 
-Source: [`steps/07-client-boundaries`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/07-client-boundaries).
+The route is already a complete app. Streaming SSR for reads, Server Functions for writes, and a few interactive leaves for input cover most of what apps need. The JavaScript you ship stays small because only those leaves cross into the client.
+
+Source: [`steps/06-client-boundaries`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/06-client-boundaries).
+
+## Step 7: Cache reusable work
+
+The route works end-to-end now, but moving between routes still feels server-y. Click into a project, click back, click into another, and every read runs from scratch on each navigation. The shell paints fast, the fallbacks reappear, and the new section streams in.
+
+Caching is the move that gets the rest of the way to the instant feel of a Single Page App (SPA), without giving up the server-component model. Data lives next to the read, there's no client cache to hand-maintain across viewers, and no API contract to keep in sync. The reads stay where the JSX uses them, the server keeps doing the work, but most of those reads don't have to run again for the next viewer.
+
+What kept coming back was that most of these reads aren't actually different per visitor. The project list, project header, and deployments list don't change between viewers from one second to the next.
+
+The natural question:
+
+> Would the next viewer see the same thing?
+
+If yes, the work doesn't need to run on every request. The result can be reused, and the section can join the static shell instead of streaming behind a fallback.
+
+Walk down the tree once and answer the question for each piece:
+
+| UI piece                          | Same for every viewer? | Becomes                         |
+| --------------------------------- | ---------------------- | ------------------------------- |
+| `ProjectGrid`, `ProjectHeader`    | Yes                    | `'use cache'`                   |
+| `Deployments`, `DeploymentHeader` | Yes                    | `'use cache'`                   |
+| `RecentDeploysSection`            | Yes                    | `'use cache'`                   |
+| `BuildLogs`, completed build      | Yes                    | `'use cache'`                   |
+| `BuildLogs`, in-progress build    | No, live               | uncached, streamed              |
+| `ViewerAvatar`                    | No, per viewer         | per-viewer cache                |
+| `PinnedSection`                   | No, per viewer         | `'use cache'` keyed by `userId` |
+
+A directive at the top of the function flips a read into the shared cache:
+
+```tsx
+async function getProject(id) {
+  'use cache'
+  cacheLife('hours')
+  cacheTag('projects', `project-${id}`)
+
+  return db.project.find({ where: byId(id) })
+}
+```
+
+[`'use cache'`](/docs/app/api-reference/directives/use-cache) at the top of `getProject` marks the function as cacheable, and its arguments (together with any closed-over values) form the cache key. `getProject('compass')` and `getProject('feather')` end up as separate entries, each one kept for as long as [`cacheLife`](/docs/app/api-reference/functions/cacheLife) declares (`'hours'` on this read).
+
+[`cacheTag`](/docs/app/api-reference/functions/cacheTag) labels each entry by name so a mutation can invalidate it later. The per-id tag `project-${id}` gives a single project its own handle, and the broader `projects` tag still covers the list, so a rename on `compass` invalidates one entry without touching `feather`.
+
+A list read works the same way, keyed by whatever inputs the call takes:
+
+```tsx
+async function getProjects({ query }) {
+  'use cache'
+  cacheLife('hours')
+  cacheTag('projects')
+
+  return db.project.findMany({ where: matches(query) })
+}
+```
+
+The other cached reads on the route follow the same shape, with a `cacheTag` named after what each one covers (`getDeployments`, `getDeployment`, `getRecentDeployments`, and `getCompletedBuildLog`).
+
+There's a subtlety on this route. `getProjects` is cached, but the page also awaits `searchParams` to pick the query, and `searchParams` only resolves at request time. So the static prerender can't bake the cards in.
+
+The cache still applies once the request lands. The entry for that exact `?q=` is reused across viewers, and the cards swap in as soon as the param resolves.
+
+The param isn't read inside `getProjects`; it arrives as `query`. The cache key follows the arguments.
+
+A plain `'use cache'` function can't read [`cookies()`](/docs/app/api-reference/functions/cookies) or [`headers()`](/docs/app/api-reference/functions/headers) inside itself for the same reason. Resolve those at the edge of the tree and pass what you need down.
+
+That leaves the per-viewer reads, the avatar and the pinned ids. Both produce different output for each viewer, but they need different caching primitives.
+
+Take pinned ids first. They're a database read keyed on the user's id, so the cache key for the read is the id itself. The same `'use cache'` primitive works, with `userId` taken as an argument so the per-viewer entry falls out of the cache key:
+
+```tsx
+async function getPinnedIds(userId) {
+  'use cache'
+  cacheLife({ stale: 60 })
+  cacheTag(`pinned-${userId}`)
+
+  return db.pin.list({ userId })
+}
+```
+
+The store is shared. The argument is what makes the entry per-viewer. `getPinnedIds('aurora')` and `getPinnedIds('sam')` are stored as separate entries, the same way `getProject('compass')` and `getProject('feather')` are.
+
+But the lookup needs a `userId` to start with. That comes from the session cookie, and a plain `'use cache'` can't read [`cookies()`](/docs/app/api-reference/functions/cookies) inside itself.
+
+For the viewer-identity read, the entry's scope is the viewer's session, so it uses a different variant. [`'use cache: private'`](/docs/app/api-reference/directives/use-cache-private) keeps the same directive shape, but the entry is scoped to the viewer and stored in the browser cache instead of being shared on the server.
+
+Inside it, `cookies()` and `headers()` are allowed. That's the whole point.
+
+This shape takes a beat to internalize. That's normal.
+
+```tsx
+async function getCurrentUser() {
+  'use cache: private'
+  cacheLife({ stale: 60 })
+
+  const session = (await cookies()).get('session')?.value
+  return session ? JSON.parse(session) : DEFAULT_USER
+}
+```
+
+The two reads compose. Read the viewer once, hand the id down:
+
+```tsx
+const user = await getCurrentUser()
+const pinnedIds = await getPinnedIds(user.id)
+```
+
+Both reads are per-viewer, but the mechanism is different. The lookup uses a plain `'use cache'` keyed on `userId`, because the id is the only input the read needs. The cookie read uses `'use cache: private'`, because the entry's scope is the viewer's session.
+
+There's a third variant ([`'use cache: remote'`](/docs/app/api-reference/directives/use-cache-remote)) for durable shared cache across server instances when the default in-memory store isn't enough. The hosting layer usually wires the handler.
+
+The [Cache Components](/docs/app/getting-started/caching) introduction compares all three. This guide uses plain `'use cache'` for project data and pinned ids, with `'use cache: private'` reserved for the viewer's identity behind the avatar.
+
+The tree now carries a decision per node:
+
+```txt
+persistent shell
+ProjectsLayout
+├── HeaderBar
+│   └── ViewerAvatar            use cache: private
+└── Sidebar
+    ├── PinnedSection           use cache (keyed by userId)
+    └── RecentDeploysSection    use cache
+
+/projects
+└── ProjectGrid                 use cache
+
+/projects/[id]
+├── ProjectHeader               use cache
+└── Deployments                 use cache
+
+/projects/[id]/deployments/[deployId]
+├── DeploymentHeader            use cache
+└── BuildLogs                   use cache when complete, live while building
+```
+
+The Suspense rule sharpens with caching in place. A boundary is needed wherever the render touches runtime data. Anything else (a `'use cache'` read with no per-request inputs) joins the static shell, and the wrapper around it has nothing to defer. `RecentDeploys` is the cleanest example.
+
+What stays wrapped is what still resolves per request. The avatar and pinned section depend on cookies via `'use cache: private'`, `ProjectGrid` reads `?q=` from `searchParams`, and the per-viewer `ProjectPin` keeps its boundary inside each project card and project header. Inside `BuildLogs`, the live stream stays wrapped because it's live by definition.
+
+Adding the cache layer changes the picture for the mutations from [Step 5: Mutate data](#step-5-mutate-data). `refresh()` re-runs the dynamic reads on the route, but it doesn't move cached entries. After a deploy, the cached deployments list still serves the old value. After a pin, the cached `getPinnedIds` still returns the old set.
+
+[`updateTag`](/docs/app/api-reference/functions/updateTag) is the surgical answer for cached entries. From inside a Server Function, it invalidates a cached read by name, so the same write that touched the underlying state can call out the entries that stopped being true. The route re-renders with the fresh values, which is what `refresh()` was doing before. Calling both is the wrong shape, so the Server Function calls `updateTag` in place of `refresh()`.
+
+The deploy mutation from [Step 5](#step-5-mutate-data) was a write plus `refresh()`:
+
+```tsx
+'use server'
+
+import { refresh } from 'next/cache'
+
+async function triggerDeploy(projectId) {
+  await db.deployment.create({ projectId })
+  refresh()
+}
+```
+
+With the cached deployments list and the cached recent-deploys list in the picture, the same Server Function calls `updateTag` for each one:
+
+```tsx
+'use server'
+
+import { updateTag } from 'next/cache'
+
+async function triggerDeploy(projectId) {
+  await db.deployment.create({ projectId })
+  updateTag(`deployments-${projectId}`)
+  updateTag('recent-deployments')
+}
+```
+
+The tag names match the cached reads. `deployments-${projectId}` is the per-project tag from `getDeployments`, and `recent-deployments` is the tag the sidebar's recent-deploys list applied. One Server Function call lines up with the cache entries it touched, and the route re-renders against the fresh values.
+
+`updateTag` and [`revalidateTag`](/docs/app/api-reference/functions/revalidateTag) differ in how they treat the response that contains the mutation. `updateTag` handles read-your-writes, so the new value shows up in the same response that triggered it. `revalidateTag` handles stale-while-revalidate, so the previous value keeps serving while the next read fetches a fresh one.
+
+Pinning takes the same shape. `getPinnedIds` was tagged earlier with ``cacheTag(`pinned-${userId}`)``, so `addPin` and `removePin` each invalidate that viewer's tag:
+
+```tsx
+'use server'
+
+import { updateTag } from 'next/cache'
+
+async function addPin(projectId) {
+  const { id: userId } = await getCurrentUser()
+  await db.pin.add({ userId, projectId })
+  updateTag(`pinned-${userId}`)
+}
+```
+
+The mutation pattern is now uniform across the app. Each Server Function runs the write and calls `updateTag` for any cached read it touched.
+
+The same `updateTag` call works against either cache. `updateTag` invalidates a `'use cache: private'` entry the same way it invalidates a shared entry. The only difference is where the entry is stored.
+
+You could have skipped [Step 4: Stream async work](#step-4-stream-async-work) if you'd known the cache plan up front. The question was sharper when you asked it of each component on its own.
+
+Click into a project and into a deployment, then back. Watch which sections paint instantly and which still show a fallback before resolving.
+
+<Demo
+  src="https://thinking-in-nextjs-07-caching.labs.vercel.dev/projects"
+  title="Step 7: Cache reusable work"
+/>
+
+The shared cached sections paint with no fallback because they're already in the prerendered shell. The avatar and pinned section still show their fallback on the first visit, then stay cached in the browser for the rest of the session. Reload the tab and the per-viewer reads run again from scratch.
+
+Source: [`steps/07-caching`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/07-caching).
 
 ## Step 8: Optimize prefetching
 
@@ -625,15 +698,21 @@ By now you know what to render and what to reuse. The last question is timing. W
 
 Not at click time. When a [`<Link>`](/docs/app/api-reference/components/link) enters the viewport, Next.js uses that as a hint and renders its destination in the background. By the time the click lands, the tree is already there.
 
-There's a wrinkle. The destination might depend on the viewer, and there's no real request at prefetch time, so the prefetch has to choose which session it renders against.
+There's a wrinkle. The destination might depend on the viewer, and there's no real request at prefetch time. The prefetch renders against one of two shapes, and the route declares which.
 
 The default is [**static**](/docs/app/guides/prefetching). The prefetch renders against build-time inputs, with no cookies, headers, or search string in scope. That's enough for the shared layout and any cached read that doesn't key on the viewer.
 
-[**Runtime**](/docs/app/api-reference/file-conventions/route-segment-config/prefetch) prefetch is opt-in. It renders with the same cookies, headers, and search string the navigation would send, so per-viewer reads see the real session before the click.
+[**Runtime**](/docs/app/api-reference/file-conventions/route-segment-config/prefetch) prefetch is opt-in. It renders with the same cookies, headers, and search string the navigation would send, so per-viewer reads run against the real session before the click.
 
-That's what unlocks every cached read whose key depends on the request. Static prefetch already fills the request-independent slice (the shared layout, project data, anything keyed on build-time inputs). Runtime prefetch fills the rest.
+That's what unlocks every cached read whose key depends on the request. Static prefetch already fills the request-independent slice (the shared layout and any cached read keyed on build-time inputs). Runtime prefetch fills the rest.
 
-The per-viewer reads from [Step 5: Cache reusable work](#step-5-cache-reusable-work) are one case. `getCurrentUser` reads cookies, and `getPinnedIds(userId)` keys on the id it returns. The projects grid is another, keyed on `?q=`, a value a static prefetch can't see.
+Most of [Step 7: Cache reusable work](#step-7-cache-reusable-work)'s cached reads sit on this side:
+
+- `getProject` and `getDeployments` key on `params`.
+- `getCurrentUser` reads cookies, and `getPinnedIds(userId)` keys on the id it returns.
+- The projects grid keys on `?q=` from `searchParams`.
+
+None of those keys exist at prefetch time without a real request behind them.
 
 Runtime prefetch handles them all in the same pass, so the full cache graph for the route is populated before the click resolves.
 
@@ -643,7 +722,9 @@ Opting into runtime prefetch is one segment-config line:
 export const prefetch = 'force-runtime'
 ```
 
-The companion job is [**instant validation**](/docs/app/guides/instant-navigation), a check that every path into the route still exposes an instant shell. The shared layout stays in the static part of the prerender, anything dynamic sits behind a Suspense boundary, and the navigation never tears the frame apart mid-transition.
+On this route, every page with per-request reads carries the directive (the projects index, each project page, and each deployment page).
+
+The companion job is [**instant validation**](/docs/app/guides/instant-navigation), a check that every path into the route still exposes an instant shell. The shared layout stays in the static part of the prerender, and anything dynamic sits behind a Suspense boundary so the navigation can paint the shell before the runtime work resolves.
 
 Validation is a development-time check you turn on once. A single line in `next.config.ts` puts every route in the loop:
 
@@ -670,7 +751,7 @@ Try the demo. Click between projects, into deployments, and back. Everything lan
   title="Step 8: Optimize prefetching"
 />
 
-The shift the demo highlights is which sections are already populated when the click resolves. The projects grid keyed on `?q=`, the avatar, and the pinned section all used to stream on first visit. Runtime prefetch now fills those request-dependent reads in parallel during the prefetch pass, so they're served from cache instead of streaming.
+The shift the demo highlights is which sections are already populated when the click resolves. Every Suspense boundary on this route is there because the read inside it resolves at request time, whether that's cookies (avatar, pinned section, the per-viewer `ProjectPin`), `?q=` (projects grid, search bar), or `params` (`DeploymentHeader` and `BuildLogs`). Static prefetch couldn't fill any of them. Runtime prefetch fills them all in the same pass, so the boundaries stay in the source but stop painting a fallback at navigation time.
 
 Whatever the prefetch pass touched, static or runtime, is cached in the browser and works offline. The only parts that need an active connection are the live-streamed sections, so flaky networks stop being a meaningful problem for most of the app.
 
@@ -678,7 +759,11 @@ Source: [`steps/08-prefetching`](https://github.com/vercel-labs/thinking-in-next
 
 ## Where to go from here
 
-Look back at the route. You didn't redesign it. You asked each component the same question. _What kind of work is this?_ A read here, a Suspense boundary there, a cache where the work repeats, a tag where it doesn't, a Client leaf where input lives. The route got more honest about what each piece was doing. One model carries the whole thing, and the decisions it surfaces are the ones that scale.
+Look back at the route. You didn't redesign it. You asked each component the same question. _What kind of work is this?_ A read here, a Suspense boundary there, a cache where the work repeats, a tag where it doesn't, a Client leaf where input lives. The route got more honest about what each piece was doing. One model carries the whole thing, and the decisions you made along the way are the ones that scale.
+
+The arc was short. Each step added a single primitive to the tree (a `<Suspense>` boundary, a Server Function, a Client leaf, a `'use cache'` directive, a runtime prefetch), and each one answered a question the previous step had made concrete.
+
+The server-component model carries the reads and the scaling. Caching and prefetching are how you got the SPA feel on top, without leaving that model behind.
 
 Try it on a route in your own codebase. Name the regions, then label each one as static, dynamic, cached, or a Client leaf. The decisions usually fall out once you've labeled what each piece is doing.
 
@@ -689,7 +774,7 @@ The docs go deeper on each piece used here.
 - [Server and Client Components](/docs/app/getting-started/server-and-client-components) goes further on the prop boundary, including the donut pattern (Client Components receiving Server Components as `children`) for cases this guide didn't run into.
 - [Prefetching](/docs/app/guides/prefetching) and [instant navigation](/docs/app/guides/instant-navigation) cover runtime prefetch and shell validation in more depth.
 
-For the parts this route didn't ask about, the docs cover those too.
+The guide didn't reach all of the App Router. The docs cover the rest.
 
 - [Authentication](/docs/app/guides/authentication) for knowing who's reading.
 - [Proxy](/docs/app/getting-started/proxy) for intercepting requests before they reach a page.
@@ -708,7 +793,7 @@ Jump to a step on GitHub:
 - [`steps/02-static-jsx`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/02-static-jsx). Static JSX with mock data.
 - [`steps/03-fetch-data`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/03-fetch-data). Server Components reading from a data layer.
 - [`steps/04-streaming`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/04-streaming). Suspense around async sections.
-- [`steps/05-caching`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/05-caching). `'use cache'` and tags on shared reads, including pinned ids keyed by `userId`; `'use cache: private'` reserved for the viewer's identity behind the avatar.
-- [`steps/06-mutations`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/06-mutations). Server Functions; `updateTag` for every cached read.
-- [`steps/07-client-boundaries`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/07-client-boundaries). Client leaves; optimistic `ProjectPin` reading the per-viewer promise with `use`; URL-driven `SearchBar` with `useTransition`.
+- [`steps/05-mutations`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/05-mutations). Server Functions; `refresh()` to re-run dynamic reads after a write.
+- [`steps/06-client-boundaries`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/06-client-boundaries). Client leaves; optimistic `ProjectPin` reading the per-viewer promise with `use`; URL-driven `SearchBar` with `useTransition`.
+- [`steps/07-caching`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/07-caching). `'use cache'` and tags on shared reads, including pinned ids keyed by `userId`; `'use cache: private'` reserved for the viewer's identity behind the avatar; `updateTag` to invalidate cached entries on a write.
 - [`steps/08-prefetching`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/08-prefetching). Runtime prefetch with the navigation's cookies and search; instant validation for the static shell.

--- a/docs/01-app/02-guides/thinking-in-nextjs.mdx
+++ b/docs/01-app/02-guides/thinking-in-nextjs.mdx
@@ -1,7 +1,7 @@
 ---
 title: Thinking in Next.js
 nav_title: Thinking in Next.js
-description: A way of thinking about App Router apps as components that decide where their data comes from, what gets reused, and what stays in the browser.
+description: A way of thinking about App Router apps as one component tree that decides where its data comes from, what gets reused, and what stays in the browser.
 related:
   title: Related
   description: Continue learning about the App Router model.
@@ -10,15 +10,17 @@ related:
     - app/guides/streaming
 ---
 
-In React, you build a UI by breaking the screen into components and letting data flow through the tree. The original [Thinking in React](https://react.dev/learn/thinking-in-react) walks through that mental model. Break it down, build it static, then add state.
+In React, you build a UI by breaking the screen into components and letting data flow through the tree. The original [Thinking in React](https://react.dev/learn/thinking-in-react) walks through that model in three moves: name the parts, render them static from mock data, then layer state on top.
 
-In Next.js, the same component tree also says where data comes from, what renders immediately, what streams later, and what can be reused across navigations. You compose server and client work as plain components, with each piece running where it belongs. React's [Server Components](https://react.dev/reference/rsc/server-components), [Suspense](https://react.dev/reference/react/Suspense), and [Transitions](https://react.dev/reference/react/useTransition) coordinate the result.
+In Next.js, the same component tree carries a few more decisions. Where does the data come from? What can render right away? What waits, and what gets reused for the next visitor? The pieces are still components — some run on the server, some run in the browser, and they compose like any other React tree. Each one runs where it belongs.
+
+This guide builds one small app one decision at a time, the same way you would in your own codebase.
 
 ## Start with the mockup
 
 The brief: a small projects dashboard. Each viewer sees their projects, opens one to see its deployments, and opens a deployment to read its build log. They can search the list, pin favorites, and trigger a redeploy from the project page.
 
-Imagine the designer hands you mockups for three routes.
+The designer hands over mockups for three routes.
 
 <Image
   alt="Three route cards labeled /projects, /projects/compass, and /projects/compass/deployments/compass-jx9q3, each split into top bar, sidebar, and content regions."
@@ -30,50 +32,40 @@ Imagine the designer hands you mockups for three routes.
 
 The data layer returns four shapes:
 
-| Type                  | Notes                                                                            |
-| --------------------- | -------------------------------------------------------------------------------- |
-| `Project`             | One per project. Status is `production`, `building`, `paused`, or `failed`.      |
-| `Deployment`          | Newest first. Status is `ready`, `building`, `failed`, `queued`, or `cancelled`. |
-| `LogLine`             | The build log is one ordered list of these.                                      |
-| `pinnedIds: string[]` | The project ids the current viewer has pinned.                                   |
+| Type                  | Notes                                                                                                                                             |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Project`             | One per project. Status is `production`, `building`, `paused`, or `failed`.                                                                       |
+| `Deployment`          | Newest first. Status is `ready`, `building`, `failed`, `queued`, or `cancelled`.                                                                  |
+| `LogLine`             | A timestamped line with a message and a level (`info`, `warn`, `error`, `success`, `dim`) for styling. The build log is an ordered list of these. |
+| `pinnedIds: string[]` | The project ids the current viewer has pinned.                                                                                                    |
 
-Building this happens one decision at a time:
+The build happens one decision at a time:
 
 1. Break the UI into a component hierarchy.
 2. Build a static version with JSX.
 3. Fetch data where it is used.
 4. Stream async work.
 5. Cache reusable work.
-6. Add mutations.
-7. Add client boundaries.
-8. Configure prefetching.
+6. Mutate data.
+7. Add client interactivity.
+8. Optimize prefetching.
 
-The order matters. It's hard to think about caching before knowing what data is being fetched, and hard to think about prefetching before knowing what's cached.
+The order is not arbitrary. It is hard to think about caching before knowing what data is being fetched, and hard to think about prefetching before knowing what's cached. Each step earns the next one.
 
 ## Step 1: Break the UI into a component hierarchy
 
-Start by drawing boxes around each region and naming them.
+The first pass draws a box around each region of the mockup and gives it a name. Each repeating piece of data turns into one component: one `ProjectCard` per `Project`, one row per `Deployment`, one row per `LogLine`. [Thinking in React](https://react.dev/learn/thinking-in-react#step-1-break-the-ui-into-a-component-hierarchy) calls this matching the component structure to the data model. UI and data tend to share the same shape.
 
-<Image
-  alt="A /projects mockup with four numbered regions next to a legend: 1 ProjectsLayout (frame around every page), 2 HeaderBar (top bar across every route), 3 Sidebar (Pinned and Recent deploys), 4 ProjectCard (one project tile in the list)."
-  srcLight="/docs/guides/thinking-in-nextjs/component-legend-light.png"
-  srcDark="/docs/guides/thinking-in-nextjs/component-legend-dark.png"
-  width={1088}
-  height={636}
-/>
-
-The full table fills in the project and build pages:
-
-| Region                  | Component                             |
-| ----------------------- | ------------------------------------- |
-| Frame around every page | `ProjectsLayout`                      |
-| Top bar                 | `HeaderBar`                           |
-| Sidebar                 | `Sidebar` (Pinned and Recent deploys) |
-| Project tile            | `ProjectCard`                         |
-| Project page header     | `ProjectHeader`                       |
-| Deployments list        | `Deployments`                         |
-| Build page header       | `DeploymentHeader`                    |
-| Build logs              | `BuildLogs`                           |
+| Region                  | Component                                                        |
+| ----------------------- | ---------------------------------------------------------------- |
+| Frame around every page | `ProjectsLayout`                                                 |
+| Top bar                 | `HeaderBar`                                                      |
+| Sidebar                 | `Sidebar`, containing `PinnedSection` and `RecentDeploysSection` |
+| Project tile            | `ProjectCard`                                                    |
+| Project page header     | `ProjectHeader`                                                  |
+| Deployments list        | `Deployments`                                                    |
+| Build page header       | `DeploymentHeader`                                               |
+| Build logs              | `BuildLogs`                                                      |
 
 The route shape lines up with the table:
 
@@ -84,15 +76,23 @@ ProjectsLayout                      ← persistent: HeaderBar + Sidebar
 └── /…/deployments/[deployId]       → DeploymentHeader + BuildLogs
 ```
 
-The split mirrors the data. Each repeating piece of data gets one component: one `ProjectCard` per `Project`, one row per `Deployment`, one row per `LogLine`. [Thinking in React](https://react.dev/learn/thinking-in-react#step-1-break-the-ui-into-a-component-hierarchy) calls this matching the component structure to the data model — UI and data tend to share the same shape.
-
-At this stage, no decisions about how the data arrives, what's reused, or where components run. Naming and grouping is enough.
+Nothing decided yet about how the data arrives, what's reused, or where each component runs. Naming and grouping is enough.
 
 ## Step 2: Build a static version with JSX
 
-Now that the regions are named, render them as JSX from inline mock data. The database, Server Functions, and client state come later. It's easier to see the UI before any of those decisions come in.
+With the regions named, the question of where their values come from can wait. A first pass renders them as JSX from inline mock data, with values that already sit in the component file:
 
 ```tsx
+const projects = [
+  {
+    id: 'compass',
+    name: 'compass',
+    description: 'Routing service for the platform.',
+  },
+  { id: 'feather', name: 'feather', description: 'Edge image transforms.' },
+  // ...
+]
+
 function ProjectsPage() {
   return projects.map((p) => <ProjectCard key={p.id} project={p} />)
 }
@@ -107,11 +107,19 @@ function ProjectCard({ project }) {
 }
 ```
 
-Layouts and pages are [Server Components](/docs/app/getting-started/server-and-client-components) by default. They run on the server and never run again in the browser. Since this version only renders JSX from local data, no [Client Component](/docs/app/getting-started/server-and-client-components#using-client-components) is needed yet. Running `next build` prerenders the route as static HTML.
+Layouts and pages are [Server Components](/docs/app/glossary#server-component) by default. They run on the server and never run again in the browser. Since this version only renders JSX from local data, no [Client Component](/docs/app/glossary#client-component) is needed yet. Running `next build` [prerenders](/docs/app/glossary#prerendering) the route as static HTML:
 
-This is the App Router version of "build a static version" from Thinking in React. The UI is visible before any decision about where the real data comes from.
+```txt
+Route (app)
+┌ ○ /
+└ ○ /projects
 
-Notice that the deployed route paints in one shot, with nothing to wait for. The HTML comes back from a static prerender, since every value the components need is inline mock data. Think of it as the route's flat baseline. Every later step adds shape only where the route needs it.
+○  (Static)  prerendered as static content
+```
+
+The `○` next to `/projects` is what to look for: every value the route needs is known at build time, so the HTML is produced once and reused on every request. This is the App Router version of "build a static version" from Thinking in React. The UI is visible before any decision about where the real data comes from.
+
+Notice that the deployed route paints in one shot, with nothing to wait for. The HTML comes back from a static prerender, since every value the components need is already in the file. This is the route's flat baseline.
 
 <Demo
   src="https://thinking-in-nextjs-02.labs.vercel.dev/projects"
@@ -122,7 +130,13 @@ Source: [`steps/02-static-jsx`](https://github.com/vercel-labs/thinking-in-nextj
 
 ## Step 3: Fetch data where it is used
 
-With the static version painting, each region is ready to read from the real data layer. The data layer is the small set of functions that talk to the database or an upstream API. In Server Components, the component that displays the data reads it directly:
+Now the mock array has to go. The data lives in a database (or behind an API), and the page needs a function to ask for it. Each read becomes a small async function — `getProjects()`, `getProject(id)`, `getDeployments(projectId)` — and the collection of those functions is the route's data layer.
+
+Where in the tree should those reads happen?
+
+The page could do all the fetching at the top and pass values down. That works, but it couples otherwise-independent sections — the deployments list ends up waiting on the same parent as the sidebar — and the reads tend to run in sequence rather than in parallel.
+
+The other option is for each component to read what it needs, right next to the JSX that uses it:
 
 ```tsx
 async function ProjectGrid({ searchParams }) {
@@ -132,26 +146,24 @@ async function ProjectGrid({ searchParams }) {
 }
 ```
 
-Each component owns its read, kept close to the JSX that uses it. Lifting every fetch into a single parent and passing data down through props couples otherwise independent components, and tends to run their reads one after another instead of in parallel.
+Each section stays independent, and unrelated reads run in parallel. Co-locating the read with the JSX that uses it is the same instinct as `useEffect` or a query library — except a [Server Component](/docs/app/glossary#server-component) can `await` the read directly, without the loading-state boilerplate.
 
-Search uses a plain HTML form. Submitting it navigates to `/projects?q=...`, which `ProjectGrid` reads from `searchParams`. Step 7 layers a Client Component on top for live URL updates.
+The reads themselves stay thin. Each one calls into a small `db` module that stands in for the real data source — a Postgres ORM, a remote API client, whatever the app uses:
 
-Walking the tree from this angle, every piece of UI shows what it depends on:
+```tsx
+// data/queries/projects.ts
+async function getProjects({ query }) {
+  return db.project.findMany({ where: matches(query) })
+}
+```
 
-| UI piece                   | What it shows                                   |
-| -------------------------- | ----------------------------------------------- |
-| `ProjectGrid`              | The project list, optionally filtered by `?q=`. |
-| `ProjectHeader`            | One project's name, status, and metadata.       |
-| `Deployments`              | The deployments for one project.                |
-| `DeploymentHeader`         | One deployment's status and commit.             |
-| `BuildLogs`                | The log for one deployment.                     |
-| `RecentDeploys`            | The latest deployments across all projects.     |
-| `PinnedList`, `ProjectPin` | The viewer's pinned ids, stored in a cookie.    |
-| `ViewerAvatar`             | The current viewer, also from a cookie.         |
+Caching, formatting, retries — those concerns live around the wrapper, not inside.
 
-Each component now reads its own data, but every read is dynamic. The route works, but every request runs every read, and the build doesn't try to prerender. Step 4 takes this further.
+Search is the first place where a [Client Component](/docs/app/glossary#client-component) would feel natural, but it doesn't have to be. The first cut is a plain HTML form. Submitting it navigates to `/projects?q=...`, and `ProjectGrid` reads `?q=` from `searchParams` to render the right list. No `'use client'` yet.
 
-Notice that the deployed route waits on the slowest read before it paints. Nothing on the page shows until every section's data is ready, even the parts that don't depend on it. Hit the refresh button in the demo's browser chrome to load it again.
+By now every region has a read attached to it. The route works — but every request runs every read, and the build no longer tries to prerender.
+
+Notice that the deployed route now waits on the slowest read before it paints. Nothing on the page shows until every section's data is ready, even the parts that don't depend on it. The refresh button in the demo's browser chrome replays the load.
 
 <Demo
   src="https://thinking-in-nextjs-03.labs.vercel.dev/projects"
@@ -162,7 +174,9 @@ Source: [`steps/03-fetch-data`](https://github.com/vercel-labs/thinking-in-nextj
 
 ## Step 4: Stream async work
 
-Earlier versions of App Router built the route either way. Finding the read that kept it from being static meant reading the build output or watching the request waterfall by hand. The refined model surfaces it for you. [`cacheComponents`](/docs/app/getting-started/caching) is the app-wide switch in `next.config.ts`:
+Why should the rest of the page wait for the slowest read? It shouldn't. [`<Suspense>`](https://react.dev/reference/react/Suspense) is how you say so: render this part when it's ready, render the rest now.
+
+[`cacheComponents`](/docs/app/getting-started/caching) is the app-wide switch that makes the framework hold you to that:
 
 ```ts filename="next.config.ts"
 import type { NextConfig } from 'next'
@@ -174,7 +188,7 @@ const nextConfig: NextConfig = {
 export default nextConfig
 ```
 
-With it on, the prerender expects every async read to either be cached or sit behind a Suspense boundary. Anything else surfaces in both `next dev` and `next build` as [`Uncached data was accessed outside of <Suspense>`](https://nextjs.org/docs/messages/blocking-route), pointing at the call site:
+With it on, the prerender expects every async read to either be cached or sit behind a [Suspense boundary](/docs/app/glossary#suspense-boundary). Anything else surfaces in `next dev` and `next build` as [`Uncached data was accessed outside of <Suspense>`](https://nextjs.org/docs/messages/blocking-route), pointing at the call site:
 
 <Image
   alt="Next.js dev overlay reading 'Next.js encountered uncached data during the initial render.' A code preview highlights an uncached fetch call inside a Page component. Below, three fix cards are listed: 'Prerender and cache' with a 'use cache' snippet, 'Provide a placeholder with Suspense', and 'Allow blocking route' with `export const instant = false`."
@@ -184,7 +198,7 @@ With it on, the prerender expects every async read to either be cached or sit be
   height={600}
 />
 
-Each error gives you two options: stream the read (this step) or cache it (Step 5). Wrap the sections that load data in [`<Suspense>`](https://react.dev/reference/react/Suspense) so the [static shell](/docs/app/glossary#static-shell) (the parts that don't need to wait) can render first:
+Each error offers two ways out: stream the read or cache it. Streaming first. Wrap each async section in its own boundary, and the [static shell](/docs/app/glossary#static-shell) — the parts that don't need to wait — ships first:
 
 ```tsx
 <HeaderBar />
@@ -202,9 +216,11 @@ A _fallback_ is the UI that ships with the shell. It gets replaced with the real
 - **400 ms.** Sidebar resolves. Its fallback is replaced with the real output.
 - **900 ms.** Grid resolves. Last fallback replaced.
 
-Size each fallback to match the shape of what's coming. A skeleton with the same width, height, and number of rows as the streamed result keeps the shell stable. A wrong-sized fallback pushes the page around when content arrives.
+The fallback's shape matters. A skeleton matching the streamed result's width, height, and row count keeps the shell stable. A wrong-sized fallback pushes the page around when the content arrives.
 
-Suspense boundaries can nest. When the server produces output as it goes (log lines on an in-progress build, LLM tokens, paginated work), each piece wraps the next in its own boundary so each one streams independently:
+A boundary does not have to wrap an entire region. It can wrap a single nested child while the rest of the surrounding layout already has its props: the outer tree paints from data the parent resolved, and only the inner subtree shows a fallback while something inside awaits.
+
+What about output that arrives bit by bit, like log lines on an in-progress build, LLM tokens, or paginated work? Suspense boundaries can nest. Each piece wraps the next in its own boundary so each one streams independently:
 
 ```tsx
 function LiveLines({ lines, index }) {
@@ -220,11 +236,9 @@ function LiveLines({ lines, index }) {
 }
 ```
 
-For feeds that arrive outside the request (a real build log from the platform, telemetry, chat), the typical pattern is a Client Component that polls or subscribes to a stream.
+For feeds that arrive outside the request — a real build log streamed from the platform, telemetry, chat — the typical pattern is a Client Component that polls or subscribes.
 
-From here on, cached output is shell content and uncached output streams. Suspense marks the streaming part. A `'use cache'` read doesn't need a Suspense wrapper, because the cached output is already there.
-
-Notice that the projects route paints the shell immediately, then swaps in the sidebar and grid as each Suspense boundary resolves. Open a deployment that's still building to see the same primitive nested: each log line streams in on its own. Hit the refresh button to replay the reveal.
+Notice that the projects route paints the shell immediately, then swaps in the sidebar and grid as each Suspense boundary resolves. A deployment that's still building shows the same primitive nested, with each log line streaming in on its own. The refresh button replays the reveal.
 
 <Demo
   src="https://thinking-in-nextjs-04.labs.vercel.dev/projects"
@@ -235,21 +249,25 @@ Source: [`steps/04-streaming`](https://github.com/vercel-labs/thinking-in-nextjs
 
 ## Step 5: Cache reusable work
 
-Some of the streamed sections are stable enough to share between viewers. A cached read joins the shell, so the section behind it stops needing a Suspense boundary. Ask of each piece:
+Streaming hides slow reads behind fallbacks, but most of those reads aren't actually different per visitor. The project list, the project header, the deployments list — none of that changes between viewers from one second to the next. The natural question:
 
 > Would the next viewer see the same thing?
 
-| UI piece                          | Same for every viewer? | Becomes                  |
-| --------------------------------- | ---------------------- | ------------------------ |
-| `ProjectGrid`, `ProjectHeader`    | Yes                    | `'use cache'`            |
-| `Deployments`, `DeploymentHeader` | Yes                    | `'use cache'`            |
-| `RecentDeploys`                   | Yes                    | `'use cache'`            |
-| `BuildLogs`, completed build      | Yes                    | `'use cache'`            |
-| `BuildLogs`, in-progress build    | No, live               | uncached, streamed       |
-| `ViewerAvatar`                    | No, per viewer         | uncached, runtime cookie |
-| `PinnedList`, `ProjectPin`        | No, per viewer         | uncached, runtime cookie |
+If yes, the work doesn't need to run on every request. The result can be reused, and the section can join the [static shell](/docs/app/glossary#static-shell) instead of streaming behind a fallback.
 
-A directive enters the picture when the read is worth reusing. The shape:
+Walk down the tree once and answer the question for each piece:
+
+| UI piece                          | Same for every viewer? | Becomes            |
+| --------------------------------- | ---------------------- | ------------------ |
+| `ProjectGrid`, `ProjectHeader`    | Yes                    | `'use cache'`      |
+| `Deployments`, `DeploymentHeader` | Yes                    | `'use cache'`      |
+| `RecentDeploysSection`            | Yes                    | `'use cache'`      |
+| `BuildLogs`, completed build      | Yes                    | `'use cache'`      |
+| `BuildLogs`, in-progress build    | No, live               | uncached, streamed |
+| `ViewerAvatar`                    | No, per viewer         | per-viewer cache   |
+| `PinnedSection`, `ProjectPin`     | No, per viewer         | per-viewer cache   |
+
+A directive at the top of the function flips a read into the shared cache:
 
 ```tsx
 async function getProjects({ query }) {
@@ -261,38 +279,57 @@ async function getProjects({ query }) {
 }
 ```
 
-[`'use cache'`](/docs/app/api-reference/directives/use-cache) marks the function as cacheable. Different arguments (and any closed-over values) become different entries, so a search for `?q=foo` and `?q=bar` are stored separately. [`cacheLife`](/docs/app/api-reference/functions/cacheLife) sets how long an entry stays valid. [`cacheTag`](/docs/app/api-reference/functions/cacheTag) labels the entry, which gives mutations a way to refer to it by name later.
+[`'use cache'`](/docs/app/api-reference/directives/use-cache) marks the function as cacheable. Different arguments — and any closed-over values — become different entries, so a search for `?q=foo` and `?q=bar` are stored separately. [`cacheLife`](/docs/app/api-reference/functions/cacheLife) sets how long an entry stays valid. [`cacheTag`](/docs/app/api-reference/functions/cacheTag) labels the entry so that other code can refer to it by name — usually from a Server Function that calls [`updateTag`](/docs/app/api-reference/functions/updateTag) after a write.
 
-Cookies, headers, and `searchParams` are request inputs, not external data. The pinned list is a cookie read:
+There's a subtlety on this route. The directive on `getProjects` says the read is cached, but the page also awaits `searchParams` to pick the query, and `searchParams` only resolves at request time. So the static prerender can't bake the cards in. The cache still applies once the request lands: the entry for that exact `?q=` is reused across viewers, and the cards swap in as soon as the param resolves. That is **extract-and-pass** in the wild — the param is not read inside `getProjects`, it arrives as `query`. A plain `'use cache'` function can't read [`cookies()`](/docs/app/api-reference/functions/cookies) or [`headers()`](/docs/app/api-reference/functions/headers) inside itself for the same reason; the pattern is to resolve those at the edge of the tree and pass what you need down. The cache key follows the arguments.
+
+What about a read keyed to one project? `cacheTag` accepts more than one tag, so a per-id read can carry both a broad label and an entry-specific one:
 
 ```tsx
-async function getPinnedIds() {
-  return (await cookies()).get('pinned')?.value?.split(',') ?? []
+async function getProject(id) {
+  'use cache'
+  cacheLife('hours')
+  cacheTag('projects', `project-${id}`)
+
+  return db.project.find({ where: byId(id) })
 }
 ```
 
-There isn't much for plain `'use cache'` to share here, since the answer changes per viewer. The read stays uncached, with the component that needs it sitting behind a Suspense boundary.
+The per-id tag gives a single project entry its own handle, separate from the all-projects entry. A mutation can invalidate one project without touching the rest of the list.
 
-`'use cache'` covers most of what this app needs to share. Two related directives, [`'use cache: remote'`](/docs/app/api-reference/directives/use-cache-remote) and [`'use cache: private'`](/docs/app/api-reference/directives/use-cache-private), handle cases where the default in-memory, shared-across-viewers cache isn't the right fit. Check them before deciding a read can't be cached.
+That leaves the per-viewer reads — avatar, pinned ids. Sharing those between viewers would leak one person's data to the next, so they aren't candidates for plain `'use cache'`. They want a different variant: [`'use cache: private'`](/docs/app/api-reference/directives/use-cache-private). Same directive shape, but the entry is scoped to the viewer and stored in the browser cache instead of being shared on the server. Inside it, `cookies()` and `headers()` are allowed — that's the whole point.
+
+```tsx
+async function getPinnedIds() {
+  'use cache: private'
+  cacheLife({ stale: 60 })
+  cacheTag('pinned')
+
+  return db.pin.list({ userId })
+}
+```
+
+The tag works the same way as the shared cache: a Server Function that mutates pins calls `updateTag('pinned')` and the next read on that viewer's device sees the new value. The cache is browser-scoped, so a single tag is enough — there's no risk of one viewer's invalidation reaching another.
+
+There's a third variant — [`'use cache: remote'`](/docs/app/api-reference/directives/use-cache-remote) — for durable shared cache across server instances when the default in-memory store is not enough. The hosting layer usually wires the handler. The [Cache Components](/docs/app/getting-started/caching) introduction compares all three; this guide uses plain `'use cache'` for project data and `'use cache: private'` for the viewer's avatar and pinned ids.
 
 The tree now carries a decision per node:
 
 ```txt
 ProjectsLayout                  (persistent shell)
 ├── HeaderBar
-│   ├── SearchBar               Client · URL state
-│   └── ViewerAvatar            runtime (cookie)
+│   └── ViewerAvatar            use cache: private
 └── Sidebar
-    ├── PinnedList              runtime (cookie)
-    └── RecentDeploys           use cache
+    ├── PinnedSection           use cache: private
+    └── RecentDeploysSection    use cache
 
 /projects
 └── ProjectGrid                 use cache
     └── ProjectCard             server
-        └── ProjectPin          runtime (cookie) · wraps PinButton (Client)
+        └── ProjectPin          use cache: private
 
 /projects/[id]
-├── ProjectHeader               use cache · wraps ProjectPin + DeployButton (Client)
+├── ProjectHeader               use cache
 └── Deployments                 use cache
 
 /projects/[id]/deployments/[deployId]
@@ -300,9 +337,7 @@ ProjectsLayout                  (persistent shell)
 └── BuildLogs                   use cache (completed) / uncached, streamed (building)
 ```
 
-Cached output also moves when the underlying data changes. The next step covers how mutations mark cached entries stale.
-
-Notice that the cached sections (project list, project header, deployment list) are already painted on first load, with no fallback. The only thing that still streams is the live build log on an in-progress build, the one read that changes per request. Hit the refresh button to load it again.
+Notice that the cached sections — sidebar's recent deploys, project header, deployments list — are already painted on first load, with no fallback. The project grid still streams behind its Suspense boundary because it reads `?q=` from search params. The per-viewer reads (avatar, pinned ids) still suspend on first load too, since the private cache lives in the browser and a fresh visit has nothing in it yet — but every subsequent render on that device pulls from cache. The live build log on an in-progress build is the one read that genuinely changes per request. The refresh button reloads the route.
 
 <Demo
   src="https://thinking-in-nextjs-05.labs.vercel.dev/projects"
@@ -311,31 +346,28 @@ Notice that the cached sections (project list, project header, deployment list) 
 
 Source: [`steps/05-caching`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/05-caching).
 
-## Step 6: Add mutations
+## Step 6: Mutate data
 
-Caching decides what output gets reused; mutations decide when that output stops being true. In the App Router, mutations live in [Server Functions](/docs/app/getting-started/updating-data) marked with `'use server'`. They can be called from anywhere on the server, and from a Client Component once the next step introduces one. Every mutation does two jobs in one call:
+Caching decides what output gets reused. Mutations decide when that output stops being true.
 
-- Change the underlying state in a database, a cookie, or an external service.
-- Tell the cache which tagged entries the change made stale.
+In the App Router, mutations live in [Server Functions](/docs/app/glossary#server-function) marked with `'use server'`. Each one does two things in the same call: change the underlying state, then tell the cache the write happened.
 
-Deploying a project is the clearest example. The write goes to an upstream API, then a tag call invalidates the cached deployments list so the next read sees the new row:
+Triggering a deploy is the cleanest version of that. The write hits the upstream, then a tag call invalidates the cached deployments list so the next read sees the new row:
 
 ```tsx
 'use server'
 
 async function triggerDeploy(projectId) {
-  await pushNewDeployment(projectId)
+  await db.deployment.create({ projectId })
   updateTag(`deployments-${projectId}`)
 }
 ```
 
-The tag name matches the one the cached read applied in Step 5, so one Server Function call lines up with one set of cached entries. Any route that reads through `deployments-${projectId}` picks up the change.
+The tag name matches the one the cached read applied earlier, so one Server Function call lines up with one set of cached entries. Any route that reads through `deployments-${projectId}` picks up the change.
 
-[`updateTag`](/docs/app/api-reference/functions/updateTag) and [`revalidateTag`](/docs/app/api-reference/functions/revalidateTag) differ in how they treat the response that contains the mutation. `updateTag` handles read-your-writes, so the new value shows up in the same response that triggered it. `revalidateTag` handles stale-while-revalidate, so the previous value keeps serving while the next read fetches a fresh one.
+[`updateTag`](/docs/app/api-reference/functions/updateTag) and [`revalidateTag`](/docs/app/api-reference/functions/revalidateTag) differ in how they treat the response that contains the mutation. `updateTag` handles read-your-writes: the new value shows up in the same response that triggered it. `revalidateTag` handles stale-while-revalidate: the previous value keeps serving while the next read fetches a fresh one.
 
-Not every mutation invalidates something. A toggle that only writes a cookie (like `togglePinned`) has no cached read standing in for it. [Server Actions](/docs/app/getting-started/updating-data#server-functions) automatically re-render the active route after the call, and the next cookie read picks up the new value. No tag call is needed because nothing was cached on the way in.
-
-Calling a Server Function from input doesn't need any client code. A plain HTML form posts to the server, runs the function, and re-renders the active route with the new state. The button stays a Server Component.
+What does that look like wired up to a button? Calling a Server Function from input doesn't have to mean shipping a Client Component. An HTML form posts to the server, the function runs, and React re-renders the active route with the new state. The button stays a Server Component:
 
 ```tsx
 <form action={triggerDeploy.bind(null, projectId)}>
@@ -343,35 +375,55 @@ Calling a Server Function from input doesn't need any client code. A plain HTML 
 </form>
 ```
 
-Notice that submitting the deploy form runs the Server Function and re-renders the route with the new deployments list, without shipping any Client Component.
+This is the same request-response loop PHP and Rails apps ran on: the browser posts a form, the server runs a function, the server re-renders the page. The difference is that React produces the response.
+
+Pinning has the same shape. `getPinnedIds` was tagged in the previous step with `cacheTag('pinned')`, so the pin actions invalidate the same tag:
+
+```tsx
+'use server'
+
+async function addPin(projectId) {
+  await db.pin.add({ userId, projectId })
+  updateTag('pinned')
+}
+```
+
+The mutation pattern is now uniform across the app: the write touches the underlying state, then `updateTag` calls out the cache entries that just stopped being true. The shared cache and the per-viewer cache use the same call — the difference is only in where the entry lives.
+
+Notice that submitting the deploy form runs the Server Function and re-renders the route with the new deployments list. Pinning runs through the same path: `updateTag('pinned')` invalidates that viewer's cache entry, and the next render shows the new state.
 
 <Demo
   src="https://thinking-in-nextjs-06.labs.vercel.dev/projects"
-  title="Step 6: Add mutations"
+  title="Step 6: Mutate data"
 />
 
 Source: [`steps/06-mutations`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/06-mutations).
 
-The next step keeps the form action and wraps the buttons in Client Components for optimistic state and pending state.
+## Step 7: Add client interactivity
 
-## Step 7: Add client boundaries
+So far Server Components handle every read, Server Functions handle every write, and an HTML form is enough to get from input to mutation. What's a [Client Component](/docs/app/glossary#client-component) actually for?
 
-Inside a Client Component, the full React API is back. Many things that would be component state in a typical SPA fit other patterns in App Router: updating the URL, calling a Server Function, showing optimistic state until server-rendered data catches up. The components that do need React state become Client Components.
+The moments the request-response loop can't answer in time. Instant feedback before the server confirms. A pending state while a request is in flight. A URL update on every keystroke instead of one per submit. Inside a [`'use client'`](/docs/app/glossary#use-client-directive) boundary the full React API is back: `onClick`, `useState`, hooks, refs — all of it.
 
-The form action from Step 6 already lets a click reach the server. What's still missing is anything only the client can do: instant feedback before the server confirms, pending state while a request is in flight, URL updates without a full submit.
-
-A client leaf wraps the form action from Step 6 with whatever the client owns on top. `onClick` and React state would work the same once the component is `'use client'`:
+`PinButton` is the smallest version. The same form action from Step 6, wrapped in a Client Component that owns the optimistic flip:
 
 ```tsx
 'use client'
 
+import { useOptimistic, useTransition } from 'react'
+
 function PinButton({ projectId, pinned }) {
   const [optimistic, setOptimistic] = useOptimistic(pinned)
+  const [, startTransition] = useTransition()
+
   return (
     <form
-      action={async () => {
-        setOptimistic(!optimistic)
-        await togglePinned(projectId)
+      action={() => {
+        startTransition(async () => {
+          const wasPinned = optimistic
+          setOptimistic((p) => !p)
+          await (wasPinned ? removePin(projectId) : addPin(projectId))
+        })
       }}
     >
       <button type="submit">{optimistic ? 'Pinned' : 'Pin'}</button>
@@ -380,7 +432,9 @@ function PinButton({ projectId, pinned }) {
 }
 ```
 
-The boundary between server and client is one prop wide. A Server Component computes a value and hands it down:
+[`useOptimistic`](https://react.dev/reference/react/useOptimistic) gives the button its temporary value to display while the Server Function is in flight; React reverts to the server-confirmed value once the response lands. The flip uses `wasPinned` so the Server Function always matches the state **before** the optimistic update — that way, two fast clicks don't accidentally cancel each other out. Nothing else is needed: the `updateTag('pinned')` call inside `addPin` / `removePin` invalidates the cached read, the framework re-renders the route with fresh data, and the optimistic state hands off to the real one.
+
+How wide does the boundary between server and client need to be? One prop. A Server Component computes the value and hands it down:
 
 ```tsx
 async function ProjectPin({ projectId }) {
@@ -391,24 +445,37 @@ async function ProjectPin({ projectId }) {
 }
 ```
 
-The cookie read happens on the server and never reaches the browser. Server Components can render Client Components directly, so the wrapper sits right above the leaf.
+In `ProjectCard`, the icon, title, framework line, description, and status all come from the `project` object the grid already loaded. Only the pin needs `getPinnedIds`, so only that control sits behind [`<Suspense>`](/docs/app/glossary#suspense-boundary): the rest of the card is not blocked by the per-viewer read, and the fallback is a pin-shaped skeleton, not a skeleton for the whole card.
 
-Search follows the same pattern. A Client Component reads the URL on render and pushes it on each keystroke, with pending state while the new page renders:
+```tsx
+<header className="flex …">
+  {/* icon, title, meta from `project` — synchronous */}
+  <Suspense fallback={<ProjectPinSkeleton />}>
+    <ProjectPin projectId={project.id} />
+  </Suspense>
+</header>
+```
+
+It might look like marking `PinButton` with `'use client'` would pull its parent into the client too. It doesn't. `'use client'` is a _boundary_, not a whole-tree switch. The `getPinnedIds` read stays in `ProjectPin`, the Server Component wrapper; only the boolean it computes crosses into the client. Server Components can render Client Components directly, so the wrapper sits right above the leaf.
+
+Search shows up again here. The plain HTML form from Step 3 handled a single submit. Updating the URL on every keystroke needs more — the input reads the URL on render, pushes the next one on each change, and holds the previous page visible while the new one resolves:
 
 ```tsx
 'use client'
+
 import { useRouter, useSearchParams } from 'next/navigation'
 import { useTransition } from 'react'
 
 function SearchBar() {
   const router = useRouter()
   const searchParams = useSearchParams()
-  const [, startTransition] = useTransition()
+  const [isPending, startTransition] = useTransition()
 
   return (
     <input
       type="search"
       defaultValue={searchParams.get('q') ?? ''}
+      className={isPending ? 'opacity-80' : undefined}
       onChange={(event) => {
         const next = event.target.value
         startTransition(() => {
@@ -420,45 +487,62 @@ function SearchBar() {
 }
 ```
 
-[`useTransition`](https://react.dev/reference/react/useTransition) keeps the input responsive and holds the rest of the page on the previous render until the new one is ready. There's no half-rendered intermediate to look at while the keystroke is in flight.
+App Router runs `router.push` inside a [transition](https://react.dev/reference/react/useTransition) by default — the input stays responsive and the previous page stays visible whether or not the call is wrapped. What [`useTransition`](https://react.dev/reference/react/useTransition) adds is `isPending`: a value the input can read to show a hint while the new render resolves. [`useLinkStatus`](/docs/app/api-reference/functions/use-link-status) gives the same signal for `<Link>` navigations.
 
 Notice that the leaves react directly to input on the deployed route. Pinning flips before the server confirms, search edits the URL on each keystroke, and the deploy button stays in a pending state until the Server Function returns. Everything else around them stays a Server Component.
 
 <Demo
   src="https://thinking-in-nextjs-07.labs.vercel.dev/projects"
-  title="Step 7: Add client boundaries"
+  title="Step 7: Add client interactivity"
 />
 
 Source: [`steps/07-client-boundaries`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/07-client-boundaries).
 
-## Step 8: Configure prefetching
+## Step 8: Optimize prefetching
 
-The cached pieces from Step 5 don't have to wait until the click. The router can fetch them ahead of time and have them ready in the client cache when the navigation happens. The route opts in with one line:
+By now the tree knows what to render and what to reuse. The last question is one of timing: when can that work happen?
+
+It doesn't have to wait for the click. A `<Link>` that's been on the page long enough — sitting in the viewport, hovered, idle — is a hint that a navigation is likely. The runtime can use that hint to render the destination ahead of time, so the click lands on a tree that's already there.
+
+There are two flavors. A **static** prefetch renders the destination against build-time inputs: useful for shared content, but blind to anything that depends on the request. A **runtime** prefetch is a real render with the same cookies, headers, and search string the navigation would send. That second flavor is what makes the per-viewer cache pay off across navigations — `getPinnedIds` was already cached in Step 5, but a static prefetch couldn't see the session, so it couldn't fill that entry. Runtime prefetch can.
+
+Opting into runtime prefetch is one segment-config line:
 
 ```tsx
-export const prefetch = 'force-runtime'
+export const unstable_prefetch = 'force-runtime'
 ```
 
-`prefetch = 'force-runtime'` tells the router to prefetch this route at runtime, so the cached parts land in the client cache before the click.
+The companion job is **instant validation**: a check that every path into the route still exposes an instant shell. Shared chrome stays in the static part of the prerender, anything dynamic sits behind a Suspense boundary, and the navigation never tears the frame apart mid-transition. Validation needs a believable example to work against, and that's what `samples` provides:
 
-What the router prefetches is decided by the cache boundaries from Step 5. Push more reads into `'use cache'` to prefetch more, leave a section uncached behind Suspense to prefetch less. There's no separate "what to prefetch" knob.
+```tsx
+export const unstable_instant = {
+  samples: [
+    {
+      searchParams: { q: null },
+      cookies: [{ name: 'session', value: null }],
+    },
+  ],
+}
+```
 
-`prefetch` is the explicit step. [`instant`](/docs/app/api-reference/file-conventions/route-segment-config/instant) runs in the background as a default validator, checking that the caching structure on each route produces an instant static shell, so a `force-runtime` prefetch has something cached to land.
+The source may still prefix these exports with `unstable_`; the docs call them prefetch and instant navigation validation.
 
-The same cache also lets the route render without a network. Cached output sits on the device; only the dynamic sections behind Suspense have to wait for a request.
+Prefetch never widens what you cached — it only moves eligible work earlier. What you feel is simpler. Clicks land reconciled when the cache lines up. Back navigation picks up what the forward pass stashed. Underneath it is still the same server-rendered tree.
 
-Notice that clicking a project card lands on the project route with the header and deployment list already painted, while the per-viewer and live sections stream in after. The cached shell prefetched as the cards came into view, so the click has nothing to wait on.
+Notice that opening a project shows the header and deployments without a blank beat; only the live build log on an in-progress deployment still streams. Pins and avatar ride along because the prefetch pass sees the same session the navigation will, and the cached entries from earlier steps are already on the device when the click happens.
 
 <Demo
   src="https://thinking-in-nextjs.labs.vercel.dev/projects"
-  title="Step 8: Configure prefetching"
+  title="Step 8: Optimize prefetching"
 />
 
 Source: [`steps/08-prefetching`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/08-prefetching).
 
 ## Where to go from here
 
-The route grew in layers from a flat baseline: Suspense boundaries around dynamic reads, caching for the reusable parts, client islands where input lives. Each one was added because the route needed it.
+The route grew in layers. A flat baseline. Reads next to the JSX that uses them. Suspense around the slow ones. Caching for the parts that repeat. Mutations that invalidate by tag. Client islands where input lives. Prefetch and validation so navigations land already painted.
+
+None of those steps needed a new framework. Each one was the next question the route asked.
 
 Try the same exercise on a route in your own codebase. Name the regions, then label each one as static, dynamic, cached, or a Client leaf. The decisions usually fall out once each component answers what kind of work it is.
 
@@ -467,7 +551,7 @@ The docs go deeper on each piece used here.
 - [Cache Components](/docs/app/getting-started/caching) covers what `cacheComponents: true` changes and what each `'use cache'` variant is for.
 - [Streaming](/docs/app/guides/streaming) covers `loading.tsx`, nested Suspense, and where to place `<Suspense>`.
 - [Server and Client Components](/docs/app/getting-started/server-and-client-components) goes further on the prop boundary, including the donut pattern (Client Components receiving Server Components as `children`) for cases this guide didn't run into.
-- [`prefetch`](/docs/app/api-reference/file-conventions/route-segment-config/prefetch) is the route segment config used in this guide to tell the router to prefetch a route at runtime. [`instant`](/docs/app/api-reference/file-conventions/route-segment-config/instant) is the default validator that keeps the static shell honest. The other per-route options live next to them in the [route segment config](/docs/app/api-reference/file-conventions/route-segment-config) reference.
+- [Prefetch](/docs/app/api-reference/file-conventions/route-segment-config/prefetch) and [instant](/docs/app/api-reference/file-conventions/route-segment-config/instant) segment config: runtime prefetch and shell validation. Other options sit in the [route segment config](/docs/app/api-reference/file-conventions/route-segment-config) reference.
 
 ## Browse the source
 
@@ -480,7 +564,7 @@ Jump to a step on GitHub:
 - [`steps/02-static-jsx`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/02-static-jsx). Static JSX with mock data.
 - [`steps/03-fetch-data`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/03-fetch-data). Server Components reading from a data layer.
 - [`steps/04-streaming`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/04-streaming). Suspense around async sections.
-- [`steps/05-caching`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/05-caching). `'use cache'` on stable reads.
-- [`steps/06-mutations`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/06-mutations). Server Functions and `updateTag` called from a plain form.
-- [`steps/07-client-boundaries`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/07-client-boundaries). Client leaves and server actions.
-- [`steps/08-prefetching`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/08-prefetching). `prefetch` and `instant` route configs.
+- [`steps/05-caching`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/05-caching). `'use cache'` and tags on shared reads; `'use cache: private'` for the per-viewer reads (avatar, pinned ids).
+- [`steps/06-mutations`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/06-mutations). Server Functions; `updateTag` for every cached read.
+- [`steps/07-client-boundaries`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/07-client-boundaries). Client leaves; optimistic `PinButton`; URL-driven `SearchBar` with `useTransition`.
+- [`steps/08-prefetching`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/08-prefetching). Runtime prefetch and instant samples; real session model.

--- a/docs/01-app/02-guides/thinking-in-nextjs.mdx
+++ b/docs/01-app/02-guides/thinking-in-nextjs.mdx
@@ -58,17 +58,18 @@ The breakdown follows one decision at a time:
 
 Draw a box around each section of the mockup and give it a name. Each repeating piece of data becomes one component, with one `ProjectCard` per `Project`, one row per `Deployment`, and one row per `LogLine`.
 
-| Section                 | Component                                                        |
-| ----------------------- | ---------------------------------------------------------------- |
-| Frame around every page | `ProjectsLayout`                                                 |
-| Top bar                 | `HeaderBar`                                                      |
-| Sidebar                 | `Sidebar`, containing `PinnedSection` and `RecentDeploysSection` |
-| Project list            | `ProjectGrid`, containing one `ProjectCard` per project          |
-| Project tile            | `ProjectCard`                                                    |
-| Project page header     | `ProjectHeader`                                                  |
-| Deployments list        | `Deployments`                                                    |
-| Build page header       | `DeploymentHeader`                                               |
-| Build logs              | `BuildLogs`                                                      |
+| Section                 | Component                                               |
+| ----------------------- | ------------------------------------------------------- |
+| Frame around every page | `ProjectsLayout`                                        |
+| Top bar                 | `Header`                                                |
+| Sidebar pinned projects | `PinnedProjects`                                        |
+| Sidebar recent deploys  | `RecentDeploys`                                         |
+| Project list            | `ProjectGrid`, containing one `ProjectCard` per project |
+| Project tile            | `ProjectCard`                                           |
+| Project page header     | `ProjectHeader`                                         |
+| Deployments list        | `Deployments`                                           |
+| Build page header       | `DeploymentHeader`                                      |
+| Build logs              | `BuildLogs`                                             |
 
 The route shape lines up with the table and with the App Router file tree:
 
@@ -144,21 +145,41 @@ Source: [`steps/02-static-jsx`](https://github.com/vercel-labs/thinking-in-nextj
 
 Replace the mock arrays with real reads. Where in the tree should those reads happen?
 
-One option is to fetch everything at the top with `Promise.all` and pass values down. That works, but it couples unrelated sections. The deployments list waits on the same parent as the sidebar, and the parent has to know what every child reads.
+One option is to fetch everything at the top of the page and pass values down. That works, but it couples unrelated sections. The header waits on the deployments list, the page has to know what every child needs, and adding a new section means changing the page even though it doesn't use that data.
 
 The other option is for each component to read what it needs, right next to the JSX that uses it:
 
-```tsx filename="app/projects/page.tsx" highlight={3-4}
-async function ProjectGrid({ searchParams }) {
-  const { q } = await searchParams
-  const projects = await getProjects({ query: q })
-  return projects.map((p) => <ProjectCard key={p.id} project={p} />)
+```tsx filename="components/ProjectHeader.tsx"
+export async function ProjectHeader({ id }: { id: string }) {
+  const project = await getProject(id)
+  return (
+    <>
+      <BackLink href="/projects" label="Back to projects" />
+      <header>{/* ... render project details ... */}</header>
+    </>
+  )
 }
 ```
 
-Co-locating the read with the JSX that uses it is the same instinct as `useEffect` or a query library, except a Server Component can `await` the read directly, with no client state to plumb through.
+Co-locating the read with the JSX that uses it is the same instinct as `useEffect` or a query library, except a Server Component can `await` the read directly, with no client state to manage.
 
-The read runs on the server, and the component gets the data back before it renders. The query itself can stay in the route's [data access layer](/docs/app/guides/data-security#data-access-layer) under `data/queries/`, away from the JSX that renders the result:
+The page awaits `params` and passes each component the identifier it needs:
+
+```tsx filename="app/projects/[id]/page.tsx"
+export default async function ProjectDetailPage({
+  params,
+}: PageProps<'/projects/[id]'>) {
+  const { id } = await params
+  return (
+    <>
+      <ProjectHeader id={id} />
+      <Deployments projectId={id} />
+    </>
+  )
+}
+```
+
+The read runs on the server, and the component gets the data back before it renders. The query can stay in a [data access layer](/docs/app/guides/data-security#data-access-layer) under `data/queries/`:
 
 ```tsx filename="data/queries/projects.ts" highlight={3}
 import { cache } from 'react'
@@ -194,73 +215,69 @@ Route (app)
 ƒ  (Dynamic)  server-rendered on demand
 ```
 
-Every section has something it waits on now. The slowest one blocks the initial render. That's what comes next.
+Every section blocks the response until the slowest one finishes.
 
 Source: [`steps/03-fetch-data`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/03-fetch-data).
 
 ## Step 4: Stream dynamic content
 
-Why should the rest of the page wait for the slowest read? It shouldn't. Next.js already streams the response by default, and React's [`<Suspense>`](https://react.dev/reference/react/Suspense) is how you mark each section that can wait behind a fallback.
+Why should the rest of the page wait for the slowest read? It shouldn't. Each async component already fetches independently. Now the page can _render_ each one independently too.
 
-Wrap each section with dynamic content in its own boundary. In the sidebar, the pinned section and the recent deploys each get one:
+React's [`<Suspense>`](https://react.dev/reference/react/Suspense) can wrap each async component in a boundary. The page sends the surrounding layout immediately while each section fills in as its data resolves.
 
-```tsx filename="app/projects/_components/Sidebar.tsx" highlight={4,7}
-function Sidebar() {
+On the project detail page, that looks like this:
+
+```tsx filename="app/projects/[id]/page.tsx" highlight={5,8}
+export default async function ProjectDetailPage({
+  params,
+}: PageProps<'/projects/[id]'>) {
+  const { id } = await params
   return (
     <>
-      <Suspense fallback={<PinnedSkeleton />}>
-        <PinnedSection />
+      <Suspense fallback={<ProjectHeaderSkeleton />}>
+        <ProjectHeader id={id} />
       </Suspense>
-      <Suspense fallback={<RecentDeploysSkeleton />}>
-        <RecentDeploysSection />
+      <Suspense fallback={<DeploymentsSkeleton />}>
+        <Deployments projectId={id} />
       </Suspense>
     </>
   )
 }
 ```
 
-`Sidebar` itself stays synchronous. Each child gets [loading UI](/docs/app/glossary#loading-ui) shaped like the section that will replace it.
+Each async component can export its own skeleton from the same file:
 
-The same pass covers the rest of the route. Avatar, grid, project header, deployments list, deployment header, and build logs each need something to show while their content is still resolving.
-
-This gets brittle to manage by hand. Every new async read needs a matching boundary, and missing one quietly stalls the first chunk.
-
-We can turn on [`cacheComponents`](/docs/app/glossary#cache-components) to make the choice explicit. With it enabled, every uncached read or Request-time API has to be marked, and `next dev` and `next build` flag the ones that aren't.
-
-```ts filename="next.config.ts" highlight={4}
-import type { NextConfig } from 'next'
-
-const nextConfig: NextConfig = {
-  cacheComponents: true,
+```tsx filename="components/ProjectHeader.tsx"
+export async function ProjectHeader({ id }: { id: string }) {
+  const project = await getProject(id)
+  return (/* … render project details … */)
 }
 
-export default nextConfig
+export function ProjectHeaderSkeleton() {
+  return (
+    <header>
+      <Skeleton />
+      <Skeleton />
+      <Skeleton />
+    </header>
+  )
+}
 ```
 
-With `cacheComponents` enabled, `next build` separates a [static shell](/docs/app/glossary#static-shell) from sections that still stream at request time:
+The same pattern covers the sidebar sections in the layout:
 
-```txt
-Route (app)
-┌ ○ /
-└ ◐ /projects
-
-○  (Static)             prerendered as static content
-◐  (Partial Prerender)  prerendered as static HTML with dynamic server-streamed content
+```tsx filename="app/projects/layout.tsx"
+<aside>
+  <Suspense fallback={<PinnedProjectsSkeleton />}>
+    <PinnedProjects />
+  </Suspense>
+  <Suspense fallback={<RecentDeploysSkeleton />}>
+    <RecentDeploys />
+  </Suspense>
+</aside>
 ```
 
-The `◐` is [Partial Prerendering](/docs/app/glossary#partial-prerendering-ppr) (PPR): a prerendered shell with dynamic content that streams from the server.
-
-If a read is still uncached and outside a boundary, the overlay points at it and lists three choices:
-
-- **Stream** it by adding a `<Suspense>` fallback, like the sidebar above.
-- **Cache** it when the result can be reused, covered later.
-- **Block** the route when you knowingly want the whole route to wait.
-
-For these sections, the decision is **Stream**. They need fresh or request-specific values, but the rest of the page can render without them. Each `<Suspense>` boundary fixes when its subtree replaces the fallback; it does not make the underlying reads reusable. Those reads still rerun on each request until they're cached.
-
-`cacheComponents` runs these checks on every server render. [Instant validation](/docs/app/guides/instant-navigation) is the same kind of check for navigations, catching reads that would still block a click even when they sit behind `<Suspense>`.
-
-Try the demo. The static shell ships immediately, and each section fills in as its read resolves.
+Try the demo. The layout and skeletons paint immediately, and each section fills in as its read resolves.
 
 <Demo
   src="https://thinking-in-nextjs-04-streaming.labs.vercel.dev/projects"
@@ -269,18 +286,15 @@ Try the demo. The static shell ships immediately, and each section fills in as i
 
 On `/projects`, the timing reads roughly:
 
-- **0 ms**: Shell sent. The header and search form land immediately, with fallbacks for the avatar, pinned section, recent deploys, and grid.
+- **0 ms**: Layout and skeletons sent. The header and search form land immediately, with fallbacks for the avatar, pinned section, recent deploys, and grid.
 - **500 ms**: Avatar resolves.
 - **1000 ms**: Pinned section and grid resolve.
 - **1500 ms**: Recent deploys resolves last.
 
-Streaming fixes the initial render but doesn't make later navigations reuse work. While sections stream, the shared layout UI stays interactive, so a click can start the next navigation even while another section is still filling in.
+The pattern holds at every level in the tree. `BuildLogs` already sits behind the page's `<Suspense fallback={<BuildLogsSkeleton />}>`, but the in-progress branch has its own live read. We can nest another boundary so the log frame renders first and the live rows stream behind it:
 
-Nested reads follow the same rule. `BuildLogs` already sits behind the page's `<Suspense fallback={<BuildLogsSkeleton />}>`, but the in-progress branch has its own live read. We can wrap that branch in its own `<Suspense>` so the log frame can render first and the live rows can stream behind it:
-
-```tsx filename="app/projects/[id]/deployments/[deployId]/_components/BuildLogs.tsx" highlight={6-8}
-export async function BuildLogs({ params }) {
-  const { deployId } = await params
+```tsx filename="components/BuildLogs.tsx" highlight={6-8}
+export async function BuildLogs({ deployId }: { deployId: string }) {
   const deployment = await getDeployment(deployId)
   return (
     <BuildLogsShell>
@@ -296,7 +310,7 @@ export async function BuildLogs({ params }) {
 }
 ```
 
-The reads are covered. The `building` branch becomes visible once the app can start a deploy.
+Streaming fixes the initial render. While sections stream, the shared layout UI stays interactive, so a click can start the next navigation even while another section is still filling in.
 
 Source: [`steps/04-streaming`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/04-streaming).
 
@@ -359,22 +373,52 @@ Source: [`steps/05-mutations`](https://github.com/vercel-labs/thinking-in-nextjs
 
 ## Step 6: Add client interactivity
 
-The writes stay on the server. The browser still needs to react immediately in a few places.
+Every click still waits for a full server round trip. The pin doesn't flip until the server confirms, the deploy button sits unresponsive, and search submits the whole form.
 
-Four pieces still wait on a round trip. Each one needs a different kind of immediate feedback:
+Where should the client boundary go? The instinct from client-first React is to put `'use client'` at the page level, but that pulls the entire subtree into the browser. The boundary can go on the leaf instead.
 
-| Control         | Should update on  | Needs client |
+| Control         | Updates on        | Needs client |
 | --------------- | ----------------- | ------------ |
 | Pin button      | click             | yes          |
 | Search field    | each keystroke    | yes          |
 | Deploy button   | click             | yes          |
 | In-progress log | every few seconds | yes          |
 
-Only those controls become Client Components, marked with [`'use client'`](/docs/app/glossary#use-client-directive). The browser handles the immediate feedback; the server still handles the data changes.
+Only those four controls need [`'use client'`](/docs/app/glossary#use-client-directive).
 
-The pin is the clearest case. The label can flip the moment the user clicks, then settle on the server's confirmed value. React calls this an [optimistic update](https://react.dev/reference/react/useOptimistic). We can start `getPinnedIds()` once on the page and pass the promise into each card, and the button reads that promise in the browser:
+The pin button is the clearest case. React's [`useOptimistic`](https://react.dev/reference/react/useOptimistic) can flip the label on click, then settle on the server's confirmed value.
 
-```tsx filename="app/projects/_components/ProjectPin.tsx" highlight={1,6,9}
+The server can start the `getPinnedIds()` read once and pass the promise down to each card:
+
+```tsx filename="app/projects/page.tsx" highlight={4,9}
+async function ProjectGrid({ searchParams }) {
+  const { q } = await searchParams
+  const projects = await getProjects({ query: q })
+  const pinnedIdsPromise = getPinnedIds()
+  return projects.map((project) => (
+    <ProjectCard
+      key={project.id}
+      project={project}
+      pinnedIdsPromise={pinnedIdsPromise}
+    />
+  ))
+}
+```
+
+The boundary can go around the button alone:
+
+```tsx
+<header className="flex …">
+  {/* icon, title, meta from `project` (synchronous) */}
+  <Suspense fallback={<ProjectPinSkeleton />}>
+    <ProjectPin projectId={project.id} pinnedIdsPromise={pinnedIdsPromise} />
+  </Suspense>
+</header>
+```
+
+Inside the client component:
+
+```tsx filename="components/ProjectPin.tsx" highlight={1,6,9}
 'use client'
 
 import { use, useOptimistic } from 'react'
@@ -399,39 +443,9 @@ function ProjectPin({ projectId, pinnedIdsPromise }) {
 }
 ```
 
-The label changes immediately. When the server response lands, the confirmed pinned ids replace the optimistic value.
+Search keeps the same server read from `searchParams`. The client input pushes the next URL as the user types:
 
-On the server, we can start the read once and pass the same promise to each card:
-
-```tsx filename="app/projects/page.tsx" highlight={4,9}
-async function ProjectGrid({ searchParams }) {
-  const { q } = await searchParams
-  const projects = await getProjects({ query: q })
-  const pinnedIdsPromise = getPinnedIds()
-  return projects.map((project) => (
-    <ProjectCard
-      key={project.id}
-      project={project}
-      pinnedIdsPromise={pinnedIdsPromise}
-    />
-  ))
-}
-```
-
-The boundary can be placed around the button alone:
-
-```tsx
-<header className="flex …">
-  {/* icon, title, meta from `project` (synchronous) */}
-  <Suspense fallback={<ProjectPinSkeleton />}>
-    <ProjectPin projectId={project.id} pinnedIdsPromise={pinnedIdsPromise} />
-  </Suspense>
-</header>
-```
-
-Search can keep the same server read from `searchParams`. The client input pushes the next URL as the user types:
-
-```tsx filename="app/projects/_components/SearchBar.tsx" highlight={9,18}
+```tsx filename="components/SearchBar.tsx" highlight={9,18}
 'use client'
 
 import { useRouter, useSearchParams } from 'next/navigation'
@@ -468,7 +482,7 @@ function SearchBar() {
 
 Deploy can use the same Server Function as before, wrapped in a [React transition](https://react.dev/reference/react/useTransition) so the button can show pending state:
 
-```tsx filename="app/projects/[id]/_components/DeployButton.tsx" highlight={9-10}
+```tsx filename="components/DeployButton.tsx" highlight={9-10}
 'use client'
 
 import { useTransition } from 'react'
@@ -490,7 +504,7 @@ The form stays. Nothing about the server write needs to change.
 
 The live log needs a timer instead of a click. We can drop a small poller beside `<LiveLogStream>` that refreshes the route every few seconds while the deployment is building:
 
-```tsx filename="app/projects/[id]/deployments/[deployId]/_components/BuildLogPoller.tsx" highlight={1,9}
+```tsx filename="components/BuildLogPoller.tsx" highlight={1,9}
 'use client'
 
 import { useRouter } from 'next/navigation'
@@ -515,7 +529,7 @@ Try the demo. Pin a project and watch the button flip immediately, then type in 
   title="Step 6: Add client interactivity"
 />
 
-The sidebar catches up once the server confirms the pin, and Client JavaScript stays small because only these four controls run in the browser; the rest of the route stays as Server Components. The app responds quickly to input now, but navigation still reruns the same server reads.
+The sidebar catches up once the server confirms the pin. Four leaf components run in the browser; everything else stayed on the server. Navigation still reruns every server read from scratch.
 
 Source: [`steps/06-client-boundaries`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/06-client-boundaries).
 
@@ -523,17 +537,84 @@ Source: [`steps/06-client-boundaries`](https://github.com/vercel-labs/thinking-i
 
 Client Components fixed input feedback, not navigation. Between project pages, the same reads still rerun and the same fallbacks still paint. Caching closes that gap without moving the data model into the browser.
 
-For each read, ask one question. _Would the next viewer see the same thing?_ Most of these reads do.
+### Enable Cache Components
+
+[`cacheComponents`](/docs/app/api-reference/config/next-config-js/cacheComponents) enables caching at the component and function level:
+
+```ts filename="next.config.ts" highlight={4}
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  cacheComponents: true,
+}
+
+export default nextConfig
+```
+
+With it on, data fetching stays **dynamic by default**. If a read blocks the static shell from prerendering, the dev overlay flags it with three choices:
+
+- **Stream** it by adding a `<Suspense>` fallback.
+- **Cache** it when the result can be reused, covered next.
+- **Block** the route when you knowingly want the whole route to wait.
+
+For route params specifically, [`generateStaticParams`](/docs/app/api-reference/functions/generateStaticParams) is a fourth option: prerender each page at build time so the param values are baked in.
+
+Because each component already fetches its own data and pages already place deliberate `<Suspense>` boundaries, only a few spots need fixing. On the detail pages, `await params` at the top blocks the shell. The page can switch to `.then()` instead, keeping the page function synchronous and moving the params resolution inside a `<Suspense>` boundary:
+
+```tsx filename="app/projects/[id]/page.tsx" highlight={4}
+export default function ProjectDetailPage({
+  params,
+}: PageProps<'/projects/[id]'>) {
+  return (
+    <Suspense
+      fallback={
+        <>
+          <ProjectHeaderSkeleton />
+          <DeploymentsSkeleton />
+        </>
+      }
+    >
+      {params.then(({ id }) => (
+        <>
+          <Suspense fallback={<ProjectHeaderSkeleton />}>
+            <ProjectHeader id={id} />
+          </Suspense>
+          <Suspense fallback={<DeploymentsSkeleton />}>
+            <Deployments projectId={id} />
+          </Suspense>
+        </>
+      ))}
+    </Suspense>
+  )
+}
+```
+
+On this route the projects come from a database that changes at runtime, so the pages stay dynamic and `generateStaticParams` doesn't apply.
+
+With that fixed, `next build` can separate a [static shell](/docs/app/glossary#static-shell) from sections that stream at request time. The [Partial Prerendering](/docs/app/glossary#partial-prerendering-ppr) marker (`◐`) confirms it:
+
+```txt
+Route (app)
+┌ ○ /
+└ ◐ /projects
+
+○  (Static)             prerendered as static content
+◐  (Partial Prerender)  prerendered as static HTML with dynamic server-streamed content
+```
+
+### Marking reads as cacheable
+
+For each read, ask one question. _Would the next viewer see the same thing?_ Most of these reads would.
 
 | UI piece                          | Reusable?       |
 | --------------------------------- | --------------- |
 | `ProjectGrid`, `ProjectHeader`    | Yes             |
 | `Deployments`, `DeploymentHeader` | Yes             |
-| `RecentDeploysSection`            | Yes             |
+| `RecentDeploys`                   | Yes             |
 | `BuildLogs`, completed build      | Yes             |
 | `BuildLogs`, in-progress build    | No, live        |
 | `ViewerAvatar`                    | Yes, per viewer |
-| `PinnedSection`                   | Yes, per viewer |
+| `PinnedProjects`                  | Yes, per viewer |
 
 We can mark a reusable read with [`'use cache'`](/docs/app/glossary#use-cache-directive), plus a lifetime and tags so mutations can refresh the right entries later:
 
@@ -626,11 +707,10 @@ After the pass, the route looks like this:
 
 ```txt
 shared layout (app/projects/layout.tsx)
-├── HeaderBar
+├── Header
 │   └── ViewerAvatar            use cache: private
-└── Sidebar
-    ├── PinnedSection           use cache (keyed by userId)
-    └── RecentDeploysSection    use cache
+├── PinnedProjects               use cache (keyed by userId)
+└── RecentDeploys        use cache
 
 app/projects/page.tsx
 └── ProjectGrid                 use cache
@@ -646,19 +726,15 @@ app/projects/[id]/deployments/[deployId]/page.tsx
 
 Sections whose keys come from the request, like `cookies()`, `searchParams`, `params`, or live output, keep `<Suspense>`.
 
-Cached slices with no request input can join the static shell. On this route, `RecentDeploysSection` is the example, so its boundary can be removed:
+Cached slices with no request input can join the static shell. On this route, `RecentDeploys` is the example, so its `<Suspense>` boundary in the layout can be removed:
 
-```tsx filename="app/projects/_components/Sidebar.tsx" highlight={7}
-export function Sidebar() {
-  return (
-    <div className="space-y-6">
-      <Suspense fallback={<PinnedSkeleton />}>
-        <PinnedSection />
-      </Suspense>
-      <RecentDeploysSection />
-    </div>
-  )
-}
+```tsx filename="app/projects/layout.tsx"
+<div className="space-y-6">
+  <Suspense fallback={<PinnedProjectsSkeleton />}>
+    <PinnedProjects />
+  </Suspense>
+  <RecentDeploys />
+</div>
 ```
 
 After `'use cache'` backs those reads, calling [`refresh()`](/docs/app/api-reference/functions/refresh) reruns dynamic work but leaves cached entries in place until something invalidates them. Lists can stay stale after a deploy or pin.
@@ -703,7 +779,7 @@ Click into a project, then back to the list, then into a deployment. The sidebar
   title="Step 7: Cache reusable work"
 />
 
-`RecentDeploysSection` is the one cached read with no per-request input, so it joins the static shell. The others are keyed by cookies, `params`, or [`searchParams`](/docs/app/api-reference/file-conventions/page#searchparams-optional). Those values only arrive with a real request, so the cache slots stay empty until the user clicks.
+`RecentDeploys` is the one cached read with no per-request input, so it joins the static shell. The others are keyed by cookies, `params`, or [`searchParams`](/docs/app/api-reference/file-conventions/page#searchparams-optional). Those values only arrive with a real request, so the cache slots stay empty until the user clicks.
 
 The cache is set up, but the visible paint hasn't changed for sections waiting on a request. The missing piece is filling those entries before the click.
 
@@ -765,8 +841,6 @@ Source: [`steps/07-caching`](https://github.com/vercel-labs/thinking-in-nextjs/t
 
 ## Where to go from here
 
-React's model is declarative: components describe the output, and React renders them when inputs change. The App Router extends that model past the browser. The route stayed one component tree; each part now declares where to read, what to stream, what to mutate, what runs in the browser, and what can be reused.
-
-Try it on a route in your own codebase. Name the regions, then label each one as static, dynamic, cached, or a Client leaf.
+Try it on a route in your own codebase. Draw the boxes, name the regions, then label each one: static, dynamic, cached, or a client leaf.
 
 Each step's source is under `steps/` in the [example repo](https://github.com/vercel-labs/thinking-in-nextjs). The production mirror is at [thinking-in-nextjs.labs.vercel.dev](https://thinking-in-nextjs.labs.vercel.dev/).

--- a/docs/01-app/02-guides/thinking-in-nextjs.mdx
+++ b/docs/01-app/02-guides/thinking-in-nextjs.mdx
@@ -11,6 +11,7 @@ related:
     - app/getting-started/server-and-client-components
     - app/guides/server-actions
     - app/guides/prefetching
+    - app/guides/adopting-partial-prefetching
     - app/guides/runtime-prefetching
     - app/guides/instant-navigation
     - app/guides/offline-support
@@ -667,22 +668,57 @@ Click into a project, then back to the list, then into a deployment. The sidebar
   title="Step 7: Cache reusable work"
 />
 
-The cache is set up, but the visible paint hasn't changed for sections waiting on a request. The missing piece is filling those entries before the click.
+The cache is set up, but the visible paint hasn't changed for sections waiting on a request. The missing piece is shipping work ahead of the click so the next page is ready by the time the user gets there.
+
+### Prefetch a shell per route
+
+Historically, `<Link>` fired a prefetch request for every distinct destination in the viewport. A grid with a thousand profile cards meant a thousand prefetches — most of them wasted on content the user would never reach.
+
+Each route now has an [App Shell](/docs/app/glossary#app-shell): the cached parts of the page that can be served without a request, plus suspense fallbacks for everything that streams. The shell is the same for every link to the same route, so it doesn't have to be fetched per link. [Partial Prefetching](/docs/app/glossary#partial-prefetching) is the prefetch model that takes advantage of this — one shell per route, cached for the session, regardless of how many links point at it.
+
+Turn it on alongside `cacheComponents`:
+
+```ts filename="next.config.ts" highlight={5}
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  cacheComponents: true,
+  partialPrefetching: true,
+}
+
+export default nextConfig
+```
+
+For an existing app where flipping the global flag at once isn't realistic, the [Adopting Partial Prefetching guide](/docs/app/guides/adopting-partial-prefetching) covers opting routes in one at a time with `export const prefetch = 'partial'`.
+
+To see what each route's shell looks like, the **Navigation Inspector** in the Next.js DevTools pauses navigations at the shell so you can see exactly what's available instantly before dynamic content streams in. Use it as a feedback loop while placing `<Suspense>` boundaries: too much fallback, and the shell ships skeletons where it could ship real UI; too little, and the route can't prerender at all.
+
+### Prefetch more than the shell
+
+Sometimes the shell isn't enough. The project detail page is the example here: the project metadata and deployments list are cached, and would feel snappier if they landed with the click instead of streaming in.
+
+For a `<Link>` whose destination has worth-shipping cached content, opt in with the [`prefetch`](/docs/app/api-reference/components/link#prefetch) prop:
+
+```tsx
+<Link href={`/projects/${project.id}`} prefetch>
+  {project.name}
+</Link>
+```
+
+This prefetches the shell **plus** whatever's cached down the tree — anything synchronous or marked `'use cache'`. Dynamic data (cookies, headers, `searchParams`) still streams in after the navigation.
+
+This is per-link, not per-route. A different `<Link>` to the same destination can leave `prefetch` off; the cost only applies where the prop is set.
 
 ### Prefetch runtime data
 
-Prefetching is what fills cache entries before the click. By default, [`<Link>`](/docs/app/api-reference/components/link) prefetches its destinations against build-time inputs only when they enter the viewport, which covers the static shell and any cached read keyed on build-time inputs. See [Prefetching](/docs/app/guides/prefetching) for the default behavior.
+Some destinations need request-time data to render anything useful — search results depend on `?q=`, the project page reads the viewer's cookies for pin state. By default `<Link prefetch>` skips that data, since prefetching it for every link would be expensive.
 
-[Runtime prefetch](/docs/app/guides/runtime-prefetching) does the render with the real cookies, headers, and `searchParams` the navigation would carry, then stores the result in the [Client Cache](/docs/app/glossary#client-cache). It's the same skip-recomputation goal as the server cache, only filled before the click instead of during it.
-
-Prefetch only sticks if the destination reads are cached. Without `'use cache'` and tags on those reads, the prefetched output has no entry to reuse, and the next click rerenders from scratch. The reads above already carry tags and lifetimes, so prefetched output has a stable slot.
-
-We can opt a page into runtime prefetch with the [`unstable_prefetch`](/docs/app/api-reference/file-conventions/route-segment-config/prefetch) segment export:
+To extend per-link prefetching to request-time cached content, opt the destination segment into [runtime prefetching](/docs/app/guides/runtime-prefetching) with the [`prefetch`](/docs/app/api-reference/file-conventions/route-segment-config/prefetch) segment export:
 
 ```tsx filename="app/projects/page.tsx" highlight={3}
 import { Suspense } from 'react'
 
-export const unstable_prefetch = 'force-runtime'
+export const prefetch = 'allow-runtime'
 
 export default function ProjectsPage({ searchParams }) {
   return (
@@ -695,20 +731,19 @@ export default function ProjectsPage({ searchParams }) {
 }
 ```
 
-Each page declares its own choice. On this app, `/projects` opts in for the avatar and pinned section (cookies) and the grid (`?q=`). `/projects/[id]` and `/projects/[id]/deployments/[deployId]` opt in for cookies and `params`. Other pages stay on static prefetch.
+Each page declares its own choice. On this app, `/projects` opts in for the avatar and pinned section (cookies) and the grid (`?q=`). `/projects/[id]` and `/projects/[id]/deployments/[deployId]` opt in for cookies and `params`. Other pages stay on the default static prefetch.
 
-As links scroll into view, the prefetches show up as ordinary fetches:
+Runtime prefetch only sticks if the destination reads are cached. Without `'use cache'` and tags on those reads, the prefetched output has no entry to reuse and the next click rerenders from scratch. The reads above already carry tags and lifetimes, so prefetched output has a stable slot in the [Client Cache](/docs/app/glossary#client-cache).
+
+As links scroll into view, the prefetches show up as ordinary fetches — one per route, not one per link:
 
 ```txt
 Name                                          Status  Type   Size      Time
-projects/compass                              200     fetch  12.4 KB    84 ms
-projects/feather                              200     fetch  11.8 KB    79 ms
-projects/compass/deployments/compass-jx9q3    200     fetch  18.2 KB   112 ms
-projects/aurora                               200     fetch  12.1 KB    81 ms
-projects/aurora/deployments/aurora-7k8h1      200     fetch  17.6 KB   108 ms
+projects/[id]                                 200     fetch  12.4 KB    84 ms
+projects/[id]/deployments/[deployId]          200     fetch  18.2 KB   112 ms
 ```
 
-Each row is a per-request render of the destination, and the result is stored in the Client Cache. Before prefetch finishes, the fallback still appears. After it finishes, the section is already in the Client Cache.
+Each row is a per-request render of the destination's runtime-cacheable content, stored in the Client Cache and reused across every link to that route for the session. Before prefetch finishes, the fallback still appears. After it finishes, the section is already in the cache.
 
 Click between projects fast and the fallback paints. Wait a beat before clicking, and the section is already prefetched.
 
@@ -719,9 +754,9 @@ Click between projects fast and the fallback paints. Wait a beat before clicking
 
 When prefetch finishes before the click, the destination renders real markup instead of skeletons. The `<Suspense>` boundaries stay in place because they still guard reads that need a real request.
 
-Every route the prefetch pass touched, static or runtime, is cached in the browser, so subsequent navigations work even over a flaky connection. [Offline support](/docs/app/guides/offline-support) covers the broader story for apps that go fully offline.
+Every route the prefetch pass touched is cached in the browser, so subsequent navigations work even over a flaky connection. [Offline support](/docs/app/guides/offline-support) covers the broader story for apps that go fully offline.
 
-Three layers combine for instant repeat navigation. `<Suspense>` handles the first visit, `'use cache'` gives prefetched output a stable entry, and runtime prefetch fills that entry before the click. Each layer has a cost, so apply them where smoother repeat navigation is worth the server work and the browser memory.
+Three layers combine for instant navigation. `<Suspense>` handles the first visit, `'use cache'` builds an App Shell that `<Link>` ships by default, and per-link `prefetch` (with `prefetch = 'allow-runtime'` where personalized) fills the cached parts of that shell before the click. Each layer has a cost, so apply them where smoother repeat navigation is worth the server work and the browser memory.
 
 Source: [`steps/07-caching`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/07-caching) and [`steps/08-prefetching`](https://github.com/vercel-labs/thinking-in-nextjs/tree/main/steps/08-prefetching).
 

--- a/docs/01-app/02-guides/thinking-in-nextjs.mdx
+++ b/docs/01-app/02-guides/thinking-in-nextjs.mdx
@@ -707,7 +707,7 @@ Click into a project, then back to the list, then into a deployment. The sidebar
 
 The cache is set up, but the visible paint hasn't changed for sections waiting on a request. The missing piece is filling those entries before the click.
 
-### Cache reads that depend on the request
+### Prefetch runtime data
 
 Prefetching is what fills cache entries before the click. By default, [`<Link>`](/docs/app/api-reference/components/link) prefetches its destinations against build-time inputs only when they enter the viewport, which covers the static shell and any cached read keyed on build-time inputs.
 

--- a/docs/01-app/02-guides/thinking-in-nextjs.mdx
+++ b/docs/01-app/02-guides/thinking-in-nextjs.mdx
@@ -54,6 +54,8 @@ The breakdown follows one decision at a time:
 6. Add client interactivity.
 7. Cache reusable work.
 
+Each step picks one or two examples from the mockup to walk through in detail. The same patterns apply to every other section in the route, and each step ends with a link to that step's source if you want to see how the rest of the page was filled in.
+
 ## Step 1: Break the UI into a component hierarchy
 
 Draw a box around each section of the mockup and give it a name. Each repeating piece of data becomes one component, with one `ProjectCard` per `Project`, one row per `Deployment`, and one row per `LogLine`.
@@ -145,11 +147,11 @@ Source: [`steps/02-static-jsx`](https://github.com/vercel-labs/thinking-in-nextj
 
 Replace the mock arrays with real reads. Where in the tree should those reads happen?
 
-One option is to fetch everything at the top of the page and pass values down. That works, but it couples unrelated sections. The header waits on the deployments list, the page has to know what every child needs, and adding a new section means changing the page even though it doesn't use that data.
+One option is to fetch everything at the top of the page and pass values down. That's the [loader pattern](https://reactrouter.com/start/data/data-loading) from React Router and Remix, and it works. The trade-off is that it couples unrelated sections. The header waits on the deployments list, the page has to know what every child needs, and adding a new section means changing the page even though it doesn't use that data.
 
-The other option is for each component to read what it needs, right next to the JSX that uses it:
+In the App Router, a Server Component can `await` directly, so the same instinct doesn't have to land in the same place. Each component can read what it needs, right next to the JSX that uses it:
 
-```tsx filename="components/ProjectHeader.tsx"
+```tsx filename="features/projects/components/ProjectHeader.tsx"
 export async function ProjectHeader({ id }: { id: string }) {
   const project = await getProject(id)
   return (
@@ -179,9 +181,9 @@ export default async function ProjectDetailPage({
 }
 ```
 
-The read runs on the server, and the component gets the data back before it renders. The query can stay in a [data access layer](/docs/app/guides/data-security#data-access-layer) under `data/queries/`:
+The read runs on the server, and the component gets the data back before it renders. The query itself doesn't live in the component file. Component files describe shape, query files describe access. Pulling the read into a [data access layer](/docs/app/guides/data-security#data-access-layer) keeps one place to add the auth check, the cache annotation (Step 7), or a future migration. Two components that need the same data import the same function instead of two slightly different inline queries:
 
-```tsx filename="data/queries/projects.ts" highlight={3}
+```tsx filename="features/projects/projects-queries.ts" highlight={3}
 import { cache } from 'react'
 
 export const getProjects = cache(async ({ query }) => {
@@ -191,9 +193,11 @@ export const getProjects = cache(async ({ query }) => {
 })
 ```
 
-> **Note**: [Request-time APIs](/docs/app/glossary#request-time-apis) like `cookies()`, `headers()`, `searchParams`, and uncached `fetch()` mark a component as dynamic on their own. Other reads like a database query, `Math.random()`, or `new Date()` don't, so add [`await connection()`](/docs/app/api-reference/functions/connection) at the top to make the read dynamic explicitly. The example database queries call it for this reason.
+> **Note**: [Request-time APIs](/docs/app/glossary#request-time-apis) like `cookies()`, `headers()`, `searchParams`, and uncached `fetch()` mark a component as dynamic on their own. A raw database query doesn't, so until Step 7 adds caching, [`await connection()`](/docs/app/api-reference/functions/connection) at the top of each read is the explicit signal that the call is dynamic.
 
 React's [`cache`](https://react.dev/reference/react/cache) runs each call once per render, so two components asking for the same data share one read.
+
+> **The same applies to:** every other read. `getProject`, `getDeployments`, `getDeployment`, `getBuildLog`, `getPinnedIds`, and `getCurrentUser` all live in their domain's `*-queries.ts` file and follow the same shape.
 
 For search, a plain GET form posts to `/projects?q=…`, and `ProjectGrid` reads [`searchParams`](/docs/app/api-reference/file-conventions/page#searchparams-optional) to render the filtered list.
 
@@ -221,9 +225,9 @@ Source: [`steps/03-fetch-data`](https://github.com/vercel-labs/thinking-in-nextj
 
 ## Step 4: Stream dynamic content
 
-Why should the rest of the page wait for the slowest read? It shouldn't. Each async component already fetches independently. Now the page can _render_ each one independently too.
+Why should the rest of the page wait for the slowest read? Each async component already fetches independently. Can the page _render_ each one independently too, so the layout paints right away and the sections fill in as their data resolves?
 
-React's [`<Suspense>`](https://react.dev/reference/react/Suspense) can wrap each async component in a boundary. The page sends the surrounding layout immediately while each section fills in as its data resolves.
+React's [`<Suspense>`](https://react.dev/reference/react/Suspense) is what makes that possible. Wrap each async component in a boundary, give it a fallback, and the page sends the surrounding layout immediately while each section streams in as its data resolves.
 
 On the project detail page, that looks like this:
 
@@ -247,35 +251,20 @@ export default async function ProjectDetailPage({
 
 Each async component can export its own skeleton from the same file:
 
-```tsx filename="components/ProjectHeader.tsx"
+```tsx filename="features/projects/components/ProjectHeader.tsx"
 export async function ProjectHeader({ id }: { id: string }) {
   const project = await getProject(id)
   return (/* … render project details … */)
 }
 
 export function ProjectHeaderSkeleton() {
-  return (
-    <header>
-      <Skeleton />
-      <Skeleton />
-      <Skeleton />
-    </header>
-  )
+  return <header>{/* … skeleton placeholders … */}</header>
 }
 ```
 
-The same pattern covers the sidebar sections in the layout:
+The skeleton should mirror the real component's layout, same heights and gaps, so the page doesn't shift when the content resolves. Co-located with the component, it can't drift out of sync.
 
-```tsx filename="app/projects/layout.tsx"
-<aside>
-  <Suspense fallback={<PinnedProjectsSkeleton />}>
-    <PinnedProjects />
-  </Suspense>
-  <Suspense fallback={<RecentDeploysSkeleton />}>
-    <RecentDeploys />
-  </Suspense>
-</aside>
-```
+> **The same applies to:** every async component in the route. `Deployments`, `BuildLogs`, `PinnedProjects`, `RecentDeploys`, and `ViewerAvatar` each wrap in a `<Suspense>` boundary and export a sibling skeleton.
 
 Try the demo. The layout and skeletons paint immediately, and each section fills in as its read resolves.
 
@@ -293,7 +282,7 @@ On `/projects`, the timing reads roughly:
 
 The pattern holds at every level in the tree. `BuildLogs` already sits behind the page's `<Suspense fallback={<BuildLogsSkeleton />}>`, but the in-progress branch has its own live read. We can nest another boundary so the log frame renders first and the live rows stream behind it:
 
-```tsx filename="components/BuildLogs.tsx" highlight={6-8}
+```tsx filename="features/deployments/components/BuildLogs.tsx" highlight={6-8}
 export async function BuildLogs({ deployId }: { deployId: string }) {
   const deployment = await getDeployment(deployId)
   return (
@@ -316,13 +305,13 @@ Source: [`steps/04-streaming`](https://github.com/vercel-labs/thinking-in-nextjs
 
 ## Step 5: Mutate data
 
-Reads are covered. Now deploy and pin change data.
+Reads are covered. How does a click that creates a deployment or pins a project get from the browser back to the database?
 
 An HTML form is the natural shape. The browser already knows how to submit one over the network, and the write can run on the server with no extra wiring. A [Route Handler](/docs/app/glossary#route-handler) would work too, but the route ends up with a separate endpoint for one button.
 
-We can keep the write with the route by adding a colocated React [Server Function](/docs/app/glossary#server-function), marked with `'use server'`:
+We can keep the write next to the component that triggers it by adding a colocated React [Server Function](/docs/app/glossary#server-function), marked with `'use server'`:
 
-```tsx filename="data/actions/deployments.ts" highlight={1,7}
+```tsx filename="features/deployments/deployments-actions.ts" highlight={1,7}
 'use server'
 
 import { refresh } from 'next/cache'
@@ -342,23 +331,13 @@ React's [`<form action>`](https://react.dev/reference/react-dom/components/form#
 </form>
 ```
 
+This is the smallest version of a working form, enough to prove the data flow. The button doesn't show pending state yet, but that comes later.
+
 The browser posts the form, the server runs the write, and React renders the response. [`refresh`](/docs/app/api-reference/functions/refresh) reruns the route's dynamic reads so the new deployment shows up in the list and recent-deploys section.
 
 > **Note**: A Server Function is an exposed endpoint, so anything it touches needs the same auth checks and input validation a public API would get. The labs gate every write with `requireSession()` and skip the broader story to keep the focus on the data flow. The [Server Actions guide](/docs/app/guides/server-actions) covers the broader API, and [How to Think About Security in Next.js](https://nextjs.org/blog/security-nextjs-server-components-actions) is the reference to read before shipping.
 
-The pin write follows the same shape:
-
-```tsx filename="data/actions/pinned.ts" highlight={8}
-'use server'
-
-import { refresh } from 'next/cache'
-
-export async function addPin(projectId) {
-  const { id: userId } = await requireSession()
-  await db.pin.add({ userId, projectId })
-  refresh()
-}
-```
+> **The same applies to:** every other write. `addPin` and `removePin` follow the same shape, `'use server'` + a write + `refresh()`, in `features/projects/pinned-actions.ts`.
 
 Submit the deploy form, then open the new `building` row to see the build log fill in the lines that have run so far. Refresh a few seconds later and a few more have arrived. Pin and unpin a project to see the pin state flip after each round trip.
 
@@ -388,7 +367,9 @@ Only those four controls need [`'use client'`](/docs/app/glossary#use-client-dir
 
 The pin button is the clearest case. React's [`useOptimistic`](https://react.dev/reference/react/useOptimistic) can flip the label on click, then settle on the server's confirmed value.
 
-The server can start the `getPinnedIds()` read once and pass the promise down to each card:
+The pin button needs to know whether the project is already pinned, which means it needs `getPinnedIds()`. The instinct from loader-driven apps is to hoist that read up to the page and pass the resolved value down through every card. That re-couples the page to data it doesn't use, and every card re-renders when the result changes.
+
+A Server Component can hand a **promise** down instead. The server starts the read once, each card forwards the promise to its own pin button, and only the button reads it. The read is shared, the loading is local, and the page never sees the result:
 
 ```tsx filename="app/projects/page.tsx" highlight={4,9}
 async function ProjectGrid({ searchParams }) {
@@ -418,7 +399,7 @@ The boundary can go around the button alone:
 
 Inside the client component:
 
-```tsx filename="components/ProjectPin.tsx" highlight={1,6,9}
+```tsx filename="features/projects/components/ProjectPin.tsx" highlight={1,6,9}
 'use client'
 
 import { use, useOptimistic } from 'react'
@@ -445,7 +426,7 @@ function ProjectPin({ projectId, pinnedIdsPromise }) {
 
 Search keeps the same server read from `searchParams`. The client input pushes the next URL as the user types:
 
-```tsx filename="components/SearchBar.tsx" highlight={9,18}
+```tsx filename="features/projects/components/SearchBar.tsx" highlight={9,18}
 'use client'
 
 import { useRouter, useSearchParams } from 'next/navigation'
@@ -480,16 +461,15 @@ function SearchBar() {
 }
 ```
 
-Deploy can use the same Server Function as before, wrapped in a [React transition](https://react.dev/reference/react/useTransition) so the button can show pending state:
+Deploy follows the same shape as pin, only the button needs pending state instead of optimistic state. Wrap the Server Function call in [`useTransition`](https://react.dev/reference/react/useTransition) and read `pending` while the click is in flight:
 
-```tsx filename="components/DeployButton.tsx" highlight={9-10}
+```tsx filename="features/deployments/components/DeployButton.tsx" highlight={6,9-10}
 'use client'
 
 import { useTransition } from 'react'
 
 function DeployButton({ projectId }) {
   const [pending, startTransition] = useTransition()
-
   return (
     <form action={() => startTransition(() => triggerDeploy(projectId))}>
       <button type="submit" disabled={pending}>
@@ -500,11 +480,9 @@ function DeployButton({ projectId }) {
 }
 ```
 
-The form stays. Nothing about the server write needs to change.
+The live log needs a timer instead of a click. A small poller beside `<LiveLogStream>` refreshes the route while the deployment is building:
 
-The live log needs a timer instead of a click. We can drop a small poller beside `<LiveLogStream>` that refreshes the route every few seconds while the deployment is building:
-
-```tsx filename="components/BuildLogPoller.tsx" highlight={1,9}
+```tsx filename="features/deployments/components/BuildLogPoller.tsx" highlight={1,9}
 'use client'
 
 import { useRouter } from 'next/navigation'
@@ -520,7 +498,9 @@ export function BuildLogPoller({ intervalMs = 4000 }) {
 }
 ```
 
-Each refresh re-runs the live log read, and the new rows render under the cursor.
+Each refresh re-runs the live log read, and the new rows render under the cursor. The same shape works anywhere the UI needs to reflect server state without a user action: a notification badge, a vote count, a deployment status. Drop a `<Poller>` next to the section that should re-fetch.
+
+Polling is fine for low-frequency updates. For truly real-time data, the leaf needs to do its own subscribing, typically a Server-Sent Events stream or a WebSocket connection inside the client component.
 
 Try the demo. Pin a project and watch the button flip immediately, then type in the search bar to see the URL update on each keystroke. Open a project, click Deploy, and watch the build log grow on its own.
 
@@ -535,7 +515,7 @@ Source: [`steps/06-client-boundaries`](https://github.com/vercel-labs/thinking-i
 
 ## Step 7: Cache reusable work
 
-Client Components fixed input feedback, not navigation. Between project pages, the same reads still rerun and the same fallbacks still paint. Caching closes that gap without moving the data model into the browser.
+Client Components fixed input feedback. Why does the route still flash skeletons every time someone clicks into a different project? The reads run from scratch on every navigation, even when the data hasn't changed. Caching is what closes that gap, without moving the data model into the browser.
 
 ### Enable Cache Components
 
@@ -616,9 +596,9 @@ For each read, ask one question. _Would the next viewer see the same thing?_ Mos
 | `ViewerAvatar`                    | Yes, per viewer |
 | `PinnedProjects`                  | Yes, per viewer |
 
-We can mark a reusable read with [`'use cache'`](/docs/app/glossary#use-cache-directive), plus a lifetime and tags so mutations can refresh the right entries later:
+Mark a reusable read with [`'use cache'`](/docs/app/glossary#use-cache-directive), plus a lifetime and tags so mutations can refresh the right entries later:
 
-```tsx filename="data/queries/projects.ts" highlight={2,4}
+```tsx filename="features/projects/projects-queries.ts" highlight={2,4}
 async function getProject(id) {
   'use cache'
   cacheLife('hours')
@@ -628,41 +608,11 @@ async function getProject(id) {
 }
 ```
 
-The function's arguments form the cache key. `getProject('compass')` and `getProject('feather')` end up as separate entries, each kept for as long as `cacheLife` declares (`'hours'` here).
+The function's arguments form the cache key. Calls with different ids end up as separate entries, kept for as long as `cacheLife` declares. The per-id tag gives one project its own handle; the broader `projects` tag covers the list. The rest of the reusable reads (`getProjects`, `getCompletedBuildLog`, `getDeployments`) follow the same shape: pick a lifetime, name the tags.
 
-`cacheTag` labels each entry by name so a mutation can invalidate it later. The per-id tag `project-${id}` gives a single project its own handle, and the broader `projects` tag covers the list.
+Some reads are reusable but only for one viewer. `getPinnedIds` reads the current user's pins, so the cache has to be keyed by user. The trick is to split the read in two so the inner half can cache by a plain `userId` argument:
 
-The project list can cache too. Pass the search value as an argument so each query gets its own entry:
-
-```tsx filename="data/queries/projects.ts" highlight={2,4}
-async function getProjects({ query }) {
-  'use cache'
-  cacheLife('hours')
-  cacheTag('projects')
-
-  return db.project.findMany({ where: matches(query) })
-}
-```
-
-Logs split by status. A finished build log can be cached, but an in-progress log is live, so it stays uncached:
-
-```tsx filename="data/queries/build-logs.ts" highlight={2-4,8}
-export const getCompletedBuildLog = cache(async (deployId) => {
-  'use cache'
-  cacheLife('minutes')
-  cacheTag(`build-log-${deployId}`)
-  // … read and return
-})
-
-export const getInProgressBuildLog = cache(async (deployId) => {
-  await connection()
-  // … read and return
-})
-```
-
-Pinned ids are reusable too, but only for one viewer. Split the read in two. The outer one finds the viewer; the inner one caches by `userId`:
-
-```tsx filename="data/queries/pinned.ts" highlight={2,4}
+```tsx filename="features/projects/projects-queries.ts" highlight={2,4}
 const getPinnedIdsForUser = cache(async (userId) => {
   'use cache'
   cacheLife({ stale: 60 })
@@ -677,13 +627,9 @@ export const getPinnedIds = cache(async () => {
 })
 ```
 
-The store is shared; the `userId` argument is what makes each entry per-viewer. Two different ids become two entries, the same way `getProject('compass')` and `getProject('feather')` do.
+Request values like [`cookies()`](/docs/app/api-reference/functions/cookies), [`headers()`](/docs/app/api-reference/functions/headers), and `searchParams` stay outside plain `'use cache'` functions. Read them first, then pass values in as arguments. When there's nothing to lift out, [`'use cache: private'`](/docs/app/api-reference/directives/use-cache-private) is the variant that runs per viewer and can read request values directly:
 
-Request values like [`cookies()`](/docs/app/api-reference/functions/cookies), [`headers()`](/docs/app/api-reference/functions/headers), and `searchParams` stay outside plain `'use cache'` functions. Read them first, then pass values in as arguments.
-
-For `getCurrentUser`, the cookie is the input. There's nothing to lift out, so we can reach for [`'use cache: private'`](/docs/app/api-reference/directives/use-cache-private) instead. It's the variant that runs per viewer and can read request values directly:
-
-```tsx filename="data/queries/auth.ts" highlight={2-3}
+```tsx filename="features/user/auth-queries.ts" highlight={2-3}
 export const getCurrentUser = cache(async () => {
   'use cache: private'
   cacheLife({ stale: 60 })
@@ -693,57 +639,13 @@ export const getCurrentUser = cache(async () => {
 })
 ```
 
-The page can still start the pinned-id read once:
-
-```tsx
-const pinnedIdsPromise = getPinnedIds()
-```
-
-The pin button can still call `use` on that promise, and sidebar segments can still `await getPinnedIds()` directly. The render shares the same in-flight work.
-
 > **Note**: A third variant, [`'use cache: remote'`](/docs/app/api-reference/directives/use-cache-remote), backs a durable shared cache across server instances. See the [Cache Components](/docs/app/getting-started/caching) intro for the full comparison.
 
-After the pass, the route looks like this:
+A cached read with no per-request input can join the static shell. `RecentDeploys` is the example here, so its `<Suspense>` boundary in the layout can be removed and the rendered HTML ships with the shell.
 
-```txt
-shared layout (app/projects/layout.tsx)
-├── Header
-│   └── ViewerAvatar            use cache: private
-├── PinnedProjects               use cache (keyed by userId)
-└── RecentDeploys        use cache
+After `'use cache'` backs those reads, [`refresh()`](/docs/app/api-reference/functions/refresh) reruns dynamic work but leaves cached entries in place. To invalidate the right entries after a write, call [`updateTag`](/docs/app/api-reference/functions/updateTag) from the Server Function for whichever reads changed:
 
-app/projects/page.tsx
-└── ProjectGrid                 use cache
-
-app/projects/[id]/page.tsx
-├── ProjectHeader               use cache
-└── Deployments                 use cache
-
-app/projects/[id]/deployments/[deployId]/page.tsx
-├── DeploymentHeader            use cache
-└── BuildLogs                   use cache (complete) / streamed (building)
-```
-
-Sections whose keys come from the request, like `cookies()`, `searchParams`, `params`, or live output, keep `<Suspense>`.
-
-Cached slices with no request input can join the static shell. On this route, `RecentDeploys` is the example, so its `<Suspense>` boundary in the layout can be removed:
-
-```tsx filename="app/projects/layout.tsx"
-<div className="space-y-6">
-  <Suspense fallback={<PinnedProjectsSkeleton />}>
-    <PinnedProjects />
-  </Suspense>
-  <RecentDeploys />
-</div>
-```
-
-After `'use cache'` backs those reads, calling [`refresh()`](/docs/app/api-reference/functions/refresh) reruns dynamic work but leaves cached entries in place until something invalidates them. Lists can stay stale after a deploy or pin.
-
-[`updateTag`](/docs/app/api-reference/functions/updateTag) names the entries the write touched so the next render pulls fresh values. Use it from the Server Function instead of `refresh()` (or alongside [`revalidateTag`](/docs/app/api-reference/functions/revalidateTag) for stale-while-revalidate).
-
-Each Server Function can call `updateTag` for the entries its write touched:
-
-```tsx filename="data/actions/deployments.ts" highlight={6,8-9}
+```tsx filename="features/deployments/deployments-actions.ts" highlight={6,8-9}
 'use server'
 
 import { updateTag } from 'next/cache'
@@ -756,30 +658,14 @@ async function triggerDeploy(projectId) {
 }
 ```
 
-Pins use the same pattern. `getPinnedIdsForUser` has a `pinned-${userId}` tag, so pin mutations invalidate that viewer's entry:
+Each write follows the same shape: run the write, then `updateTag` the reads it changed.
 
-```tsx filename="data/actions/pinned.ts" highlight={8}
-'use server'
-
-import { updateTag } from 'next/cache'
-
-async function addPin(projectId) {
-  const { id: userId } = await requireSession()
-  await db.pin.add({ userId, projectId })
-  updateTag(`pinned-${userId}`)
-}
-```
-
-Each write follows the same shape. Run the write, then call `updateTag` for whichever cached reads changed.
-
-Click into a project, then back to the list, then into a deployment. The sidebar's recent-deploys list paints with the static shell on every click. The other sections still flash a fallback before resolving.
+Click into a project, then back to the list, then into a deployment. The sidebar's recent-deploys list paints with the static shell on every click. The other sections still flash a fallback before resolving, because their cache keys depend on a real request and only get filled once one arrives.
 
 <Demo
   src="https://thinking-in-nextjs-07-caching.labs.vercel.dev/projects"
   title="Step 7: Cache reusable work"
 />
-
-`RecentDeploys` is the one cached read with no per-request input, so it joins the static shell. The others are keyed by cookies, `params`, or [`searchParams`](/docs/app/api-reference/file-conventions/page#searchparams-optional). Those values only arrive with a real request, so the cache slots stay empty until the user clicks.
 
 The cache is set up, but the visible paint hasn't changed for sections waiting on a request. The missing piece is filling those entries before the click.
 
@@ -841,6 +727,6 @@ Source: [`steps/07-caching`](https://github.com/vercel-labs/thinking-in-nextjs/t
 
 ## Where to go from here
 
-Try it on a route in your own codebase. Draw the boxes, name the regions, then label each one: static, dynamic, cached, or a client leaf.
+Try it on a route in your own codebase. For each section on the page, ask the same questions this guide asks. Where does the data come from? What can stream? What can be cached, and for how long? What needs to run in the browser?
 
 Each step's source is under `steps/` in the [example repo](https://github.com/vercel-labs/thinking-in-nextjs). The production mirror is at [thinking-in-nextjs.labs.vercel.dev](https://thinking-in-nextjs.labs.vercel.dev/).

--- a/docs/01-app/02-guides/thinking-in-nextjs.mdx
+++ b/docs/01-app/02-guides/thinking-in-nextjs.mdx
@@ -163,7 +163,7 @@ export async function ProjectHeader({ id }: { id: string }) {
 }
 ```
 
-Co-locating the read with the JSX that uses it is the same instinct as `useEffect` or a query library, except a Server Component can `await` the read directly, with no client state to manage.
+Co-locating the read with the JSX that uses it is the same instinct as [`useEffect`](https://react.dev/reference/react/useEffect) or a query library, except a Server Component can `await` the read directly, with no client state to manage.
 
 The page awaits `params` and passes each component the identifier it needs:
 
@@ -227,7 +227,7 @@ Source: [`steps/03-fetch-data`](https://github.com/vercel-labs/thinking-in-nextj
 
 Why should the rest of the page wait for the slowest read? Each async component already fetches independently. Can the page _render_ each one independently too, so the layout paints right away and the sections fill in as their data resolves?
 
-React's [`<Suspense>`](https://react.dev/reference/react/Suspense) is what makes that possible. Wrap each async component in a boundary, give it a fallback, and the page sends the surrounding layout immediately while each section streams in as its data resolves.
+React's [`<Suspense>`](https://react.dev/reference/react/Suspense) is what makes that possible. Wrap each async component in a boundary, give it a fallback, and the page sends the surrounding layout immediately while each section streams in as its data resolves. See [Streaming](/docs/app/guides/streaming) for the full pattern.
 
 On the project detail page, that looks like this:
 
@@ -309,7 +309,7 @@ Reads are covered. How does a click that creates a deployment or pins a project 
 
 An HTML form is the natural shape. The browser already knows how to submit one over the network, and the write can run on the server with no extra wiring. A [Route Handler](/docs/app/glossary#route-handler) would work too, but the route ends up with a separate endpoint for one button.
 
-We can keep the write next to the component that triggers it by adding a colocated React [Server Function](/docs/app/glossary#server-function), marked with `'use server'`:
+We can keep the write next to the component that triggers it by adding a colocated React [Server Function](/docs/app/glossary#server-function), marked with [`'use server'`](/docs/app/api-reference/directives/use-server):
 
 ```tsx filename="features/deployments/deployments-actions.ts" highlight={1,7}
 'use server'
@@ -354,7 +354,7 @@ Source: [`steps/05-mutations`](https://github.com/vercel-labs/thinking-in-nextjs
 
 Every click still waits for a full server round trip. The pin doesn't flip until the server confirms, the deploy button sits unresponsive, and search submits the whole form.
 
-Where should the client boundary go? The instinct from client-first React is to put `'use client'` at the page level, but that pulls the entire subtree into the browser. The boundary can go on the leaf instead.
+Where should the client boundary go? The instinct from client-first React is to put [`'use client'`](/docs/app/api-reference/directives/use-client) at the page level, but that pulls the entire subtree into the browser. The boundary can go on the leaf instead. The [Server and Client Components](/docs/app/getting-started/server-and-client-components) guide covers the model in depth.
 
 | Control         | Updates on        | Needs client |
 | --------------- | ----------------- | ------------ |
@@ -424,7 +424,7 @@ function ProjectPin({ projectId, pinnedIdsPromise }) {
 }
 ```
 
-Search keeps the same server read from `searchParams`. The client input pushes the next URL as the user types:
+Search keeps the same server read from `searchParams`. The client input pushes the next URL as the user types via [`useRouter`](/docs/app/api-reference/functions/use-router) and [`useSearchParams`](/docs/app/api-reference/functions/use-search-params):
 
 ```tsx filename="features/projects/components/SearchBar.tsx" highlight={9,18}
 'use client'
@@ -519,7 +519,7 @@ Client Components fixed input feedback. Why does the route still flash skeletons
 
 ### Enable Cache Components
 
-[`cacheComponents`](/docs/app/api-reference/config/next-config-js/cacheComponents) enables caching at the component and function level:
+[`cacheComponents`](/docs/app/api-reference/config/next-config-js/cacheComponents) enables caching at the component and function level. In a real app you'd turn this on from the start. The full story is in [Caching](/docs/app/getting-started/caching), which is worth reading once before reaching for the directives below.
 
 ```ts filename="next.config.ts" highlight={4}
 import type { NextConfig } from 'next'
@@ -539,7 +539,7 @@ With it on, data fetching stays **dynamic by default**. If a read blocks the sta
 
 For route params specifically, [`generateStaticParams`](/docs/app/api-reference/functions/generateStaticParams) is a fourth option: prerender each page at build time so the param values are baked in.
 
-Because each component already fetches its own data and pages already place deliberate `<Suspense>` boundaries, only a few spots need fixing. On the detail pages, `await params` at the top blocks the shell. The page can switch to `.then()` instead, keeping the page function synchronous and moving the params resolution inside a `<Suspense>` boundary:
+Because each component already fetches its own data and pages already place deliberate `<Suspense>` boundaries, only a few spots need fixing. The dev overlay flags `await params` at the top of the detail pages: it blocks the whole route from [Partial Prerendering](/docs/app/glossary#partial-prerendering-ppr) because nothing above it can be served until the request arrives. The page can switch to `.then()` instead, keeping the page function synchronous and moving the params resolution inside a `<Suspense>` boundary:
 
 ```tsx filename="app/projects/[id]/page.tsx" highlight={4}
 export default function ProjectDetailPage({
@@ -671,7 +671,7 @@ The cache is set up, but the visible paint hasn't changed for sections waiting o
 
 ### Prefetch runtime data
 
-Prefetching is what fills cache entries before the click. By default, [`<Link>`](/docs/app/api-reference/components/link) prefetches its destinations against build-time inputs only when they enter the viewport, which covers the static shell and any cached read keyed on build-time inputs.
+Prefetching is what fills cache entries before the click. By default, [`<Link>`](/docs/app/api-reference/components/link) prefetches its destinations against build-time inputs only when they enter the viewport, which covers the static shell and any cached read keyed on build-time inputs. See [Prefetching](/docs/app/guides/prefetching) for the default behavior.
 
 [Runtime prefetch](/docs/app/guides/runtime-prefetching) does the render with the real cookies, headers, and `searchParams` the navigation would carry, then stores the result in the [Client Cache](/docs/app/glossary#client-cache). It's the same skip-recomputation goal as the server cache, only filled before the click instead of during it.
 


### PR DESCRIPTION
### What?

A new "Thinking in Next.js" guide that walks through building a small Vercel-style projects dashboard one decision at a time, mirroring the structure of React's [Thinking in React](https://react.dev/learn/thinking-in-react).

### Why?

Help readers form a mental model of App Router apps as components that decide where their data comes from, what gets reused, and what stays in the browser. The progression covers the eight choices each component answers: hierarchy, static JSX, data fetching, streaming, mutations, client interactivity, caching, and prefetching.

### How?

- New MDX guide at `docs/01-app/02-guides/thinking-in-nextjs.mdx`, sitting alongside `instant-navigation.mdx`, `forms.mdx`, etc.
- Companion runnable app per step lives at [`vercel-labs/thinking-in-nextjs`](https://github.com/vercel-labs/thinking-in-nextjs) with one folder per guide step, deployed under `*.labs.vercel.dev` and embedded via `<Demo />` in each step. Final step: https://thinking-in-nextjs.labs.vercel.dev/
- Mockup images uploaded to the docs blob at `/docs/guides/thinking-in-nextjs/`.