### PR TITLE
[ci] Move Turbopack, Rspack and font data workflows off of `RELEASE_BOT_GITHUB_TOKEN`

### DIFF
--- a/.github/workflows/rspack-update-tests-manifest.yml
+++ b/.github/workflows/rspack-update-tests-manifest.yml
@@ -13,12 +13,30 @@ jobs:
     if: github.repository_owner == 'vercel'
     runs-on: ubuntu-latest
     steps:
+      - name: Create GitHub App token
+        id: release-app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.RELEASE_GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: next.js
+          permission-contents: write
+
+      - name: Get GitHub App user ID
+        id: release-app-user
+        run: |
+          user_id="$(gh api "/users/${{ steps.release-app-token.outputs.app-slug }}[bot]" --jq .id)"
+          echo "user-id=$user_id" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.release-app-token.outputs.token }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           # Commits made with the default `GITHUB_TOKEN` won't trigger workflows.
           # See: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
-          token: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
+          token: ${{ steps.release-app-token.outputs.token }}
 
       - name: Setup node
         uses: actions/setup-node@v4
@@ -39,7 +57,10 @@ jobs:
         shell: bash
         run: node scripts/automated-update-workflow.js
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}
+          RELEASE_GITHUB_TOKEN: ${{ steps.release-app-token.outputs.token }}
+          RELEASE_GITHUB_APP_SLUG: ${{ steps.release-app-token.outputs.app-slug }}
+          RELEASE_GITHUB_APP_USER_ID: ${{ steps.release-app-user.outputs.user-id }}
+          PR_GITHUB_TOKEN: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}
           BRANCH_NAME: rspack-manifest
           # We need to use `--override` for rspack (but not for turbopack).
           # We don't currently have any CI running on every PR, so it's quite
@@ -53,12 +74,30 @@ jobs:
     if: github.repository_owner == 'vercel'
     runs-on: ubuntu-latest
     steps:
+      - name: Create GitHub App token
+        id: release-app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.RELEASE_GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: next.js
+          permission-contents: write
+
+      - name: Get GitHub App user ID
+        id: release-app-user
+        run: |
+          user_id="$(gh api "/users/${{ steps.release-app-token.outputs.app-slug }}[bot]" --jq .id)"
+          echo "user-id=$user_id" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.release-app-token.outputs.token }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           # Commits made with the default `GITHUB_TOKEN` won't trigger workflows.
           # See: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
-          token: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
+          token: ${{ steps.release-app-token.outputs.token }}
 
       - name: Setup node
         uses: actions/setup-node@v4
@@ -79,7 +118,10 @@ jobs:
         shell: bash
         run: node scripts/automated-update-workflow.js
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}
+          RELEASE_GITHUB_TOKEN: ${{ steps.release-app-token.outputs.token }}
+          RELEASE_GITHUB_APP_SLUG: ${{ steps.release-app-token.outputs.app-slug }}
+          RELEASE_GITHUB_APP_USER_ID: ${{ steps.release-app-user.outputs.user-id }}
+          PR_GITHUB_TOKEN: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}
           BRANCH_NAME: rspack-manifest
           SCRIPT: test/update-bundler-manifest.js --bundler rspack --test-suite build --override
           PR_TITLE: Update Rspack production test manifest

--- a/.github/workflows/turbopack-update-tests-manifest.yml
+++ b/.github/workflows/turbopack-update-tests-manifest.yml
@@ -13,12 +13,30 @@ jobs:
     if: github.repository_owner == 'vercel'
     runs-on: ubuntu-latest
     steps:
+      - name: Create GitHub App token
+        id: release-app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.RELEASE_GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: next.js
+          permission-contents: write
+
+      - name: Get GitHub App user ID
+        id: release-app-user
+        run: |
+          user_id="$(gh api "/users/${{ steps.release-app-token.outputs.app-slug }}[bot]" --jq .id)"
+          echo "user-id=$user_id" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.release-app-token.outputs.token }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           # Commits made with the default `GITHUB_TOKEN` won't trigger workflows.
           # See: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
-          token: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
+          token: ${{ steps.release-app-token.outputs.token }}
 
       - name: Setup node
         uses: actions/setup-node@v4
@@ -39,7 +57,10 @@ jobs:
         shell: bash
         run: node scripts/automated-update-workflow.js
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}
+          RELEASE_GITHUB_TOKEN: ${{ steps.release-app-token.outputs.token }}
+          RELEASE_GITHUB_APP_SLUG: ${{ steps.release-app-token.outputs.app-slug }}
+          RELEASE_GITHUB_APP_USER_ID: ${{ steps.release-app-user.outputs.user-id }}
+          PR_GITHUB_TOKEN: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}
           BRANCH_NAME: turbopack-manifest
           SCRIPT: test/update-bundler-manifest.js --bundler turbopack --test-suite dev
           PR_TITLE: Update Turbopack development test manifest
@@ -49,12 +70,30 @@ jobs:
     if: github.repository_owner == 'vercel'
     runs-on: ubuntu-latest
     steps:
+      - name: Create GitHub App token
+        id: release-app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.RELEASE_GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: next.js
+          permission-contents: write
+
+      - name: Get GitHub App user ID
+        id: release-app-user
+        run: |
+          user_id="$(gh api "/users/${{ steps.release-app-token.outputs.app-slug }}[bot]" --jq .id)"
+          echo "user-id=$user_id" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.release-app-token.outputs.token }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           # Commits made with the default `GITHUB_TOKEN` won't trigger workflows.
           # See: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
-          token: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
+          token: ${{ steps.release-app-token.outputs.token }}
 
       - name: Setup node
         uses: actions/setup-node@v4
@@ -75,7 +114,10 @@ jobs:
         shell: bash
         run: node scripts/automated-update-workflow.js
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}
+          RELEASE_GITHUB_TOKEN: ${{ steps.release-app-token.outputs.token }}
+          RELEASE_GITHUB_APP_SLUG: ${{ steps.release-app-token.outputs.app-slug }}
+          RELEASE_GITHUB_APP_USER_ID: ${{ steps.release-app-user.outputs.user-id }}
+          PR_GITHUB_TOKEN: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}
           BRANCH_NAME: turbopack-manifest
           SCRIPT: test/update-bundler-manifest.js --bundler turbopack --test-suite build
           PR_TITLE: Update Turbopack production test manifest

--- a/.github/workflows/update_fonts_data.yml
+++ b/.github/workflows/update_fonts_data.yml
@@ -15,12 +15,30 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'vercel'
     steps:
+      - name: Create GitHub App token
+        id: release-app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.RELEASE_GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: next.js
+          permission-contents: write
+
+      - name: Get GitHub App user ID
+        id: release-app-user
+        run: |
+          user_id="$(gh api "/users/${{ steps.release-app-token.outputs.app-slug }}[bot]" --jq .id)"
+          echo "user-id=$user_id" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.release-app-token.outputs.token }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           # Commits made with the default `GITHUB_TOKEN` won't trigger workflows.
           # See: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
-          token: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
+          token: ${{ steps.release-app-token.outputs.token }}
 
       - name: Setup node
         uses: actions/setup-node@v4
@@ -41,7 +59,10 @@ jobs:
         shell: bash
         run: node scripts/automated-update-workflow.js
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}
+          RELEASE_GITHUB_TOKEN: ${{ steps.release-app-token.outputs.token }}
+          RELEASE_GITHUB_APP_SLUG: ${{ steps.release-app-token.outputs.app-slug }}
+          RELEASE_GITHUB_APP_USER_ID: ${{ steps.release-app-user.outputs.user-id }}
+          PR_GITHUB_TOKEN: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}
           BRANCH_NAME: fonts-data
           SCRIPT: scripts/update-google-fonts.js
           PR_TITLE: Update font data

--- a/scripts/automated-update-workflow.js
+++ b/scripts/automated-update-workflow.js
@@ -1,19 +1,37 @@
+// @ts-check
 const { promisify } = require('util')
 const { Octokit } = require('octokit')
 const { exec: execOriginal } = require('child_process')
+const {
+  createSignedCommit,
+  upsertBranchRef,
+} = require('./github-utils/signed-commit')
 
 const exec = promisify(execOriginal)
 
 const {
-  GITHUB_TOKEN = '',
+  RELEASE_GITHUB_TOKEN = '',
+  PR_GITHUB_TOKEN = '',
+  RELEASE_GITHUB_APP_SLUG = '',
+  RELEASE_GITHUB_APP_USER_ID = '',
   SCRIPT = '',
   BRANCH_NAME = 'unknown',
   PR_TITLE = 'Automated update',
   PR_BODY = '',
 } = process.env
 
-if (!GITHUB_TOKEN) {
-  console.log('missing GITHUB_TOKEN env')
+if (!RELEASE_GITHUB_TOKEN) {
+  console.log('missing RELEASE_GITHUB_TOKEN env')
+  process.exit(1)
+}
+if (!PR_GITHUB_TOKEN) {
+  console.log('missing PR_GITHUB_TOKEN env')
+  process.exit(1)
+}
+if (!RELEASE_GITHUB_APP_SLUG || !RELEASE_GITHUB_APP_USER_ID) {
+  console.log(
+    'missing RELEASE_GITHUB_APP_SLUG or RELEASE_GITHUB_APP_USER_ID env'
+  )
   process.exit(1)
 }
 if (!SCRIPT) {
@@ -21,14 +39,19 @@ if (!SCRIPT) {
   process.exit(1)
 }
 
+const REPO_OWNER = 'vercel'
+const REPO_NAME = 'next.js'
+
 async function main() {
-  const octokit = new Octokit({ auth: GITHUB_TOKEN })
+  const octokit = new Octokit({ auth: PR_GITHUB_TOKEN })
   const branchName = `update/${BRANCH_NAME}-${Date.now()}`
+  const botUserName = `${RELEASE_GITHUB_APP_SLUG}[bot]`
+  const botUserEmail = `${RELEASE_GITHUB_APP_USER_ID}+${RELEASE_GITHUB_APP_SLUG}[bot]@users.noreply.github.com`
 
   await exec(`node ${SCRIPT}`)
 
-  await exec(`git config user.name "nextjs-bot"`)
-  await exec(`git config user.email "it+nextjs-bot@vercel.com"`)
+  await exec(`git config user.name "${botUserName}"`)
+  await exec(`git config user.email "${botUserEmail}"`)
   await exec(`git checkout -b ${branchName}`)
   await exec(`git add -A`)
   await exec(`git commit --message ${branchName}`)
@@ -43,14 +66,33 @@ async function main() {
     return
   }
 
-  await exec(`git push origin ${branchName}`)
+  // Branch protection requires signed commits, so push the local commit to
+  // the remote as a GitHub-signed commit via the REST API instead of
+  // running `git push` (which would push an unsigned commit). The branch
+  // name is unique per run, so this always creates a fresh ref.
+  const baseSha = (await exec(`git rev-parse HEAD~1`)).stdout.trim()
+  const localCommitSha = (await exec(`git rev-parse HEAD`)).stdout.trim()
 
-  const repo = 'next.js'
-  const owner = 'vercel'
+  const signedCommit = await createSignedCommit({
+    token: RELEASE_GITHUB_TOKEN,
+    owner: REPO_OWNER,
+    repo: REPO_NAME,
+    baseSha,
+    localCommitSha,
+    message: branchName,
+  })
+
+  await upsertBranchRef({
+    token: RELEASE_GITHUB_TOKEN,
+    owner: REPO_OWNER,
+    repo: REPO_NAME,
+    branch: branchName,
+    sha: signedCommit.sha,
+  })
 
   const { data: pullRequests } = await octokit.rest.pulls.list({
-    owner,
-    repo,
+    owner: REPO_OWNER,
+    repo: REPO_NAME,
     state: 'open',
     sort: 'created',
     direction: 'desc',
@@ -58,8 +100,8 @@ async function main() {
   })
 
   const pullRequest = await octokit.rest.pulls.create({
-    owner,
-    repo,
+    owner: REPO_OWNER,
+    repo: REPO_NAME,
     head: branchName,
     base: 'canary',
     title: PR_TITLE,
@@ -67,8 +109,8 @@ async function main() {
   })
 
   await octokit.rest.issues.addLabels({
-    owner,
-    repo,
+    owner: REPO_OWNER,
+    repo: REPO_NAME,
     issue_number: pullRequest.data.number,
     labels: ['run-react-18-tests'],
   })
@@ -76,7 +118,7 @@ async function main() {
   console.log('Created pull request', pullRequest.url)
 
   const previousPullRequests = pullRequests.filter(({ title, user }) => {
-    return title.includes(PR_TITLE) && user.login === 'nextjs-bot'
+    return title.includes(PR_TITLE) && user.login === botUserName
   })
 
   if (previousPullRequests.length) {
@@ -86,8 +128,8 @@ async function main() {
       )
 
       await octokit.rest.pulls.update({
-        owner,
-        repo,
+        owner: REPO_OWNER,
+        repo: REPO_NAME,
         pull_number: previousPullRequest.number,
         state: 'closed',
       })

--- a/scripts/automated-update-workflow.js
+++ b/scripts/automated-update-workflow.js
@@ -28,10 +28,12 @@ if (!PR_GITHUB_TOKEN) {
   console.log('missing PR_GITHUB_TOKEN env')
   process.exit(1)
 }
-if (!RELEASE_GITHUB_APP_SLUG || !RELEASE_GITHUB_APP_USER_ID) {
-  console.log(
-    'missing RELEASE_GITHUB_APP_SLUG or RELEASE_GITHUB_APP_USER_ID env'
-  )
+if (!RELEASE_GITHUB_APP_SLUG) {
+  console.log('missing RELEASE_GITHUB_APP_SLUG env')
+  process.exit(1)
+}
+if (!RELEASE_GITHUB_APP_USER_ID) {
+  console.log('missing RELEASE_GITHUB_APP_USER_ID env')
   process.exit(1)
 }
 if (!SCRIPT) {

--- a/scripts/github-utils/signed-commit.js
+++ b/scripts/github-utils/signed-commit.js
@@ -1,0 +1,260 @@
+// @ts-check
+
+const execa = require('execa')
+
+/**
+ * Call the GitHub REST API and include response bodies in thrown errors so
+ * workflow failures show actionable details.
+ */
+async function githubRequest(token, method, path, body) {
+  const response = await fetch(`https://api.github.com${path}`, {
+    method,
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${token}`,
+      'X-GitHub-Api-Version': '2022-11-28',
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  })
+
+  if (!response.ok) {
+    const responseText = await response.text()
+
+    throw new Error(
+      `GitHub API ${method} ${path} failed (${response.status}): ${responseText}`
+    )
+  }
+
+  if (response.status === 204) {
+    return null
+  }
+
+  return response.json()
+}
+
+async function git(args, options = {}) {
+  const { captureOutput = false, ...execaOptions } = options
+  const { stdout } = await execa('git', args, {
+    stdio: captureOutput ? 'pipe' : 'inherit',
+    ...execaOptions,
+  })
+
+  return typeof stdout === 'string' ? stdout.trim() : stdout
+}
+
+/**
+ * List paths changed between two commits, using "\0" delimiters so unusual
+ * file names do not affect parsing.
+ */
+async function getChangedFiles(baseSha, headSha) {
+  const stdout = await git(
+    ['diff-tree', '-r', '--name-only', '--no-renames', '-z', baseSha, headSha],
+    { captureOutput: true, encoding: 'utf8' }
+  )
+
+  return String(stdout).split('\0').filter(Boolean)
+}
+
+/**
+ * Read the Git tree metadata for a path so recreated tree entries preserve
+ * file modes, blob types, and submodule commit pointers.
+ */
+async function getTreeEntry(commitSha, filePath) {
+  const stdout = await git(['ls-tree', '-z', commitSha, '--', filePath], {
+    captureOutput: true,
+    encoding: 'utf8',
+  })
+
+  if (!stdout) {
+    return null
+  }
+
+  // git ls-tree -z emits "<mode> <type> <object>\t<path>\0".
+  const match = /^(\d{6}) (\w+) ([0-9a-f]{40})\t/.exec(String(stdout))
+
+  if (!match) {
+    throw new Error(`Failed to parse git tree entry for ${filePath}`)
+  }
+
+  return {
+    mode: match[1],
+    type: match[2],
+    sha: match[3],
+  }
+}
+
+/**
+ * Upload one file from a local commit as a GitHub blob and return the blob
+ * SHA for the recreated tree entry.
+ */
+async function createBlobForFile(token, repoApiPath, commitSha, filePath) {
+  const content = await git(['show', `${commitSha}:${filePath}`], {
+    captureOutput: true,
+    encoding: null,
+    stripFinalNewline: false,
+    maxBuffer: 1024 * 1024 * 100,
+  })
+  const blob = await githubRequest(token, 'POST', `${repoApiPath}/git/blobs`, {
+    content: Buffer.from(content).toString('base64'),
+    encoding: 'base64',
+  })
+
+  return blob.sha
+}
+
+/**
+ * Build a GitHub tree matching a local commit, creating new blob objects for
+ * changed files in parallel while preserving deletions and submodules.
+ */
+async function createTreeFromLocalCommit({
+  token,
+  repoApiPath,
+  baseSha,
+  localCommitSha,
+}) {
+  const baseTreeSha = await git(['rev-parse', `${baseSha}^{tree}`], {
+    captureOutput: true,
+  })
+  const changedFiles = await getChangedFiles(baseSha, localCommitSha)
+
+  if (changedFiles.length === 0) {
+    throw new Error(`Commit ${localCommitSha} has no file changes`)
+  }
+
+  const tree = await Promise.all(
+    changedFiles.map(async (filePath) => {
+      const treeEntry = await getTreeEntry(localCommitSha, filePath)
+
+      if (!treeEntry) {
+        return {
+          path: filePath,
+          sha: null,
+        }
+      }
+
+      if (treeEntry.type === 'commit') {
+        return {
+          path: filePath,
+          mode: treeEntry.mode,
+          type: treeEntry.type,
+          sha: treeEntry.sha,
+        }
+      }
+
+      const blobSha = await createBlobForFile(
+        token,
+        repoApiPath,
+        localCommitSha,
+        filePath
+      )
+
+      return {
+        path: filePath,
+        mode: treeEntry.mode,
+        type: treeEntry.type,
+        sha: blobSha,
+      }
+    })
+  )
+
+  const createdTree = await githubRequest(
+    token,
+    'POST',
+    `${repoApiPath}/git/trees`,
+    {
+      base_tree: baseTreeSha,
+      tree,
+    }
+  )
+
+  return createdTree.sha
+}
+
+/**
+ * Build a GitHub tree from the local commit's diff against `baseSha`, then
+ * create a GitHub-signed commit on top of `baseSha`. Returns the new commit
+ * payload (including `sha`). Verifies `verification.verified`.
+ */
+async function createSignedCommit({
+  token,
+  owner,
+  repo,
+  baseSha,
+  localCommitSha,
+  message,
+}) {
+  const repoApiPath = `/repos/${owner}/${repo}`
+
+  const treeSha = await createTreeFromLocalCommit({
+    token,
+    repoApiPath,
+    baseSha,
+    localCommitSha,
+  })
+
+  const commit = await githubRequest(
+    token,
+    'POST',
+    `${repoApiPath}/git/commits`,
+    {
+      message,
+      tree: treeSha,
+      parents: [baseSha],
+    }
+  )
+
+  if (!commit.verification?.verified) {
+    throw new Error(
+      `GitHub API created unsigned commit ${commit.sha}: ${commit.verification?.reason}`
+    )
+  }
+
+  return commit
+}
+
+/**
+ * Refresh local refs after API writes so subsequent steps see the
+ * GitHub-signed commit instead of the unsigned local commit. Optionally also
+ * fetches a freshly created tag.
+ */
+async function alignLocalBranchWithSignedCommit(
+  branch,
+  commitSha,
+  options = {}
+) {
+  const { tagName } = options
+
+  if (tagName) {
+    const tagExists = await execa(
+      'git',
+      ['show-ref', '--verify', '--quiet', `refs/tags/${tagName}`],
+      {
+        stdio: 'ignore',
+        reject: false,
+      }
+    )
+
+    if (tagExists.exitCode === 0) {
+      await git(['tag', '-d', tagName])
+    }
+  }
+
+  const fetchRefs = [`refs/heads/${branch}:refs/remotes/origin/${branch}`]
+  if (tagName) {
+    fetchRefs.push(`refs/tags/${tagName}:refs/tags/${tagName}`)
+  }
+
+  await git(['fetch', 'origin', ...fetchRefs])
+  await git(['reset', '--hard', commitSha])
+}
+
+module.exports = {
+  githubRequest,
+  getChangedFiles,
+  getTreeEntry,
+  createBlobForFile,
+  createTreeFromLocalCommit,
+  createSignedCommit,
+  alignLocalBranchWithSignedCommit,
+}

--- a/scripts/github-utils/signed-commit.js
+++ b/scripts/github-utils/signed-commit.js
@@ -214,6 +214,47 @@ async function createSignedCommit({
 }
 
 /**
+ * Create the branch ref if it does not exist, otherwise fast-forward (or
+ * `force`-update) it to the given commit SHA.
+ */
+async function upsertBranchRef({
+  token,
+  owner,
+  repo,
+  branch,
+  sha,
+  force = false,
+}) {
+  const repoApiPath = `/repos/${owner}/${repo}`
+
+  try {
+    await githubRequest(token, 'POST', `${repoApiPath}/git/refs`, {
+      ref: `refs/heads/${branch}`,
+      sha,
+    })
+    return { created: true }
+  } catch (error) {
+    const errMessage = error instanceof Error ? error.message : String(error)
+
+    if (!errMessage.includes('Reference already exists')) {
+      throw error
+    }
+
+    await githubRequest(
+      token,
+      'PATCH',
+      `${repoApiPath}/git/refs/heads/${branch}`,
+      {
+        sha,
+        force,
+      }
+    )
+
+    return { created: false }
+  }
+}
+
+/**
  * Refresh local refs after API writes so subsequent steps see the
  * GitHub-signed commit instead of the unsigned local commit. Optionally also
  * fetches a freshly created tag.
@@ -256,5 +297,6 @@ module.exports = {
   createBlobForFile,
   createTreeFromLocalCommit,
   createSignedCommit,
+  upsertBranchRef,
   alignLocalBranchWithSignedCommit,
 }

--- a/scripts/release-github-api.js
+++ b/scripts/release-github-api.js
@@ -2,6 +2,11 @@
 
 const execa = require('execa')
 const fs = require('fs/promises')
+const {
+  createSignedCommit,
+  githubRequest,
+  alignLocalBranchWithSignedCommit,
+} = require('./github-utils/signed-commit')
 
 const REPO_API_PATH = '/repos/vercel/next.js'
 
@@ -13,37 +18,6 @@ async function git(args, options = {}) {
   })
 
   return typeof stdout === 'string' ? stdout.trim() : stdout
-}
-
-/**
- * Call the GitHub REST API with the release app token and include response
- * bodies in thrown errors so workflow failures show actionable details.
- */
-async function githubRequest(token, method, path, body) {
-  const response = await fetch(`https://api.github.com${path}`, {
-    method,
-    headers: {
-      Accept: 'application/vnd.github+json',
-      Authorization: `Bearer ${token}`,
-      'X-GitHub-Api-Version': '2022-11-28',
-      ...(body ? { 'Content-Type': 'application/json' } : {}),
-    },
-    body: body ? JSON.stringify(body) : undefined,
-  })
-
-  if (!response.ok) {
-    const responseText = await response.text()
-
-    throw new Error(
-      `GitHub API ${method} ${path} failed (${response.status}): ${responseText}`
-    )
-  }
-
-  if (response.status === 204) {
-    return null
-  }
-
-  return response.json()
 }
 
 /**
@@ -94,164 +68,6 @@ async function getSingleParent(commitSha) {
 }
 
 /**
- * List paths changed by the local release commit, using "\0" delimiters so
- * unusual file names do not affect parsing.
- */
-async function getChangedFiles(baseSha, headSha) {
-  const stdout = await git(
-    ['diff-tree', '-r', '--name-only', '--no-renames', '-z', baseSha, headSha],
-    { captureOutput: true, encoding: 'utf8' }
-  )
-
-  return String(stdout).split('\0').filter(Boolean)
-}
-
-/**
- * Read the Git tree metadata for a path so recreated tree entries preserve
- * file modes, blob types, and submodule commit pointers.
- */
-async function getTreeEntry(commitSha, filePath) {
-  const stdout = await git(['ls-tree', '-z', commitSha, '--', filePath], {
-    captureOutput: true,
-    encoding: 'utf8',
-  })
-
-  if (!stdout) {
-    return null
-  }
-
-  // Reuse the existing Git object metadata for this path when building the
-  // GitHub tree payload. git ls-tree -z emits "<mode> <type> <object>\t<path>\0".
-  const match = /^(\d{6}) (\w+) ([0-9a-f]{40})\t/.exec(String(stdout))
-
-  if (!match) {
-    throw new Error(`Failed to parse git tree entry for ${filePath}`)
-  }
-
-  return {
-    mode: match[1],
-    type: match[2],
-    sha: match[3],
-  }
-}
-
-/**
- * Upload one file from the local release commit as a GitHub blob and return
- * the blob SHA for the recreated tree entry.
- */
-async function createBlobForFile(token, commitSha, filePath) {
-  const content = await git(['show', `${commitSha}:${filePath}`], {
-    captureOutput: true,
-    encoding: null,
-    stripFinalNewline: false,
-    maxBuffer: 1024 * 1024 * 100,
-  })
-  const blob = await githubRequest(
-    token,
-    'POST',
-    `${REPO_API_PATH}/git/blobs`,
-    {
-      content: Buffer.from(content).toString('base64'),
-      encoding: 'base64',
-    }
-  )
-
-  return blob.sha
-}
-
-/**
- * Build a GitHub tree matching the local Lerna release commit, creating new
- * blob objects for changed files in parallel while preserving deletions and
- * submodules.
- */
-async function createTreeFromLocalCommit({ token, baseSha, localReleaseSha }) {
-  const baseTreeSha = await git(['rev-parse', `${baseSha}^{tree}`], {
-    captureOutput: true,
-  })
-  const changedFiles = await getChangedFiles(baseSha, localReleaseSha)
-
-  if (changedFiles.length === 0) {
-    throw new Error(`Release commit ${localReleaseSha} has no file changes`)
-  }
-
-  const tree = await Promise.all(
-    changedFiles.map(async (filePath) => {
-      const treeEntry = await getTreeEntry(localReleaseSha, filePath)
-
-      if (!treeEntry) {
-        return {
-          path: filePath,
-          sha: null,
-        }
-      }
-
-      if (treeEntry.type === 'commit') {
-        return {
-          path: filePath,
-          mode: treeEntry.mode,
-          type: treeEntry.type,
-          sha: treeEntry.sha,
-        }
-      }
-
-      const blobSha = await createBlobForFile(token, localReleaseSha, filePath)
-
-      return {
-        path: filePath,
-        mode: treeEntry.mode,
-        type: treeEntry.type,
-        sha: blobSha,
-      }
-    })
-  )
-
-  const createdTree = await githubRequest(
-    token,
-    'POST',
-    `${REPO_API_PATH}/git/trees`,
-    {
-      base_tree: baseTreeSha,
-      tree,
-    }
-  )
-
-  return createdTree.sha
-}
-
-/**
- * Refresh local refs after the API writes so later release steps see the
- * GitHub-signed commit and tag instead of Lerna's unsigned local commit.
- */
-async function alignLocalBranchWithGitHubReleaseCommit(
-  branch,
-  tagName,
-  commitSha
-) {
-  const tagExists = await execa(
-    'git',
-    ['show-ref', '--verify', '--quiet', `refs/tags/${tagName}`],
-    {
-      stdio: 'ignore',
-      reject: false,
-    }
-  )
-
-  if (tagExists.exitCode === 0) {
-    await git(['tag', '-d', tagName])
-  } else {
-    console.log(`Local tag ${tagName} does not exist; skipping delete`)
-  }
-
-  await git([
-    'fetch',
-    'origin',
-    `refs/heads/${branch}:refs/remotes/origin/${branch}`,
-    `refs/tags/${tagName}:refs/tags/${tagName}`,
-  ])
-  await git(['reset', '--hard', commitSha])
-}
-
-/**
  * Replace Lerna's local release commit with an equivalent GitHub-signed commit,
  * then move the release tag and current branch to that new commit.
  */
@@ -277,27 +93,14 @@ async function createGitHubReleaseCommit(token) {
     `Creating GitHub-signed release commit for ${tagName} from local Lerna commit ${localReleaseSha}`
   )
 
-  const treeSha = await createTreeFromLocalCommit({
+  const commit = await createSignedCommit({
     token,
+    owner: 'vercel',
+    repo: 'next.js',
     baseSha,
-    localReleaseSha,
+    localCommitSha: localReleaseSha,
+    message,
   })
-  const commit = await githubRequest(
-    token,
-    'POST',
-    `${REPO_API_PATH}/git/commits`,
-    {
-      message,
-      tree: treeSha,
-      parents: [baseSha],
-    }
-  )
-
-  if (!commit.verification?.verified) {
-    throw new Error(
-      `GitHub API created unsigned release commit ${commit.sha}: ${commit.verification?.reason}`
-    )
-  }
 
   let createdTag = false
 
@@ -332,7 +135,7 @@ async function createGitHubReleaseCommit(token) {
     throw error
   }
 
-  await alignLocalBranchWithGitHubReleaseCommit(branch, tagName, commit.sha)
+  await alignLocalBranchWithSignedCommit(branch, commit.sha, { tagName })
 
   console.log(
     `Created GitHub-signed release commit ${commit.sha} and tag ${tagName}`


### PR DESCRIPTION
`RELEASE_BOT_GITHUB_TOKEN` is no longer working. Instead we use a dedicated GH app to push, sign and create commits that trigger workflows.

Based off of https://github.com/vercel/next.js/pull/93245

I extracted https://github.com/vercel/next.js/pull/93285 into separate utils since we're no using those in 4 places (5 once I migrated the React sync which requires more work).