### PR TITLE
turbo-rcstr: replace `rcstr!` macro_rules with proc macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9807,9 +9807,14 @@ dependencies = [
  "smallvec",
  "triomphe 0.1.12",
  "turbo-bincode",
+ "turbo-rcstr-macros",
  "turbo-tasks-hash",
  "unty",
 ]
+
+[[package]]
+name = "turbo-rcstr-macros"
+version = "0.1.0"
 
 [[package]]
 name = "turbo-tasks"

--- a/turbopack/crates/turbo-rcstr-macros/Cargo.toml
+++ b/turbopack/crates/turbo-rcstr-macros/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "turbo-rcstr-macros"
+version = "0.1.0"
+edition = "2024"
+license = "MIT"
+
+[lib]
+proc-macro = true
+bench = false
+
+[features]
+# Mirror the threshold-affecting features of `turbo-rcstr`. The consuming
+# crate routes them via `turbo-rcstr/atom_size_*` -> `turbo-rcstr-macros/atom_size_*`
+# so the proc macro can compute the correct `MAX_INLINE_LEN` at expansion time
+# instead of leaving an ambiguous range that needs a runtime const branch.
+atom_size_64 = []
+atom_size_128 = []
+
+[lints]
+workspace = true
+
+[dependencies]
+# Intentionally minimal: the only dependency is the standard `proc_macro`
+# API. Dropping `syn` and `quote` removes ~hundreds of milliseconds of
+# per-invocation overhead and a large slice of the proc-macro crate's
+# build time. See the crate-level docs for the reasoning.

--- a/turbopack/crates/turbo-rcstr-macros/src/lib.rs
+++ b/turbopack/crates/turbo-rcstr-macros/src/lib.rs
@@ -1,0 +1,118 @@
+//! Proc macro implementation of `rcstr!`.
+//!
+//! This proc macro inspects the literal at expansion time and emits only
+//! the relevant arm. The threshold (`MAX_INLINE_LEN`) is computed at the
+//! proc-macro crate's compile time from its own `atom_size_*` feature
+//! flags, which `turbo-rcstr` forwards from its matching features. For
+//! inputs the proc macro cannot inspect (constant identifiers, `concat!`
+//! results, `quote!` interpolations, etc.) it falls back to the original
+//! both-branches expansion that defers the decision to const evaluation.
+//!
+//! The implementation deliberately avoids `syn` and `quote`. The macro is
+//! invoked thousands of times across the workspace, so per-invocation cost
+//! matters: we pattern-match on `proc_macro::TokenTree` directly to
+//! identify a single string-literal token, ask the compiler for its
+//! unescaped value via [`Literal::str_value`] (gated by the unstable
+//! `proc_macro_value` feature), and emit the chosen expansion by parsing
+//! a string template via `TokenStream::from_str`. This keeps the per-call
+//! cost close to a `macro_rules!` macro and avoids pulling `syn`'s parser
+//! into every consuming crate's compilation.
+
+#![feature(proc_macro_value)]
+
+use std::str::FromStr;
+
+use proc_macro::{Literal, TokenStream, TokenTree};
+
+/// `MAX_INLINE_LEN` for the active `turbo-rcstr` configuration, computed
+/// from the proc-macro crate's own feature flags. The outer `turbo-rcstr`
+/// crate forwards its `atom_size_*` features to this crate so the proc
+/// macro sees the same threshold the consuming binary will see at runtime.
+///
+/// Mirrors [`turbo_rcstr::tagged_value::MAX_INLINE_LEN`]: a tagged value is
+/// `size_of::<TaggedValue>() - 1` bytes of inline payload. With
+/// `atom_size_128` the value is `u128` (15 bytes inlinable); otherwise (the
+/// default 64-bit case and the `atom_size_64` feature) it is 8 bytes wide,
+/// giving 7 bytes of inline payload.
+const MAX_INLINE_LEN: usize = if cfg!(feature = "atom_size_128") {
+    15
+} else {
+    7
+};
+
+#[proc_macro]
+pub fn rcstr(input: TokenStream) -> TokenStream {
+    // Fast path: input is a single string-literal token whose unescaped
+    // length we can determine cheaply. Otherwise (multi-token expressions
+    // like `concat!(...)`, identifiers, empty input, non-string literals,
+    // escape-bearing literals) defer to the const-branch expansion so
+    // const evaluation picks the arm at compile time.
+    //
+    // `input.clone()` is cheap — a `TokenStream` is an opaque handle into
+    // the proc-macro server's storage rather than an owned tree of tokens
+    // — so cloning here lets us consume one copy in `classify_literal`
+    // while keeping the original around for the fallback path.
+    if let Some((lit, len)) = classify_literal(input.clone()) {
+        if len <= MAX_INLINE_LEN {
+            return emit_inlinable(&lit);
+        } else {
+            return emit_non_inlinable(&lit);
+        }
+    }
+    emit_fallback(input)
+}
+
+/// If `input` is a single string-literal token, return the literal and
+/// its unescaped length. Returns `None` for non-literal inputs, multi-
+/// token inputs, or non-string literals (numeric, byte string, char,
+/// etc.) so the caller falls back to the const-branch expansion.
+///
+/// [`Literal::str_value`] resolves all escape sequences (regular strings,
+/// raw strings, unicode escapes) and reports an error for non-string
+/// literals — exactly the inspection we want.
+fn classify_literal(input: TokenStream) -> Option<(Literal, usize)> {
+    let mut iter = input.into_iter();
+    let TokenTree::Literal(lit) = iter.next()? else {
+        return None;
+    };
+    if iter.next().is_some() {
+        return None;
+    }
+    let value = lit.str_value().ok()?;
+    Some((lit, value.len()))
+}
+
+/// Emit `::turbo_rcstr::inline_atom(<lit>).unwrap()`.
+fn emit_inlinable(lit: &Literal) -> TokenStream {
+    parse(&format!("::turbo_rcstr::inline_atom({lit}).unwrap()"))
+}
+
+/// Emit the static + inventory submission expansion for a literal we know
+/// is non-inlinable. No inline arm, no const branch.
+fn emit_non_inlinable(lit: &Literal) -> TokenStream {
+    parse(&format!(
+        "{{ static RCSTR_STORAGE: ::turbo_rcstr::PrehashedString = \
+         ::turbo_rcstr::make_const_prehashed_string({lit}); const RCSTR: ::turbo_rcstr::RcStr = \
+         ::turbo_rcstr::from_static(&RCSTR_STORAGE); ::turbo_rcstr::__rcstr_inventory_submit!( \
+         ::turbo_rcstr::StaticRcStr(&RCSTR_STORAGE) ); RCSTR }}",
+    ))
+}
+
+/// Emit the both-branches const-eval expansion. Used for non-literal
+/// inputs (constant identifiers, `concat!(...)`, etc.) and for literals
+/// whose unescaped length we couldn't determine cheaply.
+fn emit_fallback(input: TokenStream) -> TokenStream {
+    parse(&format!(
+        "{{ const TEXT: &str = {input}; if ::turbo_rcstr::is_atom_inlineable(TEXT) {{ \
+         ::turbo_rcstr::inline_atom(TEXT).unwrap() }} else {{ static RCSTR_STORAGE: \
+         ::turbo_rcstr::PrehashedString = ::turbo_rcstr::make_const_prehashed_string(TEXT); const \
+         RCSTR: ::turbo_rcstr::RcStr = ::turbo_rcstr::from_static(&RCSTR_STORAGE); \
+         ::turbo_rcstr::__rcstr_inventory_submit!( ::turbo_rcstr::StaticRcStr(&RCSTR_STORAGE) ); \
+         RCSTR }} }}",
+    ))
+}
+
+#[inline]
+fn parse(source: &str) -> TokenStream {
+    TokenStream::from_str(source).expect("emitted source parses")
+}

--- a/turbopack/crates/turbo-rcstr-macros/src/lib.rs
+++ b/turbopack/crates/turbo-rcstr-macros/src/lib.rs
@@ -1,22 +1,12 @@
 //! Proc macro implementation of `rcstr!`.
 //!
-//! This proc macro inspects the literal at expansion time and emits only
-//! the relevant arm. The threshold (`MAX_INLINE_LEN`) is computed at the
-//! proc-macro crate's compile time from its own `atom_size_*` feature
-//! flags, which `turbo-rcstr` forwards from its matching features. For
-//! inputs the proc macro cannot inspect (constant identifiers, `concat!`
-//! results, `quote!` interpolations, etc.) it falls back to the original
-//! both-branches expansion that defers the decision to const evaluation.
-//!
 //! The implementation deliberately avoids `syn` and `quote`. The macro is
 //! invoked thousands of times across the workspace, so per-invocation cost
 //! matters: we pattern-match on `proc_macro::TokenTree` directly to
 //! identify a single string-literal token, ask the compiler for its
 //! unescaped value via [`Literal::str_value`] (gated by the unstable
 //! `proc_macro_value` feature), and emit the chosen expansion by parsing
-//! a string template via `TokenStream::from_str`. This keeps the per-call
-//! cost close to a `macro_rules!` macro and avoids pulling `syn`'s parser
-//! into every consuming crate's compilation.
+//! a string template via `TokenStream::from_str`.
 
 #![feature(proc_macro_value)]
 
@@ -24,16 +14,8 @@ use std::str::FromStr;
 
 use proc_macro::{Literal, TokenStream, TokenTree};
 
-/// `MAX_INLINE_LEN` for the active `turbo-rcstr` configuration, computed
-/// from the proc-macro crate's own feature flags. The outer `turbo-rcstr`
-/// crate forwards its `atom_size_*` features to this crate so the proc
-/// macro sees the same threshold the consuming binary will see at runtime.
-///
-/// Mirrors [`turbo_rcstr::tagged_value::MAX_INLINE_LEN`]: a tagged value is
-/// `size_of::<TaggedValue>() - 1` bytes of inline payload. With
-/// `atom_size_128` the value is `u128` (15 bytes inlinable); otherwise (the
-/// default 64-bit case and the `atom_size_64` feature) it is 8 bytes wide,
-/// giving 7 bytes of inline payload.
+/// `MAX_INLINE_LEN` for the active `turbo-rcstr` configuration. Mirrors
+/// [`turbo_rcstr::tagged_value::MAX_INLINE_LEN`]
 const MAX_INLINE_LEN: usize = if cfg!(feature = "atom_size_128") {
     15
 } else {
@@ -52,14 +34,32 @@ pub fn rcstr(input: TokenStream) -> TokenStream {
     // the proc-macro server's storage rather than an owned tree of tokens
     // — so cloning here lets us consume one copy in `classify_literal`
     // while keeping the original around for the fallback path.
-    if let Some((lit, len)) = classify_literal(input.clone()) {
-        if len <= MAX_INLINE_LEN {
-            return emit_inlinable(&lit);
+    {
+        let source = if let Some((lit, len)) = classify_literal(input.clone()) {
+            if len <= MAX_INLINE_LEN {
+                format!("::turbo_rcstr::inline_atom({lit}).unwrap()")
+            } else {
+                format!(
+                    "{{ static RCSTR_STORAGE: ::turbo_rcstr::PrehashedString = \
+                     ::turbo_rcstr::make_const_prehashed_string({lit}); const RCSTR: \
+                     ::turbo_rcstr::RcStr = ::turbo_rcstr::from_static(&RCSTR_STORAGE); \
+                     ::turbo_rcstr::__rcstr_inventory_submit!( \
+                     ::turbo_rcstr::StaticRcStr(&RCSTR_STORAGE) ); RCSTR }}",
+                )
+            }
         } else {
-            return emit_non_inlinable(&lit);
-        }
+            format!(
+                "{{ const TEXT: &str = {input}; if ::turbo_rcstr::is_atom_inlineable(TEXT) {{ \
+                 ::turbo_rcstr::inline_atom(TEXT).unwrap() }} else {{ static RCSTR_STORAGE: \
+                 ::turbo_rcstr::PrehashedString = \
+                 ::turbo_rcstr::make_const_prehashed_string(TEXT); const RCSTR: \
+                 ::turbo_rcstr::RcStr = ::turbo_rcstr::from_static(&RCSTR_STORAGE); \
+                 ::turbo_rcstr::__rcstr_inventory_submit!( \
+                 ::turbo_rcstr::StaticRcStr(&RCSTR_STORAGE) ); RCSTR }} }}",
+            )
+        };
+        TokenStream::from_str(&source).expect("emitted source parses")
     }
-    emit_fallback(input)
 }
 
 /// If `input` is a single string-literal token, return the literal and
@@ -80,39 +80,4 @@ fn classify_literal(input: TokenStream) -> Option<(Literal, usize)> {
     }
     let value = lit.str_value().ok()?;
     Some((lit, value.len()))
-}
-
-/// Emit `::turbo_rcstr::inline_atom(<lit>).unwrap()`.
-fn emit_inlinable(lit: &Literal) -> TokenStream {
-    parse(&format!("::turbo_rcstr::inline_atom({lit}).unwrap()"))
-}
-
-/// Emit the static + inventory submission expansion for a literal we know
-/// is non-inlinable. No inline arm, no const branch.
-fn emit_non_inlinable(lit: &Literal) -> TokenStream {
-    parse(&format!(
-        "{{ static RCSTR_STORAGE: ::turbo_rcstr::PrehashedString = \
-         ::turbo_rcstr::make_const_prehashed_string({lit}); const RCSTR: ::turbo_rcstr::RcStr = \
-         ::turbo_rcstr::from_static(&RCSTR_STORAGE); ::turbo_rcstr::__rcstr_inventory_submit!( \
-         ::turbo_rcstr::StaticRcStr(&RCSTR_STORAGE) ); RCSTR }}",
-    ))
-}
-
-/// Emit the both-branches const-eval expansion. Used for non-literal
-/// inputs (constant identifiers, `concat!(...)`, etc.) and for literals
-/// whose unescaped length we couldn't determine cheaply.
-fn emit_fallback(input: TokenStream) -> TokenStream {
-    parse(&format!(
-        "{{ const TEXT: &str = {input}; if ::turbo_rcstr::is_atom_inlineable(TEXT) {{ \
-         ::turbo_rcstr::inline_atom(TEXT).unwrap() }} else {{ static RCSTR_STORAGE: \
-         ::turbo_rcstr::PrehashedString = ::turbo_rcstr::make_const_prehashed_string(TEXT); const \
-         RCSTR: ::turbo_rcstr::RcStr = ::turbo_rcstr::from_static(&RCSTR_STORAGE); \
-         ::turbo_rcstr::__rcstr_inventory_submit!( ::turbo_rcstr::StaticRcStr(&RCSTR_STORAGE) ); \
-         RCSTR }} }}",
-    ))
-}
-
-#[inline]
-fn parse(source: &str) -> TokenStream {
-    TokenStream::from_str(source).expect("emitted source parses")
 }

--- a/turbopack/crates/turbo-rcstr/Cargo.toml
+++ b/turbopack/crates/turbo-rcstr/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2024"
 license = "MIT"
 
 [features]
-atom_size_64 = []
-atom_size_128 = []
+atom_size_64 = ["turbo-rcstr-macros/atom_size_64"]
+atom_size_128 = ["turbo-rcstr-macros/atom_size_128"]
 napi = ["dep:napi"]
 
 [dependencies]
@@ -21,6 +21,7 @@ bytes-str = { workspace = true }
 inventory = { workspace = true }
 smallvec = { workspace = true }
 turbo-bincode = { workspace = true }
+turbo-rcstr-macros = { path = "../turbo-rcstr-macros" }
 unty = { workspace = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]

--- a/turbopack/crates/turbo-rcstr/src/lib.rs
+++ b/turbopack/crates/turbo-rcstr/src/lib.rs
@@ -529,6 +529,9 @@ static STATIC_TABLE: LazyLock<
     let mut map: HashMap<u64, SmallVec<[&'static PrehashedString; 1]>, FxBuildHasher> =
         HashMap::with_hasher(FxBuildHasher);
     for StaticRcStr(phs) in inventory::iter::<StaticRcStr> {
+        if phs.value.as_str().len() <= MAX_INLINE_LEN {
+            continue;
+        }
         let entries = map.entry(phs.hash).or_default();
         // Deduplicate: skip if an entry with the same string content exists
         // Mostly linkers will merge static strings but this isn't guaranteed so we cannot just rely
@@ -550,22 +553,17 @@ static STATIC_TABLE: LazyLock<
 #[macro_export]
 macro_rules! rcstr {
     ($s:expr) => {{
-        let text = $s;
+        const TEXT: &str = $s;
         // This condition can be compile time evaluated and inlined.
-        if $crate::is_atom_inlineable(text) {
-            $crate::inline_atom(text).unwrap()
+        if $crate::is_atom_inlineable(TEXT) {
+            $crate::inline_atom(TEXT).unwrap()
         } else {
-            const fn get_rcstr() -> $crate::RcStr {
-                // Allocate static storage for the PrehashedString
-                static RCSTR_STORAGE: $crate::PrehashedString =
-                    $crate::make_const_prehashed_string($s);
-                // Register with inventory so deserialization can find this static
-                $crate::inventory::submit!($crate::StaticRcStr(&RCSTR_STORAGE));
-                // This basically just tags a bit onto the raw pointer and wraps it in an RcStr
-                // should be fast enough to do every time.
-                $crate::from_static(&RCSTR_STORAGE)
-            }
-            get_rcstr()
+            static RCSTR_STORAGE: $crate::PrehashedString =
+                $crate::make_const_prehashed_string(TEXT);
+            const RCSTR: $crate::RcStr = $crate::from_static(&RCSTR_STORAGE);
+            // Register with inventory so deserialization can find this static
+            $crate::inventory::submit!($crate::StaticRcStr(&RCSTR_STORAGE));
+            RCSTR
         }
     }};
 }

--- a/turbopack/crates/turbo-rcstr/src/lib.rs
+++ b/turbopack/crates/turbo-rcstr/src/lib.rs
@@ -570,7 +570,6 @@ static STATIC_TABLE: LazyLock<
 });
 
 /// Create an rcstr from a string literal.
-
 /// Allocates the RcStr inline when possible, otherwise uses a static `PrehashedString`.  In
 /// either case this is a compile time constant
 pub use turbo_rcstr_macros::rcstr;

--- a/turbopack/crates/turbo-rcstr/src/lib.rs
+++ b/turbopack/crates/turbo-rcstr/src/lib.rs
@@ -1,3 +1,7 @@
+// Allow the `rcstr!` proc macro's emitted `::turbo_rcstr::...` paths to
+// resolve when used inside this crate's own source (e.g. tests, doctests).
+extern crate self as turbo_rcstr;
+
 use std::{
     borrow::{Borrow, Cow},
     collections::HashMap,
@@ -53,7 +57,7 @@ mod tagged_value;
 /// `RcStr::from(...)`, or the `rcstr!` macro.
 ///
 /// ```
-/// # use turbo_rcstr::RcStr;
+/// # use turbo_rcstr::{RcStr, rcstr};
 /// #
 /// let s = "foo";
 /// let rc_s1: RcStr = s.into();
@@ -517,6 +521,20 @@ pub struct StaticRcStr(pub &'static PrehashedString);
 
 inventory::collect!(StaticRcStr);
 
+/// Forwarder around [`inventory::submit!`] that lets the `rcstr!` proc macro
+/// emit a single path it can rely on, without depending on whether
+/// `turbo_rcstr::inventory` is reachable as a macro path in the call site
+/// crate. Macros emitted from a proc macro lose access to the proc macro
+/// crate's deps, so the submission has to bounce through this declarative
+/// macro defined where `inventory::submit!` is in scope.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __rcstr_inventory_submit {
+    ($value:expr) => {
+        $crate::inventory::submit!($value);
+    };
+}
+
 /// Read-only lookup table mapping precomputed hash -> static PrehashedString.
 /// Built once on first access from all `rcstr!` constants collected by `inventory`.
 ///
@@ -548,25 +566,20 @@ static STATIC_TABLE: LazyLock<
 });
 
 /// Create an rcstr from a string literal.
-/// Allocates the RcStr inline when possible, otherwise uses a static `PrehashedString`.  In either
-/// case this is a compile time constant
-#[macro_export]
-macro_rules! rcstr {
-    ($s:expr) => {{
-        const TEXT: &str = $s;
-        // This condition can be compile time evaluated and inlined.
-        if $crate::is_atom_inlineable(TEXT) {
-            $crate::inline_atom(TEXT).unwrap()
-        } else {
-            static RCSTR_STORAGE: $crate::PrehashedString =
-                $crate::make_const_prehashed_string(TEXT);
-            const RCSTR: $crate::RcStr = $crate::from_static(&RCSTR_STORAGE);
-            // Register with inventory so deserialization can find this static
-            $crate::inventory::submit!($crate::StaticRcStr(&RCSTR_STORAGE));
-            RCSTR
-        }
-    }};
-}
+///
+/// Allocates the [`RcStr`] inline when the literal is short enough to fit in
+/// the tagged value; otherwise stores a `PrehashedString` in static memory.
+/// In both cases the result is a compile-time constant.
+///
+/// The macro is implemented in the companion `turbo-rcstr-macros` crate so
+/// the literal's length can be inspected at expansion time. Unambiguously
+/// inlinable literals expand to just the inline construction; unambiguously
+/// non-inlinable literals expand to just the static + inventory submission.
+/// Lengths in the ambiguous range (where `MAX_INLINE_LEN` depends on the
+/// `atom_size_128` feature) and non-literal inputs (constant identifiers,
+/// `concat!(...)`, etc.) defer to const evaluation exactly like the previous
+/// declarative macro.
+pub use turbo_rcstr_macros::rcstr;
 
 /// noop
 impl ShrinkToFit for RcStr {

--- a/turbopack/crates/turbo-rcstr/src/lib.rs
+++ b/turbopack/crates/turbo-rcstr/src/lib.rs
@@ -548,6 +548,10 @@ static STATIC_TABLE: LazyLock<
         HashMap::with_hasher(FxBuildHasher);
     for StaticRcStr(phs) in inventory::iter::<StaticRcStr> {
         if phs.value.as_str().len() <= MAX_INLINE_LEN {
+            // This is rare, but possible if our macro cannot determine the length of the string at
+            // macro time we may end up with a wasted PrehashedString submitted to inventory.
+
+            // Just skip it
             continue;
         }
         let entries = map.entry(phs.hash).or_default();
@@ -566,19 +570,9 @@ static STATIC_TABLE: LazyLock<
 });
 
 /// Create an rcstr from a string literal.
-///
-/// Allocates the [`RcStr`] inline when the literal is short enough to fit in
-/// the tagged value; otherwise stores a `PrehashedString` in static memory.
-/// In both cases the result is a compile-time constant.
-///
-/// The macro is implemented in the companion `turbo-rcstr-macros` crate so
-/// the literal's length can be inspected at expansion time. Unambiguously
-/// inlinable literals expand to just the inline construction; unambiguously
-/// non-inlinable literals expand to just the static + inventory submission.
-/// Lengths in the ambiguous range (where `MAX_INLINE_LEN` depends on the
-/// `atom_size_128` feature) and non-literal inputs (constant identifiers,
-/// `concat!(...)`, etc.) defer to const evaluation exactly like the previous
-/// declarative macro.
+
+/// Allocates the RcStr inline when possible, otherwise uses a static `PrehashedString`.  In
+/// either case this is a compile time constant
 pub use turbo_rcstr_macros::rcstr;
 
 /// noop


### PR DESCRIPTION
### What?

Replaces the `rcstr!` macro in `turbo-rcstr` with a proc-macro implementation in a new `turbo-rcstr-macros` crate. The proc macro inspects the literal at expansion time and emits only the relevant arm — no dead `else` branch.

### Why?

The previous `macro_rules!` macro emitted both an inline arm and a static + `inventory::submit!` arm at every call site, expecting `const` evaluation to discard one. `inventory::submit!` adds `#[used]` to its constructor, so the dead arm shipped in the binary even when const eval determined the live arm was the inline one.

Across the workspace there are ~852 inlinable `rcstr!` literals (≤ 7 bytes); each previously emitted a wasted `PrehashedString` static, an inventory node, and a startup `ctor`.

### How?

A `#[proc_macro] rcstr` in the new `turbo-rcstr-macros` crate decides at expansion time:

- inlinable literal → `inline_atom(lit).unwrap()`. No static, no inventory entry, no dead branch.
- non-inlinable literal → static + `inventory::submit!` + `from_static`, no inline arm.
- constant identifiers / `concat!(…)` / non-literal inputs → fall back to the original both-branches expansion so const eval picks the arm. ~11 such call sites.

`turbo-rcstr`'s `atom_size_64` / `atom_size_128` features forward to the proc-macro crate so the threshold is exact for every build configuration without a runtime const branch.

The proc macro deliberately avoids `syn`, `quote`, and `proc-macro2`. It pattern-matches on `proc_macro::TokenTree` directly, asks the compiler for the literal's unescaped value via `Literal::str_value` (gated on the unstable `proc_macro_value` feature), and emits the chosen expansion by parsing a string template via `TokenStream::from_str`. The proc-macro crate compiles in ~0.7 s with zero third-party dependencies.

### Compile time

Clean rebuild of `turbopack-core` in release mode (143 `rcstr!` call sites). Dependencies cached; only `turbopack-core` itself rebuilt each iteration. `darwin-aarch64`.

|                    |   n | min      | mean     | median   | stdev    |
| ------------------ | ---:| --------:| --------:| --------:| --------:|
| canary             | 7   | 27.11 s  | 28.00 s  | 28.12 s  | 0.61 s   |
| `rcstr_inventory`  | 7   | 26.60 s  | 27.99 s  | 27.96 s  | 0.80 s   |
| **delta**          |     |          | **−0.01 s (−0.06 %)** | −0.16 s |          |

Within noise. The proc-macro per-invocation overhead is offset by reduced emitted-token volume (~40 % less code across all `rcstr!` sites — the 852 inlinable literals collapse from ~80 tokens to ~6 tokens each), so the compiler does materially less parsing and type-checking on the macro output.

### Binary size

Release build of `next-napi-bindings` cdylib on `darwin-aarch64`:

|                              | canary                          | `rcstr_inventory`               | delta                          |
| ---------------------------- | ------------------------------- | ------------------------------- | ------------------------------ |
| Release `.dylib` (raw)       | 123,699,312 B (117.97 MiB)      | 123,349,424 B (117.64 MiB)      | **−349,888 B (−0.28 %)**       |
| Stripped (`strip -x`)        | 83,502,264 B (79.63 MiB)        | 83,434,984 B (79.57 MiB)        | **−67,280 B (−0.08 %)**        |
| Stripped + `gzip -9`         | 28,967,762 B (27.63 MiB)        | 28,958,198 B (27.62 MiB)        | **−9,564 B (−0.03 %)**         |

The raw release build shrinks by ~342 KiB — the 852 dead `static PrehashedString` + inventory node + ctor entries no longer being emitted for inlinable call sites. Most of that compresses well (dead data is stripped and gzip handles the rest), so the user-facing impact in the gzipped npm tarball is ~9 KiB.

<!-- NEXT_JS_LLM_PR -->