### PR TITLE
server: warn when NEXT_PRIVATE_TEST_HEADERS is set in production

### DIFF
--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -99,6 +99,17 @@ export async function initialize(opts: {
     process.env.NODE_ENV = opts.dev ? 'development' : 'production'
   }
 
+  if (
+    process.env.NEXT_PRIVATE_TEST_HEADERS &&
+    process.env.NODE_ENV === 'production'
+  ) {
+    Log.warn(
+      '`NEXT_PRIVATE_TEST_HEADERS` is set in a production environment. ' +
+        'Internal header filtering is disabled, which may expose security vulnerabilities. ' +
+        'This environment variable should only be used in test environments.'
+    )
+  }
+
   let experimentalFeatures: ConfiguredExperimentalFeature[] = []
   const config = await loadConfig(
     opts.dev ? PHASE_DEVELOPMENT_SERVER : PHASE_PRODUCTION_SERVER,


### PR DESCRIPTION
## Summary

Fixes #93440

When `NEXT_PRIVATE_TEST_HEADERS` is set, `filterInternalHeaders()` is skipped entirely, allowing internal-only headers (e.g. `x-middleware-rewrite`, `x-matched-path`) to pass through unfiltered. This is intentional for test environments but dangerous in production.

This PR adds a startup warning when `NEXT_PRIVATE_TEST_HEADERS` is detected in a `NODE_ENV=production` environment, so operators are alerted that internal header filtering is disabled.

## Changes

- `packages/next/src/server/lib/router-server.ts`: Emit `Log.warn` once during `initialize()` when `NEXT_PRIVATE_TEST_HEADERS` is set and `NODE_ENV === 'production'`

## Test plan

- [ ] Start a production server with `NEXT_PRIVATE_TEST_HEADERS=1 NODE_ENV=production` and confirm the warning appears in the startup logs
- [ ] Start without the env var and confirm no warning is emitted
- [ ] Start in development mode with the env var set and confirm no warning is emitted

<!-- NEXT_JS_LLM_PR -->