### PR TITLE
Order loader tree imports by tree depth

### DIFF
--- a/crates/next-core/src/app_page_loader_tree.rs
+++ b/crates/next-core/src/app_page_loader_tree.rs
@@ -50,11 +50,12 @@ impl AppPageLoaderTreeBuilder {
         &mut self,
         module_type: AppDirModuleType,
         path: Option<FileSystemPath>,
+        depth: u32,
     ) -> Result<()> {
         if let Some(path) = path {
             let tuple_code = self
                 .base
-                .create_module_tuple_code(module_type, path)
+                .create_module_tuple_code(module_type, path, depth)
                 .await?;
 
             writeln!(
@@ -71,6 +72,7 @@ impl AppPageLoaderTreeBuilder {
         app_page: &AppPage,
         metadata: &Metadata,
         global_metadata: Option<&GlobalMetadata>,
+        depth: u32,
     ) -> Result<()> {
         if metadata.is_empty()
             && global_metadata
@@ -107,13 +109,13 @@ impl AppPageLoaderTreeBuilder {
             icon.clone()
         };
 
-        self.write_metadata_items(app_page, "icon", icon.iter())
+        self.write_metadata_items(app_page, "icon", icon.iter(), depth)
             .await?;
-        self.write_metadata_items(app_page, "apple", apple.iter())
+        self.write_metadata_items(app_page, "apple", apple.iter(), depth)
             .await?;
-        self.write_metadata_items(app_page, "twitter", twitter.iter())
+        self.write_metadata_items(app_page, "twitter", twitter.iter(), depth)
             .await?;
-        self.write_metadata_items(app_page, "openGraph", open_graph.iter())
+        self.write_metadata_items(app_page, "openGraph", open_graph.iter(), depth)
             .await?;
 
         if let Some(global_metadata) = global_metadata {
@@ -151,6 +153,7 @@ impl AppPageLoaderTreeBuilder {
         app_page: &AppPage,
         name: &str,
         it: impl Iterator<Item = &'a MetadataWithAltItem>,
+        depth: u32,
     ) -> Result<()> {
         let mut it = it.peekable();
         if it.peek().is_none() {
@@ -158,7 +161,8 @@ impl AppPageLoaderTreeBuilder {
         }
         writeln!(self.loader_tree_code, "    {name}: [")?;
         for item in it {
-            self.write_metadata_item(app_page, name, item).await?;
+            self.write_metadata_item(app_page, name, item, depth)
+                .await?;
         }
         writeln!(self.loader_tree_code, "    ],")?;
         Ok(())
@@ -169,6 +173,7 @@ impl AppPageLoaderTreeBuilder {
         app_page: &AppPage,
         name: &str,
         item: &MetadataWithAltItem,
+        depth: u32,
     ) -> Result<()> {
         match item {
             MetadataWithAltItem::Static { path, alt_path } => {
@@ -178,6 +183,7 @@ impl AppPageLoaderTreeBuilder {
                     item,
                     path.clone(),
                     alt_path.clone(),
+                    depth,
                 )
                 .await?;
             }
@@ -189,13 +195,14 @@ impl AppPageLoaderTreeBuilder {
                 // This should use the same importing mechanism as create_module_tuple_code, so that
                 // the relative order of items is retained (which isn't the case
                 // when mixing ESM imports and requires).
-                self.base.imports.push(
+                self.base.imports.push((
+                    depth,
                     format!(
                         "const {identifier} = () => require(/*turbopackChunkingType: \
                          shared*/\"{inner_module_id}\");"
                     )
                     .into(),
-                );
+                ));
 
                 let source = dynamic_image_metadata_source(
                     *ResolvedVc::upcast(self.base.module_asset_context),
@@ -226,6 +233,7 @@ impl AppPageLoaderTreeBuilder {
         item: &MetadataWithAltItem,
         path: FileSystemPath,
         alt_path: Option<FileSystemPath>,
+        depth: u32,
     ) -> Result<()> {
         let i = self.base.unique_number();
 
@@ -235,13 +243,14 @@ impl AppPageLoaderTreeBuilder {
         // This should use the same importing mechanism as create_module_tuple_code, so that the
         // relative order of items is retained (which isn't the case when mixing ESM imports and
         // requires).
-        self.base.imports.push(
+        self.base.imports.push((
+            depth,
             format!(
                 "const {identifier} = () => require(/*turbopackChunkingType: \
                  shared*/\"{inner_module_id}\");"
             )
             .into(),
-        );
+        ));
         let module = StructuredImageModuleType::create_module(
             Vc::upcast(FileSource::new(path.clone())),
             BlurPlaceholderMode::None,
@@ -259,13 +268,14 @@ impl AppPageLoaderTreeBuilder {
             // This should use the same importing mechanism as create_module_tuple_code, so that the
             // relative order of items is retained (which isn't the case when mixing ESM imports and
             // requires).
-            self.base.imports.push(
+            self.base.imports.push((
+                depth,
                 format!(
                     "const {identifier} = () => require(/*turbopackChunkingType: \
                      shared*/\"{inner_module_id}\");"
                 )
                 .into(),
-            );
+            ));
 
             let module = self
                 .base
@@ -342,7 +352,12 @@ impl AppPageLoaderTreeBuilder {
         Ok(())
     }
 
-    async fn walk_tree(&mut self, loader_tree: &AppPageLoaderTree, root: bool) -> Result<()> {
+    async fn walk_tree(
+        &mut self,
+        loader_tree: &AppPageLoaderTree,
+        root: bool,
+        depth: u32,
+    ) -> Result<()> {
         use std::fmt::Write;
 
         let AppPageLoaderTree {
@@ -385,38 +400,48 @@ impl AppPageLoaderTreeBuilder {
             app_page,
             metadata,
             if root { Some(global_metadata) } else { None },
+            depth,
         )
         .await?;
 
-        self.write_modules_entry(AppDirModuleType::Layout, layout.clone())
+        self.write_modules_entry(AppDirModuleType::Layout, layout.clone(), depth)
             .await?;
-        self.write_modules_entry(AppDirModuleType::Error, error.clone())
+        self.write_modules_entry(AppDirModuleType::Error, error.clone(), depth)
             .await?;
-        self.write_modules_entry(AppDirModuleType::Loading, loading.clone())
+        self.write_modules_entry(AppDirModuleType::Loading, loading.clone(), depth)
             .await?;
-        self.write_modules_entry(AppDirModuleType::Template, template.clone())
+        self.write_modules_entry(AppDirModuleType::Template, template.clone(), depth)
             .await?;
-        self.write_modules_entry(AppDirModuleType::NotFound, not_found.clone())
+        self.write_modules_entry(AppDirModuleType::NotFound, not_found.clone(), depth)
             .await?;
-        self.write_modules_entry(AppDirModuleType::Forbidden, forbidden.clone())
+        self.write_modules_entry(AppDirModuleType::Forbidden, forbidden.clone(), depth)
             .await?;
-        self.write_modules_entry(AppDirModuleType::Unauthorized, unauthorized.clone())
+        self.write_modules_entry(AppDirModuleType::Unauthorized, unauthorized.clone(), depth)
             .await?;
-        self.write_modules_entry(AppDirModuleType::Page, page.clone())
+        self.write_modules_entry(AppDirModuleType::Page, page.clone(), depth)
             .await?;
-        self.write_modules_entry(AppDirModuleType::DefaultPage, default.clone())
+        self.write_modules_entry(AppDirModuleType::DefaultPage, default.clone(), depth)
             .await?;
-        self.write_modules_entry(AppDirModuleType::GlobalError, global_error.clone())
+        self.write_modules_entry(AppDirModuleType::GlobalError, global_error.clone(), depth)
             .await?;
-        self.write_modules_entry(AppDirModuleType::GlobalNotFound, global_not_found.clone())
-            .await?;
+        self.write_modules_entry(
+            AppDirModuleType::GlobalNotFound,
+            global_not_found.clone(),
+            depth,
+        )
+        .await?;
 
         let modules_code = replace(&mut self.loader_tree_code, temp_loader_tree_code);
 
         // add parallel_routes
         for (key, parallel_route) in parallel_routes.iter() {
             write!(self.loader_tree_code, "{key}: ", key = StringifyJs(key))?;
-            Box::pin(self.walk_tree(parallel_route, false)).await?;
+            let next_depth = if key.as_str() == "children" {
+                depth + 1
+            } else {
+                depth
+            };
+            Box::pin(self.walk_tree(parallel_route, false, next_depth)).await?;
             writeln!(self.loader_tree_code, ",")?;
         }
         writeln!(self.loader_tree_code, "}}, {{")?;
@@ -454,9 +479,11 @@ impl AppPageLoaderTreeBuilder {
                 .insert(GLOBAL_NOT_FOUND.into(), module);
         };
 
-        self.walk_tree(loader_tree, true).await?;
+        self.walk_tree(loader_tree, true, 0).await?;
+        let mut imports = self.base.imports;
+        imports.sort_by_key(|(position, _)| *position);
         Ok(AppPageLoaderTreeModule {
-            imports: self.base.imports,
+            imports: imports.into_iter().map(|(_, import)| import).collect(),
             loader_tree_code: self.loader_tree_code.into(),
             inner_assets: self.base.inner_assets,
         })

--- a/crates/next-core/src/base_loader_tree.rs
+++ b/crates/next-core/src/base_loader_tree.rs
@@ -15,7 +15,7 @@ use turbopack_ecmascript::{magic_identifier, utils::StringifyJs};
 pub struct BaseLoaderTreeBuilder {
     pub inner_assets: FxIndexMap<RcStr, ResolvedVc<Box<dyn Module>>>,
     counter: usize,
-    pub imports: Vec<RcStr>,
+    pub imports: Vec<(u32, RcStr)>,
     pub module_asset_context: ResolvedVc<ModuleAssetContext>,
     pub server_component_transition: ResolvedVc<Box<dyn Transition>>,
 }
@@ -91,12 +91,14 @@ impl BaseLoaderTreeBuilder {
         &mut self,
         module_type: AppDirModuleType,
         path: FileSystemPath,
+        position: u32,
     ) -> Result<String> {
         let name = module_type.name();
         let i = self.unique_number();
         let identifier = magic_identifier::mangle(&format!("{name} #{i}"));
 
-        self.imports.push(
+        self.imports.push((
+            position,
             formatdoc!(
                 r#"
                 const {} = () => require(/*turbopackChunkingType: shared*/"MODULE_{}");
@@ -105,7 +107,7 @@ impl BaseLoaderTreeBuilder {
                 i
             )
             .into(),
-        );
+        ));
 
         let module = self
             .process_source(Vc::upcast(FileSource::new(path.clone())))


### PR DESCRIPTION
### What?

Reorder the imports emitted by the app-page loader-tree builder so that they are grouped by their depth in the loader tree (shallow segments first, deep segments last) instead of the somewhat arbitrary order produced by recursive walking.

### Why?

The loader tree is built by walking the app router tree recursively, and each segment contributes a few `require(...)` declarations (layout, error, loading, page, metadata, ...) to a shared list of imports that is later concatenated into the generated entry module. The order of that list is what ends up in the bundle, and walking the tree recursively interleaves segments at different depths in a way that depends on traversal order rather than on the structure of the route.

For chunking and readability we want a more predictable order: *outer (shallower) layouts/segments before inner (deeper) ones*, with imports inside the same depth keeping their original relative order. This gives downstream chunking a more useful signal.

### How?

In `crates/next-core/src/base_loader_tree.rs`:

- `BaseLoaderTreeBuilder::imports` is now `Vec<(u32, RcStr)>` instead of `Vec<RcStr>`. The `u32` is a sort key (the depth at which the import was produced).
- `create_module_tuple_code` takes a new `position: u32` argument and stores it alongside the generated `require` line.

In `crates/next-core/src/app_page_loader_tree.rs`:

- `walk_tree` takes a new `depth: u32` argument. The initial call from `build()` passes `0`.
- `depth` is threaded through `write_modules_entry`, `write_metadata`, `write_metadata_items`, `write_metadata_item`, and `write_static_metadata_item`, so the three other places that push directly into `self.base.imports` (dynamic image metadata, static metadata items, and their alt-text companions) also tag their entries with the current depth.
- When recursing into `parallel_routes`, depth is incremented only for the `"children"` slot. Named parallel routes (e.g. `@modal`) are sibling slots of the same segment and therefore stay at the same depth.
- In `AppPageLoaderTreeBuilder::build`, the collected `(depth, import)` pairs are stable-sorted by depth (`sort_by_key`, which is stable in Rust, preserving the original relative order within each depth) and then stripped back to `Vec<RcStr>` before being placed on `AppPageLoaderTreeModule.imports`.

The public type of `AppPageLoaderTreeModule.imports` (`Vec<RcStr>`) is unchanged, so consumers in `crates/next-core/src/next_app/app_page_entry.rs` need no adjustments.
