### PR TITLE
fix: support current Partytown package

### DIFF
--- a/packages/next/src/lib/verify-partytown-setup.ts
+++ b/packages/next/src/lib/verify-partytown-setup.ts
@@ -8,6 +8,22 @@ import { fileExists, FileType } from './file-exists'
 import * as Log from '../build/output/log'
 import { getPkgManager } from './helpers/get-pkg-manager'
 
+const PARTYTOWN_PACKAGE = '@qwik.dev/partytown'
+const LEGACY_PARTYTOWN_PACKAGE = '@builder.io/partytown'
+
+function getPartytownDependencies(
+  dir: string,
+  partytownPackage: string
+): NecessaryDependencies {
+  return hasNecessaryDependencies(dir, [
+    {
+      file: partytownPackage,
+      pkg: partytownPackage,
+      exportsRestrict: false,
+    },
+  ])
+}
+
 async function missingDependencyError(dir: string) {
   const packageManager = getPkgManager(dir)
 
@@ -26,7 +42,7 @@ async function missingDependencyError(dir: string) {
             ? 'yarn add --dev'
             : packageManager === 'pnpm'
               ? 'pnpm install --save-dev'
-              : 'npm install --save-dev') + ' @builder.io/partytown'
+              : 'npm install --save-dev') + ` ${PARTYTOWN_PACKAGE}`
         )
       )}` +
       '\n\n' +
@@ -41,6 +57,7 @@ async function missingDependencyError(dir: string) {
 
 async function copyPartytownStaticFiles(
   deps: NecessaryDependencies,
+  partytownPackage: string,
   staticDir: string
 ) {
   const partytownLibDir = path.join(staticDir, '~partytown')
@@ -54,7 +71,7 @@ async function copyPartytownStaticFiles(
   }
 
   const { copyLibFiles } = await Promise.resolve(
-    require(path.join(deps.resolved.get('@builder.io/partytown')!, '../utils'))
+    require(path.join(deps.resolved.get(partytownPackage)!, '../utils'))
   )
 
   await copyLibFiles(partytownLibDir)
@@ -64,25 +81,30 @@ export async function verifyPartytownSetup(
   dir: string,
   targetDir: string
 ): Promise<void> {
-  const partytownDeps: NecessaryDependencies = hasNecessaryDependencies(dir, [
-    {
-      file: '@builder.io/partytown',
-      pkg: '@builder.io/partytown',
-      exportsRestrict: false,
-    },
-  ])
+  let partytownPackage = PARTYTOWN_PACKAGE
+  let partytownDeps = getPartytownDependencies(dir, partytownPackage)
 
   if (partytownDeps.missing?.length > 0) {
-    await missingDependencyError(dir)
-  } else {
-    try {
-      await copyPartytownStaticFiles(partytownDeps, targetDir)
-    } catch (err) {
-      Log.warn(
-        `Partytown library files could not be copied to the static directory. Please ensure that ${bold(
-          cyan('@builder.io/partytown')
-        )} is installed as a dependency.`
-      )
+    const legacyPartytownDeps = getPartytownDependencies(
+      dir,
+      LEGACY_PARTYTOWN_PACKAGE
+    )
+
+    if (legacyPartytownDeps.missing?.length > 0) {
+      await missingDependencyError(dir)
     }
+
+    partytownPackage = LEGACY_PARTYTOWN_PACKAGE
+    partytownDeps = legacyPartytownDeps
+  }
+
+  try {
+    await copyPartytownStaticFiles(partytownDeps, partytownPackage, targetDir)
+  } catch (err) {
+    Log.warn(
+      `Partytown library files could not be copied to the static directory. Please ensure that ${bold(
+        cyan(partytownPackage)
+      )} is installed as a dependency.`
+    )
   }
 }

--- a/packages/next/src/pages/_document.tsx
+++ b/packages/next/src/pages/_document.tsx
@@ -174,10 +174,23 @@ function getPreNextWorkerScripts(context: HtmlProps, props: OriginProps) {
   if (!nextScriptWorkers || process.env.NEXT_RUNTIME === 'edge') return null
 
   try {
-    // @ts-expect-error: Prevent webpack from processing this require
-    let { partytownSnippet } = __non_webpack_require__(
-      '@builder.io/partytown/integration'!
-    )
+    let partytownSnippet: () => string
+
+    try {
+      // @ts-expect-error: Prevent webpack from processing this require
+      ;({ partytownSnippet } = __non_webpack_require__(
+        '@qwik.dev/partytown/integration'
+      ))
+    } catch (err) {
+      if (!isError(err) || err.code !== 'MODULE_NOT_FOUND') {
+        throw err
+      }
+
+      // @ts-expect-error: Prevent webpack from processing this require
+      ;({ partytownSnippet } = __non_webpack_require__(
+        '@builder.io/partytown/integration'
+      ))
+    }
 
     const children = Array.isArray(props.children)
       ? props.children


### PR DESCRIPTION
### What?

Updates the Partytown setup check used by `nextScriptWorkers` to prefer `@qwik.dev/partytown` while keeping `@builder.io/partytown` as a fallback.

### Why?

The docs currently tell users to install `@qwik.dev/partytown`, but the runtime check still requires `@builder.io/partytown`. Users following the docs can hit a missing dependency error when starting or building the app.

### How?

- Checks for `@qwik.dev/partytown` first
- Falls back to `@builder.io/partytown` for backwards compatibility
- Resolves `copyLibFiles` from whichever Partytown package is installed
- Updates the install error message to suggest `@qwik.dev/partytown`
- Updates the copy warning to reference the resolved Partytown package

### Testing

- Ran `pnpm dlx prettier --write packages/next/src/lib/verify-partytown-setup.ts`

Fixes #92827