### PR TITLE
[ci] Migrate React sync off of `RELEASE_BOT_GITHUB_TOKEN`

### DIFF
--- a/.github/workflows/update_react.yml
+++ b/.github/workflows/update_react.yml
@@ -21,17 +21,30 @@ jobs:
   create-pull-request:
     runs-on: ubuntu-latest
     steps:
+      - name: Create GitHub App token
+        id: release-app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.RELEASE_GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: next.js
+          permission-contents: write
+
+      - name: Get GitHub App user ID
+        id: release-app-user
+        run: |
+          user_id="$(gh api "/users/${{ steps.release-app-token.outputs.app-slug }}[bot]" --jq .id)"
+          echo "user-id=$user_id" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.release-app-token.outputs.token }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           # Commits made with the default `GITHUB_TOKEN` won't trigger workflows.
           # See: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
-          token: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
-
-      - name: Set Git author
-        run: |
-          git config user.name "nextjs-bot"
-          git config user.email "it+nextjs-bot@vercel.com"
+          token: ${{ steps.release-app-token.outputs.token }}
 
       - name: Setup node
         uses: actions/setup-node@v4
@@ -53,4 +66,7 @@ jobs:
         shell: bash
         run: pnpm sync-react --actor "${{ github.actor }}" --commit --create-pull --version "${{ inputs.version }}"
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}
+          RELEASE_GITHUB_TOKEN: ${{ steps.release-app-token.outputs.token }}
+          RELEASE_GITHUB_APP_SLUG: ${{ steps.release-app-token.outputs.app-slug }}
+          RELEASE_GITHUB_APP_USER_ID: ${{ steps.release-app-user.outputs.user-id }}

--- a/scripts/github-utils/signed-commit.js
+++ b/scripts/github-utils/signed-commit.js
@@ -110,15 +110,19 @@ async function createBlobForFile(token, repoApiPath, commitSha, filePath) {
 async function createTreeFromLocalCommit({
   token,
   repoApiPath,
-  baseSha,
+  diffBaseSha,
+  baseTreeSha,
   localCommitSha,
+  allowEmpty = false,
 }) {
-  const baseTreeSha = await git(['rev-parse', `${baseSha}^{tree}`], {
-    captureOutput: true,
-  })
-  const changedFiles = await getChangedFiles(baseSha, localCommitSha)
+  const changedFiles = await getChangedFiles(diffBaseSha, localCommitSha)
 
   if (changedFiles.length === 0) {
+    if (allowEmpty) {
+      // Nothing changed — reuse the parent tree so the resulting commit is
+      // a no-op.
+      return baseTreeSha
+    }
     throw new Error(`Commit ${localCommitSha} has no file changes`)
   }
 
@@ -183,14 +187,21 @@ async function createSignedCommit({
   baseSha,
   localCommitSha,
   message,
+  allowEmpty = false,
 }) {
   const repoApiPath = `/repos/${owner}/${repo}`
+
+  const baseTreeSha = await git(['rev-parse', `${baseSha}^{tree}`], {
+    captureOutput: true,
+  })
 
   const treeSha = await createTreeFromLocalCommit({
     token,
     repoApiPath,
-    baseSha,
+    diffBaseSha: baseSha,
+    baseTreeSha,
     localCommitSha,
+    allowEmpty,
   })
 
   const commit = await githubRequest(
@@ -211,6 +222,84 @@ async function createSignedCommit({
   }
 
   return commit
+}
+
+/**
+ * Replay every local commit between `fromBaseSha` (exclusive) and
+ * `toLocalSha` (inclusive) as a chain of GitHub-signed commits whose root is
+ * `fromBaseSha` on the remote. Each replayed commit's tree is built by
+ * applying that local commit's file-tree diff (against its local parent) on
+ * top of the previous signed commit's tree. The local commit message is
+ * preserved.
+ *
+ * Returns the SHA of the final signed commit.
+ */
+async function replayLocalCommitsAsSigned({
+  token,
+  owner,
+  repo,
+  fromBaseSha,
+  toLocalSha,
+  allowEmpty = false,
+}) {
+  const repoApiPath = `/repos/${owner}/${repo}`
+
+  const revListOutput = await git(
+    ['rev-list', '--reverse', `${fromBaseSha}..${toLocalSha}`],
+    { captureOutput: true }
+  )
+  const localCommits = String(revListOutput).split('\n').filter(Boolean)
+
+  if (localCommits.length === 0) {
+    throw new Error(
+      `No commits to replay between ${fromBaseSha} and ${toLocalSha}`
+    )
+  }
+
+  let parentSha = fromBaseSha
+  let parentTreeSha = await git(['rev-parse', `${fromBaseSha}^{tree}`], {
+    captureOutput: true,
+  })
+
+  for (const localSha of localCommits) {
+    const localParentSha = await git(['rev-parse', `${localSha}^`], {
+      captureOutput: true,
+    })
+    const message = await git(['log', '-1', '--pretty=%B', localSha], {
+      captureOutput: true,
+    })
+
+    const treeSha = await createTreeFromLocalCommit({
+      token,
+      repoApiPath,
+      diffBaseSha: localParentSha,
+      baseTreeSha: parentTreeSha,
+      localCommitSha: localSha,
+      allowEmpty,
+    })
+
+    const commit = await githubRequest(
+      token,
+      'POST',
+      `${repoApiPath}/git/commits`,
+      {
+        message,
+        tree: treeSha,
+        parents: [parentSha],
+      }
+    )
+
+    if (!commit.verification?.verified) {
+      throw new Error(
+        `GitHub API created unsigned commit ${commit.sha}: ${commit.verification?.reason}`
+      )
+    }
+
+    parentSha = commit.sha
+    parentTreeSha = treeSha
+  }
+
+  return parentSha
 }
 
 /**
@@ -297,6 +386,7 @@ module.exports = {
   createBlobForFile,
   createTreeFromLocalCommit,
   createSignedCommit,
+  replayLocalCommitsAsSigned,
   upsertBranchRef,
   alignLocalBranchWithSignedCommit,
 }

--- a/scripts/release-github-auth.js
+++ b/scripts/release-github-auth.js
@@ -5,13 +5,11 @@ const execa = require('execa')
 const REPO_URL = 'github.com/vercel/next.js.git'
 
 function getGitHubToken() {
-  return (
-    process.env.RELEASE_GITHUB_TOKEN || process.env.RELEASE_BOT_GITHUB_TOKEN
-  )
+  return process.env.RELEASE_GITHUB_TOKEN
 }
 
 function getGitHubTokenMissingMessage() {
-  return 'Missing RELEASE_GITHUB_TOKEN or RELEASE_BOT_GITHUB_TOKEN'
+  return 'Missing RELEASE_GITHUB_TOKEN'
 }
 
 function getGitUser() {

--- a/scripts/sync-react.js
+++ b/scripts/sync-react.js
@@ -8,6 +8,10 @@ const execa = require('execa')
 const { Octokit } = require('octokit')
 const SemVer = require('semver')
 const yargs = require('yargs')
+const {
+  replayLocalCommitsAsSigned,
+  upsertBranchRef,
+} = require('./github-utils/signed-commit')
 
 // Use this script to update Next's vendored copy of React and related packages:
 //
@@ -358,6 +362,32 @@ async function main() {
       `Environment variable 'GITHUB_TOKEN' not specified but required when --create-pull is specified.`
     )
   }
+  const releaseGithubToken = process.env.RELEASE_GITHUB_TOKEN
+  const releaseAppSlug = process.env.RELEASE_GITHUB_APP_SLUG
+  const releaseAppUserId = process.env.RELEASE_GITHUB_APP_USER_ID
+  if (createPull) {
+    if (!releaseGithubToken) {
+      throw new Error(
+        `Environment variable 'RELEASE_GITHUB_TOKEN' not specified but required when --create-pull is specified.`
+      )
+    }
+    if (!releaseAppSlug || !releaseAppUserId) {
+      throw new Error(
+        `Environment variables 'RELEASE_GITHUB_APP_SLUG' and 'RELEASE_GITHUB_APP_USER_ID' must be set when --create-pull is specified.`
+      )
+    }
+
+    // Set the git author up-front so all subsequent local commits made by
+    // this script (intermediate `--commit` steps and the final PR commit)
+    // succeed even on CI runners that don't have a default git identity.
+    // The values themselves are discarded by the GitHub REST API: the
+    // GPG-signed commits on the remote are attributed to the app token's
+    // identity regardless of local git config.
+    const botUserName = `${releaseAppSlug}[bot]`
+    const botUserEmail = `${releaseAppUserId}+${releaseAppSlug}[bot]@users.noreply.github.com`
+    await execa('git', ['config', 'user.name', botUserName])
+    await execa('git', ['config', 'user.email', botUserEmail])
+  }
 
   let newVersionStr = version
   if (
@@ -640,9 +670,38 @@ Or run this command again without the --no-install flag to do both automatically
     await execa('git', ['checkout', '-b', branchName])
     // We didn't commit intermediate steps yet so now we need to commit to create a PR.
     if (!commit) {
-      commitEverything(prTitle)
+      await commitEverything(prTitle)
     }
-    await execa('git', ['push', 'origin', branchName])
+
+    // Branch protection on canary requires signed commits. Push each local
+    // commit to the remote as a GitHub-signed commit via the REST API
+    // instead of `git push` (which would push unsigned commits).
+    const baseRef = process.env.GITHUB_REF_NAME || 'canary'
+    const remoteBaseSha = (
+      await execa('git', ['rev-parse', `origin/${baseRef}`])
+    ).stdout.trim()
+    const localCommitSha = (
+      await execa('git', ['rev-parse', 'HEAD'])
+    ).stdout.trim()
+
+    const finalSignedSha = await replayLocalCommitsAsSigned({
+      token: releaseGithubToken,
+      owner: repoOwner,
+      repo: repoName,
+      fromBaseSha: remoteBaseSha,
+      toLocalSha: localCommitSha,
+      // commitEverything uses --allow-empty for steps that didn't change
+      // any files (e.g. when Pages Router doesn't need a sync); preserve
+      // that on the remote signed commits.
+      allowEmpty: true,
+    })
+    await upsertBranchRef({
+      token: releaseGithubToken,
+      owner: repoOwner,
+      repo: repoName,
+      branch: branchName,
+      sha: finalSignedSha,
+    })
     const pullRequest = await octokit.rest.pulls.create({
       owner: repoOwner,
       repo: repoName,


### PR DESCRIPTION
Same pattern as with the other workflows. However, for easier diffing, automatic React syncs create multiple commits. I had to adjust the signing utils to allow for creating multiple, signed commits.

## Test plan

- [x] Manual workflow run from this branch: https://github.com/vercel/next.js/actions/runs/25314731130/job/74209564080 -> https://github.com/vercel/next.js/pull/93457