### PR TITLE
docs: broken link from usePathname compat call out

### DIFF
--- a/docs/01-app/03-api-reference/04-functions/use-pathname.mdx
+++ b/docs/01-app/03-api-reference/04-functions/use-pathname.mdx
@@ -42,7 +42,7 @@ For example, a Client Component with `usePathname` will be rendered into HTML on
 
 <summary>Compatibility with Pages Router</summary>
 
-If you have components that use `usePathname` and they are imported into routes within the Pages Router, be aware that `usePathname` may return `null` if the router is not yet initialized. This can occur in cases such as [fallback routes](/docs/pages/api-reference/functions/get-static-paths#fallback-true) or during [Automatic Static Optimization](https://nextjs.org/docs/pages/building-your-application/rendering/static#automatic-static-optimization) in the Pages Router.
+If you have components that use `usePathname` and they are imported into routes within the Pages Router, be aware that `usePathname` may return `null` if the router is not yet initialized. This can occur in cases such as [fallback routes](/docs/pages/api-reference/functions/get-static-paths#fallback-true) or during [Automatic Static Optimization](/docs/pages/building-your-application/rendering/automatic-static-optimization) in the Pages Router.
 
 To enhance compatibility between routing systems, if your project contains both an `app` and a `pages` directory, Next.js will automatically adjust the return type of `usePathname`.
 


### PR DESCRIPTION
The compatibility section in `usePathname` used a broken link - in the sense that it links to the wrong page.