### PR TITLE
(9/19) Resolve export dynamic fallbacks during soft navigation

### DIFF
--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -32,6 +32,7 @@ import {
 import { callServer } from '../../app-call-server'
 import { findSourceMapURL } from '../../app-find-source-map-url'
 import {
+  fillInFallbackFlightData,
   normalizeFlightData,
   prepareFlightRouterStateForRequest,
   type NormalizedFlightData,
@@ -167,18 +168,34 @@ export async function fetchServerResponse(
   const originalUrl = url
 
   try {
-    if (process.env.NODE_ENV === 'production') {
-      if (process.env.__NEXT_CONFIG_OUTPUT === 'export') {
-        // In "output: export" mode, we can't rely on headers to distinguish
-        // between HTML and RSC requests. Instead, we append an extra prefix
-        // to the request.
-        url = new URL(url)
-        if (url.pathname.endsWith('/')) {
-          url.pathname += 'index.txt'
-        } else {
-          url.pathname += '.txt'
-        }
+    let usedCachedOutputExportFallback = false
+    if (
+      process.env.NODE_ENV === 'production' &&
+      process.env.__NEXT_CONFIG_OUTPUT === 'export'
+    ) {
+      // In "output: export" mode, we can't rely on headers to distinguish
+      // between HTML and RSC requests. Instead, we append an extra prefix
+      // to the request.
+      url = new URL(url)
+      if (url.pathname.endsWith('/')) {
+        url.pathname += 'index.txt'
+      } else {
+        url.pathname += '.txt'
       }
+
+      if (process.env.__NEXT_OUTPUT_EXPORT_DYNAMIC_FALLBACKS) {
+        const { getCachedOutputExportFallbackRequestUrl } =
+          require('../../output-export-fallback') as typeof import('../../output-export-fallback')
+        const fallbackRequestUrl = getCachedOutputExportFallbackRequestUrl(url)
+        if (fallbackRequestUrl !== null) {
+          usedCachedOutputExportFallback = true
+          url = fallbackRequestUrl
+        }
+      } else {
+        // Static export fallback URL remapping is erased when the feature is off.
+      }
+    } else {
+      // Static export fallback URL remapping is erased from non-export bundles.
     }
 
     // Typically, during a navigation, we decode the response using Flight's
@@ -186,8 +203,10 @@ export async function fetchServerResponse(
     // TODO: Remove this check once the old PPR flag is removed
     const isLegacyPPR =
       process.env.__NEXT_PPR && !process.env.__NEXT_CACHE_COMPONENTS
-    const shouldImmediatelyDecode = !isLegacyPPR
-    const res = await createFetch<NavigationFlightResponse>(
+    const shouldImmediatelyDecode =
+      !isLegacyPPR && process.env.__NEXT_CONFIG_OUTPUT !== 'export'
+    let usedOutputExportFallback = false
+    let res = await createFetch<NavigationFlightResponse>(
       url,
       headers,
       'auto',
@@ -202,20 +221,68 @@ export async function fetchServerResponse(
       notifyOnline()
     }
 
-    const responseUrl = urlToUrlWithoutFlightMarker(new URL(res.url))
-    const canonicalUrl = res.redirected ? responseUrl : originalUrl
+    let responseUrl = urlToUrlWithoutFlightMarker(new URL(res.url))
+    let canonicalUrl = res.redirected ? responseUrl : originalUrl
 
-    const contentType = res.headers.get('content-type') || ''
-    const interception = !!res.headers.get('vary')?.includes(NEXT_URL)
-    const postponed = !!res.headers.get(NEXT_DID_POSTPONE_HEADER)
+    let contentType = res.headers.get('content-type') || ''
+    let interception = !!res.headers.get('vary')?.includes(NEXT_URL)
+    let postponed = !!res.headers.get(NEXT_DID_POSTPONE_HEADER)
     let isFlightResponse = contentType.startsWith(RSC_CONTENT_TYPE_HEADER)
 
-    if (process.env.NODE_ENV === 'production') {
-      if (process.env.__NEXT_CONFIG_OUTPUT === 'export') {
-        if (!isFlightResponse) {
-          isFlightResponse = contentType.startsWith('text/plain')
-        }
+    if (
+      process.env.NODE_ENV === 'production' &&
+      process.env.__NEXT_CONFIG_OUTPUT === 'export'
+    ) {
+      if (!isFlightResponse) {
+        isFlightResponse = contentType.startsWith('text/plain')
       }
+
+      if (process.env.__NEXT_OUTPUT_EXPORT_DYNAMIC_FALLBACKS) {
+        if (!isFlightResponse || !res.ok || !res.body) {
+          const { fetchOutputExportFallbackResponse } =
+            require('../../output-export-fallback') as typeof import('../../output-export-fallback')
+
+          const fallbackResult = await fetchOutputExportFallbackResponse(
+            originalUrl,
+            {
+              credentials: 'same-origin',
+              headers,
+            }
+          )
+
+          if (fallbackResult !== null) {
+            usedOutputExportFallback = true
+            const { response: processed, cacheData } = await processFetch(
+              fallbackResult.response
+            )
+
+            res = {
+              ok: processed.ok,
+              redirected: false,
+              headers: processed.headers,
+              body: processed.body,
+              status: processed.status,
+              url: originalUrl.href,
+              flightResponsePromise: null,
+              cacheData: Promise.resolve(cacheData),
+            }
+            responseUrl = originalUrl
+            canonicalUrl = originalUrl
+            contentType = res.headers.get('content-type') || ''
+            interception = !!res.headers.get('vary')?.includes(NEXT_URL)
+            // Static export fallback payloads are partial-by-construction, but
+            // static hosts cannot attach the normal postpone header. Treat them as
+            // partial so Flight decoding accepts the closed stream and the router
+            // keeps the fallback shell suspended until dynamic holes resolve.
+            postponed = true
+            isFlightResponse = true
+          }
+        }
+      } else {
+        // Static export fallback discovery is erased when the feature is off.
+      }
+    } else {
+      // Static export fallback discovery is erased from non-export bundles.
     }
 
     // If fetch returns something different than flight response handle it like a mpa navigation
@@ -270,7 +337,18 @@ export async function fetchServerResponse(
       return doMpaNavigation(res.url)
     }
 
-    const normalizedFlightData = normalizeFlightData(flightResponse.f)
+    const fallbackFlightData =
+      usedOutputExportFallback || usedCachedOutputExportFallback
+        ? fillInFallbackFlightData(
+            flightResponse.f,
+            originalUrl.pathname,
+            originalUrl.search as NormalizedSearch
+          )
+        : null
+
+    const normalizedFlightData = normalizeFlightData(
+      fallbackFlightData ?? flightResponse.f
+    )
     if (typeof normalizedFlightData === 'string') {
       return doMpaNavigation(normalizedFlightData)
     }

--- a/packages/next/src/client/output-export-fallback.ts
+++ b/packages/next/src/client/output-export-fallback.ts
@@ -1,6 +1,40 @@
 import { getOutputExportFallbackPath } from '../lib/output-export-dynamic-fallback'
 import { RSC_CONTENT_TYPE_HEADER } from './components/app-router-headers'
 
+type OutputExportCachedResponse = {
+  body: ArrayBuffer
+  headers: Array<[string, string]>
+  status: number
+  statusText: string
+}
+
+type OutputExportFallbackCacheStore = {
+  dataResponses: Map<string, Promise<OutputExportCachedResponse | null>>
+  dataUrls: Map<string, string>
+  basePaths: Map<string, string>
+}
+
+function getOutputExportFallbackCacheStore(): OutputExportFallbackCacheStore {
+  const globalWithCache = globalThis as typeof globalThis & {
+    __NEXT_OUTPUT_EXPORT_FALLBACK_CACHE_STORE?: OutputExportFallbackCacheStore
+  }
+  const existing = globalWithCache.__NEXT_OUTPUT_EXPORT_FALLBACK_CACHE_STORE
+  if (existing !== undefined) {
+    return existing
+  }
+
+  const cacheStore = {
+    dataResponses: new Map<
+      string,
+      Promise<OutputExportCachedResponse | null>
+    >(),
+    dataUrls: new Map<string, string>(),
+    basePaths: new Map<string, string>(),
+  }
+  globalWithCache.__NEXT_OUTPUT_EXPORT_FALLBACK_CACHE_STORE = cacheStore
+  return cacheStore
+}
+
 function getOutputExportCandidatePrefixes(pathname: string): string[] {
   const segments = pathname.split('/').filter(Boolean)
   const candidates: string[] = []
@@ -54,6 +88,93 @@ function getConfiguredOutputExportDataUrl(
   return addOutputExportDataSuffix(configuredUrl)
 }
 
+function getOutputExportDataCandidates(url: URL): URL[] {
+  const direct = addOutputExportDataSuffix(url)
+
+  if (url.pathname.endsWith('/')) {
+    return [direct]
+  }
+
+  const trailingSlashUrl = new URL(url)
+  trailingSlashUrl.pathname = `${trailingSlashUrl.pathname}/`
+  const trailingSlash = addOutputExportDataSuffix(trailingSlashUrl)
+
+  return [direct, trailingSlash]
+}
+
+function normalizeOutputExportRouteDirectory(pathname: string): string {
+  if (pathname === '/') {
+    return ''
+  }
+  return pathname.endsWith('/') ? pathname.slice(0, -1) : pathname
+}
+
+function cacheOutputExportFallbackDataUrl(
+  renderedUrl: URL,
+  fallbackUrl: URL,
+  resolvedDataUrl: URL
+) {
+  const { dataUrls, basePaths } = getOutputExportFallbackCacheStore()
+  for (const candidateUrl of getOutputExportDataCandidates(renderedUrl)) {
+    dataUrls.set(candidateUrl.href, resolvedDataUrl.href)
+  }
+  basePaths.set(
+    normalizeOutputExportRouteDirectory(renderedUrl.pathname),
+    normalizeOutputExportRouteDirectory(fallbackUrl.pathname)
+  )
+}
+
+export function getCachedOutputExportFallbackDataUrl(url: URL): URL | null {
+  const cached = getOutputExportFallbackCacheStore().dataUrls.get(url.href)
+  return cached !== undefined ? new URL(cached) : null
+}
+
+export function getCachedOutputExportFallbackBasePath(url: URL): string | null {
+  let routeDirectory: string
+  if (url.pathname.endsWith('/index.txt')) {
+    routeDirectory = normalizeOutputExportRouteDirectory(
+      url.pathname.slice(0, -10) || '/'
+    )
+  } else if (url.pathname.endsWith('.txt')) {
+    routeDirectory = normalizeOutputExportRouteDirectory(
+      url.pathname.slice(0, -4) || '/'
+    )
+  } else {
+    routeDirectory = normalizeOutputExportRouteDirectory(
+      url.pathname.slice(0, url.pathname.lastIndexOf('/')) || '/'
+    )
+  }
+
+  const fallbackBasePath =
+    getOutputExportFallbackCacheStore().basePaths.get(routeDirectory)
+  return fallbackBasePath !== undefined ? fallbackBasePath : null
+}
+
+export function getCachedOutputExportFallbackRequestUrl(url: URL): URL | null {
+  const cachedDataUrl = getCachedOutputExportFallbackDataUrl(url)
+  if (cachedDataUrl !== null) {
+    return cachedDataUrl
+  }
+
+  const filename = url.pathname.slice(url.pathname.lastIndexOf('/') + 1)
+  if (!filename.startsWith('__next.')) {
+    return null
+  }
+
+  const routeDirectory = normalizeOutputExportRouteDirectory(
+    url.pathname.slice(0, url.pathname.lastIndexOf('/')) || '/'
+  )
+  const fallbackBasePath =
+    getOutputExportFallbackCacheStore().basePaths.get(routeDirectory)
+  if (fallbackBasePath === undefined) {
+    return null
+  }
+
+  const nextUrl = new URL(url)
+  nextUrl.pathname = `${fallbackBasePath}/${filename}`
+  return nextUrl
+}
+
 async function fetchConfiguredOutputExportDataResult(
   renderedUrl: URL,
   prefersTrailingSlash: boolean,
@@ -64,13 +185,11 @@ async function fetchConfiguredOutputExportDataResult(
     prefersTrailingSlash
   )
 
-  const response = await fetch(configuredDataUrl, init)
-  const contentType = response.headers.get('content-type') || ''
-  if (
-    !response.ok ||
-    !response.body ||
-    !isOutputExportFlightContentType(contentType)
-  ) {
+  const response = await fetchOutputExportDataResponseByUrl(
+    configuredDataUrl,
+    init
+  )
+  if (response === null) {
     return null
   }
 
@@ -78,6 +197,52 @@ async function fetchConfiguredOutputExportDataResult(
     response,
     dataUrl: configuredDataUrl,
   }
+}
+
+async function fetchOutputExportDataResponseByUrl(
+  dataUrl: URL,
+  init?: RequestInit
+): Promise<Response | null> {
+  const cacheKey = dataUrl.href
+  const dataResponseCache = getOutputExportFallbackCacheStore().dataResponses
+
+  let cachedResponse = dataResponseCache.get(cacheKey)
+  if (cachedResponse === undefined) {
+    cachedResponse = fetch(dataUrl, init)
+      .then(async (response) => {
+        const contentType = response.headers.get('content-type') || ''
+        if (
+          !response.ok ||
+          !response.body ||
+          !isOutputExportFlightContentType(contentType)
+        ) {
+          return null
+        }
+
+        return {
+          body: await response.arrayBuffer(),
+          headers: Array.from(response.headers.entries()),
+          status: response.status,
+          statusText: response.statusText,
+        }
+      })
+      .catch((error) => {
+        dataResponseCache.delete(cacheKey)
+        throw error
+      })
+    dataResponseCache.set(cacheKey, cachedResponse)
+  }
+
+  const response = await cachedResponse
+  if (response === null) {
+    return null
+  }
+
+  return new Response(response.body.slice(0), {
+    headers: response.headers,
+    status: response.status,
+    statusText: response.statusText,
+  })
 }
 
 export async function fetchOutputExportFallbackResponse(
@@ -98,6 +263,11 @@ export async function fetchOutputExportFallbackResponse(
       init
     )
     if (result) {
+      cacheOutputExportFallbackDataUrl(
+        renderedUrl,
+        candidateUrl,
+        result.dataUrl
+      )
       return {
         response: result.response,
         renderedUrl,

--- a/test/e2e/app-dir/output-export-dynamic-fallbacks/app/another/page.tsx
+++ b/test/e2e/app-dir/output-export-dynamic-fallbacks/app/another/page.tsx
@@ -4,7 +4,9 @@ export default function Page() {
   return (
     <main>
       <h1>Another</h1>
-      <Link href="/another/alpha">Alpha</Link>
+      <Link href="/another/alpha" prefetch={false}>
+        Alpha
+      </Link>
     </main>
   )
 }

--- a/test/e2e/app-dir/output-export-dynamic-fallbacks/output-export-dynamic-fallbacks.test.ts
+++ b/test/e2e/app-dir/output-export-dynamic-fallbacks/output-export-dynamic-fallbacks.test.ts
@@ -59,6 +59,16 @@ describe('output-export-dynamic-fallbacks', () => {
       } finally {
         await hardLoad.close()
       }
+
+      const softNav = await webdriver(port, '/another')
+      try {
+        await softNav.elementByCss('a[href^="/another/alpha"]').click()
+        await retry(async () => {
+          expect(await softNav.elementByCss('h1').text()).toBe('alpha')
+        })
+      } finally {
+        await softNav.close()
+      }
     } finally {
       await stopApp(app)
     }


### PR DESCRIPTION
## Stack position

Part 9 of 19 in the output export dynamic fallback stack.

Previous PR: #93559 (8/19)
Next PR: #93569 (10/19)

## Context

The stack is split so build-time output can land behind `experimental.outputExportDynamicFallbacks` before the client router behavior is enabled. The target behavior is for `output: 'export'` apps with parameterized App Router routes to emit fallback HTML/RSC artifacts that a later client can resolve for hard loads and soft navigations.

This PR scope: Client router fallback discovery for soft navigation.

Hard loads now have a bootstrap path, but client transitions still request concrete `.txt` files that do not exist for unknown params. This PR adds the first soft-navigation fallback lookup path.

## What changed

- Falls back from a missing concrete export data request to a matching fallback RSC response.
- Keeps normal static export `.txt` URL rewriting separate from dynamic-fallback discovery.
- Routes cached fallback request URLs explicitly in `fetchServerResponse` instead of hiding the rewrite inside shared `createFetch`.
- Keeps the fallback imports behind the dynamic-fallback feature flag.

## Deliberately not included

- Does not key the segment cache by fallback base path yet.
- Does not handle all route-shape conflicts yet.
- Does not add the full e2e matrix. Later PRs add focused coverage.

## Verification

After restacking and autosquashing, I verified the full stack with:

- `pnpm --filter=next build`
- `pnpm testonly packages/next/src/lib/output-export-dynamic-fallback.test.ts packages/next/src/lib/output-export-fallback-routes.test.ts packages/next/src/export/helpers/output-export-fallback.test.ts packages/next/src/server/request/fallback-params.test.ts`
- `pnpm testonly packages/next/src/client/output-export-fallback.test.ts packages/next/src/client/components/router-reducer/fetch-server-response.test.ts packages/next/src/client/components/router-reducer/create-initial-router-state.test.ts packages/next/src/client/components/segment-cache/cache.test.ts packages/next/src/client/components/segment-cache/vary-path.test.ts`
- `pnpm testonly packages/next/src/client/components/router-reducer/compute-changed-path.test.ts packages/next/src/client/flight-data-helpers.test.ts packages/next/src/server/app-render/postponed-state.test.ts`
- `pnpm test-start-turbo test/e2e/app-dir-export/test/dynamic-fallback-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-route-shapes-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-cache-components-basepath.test.ts test/e2e/app-dir-export/test/dynamic-fallback-optimizations-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-known-params-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-conflict.test.ts`
- `pnpm test-start-turbo test/e2e/app-dir/output-export-dynamic-fallbacks/output-export-dynamic-fallbacks.test.ts test/e2e/app-dir-export/test/output-export-server-io.test.ts test/e2e/app-dir-export/test/output-export-server-io-use-cache.test.ts test/e2e/app-dir-export/test/dynamic-fallback-server-params.test.ts`

<!-- NEXT_JS_LLM_PR -->
