### PR TITLE
Narrow per-segment `allowQuery` to reachable params

### DIFF
--- a/packages/next/src/build/adapter/build-complete.ts
+++ b/packages/next/src/build/adapter/build-complete.ts
@@ -37,6 +37,7 @@ import {
   CACHE_ONE_YEAR_SECONDS,
   HTML_CONTENT_TYPE_HEADER,
   JSON_CONTENT_TYPE_HEADER,
+  NEXT_INTERCEPTION_MARKER_PREFIX,
   NEXT_QUERY_PARAM_PREFIX,
   NEXT_RESUME_HEADER,
 } from '../../lib/constants'
@@ -426,6 +427,53 @@ export interface NextAdapter {
      */
     buildId: string
   }) => Promise<void> | void
+}
+
+// Recover the raw param name from a cache-key form (e.g. "nxtPmy-slug" →
+// "my-slug", "nxtIfoo" → "foo"). Cache keys are produced inside
+// `getNamedParametrizedRoute` as `${prefix}${rawParam}` where the prefix
+// is one of these constants (or empty when none was applied).
+function paramNameFromCacheKey(cacheKey: string): string {
+  if (cacheKey.startsWith(NEXT_INTERCEPTION_MARKER_PREFIX)) {
+    return cacheKey.slice(NEXT_INTERCEPTION_MARKER_PREFIX.length)
+  }
+  if (cacheKey.startsWith(NEXT_QUERY_PARAM_PREFIX)) {
+    return cacheKey.slice(NEXT_QUERY_PARAM_PREFIX.length)
+  }
+  return cacheKey
+}
+
+// Build the cache-key form for a query-prefixed param ("my-slug" →
+// "nxtPmy-slug"). Mirrors the encoding `getNamedParametrizedRoute`
+// applies to non-intercepted dynamic segments.
+function cacheKeyFromQueryParamName(paramName: string): string {
+  return `${NEXT_QUERY_PARAM_PREFIX}${paramName}`
+}
+
+// Narrow a page-level allowQuery to just the cache keys that this segment's
+// structural vary set actually depends on. The result is always a fresh
+// array so callers can mutate it.
+//
+// - structuralVaryParams === null: the segment spans the full route (e.g.
+//   /_full, /_head). Return the page-level allowQuery unchanged.
+// - Otherwise: keep entries whose underlying param name appears in the
+//   structural vary set. Empty result means the segment doesn't depend on
+//   any param (e.g. /_tree).
+function computeSegmentAllowQuery(
+  structuralVaryParams: string[] | null,
+  pageAllowQuery: string[] | undefined
+): string[] {
+  const base = pageAllowQuery ?? []
+  if (structuralVaryParams === null) {
+    return base.slice()
+  }
+  if (structuralVaryParams.length === 0 || base.length === 0) {
+    return []
+  }
+  const varyNameSet = new Set(structuralVaryParams)
+  return base.filter((cacheKey) =>
+    varyNameSet.has(paramNameFromCacheKey(cacheKey))
+  )
 }
 
 function normalizePathnames(
@@ -1212,7 +1260,7 @@ export async function handleBuildComplete({
           initialOutput.fallback.postponedState = meta.postponed
         }
 
-        if (meta?.segmentPaths) {
+        if (meta?.segments) {
           const normalizedRoute = normalizePagePath(route)
           const segmentsDir = path.join(
             appDistDir,
@@ -1229,28 +1277,43 @@ export async function handleBuildComplete({
           // If client param parsing is not enabled, we have to use the
           // allowQuery because the segment payloads will contain dynamic
           // segment values.
-          const segmentAllowQuery = routesManifest.rsc.clientParamParsing
+          const pageSegmentAllowQuery = routesManifest.rsc.clientParamParsing
             ? ctx.htmlAllowQuery
             : ctx.dataAllowQuery
 
-          for (const segmentPath of meta.segmentPaths) {
+          for (const segment of meta.segments) {
             const outputSegmentPath =
               path.join(
                 normalizedRoute + prefetchSegmentDirSuffix,
-                segmentPath
+                segment.path
               ) + prefetchSegmentSuffix
+
+            // Compute the per-segment allowQuery from its structural vary
+            // params (the path params reachable via this segment's `params`
+            // prop, plus all dynamic ancestors). The allowQuery is part of
+            // immutable build output, so we have to use *structural* vary —
+            // we cannot use the vary params tracked during the actual render,
+            // since they may change during a revalidation.
+            //
+            // null means the segment spans the full route (e.g. /_full,
+            // /_head). In that case, fall back to the page-level allowQuery
+            // — the existing behavior before per-segment narrowing.
+            const segmentAllowQueryForOutput = computeSegmentAllowQuery(
+              segment.structuralVaryParams,
+              initialOutput.config.allowQuery
+            )
 
             // Only use the fallback value when the allowQuery is defined and
             // either: (1) it is empty, meaning segments do not vary by params,
             // or (2) client param parsing is enabled, meaning the segment
             // payloads are safe to reuse across params.
             const shouldAttachSegmentFallback =
-              segmentAllowQuery &&
-              (segmentAllowQuery.length === 0 ||
+              pageSegmentAllowQuery &&
+              (pageSegmentAllowQuery.length === 0 ||
                 routesManifest.rsc.clientParamParsing)
 
             const fallbackPathname = shouldAttachSegmentFallback
-              ? path.join(segmentsDir, segmentPath + prefetchSegmentSuffix)
+              ? path.join(segmentsDir, segment.path + prefetchSegmentSuffix)
               : undefined
 
             outputs.prerenders.push({
@@ -1262,6 +1325,7 @@ export async function handleBuildComplete({
 
               config: {
                 ...initialOutput.config,
+                allowQuery: segmentAllowQueryForOutput,
                 bypassFor: undefined,
                 partialFallback: initialOutput.config.partialFallback,
               },
@@ -1287,8 +1351,13 @@ export async function handleBuildComplete({
 
       let prerenderGroupId = 1
 
+      type AppSegmentMeta = {
+        path: string
+        structuralVaryParams: string[] | null
+      }
+
       type AppRouteMeta = {
-        segmentPaths?: string[]
+        segments?: AppSegmentMeta[]
         postponed?: string
         headers?: Record<string, string>
         status?: number
@@ -1676,8 +1745,8 @@ export async function handleBuildComplete({
             // For opt-in partial fallbacks in cache components, keep only the
             // params that can still complete this shell.
             const remainingPrerenderableQueryKeys = new Set(
-              (remainingPrerenderableParams ?? []).map(
-                (param) => `${NEXT_QUERY_PARAM_PREFIX}${param.paramName}`
+              (remainingPrerenderableParams ?? []).map((param) =>
+                cacheKeyFromQueryParamName(param.paramName)
               )
             )
             htmlAllowQuery =

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -3400,7 +3400,7 @@ export default async function build(
 
                 if (
                   !isAppRouteHandler &&
-                  (metadata?.segmentPaths ||
+                  (metadata?.segments ||
                     (route.fallbackRootParams &&
                       route.fallbackRootParams.length > 0))
                 ) {
@@ -3416,11 +3416,11 @@ export default async function build(
                     }
                   }
 
-                  if (metadata?.segmentPaths) {
-                    const pageSegmentPath = metadata.segmentPaths.find((item) =>
-                      item.endsWith('__PAGE__')
+                  if (metadata?.segments) {
+                    const pageSegment = metadata.segments.find((item) =>
+                      item.path.endsWith('__PAGE__')
                     )
-                    if (!pageSegmentPath) {
+                    if (!pageSegment) {
                       throw new Error(`Invariant: missing __PAGE__ segmentPath`)
                     }
 
@@ -3429,7 +3429,7 @@ export default async function build(
                     // routes we output and they can be shared
                     const builtSegmentDataRoute = buildPrefetchSegmentDataRoute(
                       route.pathname,
-                      pageSegmentPath
+                      pageSegment.path
                     )
 
                     builtSegmentDataRoute.source =

--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -1654,7 +1654,7 @@ export async function handler(
             generateEtags: nextConfig.generateEtags,
             poweredByHeader: nextConfig.poweredByHeader,
             result: RenderResult.fromStatic(
-              matchedSegment,
+              matchedSegment.buffer,
               RSC_CONTENT_TYPE_HEADER
             ),
             cacheControl: cacheEntry.cacheControl,

--- a/packages/next/src/export/routes/app-page.ts
+++ b/packages/next/src/export/routes/app-page.ts
@@ -2,7 +2,7 @@ import type { OutgoingHttpHeaders } from 'node:http'
 import type { ExportRouteResult } from '../types'
 import type { RenderOpts } from '../../server/app-render/types'
 import type { NextParsedUrlQuery } from '../../server/request-meta'
-import type { RouteMetadata } from './types'
+import type { RouteMetadata, SegmentMetadata } from './types'
 
 import type {
   MockedRequest,
@@ -161,22 +161,31 @@ export async function exportAppPage(
       }
     }
 
-    let segmentPaths
+    let segments: Array<SegmentMetadata> | undefined
     if (segmentData) {
       // Emit the per-segment prefetch data. We emit them as separate files
       // so that the cache handler has the option to treat each as a
       // separate entry.
-      segmentPaths = []
+      segments = []
       const segmentsDir = htmlFilepath.replace(
         /\.html$/,
         RSC_SEGMENTS_DIR_SUFFIX
       )
 
-      for (const [segmentPath, buffer] of segmentData) {
-        segmentPaths.push(segmentPath)
+      for (const [segmentPath, entry] of segmentData) {
+        segments.push({
+          path: segmentPath,
+          // Use `null` (not an empty array) when the segment's vary set
+          // wasn't tracked (e.g. /_full, /_head). Empty array still means
+          // "no params" — important for the `/_tree` segment.
+          structuralVaryParams:
+            entry.structuralVaryParams === null
+              ? null
+              : Array.from(entry.structuralVaryParams),
+        })
         const segmentDataFilePath =
           segmentsDir + segmentPath + RSC_SEGMENT_SUFFIX
-        fileWriter.append(segmentDataFilePath, buffer)
+        fileWriter.append(segmentDataFilePath, entry.buffer)
       }
     }
 
@@ -218,7 +227,7 @@ export async function exportAppPage(
       status,
       headers,
       postponed,
-      segmentPaths,
+      segments,
       prefetchHints,
     }
 
@@ -232,7 +241,7 @@ export async function exportAppPage(
       metadata: hasNextSupport
         ? meta
         : {
-            segmentPaths: meta.segmentPaths,
+            segments: meta.segments,
             prefetchHints: meta.prefetchHints,
           },
       hasEmptyStaticShell: Boolean(postponed) && html === '',

--- a/packages/next/src/export/routes/types.ts
+++ b/packages/next/src/export/routes/types.ts
@@ -1,10 +1,27 @@
 import type { OutgoingHttpHeaders } from 'node:http'
 import type { PrefetchHints } from '../../shared/lib/app-router-types'
 
+/**
+ * Per-segment metadata persisted to the `.meta` file. The build adapter
+ * reads this to compute the cache-key allowQuery for each segment
+ * prerender, instead of inheriting the page-level value.
+ */
+export type SegmentMetadata = {
+  /** Path of the segment within the page's segments directory (e.g. `/_tree`). */
+  path: string
+  /**
+   * Structural vary params for this segment: dynamic path-param names
+   * (without the `nxtP` prefix) that are reachable via the `params` prop.
+   * `null` means the segment spans the full route — consumers should fall
+   * back to the page-level allowQuery.
+   */
+  structuralVaryParams: Array<string> | null
+}
+
 export type RouteMetadata = {
   status: number | undefined
   headers: OutgoingHttpHeaders | undefined
   postponed: string | undefined
-  segmentPaths: Array<string> | undefined
+  segments: Array<SegmentMetadata> | undefined
   prefetchHints: PrefetchHints | undefined
 }

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -7821,7 +7821,8 @@ async function prerenderToStream(
         ComponentMod,
         renderOpts,
         ctx.pagePath,
-        metadata
+        metadata,
+        fallbackRouteParams
       )
 
       if (serverIsDynamic) {
@@ -8079,7 +8080,8 @@ async function prerenderToStream(
           ComponentMod,
           renderOpts,
           ctx.pagePath,
-          metadata
+          metadata,
+          fallbackRouteParams
         )
       }
 
@@ -8290,7 +8292,8 @@ async function prerenderToStream(
           ComponentMod,
           renderOpts,
           ctx.pagePath,
-          metadata
+          metadata,
+          fallbackRouteParams
         )
       }
 
@@ -8508,7 +8511,8 @@ async function prerenderToStream(
           ComponentMod,
           renderOpts,
           ctx.pagePath,
-          metadata
+          metadata,
+          fallbackRouteParams
         )
       }
 
@@ -8628,7 +8632,8 @@ async function collectSegmentData(
   ComponentMod: AppPageModule,
   renderOpts: RenderOpts,
   pagePath: string,
-  metadata: AppPageRenderResultMetadata
+  metadata: AppPageRenderResultMetadata,
+  fallbackRouteParams: OpaqueFallbackRouteParams | null
 ): Promise<void> {
   // Per-segment prefetch data
   //
@@ -8716,6 +8721,11 @@ async function collectSegmentData(
   // the buffer doesn't have inlining hints yet (they were just computed
   // above), so we need to merge them in here. At runtime/ISR the hints
   // are already embedded in the FlightRouterState, so this is null.
+  //
+  // Pass fallbackRouteParams so the structural vary set can exclude any
+  // param whose value is a baked-in placeholder at render time — the
+  // runtime substitutes those per request, so the segment bytes don't
+  // depend on them and the cache key shouldn't either.
   metadata.segmentData = await ComponentMod.collectSegmentData(
     renderOpts.cacheComponents,
     fullPageDataBuffer,
@@ -8723,7 +8733,8 @@ async function collectSegmentData(
     clientModules,
     serverConsumerManifest,
     Boolean(renderOpts.experimental.prefetchInlining),
-    hints
+    hints,
+    fallbackRouteParams
   )
 }
 

--- a/packages/next/src/server/app-render/collect-segment-data.tsx
+++ b/packages/next/src/server/app-render/collect-segment-data.tsx
@@ -177,6 +177,35 @@ function extractFlightData(initialRSCPayload: InitialRSCPayload): {
   }
 }
 
+// Singleton empty set, reused for segments with no structural vary params
+// (e.g. the synthetic /_tree segment, or render tasks rooted at a static path).
+const EMPTY_STRUCTURAL_VARY_PARAMS: ReadonlySet<string> = new Set()
+
+export type CollectedSegmentData = {
+  /**
+   * The serialized prefetch response buffer for this segment. This is
+   * what gets written to disk and served to clients.
+   */
+  buffer: Buffer
+  /**
+   * Structural vary params for this segment: the set of dynamic path
+   * params reachable via the `params` prop from this segment (its own
+   * dynamic segment, plus all dynamic ancestors). Determined by route
+   * structure, not by what the render actually accessed — which means
+   * the build pipeline can use it to derive a per-segment allowQuery
+   * that's constant for the deployment, unlike the per-render dynamic
+   * vary set.
+   *
+   * - Empty set: no path param is in scope. The cache key never needs
+   *   to vary on params (e.g. the synthetic `/_tree` segment).
+   * - Populated set: only those params should vary the cache key.
+   * - `null`: untracked / spans the full route. Consumers should fall
+   *   back to the page-level allowQuery (e.g. the `/_full` and `/_head`
+   *   segments, which carry the entire page response or its metadata).
+   */
+  structuralVaryParams: ReadonlySet<string> | null
+}
+
 export async function collectSegmentData(
   isCacheComponentsEnabled: boolean,
   fullPageDataBuffer: Buffer,
@@ -185,11 +214,11 @@ export async function collectSegmentData(
   serverConsumerManifest: any,
   prefetchInlining: boolean,
   hints: PrefetchHints | null
-): Promise<Map<SegmentRequestKey, Buffer>> {
+): Promise<Map<SegmentRequestKey, CollectedSegmentData>> {
   // Traverse the router tree and generate a prefetch response for each segment.
 
   // A mutable map to collect the results as we traverse the route tree.
-  const resultMap = new Map<SegmentRequestKey, Buffer>()
+  const resultMap = new Map<SegmentRequestKey, CollectedSegmentData>()
 
   // Before we start, warm up the module cache by decoding the page data once.
   // Then we can assume that any remaining async tasks that occur the next time
@@ -218,7 +247,9 @@ export async function collectSegmentData(
   // tree, we'll also spawn additional tasks to generate the segment prefetches.
   // The promises for these tasks are pushed to a mutable array that we will
   // await once the route tree is fully rendered.
-  const segmentTasks: Array<Promise<[SegmentRequestKey, Buffer]>> = []
+  const segmentTasks: Array<
+    Promise<[SegmentRequestKey, CollectedSegmentData]>
+  > = []
   const { prelude: treeStream } = await prerender(
     // RootTreePrefetch is not a valid return type for a React component, but
     // we need to use a component so that when we decode the original stream
@@ -243,19 +274,29 @@ export async function collectSegmentData(
     }
   )
 
-  // Write the route tree to a special `/_tree` segment.
+  // Write the route tree to a special `/_tree` segment. The tree payload only
+  // encodes route structure (no param values), so no path param is in scope
+  // and the cache key never needs to vary by params.
   const treeBuffer = await streamToBuffer(treeStream)
-  resultMap.set('/_tree' as SegmentRequestKey, treeBuffer)
+  resultMap.set('/_tree' as SegmentRequestKey, {
+    buffer: treeBuffer,
+    structuralVaryParams: EMPTY_STRUCTURAL_VARY_PARAMS,
+  })
 
-  // Also output the entire full page data response
-  resultMap.set('/_full' as SegmentRequestKey, fullPageDataBuffer)
+  // Also output the entire full page data response. The full payload is the
+  // whole flight stream, so every path param in the route is structurally in
+  // scope — null tells consumers to fall back to the page-level allowQuery.
+  resultMap.set('/_full' as SegmentRequestKey, {
+    buffer: fullPageDataBuffer,
+    structuralVaryParams: null,
+  })
 
   // Now that we've finished rendering the route tree, all the segment tasks
   // should have been spawned. Await them in parallel and write the segment
   // prefetches to the result map.
   let hasPageSegment = false
-  for (const [segmentPath, buffer] of await Promise.all(segmentTasks)) {
-    resultMap.set(segmentPath, buffer)
+  for (const [segmentPath, entry] of await Promise.all(segmentTasks)) {
+    resultMap.set(segmentPath, entry)
     if (segmentPath.endsWith('__PAGE__')) {
       hasPageSegment = true
     }
@@ -271,10 +312,10 @@ export async function collectSegmentData(
     // TODO: Remove the __PAGE__ requirement from the build instead of
     // working around it here. The invariant is outdated now that segments
     // can be disabled.
-    resultMap.set(
-      '/todo-remove-fake-segment/__PAGE__' as SegmentRequestKey,
-      Buffer.alloc(0)
-    )
+    resultMap.set('/todo-remove-fake-segment/__PAGE__' as SegmentRequestKey, {
+      buffer: Buffer.alloc(0),
+      structuralVaryParams: EMPTY_STRUCTURAL_VARY_PARAMS,
+    })
   }
 
   return resultMap
@@ -329,16 +370,19 @@ export async function collectPrefetchHints(
       ? readVaryParams(headVaryParamsThenable)
       : null
 
-  const [, headBuffer] = await renderSegmentPrefetch(
+  // Used only to measure gzip size during hint computation; the resulting
+  // entry is discarded so the structural vary is irrelevant here.
+  const [, headEntry] = await renderSegmentPrefetch(
     buildId,
     staleTime,
     head,
     HEAD_REQUEST_KEY,
     headVaryParams,
+    null,
     clientModules,
     null
   )
-  const headGzipSize = await getGzipSize(headBuffer)
+  const headGzipSize = await getGzipSize(headEntry.buffer)
 
   // Mutable accumulator: the first segment that accepts the head sets this
   // to true. Once set, subsequent segments skip the check.
@@ -442,16 +486,19 @@ async function collectPrefetchHintsImpl(
     const varyParams =
       varyParamsThenable !== null ? readVaryParams(varyParamsThenable) : null
 
-    const [, buffer] = await renderSegmentPrefetch(
+    // Used only to measure gzip size during hint computation; the resulting
+    // entry is discarded so the structural vary is irrelevant here.
+    const [, entry] = await renderSegmentPrefetch(
       buildId,
       staleTime,
       seedData[0],
       requestKey,
       varyParams,
+      null,
       clientModules,
       null
     )
-    currentGzipSize = await getGzipSize(buffer)
+    currentGzipSize = await getGzipSize(entry.buffer)
   }
 
   // Only offer this segment to its children for inlining if its gzip size
@@ -671,7 +718,7 @@ async function PrefetchTreeData({
   serverConsumerManifest: any
   clientModules: ManifestNode
   staleTime: number
-  segmentTasks: Array<Promise<[SegmentRequestKey, Buffer]>>
+  segmentTasks: Array<Promise<[SegmentRequestKey, CollectedSegmentData]>>
   onCompletedProcessingRouteTree: () => void
   prefetchInlining: boolean
   hints: PrefetchHints | null
@@ -730,11 +777,15 @@ async function PrefetchTreeData({
     prefetchInlining,
     hints,
     null,
-    headBundle
+    headBundle,
+    EMPTY_STRUCTURAL_VARY_PARAMS
   )
 
   // Spawn a task to produce a prefetch response for the "head" segment,
-  // unless it was inlined into a page's bundle.
+  // unless it was inlined into a page's bundle. The head metadata can read
+  // any of the route's path params via generateMetadata, so its structural
+  // vary covers the full route — null tells consumers to fall back to the
+  // page-level allowQuery.
   if (!headIsInlined) {
     segmentTasks.push(
       waitAtLeastOneReactRenderTask().then(() =>
@@ -744,6 +795,7 @@ async function PrefetchTreeData({
           head,
           HEAD_REQUEST_KEY,
           headVaryParams,
+          null,
           clientModules,
           null
         )
@@ -775,11 +827,12 @@ function collectSegmentDataImpl(
   seedData: CacheNodeSeedData | null,
   clientModules: ManifestNode,
   requestKey: SegmentRequestKey,
-  segmentTasks: Array<Promise<[string, Buffer]>>,
+  segmentTasks: Array<Promise<[SegmentRequestKey, CollectedSegmentData]>>,
   prefetchInlining: boolean,
   hintTree: PrefetchHints | null,
   parentBundle: SegmentBundleNode | null,
-  headBundle: SegmentBundleNode | null
+  headBundle: SegmentBundleNode | null,
+  parentStructuralVaryParams: ReadonlySet<string>
 ): TreePrefetch {
   // Union the hints already embedded in the FlightRouterState with the
   // separately-computed build-time hints. During the initial build, the
@@ -800,6 +853,36 @@ function collectSegmentDataImpl(
   const varyParamsThenable = seedData !== null ? seedData[4] : null
   const varyParams =
     varyParamsThenable !== null ? readVaryParams(varyParamsThenable) : null
+
+  const segment = route[0]
+  let name: string
+  let param: TreePrefetchParam | null
+  let structuralVaryParams: ReadonlySet<string> = parentStructuralVaryParams
+  if (typeof segment === 'string') {
+    name = segment
+    param = null
+  } else {
+    name = segment[0]
+    param = {
+      type: segment[2],
+      // This value is omitted from the prefetch response when
+      // cacheComponents is enabled.
+      key: isClientParamParsingEnabled ? null : segment[1],
+      siblings: segment[3],
+    }
+
+    // Accumulate the set of params that this segment "structurally" varies on.
+    // This is different from the params that were tracked during the actual
+    // render, because they must be constant for the duration of an entire
+    // deployment; they cannot change during a revalidation, for example. So we
+    // use the set of all params that the segment has access to.
+    // TODO: This is used to compute the "allowQuery" of each segment prerender.
+    // If in the future the allowQuery is permitted to change at runtime, then
+    // we can use the vary params set (the one tracked during render) instead.
+    const next = new Set(parentStructuralVaryParams)
+    next.add(name)
+    structuralVaryParams = next
+  }
 
   // If static prefetching is disabled for this segment (runtime prefetch or
   // instant = false), it still participates in the bundle chain but with
@@ -853,6 +936,7 @@ function collectSegmentDataImpl(
             rsc,
             requestKey,
             varyParams,
+            structuralVaryParams,
             clientModules,
             bundle
           )
@@ -897,29 +981,13 @@ function collectSegmentDataImpl(
       prefetchInlining,
       childHintTree,
       childBundle,
-      headBundle
+      headBundle,
+      structuralVaryParams
     )
     if (slotMetadata === null) {
       slotMetadata = {}
     }
     slotMetadata[parallelRouteKey] = childTree
-  }
-
-  const segment = route[0]
-  let name: string
-  let param: TreePrefetchParam | null
-  if (typeof segment === 'string') {
-    name = segment
-    param = null
-  } else {
-    name = segment[0]
-    param = {
-      type: segment[2],
-      // This value is omitted from the prefetch response when cacheComponents
-      // is enabled.
-      key: isClientParamParsingEnabled ? null : segment[1],
-      siblings: segment[3],
-    }
   }
 
   // Metadata about the segment. Sent to the client as part of the
@@ -938,9 +1006,10 @@ async function renderSegmentPrefetch(
   rsc: React.ReactNode,
   requestKey: SegmentRequestKey,
   varyParams: Set<string> | null,
+  structuralVaryParams: ReadonlySet<string> | null,
   clientModules: ManifestNode,
   bundle: SegmentBundleNode | null
-): Promise<[SegmentRequestKey, Buffer]> {
+): Promise<[SegmentRequestKey, CollectedSegmentData]> {
   // Build the SegmentPrefetch for the terminal (requested) segment.
   // The terminal always has non-null rsc data — disabled segments are
   // skipped by the caller and don't reach this function.
@@ -991,10 +1060,14 @@ async function renderSegmentPrefetch(
     onError: onSegmentPrerenderError,
   })
   const segmentBuffer = await streamToBuffer(segmentStream)
+  const entry: CollectedSegmentData = {
+    buffer: segmentBuffer,
+    structuralVaryParams,
+  }
   if (requestKey === ROOT_SEGMENT_REQUEST_KEY) {
-    return ['/_index' as SegmentRequestKey, segmentBuffer]
+    return ['/_index' as SegmentRequestKey, entry]
   } else {
-    return [requestKey, segmentBuffer]
+    return [requestKey, entry]
   }
 }
 

--- a/packages/next/src/server/app-render/collect-segment-data.tsx
+++ b/packages/next/src/server/app-render/collect-segment-data.tsx
@@ -38,6 +38,7 @@ import {
   printDebugThrownValueForProspectiveRender,
 } from './prospective-render-utils'
 import { workAsyncStorage } from './work-async-storage.external'
+import type { OpaqueFallbackRouteParams } from '../request/fallback-params'
 
 // Contains metadata about the route tree. The client must fetch this before
 // it can fetch any actual segment data.
@@ -213,7 +214,8 @@ export async function collectSegmentData(
   clientModules: ManifestNode,
   serverConsumerManifest: any,
   prefetchInlining: boolean,
-  hints: PrefetchHints | null
+  hints: PrefetchHints | null,
+  fallbackRouteParams: OpaqueFallbackRouteParams | null
 ): Promise<Map<SegmentRequestKey, CollectedSegmentData>> {
   // Traverse the router tree and generate a prefetch response for each segment.
 
@@ -265,6 +267,7 @@ export async function collectSegmentData(
       onCompletedProcessingRouteTree={onCompletedProcessingRouteTree}
       prefetchInlining={prefetchInlining}
       hints={hints}
+      fallbackRouteParams={fallbackRouteParams}
     />,
     clientModules,
     {
@@ -712,6 +715,7 @@ async function PrefetchTreeData({
   onCompletedProcessingRouteTree,
   prefetchInlining,
   hints,
+  fallbackRouteParams,
 }: {
   isClientParamParsingEnabled: boolean
   fullPageDataBuffer: Buffer
@@ -722,6 +726,7 @@ async function PrefetchTreeData({
   onCompletedProcessingRouteTree: () => void
   prefetchInlining: boolean
   hints: PrefetchHints | null
+  fallbackRouteParams: OpaqueFallbackRouteParams | null
 }): Promise<RootTreePrefetch | null> {
   // We're currently rendering a Flight response for the route tree prefetch.
   // Inside this component, decode the Flight stream for the whole page. This is
@@ -778,7 +783,8 @@ async function PrefetchTreeData({
     hints,
     null,
     headBundle,
-    EMPTY_STRUCTURAL_VARY_PARAMS
+    EMPTY_STRUCTURAL_VARY_PARAMS,
+    fallbackRouteParams
   )
 
   // Spawn a task to produce a prefetch response for the "head" segment,
@@ -832,7 +838,8 @@ function collectSegmentDataImpl(
   hintTree: PrefetchHints | null,
   parentBundle: SegmentBundleNode | null,
   headBundle: SegmentBundleNode | null,
-  parentStructuralVaryParams: ReadonlySet<string>
+  parentStructuralVaryParams: ReadonlySet<string>,
+  fallbackRouteParams: OpaqueFallbackRouteParams | null
 ): TreePrefetch {
   // Union the hints already embedded in the FlightRouterState with the
   // separately-computed build-time hints. During the initial build, the
@@ -876,12 +883,20 @@ function collectSegmentDataImpl(
     // render, because they must be constant for the duration of an entire
     // deployment; they cannot change during a revalidation, for example. So we
     // use the set of all params that the segment has access to.
+    //
+    // Skip fallback route params: at fallback-shell render time those values
+    // are baked-in placeholders that the runtime substitutes per request, so
+    // the segment bytes don't actually depend on them. Including them in the
+    // structural set would force the cache key to vary on a param that can't
+    // change the response.
     // TODO: This is used to compute the "allowQuery" of each segment prerender.
     // If in the future the allowQuery is permitted to change at runtime, then
     // we can use the vary params set (the one tracked during render) instead.
-    const next = new Set(parentStructuralVaryParams)
-    next.add(name)
-    structuralVaryParams = next
+    if (fallbackRouteParams === null || !fallbackRouteParams.has(name)) {
+      const next = new Set(parentStructuralVaryParams)
+      next.add(name)
+      structuralVaryParams = next
+    }
   }
 
   // If static prefetching is disabled for this segment (runtime prefetch or
@@ -982,7 +997,8 @@ function collectSegmentDataImpl(
       childHintTree,
       childBundle,
       headBundle,
-      structuralVaryParams
+      structuralVaryParams,
+      fallbackRouteParams
     )
     if (slotMetadata === null) {
       slotMetadata = {}

--- a/packages/next/src/server/lib/incremental-cache/file-system-cache.ts
+++ b/packages/next/src/server/lib/incremental-cache/file-system-cache.ts
@@ -1,4 +1,7 @@
-import type { RouteMetadata } from '../../../export/routes/types'
+import type {
+  RouteMetadata,
+  SegmentMetadata,
+} from '../../../export/routes/types'
 import type { CacheHandler, CacheHandlerContext, CacheHandlerValue } from '.'
 import type { CacheFs } from '../../../shared/lib/utils'
 import type { TagManifestEntry } from './tags-manifest.external'
@@ -12,6 +15,7 @@ import {
 } from '../../response-cache'
 
 import type { LRUCache } from '../lru-cache'
+import type { CollectedSegmentData } from '../../app-render/collect-segment-data'
 import path from '../../../shared/lib/isomorphic/path'
 import {
   NEXT_CACHE_TAGS_HEADER,
@@ -199,27 +203,29 @@ export default class FileSystemCache implements CacheHandler {
               )
             } catch {}
 
-            let maybeSegmentData: Map<string, Buffer> | undefined
-            if (meta?.segmentPaths) {
+            let maybeSegmentData: Map<string, CollectedSegmentData> | undefined
+            if (meta?.segments) {
               // Collect all the segment data for this page.
               // TODO: To optimize file system reads, we should consider creating
               // separate cache entries for each segment, rather than storing them
               // all on the page's entry. Though the behavior is
               // identical regardless.
-              const segmentData: Map<string, Buffer> = new Map()
+              const segmentData: Map<string, CollectedSegmentData> = new Map()
               maybeSegmentData = segmentData
               const segmentsDir = key + RSC_SEGMENTS_DIR_SUFFIX
               await Promise.all(
-                meta.segmentPaths.map(async (segmentPath: string) => {
+                meta.segments.map(async ({ path: segmentPath }) => {
                   const segmentDataFilePath = this.getFilePath(
                     segmentsDir + segmentPath + RSC_SEGMENT_SUFFIX,
                     IncrementalCacheKind.APP_PAGE
                   )
                   try {
-                    segmentData.set(
-                      segmentPath,
-                      await this.fs.readFile(segmentDataFilePath)
-                    )
+                    // structuralVaryParams is build-only metadata; runtime
+                    // cache reads always emit `null` (page-level allowQuery).
+                    segmentData.set(segmentPath, {
+                      buffer: await this.fs.readFile(segmentDataFilePath),
+                      structuralVaryParams: null,
+                    })
                   } catch {
                     // This shouldn't happen, but if for some reason we fail to
                     // load a segment from the filesystem, treat it the same as if
@@ -378,7 +384,7 @@ export default class FileSystemCache implements CacheHandler {
         headers: data.headers,
         status: data.status,
         postponed: undefined,
-        segmentPaths: undefined,
+        segments: undefined,
         prefetchHints: undefined,
       }
 
@@ -412,16 +418,20 @@ export default class FileSystemCache implements CacheHandler {
       }
 
       if (data?.kind === CachedRouteKind.APP_PAGE) {
-        let segmentPaths: string[] | undefined
+        let segments: SegmentMetadata[] | undefined
         if (data.segmentData) {
-          segmentPaths = []
+          segments = []
           const segmentsDir = htmlPath.replace(
             /\.html$/,
             RSC_SEGMENTS_DIR_SUFFIX
           )
 
-          for (const [segmentPath, buffer] of data.segmentData) {
-            segmentPaths.push(segmentPath)
+          for (const [segmentPath, { buffer }] of data.segmentData) {
+            // The runtime cache path doesn't carry per-segment structural
+            // vary params — they're a build-time concept used by the
+            // adapter to compute allowQuery for prerender outputs. At
+            // runtime, fall back to null (page-level allowQuery).
+            segments.push({ path: segmentPath, structuralVaryParams: null })
             const segmentDataFilePath =
               segmentsDir + segmentPath + RSC_SEGMENT_SUFFIX
             writer.append(segmentDataFilePath, buffer)
@@ -432,7 +442,7 @@ export default class FileSystemCache implements CacheHandler {
           headers: data.headers,
           status: data.status,
           postponed: data.postponed,
-          segmentPaths,
+          segments,
           prefetchHints: undefined,
         }
 

--- a/packages/next/src/server/lib/incremental-cache/memory-cache.external.ts
+++ b/packages/next/src/server/lib/incremental-cache/memory-cache.external.ts
@@ -1,4 +1,5 @@
 import type { CacheHandlerValue } from '.'
+import type { CollectedSegmentData } from '../../app-render/collect-segment-data'
 import { CachedRouteKind } from '../../response-cache/types'
 import { LRUCache } from '../lru-cache'
 
@@ -8,14 +9,16 @@ function getBufferSize(buffer: Buffer | undefined) {
   return buffer?.length || 0
 }
 
-function getSegmentDataSize(segmentData: Map<string, Buffer> | undefined) {
+function getSegmentDataSize(
+  segmentData: Map<string, CollectedSegmentData> | undefined
+) {
   if (!segmentData) {
     return 0
   }
 
   let size = 0
 
-  for (const [segmentPath, buffer] of segmentData) {
+  for (const [segmentPath, { buffer }] of segmentData) {
     size += segmentPath.length + getBufferSize(buffer)
   }
 

--- a/packages/next/src/server/render-result.ts
+++ b/packages/next/src/server/render-result.ts
@@ -16,6 +16,7 @@ import {
   pipeNodeReadableToNodeResponse,
 } from './pipe-readable'
 import type { RenderResumeDataCache } from './resume-data-cache/resume-data-cache'
+import type { CollectedSegmentData } from './app-render/collect-segment-data'
 import { InvariantError } from '../shared/lib/invariant-error'
 import type {
   HTML_CONTENT_TYPE_HEADER,
@@ -51,7 +52,14 @@ export type AppPageRenderResultMetadata = {
   fetchTags?: string
   fetchMetrics?: FetchMetrics
 
-  segmentData?: Map<string, Buffer>
+  /**
+   * Per-segment prefetch data. Each entry carries the serialized response
+   * buffer (served to clients) plus the segment's structural vary params,
+   * which the export pipeline reads when computing per-segment allowQuery.
+   * Runtime cache reads have `structuralVaryParams: null` since that
+   * field is only meaningful at build time.
+   */
+  segmentData?: Map<string, CollectedSegmentData>
 
   /**
    * Per-route prefetch hints computed at build time (e.g. segment inlining

--- a/packages/next/src/server/response-cache/types.ts
+++ b/packages/next/src/server/response-cache/types.ts
@@ -2,6 +2,7 @@ import type { OutgoingHttpHeaders } from 'http'
 import type RenderResult from '../render-result'
 import type { CacheControl, Revalidate } from '../lib/cache-control'
 import type { RouteKind } from '../route-kind'
+import type { CollectedSegmentData } from '../app-render/collect-segment-data'
 
 export interface ResponseCacheBase {
   get(
@@ -77,7 +78,7 @@ export interface CachedAppPageValue {
   status: number | undefined
   postponed: string | undefined
   headers: OutgoingHttpHeaders | undefined
-  segmentData: Map<string, Buffer> | undefined
+  segmentData: Map<string, CollectedSegmentData> | undefined
 }
 
 export interface CachedPageValue {
@@ -119,7 +120,7 @@ export interface IncrementalCachedAppPageValue {
   headers: OutgoingHttpHeaders | undefined
   postponed: string | undefined
   status: number | undefined
-  segmentData: Map<string, Buffer> | undefined
+  segmentData: Map<string, CollectedSegmentData> | undefined
 }
 
 export interface IncrementalCachedPageValue {

--- a/test/production/app-dir/adapter-partial-fallback/adapter-partial-fallback.test.ts
+++ b/test/production/app-dir/adapter-partial-fallback/adapter-partial-fallback.test.ts
@@ -71,8 +71,10 @@ describe('adapter-partial-fallback', () => {
 
     expect(withGspPrerender.config.partialFallback).toBe(true)
     expect(withGspPrerender.config.allowQuery).toEqual(['nxtPslug'])
+    // The /_tree segment never reads any param via `params`, so its
+    // structural vary is empty regardless of the page's allowQuery.
     expect(withGspRouteTreePrerender.config.partialFallback).toBe(true)
-    expect(withGspRouteTreePrerender.config.allowQuery).toEqual(['nxtPslug'])
+    expect(withGspRouteTreePrerender.config.allowQuery).toEqual([])
     for (const output of withGspOtherSegmentPrerenders) {
       expect(output.config.partialFallback).toBe(true)
       expect(output.config.allowQuery).toEqual(['nxtPslug'])
@@ -90,9 +92,7 @@ describe('adapter-partial-fallback', () => {
     expect(genericPrefixPrerender.config.partialFallback).toBe(true)
     expect(genericPrefixPrerender.config.allowQuery).toEqual(['nxtPone'])
     expect(genericPrefixRouteTreePrerender.config.partialFallback).toBe(true)
-    expect(genericPrefixRouteTreePrerender.config.allowQuery).toEqual([
-      'nxtPone',
-    ])
+    expect(genericPrefixRouteTreePrerender.config.allowQuery).toEqual([])
     for (const output of genericPrefixOtherSegmentPrerenders) {
       expect(output.config.partialFallback).toBe(true)
       expect(output.config.allowQuery).toEqual(['nxtPone'])
@@ -106,5 +106,52 @@ describe('adapter-partial-fallback', () => {
 
     expect(generatedDashedPrerender.config.partialFallback).toBeUndefined()
     expect(generatedDashedPrerender.config.allowQuery).toEqual([])
+  })
+
+  it('omits params from a segment.allowQuery when the segment cannot structurally reach them', async () => {
+    // /structural-narrowing/[outer]/[inner] has no GSP and no
+    // fallbackRootParams, so its page-level allowQuery contains both
+    // dynamic params. That's what makes this route useful as a witness:
+    // each segment's allowQuery starts from the same multi-param set,
+    // so the per-segment narrowing is the only thing that can drop
+    // entries.
+    const { outputs }: Parameters<NextAdapter['onBuildComplete']>[0] =
+      await next.readJSON('build-complete.json')
+
+    const route = '/structural-narrowing/[outer]/[inner]'
+    const segmentsDirPrefix = `${route}.segments/`
+
+    const pagePrerender = outputs.prerenders.find((o) => o.pathname === route)
+    if (!pagePrerender) {
+      throw new Error(`No prerender for ${route}`)
+    }
+    expect(pagePrerender.config.allowQuery).toEqual(
+      expect.arrayContaining(['nxtPouter', 'nxtPinner'])
+    )
+
+    const segments = outputs.prerenders.filter((o) =>
+      o.pathname.startsWith(segmentsDirPrefix)
+    )
+
+    // The synthetic _tree segment never receives `params`, so its
+    // allowQuery must be empty even though the page-level set has two
+    // entries. Without structural narrowing this would inherit
+    // nxtPouter and nxtPinner, so the negative checks are load-bearing.
+    const treeSegment = segments.find((o) => o.pathname.includes('/_tree.'))
+    if (!treeSegment) {
+      throw new Error(`No tree segment for ${route}`)
+    }
+    expect(treeSegment.config.allowQuery).toEqual([])
+
+    // The __PAGE__ segment can reach both params, so narrowing must keep
+    // both. We match by substring rather than the full segment path so
+    // the test isn't coupled to the segment-encoding scheme.
+    const pageSegment = segments.find((o) => o.pathname.includes('__PAGE__'))
+    if (!pageSegment) {
+      throw new Error(`No page segment for ${route}`)
+    }
+    expect(pageSegment.config.allowQuery).toEqual(
+      expect.arrayContaining(['nxtPouter', 'nxtPinner'])
+    )
   })
 })

--- a/test/production/app-dir/adapter-partial-fallback/adapter-partial-fallback.test.ts
+++ b/test/production/app-dir/adapter-partial-fallback/adapter-partial-fallback.test.ts
@@ -77,7 +77,19 @@ describe('adapter-partial-fallback', () => {
     expect(withGspRouteTreePrerender.config.allowQuery).toEqual([])
     for (const output of withGspOtherSegmentPrerenders) {
       expect(output.config.partialFallback).toBe(true)
-      expect(output.config.allowQuery).toEqual(['nxtPslug'])
+      // `slug` is a fallback root param. For segments whose structural
+      // vary set is tracked (e.g. the __PAGE__ segment and any layout),
+      // the placeholder substitution model means the segment bytes don't
+      // depend on `slug`, so the cache key must not include it. For
+      // /_full and /_head, structural vary is `null` (full route) and we
+      // fall back to the page-level allowQuery, which still includes
+      // `nxtPslug`.
+      const expected =
+        output.pathname.includes('/_full.') ||
+        output.pathname.includes('/_head.')
+          ? ['nxtPslug']
+          : []
+      expect(output.config.allowQuery).toEqual(expected)
     }
 
     expect(withoutGspPrerender.config.partialFallback).toBeUndefined()
@@ -93,9 +105,17 @@ describe('adapter-partial-fallback', () => {
     expect(genericPrefixPrerender.config.allowQuery).toEqual(['nxtPone'])
     expect(genericPrefixRouteTreePrerender.config.partialFallback).toBe(true)
     expect(genericPrefixRouteTreePrerender.config.allowQuery).toEqual([])
+    // Same fallback-param exclusion as `with-gsp`: structural-tracked
+    // segments drop `one` (a fallback root param); /_full and /_head fall
+    // back to the page-level allowQuery.
     for (const output of genericPrefixOtherSegmentPrerenders) {
       expect(output.config.partialFallback).toBe(true)
-      expect(output.config.allowQuery).toEqual(['nxtPone'])
+      const expected =
+        output.pathname.includes('/_full.') ||
+        output.pathname.includes('/_head.')
+          ? ['nxtPone']
+          : []
+      expect(output.config.allowQuery).toEqual(expected)
     }
 
     expect(generatedPrefixPrerender.config.partialFallback).toBeUndefined()
@@ -108,13 +128,18 @@ describe('adapter-partial-fallback', () => {
     expect(generatedDashedPrerender.config.allowQuery).toEqual([])
   })
 
-  it('omits params from a segment.allowQuery when the segment cannot structurally reach them', async () => {
-    // /structural-narrowing/[outer]/[inner] has no GSP and no
-    // fallbackRootParams, so its page-level allowQuery contains both
-    // dynamic params. That's what makes this route useful as a witness:
-    // each segment's allowQuery starts from the same multi-param set,
-    // so the per-segment narrowing is the only thing that can drop
-    // entries.
+  it('narrows segment allowQuery by structural and fallback exclusion', async () => {
+    // /structural-narrowing/[outer]/[inner] has no GSP. Its page-level
+    // allowQuery contains both dynamic params, so any non-empty segment
+    // allowQuery would have to come from inheriting that set wholesale.
+    // The narrowing here is two-step:
+    //   1. Structural: only count params reachable via this segment's
+    //      `params` prop (the synthetic _tree segment reads none).
+    //   2. Fallback: drop params whose values are baked-in placeholders
+    //      at render time (substituted per request), since the segment
+    //      bytes don't actually depend on them.
+    // For this fully-dynamic shell both `outer` and `inner` are fallback
+    // route params, so even the __PAGE__ segment ends up empty.
     const { outputs }: Parameters<NextAdapter['onBuildComplete']>[0] =
       await next.readJSON('build-complete.json')
 
@@ -125,6 +150,9 @@ describe('adapter-partial-fallback', () => {
     if (!pagePrerender) {
       throw new Error(`No prerender for ${route}`)
     }
+    // Page-level allowQuery still carries both params: the page response
+    // varies on them at the cache layer (one fallback shell per param
+    // value combination, with placeholders substituted at request time).
     expect(pagePrerender.config.allowQuery).toEqual(
       expect.arrayContaining(['nxtPouter', 'nxtPinner'])
     )
@@ -133,25 +161,23 @@ describe('adapter-partial-fallback', () => {
       o.pathname.startsWith(segmentsDirPrefix)
     )
 
-    // The synthetic _tree segment never receives `params`, so its
-    // allowQuery must be empty even though the page-level set has two
-    // entries. Without structural narrowing this would inherit
-    // nxtPouter and nxtPinner, so the negative checks are load-bearing.
+    // The synthetic _tree segment never receives `params`. Without
+    // structural narrowing it would inherit the page-level set; the
+    // empty assertion is load-bearing for the structural pass.
     const treeSegment = segments.find((o) => o.pathname.includes('/_tree.'))
     if (!treeSegment) {
       throw new Error(`No tree segment for ${route}`)
     }
     expect(treeSegment.config.allowQuery).toEqual([])
 
-    // The __PAGE__ segment can reach both params, so narrowing must keep
-    // both. We match by substring rather than the full segment path so
-    // the test isn't coupled to the segment-encoding scheme.
+    // The __PAGE__ segment structurally reaches both params, so without
+    // fallback exclusion it would inherit ['nxtPouter','nxtPinner'].
+    // The empty assertion is load-bearing for the fallback pass: it
+    // proves both placeholder params are dropped from the cache key.
     const pageSegment = segments.find((o) => o.pathname.includes('__PAGE__'))
     if (!pageSegment) {
       throw new Error(`No page segment for ${route}`)
     }
-    expect(pageSegment.config.allowQuery).toEqual(
-      expect.arrayContaining(['nxtPouter', 'nxtPinner'])
-    )
+    expect(pageSegment.config.allowQuery).toEqual([])
   })
 })

--- a/test/production/app-dir/adapter-partial-fallback/app/structural-narrowing/[outer]/[inner]/page.tsx
+++ b/test/production/app-dir/adapter-partial-fallback/app/structural-narrowing/[outer]/[inner]/page.tsx
@@ -1,0 +1,29 @@
+import { Suspense } from 'react'
+
+async function Dynamic() {
+  await new Promise((resolve) => setTimeout(resolve, 1000))
+  return <div>Custom Data</div>
+}
+
+export function generateStaticParams() {
+  return [{ outer: 'a', inner: 'x' }]
+}
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ outer: string; inner: string }>
+}) {
+  const { outer, inner } = await params
+
+  return (
+    <div>
+      <div>
+        {outer}/{inner}
+      </div>
+      <Suspense fallback={<div>Loading...</div>}>
+        <Dynamic />
+      </Suspense>
+    </div>
+  )
+}

--- a/test/production/app-dir/adapter-partial-fallback/app/structural-narrowing/[outer]/layout.tsx
+++ b/test/production/app-dir/adapter-partial-fallback/app/structural-narrowing/[outer]/layout.tsx
@@ -1,0 +1,5 @@
+import type { ReactNode } from 'react'
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return <>{children}</>
+}

--- a/test/production/app-dir/empty-shell-route-cache/empty-shell-route-cache.test.ts
+++ b/test/production/app-dir/empty-shell-route-cache/empty-shell-route-cache.test.ts
@@ -19,8 +19,9 @@ describe('empty-shell-route-cache', () => {
     const files = [
       `${route}.html`,
       `${route}.meta`,
-      ...routeMeta.segmentPaths.map(
-        (segmentPath: string) => `${route}.segments${segmentPath}.segment.rsc`
+      ...routeMeta.segments.map(
+        ({ path: segmentPath }: { path: string }) =>
+          `${route}.segments${segmentPath}.segment.rsc`
       ),
     ]
 

--- a/test/production/standalone-mode/required-server-files/required-server-files-ppr.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files-ppr.test.ts
@@ -135,12 +135,12 @@ describe.skip('required server files app router', () => {
   })
 
   it('should de-dupe client segment tree revalidate requests', async () => {
-    const { segmentPaths } = await next.readJSON(
+    const { segments } = await next.readJSON(
       'standalone/.next/server/app/isr/first.meta'
     )
     const outputIdx = cliOutput.length
 
-    for (const segmentPath of segmentPaths) {
+    for (const { path: segmentPath } of segments) {
       const outputSegmentPath =
         join('/isr/[slug].segments', segmentPath) + '.segment.rsc'
 


### PR DESCRIPTION
The build adapter previously gave every segment of a route the same page-level `allowQuery`. For routes with high-cardinality params, that forced segments whose responses don't depend on a param to still use it as part of their ISR cache key — producing many distinct cache entries of byte-identical output.

Each segment now gets an `allowQuery` narrowed to just the params it can actually reach. For the route tree prefetch, that set is always empty. This significantly reduces the number of ISR writes for affected routes.

<!-- NEXT_JS_LLM_PR -->