### PR TITLE
[turbopack] Resolve inherited tsconfig living outside Next.js app directory

### DIFF
--- a/test/e2e/typescript-paths-extends-inherited/fixtures/inherited/tsconfig.base.json
+++ b/test/e2e/typescript-paths-extends-inherited/fixtures/inherited/tsconfig.base.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "strict": true
+  }
+}

--- a/test/e2e/typescript-paths-extends-inherited/fixtures/inherited/web/app/layout.tsx
+++ b/test/e2e/typescript-paths-extends-inherited/fixtures/inherited/web/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/typescript-paths-extends-inherited/fixtures/inherited/web/app/page.tsx
+++ b/test/e2e/typescript-paths-extends-inherited/fixtures/inherited/web/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>Hello, Dave!</p>
+}

--- a/test/e2e/typescript-paths-extends-inherited/fixtures/inherited/web/next.config.js
+++ b/test/e2e/typescript-paths-extends-inherited/fixtures/inherited/web/next.config.js
@@ -1,0 +1,7 @@
+/** @type {import('next').NextConfig} */
+const config = {
+  typescript: {
+    ignoreBuildErrors: false,
+  },
+}
+module.exports = config

--- a/test/e2e/typescript-paths-extends-inherited/fixtures/inherited/web/tsconfig.json
+++ b/test/e2e/typescript-paths-extends-inherited/fixtures/inherited/web/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "plugins": [{ "name": "next" }]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/test/e2e/typescript-paths-extends-inherited/typescript-paths-extends-inherited.test.ts
+++ b/test/e2e/typescript-paths-extends-inherited/typescript-paths-extends-inherited.test.ts
@@ -1,0 +1,24 @@
+import path from 'path'
+import { FileRef, nextTestSetup } from 'e2e-utils'
+
+describe('tsconfig inheriting from outside Next.js directory', () => {
+  const fixtureDir = path.join(__dirname, 'fixtures/inherited')
+  const { next } = nextTestSetup({
+    files: {
+      '../tsconfig.base.json': new FileRef(
+        path.join(fixtureDir, 'tsconfig.base.json')
+      ),
+      'next.config.js': new FileRef(
+        path.join(fixtureDir, 'web/next.config.js')
+      ),
+      'tsconfig.json': new FileRef(path.join(fixtureDir, 'web/tsconfig.json')),
+      app: new FileRef(path.join(fixtureDir, 'web/app')),
+    },
+    subDir: 'web',
+  })
+
+  it('should render the page that uses the aliased module', async () => {
+    const html = await next.render('/')
+    expect(html).toContain('Hello, Dave!')
+  })
+})

--- a/turbopack/crates/turbopack-resolve/src/typescript.rs
+++ b/turbopack/crates/turbopack-resolve/src/typescript.rs
@@ -1,11 +1,14 @@
-use std::mem::take;
+use std::{mem::take, path::PathBuf};
 
 use anyhow::Result;
 use async_trait::async_trait;
 use serde_json::Value as JsonValue;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{FxIndexMap, ResolvedVc, ValueDefault, Vc, fxindexset};
-use turbo_tasks_fs::{FileContent, FileJsonContent, FileSystemPath, FileSystemPathOption};
+use turbo_tasks_fs::{
+    DiskFileSystem, FileContent, FileJsonContent, FileSystem, FileSystemPath, FileSystemPathOption,
+    to_sys_path,
+};
 use turbopack_core::{
     asset::Asset,
     context::AssetContext,
@@ -191,7 +194,72 @@ async fn resolve_extends_rooted_or_relative(
         )
         .first_source();
     }
-    Ok(result)
+    if result.await?.is_some() {
+        return Ok(result);
+    }
+
+    // TypeScript resolves `extends` against the OS filesystem with no sandboxing
+    // (https://github.com/microsoft/TypeScript/blob/611a912d/src/compiler/commandLineParser.ts#L3294-L3326).
+    // When the joined path leaves the project filesystem (e.g. monorepo
+    // `extends: "../tsconfig.base.json"` where the project root is the inner
+    // workspace directory), the project-FS-bound `resolve()` cannot represent it,
+    // so fall back to mounting a disk-rooted filesystem at the resolved file's
+    // parent directory.
+    resolve_extends_via_disk(lookup_path, path).await
+}
+
+async fn resolve_extends_via_disk(
+    lookup_path: FileSystemPath,
+    path: &str,
+) -> Result<Vc<OptionSource>> {
+    let Some(lookup_sys) = to_sys_path(lookup_path).await? else {
+        return Ok(Vc::cell(None));
+    };
+    let candidates: Vec<PathBuf> = if path.ends_with(".json") {
+        vec![normalize_pathbuf(&lookup_sys.join(path))]
+    } else {
+        vec![
+            normalize_pathbuf(&lookup_sys.join(format!("{path}.json"))),
+            normalize_pathbuf(&lookup_sys.join(path)),
+        ]
+    };
+
+    for absolute in candidates {
+        let Some(parent) = absolute.parent() else {
+            continue;
+        };
+        let Some(file_name) = absolute.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        if file_name.is_empty() {
+            continue;
+        }
+        let parent_str: RcStr = parent.to_string_lossy().into_owned().into();
+        let fs = DiskFileSystem::new(rcstr!("tsconfig-extends"), Vc::cell(parent_str));
+        let candidate_path = fs.root().owned().await?.join(file_name)?;
+        if let FileContent::Content(_) = &*candidate_path.read().await? {
+            let source: ResolvedVc<Box<dyn Source>> =
+                ResolvedVc::upcast(FileSource::new(candidate_path).to_resolved().await?);
+            return Ok(Vc::cell(Some(source)));
+        }
+    }
+    Ok(Vc::cell(None))
+}
+
+/// Normalizes a path by resolving `.` and `..` components purely lexically.
+fn normalize_pathbuf(p: &std::path::Path) -> PathBuf {
+    use std::path::Component;
+    let mut result = PathBuf::new();
+    for component in p.components() {
+        match component {
+            Component::ParentDir => {
+                result.pop();
+            }
+            Component::CurDir => {}
+            other => result.push(other),
+        }
+    }
+    result
 }
 
 pub async fn read_from_tsconfigs<T>(


### PR DESCRIPTION
Turbopack used to crash during `next build` if the `tsconfig.js` inherited (`extends`) from a `tsconfig` outside the directory:

> Build error occurred
Error: Turbopack build failed with 1 errors:
./tsconfig.json
An issue occurred while parsing a tsconfig.json file.
extends: "../tsconfig.base.json" doesn't resolve correctly
>
>
>    at ignore-listed frames

Hit this case when working on https://github.com/vercel/next.js/pull/93377