### PR TITLE
[devtools] Detect current VS Code executable on macOS

### DIFF
--- a/packages/next/src/next-devtools/server/launch-editor.test.ts
+++ b/packages/next/src/next-devtools/server/launch-editor.test.ts
@@ -1,8 +1,76 @@
-import { escapeApplescriptStringFragment } from './launch-editor'
+import child_process from 'child_process'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { escapeApplescriptStringFragment, launchEditor } from './launch-editor'
+
+const VISUAL_STUDIO_CODE_CLI =
+  '/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code'
+const VISUAL_STUDIO_CODE_INSIDERS_CLI =
+  '/Applications/Visual Studio Code - Insiders.app/Contents/Resources/app/bin/code'
+
+const macOSEditorDetectionCases = [
+  [
+    'current Visual Studio Code executable name',
+    '/Applications/Visual Studio Code.app/Contents/MacOS/Code',
+    VISUAL_STUDIO_CODE_CLI,
+  ],
+  [
+    'legacy Visual Studio Code executable name',
+    '/Applications/Visual Studio Code.app/Contents/MacOS/Electron',
+    VISUAL_STUDIO_CODE_CLI,
+  ],
+  [
+    'current Visual Studio Code Insiders executable name',
+    '/Applications/Visual Studio Code - Insiders.app/Contents/MacOS/Code - Insiders',
+    VISUAL_STUDIO_CODE_INSIDERS_CLI,
+  ],
+] as const
 
 describe('applescript string escaping', () => {
   it('should escape strings correctly', () => {
     const result = escapeApplescriptStringFragment(`abc\\def"ghi\\\\`)
     expect(result).toBe(`abc\\\\def\\"ghi\\\\\\\\`)
   })
+})
+
+describe('macOS editor detection', () => {
+  const originalPlatform = process.platform
+  let fileName: string
+  let testDirectory: string
+
+  beforeEach(() => {
+    Object.defineProperty(process, 'platform', {
+      value: 'darwin',
+    })
+    testDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'next-editor-test-'))
+    fileName = path.join(testDirectory, 'page.tsx')
+    fs.writeFileSync(fileName, '')
+  })
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', {
+      value: originalPlatform,
+    })
+    fs.rmSync(testDirectory, { force: true, recursive: true })
+    jest.restoreAllMocks()
+  })
+
+  it.each(macOSEditorDetectionCases)(
+    'detects the %s',
+    (_, processName, cli) => {
+      jest
+        .spyOn(child_process, 'execSync')
+        .mockReturnValue(Buffer.from(`123 ?? 0:00.00 ${processName}`))
+      const spawn = jest.spyOn(child_process, 'spawn').mockReturnValue({
+        on: jest.fn(),
+      } as unknown as child_process.ChildProcess)
+
+      launchEditor(fileName, 1, 1)
+
+      expect(spawn).toHaveBeenCalledWith(cli, ['-g', `${fileName}:1:1`], {
+        stdio: 'inherit',
+      })
+    }
+  )
 })

--- a/packages/next/src/next-devtools/server/launch-editor.ts
+++ b/packages/next/src/next-devtools/server/launch-editor.ts
@@ -48,7 +48,7 @@ function isTerminalEditor(editor: string) {
 // Map from full process name to binary that starts the process
 // We can't just re-use full process name, because it will spawn a new instance
 // of the app every time
-const COMMON_EDITORS_MACOS = {
+const COMMON_EDITORS_MACOS: Record<string, string> = {
   '/Applications/Atom.app/Contents/MacOS/Atom': 'atom',
   '/Applications/Atom Beta.app/Contents/MacOS/Atom Beta':
     '/Applications/Atom Beta.app/Contents/MacOS/Atom Beta',
@@ -59,8 +59,12 @@ const COMMON_EDITORS_MACOS = {
     '/Applications/Sublime Text Dev.app/Contents/SharedSupport/bin/subl',
   '/Applications/Sublime Text 2.app/Contents/MacOS/Sublime Text 2':
     '/Applications/Sublime Text 2.app/Contents/SharedSupport/bin/subl',
+  '/Applications/Visual Studio Code.app/Contents/MacOS/Code':
+    '/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code',
   '/Applications/Visual Studio Code.app/Contents/MacOS/Electron':
     '/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code',
+  '/Applications/Visual Studio Code - Insiders.app/Contents/MacOS/Code - Insiders':
+    '/Applications/Visual Studio Code - Insiders.app/Contents/Resources/app/bin/code',
   '/Applications/Visual Studio Code - Insiders.app/Contents/MacOS/Electron':
     '/Applications/Visual Studio Code - Insiders.app/Contents/Resources/app/bin/code',
   '/Applications/VSCodium.app/Contents/MacOS/Electron':
@@ -218,6 +222,18 @@ function getArgumentsForLineNumber(
   }
 }
 
+function getMacOSEditorFromProcessList(output: string): string | null {
+  const processNames = Object.keys(COMMON_EDITORS_MACOS)
+  for (let i = 0; i < processNames.length; i++) {
+    const processName = processNames[i]
+    if (output.indexOf(processName) !== -1) {
+      return COMMON_EDITORS_MACOS[processName]
+    }
+  }
+
+  return null
+}
+
 function guessEditor(): string[] {
   // Explicit config always wins
   if (process.env.REACT_EDITOR) {
@@ -230,12 +246,9 @@ function guessEditor(): string[] {
   try {
     if (process.platform === 'darwin') {
       const output = child_process.execSync('ps x').toString()
-      const processNames = Object.keys(COMMON_EDITORS_MACOS)
-      for (let i = 0; i < processNames.length; i++) {
-        const processName = processNames[i]
-        if (output.indexOf(processName) !== -1) {
-          return [(COMMON_EDITORS_MACOS as any)[processName]]
-        }
+      const editor = getMacOSEditorFromProcessList(output)
+      if (editor !== null) {
+        return [editor]
       }
     } else if (process.platform === 'win32') {
       // Some processes need elevated rights to get its executable path.


### PR DESCRIPTION
### What?

Adds the current macOS executable names for Visual Studio Code and Visual Studio Code Insiders to the dev overlay launch-editor detection table.

This keeps the existing `Electron` entries for older VS Code builds, while also detecting:

- `/Applications/Visual Studio Code.app/Contents/MacOS/Code`
- `/Applications/Visual Studio Code - Insiders.app/Contents/MacOS/Code - Insiders`

### Why?

VS Code renamed its macOS executable from `Electron` to the product short name in microsoft/vscode#291948. That PR also added an `Electron` symlink for backwards compatibility, but `ps x` reports the real executable path as `Code` for current VS Code builds.

When Next.js only scans for `.../Contents/MacOS/Electron`, it can miss a running VS Code process and fall back to `VISUAL` / `EDITOR`. If that fallback is a terminal editor such as `vim`, the dev overlay opens Terminal instead of VS Code.

### How?

- Add the current VS Code and VS Code Insiders executable paths to `COMMON_EDITORS_MACOS`.
- Keep the legacy `Electron` paths so older VS Code builds continue to be detected.
- Factor macOS process-list matching into a small helper used by `guessEditor()`.
- Add unit coverage for current VS Code, legacy VS Code, and current VS Code Insiders process names.

### Tests

- `npx pnpm@10.33.0 install --frozen-lockfile`
- `npx pnpm@10.33.0 testonly packages/next/src/next-devtools/server/launch-editor.test.ts`
- `npx pnpm@10.33.0 --filter=@next/font build`
- `npx pnpm@10.33.0 --filter=next types`
- `npx prettier@3.6.2 --check packages/next/src/next-devtools/server/launch-editor.ts packages/next/src/next-devtools/server/launch-editor.test.ts`
- `git diff --check`
- `npx pnpm@10.33.0 --filter=next build`
