### PR TITLE
(11/19) Key export fallback segment cache entries

### DIFF
--- a/packages/next/src/client/app-globals.ts
+++ b/packages/next/src/client/app-globals.ts
@@ -1,6 +1,12 @@
 // imports polyfill from `@next/polyfill-module` after build.
 import '../build/polyfills/polyfill-module'
 
+declare global {
+  interface Window {
+    __NEXT_ARM_INSTANT_NAVIGATION_LOCK?: () => void
+  }
+}
+
 // Only set up devtools for the dev server.
 if (process.env.__NEXT_DEV_SERVER) {
   require('../next-devtools/userspace/app/app-dev-overlay-setup') as typeof import('../next-devtools/userspace/app/app-dev-overlay-setup')
@@ -10,7 +16,11 @@ if (process.env.__NEXT_DEV_SERVER) {
 // (e.g. Playwright) sets/clears this cookie to control the navigation lock.
 // Browser-only.
 if (process.env.__NEXT_EXPOSE_TESTING_API && typeof window !== 'undefined') {
-  const { startListeningForInstantNavigationCookie } =
+  const {
+    startListeningForInstantNavigationCookie,
+    armNavigationLockForTesting,
+  } =
     require('./components/segment-cache/navigation-testing-lock') as typeof import('./components/segment-cache/navigation-testing-lock')
   startListeningForInstantNavigationCookie()
+  window.__NEXT_ARM_INSTANT_NAVIGATION_LOCK = armNavigationLockForTesting
 }

--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -249,6 +249,7 @@ if (
 }
 
 let initialServerResponse: Promise<InitialRSCPayload>
+let initialOutputExportFallbackBasePath: string | null = null
 if (instantTestStaticFetch) {
   const processedStaticFetch = Promise.resolve(instantTestStaticFetch)
     .then(processFetch)
@@ -281,10 +282,14 @@ if (instantTestStaticFetch) {
   // _fallback.html may be based on a PPR shell that also sets
   // __NEXT_CLIENT_RESUME. In export fallback mode, we always
   // fetch the correct route's RSC payload from the network.
-  initialServerResponse =
-    outputExportFallbackBootstrap.createOutputExportFallbackInitialResponse({
+  initialServerResponse = outputExportFallbackBootstrap
+    .createOutputExportFallbackInitialResponse({
       createFromFetch,
       debugChannel,
+    })
+    .then(({ initialRSCPayload, fallbackBasePath }) => {
+      initialOutputExportFallbackBasePath = fallbackBasePath
+      return initialRSCPayload
     })
 } else if (
   // @ts-expect-error
@@ -431,6 +436,7 @@ export async function hydrate(
       initialRSCPayload,
       initialFlightStreamForCache,
       location: window.location,
+      outputExportFallbackBasePath: initialOutputExportFallbackBasePath,
     }),
     instrumentationHooks
   )

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -27,6 +27,7 @@ export interface InitialRouterStateParameters {
   initialRSCPayload: InitialRSCPayload
   initialFlightStreamForCache?: ReadableStream<Uint8Array> | null
   location: Location | null
+  outputExportFallbackBasePath?: string | null
 }
 
 export function createInitialRouterState({
@@ -34,6 +35,7 @@ export function createInitialRouterState({
   initialRSCPayload,
   initialFlightStreamForCache,
   location,
+  outputExportFallbackBasePath = null,
 }: InitialRouterStateParameters): AppRouterState {
   const {
     c: initialCanonicalUrlParts,
@@ -113,7 +115,8 @@ export function createInitialRouterState({
       initialCouldBeIntercepted,
       canonicalUrl,
       initialSupportsPerSegmentPrefetching,
-      false // hasDynamicRewrite
+      false, // hasDynamicRewrite
+      { outputExportFallbackBasePath }
     )
 
     // Write the initial seed data into the segment cache so subsequent
@@ -142,7 +145,8 @@ export function createInitialRouterState({
               staleAt,
               initialTree,
               initialRenderedSearch,
-              true // isResponsePartial
+              true, // isResponsePartial
+              outputExportFallbackBasePath
             )
           })
           .catch(() => {
@@ -167,7 +171,8 @@ export function createInitialRouterState({
               staleAt,
               initialTree,
               initialRenderedSearch,
-              false // isResponsePartial
+              false, // isResponsePartial
+              outputExportFallbackBasePath
             )
           })
           .catch(() => {
@@ -192,7 +197,8 @@ export function createInitialRouterState({
         Date.now(),
         initialRuntimePrefetchStream,
         initialTree,
-        initialRenderedSearch
+        initialRenderedSearch,
+        outputExportFallbackBasePath
       )
         .then((processed) => {
           if (processed !== null) {

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -83,6 +83,7 @@ type SpaFetchServerResponseResult = {
   flightData: NormalizedFlightData[]
   canonicalUrl: URL
   renderedSearch: NormalizedSearch
+  outputExportFallbackBasePath: string | null
   couldBeIntercepted: boolean
   supportsPerSegmentPrefetching: boolean
   postponed: boolean
@@ -169,6 +170,7 @@ export async function fetchServerResponse(
 
   try {
     let usedCachedOutputExportFallback = false
+    let outputExportFallbackBasePath: string | null = null
     if (
       process.env.NODE_ENV === 'production' &&
       process.env.__NEXT_CONFIG_OUTPUT === 'export'
@@ -184,11 +186,16 @@ export async function fetchServerResponse(
       }
 
       if (process.env.__NEXT_OUTPUT_EXPORT_DYNAMIC_FALLBACKS) {
-        const { getCachedOutputExportFallbackRequestUrl } =
+        const {
+          getCachedOutputExportFallbackBasePath,
+          getCachedOutputExportFallbackRequestUrl,
+        } =
           require('../../output-export-fallback') as typeof import('../../output-export-fallback')
         const fallbackRequestUrl = getCachedOutputExportFallbackRequestUrl(url)
         if (fallbackRequestUrl !== null) {
           usedCachedOutputExportFallback = true
+          outputExportFallbackBasePath =
+            getCachedOutputExportFallbackBasePath(url)
           url = fallbackRequestUrl
         }
       } else {
@@ -252,6 +259,7 @@ export async function fetchServerResponse(
 
           if (fallbackResult !== null) {
             usedOutputExportFallback = true
+            outputExportFallbackBasePath = fallbackResult.fallbackUrl.pathname
             const { response: processed, cacheData } = await processFetch(
               fallbackResult.response
             )
@@ -369,6 +377,7 @@ export async function fetchServerResponse(
       // header alone. So we need to investigate why the header is sometimes
       // wrong for interception routes.
       renderedSearch: flightResponse.q as NormalizedSearch,
+      outputExportFallbackBasePath,
       couldBeIntercepted: interception,
       supportsPerSegmentPrefetching: flightResponse.S,
       postponed,

--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -1625,7 +1625,8 @@ async function fetchMissingDynamicData(
       task.route,
       result.flightData,
       result.renderedSearch,
-      result.dynamicStaleTime
+      result.dynamicStaleTime,
+      result.outputExportFallbackBasePath
     )
 
     // If the navigation lock is active, wait for it to be released before
@@ -1653,7 +1654,8 @@ async function fetchMissingDynamicData(
             staleAt,
             dynamicRequestTree,
             result.renderedSearch,
-            isResponsePartial
+            isResponsePartial,
+            result.outputExportFallbackBasePath
           )
         })
         .catch(() => {
@@ -1667,7 +1669,8 @@ async function fetchMissingDynamicData(
         now,
         result.runtimePrefetchStream,
         dynamicRequestTree,
-        result.renderedSearch
+        result.renderedSearch,
+        result.outputExportFallbackBasePath
       )
         .then((processed) => {
           if (processed !== null) {

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -68,6 +68,7 @@ import { createCacheKey as createPrefetchRequestKey } from './cache-key'
 import {
   doesStaticSegmentAppearInURL,
   getCacheKeyForDynamicParam,
+  getNextPathnamePartsIndexForParam,
   getRenderedPathname,
   getRenderedSearch,
   parseDynamicParamFromURLPart,
@@ -224,6 +225,7 @@ export type FulfilledRouteCacheEntry = RouteCacheEntryShared & {
   tree: RouteTree
   metadata: RouteTree
   supportsPerSegmentPrefetching: boolean
+  outputExportFallbackBasePath: string | null
   // When true, this entry should not be used as a template for route
   // prediction. Set when we discover that the URL was rewritten by middleware
   // to a different route structure (e.g., /foo was rewritten to /bar). Since
@@ -681,6 +683,9 @@ export function deprecated_requestOptimisticRouteCacheEntry(
     couldBeIntercepted: routeWithNoSearchParams.couldBeIntercepted,
     supportsPerSegmentPrefetching:
       routeWithNoSearchParams.supportsPerSegmentPrefetching,
+    // Output export fallback always enables the new optimistic route matcher,
+    // so the deprecated search-param prediction path stays export-agnostic.
+    outputExportFallbackBasePath: null,
     hasDynamicRewrite: routeWithNoSearchParams.hasDynamicRewrite,
 
     // Override the rendered search with the optimistic value.
@@ -753,7 +758,8 @@ function deprecated_createOptimisticRouteTree(
 export function readOrCreateSegmentCacheEntry(
   now: number,
   fetchStrategy: FetchStrategy,
-  tree: RouteTree
+  tree: RouteTree,
+  outputExportFallbackBasePath: string | null = null
 ): SegmentCacheEntry {
   const existingEntry = readSegmentCacheEntry(now, tree.varyPath)
   if (existingEntry !== null) {
@@ -762,7 +768,11 @@ export function readOrCreateSegmentCacheEntry(
   // Create a pending entry and add it to the cache. The stale time is set to a
   // default value; the actual stale time will be set when the entry is
   // fulfilled with data from the server response.
-  const varyPathForRequest = getSegmentVaryPathForRequest(fetchStrategy, tree)
+  const varyPathForRequest = getSegmentVaryPathForRequest(
+    fetchStrategy,
+    tree,
+    outputExportFallbackBasePath
+  )
   const pendingEntry = createDetachedSegmentCacheEntry(now)
   const isRevalidation = false
   setInCacheMap(
@@ -777,7 +787,8 @@ export function readOrCreateSegmentCacheEntry(
 export function readOrCreateRevalidatingSegmentEntry(
   now: number,
   fetchStrategy: FetchStrategy,
-  tree: RouteTree
+  tree: RouteTree,
+  outputExportFallbackBasePath: string | null = null
 ): SegmentCacheEntry {
   // This function is called when we've already confirmed that a particular
   // segment is cached, but we want to perform another request anyway in case it
@@ -813,7 +824,11 @@ export function readOrCreateRevalidatingSegmentEntry(
   // Create a pending entry and add it to the cache. The stale time is set to a
   // default value; the actual stale time will be set when the entry is
   // fulfilled with data from the server response.
-  const varyPathForRequest = getSegmentVaryPathForRequest(fetchStrategy, tree)
+  const varyPathForRequest = getSegmentVaryPathForRequest(
+    fetchStrategy,
+    tree,
+    outputExportFallbackBasePath
+  )
   const pendingEntry = createDetachedSegmentCacheEntry(now)
   const isRevalidation = true
   setInCacheMap(
@@ -828,14 +843,19 @@ export function readOrCreateRevalidatingSegmentEntry(
 export function overwriteRevalidatingSegmentCacheEntry(
   now: number,
   fetchStrategy: FetchStrategy,
-  tree: RouteTree
+  tree: RouteTree,
+  outputExportFallbackBasePath: string | null = null
 ) {
   // This function is called when we've already decided to replace an existing
   // revalidation entry. Create a new entry and write it into the cache,
   // overwriting the previous value. The stale time is set to a default value;
   // the actual stale time will be set when the entry is fulfilled with data
   // from the server response.
-  const varyPathForRequest = getSegmentVaryPathForRequest(fetchStrategy, tree)
+  const varyPathForRequest = getSegmentVaryPathForRequest(
+    fetchStrategy,
+    tree,
+    outputExportFallbackBasePath
+  )
   const pendingEntry = createDetachedSegmentCacheEntry(now)
   const isRevalidation = true
   setInCacheMap(
@@ -1101,6 +1121,7 @@ export function fulfillRouteCacheEntry(
   fulfilledEntry.canonicalUrl = canonicalUrl
   fulfilledEntry.renderedSearch = renderedSearch
   fulfilledEntry.supportsPerSegmentPrefetching = supportsPerSegmentPrefetching
+  fulfilledEntry.outputExportFallbackBasePath = null
   fulfilledEntry.hasDynamicRewrite = false
   pingBlockedTasks(entry)
   return fulfilledEntry
@@ -1257,7 +1278,7 @@ function convertTreePrefetchToRouteTree(
       const childSegmentName = childPrefetch.name
       const childParam = childPrefetch.param
 
-      let childDoesAppearInURL: boolean
+      let childPathnamePartsIndex: number
       let childSegment: FlightRouterStateSegment
       let childPartialVaryPath: PartialSegmentVaryPath | null
       if (childParam !== null) {
@@ -1300,20 +1321,20 @@ function convertTreePrefetchToRouteTree(
           childParam.type,
           childParam.siblings,
         ]
-        childDoesAppearInURL = true
+        childPathnamePartsIndex = getNextPathnamePartsIndexForParam(
+          childParam.type,
+          pathnameParts,
+          pathnamePartsIndex
+        )
       } else {
         // This segment does not have a param. Inherit the partial vary path of
         // the parent.
         childPartialVaryPath = partialVaryPath
         childSegment = childSegmentName
-        childDoesAppearInURL = doesStaticSegmentAppearInURL(childSegmentName)
+        childPathnamePartsIndex = doesStaticSegmentAppearInURL(childSegmentName)
+          ? pathnamePartsIndex + 1
+          : pathnamePartsIndex
       }
-
-      // Only increment the index if the segment appears in the URL. If it's a
-      // "virtual" segment, like a route group, it remains the same.
-      const childPathnamePartsIndex = childDoesAppearInURL
-        ? pathnamePartsIndex + 1
-        : pathnamePartsIndex
 
       const childRequestKeyPart = createSegmentRequestKeyPart(childSegment)
       const childRequestKey = appendSegmentRequestKeyPart(
@@ -1673,7 +1694,15 @@ export async function fetchRouteOnCacheMiss(
         response !== null && response.redirected ? new URL(response.url) : url
     }
 
-    if (!response || !response.ok || !response.body) {
+    if (
+      !response ||
+      !response.ok ||
+      // 204 is a Cache miss. Though theoretically this shouldn't happen when
+      // PPR is enabled, because we always respond to route tree requests, even
+      // if it needs to be blockingly generated on demand.
+      response.status === 204 ||
+      !response.body
+    ) {
       // Server responded with an error, or with a miss. We should still cache
       // the response, but we can try again after 10 seconds.
       rejectRouteCacheEntry(entry, Date.now() + 10 * 1000)
@@ -1744,8 +1773,12 @@ export async function fetchRouteOnCacheMiss(
       // Get the params that were used to render the target page. These may
       // be different from the params in the request URL, if the page
       // was rewritten.
-      const renderedPathname = getRenderedPathname(response)
-      const renderedSearch = getRenderedSearch(response)
+      const renderedPathname = isOutputExportMode
+        ? (urlAfterRedirects.pathname as NormalizedPathname)
+        : getRenderedPathname(response)
+      const renderedSearch = isOutputExportMode
+        ? (urlAfterRedirects.search as NormalizedSearch)
+        : getRenderedSearch(response)
 
       // Convert the server-sent data into the RouteTree format used by the
       // client cache.
@@ -1934,10 +1967,14 @@ export async function fetchSegmentsOnCacheMiss(
   // Testing API. Static pre-renders don't normally happen during development.
   addInstantPrefetchHeaderIfLocked(headers)
 
-  const requestUrl = isOutputExportMode
-    ? // In output: "export" mode, we need to add the segment path to the URL.
-      addSegmentPathToUrlInOutputExportMode(url, normalizedRequestKey)
-    : url
+  let requestUrl = url
+  if (isOutputExportMode) {
+    requestUrl = getOutputExportSegmentRequestUrl(
+      url,
+      normalizedRequestKey,
+      route.outputExportFallbackBasePath
+    )
+  }
   try {
     const response = await fetchPrefetchResponse(requestUrl, headers)
     if (
@@ -2026,8 +2063,16 @@ export async function fetchSegmentsOnCacheMiss(
       // generic path. Otherwise use the request vary path.
       const canonicalVaryPath =
         process.env.__NEXT_VARY_PARAMS && data.varyParams !== null
-          ? getFulfilledSegmentVaryPath(node.tree.varyPath, data.varyParams)
-          : getSegmentVaryPathForRequest(FetchStrategy.PPR, node.tree)
+          ? getFulfilledSegmentVaryPath(
+              node.tree.varyPath,
+              data.varyParams,
+              route.outputExportFallbackBasePath !== null
+            )
+          : getSegmentVaryPathForRequest(
+              FetchStrategy.PPR,
+              node.tree,
+              route.outputExportFallbackBasePath
+            )
 
       let fulfilled: FulfilledSegmentCacheEntry | null = null
       const nodeEntry = node.entry
@@ -2473,6 +2518,7 @@ export function writeDynamicRenderResponseIntoCache(
         staleAt,
         seedData,
         isResponsePartial,
+        navigationSeed.outputExportFallbackBasePath,
         spawnedEntries
       )
     }
@@ -2502,6 +2548,7 @@ export function writeDynamicRenderResponseIntoCache(
         // parameter.
         headVaryParams,
         metadataTree,
+        navigationSeed.outputExportFallbackBasePath,
         spawnedEntries
       )
     }
@@ -2535,6 +2582,7 @@ function writeSeedDataIntoCache(
   staleAt: number,
   seedData: CacheNodeSeedData,
   isResponsePartial: boolean,
+  outputExportFallbackBasePath: string | null,
   entriesOwnedByCurrentTask: Map<
     SegmentRequestKey,
     PendingSegmentCacheEntry
@@ -2558,6 +2606,7 @@ function writeSeedDataIntoCache(
     staleAt,
     varyParams,
     tree,
+    outputExportFallbackBasePath,
     entriesOwnedByCurrentTask
   )
 
@@ -2577,6 +2626,7 @@ function writeSeedDataIntoCache(
           staleAt,
           childSeedData,
           isResponsePartial,
+          outputExportFallbackBasePath,
           entriesOwnedByCurrentTask
         )
       }
@@ -2596,6 +2646,7 @@ function fulfillEntrySpawnedByRuntimePrefetch(
   staleAt: number,
   segmentVaryParams: Set<string> | null,
   tree: RouteTree,
+  outputExportFallbackBasePath: string | null,
   entriesOwnedByCurrentTask: Map<
     SegmentRequestKey,
     PendingSegmentCacheEntry
@@ -2619,7 +2670,8 @@ function fulfillEntrySpawnedByRuntimePrefetch(
     if (process.env.__NEXT_VARY_PARAMS && segmentVaryParams !== null) {
       const fulfilledVaryPath = getFulfilledSegmentVaryPath(
         tree.varyPath,
-        segmentVaryParams
+        segmentVaryParams,
+        outputExportFallbackBasePath !== null
       )
       const isRevalidation = false
       setInCacheMap(
@@ -2634,7 +2686,8 @@ function fulfillEntrySpawnedByRuntimePrefetch(
     const possiblyNewEntry = readOrCreateSegmentCacheEntry(
       now,
       fetchStrategy,
-      tree
+      tree,
+      outputExportFallbackBasePath
     )
     if (possiblyNewEntry.status === EntryStatus.Empty) {
       // Confirmed this is a new entry. We can fulfill it.
@@ -2649,7 +2702,8 @@ function fulfillEntrySpawnedByRuntimePrefetch(
       if (process.env.__NEXT_VARY_PARAMS && segmentVaryParams !== null) {
         const fulfilledVaryPath = getFulfilledSegmentVaryPath(
           tree.varyPath,
-          segmentVaryParams
+          segmentVaryParams,
+          outputExportFallbackBasePath !== null
         )
         const isRevalidation = false
         setInCacheMap(
@@ -2675,8 +2729,16 @@ function fulfillEntrySpawnedByRuntimePrefetch(
       // the request vary path.
       const varyPath =
         process.env.__NEXT_VARY_PARAMS && segmentVaryParams !== null
-          ? getFulfilledSegmentVaryPath(tree.varyPath, segmentVaryParams)
-          : getSegmentVaryPathForRequest(fetchStrategy, tree)
+          ? getFulfilledSegmentVaryPath(
+              tree.varyPath,
+              segmentVaryParams,
+              outputExportFallbackBasePath !== null
+            )
+          : getSegmentVaryPathForRequest(
+              fetchStrategy,
+              tree,
+              outputExportFallbackBasePath
+            )
       upsertSegmentEntry(now, varyPath, newEntry)
     }
   }
@@ -2703,15 +2765,22 @@ async function fetchPrefetchResponse<T>(
   }
 
   // Check the content type
+  const contentType = response.headers.get('content-type') || ''
   if (isOutputExportMode) {
-    // In output: "export" mode, we relaxed about the content type, since it's
-    // not Next.js that's serving the response. If the status is OK, assume the
-    // response is valid. If it's not a valid response, the Flight client won't
-    // be able to decode it, and we'll treat it as a miss.
+    if (process.env.__NEXT_OUTPUT_EXPORT_DYNAMIC_FALLBACKS) {
+      const { isOutputExportFlightContentType } =
+        require('../../output-export-fallback') as typeof import('../../output-export-fallback')
+      if (!isOutputExportFlightContentType(contentType)) {
+        return null
+      }
+    } else {
+      // Preserve the existing static export behavior when dynamic fallbacks are
+      // disabled: static hosts may not provide the normal RSC content type, so
+      // an OK response is allowed through and Flight decoding determines
+      // whether it was usable.
+    }
   } else {
-    const contentType = response.headers.get('content-type')
-    const isFlightResponse =
-      contentType && contentType.startsWith(RSC_CONTENT_TYPE_HEADER)
+    const isFlightResponse = contentType.startsWith(RSC_CONTENT_TYPE_HEADER)
     if (!isFlightResponse) {
       return null
     }
@@ -2824,6 +2893,24 @@ function createIncrementalPrefetchResponseStream(
   })
 }
 
+export function getOutputExportSegmentRequestUrl(
+  url: URL,
+  segmentPath: SegmentRequestKey,
+  outputExportFallbackBasePath: string | null
+): URL {
+  const staticUrl = new URL(url)
+  if (outputExportFallbackBasePath !== null) {
+    staticUrl.pathname = outputExportFallbackBasePath
+  }
+  const routeDir = staticUrl.pathname.endsWith('/')
+    ? staticUrl.pathname.slice(0, -1)
+    : staticUrl.pathname
+  const staticExportFilename =
+    convertSegmentPathToStaticExportFilename(segmentPath)
+  staticUrl.pathname = `${routeDir}/${staticExportFilename}`
+  return staticUrl
+}
+
 function addSegmentPathToUrlInOutputExportMode(
   url: URL,
   segmentPath: SegmentRequestKey
@@ -2831,14 +2918,7 @@ function addSegmentPathToUrlInOutputExportMode(
   if (isOutputExportMode) {
     // In output: "export" mode, we cannot use a header to encode the segment
     // path. Instead, we append it to the end of the pathname.
-    const staticUrl = new URL(url)
-    const routeDir = staticUrl.pathname.endsWith('/')
-      ? staticUrl.pathname.slice(0, -1)
-      : staticUrl.pathname
-    const staticExportFilename =
-      convertSegmentPathToStaticExportFilename(segmentPath)
-    staticUrl.pathname = `${routeDir}/${staticExportFilename}`
-    return staticUrl
+    return getOutputExportSegmentRequestUrl(url, segmentPath, null)
   }
   return url
 }
@@ -2959,7 +3039,8 @@ export function writeStaticStageResponseIntoCache(
   staleAt: number,
   baseTree: FlightRouterState,
   renderedSearch: string,
-  isResponsePartial: boolean
+  isResponsePartial: boolean,
+  outputExportFallbackBasePath: string | null = null
 ): void {
   const fetchStrategy = isResponsePartial
     ? FetchStrategy.PPR
@@ -2979,7 +3060,8 @@ export function writeStaticStageResponseIntoCache(
     baseTree,
     flightDatas,
     renderedSearch,
-    UnknownDynamicStaleTime
+    UnknownDynamicStaleTime,
+    outputExportFallbackBasePath
   )
   writeDynamicRenderResponseIntoCache(
     now,
@@ -3004,7 +3086,8 @@ export async function processRuntimePrefetchStream(
   now: number,
   runtimePrefetchStream: ReadableStream<Uint8Array>,
   baseTree: FlightRouterState,
-  renderedSearch: string
+  renderedSearch: string,
+  outputExportFallbackBasePath: string | null = null
 ): Promise<{
   flightDatas: NormalizedFlightData[]
   navigationSeed: NavigationSeed
@@ -3039,7 +3122,8 @@ export async function processRuntimePrefetchStream(
     baseTree,
     flightDatas,
     renderedSearch,
-    UnknownDynamicStaleTime
+    UnknownDynamicStaleTime,
+    outputExportFallbackBasePath
   )
 
   return {

--- a/packages/next/src/client/components/segment-cache/navigation-testing-lock.ts
+++ b/packages/next/src/client/components/segment-cache/navigation-testing-lock.ts
@@ -109,6 +109,12 @@ function acquireLock(): void {
   }
 }
 
+export function armNavigationLockForTesting(): void {
+  if (process.env.__NEXT_EXPOSE_TESTING_API) {
+    acquireLock()
+  }
+}
+
 function releaseLock(): void {
   if (lockState === null) {
     return

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -317,6 +317,7 @@ function navigateUsingPrefetchedRouteTree(
     data: null,
     head: null,
     dynamicStaleAt: computeDynamicStaleAt(now, UnknownDynamicStaleTime),
+    outputExportFallbackBasePath: route.outputExportFallbackBasePath,
   }
   return navigateToKnownRoute(
     now,
@@ -407,6 +408,7 @@ async function navigateToUnknownRoute(
     flightData,
     canonicalUrl,
     renderedSearch,
+    outputExportFallbackBasePath,
     couldBeIntercepted,
     supportsPerSegmentPrefetching,
     dynamicStaleTime,
@@ -424,7 +426,8 @@ async function navigateToUnknownRoute(
     currentFlightRouterState,
     flightData,
     renderedSearch,
-    dynamicStaleTime
+    dynamicStaleTime,
+    outputExportFallbackBasePath
   )
 
   // Learn the route pattern so we can predict it for future navigations.
@@ -444,7 +447,8 @@ async function navigateToUnknownRoute(
       couldBeIntercepted,
       createHrefFromUrl(canonicalUrl),
       supportsPerSegmentPrefetching,
-      false // hasDynamicRewrite - not a retry, rewrite detection happens during traversal
+      false, // hasDynamicRewrite - not a retry, rewrite detection happens during traversal
+      { outputExportFallbackBasePath }
     )
 
     if (staticStageData !== null) {
@@ -467,7 +471,8 @@ async function navigateToUnknownRoute(
             staleAt,
             currentFlightRouterState,
             renderedSearch,
-            isResponsePartial
+            isResponsePartial,
+            outputExportFallbackBasePath
           )
         })
         .catch(() => {
@@ -481,7 +486,8 @@ async function navigateToUnknownRoute(
         now,
         runtimePrefetchStream,
         currentFlightRouterState,
-        renderedSearch
+        renderedSearch,
+        outputExportFallbackBasePath
       )
         .then((processed) => {
           if (processed !== null) {
@@ -743,6 +749,7 @@ export type NavigationSeed = {
   data: CacheNodeSeedData | null
   head: HeadData | null
   dynamicStaleAt: number
+  outputExportFallbackBasePath: string | null
 }
 
 export function convertServerPatchToFullTree(
@@ -750,7 +757,8 @@ export function convertServerPatchToFullTree(
   currentTree: FlightRouterState,
   flightData: Array<NormalizedFlightData> | null,
   renderedSearch: string,
-  dynamicStaleTimeSeconds: number
+  dynamicStaleTimeSeconds: number,
+  outputExportFallbackBasePath: string | null = null
 ): NavigationSeed {
   // During a client navigation or prefetch, the server sends back only a patch
   // for the parts of the tree that have changed.
@@ -816,6 +824,7 @@ export function convertServerPatchToFullTree(
     renderedSearch,
     head,
     dynamicStaleAt: computeDynamicStaleAt(now, dynamicStaleTimeSeconds),
+    outputExportFallbackBasePath,
   }
 }
 

--- a/packages/next/src/client/components/segment-cache/optimistic-routes.ts
+++ b/packages/next/src/client/components/segment-cache/optimistic-routes.ts
@@ -139,6 +139,21 @@ type KnownRoutePart =
  */
 type ResolvedParams = Map<string, string | string[]>
 
+type DiscoverKnownRouteOptions = {
+  outputExportFallbackBasePath?: string | null
+}
+
+function applyDiscoverKnownRouteOptions(
+  entry: FulfilledRouteCacheEntry,
+  options: DiscoverKnownRouteOptions | undefined
+): FulfilledRouteCacheEntry {
+  const outputExportFallbackBasePath = options?.outputExportFallbackBasePath
+  if (outputExportFallbackBasePath != null) {
+    entry.outputExportFallbackBasePath = outputExportFallbackBasePath
+  }
+  return entry
+}
+
 /**
  * Read the pattern from a KnownRoutePart, evicting it if expired.
  *
@@ -155,7 +170,10 @@ function readPattern(
   if (pattern === null) {
     return null
   }
-  if (isValueExpired(now, getCurrentRouteCacheVersion(), pattern)) {
+  if (
+    pattern.outputExportFallbackBasePath === null &&
+    isValueExpired(now, getCurrentRouteCacheVersion(), pattern)
+  ) {
     // The pattern is expired. Null it out so the slot can be repopulated.
     part.pattern = null
     return null
@@ -204,7 +222,8 @@ export function discoverKnownRoute(
   couldBeIntercepted: boolean,
   canonicalUrl: string,
   supportsPerSegmentPrefetching: boolean,
-  hasDynamicRewrite: boolean
+  hasDynamicRewrite: boolean,
+  options?: DiscoverKnownRouteOptions
 ): FulfilledRouteCacheEntry {
   const tree = routeTree
 
@@ -226,6 +245,7 @@ export function discoverKnownRoute(
     if (hasDynamicRewrite) {
       fulfilledEntry.hasDynamicRewrite = true
     }
+    applyDiscoverKnownRouteOptions(fulfilledEntry, options)
     // Populate the known route tree (handles rewrite detection internally).
     // The entry is already in the cache; this just stores it as a pattern
     // if the URL matches the route structure.
@@ -243,7 +263,8 @@ export function discoverKnownRoute(
       couldBeIntercepted,
       canonicalUrl,
       supportsPerSegmentPrefetching,
-      hasDynamicRewrite
+      hasDynamicRewrite,
+      options
     )
     return fulfilledEntry
   }
@@ -264,7 +285,8 @@ export function discoverKnownRoute(
     couldBeIntercepted,
     canonicalUrl,
     supportsPerSegmentPrefetching,
-    hasDynamicRewrite
+    hasDynamicRewrite,
+    options
   )
 }
 
@@ -320,7 +342,8 @@ function discoverKnownRoutePart(
   couldBeIntercepted: boolean,
   canonicalUrl: string,
   supportsPerSegmentPrefetching: boolean,
-  hasDynamicRewrite: boolean
+  hasDynamicRewrite: boolean,
+  options: DiscoverKnownRouteOptions | undefined
 ): FulfilledRouteCacheEntry {
   const segment = routeTree.segment
 
@@ -350,17 +373,20 @@ function discoverKnownRoutePart(
       // Don't populate the known route tree, just write the route into the
       // cache and return immediately.
       if (existingEntry !== null) {
-        return existingEntry
+        return applyDiscoverKnownRouteOptions(existingEntry, options)
       }
-      return writeRouteIntoCache(
-        now,
-        pathname as NormalizedPathname,
-        nextUrl,
-        fullTree,
-        metadataVaryPath,
-        couldBeIntercepted,
-        canonicalUrl,
-        supportsPerSegmentPrefetching
+      return applyDiscoverKnownRouteOptions(
+        writeRouteIntoCache(
+          now,
+          pathname as NormalizedPathname,
+          nextUrl,
+          fullTree,
+          metadataVaryPath,
+          couldBeIntercepted,
+          canonicalUrl,
+          supportsPerSegmentPrefetching
+        ),
+        options
       )
     }
 
@@ -379,14 +405,22 @@ function discoverKnownRoutePart(
       // - staticChildren: null = siblings unknown (can't safely match dynamic)
       // - staticChildren: Map = siblings known (even if empty)
       // This matters in dev mode where webpack may not know all siblings yet.
-      if (staticSiblings !== null) {
+      if (staticSiblings !== null || process.env.NODE_ENV === 'production') {
         // Siblings are known - ensure we have a Map (even if empty)
         if (parentKnownRoutePart.staticChildren === null) {
           parentKnownRoutePart.staticChildren = new Map()
         }
+      }
+      if (staticSiblings !== null) {
+        const staticChildren = parentKnownRoutePart.staticChildren
+        if (staticChildren === null) {
+          throw new Error(
+            'Expected staticChildren to be initialized for known dynamic siblings.'
+          )
+        }
         for (const sibling of staticSiblings) {
-          if (!parentKnownRoutePart.staticChildren.has(sibling)) {
-            parentKnownRoutePart.staticChildren.set(sibling, createEmptyPart())
+          if (!staticChildren.has(sibling)) {
+            staticChildren.set(sibling, createEmptyPart())
           }
         }
       }
@@ -440,7 +474,8 @@ function discoverKnownRoutePart(
         couldBeIntercepted,
         canonicalUrl,
         supportsPerSegmentPrefetching,
-        hasDynamicRewrite
+        hasDynamicRewrite,
+        options
       )
       // All parallel route branches share the same URL, so they should all
       // reach compatible leaf nodes. We capture any result.
@@ -452,17 +487,20 @@ function discoverKnownRoutePart(
     // Defensive fallback: no children returned a result. This shouldn't happen
     // for valid route trees, but handle it gracefully.
     if (existingEntry !== null) {
-      return existingEntry
+      return applyDiscoverKnownRouteOptions(existingEntry, options)
     }
-    return writeRouteIntoCache(
-      now,
-      pathname as NormalizedPathname,
-      nextUrl,
-      fullTree,
-      metadataVaryPath,
-      couldBeIntercepted,
-      canonicalUrl,
-      supportsPerSegmentPrefetching
+    return applyDiscoverKnownRouteOptions(
+      writeRouteIntoCache(
+        now,
+        pathname as NormalizedPathname,
+        nextUrl,
+        fullTree,
+        metadataVaryPath,
+        couldBeIntercepted,
+        canonicalUrl,
+        supportsPerSegmentPrefetching
+      ),
+      options
     )
   }
 
@@ -474,7 +512,7 @@ function discoverKnownRoutePart(
     if (hasDynamicRewrite) {
       existingPattern.hasDynamicRewrite = true
     }
-    return existingPattern
+    return applyDiscoverKnownRouteOptions(existingPattern, options)
   }
 
   // Get or create the entry
@@ -500,6 +538,7 @@ function discoverKnownRoutePart(
   if (hasDynamicRewrite) {
     entry.hasDynamicRewrite = true
   }
+  applyDiscoverKnownRouteOptions(entry, options)
 
   // Store as pattern
   knownRoutePart.pattern = entry
@@ -587,6 +626,7 @@ export function matchKnownRoute(
     metadata: reifiedMetadata,
     couldBeIntercepted: pattern.couldBeIntercepted,
     supportsPerSegmentPrefetching: pattern.supportsPerSegmentPrefetching,
+    outputExportFallbackBasePath: pattern.outputExportFallbackBasePath,
     hasDynamicRewrite: false,
     renderedSearch: search,
     ref: null,

--- a/packages/next/src/client/components/segment-cache/scheduler.ts
+++ b/packages/next/src/client/components/segment-cache/scheduler.ts
@@ -903,7 +903,8 @@ function pingStaticHead(
     entry: readOrCreateSegmentCacheEntry(
       now,
       FetchStrategy.PPR,
-      route.metadata
+      route.metadata,
+      route.outputExportFallbackBasePath
     ),
     parent: null,
   }
@@ -1263,7 +1264,12 @@ function pingPPRDisabledRouteTreeUpToLoadingBoundary(
   let refetchMarker: 'refetch' | 'inside-shared-layout' | null =
     refetchMarkerContext === null ? 'inside-shared-layout' : null
 
-  const segment = readOrCreateSegmentCacheEntry(now, task.fetchStrategy, tree)
+  const segment = readOrCreateSegmentCacheEntry(
+    now,
+    task.fetchStrategy,
+    tree,
+    route.outputExportFallbackBasePath
+  )
   switch (segment.status) {
     case EntryStatus.Empty: {
       // This segment is not cached. Add a refetch marker so the server knows
@@ -1373,7 +1379,8 @@ function pingRouteTreeAndIncludeDynamicData(
     // always use runtime prefetching (via `export const prefetch`), and those should check for
     // entries that include search params.
     fetchStrategy,
-    tree
+    tree,
+    route.outputExportFallbackBasePath
   )
 
   let spawnedSegment: PendingSegmentCacheEntry | null = null
@@ -1422,7 +1429,12 @@ function pingRouteTreeAndIncludeDynamicData(
             break
           }
         }
-        spawnedSegment = pingFullSegmentRevalidation(now, tree, fetchStrategy)
+        spawnedSegment = pingFullSegmentRevalidation(
+          now,
+          route,
+          tree,
+          fetchStrategy
+        )
       }
       break
     }
@@ -1436,7 +1448,12 @@ function pingRouteTreeAndIncludeDynamicData(
           fetchStrategy
         )
       ) {
-        spawnedSegment = pingFullSegmentRevalidation(now, tree, fetchStrategy)
+        spawnedSegment = pingFullSegmentRevalidation(
+          now,
+          route,
+          tree,
+          fetchStrategy
+        )
       }
       break
     }
@@ -1656,7 +1673,12 @@ function accumulateSegmentBundle(
     }
   }
 
-  const segment = readOrCreateSegmentCacheEntry(now, task.fetchStrategy, tree)
+  const segment = readOrCreateSegmentCacheEntry(
+    now,
+    task.fetchStrategy,
+    tree,
+    route.outputExportFallbackBasePath
+  )
 
   if (
     process.env.__NEXT_PREFETCH_INLINING &&
@@ -1682,7 +1704,8 @@ function accumulateSegmentBundle(
       entry: readOrCreateSegmentCacheEntry(
         now,
         FetchStrategy.PPR,
-        route.metadata
+        route.metadata,
+        route.outputExportFallbackBasePath
       ),
       parent: parentBundle,
     }
@@ -1722,13 +1745,15 @@ function finishStaticBundleOnRuntimeBailout(
 
 function pingFullSegmentRevalidation(
   now: number,
+  route: FulfilledRouteCacheEntry,
   tree: RouteTree,
   fetchStrategy: FetchStrategy.Full | FetchStrategy.PPRRuntime
 ): PendingSegmentCacheEntry | null {
   const revalidatingSegment = readOrCreateRevalidatingSegmentEntry(
     now,
     fetchStrategy,
-    tree
+    tree,
+    route.outputExportFallbackBasePath
   )
   if (revalidatingSegment.status === EntryStatus.Empty) {
     // During a Full/PPRRuntime prefetch, a single dynamic request is made for all the

--- a/packages/next/src/client/components/segment-cache/vary-path.ts
+++ b/packages/next/src/client/components/segment-cache/vary-path.ts
@@ -244,7 +244,8 @@ export function finalizeMetadataVaryPath(
 
 export function getSegmentVaryPathForRequest(
   fetchStrategy: FetchStrategy,
-  tree: RouteTree
+  tree: RouteTree,
+  outputExportFallbackBasePath: string | null = null
 ): SegmentVaryPath {
   // This is used for storing pending requests in the cache. We want to choose
   // the most generic vary path based on the strategy used to fetch it, i.e.
@@ -272,6 +273,15 @@ export function getSegmentVaryPathForRequest(
   // Only page segments (and the special "metadata" segment, which is treated
   // like a page segment for the purposes of caching) may contain search
   // params. There's no reason to include them in the vary path otherwise.
+  const originalPathParamsVaryPath = tree.isPage
+    ? getPartialPageVaryPath(originalVaryPath as PageVaryPath)
+    : getPartialLayoutVaryPath(originalVaryPath as LayoutVaryPath)
+
+  const pathParamsVaryPath =
+    outputExportFallbackBasePath !== null
+      ? clonePathParamsVaryPathWithFallback(originalPathParamsVaryPath)
+      : originalPathParamsVaryPath
+
   if (tree.isPage) {
     // Only a runtime prefetch will include search params in the vary path.
     // Static prefetches never include search params, so they can be reused
@@ -287,8 +297,6 @@ export function getSegmentVaryPathForRequest(
       //
       // requestKey -> searchParams -> pathParams
       //               ^ This part gets replaced with Fallback
-      const searchParamsVaryPath = (originalVaryPath as PageVaryPath).parent
-      const pathParamsVaryPath = searchParamsVaryPath.parent
       const patchedVaryPath: VaryPath = {
         id: null,
         value: originalVaryPath.value,
@@ -300,10 +308,51 @@ export function getSegmentVaryPathForRequest(
       }
       return patchedVaryPath as SegmentVaryPath
     }
+
+    if (pathParamsVaryPath !== originalPathParamsVaryPath) {
+      const searchParamsVaryPath = (originalVaryPath as PageVaryPath).parent
+      const patchedVaryPath: VaryPath = {
+        id: null,
+        value: originalVaryPath.value,
+        parent: {
+          id: '?',
+          value: searchParamsVaryPath.value,
+          parent: pathParamsVaryPath,
+        },
+      }
+      return patchedVaryPath as SegmentVaryPath
+    }
+  }
+
+  if (pathParamsVaryPath !== originalPathParamsVaryPath) {
+    const patchedVaryPath: VaryPath = {
+      id: null,
+      value: originalVaryPath.value,
+      parent: pathParamsVaryPath,
+    }
+    return patchedVaryPath as SegmentVaryPath
   }
 
   // The request does vary on search params. We don't need to modify anything.
   return originalVaryPath as SegmentVaryPath
+}
+
+function clonePathParamsVaryPathWithFallback(
+  originalVaryPath: PartialSegmentVaryPath | null
+): PartialSegmentVaryPath | null {
+  if (originalVaryPath === null) {
+    return null
+  }
+
+  const clonedParent = clonePathParamsVaryPathWithFallback(
+    originalVaryPath.parent as PartialSegmentVaryPath | null
+  )
+  const clonedVaryPath: VaryPath = {
+    id: originalVaryPath.id,
+    value: originalVaryPath.id === null ? originalVaryPath.value : Fallback,
+    parent: clonedParent,
+  }
+  return clonedVaryPath as PartialSegmentVaryPath
 }
 
 export function clonePageVaryPathWithNewSearchParams(
@@ -336,7 +385,8 @@ export function getRenderedSearchFromVaryPath(
 
 export function getFulfilledSegmentVaryPath(
   original: VaryPath,
-  varyParams: Set<string>
+  varyParams: Set<string>,
+  forceFallbackPathParams: boolean = false
 ): SegmentVaryPath {
   // Re-keys a segment's vary path based on which params the segment actually
   // depends on. Params that are NOT in the varyParams set are replaced with
@@ -348,17 +398,26 @@ export function getFulfilledSegmentVaryPath(
   // accessed during rendering.
   const clone: VaryPath = {
     id: original.id,
-    // If the id is null, this node is not a param (e.g., it's a request key).
-    // If the id is in the varyParams set, keep the original value.
-    // Otherwise, replace with Fallback to make it reusable.
+    // If the id is null, this node is not a param (e.g., it's a request key),
+    // so always preserve it. For output export fallback routes, path params
+    // are always generic even if the server reports them as accessed, because
+    // the emitted fallback artifacts are shared across all param values.
     value:
-      original.id === null || varyParams.has(original.id)
+      original.id === null
         ? original.value
-        : Fallback,
+        : forceFallbackPathParams && original.id !== '?'
+          ? Fallback
+          : varyParams.has(original.id)
+            ? original.value
+            : Fallback,
     parent:
       original.parent === null
         ? null
-        : getFulfilledSegmentVaryPath(original.parent, varyParams),
+        : getFulfilledSegmentVaryPath(
+            original.parent,
+            varyParams,
+            forceFallbackPathParams
+          ),
   }
   return clone as SegmentVaryPath
 }

--- a/packages/next/src/client/output-export-fallback-bootstrap.ts
+++ b/packages/next/src/client/output-export-fallback-bootstrap.ts
@@ -23,6 +23,11 @@ type OutputExportFallbackState = {
   isFallback: boolean
 }
 
+type OutputExportFallbackInitialResponse = {
+  initialRSCPayload: InitialRSCPayload
+  fallbackBasePath: string | null
+}
+
 declare global {
   interface Window {
     __NEXT_EXPORT_FALLBACK?: boolean
@@ -41,7 +46,7 @@ export async function createOutputExportFallbackInitialResponse({
 }: {
   createFromFetch: CreateFromFetch
   debugChannel: DebugChannel
-}): Promise<InitialRSCPayload> {
+}): Promise<OutputExportFallbackInitialResponse> {
   const renderedUrl = new URL(window.location.href)
   const fallbackResult = await fetchOutputExportFallbackResponse(renderedUrl, {
     credentials: 'same-origin',
@@ -53,12 +58,15 @@ export async function createOutputExportFallbackInitialResponse({
     )
   }
 
-  return decodeFallbackPrerenderPayload(
-    Promise.resolve(fallbackResult.response),
-    renderedUrl,
-    createFromFetch,
-    debugChannel
-  )
+  return {
+    initialRSCPayload: await decodeFallbackPrerenderPayload(
+      Promise.resolve(fallbackResult.response),
+      renderedUrl,
+      createFromFetch,
+      debugChannel
+    ),
+    fallbackBasePath: fallbackResult.fallbackUrl.pathname,
+  }
 }
 
 async function decodeFallbackPrerenderPayload(


### PR DESCRIPTION
## Stack position

Part 11 of 19 in the output export dynamic fallback stack.

Previous PR: #93569 (10/19)
Next PR: #93570 (12/19)

## Context

The stack is split so build-time output can land behind `experimental.outputExportDynamicFallbacks` before the client router behavior is enabled. The target behavior is for `output: 'export'` apps with parameterized App Router routes to emit fallback HTML/RSC artifacts that a later client can resolve for hard loads and soft navigations.

This PR scope: Segment-cache identity for fallback artifacts.

Different requested URLs can resolve to the same fallback artifact. The cache needs to know the fallback base path so segment entries are keyed by the reusable artifact shape instead of the concrete missing URL.

## What changed

- Carries `outputExportFallbackBasePath` through initial router state, navigation results, and segment-cache writes.
- Keys fallback segment requests against the fallback artifact base path.
- Uses the fresh `fetchServerResponse` result when runtime-prefetch data learns a fallback base path.

## Deliberately not included

- Does not add route-manifest conflict resolution.
- Does not add cache-miss fallback recovery yet.
- Does not change non-export cache keying.

## Verification

After restacking and autosquashing, I verified the full stack with:

- `pnpm --filter=next build`
- `pnpm testonly packages/next/src/lib/output-export-dynamic-fallback.test.ts packages/next/src/lib/output-export-fallback-routes.test.ts packages/next/src/export/helpers/output-export-fallback.test.ts packages/next/src/server/request/fallback-params.test.ts`
- `pnpm testonly packages/next/src/client/output-export-fallback.test.ts packages/next/src/client/components/router-reducer/fetch-server-response.test.ts packages/next/src/client/components/router-reducer/create-initial-router-state.test.ts packages/next/src/client/components/segment-cache/cache.test.ts packages/next/src/client/components/segment-cache/vary-path.test.ts`
- `pnpm testonly packages/next/src/client/components/router-reducer/compute-changed-path.test.ts packages/next/src/client/flight-data-helpers.test.ts packages/next/src/server/app-render/postponed-state.test.ts`
- `pnpm test-start-turbo test/e2e/app-dir-export/test/dynamic-fallback-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-route-shapes-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-cache-components-basepath.test.ts test/e2e/app-dir-export/test/dynamic-fallback-optimizations-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-known-params-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-conflict.test.ts`
- `pnpm test-start-turbo test/e2e/app-dir/output-export-dynamic-fallbacks/output-export-dynamic-fallbacks.test.ts test/e2e/app-dir-export/test/output-export-server-io.test.ts test/e2e/app-dir-export/test/output-export-server-io-use-cache.test.ts test/e2e/app-dir-export/test/dynamic-fallback-server-params.test.ts`

<!-- NEXT_JS_LLM_PR -->
