### PR TITLE
Update `unstable_prefetch` and `unstable_instant` docs to reflect current API shape

### DIFF
--- a/docs/01-app/03-api-reference/03-file-conventions/02-route-segment-config/instant.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/02-route-segment-config/instant.mdx
@@ -12,17 +12,20 @@ related:
     - app/api-reference/directives/use-cache
 ---
 
-The `unstable_instant` route segment config opts a route into validation for instant client-side navigations. Next.js checks, during development and at build time, that the caching structure produces an instant [static shell](/docs/app/glossary#static-shell) at every possible entry point into the route.
+The `unstable_instant` route segment config controls how Next.js validates whether a navigation into this segment would produce an instant UI.
+
+Next.js uses prefetching to preload navigations for all in-app links on the current page. However, client-side data fetching or partially prerendered results from the server can lead to navigations that don't update the UI immediately. To help you build fast-feeling navigations, `unstable_instant` lets you tell Next.js what to expect from navigations through the configured segment. For instance, you can indicate that navigations into this segment should produce a UI that renders instantly without waiting on any externally loaded data. You can also indicate that navigations aren't expected to be instant.
+
+When a segment is configured to expect an instant UI, Next.js surfaces any code in your application that would block the navigation from updating the UI immediately. See the [Instant Navigation guide](/docs/app/guides/instant-navigation) for an end-to-end walkthrough.
 
 > **Good to know**:
 >
 > - The `unstable_instant` export only works when [`cacheComponents`](/docs/app/api-reference/config/next-config-js/cacheComponents) is enabled.
 > - `unstable_instant` cannot be used in Client Components. It will throw an error.
+> - Next.js does not perform prefetches in development, so navigations may not feel as instant as they will in production. Validation reflects what will happen during `next start`, where prefetching is enabled.
 
 ```tsx filename="layout.tsx | page.tsx" switcher
-export const unstable_instant = {
-  prefetch: 'static',
-}
+export const unstable_instant = true
 
 export default function Page() {
   return <div>...</div>
@@ -30,9 +33,7 @@ export default function Page() {
 ```
 
 ```jsx filename="layout.js | page.js" switcher
-export const unstable_instant = {
-  prefetch: 'static',
-}
+export const unstable_instant = true
 
 export default function Page() {
   return <div>...</div>
@@ -41,25 +42,52 @@ export default function Page() {
 
 ## Reference
 
-### `prefetch`
+The export accepts:
 
-Controls the validation and prefetching mode.
+- **`true`**: Opts the segment into validation. Validation runs in development (in the dev overlay) and at build (failing the build on violations).
+- **`false`**: Opts the segment out (see [Disabling instant](#disabling-instant)).
+- An **object**: Opts in with additional options. See [`samples`](#samples).
+
+### `samples`
+
+Provides representative request data used to validate runtime prefetches. Pair this with [`unstable_prefetch = 'force-runtime'`](/docs/app/api-reference/file-conventions/route-segment-config/prefetch#force-runtime) so validation can verify the caching structure against realistic inputs.
 
 ```tsx filename="page.tsx"
+export const unstable_prefetch = 'force-runtime'
 export const unstable_instant = {
-  prefetch: 'static',
+  samples: [
+    {
+      cookies: [{ name: 'session', value: 'test' }],
+    },
+  ],
 }
 ```
 
-- **`'static'`**: Enables validation. Prefetching behavior stays the same (static by default). Components that read cookies or headers are treated as dynamic and must be behind Suspense.
+Each sample can specify any of `cookies`, `headers`, `params`, or `searchParams`. Provide one entry per representative request shape — for example, one for an authenticated visit and one for an anonymous visit.
 
 ### Disabling instant
 
-Set `false` to exempt a segment from validation:
+Set `false` on a layout or page to indicate that this segment is allowed to block when navigating to it.
 
-```tsx filename="app/dashboard/layout.tsx"
+This is useful when a deeper page should be instant but an ancestor can't be. For instance, if a shared layout cannot load instantly but you still want to assert that pages beneath this layout can be navigated to instantly, you can ensure that the pages have `unstable_instant = true` while the shared layout has `unstable_instant = false`.
+
+```tsx filename="app/tabs/layout.tsx"
 export const unstable_instant = false
 ```
+
+```tsx filename="app/tabs/[tab]/page.tsx"
+export const unstable_instant = true
+```
+
+Navigations from outside into a tab are allowed to block at the layout. Navigations between tabs are validated for instant UI.
+
+You don't need to add `false` to ancestors of an instant page just because they do something blocking — a higher-up `unstable_instant = true` doesn't force its descendants to validate, and leaving an ancestor unconfigured is fine. Reach for `false` only when you've configured a deeper page as instant and need to exempt navigations that pass through a blocking ancestor.
+
+### Disabling static shell validation
+
+Cache Components also validates that each page in your app produces a non-empty static shell at prerender time. To opt a route out of this validation, ensure the highest `unstable_instant` config in the route's tree is `false` — a `false` higher in the tree takes precedence over any deeper `true` for the static-shell check.
+
+Setting `false` on the root layout disables static shell validation for the entire app. Place the `false` as low as possible — only as high as needed to cover the routes you want to opt out — so the rest of the app keeps validating.
 
 ## How validation works
 
@@ -88,7 +116,7 @@ Use both to check that your loading states look right on first visit and on navi
 
 ## Testing instant navigation
 
-The `@next/playwright` package exports an `instant()` helper that holds back dynamic content while the callback runs against the static shell. See the [guide](/docs/app/guides/instant-navigation#prevent-regressions-with-e2e-tests) for a full example.
+The `@next/playwright` package exports an `instant()` helper that holds back dynamic content while the callback runs against the instant UI. See the [guide](/docs/app/guides/instant-navigation#prevent-regressions-with-e2e-tests) for a full example.
 
 ```typescript
 import { instant } from '@next/playwright'
@@ -98,7 +126,7 @@ import { instant } from '@next/playwright'
 
 ## Known issue: shared cookie across projects
 
-The DevTools use a `next-instant-navigation-testing` cookie to freeze the UI at the static shell. Because cookies are scoped to the domain and not the port, running multiple projects on the same domain (typically `localhost`) means the cookie is shared across them and can cause unexpected behavior. Clear the cookie or close the Instant Navs panel when switching between projects to avoid issues.
+The DevTools use a `next-instant-navigation-testing` cookie to hold back dynamic content and freeze the page at the instant UI. Because cookies are scoped to the domain and not the port, running multiple projects on the same domain (typically `localhost`) means the cookie is shared across them and can cause unexpected behavior. Clear the cookie or close the Instant Navs panel when switching between projects to avoid issues.
 
 > **Good to know:** This will be fixed as part of stabilizing the feature.
 
@@ -106,29 +134,20 @@ The DevTools use a `next-instant-navigation-testing` cookie to freeze the UI at 
 
 ```tsx
 type RuntimeSample = {
-  cookies?: Array<{ name: string; value: string }>
-  headers?: Array<[string, string]>
+  cookies?: Array<{ name: string; value: string | null }>
+  headers?: Array<[string, string | null]>
   params?: Record<string, string | string[]>
-  searchParams?: Record<string, string | string[]>
+  searchParams?: Record<string, string | string[] | null>
 }
 
 type InstantConfig =
+  | true
   | false
   | {
-      prefetch: 'static'
-      from?: string[]
-      unstable_disableValidation?: boolean
-    }
-  | {
-      prefetch: 'runtime'
-      samples: RuntimeSample[]
-      from?: string[]
-      unstable_disableValidation?: boolean
+      samples?: RuntimeSample[]
     }
 
-export const unstable_instant: InstantConfig = {
-  prefetch: 'static',
-}
+export const unstable_instant: InstantConfig = true
 ```
 
 ## Version History

--- a/docs/01-app/03-api-reference/03-file-conventions/02-route-segment-config/prefetch.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/02-route-segment-config/prefetch.mdx
@@ -10,12 +10,14 @@ related:
     - app/api-reference/file-conventions/route-segment-config/instant
 ---
 
-The `unstable_prefetch` route segment config controls how a segment is prefetched during client-side navigation. By default (`'auto'`), the framework decides based on the segment's instant validation configuration and caching structure. The `force-` options let you declare a specific behavior. Use the force options with care since they can have implications for the speed of navigation and cost of naviagation. If you are configuring prefetching using this export consider pairing it with `unstable_instant` to validate that navigations to this Segment will in fact produce an instant UI with the prefetched data. This is especially important with runtime prefetching.
+The `unstable_prefetch` route segment config controls how a segment is prefetched during client-side navigation. The default (`'auto'`) lets Next.js manage the strategy on your behalf — today that always means a static prefetch. The `force-*` options let you declare a specific behavior — use them with care, since they can affect both navigation latency and prefetch cost.
+
+When you do set this export, consider pairing it with [`unstable_instant`](/docs/app/api-reference/file-conventions/route-segment-config/instant) so validation can confirm that navigations to this segment actually produce an instant UI from the prefetched data. This is especially important for runtime prefetching.
 
 > **Good to know**:
 >
 > - The `unstable_prefetch` export only works when [`cacheComponents`](/docs/app/api-reference/config/next-config-js/cacheComponents) is enabled.
-> - `unstable_prefetch` cannot be used when your Segment is a Client Component.
+> - `unstable_prefetch` cannot be used when the segment is a Client Component.
 
 ```tsx filename="layout.tsx | page.tsx" switcher
 export const unstable_prefetch = 'force-runtime'
@@ -37,7 +39,11 @@ export default function Page() {
 
 ### `'auto'` (default)
 
-The framework decides how to prefetch this segment. Segments with instant validation enabled are prefetched statically. Segments without instant validation may not be prefetched at all. You do not need to set this explicitly. While this option is available for completeness it is generally not expected that you use it and insteaed expect that you just omit the export from this segment.
+Lets Next.js manage prefetching for this segment. Today this always means a static prefetch — to try runtime prefetching, opt in explicitly with [`'force-runtime'`](#force-runtime).
+
+A future release will use [`unstable_instant`](/docs/app/api-reference/file-conventions/route-segment-config/instant) validation to choose between static and runtime prefetching automatically. Leaving the default in place means your app will pick up that improvement without code changes.
+
+You typically don't need to set this explicitly — omitting the export has the same effect.
 
 ### `'force-runtime'`
 
@@ -75,7 +81,7 @@ The `unstable_prefetch` segment config and the [`<Link prefetch>` prop](/docs/ap
 - The **segment config** informs Next.js about a segment's caching characteristics — whether its data can be prefetched statically, requires a runtime prefetch with the user's session, or should be skipped entirely. This applies to the segment regardless of which link points to it.
 - The **`<Link prefetch>` prop** reflects the anticipated intent of a specific link on a specific page. A link that users rarely click can be deprioritized with `prefetch={false}`, independent of how the destination segments are configured.
 
-In general, both of these are special circumstances. The default behavior — where Next.js decides what to prefetch based on [`unstable_instant`](/docs/app/api-reference/file-conventions/route-segment-config/instant) validation and the segment's caching structure — is optimized to provide a good navigation experience without manual configuration.
+In general, both of these are special circumstances. The default behavior — where Next.js manages prefetching for you — is optimized to provide a good navigation experience without manual configuration.
 
 ## TypeScript
 


### PR DESCRIPTION
Updates docs to reflect the current shape of these APIs. these will change further when we land default avlidation and switch to levels.