### PR TITLE
[turbopack] Simplify local task tracking

### DIFF
--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -29,6 +29,7 @@ mod id_factory;
 mod invalidation;
 mod join_iter_ext;
 pub mod keyed;
+mod local_task_tracker;
 #[doc(hidden)]
 pub mod macro_helpers;
 mod manager;

--- a/turbopack/crates/turbo-tasks/src/local_task_tracker.rs
+++ b/turbopack/crates/turbo-tasks/src/local_task_tracker.rs
@@ -1,5 +1,7 @@
 //! Tracker for the local tasks of a single global task execution.
 
+use std::fmt::Display;
+
 use crate::{
     OutputContent,
     event::{Event, EventListener},
@@ -36,11 +38,14 @@ impl LocalTaskTracker {
     /// Tasks should call [`complete`] when the task transitions to `Done`.
     ///
     /// [`complete`]: LocalTaskTracker::complete
-    pub(crate) fn create(&mut self, task: LocalTask) -> LocalTaskId {
-        debug_assert!(
-            matches!(task, LocalTask::Scheduled { .. }),
-            "newly created local tasks must start in the Scheduled state"
-        );
+    pub(crate) fn create(
+        &mut self,
+        task_type: impl Display + Send + Sync + 'static,
+    ) -> LocalTaskId {
+        let task = LocalTask::Scheduled {
+            done_event: Event::new(move || move || format!("LocalTask({task_type})::done_event")),
+        };
+
         self.tasks.push(task);
         self.in_flight += 1;
         // generate a one-indexed id from len() -- we just pushed so len() is >= 1
@@ -62,7 +67,7 @@ impl LocalTaskTracker {
         // Do this before decrementing in-flight so we can ensure that tasks are always completed
         // before the task completes.
         done_event.notify(usize::MAX);
-        self.dec_in_flight();
+        self.decrement_in_flight();
     }
 
     /// Test-only: register an in-flight detached future (`spawn_detached_for_testing`). No
@@ -79,7 +84,7 @@ impl LocalTaskTracker {
     /// [`complete`] which decrements as part of the slot transition.
     ///
     /// [`complete`]: LocalTaskTracker::complete
-    pub(crate) fn dec_in_flight(&mut self) {
+    pub(crate) fn decrement_in_flight(&mut self) {
         debug_assert!(
             self.in_flight > 0,
             "LocalTaskTracker::dec_in_flight without matching increment"
@@ -92,6 +97,7 @@ impl LocalTaskTracker {
 
     /// Current in-flight count. Cheap snapshot for the early-return path in
     /// `wait_for_local_tasks`.
+    #[cfg(test)]
     pub(crate) fn in_flight(&self) -> u32 {
         self.in_flight
     }
@@ -99,8 +105,12 @@ impl LocalTaskTracker {
     /// Listen for the next "in-flight reached zero" notification. Used by
     /// `wait_for_local_tasks` together with `in_flight()` for the standard double-check
     /// pattern that avoids lost wakeups.
-    pub(crate) fn listen(&self) -> EventListener {
-        self.done.listen()
+    pub(crate) fn listen_for_in_flight(&self) -> Option<EventListener> {
+        if self.in_flight > 0 {
+            Some(self.done.listen())
+        } else {
+            None
+        }
     }
 }
 
@@ -121,9 +131,7 @@ mod tests {
         let mut tracker = LocalTaskTracker::new();
         assert_eq!(tracker.in_flight(), 0);
 
-        let id = tracker.create(LocalTask::Scheduled {
-            done_event: Event::new(|| || "test".to_string()),
-        });
+        let id = tracker.create("test");
         assert_eq!(tracker.in_flight(), 1);
 
         tracker.complete(id, dummy_output());
@@ -136,9 +144,9 @@ mod tests {
         tracker.register_detached();
         tracker.register_detached();
         assert_eq!(tracker.in_flight(), 2);
-        tracker.dec_in_flight();
+        tracker.decrement_in_flight();
         assert_eq!(tracker.in_flight(), 1);
-        tracker.dec_in_flight();
+        tracker.decrement_in_flight();
         assert_eq!(tracker.in_flight(), 0);
     }
 
@@ -147,11 +155,11 @@ mod tests {
     #[test]
     fn complete_notifies_per_task_listener() {
         let mut tracker = LocalTaskTracker::new();
-        let per_task_event = Event::new(|| || "per-task".to_string());
-        let listener = per_task_event.listen();
-        let id = tracker.create(LocalTask::Scheduled {
-            done_event: per_task_event,
-        });
+        let id = tracker.create("test");
+        let LocalTask::Scheduled { done_event: event } = tracker.get(id) else {
+            unreachable!()
+        };
+        let listener = event.listen();
         tracker.complete(id, dummy_output());
         // The listener is now ready (notify already fired) — `wait()` should return without
         // blocking. We can't `.await` in a sync test, so just check `is_notified` indirectly

--- a/turbopack/crates/turbo-tasks/src/local_task_tracker.rs
+++ b/turbopack/crates/turbo-tasks/src/local_task_tracker.rs
@@ -1,0 +1,161 @@
+//! Tracker for the local tasks of a single global task execution.
+
+use crate::{
+    OutputContent,
+    event::{Event, EventListener},
+    id::LocalTaskId,
+    task::local_task::LocalTask,
+};
+
+pub(crate) struct LocalTaskTracker {
+    /// Slot vector for `LocalTask` entries. One-indexed via `LocalTaskId`.
+    tasks: Vec<LocalTask>,
+    /// Count of `tasks` entries still in `Scheduled` state, plus any in-flight detached test
+    /// futures. Decrementing to zero notifies `done`.
+    in_flight: u32,
+    /// Notified each time `in_flight` transitions to zero.
+    done: Event,
+}
+
+impl LocalTaskTracker {
+    pub(crate) fn new() -> Self {
+        Self {
+            tasks: Vec::new(),
+            in_flight: 0,
+            done: Event::new(|| || "LocalTaskTracker::done".to_string()),
+        }
+    }
+
+    pub(crate) fn get(&self, id: LocalTaskId) -> &LocalTask {
+        // local task ids are one-indexed (they use NonZeroU32)
+        &self.tasks[(*id as usize) - 1]
+    }
+
+    /// Create a new `Scheduled` local task and returns the new task id.
+    ///
+    /// Tasks should call [`complete`] when the task transitions to `Done`.
+    ///
+    /// [`complete`]: LocalTaskTracker::complete
+    pub(crate) fn create(&mut self, task: LocalTask) -> LocalTaskId {
+        debug_assert!(
+            matches!(task, LocalTask::Scheduled { .. }),
+            "newly created local tasks must start in the Scheduled state"
+        );
+        self.tasks.push(task);
+        self.in_flight += 1;
+        // generate a one-indexed id from len() -- we just pushed so len() is >= 1
+
+        // SAFETY: len() is >= 1 because we just pushed.
+        unsafe { LocalTaskId::new_unchecked(self.tasks.len() as u32) }
+    }
+
+    /// Transition the slot for `id` from `Scheduled` to `Done`, notify any
+    /// `try_read_local_output` waiters on this specific task, decrement the in-flight
+    /// counter, and notify the collective `done` event if it reached zero.
+    pub(crate) fn complete(&mut self, id: LocalTaskId, output: OutputContent) {
+        let slot = &mut self.tasks[(*id as usize) - 1];
+        let prev = std::mem::replace(slot, LocalTask::Done { output });
+        let LocalTask::Scheduled { done_event } = prev else {
+            panic!("local task finished, but was not in the scheduled state?");
+        };
+        // notify waiter on this task that it is complete.
+        // Do this before decrementing in-flight so we can ensure that tasks are always completed
+        // before the task completes.
+        done_event.notify(usize::MAX);
+        self.dec_in_flight();
+    }
+
+    /// Test-only: register an in-flight detached future (`spawn_detached_for_testing`). No
+    /// `LocalTask` slot is allocated; this just bumps the counter. Balanced by a matching
+    /// [`dec_in_flight`] when the wrapped future completes.
+    ///
+    /// [`dec_in_flight`]: LocalTaskTracker::dec_in_flight
+    pub(crate) fn register_detached(&mut self) {
+        self.in_flight += 1;
+    }
+
+    /// Decrement the in-flight counter and notify the collective `done` event if it reached
+    /// zero. Used by the test-only detached path; the production path goes through
+    /// [`complete`] which decrements as part of the slot transition.
+    ///
+    /// [`complete`]: LocalTaskTracker::complete
+    pub(crate) fn dec_in_flight(&mut self) {
+        debug_assert!(
+            self.in_flight > 0,
+            "LocalTaskTracker::dec_in_flight without matching increment"
+        );
+        self.in_flight -= 1;
+        if self.in_flight == 0 {
+            self.done.notify(usize::MAX);
+        }
+    }
+
+    /// Current in-flight count. Cheap snapshot for the early-return path in
+    /// `wait_for_local_tasks`.
+    pub(crate) fn in_flight(&self) -> u32 {
+        self.in_flight
+    }
+
+    /// Listen for the next "in-flight reached zero" notification. Used by
+    /// `wait_for_local_tasks` together with `in_flight()` for the standard double-check
+    /// pattern that avoids lost wakeups.
+    pub(crate) fn listen(&self) -> EventListener {
+        self.done.listen()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dummy_output() -> OutputContent {
+        OutputContent::Link(crate::raw_vc::RawVc::TaskOutput(
+            crate::TaskId::try_from(1).unwrap(),
+        ))
+    }
+
+    /// `create` increments `in_flight`; `complete` performs the slot transition AND
+    /// decrements in one step.
+    #[test]
+    fn create_then_complete_balances_in_flight() {
+        let mut tracker = LocalTaskTracker::new();
+        assert_eq!(tracker.in_flight(), 0);
+
+        let id = tracker.create(LocalTask::Scheduled {
+            done_event: Event::new(|| || "test".to_string()),
+        });
+        assert_eq!(tracker.in_flight(), 1);
+
+        tracker.complete(id, dummy_output());
+        assert_eq!(tracker.in_flight(), 0);
+    }
+
+    #[test]
+    fn detached_inc_dec_balances_in_flight() {
+        let mut tracker = LocalTaskTracker::new();
+        tracker.register_detached();
+        tracker.register_detached();
+        assert_eq!(tracker.in_flight(), 2);
+        tracker.dec_in_flight();
+        assert_eq!(tracker.in_flight(), 1);
+        tracker.dec_in_flight();
+        assert_eq!(tracker.in_flight(), 0);
+    }
+
+    /// `complete` notifies per-task waiters (the equivalent of `try_read_local_output`'s
+    /// `EventListener` users) as part of the transition.
+    #[test]
+    fn complete_notifies_per_task_listener() {
+        let mut tracker = LocalTaskTracker::new();
+        let per_task_event = Event::new(|| || "per-task".to_string());
+        let listener = per_task_event.listen();
+        let id = tracker.create(LocalTask::Scheduled {
+            done_event: per_task_event,
+        });
+        tracker.complete(id, dummy_output());
+        // The listener is now ready (notify already fired) — `wait()` should return without
+        // blocking. We can't `.await` in a sync test, so just check `is_notified` indirectly
+        // by relying on the synchronous `wait()` API exposed by `EventListener`.
+        listener.wait();
+    }
+}

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -18,7 +18,7 @@ use anyhow::{Result, anyhow};
 use auto_hash_map::AutoMap;
 use bincode::{Decode, Encode};
 use either::Either;
-use futures::{FutureExt, stream::FuturesUnordered};
+use futures::FutureExt;
 use rustc_hash::{FxBuildHasher, FxHasher};
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
@@ -40,9 +40,10 @@ use crate::{
     id::{ExecutionId, LocalTaskId, TRANSIENT_TASK_BIT, TraitTypeId},
     id_factory::IdFactoryWithReuse,
     keyed::KeyedEq,
+    local_task_tracker::LocalTaskTracker,
     macro_helpers::NativeFunction,
     message_queue::{CompilationEvent, CompilationEventQueue},
-    priority_runner::{Executor, JoinHandle, PriorityRunner},
+    priority_runner::{Executor, PriorityRunner},
     raw_vc::{CellId, RawVc},
     registry,
     serialization_invalidation::SerializationInvalidator,
@@ -497,10 +498,6 @@ pub struct TurboTasks<B: Backend + 'static> {
     compilation_events: CompilationEventQueue,
 }
 
-type LocalTaskTracker = Option<
-    FuturesUnordered<Either<JoinHandle, Pin<Box<dyn Future<Output = ()> + Send + Sync + 'static>>>>,
->;
-
 /// Information about a non-local task. A non-local task can contain multiple "local" tasks, which
 /// all share the same non-local task state.
 ///
@@ -532,12 +529,9 @@ struct CurrentTaskState {
     /// This is taken (and becomes `None`) during teardown of a task.
     cell_counters: Option<AutoMap<ValueTypeId, u32, BuildHasherDefault<FxHasher>, 8>>,
 
-    /// Local tasks created while this global task has been running. Indexed by `LocalTaskId`.
-    local_tasks: Vec<LocalTask>,
-
-    /// Tracks currently running local tasks, and defers cleanup of the global task until those
-    /// complete. Also used by `spawn_detached_for_testing`.
-    local_task_tracker: LocalTaskTracker,
+    /// Tracks execution of Local tasks (and detached test futures) created during this global
+    /// task's execution.
+    local_tasks: LocalTaskTracker,
 }
 
 impl CurrentTaskState {
@@ -556,8 +550,7 @@ impl CurrentTaskState {
             has_invalidator: false,
             in_top_level_task,
             cell_counters: Some(AutoMap::default()),
-            local_tasks: Vec::new(),
-            local_task_tracker: None,
+            local_tasks: LocalTaskTracker::new(),
         }
     }
 
@@ -575,8 +568,7 @@ impl CurrentTaskState {
             has_invalidator: false,
             in_top_level_task,
             cell_counters: None,
-            local_tasks: Vec::new(),
-            local_task_tracker: None,
+            local_tasks: LocalTaskTracker::new(),
         }
     }
 
@@ -587,25 +579,6 @@ impl CurrentTaskState {
                  parent task that created them"
             );
         }
-    }
-
-    fn create_local_task(&mut self, local_task: LocalTask) -> LocalTaskId {
-        self.local_tasks.push(local_task);
-        // generate a one-indexed id from len() -- we just pushed so len() is >= 1
-        if cfg!(debug_assertions) {
-            LocalTaskId::try_from(u32::try_from(self.local_tasks.len()).unwrap()).unwrap()
-        } else {
-            unsafe { LocalTaskId::new_unchecked(self.local_tasks.len() as u32) }
-        }
-    }
-
-    fn get_local_task(&self, local_task_id: LocalTaskId) -> &LocalTask {
-        // local task ids are one-indexed (they use NonZeroU32)
-        &self.local_tasks[(*local_task_id as usize) - 1]
-    }
-
-    fn get_mut_local_task(&mut self, local_task_id: LocalTaskId) -> &mut LocalTask {
-        &mut self.local_tasks[(*local_task_id as usize) - 1]
     }
 }
 
@@ -884,7 +857,7 @@ impl<B: Backend + 'static> TurboTasks<B> {
         let (global_task_state, execution_id, priority, local_task_id) =
             CURRENT_TASK_STATE.with(|gts| {
                 let mut gts_write = gts.write().unwrap();
-                let local_task_id = gts_write.create_local_task(LocalTask::Scheduled {
+                let local_task_id = gts_write.local_tasks.create(LocalTask::Scheduled {
                     done_event: Event::new(move || {
                         move || format!("LocalTask({task_type})::done_event")
                     }),
@@ -897,23 +870,17 @@ impl<B: Backend + 'static> TurboTasks<B> {
                 )
             });
 
-        let future = self.priority_runner.schedule_with_join_handle(
+        self.priority_runner.schedule(
             &self.pin(),
             ScheduledTask::LocalTask {
                 ty,
                 persistence,
                 local_task_id,
-                global_task_state: global_task_state.clone(),
+                global_task_state,
                 span: Span::current(),
             },
             priority,
         );
-        global_task_state
-            .write()
-            .unwrap()
-            .local_task_tracker
-            .get_or_insert_default()
-            .push(Either::Left(future));
 
         RawVc::LocalOutput(execution_id, local_task_id, persistence)
     }
@@ -1346,22 +1313,12 @@ impl<B: Backend> Executor<TurboTasks<B>, ScheduledTask, TaskPriority> for TurboT
                                 ),
                             };
 
-                            let local_task = LocalTask::Done { output };
-
-                            let done_event = CURRENT_TASK_STATE.with(move |gts| {
-                                let mut gts_write = gts.write().unwrap();
-                                let scheduled_task = std::mem::replace(
-                                    gts_write.get_mut_local_task(local_task_id),
-                                    local_task,
-                                );
-                                let LocalTask::Scheduled { done_event } = scheduled_task else {
-                                    panic!(
-                                        "local task finished, but was not in the scheduled state?"
-                                    );
-                                };
-                                done_event
+                            CURRENT_TASK_STATE.with(move |gts| {
+                                gts.write()
+                                    .unwrap()
+                                    .local_tasks
+                                    .complete(local_task_id, output);
                             });
-                            done_event.notify(usize::MAX)
                         }
                         .instrument(span),
                     )
@@ -1535,7 +1492,7 @@ impl<B: Backend + 'static> TurboTasksApi for TurboTasks<B> {
             // compile-time checks cannot capture.
             gts_read.assert_execution_id(execution_id);
 
-            match gts_read.get_local_task(local_task_id) {
+            match gts_read.local_tasks.get(local_task_id) {
                 LocalTask::Scheduled { done_event } => Ok(Err(done_event.listen())),
                 LocalTask::Done { output } => Ok(Ok(output.as_read_result()?)),
             }
@@ -1629,17 +1586,21 @@ impl<B: Backend + 'static> TurboTasksApi for TurboTasks<B> {
         // this is similar to what happens for a local task, except that we keep the local task's
         // state as well.
         let global_task_state = CURRENT_TASK_STATE.with(|ts| ts.clone());
-        let fut = tokio::spawn(TURBO_TASKS.scope(
+        global_task_state
+            .write()
+            .unwrap()
+            .local_tasks
+            .register_detached();
+        let wrapped = async move {
+            fut.await;
+            // Pair for `register_detached`. Tasks panic-aborting upstream means we don't need
+            // RAII guard semantics here; if `fut` panics, the process aborts before this dec.
+            CURRENT_TASK_STATE.with(|ts| ts.write().unwrap().local_tasks.dec_in_flight());
+        };
+        tokio::spawn(TURBO_TASKS.scope(
             turbo_tasks(),
-            CURRENT_TASK_STATE.scope(global_task_state.clone(), fut),
+            CURRENT_TASK_STATE.scope(global_task_state, wrapped),
         ));
-        let fut = Box::pin(async move {
-            fut.await.unwrap();
-        });
-        let mut ts = global_task_state.write().unwrap();
-        ts.local_task_tracker
-            .get_or_insert_default()
-            .push(Either::Right(fut));
     }
 
     fn task_statistics(&self) -> &TaskStatisticsApi {
@@ -1730,13 +1691,31 @@ impl<B: Backend + 'static> TurboTasksBackendApi<B> for TurboTasks<B> {
 }
 
 async fn wait_for_local_tasks() {
-    // This needs to be a while loop in case one local task completing/exeucting triggers another.
-    while let Some(mut ltt) =
-        CURRENT_TASK_STATE.with(|ts| ts.write().unwrap().local_task_tracker.take())
-    {
-        use futures::StreamExt;
-        while ltt.next().await.is_some() {}
+    // Standard double-check pattern: take a listener, re-check the counter, then await.
+    // If a notify fires between the first read and the listen, the second read sees zero and
+    // returns. Otherwise the listener will be woken by the eventual transition-to-zero notify.
+    //
+    // No loop after the await: by the time `wait_for_local_tasks` runs, the user task body has
+    // already returned and no new local tasks (or detached test futures) can be registered
+    // from outside an existing in-flight scope. So when the notify fires, the counter is
+    // genuinely at zero — we don't need to re-check.
+    let listener = CURRENT_TASK_STATE.with(|ts| {
+        let tracker = &ts.read().unwrap().local_tasks;
+        if tracker.in_flight() == 0 {
+            None
+        } else {
+            Some(tracker.listen())
+        }
+    });
+    let Some(listener) = listener else {
+        return;
+    };
+    // Re-check after registering the listener.
+    let still_in_flight = CURRENT_TASK_STATE.with(|ts| ts.read().unwrap().local_tasks.in_flight());
+    if still_in_flight == 0 {
+        return;
     }
+    listener.await;
 }
 
 pub(crate) fn current_task_if_available(from: &str) -> Option<TaskId> {

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -1588,10 +1588,16 @@ impl<B: Backend + 'static> TurboTasksApi for TurboTasks<B> {
             .local_tasks
             .register_detached();
         let wrapped = async move {
+            // use a drop guard for panic safety
+            struct DropGuard;
+            impl Drop for DropGuard {
+                fn drop(&mut self) {
+                    CURRENT_TASK_STATE
+                        .with(|ts| ts.write().unwrap().local_tasks.decrement_in_flight());
+                }
+            }
+            let _guard = DropGuard;
             fut.await;
-            // Pair for `register_detached`. Tasks panic-aborting upstream means we don't need
-            // RAII guard semantics here; if `fut` panics, the process aborts before this dec.
-            CURRENT_TASK_STATE.with(|ts| ts.write().unwrap().local_tasks.decrement_in_flight());
         };
         tokio::spawn(TURBO_TASKS.scope(
             turbo_tasks(),

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -729,7 +729,7 @@ impl<B: Backend + 'static> TurboTasks<B> {
                     wait_for_local_tasks().await;
 
                     match result {
-                        Ok(Ok(raw_vc)) => Ok(raw_vc),
+                        Ok(Ok(value)) => Ok(value),
                         Ok(Err(err)) => Err(err.into()),
                         Err(err) => Err(TurboTasksExecutionError::Panic(Arc::new(err))),
                     }
@@ -857,11 +857,7 @@ impl<B: Backend + 'static> TurboTasks<B> {
         let (global_task_state, execution_id, priority, local_task_id) =
             CURRENT_TASK_STATE.with(|gts| {
                 let mut gts_write = gts.write().unwrap();
-                let local_task_id = gts_write.local_tasks.create(LocalTask::Scheduled {
-                    done_event: Event::new(move || {
-                        move || format!("LocalTask({task_type})::done_event")
-                    }),
-                });
+                let local_task_id = gts_write.local_tasks.create(task_type);
                 (
                     Arc::clone(gts),
                     gts_write.execution_id,
@@ -1595,7 +1591,7 @@ impl<B: Backend + 'static> TurboTasksApi for TurboTasks<B> {
             fut.await;
             // Pair for `register_detached`. Tasks panic-aborting upstream means we don't need
             // RAII guard semantics here; if `fut` panics, the process aborts before this dec.
-            CURRENT_TASK_STATE.with(|ts| ts.write().unwrap().local_tasks.dec_in_flight());
+            CURRENT_TASK_STATE.with(|ts| ts.write().unwrap().local_tasks.decrement_in_flight());
         };
         tokio::spawn(TURBO_TASKS.scope(
             turbo_tasks(),
@@ -1691,30 +1687,11 @@ impl<B: Backend + 'static> TurboTasksBackendApi<B> for TurboTasks<B> {
 }
 
 async fn wait_for_local_tasks() {
-    // Standard double-check pattern: take a listener, re-check the counter, then await.
-    // If a notify fires between the first read and the listen, the second read sees zero and
-    // returns. Otherwise the listener will be woken by the eventual transition-to-zero notify.
-    //
-    // No loop after the await: by the time `wait_for_local_tasks` runs, the user task body has
-    // already returned and no new local tasks (or detached test futures) can be registered
-    // from outside an existing in-flight scope. So when the notify fires, the counter is
-    // genuinely at zero — we don't need to re-check.
-    let listener = CURRENT_TASK_STATE.with(|ts| {
-        let tracker = &ts.read().unwrap().local_tasks;
-        if tracker.in_flight() == 0 {
-            None
-        } else {
-            Some(tracker.listen())
-        }
-    });
+    let listener =
+        CURRENT_TASK_STATE.with(|ts| ts.read().unwrap().local_tasks.listen_for_in_flight());
     let Some(listener) = listener else {
         return;
     };
-    // Re-check after registering the listener.
-    let still_in_flight = CURRENT_TASK_STATE.with(|ts| ts.read().unwrap().local_tasks.in_flight());
-    if still_in_flight == 0 {
-        return;
-    }
     listener.await;
 }
 

--- a/turbopack/crates/turbo-tasks/src/priority_runner.rs
+++ b/turbopack/crates/turbo-tasks/src/priority_runner.rs
@@ -14,7 +14,6 @@ use std::{
 
 use parking_lot::Mutex;
 use pin_project_lite::pin_project;
-use tokio::sync::oneshot::{Receiver, Sender};
 
 pub trait Executor<C, T, P>: Send + Sync {
     type Future: Future<Output = ()> + Send;
@@ -37,7 +36,6 @@ where
 struct HeapItem<P, T> {
     priority: P,
     task: T,
-    tx: Option<Sender<()>>,
 }
 
 impl<P: Eq, T> PartialEq for HeapItem<P, T> {
@@ -95,33 +93,12 @@ impl<
     }
 
     pub fn schedule(self: &Arc<Self>, execute_context: &Arc<C>, task: T, priority: P) {
-        self.schedule_internal(execute_context, task, priority, None);
-    }
-
-    pub fn schedule_with_join_handle(
-        self: &Arc<Self>,
-        execute_context: &Arc<C>,
-        task: T,
-        priority: P,
-    ) -> JoinHandle {
-        let (tx, rx) = tokio::sync::oneshot::channel();
-        self.schedule_internal(execute_context, task, priority, Some(tx));
-        JoinHandle { receiver: rx }
-    }
-
-    fn schedule_internal(
-        self: &Arc<Self>,
-        execute_context: &Arc<C>,
-        task: T,
-        priority: P,
-        tx: Option<Sender<()>>,
-    ) {
         let mut queue = self.queue.lock();
         if !queue.is_empty() {
             // If there is already work in the queue, we don't have any
             // free capacity so we can just push the task to the queue.
             // It will be picked up by existing workers.
-            queue.push(HeapItem { priority, task, tx });
+            queue.push(HeapItem { priority, task });
             return;
         }
         // The queue is empty, so we might have free capacity to spawn a new worker.
@@ -131,10 +108,10 @@ impl<
             drop(queue);
 
             let future = self.executor.execute(execute_context, task, priority);
-            WorkerFuture::spawn(future, tx, execute_context.clone(), self.clone());
+            WorkerFuture::spawn(future, execute_context.clone(), self.clone());
         } else {
             // No free capacity, push the task to the queue.
-            queue.push(HeapItem { priority, task, tx });
+            queue.push(HeapItem { priority, task });
             drop(queue);
 
             // Undo the added active worker since we didn't spawn a new worker.
@@ -170,20 +147,15 @@ impl<
         }
     }
 
-    fn pop_future_from_worker(
-        &self,
-        execute_context: &Arc<C>,
-    ) -> Option<(E::Future, Option<Sender<()>>)> {
+    fn pop_future_from_worker(&self, execute_context: &Arc<C>) -> Option<E::Future> {
         let mut queue = self.queue.lock();
         if let Some(heap_item) = queue.pop() {
             shrink_amortized(&mut queue);
             drop(queue);
-            let tx = heap_item.tx;
-            Some((
+            Some(
                 self.executor
                     .execute(execute_context, heap_item.task, heap_item.priority),
-                tx,
-            ))
+            )
         } else {
             None
         }
@@ -198,7 +170,6 @@ impl<
         if let Some(heap_item) = queue.pop() {
             shrink_amortized(&mut queue);
             drop(queue);
-            let tx = heap_item.tx;
             let new_future =
                 self.executor
                     .execute(execute_context, heap_item.task, heap_item.priority);
@@ -206,7 +177,7 @@ impl<
             if !unused_active_count {
                 self.active_workers.fetch_add(1, Ordering::Relaxed);
             }
-            WorkerFuture::spawn(new_future, tx, execute_context.clone(), self.clone());
+            WorkerFuture::spawn(new_future, execute_context.clone(), self.clone());
             true
         } else {
             false
@@ -249,7 +220,6 @@ pin_project! {
     {
         #[pin]
         future: E::Future,
-        tx: Option<Sender<()>>,
         execute_context: Arc<C>,
         runner: Arc<PriorityRunner<C, T, P, E>>,
         state: WorkerState,
@@ -263,15 +233,9 @@ impl<
     E: Executor<C, T, P> + 'static,
 > WorkerFuture<C, T, P, E>
 {
-    fn spawn(
-        future: E::Future,
-        tx: Option<Sender<()>>,
-        execute_context: Arc<C>,
-        runner: Arc<PriorityRunner<C, T, P, E>>,
-    ) {
+    fn spawn(future: E::Future, execute_context: Arc<C>, runner: Arc<PriorityRunner<C, T, P, E>>) {
         tokio::task::spawn(Self {
             future,
-            tx,
             execute_context,
             runner,
             state: WorkerState::UnfinishedFuture,
@@ -304,11 +268,6 @@ impl<
                 WorkerState::UnfinishedFuture => {
                     match this.future.as_mut().poll(cx) {
                         Poll::Ready(()) => {
-                            // Notify that the task is done
-                            if let Some(tx) = this.tx.take() {
-                                let _ = tx.send(());
-                            }
-
                             *this.state = WorkerState::Done;
 
                             if last_yield.elapsed() > Duration::from_millis(5) {
@@ -339,7 +298,7 @@ impl<
 
                     // This future is done, we need to check the queue for more tasks,
                     // so we can continue working on a new future in this worker.
-                    if let Some((new_future, new_tx)) =
+                    if let Some(new_future) =
                         this.runner.pop_future_from_worker(this.execute_context)
                     {
                         // We are replacing the future with a new one, but the current future is
@@ -353,7 +312,6 @@ impl<
                             drop_in_place(future_slot);
                             future_slot.write(new_future);
                         }
-                        *this.tx = new_tx;
                         *this.state = WorkerState::UnfinishedFuture;
                     } else {
                         // No more tasks to execute
@@ -364,25 +322,6 @@ impl<
                     }
                 }
             }
-        }
-    }
-}
-
-pub struct JoinHandle {
-    receiver: Receiver<()>,
-}
-
-impl Future for JoinHandle {
-    type Output = ();
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let this = self.get_mut();
-        match Pin::new(&mut this.receiver).poll(cx) {
-            Poll::Ready(result) => {
-                let _ = result;
-                Poll::Ready(())
-            }
-            Poll::Pending => Poll::Pending,
         }
     }
 }


### PR DESCRIPTION
### What?

Replace the `FuturesUnordered<Either<JoinHandle, ...>>` that tracks a global task's in-flight local tasks with a small in-place counter+`Event` bundled into a new `LocalTaskTracker` that lives directly on `CurrentTaskState`.

### Why?

`wait_for_local_tasks` only needs a barrier — "have all in-flight local tasks completed?" — not a stream of outputs. `FuturesUnordered` was overkill for that, and its supporting machinery cost an allocation per parent task plus an allocation per local task, plus repeated lock acquisitions per registration and per completion.

Per parent task execution, this PR removes:

- **One `FuturesUnordered` allocation.** The lazy `Option<FuturesUnordered<…>>` is gone; the counter+event is inline on `CurrentTaskState`.
- **One `tokio::sync::oneshot::channel()` allocation per local task.** `priority_runner::schedule_with_join_handle` (and `JoinHandle`) is deleted; local tasks now use plain `schedule`.
- **One intrusive `FuturesUnordered::Task` node allocation per local task.**
- **One `RwLock<CurrentTaskState>` write-lock acquisition per local task spawn.** The pre-existing `create_local_task` write lock now also bumps the in-flight counter, so we no longer take a separate lock to push into the tracker.
- **One `RwLock<CurrentTaskState>` write-lock acquisition per local task completion.** The pre-existing `Scheduled → Done` write lock now also decrements the counter, notifies per-task waiters, and (if the count hit zero) notifies the collective wait event — all under one lock.

Net effect on hot paths:

- **Spawn**: was 2 allocations + 2 locks; now 0 allocations + 1 lock (the existing `create_local_task` lock).
- **Wait when nothing was spawned**: a single read-lock that finds `in_flight == 0` and returns. No allocation, no listener, no await.

### How?

- New `LocalTaskTracker` ([`turbopack/crates/turbo-tasks/src/local_task_tracker.rs`](turbopack/crates/turbo-tasks/src/local_task_tracker.rs)) bundles:
  - `tasks: Vec<LocalTask>` (was a separate field on `CurrentTaskState`),
  - `in_flight: u32` (plain integer; the surrounding `RwLock` provides synchronization),
  - `done: Event` (notified on transitions to zero).
- `CurrentTaskState::local_tasks` is now `LocalTaskTracker` instead of `Vec<LocalTask>`. The wait-group is part of the same struct, so a parent task that doesn't spawn any local tasks pays nothing beyond the inline fields.
- `LocalTaskTracker::create` pushes a new `Scheduled` entry and increments the counter.
- `LocalTaskTracker::complete` does the `Scheduled → Done` swap, fires the per-task `done_event` (waking `try_read_local_output` waiters), decrements the counter, and notifies the collective `done` event if the count hit zero — all while holding one write lock.
- `wait_for_local_tasks` is the standard double-check pattern (snapshot the counter, register a listener, re-check, await) against the tracker. No loop after the await — the codebase contract is that no new local tasks (or detached test futures) can be registered after the parent's user body returns, except from inside an already-in-flight scope, so a single notify is sufficient.
- `spawn_detached_for_testing` uses a tiny `register_detached` / `dec_in_flight` pair (test path; no RAII guard, panics abort upstream).
- `priority_runner::schedule_with_join_handle`, `JoinHandle`, the `Option<Sender<()>>` field on `HeapItem`, and the matching `tx.send(())` in `WorkerFuture::poll` are all deleted; nothing else used them.

Unit tests for the tracker cover balanced create/complete, balanced detached register/dec, and that `complete` wakes per-task listeners. The existing detached integration tests (including the nested `spawn_detached_for_testing` case in `detached.rs`) still pass.

<!-- NEXT_JS_LLM_PR -->