### PR TITLE
fix(router): prevent eager prefetching during router.refresh()

### DIFF
--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -105,7 +105,14 @@ function HistoryUpdater({
     // task. Re-prefetch all visible links with the updated values. In most
     // cases, this will not result in any new network requests, only if
     // the prefetch result actually varies on one of these inputs.
-    pingVisibleLinks(appRouterState.nextUrl, appRouterState.tree)
+    const isRefresh = !!(
+      appRouterState.tree[2] &&
+      typeof appRouterState.tree[2] === 'object' &&
+      'refresh' in appRouterState.tree[2] &&
+      appRouterState.tree[2].refresh === 'refetch'
+    )
+
+    pingVisibleLinks(appRouterState.nextUrl, appRouterState.tree, !isRefresh)
   }, [appRouterState.nextUrl, appRouterState.tree])
 
   return null

--- a/packages/next/src/client/components/links.ts
+++ b/packages/next/src/client/components/links.ts
@@ -340,7 +340,8 @@ function rescheduleLinkPrefetch(
 
 export function pingVisibleLinks(
   nextUrl: string | null,
-  tree: FlightRouterState
+  tree: FlightRouterState,
+  shouldRescheduleLazyLinks: boolean = true
 ) {
   // For each currently visible link, cancel the existing prefetch task (if it
   // exists) and schedule a new one. This is effectively the same as if all the
@@ -356,6 +357,16 @@ export function pingVisibleLinks(
       // changed. Bail out.
       continue
     }
+
+    if (
+      !shouldRescheduleLazyLinks &&
+      task?.priority === PrefetchPriority.Default
+    ) {
+      // If we are suppressing lazy prefetches (e.g. during a refresh), and this
+      // link hasn't been hovered yet, don't re-prefetch it.
+      continue
+    }
+
     // Something changed. Cancel the existing prefetch task and schedule a
     // new one.
     if (task !== null) {

--- a/test/e2e/app-dir/prefetch-refresh-lazy/app/other-1/page.tsx
+++ b/test/e2e/app-dir/prefetch-refresh-lazy/app/other-1/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Other Page</div>
+}

--- a/test/e2e/app-dir/prefetch-refresh-lazy/app/other-2/page.tsx
+++ b/test/e2e/app-dir/prefetch-refresh-lazy/app/other-2/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Other Page 2</div>
+}

--- a/test/e2e/app-dir/prefetch-refresh-lazy/app/page.tsx
+++ b/test/e2e/app-dir/prefetch-refresh-lazy/app/page.tsx
@@ -1,0 +1,18 @@
+import Link from 'next/link'
+import { RefreshButton } from './refresh-button'
+
+export default function Page() {
+  return (
+    <div>
+      <h1 id="page-title">Prefetch Refresh Lazy</h1>
+      <Link href="/other-1" prefetch={false} id="link-1">
+        Other 1
+      </Link>
+      <Link href="/other-2" prefetch={false} id="link-2">
+        Other 2
+      </Link>
+      <RefreshButton />
+      <div id="timestamp">{Date.now()}</div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/prefetch-refresh-lazy/app/refresh-button.tsx
+++ b/test/e2e/app-dir/prefetch-refresh-lazy/app/refresh-button.tsx
@@ -1,0 +1,11 @@
+'use client'
+import { useRouter } from 'next/navigation'
+
+export function RefreshButton() {
+  const router = useRouter()
+  return (
+    <button id="refresh-button" onClick={() => router.refresh()}>
+      Refresh
+    </button>
+  )
+}

--- a/test/e2e/app-dir/prefetch-refresh-lazy/prefetch-refresh-lazy.test.ts
+++ b/test/e2e/app-dir/prefetch-refresh-lazy/prefetch-refresh-lazy.test.ts
@@ -1,0 +1,50 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('prefetch-refresh-lazy', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should not trigger new prefetches for prefetch={false} links on router.refresh()', async () => {
+    let prefetchRequests = []
+    const browser = await next.browser('/', {
+      beforePageLoad(page) {
+        page.on('request', (request) => {
+          const url = request.url()
+          if (url.includes('prefetch=1')) {
+            prefetchRequests.push(url)
+          }
+        })
+      },
+    })
+
+    // Confirm links are visible
+    expect(await browser.elementById('link-1').isDisplayed()).toBe(true)
+    expect(await browser.elementById('link-2').isDisplayed()).toBe(true)
+
+    // Wait a bit to ensure no initial prefetches were fired (since prefetch={false})
+    await new Promise((resolve) => setTimeout(resolve, 2000))
+    expect(prefetchRequests.length).toBe(0)
+
+    const initialTimestamp = await browser.elementById('timestamp').text()
+
+    // Trigger refresh
+    await browser.elementById('refresh-button').click()
+
+    // Wait for the page to update (timestamp should change)
+    await (async () => {
+      for (let i = 0; i < 50; i++) {
+        const currentTimestamp = await browser.elementById('timestamp').text()
+        if (currentTimestamp !== initialTimestamp) return
+        await new Promise((resolve) => setTimeout(resolve, 100))
+      }
+      throw new Error('Timed out waiting for re-render after refresh')
+    })()
+
+    // Wait a bit more to see if any prefetches are triggered after refresh
+    await new Promise((resolve) => setTimeout(resolve, 2000))
+
+    // Assert that zero new prefetch requests were fired for the visible links
+    expect(prefetchRequests.length).toBe(0)
+  })
+})


### PR DESCRIPTION
# Restore lazy prefetch behavior for `<Link>` on `router.refresh()`

### What?

Fixes a regression where `router.refresh()` eagerly re-prefetches all in-viewport `<Link>` elements, including those configured for lazy or disabled prefetching (e.g. `prefetch={false}`).

---

### Why?

In Next.js v15, `router.refresh()` would mark visible links as **stale** without immediately refetching them. Prefetching remained lazy and only occurred when the user showed intent (hover/touch) or when the link re-entered the viewport.

In v16, changes introduced around dynamic IO and the segment cache (likely in #71567) caused `pingVisibleLinks` to treat all visible links as “dirty” after a refresh. As a result, it eagerly reschedules prefetch tasks for every visible link.

This leads to:

* Unintended network requests
* Excessive cache invalidations (e.g. ISR writes)
* A behavior change from the previously expected lazy semantics

---

### How?

This change makes `pingVisibleLinks` aware of refresh cycles without introducing new router state.

Instead, it derives whether a refresh is in progress from the root `FlightRouterState`. When `tree[2].refresh === 'refetch'` is detected, the router is currently performing a refresh.

During this phase, lazy prefetch tasks (including `prefetch={false}` links) are **not rescheduled**, preventing eager refetching of visible links.

This restores the expected behavior:

* Links are marked stale after a refresh
* Prefetching only occurs on user intent or viewport re-entry

---

### Fixed Issues

* Fixes unintended eager prefetching triggered by `router.refresh()`
* Prevents unnecessary network traffic and cache invalidations for lazy links

Fixes #93210

> Regression likely introduced by #71567

---

### Checklist

* [x] Related issue linked (`#93210`)
* [x] Added regression test in `prefetch-refresh-lazy.test.ts`
* [x] Verified type safety in `app-router.tsx`
* [x] Passed local `pnpm types` check