### PR TITLE
[ci] Clarify new preview build flow

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -434,7 +434,7 @@ jobs:
 
   deploy-tarball:
     if: ${{ needs.deploy-target.outputs.value != 'production' }}
-    name: Deploy preview tarball
+    name: Prepare preview tarball
     runs-on: ubuntu-latest
     needs:
       - deploy-target
@@ -485,10 +485,10 @@ jobs:
         # For workflow_dispatch events, github.sha is the head commit.
         run: node scripts/create-preview-tarballs.js "${{ github.event.after || github.sha }}" "${{ runner.temp }}/preview-tarballs" "${{ vars.PREVIEW_BUILDS_BASE_URL }}"
 
-      - name: Upload tarballs
+      - name: Persist tarballs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          # Update all mentions of this name in vercel-packages when changing.
+          # Used by file://./upload_preview_tarballs.yml
           name: preview-tarballs
           path: ${{ runner.temp }}/preview-tarballs/*
 

--- a/scripts/create-preview-tarballs.js
+++ b/scripts/create-preview-tarballs.js
@@ -158,7 +158,7 @@ async function main() {
   }
 
   console.info(
-    `When this job is completed, a Next.js preview build will be available under ${packagesByVersion.get('next')}`
+    `A upload_preview_tarballs (https://github.com/vercel/next.js/actions/workflows/upload_preview_tarballs.yml) will be started once this workflow completes which will make the Next.js preview build available under ${packagesByVersion.get('next')}`
   )
 }
 


### PR DESCRIPTION
Preview builds are no longer available once build_and_deploy finishes.
The builds are only available once upload_preview_tarballs finishes, which runs after build_and_deploy is completed.

Due to https://github.com/vercel/next.js/pull/93207 preview builds are available slightly later than build_and_deploy completing so the language should reflect that