### PR TITLE
Detect `'use cache'` module-scope deadlocks early in dev

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1178,5 +1178,8 @@
   "1177": "The middleware \"%s\" accepts an async API directly with the form:\n  \n  export function middleware(request, event) {\n    return NextResponse.redirect('/new-location')\n  }\n  \n  Read more: https://nextjs.org/docs/messages/middleware-new-signature\n  ",
   "1178": "The request.page has been deprecated in favour of \\`URLPattern\\`.\n  Read more: https://nextjs.org/docs/messages/middleware-request-page\n  ",
   "1179": "Invariant: %s This is a bug in Next.js.",
-  "1180": "Cookies can only be modified in a Server Action or Route Handler. Read more: https://nextjs.org/docs/app/api-reference/functions/cookies#options"
+  "1180": "Cookies can only be modified in a Server Action or Route Handler. Read more: https://nextjs.org/docs/app/api-reference/functions/cookies#options",
+  "1181": "Filling a \"use cache\" entry appears to be stuck on shared state from the outer render scope. The same function completed when run in isolation, which usually means a module-scoped value (for example a top-level Map used to dedupe fetches) is joining a promise created outside the cache. \"use cache\" already dedupes calls with the same arguments — within a request and across requests on the same server instance — so the surrounding dedupe layer is both unnecessary and the likely cause. Remove it and rely on \"use cache\" alone for deduping.",
+  "1182": "`deadlockError` should be constructed inside `cache()` before reaching the probe scheduler.",
+  "1183": "Unexpected `prerender-dynamic` result in `use cache` probe mode."
 }

--- a/packages/next/src/server/app-render/work-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-async-storage.external.ts
@@ -95,6 +95,23 @@ export interface WorkStore {
    */
   pendingCacheInvocations?: Map<string, Promise<SharedCacheResult>>
 
+  /**
+   * Set by the dev-server's hang-detection probe worker (see
+   * `use-cache-probe-worker.ts`) to switch `cache()` into a one-shot fill
+   * path: run `generateCacheEntry` as for a cold fill, drain the resulting
+   * stream, return. No cache-handler or resume-data-cache I/O, no
+   * intra-request leader election — the probe just needs to learn whether
+   * the body completes in module-scope isolation.
+   */
+  readonly useCacheProbeMode?: {
+    /**
+     * Max wall time the probe fill may take. `cache()` enforces this with
+     * `UseCacheTimeoutError`, which the probe worker translates to
+     * `{ outcome: 'hung' }` for the parent process.
+     */
+    readonly timeoutMs: number
+  }
+
   isDraftMode?: boolean
   isUnstableNoStore?: boolean
   isPrefetchRequest?: boolean

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -25,6 +25,7 @@ import type { PagesManifest } from '../../build/webpack/plugins/pages-manifest-p
 import * as React from 'react'
 import fs from 'fs'
 import { Worker } from 'next/dist/compiled/jest-worker'
+import { installUseCacheProbe } from './use-cache-probe-pool'
 import { join as pathJoin } from 'path'
 import { PUBLIC_DIR_MIDDLEWARE_CONFLICT } from '../../lib/constants'
 import { findPagesDir } from '../../lib/find-pages-dir'
@@ -214,6 +215,13 @@ export default class DevServer extends Server {
         }
       )
     }
+
+    installUseCacheProbe({
+      distDir: this.distDir,
+      buildId: this.buildId,
+      deploymentId: this.deploymentId,
+      nextConfig: this.nextConfig,
+    })
   }
 
   protected override getServerComponentsHmrCache() {

--- a/packages/next/src/server/dev/require-cache.ts
+++ b/packages/next/src/server/dev/require-cache.ts
@@ -60,9 +60,31 @@ function deleteFromRequireCache(filePaths: string[]): void {
   }
 }
 
+// Listeners notified after the dev server's main-process require/manifest
+// caches are cleared. Worker pools that hold their own cached state —
+// distinct from the main process's — subscribe here so they can invalidate
+// in response to the same HMR events.
+const cacheInvalidationListeners = new Set<(filePaths: string[]) => void>()
+
+export function onCacheInvalidation(
+  listener: (filePaths: string[]) => void
+): () => void {
+  cacheInvalidationListeners.add(listener)
+  return () => {
+    cacheInvalidationListeners.delete(listener)
+  }
+}
+
 export function deleteCache(filePaths: string[]) {
   for (const filePath of filePaths) {
     clearManifestCache(filePath)
   }
   deleteFromRequireCache(filePaths)
+  for (const listener of cacheInvalidationListeners) {
+    try {
+      listener(filePaths)
+    } catch {
+      // Listener errors must not interfere with cache cleanup.
+    }
+  }
 }

--- a/packages/next/src/server/dev/use-cache-probe-pool.ts
+++ b/packages/next/src/server/dev/use-cache-probe-pool.ts
@@ -1,0 +1,190 @@
+import type { NextConfigComplete } from '../config-shared'
+import type {
+  EncodedArgumentsForProbe,
+  ProbeMessage,
+  probeUseCache,
+} from './use-cache-probe-worker'
+
+import { Worker } from 'next/dist/compiled/jest-worker'
+import { setUseCacheProbe } from '../use-cache/use-cache-probe-globals'
+import { onCacheInvalidation } from './require-cache'
+import { getFormattedNodeOptionsWithoutInspect } from '../lib/utils'
+
+interface InstallOptions {
+  distDir: string
+  buildId: string
+  deploymentId: string
+  nextConfig: NextConfigComplete
+}
+
+type ProbePool = { [key: string]: any } & {
+  probeUseCache: typeof probeUseCache
+}
+
+/**
+ * Convert the `encodedArguments` that `use-cache-wrapper.ts` already holds into
+ * the worker-transport shape. Blob values are base64-encoded so the payload
+ * survives the child-process JSON-only fallback transport — the worker_threads
+ * path would handle Blobs via structured clone, but we need one shape that
+ * works for both.
+ */
+async function toEncodedArgumentsForProbe(
+  encoded: string | FormData
+): Promise<EncodedArgumentsForProbe> {
+  if (typeof encoded === 'string') {
+    return { kind: 'string', data: encoded }
+  }
+
+  type FormDataEntries = Extract<
+    EncodedArgumentsForProbe,
+    { kind: 'formdata' }
+  >['entries']
+  const entries: FormDataEntries = []
+
+  for (const [key, value] of encoded.entries()) {
+    if (typeof value === 'string') {
+      entries.push([key, value])
+    } else {
+      const bytes = Buffer.from(await value.arrayBuffer()).toString('base64')
+      entries.push([key, { kind: 'blob', bytes, type: value.type }])
+    }
+  }
+
+  return { kind: 'formdata', entries }
+}
+
+/**
+ * Wire up the dev-server's `'use cache'` hang-detection probe: register the HMR
+ * teardown listener and install the probe hook that `use-cache-wrapper` calls
+ * when a fill stalls. Workers are spawned lazily — no process is forked until
+ * the first probe actually fires.
+ */
+export function installUseCacheProbe(options: InstallOptions): void {
+  const { distDir, buildId, deploymentId, nextConfig } = options
+
+  // The deadlock pattern we're detecting requires the outer render's
+  // dynamic-stage semantics to produce a halted promise that a user-space
+  // `Map<string, Promise>` captures. A probe worker has no outer render, so its
+  // cache-scope fetches resolve normally — the shared module scope can never
+  // accumulate a halted promise that would poison a sibling probe. That's why
+  // reusing workers across probes is safe: isolation between main and probe is
+  // what matters, not between probe invocations.
+  //
+  // Torn down on HMR (stale user modules) and on worker crash. Hung probes
+  // don't trigger teardown — the worker is still able to handle further tasks
+  // (the hung promise just sits in its heap), and that leak is bounded by the
+  // next HMR clear.
+  let pool: ProbePool | undefined
+
+  const getPool = (): ProbePool => {
+    if (pool) {
+      return pool
+    }
+    // The probe worker invokes the same RSC pipeline as a real cache fill,
+    // which imports `react-server-dom-webpack/server`. That package's
+    // `./server` export throws unless Node was started with the
+    // `react-server` condition. NODE_OPTIONS is the only way to set
+    // conditions in spawned processes (and inherited by both worker_threads
+    // and the child-process fallback transport).
+    const baseNodeOptions = getFormattedNodeOptionsWithoutInspect()
+    const probeNodeOptions = baseNodeOptions
+      ? `${baseNodeOptions} --conditions=react-server`
+      : '--conditions=react-server'
+    const worker = new Worker(require.resolve('./use-cache-probe-worker'), {
+      maxRetries: 0,
+      // jest-worker has no per-task scaling: once the pool is created, all
+      // `numWorkers` workers are alive until pool teardown. Set to absorb
+      // the realistic case of a single dev request fanning out into
+      // multiple concurrent `'use cache'` invocations that each hit the
+      // probe threshold.
+      // TODO: replace with on-demand scaling once
+      // https://github.com/vercel/next.js/pull/90532 lands — workers can
+      // then spawn lazily and shrink back when idle.
+      numWorkers: 4,
+      enableWorkerThreads: nextConfig.experimental.workerThreads,
+      // The worker's top-level imports include
+      // `react-server-dom-webpack/server`, which throws under the parent
+      // process's package-export conditions. Listing the methods explicitly
+      // tells jest-worker to skip the discovery `require()` it would
+      // otherwise do in the parent.
+      exposedMethods: ['probeUseCache'],
+      forkOptions: {
+        env: {
+          ...process.env,
+          NODE_OPTIONS: probeNodeOptions,
+        },
+      },
+    }) as Worker & ProbePool
+    worker.getStdout().pipe(process.stdout)
+    worker.getStderr().pipe(process.stderr)
+    pool = worker
+    return worker
+  }
+
+  const tearDownPool = async (): Promise<void> => {
+    const current = pool
+    if (!current) {
+      return
+    }
+    pool = undefined
+    await current.end().catch(() => {
+      // The worker process will exit on its own when nothing else holds it
+      // open; a failed `.end()` here just means we couldn't wait cleanly.
+    })
+  }
+
+  const runProbe = async (msg: ProbeMessage): Promise<boolean> => {
+    let activePool: ProbePool
+    try {
+      activePool = getPool()
+    } catch {
+      return false
+    }
+
+    try {
+      return await activePool.probeUseCache(msg)
+    } catch {
+      // Worker crash or IPC error: tear down the pool so the next probe starts
+      // fresh.
+      await tearDownPool()
+      return false
+    }
+  }
+
+  // The dev server can't reach into worker isolates to clear their
+  // `require.cache` or `loadManifest` `sharedCache`, so we drop the whole pool
+  // whenever the parent's caches are invalidated. The next probe lazy-spawns a
+  // fresh worker with empty caches. No path-level bookkeeping — cache
+  // invalidation in dev is infrequent and pool startup is cheap.
+  onCacheInvalidation(() => {
+    void tearDownPool()
+  })
+
+  // Wire the probe hook that `use-cache-wrapper` calls when a cache fill has
+  // been idle long enough to suspect a hang. The forwarded request snapshot
+  // lets the worker rebuild a faithful request store so cache bodies that read
+  // cookies/headers/etc. behave as in a real fill.
+  setUseCacheProbe(async (args) => {
+    const encodedArguments = await toEncodedArgumentsForProbe(
+      args.encodedArguments
+    )
+    return runProbe({
+      distDir,
+      page: args.page,
+      route: args.route,
+      id: args.id,
+      kind: args.kind,
+      encodedArguments,
+      request: args.request,
+      buildId,
+      deploymentId,
+      nextConfigSerializable: {
+        httpAgentOptions: nextConfig.httpAgentOptions,
+        cacheLifeProfiles: nextConfig.cacheLife,
+        useCacheTimeout: nextConfig.experimental.useCacheTimeout,
+        staticPageGenerationTimeout: nextConfig.staticPageGenerationTimeout,
+      },
+      timeoutMs: args.timeoutMs,
+    })
+  })
+}

--- a/packages/next/src/server/dev/use-cache-probe-require-hook.ts
+++ b/packages/next/src/server/dev/use-cache-probe-require-hook.ts
@@ -1,0 +1,26 @@
+import { addHookAliases } from '../require-hook'
+
+// The probe worker is a freestanding Node entry — `tsc`-emitted JS, not
+// bundled. Its `require('react-server-dom-webpack/server')` would otherwise
+// fail in a real install because Next.js doesn't ship that package as a
+// top-level dependency; only the vendored copies under `dist/compiled/` exist.
+// Mirrors the alias convention from `create-compiler-aliases.ts` and
+// `next-runtime.webpack-config.js`: source code always references
+// `react-server-dom-webpack/*` and the alias layer picks the bundler-specific
+// vendored target.
+//
+// This hook is loaded only by the worker process (jest-worker spawns it via
+// `use-cache-probe-worker.ts`), so the shared `require-hook.ts` stays untouched
+// and this redirect doesn't apply to any other entry.
+const bundler = process.env.TURBOPACK ? 'turbopack' : 'webpack'
+
+try {
+  addHookAliases([
+    [
+      'react-server-dom-webpack/server',
+      require.resolve(
+        `next/dist/compiled/react-server-dom-${bundler}/server.node`
+      ),
+    ],
+  ])
+} catch {}

--- a/packages/next/src/server/dev/use-cache-probe-worker.ts
+++ b/packages/next/src/server/dev/use-cache-probe-worker.ts
@@ -3,7 +3,7 @@ import type { AppPageModule } from '../route-modules/app-page/module'
 import type { WorkStore } from '../app-render/work-async-storage.external'
 import type { UseCacheProbeRequestSnapshot } from '../use-cache/use-cache-probe-globals'
 
-import '../require-hook'
+import './use-cache-probe-require-hook'
 import '../node-environment'
 
 import { AfterContext } from '../after/after-context'

--- a/packages/next/src/server/dev/use-cache-probe-worker.ts
+++ b/packages/next/src/server/dev/use-cache-probe-worker.ts
@@ -1,0 +1,217 @@
+import type { NextConfigComplete } from '../config-shared'
+import type { AppPageModule } from '../route-modules/app-page/module'
+import type { WorkStore } from '../app-render/work-async-storage.external'
+import type { UseCacheProbeRequestSnapshot } from '../use-cache/use-cache-probe-globals'
+
+import '../require-hook'
+import '../node-environment'
+
+import { AfterContext } from '../after/after-context'
+import { loadComponents } from '../load-components'
+import { setHttpClientAndAgentOptions } from '../setup-http-agent-env'
+import { workAsyncStorage } from '../app-render/work-async-storage.external'
+import { workUnitAsyncStorage } from '../app-render/work-unit-async-storage.external'
+import { getServerModuleMap } from '../app-render/manifests-singleton'
+import { createSnapshot } from '../app-render/async-local-storage'
+import { createRequestStore } from '../async-storage/request-store'
+/* eslint-disable import/no-extraneous-dependencies */
+import {
+  decodeReply,
+  decodeReplyFromAsyncIterable,
+  createTemporaryReferenceSet,
+} from 'react-server-dom-webpack/server'
+import type { CacheKeyParts } from '../use-cache/use-cache-wrapper'
+/* eslint-enable import/no-extraneous-dependencies */
+
+// Round-trippable view of `encodedArguments: FormData | string` from
+// `generateCacheEntryImpl`. The flattened `encodeFormData()` string used as a
+// cache-map key isn't usable here — it's lossy and only valid for equality
+// comparisons; the worker needs to call `decodeReply` on the original
+// `encodeReply` output.
+export type EncodedArgumentsForProbe =
+  | {
+      kind: 'string'
+      data: string
+    }
+  | {
+      kind: 'formdata'
+      // Blobs are base64-encoded so the payload survives both `worker_threads`
+      // structured clone AND the child-process JSON-only fallback transport.
+      entries: Array<
+        | [string, string]
+        | [string, { kind: 'blob'; bytes: string; type: string }]
+      >
+    }
+
+export type ProbeMessage = {
+  distDir: string
+  page: string
+  route: string
+  id: string
+  kind: string
+  encodedArguments: EncodedArgumentsForProbe
+  buildId: string
+  deploymentId: string
+  request: UseCacheProbeRequestSnapshot
+  nextConfigSerializable: {
+    httpAgentOptions: NextConfigComplete['httpAgentOptions']
+    cacheLifeProfiles: NextConfigComplete['cacheLife']
+    useCacheTimeout: number
+    staticPageGenerationTimeout: number
+  }
+  timeoutMs: number
+}
+
+export async function probeUseCache(msg: ProbeMessage): Promise<boolean> {
+  try {
+    setHttpClientAndAgentOptions({
+      httpAgentOptions: msg.nextConfigSerializable.httpAgentOptions,
+    })
+
+    // Populates the manifests singleton for the route via
+    // `setManifestsSingleton` inside the compiled app-page module — same
+    // mechanism a real request uses. The dev server tears the pool down
+    // whenever it invalidates its own require/manifest caches (HMR, route
+    // recompile) so the next probe lazy-spawns a worker with empty
+    // `require.cache` and `loadManifest` caches. Without that teardown, a
+    // second probe in the same worker would resolve user modules and manifests
+    // from the first probe's cached state.
+    //
+    // Narrowed to `AppPageModule` because the probe is only set up from the dev
+    // block in `generateCacheEntryImpl`, which is gated on
+    // `outerWorkUnitStore.cacheSignal` — currently only set for app pages.
+    // `'use cache'` in route handlers has no dev-mode hang protection at all
+    // today (no probe, no dev-fill timeout); when that gate is broadened, this
+    // loader will need to handle `AppRouteModule` and a different require
+    // mechanism (route handlers don't expose `__next_app__`).
+    const { ComponentMod } = await loadComponents<AppPageModule>({
+      distDir: msg.distDir,
+      page: msg.page,
+      isAppPath: true,
+      isDev: true,
+      sriEnabled: false,
+      needsManifestsForLegacyReasons: true,
+    })
+
+    // Resolve the wrapped `'use cache'` function by its server reference
+    // id. Same path `action-handler.ts` takes for server actions: server
+    // module map → bundler module id → `__next_app__.require` → exported
+    // function keyed by the action id.
+    const serverModuleMap = getServerModuleMap()
+    const entry = serverModuleMap[msg.id]
+    if (!entry) {
+      return false
+    }
+
+    const actionMod = (await ComponentMod.__next_app__.require(
+      entry.id
+    )) as Record<string, (...args: unknown[]) => Promise<unknown>>
+    const wrappedFn = actionMod[msg.id]
+    if (typeof wrappedFn !== 'function') {
+      return false
+    }
+
+    // Decode the args with the worker's own server module map. See the
+    // `EncodedArgumentsForProbe` comment for why we don't use the cache-map key
+    // string here.
+    const temporaryReferences = createTemporaryReferenceSet()
+    let decoded: CacheKeyParts
+    if (msg.encodedArguments.kind === 'string') {
+      decoded = (await decodeReply(msg.encodedArguments.data, serverModuleMap, {
+        temporaryReferences,
+      })) as CacheKeyParts
+    } else {
+      const entries = msg.encodedArguments.entries.map<[string, string | File]>(
+        ([key, value]) => {
+          if (typeof value === 'string') {
+            return [key, value]
+          }
+          const bytes = Buffer.from(value.bytes, 'base64')
+          return [key, new File([bytes], '', { type: value.type })]
+        }
+      )
+      decoded = (await decodeReplyFromAsyncIterable(
+        {
+          async *[Symbol.asyncIterator]() {
+            for (const pair of entries) {
+              yield pair
+            }
+          },
+        },
+        serverModuleMap,
+        { temporaryReferences }
+      )) as CacheKeyParts
+    }
+
+    const args = decoded[2]
+    const workStore: WorkStore = buildProbeWorkStore(msg)
+
+    // The outer store is `'request'`-typed and built from the forwarded
+    // snapshot so the cache body sees the same `headers` / `cookies` /
+    // `draftMode` it would in a real fill. `cacheSignal` defaults to undefined,
+    // which disables the dev-timeout/probe block in `generateCacheEntryImpl` —
+    // the primary guard against a probe inside the worker spawning another
+    // probe.
+    const workUnitStore = createRequestStore({
+      phase: 'render',
+      headers: new Headers(msg.request.headers),
+      onUpdateCookies: undefined,
+      url: { pathname: msg.request.urlPathname, search: msg.request.urlSearch },
+      rootParams: msg.request.rootParams,
+      implicitTags: { tags: [], expirationsByCacheKind: new Map() },
+      renderResumeDataCache: null,
+      previewProps: undefined,
+      isHmrRefresh: msg.request.isHmrRefresh,
+      serverComponentsHmrCache: undefined,
+      fallbackParams: null,
+    })
+
+    await workAsyncStorage.run(workStore, () =>
+      workUnitAsyncStorage.run(workUnitStore, wrappedFn.bind(null, ...args))
+    )
+
+    return true
+  } catch {
+    // Any error along the way — module resolution, decode, the actual run —
+    // collapses to "the probe didn't complete in isolation," so the main thread
+    // won't false-positive a deadlock.
+    return false
+  }
+}
+
+function buildProbeWorkStore(msg: ProbeMessage): WorkStore {
+  // `after()` callbacks would duplicate the real fill's side effects — the
+  // probe is a throwaway re-execution, not a second request. Same shape as the
+  // validation-render `AfterContext` in `app-render.tsx`.
+  const afterContext = new AfterContext({
+    waitUntil(promise) {
+      promise.catch(() => {})
+    },
+    onClose() {},
+    onTaskError() {},
+  })
+
+  return {
+    isStaticGeneration: false,
+    page: msg.page,
+    route: msg.route,
+    useCacheProbeMode: { timeoutMs: msg.timeoutMs },
+    isDraftMode: msg.request.isDraftMode,
+    useCacheTimeout: msg.nextConfigSerializable.useCacheTimeout,
+    staticPageGenerationTimeout:
+      msg.nextConfigSerializable.staticPageGenerationTimeout,
+    cacheLifeProfiles: msg.nextConfigSerializable.cacheLifeProfiles,
+    buildId: msg.buildId,
+    deploymentId: msg.deploymentId,
+    // Empty values for cache-handler / RDC bookkeeping. The `useCacheProbeMode`
+    // branch in `cache()` returns before any code that reads or writes these
+    // fields, so the values can never be observed.
+    previouslyRevalidatedTags: [],
+    refreshTagsByCacheKind: new Map(),
+    runInCleanSnapshot: createSnapshot(),
+    shouldTrackFetchMetrics: false,
+    reactServerErrorsByDigest: new Map(),
+    afterContext,
+    cacheComponentsEnabled: true,
+  }
+}

--- a/packages/next/src/server/use-cache/use-cache-errors.ts
+++ b/packages/next/src/server/use-cache/use-cache-errors.ts
@@ -1,4 +1,5 @@
 const USE_CACHE_TIMEOUT_ERROR_CODE = 'USE_CACHE_TIMEOUT'
+const USE_CACHE_DEADLOCK_ERROR_CODE = 'USE_CACHE_DEADLOCK'
 
 export class UseCacheTimeoutError extends Error {
   digest: typeof USE_CACHE_TIMEOUT_ERROR_CODE = USE_CACHE_TIMEOUT_ERROR_CODE
@@ -6,6 +7,16 @@ export class UseCacheTimeoutError extends Error {
   constructor() {
     super(
       'Filling a cache during prerender timed out, likely because request-specific arguments such as params, searchParams, cookies() or dynamic data were used inside "use cache".'
+    )
+  }
+}
+
+export class UseCacheDeadlockError extends Error {
+  digest: typeof USE_CACHE_DEADLOCK_ERROR_CODE = USE_CACHE_DEADLOCK_ERROR_CODE
+
+  constructor() {
+    super(
+      'Filling a "use cache" entry appears to be stuck on shared state from the outer render scope. The same function completed when run in isolation, which usually means a module-scoped value (for example a top-level Map used to dedupe fetches) is joining a promise created outside the cache. "use cache" already dedupes calls with the same arguments — within a request and across requests on the same server instance — so the surrounding dedupe layer is both unnecessary and the likely cause. Remove it and rely on "use cache" alone for deduping.'
     )
   }
 }
@@ -23,4 +34,19 @@ export function isUseCacheTimeoutError(
   }
 
   return err.digest === USE_CACHE_TIMEOUT_ERROR_CODE
+}
+
+export function isUseCacheDeadlockError(
+  err: unknown
+): err is UseCacheDeadlockError {
+  if (
+    typeof err !== 'object' ||
+    err === null ||
+    !('digest' in err) ||
+    typeof err.digest !== 'string'
+  ) {
+    return false
+  }
+
+  return err.digest === USE_CACHE_DEADLOCK_ERROR_CODE
 }

--- a/packages/next/src/server/use-cache/use-cache-probe-globals.ts
+++ b/packages/next/src/server/use-cache/use-cache-probe-globals.ts
@@ -1,0 +1,61 @@
+import type { Params } from '../request/params'
+
+// Cross-module handoff for the `'use cache'` hang-detection probe. A symbol on
+// `globalThis` decouples the dev-server entry point (which installs the
+// jest-worker pool) from the read site inside `use-cache-wrapper.ts` — avoiding
+// a direct import of dev-only code from the use-cache module. In any process
+// where the symbol is not set (prod, edge, unit tests, the probe worker itself)
+// `getUseCacheProbe()` returns undefined, which doubles as the recursion guard
+// against a probe spawning another probe.
+const SYMBOL: unique symbol = Symbol.for('next.dev.useCacheProbe')
+
+/**
+ * Serializable view of the outer `RequestStore` forwarded to the probe
+ * worker. The worker rebuilds a real `RequestStore` from this so cache
+ * bodies that read `cookies()`, `headers()`, or `draftMode()` behave the
+ * same as in a real fill — without it, those reads would diverge from
+ * production behaviour and could mask the actual deadlock.
+ */
+export type UseCacheProbeRequestSnapshot = {
+  headers: [string, string][]
+  cookieHeader: string | undefined
+  urlPathname: string
+  urlSearch: string
+  rootParams: Params
+  isDraftMode: boolean
+  isHmrRefresh: boolean
+}
+
+/**
+ * Probe hook installed by the dev server. Resolves to `true` if the cache
+ * function ran to completion in isolation — the strong signal that shared
+ * outer-scope state is deadlocking the main fill. Resolves to `false` for
+ * any other outcome (probe timeout, decode failure, missing module, etc.).
+ */
+export type UseCacheProbe = (args: {
+  /**
+   * Page key as it appears in the build manifest, e.g. `/static/page` for
+   * `app/static/page.tsx`. The trailing `/page` (or `/route`) suffix is
+   * load-bearing — the worker passes this directly to `loadComponents()`.
+   */
+  page: string
+  /** Route pathname; used to populate the worker's `WorkStore.route`. */
+  route: string
+  id: string
+  kind: string
+  encodedArguments: string | FormData
+  request: UseCacheProbeRequestSnapshot
+  timeoutMs: number
+}) => Promise<boolean>
+
+interface ProbeHolder {
+  [SYMBOL]?: UseCacheProbe
+}
+
+export function setUseCacheProbe(fn: UseCacheProbe | undefined): void {
+  ;(globalThis as ProbeHolder)[SYMBOL] = fn
+}
+
+export function getUseCacheProbe(): UseCacheProbe | undefined {
+  return (globalThis as ProbeHolder)[SYMBOL]
+}

--- a/packages/next/src/server/use-cache/use-cache-probe-scheduler.ts
+++ b/packages/next/src/server/use-cache/use-cache-probe-scheduler.ts
@@ -1,0 +1,193 @@
+import type { WorkStore } from '../app-render/work-async-storage.external'
+import type { RequestStore } from '../app-render/work-unit-async-storage.external'
+
+import { getUseCacheProbe } from './use-cache-probe-globals'
+
+const PROBE_THRESHOLD_MS = 10_000
+const MIN_PROBE_BUDGET_MS = 3_000
+
+interface CacheContextWithProbeFields {
+  readonly functionId: string
+  readonly handlerKind: string
+}
+
+interface SetupOptions {
+  workStore: WorkStore
+  outerRequestStore: RequestStore
+  cacheContext: CacheContextWithProbeFields
+  encodedArguments: string | FormData
+  /**
+   * Absolute monotonic deadline (in `performance.now()` units) at which the
+   * outer cache fill will be aborted by the dev render-timeout timer. The
+   * scheduler derives the up-front budget check, every reschedule budget check,
+   * and each probe's internal timeout from this single value.
+   */
+  fillDeadlineAt: number
+  /**
+   * Cache stream to track. Each chunk that flows through resets the idle timer;
+   * the returned stream is the same data, transparently observed.
+   */
+  stream: ReadableStream<Uint8Array>
+  /**
+   * Aborts when the probe should stop watching: the cache fill bailed (timeout,
+   * upstream cancel, deadlock detection), or it settled normally.
+   */
+  abortSignal: AbortSignal
+  /**
+   * Called once if the probe ran the cache function to completion in isolation
+   * while the main fill was still pending. Strong signal that shared state from
+   * the outer scope is preventing the body from progressing — the caller
+   * decides what to do with that (typically abort the fill and surface a
+   * deadlock error).
+   */
+  onProbeCompleted: () => void
+}
+
+/**
+ * Schedule an idle-deadline probe over a cache fill stream (dev-only).
+ *
+ * Fires the probe when the stream has been idle for `PROBE_THRESHOLD_MS`. The
+ * probe re-runs the cache function in a fresh V8 isolate so module-scoped state
+ * from the outer render — e.g. a top-level `Map<string, Promise>` deduping
+ * fetches — can't poison the body. If the function completes in isolation, the
+ * hang is attributable to that shared state and the caller surfaces a specific
+ * error instead of waiting out the generic timeout.
+ *
+ * Returns the input stream unchanged when the scheduler should be skipped: no
+ * probe hook installed, or the remaining time until `fillDeadlineAt` is too
+ * short to leave room for both the idle threshold and a minimum probe budget.
+ */
+export function setupProbeScheduler(
+  opts: SetupOptions
+): ReadableStream<Uint8Array> {
+  const {
+    workStore,
+    outerRequestStore,
+    cacheContext,
+    encodedArguments,
+    fillDeadlineAt,
+    stream,
+    abortSignal,
+    onProbeCompleted,
+  } = opts
+
+  if (
+    fillDeadlineAt - performance.now() <
+    PROBE_THRESHOLD_MS + MIN_PROBE_BUDGET_MS
+  ) {
+    return stream
+  }
+
+  const probe = getUseCacheProbe()
+  if (!probe) {
+    return stream
+  }
+
+  let lastChunkAt = performance.now()
+  let idleTimer: ReturnType<typeof setTimeout> | undefined
+
+  const startProbe = () => {
+    if (abortSignal.aborted) {
+      return
+    }
+
+    const probeStartedAtChunk = lastChunkAt
+
+    // Computed when the probe is about to run so it gets the actual remaining
+    // budget, not a stale value baked in at scheduler setup. Reserves a 1s
+    // buffer so the probe's internal timeout fires before the outer render
+    // timeout.
+    const probeInternalTimeoutMs = fillDeadlineAt - performance.now() - 1_000
+
+    probe({
+      page: workStore.page,
+      route: workStore.route,
+      id: cacheContext.functionId,
+      kind: cacheContext.handlerKind,
+      encodedArguments,
+      // Built lazily because most fills complete before the idle timer fires;
+      // only worth assembling once we know the probe is running.
+      request: {
+        headers: Array.from(outerRequestStore.headers.entries()),
+        cookieHeader: outerRequestStore.headers.get('cookie') ?? undefined,
+        urlPathname: outerRequestStore.url.pathname,
+        urlSearch: outerRequestStore.url.search,
+        rootParams: outerRequestStore.rootParams ?? {},
+        isDraftMode: workStore.isDraftMode ?? false,
+        isHmrRefresh: outerRequestStore.isHmrRefresh ?? false,
+      },
+      timeoutMs: probeInternalTimeoutMs,
+    }).then(
+      (completed) => {
+        // Mid-probe recovery: chunks arrived while the probe was running, so
+        // the main stream is making progress. Discard the probe's result rather
+        // than reporting a deadlock that no longer holds.
+        if (lastChunkAt > probeStartedAtChunk) {
+          return
+        }
+        if (completed && !abortSignal.aborted) {
+          onProbeCompleted()
+        }
+      },
+      () => {
+        // Probe failures are inconclusive; fall back to the regular cache-fill
+        // timeout.
+      }
+    )
+  }
+
+  const scheduleAfterIdle = () => {
+    if (idleTimer !== undefined || abortSignal.aborted) {
+      return
+    }
+    const now = performance.now()
+    const idleFor = now - lastChunkAt
+    const wait = Math.max(0, PROBE_THRESHOLD_MS - idleFor)
+
+    // Skip scheduling if the outer fill timeout will fire before the probe
+    // could even start running with at least a minimum useful budget. Without
+    // this check, a chunk arriving late in the fill could reschedule a probe
+    // that the outer timeout would then abort — wasted worker spawn for a probe
+    // that can't meaningfully complete.
+    if (fillDeadlineAt - now < wait + MIN_PROBE_BUDGET_MS) {
+      return
+    }
+
+    idleTimer = setTimeout(() => {
+      idleTimer = undefined
+      if (abortSignal.aborted) {
+        return
+      }
+      const idleNow = performance.now() - lastChunkAt
+      if (idleNow < PROBE_THRESHOLD_MS) {
+        // A chunk arrived since we set this timer; reschedule.
+        scheduleAfterIdle()
+        return
+      }
+      startProbe()
+    }, wait)
+  }
+
+  abortSignal.addEventListener(
+    'abort',
+    () => {
+      if (idleTimer !== undefined) {
+        clearTimeout(idleTimer)
+        idleTimer = undefined
+      }
+    },
+    { once: true }
+  )
+
+  scheduleAfterIdle()
+
+  return stream.pipeThrough(
+    new TransformStream<Uint8Array, Uint8Array>({
+      transform(chunk, controller) {
+        lastChunkAt = performance.now()
+        scheduleAfterIdle()
+        controller.enqueue(chunk)
+      },
+    })
+  )
+}

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -59,7 +59,7 @@ import { DYNAMIC_EXPIRE, RUNTIME_PREFETCH_DYNAMIC_STALE } from './constants'
 import { NEXT_CACHE_ROOT_PARAM_TAG_ID } from '../../lib/constants'
 import type { CacheHandler } from '../lib/cache-handlers/types'
 import { getCacheHandler } from './handlers'
-import { UseCacheTimeoutError } from './use-cache-errors'
+import { UseCacheDeadlockError, UseCacheTimeoutError } from './use-cache-errors'
 import {
   createHangingInputAbortSignal,
   postponeWithTracking,
@@ -87,6 +87,10 @@ interface PrivateCacheContext {
     | PrerenderStoreModernRuntime
   readonly skipPropagation: boolean
   readonly outerOwnerStack: string | undefined
+  /** The `'use cache'` function's server reference id (second arg of `cache()`). */
+  readonly functionId: string
+  /** The cache handler kind (first arg of `cache()`, e.g. 'default'). */
+  readonly handlerKind: string
 }
 
 interface PublicCacheContext {
@@ -98,11 +102,15 @@ interface PublicCacheContext {
   >
   readonly skipPropagation: boolean
   readonly outerOwnerStack: string | undefined
+  /** The `'use cache'` function's server reference id (second arg of `cache()`). */
+  readonly functionId: string
+  /** The cache handler kind (first arg of `cache()`, e.g. 'default'). */
+  readonly handlerKind: string
 }
 
 type CacheContext = PrivateCacheContext | PublicCacheContext
 
-type CacheKeyParts =
+export type CacheKeyParts =
   | [buildId: string, id: string, args: unknown[]]
   | [buildId: string, id: string, args: unknown[], hmrRefreshHash: string]
 
@@ -452,7 +460,8 @@ function generateCacheEntry(
   clientReferenceManifest: DeepReadonly<ClientReferenceManifest>,
   encodedArguments: FormData | string,
   fn: (...args: unknown[]) => Promise<unknown>,
-  timeoutError: UseCacheTimeoutError
+  timeoutError: UseCacheTimeoutError,
+  deadlockError: UseCacheDeadlockError | undefined
 ) {
   // We need to run this inside a clean AsyncLocalStorage snapshot so that the cache
   // generation cannot read anything from the context we're currently executing which
@@ -466,7 +475,8 @@ function generateCacheEntry(
     clientReferenceManifest,
     encodedArguments,
     fn,
-    timeoutError
+    timeoutError,
+    deadlockError
   )
 }
 
@@ -476,7 +486,8 @@ function generateCacheEntryWithRestoredWorkStore(
   clientReferenceManifest: DeepReadonly<ClientReferenceManifest>,
   encodedArguments: FormData | string,
   fn: (...args: unknown[]) => Promise<unknown>,
-  timeoutError: UseCacheTimeoutError
+  timeoutError: UseCacheTimeoutError,
+  deadlockError: UseCacheDeadlockError | undefined
 ) {
   // Since we cleared the AsyncLocalStorage we need to restore the workStore.
   // Note: We explicitly don't restore the RequestStore nor the PrerenderStore.
@@ -493,7 +504,8 @@ function generateCacheEntryWithRestoredWorkStore(
     clientReferenceManifest,
     encodedArguments,
     fn,
-    timeoutError
+    timeoutError,
+    deadlockError
   )
 }
 
@@ -657,7 +669,8 @@ function generateCacheEntryWithCacheContext(
   clientReferenceManifest: DeepReadonly<ClientReferenceManifest>,
   encodedArguments: FormData | string,
   fn: (...args: unknown[]) => Promise<unknown>,
-  timeoutError: UseCacheTimeoutError
+  timeoutError: UseCacheTimeoutError,
+  deadlockError: UseCacheDeadlockError | undefined
 ) {
   if (!workStore.cacheLifeProfiles) {
     throw new InvariantError('cacheLifeProfiles should always be provided.')
@@ -682,7 +695,8 @@ function generateCacheEntryWithCacheContext(
       clientReferenceManifest,
       encodedArguments,
       fn,
-      timeoutError
+      timeoutError,
+      deadlockError
     )
   )
 }
@@ -985,7 +999,8 @@ async function generateCacheEntryImpl(
   clientReferenceManifest: DeepReadonly<ClientReferenceManifest>,
   encodedArguments: FormData | string,
   fn: (...args: unknown[]) => Promise<unknown>,
-  timeoutError: UseCacheTimeoutError
+  timeoutError: UseCacheTimeoutError,
+  deadlockError: UseCacheDeadlockError | undefined
 ): Promise<GenerateCacheEntryResult> {
   const temporaryReferences = createServerTemporaryReferenceSet()
   const outerWorkUnitStore = cacheContext.outerWorkUnitStore
@@ -1074,8 +1089,7 @@ async function generateCacheEntryImpl(
   )
 
   let stream: ReadableStream<Uint8Array>
-  let devTimeoutSignal: AbortSignal | undefined
-  let devTimeoutTimer: ReturnType<typeof setTimeout> | undefined
+  let devTimeoutAbortController: AbortController | undefined
 
   switch (outerWorkUnitStore.type) {
     case 'prerender-runtime':
@@ -1179,15 +1193,65 @@ async function generateCacheEntryImpl(
         // deadlock.
         const stagedRendering = outerWorkUnitStore.stagedRendering
         if (stagedRendering?.currentStage !== RenderStage.Dynamic) {
-          const devTimeoutAbortController = new AbortController()
-          devTimeoutSignal = devTimeoutAbortController.signal
-          devTimeoutTimer = setTimeout(
-            () => {
-              workStore.invalidDynamicUsageError = timeoutError
-              devTimeoutAbortController.abort(timeoutError)
-            },
-            getUseCacheFillTimeoutMs(workStore, outerWorkUnitStore.type)
+          const devRenderAbortController = new AbortController()
+          const fillTimeoutMs = getUseCacheFillTimeoutMs(
+            workStore,
+            outerWorkUnitStore.type
           )
+          const fillDeadlineAt = performance.now() + fillTimeoutMs
+          const devRenderTimeoutTimer = setTimeout(() => {
+            workStore.invalidDynamicUsageError = timeoutError
+            devRenderAbortController.abort(timeoutError)
+          }, fillTimeoutMs)
+
+          devTimeoutAbortController = new AbortController()
+          devTimeoutAbortController.signal.addEventListener(
+            'abort',
+            () => {
+              clearTimeout(devRenderTimeoutTimer)
+            },
+            { once: true }
+          )
+
+          stream = renderToReadableStream(
+            resultPromise,
+            clientReferenceManifest.clientModules,
+            {
+              environmentName: 'Cache',
+              filterStackFrame,
+              signal: devRenderAbortController.signal,
+              temporaryReferences,
+              onError: handleError,
+            }
+          )
+
+          // `require` (rather than a top-level import) so the bundler can
+          // tree-shake the probe scheduler out of the production runtime, where
+          // this whole dev-server-gated branch is dead code.
+          const { setupProbeScheduler } =
+            require('./use-cache-probe-scheduler') as typeof import('./use-cache-probe-scheduler')
+          stream = setupProbeScheduler({
+            workStore,
+            outerRequestStore: outerWorkUnitStore,
+            cacheContext,
+            encodedArguments,
+            fillDeadlineAt,
+            stream,
+            abortSignal: AbortSignal.any([
+              devRenderAbortController.signal,
+              devTimeoutAbortController.signal,
+            ]),
+            onProbeCompleted() {
+              const error =
+                deadlockError ??
+                new InvariantError(
+                  '`deadlockError` should be constructed inside `cache()` before reaching the probe scheduler.'
+                )
+              workStore.invalidDynamicUsageError = error
+              devRenderAbortController.abort(error)
+            },
+          })
+          break
         }
       }
     // fallthrough
@@ -1203,7 +1267,6 @@ async function generateCacheEntryImpl(
         {
           environmentName: 'Cache',
           filterStackFrame,
-          signal: devTimeoutSignal,
           temporaryReferences,
           onError: handleError,
         }
@@ -1223,9 +1286,7 @@ async function generateCacheEntryImpl(
     startTime,
     errors
   ).finally(() => {
-    if (devTimeoutTimer !== undefined) {
-      clearTimeout(devTimeoutTimer)
-    }
+    devTimeoutAbortController?.abort()
   })
 
   if (process.env.NODE_ENV === 'development') {
@@ -1353,11 +1414,29 @@ export async function cache(
 ) {
   const isPrivate = kind === 'private'
 
+  const workStore = workAsyncStorage.getStore()
+  if (workStore === undefined) {
+    throw new Error(
+      '"use cache" cannot be used outside of App Router. Expected a WorkStore.'
+    )
+  }
+
+  // Probe re-executions inside the dev-server's hang-detection worker never
+  // reach the cache-handler get/set paths — the `useCacheProbeMode` branch
+  // below returns before any handler is consulted — so we skip both the
+  // lookup and the "Unknown cache handler" guard. This lets the probe
+  // worker boot without registering handlers at all. The
+  // `__NEXT_DEV_SERVER` gate also lets the bundler fold `isProbeMode` to
+  // `false` in production, simplifying the conditionals below.
+  const isProbeMode =
+    !!process.env.__NEXT_DEV_SERVER && workStore.useCacheProbeMode !== undefined
+
   // Private caches are currently only stored in the Resume Data Cache (RDC),
   // and not in cache handlers.
-  const cacheHandler = isPrivate ? undefined : getCacheHandler(kind)
+  const cacheHandler =
+    isPrivate || isProbeMode ? undefined : getCacheHandler(kind)
 
-  if (!isPrivate && !cacheHandler) {
+  if (!isPrivate && !isProbeMode && !cacheHandler) {
     throw new Error('Unknown cache handler: ' + kind)
   }
 
@@ -1365,21 +1444,24 @@ export async function cache(
   Error.captureStackTrace(timeoutError, cache)
   applyOwnerStack(timeoutError)
 
-  const wrapAsInvalidDynamicUsageError = (
-    error: Error,
-    workStore: WorkStore
-  ) => {
+  // Only ever thrown by the dev-server's hang-detection probe.
+  // `Error.captureStackTrace` has to run while `cache()` is still on the
+  // synchronous stack, otherwise the user's `'use cache'` invocation frames
+  // would already be gone — that's why the construction sits up here rather
+  // than next to the trigger that actually consumes it. The `__NEXT_DEV_SERVER`
+  // gate lets the error class drop out of the production runtime bundle.
+  let deadlockError: UseCacheDeadlockError | undefined
+  if (process.env.__NEXT_DEV_SERVER) {
+    deadlockError = new UseCacheDeadlockError()
+    Error.captureStackTrace(deadlockError, cache)
+    applyOwnerStack(deadlockError)
+  }
+
+  const wrapAsInvalidDynamicUsageError = (error: Error) => {
     Error.captureStackTrace(error, cache)
     workStore.invalidDynamicUsageError ??= error
 
     return error
-  }
-
-  const workStore = workAsyncStorage.getStore()
-  if (workStore === undefined) {
-    throw new Error(
-      '"use cache" cannot be used outside of App Router. Expected a WorkStore.'
-    )
   }
 
   const workUnitStore = workUnitAsyncStorage.getStore()
@@ -1431,8 +1513,7 @@ export async function cache(
           new Error(
             // TODO: Add a link to an error documentation page when we have one.
             `${expression} must not be used within \`unstable_cache()\`.`
-          ),
-          workStore
+          )
         )
       }
       case 'cache': {
@@ -1440,8 +1521,7 @@ export async function cache(
           new Error(
             // TODO: Add a link to an error documentation page when we have one.
             `${expression} must not be used within "use cache". It can only be nested inside of another ${expression}.`
-          ),
-          workStore
+          )
         )
       }
       case 'request':
@@ -1452,6 +1532,8 @@ export async function cache(
           outerWorkUnitStore: workUnitStore,
           skipPropagation: false,
           outerOwnerStack,
+          functionId: id,
+          handlerKind: kind,
         }
         break
       case 'generate-static-params':
@@ -1459,8 +1541,7 @@ export async function cache(
           new Error(
             // TODO: Add a link to an error documentation page when we have one.
             `${expression} cannot be used outside of a request context.`
-          ),
-          workStore
+          )
         )
       default:
         workUnitStore satisfies never
@@ -1492,6 +1573,8 @@ export async function cache(
           outerWorkUnitStore: workUnitStore,
           skipPropagation: false,
           outerOwnerStack,
+          functionId: id,
+          handlerKind: kind,
         }
         break
       default:
@@ -1745,6 +1828,67 @@ export async function cache(
       return workUnitStore satisfies never
   }
 
+  // Probe path: we're running inside a pooled worker spawned by the dev
+  // server to check whether a stalled cache fill would complete in an
+  // isolated module scope. Skip the RDC / cache-handler / leader-election
+  // machinery, call `generateCacheEntry` (same as a real cold fill), drain
+  // the returned stream via `pendingCacheResult`, and apply the probe's own
+  // timeout. The caller only cares whether the fill resolves; the result
+  // value is discarded.
+  //
+  // Gated on `__NEXT_DEV_SERVER` so the entire branch — including its
+  // `generateCacheEntry` call site and the threading of
+  // `deadlockError` — drops out of the production runtime
+  // bundle.
+  if (process.env.__NEXT_DEV_SERVER && workStore.useCacheProbeMode) {
+    // Both public and private caches probe via the same path. The worker
+    // reconstructs real `headers` / `cookies` / `draftMode` from the
+    // forwarded request snapshot, so private caches that legitimately read
+    // those work in the probe just like in the real fill.
+    const probeTimeoutMs = workStore.useCacheProbeMode.timeoutMs
+    // The deadlock error never gets thrown from inside the worker: the
+    // worker's outer store has `cacheSignal: undefined`, so
+    // `generateCacheEntryImpl` skips the dev-request branch and the idle
+    // probe is never set up.
+    const result = await generateCacheEntry(
+      workStore,
+      cacheContext,
+      clientReferenceManifest,
+      encodedCacheKeyParts,
+      fn,
+      timeoutError,
+      undefined
+    )
+    if (result.type === 'prerender-dynamic') {
+      // Unreachable in the probe: outer store is `'request'`-typed, which
+      // never produces this variant.
+      throw new InvariantError(
+        'Unexpected `prerender-dynamic` result in `use cache` probe mode.'
+      )
+    }
+    // We don't consume the returned stream — `pendingCacheResult` is what
+    // completes when `collectResult` has drained `savedStream`. Cancel the
+    // unused copy so it doesn't buffer forever.
+    result.stream.cancel().catch(() => {})
+    let probeTimeoutTimer: ReturnType<typeof setTimeout> | undefined
+    try {
+      await Promise.race([
+        result.pendingCacheResult,
+        new Promise<never>((_, reject) => {
+          probeTimeoutTimer = setTimeout(
+            () => reject(timeoutError),
+            probeTimeoutMs
+          )
+        }),
+      ])
+    } finally {
+      if (probeTimeoutTimer !== undefined) {
+        clearTimeout(probeTimeoutTimer)
+      }
+    }
+    return
+  }
+
   const serializedCacheKey =
     typeof encodedCacheKeyParts === 'string'
       ? // Fast path for the simple case for simple inputs. We let the CacheHandler
@@ -1841,8 +1985,7 @@ export async function cache(
               if (rdcResult.entry.revalidate === 0) {
                 if (rdcResult.hasExplicitRevalidate === false) {
                   throw wrapAsInvalidDynamicUsageError(
-                    new Error(nestedCacheZeroRevalidateErrorMessage),
-                    workStore
+                    new Error(nestedCacheZeroRevalidateErrorMessage)
                   )
                 }
                 debug?.(
@@ -1853,8 +1996,7 @@ export async function cache(
               } else {
                 if (rdcResult.hasExplicitExpire === false) {
                   throw wrapAsInvalidDynamicUsageError(
-                    new Error(nestedCacheShortExpireErrorMessage),
-                    workStore
+                    new Error(nestedCacheShortExpireErrorMessage)
                   )
                 }
                 debug?.(
@@ -1891,8 +2033,7 @@ export async function cache(
                   rdcResult.hasExplicitRevalidate === false
                 ) {
                   throw wrapAsInvalidDynamicUsageError(
-                    new Error(nestedCacheZeroRevalidateErrorMessage),
-                    workStore
+                    new Error(nestedCacheZeroRevalidateErrorMessage)
                   )
                 }
                 if (
@@ -1900,8 +2041,7 @@ export async function cache(
                   rdcResult.hasExplicitExpire === false
                 ) {
                   throw wrapAsInvalidDynamicUsageError(
-                    new Error(nestedCacheShortExpireErrorMessage),
-                    workStore
+                    new Error(nestedCacheShortExpireErrorMessage)
                   )
                 }
                 // We delay the cache here so that it doesn't resolve in the static task --
@@ -2492,7 +2632,8 @@ export async function cache(
             clientReferenceManifest,
             encodedCacheKeyParts,
             fn,
-            timeoutError
+            timeoutError,
+            deadlockError
           )
 
           if (result.type === 'prerender-dynamic') {
@@ -2634,15 +2775,14 @@ export async function cache(
               // reading (e.g. implicitTags) but skips propagation of cache life
               // and tags back to the outer scope.
               {
-                kind: cacheContext.kind,
-                outerWorkUnitStore: cacheContext.outerWorkUnitStore,
+                ...cacheContext,
                 skipPropagation: true,
-                outerOwnerStack: cacheContext.outerOwnerStack,
               },
               clientReferenceManifest,
               encodedCacheKeyParts,
               fn,
-              timeoutError
+              timeoutError,
+              deadlockError
             )
               .then(async (result) => {
                 if (result.type === 'cached') {

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -1421,23 +1421,17 @@ export async function cache(
     )
   }
 
-  // Probe re-executions inside the dev-server's hang-detection worker never
-  // reach the cache-handler get/set paths — the `useCacheProbeMode` branch
-  // below returns before any handler is consulted — so we skip both the
-  // lookup and the "Unknown cache handler" guard. This lets the probe
-  // worker boot without registering handlers at all. The
-  // `__NEXT_DEV_SERVER` gate also lets the bundler fold `isProbeMode` to
-  // `false` in production, simplifying the conditionals below.
-  const isProbeMode =
-    !!process.env.__NEXT_DEV_SERVER && workStore.useCacheProbeMode !== undefined
-
-  // Private caches are currently only stored in the Resume Data Cache (RDC),
-  // and not in cache handlers.
-  const cacheHandler =
-    isPrivate || isProbeMode ? undefined : getCacheHandler(kind)
-
-  if (!isPrivate && !isProbeMode && !cacheHandler) {
-    throw new Error('Unknown cache handler: ' + kind)
+  // Two cases skip the cache handler lookup:
+  //   - Private caches go to the Resume Data Cache (RDC), not cache handlers.
+  //   - Probe re-executions short-circuit further down before any handler is
+  //     consulted, so the dev-server's hang-detection worker can boot without
+  //     registering handlers at all.
+  let cacheHandler: CacheHandler | undefined
+  if (!isPrivate && workStore.useCacheProbeMode === undefined) {
+    cacheHandler = getCacheHandler(kind)
+    if (!cacheHandler) {
+      throw new Error('Unknown cache handler: ' + kind)
+    }
   }
 
   const timeoutError = new UseCacheTimeoutError()

--- a/test/e2e/app-dir/use-cache-deadlock-probe/app/also-hangs/page.tsx
+++ b/test/e2e/app-dir/use-cache-deadlock-probe/app/also-hangs/page.tsx
@@ -1,0 +1,24 @@
+// The cache body hangs on a promise that is NOT tied to outer-scope module
+// state. The probe will hang in isolation just like the main render does;
+// the outer cache fill should fall through to the regular `UseCacheTimeoutError`
+// at the configured `useCacheTimeout`.
+async function getCachedData(): Promise<string> {
+  'use cache'
+
+  // Intentionally never resolves; not dependent on module scope.
+  await new Promise(() => {})
+  return 'unreachable'
+}
+
+async function Cached() {
+  try {
+    const data = await getCachedData()
+    return <p id="result">{data}</p>
+  } catch (error: any) {
+    return <p id="result">Error: {error.message}</p>
+  }
+}
+
+export default function Page() {
+  return <Cached />
+}

--- a/test/e2e/app-dir/use-cache-deadlock-probe/app/dynamic/page.tsx
+++ b/test/e2e/app-dir/use-cache-deadlock-probe/app/dynamic/page.tsx
@@ -1,0 +1,30 @@
+import { connection } from 'next/server'
+import { ReactNode, Suspense } from 'react'
+
+// A cache fill in the Dynamic stage (after `connection()`) should not be
+// subject to the dev fill timeout — and the probe-watchdog is skipped for
+// the same reason. Both are gated on `outerWorkUnitStore.cacheSignal` /
+// the Dynamic-stage check in `generateCacheEntryImpl`. The sleep is longer
+// than the 10s probe idle threshold so the test would fail if the
+// watchdog were armed.
+async function Cached(): Promise<ReactNode> {
+  'use cache'
+
+  await new Promise((resolve) => setTimeout(resolve, 12_000))
+
+  return <p id="cached">cached</p>
+}
+
+async function Dynamic(): Promise<ReactNode> {
+  await connection()
+
+  return <Cached />
+}
+
+export default function Page() {
+  return (
+    <Suspense fallback="Loading...">
+      <Dynamic />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir/use-cache-deadlock-probe/app/layout.tsx
+++ b/test/e2e/app-dir/use-cache-deadlock-probe/app/layout.tsx
@@ -1,0 +1,20 @@
+import Link from 'next/link'
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>
+        <nav>
+          <Link href="/">Home</Link>
+          {' | '}
+          <Link href="/static">Static</Link>
+          {' | '}
+          <Link href="/runtime">Runtime</Link>
+          {' | '}
+          <Link href="/dynamic">Dynamic</Link>
+        </nav>
+        {children}
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/use-cache-deadlock-probe/app/page.tsx
+++ b/test/e2e/app-dir/use-cache-deadlock-probe/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>Home</p>
+}

--- a/test/e2e/app-dir/use-cache-deadlock-probe/app/private-cookies/page.tsx
+++ b/test/e2e/app-dir/use-cache-deadlock-probe/app/private-cookies/page.tsx
@@ -1,0 +1,58 @@
+import { cookies } from 'next/headers'
+import { Suspense } from 'react'
+import { getData, preload } from '../shared'
+
+const sharedUrl =
+  'https://next-data-api-endpoint.vercel.app/api/random?page=private-cookies'
+
+// A `'use cache: private'` body that legitimately reads `cookies()` AND
+// joins the module-scoped hanging promise from `shared.ts`. The probe must:
+//
+//   1. Forward the real cookie values into the worker's request store so
+//      `cookies()` returns the same values as it would in the real fill
+//      (rather than throwing).
+//   2. Run the body in a fresh module scope so `getData(sharedUrl)` returns
+//      a fresh fetch instead of joining the outer scope's hanging promise.
+//
+// Both pieces have to work for this test to pass; if request-snapshot
+// forwarding regresses, this fixture catches it before any "no-snapshot"
+// fallback path.
+async function getCachedData(): Promise<string> {
+  'use cache: private'
+
+  // Read a cookie — exercises the worker's reconstructed `cookies` object.
+  const sessionCookie = (await cookies()).get('next-session')
+
+  // Joins the outer fetch via the module-scoped dedupe map (see note in
+  // ../shared.ts).
+  const text = await getData(sharedUrl).then((res) => res.text())
+
+  return `${sessionCookie?.value ?? 'no-session'}:${text}`
+}
+
+async function Cached() {
+  try {
+    const data = await getCachedData()
+    return <p id="result">{data}</p>
+  } catch (error: any) {
+    return <p id="result">Error: {error.message}</p>
+  }
+}
+
+async function Runtime() {
+  // Touch cookies in the outer scope to advance to the runtime stage and
+  // start the deadlock-prone outer fetch.
+  await cookies()
+
+  preload(sharedUrl)
+
+  return <Cached />
+}
+
+export default function Page() {
+  return (
+    <Suspense fallback="Loading...">
+      <Runtime />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir/use-cache-deadlock-probe/app/recovery-stuck/page.tsx
+++ b/test/e2e/app-dir/use-cache-deadlock-probe/app/recovery-stuck/page.tsx
@@ -1,0 +1,50 @@
+import { Suspense } from 'react'
+import { getData, preload } from '../shared'
+
+const sharedUrl =
+  'https://next-data-api-endpoint.vercel.app/api/random?page=recovery-stuck'
+
+// `Quick` emits a chunk during the first probe's window, which suppresses
+// that probe's verdict via the mid-probe recovery check. `Stuck` is
+// deadlocked on outer-scope state, so the cache body never settles —
+// after the chunk, the scheduler reschedules the idle timer and a second
+// probe fires once the fill has been quiet for another threshold. That
+// second probe sees no chunks during its own window and correctly
+// reports the deadlock.
+async function Quick() {
+  await new Promise((resolve) => setTimeout(resolve, 11_000))
+  return <p id="quick">quick</p>
+}
+
+async function Stuck() {
+  const data = await getData(sharedUrl).then((res) => res.text())
+  return <p id="stuck">{data}</p>
+}
+
+async function getCachedData() {
+  'use cache'
+
+  return (
+    <>
+      <Suspense fallback={null}>
+        <Quick />
+      </Suspense>
+      <Suspense fallback={null}>
+        <Stuck />
+      </Suspense>
+    </>
+  )
+}
+
+async function Cached() {
+  try {
+    return await getCachedData()
+  } catch (error: any) {
+    return <p id="result">Error: {error.message}</p>
+  }
+}
+
+export default function Page() {
+  preload(sharedUrl)
+  return <Cached />
+}

--- a/test/e2e/app-dir/use-cache-deadlock-probe/app/recovery/page.tsx
+++ b/test/e2e/app-dir/use-cache-deadlock-probe/app/recovery/page.tsx
@@ -1,0 +1,35 @@
+import { Suspense } from 'react'
+
+// `Quick` resolves comfortably after the 10s probe-idle threshold so its
+// chunk arrives _during_ the probe; `Slow` resolves shortly after so the
+// fill settles before any rescheduled probe could run.
+async function Quick() {
+  await new Promise((resolve) => setTimeout(resolve, 11_000))
+  return <p id="quick">quick</p>
+}
+
+async function Slow() {
+  await new Promise((resolve) => setTimeout(resolve, 14_000))
+  return <p id="slow">slow</p>
+}
+
+async function getCachedData() {
+  'use cache'
+
+  return (
+    <>
+      <Suspense fallback={null}>
+        <Quick />
+      </Suspense>
+      <Slow />
+    </>
+  )
+}
+
+async function Cached() {
+  return await getCachedData()
+}
+
+export default function Page() {
+  return <Cached />
+}

--- a/test/e2e/app-dir/use-cache-deadlock-probe/app/runtime/page.tsx
+++ b/test/e2e/app-dir/use-cache-deadlock-probe/app/runtime/page.tsx
@@ -1,0 +1,45 @@
+import { cookies } from 'next/headers'
+import { Suspense } from 'react'
+import { getData, preload } from '../shared'
+
+const sharedUrl =
+  'https://next-data-api-endpoint.vercel.app/api/random?page=runtime'
+
+async function getCachedData(): Promise<string> {
+  'use cache'
+
+  // Joins the outer fetch via the module-scoped dedupe map (see note in
+  // ../shared.ts).
+  return getData(sharedUrl).then((res) => res.text())
+}
+
+async function Cached() {
+  // The timeout error must also be shown in the Next.js DevTools when the
+  // invocation is wrapped in a try/catch.
+  try {
+    const data = await getCachedData()
+
+    return <p id="result">{data}</p>
+  } catch (error) {
+    return <p id="result">Error: {error.message}</p>
+  }
+}
+
+async function Runtime() {
+  await cookies()
+
+  // Simulate another part of the tree (e.g. a sibling component or a shared
+  // data loader) kicking off the same fetch in outer scope before `Cached`
+  // runs.
+  preload(sharedUrl)
+
+  return <Cached />
+}
+
+export default function Page() {
+  return (
+    <Suspense fallback="Loading...">
+      <Runtime />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir/use-cache-deadlock-probe/app/shared.ts
+++ b/test/e2e/app-dir/use-cache-deadlock-probe/app/shared.ts
@@ -1,0 +1,38 @@
+// This module simulates a realistic migration hazard. The documented "preload"
+// pattern (see the "Preloading data" section of the
+// caching-without-cache-components guide in the Next.js docs) wraps the loader
+// in `React.cache`, so its store is tied to the ALS snapshot — `'use cache'`
+// bodies run in a clean snapshot and miss, re-executing the loader in cache
+// scope. That path is safe during migration.
+//
+// What's modeled here is the common-in-the-wild variant that uses a
+// module-scoped `Map` instead of `React.cache`. The map lives above ALS, so a
+// `'use cache'` body joining it reuses the outer-scope promise (request scope
+// or prerender scope) — a promise that was never meant to resolve for the
+// cache:
+//   - During prerendering, an uncached fetch in the outer scope returns a
+//     hanging promise that intentionally never resolves.
+//   - In dev, the outer fetch is parked on the Dynamic stage, which can't
+//     advance until the cache fills. The cache awaits the outer fetch via the
+//     shared loader, so neither can make progress.
+// In both cases, the cache never fills and times out.
+const pendingFetches = new Map<string, Promise<Response>>()
+
+export function getData(url: string): Promise<Response> {
+  let promise = pendingFetches.get(url)
+  if (!promise) {
+    promise = fetch(url)
+    pendingFetches.set(url, promise)
+    promise.then(
+      () => pendingFetches.delete(url),
+      () => pendingFetches.delete(url)
+    )
+  }
+  return promise
+}
+
+// "Preload" primes the shared loader without awaiting so later callers reuse
+// the stored promise.
+export function preload(url: string): void {
+  void getData(url)
+}

--- a/test/e2e/app-dir/use-cache-deadlock-probe/app/static/page.tsx
+++ b/test/e2e/app-dir/use-cache-deadlock-probe/app/static/page.tsx
@@ -1,0 +1,33 @@
+import { getData, preload } from '../shared'
+
+const sharedUrl =
+  'https://next-data-api-endpoint.vercel.app/api/random?page=static'
+
+async function getCachedData(): Promise<string> {
+  'use cache'
+
+  // Joins the outer fetch via the module-scoped dedupe map (see note in
+  // ../shared.ts).
+  return getData(sharedUrl).then((res) => res.text())
+}
+
+async function Cached() {
+  // The timeout error must also be shown in the Next.js DevTools when the
+  // invocation is wrapped in a try/catch.
+  try {
+    const data = await getCachedData()
+
+    return <p id="result">{data}</p>
+  } catch (error) {
+    return <p id="result">Error: {error.message}</p>
+  }
+}
+
+export default function Page() {
+  // Simulate another part of the tree (e.g. a sibling component or a shared
+  // data loader) kicking off the same fetch in outer scope before `Cached`
+  // runs.
+  preload(sharedUrl)
+
+  return <Cached />
+}

--- a/test/e2e/app-dir/use-cache-deadlock-probe/next.config.js
+++ b/test/e2e/app-dir/use-cache-deadlock-probe/next.config.js
@@ -1,0 +1,17 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+  experimental: {
+    // Set high enough to cover the second probe in the "stuck after some
+    // chunks" recovery test, where the rescheduled probe completes around
+    // ~t=32s and must be allowed to fire before the outer timeout.
+    // Existing dev-deadlock cases fire at probe completion (~t=22s) and
+    // are unaffected; only `also-hangs` relies on the outer timeout, and
+    // taking 40s instead of 25s is acceptable in dev tests.
+    useCacheTimeout: 40,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/use-cache-deadlock-probe/use-cache-deadlock-probe.test.ts
+++ b/test/e2e/app-dir/use-cache-deadlock-probe/use-cache-deadlock-probe.test.ts
@@ -1,0 +1,282 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+import stripAnsi from 'strip-ansi'
+
+const expectedTimeoutErrorMessage =
+  'Filling a cache during prerender timed out, likely because request-specific arguments such as params, searchParams, cookies() or dynamic data were used inside "use cache".'
+
+const expectedDeadlockMessage =
+  'Filling a "use cache" entry appears to be stuck on shared state from the outer render scope. The same function completed when run in isolation, which usually means a module-scoped value (for example a top-level Map used to dedupe fetches) is joining a promise created outside the cache. "use cache" already dedupes calls with the same arguments — within a request and across requests on the same server instance — so the surrounding dedupe layer is both unnecessary and the likely cause. Remove it and rely on "use cache" alone for deduping.'
+
+describe('use-cache-deadlock-probe', () => {
+  const { next, isNextDev, skipped } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+    // Probe behavior is dev-only; skip the production server start, but
+    // let dev mode auto-start.
+    skipStart: process.env.NEXT_TEST_MODE !== 'dev',
+  })
+
+  if (skipped) {
+    return
+  }
+
+  if (!isNextDev) {
+    it('is a dev-only suite', () => {})
+    return
+  }
+
+  describe('when a "use cache" fill hangs in the static stage due to module-scope state', () => {
+    it('should show a module-scope deadlock error early', async () => {
+      const outputIndex = next.cliOutput.length
+      const browser = await next.browser('/static')
+
+      await expect(browser).toDisplayRedbox(`
+       {
+         "code": "E1181",
+         "description": "Filling a "use cache" entry appears to be stuck on shared state from the outer render scope. The same function completed when run in isolation, which usually means a module-scoped value (for example a top-level Map used to dedupe fetches) is joining a promise created outside the cache. "use cache" already dedupes calls with the same arguments — within a request and across requests on the same server instance — so the surrounding dedupe layer is both unnecessary and the likely cause. Remove it and rely on "use cache" alone for deduping.",
+         "environmentLabel": null,
+         "label": "Runtime Error",
+         "source": "app/static/page.tsx (6:1) @ getCachedData
+       > 6 | async function getCachedData(): Promise<string> {
+           | ^",
+         "stack": [
+           "getCachedData app/static/page.tsx (6:1)",
+           "Cached app/static/page.tsx (18:24)",
+           "Page app/static/page.tsx (32:10)",
+         ],
+       }
+      `)
+
+      const cliOutput = stripAnsi(next.cliOutput.slice(outputIndex))
+
+      expect(cliOutput).toContain(`Error: ${expectedDeadlockMessage}`)
+    })
+  })
+
+  describe('when a "use cache" fill hangs in the runtime stage due to module-scope state', () => {
+    it('should show a module-scope deadlock error early', async () => {
+      const outputIndex = next.cliOutput.length
+      const browser = await next.browser('/runtime')
+
+      await expect(browser).toDisplayRedbox(`
+       {
+         "code": "E1181",
+         "description": "Filling a "use cache" entry appears to be stuck on shared state from the outer render scope. The same function completed when run in isolation, which usually means a module-scoped value (for example a top-level Map used to dedupe fetches) is joining a promise created outside the cache. "use cache" already dedupes calls with the same arguments — within a request and across requests on the same server instance — so the surrounding dedupe layer is both unnecessary and the likely cause. Remove it and rely on "use cache" alone for deduping.",
+         "environmentLabel": null,
+         "label": "Runtime Error",
+         "source": "app/runtime/page.tsx (8:1) @ getCachedData
+       >  8 | async function getCachedData(): Promise<string> {
+            | ^",
+         "stack": [
+           "getCachedData app/runtime/page.tsx (8:1)",
+           "Cached app/runtime/page.tsx (20:24)",
+           "Page app/runtime/page.tsx (42:7)",
+         ],
+       }
+      `)
+
+      const cliOutput = stripAnsi(next.cliOutput.slice(outputIndex))
+
+      expect(cliOutput).toContain(`Error: ${expectedDeadlockMessage}`)
+    })
+  })
+
+  describe('when navigating to the static page', () => {
+    it('should show a deadlock error toast early', async () => {
+      const outputIndex = next.cliOutput.length
+      const browser = await next.browser('/')
+
+      await browser.elementByCss('a[href="/static"]').click()
+
+      await retry(() => {
+        const cliOutput = stripAnsi(next.cliOutput.slice(outputIndex))
+
+        expect(cliOutput).toContain(`Error: ${expectedDeadlockMessage}`)
+      }, 30_000)
+
+      await expect(browser).toDisplayCollapsedRedbox(`
+       {
+         "code": "E1181",
+         "description": "Filling a "use cache" entry appears to be stuck on shared state from the outer render scope. The same function completed when run in isolation, which usually means a module-scoped value (for example a top-level Map used to dedupe fetches) is joining a promise created outside the cache. "use cache" already dedupes calls with the same arguments — within a request and across requests on the same server instance — so the surrounding dedupe layer is both unnecessary and the likely cause. Remove it and rely on "use cache" alone for deduping.",
+         "environmentLabel": "Server",
+         "label": "Console Error",
+         "source": "app/static/page.tsx (6:1) @ getCachedData
+       > 6 | async function getCachedData(): Promise<string> {
+           | ^",
+         "stack": [
+           "getCachedData app/static/page.tsx (6:1)",
+           "Cached app/static/page.tsx (18:24)",
+           "Page app/static/page.tsx (32:10)",
+         ],
+       }
+      `)
+    })
+  })
+
+  describe('when navigating to the runtime page', () => {
+    it('should show a deadlock error toast early', async () => {
+      const outputIndex = next.cliOutput.length
+      const browser = await next.browser('/')
+
+      await browser.elementByCss('a[href="/runtime"]').click()
+
+      await retry(() => {
+        const cliOutput = stripAnsi(next.cliOutput.slice(outputIndex))
+
+        expect(cliOutput).toContain(`Error: ${expectedDeadlockMessage}`)
+      }, 30_000)
+
+      await expect(browser).toDisplayCollapsedRedbox(`
+       {
+         "code": "E1181",
+         "description": "Filling a "use cache" entry appears to be stuck on shared state from the outer render scope. The same function completed when run in isolation, which usually means a module-scoped value (for example a top-level Map used to dedupe fetches) is joining a promise created outside the cache. "use cache" already dedupes calls with the same arguments — within a request and across requests on the same server instance — so the surrounding dedupe layer is both unnecessary and the likely cause. Remove it and rely on "use cache" alone for deduping.",
+         "environmentLabel": "Server",
+         "label": "Console Error",
+         "source": "app/runtime/page.tsx (8:1) @ getCachedData
+       >  8 | async function getCachedData(): Promise<string> {
+            | ^",
+         "stack": [
+           "getCachedData app/runtime/page.tsx (8:1)",
+           "Cached app/runtime/page.tsx (20:24)",
+           "Page app/runtime/page.tsx (42:7)",
+         ],
+       }
+      `)
+    })
+  })
+
+  describe('when a "use cache" performs long-running I/O in the dynamic stage', () => {
+    it('should not time out and should not report a deadlock', async () => {
+      const outputIndex = next.cliOutput.length
+      const browser = await next.browser('/dynamic')
+
+      await expect(browser.elementByCss('#cached').text()).resolves.toBe(
+        'cached'
+      )
+
+      const cliOutput = stripAnsi(next.cliOutput.slice(outputIndex))
+
+      expect(cliOutput).not.toContain(expectedTimeoutErrorMessage)
+      expect(cliOutput).not.toContain(expectedDeadlockMessage)
+    })
+  })
+
+  describe('when a "use cache" fill hangs unrelated to module scope', () => {
+    it('should fall back to the regular cache-fill timeout error', async () => {
+      const outputIndex = next.cliOutput.length
+      // The page genuinely hangs for the full 25s `useCacheTimeout` before
+      // surfacing the redbox; `waitUntil: 'commit'` avoids racing Playwright's
+      // 30s default `page.goto` timeout.
+      const browser = await next.browser('/also-hangs', { waitUntil: 'commit' })
+
+      await expect(browser).toDisplayRedbox(`
+       {
+         "code": "E236",
+         "description": "Filling a cache during prerender timed out, likely because request-specific arguments such as params, searchParams, cookies() or dynamic data were used inside "use cache".",
+         "environmentLabel": null,
+         "label": "Runtime Error",
+         "source": "app/also-hangs/page.tsx (5:1) @ getCachedData
+       > 5 | async function getCachedData(): Promise<string> {
+           | ^",
+         "stack": [
+           "getCachedData app/also-hangs/page.tsx (5:1)",
+           "Cached app/also-hangs/page.tsx (15:24)",
+           "Page app/also-hangs/page.tsx (23:10)",
+         ],
+       }
+      `)
+
+      const cliOutput = stripAnsi(next.cliOutput.slice(outputIndex))
+
+      expect(cliOutput).toContain(`Error: ${expectedTimeoutErrorMessage}`)
+      expect(cliOutput).not.toContain(expectedDeadlockMessage)
+    })
+  })
+
+  describe('when a chunk is emitted during the probe and the fill eventually settles', () => {
+    it('should not report a deadlock', async () => {
+      const outputIndex = next.cliOutput.length
+      // `Quick` resolves at ~11s (during the probe's window), `Slow`
+      // settles the fill at ~14s. The fill aborts the probe scheduler
+      // before the rescheduled idle timer can fire a second probe; the
+      // first probe's verdict is suppressed by the mid-probe recovery
+      // check (or, equivalently, by the abort that fires when the fill
+      // settles). No deadlock should be attributed to a slow-but-working
+      // cache.
+      const browser = await next.browser('/recovery')
+
+      await expect(browser.elementByCss('#slow').text()).resolves.toBe('slow')
+      await expect(browser.elementByCss('#quick').text()).resolves.toBe('quick')
+
+      const cliOutput = stripAnsi(next.cliOutput.slice(outputIndex))
+
+      expect(cliOutput).not.toContain(expectedDeadlockMessage)
+      expect(cliOutput).not.toContain(expectedTimeoutErrorMessage)
+    })
+  })
+
+  describe('when a chunk is emitted during the probe and the fill stays stuck', () => {
+    it('should suppress the first probe and report the deadlock from the rescheduled probe', async () => {
+      const outputIndex = next.cliOutput.length
+      // `Quick` emits a chunk at ~11s, suppressing the first probe's
+      // verdict via mid-probe recovery. The fill never settles (`Stuck`
+      // is deadlocked), so the scheduler reschedules another probe ~10s
+      // after that chunk; the second probe sees no chunks during its
+      // own window and correctly reports the deadlock.
+      const browser = await next.browser('/recovery-stuck', {
+        waitUntil: 'commit',
+      })
+
+      await expect(browser).toDisplayRedbox(`
+       {
+         "code": "E1181",
+         "description": "Filling a "use cache" entry appears to be stuck on shared state from the outer render scope. The same function completed when run in isolation, which usually means a module-scoped value (for example a top-level Map used to dedupe fetches) is joining a promise created outside the cache. "use cache" already dedupes calls with the same arguments — within a request and across requests on the same server instance — so the surrounding dedupe layer is both unnecessary and the likely cause. Remove it and rely on "use cache" alone for deduping.",
+         "environmentLabel": null,
+         "label": "Runtime Error",
+         "source": "app/recovery-stuck/page.tsx (24:1) @ getCachedData
+       > 24 | async function getCachedData() {
+            | ^",
+         "stack": [
+           "getCachedData app/recovery-stuck/page.tsx (24:1)",
+           "Cached app/recovery-stuck/page.tsx (41:18)",
+           "Page app/recovery-stuck/page.tsx (49:10)",
+         ],
+       }
+      `)
+
+      const cliOutput = stripAnsi(next.cliOutput.slice(outputIndex))
+
+      expect(cliOutput).toContain(`Error: ${expectedDeadlockMessage}`)
+      expect(cliOutput).not.toContain(expectedTimeoutErrorMessage)
+    })
+  })
+
+  describe('when a private "use cache" body reads cookies and hits a module-scope deadlock', () => {
+    it('should still report a deadlock — proves cookies are forwarded into the probe', async () => {
+      const outputIndex = next.cliOutput.length
+      const browser = await next.browser('/private-cookies')
+
+      await expect(browser).toDisplayRedbox(`
+       {
+         "code": "E1181",
+         "description": "Filling a "use cache" entry appears to be stuck on shared state from the outer render scope. The same function completed when run in isolation, which usually means a module-scoped value (for example a top-level Map used to dedupe fetches) is joining a promise created outside the cache. "use cache" already dedupes calls with the same arguments — within a request and across requests on the same server instance — so the surrounding dedupe layer is both unnecessary and the likely cause. Remove it and rely on "use cache" alone for deduping.",
+         "environmentLabel": null,
+         "label": "Runtime Error",
+         "source": "app/private-cookies/page.tsx (20:1) @ getCachedData
+       > 20 | async function getCachedData(): Promise<string> {
+            | ^",
+         "stack": [
+           "getCachedData app/private-cookies/page.tsx (20:1)",
+           "Cached app/private-cookies/page.tsx (35:24)",
+           "Page app/private-cookies/page.tsx (55:7)",
+         ],
+       }
+      `)
+
+      const cliOutput = stripAnsi(next.cliOutput.slice(outputIndex))
+
+      expect(cliOutput).toContain(`Error: ${expectedDeadlockMessage}`)
+    })
+  })
+})


### PR DESCRIPTION
When a `'use cache'` fill stalls in dev today, the user has to wait the full `useCacheTimeout` — 54 seconds by default — before any error surfaces, and the resulting `UseCacheTimeoutError` is too generic to point at the cause. A common cause is module-scoped state that ends up joining a promise from the outer render scope — for example a top-level `Map<string, Promise>` used to dedupe fetches, where the cache body and the outer scope both await the same promise. That promise hangs because Next.js intentionally converts uncached fetches into hanging promises during prerendering (and in dev while filling caches in the static or runtime stage), so the cache function ends up waiting forever on an outer-scope fetch that will never resolve. Most users reload long before the timeout appears, so they never see any signal that something specific is wrong.

This change adds a dev-only probe that surfaces this class of deadlock earlier. Once a cache fill has been idle for ten seconds, the dev server re-runs the same cache function in a worker thread with a fresh module scope. If it completes there, the hang in the main process is attributable to outer-scope state, and we abort the fill with `UseCacheDeadlockError` whose message points the user at the dedupe pattern and how to fix it. If the probe also hangs or fails for any other reason — decode failure, missing module, the body throwing — we fall back to the regular cache-fill timeout, so the probe is a positive signal only and never false-positives a deadlock.

The probe is gated on `__NEXT_DEV_SERVER` and tree-shakes out of the production runtime entirely. The worker pool is lazy, with no process forked until a probe actually fires, reused across probes for the same dev session, and torn down on HMR or worker crash. A snapshot of the outer request store is forwarded to the worker so that cache functions — including private caches that read `cookies()`, `headers()`, or `draftMode()` — see the same values they would in a real invocation.