### PR TITLE
(14/19) Validate export fallback route shapes on the client

### DIFF
--- a/packages/next/src/client/components/router-reducer/compute-changed-path.ts
+++ b/packages/next/src/client/components/router-reducer/compute-changed-path.ts
@@ -4,12 +4,17 @@ import type {
 } from '../../../shared/lib/app-router-types'
 import { INTERCEPTION_ROUTE_MARKERS } from '../../../shared/lib/router/utils/interception-routes'
 import type { Params } from '../../../server/request/params'
+import { removePathPrefix } from '../../../shared/lib/router/utils/remove-path-prefix'
 import {
   isGroupSegment,
   DEFAULT_SEGMENT_KEY,
   PAGE_SEGMENT_KEY,
 } from '../../../shared/lib/segment'
 import { matchSegment } from '../match-segments'
+import {
+  doesStaticSegmentAppearInURL,
+  parseDynamicParamFromURLPart,
+} from '../../route-params'
 
 const removeLeadingSlash = (segment: string): string => {
   return segment[0] === '/' ? segment.slice(1) : segment
@@ -226,6 +231,23 @@ export function getSelectedParams(
   currentTree: FlightRouterState,
   params: Params = {}
 ): Params {
+  const basePath = process.env.__NEXT_ROUTER_BASEPATH || ''
+  const pathnameParts =
+    typeof window !== 'undefined'
+      ? removePathPrefix(window.location.pathname, basePath)
+          .split('/')
+          .filter((p) => p !== '')
+      : null
+
+  return getSelectedParamsImpl(currentTree, params, pathnameParts, 0)
+}
+
+function getSelectedParamsImpl(
+  currentTree: FlightRouterState,
+  params: Params,
+  pathnameParts: string[] | null,
+  pathnamePartsIndex: number
+): Params {
   const parallelRoutes = currentTree[1]
 
   for (const parallelRoute of Object.values(parallelRoutes)) {
@@ -234,17 +256,47 @@ export function getSelectedParams(
     const segmentValue = isDynamicParameter ? segment[1] : segment
     if (!segmentValue || segmentValue.startsWith(PAGE_SEGMENT_KEY)) continue
 
+    let childPathnamePartsIndex = pathnamePartsIndex
+
     // Ensure catchAll and optional catchall are turned into an array
     const isCatchAll =
       isDynamicParameter && (segment[2] === 'c' || segment[2] === 'oc')
 
     if (isCatchAll) {
-      params[segment[0]] = segment[1].split('/')
+      if (pathnameParts !== null && segment[1].startsWith('%%drp:')) {
+        const paramValue = parseDynamicParamFromURLPart(
+          segment[2],
+          pathnameParts,
+          pathnamePartsIndex
+        )
+        params[segment[0]] = paramValue === null ? undefined : paramValue
+      } else {
+        params[segment[0]] = segment[1].split('/')
+      }
+      childPathnamePartsIndex =
+        pathnameParts !== null ? pathnameParts.length : pathnamePartsIndex
     } else if (isDynamicParameter) {
-      params[segment[0]] = segment[1]
+      if (pathnameParts !== null && segment[1].startsWith('%%drp:')) {
+        const paramValue = parseDynamicParamFromURLPart(
+          segment[2],
+          pathnameParts,
+          pathnamePartsIndex
+        )
+        params[segment[0]] = paramValue === null ? undefined : paramValue
+      } else {
+        params[segment[0]] = segment[1]
+      }
+      childPathnamePartsIndex = pathnamePartsIndex + 1
+    } else if (doesStaticSegmentAppearInURL(segmentValue)) {
+      childPathnamePartsIndex = pathnamePartsIndex + 1
     }
 
-    params = getSelectedParams(parallelRoute, params)
+    params = getSelectedParamsImpl(
+      parallelRoute,
+      params,
+      pathnameParts,
+      childPathnamePartsIndex
+    )
   }
 
   return params

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -32,6 +32,7 @@ import {
 import { callServer } from '../../app-call-server'
 import { findSourceMapURL } from '../../app-find-source-map-url'
 import {
+  fillInAndValidateFallbackFlightData,
   fillInFallbackFlightData,
   normalizeFlightData,
   prepareFlightRouterStateForRequest,
@@ -171,6 +172,8 @@ export async function fetchServerResponse(
   try {
     let usedCachedOutputExportFallback = false
     let outputExportFallbackBasePath: string | null = null
+    let outputExportFallbackFetchResult: OutputExportFallbackFetchResult | null =
+      null
     if (
       process.env.NODE_ENV === 'production' &&
       process.env.__NEXT_CONFIG_OUTPUT === 'export'
@@ -246,34 +249,17 @@ export async function fetchServerResponse(
 
       if (process.env.__NEXT_OUTPUT_EXPORT_DYNAMIC_FALLBACKS) {
         if (!isFlightResponse || !res.ok || !res.body) {
-          const { fetchOutputExportFallbackResponse } =
-            require('../../output-export-fallback') as typeof import('../../output-export-fallback')
-
-          const fallbackResult = await fetchOutputExportFallbackResponse(
+          const fallbackResult = await fetchOutputExportFallbackFetchResult(
             originalUrl,
-            {
-              credentials: 'same-origin',
-              headers,
-            }
+            headers
           )
 
           if (fallbackResult !== null) {
             usedOutputExportFallback = true
-            outputExportFallbackBasePath = fallbackResult.fallbackUrl.pathname
-            const { response: processed, cacheData } = await processFetch(
-              fallbackResult.response
-            )
-
-            res = {
-              ok: processed.ok,
-              redirected: false,
-              headers: processed.headers,
-              body: processed.body,
-              status: processed.status,
-              url: originalUrl.href,
-              flightResponsePromise: null,
-              cacheData: Promise.resolve(cacheData),
-            }
+            outputExportFallbackFetchResult = fallbackResult
+            outputExportFallbackBasePath =
+              fallbackResult.outputExportFallbackBasePath
+            res = fallbackResult.response
             responseUrl = originalUrl
             canonicalUrl = originalUrl
             contentType = res.headers.get('content-type') || ''
@@ -332,7 +318,7 @@ export async function fetchServerResponse(
         )
     }
 
-    const [flightResponse, cacheData] = await Promise.all([
+    let [flightResponse, cacheData] = await Promise.all([
       flightResponsePromise,
       res.cacheData,
     ])
@@ -345,14 +331,63 @@ export async function fetchServerResponse(
       return doMpaNavigation(res.url)
     }
 
-    const fallbackFlightData =
-      usedOutputExportFallback || usedCachedOutputExportFallback
-        ? fillInFallbackFlightData(
-            flightResponse.f,
-            originalUrl.pathname,
-            originalUrl.search as NormalizedSearch
-          )
-        : null
+    let fallbackFlightData: NavigationFlightResponse['f'] | null =
+      outputExportFallbackFetchResult?.fallbackFlightData ?? null
+    let shouldFetchOutputExportNotFound =
+      usedOutputExportFallback &&
+      outputExportFallbackFetchResult !== null &&
+      !outputExportFallbackFetchResult.matchesRenderedPathname
+    if (
+      fallbackFlightData === null &&
+      (usedOutputExportFallback || usedCachedOutputExportFallback)
+    ) {
+      if (process.env.__NEXT_OUTPUT_EXPORT_DYNAMIC_FALLBACKS) {
+        fallbackFlightData = fillInAndValidateFallbackFlightData(
+          flightResponse.f,
+          originalUrl.pathname,
+          originalUrl.search as NormalizedSearch
+        )
+        if (fallbackFlightData === null) {
+          shouldFetchOutputExportNotFound = true
+        }
+      } else {
+        fallbackFlightData = fillInFallbackFlightData(
+          flightResponse.f,
+          originalUrl.pathname,
+          originalUrl.search as NormalizedSearch
+        )
+      }
+    }
+
+    if (process.env.__NEXT_OUTPUT_EXPORT_DYNAMIC_FALLBACKS) {
+      if (shouldFetchOutputExportNotFound) {
+        const notFoundResult = await fetchOutputExportNotFoundFetchResult(
+          originalUrl,
+          headers
+        )
+
+        if (notFoundResult === null) {
+          return doMpaNavigation(originalUrl.href)
+        }
+
+        res = notFoundResult.response
+        responseUrl = originalUrl
+        canonicalUrl = originalUrl
+        contentType = res.headers.get('content-type') || ''
+        interception = !!res.headers.get('vary')?.includes(NEXT_URL)
+        postponed = true
+        isFlightResponse = true
+        flightResponse = notFoundResult.flightResponse
+        cacheData = notFoundResult.cacheData
+        fallbackFlightData = notFoundResult.fallbackFlightData
+        outputExportFallbackBasePath =
+          notFoundResult.outputExportFallbackBasePath
+        usedOutputExportFallback = false
+        usedCachedOutputExportFallback = true
+      }
+    } else {
+      // Static export fallback route-shape checks are erased when the feature is off.
+    }
 
     const normalizedFlightData = normalizeFlightData(
       fallbackFlightData ?? flightResponse.f
@@ -447,6 +482,128 @@ export type RSCResponse<T> = {
 type FetchResponseCacheData = {
   isResponsePartial: boolean
   responseBodyClone?: ReadableStream<Uint8Array>
+}
+
+type OutputExportFallbackFetchResult = {
+  response: RSCResponse<NavigationFlightResponse>
+  flightResponse: NavigationFlightResponse
+  cacheData: FetchResponseCacheData | null
+  fallbackFlightData: NavigationFlightResponse['f']
+  matchesRenderedPathname: boolean
+  outputExportFallbackBasePath: string
+}
+
+async function createOutputExportFallbackFetchResult({
+  response,
+  renderedUrl,
+  outputExportFallbackBasePath,
+  headers,
+}: {
+  response: Response
+  renderedUrl: URL
+  outputExportFallbackBasePath: string
+  headers: RequestHeaders
+}): Promise<OutputExportFallbackFetchResult | null> {
+  const { response: processed, cacheData } = await processFetch(response)
+
+  if (!processed.body) {
+    return null
+  }
+
+  const flightResponse =
+    await createFromNextReadableStream<NavigationFlightResponse>(
+      processed.body,
+      headers,
+      { allowPartialStream: true }
+    )
+  const matchedFallbackFlightData = fillInAndValidateFallbackFlightData(
+    flightResponse.f,
+    renderedUrl.pathname,
+    renderedUrl.search as NormalizedSearch
+  )
+  const fallbackFlightData =
+    matchedFallbackFlightData ??
+    fillInFallbackFlightData(
+      flightResponse.f,
+      renderedUrl.pathname,
+      renderedUrl.search as NormalizedSearch
+    )
+
+  return {
+    response: {
+      ok: processed.ok,
+      redirected: false,
+      headers: processed.headers,
+      body: processed.body,
+      status: processed.status,
+      url: renderedUrl.href,
+      flightResponsePromise: Promise.resolve(flightResponse),
+      cacheData: Promise.resolve(cacheData),
+    },
+    flightResponse,
+    cacheData,
+    fallbackFlightData,
+    matchesRenderedPathname: matchedFallbackFlightData !== null,
+    outputExportFallbackBasePath,
+  }
+}
+
+async function fetchOutputExportFallbackFetchResult(
+  renderedUrl: URL,
+  headers: RequestHeaders
+): Promise<OutputExportFallbackFetchResult | null> {
+  const { fetchOutputExportFallbackResponse } =
+    require('../../output-export-fallback') as typeof import('../../output-export-fallback')
+
+  const fallbackResult = await fetchOutputExportFallbackResponse(renderedUrl, {
+    credentials: 'same-origin',
+    headers,
+  })
+
+  if (fallbackResult === null) {
+    return null
+  }
+
+  return createOutputExportFallbackFetchResult({
+    response: fallbackResult.response,
+    renderedUrl,
+    outputExportFallbackBasePath: fallbackResult.fallbackUrl.pathname,
+    headers,
+  })
+}
+
+async function fetchOutputExportNotFoundFetchResult(
+  renderedUrl: URL,
+  headers: RequestHeaders
+): Promise<OutputExportFallbackFetchResult | null> {
+  const {
+    addOutputExportDataSuffix,
+    fetchOutputExportNotFoundDataResponse,
+    fetchOutputExportNotFoundResponse,
+    getCachedOutputExportFallbackBasePath,
+    getConfiguredOutputExportNotFoundCandidate,
+  } =
+    require('../../output-export-fallback') as typeof import('../../output-export-fallback')
+
+  const notFoundResponse =
+    (await fetchOutputExportNotFoundDataResponse(renderedUrl, {
+      credentials: 'same-origin',
+      headers,
+    })) ??
+    (await fetchOutputExportNotFoundResponse(renderedUrl, {
+      credentials: 'same-origin',
+      headers,
+    }))
+
+  return createOutputExportFallbackFetchResult({
+    response: notFoundResponse,
+    renderedUrl,
+    outputExportFallbackBasePath:
+      getCachedOutputExportFallbackBasePath(
+        addOutputExportDataSuffix(renderedUrl)
+      ) ?? getConfiguredOutputExportNotFoundCandidate(renderedUrl.pathname),
+    headers,
+  })
 }
 
 /**

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -74,6 +74,7 @@ import {
   getRenderedSearch,
   parseDynamicParamFromURLPart,
 } from '../../route-params'
+import { removePathPrefix } from '../../../shared/lib/router/utils/remove-path-prefix'
 import {
   createCacheMap,
   getFromCacheMap,
@@ -97,7 +98,7 @@ import type {
   NavigationFlightResponse,
 } from '../../../shared/lib/app-router-types'
 import {
-  fillInFallbackFlightData,
+  fillInAndValidateFallbackFlightData,
   type NormalizedFlightData,
   normalizeFlightData,
   prepareFlightRouterStateForRequest,
@@ -1249,8 +1250,13 @@ function convertRootTreePrefetchToRouteTree(
   renderedSearch: NormalizedSearch,
   acc: RouteTreeAccumulator
 ) {
+  const basePath = process.env.__NEXT_ROUTER_BASEPATH || ''
+  const pathname =
+    basePath === ''
+      ? renderedPathname
+      : removePathPrefix(renderedPathname, basePath)
   // Remove trailing and leading slashes
-  const pathnameParts = renderedPathname.split('/').filter((p) => p !== '')
+  const pathnameParts = pathname.split('/').filter((p) => p !== '')
   const index = 0
   const rootSegment = ROOT_SEGMENT_REQUEST_KEY
   return convertTreePrefetchToRouteTree(
@@ -1995,11 +2001,15 @@ async function fetchOutputExportFallbackNavigationData(
     headVaryParamsThenable !== null
       ? readVaryParams(headVaryParamsThenable)
       : null
-  const patchedFlightData = fillInFallbackFlightData(
+  const patchedFlightData = fillInAndValidateFallbackFlightData(
     serverData.f,
     renderedUrl.pathname,
     renderedSearch
   )
+  if (patchedFlightData === null) {
+    return null
+  }
+
   const flightDatas = normalizeFlightData(patchedFlightData)
 
   if (typeof flightDatas === 'string') {

--- a/packages/next/src/client/flight-data-helpers.ts
+++ b/packages/next/src/client/flight-data-helpers.ts
@@ -10,6 +10,8 @@ import type {
 } from '../shared/lib/app-router-types'
 import { PAGE_SEGMENT_KEY } from '../shared/lib/segment'
 import type { NormalizedSearch } from './components/segment-cache/cache-key'
+import { extractPathFromFlightRouterState } from './components/router-reducer/compute-changed-path'
+import { removePathPrefix } from '../shared/lib/router/utils/remove-path-prefix'
 import {
   NEXT_REWRITTEN_PATH_HEADER,
   NEXT_REWRITTEN_QUERY_HEADER,
@@ -23,6 +25,12 @@ import {
   getRenderedSearch,
 } from './route-params'
 import { createHrefFromUrl } from './components/router-reducer/create-href-from-url'
+import { normalizePathTrailingSlash } from './normalize-trailing-slash'
+
+function removeConfiguredBasePath(pathname: string): string {
+  const basePath = process.env.__NEXT_ROUTER_BASEPATH || ''
+  return basePath ? removePathPrefix(pathname, basePath) : pathname
+}
 
 export type NormalizedFlightData = {
   /**
@@ -141,12 +149,60 @@ export function fillInFallbackFlightData<T extends FlightData>(
     return flightData
   }
 
-  const pathnameParts = getPathnameParts(renderedPathname)
+  const pathnameParts = getPathnameParts(
+    removeConfiguredBasePath(renderedPathname)
+  )
   const filledFlightData = flightData.map((flightDataPath) =>
     fillInFallbackFlightDataPath(flightDataPath, renderedSearch, pathnameParts)
   ) as FlightDataPath[]
 
   return filledFlightData as T
+}
+
+export function fillInAndValidateFallbackFlightData<T extends FlightData>(
+  flightData: T,
+  renderedPathname: string,
+  renderedSearch: NormalizedSearch
+): T | null {
+  const filledFlightData = fillInFallbackFlightData(
+    flightData,
+    renderedPathname,
+    renderedSearch
+  )
+  return doesFilledFallbackFlightDataMatchRenderedPathname(
+    filledFlightData,
+    renderedPathname
+  )
+    ? filledFlightData
+    : null
+}
+
+export function doesFilledFallbackFlightDataMatchRenderedPathname(
+  flightData: FlightData,
+  renderedPathname: string
+): boolean {
+  if (typeof flightData === 'string') {
+    return true
+  }
+
+  const normalizedRenderedPathname = normalizePathTrailingSlash(
+    removeConfiguredBasePath(renderedPathname)
+  )
+
+  return flightData.some((flightDataPath) => {
+    const { tree } = getFlightDataPartsFromPath(flightDataPath)
+    const extractedPath = extractPathFromFlightRouterState(tree)
+    const extractedPathname = extractedPath === '' ? '/' : extractedPath
+
+    if (extractedPathname == null) {
+      return false
+    }
+
+    return (
+      normalizePathTrailingSlash(extractedPathname) ===
+      normalizedRenderedPathname
+    )
+  })
 }
 
 function fillInFallbackFlightDataPath(

--- a/packages/next/src/client/output-export-fallback-bootstrap.ts
+++ b/packages/next/src/client/output-export-fallback-bootstrap.ts
@@ -2,8 +2,18 @@ import type { InitialRSCPayload } from '../shared/lib/app-router-types'
 import { callServer } from './app-call-server'
 import { findSourceMapURL } from './app-find-source-map-url'
 import { processFetch } from './components/router-reducer/fetch-server-response'
-import { createInitialRSCPayloadFromFallbackPrerender } from './flight-data-helpers'
-import { fetchOutputExportFallbackResponse } from './output-export-fallback'
+import {
+  createInitialRSCPayloadFromFallbackPrerender,
+  doesFilledFallbackFlightDataMatchRenderedPathname,
+} from './flight-data-helpers'
+import {
+  addOutputExportDataSuffix,
+  getCachedOutputExportFallbackBasePath,
+  fetchOutputExportFallbackResponse,
+  fetchOutputExportNotFoundDataResponse,
+  fetchOutputExportNotFoundResponse,
+  getConfiguredOutputExportNotFoundCandidate,
+} from './output-export-fallback'
 
 type DebugChannel =
   | { readable?: ReadableStream; writable?: WritableStream }
@@ -52,20 +62,46 @@ export async function createOutputExportFallbackInitialResponse({
     credentials: 'same-origin',
   })
 
-  if (fallbackResult === null) {
-    throw new Error(
-      `Could not find an output export fallback for "${renderedUrl.pathname}".`
-    )
-  }
-
-  return {
-    initialRSCPayload: await decodeFallbackPrerenderPayload(
+  if (fallbackResult !== null) {
+    const fallbackPayload = await decodeFallbackPrerenderPayload(
       Promise.resolve(fallbackResult.response),
       renderedUrl,
       createFromFetch,
       debugChannel
+    )
+
+    if (
+      doesFilledFallbackFlightDataMatchRenderedPathname(
+        fallbackPayload.f,
+        renderedUrl.pathname
+      )
+    ) {
+      return {
+        initialRSCPayload: fallbackPayload,
+        fallbackBasePath: fallbackResult.fallbackUrl.pathname,
+      }
+    }
+  }
+
+  const response =
+    (await fetchOutputExportNotFoundDataResponse(renderedUrl, {
+      credentials: 'same-origin',
+    })) ??
+    (await fetchOutputExportNotFoundResponse(renderedUrl, {
+      credentials: 'same-origin',
+    }))
+
+  return {
+    initialRSCPayload: await decodeFallbackPrerenderPayload(
+      Promise.resolve(response),
+      renderedUrl,
+      createFromFetch,
+      debugChannel
     ),
-    fallbackBasePath: fallbackResult.fallbackUrl.pathname,
+    fallbackBasePath:
+      getCachedOutputExportFallbackBasePath(
+        addOutputExportDataSuffix(renderedUrl)
+      ) ?? getConfiguredOutputExportNotFoundCandidate(renderedUrl.pathname),
   }
 }
 


### PR DESCRIPTION
## Stack position

Part 14 of 19 in the output export dynamic fallback stack.

Previous PR: #93571 (13/19)
Next PR: #93572 (15/19)

## Context

The stack is split so build-time output can land behind `experimental.outputExportDynamicFallbacks` before the client router behavior is enabled. The target behavior is for `output: 'export'` apps with parameterized App Router routes to emit fallback HTML/RSC artifacts that a later client can resolve for hard loads and soft navigations.

This PR scope: Client-side route-shape validation for fallback data.

Earlier client PRs teach the router how to find and use exported fallback artifacts. At this point in the stack, the client also needs to prove that a discovered fallback payload actually describes the requested route shape. Without this check, a broad fallback artifact could be filled with the requested params and then cached or rendered for a route it does not represent.

This PR also keeps the ownership boundary explicit:

- `output-export-fallback.ts` remains the low-level artifact resolver for fallback paths, manifests, basePath, trailingSlash, and response caching.
- `fetch-server-response.ts` remains responsible for router Flight decoding and soft-navigation response shaping.
- `segment-cache/cache.ts` remains responsible for turning valid fallback Flight data into route and segment cache entries.

## What changed

- Adds a shared `fillInAndValidateFallbackFlightData` helper so callers do not separately fill fallback params and then remember to validate the resulting tree against the requested pathname.
- Refactors `fetchServerResponse` fallback handling into router-local helpers that produce a decoded fallback result with the filled Flight data, match status, cache data, and fallback base path.
- Falls back to exported not-found data when a fallback payload resolves but does not match the requested route shape.
- Applies the same shape check to segment-cache fallback recovery so route and segment cache misses cannot write mismatched fallback data.

## Deliberately not included

- Does not move artifact lookup or manifest matching into router code.
- Does not move router cache writes into `output-export-fallback.ts`.
- Does not add new user-facing e2e cases in this PR; later PRs cover the visible route-shape scenarios.
- Does not change build-time manifest generation.

## Verification

After folding in the fallback Flight resolution cleanup and autosquashing PR14 through the stack, I verified the rewritten tip with:

- `pnpm testonly packages/next/src/client/flight-data-helpers.test.ts packages/next/src/client/components/router-reducer/fetch-server-response.test.ts packages/next/src/client/components/segment-cache/cache.test.ts`
  - 3 suites passed, 29 tests passed
- `pnpm --filter=next build`
- `pnpm test-start-turbo test/e2e/app-dir-export/test/dynamic-fallback*.test.ts`
  - 10 suites passed, 45 tests passed, 3 skipped
- `git diff --check 225be6afd8e5f0ca1075a8f7a789eea9bd352bbc..HEAD`

<!-- NEXT_JS_LLM_PR -->
