### PR TITLE
(4/19) Plan export fallback route variants

### DIFF
--- a/packages/next/src/export/helpers/output-export-fallback.test.ts
+++ b/packages/next/src/export/helpers/output-export-fallback.test.ts
@@ -1,0 +1,116 @@
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { dirname, join } from 'path'
+import {
+  emitOutputExportFallbackArtifacts,
+  writeOutputExportFallbackHtml,
+} from './output-export-fallback'
+
+describe('output export fallback artifacts', () => {
+  const tmpDirs = new Set<string>()
+
+  afterEach(async () => {
+    await Promise.all(
+      [...tmpDirs].map((dir) => rm(dir, { recursive: true, force: true }))
+    )
+    tmpDirs.clear()
+  })
+
+  async function createTempDir(): Promise<string> {
+    const dir = await mkdtemp(join(tmpdir(), 'next-export-fallback-'))
+    tmpDirs.add(dir)
+    return dir
+  }
+
+  async function createFallbackSource(outDir: string): Promise<string> {
+    const orig = join(outDir, '..', 'server', 'app', 'docs', '[slug]')
+    await mkdir(dirname(orig), { recursive: true })
+    await writeFile(
+      `${orig}.html`,
+      '<html><head></head><body>docs</body></html>'
+    )
+    await writeFile(`${orig}.rsc`, 'rsc')
+    await mkdir(`${orig}.segments`, { recursive: true })
+    await writeFile(join(`${orig}.segments`, '_tree.segment.rsc'), 'tree')
+    return orig
+  }
+
+  it('does not overwrite a user-provided global fallback file', async () => {
+    const outDir = await createTempDir()
+    await mkdir(outDir, { recursive: true })
+    await writeFile(
+      join(outDir, 'index.html'),
+      '<html><head></head><body>index</body></html>'
+    )
+    await writeFile(join(outDir, '_fallback.html'), 'user fallback')
+
+    await expect(
+      writeOutputExportFallbackHtml(outDir, [])
+    ).rejects.toMatchObject({
+      code: 'NEXT_EXPORT_ERROR',
+    })
+
+    await expect(
+      readFile(join(outDir, '_fallback.html'), 'utf8')
+    ).resolves.toBe('user fallback')
+  })
+
+  it('does not overwrite a user-provided fallback manifest file', async () => {
+    const outDir = await createTempDir()
+    await mkdir(join(outDir, 'docs'), { recursive: true })
+    await writeFile(join(outDir, 'docs', '__fallback.meta.json'), '{}')
+
+    await expect(
+      emitOutputExportFallbackArtifacts(
+        [
+          {
+            fallbackRoute: '/docs/__fallback',
+            needsManifest: true,
+            variants: [
+              {
+                route: '/docs/[slug]/[page]',
+                fallbackPath: '/docs/__fallback/__route_0',
+                orig: await createFallbackSource(outDir),
+              },
+            ],
+          },
+        ],
+        outDir,
+        true
+      )
+    ).rejects.toMatchObject({
+      code: 'NEXT_EXPORT_ERROR',
+    })
+  })
+
+  it('does not overwrite user-provided fallback segment files', async () => {
+    const outDir = await createTempDir()
+    await mkdir(join(outDir, 'docs', '__fallback'), { recursive: true })
+    await writeFile(
+      join(outDir, 'docs', '__fallback', '__next._tree.txt'),
+      'user'
+    )
+
+    await expect(
+      emitOutputExportFallbackArtifacts(
+        [
+          {
+            fallbackRoute: '/docs/__fallback',
+            needsManifest: false,
+            variants: [
+              {
+                route: '/docs/[slug]',
+                fallbackPath: '/docs/__fallback',
+                orig: await createFallbackSource(outDir),
+              },
+            ],
+          },
+        ],
+        outDir,
+        true
+      )
+    ).rejects.toMatchObject({
+      code: 'NEXT_EXPORT_ERROR',
+    })
+  })
+})

--- a/packages/next/src/export/helpers/output-export-fallback.ts
+++ b/packages/next/src/export/helpers/output-export-fallback.ts
@@ -5,34 +5,39 @@ import {
   RSC_SEGMENT_SUFFIX,
   RSC_SUFFIX,
 } from '../../lib/constants'
+import { getOutputExportFallbackMetadataPath } from '../../lib/output-export-dynamic-fallback'
+import {
+  planOutputExportFallbackRoutes,
+  type OutputExportDynamicRouteInfo,
+} from '../../lib/output-export-fallback-routes'
+import { normalizePagePath } from '../../shared/lib/page-path/normalize-page-path'
 import { getPagePath } from '../../server/require'
 import { convertSegmentPathToStaticExportFilename } from '../../shared/lib/segment-cache/segment-value-encoding'
-import { normalizePagePath } from '../../shared/lib/page-path/normalize-page-path'
-import {
-  getOutputExportFallbackPath,
-  getOutputExportFallbackStaticPrefix,
-} from '../../lib/output-export-dynamic-fallback'
 
-type OutputExportDynamicRouteInfo = {
-  fallbackSourceRoute: string | undefined
-  fallbackRouteParams:
-    | ReadonlyArray<{
-        paramName: string
-        paramType: string
-      }>
-    | undefined
+export type OutputExportFallbackArtifactVariant = {
+  route: string
+  fallbackPath: string
+  orig: string
+}
+
+export type OutputExportFallbackArtifactPlan = {
+  fallbackRoute: string
+  needsManifest: boolean
+  variants: OutputExportFallbackArtifactVariant[]
+}
+
+type OutputExportError = Error & {
+  code: 'NEXT_EXPORT_ERROR'
 }
 
 type CopyExportedAppArtifactsOptions = {
   outDir: string
   orig: string
   routePath: string
+  segmentsRoutePath: string
   subFolders: boolean
   checkRouteCollision?: boolean
-}
-
-type OutputExportError = Error & {
-  code: 'NEXT_EXPORT_ERROR'
+  routeCollisionPath?: string
 }
 
 function createOutputExportError(message: string): OutputExportError {
@@ -69,8 +74,10 @@ export async function copyExportedAppArtifacts({
   outDir,
   orig,
   routePath,
+  segmentsRoutePath,
   subFolders,
   checkRouteCollision = false,
+  routeCollisionPath,
 }: CopyExportedAppArtifactsOptions): Promise<string> {
   const route = normalizePagePath(routePath)
   const flatHtmlDest = join(outDir, `${route}.html`)
@@ -95,7 +102,7 @@ export async function copyExportedAppArtifacts({
   }> = []
 
   if (existsSync(segmentsDir)) {
-    const segmentsDirDest = join(outDir, routePath)
+    const segmentsDirDest = join(outDir, segmentsRoutePath)
     const segmentPaths = await collectSegmentPaths(segmentsDir)
     for (const segmentFileSrc of segmentPaths) {
       const segmentPath =
@@ -119,7 +126,7 @@ export async function copyExportedAppArtifacts({
         folderJsonDest,
         ...segmentCopies.map(({ dest }) => dest),
       ],
-      routePath
+      routeCollisionPath ?? routePath
     )
   }
 
@@ -138,14 +145,16 @@ export async function copyExportedAppArtifacts({
   return htmlDest
 }
 
-export async function emitOutputExportFallbackArtifacts(
+export function planOutputExportFallbackArtifacts(
   dynamicRoutes: Readonly<Record<string, OutputExportDynamicRouteInfo>>,
   mapAppRouteToPage: Map<string, string>,
-  distDir: string,
-  outDir: string,
-  subFolders: boolean
-): Promise<string[]> {
-  const fallbackHtmlPaths: string[] = []
+  distDir: string
+): OutputExportFallbackArtifactPlan[] {
+  const dynamicRoutesWithArtifacts: Record<
+    string,
+    OutputExportDynamicRouteInfo
+  > = {}
+  const origByRoute = new Map<string, string>()
 
   for (const [dynamicRoute, prerenderInfo] of Object.entries(dynamicRoutes)) {
     if (
@@ -153,11 +162,6 @@ export async function emitOutputExportFallbackArtifacts(
       !prerenderInfo.fallbackRouteParams ||
       prerenderInfo.fallbackRouteParams.length === 0
     ) {
-      continue
-    }
-
-    const staticPrefix = getOutputExportFallbackStaticPrefix(dynamicRoute)
-    if (staticPrefix === null) {
       continue
     }
 
@@ -182,25 +186,79 @@ export async function emitOutputExportFallbackArtifacts(
       continue
     }
 
-    const fallbackPath = getOutputExportFallbackPath(staticPrefix)
-    fallbackHtmlPaths.push(
-      await copyExportedAppArtifacts({
-        outDir,
-        orig,
-        routePath: fallbackPath,
-        subFolders,
-        checkRouteCollision: true,
-      })
-    )
+    dynamicRoutesWithArtifacts[dynamicRoute] = prerenderInfo
+    origByRoute.set(dynamicRoute, orig)
   }
 
-  return fallbackHtmlPaths
+  return planOutputExportFallbackRoutes(dynamicRoutesWithArtifacts).map(
+    ({ fallbackRoute, needsManifest, entries }) => ({
+      fallbackRoute,
+      needsManifest,
+      variants: entries.map(({ route, fallbackPath }) => ({
+        route,
+        fallbackPath,
+        orig: origByRoute.get(route)!,
+      })),
+    })
+  )
+}
+
+export async function emitOutputExportFallbackArtifacts(
+  plans: OutputExportFallbackArtifactPlan[],
+  outDir: string,
+  subFolders: boolean
+): Promise<string[]> {
+  const fallbackHtmlPathsByPlan = await Promise.all(
+    plans.map(async ({ fallbackRoute, needsManifest, variants }) => {
+      if (needsManifest) {
+        const manifestPath = join(
+          outDir,
+          getOutputExportFallbackMetadataPath(fallbackRoute)
+        )
+        assertNoOutputExportPathCollision(outDir, [manifestPath], fallbackRoute)
+        await fs.mkdir(dirname(manifestPath), { recursive: true })
+        await fs.writeFile(
+          manifestPath,
+          JSON.stringify(
+            {
+              version: 1,
+              routes: variants.map(({ route, fallbackPath }) => ({
+                route,
+                fallbackPath,
+              })),
+            },
+            null,
+            2
+          )
+        )
+      }
+
+      return Promise.all(
+        variants.map(async ({ fallbackPath, orig }) => {
+          return copyExportedAppArtifacts({
+            outDir,
+            orig,
+            routePath: fallbackPath,
+            segmentsRoutePath: fallbackPath,
+            subFolders,
+            checkRouteCollision: true,
+            routeCollisionPath: fallbackPath,
+          })
+        })
+      )
+    })
+  )
+
+  return fallbackHtmlPathsByPlan.flat()
 }
 
 export async function writeOutputExportFallbackHtml(
   outDir: string,
   fallbackHtmlPaths: string[]
 ): Promise<void> {
+  // Prefer a shallow __fallback shell for the global fallback entry point so
+  // the bootstrap document still carries the right root structure and assets.
+  // Fall back to a generic document only if no __fallback shell exists.
   const genericSource = [
     join(outDir, 'index.html'),
     join(outDir, '404.html'),
@@ -209,7 +267,8 @@ export async function writeOutputExportFallbackHtml(
   const sortedFallbackPaths = [...fallbackHtmlPaths].sort(
     (a, b) => a.length - b.length
   )
-  const fallbackSource = sortedFallbackPaths[0] ?? genericSource
+  const pprShellSource = sortedFallbackPaths[0]
+  const fallbackSource = pprShellSource ?? genericSource
   if (!fallbackSource) {
     return
   }
@@ -225,6 +284,9 @@ export async function writeOutputExportFallbackHtml(
 
   const fallbackHtml = await fs.readFile(fallbackSource, 'utf8')
   const exportFallbackScript = '<script>self.__NEXT_EXPORT_FALLBACK=1</script>'
+  // The global fallback document is only a bootstrap shell. Keep it hidden
+  // until the client resolves the actual route-specific fallback payload and
+  // React commits the real tree. Removed in app-index.tsx after hydration.
   const exportFallbackStyle =
     '<style id="__next-export-fallback-style">#__next{visibility:hidden}</style>'
   const injection = `${exportFallbackStyle}${exportFallbackScript}`

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -18,16 +18,14 @@ import { existsSync, promises as fs } from 'fs'
 
 import '../server/require-hook'
 
-import { dirname, join, resolve, sep, relative } from 'path'
+import { dirname, join, resolve, sep } from 'path'
 import * as Log from '../build/output/log'
-import {
-  RSC_SEGMENT_SUFFIX,
-  RSC_SEGMENTS_DIR_SUFFIX,
-  RSC_SUFFIX,
-  SSG_FALLBACK_EXPORT_ERROR,
-} from '../lib/constants'
+import { SSG_FALLBACK_EXPORT_ERROR } from '../lib/constants'
 import { recursiveCopy } from '../lib/recursive-copy'
-import { isOutputExportDynamicFallbackEnabled } from '../lib/output-export-dynamic-fallback'
+import {
+  isOutputExportDynamicFallbackEnabled,
+  isOutputExportOptimisticRoutingEnabled,
+} from '../lib/output-export-dynamic-fallback'
 import {
   BUILD_ID_FILE,
   CLIENT_PUBLIC_FILES_PATH,
@@ -68,11 +66,12 @@ import type { DeepReadonly } from '../shared/lib/deep-readonly'
 import { isInterceptionRouteRewrite } from '../lib/is-interception-route-rewrite'
 import type { ActionManifest } from '../build/webpack/plugins/flight-client-entry-plugin'
 import { extractInfoFromServerReferenceId } from '../shared/lib/server-reference-info'
-import { convertSegmentPathToStaticExportFilename } from '../shared/lib/segment-cache/segment-value-encoding'
 import { getNextBuildDebuggerPortOffset } from '../lib/worker'
 import { getParams } from './helpers/get-params'
 import {
+  copyExportedAppArtifacts,
   emitOutputExportFallbackArtifacts,
+  planOutputExportFallbackArtifacts,
   writeOutputExportFallbackHtml,
 } from './helpers/output-export-fallback'
 import { isDynamicRoute } from '../shared/lib/router/utils/is-dynamic'
@@ -515,7 +514,7 @@ async function exportAppImpl(
       clientParamParsingOrigins:
         nextConfig.experimental.clientParamParsingOrigins,
       dynamicOnHover: nextConfig.experimental.dynamicOnHover ?? false,
-      optimisticRouting: nextConfig.experimental.optimisticRouting ?? false,
+      optimisticRouting: isOutputExportOptimisticRoutingEnabled(nextConfig),
       inlineCss: nextConfig.experimental.inlineCss ?? false,
       prefetchInlining: nextConfig.experimental.prefetchInlining ?? false,
       authInterrupts: !!nextConfig.experimental.authInterrupts,
@@ -752,10 +751,6 @@ async function exportAppImpl(
         initialPhaseExportPaths.push(exportPath)
       }
 
-      // Always mark routes for potential build validation. The actual
-      // decision of whether to validate is made per-route by
-      // anySegmentNeedsInstantValidationInBuild, which checks both the
-      // default validation level and per-segment level overrides.
       const route = exportPath.page
       if (!routesWithInstantValidation.has(route)) {
         exportPath._runInstantValidation = true
@@ -967,71 +962,48 @@ async function exportAppImpl(
           return
         }
 
-        const htmlDest = join(
-          outDir,
-          `${route}${
-            subFolders && route !== '/index' ? `${sep}index` : ''
-          }.html`
-        )
-        const jsonDest = isAppPath
-          ? join(
-              outDir,
-              `${route}${
-                subFolders && route !== '/index' ? `${sep}index` : ''
-              }.txt`
-            )
-          : join(pagesDataDir, `${route}.json`)
-
-        await fs.mkdir(dirname(htmlDest), { recursive: true })
-        await fs.mkdir(dirname(jsonDest), { recursive: true })
-
-        const htmlSrc = `${orig}.html`
-        const jsonSrc = `${orig}${isAppPath ? RSC_SUFFIX : '.json'}`
-
-        await fs.copyFile(htmlSrc, htmlDest)
-        await fs.copyFile(jsonSrc, jsonDest)
-
-        const segmentsDir = `${orig}${RSC_SEGMENTS_DIR_SUFFIX}`
-
-        if (isAppPath && existsSync(segmentsDir)) {
-          // Output a data file for each of this page's segments
-          //
-          // These files are requested by the client router's internal
-          // prefetcher, not the user directly. So we don't need to account for
-          // things like trailing slash handling.
-          //
-          // To keep the protocol simple, we can use the non-normalized route
-          // path instead of the normalized one (which, among other things,
-          // rewrites `/` to `/index`).
-          const segmentsDirDest = join(outDir, unnormalizedRoute)
-          const segmentPaths = await collectSegmentPaths(segmentsDir)
-          await Promise.all(
-            segmentPaths.map(async (segmentFileSrc) => {
-              const segmentPath =
-                '/' + segmentFileSrc.slice(0, -RSC_SEGMENT_SUFFIX.length)
-              const segmentFilename =
-                convertSegmentPathToStaticExportFilename(segmentPath)
-              const segmentFileDest = join(segmentsDirDest, segmentFilename)
-              await fs.mkdir(dirname(segmentFileDest), { recursive: true })
-              await fs.copyFile(
-                join(segmentsDir, segmentFileSrc),
-                segmentFileDest
-              )
-            })
+        if (isAppPath) {
+          await copyExportedAppArtifacts({
+            outDir,
+            orig,
+            routePath: unnormalizedRoute,
+            segmentsRoutePath: unnormalizedRoute,
+            subFolders,
+          })
+        } else {
+          const htmlDest = join(
+            outDir,
+            `${route}${
+              subFolders && route !== '/index' ? `${sep}index` : ''
+            }.html`
           )
+          const jsonDest = join(pagesDataDir, `${route}.json`)
+
+          await fs.mkdir(dirname(htmlDest), { recursive: true })
+          await fs.mkdir(dirname(jsonDest), { recursive: true })
+          await fs.copyFile(`${orig}.html`, htmlDest)
+          await fs.copyFile(`${orig}.json`, jsonDest)
         }
       })
     )
 
     if (isOutputExportDynamicFallbackEnabled(nextConfig)) {
-      const fallbackHtmlPaths = await emitOutputExportFallbackArtifacts(
+      const fallbackArtifactPlans = planOutputExportFallbackArtifacts(
         prerenderManifest.dynamicRoutes,
         mapAppRouteToPage,
-        distDir,
+        distDir
+      )
+      const fallbackHtmlPaths = await emitOutputExportFallbackArtifacts(
+        fallbackArtifactPlans,
         outDir,
         subFolders
       )
-      await writeOutputExportFallbackHtml(outDir, fallbackHtmlPaths)
+
+      if (
+        hasOutputExportDynamicFallbackRoutes(allExportPaths, prerenderManifest)
+      ) {
+        await writeOutputExportFallbackHtml(outDir, fallbackHtmlPaths)
+      }
     }
   }
 
@@ -1071,37 +1043,17 @@ async function exportAppImpl(
   return collector
 }
 
-async function collectSegmentPaths(segmentsDirectory: string) {
-  const results: Array<string> = []
-  await collectSegmentPathsImpl(segmentsDirectory, segmentsDirectory, results)
-  return results
-}
-
-async function collectSegmentPathsImpl(
-  segmentsDirectory: string,
-  directory: string,
-  results: Array<string>
-) {
-  const segmentFiles = await fs.readdir(directory, {
-    withFileTypes: true,
-  })
-  await Promise.all(
-    segmentFiles.map(async (segmentFile) => {
-      if (segmentFile.isDirectory()) {
-        await collectSegmentPathsImpl(
-          segmentsDirectory,
-          join(directory, segmentFile.name),
-          results
-        )
-        return
-      }
-      if (!segmentFile.name.endsWith(RSC_SEGMENT_SUFFIX)) {
-        return
-      }
-      results.push(
-        relative(segmentsDirectory, join(directory, segmentFile.name))
-      )
-    })
+function hasOutputExportDynamicFallbackRoutes(
+  allExportPaths: ExportPathEntry[],
+  prerenderManifest: DeepReadonly<PrerenderManifest> | undefined
+): boolean {
+  return (
+    allExportPaths.some(
+      ({ _fallbackRouteParams = [] }) => _fallbackRouteParams.length > 0
+    ) ||
+    Object.values(prerenderManifest?.dynamicRoutes ?? {}).some(
+      (route) => (route.fallbackRouteParams?.length ?? 0) > 0
+    )
   )
 }
 

--- a/packages/next/src/lib/output-export-dynamic-fallback.ts
+++ b/packages/next/src/lib/output-export-dynamic-fallback.ts
@@ -1,15 +1,41 @@
 import { parseNormalizedAppRoute } from '../shared/lib/router/routes/app'
+import { getParamProperties } from '../shared/lib/router/utils/get-segment-param'
 
 type OutputExportDynamicFallbackConfig = {
   output?: string
   cacheComponents?: boolean
   experimental?: {
+    optimisticRouting?: boolean
     outputExportDynamicFallbacks?: boolean
+    varyParams?: boolean
   }
+}
+
+type OutputExportFallbackConflict = {
+  fallbackPath: string
+  routes: string[]
+}
+
+export type OutputExportFallbackManifestEntry = {
+  route: string
+  fallbackPath: string
 }
 
 export function getOutputExportFallbackPath(staticPrefix: string): string {
   return staticPrefix.length > 0 ? `/${staticPrefix}/__fallback` : '/__fallback'
+}
+
+export function getOutputExportFallbackMetadataPath(
+  fallbackPath: string
+): string {
+  return `${fallbackPath}.meta.json`
+}
+
+export function getOutputExportFallbackVariantPath(
+  fallbackPath: string,
+  index: number
+): string {
+  return `${fallbackPath}/__route_${index}`
 }
 
 export function getOutputExportFallbackStaticPrefix(
@@ -30,6 +56,66 @@ export function getOutputExportFallbackStaticPrefix(
     .join('/')
 }
 
+export function needsOutputExportFallbackManifest(routePath: string): boolean {
+  const route = parseNormalizedAppRoute(routePath)
+  const firstDynamicIndex = route.segments.findIndex(
+    (segment) => segment.type === 'dynamic'
+  )
+
+  if (firstDynamicIndex === -1) {
+    return false
+  }
+
+  if (route.segments.length - firstDynamicIndex <= 1) {
+    return false
+  }
+
+  const firstDynamicSegment = route.segments[firstDynamicIndex]
+  return (
+    firstDynamicSegment.type === 'dynamic' &&
+    !getParamProperties(firstDynamicSegment.param.paramType).repeat
+  )
+}
+
+export function getOutputExportFallbackConflicts(
+  routePaths: Iterable<string>
+): OutputExportFallbackConflict[] {
+  const fallbackPathToRoutes = new Map<string, string[]>()
+
+  for (const routePath of routePaths) {
+    const staticPrefix = getOutputExportFallbackStaticPrefix(routePath)
+    if (staticPrefix === null) {
+      continue
+    }
+
+    const fallbackPath = getOutputExportFallbackPath(staticPrefix)
+    const routes = fallbackPathToRoutes.get(fallbackPath)
+    if (routes) {
+      routes.push(routePath)
+    } else {
+      fallbackPathToRoutes.set(fallbackPath, [routePath])
+    }
+  }
+
+  const conflicts: OutputExportFallbackConflict[] = []
+  for (const [fallbackPath, routes] of fallbackPathToRoutes) {
+    if (routes.length > 1) {
+      conflicts.push({
+        fallbackPath,
+        routes: routes.sort(),
+      })
+    }
+  }
+
+  return conflicts.sort((a, b) =>
+    a.fallbackPath < b.fallbackPath
+      ? -1
+      : a.fallbackPath > b.fallbackPath
+        ? 1
+        : 0
+  )
+}
+
 export function isOutputExportDynamicFallbackEnabled(
   config: OutputExportDynamicFallbackConfig
 ): boolean {
@@ -37,5 +123,23 @@ export function isOutputExportDynamicFallbackEnabled(
     config.output === 'export' &&
     config.cacheComponents === true &&
     config.experimental?.outputExportDynamicFallbacks === true
+  )
+}
+
+export function isOutputExportOptimisticRoutingEnabled(
+  config: OutputExportDynamicFallbackConfig
+): boolean {
+  return (
+    Boolean(config.experimental?.optimisticRouting) ||
+    isOutputExportDynamicFallbackEnabled(config)
+  )
+}
+
+export function isOutputExportVaryParamsEnabled(
+  config: OutputExportDynamicFallbackConfig
+): boolean {
+  return (
+    Boolean(config.experimental?.varyParams) ||
+    isOutputExportDynamicFallbackEnabled(config)
   )
 }

--- a/packages/next/src/lib/output-export-fallback-routes.test.ts
+++ b/packages/next/src/lib/output-export-fallback-routes.test.ts
@@ -1,0 +1,89 @@
+import { planOutputExportFallbackRoutes } from './output-export-fallback-routes'
+
+describe('planOutputExportFallbackRoutes', () => {
+  it('uses the shared fallback path for a single dynamic segment route', () => {
+    expect(
+      planOutputExportFallbackRoutes({
+        '/docs/[slug]': {
+          fallbackSourceRoute: '/docs/[slug]',
+          fallbackRouteParams: [{ paramName: 'slug', paramType: 'd' }],
+        },
+      })
+    ).toEqual([
+      {
+        fallbackRoute: '/docs/__fallback',
+        needsManifest: false,
+        entries: [
+          {
+            route: '/docs/[slug]',
+            fallbackSourceRoute: '/docs/[slug]',
+            fallbackRoute: '/docs/__fallback',
+            fallbackPath: '/docs/__fallback',
+            staticPrefix: 'docs',
+          },
+        ],
+      },
+    ])
+  })
+
+  it('keeps a manifest for a single route with static segments after the first dynamic segment', () => {
+    expect(
+      planOutputExportFallbackRoutes({
+        '/docs/[section]/intro': {
+          fallbackSourceRoute: '/docs/[section]/intro',
+          fallbackRouteParams: [{ paramName: 'section', paramType: 'd' }],
+        },
+      })
+    ).toEqual([
+      {
+        fallbackRoute: '/docs/__fallback',
+        needsManifest: true,
+        entries: [
+          {
+            route: '/docs/[section]/intro',
+            fallbackSourceRoute: '/docs/[section]/intro',
+            fallbackRoute: '/docs/__fallback',
+            fallbackPath: '/docs/__fallback',
+            staticPrefix: 'docs',
+          },
+        ],
+      },
+    ])
+  })
+
+  it('assigns deterministic variant paths for multiple routes with the same fallback route', () => {
+    expect(
+      planOutputExportFallbackRoutes({
+        '/docs/[section]/reference': {
+          fallbackSourceRoute: '/docs/[section]/reference',
+          fallbackRouteParams: [{ paramName: 'section', paramType: 'd' }],
+        },
+        '/docs/[section]/guide': {
+          fallbackSourceRoute: '/docs/[section]/guide',
+          fallbackRouteParams: [{ paramName: 'section', paramType: 'd' }],
+        },
+      })
+    ).toEqual([
+      {
+        fallbackRoute: '/docs/__fallback',
+        needsManifest: true,
+        entries: [
+          {
+            route: '/docs/[section]/guide',
+            fallbackSourceRoute: '/docs/[section]/guide',
+            fallbackRoute: '/docs/__fallback',
+            fallbackPath: '/docs/__fallback/__route_0',
+            staticPrefix: 'docs',
+          },
+          {
+            route: '/docs/[section]/reference',
+            fallbackSourceRoute: '/docs/[section]/reference',
+            fallbackRoute: '/docs/__fallback',
+            fallbackPath: '/docs/__fallback/__route_1',
+            staticPrefix: 'docs',
+          },
+        ],
+      },
+    ])
+  })
+})

--- a/packages/next/src/lib/output-export-fallback-routes.ts
+++ b/packages/next/src/lib/output-export-fallback-routes.ts
@@ -1,0 +1,103 @@
+import { getSortedRoutes } from '../shared/lib/router/utils'
+import {
+  getOutputExportFallbackPath,
+  getOutputExportFallbackStaticPrefix,
+  getOutputExportFallbackVariantPath,
+  needsOutputExportFallbackManifest,
+} from './output-export-dynamic-fallback'
+
+export type OutputExportDynamicRouteInfo = {
+  fallbackSourceRoute: string | undefined
+  fallbackRouteParams:
+    | ReadonlyArray<{
+        paramName: string
+        paramType: string
+      }>
+    | undefined
+}
+
+export type OutputExportFallbackRouteEntry = {
+  route: string
+  fallbackSourceRoute: string
+  fallbackRoute: string
+  fallbackPath: string
+  staticPrefix: string
+}
+
+export type OutputExportFallbackRoutePlan = {
+  fallbackRoute: string
+  needsManifest: boolean
+  entries: OutputExportFallbackRouteEntry[]
+}
+
+export function planOutputExportFallbackRoutes(
+  dynamicRoutes: Readonly<Record<string, OutputExportDynamicRouteInfo>>
+): OutputExportFallbackRoutePlan[] {
+  const fallbackEntriesByRoute = new Map<
+    string,
+    Array<Omit<OutputExportFallbackRouteEntry, 'fallbackPath'>>
+  >()
+
+  for (const [dynamicRoute, prerenderInfo] of Object.entries(dynamicRoutes)) {
+    if (
+      !prerenderInfo.fallbackSourceRoute ||
+      !prerenderInfo.fallbackRouteParams ||
+      prerenderInfo.fallbackRouteParams.length === 0
+    ) {
+      continue
+    }
+
+    const staticPrefix = getOutputExportFallbackStaticPrefix(dynamicRoute)
+    if (staticPrefix === null) {
+      continue
+    }
+
+    const fallbackRoute = getOutputExportFallbackPath(staticPrefix)
+    const entries = fallbackEntriesByRoute.get(fallbackRoute)
+    const entry = {
+      route: dynamicRoute,
+      fallbackSourceRoute: prerenderInfo.fallbackSourceRoute,
+      fallbackRoute,
+      staticPrefix,
+    }
+
+    if (entries) {
+      entries.push(entry)
+    } else {
+      fallbackEntriesByRoute.set(fallbackRoute, [entry])
+    }
+  }
+
+  return Array.from(fallbackEntriesByRoute.entries())
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    .map(([fallbackRoute, entries]) => {
+      if (entries.length === 1) {
+        return {
+          fallbackRoute,
+          needsManifest: needsOutputExportFallbackManifest(entries[0].route),
+          entries: [
+            {
+              ...entries[0],
+              fallbackPath: fallbackRoute,
+            },
+          ],
+        }
+      }
+
+      const entriesByRoute = new Map(
+        entries.map((entry) => [entry.route, entry])
+      )
+      const sortedRoutes = getSortedRoutes(entries.map((entry) => entry.route))
+      return {
+        fallbackRoute,
+        needsManifest: true,
+        entries: sortedRoutes.map((route, index) => ({
+          ...entriesByRoute.get(route)!,
+          fallbackPath: getOutputExportFallbackVariantPath(
+            fallbackRoute,
+            index
+          ),
+        })),
+      }
+    })
+}

--- a/test/production/next-server-nft/next-server-nft.test.ts
+++ b/test/production/next-server-nft/next-server-nft.test.ts
@@ -316,6 +316,7 @@ async function readNormalizedNFT(next, name) {
            "/node_modules/next/dist/lib/non-nullable.js",
            "/node_modules/next/dist/lib/normalize-path.js",
            "/node_modules/next/dist/lib/output-export-dynamic-fallback.js",
+           "/node_modules/next/dist/lib/output-export-fallback-routes.js",
            "/node_modules/next/dist/lib/oxford-comma-list.js",
            "/node_modules/next/dist/lib/page-types.js",
            "/node_modules/next/dist/lib/patch-incorrect-lockfile.js",


### PR DESCRIPTION
## Stack position

Part 4 of 19 in the output export dynamic fallback stack.

Previous PR: #93560 (3/19)
Next PR: #93566 (5/19)

## Context

The stack is split so build-time output can land behind `experimental.outputExportDynamicFallbacks` before the client router behavior is enabled. The target behavior is for `output: 'export'` apps with parameterized App Router routes to emit fallback HTML/RSC artifacts that a later client can resolve for hard loads and soft navigations.

This PR scope: Build-time planning for fallback route variants.

Some route directories can contain multiple dynamic shapes that map to the same fallback directory. This PR keeps that decision in build output so the client can later select the right fallback artifact without guessing.

## What changed

- Builds fallback route metadata for route variants that share a directory.
- Writes enough route-shape information for a later client resolver to choose the correct fallback path.
- Keeps the planning based on build-time route structure instead of runtime probing.

## Deliberately not included

- Does not add the browser resolver for this metadata.
- Does not change the segment cache.
- Does not add soft-navigation support.

## Verification

After restacking and autosquashing, I verified the full stack with:

- `pnpm --filter=next build`
- `pnpm testonly packages/next/src/lib/output-export-dynamic-fallback.test.ts packages/next/src/lib/output-export-fallback-routes.test.ts packages/next/src/export/helpers/output-export-fallback.test.ts packages/next/src/server/request/fallback-params.test.ts`
- `pnpm testonly packages/next/src/client/output-export-fallback.test.ts packages/next/src/client/components/router-reducer/fetch-server-response.test.ts packages/next/src/client/components/router-reducer/create-initial-router-state.test.ts packages/next/src/client/components/segment-cache/cache.test.ts packages/next/src/client/components/segment-cache/vary-path.test.ts`
- `pnpm testonly packages/next/src/client/components/router-reducer/compute-changed-path.test.ts packages/next/src/client/flight-data-helpers.test.ts packages/next/src/server/app-render/postponed-state.test.ts`
- `pnpm test-start-turbo test/e2e/app-dir-export/test/dynamic-fallback-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-route-shapes-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-cache-components-basepath.test.ts test/e2e/app-dir-export/test/dynamic-fallback-optimizations-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-known-params-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-conflict.test.ts`
- `pnpm test-start-turbo test/e2e/app-dir/output-export-dynamic-fallbacks/output-export-dynamic-fallbacks.test.ts test/e2e/app-dir-export/test/output-export-server-io.test.ts test/e2e/app-dir-export/test/output-export-server-io-use-cache.test.ts test/e2e/app-dir-export/test/dynamic-fallback-server-params.test.ts`

<!-- NEXT_JS_LLM_PR -->
