### PR TITLE
docs: clarify proxy runtime history

### DIFF
--- a/docs/01-app/03-api-reference/03-file-conventions/proxy.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/proxy.mdx
@@ -744,7 +744,7 @@ Next.js is moving forward to provide better APIs with better ergonomics so that 
 
 ### Why "Proxy"
 
-The name Proxy clarifies what Middleware is capable of. The term "proxy" implies that it has a network boundary in front of the app, which is the behavior of Middleware. Historically, Middleware commonly ran at the [Edge Runtime](/docs/app/api-reference/edge), closer to the client and separated from the app's region. These network-boundary semantics align better with the term "proxy" and provide a clearer purpose of the feature.
+The name Proxy clarifies what Middleware is capable of. The term "proxy" implies a network boundary in front of the app, which is how this feature behaves. It can run outside of your application’s main runtime and handle requests before they reach your app. These characteristics align better with the term "proxy" and provide a clearer purpose for the feature.
 
 ### How to Migrate
 

--- a/docs/01-app/03-api-reference/03-file-conventions/proxy.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/proxy.mdx
@@ -744,7 +744,7 @@ Next.js is moving forward to provide better APIs with better ergonomics so that 
 
 ### Why "Proxy"
 
-The name Proxy clarifies what Middleware is capable of. The term "proxy" implies that it has a network boundary in front of the app, which is the behavior of Middleware. Also, Middleware defaults to run at the [Edge Runtime](/docs/app/api-reference/edge), which can run closer to the client, separated from the app's region. These behaviors align better with the term "proxy" and provide a clearer purpose of the feature.
+The name Proxy clarifies what Middleware is capable of. The term "proxy" implies that it has a network boundary in front of the app, which is the behavior of Middleware. Historically, Middleware commonly ran at the [Edge Runtime](/docs/app/api-reference/edge), closer to the client and separated from the app's region. These network-boundary semantics align better with the term "proxy" and provide a clearer purpose of the feature.
 
 ### How to Migrate
 
@@ -771,7 +771,7 @@ The codemod will rename the file and the function name from `middleware` to `pro
 
 | Version   | Changes                                                                                       |
 | --------- | --------------------------------------------------------------------------------------------- |
-| `v16.0.0` | Middleware is deprecated and renamed to Proxy                                                 |
+| `v16.0.0` | Middleware is deprecated and renamed to Proxy. Proxy defaults to the Node.js runtime          |
 | `v15.5.0` | Middleware can now use the Node.js runtime (stable)                                           |
 | `v15.2.0` | Middleware can now use the Node.js runtime (experimental)                                     |
 | `v13.1.0` | Advanced Middleware flags added                                                               |


### PR DESCRIPTION
### What?

Clarifies the Proxy docs so the “Why Proxy” section no longer appears to contradict the Runtime section.

### Why?

The Runtime section states that Proxy defaults to the Node.js runtime, but the “Why Proxy” section still said Middleware defaults to the Edge Runtime. Since Middleware was renamed to Proxy in v16, that wording could make readers think the current default runtime is Edge.

### How?

Updates the “Why Proxy” paragraph to frame Edge Runtime wording as historical context rather than current default behavior.

Also updates the v16.0.0 version history entry to mention that Proxy defaults to the Node.js runtime.

Closes #93463