### PR TITLE
Turbopack: make rcstr! macro expansion const

### DIFF
--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -1065,7 +1065,7 @@ impl Project {
         };
 
         Ok(DiskFileSystem::new_with_denied_paths(
-            rcstr!(PROJECT_FILESYSTEM_NAME),
+            PROJECT_FILESYSTEM_NAME,
             *self.root_path,
             vec![denied_path],
         ))

--- a/crates/next-core/src/next_font/google/mod.rs
+++ b/crates/next-core/src/next_font/google/mod.rs
@@ -68,13 +68,15 @@ pub const GOOGLE_FONTS_STYLESHEET_URL: &str = "https://fonts.googleapis.com/css2
 // Always sending this user agent ensures consistent results from Google Fonts.
 // Google Fonts will vary responses based on user agent, e.g. only returning
 // references to certain font types for certain browsers.
-pub const USER_AGENT_FOR_GOOGLE_FONTS: &str = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) \
-                                               AppleWebKit/537.36 (KHTML, like Gecko) \
-                                               Chrome/104.0.0.0 Safari/537.36";
+pub const USER_AGENT_FOR_GOOGLE_FONTS: RcStr = rcstr!(
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) \
+     Chrome/104.0.0.0 Safari/537.36"
+);
 
 /// The google fonts plugin downloads fonts locally and transforms the url in the css into a
 /// specific format that is then intercepted later. This is the prefix we use for the new url.
-pub const GOOGLE_FONTS_INTERNAL_PREFIX: &str = "@vercel/turbopack-next/internal/font/google/font";
+pub const GOOGLE_FONTS_INTERNAL_PREFIX: RcStr =
+    rcstr!("@vercel/turbopack-next/internal/font/google/font");
 
 #[turbo_tasks::value(transparent)]
 #[derive(Deserialize)]
@@ -705,7 +707,7 @@ async fn fetch_from_google_fonts(
     virtual_path: FileSystemPath,
 ) -> Result<Option<Vc<HttpResponseBody>>> {
     let result = fetch_client
-        .fetch(url, Some(rcstr!(USER_AGENT_FOR_GOOGLE_FONTS)))
+        .fetch(url, Some(USER_AGENT_FOR_GOOGLE_FONTS))
         .await?;
 
     Ok(match *result {

--- a/crates/next-core/src/next_import_map.rs
+++ b/crates/next-core/src/next_import_map.rs
@@ -1077,7 +1077,7 @@ async fn insert_next_shared_aliases(
     );
 
     import_map.insert_alias(
-        AliasPattern::exact(rcstr!(GOOGLE_FONTS_INTERNAL_PREFIX)),
+        AliasPattern::exact(GOOGLE_FONTS_INTERNAL_PREFIX),
         ImportMapping::Dynamic(ResolvedVc::upcast(
             NextFontGoogleFontFileReplacer::new(project_path.clone(), fetch_client)
                 .to_resolved()

--- a/crates/next-core/src/next_shared/webpack_rules/babel.rs
+++ b/crates/next-core/src/next_shared/webpack_rules/babel.rs
@@ -46,10 +46,11 @@ static BABEL_LOADER_RE: LazyLock<Regex> =
 
 /// The forked version of babel-loader that we should use for automatic configuration. This version
 /// is always available, as it's installed as part of next.js.
-const NEXT_JS_BABEL_LOADER: &str = "next/dist/build/babel/loader";
+const NEXT_JS_BABEL_LOADER: RcStr = rcstr!("next/dist/build/babel/loader");
 
-const BABEL_PLUGIN_REACT_COMPILER: &str = "babel-plugin-react-compiler";
-const BABEL_PLUGIN_REACT_COMPILER_PACKAGE_JSON: &str = "babel-plugin-react-compiler/package.json";
+const BABEL_PLUGIN_REACT_COMPILER: RcStr = rcstr!("babel-plugin-react-compiler");
+const BABEL_PLUGIN_REACT_COMPILER_PACKAGE_JSON: RcStr =
+    rcstr!("babel-plugin-react-compiler/package.json");
 
 /// Detect manually-configured babel loaders. This is used to generate a warning, suggesting using
 /// the built-in babel support.
@@ -234,7 +235,7 @@ pub async fn get_babel_loader_rules(
         rcstr!("*.{js,jsx,ts,tsx,cjs,mjs,mts,cts}"),
         LoaderRuleItem {
             loaders: ResolvedVc::cell(vec![WebpackLoaderItem {
-                loader: rcstr!(NEXT_JS_BABEL_LOADER),
+                loader: NEXT_JS_BABEL_LOADER,
                 options: loader_options,
             }]),
             rename_as: Some(rcstr!("*")),
@@ -330,14 +331,12 @@ pub async fn resolve_babel_plugin_react_compiler(
     let babel_plugin_result = resolve(
         next_package.clone(),
         ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined),
-        Request::parse(Pattern::Constant(rcstr!(
-            BABEL_PLUGIN_REACT_COMPILER_PACKAGE_JSON
-        ))),
+        Request::parse(Pattern::Constant(BABEL_PLUGIN_REACT_COMPILER_PACKAGE_JSON)),
         node_cjs_resolve_options(project_path.root().owned().await?),
     );
     let Some(source) = &*babel_plugin_result.first_source().await? else {
         BabelPluginReactCompilerResolutionIssue {
-            failed_resolution: rcstr!(BABEL_PLUGIN_REACT_COMPILER),
+            failed_resolution: BABEL_PLUGIN_REACT_COMPILER,
             config_file_path: next_config
                 .config_file_path(project_path.clone())
                 .owned()
@@ -395,7 +394,7 @@ impl Issue for BabelPluginReactCompilerResolutionIssue {
             )),
             StyledString::Code(rcstr!("next")),
             StyledString::Text(rcstr!(" package. Is ")),
-            StyledString::Code(rcstr!(BABEL_PLUGIN_REACT_COMPILER)),
+            StyledString::Code(BABEL_PLUGIN_REACT_COMPILER),
             StyledString::Text(rcstr!(" installed in your ")),
             StyledString::Code(rcstr!("node_modules")),
             StyledString::Text(rcstr!(" directory?")),

--- a/turbopack/crates/turbo-rcstr/src/dynamic.rs
+++ b/turbopack/crates/turbo-rcstr/src/dynamic.rs
@@ -3,7 +3,7 @@ use std::{num::NonZeroU8, ptr::NonNull};
 use triomphe::Arc;
 
 use crate::{
-    INLINE_TAG, INLINE_TAG_INIT, LEN_OFFSET, RcStr, STATIC_TAG, TAG_MASK,
+    DYNAMIC_TAG, INLINE_TAG, INLINE_TAG_INIT, LEN_OFFSET, RcStr, STATIC_TAG, TAG_MASK,
     tagged_value::{MAX_INLINE_LEN, TaggedValue},
 };
 
@@ -80,24 +80,28 @@ pub(crate) fn new_atom<T: AsRef<str> + Into<String>>(text: T) -> RcStr {
 /// Construct a new dynamic RcStr from a PrehashedString
 pub(crate) fn new_atom_from_prehashed(prehashed: PrehashedString) -> RcStr {
     let entry: Arc<PrehashedString> = Arc::new(prehashed);
-    let entry = Arc::into_raw(entry);
-
+    let mut entry = Arc::into_raw(entry);
+    debug_assert!(0 == entry as u8 & TAG_MASK);
+    entry = ((entry as usize) | DYNAMIC_TAG as usize) as *mut PrehashedString;
     let ptr: NonNull<PrehashedString> = unsafe {
         // Safety: Arc::into_raw returns a non-null pointer
         NonNull::new_unchecked(entry as *mut _)
     };
-    debug_assert!(0 == ptr.as_ptr() as u8 & TAG_MASK);
+
     RcStr {
         unsafe_data: TaggedValue::new_ptr(ptr),
     }
 }
 
 #[inline(always)]
-pub(crate) fn new_static_atom(string: &'static PrehashedString) -> RcStr {
-    let mut entry = string as *const PrehashedString;
-    debug_assert!(0 == entry as u8 & TAG_MASK);
-    // Tag it as a static pointer
-    entry = ((entry as usize) | STATIC_TAG as usize) as *mut PrehashedString;
+pub(crate) const fn new_static_atom(string: &'static PrehashedString) -> RcStr {
+    let entry = string as *const PrehashedString;
+    const {
+        debug_assert!(align_of::<PrehashedString>() >= 4);
+        // This must be 00, so that we don't have to remove the tag, which we can't since it would
+        // require pointer-integer casts in a const context.
+        debug_assert!(STATIC_TAG == 0b_00);
+    }
     let ptr: NonNull<PrehashedString> = unsafe {
         // Safety: references always return a non-null pointers
         NonNull::new_unchecked(entry as *mut _)

--- a/turbopack/crates/turbo-rcstr/src/lib.rs
+++ b/turbopack/crates/turbo-rcstr/src/lib.rs
@@ -29,7 +29,7 @@ use turbo_tasks_hash::{DeterministicHash, DeterministicHasher};
 
 use crate::{
     dynamic::{deref_from, hash_bytes, new_atom, new_atom_from_prehashed, new_static_atom},
-    tagged_value::TaggedValue,
+    tagged_value::{MAX_INLINE_LEN, TaggedValue},
 };
 
 mod dynamic;
@@ -91,10 +91,10 @@ unsafe impl Send for RcStr {}
 unsafe impl Sync for RcStr {}
 
 // Marks a payload that is stored in an Arc
-const DYNAMIC_TAG: u8 = 0b_00;
+const DYNAMIC_TAG: u8 = 0b_10;
 const PREHASHED_STRING_LOCATION: u8 = 0b_0;
 // Marks a payload that has been leaked since it has a static lifetime
-const STATIC_TAG: u8 = 0b_10;
+const STATIC_TAG: u8 = 0b_00;
 // The payload is stored inline
 const INLINE_TAG: u8 = 0b_01; // len in upper nybble
 const INLINE_LOCATION: u8 = 0b_1;
@@ -486,9 +486,15 @@ pub const fn inline_atom(s: &str) -> Option<RcStr> {
     dynamic::inline_atom(s)
 }
 
+// Exports for our macro
+#[doc(hidden)]
+pub const fn is_atom_inlineable(s: &str) -> bool {
+    s.len() < MAX_INLINE_LEN
+}
+
 #[doc(hidden)]
 #[inline(always)]
-pub fn from_static(s: &'static PrehashedString) -> RcStr {
+pub const fn from_static(s: &'static PrehashedString) -> RcStr {
     dynamic::new_static_atom(s)
 }
 #[doc(hidden)]
@@ -545,12 +551,12 @@ static STATIC_TABLE: LazyLock<
 #[macro_export]
 macro_rules! rcstr {
     ($s:expr) => {{
-        const INLINE: core::option::Option<$crate::RcStr> = $crate::inline_atom($s);
+        let text = $s;
         // This condition can be compile time evaluated and inlined.
-        if INLINE.is_some() {
-            INLINE.unwrap()
+        if $crate::is_atom_inlineable(text) {
+            $crate::inline_atom(text).unwrap()
         } else {
-            fn get_rcstr() -> $crate::RcStr {
+            const fn get_rcstr() -> $crate::RcStr {
                 // Allocate static storage for the PrehashedString
                 static RCSTR_STORAGE: $crate::PrehashedString =
                     $crate::make_const_prehashed_string($s);

--- a/turbopack/crates/turbo-rcstr/src/tagged_value.rs
+++ b/turbopack/crates/turbo-rcstr/src/tagged_value.rs
@@ -51,7 +51,7 @@ pub(crate) struct TaggedValue {
 
 impl TaggedValue {
     #[inline(always)]
-    pub fn new_ptr<T>(value: NonNull<T>) -> Self {
+    pub const fn new_ptr<T>(value: NonNull<T>) -> Self {
         #[cfg(any(
             target_pointer_width = "32",
             target_pointer_width = "16",

--- a/turbopack/crates/turbopack-core/src/lib.rs
+++ b/turbopack/crates/turbopack-core/src/lib.rs
@@ -5,6 +5,8 @@
 #![feature(map_try_insert)]
 #![feature(hash_set_entry)]
 
+use turbo_rcstr::{RcStr, rcstr};
+
 pub mod asset;
 pub mod changed;
 pub mod chunk;
@@ -56,8 +58,10 @@ pub mod _chunking {}
 #[doc = include_str!("../layers.md")]
 pub mod _layers {}
 
-pub const PROJECT_FILESYSTEM_NAME: &str = "project";
-pub const SOURCE_URL_PROTOCOL: &str = "turbopack:";
+pub const PROJECT_FILESYSTEM_NAME_STR: &str = "project";
+pub const PROJECT_FILESYSTEM_NAME: RcStr = rcstr!(PROJECT_FILESYSTEM_NAME_STR);
+pub const SOURCE_URL_PROTOCOL_STR: &str = "turbopack:";
+pub const SOURCE_URL_PROTOCOL: RcStr = rcstr!(SOURCE_URL_PROTOCOL_STR);
 
 #[doc(hidden)]
 pub mod __private {

--- a/turbopack/crates/turbopack-core/src/source_map/utils.rs
+++ b/turbopack/crates/turbopack-core/src/source_map/utils.rs
@@ -12,14 +12,14 @@ use turbo_tasks_fs::{
 };
 use url::Url;
 
-use crate::SOURCE_URL_PROTOCOL;
+use crate::SOURCE_URL_PROTOCOL_STR;
 
 pub fn add_default_ignore_list(map: &mut swc_sourcemap::SourceMap) {
     let mut ignored_ids = HashSet::new();
 
     for (source_id, source) in map.sources().enumerate() {
-        if source.starts_with(concatcp!(SOURCE_URL_PROTOCOL, "///[next]"))
-            || source.starts_with(concatcp!(SOURCE_URL_PROTOCOL, "///[turbopack]"))
+        if source.starts_with(concatcp!(SOURCE_URL_PROTOCOL_STR, "///[next]"))
+            || source.starts_with(concatcp!(SOURCE_URL_PROTOCOL_STR, "///[turbopack]"))
             || source.contains("/node_modules/")
             || source.ends_with("__nextjs-internal-proxy.cjs")
             || source.ends_with("__nextjs-internal-proxy.mjs")
@@ -137,7 +137,7 @@ pub async fn resolve_source_map_sources(
                 // valid URLs. However, `project_trace_source_operation` (and `uri_from_file`) need
                 // to handle percent encoding correctly first.
                 let fs_path_str = &fs_path.path;
-                *source_url = format!("{SOURCE_URL_PROTOCOL}///{fs_str}/{fs_path_str}");
+                *source_url = format!("{SOURCE_URL_PROTOCOL_STR}///{fs_str}/{fs_path_str}");
 
                 if let Some(source_content) = source_content
                     && source_content.is_none()
@@ -166,7 +166,7 @@ pub async fn resolve_source_map_sources(
                     LazyLock::new(|| Regex::new(r#"(?:^|/)(?:\.\.?(?:/|$))+"#).unwrap());
                 let source = INVALID_REGEX
                     .replace_all(source_url, |s: &regex::Captures<'_>| s[0].replace('.', "_"));
-                *source_url = format!("{SOURCE_URL_PROTOCOL}///{fs_str}/{origin_str}/{source}");
+                *source_url = format!("{SOURCE_URL_PROTOCOL_STR}///{fs_str}/{origin_str}/{source}");
             }
             anyhow::Ok(())
         };
@@ -251,7 +251,7 @@ where
         .context("Expected the chunking context to have a DiskFileSystem")?
         .await?;
 
-    let prefix = format!("{}///[{}]/", SOURCE_URL_PROTOCOL, context_fs.name());
+    let prefix = format!("{}///[{}]/", SOURCE_URL_PROTOCOL_STR, context_fs.name());
 
     let mut apply_transform = |src: &mut String| -> Result<()> {
         if let Some(src_rest) = src.strip_prefix(&prefix) {
@@ -438,7 +438,7 @@ mod tests {
                 .read_strongly_consistent()
                 .await?;
 
-            let prefix = format!("{SOURCE_URL_PROTOCOL}///[mock]");
+            let prefix = format!("{SOURCE_URL_PROTOCOL_STR}///[mock]");
             assert_eq!(
                 resolved_source_maps.resolved_sources,
                 vec![

--- a/turbopack/crates/turbopack-node/src/source_map/mod.rs
+++ b/turbopack/crates/turbopack-node/src/source_map/mod.rs
@@ -15,7 +15,7 @@ use turbo_tasks_fs::{
 };
 use turbopack_cli_utils::source_context::format_source_context_lines;
 use turbopack_core::{
-    PROJECT_FILESYSTEM_NAME, SOURCE_URL_PROTOCOL,
+    PROJECT_FILESYSTEM_NAME_STR, SOURCE_URL_PROTOCOL_STR,
     source_map::{GenerateSourceMap, SourceMap},
 };
 use turbopack_ecmascript::magic_identifier::unmangle_identifiers;
@@ -236,9 +236,9 @@ async fn resolve_source_mapping(
         TraceResult::Found(frame) => {
             let lib_code = frame.file.contains("/node_modules/");
             if let Some(project_path) = frame.file.strip_prefix(concatcp!(
-                SOURCE_URL_PROTOCOL,
+                SOURCE_URL_PROTOCOL_STR,
                 "///[",
-                PROJECT_FILESYSTEM_NAME,
+                PROJECT_FILESYSTEM_NAME_STR,
                 "]/"
             )) {
                 let fs_path = project_dir.join(project_path)?;

--- a/turbopack/crates/turbopack/examples/turbopack.rs
+++ b/turbopack/crates/turbopack/examples/turbopack.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<()> {
     let task = tt.spawn_root_task(|| {
         Box::pin(async {
             let root: RcStr = current_dir().unwrap().to_str().unwrap().into();
-            let disk_fs = DiskFileSystem::new(PROJECT_FILESYSTEM_NAME.into(), Vc::cell(root));
+            let disk_fs = DiskFileSystem::new(PROJECT_FILESYSTEM_NAME, Vc::cell(root));
             disk_fs.await?.start_watching(None).await?;
 
             // Smart Pointer cast


### PR DESCRIPTION
Brought to you by
```
destructor of `std::option::Option<turbo_rcstr::RcStr>` cannot be evaluated at compile-time
```
and
```
cannot perform conditionally-const deref coercion on `std::mem::ManuallyDrop<std::option::Option<RcStr>>` in constants
```
