### PR TITLE
fix: `Infinity` cacheLife in next config should be respected

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1178,5 +1178,6 @@
   "1177": "The middleware \"%s\" accepts an async API directly with the form:\n  \n  export function middleware(request, event) {\n    return NextResponse.redirect('/new-location')\n  }\n  \n  Read more: https://nextjs.org/docs/messages/middleware-new-signature\n  ",
   "1178": "The request.page has been deprecated in favour of \\`URLPattern\\`.\n  Read more: https://nextjs.org/docs/messages/middleware-request-page\n  ",
   "1179": "Invariant: %s This is a bug in Next.js.",
-  "1180": "Cookies can only be modified in a Server Action or Route Handler. Read more: https://nextjs.org/docs/app/api-reference/functions/cookies#options"
+  "1180": "Cookies can only be modified in a Server Action or Route Handler. Read more: https://nextjs.org/docs/app/api-reference/functions/cookies#options",
+  "1181": "Unknown cacheLife option %s"
 }

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -33,6 +33,7 @@ import {
 import { setHttpClientAndAgentOptions } from './setup-http-agent-env'
 import { pathHasPrefix } from '../shared/lib/router/utils/path-has-prefix'
 import { matchRemotePattern } from '../shared/lib/match-remote-pattern'
+import { validateAndNormalizeCacheLifeProfile } from './use-cache/cache-life-profile'
 
 import type { ZodError } from 'next/dist/compiled/zod'
 import { hasNextSupport } from '../server/ci-info'
@@ -1290,6 +1291,13 @@ function assignDefaultsAndValidate(
         defaultCacheLifeProfile.expire =
           result.expireTime ?? defaultDefault.expire
       }
+    }
+
+    for (const [profileName, profile] of Object.entries(result.cacheLife)) {
+      validateAndNormalizeCacheLifeProfile(profile, {
+        kind: 'config',
+        profileName,
+      })
     }
   }
 

--- a/packages/next/src/server/use-cache/cache-life-profile.ts
+++ b/packages/next/src/server/use-cache/cache-life-profile.ts
@@ -1,0 +1,127 @@
+import { INFINITE_CACHE } from '../../lib/constants'
+
+export type CacheLife = {
+  // How long the client can cache a value without checking with the server.
+  stale?: number
+  // How frequently you want the cache to refresh on the server.
+  // Stale values may be served while revalidating.
+  revalidate?: number
+  // In the worst case scenario, where you haven't had traffic in a while,
+  // how stale can a value be until you prefer deopting to dynamic.
+  // Must be longer than revalidate.
+  expire?: number
+}
+
+type CacheLifeProfileKey = keyof CacheLife
+
+type CacheLifeProfileContext =
+  | { kind: 'inline' }
+  | { kind: 'config'; profileName: string }
+
+function getCacheLifeFalseError(key: CacheLifeProfileKey): string {
+  switch (key) {
+    case 'stale':
+      return (
+        'Pass `Infinity` instead of `false` if you want to cache on the client forever ' +
+        'without checking with the server.'
+      )
+    case 'revalidate':
+      return 'Pass `Infinity` instead of `false` if you do not want to revalidate by time.'
+    case 'expire':
+      return (
+        'Pass `Infinity` instead of `false` if you want to cache on the server forever ' +
+        'without checking with the origin.'
+      )
+    default:
+      key satisfies never
+      throw new Error(`Unknown cacheLife option ${String(key)}`)
+  }
+}
+
+function getInvalidCacheLifeValueError(
+  key: CacheLifeProfileKey,
+  value: unknown,
+  context: CacheLifeProfileContext
+): string {
+  if (context.kind === 'config') {
+    return `Invalid "cacheLife.${context.profileName}.${key}" provided, expected a finite number of seconds or Infinity, received ${String(
+      value
+    )}`
+  }
+
+  return `Invalid \`cacheLife()\` option "${key}" provided, expected a finite number of seconds or Infinity, received ${String(
+    value
+  )}.`
+}
+
+function getNonNumberCacheLifeValueError(
+  key: CacheLifeProfileKey,
+  value: unknown,
+  context: CacheLifeProfileContext
+): string {
+  if (context.kind === 'config') {
+    return getInvalidCacheLifeValueError(key, value, context)
+  }
+
+  return `The ${key} option must be a number of seconds.`
+}
+
+function normalizeCacheLifeValue(
+  key: CacheLifeProfileKey,
+  value: unknown,
+  context: CacheLifeProfileContext
+): number | undefined {
+  if (value === undefined) {
+    return undefined
+  }
+
+  if (value === false) {
+    throw new Error(getCacheLifeFalseError(key))
+  }
+
+  if (typeof value !== 'number') {
+    throw new Error(getNonNumberCacheLifeValueError(key, value, context))
+  }
+
+  if (value === Infinity) {
+    return INFINITE_CACHE
+  }
+
+  if (!Number.isFinite(value)) {
+    throw new Error(getInvalidCacheLifeValueError(key, value, context))
+  }
+
+  return value
+}
+
+export function validateAndNormalizeCacheLifeProfile(
+  profile: CacheLife,
+  context: CacheLifeProfileContext
+): CacheLife {
+  if (profile.stale !== undefined) {
+    profile.stale = normalizeCacheLifeValue('stale', profile.stale, context)
+  }
+  if (profile.revalidate !== undefined) {
+    profile.revalidate = normalizeCacheLifeValue(
+      'revalidate',
+      profile.revalidate,
+      context
+    )
+  }
+  if (profile.expire !== undefined) {
+    profile.expire = normalizeCacheLifeValue('expire', profile.expire, context)
+  }
+
+  if (profile.revalidate !== undefined && profile.expire !== undefined) {
+    if (profile.revalidate > profile.expire) {
+      throw new Error(
+        'If providing both the revalidate and expire options, ' +
+          'the expire option must be greater than the revalidate option. ' +
+          'The expire option indicates how many seconds from the start ' +
+          'until it can no longer be used.'
+      )
+    }
+  }
+
+  return profile
+}

--- a/packages/next/src/server/use-cache/cache-life.test.ts
+++ b/packages/next/src/server/use-cache/cache-life.test.ts
@@ -1,0 +1,65 @@
+import { INFINITE_CACHE } from '../../lib/constants'
+import { workUnitAsyncStorage } from '../app-render/work-unit-async-storage.external'
+import { cacheLife } from './cache-life'
+
+describe('cacheLife', () => {
+  const originalUseCache = process.env.__NEXT_USE_CACHE
+
+  beforeEach(() => {
+    process.env.__NEXT_USE_CACHE = '1'
+  })
+
+  afterEach(() => {
+    if (originalUseCache === undefined) {
+      delete process.env.__NEXT_USE_CACHE
+    } else {
+      process.env.__NEXT_USE_CACHE = originalUseCache
+    }
+  })
+
+  it('should normalize Infinity profile values', () => {
+    const store = {
+      type: 'cache',
+      explicitStale: undefined,
+      explicitRevalidate: undefined,
+      explicitExpire: undefined,
+    } as any
+
+    workUnitAsyncStorage.run(store, () => {
+      cacheLife({
+        stale: Infinity,
+        revalidate: Infinity,
+        expire: Infinity,
+      })
+    })
+
+    expect(store.explicitStale).toBe(INFINITE_CACHE)
+    expect(store.explicitRevalidate).toBe(INFINITE_CACHE)
+    expect(store.explicitExpire).toBe(INFINITE_CACHE)
+  })
+
+  it('should reject non-finite profile values except Infinity', () => {
+    const store = {
+      type: 'cache',
+      explicitStale: undefined,
+      explicitRevalidate: undefined,
+      explicitExpire: undefined,
+    } as any
+
+    expect(() => {
+      workUnitAsyncStorage.run(store, () => {
+        cacheLife({
+          revalidate: -Infinity,
+        })
+      })
+    }).toThrow(/Invalid `cacheLife\(\)` option "revalidate" provided/)
+
+    expect(() => {
+      workUnitAsyncStorage.run(store, () => {
+        cacheLife({
+          expire: NaN,
+        })
+      })
+    }).toThrow(/Invalid `cacheLife\(\)` option "expire" provided/)
+  })
+})

--- a/packages/next/src/server/use-cache/cache-life.ts
+++ b/packages/next/src/server/use-cache/cache-life.ts
@@ -1,18 +1,11 @@
 import { InvariantError } from '../../shared/lib/invariant-error'
 import { workAsyncStorage } from '../app-render/work-async-storage.external'
 import { workUnitAsyncStorage } from '../app-render/work-unit-async-storage.external'
+import { validateAndNormalizeCacheLifeProfile } from './cache-life-profile'
+import type { CacheLife } from './cache-life-profile'
 
-export type CacheLife = {
-  // How long the client can cache a value without checking with the server.
-  stale?: number
-  // How frequently you want the cache to refresh on the server.
-  // Stale values may be served while revalidating.
-  revalidate?: number
-  // In the worst case scenario, where you haven't had traffic in a while,
-  // how stale can a value be until you prefer deopting to dynamic.
-  // Must be longer than revalidate.
-  expire?: number
-}
+export type { CacheLife }
+
 // The equivalent header is kind of like:
 // Cache-Control: max-age=[stale],s-max-age=[revalidate],stale-while-revalidate=[expire-revalidate],stale-if-error=[expire-revalidate]
 // Except that stale-while-revalidate/stale-if-error only applies to shared caches - not private caches.
@@ -30,49 +23,6 @@ type CacheLifeProfiles =
   | 'weeks'
   | 'max'
   | (string & {})
-
-function validateCacheLife(profile: CacheLife) {
-  if (profile.stale !== undefined) {
-    if ((profile.stale as any) === false) {
-      throw new Error(
-        'Pass `Infinity` instead of `false` if you want to cache on the client forever ' +
-          'without checking with the server.'
-      )
-    } else if (typeof profile.stale !== 'number') {
-      throw new Error('The stale option must be a number of seconds.')
-    }
-  }
-  if (profile.revalidate !== undefined) {
-    if ((profile.revalidate as any) === false) {
-      throw new Error(
-        'Pass `Infinity` instead of `false` if you do not want to revalidate by time.'
-      )
-    } else if (typeof profile.revalidate !== 'number') {
-      throw new Error('The revalidate option must be a number of seconds.')
-    }
-  }
-  if (profile.expire !== undefined) {
-    if ((profile.expire as any) === false) {
-      throw new Error(
-        'Pass `Infinity` instead of `false` if you want to cache on the server forever ' +
-          'without checking with the origin.'
-      )
-    } else if (typeof profile.expire !== 'number') {
-      throw new Error('The expire option must be a number of seconds.')
-    }
-  }
-
-  if (profile.revalidate !== undefined && profile.expire !== undefined) {
-    if (profile.revalidate > profile.expire) {
-      throw new Error(
-        'If providing both the revalidate and expire options, ' +
-          'the expire option must be greater than the revalidate option. ' +
-          'The expire option indicates how many seconds from the start ' +
-          'until it can no longer be used.'
-      )
-    }
-  }
-}
 
 export function cacheLife(profile: CacheLifeProfiles | CacheLife): void {
   if (!process.env.__NEXT_USE_CACHE) {
@@ -143,7 +93,9 @@ export function cacheLife(profile: CacheLifeProfiles | CacheLife): void {
       'Invalid `cacheLife()` option. Either pass a profile name or object.'
     )
   } else {
-    validateCacheLife(profile)
+    profile = validateAndNormalizeCacheLifeProfile(profile, {
+      kind: 'inline',
+    })
   }
 
   if (profile.revalidate !== undefined) {

--- a/test/unit/isolated/config.test.ts
+++ b/test/unit/isolated/config.test.ts
@@ -1,6 +1,7 @@
 /* eslint-env jest */
 import { join } from 'path'
 import { PHASE_DEVELOPMENT_SERVER } from 'next/constants'
+import { INFINITE_CACHE } from 'next/dist/lib/constants'
 
 const pathToConfig = join(__dirname, '_resolvedata', 'without-function')
 const pathToConfigFn = join(__dirname, '_resolvedata', 'with-function')
@@ -49,6 +50,41 @@ describe('config', () => {
       },
     })
     expect((config as any).customConfigKey).toBe('customConfigValue')
+  })
+
+  it('Should normalize Infinity cacheLife profile values', async () => {
+    const config = await loadConfig(PHASE_DEVELOPMENT_SERVER, '<rootDir>', {
+      customConfig: {
+        cacheLife: {
+          infinite: {
+            stale: Infinity,
+            revalidate: Infinity,
+            expire: Infinity,
+          },
+        },
+      },
+    })
+
+    expect(config.cacheLife.infinite).toEqual({
+      stale: INFINITE_CACHE,
+      revalidate: INFINITE_CACHE,
+      expire: INFINITE_CACHE,
+    })
+    expect(JSON.stringify(config.cacheLife.infinite)).not.toContain('null')
+  })
+
+  it('Should reject negative Infinity cacheLife profile values', async () => {
+    await expect(async () => {
+      await loadConfig(PHASE_DEVELOPMENT_SERVER, '<rootDir>', {
+        customConfig: {
+          cacheLife: {
+            invalid: {
+              revalidate: -Infinity,
+            },
+          },
+        },
+      })
+    }).rejects.toThrow(/Invalid "cacheLife\.invalid\.revalidate" provided/)
   })
 
   it('Should assign object defaults deeply to customConfig', async () => {


### PR DESCRIPTION
Raw `Infinity` is not JSON-safe and can stringify to `null` when config is serialized, causing cache life profiles to behave incorrectly. 

This PR normalizes `Infinity` cache life values to `INFINITE_CACHE` for both `next.config` profiles and inline `cacheLife({ ... })` profiles and uses a shared normalization/validation util in both places. This keeps `Infinity` as an accepted user-facing value while ensuring internals use the existing sentinel.

closes NAR-95