### PR TITLE
Add dom.iterable to next-routing package tsconfig

### DIFF
--- a/packages/next-routing/tsconfig.json
+++ b/packages/next-routing/tsconfig.json
@@ -7,7 +7,7 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "skipLibCheck": false,
-    "lib": ["es2022", "dom"],
+    "lib": ["es2022", "dom", "dom.iterable"],
     "rootDir": "src",
     "types": ["jest"]
   },


### PR DESCRIPTION
Not sure how we ended up needing this b/c how did ci pass without it. but I couldn't get next to build locally due to ts errors without this change.