### PR TITLE
[turbopack] correct a fencepost error in our inline string descision

### DIFF
--- a/turbopack/crates/turbo-rcstr/src/dynamic.rs
+++ b/turbopack/crates/turbo-rcstr/src/dynamic.rs
@@ -58,7 +58,7 @@ pub unsafe fn restore_arc(v: TaggedValue) -> Arc<PrehashedString> {
 pub(crate) fn new_atom<T: AsRef<str> + Into<String>>(text: T) -> RcStr {
     let len = text.as_ref().len();
 
-    if len < MAX_INLINE_LEN {
+    if len <= MAX_INLINE_LEN {
         // INLINE_TAG ensures this is never zero
         let tag = INLINE_TAG_INIT | ((len as u8) << LEN_OFFSET);
         let mut unsafe_data = TaggedValue::new_tag(tag);
@@ -113,7 +113,7 @@ pub(crate) fn new_static_atom(string: &'static PrehashedString) -> RcStr {
 #[doc(hidden)]
 pub(crate) const fn inline_atom(text: &str) -> Option<RcStr> {
     let len = text.len();
-    if len < MAX_INLINE_LEN {
+    if len <= MAX_INLINE_LEN {
         let tag = INLINE_TAG | ((len as u8) << LEN_OFFSET);
         let mut unsafe_data = TaggedValue::new_tag(NonZeroU8::new(tag).unwrap());
 

--- a/turbopack/crates/turbo-rcstr/src/lib.rs
+++ b/turbopack/crates/turbo-rcstr/src/lib.rs
@@ -169,10 +169,10 @@ impl RcStr {
     /// zero-cost static copy instead of allocating a new Arc.
     ///
     /// Accepts `&str` so that borrow-decode paths can avoid heap allocation
-    /// entirely for inline strings (≤6 bytes) and static table hits.
+    /// entirely for inline strings (≤7 bytes) and static table hits.
     fn from_deserialized(s: &str) -> Self {
         let len = s.len();
-        if len >= tagged_value::MAX_INLINE_LEN {
+        if len > tagged_value::MAX_INLINE_LEN {
             let hash = hash_bytes(s.as_bytes());
             // Check the static table
             if let Some(entries) = STATIC_TABLE.get(&hash)
@@ -643,7 +643,7 @@ impl RcStrInterning {
     /// already zero-allocation inline atoms). Longer strings are looked up
     /// in the interning table and deduplicated.
     pub fn intern(&mut self, s: &str) -> RcStr {
-        if s.len() < tagged_value::MAX_INLINE_LEN {
+        if s.len() <= tagged_value::MAX_INLINE_LEN {
             // Inline atom — no allocation needed, don't bother with the set.
             return RcStr::from(s);
         }
@@ -658,7 +658,7 @@ impl RcStrInterning {
     /// Intern an owned `String`. When the string is not yet interned, avoids
     /// an extra copy compared to [`intern`](Self::intern).
     fn intern_owned(&mut self, s: String) -> RcStr {
-        if s.len() < tagged_value::MAX_INLINE_LEN {
+        if s.len() <= tagged_value::MAX_INLINE_LEN {
             return RcStr::from(s);
         }
         if let Some(existing) = self.set.get(s.as_str()) {


### PR DESCRIPTION
## What?

Fix an off-by-one in the `RcStr` inline-length check. Strings of length exactly `MAX_INLINE_LEN` should be stored inline, not on the heap.

## Why?

`<` should have been `<=`. The buffer holds `MAX_INLINE_LEN` bytes and the 4-bit tag field can encode that length, so the strict comparison was wasting one byte of inline capacity for no reason — 7-byte strings were allocating on the default 64-bit build. Bug dates back to #74482, the original inline-string change.

This covers fun things like: "default" (×11), "project" (×8), "process" (×8), "postcss" (×7), "require" (×6), "browser" (×4)

<!-- NEXT_JS_LLM_PR -->