### PR TITLE
Trace-server: Fix bottom up, and reduce allocations in turbopack-trace-server bottom-up grouping

### DIFF
--- a/turbopack/crates/turbopack-trace-server/src/bottom_up.rs
+++ b/turbopack/crates/turbopack-trace-server/src/bottom_up.rs
@@ -1,6 +1,7 @@
 use std::{env, sync::Arc};
 
 use hashbrown::HashMap;
+use rustc_hash::FxBuildHasher;
 use turbo_rcstr::RcStr;
 
 use crate::{
@@ -12,7 +13,7 @@ use crate::{
 pub struct SpanBottomUpBuilder {
     // These values won't change after creation:
     pub self_spans: Vec<SpanIndex>,
-    pub children: HashMap<(RcStr, RcStr), SpanBottomUpBuilder>,
+    pub children: HashMap<(RcStr, RcStr), SpanBottomUpBuilder, FxBuildHasher>,
     pub example_span: SpanIndex,
 }
 
@@ -44,7 +45,7 @@ pub fn build_bottom_up_graph<'a>(
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(usize::MAX);
-    let mut roots: HashMap<(RcStr, RcStr), SpanBottomUpBuilder> = HashMap::default();
+    let mut roots: HashMap<(RcStr, RcStr), SpanBottomUpBuilder, FxBuildHasher> = HashMap::default();
 
     // unfortunately there is a rustc bug that fails the typechecking here
     // when using Either<impl Iterator, impl Iterator>. This error appears

--- a/turbopack/crates/turbopack-trace-server/src/bottom_up.rs
+++ b/turbopack/crates/turbopack-trace-server/src/bottom_up.rs
@@ -54,7 +54,7 @@ pub fn build_bottom_up_graph<'a>(
     let mut current_iterators: Vec<Box<dyn Iterator<Item = SpanRef<'_>>>> =
         vec![Box::new(spans.flat_map(|span| span.children()))];
 
-    let mut current_path: Vec<((&'_ str, &'_ str), SpanIndex)> = vec![];
+    let mut current_path: Vec<((&'_ RcStr, &'_ RcStr), SpanIndex)> = vec![];
     while let Some(mut iter) = current_iterators.pop() {
         if let Some(child) = iter.next() {
             current_iterators.push(iter);
@@ -65,7 +65,7 @@ pub fn build_bottom_up_graph<'a>(
                 .from_key(&StringTupleRef(category, name))
                 .or_insert_with(|| {
                     (
-                        (RcStr::from(category), RcStr::from(name)),
+                        (category.clone(), name.clone()),
                         SpanBottomUpBuilder::new(child.index()),
                     )
                 });
@@ -81,7 +81,7 @@ pub fn build_bottom_up_graph<'a>(
                     .from_key(&StringTupleRef(category, title))
                     .or_insert_with(|| {
                         (
-                            (RcStr::from(category), RcStr::from(title)),
+                            (category.clone(), title.clone()),
                             SpanBottomUpBuilder::new(example_span),
                         )
                     });

--- a/turbopack/crates/turbopack-trace-server/src/span_bottom_up_ref.rs
+++ b/turbopack/crates/turbopack-trace-server/src/span_bottom_up_ref.rs
@@ -4,6 +4,8 @@ use std::{
     sync::Arc,
 };
 
+use turbo_rcstr::RcStr;
+
 use crate::{
     FxIndexMap,
     span::{SpanBottomUp, SpanGraphEvent},
@@ -54,11 +56,11 @@ impl<'a> SpanBottomUpRef<'a> {
         self.bottom_up.self_spans.len()
     }
 
-    pub fn group_name(&self) -> (&'a str, &'a str) {
+    pub fn group_name(&self) -> (&'a RcStr, &'a RcStr) {
         self.first_span().group_name()
     }
 
-    pub fn nice_name(&self) -> (&'a str, &'a str) {
+    pub fn nice_name(&self) -> (&'a RcStr, &'a RcStr) {
         if self.count() == 1 {
             self.example_span().nice_name()
         } else {

--- a/turbopack/crates/turbopack-trace-server/src/span_graph_ref.rs
+++ b/turbopack/crates/turbopack-trace-server/src/span_graph_ref.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
+use turbo_rcstr::RcStr;
 
 use crate::{
     FxIndexMap,
@@ -36,7 +37,7 @@ impl<'a> SpanGraphRef<'a> {
         unsafe { SpanId::new_unchecked((self.first_span().index << 1) | 1) }
     }
 
-    pub fn nice_name(&self) -> (&str, &str) {
+    pub fn nice_name(&self) -> (&RcStr, &RcStr) {
         if self.count() == 1 {
             self.first_span().nice_name()
         } else {

--- a/turbopack/crates/turbopack-trace-server/src/span_ref.rs
+++ b/turbopack/crates/turbopack-trace-server/src/span_ref.rs
@@ -24,7 +24,7 @@ use crate::{
 };
 
 pub type GroupNameToDirectAndRecusiveSpans<'l> =
-    FxIndexMap<(&'l str, &'l str), (Vec<SpanIndex>, Vec<SpanIndex>)>;
+    FxIndexMap<(&'l RcStr, &'l RcStr), (Vec<SpanIndex>, Vec<SpanIndex>)>;
 
 #[derive(Copy, Clone)]
 pub struct SpanRef<'a> {
@@ -87,18 +87,18 @@ impl<'a> SpanRef<'a> {
         self.index == 0
     }
 
-    pub fn nice_name(&self) -> (&'a str, &'a str) {
+    pub fn nice_name(&self) -> (&'a RcStr, &'a RcStr) {
         let SpanName { category, title } = &self.names().nice_name;
-        (category.as_str(), title.as_str())
+        (category, title)
     }
 
-    pub fn group_name(&self) -> (&'a str, &'a str) {
+    pub fn group_name(&self) -> (&'a RcStr, &'a RcStr) {
         let SpanName { category, title } = &self.names().group_name;
-        (category.as_str(), title.as_str())
+        (category, title)
     }
 
-    pub fn args(&self) -> impl Iterator<Item = (&str, &str)> {
-        self.span.args.iter().map(|(k, v)| (k.as_str(), v.as_str()))
+    pub fn args(&self) -> impl Iterator<Item = (&RcStr, &RcStr)> {
+        self.span.args.iter().map(|(k, v)| (k, v))
     }
 
     pub fn self_time(&self) -> Timestamp {
@@ -413,7 +413,7 @@ impl<'a> SpanRef<'a> {
                 }
                 let (cat, name) = span.nice_name();
                 if !cat.is_empty() {
-                    push_to_index(index, cat, || RcStr::from(cat), span.index());
+                    push_to_index(index, cat, || cat.clone(), span.index());
                 }
                 if !name.is_empty() {
                     push_to_index(

--- a/turbopack/crates/turbopack-trace-server/src/string_tuple_ref.rs
+++ b/turbopack/crates/turbopack-trace-server/src/string_tuple_ref.rs
@@ -12,15 +12,15 @@ impl<'a> Equivalent<(RcStr, RcStr)> for StringTupleRef<'a> {
 
 #[cfg(test)]
 mod string_tuple_ref_tests {
-    use std::hash::RandomState;
+    use std::hash::BuildHasher;
+
+    use rustc_hash::FxBuildHasher;
 
     use super::*;
 
     #[test]
     fn test_string_tuple_ref_hash() {
-        use std::hash::BuildHasher;
-
-        let s = RandomState::new();
+        let s = FxBuildHasher::default();
         assert_eq!(
             s.hash_one(StringTupleRef("abc", "def")),
             s.hash_one(&(RcStr::from("abc"), RcStr::from("def")))

--- a/turbopack/crates/turbopack-trace-server/src/string_tuple_ref.rs
+++ b/turbopack/crates/turbopack-trace-server/src/string_tuple_ref.rs
@@ -25,5 +25,16 @@ mod string_tuple_ref_tests {
             s.hash_one(StringTupleRef("abc", "def")),
             s.hash_one(&(RcStr::from("abc"), RcStr::from("def")))
         );
+
+        assert_eq!(
+            s.hash_one(StringTupleRef(
+                "a_very_long_string_that_is_not_inlined",
+                "def"
+            )),
+            s.hash_one(&(
+                RcStr::from("a_very_long_string_that_is_not_inlined"),
+                RcStr::from("def")
+            ))
+        );
     }
 }

--- a/turbopack/crates/turbopack-trace-server/src/string_tuple_ref.rs
+++ b/turbopack/crates/turbopack-trace-server/src/string_tuple_ref.rs
@@ -20,7 +20,7 @@ mod string_tuple_ref_tests {
 
     #[test]
     fn test_string_tuple_ref_hash() {
-        let s = FxBuildHasher::default();
+        let s = FxBuildHasher;
         assert_eq!(
             s.hash_one(StringTupleRef("abc", "def")),
             s.hash_one(&(RcStr::from("abc"), RcStr::from("def")))

--- a/turbopack/crates/turbopack-trace-server/src/viewer.rs
+++ b/turbopack/crates/turbopack-trace-server/src/viewer.rs
@@ -5,6 +5,7 @@ use itertools::Itertools;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use rustc_hash::{FxHashMap, FxHashSet};
 use serde::Serialize;
+use turbo_rcstr::rcstr;
 
 use crate::{
     server::ViewRect,
@@ -701,7 +702,7 @@ impl Viewer {
                                 Either::Left(span.events().sorted_by_cached_key(|child| {
                                     let (cat, title) = match child {
                                         SpanEventRef::Child { span } => span.nice_name(),
-                                        SpanEventRef::SelfTime { .. } => ("", ""),
+                                        SpanEventRef::SelfTime { .. } => (&rcstr!(""), &rcstr!("")),
                                     };
                                     (title.to_string(), cat.to_string())
                                 }))
@@ -739,7 +740,9 @@ impl Viewer {
                                 Either::Left(span.graph().sorted_by_cached_key(|child| {
                                     let (cat, title) = match child {
                                         SpanGraphEventRef::Child { graph } => graph.nice_name(),
-                                        SpanGraphEventRef::SelfTime { .. } => ("", ""),
+                                        SpanGraphEventRef::SelfTime { .. } => {
+                                            (&rcstr!(""), &rcstr!(""))
+                                        }
                                     };
                                     (title.to_string(), cat.to_string())
                                 }))
@@ -886,7 +889,9 @@ impl Viewer {
                                 Either::Left(span_graph.events().sorted_by_cached_key(|child| {
                                     let (cat, title) = match child {
                                         SpanGraphEventRef::Child { graph } => graph.nice_name(),
-                                        SpanGraphEventRef::SelfTime { .. } => ("", ""),
+                                        SpanGraphEventRef::SelfTime { .. } => {
+                                            (&rcstr!(""), &rcstr!(""))
+                                        }
                                     };
                                     (title.to_string(), cat.to_string())
                                 }))


### PR DESCRIPTION
### What?

Speeds up the bottom-up grouping pass in `turbopack-trace-server` by removing per-span `RcStr` allocations and fixes the hash map using the correct hasher for the grouping `HashMap`.

### Why?

When loading large traces, building the bottom-up graph spent measurable time (1) allocating fresh `RcStr` values from `&str` keys for every span just to use them as `HashMap` keys, and (2) hashing those keys with the default randomized hasher. Both are avoidable: the underlying spans already own `RcStr`s, and the `StringTupleRef` equivalence-based lookup needs `FxHasher` anyway because `RcStr`'s `Hash` impl only matches `&str`'s `Hash` under `FxHasher`.

### How?

- Change `nice_name`/`group_name`/`args` accessors on `SpanRef` and friends to return `&RcStr` instead of `&str`. The bottom-up grouping code can now clone the existing `RcStr` (a cheap ref-count bump) instead of allocating a new one from a `&str`.
- Switch the `(RcStr, RcStr) -> SpanBottomUpBuilder` map in `bottom_up.rs` to use `FxBuildHasher`. This is required for the `StringTupleRef` equivalence lookup to produce matching hashes for the owned `(RcStr, RcStr)` keys, and it also removes the overhead of the default randomized hasher.
- Update the `string_tuple_ref` test to use `FxBuildHasher` accordingly.

No behavior changes; this is a pure refactor for performance inside the trace viewer tool.

<!-- NEXT_JS_LLM_PR -->