### PR TITLE
(1/19) Add feature-flagged export dynamic fallback HTML

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -189,10 +189,8 @@ import { traceMemoryUsage } from '../lib/memory/trace'
 import { generateEncryptionKeyBase64 } from '../server/app-render/encryption-utils-server'
 import type { DeepReadonly } from '../shared/lib/deep-readonly'
 import uploadTrace from '../trace/upload-trace'
-import {
-  checkIsAppPPREnabled,
-  checkIsRoutePPREnabled,
-} from '../server/lib/experimental/ppr'
+import { checkIsAppPPREnabled } from '../server/lib/experimental/ppr'
+import { isOutputExportDynamicFallbackEnabled } from '../lib/output-export-dynamic-fallback'
 import { FallbackMode, fallbackModeToFallbackField } from '../lib/fallback'
 import { RenderingMode } from './rendering-mode'
 import { InvariantError } from '../shared/lib/invariant-error'
@@ -2104,6 +2102,8 @@ export default async function build(
               locales: config.i18n?.locales,
               defaultLocale: config.i18n?.defaultLocale,
               nextConfigOutput: config.output,
+              outputExportDynamicFallbacks:
+                config.experimental.outputExportDynamicFallbacks === true,
               pprConfig: config.experimental.ppr,
               partialFallbacksEnabled:
                 config.experimental.partialFallbacks === true,
@@ -2339,6 +2339,9 @@ export default async function build(
                               : config.experimental.isrFlushToDisk,
                             cacheMaxMemorySize: config.cacheMaxMemorySize,
                             nextConfigOutput: config.output,
+                            outputExportDynamicFallbacks:
+                              config.experimental
+                                .outputExportDynamicFallbacks === true,
                             pprConfig: config.experimental.ppr,
                             partialFallbacksEnabled:
                               config.experimental.partialFallbacks === true,
@@ -2403,7 +2406,8 @@ export default async function build(
                             if (
                               config.output === 'export' &&
                               isDynamic &&
-                              !hasGenerateStaticParams
+                              !hasGenerateStaticParams &&
+                              !isOutputExportDynamicFallbackEnabled(config)
                             ) {
                               throw new Error(
                                 `Page "${page}" is missing "generateStaticParams()" so it cannot be used with "output: export" config.`
@@ -2938,9 +2942,12 @@ export default async function build(
               sortedStaticPaths.forEach(([originalAppPath, routes]) => {
                 const appConfig = appDefaultConfigs.get(originalAppPath)
                 const isDynamicError = appConfig?.dynamic === 'error'
+                const normalizedAppPath =
+                  appNormalizedPaths.get(originalAppPath)
 
-                const isRoutePPREnabled: boolean = appConfig
-                  ? checkIsRoutePPREnabled(config.experimental.ppr)
+                const isRoutePPREnabled: boolean = normalizedAppPath
+                  ? (pageInfos.get(normalizedAppPath)?.isRoutePPREnabled ??
+                    false)
                   : false
 
                 routes.forEach((route) => {
@@ -3136,8 +3143,7 @@ export default async function build(
             // When this is an app page and PPR is enabled, the route supports
             // partial pre-rendering.
             const isRoutePPREnabled: true | undefined =
-              !isAppRouteHandler &&
-              checkIsRoutePPREnabled(config.experimental.ppr)
+              !isAppRouteHandler && pageInfos.get(page)?.isRoutePPREnabled
                 ? true
                 : undefined
 

--- a/packages/next/src/build/static-paths/app.ts
+++ b/packages/next/src/build/static-paths/app.ts
@@ -828,7 +828,8 @@ export async function buildAppStaticPaths({
 }): Promise<StaticPathsResult> {
   if (
     segments.some((generate) => generate.config?.dynamicParams === true) &&
-    nextConfigOutput === 'export'
+    nextConfigOutput === 'export' &&
+    !isRoutePPREnabled
   ) {
     throw new Error(
       '"dynamicParams: true" cannot be used with "output: export". See more info here: https://nextjs.org/docs/app/building-your-application/deploying/static-exports'

--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -79,6 +79,7 @@ import type {
   AppRouteRouteModule,
 } from '../server/route-modules/app-route/module'
 import type { FunctionsConfigManifest, ManifestRoute } from './index'
+import { isOutputExportDynamicFallbackEnabled } from '../lib/output-export-dynamic-fallback'
 import { getNamedRouteRegex } from '../shared/lib/router/utils/route-regex'
 import { parseNormalizedAppRoute } from '../shared/lib/router/routes/app'
 import { fillStaticMetadataSegment } from '../lib/metadata/get-metadata-route'
@@ -690,6 +691,7 @@ export async function isPageStatic({
   isrFlushToDisk,
   cacheMaxMemorySize,
   nextConfigOutput,
+  outputExportDynamicFallbacks,
   cacheHandler,
   cacheHandlers,
   cacheLifeProfiles,
@@ -724,6 +726,7 @@ export async function isPageStatic({
     [profile: string]: import('../server/use-cache/cache-life').CacheLife
   }
   nextConfigOutput: 'standalone' | 'export' | undefined
+  outputExportDynamicFallbacks: boolean
   pprConfig: ExperimentalPPRConfig | undefined
   partialFallbacksEnabled: boolean
   buildId: string
@@ -853,12 +856,22 @@ export async function isPageStatic({
 
         rootParamKeys = collectRootParamKeys(routeModule)
 
+        const route = parseNormalizedAppRoute(page)
+        const isOutputExportFallbackRoute =
+          isOutputExportDynamicFallbackEnabled({
+            output: nextConfigOutput,
+            cacheComponents,
+            experimental: {
+              outputExportDynamicFallbacks,
+            },
+          }) && route.dynamicSegments.length > 0
+
         // A page supports partial prerendering if it is an app page and either
-        // the whole app has PPR enabled or this page has PPR enabled when we're
-        // in incremental mode.
+        // the whole app has PPR enabled or this is an export-mode dynamic route
+        // using Cache Components, which reuses the fallback-shell render path.
         isRoutePPREnabled =
           routeModule.definition.kind === RouteKind.APP_PAGE &&
-          checkIsRoutePPREnabled(pprConfig)
+          (checkIsRoutePPREnabled(pprConfig) || isOutputExportFallbackRoute)
 
         // If force dynamic was set and we don't have PPR enabled, then set the
         // revalidate to 0.
@@ -866,8 +879,6 @@ export async function isPageStatic({
         if (appConfig.dynamic === 'force-dynamic' && !isRoutePPREnabled) {
           appConfig.revalidate = 0
         }
-
-        const route = parseNormalizedAppRoute(page)
 
         // If the page is dynamic and we're not in edge runtime, then we need to
         // build the static paths. The edge runtime doesn't support static

--- a/packages/next/src/export/helpers/output-export-fallback.ts
+++ b/packages/next/src/export/helpers/output-export-fallback.ts
@@ -1,0 +1,149 @@
+import { existsSync, promises as fs } from 'fs'
+import { dirname, join, relative, sep } from 'path'
+import { getPagePath } from '../../server/require'
+import { normalizePagePath } from '../../shared/lib/page-path/normalize-page-path'
+import {
+  getOutputExportFallbackPath,
+  getOutputExportFallbackStaticPrefix,
+} from '../../lib/output-export-dynamic-fallback'
+
+type OutputExportDynamicRouteInfo = {
+  fallbackSourceRoute: string | undefined
+  fallbackRouteParams:
+    | ReadonlyArray<{
+        paramName: string
+        paramType: string
+      }>
+    | undefined
+}
+
+type CopyExportedAppHtmlOptions = {
+  outDir: string
+  orig: string
+  routePath: string
+  subFolders: boolean
+  checkRouteCollision?: boolean
+}
+
+type OutputExportError = Error & {
+  code: 'NEXT_EXPORT_ERROR'
+}
+
+function createOutputExportError(message: string): OutputExportError {
+  const error = new Error(message) as OutputExportError
+  error.code = 'NEXT_EXPORT_ERROR'
+  return error
+}
+
+function formatOutputPath(outDir: string, filePath: string): string {
+  return `/${relative(outDir, filePath).split(sep).join('/')}`
+}
+
+function assertNoOutputExportPathCollision(
+  outDir: string,
+  filePaths: string[],
+  routePath: string
+): void {
+  const collisionPath = filePaths.find((filePath) => existsSync(filePath))
+  if (!collisionPath) {
+    return
+  }
+
+  throw createOutputExportError(
+    `The route "${routePath}" conflicts with the internal "__fallback" path used by dynamic route fallbacks in static export mode at "${formatOutputPath(
+      outDir,
+      collisionPath
+    )}". ` +
+      `Please rename this route or public file to something else.\n\n` +
+      `Learn more: https://nextjs.org/docs/app/guides/static-exports`
+  )
+}
+
+export async function copyExportedAppHtml({
+  outDir,
+  orig,
+  routePath,
+  subFolders,
+  checkRouteCollision = false,
+}: CopyExportedAppHtmlOptions): Promise<string> {
+  const route = normalizePagePath(routePath)
+  const flatHtmlDest = join(outDir, `${route}.html`)
+  const folderHtmlDest = join(
+    outDir,
+    `${route}${route !== '/index' ? `${sep}index` : ''}.html`
+  )
+  const htmlDest =
+    subFolders && route !== '/index' ? folderHtmlDest : flatHtmlDest
+
+  if (checkRouteCollision) {
+    assertNoOutputExportPathCollision(
+      outDir,
+      [flatHtmlDest, folderHtmlDest],
+      routePath
+    )
+  }
+
+  await fs.mkdir(dirname(htmlDest), { recursive: true })
+  await fs.copyFile(`${orig}.html`, htmlDest)
+
+  return htmlDest
+}
+
+export async function emitOutputExportFallbackHtmlFiles(
+  dynamicRoutes: Readonly<Record<string, OutputExportDynamicRouteInfo>>,
+  mapAppRouteToPage: Map<string, string>,
+  distDir: string,
+  outDir: string,
+  subFolders: boolean
+): Promise<string[]> {
+  const fallbackHtmlPaths: string[] = []
+
+  for (const [dynamicRoute, prerenderInfo] of Object.entries(dynamicRoutes)) {
+    if (
+      !prerenderInfo.fallbackSourceRoute ||
+      !prerenderInfo.fallbackRouteParams ||
+      prerenderInfo.fallbackRouteParams.length === 0
+    ) {
+      continue
+    }
+
+    const staticPrefix = getOutputExportFallbackStaticPrefix(dynamicRoute)
+    if (staticPrefix === null) {
+      continue
+    }
+
+    const appPageName = mapAppRouteToPage.get(prerenderInfo.fallbackSourceRoute)
+    if (!appPageName) {
+      continue
+    }
+
+    const pagePath = getPagePath(appPageName, distDir, undefined, true)
+    const distPagesDir = join(
+      pagePath,
+      appPageName
+        .slice(1)
+        .split('/')
+        .map(() => '..')
+        .join('/')
+    )
+
+    const sourceRoute = normalizePagePath(dynamicRoute)
+    const orig = join(distPagesDir, sourceRoute)
+    if (!existsSync(`${orig}.html`)) {
+      continue
+    }
+
+    const fallbackPath = getOutputExportFallbackPath(staticPrefix)
+    fallbackHtmlPaths.push(
+      await copyExportedAppHtml({
+        outDir,
+        orig,
+        routePath: fallbackPath,
+        subFolders,
+        checkRouteCollision: true,
+      })
+    )
+  }
+
+  return fallbackHtmlPaths
+}

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -27,6 +27,7 @@ import {
   SSG_FALLBACK_EXPORT_ERROR,
 } from '../lib/constants'
 import { recursiveCopy } from '../lib/recursive-copy'
+import { isOutputExportDynamicFallbackEnabled } from '../lib/output-export-dynamic-fallback'
 import {
   BUILD_ID_FILE,
   CLIENT_PUBLIC_FILES_PATH,
@@ -70,6 +71,7 @@ import { extractInfoFromServerReferenceId } from '../shared/lib/server-reference
 import { convertSegmentPathToStaticExportFilename } from '../shared/lib/segment-cache/segment-value-encoding'
 import { getNextBuildDebuggerPortOffset } from '../lib/worker'
 import { getParams } from './helpers/get-params'
+import { emitOutputExportFallbackHtmlFiles } from './helpers/output-export-fallback'
 import { isDynamicRoute } from '../shared/lib/router/utils/is-dynamic'
 import { normalizeAppPath } from '../shared/lib/router/utils/app-paths'
 import type { Params } from '../server/request/params'
@@ -873,8 +875,11 @@ async function exportAppImpl(
     }
   }
 
-  // Export mode provide static outputs that are not compatible with PPR mode.
-  if (!options.buildExport && nextConfig.experimental.ppr) {
+  if (
+    !options.buildExport &&
+    nextConfig.experimental.ppr &&
+    !isOutputExportDynamicFallbackEnabled(nextConfig)
+  ) {
     // TODO: add message
     throw new Error('Invariant: PPR cannot be enabled in export mode')
   }
@@ -1014,6 +1019,16 @@ async function exportAppImpl(
         }
       })
     )
+
+    if (isOutputExportDynamicFallbackEnabled(nextConfig)) {
+      await emitOutputExportFallbackHtmlFiles(
+        prerenderManifest.dynamicRoutes,
+        mapAppRouteToPage,
+        distDir,
+        outDir,
+        subFolders
+      )
+    }
   }
 
   if (failedExportAttemptsByPage.size > 0) {

--- a/packages/next/src/lib/output-export-dynamic-fallback.test.ts
+++ b/packages/next/src/lib/output-export-dynamic-fallback.test.ts
@@ -1,0 +1,49 @@
+import {
+  getOutputExportFallbackPath,
+  getOutputExportFallbackStaticPrefix,
+  isOutputExportDynamicFallbackEnabled,
+} from './output-export-dynamic-fallback'
+
+describe('output export dynamic fallback', () => {
+  it('derives the fallback path from a static route prefix', () => {
+    expect(getOutputExportFallbackPath('org/acme/chat')).toBe(
+      '/org/acme/chat/__fallback'
+    )
+    expect(getOutputExportFallbackPath('')).toBe('/__fallback')
+  })
+
+  it('derives the static prefix before the first dynamic segment', () => {
+    expect(
+      getOutputExportFallbackStaticPrefix('/org/[org]/chat/[thread]')
+    ).toBe('org')
+    expect(getOutputExportFallbackStaticPrefix('/[locale]/blog/[slug]')).toBe(
+      ''
+    )
+    expect(getOutputExportFallbackStaticPrefix('/org/acme/chat')).toBeNull()
+  })
+
+  it('stays behind the explicit export fallback flag', () => {
+    expect(
+      isOutputExportDynamicFallbackEnabled({
+        output: 'export',
+        cacheComponents: true,
+        experimental: { outputExportDynamicFallbacks: true },
+      })
+    ).toBe(true)
+
+    expect(
+      isOutputExportDynamicFallbackEnabled({
+        output: 'export',
+        cacheComponents: true,
+      })
+    ).toBe(false)
+
+    expect(
+      isOutputExportDynamicFallbackEnabled({
+        output: 'standalone',
+        cacheComponents: true,
+        experimental: { outputExportDynamicFallbacks: true },
+      })
+    ).toBe(false)
+  })
+})

--- a/packages/next/src/lib/output-export-dynamic-fallback.ts
+++ b/packages/next/src/lib/output-export-dynamic-fallback.ts
@@ -1,0 +1,41 @@
+import { parseNormalizedAppRoute } from '../shared/lib/router/routes/app'
+
+type OutputExportDynamicFallbackConfig = {
+  output?: string
+  cacheComponents?: boolean
+  experimental?: {
+    outputExportDynamicFallbacks?: boolean
+  }
+}
+
+export function getOutputExportFallbackPath(staticPrefix: string): string {
+  return staticPrefix.length > 0 ? `/${staticPrefix}/__fallback` : '/__fallback'
+}
+
+export function getOutputExportFallbackStaticPrefix(
+  routePath: string
+): string | null {
+  const route = parseNormalizedAppRoute(routePath)
+  const firstDynamicIndex = route.segments.findIndex(
+    (segment) => segment.type === 'dynamic'
+  )
+
+  if (firstDynamicIndex === -1) {
+    return null
+  }
+
+  return route.segments
+    .slice(0, firstDynamicIndex)
+    .map((segment) => segment.name)
+    .join('/')
+}
+
+export function isOutputExportDynamicFallbackEnabled(
+  config: OutputExportDynamicFallbackConfig
+): boolean {
+  return (
+    config.output === 'export' &&
+    config.cacheComponents === true &&
+    config.experimental?.outputExportDynamicFallbacks === true
+  )
+}

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -221,6 +221,7 @@ export const experimentalSchema = {
   clientParamParsingOrigins: z.array(z.string()).optional(),
   cachedNavigations: z.boolean().optional(),
   partialFallbacks: z.boolean().optional(),
+  outputExportDynamicFallbacks: z.boolean().optional(),
   dynamicOnHover: z.boolean().optional(),
   useOffline: z.boolean().optional(),
   optimisticRouting: z.boolean().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -428,6 +428,11 @@ export interface ExperimentalConfig {
    * feature stabilizes.
    */
   partialFallbacks?: boolean
+  /**
+   * Enables static export fallbacks for dynamic app routes when Cache
+   * Components is enabled.
+   */
+  outputExportDynamicFallbacks?: boolean
   dynamicOnHover?: boolean
   useOffline?: boolean
   optimisticRouting?: boolean
@@ -1912,6 +1917,7 @@ export const defaultConfig = Object.freeze({
     clientParamParsingOrigins: undefined,
     cachedNavigations: false,
     partialFallbacks: true,
+    outputExportDynamicFallbacks: false,
     dynamicOnHover: false,
     useOffline: false,
     varyParams: false,
@@ -2094,6 +2100,7 @@ export interface NextConfigRuntime {
     | 'maxPostponedStateSize'
     | 'cachedNavigations'
     | 'partialFallbacks'
+    | 'outputExportDynamicFallbacks'
     | 'exposeTestingApiInProductionBuild'
     | 'supportsImmutableAssets'
     | 'useNodeStreams'
@@ -2163,6 +2170,7 @@ export function getNextConfigRuntime(
     maxPostponedStateSize: ex.maxPostponedStateSize,
     cachedNavigations: ex.cachedNavigations,
     partialFallbacks: ex.partialFallbacks,
+    outputExportDynamicFallbacks: ex.outputExportDynamicFallbacks,
     exposeTestingApiInProductionBuild: ex.exposeTestingApiInProductionBuild,
     supportsImmutableAssets: ex.supportsImmutableAssets,
     useNodeStreams: ex.useNodeStreams,

--- a/test/e2e/app-dir/output-export-dynamic-fallbacks/app/another/[slug]/page.tsx
+++ b/test/e2e/app-dir/output-export-dynamic-fallbacks/app/another/[slug]/page.tsx
@@ -1,0 +1,7 @@
+export default function Page() {
+  return (
+    <main>
+      <h1>Dynamic fallback shell</h1>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/output-export-dynamic-fallbacks/app/another/page.tsx
+++ b/test/e2e/app-dir/output-export-dynamic-fallbacks/app/another/page.tsx
@@ -1,0 +1,10 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <main>
+      <h1>Another</h1>
+      <Link href="/another/alpha">Alpha</Link>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/output-export-dynamic-fallbacks/app/layout.tsx
+++ b/test/e2e/app-dir/output-export-dynamic-fallbacks/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/output-export-dynamic-fallbacks/app/page.tsx
+++ b/test/e2e/app-dir/output-export-dynamic-fallbacks/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>home</p>
+}

--- a/test/e2e/app-dir/output-export-dynamic-fallbacks/next-env.d.ts
+++ b/test/e2e/app-dir/output-export-dynamic-fallbacks/next-env.d.ts
@@ -1,0 +1,7 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+import "./.next/types/routes.d.ts";
+import "./.next/types/root-params.d.ts";
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/test/e2e/app-dir/output-export-dynamic-fallbacks/next.config.js
+++ b/test/e2e/app-dir/output-export-dynamic-fallbacks/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  output: 'export',
+  cacheComponents: true,
+  experimental: {
+    outputExportDynamicFallbacks: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/output-export-dynamic-fallbacks/output-export-dynamic-fallbacks.test.ts
+++ b/test/e2e/app-dir/output-export-dynamic-fallbacks/output-export-dynamic-fallbacks.test.ts
@@ -1,0 +1,40 @@
+import { nextTestSetup } from 'e2e-utils'
+import fs from 'fs-extra'
+import { join } from 'path'
+import {
+  fetchViaHTTP,
+  findPort,
+  startStaticServer,
+  stopApp,
+} from 'next-test-utils'
+
+describe('output-export-dynamic-fallbacks', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+    skipStart: true,
+  })
+
+  it('writes route fallback HTML without emitting fallback RSC data', async () => {
+    await next.build()
+
+    const outDir = join(next.testDir, 'out')
+    expect(
+      await fs.pathExists(join(outDir, 'another', '__fallback.html'))
+    ).toBe(true)
+    expect(await fs.pathExists(join(outDir, 'another', '__fallback.txt'))).toBe(
+      false
+    )
+
+    const port = await findPort()
+    const app = await startStaticServer(outDir, null, port)
+
+    try {
+      const res = await fetchViaHTTP(port, '/another/__fallback.html')
+      expect(res.status).toBe(200)
+      expect(await res.text()).toContain('Dynamic fallback shell')
+    } finally {
+      await stopApp(app)
+    }
+  })
+})

--- a/test/e2e/app-dir/output-export-dynamic-fallbacks/tsconfig.json
+++ b/test/e2e/app-dir/output-export-dynamic-fallbacks/tsconfig.json
@@ -1,0 +1,34 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts",
+    "**/*.mts"
+  ],
+  "exclude": ["node_modules", "**/*.test.ts", "**/*.test.tsx"]
+}

--- a/test/production/next-server-nft/next-server-nft.test.ts
+++ b/test/production/next-server-nft/next-server-nft.test.ts
@@ -315,6 +315,7 @@ async function readNormalizedNFT(next, name) {
            "/node_modules/next/dist/lib/needs-experimental-react.js",
            "/node_modules/next/dist/lib/non-nullable.js",
            "/node_modules/next/dist/lib/normalize-path.js",
+           "/node_modules/next/dist/lib/output-export-dynamic-fallback.js",
            "/node_modules/next/dist/lib/oxford-comma-list.js",
            "/node_modules/next/dist/lib/page-types.js",
            "/node_modules/next/dist/lib/patch-incorrect-lockfile.js",


### PR DESCRIPTION
## Stack position

Part 1 of 19 in the output export dynamic fallback stack.

Previous PR: none, this starts from canary.
Next PR: #93558 (2/19)

## Context

The stack is split so build-time output can land behind `experimental.outputExportDynamicFallbacks` before the client router behavior is enabled. The target behavior is for `output: 'export'` apps with parameterized App Router routes to emit fallback HTML/RSC artifacts that a later client can resolve for hard loads and soft navigations.

This PR scope: Build-time HTML fallback output, behind the experimental flag.

This starts the stack with the smallest useful build-output change: an opt-in flag and the HTML fallback artifact needed for an initial document request to a parameterized route in `output: export`.

## What changed

- Adds the `experimental.outputExportDynamicFallbacks` configuration surface and keeps it disabled by default.
- Allows the export build to emit fallback HTML for dynamic App Router paths instead of failing before the client work exists.
- Keeps the behavior gated so canary users do not observe this partial feature.

## Deliberately not included

- Does not make soft navigation work.
- Does not add the client router lookup path.
- Does not generate the complete fallback RSC graph yet.

## Verification

After restacking and autosquashing, I verified the full stack with:

- `pnpm --filter=next build`
- `pnpm testonly packages/next/src/lib/output-export-dynamic-fallback.test.ts packages/next/src/lib/output-export-fallback-routes.test.ts packages/next/src/export/helpers/output-export-fallback.test.ts packages/next/src/server/request/fallback-params.test.ts`
- `pnpm testonly packages/next/src/client/output-export-fallback.test.ts packages/next/src/client/components/router-reducer/fetch-server-response.test.ts packages/next/src/client/components/router-reducer/create-initial-router-state.test.ts packages/next/src/client/components/segment-cache/cache.test.ts packages/next/src/client/components/segment-cache/vary-path.test.ts`
- `pnpm testonly packages/next/src/client/components/router-reducer/compute-changed-path.test.ts packages/next/src/client/flight-data-helpers.test.ts packages/next/src/server/app-render/postponed-state.test.ts`
- `pnpm test-start-turbo test/e2e/app-dir-export/test/dynamic-fallback-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-route-shapes-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-cache-components-basepath.test.ts test/e2e/app-dir-export/test/dynamic-fallback-optimizations-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-known-params-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-conflict.test.ts`
- `pnpm test-start-turbo test/e2e/app-dir/output-export-dynamic-fallbacks/output-export-dynamic-fallbacks.test.ts test/e2e/app-dir-export/test/output-export-server-io.test.ts test/e2e/app-dir-export/test/output-export-server-io-use-cache.test.ts test/e2e/app-dir-export/test/dynamic-fallback-server-params.test.ts`

<!-- NEXT_JS_LLM_PR -->
