### PR TITLE
[ci] Ensure pnpm store cache is only filled when pnpm install runs

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -141,7 +141,7 @@ jobs:
         id: cache-pnpm-store
         with:
           path: ${{ steps.get-store-path.outputs.STORE_PATH }}
-          key: pnpm-store-v2-${{ hashFiles('pnpm-lock.yaml') }}
+          key: pnpm-store-root-v1-${{ hashFiles('pnpm-lock.yaml') }}
           # Do not use restore-keys since it leads to indefinite growth of the cache.
 
       - run: pnpm install

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -308,7 +308,11 @@ jobs:
       - run: git checkout .
         if: ${{ inputs.skipInstallBuild != 'yes' }}
 
-      - run: pnpm install
+      - name: pnpm install
+        run: |
+          pnpm store path
+          ls -ls $(pnpm store path)
+          pnpm install
         if: ${{ inputs.skipInstallBuild != 'yes' || inputs.needsNextest == 'yes' }}
 
       - name: Install node-file-trace test dependencies

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -309,7 +309,7 @@ jobs:
         id: cache-pnpm-store
         with:
           path: ${{ steps.get-store-path.outputs.STORE_PATH }}
-          key: pnpm-store-v2-${{ hashFiles('pnpm-lock.yaml') }}
+          key: pnpm-store-root-v1-${{ hashFiles('pnpm-lock.yaml') }}
           # Do not use restore-keys since it leads to indefinite growth of the cache.
       - run: pnpm install
         # condititions must be superset of cache step, otherwise we risk running install without a cache and then caching the incomplete store.

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -234,16 +234,6 @@ jobs:
         id: get-store-path
         run: echo STORE_PATH=$(pnpm store path) >> $GITHUB_OUTPUT
 
-      - name: Cache pnpm store
-        if: ${{ runner.environment == 'github-hosted' }}
-        uses: actions/cache@v4
-        timeout-minutes: 5
-        id: cache-pnpm-store
-        with:
-          path: ${{ steps.get-store-path.outputs.STORE_PATH }}
-          key: pnpm-store-v2-${{ hashFiles('pnpm-lock.yaml') }}
-          # Do not use restore-keys since it leads to indefinite growth of the cache.
-
       # local action -> needs to run after checkout
       - name: Install Rust
         uses: ./.github/actions/setup-rust
@@ -308,11 +298,21 @@ jobs:
       - run: git checkout .
         if: ${{ inputs.skipInstallBuild != 'yes' }}
 
-      - name: pnpm install
-        run: |
-          pnpm store path
-          ls -ls $(pnpm store path)
-          pnpm install
+      - name: Cache pnpm store
+        # conditions must be subset of runs executing pnpm install, otherwise we
+        # risk caching an incomplete store
+        # If keep conditions in sync breaks, we can split into restore and save
+        # steps where saving runs based on the outcome of the install step
+        if: ${{ runner.environment == 'github-hosted' && (inputs.skipInstallBuild != 'yes' || inputs.needsNextest == 'yes') }}
+        uses: actions/cache@v4
+        timeout-minutes: 5
+        id: cache-pnpm-store
+        with:
+          path: ${{ steps.get-store-path.outputs.STORE_PATH }}
+          key: pnpm-store-v2-${{ hashFiles('pnpm-lock.yaml') }}
+          # Do not use restore-keys since it leads to indefinite growth of the cache.
+      - run: pnpm install
+        # condititions must be superset of cache step, otherwise we risk running install without a cache and then caching the incomplete store.
         if: ${{ inputs.skipInstallBuild != 'yes' || inputs.needsNextest == 'yes' }}
 
       - name: Install node-file-trace test dependencies

--- a/.github/workflows/create_release_branch.yml
+++ b/.github/workflows/create_release_branch.yml
@@ -81,7 +81,7 @@ jobs:
         id: cache-pnpm-store
         with:
           path: ${{ steps.get-store-path.outputs.STORE_PATH }}
-          key: pnpm-store-v2-${{ hashFiles('pnpm-lock.yaml') }}
+          key: pnpm-store-root-v1-${{ hashFiles('pnpm-lock.yaml') }}
           # Do not use restore-keys since it leads to indefinite growth of the cache.
 
       - run: pnpm install

--- a/.github/workflows/trigger_release.yml
+++ b/.github/workflows/trigger_release.yml
@@ -116,7 +116,7 @@ jobs:
         id: cache-pnpm-store
         with:
           path: ${{ steps.get-store-path.outputs.STORE_PATH }}
-          key: pnpm-store-v2-${{ hashFiles('pnpm-lock.yaml') }}
+          key: pnpm-store-root-v1-${{ hashFiles('pnpm-lock.yaml') }}
           # Do not use restore-keys since it leads to indefinite growth of the cache.
 
       - run: pnpm install


### PR DESCRIPTION
@mischnic [noticed that our installs where downloading almost all packages](https://github.com/vercel/next.js/actions/runs/25392418209/job/74473471902?pr=93504) despite cache hit.

I suspect that we cached a store in a run where no `pnpm install` was performed (14mb is way too small for a pnpm store for our monorepo). This can happen because the `if` conditions for the cache and `pnpm install` don't match.

For now I opted for copying the conditions. If this proofs to be a common source of bugs, we can split the cache step into `/restore` and `/save`. The `/save` step would then check the [outcome (not conclusion)](https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#steps-context) of the pnpm install step instead of repeating its `if` conditions.

Invalidated the cache key to get the fix out immediately. The new name tries to better reflect what is contained in this store. Running a focused install or install in another worktree would be another mistake to avoid.

## test plan

We'll see I guess. But considering a fresh cache is 440mb bit whereas we were previously restoring only 14mb is good indicator that this was the culprit.