### PR TITLE
(8/19) Hydrate export dynamic fallbacks on initial load

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1193,5 +1193,6 @@
   "1192": "Route \"%s\" accessed root param \"%s\" which is not defined in the \\`unstable_samples\\` of \\`unstable_instant\\`. Add it to the sample's \\`params\\` object.",
   "1193": "Expected staticChildren to be initialized for known dynamic siblings.",
   "1194": "Route \"%s\" used %s in a Server Component with \"output: export\". This is not supported because %s See more info here: https://nextjs.org/docs/app/guides/static-exports",
-  "1195": "Route \"%s\" used unresolved dynamic params in a Server Component with \"output: export\". This is not supported because these fallback params are only available on the client. Move param-dependent content into a Client Component or add generateStaticParams() to prerender this route. See more info here: https://nextjs.org/docs/app/guides/static-exports"
+  "1195": "Route \"%s\" used unresolved dynamic params in a Server Component with \"output: export\". This is not supported because these fallback params are only available on the client. Move param-dependent content into a Client Component or add generateStaticParams() to prerender this route. See more info here: https://nextjs.org/docs/app/guides/static-exports",
+  "1196": "Could not find an output export fallback for \"%s\"."
 }

--- a/packages/next/src/build/define-env.ts
+++ b/packages/next/src/build/define-env.ts
@@ -298,6 +298,10 @@ export function getDefineEnv({
     'process.env.__NEXT_ROUTER_BASEPATH': config.basePath,
     'process.env.__NEXT_HAS_REWRITES': hasRewrites,
     'process.env.__NEXT_CONFIG_OUTPUT': config.output,
+    'process.env.__NEXT_OUTPUT_EXPORT_DYNAMIC_FALLBACKS':
+      config.output === 'export' &&
+      config.cacheComponents === true &&
+      config.experimental.outputExportDynamicFallbacks === true,
     'process.env.__NEXT_I18N_SUPPORT': !!config.i18n,
     'process.env.__NEXT_I18N_DOMAINS': config.i18n?.domains ?? false,
     'process.env.__NEXT_I18N_CONFIG': config.i18n || '',

--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -22,6 +22,7 @@ import {
 import AppRouter from './components/app-router'
 import type { InitialRSCPayload } from '../shared/lib/app-router-types'
 import { createInitialRouterState } from './components/router-reducer/create-initial-router-state'
+import { processFetch } from './components/router-reducer/fetch-server-response'
 import { MissingSlotContext } from '../shared/lib/app-router-context.shared-runtime'
 import type { StaticIndicatorState } from './dev/hot-reloader/app/hot-reloader-app'
 import { createInitialRSCPayloadFromFallbackPrerender } from './flight-data-helpers'
@@ -44,6 +45,25 @@ const instantTestStaticFetch: Promise<Response> | undefined =
   self.__next_instant_test
     ? (self.__next_instant_test as unknown as Promise<Response>)
     : undefined
+
+let outputExportFallbackBootstrap:
+  | typeof import('./output-export-fallback-bootstrap')
+  | null
+if (process.env.__NEXT_OUTPUT_EXPORT_DYNAMIC_FALLBACKS) {
+  outputExportFallbackBootstrap =
+    require('./output-export-fallback-bootstrap') as typeof import('./output-export-fallback-bootstrap')
+} else {
+  outputExportFallbackBootstrap = null
+}
+
+const outputExportFallbackState =
+  outputExportFallbackBootstrap?.getOutputExportFallbackState()
+
+const hasLockedStaticShell =
+  Boolean(instantTestStaticFetch) ||
+  // @ts-expect-error
+  Boolean(window.__NEXT_CLIENT_RESUME) ||
+  Boolean(outputExportFallbackState?.isFallback)
 
 const encoder = new TextEncoder()
 
@@ -128,14 +148,13 @@ function nextServerDataRegisterWriter(ctr: ReadableStreamDefaultController) {
       ctr.enqueue(typeof val === 'string' ? encoder.encode(val) : val)
     })
     if (initialServerDataLoaded && !initialServerDataFlushed) {
-      // Instant Navigation Testing API: don't close or error the inline
-      // Flight stream. The static shell has no inline Flight data, so the
-      // stream is empty. Closing it would cause React to log an error about
-      // missing data. Leaving it open lets React treat any holes as
-      // "still suspended." Hydration uses the separately fetched RSC payload
-      // (self.__next_instant_test), not this stream.
+      // Locked static shells do not have a real inline Flight stream. Closing
+      // or erroring this stream causes React to report a missing-data failure,
+      // but the actual hydration data arrives through a separate fetch
+      // (self.__next_instant_test, __NEXT_CLIENT_RESUME, or export fallback
+      // discovery).
       if (isStreamErrorOrUnfinished(ctr)) {
-        if (!instantTestStaticFetch) {
+        if (!hasLockedStaticShell) {
           ctr.error(
             new Error(
               'The connection to the page was unexpectedly closed, possibly due to the stop button being clicked, loss of Wi-Fi, or an unstable internet connection.'
@@ -155,7 +174,11 @@ function nextServerDataRegisterWriter(ctr: ReadableStreamDefaultController) {
 
 // When `DOMContentLoaded`, we can close all pending writers to finish hydration.
 const DOMContentLoaded = function () {
-  if (initialServerDataWriter && !initialServerDataFlushed) {
+  if (
+    initialServerDataWriter &&
+    !initialServerDataFlushed &&
+    !hasLockedStaticShell
+  ) {
     initialServerDataWriter.close()
     initialServerDataFlushed = true
     initialServerDataBuffer = undefined
@@ -195,10 +218,15 @@ if (process.env.NODE_ENV !== 'production') {
 // truncate a clone at the static stage byte boundary and cache it. We don't
 // know if `l` is present until React decodes the payload, so always tee and
 // cancel the clone if not needed.
+//
+// Skip this for output export fallback boot. In that mode, the inline
+// `__next_f` stream belongs to `_fallback.html`, not the actual route the user
+// requested, so seeding the cache from it can poison the initial route state.
 let initialFlightStreamForCache: ReadableStream<Uint8Array> | null = null
 if (
   process.env.__NEXT_CACHE_COMPONENTS &&
-  process.env.__NEXT_EXPERIMENTAL_CACHED_NAVIGATIONS
+  process.env.__NEXT_EXPERIMENTAL_CACHED_NAVIGATIONS &&
+  !outputExportFallbackState?.isFallback
 ) {
   const [forReact, forCache] = readable.tee()
   readable = forReact
@@ -222,11 +250,14 @@ if (
 
 let initialServerResponse: Promise<InitialRSCPayload>
 if (instantTestStaticFetch) {
+  const processedStaticFetch = Promise.resolve(instantTestStaticFetch)
+    .then(processFetch)
+    .then(({ response }) => response)
   // Instant Navigation Testing API: hydrate from the static RSC payload
   // fetch kicked off by an injected <script> tag, instead of the inline
   // Flight data (which is not present in the static shell).
   initialServerResponse = Promise.resolve(
-    createFromFetch<InitialRSCPayload>(instantTestStaticFetch, {
+    createFromFetch<InitialRSCPayload>(processedStaticFetch, {
       callServer,
       findSourceMapURL,
       debugChannel,
@@ -238,10 +269,23 @@ if (instantTestStaticFetch) {
     })
   ).then(async (initialRSCPayload) => {
     return createInitialRSCPayloadFromFallbackPrerender(
-      await instantTestStaticFetch,
+      await processedStaticFetch,
       initialRSCPayload
     )
   })
+} else if (
+  outputExportFallbackBootstrap &&
+  outputExportFallbackState?.isFallback
+) {
+  // This must be checked before __NEXT_CLIENT_RESUME because
+  // _fallback.html may be based on a PPR shell that also sets
+  // __NEXT_CLIENT_RESUME. In export fallback mode, we always
+  // fetch the correct route's RSC payload from the network.
+  initialServerResponse =
+    outputExportFallbackBootstrap.createOutputExportFallbackInitialResponse({
+      createFromFetch,
+      debugChannel,
+    })
 } else if (
   // @ts-expect-error
   window.__NEXT_CLIENT_RESUME
@@ -249,15 +293,19 @@ if (instantTestStaticFetch) {
   const clientResumeFetch: Promise<Response> =
     // @ts-expect-error
     window.__NEXT_CLIENT_RESUME
+  const processedClientResumeFetch = Promise.resolve(clientResumeFetch)
+    .then(processFetch)
+    .then(({ response }) => response)
   initialServerResponse = Promise.resolve(
-    createFromFetch<InitialRSCPayload>(clientResumeFetch, {
+    createFromFetch<InitialRSCPayload>(processedClientResumeFetch, {
       callServer,
       findSourceMapURL,
       debugChannel,
+      unstable_allowPartialStream: true,
     })
   ).then(async (fallbackInitialRSCPayload) =>
     createInitialRSCPayloadFromFallbackPrerender(
-      await clientResumeFetch,
+      await processedClientResumeFetch,
       fallbackInitialRSCPayload
     )
   )
@@ -402,7 +450,10 @@ export async function hydrate(
     </StrictModeIfEnabled>
   )
 
-  if (document.documentElement.id === '__next_error__') {
+  if (
+    document.documentElement.id === '__next_error__' ||
+    outputExportFallbackState?.isFallback
+  ) {
     let element = reactEl
     // Server rendering failed, fall back to client-side rendering
     if (process.env.NODE_ENV !== 'production') {
@@ -415,7 +466,20 @@ export async function hydrate(
       )
     }
 
-    ReactDOMClient.createRoot(appElement, reactRootOptions).render(element)
+    const root = ReactDOMClient.createRoot(appElement, reactRootOptions)
+    root.render(element)
+
+    // Remove the visibility:hidden style injected by _fallback.html to
+    // prevent flashing stale content. MutationObserver fires after React
+    // commits its first render (replaces #__next children).
+    if (
+      outputExportFallbackBootstrap &&
+      outputExportFallbackState?.isFallback
+    ) {
+      outputExportFallbackBootstrap.removeOutputExportFallbackStyleOnCommit(
+        appElement
+      )
+    }
   } else {
     React.startTransition(() => {
       ReactDOMClient.hydrateRoot(appElement, reactEl, {

--- a/packages/next/src/client/flight-data-helpers.ts
+++ b/packages/next/src/client/flight-data-helpers.ts
@@ -11,7 +11,12 @@ import type {
 import { PAGE_SEGMENT_KEY } from '../shared/lib/segment'
 import type { NormalizedSearch } from './components/segment-cache/cache-key'
 import {
+  NEXT_REWRITTEN_PATH_HEADER,
+  NEXT_REWRITTEN_QUERY_HEADER,
+} from './components/app-router-headers'
+import {
   getCacheKeyForDynamicParam,
+  getNextPathnamePartsIndexForParam,
   parseDynamicParamFromURLPart,
   doesStaticSegmentAppearInURL,
   getRenderedPathname,
@@ -70,7 +75,8 @@ export function getFlightDataPartsFromPath(
 
 export function createInitialRSCPayloadFromFallbackPrerender(
   response: Response,
-  fallbackInitialRSCPayload: InitialRSCPayload
+  fallbackInitialRSCPayload: InitialRSCPayload,
+  renderedUrlOverride?: URL
 ): InitialRSCPayload {
   // This is a static fallback page. In order to hydrate the page, we need to
   // parse the client params from the URL, but to account for the possibility
@@ -94,27 +100,27 @@ export function createInitialRSCPayloadFromFallbackPrerender(
 
   // Patch the Flight data sent by the server with the correct params parsed
   // from the URL + response object.
-  const renderedPathname = getRenderedPathname(response)
-  const renderedSearch = getRenderedSearch(response)
-  const canonicalUrl = createHrefFromUrl(new URL(location.href))
-  const originalFlightDataPath = fallbackInitialRSCPayload.f[0]
-  const originalFlightRouterState = originalFlightDataPath[0]
+  const renderedPathname = response.headers.has(NEXT_REWRITTEN_PATH_HEADER)
+    ? getRenderedPathname(response)
+    : ((renderedUrlOverride?.pathname ??
+        getRenderedPathname(response)) as string)
+  const renderedSearch = response.headers.has(NEXT_REWRITTEN_QUERY_HEADER)
+    ? getRenderedSearch(response)
+    : ((renderedUrlOverride?.search ??
+        getRenderedSearch(response)) as NormalizedSearch)
+  const canonicalUrl = createHrefFromUrl(
+    renderedUrlOverride ?? new URL(location.href)
+  )
+  const patchedFlightData = fillInFallbackFlightData(
+    fallbackInitialRSCPayload.f,
+    renderedPathname,
+    renderedSearch as NormalizedSearch
+  ) as FlightDataPath[]
   const payload: InitialRSCPayload = {
     c: canonicalUrl.split('/'),
     q: renderedSearch,
     i: fallbackInitialRSCPayload.i,
-    f: [
-      [
-        fillInFallbackFlightRouterState(
-          originalFlightRouterState,
-          renderedPathname,
-          renderedSearch as NormalizedSearch
-        ),
-        originalFlightDataPath[1],
-        originalFlightDataPath[2],
-        originalFlightDataPath[2],
-      ],
-    ],
+    f: patchedFlightData,
     m: fallbackInitialRSCPayload.m,
     G: fallbackInitialRSCPayload.G,
     S: fallbackInitialRSCPayload.S,
@@ -126,19 +132,91 @@ export function createInitialRSCPayloadFromFallbackPrerender(
   return payload
 }
 
-function fillInFallbackFlightRouterState(
-  flightRouterState: FlightRouterState,
+export function fillInFallbackFlightData<T extends FlightData>(
+  flightData: T,
   renderedPathname: string,
   renderedSearch: NormalizedSearch
+): T {
+  if (typeof flightData === 'string') {
+    return flightData
+  }
+
+  const pathnameParts = getPathnameParts(renderedPathname)
+  const filledFlightData = flightData.map((flightDataPath) =>
+    fillInFallbackFlightDataPath(flightDataPath, renderedSearch, pathnameParts)
+  ) as FlightDataPath[]
+
+  return filledFlightData as T
+}
+
+function fillInFallbackFlightDataPath(
+  flightDataPath: FlightDataPath,
+  renderedSearch: NormalizedSearch,
+  pathnameParts: Array<string>
+): FlightDataPath {
+  const flightDataPathLength = 4
+  const segmentPath = flightDataPath.slice(
+    0,
+    -flightDataPathLength
+  ) as FlightSegmentPath
+  const [tree, seedData, head, isHeadPartial] = flightDataPath.slice(
+    -flightDataPathLength
+  ) as [FlightRouterState, CacheNodeSeedData | null, HeadData, boolean]
+
+  return [
+    ...fillInFallbackFlightSegmentPath(
+      segmentPath,
+      renderedSearch,
+      pathnameParts
+    ),
+    fillInFallbackFlightRouterStateFromParts(
+      tree,
+      renderedSearch,
+      pathnameParts
+    ),
+    seedData,
+    head,
+    isHeadPartial,
+  ]
+}
+
+function getPathnameParts(renderedPathname: string): Array<string> {
+  return renderedPathname.split('/').filter((part) => part !== '')
+}
+
+function fillInFallbackFlightRouterStateFromParts(
+  flightRouterState: FlightRouterState,
+  renderedSearch: NormalizedSearch,
+  pathnameParts: Array<string>
 ): FlightRouterState {
-  const pathnameParts = renderedPathname.split('/').filter((p) => p !== '')
-  const index = 0
   return fillInFallbackFlightRouterStateImpl(
     flightRouterState,
     renderedSearch,
     pathnameParts,
-    index
+    0
   )
+}
+
+function fillInFallbackFlightSegmentPath(
+  segmentPath: FlightSegmentPath,
+  renderedSearch: NormalizedSearch,
+  pathnameParts: Array<string>
+): FlightSegmentPath {
+  const newSegmentPath = [...segmentPath]
+  let pathnamePartsIndex = 0
+
+  for (let i = 1; i < segmentPath.length; i += 2) {
+    const { segment, nextPathnamePartsIndex } = fillInFallbackSegment(
+      segmentPath[i] as Segment,
+      renderedSearch,
+      pathnameParts,
+      pathnamePartsIndex
+    )
+    newSegmentPath[i] = segment
+    pathnamePartsIndex = nextPathnamePartsIndex
+  }
+
+  return newSegmentPath as FlightSegmentPath
 }
 
 function fillInFallbackFlightRouterStateImpl(
@@ -147,32 +225,15 @@ function fillInFallbackFlightRouterStateImpl(
   pathnameParts: Array<string>,
   pathnamePartsIndex: number
 ): FlightRouterState {
-  const originalSegment = flightRouterState[0]
-  let newSegment: Segment
-  let doesAppearInURL: boolean
-  if (typeof originalSegment === 'string') {
-    newSegment = originalSegment
-    doesAppearInURL = doesStaticSegmentAppearInURL(originalSegment)
-  } else {
-    const paramName = originalSegment[0]
-    const paramType = originalSegment[2]
-    const staticSiblings = originalSegment[3]
-    const paramValue = parseDynamicParamFromURLPart(
-      paramType,
-      pathnameParts,
-      pathnamePartsIndex
-    )
-    const cacheKey = getCacheKeyForDynamicParam(paramValue, renderedSearch)
-    newSegment = [paramName, cacheKey, paramType, staticSiblings]
-    doesAppearInURL = true
-  }
+  const { segment: newSegment, nextPathnamePartsIndex } = fillInFallbackSegment(
+    flightRouterState[0],
+    renderedSearch,
+    pathnameParts,
+    pathnamePartsIndex
+  )
 
   // Only increment the index if the segment appears in the URL. If it's a
   // "virtual" segment, like a route group, it remains the same.
-  const childPathnamePartsIndex = doesAppearInURL
-    ? pathnamePartsIndex + 1
-    : pathnamePartsIndex
-
   const children = flightRouterState[1]
   const newChildren: { [key: string]: FlightRouterState } = {}
   for (let key in children) {
@@ -181,7 +242,7 @@ function fillInFallbackFlightRouterStateImpl(
       childFlightRouterState,
       renderedSearch,
       pathnameParts,
-      childPathnamePartsIndex
+      nextPathnamePartsIndex
     )
   }
 
@@ -193,6 +254,42 @@ function fillInFallbackFlightRouterStateImpl(
     flightRouterState[4],
   ]
   return newState
+}
+
+function fillInFallbackSegment(
+  originalSegment: Segment,
+  renderedSearch: NormalizedSearch,
+  pathnameParts: Array<string>,
+  pathnamePartsIndex: number
+): { segment: Segment; nextPathnamePartsIndex: number } {
+  if (typeof originalSegment === 'string') {
+    const doesAppearInURL = doesStaticSegmentAppearInURL(originalSegment)
+    return {
+      segment: originalSegment,
+      nextPathnamePartsIndex: doesAppearInURL
+        ? pathnamePartsIndex + 1
+        : pathnamePartsIndex,
+    }
+  }
+
+  const paramName = originalSegment[0]
+  const paramType = originalSegment[2]
+  const staticSiblings = originalSegment[3]
+  const paramValue = parseDynamicParamFromURLPart(
+    paramType,
+    pathnameParts,
+    pathnamePartsIndex
+  )
+  const cacheKey = getCacheKeyForDynamicParam(paramValue, renderedSearch)
+
+  return {
+    segment: [paramName, cacheKey, paramType, staticSiblings],
+    nextPathnamePartsIndex: getNextPathnamePartsIndexForParam(
+      paramType,
+      pathnameParts,
+      pathnamePartsIndex
+    ),
+  }
 }
 
 export function getNextFlightSegmentPath(

--- a/packages/next/src/client/output-export-fallback-bootstrap.ts
+++ b/packages/next/src/client/output-export-fallback-bootstrap.ts
@@ -1,0 +1,99 @@
+import type { InitialRSCPayload } from '../shared/lib/app-router-types'
+import { callServer } from './app-call-server'
+import { findSourceMapURL } from './app-find-source-map-url'
+import { processFetch } from './components/router-reducer/fetch-server-response'
+import { createInitialRSCPayloadFromFallbackPrerender } from './flight-data-helpers'
+import { fetchOutputExportFallbackResponse } from './output-export-fallback'
+
+type DebugChannel =
+  | { readable?: ReadableStream; writable?: WritableStream }
+  | undefined
+
+type CreateFromFetch = <T>(
+  promiseForResponse: Promise<Response>,
+  options: {
+    callServer: typeof callServer
+    findSourceMapURL: typeof findSourceMapURL
+    debugChannel?: DebugChannel
+    unstable_allowPartialStream?: boolean
+  }
+) => Promise<T>
+
+type OutputExportFallbackState = {
+  isFallback: boolean
+}
+
+declare global {
+  interface Window {
+    __NEXT_EXPORT_FALLBACK?: boolean
+  }
+}
+
+export function getOutputExportFallbackState(): OutputExportFallbackState {
+  return {
+    isFallback: Boolean(window.__NEXT_EXPORT_FALLBACK),
+  }
+}
+
+export async function createOutputExportFallbackInitialResponse({
+  createFromFetch,
+  debugChannel,
+}: {
+  createFromFetch: CreateFromFetch
+  debugChannel: DebugChannel
+}): Promise<InitialRSCPayload> {
+  const renderedUrl = new URL(window.location.href)
+  const fallbackResult = await fetchOutputExportFallbackResponse(renderedUrl, {
+    credentials: 'same-origin',
+  })
+
+  if (fallbackResult === null) {
+    throw new Error(
+      `Could not find an output export fallback for "${renderedUrl.pathname}".`
+    )
+  }
+
+  return decodeFallbackPrerenderPayload(
+    Promise.resolve(fallbackResult.response),
+    renderedUrl,
+    createFromFetch,
+    debugChannel
+  )
+}
+
+async function decodeFallbackPrerenderPayload(
+  responsePromise: Promise<Response>,
+  renderedUrl: URL | undefined,
+  createFromFetch: CreateFromFetch,
+  debugChannel: DebugChannel
+): Promise<InitialRSCPayload> {
+  const processedResponse = responsePromise
+    .then(processFetch)
+    .then(({ response: processed }) => processed)
+
+  const fallbackInitialRSCPayload = await createFromFetch<InitialRSCPayload>(
+    processedResponse,
+    {
+      callServer,
+      findSourceMapURL,
+      debugChannel,
+      unstable_allowPartialStream: true,
+    }
+  )
+
+  return createInitialRSCPayloadFromFallbackPrerender(
+    await processedResponse,
+    fallbackInitialRSCPayload,
+    renderedUrl
+  )
+}
+
+export function removeOutputExportFallbackStyleOnCommit(
+  appElement: HTMLElement | Document
+): void {
+  const observer = new MutationObserver(() => {
+    document.getElementById('__next-export-fallback-style')?.remove()
+    observer.disconnect()
+  })
+  observer.observe(appElement, { childList: true })
+}

--- a/packages/next/src/client/output-export-fallback.ts
+++ b/packages/next/src/client/output-export-fallback.ts
@@ -1,0 +1,110 @@
+import { getOutputExportFallbackPath } from '../lib/output-export-dynamic-fallback'
+import { RSC_CONTENT_TYPE_HEADER } from './components/app-router-headers'
+
+function getOutputExportCandidatePrefixes(pathname: string): string[] {
+  const segments = pathname.split('/').filter(Boolean)
+  const candidates: string[] = []
+
+  for (let i = segments.length; i >= 1; i--) {
+    candidates.push(segments.slice(0, i).join('/'))
+  }
+
+  candidates.push('')
+
+  return candidates
+}
+
+export function getOutputExportFallbackCandidates(pathname: string): string[] {
+  return getOutputExportCandidatePrefixes(pathname).map((prefix) =>
+    getOutputExportFallbackPath(prefix)
+  )
+}
+
+export function addOutputExportDataSuffix(url: URL): URL {
+  const nextUrl = new URL(url)
+  if (nextUrl.pathname.endsWith('/')) {
+    nextUrl.pathname += 'index.txt'
+  } else {
+    nextUrl.pathname += '.txt'
+  }
+  return nextUrl
+}
+
+export function isOutputExportFlightContentType(contentType: string): boolean {
+  return (
+    contentType.startsWith(RSC_CONTENT_TYPE_HEADER) ||
+    contentType.startsWith('text/plain') ||
+    contentType.startsWith('application/octet-stream')
+  )
+}
+
+function getConfiguredOutputExportDataUrl(
+  url: URL,
+  prefersTrailingSlash: boolean
+): URL {
+  const trailingSlash = process.env.__NEXT_TRAILING_SLASH
+  const configuredUrl = new URL(url)
+  const useTrailingSlash =
+    trailingSlash == null
+      ? prefersTrailingSlash
+      : String(trailingSlash) === 'true'
+  if (useTrailingSlash && !configuredUrl.pathname.endsWith('/')) {
+    configuredUrl.pathname = `${configuredUrl.pathname}/`
+  }
+  return addOutputExportDataSuffix(configuredUrl)
+}
+
+async function fetchConfiguredOutputExportDataResult(
+  renderedUrl: URL,
+  prefersTrailingSlash: boolean,
+  init?: RequestInit
+): Promise<{ response: Response; dataUrl: URL } | null> {
+  const configuredDataUrl = getConfiguredOutputExportDataUrl(
+    renderedUrl,
+    prefersTrailingSlash
+  )
+
+  const response = await fetch(configuredDataUrl, init)
+  const contentType = response.headers.get('content-type') || ''
+  if (
+    !response.ok ||
+    !response.body ||
+    !isOutputExportFlightContentType(contentType)
+  ) {
+    return null
+  }
+
+  return {
+    response,
+    dataUrl: configuredDataUrl,
+  }
+}
+
+export async function fetchOutputExportFallbackResponse(
+  renderedUrl: URL,
+  init?: RequestInit
+): Promise<{ response: Response; renderedUrl: URL; fallbackUrl: URL } | null> {
+  const prefersTrailingSlash = renderedUrl.pathname.endsWith('/')
+
+  for (const candidate of getOutputExportFallbackCandidates(
+    renderedUrl.pathname
+  )) {
+    const candidateUrl = new URL(renderedUrl)
+    candidateUrl.pathname = candidate
+
+    const result = await fetchConfiguredOutputExportDataResult(
+      candidateUrl,
+      prefersTrailingSlash,
+      init
+    )
+    if (result) {
+      return {
+        response: result.response,
+        renderedUrl,
+        fallbackUrl: candidateUrl,
+      }
+    }
+  }
+
+  return null
+}

--- a/packages/next/src/client/route-params.ts
+++ b/packages/next/src/client/route-params.ts
@@ -145,6 +145,31 @@ export function parseDynamicParamFromURLPart(
   }
 }
 
+export function getNextPathnamePartsIndexForParam(
+  paramType: DynamicParamTypesShort,
+  pathnameParts: Array<string>,
+  partIndex: number
+): number {
+  switch (paramType) {
+    case 'c':
+    case 'ci(..)(..)':
+    case 'ci(.)':
+    case 'ci(..)':
+    case 'ci(...)':
+    case 'oc':
+      return pathnameParts.length
+    case 'd':
+    case 'di(..)(..)':
+    case 'di(.)':
+    case 'di(..)':
+    case 'di(...)':
+      return partIndex + 1
+    default:
+      paramType satisfies never
+      return partIndex
+  }
+}
+
 export function doesStaticSegmentAppearInURL(segment: string): boolean {
   // This is not a parameterized segment; however, we need to determine
   // whether or not this segment appears in the URL. For example, this route

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -7990,6 +7990,8 @@ async function prerenderToStream(
             getServerInsertedHTML,
             getServerInsertedMetadata,
             deploymentId: ctx.sharedContext.deploymentId,
+            isOutputExportFallback:
+              ctx.renderOpts.nextConfigOutput === 'export',
           })
         } else {
           // Normal static prerender case, no fallback param handling needed

--- a/packages/next/src/server/app-render/stream-ops.node.ts
+++ b/packages/next/src/server/app-render/stream-ops.node.ts
@@ -805,7 +805,7 @@ export async function continueDynamicPrerender(
 
 export async function continueStaticFallbackPrerender(
   prerenderStream: AnyStream,
-  opts: import('./stream-ops.web').ContinueStaticPrerenderOptions
+  opts: import('./stream-ops.web').ContinueStaticFallbackPrerenderOptions
 ): Promise<AnyStream> {
   const webResult = await webContinueStaticFallbackPrerender(
     nodeReadableToWebReadableStream(prerenderStream),

--- a/packages/next/src/server/app-render/stream-ops.web.ts
+++ b/packages/next/src/server/app-render/stream-ops.web.ts
@@ -57,6 +57,11 @@ export type ContinueStaticPrerenderOptions = ContinueStreamSharedOptions & {
   inlinedDataStream: AnyStream
 }
 
+export type ContinueStaticFallbackPrerenderOptions =
+  ContinueStaticPrerenderOptions & {
+    isOutputExportFallback?: boolean
+  }
+
 export type ContinueDynamicHTMLResumeOptions = ContinueStreamSharedOptions & {
   inlinedDataStream: AnyStream
   delayDataUntilFirstHtmlChunk: boolean
@@ -130,7 +135,7 @@ export async function continueDynamicPrerender(
 
 export async function continueStaticFallbackPrerender(
   prerenderStream: AnyStream,
-  opts: ContinueStaticPrerenderOptions
+  opts: ContinueStaticFallbackPrerenderOptions
 ): Promise<AnyStream> {
   return webContinueStaticFallbackPrerender(
     prerenderStream as ReadableStream<Uint8Array>,

--- a/packages/next/src/server/stream-utils/node-web-streams-helper.ts
+++ b/packages/next/src/server/stream-utils/node-web-streams-helper.ts
@@ -534,6 +534,32 @@ async function createClientResumeScriptInsertionTransformStream(): Promise<
   const searchStr = `${NEXT_RSC_UNION_QUERY}=${cacheBustingHeader}`
   const NEXT_CLIENT_RESUME_SCRIPT = `<script>__NEXT_CLIENT_RESUME=fetch(location.pathname+'?${searchStr}',{credentials:'same-origin',headers:{'${RSC_HEADER}': '1','${NEXT_ROUTER_PREFETCH_HEADER}': '1','${NEXT_ROUTER_SEGMENT_PREFETCH_HEADER}': '${segmentPath}'}})</script>`
 
+  return createClientResumeScriptInsertionTransformStreamForScript(
+    NEXT_CLIENT_RESUME_SCRIPT
+  )
+}
+
+async function createOutputExportClientResumeScriptInsertionTransformStream(): Promise<
+  TransformStream<Uint8Array, Uint8Array>
+> {
+  const segmentPath = '/_full'
+  const cacheBustingHeader = await computeCacheBustingSearchParam(
+    '1', //            headers[NEXT_ROUTER_PREFETCH_HEADER]
+    '/_full', //       headers[NEXT_ROUTER_SEGMENT_PREFETCH_HEADER]
+    undefined, //      headers[NEXT_ROUTER_STATE_TREE_HEADER]
+    undefined //       headers[NEXT_URL]
+  )
+  const searchStr = `${NEXT_RSC_UNION_QUERY}=${cacheBustingHeader}`
+  const NEXT_CLIENT_RESUME_SCRIPT = `<script>if(!self.__NEXT_EXPORT_FALLBACK){__NEXT_CLIENT_RESUME=fetch(location.pathname+'?${searchStr}',{credentials:'same-origin',headers:{'${RSC_HEADER}': '1','${NEXT_ROUTER_PREFETCH_HEADER}': '1','${NEXT_ROUTER_SEGMENT_PREFETCH_HEADER}': '${segmentPath}'}})}</script>`
+
+  return createClientResumeScriptInsertionTransformStreamForScript(
+    NEXT_CLIENT_RESUME_SCRIPT
+  )
+}
+
+function createClientResumeScriptInsertionTransformStreamForScript(
+  resumeScript: string
+): TransformStream<Uint8Array, Uint8Array> {
   let didAlreadyInsert = false
   return new TransformStream({
     transform(chunk, controller) {
@@ -555,7 +581,7 @@ async function createClientResumeScriptInsertionTransformStream(): Promise<
         return
       }
 
-      const encodedInsertion = encoder.encode(NEXT_CLIENT_RESUME_SCRIPT)
+      const encodedInsertion = encoder.encode(resumeScript)
       // Get the total count of the bytes in the chunk and the insertion
       // e.g.
       // chunk = <head><meta charset="utf-8"></head>
@@ -1092,6 +1118,10 @@ type ContinueStaticPrerenderOptions = {
   deploymentId: string | undefined
 }
 
+type ContinueStaticFallbackPrerenderOptions = ContinueStaticPrerenderOptions & {
+  isOutputExportFallback?: boolean
+}
+
 export async function continueStaticPrerender(
   prerenderStream: ReadableStream<Uint8Array>,
   {
@@ -1125,7 +1155,8 @@ export async function continueStaticFallbackPrerender(
     getServerInsertedHTML,
     getServerInsertedMetadata,
     deploymentId,
-  }: ContinueStaticPrerenderOptions
+    isOutputExportFallback,
+  }: ContinueStaticFallbackPrerenderOptions
 ) {
   // Same as `continueStaticPrerender`, but also inserts an additional script
   // to instruct the client to start fetching the hydration data as early
@@ -1138,7 +1169,9 @@ export async function continueStaticFallbackPrerender(
     // Insert generated tags to head
     createHeadInsertionTransformStream(getServerInsertedHTML),
     // Insert the client resume script into the head
-    await createClientResumeScriptInsertionTransformStream(),
+    isOutputExportFallback
+      ? await createOutputExportClientResumeScriptInsertionTransformStream()
+      : await createClientResumeScriptInsertionTransformStream(),
     // Transform metadata
     createMetadataTransformStream(getServerInsertedMetadata),
     // Insert the inlined data (Flight data, form state, etc.) stream into the HTML

--- a/test/e2e/app-dir/output-export-dynamic-fallbacks/app/another/[slug]/page.tsx
+++ b/test/e2e/app-dir/output-export-dynamic-fallbacks/app/another/[slug]/page.tsx
@@ -1,7 +1,12 @@
+import { Suspense } from 'react'
+import SlugClient from './slug-client'
+
 export default function Page() {
   return (
     <main>
-      <h1>Dynamic fallback shell</h1>
+      <Suspense fallback={<h1>Loading slug...</h1>}>
+        <SlugClient />
+      </Suspense>
     </main>
   )
 }

--- a/test/e2e/app-dir/output-export-dynamic-fallbacks/app/another/[slug]/slug-client.tsx
+++ b/test/e2e/app-dir/output-export-dynamic-fallbacks/app/another/[slug]/slug-client.tsx
@@ -1,0 +1,8 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function SlugClient() {
+  const params = useParams()
+  return <h1>{params.slug}</h1>
+}

--- a/test/e2e/app-dir/output-export-dynamic-fallbacks/output-export-dynamic-fallbacks.test.ts
+++ b/test/e2e/app-dir/output-export-dynamic-fallbacks/output-export-dynamic-fallbacks.test.ts
@@ -1,12 +1,11 @@
 import { nextTestSetup } from 'e2e-utils'
+import { createReadStream } from 'fs'
 import fs from 'fs-extra'
+import http from 'http'
 import { join } from 'path'
-import {
-  fetchViaHTTP,
-  findPort,
-  startStaticServer,
-  stopApp,
-} from 'next-test-utils'
+import express from 'express'
+import webdriver from 'next-webdriver'
+import { fetchViaHTTP, findPort, retry, stopApp } from 'next-test-utils'
 
 describe('output-export-dynamic-fallbacks', () => {
   const { next } = nextTestSetup({
@@ -37,7 +36,7 @@ describe('output-export-dynamic-fallbacks', () => {
     expect(await fs.pathExists(join(outDir, '_fallback.html'))).toBe(true)
 
     const port = await findPort()
-    const app = await startStaticServer(outDir, null, port)
+    const app = await startFallbackServer(outDir, port)
 
     try {
       const res = await fetchViaHTTP(port, '/another/__fallback.html')
@@ -51,8 +50,53 @@ describe('output-export-dynamic-fallbacks', () => {
 
       const rscRes = await fetchViaHTTP(port, '/another/__fallback.txt')
       expect(rscRes.status).toBe(200)
+
+      const hardLoad = await webdriver(port, '/another/alpha')
+      try {
+        await retry(async () => {
+          expect(await hardLoad.elementByCss('h1').text()).toBe('alpha')
+        })
+      } finally {
+        await hardLoad.close()
+      }
     } finally {
       await stopApp(app)
     }
   })
 })
+
+async function startFallbackServer(outDir: string, port: number) {
+  const app = express()
+  const server = http.createServer(app)
+  const fallbackHtml = join(outDir, '_fallback.html')
+
+  app.use((req, res, next) => {
+    if (req.method !== 'GET' && req.method !== 'HEAD') {
+      return next()
+    }
+
+    if (req.path.endsWith('/') || req.path.includes('.')) {
+      return next()
+    }
+
+    const htmlPath = join(outDir, `${req.path}.html`)
+    if (!fs.pathExistsSync(htmlPath)) {
+      return next()
+    }
+
+    res.sendFile(htmlPath)
+  })
+
+  app.use(
+    express.static(outDir, {
+      extensions: ['html'],
+      redirect: false,
+    })
+  )
+  app.use((_req, res) => {
+    createReadStream(fallbackHtml).pipe(res)
+  })
+
+  await new Promise<void>((resolve) => server.listen(port, resolve))
+  return server
+}


### PR DESCRIPTION
## Stack position

Part 8 of 19 in the output export dynamic fallback stack.

Previous PR: #93568 (7/19)
Next PR: #93561 (9/19)

## Context

The stack is split so build-time output can land behind `experimental.outputExportDynamicFallbacks` before the client router behavior is enabled. The target behavior is for `output: 'export'` apps with parameterized App Router routes to emit fallback HTML/RSC artifacts that a later client can resolve for hard loads and soft navigations.

This PR scope: Client bootstrap for hard loads of fallback documents.

At this point the build can emit fallback documents and RSC data, but a browser hard-load still lands on `_fallback.html`. This PR makes initial load fetch the route-specific fallback payload and render the requested route.

## What changed

- Adds the fallback bootstrap path for `_fallback.html` initial loads.
- Fetches route-specific fallback or not-found RSC instead of hydrating stale `_fallback.html` data.
- Uses `createRoot` for fallback bootstrap and removes the temporary hidden style after the first commit.
- Removes the hidden original-URL session/global side channel. The requested URL is read directly from `window.location`.

## Deliberately not included

- Does not make soft navigations work.
- Does not add segment-cache fallback keying.
- Does not rely on the removed `__NEXT_EXPORT_ORIGINAL_URL` mechanism.

## Verification

After restacking and autosquashing, I verified the full stack with:

- `pnpm --filter=next build`
- `pnpm testonly packages/next/src/lib/output-export-dynamic-fallback.test.ts packages/next/src/lib/output-export-fallback-routes.test.ts packages/next/src/export/helpers/output-export-fallback.test.ts packages/next/src/server/request/fallback-params.test.ts`
- `pnpm testonly packages/next/src/client/output-export-fallback.test.ts packages/next/src/client/components/router-reducer/fetch-server-response.test.ts packages/next/src/client/components/router-reducer/create-initial-router-state.test.ts packages/next/src/client/components/segment-cache/cache.test.ts packages/next/src/client/components/segment-cache/vary-path.test.ts`
- `pnpm testonly packages/next/src/client/components/router-reducer/compute-changed-path.test.ts packages/next/src/client/flight-data-helpers.test.ts packages/next/src/server/app-render/postponed-state.test.ts`
- `pnpm test-start-turbo test/e2e/app-dir-export/test/dynamic-fallback-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-route-shapes-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-cache-components-basepath.test.ts test/e2e/app-dir-export/test/dynamic-fallback-optimizations-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-known-params-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-conflict.test.ts`
- `pnpm test-start-turbo test/e2e/app-dir/output-export-dynamic-fallbacks/output-export-dynamic-fallbacks.test.ts test/e2e/app-dir-export/test/output-export-server-io.test.ts test/e2e/app-dir-export/test/output-export-server-io-use-cache.test.ts test/e2e/app-dir-export/test/dynamic-fallback-server-params.test.ts`

<!-- NEXT_JS_LLM_PR -->
