### PR TITLE
fix(turbopack): allow dynamic import retry after chunk load failure

### DIFF
--- a/test/production/chunk-load-failure/app/retry/page.tsx
+++ b/test/production/chunk-load-failure/app/retry/page.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import { useState } from 'react'
+
+export default function Page() {
+  const [status, setStatus] = useState('idle')
+
+  return (
+    <>
+      <button
+        id="load"
+        onClick={async () => {
+          setStatus('loading')
+          try {
+            const mod = await import('../dynamic/async')
+            setStatus(mod.default())
+          } catch (error) {
+            setStatus(
+              error instanceof Error
+                ? `${error.name}: ${error.message}`
+                : String(error)
+            )
+          }
+        }}
+      >
+        Load
+      </button>
+      <p id="status">{status}</p>
+    </>
+  )
+}

--- a/test/production/chunk-load-failure/chunk-load-failure.test.ts
+++ b/test/production/chunk-load-failure/chunk-load-failure.test.ts
@@ -8,7 +8,7 @@ describe('chunk-load-failure', () => {
     files: __dirname,
   })
 
-  async function getNextDynamicChunk() {
+  async function getNextDynamicChunks() {
     const browserChunks = await listClientChunks(
       path.join(next.testDir, next.distDir)
     )
@@ -19,18 +19,32 @@ describe('chunk-load-failure', () => {
           .readFileSync(path.join(next.testDir, next.distDir, f), 'utf8')
           .includes('this is a lazy loaded async component')
     )
-    expect(nextDynamicChunks).toHaveLength(1)
+    expect(nextDynamicChunks.length).toBeGreaterThan(0)
 
-    return nextDynamicChunks[0]
+    return nextDynamicChunks.map((chunk) => chunk.replace(/\\/g, '/'))
+  }
+
+  function getMatchingChunk(chunkUrl: string, chunks: string[]) {
+    return chunks.find((chunk) => chunkUrl.includes(chunk))
   }
 
   it('should report async chunk load failures', async () => {
-    let nextDynamicChunk = await getNextDynamicChunk()
+    let nextDynamicChunks = await getNextDynamicChunks()
 
     let pageError: Error | undefined
+    let failedChunk: string | undefined
     const browser = await next.browser('/dynamic', {
       beforePageLoad(page) {
-        page.route(`**/${nextDynamicChunk}*`, async (route) => {
+        page.route('**/_next/static/**/*.js*', async (route) => {
+          const matchingChunk = getMatchingChunk(
+            route.request().url(),
+            nextDynamicChunks
+          )
+          if (!matchingChunk) {
+            await route.continue()
+            return
+          }
+          failedChunk = matchingChunk
           await route.abort('connectionreset')
         })
         page.on('pageerror', (error: Error) => {
@@ -47,24 +61,81 @@ describe('chunk-load-failure', () => {
 
     expect(pageError).toBeDefined()
     expect(pageError.name).toBe('ChunkLoadError')
+    expect(failedChunk).toBeDefined()
     if (process.env.IS_TURBOPACK_TEST) {
       expect(pageError.message).toStartWith(
-        'Failed to load chunk /_next/' + nextDynamicChunk
+        'Failed to load chunk /_next/' + failedChunk
       )
     } else {
       expect(pageError.message).toMatch(/^Loading chunk \S+ failed./)
-      expect(pageError.message).toContain('/_next/' + nextDynamicChunk)
+      expect(pageError.message).toContain('/_next/' + failedChunk)
     }
   })
 
+  it('should allow async chunk loads after a transient failure', async () => {
+    let nextDynamicChunks = await getNextDynamicChunks()
+    let failedChunk: string | undefined
+    let failedChunkRequests = 0
+
+    const browser = await next.browser('/retry', {
+      beforePageLoad(page) {
+        page.route('**/_next/static/**/*.js*', async (route) => {
+          const matchingChunk = getMatchingChunk(
+            route.request().url(),
+            nextDynamicChunks
+          )
+          if (!matchingChunk) {
+            await route.continue()
+            return
+          }
+
+          if (failedChunk == null) {
+            failedChunk = matchingChunk
+            failedChunkRequests++
+            await route.abort('connectionreset')
+            return
+          }
+
+          if (matchingChunk === failedChunk) {
+            failedChunkRequests++
+          }
+          await route.continue()
+        })
+      },
+    })
+
+    await browser.elementByCss('#load').click()
+    await retry(async () => {
+      expect(await browser.elementByCss('#status').text()).toContain(
+        'ChunkLoadError'
+      )
+    })
+
+    await browser.elementByCss('#load').click()
+    await retry(async () => {
+      expect(await browser.elementByCss('#status').text()).toBe(
+        'this is a lazy loaded async component'
+      )
+    })
+    expect(failedChunkRequests).toBe(2)
+  })
+
   it('should report aborted chunks when navigating away', async () => {
-    let nextDynamicChunk = await getNextDynamicChunk()
+    let nextDynamicChunks = await getNextDynamicChunks()
 
     let resolve
     try {
       const browser = await next.browser('/dynamic', {
         beforePageLoad(page) {
-          page.route(`**/${nextDynamicChunk}*`, async (route) => {
+          page.route('**/_next/static/**/*.js*', async (route) => {
+            const matchingChunk = getMatchingChunk(
+              route.request().url(),
+              nextDynamicChunks
+            )
+            if (!matchingChunk) {
+              await route.continue()
+              return
+            }
             // deterministically ensure that the async chunk is still loading during the navigation
             await new Promise((r) => {
               resolve = r

--- a/turbopack/crates/turbopack-ecmascript-runtime/js/src/browser/runtime/base/runtime-base.ts
+++ b/turbopack/crates/turbopack-ecmascript-runtime/js/src/browser/runtime/base/runtime-base.ts
@@ -77,7 +77,8 @@ interface RuntimeBackend {
     params?: RuntimeParams
   ) => void
   /**
-   * Returns the same Promise for the same chunk URL.
+   * Returns the same Promise for the same chunk URL while it is loading or
+   * loaded. Failed loads should be evicted so they can be retried.
    */
   loadChunkCached: (sourceType: SourceType, chunkUrl: ChunkUrl) => Promise<void>
   loadWebAssembly: (
@@ -107,6 +108,18 @@ contextPrototype.M = moduleFactories
 const availableModules: Map<ModuleId, Promise<any> | true> = new Map()
 
 const availableModuleChunks: Map<ChunkPath, Promise<any> | true> = new Map()
+
+function deleteCacheEntryOnFailure<K>(
+  cache: Map<K, Promise<any> | true>,
+  key: K,
+  promise: Promise<any>
+) {
+  promise.catch(() => {
+    if (cache.get(key) === promise) {
+      cache.delete(key)
+    }
+  })
+}
 
 function loadChunk(
   this: TurbopackBrowserBaseContext<Module>,
@@ -170,6 +183,11 @@ async function loadChunkInternal(
       const promise = loadChunkPath(sourceType, sourceData, moduleChunkToLoad)
 
       availableModuleChunks.set(moduleChunkToLoad, promise)
+      deleteCacheEntryOnFailure(
+        availableModuleChunks,
+        moduleChunkToLoad,
+        promise
+      )
 
       moduleChunksPromises.push(promise)
     }
@@ -182,6 +200,11 @@ async function loadChunkInternal(
     for (const includedModuleChunk of includedModuleChunksList) {
       if (!availableModuleChunks.has(includedModuleChunk)) {
         availableModuleChunks.set(includedModuleChunk, promise)
+        deleteCacheEntryOnFailure(
+          availableModuleChunks,
+          includedModuleChunk,
+          promise
+        )
       }
     }
   }
@@ -191,6 +214,7 @@ async function loadChunkInternal(
       // It might be better to race old and new promises, but it's rare that the new promise will be faster than a request started earlier.
       // In production it's even more rare, because the chunk optimization tries to deduplicate modules anyway.
       availableModules.set(included, promise)
+      deleteCacheEntryOnFailure(availableModules, included, promise)
     }
   }
 
@@ -226,6 +250,8 @@ function loadChunkByUrlInternal(
       loadedChunk
     )
     entry = thenable.then(resolve).catch((cause) => {
+      instrumentedBackendLoadChunks.delete(thenable)
+
       let loadReason: string
       switch (sourceType) {
         case SourceType.Runtime:

--- a/turbopack/crates/turbopack-ecmascript-runtime/js/src/browser/runtime/dom/runtime-backend-dom.ts
+++ b/turbopack/crates/turbopack-ecmascript-runtime/js/src/browser/runtime/dom/runtime-backend-dom.ts
@@ -128,6 +128,21 @@ const chunkResolvers: Map<ChunkUrl, ChunkResolver> = new Map()
     return resolver
   }
 
+  function rejectChunkLoad(
+    chunkUrl: ChunkUrl,
+    resolver: ChunkResolver,
+    error?: Error,
+    element?: Element
+  ) {
+    element?.remove()
+
+    if (!resolver.resolved && chunkResolvers.get(chunkUrl) === resolver) {
+      chunkResolvers.delete(chunkUrl)
+    }
+
+    resolver.reject(error)
+  }
+
   /**
    * Loads the given chunk, and returns a promise that resolves once the chunk
    * has been loaded.
@@ -162,7 +177,11 @@ const chunkResolvers: Map<ChunkUrl, ChunkResolver> = new Map()
         // ignore
       } else if (isJs(chunkUrl)) {
         self.TURBOPACK_NEXT_CHUNK_URLS!.push(chunkUrl)
-        importScripts(chunkUrl)
+        try {
+          importScripts(chunkUrl)
+        } catch (error) {
+          rejectChunkLoad(chunkUrl, resolver, error as Error)
+        }
       } else {
         throw new Error(
           `can't infer type of chunk from URL ${chunkUrl} in worker`
@@ -186,7 +205,7 @@ const chunkResolvers: Map<ChunkUrl, ChunkResolver> = new Map()
           link.crossOrigin = CROSS_ORIGIN
           link.href = chunkUrl
           link.onerror = () => {
-            resolver.reject()
+            rejectChunkLoad(chunkUrl, resolver, undefined, link)
           }
           link.onload = () => {
             // CSS chunks do not register themselves, and as such must be marked as
@@ -205,7 +224,7 @@ const chunkResolvers: Map<ChunkUrl, ChunkResolver> = new Map()
           // can't detect that. The Promise will never resolve in this case.
           for (const script of Array.from(previousScripts)) {
             script.addEventListener('error', () => {
-              resolver.reject()
+              rejectChunkLoad(chunkUrl, resolver, undefined, script)
             })
           }
         } else {
@@ -216,7 +235,7 @@ const chunkResolvers: Map<ChunkUrl, ChunkResolver> = new Map()
           // which happens in `registerChunk`. Hence the absence of `resolve()` in
           // this branch.
           script.onerror = () => {
-            resolver.reject()
+            rejectChunkLoad(chunkUrl, resolver, undefined, script)
           }
           // Append to the `head` for webpack compatibility.
           document.head.appendChild(script)


### PR DESCRIPTION
## What?

Fixes #93489.

This updates the Turbopack browser runtime so failed dynamic chunk-load attempts do not leave rejected load state cached in a way that prevents later dynamic `import()` attempts from retrying.

Successful chunk loads continue to use the existing caching behavior. Failed loads rethrow the original error, but clear the failed cached state so a later user-triggered import can attempt to load the chunk again after connectivity is restored.

This intentionally does not add:

- configurable retry
- exponential backoff
- runtime hooks
- cache-busting URLs
- webpack behavior changes

## Why?

A transient chunk-load failure, such as a temporary offline/network failure, could leave rejected Promise state in Turbopack runtime caches. Later attempts to dynamically import the same chunk could reuse the failed state instead of issuing a fresh load attempt.

This meant the app could remain stuck until a full reload cleared runtime state.

## How?

The runtime now evicts failed cached chunk-load entries on rejection while preserving successful and in-flight caching behavior.

The fix keeps the existing `ChunkLoadError` behavior intact and does not swallow or replace the original error.

Regression coverage was added in `test/production/chunk-load-failure/chunk-load-failure.test.ts` with a new `/retry` fixture. The test aborts the first async chunk request, confirms `ChunkLoadError`, clicks the same load button again, allows the chunk request to continue, and verifies the lazy module renders.

## Verification

- `git diff --check` passed.
- Commit pre-hook / `lint-staged` passed.

I attempted the targeted Turbopack browser regression locally, but this checkout appears to require rebuilt Turbopack/native runtime artifacts for the browser test to exercise the edited TypeScript runtime source.
