### PR TITLE
fix: normalize carriage returns in metadata descriptions

### DIFF
--- a/packages/next/src/lib/metadata/metadata.tsx
+++ b/packages/next/src/lib/metadata/metadata.tsx
@@ -830,7 +830,7 @@ function createMetadataElements(
     }
     if (og.description) {
       tags.push(
-        <meta key={i++} property="og:description" content={og.description} />
+        <meta key={i++} property="og:description" content={normalizeMetadataString(og.description)} />
       )
     }
     if (og.url) {
@@ -1541,7 +1541,7 @@ function createMetadataElements(
     }
     if (tw.description) {
       tags.push(
-        <meta key={i++} name="twitter:description" content={tw.description} />
+        <meta key={i++} name="twitter:description" content={normalizeMetadataString(tw.description)} />
       )
     }
 

--- a/packages/next/src/lib/metadata/metadata.tsx
+++ b/packages/next/src/lib/metadata/metadata.tsx
@@ -420,6 +420,13 @@ function createViewportElements(
 // Metadata tag rendering
 // ---------------------------------------------------------------------------
 
+// Normalize string metadata values to prevent hydration mismatches.
+// Windows carriage returns (\r\n) are stripped during HTML serialization
+// but not in the React hydration data, causing duplicate meta tags.
+function normalizeMetadataString(value: string): string {
+  return value.replace(/\r\n/g, '\n').replace(/\r/g, '')
+}
+
 function createMetadataElements(
   metadata: ResolvedMetadata
 ): React.ReactElement[] {
@@ -434,7 +441,11 @@ function createMetadataElements(
   // --- Basic meta tags ---
   if (metadata.description) {
     tags.push(
-      <meta key={i++} name="description" content={metadata.description} />
+      <meta
+        key={i++}
+        name="description"
+        content={normalizeMetadataString(metadata.description)}
+      />
     )
   }
   if (metadata.applicationName) {

--- a/packages/next/src/lib/metadata/resolve-metadata.ts
+++ b/packages/next/src/lib/metadata/resolve-metadata.ts
@@ -952,7 +952,9 @@ function inheritFromMetadata(
       target.title = metadata.title
     }
     if (!target.description && metadata.description) {
-      target.description = metadata.description
+      // Normalize carriage returns to prevent hydration mismatches.
+      // Windows \r\n is stripped during HTML serialization but not in RSC payload.
+      target.description = metadata.description.replace(/\r\n/g, '\n').replace(/\r/g, '')
     }
   }
 }


### PR DESCRIPTION
## Problem

When `generateMetadata` returns a description containing Windows-style carriage returns (`\r\n`), the carriage return is stripped during HTML serialization but not in the React hydration data (RSC payload). This causes React to detect a mismatch and re-add the meta tag during hydration, resulting in duplicate `<meta name="description">` tags.

**Reproduction**: https://github.com/henrycatalinismith/carriage-return-duplicate-description-bug-demo

Running `document.querySelectorAll('meta[name="description"]').length` returns 2 instead of 1.

## Solution

Normalize carriage returns in metadata string values to prevent hydration mismatches:

1. **`packages/next/src/lib/metadata/resolve-metadata.ts`**: When assigning the description to resolved metadata, normalize `\r\n` to `\n` and strip remaining `\r` characters.

2. **`packages/next/src/lib/metadata/metadata.tsx`**: Added a `normalizeMetadataString` helper function that strips carriage returns, applied to the description meta tag rendering.

This ensures both the server-rendered HTML and the React hydration data contain the same normalized value.

## How to verify

1. Create a Next.js app with `generateMetadata` that returns a description with `\r\n`:
   ```typescript
   export function generateMetadata() {
     return {
       description: "Hello\r\nWorld"
     }
   }
   ```
2. Build and run the app
3. Run `document.querySelectorAll('meta[name="description"]').length` in the browser console
4. Should return 1 (not 2)

Fixes #93089