### PR TITLE
Turbopack: really fix MAX_INLINE_LEN

### DIFF
--- a/turbopack/crates/turbo-rcstr/src/dynamic.rs
+++ b/turbopack/crates/turbo-rcstr/src/dynamic.rs
@@ -4,7 +4,7 @@ use triomphe::Arc;
 
 use crate::{
     DYNAMIC_TAG, INLINE_TAG, INLINE_TAG_INIT, LEN_OFFSET, RcStr, STATIC_TAG, TAG_MASK,
-    tagged_value::{MAX_INLINE_LEN, TaggedValue},
+    is_atom_inlineable, tagged_value::TaggedValue,
 };
 
 pub enum Payload {
@@ -56,19 +56,19 @@ pub unsafe fn restore_arc(v: TaggedValue) -> Arc<PrehashedString> {
 /// This can create any kind of [Atom], although this lives in the `dynamic`
 /// module.
 pub(crate) fn new_atom<T: AsRef<str> + Into<String>>(text: T) -> RcStr {
-    let len = text.as_ref().len();
-
-    if len <= MAX_INLINE_LEN {
+    let text = text.as_ref();
+    if is_atom_inlineable(text) {
+        let len = text.len();
         // INLINE_TAG ensures this is never zero
         let tag = INLINE_TAG_INIT | ((len as u8) << LEN_OFFSET);
         let mut unsafe_data = TaggedValue::new_tag(tag);
         unsafe {
-            unsafe_data.data_mut()[..len].copy_from_slice(text.as_ref().as_bytes());
+            unsafe_data.data_mut()[..len].copy_from_slice(text.as_bytes());
         }
         return RcStr { unsafe_data };
     }
 
-    let hash = hash_bytes(text.as_ref().as_bytes());
+    let hash = hash_bytes(text.as_bytes());
 
     let prehashed = PrehashedString {
         value: Payload::String(text.into()),
@@ -116,8 +116,8 @@ pub(crate) const fn new_static_atom(string: &'static PrehashedString) -> RcStr {
 /// This is primarily useful in constant contexts.
 #[doc(hidden)]
 pub(crate) const fn inline_atom(text: &str) -> Option<RcStr> {
-    let len = text.len();
-    if len <= MAX_INLINE_LEN {
+    if is_atom_inlineable(text) {
+        let len = text.len();
         let tag = INLINE_TAG | ((len as u8) << LEN_OFFSET);
         let mut unsafe_data = TaggedValue::new_tag(NonZeroU8::new(tag).unwrap());
 

--- a/turbopack/crates/turbo-rcstr/src/lib.rs
+++ b/turbopack/crates/turbo-rcstr/src/lib.rs
@@ -171,8 +171,7 @@ impl RcStr {
     /// Accepts `&str` so that borrow-decode paths can avoid heap allocation
     /// entirely for inline strings (≤7 bytes) and static table hits.
     fn from_deserialized(s: &str) -> Self {
-        let len = s.len();
-        if len > tagged_value::MAX_INLINE_LEN {
+        if !is_atom_inlineable(s) {
             let hash = hash_bytes(s.as_bytes());
             // Check the static table
             if let Some(entries) = STATIC_TABLE.get(&hash)
@@ -489,7 +488,7 @@ pub const fn inline_atom(s: &str) -> Option<RcStr> {
 // Exports for our macro
 #[doc(hidden)]
 pub const fn is_atom_inlineable(s: &str) -> bool {
-    s.len() < MAX_INLINE_LEN
+    s.len() <= MAX_INLINE_LEN
 }
 
 #[doc(hidden)]
@@ -649,7 +648,7 @@ impl RcStrInterning {
     /// already zero-allocation inline atoms). Longer strings are looked up
     /// in the interning table and deduplicated.
     pub fn intern(&mut self, s: &str) -> RcStr {
-        if s.len() <= tagged_value::MAX_INLINE_LEN {
+        if is_atom_inlineable(s) {
             // Inline atom — no allocation needed, don't bother with the set.
             return RcStr::from(s);
         }
@@ -664,7 +663,7 @@ impl RcStrInterning {
     /// Intern an owned `String`. When the string is not yet interned, avoids
     /// an extra copy compared to [`intern`](Self::intern).
     fn intern_owned(&mut self, s: String) -> RcStr {
-        if s.len() <= tagged_value::MAX_INLINE_LEN {
+        if is_atom_inlineable(&s) {
             return RcStr::from(s);
         }
         if let Some(existing) = self.set.get(s.as_str()) {


### PR DESCRIPTION
1. https://github.com/vercel/next.js/issues/93516 was first opened. Everything worked. It introduced one more `< MAX_INLINE_LEN` comparison
2. https://github.com/vercel/next.js/issues/93524 fixed an off-by-one error (which was fine all long as all of them were consistently off by one)
3. Then https://github.com/vercel/next.js/issues/93516 merged without rebasing and on canary, the one added callsite was now inconsistent with the rest. So CI failed on canary

This caused a lot of test failures:
```
➜  next.js git:(canary) UPDATE=1 cargo nextest run -p turbopack-tests -E 'test(test_tests__execution__webpack__scope_hoisting__esModule__input__index_js)' --no-capture
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.55s
────────────
 Nextest run ID a86cddd0-85b8-4f6c-b550-0e5870a9daf1 with nextest profile: default
    Starting 1 test across 3 binaries (305 tests skipped)
       START [         ] (1/1) turbopack-tests::execution test_tests__execution__webpack__scope_hoisting__esModule__input__index_js

running 1 test
Input: next.js/turbopack/crates/turbopack-tests/tests/execution/webpack/scope-hoisting/esModule/input/index.js
updated contents of turbopack/crates/turbopack-tests/tests/execution/webpack/scope-hoisting/esModule/issues/Code generation for chunk item errored-803648.txt

thread 'test_tests__execution__webpack__scope_hoisting__esModule__input__index_js' (46528180) panicked at turbopack/crates/turbopack-tests/tests/execution.rs:105:9:
Failed with error(s) in the following test(s):

"should have the __esModule flag":
Error: An error occurred while generating the chunk item [project]/turbopack/crates/turbopack-tests/tests/execution/webpack/scope-hoisting/esModule/input/module.js [test] (ecmascript)

Caused by:
- Processing [project]/turbopack/crates/turbopack-tests/tests/execution/webpack/scope-hoisting/esModule/input/module.js [test] (ecmascript)
- Expected to find a local export for default with ctxt #4 in {"default": ("__TURBOPACK__default__export__", #0)}

Debug info:
- An error occurred while generating the chunk item [project]/turbopack/crates/turbopack-tests/tests/execution/webpack/scope-hoisting/esModule/input/module.js [test] (ecmascript)
- Execution of <MergedEcmascriptModule as EcmascriptChunkPlaceable>::chunk_item_content failed
- Execution of *EcmascriptChunkItemContent::new failed
- Execution of EcmascriptModuleContent::new_merged failed
- Processing [project]/turbopack/crates/turbopack-tests/tests/execution/webpack/scope-hoisting/esModule/input/module.js [test] (ecmascript)
- Expected to find a local export for default with ctxt #4 in {"default": ("__TURBOPACK__default__export__", #0)}
```
