### PR TITLE
(7/19) Cover export fallback server-only boundaries

### DIFF
--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params-suspense/app/layout.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params-suspense/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params-suspense/app/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params-suspense/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>home</p>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params-suspense/app/wrapped/[slug]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params-suspense/app/wrapped/[slug]/page.js
@@ -1,0 +1,15 @@
+import { Suspense } from 'react'
+
+async function ParamContent({ params }) {
+  const { slug } = await params
+
+  return <h1>{slug}</h1>
+}
+
+export default function WrappedDynamicServerPage({ params }) {
+  return (
+    <Suspense fallback={<p>loading</p>}>
+      <ParamContent params={params} />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params-suspense/next.config.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params-suspense/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  output: 'export',
+  cacheComponents: true,
+  experimental: {
+    outputExportDynamicFallbacks: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params-sync/app/another/[slug]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params-sync/app/another/[slug]/page.js
@@ -1,0 +1,5 @@
+export default function DynamicServerPage({ params }) {
+  const slug = params.slug
+
+  return <h1>{slug}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params-sync/app/layout.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params-sync/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params-sync/app/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params-sync/app/page.js
@@ -1,0 +1,3 @@
+export default function HomePage() {
+  return <h1>Home</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params-sync/next.config.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params-sync/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  output: 'export',
+  cacheComponents: true,
+  experimental: {
+    outputExportDynamicFallbacks: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params/app/another/[slug]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params/app/another/[slug]/page.js
@@ -1,0 +1,5 @@
+export default async function DynamicServerPage({ params }) {
+  const { slug } = await params
+
+  return <h1>{slug}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params/app/layout.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params/app/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params/app/page.js
@@ -1,0 +1,3 @@
+export default function HomePage() {
+  return <h1>Home</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params/next.config.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  output: 'export',
+  cacheComponents: true,
+  experimental: {
+    outputExportDynamicFallbacks: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir-export/fixtures/output-export-server-connection-suspense/app/layout.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-connection-suspense/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-connection-suspense/app/needs-connection/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-connection-suspense/app/needs-connection/page.js
@@ -1,0 +1,16 @@
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+
+async function ConnectionContent() {
+  await connection()
+
+  return <h1>connected</h1>
+}
+
+export default function ConnectionPage() {
+  return (
+    <Suspense fallback={<p>loading</p>}>
+      <ConnectionContent />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-connection-suspense/app/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-connection-suspense/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>home</p>
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-connection-suspense/next.config.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-connection-suspense/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  output: 'export',
+  cacheComponents: true,
+  experimental: {
+    outputExportDynamicFallbacks: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir-export/fixtures/output-export-server-connection/app/layout.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-connection/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-connection/app/needs-connection/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-connection/app/needs-connection/page.js
@@ -1,0 +1,7 @@
+import { connection } from 'next/server'
+
+export default async function ConnectionPage() {
+  await connection()
+
+  return <h1>connected</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-connection/app/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-connection/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>home</p>
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-connection/next.config.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-connection/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  output: 'export',
+  cacheComponents: true,
+  experimental: {
+    outputExportDynamicFallbacks: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir-export/fixtures/output-export-server-cookies-suspense/app/layout.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-cookies-suspense/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-cookies-suspense/app/needs-cookies/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-cookies-suspense/app/needs-cookies/page.js
@@ -1,0 +1,16 @@
+import { Suspense } from 'react'
+import { cookies } from 'next/headers'
+
+async function CookiesContent() {
+  const cookieStore = await cookies()
+
+  return <h1>{cookieStore.get('theme')?.value}</h1>
+}
+
+export default function CookiesPage() {
+  return (
+    <Suspense fallback={<p>loading</p>}>
+      <CookiesContent />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-cookies-suspense/app/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-cookies-suspense/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>home</p>
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-cookies-suspense/next.config.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-cookies-suspense/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  output: 'export',
+  cacheComponents: true,
+  experimental: {
+    outputExportDynamicFallbacks: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir-export/fixtures/output-export-server-cookies/app/layout.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-cookies/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-cookies/app/needs-cookies/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-cookies/app/needs-cookies/page.js
@@ -1,0 +1,7 @@
+import { cookies } from 'next/headers'
+
+export default async function CookiesPage() {
+  const cookieStore = await cookies()
+
+  return <h1>{cookieStore.get('theme')?.value}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-cookies/app/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-cookies/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>home</p>
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-cookies/next.config.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-cookies/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  output: 'export',
+  cacheComponents: true,
+  experimental: {
+    outputExportDynamicFallbacks: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir-export/fixtures/output-export-server-headers-suspense/app/layout.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-headers-suspense/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-headers-suspense/app/needs-headers/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-headers-suspense/app/needs-headers/page.js
@@ -1,0 +1,16 @@
+import { Suspense } from 'react'
+import { headers } from 'next/headers'
+
+async function HeadersContent() {
+  const requestHeaders = await headers()
+
+  return <h1>{requestHeaders.get('user-agent')}</h1>
+}
+
+export default function HeadersPage() {
+  return (
+    <Suspense fallback={<p>loading</p>}>
+      <HeadersContent />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-headers-suspense/app/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-headers-suspense/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>home</p>
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-headers-suspense/next.config.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-headers-suspense/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  output: 'export',
+  cacheComponents: true,
+  experimental: {
+    outputExportDynamicFallbacks: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir-export/fixtures/output-export-server-headers/app/layout.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-headers/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-headers/app/needs-headers/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-headers/app/needs-headers/page.js
@@ -1,0 +1,7 @@
+import { headers } from 'next/headers'
+
+export default async function HeadersPage() {
+  const requestHeaders = await headers()
+
+  return <h1>{requestHeaders.get('user-agent')}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-headers/app/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-headers/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>home</p>
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-headers/next.config.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-headers/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  output: 'export',
+  cacheComponents: true,
+  experimental: {
+    outputExportDynamicFallbacks: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir-export/fixtures/output-export-server-io-use-cache/app/cached-crypto/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-io-use-cache/app/cached-crypto/page.js
@@ -1,0 +1,14 @@
+async function getCachedCryptoValue() {
+  'use cache'
+
+  return crypto.randomUUID()
+}
+
+export default async function CachedCryptoPage() {
+  return (
+    <>
+      <p>Cached crypto</p>
+      <h1 id="value">{await getCachedCryptoValue()}</h1>
+    </>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-io-use-cache/app/cached-random/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-io-use-cache/app/cached-random/page.js
@@ -1,0 +1,14 @@
+async function getCachedRandom() {
+  'use cache'
+
+  return Math.random()
+}
+
+export default async function CachedRandomPage() {
+  return (
+    <>
+      <p>Cached random</p>
+      <h1 id="value">{String(await getCachedRandom())}</h1>
+    </>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-io-use-cache/app/cached-time/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-io-use-cache/app/cached-time/page.js
@@ -1,0 +1,14 @@
+async function getCachedTime() {
+  'use cache'
+
+  return Date.now()
+}
+
+export default async function CachedTimePage() {
+  return (
+    <>
+      <p>Cached time</p>
+      <h1 id="value">{String(await getCachedTime())}</h1>
+    </>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-io-use-cache/app/layout.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-io-use-cache/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-io-use-cache/app/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-io-use-cache/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>home</p>
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-io-use-cache/next.config.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-io-use-cache/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  output: 'export',
+  cacheComponents: true,
+  experimental: {
+    outputExportDynamicFallbacks: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir-export/fixtures/output-export-server-io/app/cached-request/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-io/app/cached-request/page.js
@@ -1,0 +1,12 @@
+import { headers } from 'next/headers'
+
+async function getHeadersInCache() {
+  'use cache'
+
+  const requestHeaders = await headers()
+  return requestHeaders.get('user-agent') ?? 'unknown'
+}
+
+export default async function CachedRequestPage() {
+  return <h1>{await getHeadersInCache()}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-io/app/layout.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-io/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-io/app/needs-crypto/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-io/app/needs-crypto/page.js
@@ -1,0 +1,3 @@
+export default function CryptoPage() {
+  return <h1>{crypto.randomUUID()}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-io/app/needs-random/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-io/app/needs-random/page.js
@@ -1,0 +1,3 @@
+export default function RandomPage() {
+  return <h1>{Math.random()}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-io/app/needs-time/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-io/app/needs-time/page.js
@@ -1,0 +1,3 @@
+export default function TimePage() {
+  return <h1>{Date.now()}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-io/app/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-io/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>home</p>
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-io/next.config.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-io/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  output: 'export',
+  cacheComponents: true,
+  experimental: {
+    outputExportDynamicFallbacks: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir-export/fixtures/output-export-server-search-params-suspense/app/layout.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-search-params-suspense/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-search-params-suspense/app/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-search-params-suspense/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>home</p>
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-search-params-suspense/app/search/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-search-params-suspense/app/search/page.js
@@ -1,0 +1,15 @@
+import { Suspense } from 'react'
+
+async function SearchContent({ searchParams }) {
+  const query = await searchParams
+
+  return <h1>{query.q}</h1>
+}
+
+export default function SearchPage({ searchParams }) {
+  return (
+    <Suspense fallback={<p>loading</p>}>
+      <SearchContent searchParams={searchParams} />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-search-params-suspense/next.config.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-search-params-suspense/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  output: 'export',
+  cacheComponents: true,
+  experimental: {
+    outputExportDynamicFallbacks: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir-export/fixtures/output-export-server-search-params/app/layout.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-search-params/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-search-params/app/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-search-params/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>home</p>
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-search-params/app/search/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-search-params/app/search/page.js
@@ -1,0 +1,5 @@
+export default async function SearchPage({ searchParams }) {
+  const query = await searchParams
+
+  return <h1>{query.q}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-search-params/next.config.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-search-params/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  output: 'export',
+  cacheComponents: true,
+  experimental: {
+    outputExportDynamicFallbacks: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir-export/test/dynamic-fallback-server-params-suspense.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-fallback-server-params-suspense.test.ts
@@ -1,0 +1,70 @@
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import {
+  expectOutputExportDevRedbox,
+  startOutputExportDevServer,
+} from './utils'
+
+const { next, skipped, isNextDev } = nextTestSetup({
+  files: join(
+    __dirname,
+    '..',
+    'fixtures',
+    'dynamic-fallback-server-params-suspense'
+  ),
+  skipStart: true,
+  skipDeployment: true,
+  disableAutoSkewProtection: true,
+})
+
+if (skipped) {
+  describe.skip('app dir - output export fallback server params suspense', () => {})
+} else {
+  const describeDevelopment = isNextDev ? describe : describe.skip
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  describeDevelopment(
+    'app dir - output export fallback server params suspense',
+    () => {
+      let port: number
+
+      beforeAll(async () => {
+        port = await startOutputExportDevServer(next)
+      })
+
+      afterAll(async () => {
+        await next.destroy()
+      })
+
+      it('shows a redbox even when unresolved fallback params are only read behind Suspense', async () => {
+        await expectOutputExportDevRedbox({
+          port,
+          path: '/wrapped/first',
+          expectedMessage:
+            'used unresolved dynamic params in a Server Component with "output: export"',
+          expectedSource: 'await params',
+        })
+      })
+    }
+  )
+
+  describeProduction(
+    'app dir - output export fallback server params suspense',
+    () => {
+      afterAll(async () => {
+        await next.destroy()
+      })
+
+      it('errors even when unresolved fallback params are only read behind Suspense', async () => {
+        const { exitCode, cliOutput } = await next.build()
+
+        expect(exitCode).toBe(1)
+        expect(cliOutput).toContain(
+          'used unresolved dynamic params in a Server Component with "output: export"'
+        )
+        expect(cliOutput).toContain('/wrapped/[slug]')
+        expect(cliOutput).toContain('Client Component')
+      })
+    }
+  )
+}

--- a/test/e2e/app-dir-export/test/dynamic-fallback-server-params-sync.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-fallback-server-params-sync.test.ts
@@ -1,0 +1,71 @@
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import {
+  expectOutputExportDevRedbox,
+  startOutputExportDevServer,
+} from './utils'
+
+const { next, skipped, isNextDev } = nextTestSetup({
+  files: join(
+    __dirname,
+    '..',
+    'fixtures',
+    'dynamic-fallback-server-params-sync'
+  ),
+  skipStart: true,
+  skipDeployment: true,
+  disableAutoSkewProtection: true,
+})
+
+if (skipped) {
+  describe.skip('app dir - output export fallback server params sync access', () => {})
+} else {
+  const describeDevelopment = isNextDev ? describe : describe.skip
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  describeDevelopment(
+    'app dir - output export fallback server params sync access',
+    () => {
+      let port: number
+
+      beforeAll(async () => {
+        port = await startOutputExportDevServer(next)
+      })
+
+      afterAll(async () => {
+        await next.destroy()
+      })
+
+      it('shows a redbox when a Server Component reads unresolved fallback params synchronously', async () => {
+        await expectOutputExportDevRedbox({
+          port,
+          path: '/another/first',
+          expectedMessage:
+            'used unresolved dynamic params in a Server Component with "output: export"',
+          expectedSource: 'params.slug',
+        })
+      })
+    }
+  )
+
+  describeProduction(
+    'app dir - output export fallback server params sync access',
+    () => {
+      afterAll(async () => {
+        await next.destroy()
+      })
+
+      it('errors when a Server Component reads unresolved fallback params synchronously', async () => {
+        const { exitCode, cliOutput } = await next.build()
+
+        expect(exitCode).toBe(1)
+        expect(cliOutput).toContain(
+          'used unresolved dynamic params in a Server Component with "output: export"'
+        )
+        expect(cliOutput).toContain('/another/[slug]')
+        expect(cliOutput).toContain('generateStaticParams()')
+        expect(cliOutput).toContain('Client Component')
+      })
+    }
+  )
+}

--- a/test/e2e/app-dir-export/test/dynamic-fallback-server-params.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-fallback-server-params.test.ts
@@ -1,0 +1,60 @@
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import {
+  expectOutputExportDevRedbox,
+  startOutputExportDevServer,
+} from './utils'
+
+const { next, skipped, isNextDev } = nextTestSetup({
+  files: join(__dirname, '..', 'fixtures', 'dynamic-fallback-server-params'),
+  skipStart: true,
+  skipDeployment: true,
+  disableAutoSkewProtection: true,
+})
+
+if (skipped) {
+  describe.skip('app dir - output export fallback server params', () => {})
+} else {
+  const describeDevelopment = isNextDev ? describe : describe.skip
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  describeDevelopment('app dir - output export fallback server params', () => {
+    let port: number
+
+    beforeAll(async () => {
+      port = await startOutputExportDevServer(next)
+    })
+
+    afterAll(async () => {
+      await next.destroy()
+    })
+
+    it('shows a redbox when a Server Component awaits unresolved fallback params', async () => {
+      await expectOutputExportDevRedbox({
+        port,
+        path: '/another/first',
+        expectedMessage:
+          'used unresolved dynamic params in a Server Component with "output: export"',
+        expectedSource: 'await params',
+      })
+    })
+  })
+
+  describeProduction('app dir - output export fallback server params', () => {
+    afterAll(async () => {
+      await next.destroy()
+    })
+
+    it('errors when a Server Component awaits unresolved fallback params', async () => {
+      const { exitCode, cliOutput } = await next.build()
+
+      expect(exitCode).toBe(1)
+      expect(cliOutput).toContain(
+        'used unresolved dynamic params in a Server Component with "output: export"'
+      )
+      expect(cliOutput).toContain('/another/[slug]')
+      expect(cliOutput).toContain('generateStaticParams()')
+      expect(cliOutput).toContain('Client Component')
+    })
+  })
+}

--- a/test/e2e/app-dir-export/test/output-export-server-connection-suspense.test.ts
+++ b/test/e2e/app-dir-export/test/output-export-server-connection-suspense.test.ts
@@ -1,0 +1,70 @@
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import {
+  expectOutputExportDevRedbox,
+  startOutputExportDevServer,
+} from './utils'
+
+const { next, skipped, isNextDev } = nextTestSetup({
+  files: join(
+    __dirname,
+    '..',
+    'fixtures',
+    'output-export-server-connection-suspense'
+  ),
+  skipStart: true,
+  skipDeployment: true,
+  disableAutoSkewProtection: true,
+})
+
+if (skipped) {
+  describe.skip('app dir - output export server connection suspense', () => {})
+} else {
+  const describeDevelopment = isNextDev ? describe : describe.skip
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  describeDevelopment(
+    'app dir - output export server connection suspense',
+    () => {
+      let port: number
+
+      beforeAll(async () => {
+        port = await startOutputExportDevServer(next)
+      })
+
+      afterAll(async () => {
+        await next.destroy()
+      })
+
+      it('shows a redbox even when connection() is only awaited behind Suspense', async () => {
+        await expectOutputExportDevRedbox({
+          port,
+          path: '/needs-connection',
+          expectedMessage:
+            'used `connection()` in a Server Component with "output: export"',
+          expectedSource: 'await connection()',
+        })
+      })
+    }
+  )
+
+  describeProduction(
+    'app dir - output export server connection suspense',
+    () => {
+      afterAll(async () => {
+        await next.destroy()
+      })
+
+      it('errors even when connection() is only awaited behind Suspense', async () => {
+        const { exitCode, cliOutput } = await next.build()
+
+        expect(exitCode).toBe(1)
+        expect(cliOutput).toContain(
+          'used `connection()` in a Server Component with "output: export"'
+        )
+        expect(cliOutput).toContain('/needs-connection')
+        expect(cliOutput).toContain('runtime server request')
+      })
+    }
+  )
+}

--- a/test/e2e/app-dir-export/test/output-export-server-connection.test.ts
+++ b/test/e2e/app-dir-export/test/output-export-server-connection.test.ts
@@ -1,0 +1,59 @@
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import {
+  expectOutputExportDevRedbox,
+  startOutputExportDevServer,
+} from './utils'
+
+const { next, skipped, isNextDev } = nextTestSetup({
+  files: join(__dirname, '..', 'fixtures', 'output-export-server-connection'),
+  skipStart: true,
+  skipDeployment: true,
+  disableAutoSkewProtection: true,
+})
+
+if (skipped) {
+  describe.skip('app dir - output export server connection', () => {})
+} else {
+  const describeDevelopment = isNextDev ? describe : describe.skip
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  describeDevelopment('app dir - output export server connection', () => {
+    let port: number
+
+    beforeAll(async () => {
+      port = await startOutputExportDevServer(next)
+    })
+
+    afterAll(async () => {
+      await next.destroy()
+    })
+
+    it('shows a redbox when a Server Component awaits connection() in output export', async () => {
+      await expectOutputExportDevRedbox({
+        port,
+        path: '/needs-connection',
+        expectedMessage:
+          'used `connection()` in a Server Component with "output: export"',
+        expectedSource: 'await connection()',
+      })
+    })
+  })
+
+  describeProduction('app dir - output export server connection', () => {
+    afterAll(async () => {
+      await next.destroy()
+    })
+
+    it('errors when a Server Component awaits connection() in output export', async () => {
+      const { exitCode, cliOutput } = await next.build()
+
+      expect(exitCode).toBe(1)
+      expect(cliOutput).toContain(
+        'used `connection()` in a Server Component with "output: export"'
+      )
+      expect(cliOutput).toContain('/needs-connection')
+      expect(cliOutput).toContain('runtime server request')
+    })
+  })
+}

--- a/test/e2e/app-dir-export/test/output-export-server-cookies-suspense.test.ts
+++ b/test/e2e/app-dir-export/test/output-export-server-cookies-suspense.test.ts
@@ -1,0 +1,64 @@
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import {
+  expectOutputExportDevRedbox,
+  startOutputExportDevServer,
+} from './utils'
+
+const { next, skipped, isNextDev } = nextTestSetup({
+  files: join(
+    __dirname,
+    '..',
+    'fixtures',
+    'output-export-server-cookies-suspense'
+  ),
+  skipStart: true,
+  skipDeployment: true,
+  disableAutoSkewProtection: true,
+})
+
+if (skipped) {
+  describe.skip('app dir - output export server cookies suspense', () => {})
+} else {
+  const describeDevelopment = isNextDev ? describe : describe.skip
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  describeDevelopment('app dir - output export server cookies suspense', () => {
+    let port: number
+
+    beforeAll(async () => {
+      port = await startOutputExportDevServer(next)
+    })
+
+    afterAll(async () => {
+      await next.destroy()
+    })
+
+    it('shows a redbox even when cookies() is only read behind Suspense', async () => {
+      await expectOutputExportDevRedbox({
+        port,
+        path: '/needs-cookies',
+        expectedMessage:
+          'used `cookies()` in a Server Component with "output: export"',
+        expectedSource: 'await cookies()',
+      })
+    })
+  })
+
+  describeProduction('app dir - output export server cookies suspense', () => {
+    afterAll(async () => {
+      await next.destroy()
+    })
+
+    it('errors even when cookies() is only read behind Suspense', async () => {
+      const { exitCode, cliOutput } = await next.build()
+
+      expect(exitCode).toBe(1)
+      expect(cliOutput).toContain(
+        'used `cookies()` in a Server Component with "output: export"'
+      )
+      expect(cliOutput).toContain('/needs-cookies')
+      expect(cliOutput).toContain('runtime server request')
+    })
+  })
+}

--- a/test/e2e/app-dir-export/test/output-export-server-cookies.test.ts
+++ b/test/e2e/app-dir-export/test/output-export-server-cookies.test.ts
@@ -1,0 +1,59 @@
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import {
+  expectOutputExportDevRedbox,
+  startOutputExportDevServer,
+} from './utils'
+
+const { next, skipped, isNextDev } = nextTestSetup({
+  files: join(__dirname, '..', 'fixtures', 'output-export-server-cookies'),
+  skipStart: true,
+  skipDeployment: true,
+  disableAutoSkewProtection: true,
+})
+
+if (skipped) {
+  describe.skip('app dir - output export server cookies', () => {})
+} else {
+  const describeDevelopment = isNextDev ? describe : describe.skip
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  describeDevelopment('app dir - output export server cookies', () => {
+    let port: number
+
+    beforeAll(async () => {
+      port = await startOutputExportDevServer(next)
+    })
+
+    afterAll(async () => {
+      await next.destroy()
+    })
+
+    it('shows a redbox when a Server Component awaits cookies() in output export', async () => {
+      await expectOutputExportDevRedbox({
+        port,
+        path: '/needs-cookies',
+        expectedMessage:
+          'used `cookies()` in a Server Component with "output: export"',
+        expectedSource: 'await cookies()',
+      })
+    })
+  })
+
+  describeProduction('app dir - output export server cookies', () => {
+    afterAll(async () => {
+      await next.destroy()
+    })
+
+    it('errors when a Server Component awaits cookies() in output export', async () => {
+      const { exitCode, cliOutput } = await next.build()
+
+      expect(exitCode).toBe(1)
+      expect(cliOutput).toContain(
+        'used `cookies()` in a Server Component with "output: export"'
+      )
+      expect(cliOutput).toContain('/needs-cookies')
+      expect(cliOutput).toContain('runtime server request')
+    })
+  })
+}

--- a/test/e2e/app-dir-export/test/output-export-server-headers-suspense.test.ts
+++ b/test/e2e/app-dir-export/test/output-export-server-headers-suspense.test.ts
@@ -1,0 +1,64 @@
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import {
+  expectOutputExportDevRedbox,
+  startOutputExportDevServer,
+} from './utils'
+
+const { next, skipped, isNextDev } = nextTestSetup({
+  files: join(
+    __dirname,
+    '..',
+    'fixtures',
+    'output-export-server-headers-suspense'
+  ),
+  skipStart: true,
+  skipDeployment: true,
+  disableAutoSkewProtection: true,
+})
+
+if (skipped) {
+  describe.skip('app dir - output export server headers suspense', () => {})
+} else {
+  const describeDevelopment = isNextDev ? describe : describe.skip
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  describeDevelopment('app dir - output export server headers suspense', () => {
+    let port: number
+
+    beforeAll(async () => {
+      port = await startOutputExportDevServer(next)
+    })
+
+    afterAll(async () => {
+      await next.destroy()
+    })
+
+    it('shows a redbox even when headers() is only read behind Suspense', async () => {
+      await expectOutputExportDevRedbox({
+        port,
+        path: '/needs-headers',
+        expectedMessage:
+          'used `headers()` in a Server Component with "output: export"',
+        expectedSource: 'await headers()',
+      })
+    })
+  })
+
+  describeProduction('app dir - output export server headers suspense', () => {
+    afterAll(async () => {
+      await next.destroy()
+    })
+
+    it('errors even when headers() is only read behind Suspense', async () => {
+      const { exitCode, cliOutput } = await next.build()
+
+      expect(exitCode).toBe(1)
+      expect(cliOutput).toContain(
+        'used `headers()` in a Server Component with "output: export"'
+      )
+      expect(cliOutput).toContain('/needs-headers')
+      expect(cliOutput).toContain('runtime server request')
+    })
+  })
+}

--- a/test/e2e/app-dir-export/test/output-export-server-headers.test.ts
+++ b/test/e2e/app-dir-export/test/output-export-server-headers.test.ts
@@ -1,0 +1,59 @@
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import {
+  expectOutputExportDevRedbox,
+  startOutputExportDevServer,
+} from './utils'
+
+const { next, skipped, isNextDev } = nextTestSetup({
+  files: join(__dirname, '..', 'fixtures', 'output-export-server-headers'),
+  skipStart: true,
+  skipDeployment: true,
+  disableAutoSkewProtection: true,
+})
+
+if (skipped) {
+  describe.skip('app dir - output export server headers', () => {})
+} else {
+  const describeDevelopment = isNextDev ? describe : describe.skip
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  describeDevelopment('app dir - output export server headers', () => {
+    let port: number
+
+    beforeAll(async () => {
+      port = await startOutputExportDevServer(next)
+    })
+
+    afterAll(async () => {
+      await next.destroy()
+    })
+
+    it('shows a redbox when a Server Component awaits headers() in output export', async () => {
+      await expectOutputExportDevRedbox({
+        port,
+        path: '/needs-headers',
+        expectedMessage:
+          'used `headers()` in a Server Component with "output: export"',
+        expectedSource: 'await headers()',
+      })
+    })
+  })
+
+  describeProduction('app dir - output export server headers', () => {
+    afterAll(async () => {
+      await next.destroy()
+    })
+
+    it('errors when a Server Component awaits headers() in output export', async () => {
+      const { exitCode, cliOutput } = await next.build()
+
+      expect(exitCode).toBe(1)
+      expect(cliOutput).toContain(
+        'used `headers()` in a Server Component with "output: export"'
+      )
+      expect(cliOutput).toContain('/needs-headers')
+      expect(cliOutput).toContain('runtime server request')
+    })
+  })
+}

--- a/test/e2e/app-dir-export/test/output-export-server-io-use-cache.test.ts
+++ b/test/e2e/app-dir-export/test/output-export-server-io-use-cache.test.ts
@@ -1,0 +1,69 @@
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import fs from 'fs-extra'
+
+const { next, skipped, isNextDev } = nextTestSetup({
+  files: join(__dirname, '..', 'fixtures', 'output-export-server-io-use-cache'),
+  skipStart: true,
+  skipDeployment: true,
+  disableAutoSkewProtection: true,
+})
+
+if (skipped) {
+  describe.skip('app dir - output export server io use cache', () => {})
+} else {
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  describeProduction('app dir - output export server io use cache', () => {
+    let cliOutput: string
+
+    beforeAll(async () => {
+      const result = await next.build()
+
+      if (result.exitCode !== 0) {
+        throw new Error(`Expected build to pass:\n${result.cliOutput}`)
+      }
+
+      cliOutput = result.cliOutput
+    })
+
+    afterAll(async () => {
+      await next.destroy()
+    })
+
+    it('exports Date.now() successfully when the read is wrapped in use cache', async () => {
+      const html = await fs.readFile(
+        join(next.testDir, 'out', 'cached-time.html'),
+        'utf8'
+      )
+
+      expect(cliOutput).not.toContain('used `Date.now()`')
+      expect(html).toContain('Cached time')
+      expect(html).toMatch(/<h1 id="value">\d+<\/h1>/)
+    })
+
+    it('exports Math.random() successfully when the read is wrapped in use cache', async () => {
+      const html = await fs.readFile(
+        join(next.testDir, 'out', 'cached-random.html'),
+        'utf8'
+      )
+
+      expect(cliOutput).not.toContain('used `Math.random()`')
+      expect(html).toContain('Cached random')
+      expect(html).toMatch(/<h1 id="value">0?\.\d+<\/h1>/)
+    })
+
+    it('exports crypto.randomUUID() successfully when the read is wrapped in use cache', async () => {
+      const html = await fs.readFile(
+        join(next.testDir, 'out', 'cached-crypto.html'),
+        'utf8'
+      )
+
+      expect(cliOutput).not.toContain('used `crypto.randomUUID()`')
+      expect(html).toContain('Cached crypto')
+      expect(html).toMatch(
+        /<h1 id="value">[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}<\/h1>/i
+      )
+    })
+  })
+}

--- a/test/e2e/app-dir-export/test/output-export-server-io.test.ts
+++ b/test/e2e/app-dir-export/test/output-export-server-io.test.ts
@@ -1,0 +1,117 @@
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import {
+  expectOutputExportDevCollapsedRedbox,
+  expectOutputExportDevRedbox,
+  startOutputExportDevServer,
+} from './utils'
+
+const { next, skipped, isNextDev } = nextTestSetup({
+  files: join(__dirname, '..', 'fixtures', 'output-export-server-io'),
+  skipStart: true,
+  skipDeployment: true,
+  disableAutoSkewProtection: true,
+})
+
+if (skipped) {
+  describe.skip('app dir - output export server io', () => {})
+} else {
+  const describeDevelopment = isNextDev ? describe : describe.skip
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  describeDevelopment('app dir - output export server io', () => {
+    let port: number
+
+    beforeAll(async () => {
+      port = await startOutputExportDevServer(next)
+    })
+
+    afterAll(async () => {
+      await next.destroy()
+    })
+
+    it('shows a redbox when Date.now() is read outside use cache', async () => {
+      await expectOutputExportDevCollapsedRedbox({
+        port,
+        path: '/needs-time',
+        expectedMessage:
+          'used `Date.now()` before accessing either uncached data',
+        expectedSource: 'Date.now()',
+      })
+    })
+
+    it('shows a redbox when Math.random() is read outside use cache', async () => {
+      await expectOutputExportDevCollapsedRedbox({
+        port,
+        path: '/needs-random',
+        expectedMessage:
+          'used `Math.random()` before accessing either uncached data',
+        expectedSource: 'Math.random()',
+      })
+    })
+
+    it('shows a redbox when crypto.randomUUID() is read outside use cache', async () => {
+      await expectOutputExportDevCollapsedRedbox({
+        port,
+        path: '/needs-crypto',
+        expectedMessage:
+          'used `crypto.randomUUID()` before accessing either uncached data',
+        expectedSource: 'crypto.randomUUID()',
+      })
+    })
+
+    it('still shows a redbox when request APIs are used inside use cache', async () => {
+      await expectOutputExportDevRedbox({
+        port,
+        path: '/cached-request',
+        expectedMessage: 'used `headers()` inside "use cache"',
+        expectedSource: 'await headers()',
+      })
+    })
+  })
+
+  describeProduction('app dir - output export server io', () => {
+    afterAll(async () => {
+      await next.destroy()
+    })
+
+    it.each([
+      [
+        '/needs-time',
+        'app/needs-time/page.js',
+        'used `Date.now()` before accessing either uncached data',
+      ],
+      [
+        '/needs-random',
+        'app/needs-random/page.js',
+        'used `Math.random()` before accessing either uncached data',
+      ],
+      [
+        '/needs-crypto',
+        'app/needs-crypto/page.js',
+        'used `crypto.randomUUID()` before accessing either uncached data',
+      ],
+    ])(
+      'errors when sync IO is used outside use cache for %s in output export',
+      async (route, buildPath, expectedMessage) => {
+        const { exitCode, cliOutput } = await next.build({
+          args: ['--debug-build-paths', buildPath],
+        })
+
+        expect(exitCode).toBe(1)
+        expect(cliOutput).toContain(expectedMessage)
+        expect(cliOutput).toContain(route)
+      }
+    )
+
+    it('still errors when request APIs are used inside use cache in output export', async () => {
+      const { exitCode, cliOutput } = await next.build({
+        args: ['--debug-build-paths', 'app/cached-request/page.js'],
+      })
+
+      expect(exitCode).toBe(1)
+      expect(cliOutput).toContain('used `headers()` inside "use cache"')
+      expect(cliOutput).toContain('/cached-request')
+    })
+  })
+}

--- a/test/e2e/app-dir-export/test/output-export-server-search-params-suspense.test.ts
+++ b/test/e2e/app-dir-export/test/output-export-server-search-params-suspense.test.ts
@@ -1,0 +1,69 @@
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import {
+  expectOutputExportDevRedbox,
+  startOutputExportDevServer,
+} from './utils'
+
+const { next, skipped, isNextDev } = nextTestSetup({
+  files: join(
+    __dirname,
+    '..',
+    'fixtures',
+    'output-export-server-search-params-suspense'
+  ),
+  skipStart: true,
+  skipDeployment: true,
+  disableAutoSkewProtection: true,
+})
+
+if (skipped) {
+  describe.skip('app dir - output export server search params suspense', () => {})
+} else {
+  const describeDevelopment = isNextDev ? describe : describe.skip
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  describeDevelopment(
+    'app dir - output export server search params suspense',
+    () => {
+      let port: number
+
+      beforeAll(async () => {
+        port = await startOutputExportDevServer(next)
+      })
+
+      afterAll(async () => {
+        await next.destroy()
+      })
+
+      it('shows a redbox even when searchParams are only read behind Suspense', async () => {
+        await expectOutputExportDevRedbox({
+          port,
+          path: '/search?q=hello',
+          expectedMessage:
+            'used `searchParams` in a Server Component with "output: export"',
+        })
+      })
+    }
+  )
+
+  describeProduction(
+    'app dir - output export server search params suspense',
+    () => {
+      afterAll(async () => {
+        await next.destroy()
+      })
+
+      it('errors even when searchParams are only read behind Suspense', async () => {
+        const { exitCode, cliOutput } = await next.build()
+
+        expect(exitCode).toBe(1)
+        expect(cliOutput).toContain(
+          'used `searchParams` in a Server Component with "output: export"'
+        )
+        expect(cliOutput).toContain('/search')
+        expect(cliOutput).toContain('Client Component')
+      })
+    }
+  )
+}

--- a/test/e2e/app-dir-export/test/output-export-server-search-params.test.ts
+++ b/test/e2e/app-dir-export/test/output-export-server-search-params.test.ts
@@ -1,0 +1,63 @@
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import {
+  expectOutputExportDevRedbox,
+  startOutputExportDevServer,
+} from './utils'
+
+const { next, skipped, isNextDev } = nextTestSetup({
+  files: join(
+    __dirname,
+    '..',
+    'fixtures',
+    'output-export-server-search-params'
+  ),
+  skipStart: true,
+  skipDeployment: true,
+  disableAutoSkewProtection: true,
+})
+
+if (skipped) {
+  describe.skip('app dir - output export server search params', () => {})
+} else {
+  const describeDevelopment = isNextDev ? describe : describe.skip
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  describeDevelopment('app dir - output export server search params', () => {
+    let port: number
+
+    beforeAll(async () => {
+      port = await startOutputExportDevServer(next)
+    })
+
+    afterAll(async () => {
+      await next.destroy()
+    })
+
+    it('shows a redbox when a Server Component awaits searchParams in output export', async () => {
+      await expectOutputExportDevRedbox({
+        port,
+        path: '/search?q=hello',
+        expectedMessage:
+          'used `searchParams` in a Server Component with "output: export"',
+      })
+    })
+  })
+
+  describeProduction('app dir - output export server search params', () => {
+    afterAll(async () => {
+      await next.destroy()
+    })
+
+    it('errors when a Server Component awaits searchParams in output export', async () => {
+      const { exitCode, cliOutput } = await next.build()
+
+      expect(exitCode).toBe(1)
+      expect(cliOutput).toContain(
+        'used `searchParams` in a Server Component with "output: export"'
+      )
+      expect(cliOutput).toContain('/search')
+      expect(cliOutput).toContain('Client Component')
+    })
+  })
+}


### PR DESCRIPTION
## Stack position

Part 7 of 19 in the output export dynamic fallback stack.

Previous PR: #93567 (6/19)
Next PR: #93559 (8/19)

## Context

The stack is split so build-time output can land behind `experimental.outputExportDynamicFallbacks` before the client router behavior is enabled. The target behavior is for `output: 'export'` apps with parameterized App Router routes to emit fallback HTML/RSC artifacts that a later client can resolve for hard loads and soft navigations.

This PR scope: E2E coverage for unsupported server-only fallback routes.

Before adding client routing, this locks down the negative build-time behavior from the server-boundary PR so invalid fallback output does not quietly slip through.

## What changed

- Adds e2e coverage for server params and server request/data APIs under export dynamic fallbacks.
- Covers expected build failures for unsupported Server Component usage.
- Uses the shared export fallback helpers from the previous PR.

## Deliberately not included

- Does not test client soft navigation.
- Does not add new fallback output formats.
- Does not change runtime behavior.

## Verification

After restacking and autosquashing, I verified the full stack with:

- `pnpm --filter=next build`
- `pnpm testonly packages/next/src/lib/output-export-dynamic-fallback.test.ts packages/next/src/lib/output-export-fallback-routes.test.ts packages/next/src/export/helpers/output-export-fallback.test.ts packages/next/src/server/request/fallback-params.test.ts`
- `pnpm testonly packages/next/src/client/output-export-fallback.test.ts packages/next/src/client/components/router-reducer/fetch-server-response.test.ts packages/next/src/client/components/router-reducer/create-initial-router-state.test.ts packages/next/src/client/components/segment-cache/cache.test.ts packages/next/src/client/components/segment-cache/vary-path.test.ts`
- `pnpm testonly packages/next/src/client/components/router-reducer/compute-changed-path.test.ts packages/next/src/client/flight-data-helpers.test.ts packages/next/src/server/app-render/postponed-state.test.ts`
- `pnpm test-start-turbo test/e2e/app-dir-export/test/dynamic-fallback-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-route-shapes-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-cache-components-basepath.test.ts test/e2e/app-dir-export/test/dynamic-fallback-optimizations-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-known-params-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-conflict.test.ts`
- `pnpm test-start-turbo test/e2e/app-dir/output-export-dynamic-fallbacks/output-export-dynamic-fallbacks.test.ts test/e2e/app-dir-export/test/output-export-server-io.test.ts test/e2e/app-dir-export/test/output-export-server-io-use-cache.test.ts test/e2e/app-dir-export/test/dynamic-fallback-server-params.test.ts`

<!-- NEXT_JS_LLM_PR -->
