### PR TITLE
(6/19) Add export dynamic fallback test helpers

### DIFF
--- a/test/e2e/app-dir-export/test/utils.ts
+++ b/test/e2e/app-dir-export/test/utils.ts
@@ -4,20 +4,161 @@ import { join } from 'path'
 import { promisify } from 'util'
 import fs from 'fs-extra'
 import globOrig from 'glob'
+import express from 'express'
+import http from 'http'
+import { createReadStream } from 'fs'
 import {
   waitForRedbox,
   getRedboxHeader,
+  getRedboxDescription,
   getRedboxSource,
+  openRedbox,
   retry,
   findPort,
   startStaticServer,
   stopApp,
   fetchViaHTTP,
 } from 'next-test-utils'
-import { nextTestSetup } from 'e2e-utils'
+import { nextTestSetup, type NextInstance } from 'e2e-utils'
 import webdriver from 'next-webdriver'
 
 const glob = promisify(globOrig)
+
+export async function buildAndStartOutputExportServer(
+  next: Pick<NextInstance, 'build' | 'testDir'>,
+  {
+    basePath,
+    useFallbackDocument,
+  }: {
+    basePath?: string
+    useFallbackDocument: boolean
+  }
+) {
+  await next.build()
+
+  const port = await findPort()
+  const outDir = join(next.testDir, 'out')
+  const requests: string[] = []
+
+  const getRequests = () => [...requests]
+  const clearRequests = () => {
+    requests.length = 0
+  }
+
+  if (!useFallbackDocument) {
+    const app = await startStaticServer(outDir, null, port)
+    return {
+      port,
+      getRequests,
+      clearRequests,
+      stopOrKill: () => stopApp(app),
+    }
+  }
+
+  const app = express()
+  const server = http.createServer(app)
+  const fallbackHtml = join(outDir, '_fallback.html')
+
+  app.use((req, _res, nextHandler) => {
+    requests.push(req.url || '/')
+    nextHandler()
+  })
+
+  if (basePath) {
+    app.use((req, _res, nextHandler) => {
+      if (req.url === basePath) {
+        req.url = '/'
+      } else if (req.url?.startsWith(`${basePath}/`)) {
+        req.url = req.url.slice(basePath.length)
+      }
+      nextHandler()
+    })
+  }
+
+  app.use(
+    express.static(outDir, {
+      extensions: ['html'],
+      redirect: false,
+    })
+  )
+  app.use((req, res) => {
+    createReadStream(fallbackHtml).pipe(res)
+  })
+
+  await new Promise<void>((resolve) => server.listen(port, resolve))
+
+  return {
+    port,
+    getRequests,
+    clearRequests,
+    stopOrKill: () => stopApp(server),
+  }
+}
+
+export async function startOutputExportDevServer(
+  next: Pick<NextInstance, 'start' | 'appPort'>
+) {
+  await next.start()
+  return Number(next.appPort)
+}
+
+export async function expectOutputExportDevRedbox({
+  port,
+  path,
+  expectedMessage,
+  expectedSource,
+}: {
+  port: number
+  path: string
+  expectedMessage: string
+  expectedSource?: string
+}) {
+  const browser = await webdriver(port, path)
+
+  try {
+    await waitForRedbox(browser)
+
+    const header = await getRedboxHeader(browser)
+    const source = await getRedboxSource(browser)
+
+    expect(header).toContain(expectedMessage)
+
+    if (expectedSource && source !== null) {
+      expect(source).toContain(expectedSource)
+    }
+  } finally {
+    await browser.close()
+  }
+}
+
+export async function expectOutputExportDevCollapsedRedbox({
+  port,
+  path,
+  expectedMessage,
+  expectedSource,
+}: {
+  port: number
+  path: string
+  expectedMessage: string
+  expectedSource?: string
+}) {
+  const browser = await webdriver(port, path)
+
+  try {
+    await openRedbox(browser)
+
+    const description = await getRedboxDescription(browser)
+    const source = await getRedboxSource(browser)
+
+    expect(description).toContain(expectedMessage)
+
+    if (expectedSource && source !== null) {
+      expect(source).toContain(expectedSource)
+    }
+  } finally {
+    await browser.close()
+  }
+}
 
 export const expectedWhenTrailingSlashTrue = [
   '404.html',

--- a/test/lib/e2e-utils/index.ts
+++ b/test/lib/e2e-utils/index.ts
@@ -334,7 +334,9 @@ export function nextTestSetup(
       // Gracefully destroy the instance if `createNext` success.
       // If next instance is not available, it's likely beforeAll hook failed and unnecessarily throws another error
       // by attempting to destroy on undefined.
-      await next?.destroy()
+      if (next && !(next as any).isDestroyed) {
+        await next.destroy()
+      }
     })
   }
 


### PR DESCRIPTION
## Stack position

Part 6 of 19 in the output export dynamic fallback stack.

Previous PR: #93566 (5/19)
Next PR: #93568 (7/19)

## Context

The stack is split so build-time output can land behind `experimental.outputExportDynamicFallbacks` before the client router behavior is enabled. The target behavior is for `output: 'export'` apps with parameterized App Router routes to emit fallback HTML/RSC artifacts that a later client can resolve for hard loads and soft navigations.

This PR scope: Reusable e2e harness support for export fallback fixtures.

The following e2e PRs need a static export server that can serve `_fallback.html` for unknown paths and record requested artifacts. This PR isolates that test infrastructure from feature behavior.

## What changed

- Adds shared helpers for building and serving output-export fallback fixtures.
- Supports fallback-document serving and request recording for later assertions.
- Keeps test setup reusable across initial-load, soft-navigation, basePath, and edge-case suites.

## Deliberately not included

- Does not add product behavior.
- Does not assert client routing yet.
- Does not change production server behavior.

## Verification

After restacking and autosquashing, I verified the full stack with:

- `pnpm --filter=next build`
- `pnpm testonly packages/next/src/lib/output-export-dynamic-fallback.test.ts packages/next/src/lib/output-export-fallback-routes.test.ts packages/next/src/export/helpers/output-export-fallback.test.ts packages/next/src/server/request/fallback-params.test.ts`
- `pnpm testonly packages/next/src/client/output-export-fallback.test.ts packages/next/src/client/components/router-reducer/fetch-server-response.test.ts packages/next/src/client/components/router-reducer/create-initial-router-state.test.ts packages/next/src/client/components/segment-cache/cache.test.ts packages/next/src/client/components/segment-cache/vary-path.test.ts`
- `pnpm testonly packages/next/src/client/components/router-reducer/compute-changed-path.test.ts packages/next/src/client/flight-data-helpers.test.ts packages/next/src/server/app-render/postponed-state.test.ts`
- `pnpm test-start-turbo test/e2e/app-dir-export/test/dynamic-fallback-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-route-shapes-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-cache-components-basepath.test.ts test/e2e/app-dir-export/test/dynamic-fallback-optimizations-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-known-params-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-conflict.test.ts`
- `pnpm test-start-turbo test/e2e/app-dir/output-export-dynamic-fallbacks/output-export-dynamic-fallbacks.test.ts test/e2e/app-dir-export/test/output-export-server-io.test.ts test/e2e/app-dir-export/test/output-export-server-io-use-cache.test.ts test/e2e/app-dir-export/test/dynamic-fallback-server-params.test.ts`

<!-- NEXT_JS_LLM_PR -->
