### PR TITLE
Refactor: Decouple request store creation from `req` / `res`

### DIFF
--- a/packages/next/src/build/templates/edge-ssr-app.ts
+++ b/packages/next/src/build/templates/edge-ssr-app.ts
@@ -96,7 +96,7 @@ async function requestHandler(
   const isPossibleServerAction = getIsPossibleServerAction(req)
   const botType = getBotType(req.headers.get('User-Agent') || '')
   const { isOnDemandRevalidate } = checkIsOnDemandRevalidate(
-    req,
+    req.headers,
     prerenderManifest.preview
   )
 

--- a/packages/next/src/server/api-utils/index.ts
+++ b/packages/next/src/server/api-utils/index.ts
@@ -1,5 +1,4 @@
 import type { IncomingHttpHeaders, IncomingMessage } from 'http'
-import type { BaseNextRequest } from '../base-http'
 import type { CookieSerializeOptions } from 'next/dist/compiled/cookie'
 import type { NextApiResponse } from '../../shared/lib/utils'
 
@@ -77,15 +76,15 @@ export function redirect(
 }
 
 export function checkIsOnDemandRevalidate(
-  req: Request | IncomingMessage | BaseNextRequest,
+  rawHeaders: Headers | IncomingHttpHeaders,
   previewProps: __ApiPreviewProps
 ): {
   isOnDemandRevalidate: boolean
   revalidateOnlyGenerated: boolean
 } {
   // Headers is a plain object for Node.js, Headers object in Edge runtime
-  if (typeof req.headers.get === 'function') {
-    const headers = HeadersAdapter.from(req.headers)
+  if (typeof rawHeaders.get === 'function') {
+    const headers = HeadersAdapter.from(rawHeaders)
 
     const previewModeId = headers.get(PRERENDER_REVALIDATE_HEADER)
     const isOnDemandRevalidate = previewModeId === previewProps.previewModeId
@@ -97,7 +96,7 @@ export function checkIsOnDemandRevalidate(
     return { isOnDemandRevalidate, revalidateOnlyGenerated }
   }
 
-  const headers = req.headers as IncomingHttpHeaders
+  const headers = rawHeaders as IncomingHttpHeaders
 
   const previewModeId = headers[PRERENDER_REVALIDATE_HEADER]
   const isOnDemandRevalidate = previewModeId === previewProps.previewModeId

--- a/packages/next/src/server/api-utils/node/try-get-preview-data.ts
+++ b/packages/next/src/server/api-utils/node/try-get-preview-data.ts
@@ -22,7 +22,10 @@ export function tryGetPreviewData(
 ): PreviewData {
   // if an On-Demand revalidation is being done preview mode
   // is disabled
-  if (options && checkIsOnDemandRevalidate(req, options).isOnDemandRevalidate) {
+  if (
+    options &&
+    checkIsOnDemandRevalidate(req.headers, options).isOnDemandRevalidate
+  ) {
     return false
   }
 

--- a/packages/next/src/server/async-storage/draft-mode-provider.ts
+++ b/packages/next/src/server/async-storage/draft-mode-provider.ts
@@ -1,8 +1,6 @@
-import type { IncomingMessage } from 'http'
+import type { IncomingHttpHeaders } from 'http'
 import type { ReadonlyRequestCookies } from '../web/spec-extension/adapters/request-cookies'
 import type { ResponseCookies } from '../web/spec-extension/cookies'
-import type { BaseNextRequest } from '../base-http'
-import type { NextRequest } from '../web/spec-extension/request'
 
 import {
   COOKIE_NAME_PRERENDER_BYPASS,
@@ -28,7 +26,7 @@ export class DraftModeProvider {
 
   constructor(
     previewProps: __ApiPreviewProps | undefined,
-    req: IncomingMessage | BaseNextRequest<unknown> | NextRequest,
+    headers: Headers | IncomingHttpHeaders,
     cookies: ReadonlyRequestCookies,
     mutableCookies: ResponseCookies
   ) {
@@ -36,7 +34,7 @@ export class DraftModeProvider {
     // but Draft Mode does not have any data associated with it.
     const isOnDemandRevalidate =
       previewProps &&
-      checkIsOnDemandRevalidate(req, previewProps).isOnDemandRevalidate
+      checkIsOnDemandRevalidate(headers, previewProps).isOnDemandRevalidate
 
     const cookieValue = cookies.get(COOKIE_NAME_PRERENDER_BYPASS)?.value
 

--- a/packages/next/src/server/async-storage/request-store.ts
+++ b/packages/next/src/server/async-storage/request-store.ts
@@ -77,19 +77,56 @@ type RequestResponsePair =
   | { req: NextRequest; res: undefined } // in an api route or middleware
 
 /**
+ * The fields the request store actually reads from `req` / `res`. Decoupling
+ * the store's construction from `IncomingMessage` / `BaseNextRequest` /
+ * `NextRequest` lets it be built without a real `req`/`res` (e.g. by the `'use
+ * cache'` deadlock probe worker, which only has a serializable snapshot of the
+ * outer request).
+ */
+export type RequestStoreInputs = {
+  phase: RequestStore['phase']
+  /**
+   * Raw headers, either as a Web `Headers` instance or Node's
+   * `IncomingHttpHeaders`.
+   */
+  headers: Headers | IncomingHttpHeaders
+  /**
+   * Called whenever userspace mutates cookies (via `cookies().set(...)` etc.).
+   * Real renders wire this to `res.setHeader('Set-Cookie', cookies)`. Pass
+   * `undefined` for callers without a response (e.g. probe workers). Cookie
+   * writes during `'render'` are still gated by
+   * `MutableRequestCookiesAdapter`'s phase guard, so leaving this off doesn't
+   * silently accept writes that would otherwise be rejected.
+   */
+  onUpdateCookies: ((cookies: string[]) => void) | undefined
+  url: { pathname: string; search?: string }
+  rootParams: Params
+  implicitTags: ImplicitTags
+  renderResumeDataCache: RenderResumeDataCache | null
+  previewProps: WrapperRenderOpts['previewProps']
+  isHmrRefresh: boolean | undefined
+  serverComponentsHmrCache: ServerComponentsHmrCache | undefined
+  fallbackParams: OpaqueFallbackRouteParams | null | undefined
+}
+
+/**
  * If middleware set cookies in this request (indicated by `x-middleware-set-cookie`),
  * then merge those into the existing cookie object, so that when `cookies()` is accessed
  * it's able to read the newly set cookies.
  */
 function mergeMiddlewareCookies(
-  req: RequestContext['req'],
+  headers: Headers | IncomingHttpHeaders,
   existingCookies: RequestCookies | ResponseCookies
 ) {
+  // TODO: this only fires for `IncomingHttpHeaders`; `Headers` instances
+  // silently fall through (the `in` check and bracket access don't reach header
+  // values stored in internal slots). Confirm whether edge / Web `Headers`
+  // callers need this merge or already handle it elsewhere.
   if (
-    'x-middleware-set-cookie' in req.headers &&
-    typeof req.headers['x-middleware-set-cookie'] === 'string'
+    'x-middleware-set-cookie' in headers &&
+    typeof headers['x-middleware-set-cookie'] === 'string'
   ) {
-    const setCookieValue = req.headers['x-middleware-set-cookie']
+    const setCookieValue = headers['x-middleware-set-cookie']
     const responseHeaders = new Headers()
 
     for (const cookie of splitCookiesString(setCookieValue)) {
@@ -118,21 +155,26 @@ export function createRequestStoreForRender(
   renderResumeDataCache: RenderResumeDataCache | null,
   fallbackParams: OpaqueFallbackRouteParams | null
 ): RequestStore {
-  return createRequestStoreImpl(
+  return createRequestStore({
     // Pages start in render phase by default
-    'render',
-    req,
-    res,
+    phase: 'render',
+    headers: req.headers,
+    onUpdateCookies:
+      onUpdateCookies ??
+      (res
+        ? (cookies: string[]) => {
+            res.setHeader('Set-Cookie', cookies)
+          }
+        : undefined),
     url,
     rootParams,
     implicitTags,
-    onUpdateCookies,
     renderResumeDataCache,
     previewProps,
     isHmrRefresh,
     serverComponentsHmrCache,
-    fallbackParams
-  )
+    fallbackParams,
+  })
 }
 
 export function createRequestStoreForAPI(
@@ -142,42 +184,43 @@ export function createRequestStoreForAPI(
   onUpdateCookies: RenderOpts['onUpdateCookies'],
   previewProps: WrapperRenderOpts['previewProps']
 ): RequestStore {
-  return createRequestStoreImpl(
+  return createRequestStore({
     // API routes start in action phase by default
-    'action',
-    req,
-    undefined,
-    url,
-    {},
-    implicitTags,
+    phase: 'action',
+    headers: req.headers,
     onUpdateCookies,
-    null,
+    url,
+    rootParams: {},
+    implicitTags,
+    renderResumeDataCache: null,
     previewProps,
-    false,
-    undefined,
-    null
-  )
+    isHmrRefresh: false,
+    serverComponentsHmrCache: undefined,
+    fallbackParams: null,
+  })
 }
 
-function createRequestStoreImpl(
-  phase: RequestStore['phase'],
-  req: RequestContext['req'],
-  res: RequestContext['res'],
-  url: RequestContext['url'],
-  rootParams: Params,
-  implicitTags: RequestContext['implicitTags'],
-  onUpdateCookies: RenderOpts['onUpdateCookies'],
-  renderResumeDataCache: RenderResumeDataCache | null,
-  previewProps: WrapperRenderOpts['previewProps'],
-  isHmrRefresh: RequestContext['isHmrRefresh'],
-  serverComponentsHmrCache: RequestContext['serverComponentsHmrCache'],
-  fallbackParams: OpaqueFallbackRouteParams | null | undefined
-): RequestStore {
-  function defaultOnUpdateCookies(cookies: string[]) {
-    if (res) {
-      res.setHeader('Set-Cookie', cookies)
-    }
-  }
+/**
+ * Build a `RequestStore` from a serializable, request-shaped input. Used
+ * directly by the existing `createRequestStoreForRender` /
+ * `createRequestStoreForAPI` wrappers, and by side-process consumers like the
+ * `'use cache'` deadlock probe worker that don't have a real `req`/`res` pair
+ * but do have a forwarded snapshot of the outer request's headers etc.
+ */
+export function createRequestStore(inputs: RequestStoreInputs): RequestStore {
+  const {
+    phase,
+    headers,
+    onUpdateCookies,
+    url,
+    rootParams,
+    implicitTags,
+    renderResumeDataCache,
+    previewProps,
+    isHmrRefresh,
+    serverComponentsHmrCache,
+    fallbackParams,
+  } = inputs
 
   const cache: {
     headers?: ReadonlyHeaders
@@ -200,7 +243,7 @@ function createRequestStoreImpl(
       if (!cache.headers) {
         // Seal the headers object that'll freeze out any methods that could
         // mutate the underlying data.
-        cache.headers = getHeaders(req.headers)
+        cache.headers = getHeaders(headers)
       }
 
       return cache.headers
@@ -209,11 +252,9 @@ function createRequestStoreImpl(
       if (!cache.cookies) {
         // if middleware is setting cookie(s), then include those in
         // the initial cached cookies so they can be read in render
-        const requestCookies = new RequestCookies(
-          HeadersAdapter.from(req.headers)
-        )
+        const requestCookies = new RequestCookies(HeadersAdapter.from(headers))
 
-        mergeMiddlewareCookies(req, requestCookies)
+        mergeMiddlewareCookies(headers, requestCookies)
 
         // Seal the cookies object that'll freeze out any methods that could
         // mutate the underlying data.
@@ -227,12 +268,9 @@ function createRequestStoreImpl(
     },
     get mutableCookies() {
       if (!cache.mutableCookies) {
-        const mutableCookies = getMutableCookies(
-          req.headers,
-          onUpdateCookies || (res ? defaultOnUpdateCookies : undefined)
-        )
+        const mutableCookies = getMutableCookies(headers, onUpdateCookies)
 
-        mergeMiddlewareCookies(req, mutableCookies)
+        mergeMiddlewareCookies(headers, mutableCookies)
 
         cache.mutableCookies = mutableCookies
       }
@@ -250,7 +288,7 @@ function createRequestStoreImpl(
       if (!cache.draftMode) {
         cache.draftMode = new DraftModeProvider(
           previewProps,
-          req,
+          headers,
           this.cookies,
           this.mutableCookies
         )

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -1632,8 +1632,10 @@ export default class NextNodeServer extends BaseServer<
 
     // Middleware is skipped for on-demand revalidate requests
     if (
-      checkIsOnDemandRevalidate(params.request, this.renderOpts.previewProps)
-        .isOnDemandRevalidate
+      checkIsOnDemandRevalidate(
+        params.request.headers,
+        this.renderOpts.previewProps
+      ).isOnDemandRevalidate
     ) {
       return {
         response: new Response(null, { headers: { 'x-middleware-next': '1' } }),

--- a/packages/next/src/server/route-modules/route-module.ts
+++ b/packages/next/src/server/route-modules/route-module.ts
@@ -982,7 +982,7 @@ export abstract class RouteModule<
     }
 
     const { isOnDemandRevalidate, revalidateOnlyGenerated } =
-      checkIsOnDemandRevalidate(req, prerenderManifest.preview)
+      checkIsOnDemandRevalidate(req.headers, prerenderManifest.preview)
 
     let isDraftMode = false
     let previewData: PreviewData


### PR DESCRIPTION
This PR refactors `createRequestStoreImpl` into a new exported `createRequestStore` function that takes a serializable `RequestStoreInputs` shape (`headers`, optional `onUpdateCookies`, `url`, etc.) instead of a concrete `req` / `res` pair. The existing `createRequestStoreForRender` and `createRequestStoreForAPI` wrappers continue to take `(req, res, ...)` and translate to the new shape internally — there is no behavioral change for any existing code path.

Two transitive refactors are included in this change, motivated by the same goal of removing the dependency on `IncomingMessage` / `BaseNextRequest` / `NextRequest` from the inner construction:

- `checkIsOnDemandRevalidate(req, previewProps)` becomes `checkIsOnDemandRevalidate(rawHeaders, previewProps)`. Every call site now passes `req.headers` (or equivalent) rather than the whole request. The function only ever read `req.headers`, so this is purely a signature cleanup.
- `DraftModeProvider`'s constructor takes `headers` instead of `req`. Its draft-mode lookup also only needed the headers to call `checkIsOnDemandRevalidate`, so the dependency on the request types is no longer load-bearing.

`mergeMiddlewareCookies` similarly takes `headers` instead of `req`, but keeps its original `'x-middleware-set-cookie' in headers` + bracket-access pattern — preserving the pre-refactor behavior exactly (silent no-op for Web `Headers`, full merge for Node `IncomingHttpHeaders`). A `TODO` comment flags the open question of whether `Headers` callers need this merge or already handle it elsewhere. That's an investigation for a separate change.

This change is groundwork for an upcoming `'use cache'` deadlock-detection probe (see the `RequestStoreInputs` doc comment). The probe runs the same cache fill in an isolated worker process when the main fill stalls, and needs to construct a real `RequestStore` from a serialized snapshot of the outer request's headers / cookies / etc. — without access to the original `req` / `res` objects, which can't cross the worker boundary. With this refactor, the probe worker can call `createRequestStore` directly with the forwarded inputs and get a fully-functional store (real `headers`, `cookies`, `draftMode`, `mutableCookies`, `userspaceMutableCookies`), rather than building a stub that throws on access.