### PR TITLE
Fix dev mode reload and error on back navigation between Next.js pages

### DIFF
--- a/packages/next/src/client/dev/debug-channel.ts
+++ b/packages/next/src/client/dev/debug-channel.ts
@@ -8,7 +8,7 @@ export interface DebugChannelReadableWriterPair {
 
 const pairs = new Map<string, DebugChannelReadableWriterPair>()
 
-const DEBUG_CHANNEL_STORAGE_KEY = '__next_debug_channel'
+const DEBUG_CHANNEL_STORAGE_KEY_PREFIX = '__next_debug_channel:'
 
 // Buffer for the initial document's debug channel data. Written to
 // sessionStorage once complete so it can be restored when the browser serves
@@ -16,22 +16,33 @@ const DEBUG_CHANNEL_STORAGE_KEY = '__next_debug_channel'
 let initialDocumentDebugChunks: Uint8Array[] = []
 
 function persistDebugChannelToSessionStorage(requestId: string): void {
-  try {
-    const chunks = initialDocumentDebugChunks.map((chunk) => {
+  const key = DEBUG_CHANNEL_STORAGE_KEY_PREFIX + requestId
+  const value = JSON.stringify(
+    initialDocumentDebugChunks.map((chunk) => {
       let binary = ''
       for (let i = 0; i < chunk.byteLength; i++) {
         binary += String.fromCharCode(chunk[i])
       }
       return btoa(binary)
     })
+  )
 
-    sessionStorage.setItem(
-      DEBUG_CHANNEL_STORAGE_KEY,
-      JSON.stringify({ requestId, chunks })
-    )
+  try {
+    sessionStorage.setItem(key, value)
   } catch {
-    // Quota exceeded or other error — skip silently. The location.reload()
+    // Likely a quota error. Drop entries from previous documents in this tab
+    // (we only need to restore the current one's entry on cache restore) and
+    // retry once. If it still fails, skip silently — the location.reload()
     // fallback in createDebugChannel handles this case.
+    for (let i = sessionStorage.length - 1; i >= 0; i--) {
+      const k = sessionStorage.key(i)
+      if (k?.startsWith(DEBUG_CHANNEL_STORAGE_KEY_PREFIX) && k !== key) {
+        sessionStorage.removeItem(k)
+      }
+    }
+    try {
+      sessionStorage.setItem(key, value)
+    } catch {}
   }
 }
 
@@ -50,22 +61,15 @@ function restoreDebugChannelFromSessionStorage(
   requestId: string
 ): ReadableStream<Uint8Array> | undefined {
   try {
-    const serializedData = sessionStorage.getItem(DEBUG_CHANNEL_STORAGE_KEY)
+    const serializedData = sessionStorage.getItem(
+      DEBUG_CHANNEL_STORAGE_KEY_PREFIX + requestId
+    )
 
     if (!serializedData) {
       return undefined
     }
 
-    const parsedData = JSON.parse(serializedData) as {
-      requestId: string
-      chunks: string[]
-    }
-
-    if (parsedData.requestId !== requestId) {
-      return undefined
-    }
-
-    const chunks = parsedData.chunks.map((base64) => {
+    const chunks = (JSON.parse(serializedData) as string[]).map((base64) => {
       const binary = atob(base64)
       const bytes = new Uint8Array(binary.length)
       for (let i = 0; i < binary.length; i++) {
@@ -153,13 +157,16 @@ export function createDebugChannel(
   if (!requestHeaders && wasServedFromCache()) {
     const readable = restoreDebugChannelFromSessionStorage(requestId)
 
-    if (!readable) {
-      // Debug channel can't be restored — debug deps would block hydration.
-      // Force a fresh page load from the server.
-      location.reload()
+    if (readable) {
+      return { readable }
     }
 
-    return { readable }
+    // Debug channel can't be restored — debug deps would block hydration.
+    // Force a fresh page load from the server. Return a never-closing stream
+    // so the Flight client stays parked until the reload tears the document
+    // down, instead of synchronously erroring with "Connection closed.".
+    location.reload()
+    return { readable: new ReadableStream() }
   }
 
   const { readable } = getOrCreateDebugChannelReadableWriterPair(requestId)

--- a/test/e2e/app-dir/bfcache-regression/app/page.tsx
+++ b/test/e2e/app-dir/bfcache-regression/app/page.tsx
@@ -12,7 +12,7 @@ export default function Page() {
         Increment
       </button>
       <p>
-        <a href="https://example.com">External Link</a>
+        <a href="/target-page">MPA Link</a>
       </p>
     </div>
   )

--- a/test/e2e/app-dir/bfcache-regression/app/target-page/page.tsx
+++ b/test/e2e/app-dir/bfcache-regression/app/target-page/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h2>Target Page</h2>
+}

--- a/test/e2e/app-dir/bfcache-regression/bfcache-regression.test.ts
+++ b/test/e2e/app-dir/bfcache-regression/bfcache-regression.test.ts
@@ -1,13 +1,21 @@
 import { nextTestSetup } from 'e2e-utils'
-import { retry } from 'next-test-utils'
+import { assertNoConsoleErrors, retry } from 'next-test-utils'
 
 describe('bfcache-regression', () => {
-  const { next } = nextTestSetup({
+  const { next, isTurbopack } = nextTestSetup({
     files: __dirname,
   })
 
-  it('should preserve interactivity after navigating back from an external page', async () => {
-    const browser = await next.browser('/')
+  it('should preserve interactivity after navigating back from another page via MPA navigation', async () => {
+    // In webpack dev, compiling a new route on demand while another page is
+    // open triggers an HMR cycle that has no Fast Refresh boundary, surfacing
+    // a "performing full reload" warning on the open page. Warm up the target
+    // page in parallel with the browser load so it's already compiled by the
+    // time we click the link.
+    const [browser] = await Promise.all([
+      next.browser('/', { pushErrorAsConsoleLog: true }),
+      !isTurbopack ? next.render('/target-page').catch(() => {}) : null,
+    ])
 
     // Verify initial state and that the counter is interactive.
     await browser.elementById('increment').click()
@@ -16,13 +24,11 @@ describe('bfcache-regression', () => {
       expect(await browser.elementById('count').text()).toBe('Count: 1')
     })
 
-    // Navigate away to an external page by clicking the link (full page
+    // Navigate away to another page by clicking the link (full page
     // navigation, not a client-side navigation).
-    await browser.elementByCss('a[href="https://example.com"]').click()
+    await browser.elementByCss('a[href="/target-page"]').click()
 
-    await retry(async () => {
-      expect(await browser.url()).toContain('example.com')
-    })
+    expect(await (await browser.elementByCss('h2')).text()).toBe('Target Page')
 
     // Navigate back (simulates clicking the browser back button).
     await browser.back()
@@ -37,5 +43,7 @@ describe('bfcache-regression', () => {
     await retry(async () => {
       expect(await browser.elementById('count').text()).toBe('Count: 1')
     })
+
+    await assertNoConsoleErrors(browser)
   })
 })


### PR DESCRIPTION
Follow-up to #92892, addressing the regression reported in https://github.com/vercel/next.js/issues/93136#issuecomment-4298124826.

That PR persisted the dev-mode debug channel chunks under a single shared `sessionStorage` key (`__next_debug_channel`) so the data could be replayed when a page is served from HTTP cache. The single-key design holds when the only navigations away from a Next.js page go to other origins, but it breaks the moment two Next.js documents share the same tab.

When a user does an MPA navigation from page A to page B (a regular `<a href>` link to another Next.js route), B's persisted entry overwrites A's under the same key. Clicking back restores A from HTTP cache; A's bootstrap re-executes with its original `self.__next_r`, looks up `sessionStorage`, finds B's `requestId`, returns `undefined` from `restoreDebugChannelFromSessionStorage`, and falls back to `location.reload()`. Before the reload completes, the main RSC stream closes; the Flight client surfaces references to debug-channel chunks that block other model chunks — references the debug channel was supposed to deliver but never did — as a `Connection closed.` error, briefly flashing the error UI.

The fix changes the storage key from `__next_debug_channel` to a per-document prefix `__next_debug_channel:${requestId}`. Each initial document persists into its own entry, so A's data survives B's load and the back-restore finds it. `requestId` is dropped from the stored value since it's now part of the key. On `setItem` failure (likely a quota issue), other entries with the prefix are removed and `setItem` is retried once; if it still fails, persistence is silently skipped and `location.reload()` remains the safety net on the read side.

The fallback path also gets a small change: when restore legitimately fails (e.g., session storage cleared mid-session), `createDebugChannel` now returns `{ readable: new ReadableStream() }` rather than `{ readable: undefined }`. The empty stream never enqueues and never closes, so from the Flight client's perspective the debug channel is still active when the main stream closes — the unresolved chunk references no longer surface as a synchronous error before `location.reload()` tears the document down.

The `bfcache-regression` test was updated to reproduce the bug. It now clicks an internal MPA link to `/target-page` instead of an external one, and asserts no console errors after the round trip via `assertNoConsoleErrors`. The fixture pre-warms `/target-page` compilation in parallel with the browser load in webpack mode, to avoid an unrelated Fast Refresh full-reload warning when the route is compiled on demand.

Fixes: https://github.com/vercel/next.js/issues/93510