### PR TITLE
(2/19) Emit export dynamic fallback RSC artifacts

### DIFF
--- a/packages/next/src/export/helpers/output-export-fallback.ts
+++ b/packages/next/src/export/helpers/output-export-fallback.ts
@@ -1,6 +1,12 @@
 import { existsSync, promises as fs } from 'fs'
 import { dirname, join, relative, sep } from 'path'
+import {
+  RSC_SEGMENTS_DIR_SUFFIX,
+  RSC_SEGMENT_SUFFIX,
+  RSC_SUFFIX,
+} from '../../lib/constants'
 import { getPagePath } from '../../server/require'
+import { convertSegmentPathToStaticExportFilename } from '../../shared/lib/segment-cache/segment-value-encoding'
 import { normalizePagePath } from '../../shared/lib/page-path/normalize-page-path'
 import {
   getOutputExportFallbackPath,
@@ -17,7 +23,7 @@ type OutputExportDynamicRouteInfo = {
     | undefined
 }
 
-type CopyExportedAppHtmlOptions = {
+type CopyExportedAppArtifactsOptions = {
   outDir: string
   orig: string
   routePath: string
@@ -59,37 +65,80 @@ function assertNoOutputExportPathCollision(
   )
 }
 
-export async function copyExportedAppHtml({
+export async function copyExportedAppArtifacts({
   outDir,
   orig,
   routePath,
   subFolders,
   checkRouteCollision = false,
-}: CopyExportedAppHtmlOptions): Promise<string> {
+}: CopyExportedAppArtifactsOptions): Promise<string> {
   const route = normalizePagePath(routePath)
   const flatHtmlDest = join(outDir, `${route}.html`)
+  const flatJsonDest = join(outDir, `${route}.txt`)
   const folderHtmlDest = join(
     outDir,
     `${route}${route !== '/index' ? `${sep}index` : ''}.html`
   )
+  const folderJsonDest = join(
+    outDir,
+    `${route}${route !== '/index' ? `${sep}index` : ''}.txt`
+  )
   const htmlDest =
     subFolders && route !== '/index' ? folderHtmlDest : flatHtmlDest
+  const jsonDest =
+    subFolders && route !== '/index' ? folderJsonDest : flatJsonDest
+
+  const segmentsDir = `${orig}${RSC_SEGMENTS_DIR_SUFFIX}`
+  const segmentCopies: Array<{
+    src: string
+    dest: string
+  }> = []
+
+  if (existsSync(segmentsDir)) {
+    const segmentsDirDest = join(outDir, routePath)
+    const segmentPaths = await collectSegmentPaths(segmentsDir)
+    for (const segmentFileSrc of segmentPaths) {
+      const segmentPath =
+        '/' + segmentFileSrc.slice(0, -RSC_SEGMENT_SUFFIX.length)
+      const segmentFilename =
+        convertSegmentPathToStaticExportFilename(segmentPath)
+      segmentCopies.push({
+        src: join(segmentsDir, segmentFileSrc),
+        dest: join(segmentsDirDest, segmentFilename),
+      })
+    }
+  }
 
   if (checkRouteCollision) {
     assertNoOutputExportPathCollision(
       outDir,
-      [flatHtmlDest, folderHtmlDest],
+      [
+        flatHtmlDest,
+        flatJsonDest,
+        folderHtmlDest,
+        folderJsonDest,
+        ...segmentCopies.map(({ dest }) => dest),
+      ],
       routePath
     )
   }
 
   await fs.mkdir(dirname(htmlDest), { recursive: true })
+  await fs.mkdir(dirname(jsonDest), { recursive: true })
   await fs.copyFile(`${orig}.html`, htmlDest)
+  await fs.copyFile(`${orig}${RSC_SUFFIX}`, jsonDest)
+
+  await Promise.all(
+    segmentCopies.map(async ({ src, dest }) => {
+      await fs.mkdir(dirname(dest), { recursive: true })
+      await fs.copyFile(src, dest)
+    })
+  )
 
   return htmlDest
 }
 
-export async function emitOutputExportFallbackHtmlFiles(
+export async function emitOutputExportFallbackArtifacts(
   dynamicRoutes: Readonly<Record<string, OutputExportDynamicRouteInfo>>,
   mapAppRouteToPage: Map<string, string>,
   distDir: string,
@@ -129,13 +178,13 @@ export async function emitOutputExportFallbackHtmlFiles(
 
     const sourceRoute = normalizePagePath(dynamicRoute)
     const orig = join(distPagesDir, sourceRoute)
-    if (!existsSync(`${orig}.html`)) {
+    if (!existsSync(`${orig}.html`) || !existsSync(`${orig}${RSC_SUFFIX}`)) {
       continue
     }
 
     const fallbackPath = getOutputExportFallbackPath(staticPrefix)
     fallbackHtmlPaths.push(
-      await copyExportedAppHtml({
+      await copyExportedAppArtifacts({
         outDir,
         orig,
         routePath: fallbackPath,
@@ -146,4 +195,38 @@ export async function emitOutputExportFallbackHtmlFiles(
   }
 
   return fallbackHtmlPaths
+}
+
+async function collectSegmentPaths(segmentsDirectory: string) {
+  const results: Array<string> = []
+  await collectSegmentPathsImpl(segmentsDirectory, segmentsDirectory, results)
+  return results
+}
+
+async function collectSegmentPathsImpl(
+  segmentsDirectory: string,
+  directory: string,
+  results: Array<string>
+) {
+  const segmentFiles = await fs.readdir(directory, {
+    withFileTypes: true,
+  })
+  await Promise.all(
+    segmentFiles.map(async (segmentFile) => {
+      if (segmentFile.isDirectory()) {
+        await collectSegmentPathsImpl(
+          segmentsDirectory,
+          join(directory, segmentFile.name),
+          results
+        )
+        return
+      }
+      if (!segmentFile.name.endsWith(RSC_SEGMENT_SUFFIX)) {
+        return
+      }
+      results.push(
+        relative(segmentsDirectory, join(directory, segmentFile.name))
+      )
+    })
+  )
 }

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -71,7 +71,7 @@ import { extractInfoFromServerReferenceId } from '../shared/lib/server-reference
 import { convertSegmentPathToStaticExportFilename } from '../shared/lib/segment-cache/segment-value-encoding'
 import { getNextBuildDebuggerPortOffset } from '../lib/worker'
 import { getParams } from './helpers/get-params'
-import { emitOutputExportFallbackHtmlFiles } from './helpers/output-export-fallback'
+import { emitOutputExportFallbackArtifacts } from './helpers/output-export-fallback'
 import { isDynamicRoute } from '../shared/lib/router/utils/is-dynamic'
 import { normalizeAppPath } from '../shared/lib/router/utils/app-paths'
 import type { Params } from '../server/request/params'
@@ -1021,7 +1021,7 @@ async function exportAppImpl(
     )
 
     if (isOutputExportDynamicFallbackEnabled(nextConfig)) {
-      await emitOutputExportFallbackHtmlFiles(
+      await emitOutputExportFallbackArtifacts(
         prerenderManifest.dynamicRoutes,
         mapAppRouteToPage,
         distDir,

--- a/packages/next/src/export/routes/app-page.ts
+++ b/packages/next/src/export/routes/app-page.ts
@@ -144,15 +144,21 @@ export async function exportAppPage(
     } else {
       const hasFallbackParams =
         fallbackRouteParams != null && fallbackRouteParams.size > 0
+      const isOutputExportFallbackShell =
+        renderOpts.nextConfigOutput === 'export' &&
+        renderOpts.cacheComponents &&
+        hasFallbackParams
       const shouldWriteRsc =
         !renderOpts.experimental.isRoutePPREnabled ||
+        isOutputExportFallbackShell ||
         (!postponed && !hasFallbackParams)
       hasStaticRsc = shouldWriteRsc
 
       // With PPR enabled, we normally skip writing .rsc because it may contain
       // dynamic data. However, for fully static outputs (no postponed state and
       // no fallback params), we can safely emit the route .rsc to support
-      // static navigations.
+      // static navigations. Static export fallback shells also need their
+      // fallback RSC artifact so exported clients can resolve dynamic routes.
       if (shouldWriteRsc) {
         fileWriter.append(
           htmlFilepath.replace(/\.html$/, RSC_SUFFIX),

--- a/test/e2e/app-dir/output-export-dynamic-fallbacks/output-export-dynamic-fallbacks.test.ts
+++ b/test/e2e/app-dir/output-export-dynamic-fallbacks/output-export-dynamic-fallbacks.test.ts
@@ -15,7 +15,7 @@ describe('output-export-dynamic-fallbacks', () => {
     skipStart: true,
   })
 
-  it('writes route fallback HTML without emitting fallback RSC data', async () => {
+  it('writes route fallback HTML and RSC artifacts', async () => {
     await next.build()
 
     const outDir = join(next.testDir, 'out')
@@ -23,7 +23,16 @@ describe('output-export-dynamic-fallbacks', () => {
       await fs.pathExists(join(outDir, 'another', '__fallback.html'))
     ).toBe(true)
     expect(await fs.pathExists(join(outDir, 'another', '__fallback.txt'))).toBe(
-      false
+      true
+    )
+
+    const segmentFiles = await fs.readdir(join(outDir, 'another', '__fallback'))
+    expect(segmentFiles).toEqual(
+      expect.arrayContaining([
+        '__next._full.txt',
+        '__next._tree.txt',
+        '__next.another.$d$slug.__PAGE__.txt',
+      ])
     )
 
     const port = await findPort()
@@ -33,6 +42,9 @@ describe('output-export-dynamic-fallbacks', () => {
       const res = await fetchViaHTTP(port, '/another/__fallback.html')
       expect(res.status).toBe(200)
       expect(await res.text()).toContain('Dynamic fallback shell')
+
+      const rscRes = await fetchViaHTTP(port, '/another/__fallback.txt')
+      expect(rscRes.status).toBe(200)
     } finally {
       await stopApp(app)
     }


### PR DESCRIPTION
## Stack position

Part 2 of 19 in the output export dynamic fallback stack.

Previous PR: #93557 (1/19)
Next PR: #93560 (3/19)

## Context

The stack is split so build-time output can land behind `experimental.outputExportDynamicFallbacks` before the client router behavior is enabled. The target behavior is for `output: 'export'` apps with parameterized App Router routes to emit fallback HTML/RSC artifacts that a later client can resolve for hard loads and soft navigations.

This PR scope: Build-time fallback RSC artifacts for route segments.

Once fallback HTML can exist, the client also needs static RSC payloads to resolve parameterized routes. This PR is still build-only: it writes the fallback data that a later client can fetch.

## What changed

- Generates fallback RSC files for dynamic route directories using the loader tree.
- Preserves static export naming for both flat and trailing-slash output.
- Keeps the output behind the same experimental flag.

## Deliberately not included

- Does not teach the client router to discover these files.
- Does not handle conflicting dynamic route shapes yet.
- Does not change runtime behavior when the flag is off.

## Verification

After restacking and autosquashing, I verified the full stack with:

- `pnpm --filter=next build`
- `pnpm testonly packages/next/src/lib/output-export-dynamic-fallback.test.ts packages/next/src/lib/output-export-fallback-routes.test.ts packages/next/src/export/helpers/output-export-fallback.test.ts packages/next/src/server/request/fallback-params.test.ts`
- `pnpm testonly packages/next/src/client/output-export-fallback.test.ts packages/next/src/client/components/router-reducer/fetch-server-response.test.ts packages/next/src/client/components/router-reducer/create-initial-router-state.test.ts packages/next/src/client/components/segment-cache/cache.test.ts packages/next/src/client/components/segment-cache/vary-path.test.ts`
- `pnpm testonly packages/next/src/client/components/router-reducer/compute-changed-path.test.ts packages/next/src/client/flight-data-helpers.test.ts packages/next/src/server/app-render/postponed-state.test.ts`
- `pnpm test-start-turbo test/e2e/app-dir-export/test/dynamic-fallback-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-route-shapes-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-cache-components-basepath.test.ts test/e2e/app-dir-export/test/dynamic-fallback-optimizations-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-known-params-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-conflict.test.ts`
- `pnpm test-start-turbo test/e2e/app-dir/output-export-dynamic-fallbacks/output-export-dynamic-fallbacks.test.ts test/e2e/app-dir-export/test/output-export-server-io.test.ts test/e2e/app-dir-export/test/output-export-server-io-use-cache.test.ts test/e2e/app-dir-export/test/dynamic-fallback-server-params.test.ts`

<!-- NEXT_JS_LLM_PR -->
