### PR TITLE
(5/19) Reject server-only export fallback data

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1190,5 +1190,8 @@
   "1189": "Route \"%s\" accessed header \"%s\" which is not defined in the \\`unstable_samples\\` of \\`unstable_instant\\`. Add it to the sample's \\`headers\\` array, or \\`[\"%s\", null]\\` if it should be absent.",
   "1190": "Route \"%s\" accessed param \"%s\" which is not defined in the \\`unstable_samples\\` of \\`unstable_instant\\`. Add it to the sample's \\`params\\` object.",
   "1191": "Route \"%s\" called %s but param%s %s %s not defined in the \\`unstable_samples\\` of \\`unstable_instant\\`. %s requires all route params to be provided.",
-  "1192": "Route \"%s\" accessed root param \"%s\" which is not defined in the \\`unstable_samples\\` of \\`unstable_instant\\`. Add it to the sample's \\`params\\` object."
+  "1192": "Route \"%s\" accessed root param \"%s\" which is not defined in the \\`unstable_samples\\` of \\`unstable_instant\\`. Add it to the sample's \\`params\\` object.",
+  "1193": "Expected staticChildren to be initialized for known dynamic siblings.",
+  "1194": "Route \"%s\" used %s in a Server Component with \"output: export\". This is not supported because %s See more info here: https://nextjs.org/docs/app/guides/static-exports",
+  "1195": "Route \"%s\" used unresolved dynamic params in a Server Component with \"output: export\". This is not supported because these fallback params are only available on the client. Move param-dependent content into a Client Component or add generateStaticParams() to prerender this route. See more info here: https://nextjs.org/docs/app/guides/static-exports"
 }

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -6840,6 +6840,7 @@ async function validateInstantConfigInBuildWithSample(
     isStaticGeneration: false,
     page: outerWorkStore.page,
     route: outerWorkStore.route,
+    nextConfigOutput: outerWorkStore.nextConfigOutput,
     incrementalCache: outerWorkStore.incrementalCache,
     cacheLifeProfiles: outerWorkStore.cacheLifeProfiles,
     useCacheTimeout: outerWorkStore.useCacheTimeout,

--- a/packages/next/src/server/app-render/work-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-async-storage.external.ts
@@ -27,6 +27,7 @@ export interface WorkStore {
    * trailing `/page` or `/route` suffix.
    */
   readonly route: string
+  readonly nextConfigOutput?: 'standalone' | 'export'
 
   readonly incrementalCache?: IncrementalCache
   readonly cacheLifeProfiles?: { [profile: string]: CacheLife }

--- a/packages/next/src/server/async-storage/work-store.ts
+++ b/packages/next/src/server/async-storage/work-store.ts
@@ -61,6 +61,7 @@ export type WorkStoreContext = {
     | 'isBuildTimePrerendering'
     | 'isDraftMode'
     | 'isDebugDynamicAccesses'
+    | 'nextConfigOutput'
   > &
     RequestLifecycleOpts &
     Partial<Pick<RenderOpts, 'reactLoadableManifest'>>
@@ -125,6 +126,7 @@ export function createWorkStore({
     isStaticGeneration,
     page,
     route: normalizeAppPath(page),
+    nextConfigOutput: renderOpts.nextConfigOutput,
     incrementalCache:
       // we fallback to a global incremental cache for edge-runtime locally
       // so that it can access the fs cache without mocks

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -89,6 +89,7 @@ import type { PrerenderManifest } from '../../build'
 import { getRouteRegex } from '../../shared/lib/router/utils/route-regex'
 import type { PrerenderedRoute } from '../../build/static-paths/types'
 import { HMR_MESSAGE_SENT_TO_BROWSER } from './hot-reloader-types'
+import { isOutputExportDynamicFallbackEnabled } from '../../lib/output-export-dynamic-fallback'
 
 // Load ReactDevOverlay only when needed
 let PagesDevOverlayBridgeImpl: PagesDevOverlayBridgeType
@@ -811,6 +812,9 @@ export default class DevServer extends Server {
               this.nextConfig.experimental.partialFallbacks === true,
             configFileName,
             cacheComponents: Boolean(this.nextConfig.cacheComponents),
+            outputExportDynamicFallbacks:
+              this.nextConfig.experimental.outputExportDynamicFallbacks ===
+              true,
           },
           httpAgentOptions,
           locales,
@@ -856,9 +860,19 @@ export default class DevServer extends Server {
               )
             }
 
-            if (
-              !prerenderedRoutes.some((item) => item.pathname === urlPathname)
-            ) {
+            const hasMatchingPrerenderedRoute = prerenderedRoutes.some(
+              (item) => item.pathname === urlPathname
+            )
+            const hasFallbackPrerenderedRoute =
+              isOutputExportDynamicFallbackEnabled(this.nextConfig) &&
+              prerenderedRoutes.some(
+                (item) =>
+                  item.pathname === pathname &&
+                  item.fallbackRouteParams &&
+                  item.fallbackRouteParams.length > 0
+              )
+
+            if (!hasMatchingPrerenderedRoute && !hasFallbackPrerenderedRoute) {
               throw new Error(
                 `Page "${page}" is missing param "${pathname}" in "generateStaticParams()", which is required with "output: export" config.`
               )

--- a/packages/next/src/server/dev/static-paths-worker.ts
+++ b/packages/next/src/server/dev/static-paths-worker.ts
@@ -27,12 +27,14 @@ import { buildAppStaticPaths } from '../../build/static-paths/app'
 import { buildPagesStaticPaths } from '../../build/static-paths/pages'
 import { createIncrementalCache } from '../../export/helpers/create-incremental-cache'
 import { parseNormalizedAppRoute } from '../../shared/lib/router/routes/app'
+import { isOutputExportDynamicFallbackEnabled } from '../../lib/output-export-dynamic-fallback'
 
 type RuntimeConfig = {
   pprConfig: ExperimentalPPRConfig | undefined
   partialFallbacks: boolean
   configFileName: string
   cacheComponents: boolean
+  outputExportDynamicFallbacks: boolean
 }
 
 // we call getStaticPaths in a separate process to ensure
@@ -132,9 +134,18 @@ export async function loadStaticPaths({
       )
     }
 
+    const isOutputExportFallbackRoute =
+      isOutputExportDynamicFallbackEnabled({
+        output: nextConfigOutput,
+        cacheComponents: config.cacheComponents,
+        experimental: {
+          outputExportDynamicFallbacks: config.outputExportDynamicFallbacks,
+        },
+      }) && route.dynamicSegments.length > 0
+
     const isRoutePPREnabled =
       isAppPageRouteModule(routeModule) &&
-      checkIsRoutePPREnabled(config.pprConfig)
+      (checkIsRoutePPREnabled(config.pprConfig) || isOutputExportFallbackRoute)
 
     const rootParamKeys = collectRootParamKeys(routeModule)
 

--- a/packages/next/src/server/request/connection.ts
+++ b/packages/next/src/server/request/connection.ts
@@ -13,8 +13,12 @@ import {
   makeHangingPromise,
   makeDevtoolsIOAwarePromise,
 } from '../dynamic-rendering-utils'
-import { isRequestAPICallableInsideAfter } from './utils'
 import { applyOwnerStack } from '../dynamic-rendering-utils'
+import {
+  isRequestAPICallableInsideAfter,
+  shouldErrorForOutputExportServerRequestAPI,
+  throwForOutputExportServerRequestAPI,
+} from './utils'
 import { RenderStage } from '../app-render/staged-rendering'
 import { InvariantError } from '../../shared/lib/invariant-error'
 
@@ -43,6 +47,19 @@ export function connection(): Promise<void> {
       // When using forceStatic, we override all other logic and always just
       // return a resolving promise without tracking.
       return Promise.resolve(undefined)
+    }
+
+    if (
+      workStore.nextConfigOutput === 'export' &&
+      workUnitStore &&
+      shouldErrorForOutputExportServerRequestAPI(workUnitStore, 'connection')
+    ) {
+      throwForOutputExportServerRequestAPI(
+        workStore,
+        '`connection()`',
+        connection,
+        'this API requires a runtime server request, which is not available when exporting to static HTML.'
+      )
     }
 
     if (workStore.dynamicShouldError) {

--- a/packages/next/src/server/request/cookies.ts
+++ b/packages/next/src/server/request/cookies.ts
@@ -27,8 +27,12 @@ import {
   makeHangingPromise,
 } from '../dynamic-rendering-utils'
 import { createDedupedByCallsiteServerErrorLoggerDev } from '../create-deduped-by-callsite-server-error-logger'
-import { isRequestAPICallableInsideAfter } from './utils'
 import { applyOwnerStack } from '../dynamic-rendering-utils'
+import {
+  isRequestAPICallableInsideAfter,
+  shouldErrorForOutputExportServerRequestAPI,
+  throwForOutputExportServerRequestAPI,
+} from './utils'
 import { InvariantError } from '../../shared/lib/invariant-error'
 import { RenderStage } from '../app-render/staged-rendering'
 
@@ -54,6 +58,19 @@ export function cookies(): Promise<ReadonlyRequestCookies> {
       // cookies object without tracking
       const underlyingCookies = createEmptyCookies()
       return makeUntrackedCookies(underlyingCookies)
+    }
+
+    if (
+      workStore.nextConfigOutput === 'export' &&
+      workUnitStore &&
+      shouldErrorForOutputExportServerRequestAPI(workUnitStore, 'request-data')
+    ) {
+      throwForOutputExportServerRequestAPI(
+        workStore,
+        '`cookies()`',
+        cookies,
+        'this API requires a runtime server request, which is not available when exporting to static HTML.'
+      )
     }
 
     if (workStore.dynamicShouldError) {

--- a/packages/next/src/server/request/fallback-params.test.ts
+++ b/packages/next/src/server/request/fallback-params.test.ts
@@ -4,9 +4,16 @@ import {
   getFallbackRouteParams,
   getPlaceholderFallbackRouteParams,
 } from './fallback-params'
+import {
+  createParamsFromClient,
+  createServerParamsForServerSegment,
+} from './params'
 import type { FallbackRouteParam } from '../../build/static-paths/types'
 import type AppPageRouteModule from '../route-modules/app-page/module'
 import type { LoaderTree } from '../lib/app-dir-module'
+import { workAsyncStorage } from '../app-render/work-async-storage.external'
+import { workUnitAsyncStorage } from '../app-render/work-unit-async-storage.external'
+import { isHangingPromiseRejectionError } from '../dynamic-rendering-utils'
 
 // Helper to create LoaderTree structures for testing
 type TestLoaderTree = [
@@ -658,6 +665,130 @@ describe('getFallbackRouteParams', () => {
 
       result = getFallbackRouteParams('/sidebar/is/real', routeModule)
       expect(result).toBeNull()
+    })
+  })
+})
+
+describe('output export fallback params consumers', () => {
+  function createOutputExportWorkStore() {
+    return {
+      isStaticGeneration: true,
+      page: '/blog/[slug]/page',
+      route: '/blog/[slug]',
+      nextConfigOutput: 'export',
+      afterContext: {} as any,
+      previouslyRevalidatedTags: [],
+      refreshTagsByCacheKind: new Map(),
+      shouldTrackFetchMetrics: false,
+      buildId: 'build-id',
+      cacheComponentsEnabled: true,
+      runInCleanSnapshot: (fn: (...args: Array<any>) => any, ...args: any[]) =>
+        fn(...args),
+      reactServerErrorsByDigest: new Map(),
+    } as any
+  }
+
+  function createPrerenderStore(
+    fallbackParams: NonNullable<
+      ReturnType<typeof createOpaqueFallbackRouteParams>
+    >,
+    rootParams: Record<string, unknown> = {}
+  ) {
+    const controller = new AbortController()
+    return {
+      controller,
+      prerenderStore: {
+        type: 'prerender',
+        phase: 'render',
+        implicitTags: {} as any,
+        revalidate: 0,
+        expire: 0,
+        stale: 0,
+        tags: null,
+        renderSignal: controller.signal,
+        controller,
+        cacheSignal: null,
+        dynamicTracking: null,
+        rootParams,
+        prerenderResumeDataCache: null,
+        renderResumeDataCache: null,
+        hmrRefreshHash: undefined,
+        varyParamsAccumulator: null,
+        fallbackRouteParams: fallbackParams,
+        allowEmptyStaticShell: false,
+      } as any,
+    }
+  }
+
+  it('does not error server params for ancestors that do not receive fallback params', async () => {
+    const fallbackParams = createOpaqueFallbackRouteParams([
+      { paramName: 'slug', paramType: 'dynamic' },
+    ])!
+    const workStore = createOutputExportWorkStore()
+    const { prerenderStore } = createPrerenderStore(fallbackParams)
+
+    await workAsyncStorage.run(workStore, async () => {
+      await workUnitAsyncStorage.run(prerenderStore, async () => {
+        await expect(
+          createServerParamsForServerSegment({}, null, null, false)
+        ).resolves.toEqual({})
+        expect(() =>
+          createServerParamsForServerSegment({}, 'slug', null, false).then(
+            () => null
+          )
+        ).toThrow('output: export')
+      })
+    })
+  })
+
+  it('does not reuse server erroring params promises for client consumers', async () => {
+    const fallbackParams = createOpaqueFallbackRouteParams([
+      { paramName: 'slug', paramType: 'dynamic' },
+    ])!
+    const underlyingParams = {
+      slug: fallbackParams.get('slug')![0],
+    }
+
+    const workStore = createOutputExportWorkStore()
+    const { controller, prerenderStore } = createPrerenderStore(
+      fallbackParams,
+      underlyingParams
+    )
+
+    await workAsyncStorage.run(workStore, async () => {
+      await workUnitAsyncStorage.run(prerenderStore, async () => {
+        const serverParams = createServerParamsForServerSegment(
+          underlyingParams,
+          null,
+          null,
+          false
+        )
+        const clientParams = createParamsFromClient(underlyingParams)
+
+        expect(serverParams).not.toBe(clientParams)
+        expect(() => serverParams.then(() => null)).toThrow('output: export')
+        expect(() => clientParams.then(() => null)).not.toThrow()
+
+        let clientSettled = false
+        clientParams.then(
+          () => {
+            clientSettled = true
+          },
+          () => {
+            clientSettled = true
+          }
+        )
+        await Promise.resolve()
+        expect(clientSettled).toBe(false)
+
+        controller.abort()
+        try {
+          await clientParams
+          throw new Error('Expected client params to reject after abort')
+        } catch (error) {
+          expect(isHangingPromiseRejectionError(error)).toBe(true)
+        }
+      })
     })
   })
 })

--- a/packages/next/src/server/request/headers.ts
+++ b/packages/next/src/server/request/headers.ts
@@ -25,8 +25,12 @@ import {
   makeHangingPromise,
 } from '../dynamic-rendering-utils'
 import { createDedupedByCallsiteServerErrorLoggerDev } from '../create-deduped-by-callsite-server-error-logger'
-import { isRequestAPICallableInsideAfter } from './utils'
 import { applyOwnerStack } from '../dynamic-rendering-utils'
+import {
+  isRequestAPICallableInsideAfter,
+  shouldErrorForOutputExportServerRequestAPI,
+  throwForOutputExportServerRequestAPI,
+} from './utils'
 import { InvariantError } from '../../shared/lib/invariant-error'
 import { RenderStage } from '../app-render/staged-rendering'
 
@@ -60,6 +64,19 @@ export function headers(): Promise<ReadonlyHeaders> {
       // headers object without tracking
       const underlyingHeaders = HeadersAdapter.seal(new Headers({}))
       return makeUntrackedHeaders(underlyingHeaders)
+    }
+
+    if (
+      workStore.nextConfigOutput === 'export' &&
+      workUnitStore &&
+      shouldErrorForOutputExportServerRequestAPI(workUnitStore, 'request-data')
+    ) {
+      throwForOutputExportServerRequestAPI(
+        workStore,
+        '`headers()`',
+        headers,
+        'this API requires a runtime server request, which is not available when exporting to static HTML.'
+      )
     }
 
     if (workUnitStore) {

--- a/packages/next/src/server/request/params.ts
+++ b/packages/next/src/server/request/params.ts
@@ -41,6 +41,7 @@ import { RenderStage } from '../app-render/staged-rendering'
 
 export type ParamValue = string | Array<string> | undefined
 export type Params = Record<string, ParamValue>
+type ParamsConsumer = 'server' | 'client'
 
 export function createParamsFromClient(
   underlyingParams: Params
@@ -65,7 +66,8 @@ export function createParamsFromClient(
           null,
           workStore,
           workUnitStore,
-          varyParamsAccumulator
+          varyParamsAccumulator,
+          'client'
         )
       case 'validation-client':
         return createClientParamsInInstantValidation(
@@ -100,7 +102,8 @@ export function createParamsFromClient(
             fallbackParams,
             workStore,
             workUnitStore,
-            isRuntimePrefetchable
+            isRuntimePrefetchable,
+            'client'
           )
         } else if (workUnitStore.validationSamples) {
           return createClientParamsInInstantValidation(
@@ -154,7 +157,8 @@ export function createServerParamsForRoute(
           null,
           workStore,
           workUnitStore,
-          varyParamsAccumulator
+          varyParamsAccumulator,
+          'server'
         )
       case 'prerender-client':
       case 'validation-client':
@@ -195,7 +199,8 @@ export function createServerParamsForRoute(
             fallbackParams,
             workStore,
             workUnitStore,
-            isRuntimePrefetchable
+            isRuntimePrefetchable,
+            'server'
           )
         } else {
           return createRenderParamsInProd(underlyingParams)
@@ -229,7 +234,8 @@ export function createServerParamsForServerSegment(
           optionalCatchAllParamName,
           workStore,
           workUnitStore,
-          varyParamsAccumulator
+          varyParamsAccumulator,
+          'server'
         )
       case 'validation-client':
         throw new InvariantError(
@@ -264,7 +270,8 @@ export function createServerParamsForServerSegment(
             fallbackParams,
             workStore,
             workUnitStore,
-            isRuntimePrefetchable
+            isRuntimePrefetchable,
+            'server'
           )
         } else if (
           workUnitStore.asyncApiPromises &&
@@ -363,7 +370,8 @@ function createStaticPrerenderParams(
   optionalCatchAllParamName: string | null,
   workStore: WorkStore,
   prerenderStore: StaticPrerenderStore,
-  varyParamsAccumulator: VaryParamsAccumulator | null
+  varyParamsAccumulator: VaryParamsAccumulator | null,
+  paramsConsumer: ParamsConsumer
 ): Promise<Params> {
   const underlyingParamsWithVarying =
     varyParamsAccumulator !== null
@@ -378,36 +386,50 @@ function createStaticPrerenderParams(
     case 'prerender':
     case 'prerender-client': {
       const fallbackParams = prerenderStore.fallbackRouteParams
-      if (fallbackParams) {
-        for (const key in underlyingParams) {
-          if (fallbackParams.has(key)) {
-            // This params object has one or more fallback params, so we need
-            // to consider the awaiting of this params object "dynamic". Since
-            // we are in cacheComponents mode we encode this as a promise that never
-            // resolves.
-            return makeHangingParams(
-              underlyingParamsWithVarying,
-              workStore,
-              prerenderStore
-            )
-          }
+      const hasFallbackParams = hasFallbackRouteParams(
+        underlyingParams,
+        fallbackParams,
+        optionalCatchAllParamName
+      )
+      if (fallbackParams && hasFallbackParams) {
+        if (
+          paramsConsumer === 'server' &&
+          workStore.nextConfigOutput === 'export'
+        ) {
+          return makeErroringExportFallbackParams(
+            underlyingParamsWithVarying,
+            fallbackParams,
+            workStore
+          )
         }
+        // This params object has one or more fallback params, so we need
+        // to consider the awaiting of this params object "dynamic". Since
+        // we are in cacheComponents mode we encode this as a promise that never
+        // resolves.
+        return makeHangingParams(
+          underlyingParamsWithVarying,
+          workStore,
+          prerenderStore
+        )
       }
       break
     }
     case 'prerender-ppr': {
       const fallbackParams = prerenderStore.fallbackRouteParams
-      if (fallbackParams) {
-        for (const key in underlyingParams) {
-          if (fallbackParams.has(key)) {
-            return makeErroringParams(
-              underlyingParamsWithVarying,
-              fallbackParams,
-              workStore,
-              prerenderStore
-            )
-          }
-        }
+      if (
+        fallbackParams &&
+        hasFallbackRouteParams(
+          underlyingParams,
+          fallbackParams,
+          optionalCatchAllParamName
+        )
+      ) {
+        return makeErroringParams(
+          underlyingParamsWithVarying,
+          fallbackParams,
+          workStore,
+          prerenderStore
+        )
       }
       break
     }
@@ -449,13 +471,21 @@ function createRuntimePrerenderParams(
 
 function hasFallbackRouteParams(
   underlyingParams: Params,
-  fallbackParams: OpaqueFallbackRouteParams | null | undefined
+  fallbackParams: OpaqueFallbackRouteParams | null | undefined,
+  optionalCatchAllParamName: string | null = null
 ): boolean {
   if (fallbackParams) {
-    for (let key in underlyingParams) {
+    for (const key in underlyingParams) {
       if (fallbackParams.has(key)) {
         return true
       }
+    }
+
+    if (
+      optionalCatchAllParamName !== null &&
+      fallbackParams.has(optionalCatchAllParamName)
+    ) {
+      return true
     }
   }
   return false
@@ -508,11 +538,30 @@ function createRenderParamsInDev(
   fallbackParams: OpaqueFallbackRouteParams | null | undefined,
   workStore: WorkStore,
   requestStore: RequestStore,
-  isRuntimePrefetchable: boolean
+  isRuntimePrefetchable: boolean,
+  paramsConsumer: ParamsConsumer
 ): Promise<Params> {
+  const hasFallbackParams = hasFallbackRouteParams(
+    underlyingParams,
+    fallbackParams
+  )
+
+  if (
+    paramsConsumer === 'server' &&
+    workStore.nextConfigOutput === 'export' &&
+    fallbackParams &&
+    hasFallbackParams
+  ) {
+    return makeErroringExportFallbackParams(
+      underlyingParams,
+      fallbackParams,
+      workStore
+    )
+  }
+
   return makeDynamicallyTrackedParamsWithDevWarnings(
     underlyingParams,
-    hasFallbackRouteParams(underlyingParams, fallbackParams),
+    hasFallbackParams,
     workStore,
     requestStore,
     isRuntimePrefetchable
@@ -521,6 +570,10 @@ function createRenderParamsInDev(
 
 interface CacheLifetime {}
 const CachedParams = new WeakMap<CacheLifetime, Promise<Params>>()
+const CachedErroringExportFallbackParams = new WeakMap<
+  CacheLifetime,
+  Promise<Params>
+>()
 
 const fallbackParamsProxyHandler: ProxyHandler<Promise<Params>> = {
   get: function get(target, prop, receiver) {
@@ -571,6 +624,71 @@ function makeHangingParams(
   CachedParams.set(underlyingParams, promise)
 
   return promise
+}
+
+function makeErroringExportFallbackParams(
+  underlyingParams: Params,
+  fallbackParams: OpaqueFallbackRouteParams,
+  workStore: WorkStore
+): Promise<Params> {
+  const cachedParams = CachedErroringExportFallbackParams.get(underlyingParams)
+  if (cachedParams) {
+    return cachedParams
+  }
+
+  const augmentedUnderlying = { ...underlyingParams }
+  const error =
+    workStore.invalidDynamicUsageError ??
+    createExportFallbackServerParamsError(workStore)
+
+  const throwError = () => {
+    workStore.invalidDynamicUsageError ??= error
+    throw error
+  }
+
+  const promise = new Proxy(Promise.resolve(augmentedUnderlying), {
+    get(target, prop, receiver) {
+      if (prop === 'then' || prop === 'catch' || prop === 'finally') {
+        return () => throwError()
+      }
+
+      if (
+        typeof prop === 'string' &&
+        !wellKnownProperties.has(prop) &&
+        fallbackParams.has(prop)
+      ) {
+        return throwError()
+      }
+
+      return ReflectAdapter.get(target, prop, receiver)
+    },
+  })
+  CachedErroringExportFallbackParams.set(underlyingParams, promise)
+
+  for (const prop of fallbackParams.keys()) {
+    if (wellKnownProperties.has(prop)) {
+      continue
+    }
+
+    Object.defineProperty(augmentedUnderlying, prop, {
+      get() {
+        return throwError()
+      },
+      enumerable: true,
+    })
+  }
+
+  return promise
+}
+
+function createExportFallbackServerParamsError(workStore: WorkStore): Error {
+  const error = new Error(
+    `Route "${workStore.route}" used unresolved dynamic params in a Server Component with "output: export". This is not supported because these fallback params are only available on the client. Move param-dependent content into a Client Component or add generateStaticParams() to prerender this route. See more info here: https://nextjs.org/docs/app/guides/static-exports`
+  )
+
+  Error.captureStackTrace(error, createExportFallbackServerParamsError)
+
+  return error
 }
 
 function makeErroringParams(

--- a/packages/next/src/server/request/search-params.ts
+++ b/packages/next/src/server/request/search-params.ts
@@ -40,6 +40,7 @@ import {
 import {
   throwWithStaticGenerationBailoutErrorWithDynamicError,
   throwForSearchParamsAccessInUseCache,
+  throwForOutputExportServerRequestAPI,
 } from './utils'
 import { RenderStage } from '../app-render/staged-rendering'
 
@@ -227,6 +228,9 @@ function createStaticPrerenderSearchParams(
   switch (prerenderStore.type) {
     case 'prerender':
     case 'prerender-client':
+      if (workStore.nextConfigOutput === 'export') {
+        return makeErroringOutputExportSearchParams(workStore)
+      }
       // We are in a cacheComponents (PPR or otherwise) prerender
       return makeHangingSearchParams(workStore, prerenderStore)
     case 'prerender-ppr':
@@ -392,10 +396,17 @@ function makeErroringSearchParams(
         const expression =
           '`await searchParams`, `searchParams.then`, or similar'
         if (workStore.dynamicShouldError) {
-          throwWithStaticGenerationBailoutErrorWithDynamicError(
-            workStore.route,
-            expression
-          )
+          if (workStore.nextConfigOutput === 'export') {
+            throwForOutputExportSearchParams(
+              workStore,
+              makeErroringSearchParams
+            )
+          } else {
+            throwWithStaticGenerationBailoutErrorWithDynamicError(
+              workStore.route,
+              expression
+            )
+          }
         } else if (prerenderStore.type === 'prerender-ppr') {
           // PPR Prerender (no cacheComponents)
           postponeWithTracking(
@@ -418,6 +429,61 @@ function makeErroringSearchParams(
 
   CachedSearchParams.set(workStore, proxiedPromise)
   return proxiedPromise
+}
+
+function makeErroringOutputExportSearchParams(
+  workStore: WorkStore
+): Promise<SearchParams> {
+  const cachedSearchParams = CachedSearchParams.get(workStore)
+  if (cachedSearchParams) {
+    return cachedSearchParams
+  }
+
+  const underlyingSearchParams = {}
+  const promise = Promise.resolve(underlyingSearchParams)
+
+  const throwError = () =>
+    throwForOutputExportServerRequestAPI(
+      workStore,
+      '`searchParams`',
+      makeErroringOutputExportSearchParams,
+      'search params are only available on the client when exporting to static HTML. Read the current URL in a Client Component instead.'
+    )
+
+  const proxiedPromise = new Proxy(promise, {
+    get(target, prop, receiver) {
+      if (Object.hasOwn(promise, prop)) {
+        return ReflectAdapter.get(target, prop, receiver)
+      }
+
+      if (typeof prop === 'string') {
+        if (prop === 'then' || prop === 'status') {
+          throwError()
+        }
+      }
+
+      return ReflectAdapter.get(target, prop, receiver)
+    },
+    ownKeys() {
+      throwError()
+      return []
+    },
+  })
+
+  CachedSearchParams.set(workStore, proxiedPromise)
+  return proxiedPromise
+}
+
+function throwForOutputExportSearchParams(
+  workStore: WorkStore,
+  constructorOpt: Function
+): never {
+  return throwForOutputExportServerRequestAPI(
+    workStore,
+    '`searchParams`',
+    constructorOpt,
+    'search params are only available on the client when exporting to static HTML. Read the current URL in a Client Component instead.'
+  )
 }
 
 /**
@@ -579,11 +645,21 @@ function instrumentSearchParamsObjectWithDevWarnings(
     get(target, prop, receiver) {
       if (typeof prop === 'string' && promiseInitialized.current) {
         if (workStore.dynamicShouldError) {
-          const expression = describeStringPropertyAccess('searchParams', prop)
-          throwWithStaticGenerationBailoutErrorWithDynamicError(
-            workStore.route,
-            expression
-          )
+          if (workStore.nextConfigOutput === 'export') {
+            throwForOutputExportSearchParams(
+              workStore,
+              instrumentSearchParamsObjectWithDevWarnings
+            )
+          } else {
+            const expression = describeStringPropertyAccess(
+              'searchParams',
+              prop
+            )
+            throwWithStaticGenerationBailoutErrorWithDynamicError(
+              workStore.route,
+              expression
+            )
+          }
         }
       }
       return ReflectAdapter.get(target, prop, receiver)
@@ -591,26 +667,40 @@ function instrumentSearchParamsObjectWithDevWarnings(
     has(target, prop) {
       if (typeof prop === 'string') {
         if (workStore.dynamicShouldError) {
-          const expression = describeHasCheckingStringProperty(
-            'searchParams',
-            prop
-          )
-          throwWithStaticGenerationBailoutErrorWithDynamicError(
-            workStore.route,
-            expression
-          )
+          if (workStore.nextConfigOutput === 'export') {
+            throwForOutputExportSearchParams(
+              workStore,
+              instrumentSearchParamsObjectWithDevWarnings
+            )
+          } else {
+            const expression = describeHasCheckingStringProperty(
+              'searchParams',
+              prop
+            )
+            throwWithStaticGenerationBailoutErrorWithDynamicError(
+              workStore.route,
+              expression
+            )
+          }
         }
       }
       return Reflect.has(target, prop)
     },
     ownKeys(target) {
       if (workStore.dynamicShouldError) {
-        const expression =
-          '`{...searchParams}`, `Object.keys(searchParams)`, or similar'
-        throwWithStaticGenerationBailoutErrorWithDynamicError(
-          workStore.route,
-          expression
-        )
+        if (workStore.nextConfigOutput === 'export') {
+          throwForOutputExportSearchParams(
+            workStore,
+            instrumentSearchParamsObjectWithDevWarnings
+          )
+        } else {
+          const expression =
+            '`{...searchParams}`, `Object.keys(searchParams)`, or similar'
+          throwWithStaticGenerationBailoutErrorWithDynamicError(
+            workStore.route,
+            expression
+          )
+        }
       }
       return Reflect.ownKeys(target)
     },
@@ -636,7 +726,11 @@ function instrumentSearchParamsPromiseWithDevWarnings(
 
   return new Proxy(promise, {
     get(target, prop, receiver) {
-      if (prop === 'then' && workStore.dynamicShouldError) {
+      if (
+        prop === 'then' &&
+        workStore.dynamicShouldError &&
+        workStore.nextConfigOutput !== 'export'
+      ) {
         const expression = '`searchParams.then`'
         throwWithStaticGenerationBailoutErrorWithDynamicError(
           workStore.route,

--- a/packages/next/src/server/request/utils.ts
+++ b/packages/next/src/server/request/utils.ts
@@ -1,6 +1,9 @@
 import { StaticGenBailoutError } from '../../client/components/static-generation-bailout'
 import { afterTaskAsyncStorage } from '../app-render/after-task-async-storage.external'
 import type { WorkStore } from '../app-render/work-async-storage.external'
+import type { WorkUnitStore } from '../app-render/work-unit-async-storage.external'
+
+type OutputExportServerRequestAPIKind = 'request-data' | 'connection'
 
 export function throwWithStaticGenerationBailoutErrorWithDynamicError(
   route: string,
@@ -23,6 +26,51 @@ export function throwForSearchParamsAccessInUseCache(
   workStore.invalidDynamicUsageError ??= error
 
   throw error
+}
+
+export function throwForOutputExportServerRequestAPI(
+  workStore: WorkStore,
+  expression: string,
+  constructorOpt: Function,
+  reason: string
+): never {
+  const existingError = workStore.invalidDynamicUsageError
+  if (existingError) {
+    throw existingError
+  }
+
+  const error = new Error(
+    `Route "${workStore.route}" used ${expression} in a Server Component with "output: export". This is not supported because ${reason} See more info here: https://nextjs.org/docs/app/guides/static-exports`
+  )
+
+  Error.captureStackTrace(error, constructorOpt)
+  workStore.invalidDynamicUsageError ??= error
+
+  throw error
+}
+
+export function shouldErrorForOutputExportServerRequestAPI(
+  workUnitStore: WorkUnitStore,
+  apiKind: OutputExportServerRequestAPIKind
+): boolean {
+  switch (workUnitStore.type) {
+    case 'request':
+    case 'prerender':
+    case 'prerender-runtime':
+    case 'prerender-ppr':
+    case 'prerender-legacy':
+      return true
+    case 'prerender-client':
+      return apiKind === 'connection'
+    case 'validation-client':
+    case 'cache':
+    case 'private-cache':
+    case 'unstable-cache':
+    case 'generate-static-params':
+      return false
+    default:
+      return workUnitStore satisfies never
+  }
 }
 
 export function isRequestAPICallableInsideAfter() {


### PR DESCRIPTION
## Stack position

Part 5 of 19 in the output export dynamic fallback stack.

Previous PR: #93565 (4/19)
Next PR: #93567 (6/19)

## Context

The stack is split so build-time output can land behind `experimental.outputExportDynamicFallbacks` before the client router behavior is enabled. The target behavior is for `output: 'export'` apps with parameterized App Router routes to emit fallback HTML/RSC artifacts that a later client can resolve for hard loads and soft navigations.

This PR scope: Server-only boundary enforcement for fallback prerenders.

Fallback params are only resolvable by the client for this export mode. Server Components that synchronously depend on unresolved params or request data cannot be safely represented as reusable static fallback output.

## What changed

- Rejects unsupported server-side access patterns while producing fallback data.
- Keeps error behavior explicit instead of silently writing invalid fallback payloads.
- Narrows fallback output to client-resolvable parameter usage.

## Deliberately not included

- Does not loosen static export server semantics.
- Does not add client-side recovery for invalid server-only fallback data.
- Does not cover every e2e boundary yet. The next test PRs do that.

## Verification

After restacking and autosquashing, I verified the full stack with:

- `pnpm --filter=next build`
- `pnpm testonly packages/next/src/lib/output-export-dynamic-fallback.test.ts packages/next/src/lib/output-export-fallback-routes.test.ts packages/next/src/export/helpers/output-export-fallback.test.ts packages/next/src/server/request/fallback-params.test.ts`
- `pnpm testonly packages/next/src/client/output-export-fallback.test.ts packages/next/src/client/components/router-reducer/fetch-server-response.test.ts packages/next/src/client/components/router-reducer/create-initial-router-state.test.ts packages/next/src/client/components/segment-cache/cache.test.ts packages/next/src/client/components/segment-cache/vary-path.test.ts`
- `pnpm testonly packages/next/src/client/components/router-reducer/compute-changed-path.test.ts packages/next/src/client/flight-data-helpers.test.ts packages/next/src/server/app-render/postponed-state.test.ts`
- `pnpm test-start-turbo test/e2e/app-dir-export/test/dynamic-fallback-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-route-shapes-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-cache-components-basepath.test.ts test/e2e/app-dir-export/test/dynamic-fallback-optimizations-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-known-params-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-conflict.test.ts`
- `pnpm test-start-turbo test/e2e/app-dir/output-export-dynamic-fallbacks/output-export-dynamic-fallbacks.test.ts test/e2e/app-dir-export/test/output-export-server-io.test.ts test/e2e/app-dir-export/test/output-export-server-io-use-cache.test.ts test/e2e/app-dir-export/test/dynamic-fallback-server-params.test.ts`

<!-- NEXT_JS_LLM_PR -->
