### PR TITLE
[ci] Create unique preview build versions for canary previews

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -147,7 +147,7 @@ jobs:
       - run: pnpm install
 
       - name: Set preview version
-        if: ${{ contains(fromJSON('["automated-preview","force-preview"]'), needs.deploy-target.outputs.value) }}
+        if: ${{ contains(fromJSON('["automated-preview", "force-preview", "staging"]'), needs.deploy-target.outputs.value) }}
         run: |
           node scripts/set-preview-version.js "${{ github.sha }}"
           pnpm install --no-frozen-lockfile

--- a/scripts/set-preview-version.js
+++ b/scripts/set-preview-version.js
@@ -30,6 +30,9 @@ async function main() {
   // 15.0.0-canary.17 -> 15.0.0
   // 15.0.0 -> 15.0.0
   const [semverStableVersion] = lernaConfig.version.split('-')
+  // This can create colliding versions between different forks which should be incredibly rare.
+  // Preview builds are installed by URL anyway which is unique between forks by
+  // controlling the repo var setting the preview builds base url.
   const version = `${semverStableVersion}-preview-${shortSha}-${dateString}`
   //
   // Lerna version requires a non-detached HEAD


### PR DESCRIPTION
Otherwise preview builds on the `canary` branch get the same version as the last Canary published on NPM.