### PR TITLE
Turbopack: more strict vergen setup

### DIFF
--- a/crates/next-api/build.rs
+++ b/crates/next-api/build.rs
@@ -6,8 +6,8 @@ fn main() -> anyhow::Result<()> {
         .target_triple(true)
         .build()?;
     vergen::Emitter::default()
-        .add_instructions(&cargo)?
         .fail_on_error()
+        .add_instructions(&cargo)?
         .emit()?;
 
     Ok(())

--- a/crates/next-napi-bindings/build.rs
+++ b/crates/next-napi-bindings/build.rs
@@ -57,9 +57,9 @@ fn main() -> anyhow::Result<()> {
         )
         .build()?;
     vergen_gitcl::Emitter::default()
+        .fail_on_error()
         .add_instructions(&cargo)?
         .add_instructions(&git)?
-        .fail_on_error()
         .emit()?;
 
     match Command::new("git").args(["rev-parse", "HEAD"]).output() {

--- a/crates/next-napi-bindings/build.rs
+++ b/crates/next-napi-bindings/build.rs
@@ -67,7 +67,12 @@ fn main() -> anyhow::Result<()> {
             "cargo:warning=git HEAD: {}",
             str::from_utf8(&out.stdout).unwrap()
         ),
-        _ => println!("cargo:warning=`git rev-parse HEAD` failed"),
+        Ok(out) => println!(
+            "cargo:warning=`git rev-parse HEAD` failed with status {}: {}",
+            out.status,
+            str::from_utf8(&out.stderr).unwrap()
+        ),
+        Err(e) => println!("cargo:warning=`git rev-parse HEAD` could not be spawned: {e}"),
     }
 
     if !is_macos_target {

--- a/scripts/docker-native-build.sh
+++ b/scripts/docker-native-build.sh
@@ -16,6 +16,10 @@
 
 set -xeo pipefail
 
+# /build is bind-mounted from the host with a uid that differs from the
+# container's root user; mark it safe so vergen's `git rev-parse` works.
+git config --global --add safe.directory /build
+
 BUILD_TASK="${BUILD_TASK:-build-native-release}"
 
 # Node.js (installed via nodesource) is used only as a build tool (runs

--- a/turbopack/crates/turbopack-cli/build.rs
+++ b/turbopack/crates/turbopack-cli/build.rs
@@ -28,8 +28,8 @@ fn main() -> anyhow::Result<()> {
         )
         .build()?;
     vergen_gitcl::Emitter::default()
-        .add_instructions(&git)?
         .fail_on_error()
+        .add_instructions(&git)?
         .emit()?;
 
     Ok(())


### PR DESCRIPTION
We were getting these errors and they didn't fail the build:
```
warning: next-napi-bindings@0.0.0: not within a suitable 'git' worktree!
warning: next-napi-bindings@0.0.0: VERGEN_GIT_DESCRIBE set to default
warning: next-napi-bindings@0.0.0: VERGEN_GIT_DIRTY set to default
warning: next-napi-bindings@0.0.0: `git rev-parse HEAD` failed
```

The issue comes from a change in Git 2.35 which started to refuse working on Git directories that were owned by a different uid. Our [self-hosted runners used 2.34.1](https://github.com/vercel/next.js/actions/runs/24619032350/job/71986251846#step:4:31) whereas GH hosted runners use [2.50](https://github.com/vercel/next.js/actions/runs/25435823240/job/74613469020?pr=93539#step:3:32).

This PR:

- Makes vergen strict (`fail_on_error` is moved before `add_instructions` so git errors actually fail the build instead of being emitted as silent warnings).
- Improves the fallback `git rev-parse HEAD` error reporting in `crates/next-napi-bindings/build.rs` so the underlying status/stderr is surfaced.
- Adds `git config --global --add safe.directory /build` to `scripts/docker-native-build.sh` so the bind-mounted workspace is accepted by Git inside the native build container.

## Test plan

Without adding the safe directory we actually get the dubious ownership error:

> warning: next-napi-bindings@0.0.0: `git rev-parse HEAD` failed with status exit status: 128: fatal: detected dubious ownership in repository at '/build'
-- https://github.com/vercel/next.js/actions/runs/25483622900/job/74773786959#step:14:732

With the fix

> warning: next-napi-bindings@0.0.0: git HEAD: 5db3944497a923e403886ede31cadfe2c9498654
-- https://github.com/vercel/next.js/actions/runs/25484197578/job/74775661519#step:14:717

<!-- NEXT_JS_LLM_PR -->