### PR TITLE
Restore export dynamic fallback coverage

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1191,5 +1191,7 @@
   "1190": "Route \"%s\" accessed param \"%s\" which is not defined in the \\`unstable_samples\\` of \\`unstable_instant\\`. Add it to the sample's \\`params\\` object.",
   "1191": "Route \"%s\" called %s but param%s %s %s not defined in the \\`unstable_samples\\` of \\`unstable_instant\\`. %s requires all route params to be provided.",
   "1192": "Route \"%s\" accessed root param \"%s\" which is not defined in the \\`unstable_samples\\` of \\`unstable_instant\\`. Add it to the sample's \\`params\\` object.",
-  "1193": "Expected staticChildren to be initialized for known dynamic siblings."
+  "1193": "Expected staticChildren to be initialized for known dynamic siblings.",
+  "1194": "Route \"%s\" used %s in a Server Component with \"output: export\". This is not supported because %s See more info here: https://nextjs.org/docs/app/guides/static-exports",
+  "1195": "Route \"%s\" used unresolved dynamic params in a Server Component with \"output: export\". This is not supported because these fallback params are only available on the client. Move param-dependent content into a Client Component or add generateStaticParams() to prerender this route. See more info here: https://nextjs.org/docs/app/guides/static-exports"
 }

--- a/packages/next/src/client/components/router-reducer/compute-changed-path.test.ts
+++ b/packages/next/src/client/components/router-reducer/compute-changed-path.test.ts
@@ -1,4 +1,4 @@
-import { computeChangedPath } from './compute-changed-path'
+import { computeChangedPath, getSelectedParams } from './compute-changed-path'
 import { PrefetchHint } from '../../../shared/lib/app-router-types'
 
 describe('computeChangedPath', () => {
@@ -57,5 +57,38 @@ describe('computeChangedPath', () => {
         ]
       )
     ).toBe('/')
+  })
+})
+
+describe('getSelectedParams', () => {
+  const originalOutput = process.env.__NEXT_CONFIG_OUTPUT
+  const originalWindow = global.window
+
+  afterEach(() => {
+    process.env.__NEXT_CONFIG_OUTPUT = originalOutput
+    global.window = originalWindow
+  })
+
+  it('resolves deferred export fallback params from the current pathname', () => {
+    process.env.__NEXT_CONFIG_OUTPUT = 'export'
+    global.window = {
+      location: {
+        pathname: '/another/third',
+      },
+    } as Window & typeof globalThis
+
+    expect(
+      getSelectedParams([
+        '',
+        {
+          children: [
+            'another',
+            {
+              children: [['slug', '%%drp:slug:abc123%%', 'd', null], {}],
+            },
+          ],
+        },
+      ])
+    ).toEqual({ slug: 'third' })
   })
 })

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.test.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.test.ts
@@ -1,0 +1,167 @@
+import type { InitialRSCPayload } from '../../../shared/lib/app-router-types'
+import { createInitialRouterState } from './create-initial-router-state'
+
+const mockGetFlightDataPartsFromPath = jest.fn()
+const mockCreateInitialCacheNodeForHydration = jest.fn()
+const mockConvertRootFlightRouterStateToRouteTree = jest.fn()
+const mockDiscoverKnownRoute = jest.fn()
+const mockProcessRuntimePrefetchStream = jest.fn()
+const mockWriteDynamicRenderResponseIntoCache = jest.fn()
+
+jest.mock('../../flight-data-helpers', () => ({
+  getFlightDataPartsFromPath: (...args: Array<unknown>) =>
+    mockGetFlightDataPartsFromPath(...args),
+}))
+
+jest.mock('./ppr-navigations', () => ({
+  createInitialCacheNodeForHydration: (...args: Array<unknown>) =>
+    mockCreateInitialCacheNodeForHydration(...args),
+}))
+
+jest.mock('../segment-cache/cache', () => ({
+  convertRootFlightRouterStateToRouteTree: (...args: Array<unknown>) =>
+    mockConvertRootFlightRouterStateToRouteTree(...args),
+  getStaleTimeMs: jest.fn((staleTime: number) => staleTime),
+  getStaleAt: jest.fn(),
+  processRuntimePrefetchStream: (...args: Array<unknown>) =>
+    mockProcessRuntimePrefetchStream(...args),
+  writeDynamicRenderResponseIntoCache: (...args: Array<unknown>) =>
+    mockWriteDynamicRenderResponseIntoCache(...args),
+  writeStaticStageResponseIntoCache: jest.fn(),
+}))
+
+jest.mock('../segment-cache/optimistic-routes', () => ({
+  discoverKnownRoute: (...args: Array<unknown>) =>
+    mockDiscoverKnownRoute(...args),
+}))
+
+describe('createInitialRouterState output export fallback', () => {
+  const discoveredRouteEntry = {
+    outputExportFallbackBasePath: null as string | null,
+  }
+
+  const initialRSCPayload: InitialRSCPayload = {
+    c: ['', 'hydrated', 'first'],
+    q: '',
+    i: false,
+    f: [[] as any],
+    m: new Set(),
+    G: [(() => null) as any, undefined],
+    S: false,
+    h: null,
+  }
+
+  beforeEach(() => {
+    mockGetFlightDataPartsFromPath.mockReset()
+    mockCreateInitialCacheNodeForHydration.mockReset()
+    mockConvertRootFlightRouterStateToRouteTree.mockReset()
+    mockDiscoverKnownRoute.mockReset()
+    mockProcessRuntimePrefetchStream.mockReset()
+    mockWriteDynamicRenderResponseIntoCache.mockReset()
+
+    discoveredRouteEntry.outputExportFallbackBasePath = null
+
+    mockGetFlightDataPartsFromPath.mockReturnValue({
+      tree: ['', {}],
+      seedData: null,
+      head: null,
+    })
+    mockCreateInitialCacheNodeForHydration.mockReturnValue({
+      rsc: null,
+      prefetchRsc: null,
+      prefetchHead: null,
+      head: null,
+      slots: null,
+      scrollRef: null,
+    })
+    mockConvertRootFlightRouterStateToRouteTree.mockImplementation(
+      (_tree, _renderedSearch, acc) => {
+        acc.metadataVaryPath = '__PAGE__'
+        return { path: '/hydrated/[thread]' }
+      }
+    )
+    mockDiscoverKnownRoute.mockReturnValue(discoveredRouteEntry)
+  })
+
+  it('passes the learned fallback artifact base path into route discovery', () => {
+    createInitialRouterState({
+      navigatedAt: Date.now(),
+      initialRSCPayload,
+      location: new URL(
+        'https://example.com/hydrated/first/'
+      ) as unknown as Location,
+      outputExportFallbackBasePath: '/hydrated/__fallback',
+    })
+
+    expect(mockDiscoverKnownRoute).toHaveBeenCalledWith(
+      expect.any(Number),
+      '/hydrated/first/',
+      null,
+      null,
+      { path: '/hydrated/[thread]' },
+      '__PAGE__',
+      false,
+      '/hydrated/first/',
+      false,
+      false,
+      { outputExportFallbackBasePath: '/hydrated/__fallback' }
+    )
+  })
+
+  it('passes the learned fallback artifact base path into runtime-prefetch cache writes', async () => {
+    const processedNavigationSeed = {
+      renderedSearch: '',
+      routeTree: { path: '/hydrated/[thread]' },
+      metadataVaryPath: null,
+      data: null,
+      head: null,
+      dynamicStaleAt: Date.now() + 30_000,
+      outputExportFallbackBasePath: '/hydrated/__fallback' as string | null,
+    }
+
+    mockProcessRuntimePrefetchStream.mockResolvedValue({
+      flightDatas: [],
+      navigationSeed: processedNavigationSeed,
+      buildId: undefined,
+      isResponsePartial: false,
+      headVaryParams: null,
+      staleAt: Date.now() + 30_000,
+    })
+
+    createInitialRouterState({
+      navigatedAt: Date.now(),
+      initialRSCPayload: {
+        ...initialRSCPayload,
+        p: new ReadableStream<Uint8Array>(),
+      },
+      location: new URL(
+        'https://example.com/hydrated/first/'
+      ) as unknown as Location,
+      outputExportFallbackBasePath: '/hydrated/__fallback',
+    })
+
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(mockProcessRuntimePrefetchStream).toHaveBeenCalledWith(
+      expect.any(Number),
+      expect.any(ReadableStream),
+      ['', {}],
+      '',
+      '/hydrated/__fallback'
+    )
+    expect(mockWriteDynamicRenderResponseIntoCache).toHaveBeenCalledWith(
+      expect.any(Number),
+      expect.anything(),
+      expect.any(Array),
+      undefined,
+      false,
+      null,
+      expect.any(Number),
+      expect.objectContaining({
+        outputExportFallbackBasePath: '/hydrated/__fallback',
+      }),
+      null
+    )
+  })
+})

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.test.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.test.ts
@@ -1,0 +1,133 @@
+/**
+ * @jest-environment node
+ */
+
+import type { NavigationFlightResponse } from '../../../shared/lib/app-router-types'
+import { setNavigationBuildId } from '../../navigation-build-id'
+import { fetchServerResponse } from './fetch-server-response'
+
+const mockCreateFromReadableStream = jest.fn()
+const mockFetchOutputExportFallbackResponse = jest.fn()
+const mockGetCachedOutputExportFallbackRequestUrl = jest.fn()
+
+jest.mock('react-server-dom-webpack/client', () => ({
+  createFromFetch: jest.fn(),
+  createFromReadableStream: (...args: Array<unknown>) =>
+    mockCreateFromReadableStream(...args),
+}))
+
+jest.mock('../../output-export-fallback', () => ({
+  fetchOutputExportFallbackResponse: (...args: Array<unknown>) =>
+    mockFetchOutputExportFallbackResponse(...args),
+  getCachedOutputExportFallbackRequestUrl: (...args: Array<unknown>) =>
+    mockGetCachedOutputExportFallbackRequestUrl(...args),
+}))
+
+function withResponseUrl(response: Response, url: string): Response {
+  Object.defineProperty(response, 'url', { value: url })
+  Object.defineProperty(response, 'redirected', { value: false })
+  return response
+}
+
+describe('fetchServerResponse output export fallback', () => {
+  const originalNodeEnv = process.env.NODE_ENV
+  const originalOutput = process.env.__NEXT_CONFIG_OUTPUT
+  const originalFetch = global.fetch
+  const originalLocation = global.location
+  const processEnv = process.env as Record<string, string | undefined>
+
+  beforeEach(() => {
+    processEnv.NODE_ENV = 'production'
+    processEnv.__NEXT_CONFIG_OUTPUT = 'export'
+    global.location = new URL('https://example.com/') as unknown as Location
+    setNavigationBuildId('build-id')
+    mockCreateFromReadableStream.mockReset()
+    mockFetchOutputExportFallbackResponse.mockReset()
+    mockGetCachedOutputExportFallbackRequestUrl.mockReset()
+    mockGetCachedOutputExportFallbackRequestUrl.mockReturnValue(null)
+  })
+
+  afterEach(() => {
+    processEnv.NODE_ENV = originalNodeEnv
+    processEnv.__NEXT_CONFIG_OUTPUT = originalOutput
+    global.fetch = originalFetch
+    global.location = originalLocation
+    jest.restoreAllMocks()
+  })
+
+  it('reuses the discovered fallback response instead of fetching it again', async () => {
+    const origin = global.location.origin
+    const initialMiss = withResponseUrl(
+      new Response('not found', {
+        status: 404,
+        headers: { 'content-type': 'text/html' },
+      }),
+      `${origin}/another/third.txt`
+    )
+    const fallbackResponse = withResponseUrl(
+      new Response('fallback payload', {
+        status: 200,
+        headers: { 'content-type': 'text/plain' },
+      }),
+      `${origin}/another/__fallback/index.txt`
+    )
+
+    global.fetch = jest
+      .fn(async () => initialMiss)
+      .mockImplementationOnce(async () => initialMiss)
+      .mockImplementation(async () => {
+        throw new Error('unexpected extra fetch')
+      }) as typeof fetch
+
+    mockFetchOutputExportFallbackResponse.mockResolvedValue({
+      response: fallbackResponse,
+      renderedUrl: new URL('/another/third', origin),
+      fallbackUrl: new URL('/another/__fallback', origin),
+    })
+    mockCreateFromReadableStream.mockResolvedValue({
+      b: 'build-id',
+      f: [
+        [
+          'children',
+          'another',
+          'children',
+          ['slug', '%%drp:slug:abc123%%', 'd', null],
+          [
+            '',
+            {
+              children: [
+                'another',
+                {
+                  children: [['slug', '%%drp:slug:abc123%%', 'd', null], {}],
+                },
+              ],
+            },
+          ],
+          null,
+          null,
+          false,
+        ],
+      ],
+      S: false,
+      q: '',
+      i: false,
+      h: null,
+    } satisfies NavigationFlightResponse)
+
+    const result = await fetchServerResponse(
+      new URL('/another/third', origin),
+      {
+        flightRouterState: ['', {}, null, null],
+        nextUrl: null,
+      }
+    )
+
+    expect(typeof result).not.toBe('string')
+    if (typeof result !== 'string') {
+      expect(result.canonicalUrl.href).toBe(`${origin}/another/third`)
+      expect(result.outputExportFallbackBasePath).toBe('/another/__fallback')
+    }
+    expect(global.fetch).toHaveBeenCalledTimes(1)
+    expect(mockFetchOutputExportFallbackResponse).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/next/src/client/components/segment-cache/cache.test.ts
+++ b/packages/next/src/client/components/segment-cache/cache.test.ts
@@ -1,0 +1,233 @@
+import {
+  HEAD_REQUEST_KEY,
+  type SegmentRequestKey,
+} from '../../../shared/lib/segment-cache/segment-value-encoding'
+import type { VaryParamsThenable } from '../../../shared/lib/segment-cache/vary-params-decoding'
+import { FetchStrategy } from './types'
+import { Fallback } from './cache-map'
+import {
+  EntryStatus,
+  getOutputExportSegmentRequestUrl,
+  invalidateEntirePrefetchCache,
+  readSegmentCacheEntry,
+  readOrCreateSegmentCacheEntry,
+  upgradeToPendingSegment,
+  writeDynamicRenderResponseIntoCache,
+} from './cache'
+import { convertServerPatchToFullTree } from './navigation'
+import { finalizeMetadataVaryPath, finalizePageVaryPath } from './vary-path'
+
+describe('getOutputExportSegmentRequestUrl', () => {
+  it('uses the concrete rendered route when no fallback base path is known', () => {
+    expect(
+      getOutputExportSegmentRequestUrl(
+        new URL('https://example.com/org/acme/chat/thread-456/?mode=full'),
+        HEAD_REQUEST_KEY,
+        null
+      ).href
+    ).toBe(
+      'https://example.com/org/acme/chat/thread-456/__next._head.txt?mode=full'
+    )
+  })
+
+  it('reuses the learned fallback base path for sibling segment requests', () => {
+    expect(
+      getOutputExportSegmentRequestUrl(
+        new URL('https://example.com/org/acme/chat/thread-456/?mode=full'),
+        '/t/$d$threadId' as SegmentRequestKey,
+        '/org/__fallback'
+      ).href
+    ).toBe(
+      'https://example.com/org/__fallback/__next.t.$d$threadId.txt?mode=full'
+    )
+  })
+
+  it('keeps the matched branch fallback base path for conflicting routes', () => {
+    expect(
+      getOutputExportSegmentRequestUrl(
+        new URL('https://example.com/docs/api/reference'),
+        '/docs/$d$section/$d$page' as SegmentRequestKey,
+        '/docs/__fallback/__route_0'
+      ).href
+    ).toBe(
+      'https://example.com/docs/__fallback/__route_0/__next.docs.$d$section.$d$page.txt'
+    )
+  })
+})
+
+describe('readOrCreateSegmentCacheEntry output export fallback', () => {
+  afterEach(() => {
+    delete process.env.__NEXT_VARY_PARAMS
+    invalidateEntirePrefetchCache(null, ['', {}])
+  })
+
+  it('dedupes pending metadata entries across sibling fallback params', () => {
+    const now = Date.now()
+    const firstTree = {
+      requestKey: HEAD_REQUEST_KEY,
+      segment: HEAD_REQUEST_KEY,
+      refreshState: null,
+      varyPath: finalizeMetadataVaryPath(
+        '/hydrated/$d$thread/__PAGE__' as SegmentRequestKey,
+        '' as any,
+        {
+          id: 'thread',
+          value: 'first' as any,
+          parent: null,
+        } as any
+      ),
+      isPage: true as const,
+      slots: null,
+      prefetchHints: 0,
+    }
+    const secondTree = {
+      ...firstTree,
+      varyPath: finalizeMetadataVaryPath(
+        '/hydrated/$d$thread/__PAGE__' as SegmentRequestKey,
+        '' as any,
+        {
+          id: 'thread',
+          value: 'second' as any,
+          parent: null,
+        } as any
+      ),
+    }
+
+    const firstEntry = readOrCreateSegmentCacheEntry(
+      now,
+      FetchStrategy.PPR,
+      firstTree,
+      '/hydrated/__fallback'
+    )
+    const secondEntry = readOrCreateSegmentCacheEntry(
+      now,
+      FetchStrategy.PPR,
+      secondTree,
+      '/hydrated/__fallback'
+    )
+
+    expect(firstEntry).toBe(secondEntry)
+    const secondThreadVaryPath = secondTree.varyPath.parent?.parent
+    expect(secondThreadVaryPath).not.toBeNull()
+    if (secondThreadVaryPath === null) {
+      throw new Error('expected metadata vary path to include thread params')
+    }
+    expect(secondThreadVaryPath.value).toBe('second')
+    expect(secondThreadVaryPath.value).not.toBe(Fallback)
+  })
+
+  it('rekeys runtime-prefetched fallback segments under generic params', () => {
+    process.env.__NEXT_VARY_PARAMS = 'true'
+
+    const now = Date.now()
+    const makeTree = (thread: string) => ({
+      requestKey: '/t/$d$threadId/__PAGE__' as SegmentRequestKey,
+      segment: '/t/$d$threadId' as SegmentRequestKey,
+      refreshState: null,
+      varyPath: finalizePageVaryPath(
+        '/t/$d$threadId/__PAGE__' as SegmentRequestKey,
+        '' as any,
+        {
+          id: 'threadId',
+          value: thread as any,
+          parent: null,
+        } as any
+      ),
+      isPage: true as const,
+      slots: null,
+      prefetchHints: 0,
+    })
+
+    const firstTree = makeTree('first')
+    const secondTree = makeTree('second')
+    const emptyEntry = readOrCreateSegmentCacheEntry(
+      now,
+      FetchStrategy.PPRRuntime,
+      firstTree,
+      '/t/__fallback'
+    )
+    expect(emptyEntry.status).toBe(EntryStatus.Empty)
+    if (emptyEntry.status !== EntryStatus.Empty) {
+      throw new Error('expected a new empty segment cache entry')
+    }
+    const ownedEntry = upgradeToPendingSegment(
+      emptyEntry,
+      FetchStrategy.PPRRuntime
+    )
+    const fulfilledVaryParams = new Set(['threadId'])
+    const fulfilledVaryParamsThenable: VaryParamsThenable = {
+      status: 'fulfilled',
+      value: fulfilledVaryParams,
+      then<TResult1 = Set<string>, TResult2 = never>(
+        onfulfilled?:
+          | ((value: Set<string>) => TResult1 | PromiseLike<TResult1>)
+          | null,
+        _onrejected?:
+          | ((reason: unknown) => TResult2 | PromiseLike<TResult2>)
+          | null
+      ): PromiseLike<TResult1 | TResult2> {
+        if (onfulfilled) {
+          return Promise.resolve(onfulfilled(fulfilledVaryParams))
+        }
+        return Promise.resolve(fulfilledVaryParams as TResult1)
+      },
+    }
+
+    writeDynamicRenderResponseIntoCache(
+      now,
+      FetchStrategy.PPRRuntime,
+      [
+        {
+          segmentPath: [],
+          pathToSegment: [],
+          segment: '',
+          tree: ['', {}],
+          seedData: [
+            'runtime fallback data',
+            {},
+            null,
+            false,
+            fulfilledVaryParamsThenable,
+          ],
+          head: null,
+          isHeadPartial: false,
+          isRootRender: true,
+        },
+      ],
+      undefined,
+      false,
+      null,
+      now + 30_000,
+      {
+        renderedSearch: '',
+        routeTree: firstTree,
+        metadataVaryPath: null,
+        data: null,
+        head: null,
+        dynamicStaleAt: now + 30_000,
+        outputExportFallbackBasePath: '/t/__fallback',
+      },
+      new Map([[firstTree.requestKey, ownedEntry]])
+    )
+
+    const secondEntry = readSegmentCacheEntry(now, secondTree.varyPath)
+
+    expect(secondEntry).toBe(ownedEntry)
+    expect(secondEntry?.status).toBe(EntryStatus.Fulfilled)
+  })
+})
+
+describe('convertServerPatchToFullTree output export fallback', () => {
+  it('records the learned fallback artifact base path on the returned navigation seed', () => {
+    const navigationSeed = convertServerPatchToFullTree(
+      Date.now(),
+      ['', {}],
+      null,
+      '',
+      0,
+      '/docs/__fallback'
+    )
+
+    expect(navigationSeed.outputExportFallbackBasePath).toBe('/docs/__fallback')
+  })
+})

--- a/packages/next/src/client/components/segment-cache/vary-path.test.ts
+++ b/packages/next/src/client/components/segment-cache/vary-path.test.ts
@@ -1,0 +1,105 @@
+import { Fallback } from './cache-map'
+import { FetchStrategy } from './types'
+import {
+  HEAD_REQUEST_KEY,
+  type SegmentRequestKey,
+} from '../../../shared/lib/segment-cache/segment-value-encoding'
+import {
+  finalizeMetadataVaryPath,
+  finalizePageVaryPath,
+  getFulfilledSegmentVaryPath,
+  getSegmentVaryPathForRequest,
+} from './vary-path'
+
+function getRequiredParent<T extends { parent: unknown | null }>(
+  path: T
+): Exclude<T['parent'], null> {
+  expect(path.parent).not.toBeNull()
+  return path.parent as Exclude<T['parent'], null>
+}
+
+describe('getSegmentVaryPathForRequest output export fallback', () => {
+  it('reuses path params for normal static prefetches', () => {
+    const varyPath = finalizeMetadataVaryPath(
+      '/t/$d$threadId/__PAGE__',
+      '' as any,
+      {
+        id: 'threadId',
+        value: 'j97358' as any,
+        parent: null,
+      } as any
+    )
+
+    const requestVaryPath = getSegmentVaryPathForRequest(
+      FetchStrategy.PPR,
+      {
+        requestKey: HEAD_REQUEST_KEY,
+        segment: HEAD_REQUEST_KEY,
+        refreshState: null,
+        varyPath,
+        isPage: true,
+        slots: null,
+        prefetchHints: 0,
+      },
+      null
+    )
+
+    expect(getRequiredParent(getRequiredParent(requestVaryPath)).value).toBe(
+      'j97358'
+    )
+  })
+
+  it('treats path params as reusable for learned output export fallback routes', () => {
+    const varyPath = finalizePageVaryPath(
+      '/t/$d$threadId/__PAGE__',
+      '' as any,
+      {
+        id: 'threadId',
+        value: 'j97358' as any,
+        parent: null,
+      } as any
+    )
+
+    const requestVaryPath = getSegmentVaryPathForRequest(
+      FetchStrategy.PPR,
+      {
+        requestKey: '/t/$d$threadId/__PAGE__' as SegmentRequestKey,
+        segment: '/t/$d$threadId' as SegmentRequestKey,
+        refreshState: null,
+        varyPath,
+        isPage: true,
+        slots: null,
+        prefetchHints: 0,
+      },
+      '/t/__fallback'
+    )
+
+    expect(getRequiredParent(requestVaryPath).value).toBe(Fallback)
+    expect(getRequiredParent(getRequiredParent(requestVaryPath)).value).toBe(
+      Fallback
+    )
+  })
+
+  it('keeps fulfilled fallback segment path params generic even when vary params include them', () => {
+    const varyPath = finalizeMetadataVaryPath(
+      '/t/$d$threadId/__PAGE__',
+      '' as any,
+      {
+        id: 'threadId',
+        value: 'j97358' as any,
+        parent: null,
+      } as any
+    )
+
+    const fulfilledVaryPath = getFulfilledSegmentVaryPath(
+      varyPath,
+      new Set(['?', 'threadId']),
+      true
+    )
+
+    expect(getRequiredParent(fulfilledVaryPath).value).toBe('')
+    expect(getRequiredParent(getRequiredParent(fulfilledVaryPath)).value).toBe(
+      Fallback
+    )
+  })
+})

--- a/packages/next/src/client/flight-data-helpers.test.ts
+++ b/packages/next/src/client/flight-data-helpers.test.ts
@@ -1,8 +1,15 @@
-import { prepareFlightRouterStateForRequest } from './flight-data-helpers'
+import {
+  createInitialRSCPayloadFromFallbackPrerender,
+  fillInFallbackFlightData,
+  prepareFlightRouterStateForRequest,
+} from './flight-data-helpers'
 import {
   PrefetchHint,
+  type FlightData,
+  type InitialRSCPayload,
   type FlightRouterState,
 } from '../shared/lib/app-router-types'
+import type { NormalizedSearch } from './components/segment-cache/cache-key'
 
 describe('prepareFlightRouterStateForRequest', () => {
   describe('HMR refresh handling', () => {
@@ -296,5 +303,212 @@ describe('prepareFlightRouterStateForRequest', () => {
       expect(sidebarRoute[2]).toBeUndefined() // URL stripped
       expect(sidebarRoute[3]).toBeUndefined() // null marker stripped
     })
+  })
+})
+
+describe('fillInFallbackFlightData', () => {
+  it('replaces deferred route param placeholders in navigation flight data', () => {
+    const flightData = [
+      [
+        'children',
+        'another',
+        'children',
+        ['slug', '%%drp:slug:abc123%%', 'd', null],
+        [
+          '',
+          {
+            children: [
+              'another',
+              {
+                children: [['slug', '%%drp:slug:abc123%%', 'd', null], {}],
+              },
+            ],
+          },
+        ],
+        null,
+        null,
+        false,
+      ],
+    ] as FlightData
+
+    const normalizedFlightData = fillInFallbackFlightData(
+      flightData,
+      '/another/third',
+      '' as NormalizedSearch
+    )
+    const patchedFlightDataPath = normalizedFlightData[0]
+
+    expect(patchedFlightDataPath[3]).toEqual(['slug', 'third', 'd', null])
+    const patchedTree = patchedFlightDataPath[4]
+    expect(patchedTree[0]).toBe('')
+    expect(patchedTree[1].children[0]).toBe('another')
+    expect(patchedTree[1].children[1].children[0]).toEqual([
+      'slug',
+      'third',
+      'd',
+      null,
+    ])
+  })
+})
+
+describe('createInitialRSCPayloadFromFallbackPrerender', () => {
+  it('preserves the trailing flight tuple fields while filling fallback params', () => {
+    const fallbackInitialRSCPayload: InitialRSCPayload = {
+      b: 'build-id',
+      c: ['', 'another', '%%drp:slug:abc123%%'],
+      q: '',
+      i: false,
+      f: [
+        [
+          [
+            '',
+            {
+              children: [
+                'another',
+                {
+                  children: [['slug', '%%drp:slug:abc123%%', 'd', null], {}],
+                },
+              ],
+            },
+          ],
+          null,
+          'head-node',
+          true,
+        ],
+      ],
+      m: new Set(),
+      G: [(() => null) as any, undefined],
+      S: false,
+      h: null,
+    }
+
+    const response = new Response(null, {
+      headers: { 'x-nextjs-rewritten-path': '/another/third' },
+    })
+
+    const payload = createInitialRSCPayloadFromFallbackPrerender(
+      response,
+      fallbackInitialRSCPayload,
+      new URL('https://example.com/another/third')
+    )
+
+    const patchedTree = payload.f[0][0]
+    expect(patchedTree[0]).toBe('')
+    expect(patchedTree[1].children[0]).toBe('another')
+    expect(patchedTree[1].children[1].children[0]).toEqual([
+      'slug',
+      'third',
+      'd',
+      null,
+    ])
+    expect(payload.f[0][1]).toBeNull()
+    expect(payload.f[0][2]).toBe('head-node')
+    expect(payload.f[0][3]).toBe(true)
+  })
+
+  it('prefers rewritten headers over the rendered URL override', () => {
+    const fallbackInitialRSCPayload: InitialRSCPayload = {
+      b: 'build-id',
+      c: ['', 'docs', '%%drp:slug:abc123%%'],
+      q: '',
+      i: false,
+      f: [
+        [
+          [
+            '',
+            {
+              children: [
+                'docs',
+                {
+                  children: [['slug', '%%drp:slug:abc123%%', 'd', null], {}],
+                },
+              ],
+            },
+          ],
+          null,
+          'head-node',
+          false,
+        ],
+      ],
+      m: new Set(),
+      G: [(() => null) as any, undefined],
+      S: false,
+      h: null,
+    }
+
+    const response = new Response(null, {
+      headers: {
+        'x-nextjs-rewritten-path': '/docs/rewritten',
+        'x-nextjs-rewritten-query': 'from=fetch',
+      },
+    })
+
+    const payload = createInitialRSCPayloadFromFallbackPrerender(
+      response,
+      fallbackInitialRSCPayload,
+      new URL('https://example.com/docs/original?from=document')
+    )
+
+    const patchedTree = payload.f[0][0]
+    expect(patchedTree[1].children[0]).toBe('docs')
+    expect(patchedTree[1].children[1].children[0]).toEqual([
+      'slug',
+      'rewritten',
+      'd',
+      null,
+    ])
+    expect(payload.q).toBe('?from=fetch')
+    expect(payload.c.join('/')).toBe('/docs/original?from=document')
+  })
+
+  it('falls back to the rendered URL override when no rewritten headers are present', () => {
+    const fallbackInitialRSCPayload: InitialRSCPayload = {
+      b: 'build-id',
+      c: ['', 'docs', '%%drp:slug:abc123%%'],
+      q: '',
+      i: false,
+      f: [
+        [
+          [
+            '',
+            {
+              children: [
+                'docs',
+                {
+                  children: [['slug', '%%drp:slug:abc123%%', 'd', null], {}],
+                },
+              ],
+            },
+          ],
+          null,
+          'head-node',
+          false,
+        ],
+      ],
+      m: new Set(),
+      G: [(() => null) as any, undefined],
+      S: false,
+      h: null,
+    }
+
+    const response = new Response(null, {
+      headers: {},
+    })
+
+    const payload = createInitialRSCPayloadFromFallbackPrerender(
+      response,
+      fallbackInitialRSCPayload,
+      new URL('https://example.com/docs/original?from=document')
+    )
+
+    const patchedTree = payload.f[0][0]
+    expect(patchedTree[1].children[0]).toBe('docs')
+    expect(patchedTree[1].children[1].children[0]).toEqual([
+      'slug',
+      'original',
+      'd',
+      null,
+    ])
+    expect(payload.q).toBe('?from=document')
   })
 })

--- a/packages/next/src/client/output-export-fallback.test.ts
+++ b/packages/next/src/client/output-export-fallback.test.ts
@@ -1,0 +1,590 @@
+import {
+  addOutputExportDataSuffix,
+  clearOutputExportFallbackManifestCache,
+  fetchOutputExportDataResponse,
+  fetchOutputExportFallbackResponse,
+  getCachedOutputExportFallbackDataUrl,
+  getCachedOutputExportFallbackRequestUrl,
+  getOutputExportFallbackCandidates,
+  stripOutputExportDataSuffix,
+} from './output-export-fallback'
+
+describe('output export fallback helpers', () => {
+  const originalFetch = global.fetch
+  const originalBasePath = process.env.__NEXT_ROUTER_BASEPATH
+  const originalTrailingSlash = process.env.__NEXT_TRAILING_SLASH
+
+  afterEach(() => {
+    global.fetch = originalFetch
+    if (originalBasePath === undefined) {
+      delete process.env.__NEXT_ROUTER_BASEPATH
+    } else {
+      process.env.__NEXT_ROUTER_BASEPATH = originalBasePath
+    }
+    if (originalTrailingSlash === undefined) {
+      delete process.env.__NEXT_TRAILING_SLASH
+    } else {
+      process.env.__NEXT_TRAILING_SLASH = originalTrailingSlash
+    }
+    clearOutputExportFallbackManifestCache()
+    jest.restoreAllMocks()
+  })
+
+  it('discovers fallback candidates from deepest static prefix to root', () => {
+    expect(getOutputExportFallbackCandidates('/org/acme/chat/123')).toEqual([
+      '/org/acme/chat/123/__fallback',
+      '/org/acme/chat/__fallback',
+      '/org/acme/__fallback',
+      '/org/__fallback',
+      '/__fallback',
+    ])
+  })
+
+  it('includes the current pathname for optional catch-all root matches', () => {
+    expect(getOutputExportFallbackCandidates('/optional/')).toEqual([
+      '/optional/__fallback',
+      '/__fallback',
+    ])
+  })
+
+  it('adds the export data suffix for flat and trailing slash routes', () => {
+    expect(
+      addOutputExportDataSuffix(new URL('https://example.com/blog/post')).href
+    ).toBe('https://example.com/blog/post.txt')
+
+    expect(
+      addOutputExportDataSuffix(new URL('https://example.com/blog/post/')).href
+    ).toBe('https://example.com/blog/post/index.txt')
+  })
+
+  it('strips the export data suffix back to the fallback document path', () => {
+    expect(
+      stripOutputExportDataSuffix(
+        new URL('https://example.com/blog/post/index.txt')
+      ).href
+    ).toBe('https://example.com/blog/post')
+
+    expect(
+      stripOutputExportDataSuffix(new URL('https://example.com/blog/post.txt'))
+        .href
+    ).toBe('https://example.com/blog/post.html')
+
+    expect(
+      stripOutputExportDataSuffix(new URL('https://example.com/index.txt')).href
+    ).toBe('https://example.com/')
+  })
+
+  it('tries both flat and trailing-slash data files', async () => {
+    const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.endsWith('/blog/post.txt')) {
+        return new Response('not found', {
+          status: 404,
+          headers: { 'content-type': 'text/html' },
+        })
+      }
+
+      return new Response('payload', {
+        status: 200,
+        headers: { 'content-type': 'text/plain' },
+      })
+    })
+
+    global.fetch = fetchMock as typeof fetch
+
+    const response = await fetchOutputExportDataResponse(
+      new URL('https://example.com/blog/post')
+    )
+
+    expect(response).not.toBeNull()
+    expect(fetchMock.mock.calls.map(([url]) => String(url))).toEqual([
+      'https://example.com/blog/post.txt',
+      'https://example.com/blog/post/index.txt',
+    ])
+  })
+
+  it('tries the direct fallback artifact before manifest lookups', async () => {
+    process.env.__NEXT_TRAILING_SLASH = 'false'
+    const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url.endsWith('/org/acme/chat/123/__fallback.txt')) {
+        return new Response('payload', {
+          status: 200,
+          headers: { 'content-type': 'text/plain' },
+        })
+      }
+
+      return new Response('not found', {
+        status: 404,
+        headers: { 'content-type': 'text/html' },
+      })
+    })
+
+    global.fetch = fetchMock as typeof fetch
+
+    const renderedUrl = new URL('https://example.com/org/acme/chat/123')
+    const result = await fetchOutputExportFallbackResponse(renderedUrl)
+
+    expect(result).not.toBeNull()
+    expect(result?.renderedUrl.href).toBe(renderedUrl.href)
+    expect(fetchMock.mock.calls.map(([url]) => String(url))).toEqual([
+      'https://example.com/org/acme/chat/123/__fallback.txt',
+      'https://example.com/org/acme/chat/123/__fallback.meta.json',
+    ])
+  })
+
+  it('uses manifest fallback base paths even when the direct artifact already exists', async () => {
+    const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url.endsWith('/hydrated/second/__fallback/index.txt')) {
+        return new Response('payload', {
+          status: 200,
+          headers: { 'content-type': 'text/plain' },
+        })
+      }
+
+      if (url.endsWith('/hydrated/second/__fallback.meta.json')) {
+        return new Response(
+          JSON.stringify({
+            version: 1,
+            routes: [
+              {
+                route: '/hydrated/[thread]',
+                fallbackPath: '/hydrated/__fallback',
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }
+        )
+      }
+
+      return new Response('not found', {
+        status: 404,
+        headers: { 'content-type': 'text/html' },
+      })
+    })
+
+    global.fetch = fetchMock as typeof fetch
+
+    const renderedUrl = new URL('https://example.com/hydrated/second/')
+    const result = await fetchOutputExportFallbackResponse(renderedUrl)
+
+    expect(result).not.toBeNull()
+    expect(result?.fallbackUrl.pathname).toBe('/hydrated/__fallback')
+    expect(fetchMock.mock.calls.map(([url]) => String(url))).toEqual([
+      'https://example.com/hydrated/second/__fallback/index.txt',
+      'https://example.com/hydrated/second/__fallback.meta.json',
+    ])
+    expect(
+      getCachedOutputExportFallbackRequestUrl(
+        new URL('https://example.com/hydrated/second/__next._tree.txt')
+      )?.href
+    ).toBe('https://example.com/hydrated/__fallback/__next._tree.txt')
+  })
+
+  it('falls through deeper prefixes before using a shallower fallback artifact', async () => {
+    process.env.__NEXT_TRAILING_SLASH = 'false'
+    const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url.endsWith('/docs/guides/export/__fallback.txt')) {
+        return new Response('not found', {
+          status: 404,
+          headers: { 'content-type': 'text/html' },
+        })
+      }
+
+      if (url.endsWith('/docs/guides/export/__fallback.meta.json')) {
+        return new Response('not found', {
+          status: 404,
+          headers: { 'content-type': 'text/html' },
+        })
+      }
+
+      if (url.endsWith('/docs/guides/__fallback.txt')) {
+        return new Response('payload', {
+          status: 200,
+          headers: { 'content-type': 'text/plain' },
+        })
+      }
+
+      return new Response('not found', {
+        status: 404,
+        headers: { 'content-type': 'text/html' },
+      })
+    })
+
+    global.fetch = fetchMock as typeof fetch
+
+    const renderedUrl = new URL('https://example.com/docs/guides/export')
+    const result = await fetchOutputExportFallbackResponse(renderedUrl)
+
+    expect(result).not.toBeNull()
+    expect(result?.renderedUrl.href).toBe(renderedUrl.href)
+    expect(result?.fallbackUrl.pathname).toBe('/docs/guides/__fallback')
+    expect(fetchMock.mock.calls.map(([url]) => String(url))).toEqual([
+      'https://example.com/docs/guides/export/__fallback.txt',
+      'https://example.com/docs/guides/export/__fallback.meta.json',
+      'https://example.com/docs/guides/__fallback.txt',
+      'https://example.com/docs/guides/__fallback.meta.json',
+    ])
+  })
+
+  it('prefers the trailing-slash fallback artifact when the request URL ends with /', async () => {
+    delete process.env.__NEXT_TRAILING_SLASH
+
+    const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url.endsWith('/org/umbrella/chat/thread-789/__fallback/index.txt')) {
+        return new Response('flight', {
+          status: 200,
+          headers: { 'content-type': 'text/x-component' },
+        })
+      }
+
+      return new Response('not found', {
+        status: 404,
+        headers: { 'content-type': 'text/html' },
+      })
+    })
+
+    global.fetch = fetchMock as typeof fetch
+
+    const renderedUrl = new URL(
+      'https://example.com/org/umbrella/chat/thread-789/'
+    )
+    const result = await fetchOutputExportFallbackResponse(renderedUrl)
+
+    expect(result).not.toBeNull()
+    expect(result?.renderedUrl.href).toBe(renderedUrl.href)
+    expect(fetchMock.mock.calls.map(([url]) => String(url))).toEqual([
+      'https://example.com/org/umbrella/chat/thread-789/__fallback/index.txt',
+      'https://example.com/org/umbrella/chat/thread-789/__fallback.meta.json',
+    ])
+  })
+
+  it('uses fallback metadata to select the most specific conflicting route', async () => {
+    process.env.__NEXT_TRAILING_SLASH = 'false'
+    const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url.endsWith('/docs/__fallback.txt')) {
+        return new Response('not found', {
+          status: 404,
+          headers: { 'content-type': 'text/html' },
+        })
+      }
+
+      if (url.endsWith('/docs/__fallback.meta.json')) {
+        return new Response(
+          JSON.stringify({
+            version: 1,
+            routes: [
+              {
+                route: '/docs/[section]/[page]',
+                fallbackPath: '/docs/__fallback/__route_0',
+              },
+              {
+                route: '/docs/[...slug]',
+                fallbackPath: '/docs/__fallback/__route_1',
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }
+        )
+      }
+
+      if (url.endsWith('/docs/__fallback/__route_0.txt')) {
+        return new Response('payload', {
+          status: 200,
+          headers: { 'content-type': 'text/plain' },
+        })
+      }
+
+      return new Response('not found', {
+        status: 404,
+        headers: { 'content-type': 'text/html' },
+      })
+    })
+
+    global.fetch = fetchMock as typeof fetch
+
+    const renderedUrl = new URL('https://example.com/docs/api/reference')
+    const result = await fetchOutputExportFallbackResponse(renderedUrl)
+
+    expect(result).not.toBeNull()
+    expect(result?.fallbackUrl.pathname).toBe('/docs/__fallback/__route_0')
+    expect(fetchMock.mock.calls.map(([url]) => String(url))).toEqual([
+      'https://example.com/docs/api/reference/__fallback.txt',
+      'https://example.com/docs/api/reference/__fallback.meta.json',
+      'https://example.com/docs/api/__fallback.txt',
+      'https://example.com/docs/api/__fallback.meta.json',
+      'https://example.com/docs/__fallback.txt',
+      'https://example.com/docs/__fallback.meta.json',
+      'https://example.com/docs/__fallback/__route_0.txt',
+    ])
+  })
+
+  it('matches and fetches conflicting fallback branches under basePath via shallower metadata', async () => {
+    process.env.__NEXT_ROUTER_BASEPATH = '/base'
+
+    const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url.endsWith('/base/docs/__fallback.meta.json')) {
+        return new Response(
+          JSON.stringify({
+            version: 1,
+            routes: [
+              {
+                route: '/docs/[section]/[page]',
+                fallbackPath: '/docs/__fallback/__route_0',
+              },
+              {
+                route: '/docs/[...slug]',
+                fallbackPath: '/docs/__fallback/__route_1',
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }
+        )
+      }
+
+      if (url.endsWith('/base/docs/__fallback/__route_0.txt')) {
+        return new Response('payload', {
+          status: 200,
+          headers: { 'content-type': 'text/plain' },
+        })
+      }
+
+      return new Response('not found', {
+        status: 404,
+        headers: { 'content-type': 'text/html' },
+      })
+    })
+
+    global.fetch = fetchMock as typeof fetch
+
+    const renderedUrl = new URL('https://example.com/base/docs/api/reference')
+    const result = await fetchOutputExportFallbackResponse(renderedUrl)
+
+    expect(result).not.toBeNull()
+    expect(result?.fallbackUrl.pathname).toBe('/base/docs/__fallback/__route_0')
+    expect(fetchMock.mock.calls.map(([url]) => String(url))).toEqual([
+      'https://example.com/base/docs/api/reference/__fallback.txt',
+      'https://example.com/base/docs/api/reference/__fallback.meta.json',
+      'https://example.com/base/docs/api/__fallback.txt',
+      'https://example.com/base/docs/api/__fallback.meta.json',
+      'https://example.com/base/docs/__fallback.txt',
+      'https://example.com/base/docs/__fallback.meta.json',
+      'https://example.com/base/docs/__fallback/__route_0.txt',
+    ])
+  })
+
+  it('caches the resolved fallback data URL for later RSC fetches', async () => {
+    process.env.__NEXT_TRAILING_SLASH = 'false'
+    const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url.endsWith('/docs/__fallback.meta.json')) {
+        return new Response(
+          JSON.stringify({
+            version: 1,
+            routes: [
+              {
+                route: '/docs/[section]/[page]',
+                fallbackPath: '/docs/__fallback/__route_0',
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }
+        )
+      }
+
+      if (url.endsWith('/docs/__fallback/__route_0.txt')) {
+        return new Response('payload', {
+          status: 200,
+          headers: { 'content-type': 'text/plain' },
+        })
+      }
+
+      return new Response('not found', {
+        status: 404,
+        headers: { 'content-type': 'text/html' },
+      })
+    })
+
+    global.fetch = fetchMock as typeof fetch
+
+    const renderedUrl = new URL('https://example.com/docs/api/reference')
+    await fetchOutputExportFallbackResponse(renderedUrl)
+
+    expect(
+      getCachedOutputExportFallbackDataUrl(
+        new URL('https://example.com/docs/api/reference.txt')
+      )?.href
+    ).toBe('https://example.com/docs/__fallback/__route_0.txt')
+    expect(
+      getCachedOutputExportFallbackDataUrl(
+        new URL('https://example.com/docs/api/reference/index.txt')
+      )?.href
+    ).toBe('https://example.com/docs/__fallback/__route_0.txt')
+    expect(
+      getCachedOutputExportFallbackRequestUrl(
+        new URL('https://example.com/docs/api/reference/__next._head.txt')
+      )?.href
+    ).toBe('https://example.com/docs/__fallback/__route_0/__next._head.txt')
+    expect(
+      getCachedOutputExportFallbackRequestUrl(
+        new URL(
+          'https://example.com/docs/api/reference/__next.docs.$d$section.$d$page.txt'
+        )
+      )?.href
+    ).toBe(
+      'https://example.com/docs/__fallback/__route_0/__next.docs.$d$section.$d$page.txt'
+    )
+  })
+
+  it('dedupes fallback artifact fetches across sibling routes', async () => {
+    process.env.__NEXT_TRAILING_SLASH = 'false'
+    const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url.endsWith('/docs/__fallback.txt')) {
+        return new Response('not found', {
+          status: 404,
+          headers: { 'content-type': 'text/html' },
+        })
+      }
+
+      if (url.endsWith('/docs/__fallback.meta.json')) {
+        return new Response(
+          JSON.stringify({
+            version: 1,
+            routes: [
+              {
+                route: '/docs/[section]/[page]',
+                fallbackPath: '/docs/__fallback/__route_0',
+              },
+              {
+                route: '/docs/[...slug]',
+                fallbackPath: '/docs/__fallback/__route_1',
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }
+        )
+      }
+
+      if (url.endsWith('/docs/__fallback/__route_0.txt')) {
+        return new Response('payload', {
+          status: 200,
+          headers: { 'content-type': 'text/plain' },
+        })
+      }
+
+      return new Response('not found', {
+        status: 404,
+        headers: { 'content-type': 'text/html' },
+      })
+    })
+
+    global.fetch = fetchMock as typeof fetch
+
+    await fetchOutputExportFallbackResponse(
+      new URL('https://example.com/docs/api/reference')
+    )
+    await fetchOutputExportFallbackResponse(
+      new URL('https://example.com/docs/api/guide')
+    )
+
+    expect(fetchMock.mock.calls.map(([url]) => String(url))).toEqual([
+      'https://example.com/docs/api/reference/__fallback.txt',
+      'https://example.com/docs/api/reference/__fallback.meta.json',
+      'https://example.com/docs/api/__fallback.txt',
+      'https://example.com/docs/api/__fallback.meta.json',
+      'https://example.com/docs/__fallback.txt',
+      'https://example.com/docs/__fallback.meta.json',
+      'https://example.com/docs/__fallback/__route_0.txt',
+      'https://example.com/docs/api/guide/__fallback.txt',
+      'https://example.com/docs/api/guide/__fallback.meta.json',
+    ])
+  })
+
+  it('matches and fetches conflicting fallback branches under basePath', async () => {
+    process.env.__NEXT_ROUTER_BASEPATH = '/base'
+
+    const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url.endsWith('/base/docs/__fallback.meta.json')) {
+        return new Response(
+          JSON.stringify({
+            version: 1,
+            routes: [
+              {
+                route: '/docs/[section]/[page]',
+                fallbackPath: '/docs/__fallback/__route_0',
+              },
+              {
+                route: '/docs/[...slug]',
+                fallbackPath: '/docs/__fallback/__route_1',
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }
+        )
+      }
+
+      if (url.endsWith('/base/docs/__fallback/__route_0.txt')) {
+        return new Response('payload', {
+          status: 200,
+          headers: { 'content-type': 'text/plain' },
+        })
+      }
+
+      return new Response('not found', {
+        status: 404,
+        headers: { 'content-type': 'text/html' },
+      })
+    })
+
+    global.fetch = fetchMock as typeof fetch
+
+    const renderedUrl = new URL('https://example.com/base/docs/api/reference')
+    const result = await fetchOutputExportFallbackResponse(renderedUrl)
+
+    expect(result).not.toBeNull()
+    expect(result?.fallbackUrl.pathname).toBe('/base/docs/__fallback/__route_0')
+    expect(fetchMock.mock.calls.map(([url]) => String(url))).toEqual([
+      'https://example.com/base/docs/api/reference/__fallback.txt',
+      'https://example.com/base/docs/api/reference/__fallback.meta.json',
+      'https://example.com/base/docs/api/__fallback.txt',
+      'https://example.com/base/docs/api/__fallback.meta.json',
+      'https://example.com/base/docs/__fallback.txt',
+      'https://example.com/base/docs/__fallback.meta.json',
+      'https://example.com/base/docs/__fallback/__route_0.txt',
+    ])
+  })
+})

--- a/packages/next/src/export/helpers/output-export-fallback.test.ts
+++ b/packages/next/src/export/helpers/output-export-fallback.test.ts
@@ -1,0 +1,116 @@
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { dirname, join } from 'path'
+import {
+  emitOutputExportFallbackArtifacts,
+  writeOutputExportFallbackHtml,
+} from './output-export-fallback'
+
+describe('output export fallback artifacts', () => {
+  const tmpDirs = new Set<string>()
+
+  afterEach(async () => {
+    await Promise.all(
+      [...tmpDirs].map((dir) => rm(dir, { recursive: true, force: true }))
+    )
+    tmpDirs.clear()
+  })
+
+  async function createTempDir(): Promise<string> {
+    const dir = await mkdtemp(join(tmpdir(), 'next-export-fallback-'))
+    tmpDirs.add(dir)
+    return dir
+  }
+
+  async function createFallbackSource(outDir: string): Promise<string> {
+    const orig = join(outDir, '..', 'server', 'app', 'docs', '[slug]')
+    await mkdir(dirname(orig), { recursive: true })
+    await writeFile(
+      `${orig}.html`,
+      '<html><head></head><body>docs</body></html>'
+    )
+    await writeFile(`${orig}.rsc`, 'rsc')
+    await mkdir(`${orig}.segments`, { recursive: true })
+    await writeFile(join(`${orig}.segments`, '_tree.segment.rsc'), 'tree')
+    return orig
+  }
+
+  it('does not overwrite a user-provided global fallback file', async () => {
+    const outDir = await createTempDir()
+    await mkdir(outDir, { recursive: true })
+    await writeFile(
+      join(outDir, 'index.html'),
+      '<html><head></head><body>index</body></html>'
+    )
+    await writeFile(join(outDir, '_fallback.html'), 'user fallback')
+
+    await expect(
+      writeOutputExportFallbackHtml(outDir, [])
+    ).rejects.toMatchObject({
+      code: 'NEXT_EXPORT_ERROR',
+    })
+
+    await expect(
+      readFile(join(outDir, '_fallback.html'), 'utf8')
+    ).resolves.toBe('user fallback')
+  })
+
+  it('does not overwrite a user-provided fallback manifest file', async () => {
+    const outDir = await createTempDir()
+    await mkdir(join(outDir, 'docs'), { recursive: true })
+    await writeFile(join(outDir, 'docs', '__fallback.meta.json'), '{}')
+
+    await expect(
+      emitOutputExportFallbackArtifacts(
+        [
+          {
+            fallbackRoute: '/docs/__fallback',
+            needsManifest: true,
+            variants: [
+              {
+                route: '/docs/[slug]/[page]',
+                fallbackPath: '/docs/__fallback/__route_0',
+                orig: await createFallbackSource(outDir),
+              },
+            ],
+          },
+        ],
+        outDir,
+        true
+      )
+    ).rejects.toMatchObject({
+      code: 'NEXT_EXPORT_ERROR',
+    })
+  })
+
+  it('does not overwrite user-provided fallback segment files', async () => {
+    const outDir = await createTempDir()
+    await mkdir(join(outDir, 'docs', '__fallback'), { recursive: true })
+    await writeFile(
+      join(outDir, 'docs', '__fallback', '__next._tree.txt'),
+      'user'
+    )
+
+    await expect(
+      emitOutputExportFallbackArtifacts(
+        [
+          {
+            fallbackRoute: '/docs/__fallback',
+            needsManifest: false,
+            variants: [
+              {
+                route: '/docs/[slug]',
+                fallbackPath: '/docs/__fallback',
+                orig: await createFallbackSource(outDir),
+              },
+            ],
+          },
+        ],
+        outDir,
+        true
+      )
+    ).rejects.toMatchObject({
+      code: 'NEXT_EXPORT_ERROR',
+    })
+  })
+})

--- a/packages/next/src/export/helpers/output-export-fallback.ts
+++ b/packages/next/src/export/helpers/output-export-fallback.ts
@@ -5,34 +5,39 @@ import {
   RSC_SEGMENT_SUFFIX,
   RSC_SUFFIX,
 } from '../../lib/constants'
+import { getOutputExportFallbackMetadataPath } from '../../lib/output-export-dynamic-fallback'
+import {
+  planOutputExportFallbackRoutes,
+  type OutputExportDynamicRouteInfo,
+} from '../../lib/output-export-fallback-routes'
+import { normalizePagePath } from '../../shared/lib/page-path/normalize-page-path'
 import { getPagePath } from '../../server/require'
 import { convertSegmentPathToStaticExportFilename } from '../../shared/lib/segment-cache/segment-value-encoding'
-import { normalizePagePath } from '../../shared/lib/page-path/normalize-page-path'
-import {
-  getOutputExportFallbackPath,
-  getOutputExportFallbackStaticPrefix,
-} from '../../lib/output-export-dynamic-fallback'
 
-type OutputExportDynamicRouteInfo = {
-  fallbackSourceRoute: string | undefined
-  fallbackRouteParams:
-    | ReadonlyArray<{
-        paramName: string
-        paramType: string
-      }>
-    | undefined
+export type OutputExportFallbackArtifactVariant = {
+  route: string
+  fallbackPath: string
+  orig: string
+}
+
+export type OutputExportFallbackArtifactPlan = {
+  fallbackRoute: string
+  needsManifest: boolean
+  variants: OutputExportFallbackArtifactVariant[]
+}
+
+type OutputExportError = Error & {
+  code: 'NEXT_EXPORT_ERROR'
 }
 
 type CopyExportedAppArtifactsOptions = {
   outDir: string
   orig: string
   routePath: string
+  segmentsRoutePath: string
   subFolders: boolean
   checkRouteCollision?: boolean
-}
-
-type OutputExportError = Error & {
-  code: 'NEXT_EXPORT_ERROR'
+  routeCollisionPath?: string
 }
 
 function createOutputExportError(message: string): OutputExportError {
@@ -69,8 +74,10 @@ export async function copyExportedAppArtifacts({
   outDir,
   orig,
   routePath,
+  segmentsRoutePath,
   subFolders,
   checkRouteCollision = false,
+  routeCollisionPath,
 }: CopyExportedAppArtifactsOptions): Promise<string> {
   const route = normalizePagePath(routePath)
   const flatHtmlDest = join(outDir, `${route}.html`)
@@ -95,7 +102,7 @@ export async function copyExportedAppArtifacts({
   }> = []
 
   if (existsSync(segmentsDir)) {
-    const segmentsDirDest = join(outDir, routePath)
+    const segmentsDirDest = join(outDir, segmentsRoutePath)
     const segmentPaths = await collectSegmentPaths(segmentsDir)
     for (const segmentFileSrc of segmentPaths) {
       const segmentPath =
@@ -119,7 +126,7 @@ export async function copyExportedAppArtifacts({
         folderJsonDest,
         ...segmentCopies.map(({ dest }) => dest),
       ],
-      routePath
+      routeCollisionPath ?? routePath
     )
   }
 
@@ -138,14 +145,16 @@ export async function copyExportedAppArtifacts({
   return htmlDest
 }
 
-export async function emitOutputExportFallbackArtifacts(
+export function planOutputExportFallbackArtifacts(
   dynamicRoutes: Readonly<Record<string, OutputExportDynamicRouteInfo>>,
   mapAppRouteToPage: Map<string, string>,
-  distDir: string,
-  outDir: string,
-  subFolders: boolean
-): Promise<string[]> {
-  const fallbackHtmlPaths: string[] = []
+  distDir: string
+): OutputExportFallbackArtifactPlan[] {
+  const dynamicRoutesWithArtifacts: Record<
+    string,
+    OutputExportDynamicRouteInfo
+  > = {}
+  const origByRoute = new Map<string, string>()
 
   for (const [dynamicRoute, prerenderInfo] of Object.entries(dynamicRoutes)) {
     if (
@@ -153,11 +162,6 @@ export async function emitOutputExportFallbackArtifacts(
       !prerenderInfo.fallbackRouteParams ||
       prerenderInfo.fallbackRouteParams.length === 0
     ) {
-      continue
-    }
-
-    const staticPrefix = getOutputExportFallbackStaticPrefix(dynamicRoute)
-    if (staticPrefix === null) {
       continue
     }
 
@@ -182,25 +186,79 @@ export async function emitOutputExportFallbackArtifacts(
       continue
     }
 
-    const fallbackPath = getOutputExportFallbackPath(staticPrefix)
-    fallbackHtmlPaths.push(
-      await copyExportedAppArtifacts({
-        outDir,
-        orig,
-        routePath: fallbackPath,
-        subFolders,
-        checkRouteCollision: true,
-      })
-    )
+    dynamicRoutesWithArtifacts[dynamicRoute] = prerenderInfo
+    origByRoute.set(dynamicRoute, orig)
   }
 
-  return fallbackHtmlPaths
+  return planOutputExportFallbackRoutes(dynamicRoutesWithArtifacts).map(
+    ({ fallbackRoute, needsManifest, entries }) => ({
+      fallbackRoute,
+      needsManifest,
+      variants: entries.map(({ route, fallbackPath }) => ({
+        route,
+        fallbackPath,
+        orig: origByRoute.get(route)!,
+      })),
+    })
+  )
+}
+
+export async function emitOutputExportFallbackArtifacts(
+  plans: OutputExportFallbackArtifactPlan[],
+  outDir: string,
+  subFolders: boolean
+): Promise<string[]> {
+  const fallbackHtmlPathsByPlan = await Promise.all(
+    plans.map(async ({ fallbackRoute, needsManifest, variants }) => {
+      if (needsManifest) {
+        const manifestPath = join(
+          outDir,
+          getOutputExportFallbackMetadataPath(fallbackRoute)
+        )
+        assertNoOutputExportPathCollision(outDir, [manifestPath], fallbackRoute)
+        await fs.mkdir(dirname(manifestPath), { recursive: true })
+        await fs.writeFile(
+          manifestPath,
+          JSON.stringify(
+            {
+              version: 1,
+              routes: variants.map(({ route, fallbackPath }) => ({
+                route,
+                fallbackPath,
+              })),
+            },
+            null,
+            2
+          )
+        )
+      }
+
+      return Promise.all(
+        variants.map(async ({ fallbackPath, orig }) => {
+          return copyExportedAppArtifacts({
+            outDir,
+            orig,
+            routePath: fallbackPath,
+            segmentsRoutePath: fallbackPath,
+            subFolders,
+            checkRouteCollision: true,
+            routeCollisionPath: fallbackPath,
+          })
+        })
+      )
+    })
+  )
+
+  return fallbackHtmlPathsByPlan.flat()
 }
 
 export async function writeOutputExportFallbackHtml(
   outDir: string,
   fallbackHtmlPaths: string[]
 ): Promise<void> {
+  // Prefer a shallow __fallback shell for the global fallback entry point so
+  // the bootstrap document still carries the right root structure and assets.
+  // Fall back to a generic document only if no __fallback shell exists.
   const genericSource = [
     join(outDir, 'index.html'),
     join(outDir, '404.html'),
@@ -209,7 +267,8 @@ export async function writeOutputExportFallbackHtml(
   const sortedFallbackPaths = [...fallbackHtmlPaths].sort(
     (a, b) => a.length - b.length
   )
-  const fallbackSource = sortedFallbackPaths[0] ?? genericSource
+  const pprShellSource = sortedFallbackPaths[0]
+  const fallbackSource = pprShellSource ?? genericSource
   if (!fallbackSource) {
     return
   }
@@ -225,6 +284,9 @@ export async function writeOutputExportFallbackHtml(
 
   const fallbackHtml = await fs.readFile(fallbackSource, 'utf8')
   const exportFallbackScript = '<script>self.__NEXT_EXPORT_FALLBACK=1</script>'
+  // The global fallback document is only a bootstrap shell. Keep it hidden
+  // until the client resolves the actual route-specific fallback payload and
+  // React commits the real tree. Removed in app-index.tsx after hydration.
   const exportFallbackStyle =
     '<style id="__next-export-fallback-style">#__next{visibility:hidden}</style>'
   const injection = `${exportFallbackStyle}${exportFallbackScript}`

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -18,16 +18,14 @@ import { existsSync, promises as fs } from 'fs'
 
 import '../server/require-hook'
 
-import { dirname, join, resolve, sep, relative } from 'path'
+import { dirname, join, resolve, sep } from 'path'
 import * as Log from '../build/output/log'
-import {
-  RSC_SEGMENT_SUFFIX,
-  RSC_SEGMENTS_DIR_SUFFIX,
-  RSC_SUFFIX,
-  SSG_FALLBACK_EXPORT_ERROR,
-} from '../lib/constants'
+import { SSG_FALLBACK_EXPORT_ERROR } from '../lib/constants'
 import { recursiveCopy } from '../lib/recursive-copy'
-import { isOutputExportDynamicFallbackEnabled } from '../lib/output-export-dynamic-fallback'
+import {
+  isOutputExportDynamicFallbackEnabled,
+  isOutputExportOptimisticRoutingEnabled,
+} from '../lib/output-export-dynamic-fallback'
 import {
   BUILD_ID_FILE,
   CLIENT_PUBLIC_FILES_PATH,
@@ -68,11 +66,12 @@ import type { DeepReadonly } from '../shared/lib/deep-readonly'
 import { isInterceptionRouteRewrite } from '../lib/is-interception-route-rewrite'
 import type { ActionManifest } from '../build/webpack/plugins/flight-client-entry-plugin'
 import { extractInfoFromServerReferenceId } from '../shared/lib/server-reference-info'
-import { convertSegmentPathToStaticExportFilename } from '../shared/lib/segment-cache/segment-value-encoding'
 import { getNextBuildDebuggerPortOffset } from '../lib/worker'
 import { getParams } from './helpers/get-params'
 import {
+  copyExportedAppArtifacts,
   emitOutputExportFallbackArtifacts,
+  planOutputExportFallbackArtifacts,
   writeOutputExportFallbackHtml,
 } from './helpers/output-export-fallback'
 import { isDynamicRoute } from '../shared/lib/router/utils/is-dynamic'
@@ -515,7 +514,7 @@ async function exportAppImpl(
       clientParamParsingOrigins:
         nextConfig.experimental.clientParamParsingOrigins,
       dynamicOnHover: nextConfig.experimental.dynamicOnHover ?? false,
-      optimisticRouting: nextConfig.experimental.optimisticRouting ?? false,
+      optimisticRouting: isOutputExportOptimisticRoutingEnabled(nextConfig),
       inlineCss: nextConfig.experimental.inlineCss ?? false,
       prefetchInlining: nextConfig.experimental.prefetchInlining ?? false,
       authInterrupts: !!nextConfig.experimental.authInterrupts,
@@ -752,10 +751,6 @@ async function exportAppImpl(
         initialPhaseExportPaths.push(exportPath)
       }
 
-      // Always mark routes for potential build validation. The actual
-      // decision of whether to validate is made per-route by
-      // anySegmentNeedsInstantValidationInBuild, which checks both the
-      // default validation level and per-segment level overrides.
       const route = exportPath.page
       if (!routesWithInstantValidation.has(route)) {
         exportPath._runInstantValidation = true
@@ -967,70 +962,45 @@ async function exportAppImpl(
           return
         }
 
-        const htmlDest = join(
-          outDir,
-          `${route}${
-            subFolders && route !== '/index' ? `${sep}index` : ''
-          }.html`
-        )
-        const jsonDest = isAppPath
-          ? join(
-              outDir,
-              `${route}${
-                subFolders && route !== '/index' ? `${sep}index` : ''
-              }.txt`
-            )
-          : join(pagesDataDir, `${route}.json`)
-
-        await fs.mkdir(dirname(htmlDest), { recursive: true })
-        await fs.mkdir(dirname(jsonDest), { recursive: true })
-
-        const htmlSrc = `${orig}.html`
-        const jsonSrc = `${orig}${isAppPath ? RSC_SUFFIX : '.json'}`
-
-        await fs.copyFile(htmlSrc, htmlDest)
-        await fs.copyFile(jsonSrc, jsonDest)
-
-        const segmentsDir = `${orig}${RSC_SEGMENTS_DIR_SUFFIX}`
-
-        if (isAppPath && existsSync(segmentsDir)) {
-          // Output a data file for each of this page's segments
-          //
-          // These files are requested by the client router's internal
-          // prefetcher, not the user directly. So we don't need to account for
-          // things like trailing slash handling.
-          //
-          // To keep the protocol simple, we can use the non-normalized route
-          // path instead of the normalized one (which, among other things,
-          // rewrites `/` to `/index`).
-          const segmentsDirDest = join(outDir, unnormalizedRoute)
-          const segmentPaths = await collectSegmentPaths(segmentsDir)
-          await Promise.all(
-            segmentPaths.map(async (segmentFileSrc) => {
-              const segmentPath =
-                '/' + segmentFileSrc.slice(0, -RSC_SEGMENT_SUFFIX.length)
-              const segmentFilename =
-                convertSegmentPathToStaticExportFilename(segmentPath)
-              const segmentFileDest = join(segmentsDirDest, segmentFilename)
-              await fs.mkdir(dirname(segmentFileDest), { recursive: true })
-              await fs.copyFile(
-                join(segmentsDir, segmentFileSrc),
-                segmentFileDest
-              )
-            })
+        if (isAppPath) {
+          await copyExportedAppArtifacts({
+            outDir,
+            orig,
+            routePath: unnormalizedRoute,
+            segmentsRoutePath: unnormalizedRoute,
+            subFolders,
+          })
+        } else {
+          const htmlDest = join(
+            outDir,
+            `${route}${
+              subFolders && route !== '/index' ? `${sep}index` : ''
+            }.html`
           )
+          const jsonDest = join(pagesDataDir, `${route}.json`)
+
+          await fs.mkdir(dirname(htmlDest), { recursive: true })
+          await fs.mkdir(dirname(jsonDest), { recursive: true })
+          await fs.copyFile(`${orig}.html`, htmlDest)
+          await fs.copyFile(`${orig}.json`, jsonDest)
         }
       })
     )
 
-    if (isOutputExportDynamicFallbackEnabled(nextConfig)) {
-      const fallbackHtmlPaths = await emitOutputExportFallbackArtifacts(
-        prerenderManifest.dynamicRoutes,
-        mapAppRouteToPage,
-        distDir,
-        outDir,
-        subFolders
-      )
+    const fallbackArtifactPlans = planOutputExportFallbackArtifacts(
+      prerenderManifest.dynamicRoutes,
+      mapAppRouteToPage,
+      distDir
+    )
+    const fallbackHtmlPaths = await emitOutputExportFallbackArtifacts(
+      fallbackArtifactPlans,
+      outDir,
+      subFolders
+    )
+
+    if (
+      hasOutputExportDynamicFallbackRoutes(allExportPaths, prerenderManifest)
+    ) {
       await writeOutputExportFallbackHtml(outDir, fallbackHtmlPaths)
     }
   }
@@ -1071,37 +1041,17 @@ async function exportAppImpl(
   return collector
 }
 
-async function collectSegmentPaths(segmentsDirectory: string) {
-  const results: Array<string> = []
-  await collectSegmentPathsImpl(segmentsDirectory, segmentsDirectory, results)
-  return results
-}
-
-async function collectSegmentPathsImpl(
-  segmentsDirectory: string,
-  directory: string,
-  results: Array<string>
-) {
-  const segmentFiles = await fs.readdir(directory, {
-    withFileTypes: true,
-  })
-  await Promise.all(
-    segmentFiles.map(async (segmentFile) => {
-      if (segmentFile.isDirectory()) {
-        await collectSegmentPathsImpl(
-          segmentsDirectory,
-          join(directory, segmentFile.name),
-          results
-        )
-        return
-      }
-      if (!segmentFile.name.endsWith(RSC_SEGMENT_SUFFIX)) {
-        return
-      }
-      results.push(
-        relative(segmentsDirectory, join(directory, segmentFile.name))
-      )
-    })
+function hasOutputExportDynamicFallbackRoutes(
+  allExportPaths: ExportPathEntry[],
+  prerenderManifest: DeepReadonly<PrerenderManifest> | undefined
+): boolean {
+  return (
+    allExportPaths.some(
+      ({ _fallbackRouteParams = [] }) => _fallbackRouteParams.length > 0
+    ) ||
+    Object.values(prerenderManifest?.dynamicRoutes ?? {}).some(
+      (route) => (route.fallbackRouteParams?.length ?? 0) > 0
+    )
   )
 }
 

--- a/packages/next/src/lib/output-export-dynamic-fallback.ts
+++ b/packages/next/src/lib/output-export-dynamic-fallback.ts
@@ -11,6 +11,11 @@ type OutputExportDynamicFallbackConfig = {
   }
 }
 
+type OutputExportFallbackConflict = {
+  fallbackPath: string
+  routes: string[]
+}
+
 export type OutputExportFallbackManifestEntry = {
   route: string
   fallbackPath: string
@@ -51,16 +56,6 @@ export function getOutputExportFallbackStaticPrefix(
     .join('/')
 }
 
-export function isOutputExportDynamicFallbackEnabled(
-  config: OutputExportDynamicFallbackConfig
-): boolean {
-  return (
-    config.output === 'export' &&
-    config.cacheComponents === true &&
-    config.experimental?.outputExportDynamicFallbacks === true
-  )
-}
-
 export function needsOutputExportFallbackManifest(routePath: string): boolean {
   const route = parseNormalizedAppRoute(routePath)
   const firstDynamicIndex = route.segments.findIndex(
@@ -79,6 +74,55 @@ export function needsOutputExportFallbackManifest(routePath: string): boolean {
   return (
     firstDynamicSegment.type === 'dynamic' &&
     !getParamProperties(firstDynamicSegment.param.paramType).repeat
+  )
+}
+
+export function getOutputExportFallbackConflicts(
+  routePaths: Iterable<string>
+): OutputExportFallbackConflict[] {
+  const fallbackPathToRoutes = new Map<string, string[]>()
+
+  for (const routePath of routePaths) {
+    const staticPrefix = getOutputExportFallbackStaticPrefix(routePath)
+    if (staticPrefix === null) {
+      continue
+    }
+
+    const fallbackPath = getOutputExportFallbackPath(staticPrefix)
+    const routes = fallbackPathToRoutes.get(fallbackPath)
+    if (routes) {
+      routes.push(routePath)
+    } else {
+      fallbackPathToRoutes.set(fallbackPath, [routePath])
+    }
+  }
+
+  const conflicts: OutputExportFallbackConflict[] = []
+  for (const [fallbackPath, routes] of fallbackPathToRoutes) {
+    if (routes.length > 1) {
+      conflicts.push({
+        fallbackPath,
+        routes: routes.sort(),
+      })
+    }
+  }
+
+  return conflicts.sort((a, b) =>
+    a.fallbackPath < b.fallbackPath
+      ? -1
+      : a.fallbackPath > b.fallbackPath
+        ? 1
+        : 0
+  )
+}
+
+export function isOutputExportDynamicFallbackEnabled(
+  config: OutputExportDynamicFallbackConfig
+): boolean {
+  return (
+    config.output === 'export' &&
+    config.cacheComponents === true &&
+    config.experimental?.outputExportDynamicFallbacks === true
   )
 }
 

--- a/packages/next/src/lib/output-export-fallback-routes.ts
+++ b/packages/next/src/lib/output-export-fallback-routes.ts
@@ -1,0 +1,103 @@
+import { getSortedRoutes } from '../shared/lib/router/utils'
+import {
+  getOutputExportFallbackPath,
+  getOutputExportFallbackStaticPrefix,
+  getOutputExportFallbackVariantPath,
+  needsOutputExportFallbackManifest,
+} from './output-export-dynamic-fallback'
+
+export type OutputExportDynamicRouteInfo = {
+  fallbackSourceRoute: string | undefined
+  fallbackRouteParams:
+    | ReadonlyArray<{
+        paramName: string
+        paramType: string
+      }>
+    | undefined
+}
+
+export type OutputExportFallbackRouteEntry = {
+  route: string
+  fallbackSourceRoute: string
+  fallbackRoute: string
+  fallbackPath: string
+  staticPrefix: string
+}
+
+export type OutputExportFallbackRoutePlan = {
+  fallbackRoute: string
+  needsManifest: boolean
+  entries: OutputExportFallbackRouteEntry[]
+}
+
+export function planOutputExportFallbackRoutes(
+  dynamicRoutes: Readonly<Record<string, OutputExportDynamicRouteInfo>>
+): OutputExportFallbackRoutePlan[] {
+  const fallbackEntriesByRoute = new Map<
+    string,
+    Array<Omit<OutputExportFallbackRouteEntry, 'fallbackPath'>>
+  >()
+
+  for (const [dynamicRoute, prerenderInfo] of Object.entries(dynamicRoutes)) {
+    if (
+      !prerenderInfo.fallbackSourceRoute ||
+      !prerenderInfo.fallbackRouteParams ||
+      prerenderInfo.fallbackRouteParams.length === 0
+    ) {
+      continue
+    }
+
+    const staticPrefix = getOutputExportFallbackStaticPrefix(dynamicRoute)
+    if (staticPrefix === null) {
+      continue
+    }
+
+    const fallbackRoute = getOutputExportFallbackPath(staticPrefix)
+    const entries = fallbackEntriesByRoute.get(fallbackRoute)
+    const entry = {
+      route: dynamicRoute,
+      fallbackSourceRoute: prerenderInfo.fallbackSourceRoute,
+      fallbackRoute,
+      staticPrefix,
+    }
+
+    if (entries) {
+      entries.push(entry)
+    } else {
+      fallbackEntriesByRoute.set(fallbackRoute, [entry])
+    }
+  }
+
+  return Array.from(fallbackEntriesByRoute.entries())
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    .map(([fallbackRoute, entries]) => {
+      if (entries.length === 1) {
+        return {
+          fallbackRoute,
+          needsManifest: needsOutputExportFallbackManifest(entries[0].route),
+          entries: [
+            {
+              ...entries[0],
+              fallbackPath: fallbackRoute,
+            },
+          ],
+        }
+      }
+
+      const entriesByRoute = new Map(
+        entries.map((entry) => [entry.route, entry])
+      )
+      const sortedRoutes = getSortedRoutes(entries.map((entry) => entry.route))
+      return {
+        fallbackRoute,
+        needsManifest: true,
+        entries: sortedRoutes.map((route, index) => ({
+          ...entriesByRoute.get(route)!,
+          fallbackPath: getOutputExportFallbackVariantPath(
+            fallbackRoute,
+            index
+          ),
+        })),
+      }
+    })
+}

--- a/packages/next/src/server/app-render/postponed-state.test.ts
+++ b/packages/next/src/server/app-render/postponed-state.test.ts
@@ -58,28 +58,22 @@ describe('getDynamicHTMLPostponedState', () => {
 
     const parsed = parsePostponedState(state, { slug: '123' }, undefined)
 
-    expect(parsed).toMatchInlineSnapshot(`
-     {
-       "data": [
-         1,
-         {
-           "123": "123",
-           "nested": {
-             "123": "123",
-           },
-         },
-       ],
-       "renderResumeDataCache": {
-         "cache": Map {
-           "1" => Promise {},
-         },
-         "decryptedBoundArgs": Map {},
-         "encryptedBoundArgs": Map {},
-         "fetch": Map {},
-       },
-       "type": 2,
-     }
-    `)
+    expect(parsed.type).toBe(2)
+    expect(parsed.data).toEqual([
+      1,
+      {
+        '123': '123',
+        nested: {
+          '123': '123',
+        },
+      },
+    ])
+    expect(parsed.renderResumeDataCache.cache.get('1')).toEqual(
+      expect.any(Promise)
+    )
+    expect(parsed.renderResumeDataCache.decryptedBoundArgs).toEqual(new Map())
+    expect(parsed.renderResumeDataCache.encryptedBoundArgs).toEqual(new Map())
+    expect(parsed.renderResumeDataCache.fetch).toEqual(new Map())
 
     const value = await parsed.renderResumeDataCache.cache.get('1')
 

--- a/packages/next/src/server/request/connection.ts
+++ b/packages/next/src/server/request/connection.ts
@@ -13,8 +13,12 @@ import {
   makeHangingPromise,
   makeDevtoolsIOAwarePromise,
 } from '../dynamic-rendering-utils'
-import { isRequestAPICallableInsideAfter } from './utils'
 import { applyOwnerStack } from '../dynamic-rendering-utils'
+import {
+  isRequestAPICallableInsideAfter,
+  shouldErrorForOutputExportServerRequestAPI,
+  throwForOutputExportServerRequestAPI,
+} from './utils'
 import { RenderStage } from '../app-render/staged-rendering'
 import { InvariantError } from '../../shared/lib/invariant-error'
 
@@ -43,6 +47,19 @@ export function connection(): Promise<void> {
       // When using forceStatic, we override all other logic and always just
       // return a resolving promise without tracking.
       return Promise.resolve(undefined)
+    }
+
+    if (
+      workStore.nextConfigOutput === 'export' &&
+      workUnitStore &&
+      shouldErrorForOutputExportServerRequestAPI(workUnitStore, 'connection')
+    ) {
+      throwForOutputExportServerRequestAPI(
+        workStore,
+        '`connection()`',
+        connection,
+        'this API requires a runtime server request, which is not available when exporting to static HTML.'
+      )
     }
 
     if (workStore.dynamicShouldError) {

--- a/packages/next/src/server/request/cookies.ts
+++ b/packages/next/src/server/request/cookies.ts
@@ -27,8 +27,12 @@ import {
   makeHangingPromise,
 } from '../dynamic-rendering-utils'
 import { createDedupedByCallsiteServerErrorLoggerDev } from '../create-deduped-by-callsite-server-error-logger'
-import { isRequestAPICallableInsideAfter } from './utils'
 import { applyOwnerStack } from '../dynamic-rendering-utils'
+import {
+  isRequestAPICallableInsideAfter,
+  shouldErrorForOutputExportServerRequestAPI,
+  throwForOutputExportServerRequestAPI,
+} from './utils'
 import { InvariantError } from '../../shared/lib/invariant-error'
 import { RenderStage } from '../app-render/staged-rendering'
 
@@ -54,6 +58,19 @@ export function cookies(): Promise<ReadonlyRequestCookies> {
       // cookies object without tracking
       const underlyingCookies = createEmptyCookies()
       return makeUntrackedCookies(underlyingCookies)
+    }
+
+    if (
+      workStore.nextConfigOutput === 'export' &&
+      workUnitStore &&
+      shouldErrorForOutputExportServerRequestAPI(workUnitStore, 'request-data')
+    ) {
+      throwForOutputExportServerRequestAPI(
+        workStore,
+        '`cookies()`',
+        cookies,
+        'this API requires a runtime server request, which is not available when exporting to static HTML.'
+      )
     }
 
     if (workStore.dynamicShouldError) {

--- a/packages/next/src/server/request/fallback-params.test.ts
+++ b/packages/next/src/server/request/fallback-params.test.ts
@@ -4,9 +4,16 @@ import {
   getFallbackRouteParams,
   getPlaceholderFallbackRouteParams,
 } from './fallback-params'
+import {
+  createParamsFromClient,
+  createServerParamsForServerSegment,
+} from './params'
 import type { FallbackRouteParam } from '../../build/static-paths/types'
 import type AppPageRouteModule from '../route-modules/app-page/module'
 import type { LoaderTree } from '../lib/app-dir-module'
+import { workAsyncStorage } from '../app-render/work-async-storage.external'
+import { workUnitAsyncStorage } from '../app-render/work-unit-async-storage.external'
+import { isHangingPromiseRejectionError } from '../dynamic-rendering-utils'
 
 // Helper to create LoaderTree structures for testing
 type TestLoaderTree = [
@@ -658,6 +665,90 @@ describe('getFallbackRouteParams', () => {
 
       result = getFallbackRouteParams('/sidebar/is/real', routeModule)
       expect(result).toBeNull()
+    })
+  })
+})
+
+describe('output export fallback params consumers', () => {
+  it('does not reuse server erroring params promises for client consumers', async () => {
+    const fallbackParams = createOpaqueFallbackRouteParams([
+      { paramName: 'slug', paramType: 'dynamic' },
+    ])!
+    const underlyingParams = {
+      slug: fallbackParams.get('slug')![0],
+    }
+
+    const workStore = {
+      isStaticGeneration: true,
+      page: '/blog/[slug]/page',
+      route: '/blog/[slug]',
+      nextConfigOutput: 'export',
+      afterContext: {} as any,
+      previouslyRevalidatedTags: [],
+      refreshTagsByCacheKind: new Map(),
+      shouldTrackFetchMetrics: false,
+      buildId: 'build-id',
+      cacheComponentsEnabled: true,
+      runInCleanSnapshot: (fn: (...args: Array<any>) => any, ...args: any[]) =>
+        fn(...args),
+      reactServerErrorsByDigest: new Map(),
+    } as any
+
+    const controller = new AbortController()
+    const prerenderStore = {
+      type: 'prerender',
+      phase: 'render',
+      implicitTags: {} as any,
+      revalidate: 0,
+      expire: 0,
+      stale: 0,
+      tags: null,
+      renderSignal: controller.signal,
+      controller,
+      cacheSignal: null,
+      dynamicTracking: null,
+      rootParams: underlyingParams,
+      prerenderResumeDataCache: null,
+      renderResumeDataCache: null,
+      hmrRefreshHash: undefined,
+      varyParamsAccumulator: null,
+      fallbackRouteParams: fallbackParams,
+      allowEmptyStaticShell: false,
+    } as any
+
+    await workAsyncStorage.run(workStore, async () => {
+      await workUnitAsyncStorage.run(prerenderStore, async () => {
+        const serverParams = createServerParamsForServerSegment(
+          underlyingParams,
+          null,
+          null,
+          false
+        )
+        const clientParams = createParamsFromClient(underlyingParams)
+
+        expect(serverParams).not.toBe(clientParams)
+        expect(() => serverParams.then(() => null)).toThrow('output: export')
+        expect(() => clientParams.then(() => null)).not.toThrow()
+
+        const clientOutcome = await Promise.race([
+          clientParams.then(
+            () => 'resolved',
+            () => 'rejected'
+          ),
+          new Promise<'pending'>((resolve) =>
+            setTimeout(() => resolve('pending'))
+          ),
+        ])
+        expect(clientOutcome).toBe('pending')
+
+        controller.abort()
+        try {
+          await clientParams
+          throw new Error('Expected client params to reject after abort')
+        } catch (error) {
+          expect(isHangingPromiseRejectionError(error)).toBe(true)
+        }
+      })
     })
   })
 })

--- a/packages/next/src/server/request/headers.ts
+++ b/packages/next/src/server/request/headers.ts
@@ -25,8 +25,12 @@ import {
   makeHangingPromise,
 } from '../dynamic-rendering-utils'
 import { createDedupedByCallsiteServerErrorLoggerDev } from '../create-deduped-by-callsite-server-error-logger'
-import { isRequestAPICallableInsideAfter } from './utils'
 import { applyOwnerStack } from '../dynamic-rendering-utils'
+import {
+  isRequestAPICallableInsideAfter,
+  shouldErrorForOutputExportServerRequestAPI,
+  throwForOutputExportServerRequestAPI,
+} from './utils'
 import { InvariantError } from '../../shared/lib/invariant-error'
 import { RenderStage } from '../app-render/staged-rendering'
 
@@ -60,6 +64,19 @@ export function headers(): Promise<ReadonlyHeaders> {
       // headers object without tracking
       const underlyingHeaders = HeadersAdapter.seal(new Headers({}))
       return makeUntrackedHeaders(underlyingHeaders)
+    }
+
+    if (
+      workStore.nextConfigOutput === 'export' &&
+      workUnitStore &&
+      shouldErrorForOutputExportServerRequestAPI(workUnitStore, 'request-data')
+    ) {
+      throwForOutputExportServerRequestAPI(
+        workStore,
+        '`headers()`',
+        headers,
+        'this API requires a runtime server request, which is not available when exporting to static HTML.'
+      )
     }
 
     if (workUnitStore) {

--- a/packages/next/src/server/request/params.ts
+++ b/packages/next/src/server/request/params.ts
@@ -41,6 +41,7 @@ import { RenderStage } from '../app-render/staged-rendering'
 
 export type ParamValue = string | Array<string> | undefined
 export type Params = Record<string, ParamValue>
+type ParamsConsumer = 'server' | 'client'
 
 export function createParamsFromClient(
   underlyingParams: Params
@@ -65,7 +66,8 @@ export function createParamsFromClient(
           null,
           workStore,
           workUnitStore,
-          varyParamsAccumulator
+          varyParamsAccumulator,
+          'client'
         )
       case 'validation-client':
         return createClientParamsInInstantValidation(
@@ -100,7 +102,8 @@ export function createParamsFromClient(
             fallbackParams,
             workStore,
             workUnitStore,
-            isRuntimePrefetchable
+            isRuntimePrefetchable,
+            'client'
           )
         } else if (workUnitStore.validationSamples) {
           return createClientParamsInInstantValidation(
@@ -154,7 +157,8 @@ export function createServerParamsForRoute(
           null,
           workStore,
           workUnitStore,
-          varyParamsAccumulator
+          varyParamsAccumulator,
+          'server'
         )
       case 'prerender-client':
       case 'validation-client':
@@ -195,7 +199,8 @@ export function createServerParamsForRoute(
             fallbackParams,
             workStore,
             workUnitStore,
-            isRuntimePrefetchable
+            isRuntimePrefetchable,
+            'server'
           )
         } else {
           return createRenderParamsInProd(underlyingParams)
@@ -229,7 +234,8 @@ export function createServerParamsForServerSegment(
           optionalCatchAllParamName,
           workStore,
           workUnitStore,
-          varyParamsAccumulator
+          varyParamsAccumulator,
+          'server'
         )
       case 'validation-client':
         throw new InvariantError(
@@ -264,7 +270,8 @@ export function createServerParamsForServerSegment(
             fallbackParams,
             workStore,
             workUnitStore,
-            isRuntimePrefetchable
+            isRuntimePrefetchable,
+            'server'
           )
         } else if (
           workUnitStore.asyncApiPromises &&
@@ -363,7 +370,8 @@ function createStaticPrerenderParams(
   optionalCatchAllParamName: string | null,
   workStore: WorkStore,
   prerenderStore: StaticPrerenderStore,
-  varyParamsAccumulator: VaryParamsAccumulator | null
+  varyParamsAccumulator: VaryParamsAccumulator | null,
+  paramsConsumer: ParamsConsumer
 ): Promise<Params> {
   const underlyingParamsWithVarying =
     varyParamsAccumulator !== null
@@ -378,36 +386,38 @@ function createStaticPrerenderParams(
     case 'prerender':
     case 'prerender-client': {
       const fallbackParams = prerenderStore.fallbackRouteParams
-      if (fallbackParams) {
-        for (const key in underlyingParams) {
-          if (fallbackParams.has(key)) {
-            // This params object has one or more fallback params, so we need
-            // to consider the awaiting of this params object "dynamic". Since
-            // we are in cacheComponents mode we encode this as a promise that never
-            // resolves.
-            return makeHangingParams(
-              underlyingParamsWithVarying,
-              workStore,
-              prerenderStore
-            )
-          }
+      if (fallbackParams && fallbackParams.size > 0) {
+        if (
+          paramsConsumer === 'server' &&
+          workStore.nextConfigOutput === 'export'
+        ) {
+          return makeErroringExportFallbackParams(
+            underlyingParamsWithVarying,
+            fallbackParams,
+            workStore
+          )
         }
+        // This params object has one or more fallback params, so we need
+        // to consider the awaiting of this params object "dynamic". Since
+        // we are in cacheComponents mode we encode this as a promise that never
+        // resolves.
+        return makeHangingParams(
+          underlyingParamsWithVarying,
+          workStore,
+          prerenderStore
+        )
       }
       break
     }
     case 'prerender-ppr': {
       const fallbackParams = prerenderStore.fallbackRouteParams
-      if (fallbackParams) {
-        for (const key in underlyingParams) {
-          if (fallbackParams.has(key)) {
-            return makeErroringParams(
-              underlyingParamsWithVarying,
-              fallbackParams,
-              workStore,
-              prerenderStore
-            )
-          }
-        }
+      if (fallbackParams && fallbackParams.size > 0) {
+        return makeErroringParams(
+          underlyingParamsWithVarying,
+          fallbackParams,
+          workStore,
+          prerenderStore
+        )
       }
       break
     }
@@ -448,15 +458,11 @@ function createRuntimePrerenderParams(
 }
 
 function hasFallbackRouteParams(
-  underlyingParams: Params,
+  _underlyingParams: Params,
   fallbackParams: OpaqueFallbackRouteParams | null | undefined
 ): boolean {
-  if (fallbackParams) {
-    for (let key in underlyingParams) {
-      if (fallbackParams.has(key)) {
-        return true
-      }
-    }
+  if (fallbackParams && fallbackParams.size > 0) {
+    return true
   }
   return false
 }
@@ -508,11 +514,30 @@ function createRenderParamsInDev(
   fallbackParams: OpaqueFallbackRouteParams | null | undefined,
   workStore: WorkStore,
   requestStore: RequestStore,
-  isRuntimePrefetchable: boolean
+  isRuntimePrefetchable: boolean,
+  paramsConsumer: ParamsConsumer
 ): Promise<Params> {
+  const hasFallbackParams = hasFallbackRouteParams(
+    underlyingParams,
+    fallbackParams
+  )
+
+  if (
+    paramsConsumer === 'server' &&
+    workStore.nextConfigOutput === 'export' &&
+    fallbackParams &&
+    hasFallbackParams
+  ) {
+    return makeErroringExportFallbackParams(
+      underlyingParams,
+      fallbackParams,
+      workStore
+    )
+  }
+
   return makeDynamicallyTrackedParamsWithDevWarnings(
     underlyingParams,
-    hasFallbackRouteParams(underlyingParams, fallbackParams),
+    hasFallbackParams,
     workStore,
     requestStore,
     isRuntimePrefetchable
@@ -521,6 +546,10 @@ function createRenderParamsInDev(
 
 interface CacheLifetime {}
 const CachedParams = new WeakMap<CacheLifetime, Promise<Params>>()
+const CachedErroringExportFallbackParams = new WeakMap<
+  CacheLifetime,
+  Promise<Params>
+>()
 
 const fallbackParamsProxyHandler: ProxyHandler<Promise<Params>> = {
   get: function get(target, prop, receiver) {
@@ -571,6 +600,71 @@ function makeHangingParams(
   CachedParams.set(underlyingParams, promise)
 
   return promise
+}
+
+function makeErroringExportFallbackParams(
+  underlyingParams: Params,
+  fallbackParams: OpaqueFallbackRouteParams,
+  workStore: WorkStore
+): Promise<Params> {
+  const cachedParams = CachedErroringExportFallbackParams.get(underlyingParams)
+  if (cachedParams) {
+    return cachedParams
+  }
+
+  const augmentedUnderlying = { ...underlyingParams }
+  const error =
+    workStore.invalidDynamicUsageError ??
+    createExportFallbackServerParamsError(workStore)
+
+  const throwError = () => {
+    workStore.invalidDynamicUsageError ??= error
+    throw error
+  }
+
+  const promise = new Proxy(Promise.resolve(augmentedUnderlying), {
+    get(target, prop, receiver) {
+      if (prop === 'then' || prop === 'catch' || prop === 'finally') {
+        return () => throwError()
+      }
+
+      if (
+        typeof prop === 'string' &&
+        !wellKnownProperties.has(prop) &&
+        fallbackParams.has(prop)
+      ) {
+        return throwError()
+      }
+
+      return ReflectAdapter.get(target, prop, receiver)
+    },
+  })
+  CachedErroringExportFallbackParams.set(underlyingParams, promise)
+
+  for (const prop of fallbackParams.keys()) {
+    if (wellKnownProperties.has(prop)) {
+      continue
+    }
+
+    Object.defineProperty(augmentedUnderlying, prop, {
+      get() {
+        return throwError()
+      },
+      enumerable: true,
+    })
+  }
+
+  return promise
+}
+
+function createExportFallbackServerParamsError(workStore: WorkStore): Error {
+  const error = new Error(
+    `Route "${workStore.route}" used unresolved dynamic params in a Server Component with "output: export". This is not supported because these fallback params are only available on the client. Move param-dependent content into a Client Component or add generateStaticParams() to prerender this route. See more info here: https://nextjs.org/docs/app/guides/static-exports`
+  )
+
+  Error.captureStackTrace(error, createExportFallbackServerParamsError)
+
+  return error
 }
 
 function makeErroringParams(

--- a/packages/next/src/server/request/search-params.ts
+++ b/packages/next/src/server/request/search-params.ts
@@ -40,6 +40,7 @@ import {
 import {
   throwWithStaticGenerationBailoutErrorWithDynamicError,
   throwForSearchParamsAccessInUseCache,
+  throwForOutputExportServerRequestAPI,
 } from './utils'
 import { RenderStage } from '../app-render/staged-rendering'
 
@@ -227,6 +228,9 @@ function createStaticPrerenderSearchParams(
   switch (prerenderStore.type) {
     case 'prerender':
     case 'prerender-client':
+      if (workStore.nextConfigOutput === 'export') {
+        return makeErroringOutputExportSearchParams(workStore)
+      }
       // We are in a cacheComponents (PPR or otherwise) prerender
       return makeHangingSearchParams(workStore, prerenderStore)
     case 'prerender-ppr':
@@ -392,10 +396,17 @@ function makeErroringSearchParams(
         const expression =
           '`await searchParams`, `searchParams.then`, or similar'
         if (workStore.dynamicShouldError) {
-          throwWithStaticGenerationBailoutErrorWithDynamicError(
-            workStore.route,
-            expression
-          )
+          if (workStore.nextConfigOutput === 'export') {
+            throwForOutputExportSearchParams(
+              workStore,
+              makeErroringSearchParams
+            )
+          } else {
+            throwWithStaticGenerationBailoutErrorWithDynamicError(
+              workStore.route,
+              expression
+            )
+          }
         } else if (prerenderStore.type === 'prerender-ppr') {
           // PPR Prerender (no cacheComponents)
           postponeWithTracking(
@@ -418,6 +429,61 @@ function makeErroringSearchParams(
 
   CachedSearchParams.set(workStore, proxiedPromise)
   return proxiedPromise
+}
+
+function makeErroringOutputExportSearchParams(
+  workStore: WorkStore
+): Promise<SearchParams> {
+  const cachedSearchParams = CachedSearchParams.get(workStore)
+  if (cachedSearchParams) {
+    return cachedSearchParams
+  }
+
+  const underlyingSearchParams = {}
+  const promise = Promise.resolve(underlyingSearchParams)
+
+  const throwError = () =>
+    throwForOutputExportServerRequestAPI(
+      workStore,
+      '`searchParams`',
+      makeErroringOutputExportSearchParams,
+      'search params are only available on the client when exporting to static HTML. Read the current URL in a Client Component instead.'
+    )
+
+  const proxiedPromise = new Proxy(promise, {
+    get(target, prop, receiver) {
+      if (Object.hasOwn(promise, prop)) {
+        return ReflectAdapter.get(target, prop, receiver)
+      }
+
+      if (typeof prop === 'string') {
+        if (prop === 'then' || prop === 'status') {
+          throwError()
+        }
+      }
+
+      return ReflectAdapter.get(target, prop, receiver)
+    },
+    ownKeys() {
+      throwError()
+      return []
+    },
+  })
+
+  CachedSearchParams.set(workStore, proxiedPromise)
+  return proxiedPromise
+}
+
+function throwForOutputExportSearchParams(
+  workStore: WorkStore,
+  constructorOpt: Function
+): never {
+  return throwForOutputExportServerRequestAPI(
+    workStore,
+    '`searchParams`',
+    constructorOpt,
+    'search params are only available on the client when exporting to static HTML. Read the current URL in a Client Component instead.'
+  )
 }
 
 /**
@@ -579,11 +645,21 @@ function instrumentSearchParamsObjectWithDevWarnings(
     get(target, prop, receiver) {
       if (typeof prop === 'string' && promiseInitialized.current) {
         if (workStore.dynamicShouldError) {
-          const expression = describeStringPropertyAccess('searchParams', prop)
-          throwWithStaticGenerationBailoutErrorWithDynamicError(
-            workStore.route,
-            expression
-          )
+          if (workStore.nextConfigOutput === 'export') {
+            throwForOutputExportSearchParams(
+              workStore,
+              instrumentSearchParamsObjectWithDevWarnings
+            )
+          } else {
+            const expression = describeStringPropertyAccess(
+              'searchParams',
+              prop
+            )
+            throwWithStaticGenerationBailoutErrorWithDynamicError(
+              workStore.route,
+              expression
+            )
+          }
         }
       }
       return ReflectAdapter.get(target, prop, receiver)
@@ -591,26 +667,40 @@ function instrumentSearchParamsObjectWithDevWarnings(
     has(target, prop) {
       if (typeof prop === 'string') {
         if (workStore.dynamicShouldError) {
-          const expression = describeHasCheckingStringProperty(
-            'searchParams',
-            prop
-          )
-          throwWithStaticGenerationBailoutErrorWithDynamicError(
-            workStore.route,
-            expression
-          )
+          if (workStore.nextConfigOutput === 'export') {
+            throwForOutputExportSearchParams(
+              workStore,
+              instrumentSearchParamsObjectWithDevWarnings
+            )
+          } else {
+            const expression = describeHasCheckingStringProperty(
+              'searchParams',
+              prop
+            )
+            throwWithStaticGenerationBailoutErrorWithDynamicError(
+              workStore.route,
+              expression
+            )
+          }
         }
       }
       return Reflect.has(target, prop)
     },
     ownKeys(target) {
       if (workStore.dynamicShouldError) {
-        const expression =
-          '`{...searchParams}`, `Object.keys(searchParams)`, or similar'
-        throwWithStaticGenerationBailoutErrorWithDynamicError(
-          workStore.route,
-          expression
-        )
+        if (workStore.nextConfigOutput === 'export') {
+          throwForOutputExportSearchParams(
+            workStore,
+            instrumentSearchParamsObjectWithDevWarnings
+          )
+        } else {
+          const expression =
+            '`{...searchParams}`, `Object.keys(searchParams)`, or similar'
+          throwWithStaticGenerationBailoutErrorWithDynamicError(
+            workStore.route,
+            expression
+          )
+        }
       }
       return Reflect.ownKeys(target)
     },
@@ -636,7 +726,11 @@ function instrumentSearchParamsPromiseWithDevWarnings(
 
   return new Proxy(promise, {
     get(target, prop, receiver) {
-      if (prop === 'then' && workStore.dynamicShouldError) {
+      if (
+        prop === 'then' &&
+        workStore.dynamicShouldError &&
+        workStore.nextConfigOutput !== 'export'
+      ) {
         const expression = '`searchParams.then`'
         throwWithStaticGenerationBailoutErrorWithDynamicError(
           workStore.route,

--- a/packages/next/src/server/request/utils.ts
+++ b/packages/next/src/server/request/utils.ts
@@ -1,6 +1,9 @@
 import { StaticGenBailoutError } from '../../client/components/static-generation-bailout'
 import { afterTaskAsyncStorage } from '../app-render/after-task-async-storage.external'
 import type { WorkStore } from '../app-render/work-async-storage.external'
+import type { WorkUnitStore } from '../app-render/work-unit-async-storage.external'
+
+type OutputExportServerRequestAPIKind = 'request-data' | 'connection'
 
 export function throwWithStaticGenerationBailoutErrorWithDynamicError(
   route: string,
@@ -23,6 +26,51 @@ export function throwForSearchParamsAccessInUseCache(
   workStore.invalidDynamicUsageError ??= error
 
   throw error
+}
+
+export function throwForOutputExportServerRequestAPI(
+  workStore: WorkStore,
+  expression: string,
+  constructorOpt: Function,
+  reason: string
+): never {
+  const existingError = workStore.invalidDynamicUsageError
+  if (existingError) {
+    throw existingError
+  }
+
+  const error = new Error(
+    `Route "${workStore.route}" used ${expression} in a Server Component with "output: export". This is not supported because ${reason} See more info here: https://nextjs.org/docs/app/guides/static-exports`
+  )
+
+  Error.captureStackTrace(error, constructorOpt)
+  workStore.invalidDynamicUsageError ??= error
+
+  throw error
+}
+
+export function shouldErrorForOutputExportServerRequestAPI(
+  workUnitStore: WorkUnitStore,
+  apiKind: OutputExportServerRequestAPIKind
+): boolean {
+  switch (workUnitStore.type) {
+    case 'request':
+    case 'prerender':
+    case 'prerender-runtime':
+      return true
+    case 'prerender-client':
+      return apiKind === 'connection'
+    case 'validation-client':
+    case 'cache':
+    case 'private-cache':
+    case 'unstable-cache':
+    case 'generate-static-params':
+    case 'prerender-ppr':
+    case 'prerender-legacy':
+      return false
+    default:
+      return workUnitStore satisfies never
+  }
 }
 
 export function isRequestAPICallableInsideAfter() {

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/another/[slug]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/another/[slug]/page.js
@@ -1,0 +1,21 @@
+import Link from 'next/link'
+import { Suspense } from 'react'
+import SlugClient from './slug-client'
+
+export default function Page() {
+  return (
+    <main>
+      <Suspense fallback={<h1>Loading slug...</h1>}>
+        <SlugClient />
+      </Suspense>
+      <ul>
+        <li>
+          <Link href="/another">Visit another page</Link>
+        </li>
+        <li>
+          <Link href="/org/acme/chat/thread-flat">Visit org thread</Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/another/[slug]/slug-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/another/[slug]/slug-client.js
@@ -1,0 +1,9 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function SlugClient() {
+  const params = useParams()
+
+  return <h1>{params.slug}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/another/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/another/page.js
@@ -1,0 +1,20 @@
+import Link from 'next/link'
+
+export default function Another() {
+  return (
+    <main>
+      <h1>Another</h1>
+      <ul>
+        <li>
+          <Link href="/">Visit the home page</Link>
+        </li>
+        <li>
+          <Link href="/another">another page</Link>
+        </li>
+        <li>
+          <Link href="/another/third">another third page</Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/layout.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/not-found.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/not-found.js
@@ -1,0 +1,3 @@
+export default function NotFound() {
+  return <h1>My custom not found page</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/org/[org]/chat/[thread]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/org/[org]/chat/[thread]/page.js
@@ -1,0 +1,18 @@
+import Link from 'next/link'
+import { Suspense } from 'react'
+import OrgThreadClient from './thread-client'
+
+export default function OrgThreadPage() {
+  return (
+    <>
+      <Suspense fallback={<h1>Loading org thread...</h1>}>
+        <OrgThreadClient />
+      </Suspense>
+      <ul>
+        <li>
+          <Link href="/org">Visit org index</Link>
+        </li>
+      </ul>
+    </>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/org/[org]/chat/[thread]/thread-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/org/[org]/chat/[thread]/thread-client.js
@@ -1,0 +1,13 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function OrgThreadClient() {
+  const params = useParams()
+
+  return (
+    <h1>
+      {params.org}:{params.thread}
+    </h1>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/org/[org]/layout.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/org/[org]/layout.js
@@ -1,0 +1,13 @@
+import { Suspense } from 'react'
+import OrgClient from './org-client'
+
+export default function OrgLayout({ children }) {
+  return (
+    <main>
+      <Suspense fallback={<p id="org-name">Loading org...</p>}>
+        <OrgClient />
+      </Suspense>
+      {children}
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/org/[org]/org-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/org/[org]/org-client.js
@@ -1,0 +1,9 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function OrgClient() {
+  const params = useParams()
+
+  return <p id="org-name">Org {params.org}</p>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/org/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/org/page.js
@@ -1,0 +1,16 @@
+import Link from 'next/link'
+
+export default function OrgIndexPage() {
+  return (
+    <main>
+      <h1>Org index</h1>
+      <ul>
+        <li>
+          <Link href="/org/acme/chat/thread-123">
+            Visit org chat thread 123
+          </Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/next.config.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/next.config.js
@@ -1,0 +1,11 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  output: 'export',
+  trailingSlash: false,
+  cacheComponents: true,
+  experimental: {
+    outputExportDynamicFallbacks: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/(grouped)/grouped/[slug]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/(grouped)/grouped/[slug]/page.js
@@ -1,0 +1,18 @@
+import Link from 'next/link'
+import { Suspense } from 'react'
+import GroupedSlugClient from './slug-client'
+
+export default function GroupedSlugPage() {
+  return (
+    <main>
+      <Suspense fallback={<h1>Loading grouped slug...</h1>}>
+        <GroupedSlugClient />
+      </Suspense>
+      <ul>
+        <li>
+          <Link href="/grouped">Visit grouped index</Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/(grouped)/grouped/[slug]/slug-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/(grouped)/grouped/[slug]/slug-client.js
@@ -1,0 +1,9 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function GroupedSlugClient() {
+  const params = useParams()
+
+  return <h1>{params.slug}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/(grouped)/grouped/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/(grouped)/grouped/page.js
@@ -1,0 +1,14 @@
+import Link from 'next/link'
+
+export default function GroupedIndexPage() {
+  return (
+    <main>
+      <h1>Grouped index</h1>
+      <ul>
+        <li>
+          <Link href="/grouped/from-group">Visit grouped fallback page</Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/another/[slug]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/another/[slug]/page.js
@@ -1,0 +1,23 @@
+import Link from 'next/link'
+import { Suspense } from 'react'
+import SlugClient from './slug-client'
+
+export default function Page() {
+  return (
+    <main>
+      <Suspense fallback={<h1>Loading slug...</h1>}>
+        <SlugClient />
+      </Suspense>
+      <ul>
+        <li>
+          <Link href="/another">Visit another page</Link>
+        </li>
+        <li>
+          <Link href="/org/acme/chat/thread-cross">
+            Visit org thread (cross-subtree)
+          </Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/another/[slug]/slug-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/another/[slug]/slug-client.js
@@ -1,0 +1,9 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function SlugClient() {
+  const params = useParams()
+
+  return <h1>{params.slug}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/another/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/another/page.js
@@ -1,0 +1,20 @@
+import Link from 'next/link'
+
+export default function Another() {
+  return (
+    <main>
+      <h1>Another</h1>
+      <ul>
+        <li>
+          <Link href="/">Visit the home page</Link>
+        </li>
+        <li>
+          <Link href="/another">another page</Link>
+        </li>
+        <li>
+          <Link href="/another/third">another third page</Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/components/link-accordion.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/components/link-accordion.js
@@ -1,0 +1,26 @@
+'use client'
+
+import Link from 'next/link'
+import { useState } from 'react'
+
+export function LinkAccordion({ href, children, prefetch }) {
+  const [isVisible, setIsVisible] = useState(false)
+
+  return (
+    <>
+      <input
+        type="checkbox"
+        checked={isVisible}
+        onChange={() => setIsVisible(!isVisible)}
+        data-link-accordion={href}
+      />
+      {isVisible ? (
+        <Link href={href} prefetch={prefetch} data-accordion-link={href}>
+          {children}
+        </Link>
+      ) : (
+        `${children} (link is hidden)`
+      )}
+    </>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/docs/[...slug]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/docs/[...slug]/page.js
@@ -1,0 +1,18 @@
+import Link from 'next/link'
+import { Suspense } from 'react'
+import DocsSlugClient from './slug-client'
+
+export default function DocsCatchAllPage() {
+  return (
+    <main>
+      <Suspense fallback={<h1>Loading docs...</h1>}>
+        <DocsSlugClient />
+      </Suspense>
+      <ul>
+        <li>
+          <Link href="/docs">Visit docs index</Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/docs/[...slug]/slug-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/docs/[...slug]/slug-client.js
@@ -1,0 +1,11 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function DocsSlugClient() {
+  const params = useParams()
+
+  return (
+    <h1>{Array.isArray(params.slug) ? params.slug.join('/') : 'missing'}</h1>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/docs/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/docs/page.js
@@ -1,0 +1,19 @@
+import Link from 'next/link'
+
+export default function DocsIndex() {
+  return (
+    <main>
+      <h1>Docs</h1>
+      <ul>
+        <li>
+          <Link href="/docs/reference/export">docs reference page</Link>
+        </li>
+        <li>
+          <Link href="/docs/guides/export/fallback">
+            docs export fallback page
+          </Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/docs/reference/[topic]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/docs/reference/[topic]/page.js
@@ -1,0 +1,18 @@
+import Link from 'next/link'
+import { Suspense } from 'react'
+import ReferenceTopicClient from './topic-client'
+
+export default function DocsReferenceTopicPage() {
+  return (
+    <main>
+      <Suspense fallback={<h1>Loading reference...</h1>}>
+        <ReferenceTopicClient />
+      </Suspense>
+      <ul>
+        <li>
+          <Link href="/docs">Visit docs index</Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/docs/reference/[topic]/topic-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/docs/reference/[topic]/topic-client.js
@@ -1,0 +1,9 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function ReferenceTopicClient() {
+  const params = useParams()
+
+  return <h1>{`reference:${params.topic ?? 'missing'}`}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/hydrated/[thread]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/hydrated/[thread]/page.js
@@ -1,0 +1,29 @@
+import Link from 'next/link'
+import { Suspense } from 'react'
+import { LinkAccordion } from '../../components/link-accordion'
+import HydratedThreadClient from './thread-client'
+
+export default function HydratedThreadPage() {
+  return (
+    <>
+      <Suspense fallback={<h1>Loading hydrated thread...</h1>}>
+        <HydratedThreadClient />
+      </Suspense>
+      <ul>
+        <li>
+          <Link href="/">Visit the home page</Link>
+        </li>
+        <li>
+          <LinkAccordion href="/hydrated/second">
+            Visit hydrated thread second
+          </LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/hydrated/third">
+            Visit hydrated thread third
+          </LinkAccordion>
+        </li>
+      </ul>
+    </>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/hydrated/[thread]/thread-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/hydrated/[thread]/thread-client.js
@@ -1,0 +1,9 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function HydratedThreadClient() {
+  const params = useParams()
+
+  return <h1>{params.thread}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/inbox/@modal/[thread]/modal-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/inbox/@modal/[thread]/modal-client.js
@@ -1,0 +1,9 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function InboxModalClient() {
+  const params = useParams()
+
+  return <p id="modal-thread">Modal {params.thread}</p>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/inbox/@modal/[thread]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/inbox/@modal/[thread]/page.js
@@ -1,0 +1,10 @@
+import { Suspense } from 'react'
+import InboxModalClient from './modal-client'
+
+export default function InboxModalPage() {
+  return (
+    <Suspense fallback={<p id="modal-thread">Loading modal...</p>}>
+      <InboxModalClient />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/inbox/@modal/default.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/inbox/@modal/default.js
@@ -1,0 +1,3 @@
+export default function InboxModalDefault() {
+  return <p id="modal-thread">No modal</p>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/inbox/[thread]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/inbox/[thread]/page.js
@@ -1,0 +1,18 @@
+import Link from 'next/link'
+import { Suspense } from 'react'
+import InboxThreadClient from './thread-client'
+
+export default function InboxThreadPage() {
+  return (
+    <>
+      <Suspense fallback={<h1>Loading inbox thread...</h1>}>
+        <InboxThreadClient />
+      </Suspense>
+      <ul>
+        <li>
+          <Link href="/inbox">Visit inbox index</Link>
+        </li>
+      </ul>
+    </>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/inbox/[thread]/thread-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/inbox/[thread]/thread-client.js
@@ -1,0 +1,9 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function InboxThreadClient() {
+  const params = useParams()
+
+  return <h1>{params.thread}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/inbox/layout.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/inbox/layout.js
@@ -1,0 +1,8 @@
+export default function InboxLayout({ children, modal }) {
+  return (
+    <main>
+      {children}
+      <section id="modal-slot">{modal}</section>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/inbox/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/inbox/page.js
@@ -1,0 +1,14 @@
+import Link from 'next/link'
+
+export default function InboxIndexPage() {
+  return (
+    <main>
+      <h1>Inbox</h1>
+      <ul>
+        <li>
+          <Link href="/inbox/thread-123">Visit inbox thread</Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/isolated/[slug]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/isolated/[slug]/page.js
@@ -1,0 +1,12 @@
+import { Suspense } from 'react'
+import IsolatedSlugClient from './slug-client'
+
+export default function Page() {
+  return (
+    <main>
+      <Suspense fallback={<h1>Loading isolated slug...</h1>}>
+        <IsolatedSlugClient />
+      </Suspense>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/isolated/[slug]/slug-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/isolated/[slug]/slug-client.js
@@ -1,0 +1,8 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function IsolatedSlugClient() {
+  const params = useParams()
+  return <h1>{params.slug}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/isolated/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/isolated/page.js
@@ -1,0 +1,21 @@
+import { LinkAccordion } from '../components/link-accordion'
+
+export default function Isolated() {
+  return (
+    <main>
+      <h1>Isolated</h1>
+      <ul>
+        <li>
+          <LinkAccordion href="/isolated/third" prefetch={true}>
+            prefetched isolated third page
+          </LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/isolated/fourth" prefetch={true}>
+            prefetched isolated fourth page
+          </LinkAccordion>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/layout.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/not-found.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/not-found.js
@@ -1,0 +1,3 @@
+export default function NotFound() {
+  return <h1>My custom not found page</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/optional/[[...slug]]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/optional/[[...slug]]/page.js
@@ -1,0 +1,18 @@
+import Link from 'next/link'
+import { Suspense } from 'react'
+import OptionalSlugClient from './slug-client'
+
+export default function OptionalCatchAllPage() {
+  return (
+    <main>
+      <Suspense fallback={<h1>Loading optional...</h1>}>
+        <OptionalSlugClient />
+      </Suspense>
+      <ul>
+        <li>
+          <Link href="/optional/deep/path">Visit optional deep path</Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/optional/[[...slug]]/slug-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/optional/[[...slug]]/slug-client.js
@@ -1,0 +1,10 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function OptionalSlugClient() {
+  const params = useParams()
+  const slug = params.slug
+
+  return <h1>{Array.isArray(slug) ? slug.join('/') : 'optional index'}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/org/[org]/chat/[thread]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/org/[org]/chat/[thread]/page.js
@@ -1,0 +1,23 @@
+import Link from 'next/link'
+import { Suspense } from 'react'
+import OrgThreadClient from './thread-client'
+
+export default function OrgThreadPage() {
+  return (
+    <>
+      <Suspense fallback={<h1>Loading org thread...</h1>}>
+        <OrgThreadClient />
+      </Suspense>
+      <ul>
+        <li>
+          <Link href="/org">Visit org index</Link>
+        </li>
+        <li>
+          <Link href="/org/acme/chat/thread-456">
+            Visit org chat thread 456
+          </Link>
+        </li>
+      </ul>
+    </>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/org/[org]/chat/[thread]/thread-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/org/[org]/chat/[thread]/thread-client.js
@@ -1,0 +1,13 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function OrgThreadClient() {
+  const params = useParams()
+
+  return (
+    <h1>
+      {params.org}:{params.thread}
+    </h1>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/org/[org]/layout.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/org/[org]/layout.js
@@ -1,0 +1,13 @@
+import { Suspense } from 'react'
+import OrgClient from './org-client'
+
+export default function OrgLayout({ children }) {
+  return (
+    <main>
+      <Suspense fallback={<p id="org-name">Loading org...</p>}>
+        <OrgClient />
+      </Suspense>
+      {children}
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/org/[org]/org-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/org/[org]/org-client.js
@@ -1,0 +1,9 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function OrgClient() {
+  const params = useParams()
+
+  return <p id="org-name">Org {params.org}</p>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/org/layout.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/org/layout.js
@@ -1,0 +1,8 @@
+export default function OrgSectionLayout({ children }) {
+  return (
+    <section>
+      <p id="org-section">Org section layout</p>
+      {children}
+    </section>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/org/not-found.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/org/not-found.js
@@ -1,0 +1,16 @@
+import Link from 'next/link'
+
+export default function OrgNotFound() {
+  return (
+    <main>
+      <h1>Org section not found</h1>
+      <ul>
+        <li>
+          <Link href="/org/acme/missing-two">
+            Visit another missing org route
+          </Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/org/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/org/page.js
@@ -1,0 +1,16 @@
+import Link from 'next/link'
+
+export default function OrgIndexPage() {
+  return (
+    <main>
+      <h1>Org index</h1>
+      <ul>
+        <li>
+          <Link href="/org/acme/chat/thread-123">
+            Visit org chat thread 123
+          </Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/page.js
@@ -1,0 +1,14 @@
+import Link from 'next/link'
+
+export default function Home() {
+  return (
+    <main>
+      <h1>Home</h1>
+      <ul>
+        <li>
+          <Link href="/hydrated/first">Visit hydrated thread first</Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/next.config.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/next.config.js
@@ -1,0 +1,12 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  output: 'export',
+  trailingSlash: true,
+  cacheComponents: true,
+  experimental: {
+    outputExportDynamicFallbacks: true,
+    optimisticRouting: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/app/docs/[...slug]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/app/docs/[...slug]/page.js
@@ -1,0 +1,12 @@
+import { Suspense } from 'react'
+import DocsCatchAllClient from './slug-client'
+
+export default function DocsCatchAllPage() {
+  return (
+    <main>
+      <Suspense fallback={<h1>Loading docs catch-all...</h1>}>
+        <DocsCatchAllClient />
+      </Suspense>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/app/docs/[...slug]/slug-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/app/docs/[...slug]/slug-client.js
@@ -1,0 +1,15 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function DocsCatchAllClient() {
+  const params = useParams()
+
+  return (
+    <h1>
+      {Array.isArray(params.slug)
+        ? `catchall:${params.slug.join('/')}`
+        : 'catchall:missing'}
+    </h1>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/app/docs/[section]/[page]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/app/docs/[section]/[page]/page.js
@@ -1,0 +1,16 @@
+import { Suspense } from 'react'
+import DocsSectionPageClient from './params-client'
+
+export function generateStaticParams() {
+  return [{ section: 'api', page: 'reference' }]
+}
+
+export default function DocsSectionPage() {
+  return (
+    <main>
+      <Suspense fallback={<h1>Loading docs section page...</h1>}>
+        <DocsSectionPageClient />
+      </Suspense>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/app/docs/[section]/[page]/params-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/app/docs/[section]/[page]/params-client.js
@@ -1,0 +1,13 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function DocsSectionPageClient() {
+  const params = useParams()
+
+  return (
+    <h1>
+      {params.section}:{params.page}
+    </h1>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/app/docs/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/app/docs/page.js
@@ -1,0 +1,3 @@
+export default function DocsIndexPage() {
+  return <h1>Docs</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/app/layout.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/app/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/app/page.js
@@ -1,0 +1,10 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <main>
+      <h1>Home</h1>
+      <Link href="/docs/guides/export/fallback">Visit docs fallback route</Link>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/next.config.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  output: 'export',
+  cacheComponents: true,
+  experimental: {
+    outputExportDynamicFallbacks: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-internal-path-conflict/app/docs/[...slug]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-internal-path-conflict/app/docs/[...slug]/page.js
@@ -1,0 +1,12 @@
+import { Suspense } from 'react'
+import DocsCatchAllClient from './slug-client'
+
+export default function DocsCatchAllPage() {
+  return (
+    <main>
+      <Suspense fallback={<h1>Loading docs catch-all...</h1>}>
+        <DocsCatchAllClient />
+      </Suspense>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-internal-path-conflict/app/docs/[...slug]/slug-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-internal-path-conflict/app/docs/[...slug]/slug-client.js
@@ -1,0 +1,8 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function DocsCatchAllClient() {
+  const { slug } = useParams()
+  return <h1>{`catchall:${slug.join('/')}`}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-internal-path-conflict/app/docs/[section]/[page]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-internal-path-conflict/app/docs/[section]/[page]/page.js
@@ -1,0 +1,16 @@
+import { Suspense } from 'react'
+import DocsSectionPageClient from './params-client'
+
+export function generateStaticParams() {
+  return [{ section: 'api', page: 'reference' }]
+}
+
+export default function DocsSectionPage() {
+  return (
+    <main>
+      <Suspense fallback={<h1>Loading docs section page...</h1>}>
+        <DocsSectionPageClient />
+      </Suspense>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-internal-path-conflict/app/docs/[section]/[page]/params-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-internal-path-conflict/app/docs/[section]/[page]/params-client.js
@@ -1,0 +1,8 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function DocsSectionPageClient() {
+  const { section, page } = useParams()
+  return <h1>{`${section}:${page}`}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-internal-path-conflict/app/docs/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-internal-path-conflict/app/docs/page.js
@@ -1,0 +1,3 @@
+export default function DocsPage() {
+  return <p>docs</p>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-internal-path-conflict/app/layout.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-internal-path-conflict/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-internal-path-conflict/app/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-internal-path-conflict/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>home</p>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-internal-path-conflict/next.config.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-internal-path-conflict/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  output: 'export',
+  cacheComponents: true,
+  experimental: {
+    outputExportDynamicFallbacks: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-internal-path-conflict/public/docs/__fallback/__route_0.html
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-internal-path-conflict/public/docs/__fallback/__route_0.html
@@ -1,0 +1,1 @@
+reserved fallback variant path

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/another/[slug]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/another/[slug]/page.js
@@ -1,0 +1,25 @@
+import Link from 'next/link'
+import { Suspense } from 'react'
+import SlugClient from './slug-client'
+
+export function generateStaticParams() {
+  return [{ slug: 'first' }, { slug: 'second' }]
+}
+
+export default function Page() {
+  return (
+    <main>
+      <Suspense fallback={<h1>Loading slug...</h1>}>
+        <SlugClient />
+      </Suspense>
+      <ul>
+        <li>
+          <Link href="/another">Visit another page</Link>
+        </li>
+        <li>
+          <Link href="/another/third">Visit another third (fallback)</Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/another/[slug]/slug-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/another/[slug]/slug-client.js
@@ -1,0 +1,9 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function SlugClient() {
+  const params = useParams()
+
+  return <h1>{params.slug}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/another/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/another/page.js
@@ -1,0 +1,26 @@
+import Link from 'next/link'
+
+export default function Another() {
+  return (
+    <main>
+      <h1>Another</h1>
+      <ul>
+        <li>
+          <Link href="/">Visit the home page</Link>
+        </li>
+        <li>
+          <Link href="/another">another page</Link>
+        </li>
+        <li>
+          <Link href="/another/first">another first page</Link>
+        </li>
+        <li>
+          <Link href="/another/second">another second page</Link>
+        </li>
+        <li>
+          <Link href="/another/third">another third page</Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/layout.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/not-found.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/not-found.js
@@ -1,0 +1,3 @@
+export default function NotFound() {
+  return <h1>My custom not found page</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/org/[org]/chat/[thread]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/org/[org]/chat/[thread]/page.js
@@ -1,0 +1,30 @@
+import Link from 'next/link'
+import { Suspense } from 'react'
+import OrgThreadClient from './thread-client'
+
+export function generateStaticParams() {
+  return [
+    { org: 'acme', thread: 'thread-123' },
+    { org: 'acme', thread: 'thread-456' },
+  ]
+}
+
+export default function OrgThreadPage() {
+  return (
+    <>
+      <Suspense fallback={<h1>Loading org thread...</h1>}>
+        <OrgThreadClient />
+      </Suspense>
+      <ul>
+        <li>
+          <Link href="/org">Visit org index</Link>
+        </li>
+        <li>
+          <Link href="/org/acme/chat/thread-789">
+            Visit fallback org chat thread
+          </Link>
+        </li>
+      </ul>
+    </>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/org/[org]/chat/[thread]/thread-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/org/[org]/chat/[thread]/thread-client.js
@@ -1,0 +1,13 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function OrgThreadClient() {
+  const params = useParams()
+
+  return (
+    <h1>
+      {params.org}:{params.thread}
+    </h1>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/org/[org]/layout.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/org/[org]/layout.js
@@ -1,0 +1,13 @@
+import { Suspense } from 'react'
+import OrgClient from './org-client'
+
+export default function OrgLayout({ children }) {
+  return (
+    <main>
+      <Suspense fallback={<p id="org-name">Loading org...</p>}>
+        <OrgClient />
+      </Suspense>
+      {children}
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/org/[org]/org-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/org/[org]/org-client.js
@@ -1,0 +1,9 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function OrgClient() {
+  const params = useParams()
+
+  return <p id="org-name">Org {params.org}</p>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/org/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/org/page.js
@@ -1,0 +1,21 @@
+import Link from 'next/link'
+
+export default function OrgIndexPage() {
+  return (
+    <main>
+      <h1>Org index</h1>
+      <ul>
+        <li>
+          <Link href="/org/acme/chat/thread-123">
+            Visit known org chat thread
+          </Link>
+        </li>
+        <li>
+          <Link href="/org/acme/chat/thread-789">
+            Visit fallback org chat thread
+          </Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/next.config.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/next.config.js
@@ -1,0 +1,11 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  output: 'export',
+  trailingSlash: true,
+  cacheComponents: true,
+  experimental: {
+    outputExportDynamicFallbacks: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params-suspense/app/layout.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params-suspense/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params-suspense/app/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params-suspense/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>home</p>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params-suspense/app/wrapped/[slug]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params-suspense/app/wrapped/[slug]/page.js
@@ -1,0 +1,15 @@
+import { Suspense } from 'react'
+
+async function ParamContent({ params }) {
+  const { slug } = await params
+
+  return <h1>{slug}</h1>
+}
+
+export default function WrappedDynamicServerPage({ params }) {
+  return (
+    <Suspense fallback={<p>loading</p>}>
+      <ParamContent params={params} />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params-suspense/next.config.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params-suspense/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  output: 'export',
+  cacheComponents: true,
+  experimental: {
+    outputExportDynamicFallbacks: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params-sync/app/another/[slug]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params-sync/app/another/[slug]/page.js
@@ -1,0 +1,5 @@
+export default function DynamicServerPage({ params }) {
+  const slug = params.slug
+
+  return <h1>{slug}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params-sync/app/layout.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params-sync/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params-sync/app/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params-sync/app/page.js
@@ -1,0 +1,3 @@
+export default function HomePage() {
+  return <h1>Home</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params-sync/next.config.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params-sync/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  output: 'export',
+  cacheComponents: true,
+  experimental: {
+    outputExportDynamicFallbacks: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params/app/another/[slug]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params/app/another/[slug]/page.js
@@ -1,0 +1,5 @@
+export default async function DynamicServerPage({ params }) {
+  const { slug } = await params
+
+  return <h1>{slug}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params/app/layout.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params/app/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params/app/page.js
@@ -1,0 +1,3 @@
+export default function HomePage() {
+  return <h1>Home</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params/next.config.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  output: 'export',
+  cacheComponents: true,
+  experimental: {
+    outputExportDynamicFallbacks: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir-export/fixtures/output-export-server-connection-suspense/app/layout.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-connection-suspense/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-connection-suspense/app/needs-connection/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-connection-suspense/app/needs-connection/page.js
@@ -1,0 +1,16 @@
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+
+async function ConnectionContent() {
+  await connection()
+
+  return <h1>connected</h1>
+}
+
+export default function ConnectionPage() {
+  return (
+    <Suspense fallback={<p>loading</p>}>
+      <ConnectionContent />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-connection-suspense/app/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-connection-suspense/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>home</p>
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-connection-suspense/next.config.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-connection-suspense/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  output: 'export',
+  cacheComponents: true,
+  experimental: {
+    outputExportDynamicFallbacks: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir-export/fixtures/output-export-server-connection/app/layout.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-connection/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-connection/app/needs-connection/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-connection/app/needs-connection/page.js
@@ -1,0 +1,7 @@
+import { connection } from 'next/server'
+
+export default async function ConnectionPage() {
+  await connection()
+
+  return <h1>connected</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-connection/app/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-connection/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>home</p>
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-connection/next.config.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-connection/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  output: 'export',
+  cacheComponents: true,
+  experimental: {
+    outputExportDynamicFallbacks: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir-export/fixtures/output-export-server-cookies-suspense/app/layout.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-cookies-suspense/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-cookies-suspense/app/needs-cookies/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-cookies-suspense/app/needs-cookies/page.js
@@ -1,0 +1,16 @@
+import { Suspense } from 'react'
+import { cookies } from 'next/headers'
+
+async function CookiesContent() {
+  const cookieStore = await cookies()
+
+  return <h1>{cookieStore.get('theme')?.value}</h1>
+}
+
+export default function CookiesPage() {
+  return (
+    <Suspense fallback={<p>loading</p>}>
+      <CookiesContent />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-cookies-suspense/app/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-cookies-suspense/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>home</p>
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-cookies-suspense/next.config.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-cookies-suspense/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  output: 'export',
+  cacheComponents: true,
+  experimental: {
+    outputExportDynamicFallbacks: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir-export/fixtures/output-export-server-cookies/app/layout.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-cookies/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-cookies/app/needs-cookies/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-cookies/app/needs-cookies/page.js
@@ -1,0 +1,7 @@
+import { cookies } from 'next/headers'
+
+export default async function CookiesPage() {
+  const cookieStore = await cookies()
+
+  return <h1>{cookieStore.get('theme')?.value}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-cookies/app/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-cookies/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>home</p>
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-cookies/next.config.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-cookies/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  output: 'export',
+  cacheComponents: true,
+  experimental: {
+    outputExportDynamicFallbacks: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir-export/fixtures/output-export-server-headers-suspense/app/layout.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-headers-suspense/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-headers-suspense/app/needs-headers/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-headers-suspense/app/needs-headers/page.js
@@ -1,0 +1,16 @@
+import { Suspense } from 'react'
+import { headers } from 'next/headers'
+
+async function HeadersContent() {
+  const requestHeaders = await headers()
+
+  return <h1>{requestHeaders.get('user-agent')}</h1>
+}
+
+export default function HeadersPage() {
+  return (
+    <Suspense fallback={<p>loading</p>}>
+      <HeadersContent />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-headers-suspense/app/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-headers-suspense/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>home</p>
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-headers-suspense/next.config.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-headers-suspense/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  output: 'export',
+  cacheComponents: true,
+  experimental: {
+    outputExportDynamicFallbacks: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir-export/fixtures/output-export-server-headers/app/layout.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-headers/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-headers/app/needs-headers/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-headers/app/needs-headers/page.js
@@ -1,0 +1,7 @@
+import { headers } from 'next/headers'
+
+export default async function HeadersPage() {
+  const requestHeaders = await headers()
+
+  return <h1>{requestHeaders.get('user-agent')}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-headers/app/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-headers/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>home</p>
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-headers/next.config.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-headers/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  output: 'export',
+  cacheComponents: true,
+  experimental: {
+    outputExportDynamicFallbacks: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir-export/fixtures/output-export-server-io-use-cache/app/cached-crypto/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-io-use-cache/app/cached-crypto/page.js
@@ -1,0 +1,14 @@
+async function getCachedCryptoValue() {
+  'use cache'
+
+  return crypto.randomUUID()
+}
+
+export default async function CachedCryptoPage() {
+  return (
+    <>
+      <p>Cached crypto</p>
+      <h1 id="value">{await getCachedCryptoValue()}</h1>
+    </>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-io-use-cache/app/cached-random/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-io-use-cache/app/cached-random/page.js
@@ -1,0 +1,14 @@
+async function getCachedRandom() {
+  'use cache'
+
+  return Math.random()
+}
+
+export default async function CachedRandomPage() {
+  return (
+    <>
+      <p>Cached random</p>
+      <h1 id="value">{String(await getCachedRandom())}</h1>
+    </>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-io-use-cache/app/cached-time/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-io-use-cache/app/cached-time/page.js
@@ -1,0 +1,14 @@
+async function getCachedTime() {
+  'use cache'
+
+  return Date.now()
+}
+
+export default async function CachedTimePage() {
+  return (
+    <>
+      <p>Cached time</p>
+      <h1 id="value">{String(await getCachedTime())}</h1>
+    </>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-io-use-cache/app/layout.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-io-use-cache/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-io-use-cache/app/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-io-use-cache/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>home</p>
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-io-use-cache/next.config.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-io-use-cache/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  output: 'export',
+  cacheComponents: true,
+  experimental: {
+    outputExportDynamicFallbacks: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir-export/fixtures/output-export-server-io/app/cached-request/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-io/app/cached-request/page.js
@@ -1,0 +1,12 @@
+import { headers } from 'next/headers'
+
+async function getHeadersInCache() {
+  'use cache'
+
+  const requestHeaders = await headers()
+  return requestHeaders.get('user-agent') ?? 'unknown'
+}
+
+export default async function CachedRequestPage() {
+  return <h1>{await getHeadersInCache()}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-io/app/layout.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-io/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-io/app/needs-crypto/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-io/app/needs-crypto/page.js
@@ -1,0 +1,3 @@
+export default function CryptoPage() {
+  return <h1>{crypto.randomUUID()}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-io/app/needs-random/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-io/app/needs-random/page.js
@@ -1,0 +1,3 @@
+export default function RandomPage() {
+  return <h1>{Math.random()}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-io/app/needs-time/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-io/app/needs-time/page.js
@@ -1,0 +1,3 @@
+export default function TimePage() {
+  return <h1>{Date.now()}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-io/app/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-io/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>home</p>
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-io/next.config.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-io/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  output: 'export',
+  cacheComponents: true,
+  experimental: {
+    outputExportDynamicFallbacks: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir-export/fixtures/output-export-server-search-params-suspense/app/layout.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-search-params-suspense/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-search-params-suspense/app/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-search-params-suspense/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>home</p>
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-search-params-suspense/app/search/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-search-params-suspense/app/search/page.js
@@ -1,0 +1,15 @@
+import { Suspense } from 'react'
+
+async function SearchContent({ searchParams }) {
+  const query = await searchParams
+
+  return <h1>{query.q}</h1>
+}
+
+export default function SearchPage({ searchParams }) {
+  return (
+    <Suspense fallback={<p>loading</p>}>
+      <SearchContent searchParams={searchParams} />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-search-params-suspense/next.config.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-search-params-suspense/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  output: 'export',
+  cacheComponents: true,
+  experimental: {
+    outputExportDynamicFallbacks: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir-export/fixtures/output-export-server-search-params/app/layout.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-search-params/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-search-params/app/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-search-params/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>home</p>
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-search-params/app/search/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-search-params/app/search/page.js
@@ -1,0 +1,5 @@
+export default async function SearchPage({ searchParams }) {
+  const query = await searchParams
+
+  return <h1>{query.q}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-search-params/next.config.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-search-params/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  output: 'export',
+  cacheComponents: true,
+  experimental: {
+    outputExportDynamicFallbacks: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir-export/test/dynamic-fallback-cache-components-basepath.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-fallback-cache-components-basepath.test.ts
@@ -1,0 +1,75 @@
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+import webdriver from 'next-webdriver'
+import { buildAndStartOutputExportServer } from './utils'
+
+const { next, skipped, isNextDev } = nextTestSetup({
+  files: join(__dirname, '..', 'fixtures', 'dynamic-fallback-cache-components'),
+  skipDeployment: true,
+  skipStart: true,
+  disableAutoSkewProtection: true,
+})
+
+if (skipped) {
+  describe.skip('app dir - output export dynamic routes with Cache Components and basePath', () => {})
+} else {
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  describeProduction(
+    'app dir - output export dynamic routes with Cache Components and basePath',
+    () => {
+      let port: number
+      let stopOrKill: (() => Promise<void>) | undefined
+      let getRequests: () => string[]
+      let clearRequests: () => void
+
+      beforeAll(async () => {
+        await next.patchFile('next.config.js', (content) =>
+          content.replace(
+            'cacheComponents: true,',
+            "cacheComponents: true,\n  basePath: '/base',"
+          )
+        )
+        ;({ port, stopOrKill, getRequests, clearRequests } =
+          await buildAndStartOutputExportServer(next, {
+            basePath: '/base',
+            trailingSlash: true,
+            useFallbackDocument: true,
+          }))
+      })
+
+      afterAll(async () => {
+        await stopOrKill?.()
+        await next.destroy()
+      })
+
+      it('keeps unmatched fallback not-found fetches under the basePath', async () => {
+        clearRequests()
+        const browser = await webdriver(port, '/base/missing/route/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'My custom not found page'
+            )
+          })
+
+          const requests = getRequests()
+          expect(
+            requests.some((requestPath) =>
+              requestPath.startsWith('/base/_not-found/index.txt')
+            )
+          ).toBe(true)
+          expect(
+            requests.some((requestPath) =>
+              requestPath.startsWith('/_not-found.txt')
+            )
+          ).toBe(false)
+        } finally {
+          await browser.close()
+        }
+      })
+    }
+  )
+}

--- a/test/e2e/app-dir-export/test/dynamic-fallback-cache-components-flat.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-fallback-cache-components-flat.test.ts
@@ -1,0 +1,122 @@
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+import webdriver from 'next-webdriver'
+import fs from 'fs-extra'
+import { buildAndStartOutputExportServer } from './utils'
+
+const { next, skipped, isNextDev } = nextTestSetup({
+  files: join(
+    __dirname,
+    '..',
+    'fixtures',
+    'dynamic-fallback-cache-components-flat'
+  ),
+  skipDeployment: true,
+  skipStart: true,
+  disableAutoSkewProtection: true,
+})
+
+if (skipped) {
+  it('skips unsupported mode', () => {})
+} else {
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  describeProduction(
+    'app dir - output export dynamic routes with Cache Components without trailing slashes',
+    () => {
+      let port: number
+      let stopOrKill: (() => Promise<void>) | undefined
+
+      beforeAll(async () => {
+        ;({ port, stopOrKill } = await buildAndStartOutputExportServer(next, {
+          trailingSlash: false,
+          useFallbackDocument: true,
+        }))
+      })
+
+      afterAll(async () => {
+        if (stopOrKill) {
+          await stopOrKill()
+        }
+        await next.destroy()
+      })
+
+      it('writes flat fallback artifacts for trailingSlash false', async () => {
+        const outDir = join(next.testDir, 'out')
+
+        expect(await fs.pathExists(join(outDir, '_fallback.html'))).toBe(true)
+        expect(
+          await fs.pathExists(join(outDir, 'another', '__fallback.html'))
+        ).toBe(true)
+        expect(
+          await fs.pathExists(join(outDir, 'another', '__fallback.txt'))
+        ).toBe(true)
+        expect(await fs.pathExists(join(outDir, 'org', '__fallback.txt'))).toBe(
+          true
+        )
+        expect(
+          await fs.pathExists(
+            join(outDir, 'another', '__fallback', 'index.html')
+          )
+        ).toBe(false)
+      })
+
+      it('renders an unenumerated slug on hard load and client navigation without adding a trailing slash', async () => {
+        const browser = await webdriver(port, '/another/third')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('third')
+            expect(await browser.eval('window.location.pathname')).toBe(
+              '/another/third'
+            )
+          })
+
+          await browser.elementByCss('a[href="/another"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('Another')
+            expect(await browser.eval('window.location.pathname')).toBe(
+              '/another'
+            )
+          })
+
+          await browser.elementByCss('a[href="/another/third"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('third')
+            expect(await browser.eval('window.location.pathname')).toBe(
+              '/another/third'
+            )
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('preserves search params and hash for nested fallback routes without trailing slashes', async () => {
+        const browser = await webdriver(
+          port,
+          '/org/umbrella/chat/thread-flat?view=full#messages'
+        )
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('#org-name').text()).toBe(
+              'Org umbrella'
+            )
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'umbrella:thread-flat'
+            )
+            expect(
+              await browser.eval(
+                'window.location.pathname + window.location.search + window.location.hash'
+              )
+            ).toBe('/org/umbrella/chat/thread-flat?view=full#messages')
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+    }
+  )
+}

--- a/test/e2e/app-dir-export/test/dynamic-fallback-cache-components.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-fallback-cache-components.test.ts
@@ -1,0 +1,341 @@
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+import webdriver from 'next-webdriver'
+import type * as Playwright from 'playwright'
+import { createRouterAct } from 'router-act'
+import fs from 'fs-extra'
+import { buildAndStartOutputExportServer } from './utils'
+
+const { next, skipped, isNextDev } = nextTestSetup({
+  files: join(__dirname, '..', 'fixtures', 'dynamic-fallback-cache-components'),
+  skipDeployment: true,
+  skipStart: true,
+  disableAutoSkewProtection: true,
+})
+
+if (skipped) {
+  it('skips unsupported mode', () => {})
+} else {
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  describeProduction(
+    'app dir - output export dynamic routes with Cache Components',
+    () => {
+      let port: number
+      let stopOrKill: (() => Promise<void>) | undefined
+      let getRequests: () => string[]
+      let clearRequests: () => void
+
+      beforeAll(async () => {
+        ;({ port, stopOrKill, getRequests, clearRequests } =
+          await buildAndStartOutputExportServer(next, {
+            trailingSlash: true,
+            useFallbackDocument: true,
+          }))
+      })
+
+      afterAll(async () => {
+        if (stopOrKill) {
+          await stopOrKill()
+        }
+        await next.destroy()
+      })
+
+      it('writes fallback artifacts instead of per-param prerenders', async () => {
+        const outDir = join(next.testDir, 'out')
+
+        expect(await fs.pathExists(join(outDir, '_fallback.html'))).toBe(true)
+        expect(
+          await fs.readFile(join(outDir, '_fallback.html'), 'utf8')
+        ).toContain('__NEXT_EXPORT_FALLBACK=1')
+        expect(
+          await fs.pathExists(
+            join(outDir, 'another', '__fallback', 'index.html')
+          )
+        ).toBe(true)
+        expect(
+          await fs.pathExists(
+            join(outDir, 'another', '__fallback', 'index.txt')
+          )
+        ).toBe(true)
+        expect(
+          await fs.pathExists(join(outDir, 'another', 'first', 'index.html'))
+        ).toBe(false)
+      })
+
+      it('renders an unenumerated slug on hard load and client navigation', async () => {
+        clearRequests()
+        const browser = await webdriver(port, '/another/third/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('third')
+          })
+
+          expect(
+            getRequests().some((requestPath) =>
+              requestPath.startsWith('/another/__fallback/index.html')
+            )
+          ).toBe(false)
+
+          await browser.elementByCss('a[href="/another/"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('Another')
+          })
+
+          await browser.elementByCss('a[href="/another/third/"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('third')
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('prefetches fallback payloads for unknown-param links before navigation', async () => {
+        let act!: ReturnType<typeof createRouterAct>
+        const browser = await webdriver(port, '/isolated/', {
+          beforePageLoad(page: Playwright.Page) {
+            act = createRouterAct(page)
+          },
+        })
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('Isolated')
+          })
+
+          await act(async () => {
+            const toggle = await browser.elementByCss(
+              'input[data-link-accordion="/isolated/third"]'
+            )
+            await toggle.click()
+          })
+
+          clearRequests()
+
+          await browser
+            .elementByCss('a[data-accordion-link="/isolated/third"]')
+            .click()
+
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('third')
+          })
+
+          const clickRequests = getRequests()
+          expect(
+            clickRequests.some((requestPath) =>
+              requestPath.startsWith('/isolated/__fallback.meta.json')
+            )
+          ).toBe(false)
+          expect(
+            clickRequests.some((requestPath) =>
+              requestPath.startsWith('/isolated/__fallback/index.txt')
+            )
+          ).toBe(false)
+          expect(
+            clickRequests.some((requestPath) =>
+              requestPath.startsWith('/isolated/third/index.txt')
+            )
+          ).toBe(false)
+          expect(
+            clickRequests.some((requestPath) =>
+              requestPath.startsWith('/isolated/third/__next.')
+            )
+          ).toBe(false)
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('dedupes fallback artifact prefetches across sibling unknown-param links', async () => {
+        let act!: ReturnType<typeof createRouterAct>
+        const browser = await webdriver(port, '/isolated/', {
+          beforePageLoad(page: Playwright.Page) {
+            act = createRouterAct(page)
+          },
+        })
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('Isolated')
+          })
+
+          clearRequests()
+
+          await act(async () => {
+            await browser
+              .elementByCss('input[data-link-accordion="/isolated/third"]')
+              .click()
+            await browser
+              .elementByCss('input[data-link-accordion="/isolated/fourth"]')
+              .click()
+          })
+
+          const prefetchRequests = getRequests().filter((requestPath) =>
+            requestPath.startsWith('/isolated/__fallback/index.txt')
+          )
+
+          expect(prefetchRequests).toHaveLength(1)
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('renders the app not-found page when no fallback route matches', async () => {
+        const browser = await webdriver(port, '/missing/route/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'My custom not found page'
+            )
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('generates _fallback.html from a PPR shell instead of index.html', async () => {
+        const outDir = join(next.testDir, 'out')
+        const fallbackHtml = await fs.readFile(
+          join(outDir, '_fallback.html'),
+          'utf8'
+        )
+
+        expect(fallbackHtml).toContain('__NEXT_EXPORT_FALLBACK=1')
+        expect(fallbackHtml).not.toContain('>Home<')
+        expect(fallbackHtml).toContain('__next-export-fallback-style')
+      })
+
+      it('supports browser back/forward between fallback routes', async () => {
+        const browser = await webdriver(port, '/another/slug-a/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('slug-a')
+          })
+
+          await browser.elementByCss('a[href="/another/"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('Another')
+          })
+
+          await browser.back()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('slug-a')
+          })
+
+          await browser.forward()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('Another')
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('handles consecutive hard navigations to different params', async () => {
+        const browser = await webdriver(port, '/another/param-one/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('param-one')
+          })
+
+          await browser.get(`http://localhost:${port}/another/param-two/`)
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('param-two')
+          })
+
+          await browser.get(`http://localhost:${port}/another/param-three/`)
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('param-three')
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('preserves search params and hash across fallback hard loads', async () => {
+        const browser = await webdriver(
+          port,
+          '/another/query-param/?tab=notes#anchor'
+        )
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('query-param')
+            expect(
+              await browser.eval(
+                'window.location.pathname + window.location.search + window.location.hash'
+              )
+            ).toBe('/another/query-param/?tab=notes#anchor')
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('supports a longer history sequence across static and fallback routes', async () => {
+        const browser = await webdriver(port, '/another/history-one/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('history-one')
+          })
+
+          await browser.elementByCss('a[href="/another/"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('Another')
+          })
+
+          await browser.elementByCss('a[href="/another/third/"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('third')
+          })
+
+          await browser.back()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('Another')
+          })
+
+          await browser.back()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('history-one')
+          })
+
+          await browser.forward()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('Another')
+          })
+
+          await browser.forward()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('third')
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('shows Suspense fallback UI during hard load of a fallback route', async () => {
+        const browser = await webdriver(port, '/another/suspense-test/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'suspense-test'
+            )
+          })
+
+          const html = await browser.eval('document.documentElement.innerHTML')
+          expect(html).not.toContain('Loading slug...')
+        } finally {
+          await browser.close()
+        }
+      })
+    }
+  )
+}

--- a/test/e2e/app-dir-export/test/dynamic-fallback-conflict.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-fallback-conflict.test.ts
@@ -1,0 +1,156 @@
+import { join } from 'path'
+import fs from 'fs-extra'
+import { nextTestSetup } from 'e2e-utils'
+import webdriver from 'next-webdriver'
+import { retry } from 'next-test-utils'
+import { buildAndStartOutputExportServer } from './utils'
+
+describe('app dir - output export fallback conflicts', () => {
+  const { next, skipped } = nextTestSetup({
+    files: join(__dirname, '..', 'fixtures', 'dynamic-fallback-conflict'),
+    skipStart: true,
+    skipDeployment: true,
+    disableAutoSkewProtection: true,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  let port: number
+  let stopOrKill: (() => Promise<void>) | undefined
+  let getRequests: () => string[]
+  let clearRequests: () => void
+
+  beforeAll(async () => {
+    ;({ port, stopOrKill, getRequests, clearRequests } =
+      await buildAndStartOutputExportServer(next, {
+        trailingSlash: true,
+        useFallbackDocument: true,
+      }))
+  })
+
+  afterAll(async () => {
+    await stopOrKill?.()
+  })
+
+  it('emits fallback metadata and branch-specific fallback artifacts', async () => {
+    const outDir = join(next.testDir, 'out')
+    const manifestPath = join(outDir, 'docs', '__fallback.meta.json')
+    const knownSpecificParamExists =
+      (await fs.pathExists(
+        join(outDir, 'docs', 'api', 'reference', 'index.html')
+      )) || (await fs.pathExists(join(outDir, 'docs', 'api', 'reference.html')))
+    const unknownSpecificParamExists =
+      (await fs.pathExists(
+        join(outDir, 'docs', 'api', 'guide', 'index.html')
+      )) || (await fs.pathExists(join(outDir, 'docs', 'api', 'guide.html')))
+
+    expect(await fs.pathExists(join(outDir, '_fallback.html'))).toBe(true)
+    expect(await fs.pathExists(manifestPath)).toBe(true)
+    expect(knownSpecificParamExists).toBe(true)
+    expect(unknownSpecificParamExists).toBe(false)
+
+    const manifest = await fs.readJson(manifestPath)
+    expect(manifest).toEqual({
+      version: 1,
+      routes: [
+        {
+          route: '/docs/[section]/[page]',
+          fallbackPath: '/docs/__fallback/__route_0',
+        },
+        {
+          route: '/docs/[...slug]',
+          fallbackPath: '/docs/__fallback/__route_1',
+        },
+      ],
+    })
+
+    for (const entry of manifest.routes) {
+      const relativeFallbackPath = entry.fallbackPath.slice(1)
+      const hasBranchPayload =
+        (await fs.pathExists(join(outDir, `${relativeFallbackPath}.txt`))) ||
+        (await fs.pathExists(join(outDir, relativeFallbackPath, 'index.txt')))
+
+      expect(hasBranchPayload).toBe(true)
+    }
+  })
+
+  it('keeps known params prerendered while unknown params on the same branch fall back', async () => {
+    const browser = await webdriver(port, '/docs/api/reference/')
+
+    try {
+      await retry(async () => {
+        expect(await browser.elementByCss('h1').text()).toBe('api:reference')
+      })
+
+      await browser.get(`http://localhost:${port}/docs/api/guide/`)
+      await retry(async () => {
+        expect(await browser.elementByCss('h1').text()).toBe('api:guide')
+      })
+    } finally {
+      await browser.close()
+    }
+  })
+
+  it('prefers the more specific route when multiple fallback branches match', async () => {
+    clearRequests()
+    const browser = await webdriver(port, '/docs/api/guide/')
+
+    try {
+      await retry(async () => {
+        expect(await browser.elementByCss('h1').text()).toBe('api:guide')
+      })
+
+      expect(
+        getRequests().some((requestPath) =>
+          requestPath.startsWith('/docs/__fallback/__route_0.html')
+        )
+      ).toBe(false)
+    } finally {
+      await browser.close()
+    }
+  })
+
+  it('falls through to the catch-all branch when the specific route does not match', async () => {
+    const browser = await webdriver(port, '/docs/guides/export/fallback/')
+
+    try {
+      await retry(async () => {
+        expect(await browser.elementByCss('h1').text()).toBe(
+          'catchall:guides/export/fallback'
+        )
+      })
+    } finally {
+      await browser.close()
+    }
+  })
+})
+
+describe('app dir - output export fallback internal path collisions', () => {
+  const { next, skipped } = nextTestSetup({
+    files: join(
+      __dirname,
+      '..',
+      'fixtures',
+      'dynamic-fallback-internal-path-conflict'
+    ),
+    skipStart: true,
+    skipDeployment: true,
+    disableAutoSkewProtection: true,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  it('errors when a multi-route fallback artifact path is already occupied', async () => {
+    const { exitCode, cliOutput } = await next.build()
+
+    expect(exitCode).toBe(1)
+    expect(cliOutput).toContain(
+      'conflicts with the internal "__fallback" path used by dynamic route fallbacks in static export mode'
+    )
+    expect(cliOutput).toContain('/docs/__fallback/__route_0')
+  })
+})

--- a/test/e2e/app-dir-export/test/dynamic-fallback-known-params-cache-components.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-fallback-known-params-cache-components.test.ts
@@ -1,0 +1,257 @@
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+import webdriver from 'next-webdriver'
+import fs from 'fs-extra'
+import { buildAndStartOutputExportServer } from './utils'
+
+const { next, skipped, isNextDev } = nextTestSetup({
+  files: join(
+    __dirname,
+    '..',
+    'fixtures',
+    'dynamic-fallback-known-params-cache-components'
+  ),
+  skipDeployment: true,
+  skipStart: true,
+  disableAutoSkewProtection: true,
+})
+
+if (skipped) {
+  it('skips unsupported mode', () => {})
+} else {
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  describeProduction(
+    'app dir - output export dynamic routes with Cache Components and known prerenders',
+    () => {
+      let port: number
+      let stopOrKill: (() => Promise<void>) | undefined
+
+      beforeAll(async () => {
+        ;({ port, stopOrKill } = await buildAndStartOutputExportServer(next, {
+          trailingSlash: true,
+          useFallbackDocument: true,
+        }))
+      })
+
+      afterAll(async () => {
+        if (stopOrKill) {
+          await stopOrKill()
+        }
+        await next.destroy()
+      })
+
+      it('emits both prerendered known params and fallback artifacts', async () => {
+        const outDir = join(next.testDir, 'out')
+
+        expect(await fs.pathExists(join(outDir, '_fallback.html'))).toBe(true)
+        expect(
+          await fs.pathExists(
+            join(outDir, 'another', '__fallback', 'index.txt')
+          )
+        ).toBe(true)
+        expect(
+          await fs.pathExists(join(outDir, 'org', '__fallback', 'index.txt'))
+        ).toBe(true)
+        expect(
+          await fs.pathExists(join(outDir, 'another', 'first', 'index.html'))
+        ).toBe(true)
+        expect(
+          await fs.pathExists(join(outDir, 'another', 'second', 'index.html'))
+        ).toBe(true)
+        expect(
+          await fs.pathExists(join(outDir, 'another', 'third', 'index.html'))
+        ).toBe(false)
+        expect(
+          await fs.pathExists(
+            join(outDir, 'org', 'acme', 'chat', 'thread-123', 'index.html')
+          )
+        ).toBe(true)
+        expect(
+          await fs.pathExists(
+            join(outDir, 'org', 'acme', 'chat', 'thread-789', 'index.html')
+          )
+        ).toBe(false)
+      })
+
+      it('serves both prerendered and fallback params', async () => {
+        const browser = await webdriver(port, '/another/first/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('first')
+          })
+
+          await browser.get(`http://localhost:${port}/another/third/`)
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('third')
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('serves both prerendered and fallback params for nested dynamic routes', async () => {
+        const browser = await webdriver(port, '/org/acme/chat/thread-123/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('#org-name').text()).toBe(
+              'Org acme'
+            )
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'acme:thread-123'
+            )
+          })
+
+          await browser.get(
+            `http://localhost:${port}/org/acme/chat/thread-789/`
+          )
+          await retry(async () => {
+            expect(await browser.elementByCss('#org-name').text()).toBe(
+              'Org acme'
+            )
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'acme:thread-789'
+            )
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('client navigates from a prerendered page to a fallback route', async () => {
+        // Start on a prerendered page (known from generateStaticParams)
+        const browser = await webdriver(port, '/another/first/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('first')
+          })
+
+          // Client navigate to an unenumerated slug (fallback)
+          await browser.elementByCss('a[href="/another/third/"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('third')
+          })
+
+          // Navigate back to the prerendered page
+          await browser.elementByCss('a[href="/another/"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('Another')
+          })
+
+          // Navigate to a different prerendered page
+          await browser.elementByCss('a[href="/another/first/"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('first')
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('client navigates from a fallback route to a prerendered page', async () => {
+        // Start on a fallback route (not in generateStaticParams)
+        const browser = await webdriver(port, '/org/acme/chat/thread-789/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'acme:thread-789'
+            )
+          })
+
+          // Client navigate to a prerendered page (known from generateStaticParams)
+          await browser.elementByCss('a[href="/org/"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('Org index')
+          })
+
+          await browser
+            .elementByCss('a[href="/org/acme/chat/thread-123/"]')
+            .click()
+          await retry(async () => {
+            expect(await browser.elementByCss('#org-name').text()).toBe(
+              'Org acme'
+            )
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'acme:thread-123'
+            )
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('navigates from a known prerendered param to an unknown param via client nav then back', async () => {
+        const browser = await webdriver(port, '/org/acme/chat/thread-123/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'acme:thread-123'
+            )
+          })
+
+          // Client navigate to a fallback param
+          await browser
+            .elementByCss('a[href="/org/acme/chat/thread-789/"]')
+            .click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'acme:thread-789'
+            )
+          })
+
+          // Browser back to the prerendered page
+          await browser.back()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'acme:thread-123'
+            )
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('preserves history across prerendered and fallback routes with search params', async () => {
+        const browser = await webdriver(port, '/another/first/?mode=known')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('first')
+            expect(await browser.eval('window.location.search')).toBe(
+              '?mode=known'
+            )
+          })
+
+          await browser.elementByCss('a[href="/another/third/"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('third')
+            expect(await browser.eval('window.location.pathname')).toBe(
+              '/another/third/'
+            )
+          })
+
+          await browser.back()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('first')
+            expect(await browser.eval('window.location.search')).toBe(
+              '?mode=known'
+            )
+          })
+
+          await browser.forward()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('third')
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+    }
+  )
+}

--- a/test/e2e/app-dir-export/test/dynamic-fallback-optimizations-cache-components.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-fallback-optimizations-cache-components.test.ts
@@ -1,0 +1,431 @@
+import { createReadStream } from 'fs'
+import http from 'http'
+import { join } from 'path'
+import { createNext, isNextDeploy, isNextDev, NextInstance } from 'e2e-utils'
+import express from 'express'
+import { findPort, retry, stopApp } from 'next-test-utils'
+import webdriver from 'next-webdriver'
+import type * as Playwright from 'playwright'
+import { createRouterAct } from 'router-act'
+
+async function buildAndStartOutputExportServer(next: NextInstance) {
+  await next.build()
+
+  const port = await findPort()
+  const app = express()
+  const server = http.createServer(app)
+  const outDir = join(next.testDir, 'out')
+  const fallbackHtml = join(outDir, '_fallback.html')
+  const requests: string[] = []
+
+  app.use((req, _res, nextMiddleware) => {
+    requests.push(req.url)
+    nextMiddleware()
+  })
+  app.use(
+    express.static(outDir, {
+      extensions: ['html'],
+      redirect: false,
+    })
+  )
+  app.use((_req, res) => {
+    createReadStream(fallbackHtml).pipe(res)
+  })
+
+  await new Promise<void>((resolve) => server.listen(port, resolve))
+
+  return {
+    port,
+    stopOrKill: () => stopApp(server),
+    getRequests: () => [...requests],
+    clearRequests: () => {
+      requests.length = 0
+    },
+  }
+}
+
+if (isNextDeploy) {
+  it('skips deploy mode', () => {})
+} else {
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  describeProduction(
+    'app dir - output export dynamic route optimizations with Cache Components',
+    () => {
+      let next: NextInstance
+      let port: number
+      let stopOrKill: (() => Promise<void>) | undefined
+      let getRequests: () => string[]
+      let clearRequests: () => void
+
+      beforeAll(async () => {
+        next = await createNext({
+          files: join(
+            __dirname,
+            '..',
+            'fixtures',
+            'dynamic-fallback-cache-components'
+          ),
+          skipStart: true,
+          disableAutoSkewProtection: true,
+        })
+        ;({ port, stopOrKill, getRequests, clearRequests } =
+          await buildAndStartOutputExportServer(next))
+      })
+
+      afterAll(async () => {
+        if (stopOrKill) {
+          await stopOrKill()
+        }
+        await next.destroy()
+      })
+
+      it('prefetches fallback payloads for unknown-param links before navigation', async () => {
+        let act!: ReturnType<typeof createRouterAct>
+        const browser = await webdriver(port, '/isolated/', {
+          beforePageLoad(page: Playwright.Page) {
+            act = createRouterAct(page)
+          },
+        })
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('Isolated')
+          })
+
+          await act(async () => {
+            const toggle = await browser.elementByCss(
+              'input[data-link-accordion="/isolated/third"]'
+            )
+            await toggle.click()
+          })
+
+          clearRequests()
+
+          await browser
+            .elementByCss('a[data-accordion-link="/isolated/third"]')
+            .click()
+
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('third')
+          })
+
+          const clickRequests = getRequests()
+          expect(
+            clickRequests.some((requestPath) =>
+              requestPath.startsWith('/isolated/__fallback.meta.json')
+            )
+          ).toBe(false)
+          expect(
+            clickRequests.some((requestPath) =>
+              requestPath.startsWith('/isolated/__fallback/index.txt')
+            )
+          ).toBe(false)
+          expect(
+            clickRequests.some((requestPath) =>
+              requestPath.startsWith('/isolated/third/index.txt')
+            )
+          ).toBe(false)
+          expect(
+            clickRequests.some((requestPath) =>
+              requestPath.startsWith('/isolated/third/__next.')
+            )
+          ).toBe(false)
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('dedupes fallback artifact prefetches across sibling unknown-param links', async () => {
+        let act!: ReturnType<typeof createRouterAct>
+        const browser = await webdriver(port, '/isolated/', {
+          beforePageLoad(page: Playwright.Page) {
+            act = createRouterAct(page)
+          },
+        })
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('Isolated')
+          })
+
+          clearRequests()
+
+          await act(async () => {
+            await browser
+              .elementByCss('input[data-link-accordion="/isolated/third"]')
+              .click()
+            await browser
+              .elementByCss('input[data-link-accordion="/isolated/fourth"]')
+              .click()
+          })
+
+          const prefetchRequests = getRequests().filter((requestPath) =>
+            requestPath.startsWith('/isolated/__fallback/index.txt')
+          )
+
+          expect(prefetchRequests).toHaveLength(1)
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('falls through from a concrete route-tree probe to the hydrated fallback tree', async () => {
+        let act!: ReturnType<typeof createRouterAct>
+        const browser = await webdriver(port, '/hydrated/first/', {
+          beforePageLoad(page: Playwright.Page) {
+            act = createRouterAct(page)
+          },
+        })
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('first')
+          })
+
+          await act(async () => {}, 'no-requests')
+          clearRequests()
+
+          await act(async () => {
+            await browser
+              .elementByCss('input[data-link-accordion="/hydrated/second"]')
+              .click()
+          })
+
+          const prefetchRequests = getRequests()
+
+          expect(prefetchRequests.length).toBeGreaterThan(0)
+          expect(
+            prefetchRequests.some((requestPath) =>
+              requestPath.startsWith('/hydrated/second/?_rsc=')
+            )
+          ).toBe(false)
+          expect(
+            prefetchRequests.some((requestPath) =>
+              requestPath.startsWith('/hydrated/second/index.txt')
+            )
+          ).toBe(false)
+          expect(
+            prefetchRequests.some((requestPath) =>
+              requestPath.startsWith('/hydrated/second/index.txt')
+            )
+          ).toBe(false)
+          expect(
+            prefetchRequests.some((requestPath) =>
+              requestPath.startsWith('/hydrated/second/__fallback/index.txt')
+            )
+          ).toBe(true)
+          expect(
+            prefetchRequests.some((requestPath) =>
+              requestPath.startsWith('/hydrated/second/__fallback.meta.json')
+            )
+          ).toBe(true)
+          expect(
+            prefetchRequests.some((requestPath) =>
+              requestPath.startsWith('/hydrated/__fallback/__next.')
+            )
+          ).toBe(true)
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('keeps shared hydrated fallback endpoints after revisiting a cached fallback route', async () => {
+        let act!: ReturnType<typeof createRouterAct>
+        const browser = await webdriver(port, '/hydrated/first/', {
+          beforePageLoad(page: Playwright.Page) {
+            act = createRouterAct(page)
+          },
+        })
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('first')
+          })
+
+          await browser.elementByCss('a[href="/"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('Home')
+          })
+
+          clearRequests()
+
+          await browser.elementByCss('a[href^="/hydrated/first"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('first')
+          })
+
+          await act(async () => {}, 'no-requests')
+          clearRequests()
+
+          await browser
+            .elementByCss('input[data-link-accordion="/hydrated/second"]')
+            .click()
+
+          await retry(async () => {
+            const prefetchRequests = getRequests()
+
+            expect(
+              prefetchRequests.some((requestPath) =>
+                requestPath.startsWith('/hydrated/second/?_rsc=')
+              )
+            ).toBe(false)
+            expect(
+              prefetchRequests.some((requestPath) =>
+                requestPath.startsWith('/hydrated/second/__next.')
+              )
+            ).toBe(false)
+            expect(
+              prefetchRequests.length === 0 ||
+                prefetchRequests.some((requestPath) =>
+                  requestPath.startsWith('/hydrated/__fallback/__next.')
+                )
+            ).toBe(true)
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('reuses the same hydrated fallback tree endpoint across sibling prefetches', async () => {
+        let act!: ReturnType<typeof createRouterAct>
+        const browser = await webdriver(port, '/hydrated/first/', {
+          beforePageLoad(page: Playwright.Page) {
+            act = createRouterAct(page)
+          },
+        })
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('first')
+          })
+
+          clearRequests()
+
+          await act(async () => {
+            await browser
+              .elementByCss('input[data-link-accordion="/hydrated/second"]')
+              .click()
+            await browser
+              .elementByCss('input[data-link-accordion="/hydrated/third"]')
+              .click()
+          })
+
+          const prefetchRequests = getRequests()
+          const fallbackTreeRequests = prefetchRequests.filter((requestPath) =>
+            requestPath.startsWith('/hydrated/__fallback/__next.')
+          )
+
+          expect(
+            prefetchRequests.some((requestPath) =>
+              requestPath.startsWith('/hydrated/second/?_rsc=')
+            )
+          ).toBe(false)
+          expect(
+            prefetchRequests.some((requestPath) =>
+              requestPath.startsWith('/hydrated/third/?_rsc=')
+            )
+          ).toBe(false)
+          expect(
+            prefetchRequests.some((requestPath) =>
+              requestPath.startsWith('/hydrated/second/index.txt')
+            )
+          ).toBe(false)
+          expect(
+            prefetchRequests.some((requestPath) =>
+              requestPath.startsWith('/hydrated/third/index.txt')
+            )
+          ).toBe(false)
+          expect(fallbackTreeRequests.length).toBeGreaterThanOrEqual(1)
+          expect(
+            fallbackTreeRequests.every((requestPath) =>
+              requestPath.startsWith('/hydrated/__fallback/__next.')
+            )
+          ).toBe(true)
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('keeps shared hydrated segment requests on the fallback artifact during sibling prefetches', async () => {
+        let act!: ReturnType<typeof createRouterAct>
+        const browser = await webdriver(port, '/hydrated/first/', {
+          beforePageLoad(page: Playwright.Page) {
+            act = createRouterAct(page)
+          },
+        })
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('first')
+          })
+
+          await act(async () => {}, 'no-requests')
+          clearRequests()
+
+          await act(async () => {
+            await browser
+              .elementByCss('input[data-link-accordion="/hydrated/second"]')
+              .click()
+          })
+
+          const prefetchRequests = getRequests()
+          const sharedFallbackSegmentRequests = prefetchRequests.filter(
+            (requestPath) =>
+              requestPath.startsWith('/hydrated/__fallback/__next.')
+          )
+
+          expect(sharedFallbackSegmentRequests.length).toBeGreaterThan(0)
+          expect(
+            prefetchRequests.some((requestPath) =>
+              requestPath.startsWith('/hydrated/second/__next.')
+            )
+          ).toBe(false)
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('loads nested fallback routes without concrete retries or extra probes', async () => {
+        clearRequests()
+        const browser = await webdriver(port, '/org/umbrella/chat/thread-789/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('#org-name').text()).toBe(
+              'Org umbrella'
+            )
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'umbrella:thread-789'
+            )
+          })
+
+          const requests = getRequests()
+
+          expect(
+            requests.some((requestPath) =>
+              requestPath.startsWith('/org/umbrella/chat/thread-789/?_rsc=')
+            )
+          ).toBe(false)
+          expect(
+            requests.some((requestPath) =>
+              requestPath.startsWith('/org/__fallback.txt')
+            )
+          ).toBe(false)
+          expect(
+            requests.filter((requestPath) =>
+              requestPath.startsWith('/org/__fallback.meta.json')
+            )
+          ).toHaveLength(1)
+          expect(
+            requests.filter((requestPath) =>
+              requestPath.startsWith('/org/__fallback/index.txt')
+            )
+          ).toHaveLength(1)
+        } finally {
+          await browser.close()
+        }
+      })
+    }
+  )
+}

--- a/test/e2e/app-dir-export/test/dynamic-fallback-route-shapes-cache-components.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-fallback-route-shapes-cache-components.test.ts
@@ -1,0 +1,220 @@
+import { join } from 'path'
+import { createNext, isNextDeploy, isNextDev, NextInstance } from 'e2e-utils'
+import fs from 'fs-extra'
+import { retry } from 'next-test-utils'
+import webdriver from 'next-webdriver'
+import { buildAndStartOutputExportServer } from './utils'
+
+if (isNextDeploy) {
+  it('skips deploy mode', () => {})
+} else {
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  describeProduction(
+    'app dir - output export fallback route shapes with Cache Components',
+    () => {
+      let next: NextInstance
+      let port: number
+      let stopOrKill: (() => Promise<void>) | undefined
+
+      beforeAll(async () => {
+        next = await createNext({
+          files: join(
+            __dirname,
+            '..',
+            'fixtures',
+            'dynamic-fallback-cache-components'
+          ),
+          skipStart: true,
+          disableAutoSkewProtection: true,
+        })
+        ;({ port, stopOrKill } = await buildAndStartOutputExportServer(next, {
+          trailingSlash: true,
+          useFallbackDocument: true,
+        }))
+      })
+
+      afterAll(async () => {
+        if (stopOrKill) {
+          await stopOrKill()
+        }
+        await next.destroy()
+      })
+
+      it('emits fallback artifacts for catch-all, optional, grouped, parallel, and nested multi-segment route shapes', async () => {
+        const outDir = join(next.testDir, 'out')
+
+        expect(
+          await fs.pathExists(join(outDir, 'docs', '__fallback', 'index.txt'))
+        ).toBe(true)
+        expect(
+          await fs.pathExists(
+            join(outDir, 'optional', '__fallback', 'index.txt')
+          )
+        ).toBe(true)
+        expect(
+          await fs.pathExists(
+            join(outDir, 'grouped', '__fallback', 'index.txt')
+          )
+        ).toBe(true)
+        expect(
+          await fs.pathExists(join(outDir, 'inbox', '__fallback', 'index.txt'))
+        ).toBe(true)
+        expect(
+          await fs.pathExists(join(outDir, 'org', '__fallback', 'index.txt'))
+        ).toBe(true)
+      })
+
+      it('renders catch-all fallback routes on hard load and client navigation', async () => {
+        const browser = await webdriver(port, '/docs/guides/export/fallback/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'guides/export/fallback'
+            )
+          })
+
+          await browser.elementByCss('a[href="/docs/"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('Docs')
+          })
+
+          await browser.eval('window.__routeShapeSentinel = 1')
+          await browser
+            .elementByCss('a[href="/docs/guides/export/fallback/"]')
+            .click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'guides/export/fallback'
+            )
+            expect(await browser.eval('window.__routeShapeSentinel')).toBe(1)
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('renders optional catch-all fallback routes for empty and nested params', async () => {
+        const browser = await webdriver(port, '/optional/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'optional index'
+            )
+          })
+
+          await browser.elementByCss('a[href="/optional/deep/path/"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('deep/path')
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('renders grouped dynamic fallback routes', async () => {
+        const browser = await webdriver(port, '/grouped/from-group/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('from-group')
+          })
+
+          await browser.elementByCss('a[href="/grouped/"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'Grouped index'
+            )
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('renders fallback params consistently across parallel routes', async () => {
+        const browser = await webdriver(port, '/inbox/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('Inbox')
+            expect(await browser.elementByCss('#modal-thread').text()).toBe(
+              'No modal'
+            )
+          })
+
+          await browser.elementByCss('a[href="/inbox/thread-123/"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('thread-123')
+            expect(await browser.elementByCss('#modal-thread').text()).toBe(
+              'Modal thread-123'
+            )
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+      it('renders nested fallback params across multiple dynamic segments with optimistic routing', async () => {
+        const browser = await webdriver(port, '/org/umbrella/chat/thread-789/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('#org-name').text()).toBe(
+              'Org umbrella'
+            )
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'umbrella:thread-789'
+            )
+          })
+
+          await browser.elementByCss('a[href="/org/"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('Org index')
+          })
+
+          await browser
+            .elementByCss('a[href="/org/acme/chat/thread-123/"]')
+            .click()
+          await retry(async () => {
+            expect(await browser.elementByCss('#org-name').text()).toBe(
+              'Org acme'
+            )
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'acme:thread-123'
+            )
+          })
+
+          await browser
+            .elementByCss('a[href="/org/acme/chat/thread-456/"]')
+            .click()
+          await retry(async () => {
+            expect(await browser.elementByCss('#org-name').text()).toBe(
+              'Org acme'
+            )
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'acme:thread-456'
+            )
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('renders the global not-found route instead of a mismatched fallback shell', async () => {
+        const browser = await webdriver(port, '/org/acme/missing-one/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'My custom not found page'
+            )
+            expect(await browser.hasElementByCss('#org-section')).toBe(false)
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+    }
+  )
+}

--- a/test/e2e/app-dir-export/test/dynamic-fallback-server-params-suspense.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-fallback-server-params-suspense.test.ts
@@ -1,0 +1,70 @@
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import {
+  expectOutputExportDevRedbox,
+  startOutputExportDevServer,
+} from './utils'
+
+const { next, skipped, isNextDev } = nextTestSetup({
+  files: join(
+    __dirname,
+    '..',
+    'fixtures',
+    'dynamic-fallback-server-params-suspense'
+  ),
+  skipStart: true,
+  skipDeployment: true,
+  disableAutoSkewProtection: true,
+})
+
+if (skipped) {
+  describe.skip('app dir - output export fallback server params suspense', () => {})
+} else {
+  const describeDevelopment = isNextDev ? describe : describe.skip
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  describeDevelopment(
+    'app dir - output export fallback server params suspense',
+    () => {
+      let port: number
+
+      beforeAll(async () => {
+        port = await startOutputExportDevServer(next)
+      })
+
+      afterAll(async () => {
+        await next.destroy()
+      })
+
+      it('shows a redbox even when unresolved fallback params are only read behind Suspense', async () => {
+        await expectOutputExportDevRedbox({
+          port,
+          path: '/wrapped/first',
+          expectedMessage:
+            'used unresolved dynamic params in a Server Component with "output: export"',
+          expectedSource: 'await params',
+        })
+      })
+    }
+  )
+
+  describeProduction(
+    'app dir - output export fallback server params suspense',
+    () => {
+      afterAll(async () => {
+        await next.destroy()
+      })
+
+      it('errors even when unresolved fallback params are only read behind Suspense', async () => {
+        const { exitCode, cliOutput } = await next.build()
+
+        expect(exitCode).toBe(1)
+        expect(cliOutput).toContain(
+          'used unresolved dynamic params in a Server Component with "output: export"'
+        )
+        expect(cliOutput).toContain('/wrapped/[slug]')
+        expect(cliOutput).toContain('Client Component')
+      })
+    }
+  )
+}

--- a/test/e2e/app-dir-export/test/dynamic-fallback-server-params-sync.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-fallback-server-params-sync.test.ts
@@ -1,0 +1,71 @@
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import {
+  expectOutputExportDevRedbox,
+  startOutputExportDevServer,
+} from './utils'
+
+const { next, skipped, isNextDev } = nextTestSetup({
+  files: join(
+    __dirname,
+    '..',
+    'fixtures',
+    'dynamic-fallback-server-params-sync'
+  ),
+  skipStart: true,
+  skipDeployment: true,
+  disableAutoSkewProtection: true,
+})
+
+if (skipped) {
+  describe.skip('app dir - output export fallback server params sync access', () => {})
+} else {
+  const describeDevelopment = isNextDev ? describe : describe.skip
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  describeDevelopment(
+    'app dir - output export fallback server params sync access',
+    () => {
+      let port: number
+
+      beforeAll(async () => {
+        port = await startOutputExportDevServer(next)
+      })
+
+      afterAll(async () => {
+        await next.destroy()
+      })
+
+      it('shows a redbox when a Server Component reads unresolved fallback params synchronously', async () => {
+        await expectOutputExportDevRedbox({
+          port,
+          path: '/another/first',
+          expectedMessage:
+            'used unresolved dynamic params in a Server Component with "output: export"',
+          expectedSource: 'params.slug',
+        })
+      })
+    }
+  )
+
+  describeProduction(
+    'app dir - output export fallback server params sync access',
+    () => {
+      afterAll(async () => {
+        await next.destroy()
+      })
+
+      it('errors when a Server Component reads unresolved fallback params synchronously', async () => {
+        const { exitCode, cliOutput } = await next.build()
+
+        expect(exitCode).toBe(1)
+        expect(cliOutput).toContain(
+          'used unresolved dynamic params in a Server Component with "output: export"'
+        )
+        expect(cliOutput).toContain('/another/[slug]')
+        expect(cliOutput).toContain('generateStaticParams()')
+        expect(cliOutput).toContain('Client Component')
+      })
+    }
+  )
+}

--- a/test/e2e/app-dir-export/test/dynamic-fallback-server-params.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-fallback-server-params.test.ts
@@ -1,0 +1,60 @@
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import {
+  expectOutputExportDevRedbox,
+  startOutputExportDevServer,
+} from './utils'
+
+const { next, skipped, isNextDev } = nextTestSetup({
+  files: join(__dirname, '..', 'fixtures', 'dynamic-fallback-server-params'),
+  skipStart: true,
+  skipDeployment: true,
+  disableAutoSkewProtection: true,
+})
+
+if (skipped) {
+  describe.skip('app dir - output export fallback server params', () => {})
+} else {
+  const describeDevelopment = isNextDev ? describe : describe.skip
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  describeDevelopment('app dir - output export fallback server params', () => {
+    let port: number
+
+    beforeAll(async () => {
+      port = await startOutputExportDevServer(next)
+    })
+
+    afterAll(async () => {
+      await next.destroy()
+    })
+
+    it('shows a redbox when a Server Component awaits unresolved fallback params', async () => {
+      await expectOutputExportDevRedbox({
+        port,
+        path: '/another/first',
+        expectedMessage:
+          'used unresolved dynamic params in a Server Component with "output: export"',
+        expectedSource: 'await params',
+      })
+    })
+  })
+
+  describeProduction('app dir - output export fallback server params', () => {
+    afterAll(async () => {
+      await next.destroy()
+    })
+
+    it('errors when a Server Component awaits unresolved fallback params', async () => {
+      const { exitCode, cliOutput } = await next.build()
+
+      expect(exitCode).toBe(1)
+      expect(cliOutput).toContain(
+        'used unresolved dynamic params in a Server Component with "output: export"'
+      )
+      expect(cliOutput).toContain('/another/[slug]')
+      expect(cliOutput).toContain('generateStaticParams()')
+      expect(cliOutput).toContain('Client Component')
+    })
+  })
+}

--- a/test/e2e/app-dir-export/test/output-export-server-connection-suspense.test.ts
+++ b/test/e2e/app-dir-export/test/output-export-server-connection-suspense.test.ts
@@ -1,0 +1,70 @@
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import {
+  expectOutputExportDevRedbox,
+  startOutputExportDevServer,
+} from './utils'
+
+const { next, skipped, isNextDev } = nextTestSetup({
+  files: join(
+    __dirname,
+    '..',
+    'fixtures',
+    'output-export-server-connection-suspense'
+  ),
+  skipStart: true,
+  skipDeployment: true,
+  disableAutoSkewProtection: true,
+})
+
+if (skipped) {
+  describe.skip('app dir - output export server connection suspense', () => {})
+} else {
+  const describeDevelopment = isNextDev ? describe : describe.skip
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  describeDevelopment(
+    'app dir - output export server connection suspense',
+    () => {
+      let port: number
+
+      beforeAll(async () => {
+        port = await startOutputExportDevServer(next)
+      })
+
+      afterAll(async () => {
+        await next.destroy()
+      })
+
+      it('shows a redbox even when connection() is only awaited behind Suspense', async () => {
+        await expectOutputExportDevRedbox({
+          port,
+          path: '/needs-connection',
+          expectedMessage:
+            'used `connection()` in a Server Component with "output: export"',
+          expectedSource: 'await connection()',
+        })
+      })
+    }
+  )
+
+  describeProduction(
+    'app dir - output export server connection suspense',
+    () => {
+      afterAll(async () => {
+        await next.destroy()
+      })
+
+      it('errors even when connection() is only awaited behind Suspense', async () => {
+        const { exitCode, cliOutput } = await next.build()
+
+        expect(exitCode).toBe(1)
+        expect(cliOutput).toContain(
+          'used `connection()` in a Server Component with "output: export"'
+        )
+        expect(cliOutput).toContain('/needs-connection')
+        expect(cliOutput).toContain('runtime server request')
+      })
+    }
+  )
+}

--- a/test/e2e/app-dir-export/test/output-export-server-connection.test.ts
+++ b/test/e2e/app-dir-export/test/output-export-server-connection.test.ts
@@ -1,0 +1,59 @@
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import {
+  expectOutputExportDevRedbox,
+  startOutputExportDevServer,
+} from './utils'
+
+const { next, skipped, isNextDev } = nextTestSetup({
+  files: join(__dirname, '..', 'fixtures', 'output-export-server-connection'),
+  skipStart: true,
+  skipDeployment: true,
+  disableAutoSkewProtection: true,
+})
+
+if (skipped) {
+  describe.skip('app dir - output export server connection', () => {})
+} else {
+  const describeDevelopment = isNextDev ? describe : describe.skip
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  describeDevelopment('app dir - output export server connection', () => {
+    let port: number
+
+    beforeAll(async () => {
+      port = await startOutputExportDevServer(next)
+    })
+
+    afterAll(async () => {
+      await next.destroy()
+    })
+
+    it('shows a redbox when a Server Component awaits connection() in output export', async () => {
+      await expectOutputExportDevRedbox({
+        port,
+        path: '/needs-connection',
+        expectedMessage:
+          'used `connection()` in a Server Component with "output: export"',
+        expectedSource: 'await connection()',
+      })
+    })
+  })
+
+  describeProduction('app dir - output export server connection', () => {
+    afterAll(async () => {
+      await next.destroy()
+    })
+
+    it('errors when a Server Component awaits connection() in output export', async () => {
+      const { exitCode, cliOutput } = await next.build()
+
+      expect(exitCode).toBe(1)
+      expect(cliOutput).toContain(
+        'used `connection()` in a Server Component with "output: export"'
+      )
+      expect(cliOutput).toContain('/needs-connection')
+      expect(cliOutput).toContain('runtime server request')
+    })
+  })
+}

--- a/test/e2e/app-dir-export/test/output-export-server-cookies-suspense.test.ts
+++ b/test/e2e/app-dir-export/test/output-export-server-cookies-suspense.test.ts
@@ -1,0 +1,64 @@
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import {
+  expectOutputExportDevRedbox,
+  startOutputExportDevServer,
+} from './utils'
+
+const { next, skipped, isNextDev } = nextTestSetup({
+  files: join(
+    __dirname,
+    '..',
+    'fixtures',
+    'output-export-server-cookies-suspense'
+  ),
+  skipStart: true,
+  skipDeployment: true,
+  disableAutoSkewProtection: true,
+})
+
+if (skipped) {
+  describe.skip('app dir - output export server cookies suspense', () => {})
+} else {
+  const describeDevelopment = isNextDev ? describe : describe.skip
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  describeDevelopment('app dir - output export server cookies suspense', () => {
+    let port: number
+
+    beforeAll(async () => {
+      port = await startOutputExportDevServer(next)
+    })
+
+    afterAll(async () => {
+      await next.destroy()
+    })
+
+    it('shows a redbox even when cookies() is only read behind Suspense', async () => {
+      await expectOutputExportDevRedbox({
+        port,
+        path: '/needs-cookies',
+        expectedMessage:
+          'used `cookies()` in a Server Component with "output: export"',
+        expectedSource: 'await cookies()',
+      })
+    })
+  })
+
+  describeProduction('app dir - output export server cookies suspense', () => {
+    afterAll(async () => {
+      await next.destroy()
+    })
+
+    it('errors even when cookies() is only read behind Suspense', async () => {
+      const { exitCode, cliOutput } = await next.build()
+
+      expect(exitCode).toBe(1)
+      expect(cliOutput).toContain(
+        'used `cookies()` in a Server Component with "output: export"'
+      )
+      expect(cliOutput).toContain('/needs-cookies')
+      expect(cliOutput).toContain('runtime server request')
+    })
+  })
+}

--- a/test/e2e/app-dir-export/test/output-export-server-cookies.test.ts
+++ b/test/e2e/app-dir-export/test/output-export-server-cookies.test.ts
@@ -1,0 +1,59 @@
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import {
+  expectOutputExportDevRedbox,
+  startOutputExportDevServer,
+} from './utils'
+
+const { next, skipped, isNextDev } = nextTestSetup({
+  files: join(__dirname, '..', 'fixtures', 'output-export-server-cookies'),
+  skipStart: true,
+  skipDeployment: true,
+  disableAutoSkewProtection: true,
+})
+
+if (skipped) {
+  describe.skip('app dir - output export server cookies', () => {})
+} else {
+  const describeDevelopment = isNextDev ? describe : describe.skip
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  describeDevelopment('app dir - output export server cookies', () => {
+    let port: number
+
+    beforeAll(async () => {
+      port = await startOutputExportDevServer(next)
+    })
+
+    afterAll(async () => {
+      await next.destroy()
+    })
+
+    it('shows a redbox when a Server Component awaits cookies() in output export', async () => {
+      await expectOutputExportDevRedbox({
+        port,
+        path: '/needs-cookies',
+        expectedMessage:
+          'used `cookies()` in a Server Component with "output: export"',
+        expectedSource: 'await cookies()',
+      })
+    })
+  })
+
+  describeProduction('app dir - output export server cookies', () => {
+    afterAll(async () => {
+      await next.destroy()
+    })
+
+    it('errors when a Server Component awaits cookies() in output export', async () => {
+      const { exitCode, cliOutput } = await next.build()
+
+      expect(exitCode).toBe(1)
+      expect(cliOutput).toContain(
+        'used `cookies()` in a Server Component with "output: export"'
+      )
+      expect(cliOutput).toContain('/needs-cookies')
+      expect(cliOutput).toContain('runtime server request')
+    })
+  })
+}

--- a/test/e2e/app-dir-export/test/output-export-server-headers-suspense.test.ts
+++ b/test/e2e/app-dir-export/test/output-export-server-headers-suspense.test.ts
@@ -1,0 +1,64 @@
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import {
+  expectOutputExportDevRedbox,
+  startOutputExportDevServer,
+} from './utils'
+
+const { next, skipped, isNextDev } = nextTestSetup({
+  files: join(
+    __dirname,
+    '..',
+    'fixtures',
+    'output-export-server-headers-suspense'
+  ),
+  skipStart: true,
+  skipDeployment: true,
+  disableAutoSkewProtection: true,
+})
+
+if (skipped) {
+  describe.skip('app dir - output export server headers suspense', () => {})
+} else {
+  const describeDevelopment = isNextDev ? describe : describe.skip
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  describeDevelopment('app dir - output export server headers suspense', () => {
+    let port: number
+
+    beforeAll(async () => {
+      port = await startOutputExportDevServer(next)
+    })
+
+    afterAll(async () => {
+      await next.destroy()
+    })
+
+    it('shows a redbox even when headers() is only read behind Suspense', async () => {
+      await expectOutputExportDevRedbox({
+        port,
+        path: '/needs-headers',
+        expectedMessage:
+          'used `headers()` in a Server Component with "output: export"',
+        expectedSource: 'await headers()',
+      })
+    })
+  })
+
+  describeProduction('app dir - output export server headers suspense', () => {
+    afterAll(async () => {
+      await next.destroy()
+    })
+
+    it('errors even when headers() is only read behind Suspense', async () => {
+      const { exitCode, cliOutput } = await next.build()
+
+      expect(exitCode).toBe(1)
+      expect(cliOutput).toContain(
+        'used `headers()` in a Server Component with "output: export"'
+      )
+      expect(cliOutput).toContain('/needs-headers')
+      expect(cliOutput).toContain('runtime server request')
+    })
+  })
+}

--- a/test/e2e/app-dir-export/test/output-export-server-headers.test.ts
+++ b/test/e2e/app-dir-export/test/output-export-server-headers.test.ts
@@ -1,0 +1,59 @@
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import {
+  expectOutputExportDevRedbox,
+  startOutputExportDevServer,
+} from './utils'
+
+const { next, skipped, isNextDev } = nextTestSetup({
+  files: join(__dirname, '..', 'fixtures', 'output-export-server-headers'),
+  skipStart: true,
+  skipDeployment: true,
+  disableAutoSkewProtection: true,
+})
+
+if (skipped) {
+  describe.skip('app dir - output export server headers', () => {})
+} else {
+  const describeDevelopment = isNextDev ? describe : describe.skip
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  describeDevelopment('app dir - output export server headers', () => {
+    let port: number
+
+    beforeAll(async () => {
+      port = await startOutputExportDevServer(next)
+    })
+
+    afterAll(async () => {
+      await next.destroy()
+    })
+
+    it('shows a redbox when a Server Component awaits headers() in output export', async () => {
+      await expectOutputExportDevRedbox({
+        port,
+        path: '/needs-headers',
+        expectedMessage:
+          'used `headers()` in a Server Component with "output: export"',
+        expectedSource: 'await headers()',
+      })
+    })
+  })
+
+  describeProduction('app dir - output export server headers', () => {
+    afterAll(async () => {
+      await next.destroy()
+    })
+
+    it('errors when a Server Component awaits headers() in output export', async () => {
+      const { exitCode, cliOutput } = await next.build()
+
+      expect(exitCode).toBe(1)
+      expect(cliOutput).toContain(
+        'used `headers()` in a Server Component with "output: export"'
+      )
+      expect(cliOutput).toContain('/needs-headers')
+      expect(cliOutput).toContain('runtime server request')
+    })
+  })
+}

--- a/test/e2e/app-dir-export/test/output-export-server-io-use-cache.test.ts
+++ b/test/e2e/app-dir-export/test/output-export-server-io-use-cache.test.ts
@@ -1,0 +1,63 @@
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import fs from 'fs-extra'
+
+const { next, skipped, isNextDev } = nextTestSetup({
+  files: join(__dirname, '..', 'fixtures', 'output-export-server-io-use-cache'),
+  skipStart: true,
+  skipDeployment: true,
+  disableAutoSkewProtection: true,
+})
+
+if (skipped) {
+  describe.skip('app dir - output export server io use cache', () => {})
+} else {
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  describeProduction('app dir - output export server io use cache', () => {
+    afterAll(async () => {
+      await next.destroy()
+    })
+
+    it('exports Date.now() successfully when the read is wrapped in use cache', async () => {
+      const { exitCode, cliOutput } = await next.build()
+      const html = await fs.readFile(
+        join(next.testDir, 'out', 'cached-time.html'),
+        'utf8'
+      )
+
+      expect(exitCode).toBe(0)
+      expect(cliOutput).not.toContain('used `Date.now()`')
+      expect(html).toContain('Cached time')
+      expect(html).toMatch(/<h1 id="value">\d+<\/h1>/)
+    })
+
+    it('exports Math.random() successfully when the read is wrapped in use cache', async () => {
+      const { exitCode, cliOutput } = await next.build()
+      const html = await fs.readFile(
+        join(next.testDir, 'out', 'cached-random.html'),
+        'utf8'
+      )
+
+      expect(exitCode).toBe(0)
+      expect(cliOutput).not.toContain('used `Math.random()`')
+      expect(html).toContain('Cached random')
+      expect(html).toMatch(/<h1 id="value">0?\.\d+<\/h1>/)
+    })
+
+    it('exports crypto.randomUUID() successfully when the read is wrapped in use cache', async () => {
+      const { exitCode, cliOutput } = await next.build()
+      const html = await fs.readFile(
+        join(next.testDir, 'out', 'cached-crypto.html'),
+        'utf8'
+      )
+
+      expect(exitCode).toBe(0)
+      expect(cliOutput).not.toContain('used `crypto.randomUUID()`')
+      expect(html).toContain('Cached crypto')
+      expect(html).toMatch(
+        /<h1 id="value">[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}<\/h1>/i
+      )
+    })
+  })
+}

--- a/test/e2e/app-dir-export/test/output-export-server-io.test.ts
+++ b/test/e2e/app-dir-export/test/output-export-server-io.test.ts
@@ -1,0 +1,117 @@
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import {
+  expectOutputExportDevCollapsedRedbox,
+  expectOutputExportDevRedbox,
+  startOutputExportDevServer,
+} from './utils'
+
+const { next, skipped, isNextDev } = nextTestSetup({
+  files: join(__dirname, '..', 'fixtures', 'output-export-server-io'),
+  skipStart: true,
+  skipDeployment: true,
+  disableAutoSkewProtection: true,
+})
+
+if (skipped) {
+  describe.skip('app dir - output export server io', () => {})
+} else {
+  const describeDevelopment = isNextDev ? describe : describe.skip
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  describeDevelopment('app dir - output export server io', () => {
+    let port: number
+
+    beforeAll(async () => {
+      port = await startOutputExportDevServer(next)
+    })
+
+    afterAll(async () => {
+      await next.destroy()
+    })
+
+    it('shows a redbox when Date.now() is read outside use cache', async () => {
+      await expectOutputExportDevCollapsedRedbox({
+        port,
+        path: '/needs-time',
+        expectedMessage:
+          'used `Date.now()` before accessing either uncached data',
+        expectedSource: 'Date.now()',
+      })
+    })
+
+    it('shows a redbox when Math.random() is read outside use cache', async () => {
+      await expectOutputExportDevCollapsedRedbox({
+        port,
+        path: '/needs-random',
+        expectedMessage:
+          'used `Math.random()` before accessing either uncached data',
+        expectedSource: 'Math.random()',
+      })
+    })
+
+    it('shows a redbox when crypto.randomUUID() is read outside use cache', async () => {
+      await expectOutputExportDevCollapsedRedbox({
+        port,
+        path: '/needs-crypto',
+        expectedMessage:
+          'used `crypto.randomUUID()` before accessing either uncached data',
+        expectedSource: 'crypto.randomUUID()',
+      })
+    })
+
+    it('still shows a redbox when request APIs are used inside use cache', async () => {
+      await expectOutputExportDevRedbox({
+        port,
+        path: '/cached-request',
+        expectedMessage: 'used `headers()` inside "use cache"',
+        expectedSource: 'await headers()',
+      })
+    })
+  })
+
+  describeProduction('app dir - output export server io', () => {
+    afterAll(async () => {
+      await next.destroy()
+    })
+
+    it.each([
+      [
+        '/needs-time',
+        'app/needs-time/page.js',
+        'used `Date.now()` before accessing either uncached data',
+      ],
+      [
+        '/needs-random',
+        'app/needs-random/page.js',
+        'used `Math.random()` before accessing either uncached data',
+      ],
+      [
+        '/needs-crypto',
+        'app/needs-crypto/page.js',
+        'used `crypto.randomUUID()` before accessing either uncached data',
+      ],
+    ])(
+      'errors when sync IO is used outside use cache for %s in output export',
+      async (route, buildPath, expectedMessage) => {
+        const { exitCode, cliOutput } = await next.build({
+          args: ['--debug-build-paths', buildPath],
+        })
+
+        expect(exitCode).toBe(1)
+        expect(cliOutput).toContain(expectedMessage)
+        expect(cliOutput).toContain(route)
+      }
+    )
+
+    it('still errors when request APIs are used inside use cache in output export', async () => {
+      const { exitCode, cliOutput } = await next.build({
+        args: ['--debug-build-paths', 'app/cached-request/page.js'],
+      })
+
+      expect(exitCode).toBe(1)
+      expect(cliOutput).toContain('used `headers()` inside "use cache"')
+      expect(cliOutput).toContain('/cached-request')
+    })
+  })
+}

--- a/test/e2e/app-dir-export/test/output-export-server-search-params-suspense.test.ts
+++ b/test/e2e/app-dir-export/test/output-export-server-search-params-suspense.test.ts
@@ -1,0 +1,69 @@
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import {
+  expectOutputExportDevRedbox,
+  startOutputExportDevServer,
+} from './utils'
+
+const { next, skipped, isNextDev } = nextTestSetup({
+  files: join(
+    __dirname,
+    '..',
+    'fixtures',
+    'output-export-server-search-params-suspense'
+  ),
+  skipStart: true,
+  skipDeployment: true,
+  disableAutoSkewProtection: true,
+})
+
+if (skipped) {
+  describe.skip('app dir - output export server search params suspense', () => {})
+} else {
+  const describeDevelopment = isNextDev ? describe : describe.skip
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  describeDevelopment(
+    'app dir - output export server search params suspense',
+    () => {
+      let port: number
+
+      beforeAll(async () => {
+        port = await startOutputExportDevServer(next)
+      })
+
+      afterAll(async () => {
+        await next.destroy()
+      })
+
+      it('shows a redbox even when searchParams are only read behind Suspense', async () => {
+        await expectOutputExportDevRedbox({
+          port,
+          path: '/search?query=hello',
+          expectedMessage:
+            'used `searchParams` in a Server Component with "output: export"',
+        })
+      })
+    }
+  )
+
+  describeProduction(
+    'app dir - output export server search params suspense',
+    () => {
+      afterAll(async () => {
+        await next.destroy()
+      })
+
+      it('errors even when searchParams are only read behind Suspense', async () => {
+        const { exitCode, cliOutput } = await next.build()
+
+        expect(exitCode).toBe(1)
+        expect(cliOutput).toContain(
+          'used `searchParams` in a Server Component with "output: export"'
+        )
+        expect(cliOutput).toContain('/search')
+        expect(cliOutput).toContain('Client Component')
+      })
+    }
+  )
+}

--- a/test/e2e/app-dir-export/test/output-export-server-search-params.test.ts
+++ b/test/e2e/app-dir-export/test/output-export-server-search-params.test.ts
@@ -1,0 +1,63 @@
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import {
+  expectOutputExportDevRedbox,
+  startOutputExportDevServer,
+} from './utils'
+
+const { next, skipped, isNextDev } = nextTestSetup({
+  files: join(
+    __dirname,
+    '..',
+    'fixtures',
+    'output-export-server-search-params'
+  ),
+  skipStart: true,
+  skipDeployment: true,
+  disableAutoSkewProtection: true,
+})
+
+if (skipped) {
+  describe.skip('app dir - output export server search params', () => {})
+} else {
+  const describeDevelopment = isNextDev ? describe : describe.skip
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  describeDevelopment('app dir - output export server search params', () => {
+    let port: number
+
+    beforeAll(async () => {
+      port = await startOutputExportDevServer(next)
+    })
+
+    afterAll(async () => {
+      await next.destroy()
+    })
+
+    it('shows a redbox when a Server Component awaits searchParams in output export', async () => {
+      await expectOutputExportDevRedbox({
+        port,
+        path: '/search?query=hello',
+        expectedMessage:
+          'used `searchParams` in a Server Component with "output: export"',
+      })
+    })
+  })
+
+  describeProduction('app dir - output export server search params', () => {
+    afterAll(async () => {
+      await next.destroy()
+    })
+
+    it('errors when a Server Component awaits searchParams in output export', async () => {
+      const { exitCode, cliOutput } = await next.build()
+
+      expect(exitCode).toBe(1)
+      expect(cliOutput).toContain(
+        'used `searchParams` in a Server Component with "output: export"'
+      )
+      expect(cliOutput).toContain('/search')
+      expect(cliOutput).toContain('Client Component')
+    })
+  })
+}

--- a/test/e2e/app-dir-export/test/utils.ts
+++ b/test/e2e/app-dir-export/test/utils.ts
@@ -4,20 +4,163 @@ import { join } from 'path'
 import { promisify } from 'util'
 import fs from 'fs-extra'
 import globOrig from 'glob'
+import express from 'express'
+import http from 'http'
+import { createReadStream } from 'fs'
 import {
   waitForRedbox,
   getRedboxHeader,
+  getRedboxDescription,
   getRedboxSource,
+  openRedbox,
   retry,
   findPort,
   startStaticServer,
   stopApp,
   fetchViaHTTP,
 } from 'next-test-utils'
-import { nextTestSetup } from 'e2e-utils'
+import { nextTestSetup, type NextInstance } from 'e2e-utils'
 import webdriver from 'next-webdriver'
 
 const glob = promisify(globOrig)
+
+export async function buildAndStartOutputExportServer(
+  next: Pick<NextInstance, 'build' | 'testDir'>,
+  {
+    basePath,
+    trailingSlash,
+    useFallbackDocument,
+  }: {
+    basePath?: string
+    trailingSlash: boolean
+    useFallbackDocument: boolean
+  }
+) {
+  await next.build()
+
+  const port = await findPort()
+  const outDir = join(next.testDir, 'out')
+  const requests: string[] = []
+
+  const getRequests = () => [...requests]
+  const clearRequests = () => {
+    requests.length = 0
+  }
+
+  if (!useFallbackDocument) {
+    const app = await startStaticServer(outDir, null, port)
+    return {
+      port,
+      getRequests,
+      clearRequests,
+      stopOrKill: () => stopApp(app),
+    }
+  }
+
+  const app = express()
+  const server = http.createServer(app)
+  const fallbackHtml = join(outDir, '_fallback.html')
+
+  app.use((req, _res, nextHandler) => {
+    requests.push(req.url || '/')
+    nextHandler()
+  })
+
+  if (basePath) {
+    app.use((req, _res, nextHandler) => {
+      if (req.url === basePath) {
+        req.url = '/'
+      } else if (req.url?.startsWith(`${basePath}/`)) {
+        req.url = req.url.slice(basePath.length)
+      }
+      nextHandler()
+    })
+  }
+
+  app.use(
+    express.static(outDir, {
+      extensions: ['html'],
+      redirect: false,
+    })
+  )
+  app.use((req, res) => {
+    createReadStream(fallbackHtml).pipe(res)
+  })
+
+  await new Promise<void>((resolve) => server.listen(port, resolve))
+
+  return {
+    port,
+    getRequests,
+    clearRequests,
+    stopOrKill: () => stopApp(server),
+  }
+}
+
+export async function startOutputExportDevServer(
+  next: Pick<NextInstance, 'start' | 'appPort'>
+) {
+  await next.start()
+  return Number(next.appPort)
+}
+
+export async function expectOutputExportDevRedbox({
+  port,
+  path,
+  expectedMessage,
+  expectedSource,
+}: {
+  port: number
+  path: string
+  expectedMessage: string
+  expectedSource?: string
+}) {
+  const browser = await webdriver(port, path)
+
+  try {
+    await waitForRedbox(browser)
+
+    const header = await getRedboxHeader(browser)
+    const source = await getRedboxSource(browser)
+
+    expect(header).toContain(expectedMessage)
+
+    if (expectedSource && source !== null) {
+      expect(source).toContain(expectedSource)
+    }
+  } finally {
+    await browser.close()
+  }
+}
+
+export async function expectOutputExportDevCollapsedRedbox({
+  port,
+  path,
+  expectedMessage,
+  expectedSource,
+}: {
+  port: number
+  path: string
+  expectedMessage: string
+  expectedSource?: string
+}) {
+  const browser = await webdriver(port, path)
+
+  try {
+    await openRedbox(browser)
+
+    const description = await getRedboxDescription(browser)
+    const source = await getRedboxSource(browser)
+
+    expect(description).toContain(expectedMessage)
+
+    if (expectedSource && source !== null) {
+      expect(source).toContain(expectedSource)
+    }
+  } finally {
+    await browser.close()
+  }
+}
 
 export const expectedWhenTrailingSlashTrue = [
   '404.html',

--- a/test/lib/e2e-utils/index.ts
+++ b/test/lib/e2e-utils/index.ts
@@ -334,7 +334,9 @@ export function nextTestSetup(
       // Gracefully destroy the instance if `createNext` success.
       // If next instance is not available, it's likely beforeAll hook failed and unnecessarily throws another error
       // by attempting to destroy on undefined.
-      await next?.destroy()
+      if (next && !(next as any).isDestroyed) {
+        await next.destroy()
+      }
     })
   }
 

--- a/test/lib/next-test-utils.ts
+++ b/test/lib/next-test-utils.ts
@@ -1,11 +1,5 @@
 import express from 'express'
-import {
-  existsSync,
-  readFileSync,
-  unlinkSync,
-  writeFileSync,
-  createReadStream,
-} from 'fs'
+import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'fs'
 import { inspect, promisify } from 'util'
 import http from 'http'
 import path from 'path'
@@ -741,8 +735,17 @@ export async function startStaticServer(
   app.use(express.static(dir))
 
   if (notFoundFile) {
+    const notFoundContent = readFileSync(notFoundFile)
+    const notFoundExtension = path.extname(notFoundFile)
+
     app.use((req, res) => {
-      createReadStream(notFoundFile).pipe(res)
+      if (notFoundExtension === '.html') {
+        res.type('html')
+      } else if (notFoundExtension === '.txt') {
+        res.type('text/plain')
+      }
+
+      res.send(notFoundContent)
     })
   }
 


### PR DESCRIPTION
## What

Restores the broader output export dynamic fallback coverage from the original stack: unit coverage, route conflict planning, request/server IO guardrails, and app-dir export e2e fixtures.

## Why

The client implementation is now split into smaller reviewable slices. This PR is the parity checkpoint that keeps the original behavior and test breadth from getting lost during the restack.

## Testing

- `pnpm --filter=next types`
- `pnpm --filter=next build`
- `pnpm test-unit test/unit/ packages/next/ packages/font packages/next/src/client/output-export-fallback.test.ts packages/next/src/client/flight-data-helpers.test.ts packages/next/src/client/components/router-reducer/fetch-server-response.test.ts packages/next/src/client/components/router-reducer/create-initial-router-state.test.ts packages/next/src/client/components/segment-cache/cache.test.ts packages/next/src/client/components/segment-cache/vary-path.test.ts packages/next/src/export/helpers/output-export-fallback.test.ts packages/next/src/lib/output-export-dynamic-fallback.test.ts packages/next/src/server/request/fallback-params.test.ts`
- `NEXT_SKIP_ISOLATE=1 NEXT_TEST_MODE=start pnpm testheadless test/e2e/app-dir/output-export-dynamic-fallbacks/output-export-dynamic-fallbacks.test.ts`
- `NEXT_SKIP_ISOLATE=1 NEXT_TEST_MODE=start pnpm testheadless test/e2e/app-dir-export/test/dynamic-fallback-cache-components-flat.test.ts`
- `NEXT_SKIP_ISOLATE=1 NEXT_TEST_MODE=start pnpm testheadless test/e2e/app-dir-export/test/dynamic-fallback-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-route-shapes-cache-components.test.ts test/e2e/app-dir-export/test/output-export-server-io.test.ts`

<!-- NEXT_JS_LLM_PR -->
