### PR TITLE
[turbopack] shrink the size of futures

### DIFF
--- a/turbopack/crates/turbo-tasks-testing/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-testing/src/lib.rs
@@ -71,6 +71,10 @@ impl VcStorage {
                 let result = AssertUnwindSafe(future).catch_unwind().await;
 
                 // Convert the unwind panic to an anyhow error that can be cloned.
+                let result = match result {
+                    Ok(Ok(raw_vc)) => Ok(raw_vc.to_non_local().await),
+                    _ => result,
+                };
                 let result = result
                     .map_err(|any| match any.downcast::<String>() {
                         Ok(owned) => anyhow!(owned),

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -1253,7 +1253,13 @@ impl<B: Backend> Executor<TurboTasks<B>, ScheduledTask, TaskPriority> for TurboT
                                     wait_for_local_tasks().await;
 
                                     let result = match result {
-                                        Ok(Ok(raw_vc)) => Ok(raw_vc),
+                                        Ok(Ok(raw_vc)) => {
+                                            // This is safe because we waited for all local tasks to
+                                            // complete above
+                                            raw_vc
+                                                .to_non_local_unchecked_sync(&*this)
+                                                .map_err(|err| err.into())
+                                        }
                                         Ok(Err(err)) => Err(err.into()),
                                         Err(err) => {
                                             Err(TurboTasksExecutionError::Panic(Arc::new(err)))
@@ -1724,6 +1730,7 @@ impl<B: Backend + 'static> TurboTasksBackendApi<B> for TurboTasks<B> {
 }
 
 async fn wait_for_local_tasks() {
+    // This needs to be a while loop in case one local task completing/exeucting triggers another.
     while let Some(mut ltt) =
         CURRENT_TASK_STATE.with(|ts| ts.write().unwrap().local_task_tracker.take())
     {

--- a/turbopack/crates/turbo-tasks/src/native_function.rs
+++ b/turbopack/crates/turbo-tasks/src/native_function.rs
@@ -259,6 +259,8 @@ impl NativeFunction {
     }
 
     /// Executed the function
+    ///
+    /// NOTE: this may return a local vc
     pub fn execute(
         &'static self,
         this: Option<RawVc>,

--- a/turbopack/crates/turbo-tasks/src/raw_vc.rs
+++ b/turbopack/crates/turbo-tasks/src/raw_vc.rs
@@ -148,11 +148,33 @@ impl RawVc {
 
     /// Convert a potentially local `RawVc` into a non-local `RawVc`. This is a subset of resolution
     /// resolution, because the returned `RawVc` can be a `TaskOutput`.
-    pub(crate) async fn to_non_local(self) -> Result<RawVc> {
+    pub async fn to_non_local(self) -> Result<RawVc> {
         Ok(match self {
             RawVc::LocalOutput(execution_id, local_task_id, ..) => {
                 let tt = turbo_tasks();
                 let local_output = read_local_output(&*tt, execution_id, local_task_id).await?;
+                debug_assert!(
+                    !matches!(local_output, RawVc::LocalOutput(_, _, _)),
+                    "a LocalOutput cannot point at other LocalOutputs"
+                );
+                local_output
+            }
+            non_local => non_local,
+        })
+    }
+
+    /// Convert a potentially local `RawVc` into a non-local `RawVc`. This is a subset of resolution
+    /// resolution, because the returned `RawVc` can be a `TaskOutput`.
+    ///
+    /// 'unchecked' because the caller must have already confirmed that the local tasks were already
+    /// completed
+    pub(crate) fn to_non_local_unchecked_sync(self, tt: &dyn TurboTasksApi) -> Result<RawVc> {
+        Ok(match self {
+            RawVc::LocalOutput(execution_id, local_task_id, ..) => {
+                let local_output = match tt.try_read_local_output(execution_id, local_task_id)? {
+                    Ok(raw_vc) => raw_vc,
+                    Err(_event_listener) => unreachable!("local output is not ready yet"),
+                };
                 debug_assert!(
                     !matches!(local_output, RawVc::LocalOutput(_, _, _)),
                     "a LocalOutput cannot point at other LocalOutputs"

--- a/turbopack/crates/turbo-tasks/src/task/function.rs
+++ b/turbopack/crates/turbo-tasks/src/task/function.rs
@@ -197,11 +197,6 @@ fn get_args<T: DynTaskInputs + Clone>(arg: &dyn DynTaskInputs) -> Result<T> {
     return anyhow::Context::context(value, "Invalid argument type");
 }
 
-// Helper function for `task_fn_impl!()`
-async fn output_try_into_non_local_raw_vc(output: impl TaskOutput) -> Result<RawVc> {
-    output.try_into_raw_vc()?.to_non_local().await
-}
-
 macro_rules! task_fn_impl {
     ( $async_fn_trait:ident $arg_len:literal $( $arg:ident )* ) => {
         impl<F, Output, $($arg,)*> TaskFnInputFunction<FunctionMode, ($($arg,)*)> for F
@@ -215,8 +210,7 @@ macro_rules! task_fn_impl {
                 let task_fn = self.clone();
                 let ($($arg,)*) = get_args::<($($arg,)*)>(arg)?;
                 Ok(Box::pin(async move {
-                    let output = (task_fn)($($arg,)*);
-                    output_try_into_non_local_raw_vc(output).await
+                    (task_fn)($($arg,)*).try_into_raw_vc()
                 }))
             }
         }
@@ -233,8 +227,7 @@ macro_rules! task_fn_impl {
                 let task_fn = self.clone();
                 let ($($arg,)*) = get_args::<($($arg,)*)>(arg)?;
                 Ok(Box::pin(async move {
-                    let output = (task_fn)($($arg,)*).await;
-                    output_try_into_non_local_raw_vc(output).await
+                    (task_fn)($($arg,)*).await.try_into_raw_vc()
                 }))
             }
         }
@@ -254,8 +247,7 @@ macro_rules! task_fn_impl {
                 Ok(Box::pin(async move {
                     let recv = recv.await?;
                     let recv = <Recv::Read as VcRead<Recv>>::target_to_value_ref(&*recv);
-                    let output = (task_fn)(recv, $($arg,)*);
-                    output_try_into_non_local_raw_vc(output).await
+                    (task_fn)(recv, $($arg,)*).try_into_raw_vc()
                 }))
             }
         }
@@ -273,8 +265,7 @@ macro_rules! task_fn_impl {
                 let recv = Vc::<Recv>::from(this);
                 let ($($arg,)*) = get_args::<($($arg,)*)>(arg)?;
                 Ok(Box::pin(async move {
-                    let output = (task_fn)(recv, $($arg,)*);
-                    output_try_into_non_local_raw_vc(output).await
+                    (task_fn)(recv, $($arg,)*).try_into_raw_vc()
                 }))
             }
         }
@@ -308,8 +299,7 @@ macro_rules! task_fn_impl {
                 Ok(Box::pin(async move {
                     let recv = recv.await?;
                     let recv = <Recv::Read as VcRead<Recv>>::target_to_value_ref(&*recv);
-                    let output = (task_fn)(recv, $($arg,)*).await;
-                    output_try_into_non_local_raw_vc(output).await
+                    (task_fn)(recv, $($arg,)*).await.try_into_raw_vc()
                 }))
             }
         }
@@ -326,8 +316,7 @@ macro_rules! task_fn_impl {
                 let recv = Vc::<Recv>::from(this);
                 let ($($arg,)*) = get_args::<($($arg,)*)>(arg)?;
                 Ok(Box::pin(async move {
-                    let output = (task_fn)(recv, $($arg,)*).await;
-                    output_try_into_non_local_raw_vc(output).await
+                    (task_fn)(recv, $($arg,)*).await.try_into_raw_vc()
                 }))
             }
         }


### PR DESCRIPTION
### What?

Move the `RawVc::to_non_local` step out of every per-task future and into the executor's outer state machine, after `wait_for_local_tasks().await`. Inline the now-trivial `output_try_into_non_local_raw_vc` helper at the six `task_fn_impl!` callsites.

### Why?

Two wins, both small per task but compounding across the millions of task invocations a real workload (e.g. `next build`) makes.

**1. Smaller per-task futures.** On canary, every `#[turbo_tasks::function]` future carried an `output_try_into_non_local_raw_vc` suspension state (a 152-byte `__awaitee` containing `RawVc::to_non_local()`'s 128-byte awaitee) regardless of arity, sync/async, or whether the user body had any internal awaits. Measured with `-Zprint-type-sizes` on representative noop tasks:

| Task | canary | this branch | shrink |
|---|---|---|---|
| `noop_arity0` (sync) | 160 B | **1 B** | -99% |
| `noop_arity0_async` | 160 B | **32 B** | -80% |
| `noop_arity1` (sync) | 168 B | **16 B** | -90% |
| `noop_arity1_async` | 168 B | **56 B** | -67% |
| `noop_arity2` (sync) | 176 B | **24 B** | -86% |
| `noop_arity2_async` | 176 B | **80 B** | -55% |
| `busy_turbo` (sync, `u64`+`Duration`) | 184 B | **32 B** | -83% |

For sync `FunctionMode`/`MethodMode` impls, removing the only awaiting work collapses the state machine to a no-suspension shape (`Unresumed | Returned | Panicked`); the 1-byte size for sync arity-0 is just the discriminant. Smaller futures mean smaller `Box::pin` allocations (often a smaller jemalloc bucket) and less memory traffic on first poll.

**2. One fewer `turbo_tasks()` call per task execution.** The async `RawVc::to_non_local` did `let tt = turbo_tasks();` — a thread-local lookup — on every per-task future poll that touched a local output. The new `to_non_local_unchecked_sync` takes `&dyn TurboTasksApi` directly from the executor scope where the reference is already in hand.

### How?

- `output_try_into_non_local_raw_vc` is no longer async; it just returns `output.try_into_raw_vc()`. Inlined at all six callsites in `task_fn_impl!` and deleted.
- `RawVc::to_non_local_unchecked_sync` is added: a synchronous variant that takes `&dyn TurboTasksApi` and assumes the local output is already populated. The executor calls it after `wait_for_local_tasks().await`, where that invariant holds. The `unreachable!()` on the not-ready path documents the contract.
- The original async `to_non_local` is kept (now `pub`) so the testing harness can do the conversion explicitly, since it doesn't go through the same executor path.
- `NativeFunction::execute`'s doc gains a note that it may now return a local Vc.

The `to_non_local` semantics are unchanged — just relocated.

<!-- NEXT_JS_LLM_PR -->