### PR TITLE
(3/19) Emit global export dynamic fallback shell

### DIFF
--- a/packages/next/src/export/helpers/output-export-fallback.ts
+++ b/packages/next/src/export/helpers/output-export-fallback.ts
@@ -197,6 +197,47 @@ export async function emitOutputExportFallbackArtifacts(
   return fallbackHtmlPaths
 }
 
+export async function writeOutputExportFallbackHtml(
+  outDir: string,
+  fallbackHtmlPaths: string[]
+): Promise<void> {
+  const genericSource = [
+    join(outDir, 'index.html'),
+    join(outDir, '404.html'),
+  ].find((candidate) => existsSync(candidate))
+
+  const sortedFallbackPaths = [...fallbackHtmlPaths].sort(
+    (a, b) => a.length - b.length
+  )
+  const fallbackSource = sortedFallbackPaths[0] ?? genericSource
+  if (!fallbackSource) {
+    return
+  }
+
+  const globalFallbackPath = join(outDir, '_fallback.html')
+  if (existsSync(globalFallbackPath)) {
+    throw createOutputExportError(
+      `The route "/_fallback" conflicts with the global "_fallback.html" path used by dynamic route fallbacks in static export mode. ` +
+        `Please remove or rename this route or public file.\n\n` +
+        `Learn more: https://nextjs.org/docs/app/guides/static-exports`
+    )
+  }
+
+  const fallbackHtml = await fs.readFile(fallbackSource, 'utf8')
+  const exportFallbackScript = '<script>self.__NEXT_EXPORT_FALLBACK=1</script>'
+  const exportFallbackStyle =
+    '<style id="__next-export-fallback-style">#__next{visibility:hidden}</style>'
+  const injection = `${exportFallbackStyle}${exportFallbackScript}`
+
+  const patchedFallbackHtml = fallbackHtml.includes('<head>')
+    ? fallbackHtml.replace('<head>', `<head>${injection}`)
+    : fallbackHtml.includes('</head>')
+      ? fallbackHtml.replace('</head>', `${injection}</head>`)
+      : injection + fallbackHtml
+
+  await fs.writeFile(globalFallbackPath, patchedFallbackHtml)
+}
+
 async function collectSegmentPaths(segmentsDirectory: string) {
   const results: Array<string> = []
   await collectSegmentPathsImpl(segmentsDirectory, segmentsDirectory, results)

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -71,7 +71,10 @@ import { extractInfoFromServerReferenceId } from '../shared/lib/server-reference
 import { convertSegmentPathToStaticExportFilename } from '../shared/lib/segment-cache/segment-value-encoding'
 import { getNextBuildDebuggerPortOffset } from '../lib/worker'
 import { getParams } from './helpers/get-params'
-import { emitOutputExportFallbackArtifacts } from './helpers/output-export-fallback'
+import {
+  emitOutputExportFallbackArtifacts,
+  writeOutputExportFallbackHtml,
+} from './helpers/output-export-fallback'
 import { isDynamicRoute } from '../shared/lib/router/utils/is-dynamic'
 import { normalizeAppPath } from '../shared/lib/router/utils/app-paths'
 import type { Params } from '../server/request/params'
@@ -1021,13 +1024,14 @@ async function exportAppImpl(
     )
 
     if (isOutputExportDynamicFallbackEnabled(nextConfig)) {
-      await emitOutputExportFallbackArtifacts(
+      const fallbackHtmlPaths = await emitOutputExportFallbackArtifacts(
         prerenderManifest.dynamicRoutes,
         mapAppRouteToPage,
         distDir,
         outDir,
         subFolders
       )
+      await writeOutputExportFallbackHtml(outDir, fallbackHtmlPaths)
     }
   }
 

--- a/test/e2e/app-dir/output-export-dynamic-fallbacks/output-export-dynamic-fallbacks.test.ts
+++ b/test/e2e/app-dir/output-export-dynamic-fallbacks/output-export-dynamic-fallbacks.test.ts
@@ -34,6 +34,7 @@ describe('output-export-dynamic-fallbacks', () => {
         '__next.another.$d$slug.__PAGE__.txt',
       ])
     )
+    expect(await fs.pathExists(join(outDir, '_fallback.html'))).toBe(true)
 
     const port = await findPort()
     const app = await startStaticServer(outDir, null, port)
@@ -41,7 +42,12 @@ describe('output-export-dynamic-fallbacks', () => {
     try {
       const res = await fetchViaHTTP(port, '/another/__fallback.html')
       expect(res.status).toBe(200)
-      expect(await res.text()).toContain('Dynamic fallback shell')
+
+      const globalFallbackRes = await fetchViaHTTP(port, '/_fallback.html')
+      expect(globalFallbackRes.status).toBe(200)
+      expect(await globalFallbackRes.text()).toContain(
+        '__NEXT_EXPORT_FALLBACK=1'
+      )
 
       const rscRes = await fetchViaHTTP(port, '/another/__fallback.txt')
       expect(rscRes.status).toBe(200)


### PR DESCRIPTION
## Stack position

Part 3 of 19 in the output export dynamic fallback stack.

Previous PR: #93558 (2/19)
Next PR: #93565 (4/19)

## Context

The stack is split so build-time output can land behind `experimental.outputExportDynamicFallbacks` before the client router behavior is enabled. The target behavior is for `output: 'export'` apps with parameterized App Router routes to emit fallback HTML/RSC artifacts that a later client can resolve for hard loads and soft navigations.

This PR scope: Global `_fallback.html` shell for unknown exported paths.

Static hosts need a single document they can serve for paths that were not emitted as concrete prerenders. This PR adds that shell while still leaving route-specific RSC resolution to later slices.

## What changed

- Emits a global fallback document for export fallback boot.
- Marks the fallback document so the client can later distinguish it from a normal hydrated page.
- Keeps initial-load coverage focused on produced output, not client routing.

## Deliberately not included

- Does not hydrate the requested route yet.
- Does not add route-manifest conflict handling.
- Does not make client transitions succeed.

## Verification

After restacking and autosquashing, I verified the full stack with:

- `pnpm --filter=next build`
- `pnpm testonly packages/next/src/lib/output-export-dynamic-fallback.test.ts packages/next/src/lib/output-export-fallback-routes.test.ts packages/next/src/export/helpers/output-export-fallback.test.ts packages/next/src/server/request/fallback-params.test.ts`
- `pnpm testonly packages/next/src/client/output-export-fallback.test.ts packages/next/src/client/components/router-reducer/fetch-server-response.test.ts packages/next/src/client/components/router-reducer/create-initial-router-state.test.ts packages/next/src/client/components/segment-cache/cache.test.ts packages/next/src/client/components/segment-cache/vary-path.test.ts`
- `pnpm testonly packages/next/src/client/components/router-reducer/compute-changed-path.test.ts packages/next/src/client/flight-data-helpers.test.ts packages/next/src/server/app-render/postponed-state.test.ts`
- `pnpm test-start-turbo test/e2e/app-dir-export/test/dynamic-fallback-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-route-shapes-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-cache-components-basepath.test.ts test/e2e/app-dir-export/test/dynamic-fallback-optimizations-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-known-params-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-conflict.test.ts`
- `pnpm test-start-turbo test/e2e/app-dir/output-export-dynamic-fallbacks/output-export-dynamic-fallbacks.test.ts test/e2e/app-dir-export/test/output-export-server-io.test.ts test/e2e/app-dir-export/test/output-export-server-io-use-cache.test.ts test/e2e/app-dir-export/test/dynamic-fallback-server-params.test.ts`

<!-- NEXT_JS_LLM_PR -->
