### PR TITLE
(12/19) Fallback to exported RSC for cache misses

### DIFF
--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -28,6 +28,7 @@ import {
 import {
   createFetch,
   createFromNextReadableStream,
+  processFetch,
   type RSCResponse,
   type RequestHeaders,
 } from '../router-reducer/fetch-server-response'
@@ -96,6 +97,7 @@ import type {
   NavigationFlightResponse,
 } from '../../../shared/lib/app-router-types'
 import {
+  fillInFallbackFlightData,
   type NormalizedFlightData,
   normalizeFlightData,
   prepareFlightRouterStateForRequest,
@@ -110,6 +112,11 @@ import { discoverKnownRoute, matchKnownRoute } from './optimistic-routes'
 import { convertServerPatchToFullTree, type NavigationSeed } from './navigation'
 import { getNavigationBuildId } from '../../navigation-build-id'
 import { NEXT_NAV_DEPLOYMENT_ID_HEADER } from '../../../lib/constants'
+
+type OutputExportFallbackModule = typeof import('../../output-export-fallback')
+type OutputExportFallbackResult = Awaited<
+  ReturnType<OutputExportFallbackModule['fetchOutputExportFallbackResponse']>
+>
 
 /**
  * Ensures a minimum stale time of 30s to avoid issues where the server sends a too
@@ -225,6 +232,7 @@ export type FulfilledRouteCacheEntry = RouteCacheEntryShared & {
   tree: RouteTree
   metadata: RouteTree
   supportsPerSegmentPrefetching: boolean
+  hasInlinedSegments: boolean
   outputExportFallbackBasePath: string | null
   // When true, this entry should not be used as a template for route
   // prediction. Set when we discover that the URL was rewritten by middleware
@@ -313,6 +321,13 @@ export const MetadataOnlyRequestTree: FlightRouterState = [
   {},
   null,
   'metadata-only',
+]
+
+const DynamicRequestTreeForEntireRoute: FlightRouterState = [
+  '',
+  {},
+  null,
+  'refetch',
 ]
 
 let routeCacheMap: CacheMap<RouteCacheEntry> = createCacheMap()
@@ -683,6 +698,7 @@ export function deprecated_requestOptimisticRouteCacheEntry(
     couldBeIntercepted: routeWithNoSearchParams.couldBeIntercepted,
     supportsPerSegmentPrefetching:
       routeWithNoSearchParams.supportsPerSegmentPrefetching,
+    hasInlinedSegments: routeWithNoSearchParams.hasInlinedSegments,
     // Output export fallback always enables the new optimistic route matcher,
     // so the deprecated search-param prediction path stays export-agnostic.
     outputExportFallbackBasePath: null,
@@ -1121,6 +1137,7 @@ export function fulfillRouteCacheEntry(
   fulfilledEntry.canonicalUrl = canonicalUrl
   fulfilledEntry.renderedSearch = renderedSearch
   fulfilledEntry.supportsPerSegmentPrefetching = supportsPerSegmentPrefetching
+  fulfilledEntry.hasInlinedSegments = false
   fulfilledEntry.outputExportFallbackBasePath = null
   fulfilledEntry.hasDynamicRewrite = false
   pingBlockedTasks(entry)
@@ -1703,6 +1720,13 @@ export async function fetchRouteOnCacheMiss(
       response.status === 204 ||
       !response.body
     ) {
+      if (process.env.__NEXT_OUTPUT_EXPORT_DYNAMIC_FALLBACKS) {
+        return fetchRouteOnCacheMissFromOutputExportFallback(
+          entry,
+          key,
+          headers
+        )
+      }
       // Server responded with an error, or with a miss. We should still cache
       // the response, but we can try again after 10 seconds.
       rejectRouteCacheEntry(entry, Date.now() + 10 * 1000)
@@ -1908,6 +1932,261 @@ export async function fetchRouteOnCacheMiss(
   }
 }
 
+type OutputExportFallbackNavigationData = {
+  buildId: string
+  closed: Promise<void>
+  couldBeIntercepted: boolean
+  flightDatas: NormalizedFlightData[]
+  headVaryParams: VaryParams | null
+  outputExportFallbackBasePath: string
+  responseSize: number
+  staleAt: number
+  supportsPerSegmentPrefetching: boolean
+}
+
+async function fetchOutputExportFallbackNavigationData(
+  renderedUrl: URL,
+  headers: RequestHeaders,
+  now: number
+): Promise<OutputExportFallbackNavigationData | null> {
+  let fallbackResult: OutputExportFallbackResult
+  if (process.env.__NEXT_OUTPUT_EXPORT_DYNAMIC_FALLBACKS) {
+    const { fetchOutputExportFallbackResponse } =
+      require('../../output-export-fallback') as typeof import('../../output-export-fallback')
+    fallbackResult = await fetchOutputExportFallbackResponse(renderedUrl, {
+      credentials: 'same-origin',
+      headers,
+    })
+  } else {
+    return null
+  }
+
+  if (fallbackResult === null) {
+    return null
+  }
+  const outputExportFallbackBasePath = fallbackResult.fallbackUrl.pathname
+
+  const { response } = await processFetch(fallbackResult.response)
+  if (!response.body) {
+    return null
+  }
+
+  const closed = createPromiseWithResolvers<void>()
+  const { stream: prefetchStream, size: responseSize } =
+    await createNonTaskyPrefetchResponseStream(response.body)
+  closed.resolve()
+
+  const serverData =
+    await createFromNextReadableStream<NavigationFlightResponse>(
+      prefetchStream,
+      headers,
+      { allowPartialStream: true }
+    )
+
+  const buildId =
+    response.headers.get(NEXT_NAV_DEPLOYMENT_ID_HEADER) ?? serverData.b
+  if (buildId !== getNavigationBuildId()) {
+    return null
+  }
+
+  const renderedSearch = renderedUrl.search as NormalizedSearch
+  const headVaryParamsThenable = serverData.h
+  const headVaryParams =
+    headVaryParamsThenable !== null
+      ? readVaryParams(headVaryParamsThenable)
+      : null
+  const patchedFlightData = fillInFallbackFlightData(
+    serverData.f,
+    renderedUrl.pathname,
+    renderedSearch
+  )
+  const flightDatas = normalizeFlightData(patchedFlightData)
+
+  if (typeof flightDatas === 'string') {
+    return null
+  }
+
+  return {
+    buildId,
+    closed: closed.promise,
+    couldBeIntercepted: serverData.i,
+    flightDatas,
+    headVaryParams,
+    outputExportFallbackBasePath,
+    responseSize,
+    staleAt: await getStaleAt(now, serverData.s),
+    supportsPerSegmentPrefetching: serverData.S,
+  }
+}
+
+async function fetchRouteOnCacheMissFromOutputExportFallback(
+  entry: PendingRouteCacheEntry,
+  key: RouteCacheKey,
+  headers: RequestHeaders
+): Promise<PrefetchSubtaskResult<null> | null> {
+  const now = Date.now()
+  const renderedUrl = new URL(key.pathname + key.search, location.origin)
+  const navigationData = await fetchOutputExportFallbackNavigationData(
+    renderedUrl,
+    headers,
+    now
+  )
+
+  if (navigationData === null) {
+    rejectRouteCacheEntry(entry, now + 10 * 1000)
+    return null
+  }
+
+  const {
+    buildId,
+    closed,
+    couldBeIntercepted,
+    flightDatas,
+    headVaryParams,
+    outputExportFallbackBasePath,
+    responseSize,
+    staleAt,
+    supportsPerSegmentPrefetching,
+  } = navigationData
+  const renderedSearch = renderedUrl.search as NormalizedSearch
+  setSizeInCacheMap(entry, responseSize)
+
+  const navigationSeed = convertServerPatchToFullTree(
+    now,
+    DynamicRequestTreeForEntireRoute,
+    flightDatas,
+    renderedSearch,
+    UnknownDynamicStaleTime,
+    outputExportFallbackBasePath
+  )
+  if (navigationSeed.metadataVaryPath === null) {
+    rejectRouteCacheEntry(entry, now + 10 * 1000)
+    return null
+  }
+
+  const fetchStrategy = supportsPerSegmentPrefetching
+    ? FetchStrategy.PPR
+    : FetchStrategy.LoadingBoundary
+  writeDynamicRenderResponseIntoCache(
+    now,
+    fetchStrategy,
+    flightDatas,
+    buildId,
+    false,
+    headVaryParams,
+    staleAt,
+    navigationSeed,
+    null
+  )
+
+  const fulfilledEntry = discoverKnownRoute(
+    now,
+    renderedUrl.pathname,
+    key.nextUrl,
+    entry,
+    navigationSeed.routeTree,
+    navigationSeed.metadataVaryPath,
+    couldBeIntercepted,
+    createHrefFromUrl(renderedUrl),
+    supportsPerSegmentPrefetching,
+    false,
+    { outputExportFallbackBasePath }
+  )
+  fulfilledEntry.hasInlinedSegments = true
+
+  if (!couldBeIntercepted) {
+    const fulfilledVaryPath = getFulfilledRouteVaryPath(
+      key.pathname,
+      key.search,
+      key.nextUrl,
+      couldBeIntercepted
+    )
+    const isRevalidation = false
+    setInCacheMap(routeCacheMap, fulfilledVaryPath, entry, isRevalidation)
+  }
+
+  return { value: null, closed }
+}
+
+async function fetchSegmentsFromOutputExportFallback(
+  _route: FulfilledRouteCacheEntry,
+  routeKey: RouteCacheKey,
+  segments: SegmentBundle,
+  headers: RequestHeaders
+): Promise<PrefetchSubtaskResult<null> | null> {
+  const now = Date.now()
+  const renderedUrl = new URL(
+    routeKey.pathname + routeKey.search,
+    location.origin
+  )
+  const navigationData = await fetchOutputExportFallbackNavigationData(
+    renderedUrl,
+    headers,
+    now
+  )
+
+  if (navigationData === null) {
+    rejectRemainingSegmentsInBundle(segments, now + 10 * 1000)
+    return null
+  }
+
+  const {
+    buildId,
+    closed,
+    flightDatas,
+    headVaryParams,
+    outputExportFallbackBasePath,
+    staleAt,
+  } = navigationData
+  const renderedSearch = renderedUrl.search as NormalizedSearch
+
+  const spawnedEntries = new Map<SegmentRequestKey, PendingSegmentCacheEntry>()
+  let node: SegmentBundle | null = segments
+  while (node !== null) {
+    const nodeEntry = node.entry
+    const nodeTree = node.tree
+    if (
+      nodeTree !== null &&
+      nodeEntry !== null &&
+      nodeEntry.status === EntryStatus.Pending
+    ) {
+      spawnedEntries.set(nodeTree.requestKey, nodeEntry)
+    }
+    node = node.parent
+  }
+
+  const navigationSeed = convertServerPatchToFullTree(
+    now,
+    DynamicRequestTreeForEntireRoute,
+    flightDatas,
+    renderedSearch,
+    UnknownDynamicStaleTime,
+    outputExportFallbackBasePath
+  )
+  if (navigationSeed.metadataVaryPath === null) {
+    rejectRemainingSegmentsInBundle(segments, now + 10 * 1000)
+    return null
+  }
+
+  // Always use PPR strategy. The scheduler creates segment entries with
+  // FetchStrategy.PPR; upsertSegmentEntry rejects candidates whose strategy
+  // is "less specific" than the existing entry. Using LoadingBoundary here
+  // would cause the fallback-written segments to be silently rejected.
+  writeDynamicRenderResponseIntoCache(
+    now,
+    FetchStrategy.PPR,
+    flightDatas,
+    buildId,
+    false,
+    headVaryParams,
+    staleAt,
+    navigationSeed,
+    spawnedEntries
+  )
+
+  return { value: null, closed }
+}
+
 function rejectRemainingSegmentsInBundle(
   entries: SegmentBundle,
   staleAt: number
@@ -1992,6 +2271,17 @@ export async function fetchSegmentsOnCacheMiss(
         !isOutputExportMode) ||
       !response.body
     ) {
+      if (process.env.__NEXT_OUTPUT_EXPORT_DYNAMIC_FALLBACKS) {
+        // Per-segment files don't exist for dynamic fallback routes. Try
+        // fetching the full fallback flight response instead and write its
+        // segments into the cache.
+        return fetchSegmentsFromOutputExportFallback(
+          route,
+          routeKey,
+          segments,
+          headers
+        )
+      }
       // Server responded with an error, or with a miss. We should still cache
       // the response, but we can try again after 10 seconds.
       rejectRemainingSegmentsInBundle(segments, Date.now() + 10 * 1000)

--- a/packages/next/src/client/components/segment-cache/optimistic-routes.ts
+++ b/packages/next/src/client/components/segment-cache/optimistic-routes.ts
@@ -626,6 +626,7 @@ export function matchKnownRoute(
     metadata: reifiedMetadata,
     couldBeIntercepted: pattern.couldBeIntercepted,
     supportsPerSegmentPrefetching: pattern.supportsPerSegmentPrefetching,
+    hasInlinedSegments: pattern.hasInlinedSegments,
     outputExportFallbackBasePath: pattern.outputExportFallbackBasePath,
     hasDynamicRewrite: false,
     renderedSearch: search,

--- a/packages/next/src/client/components/segment-cache/scheduler.ts
+++ b/packages/next/src/client/components/segment-cache/scheduler.ts
@@ -709,6 +709,11 @@ function pingRootRouteTree(
         // Do not prefetch segment data until we've entered the segment phase.
         return PrefetchTaskExitStatus.Done
       }
+      if (route.hasInlinedSegments) {
+        // Segment data was already written into the cache during route
+        // fulfillment. Skip the per-segment fetch phase.
+        return PrefetchTaskExitStatus.Done
+      }
       // Recursively fill in the segment tree.
       if (!hasNetworkBandwidth(task)) {
         // Stop prefetching segments until there's more bandwidth.


### PR DESCRIPTION
## Stack position

Part 12 of 19 in the output export dynamic fallback stack.

Previous PR: #93562 (11/19)
Next PR: #93571 (13/19)

## Context

The stack is split so build-time output can land behind `experimental.outputExportDynamicFallbacks` before the client router behavior is enabled. The target behavior is for `output: 'export'` apps with parameterized App Router routes to emit fallback HTML/RSC artifacts that a later client can resolve for hard loads and soft navigations.

This PR scope: Segment-cache recovery when no route cache entry exists.

A soft navigation can miss the route cache for an unknown param. This PR lets the segment cache fetch the full fallback RSC payload, validate it, and seed reusable cache entries.

## What changed

- Adds output-export fallback recovery for route cache misses.
- Writes fallback-derived route and segment data into the cache using the fallback base path.
- Keeps the recovery branch feature-gated so normal export behavior is unchanged when disabled.

## Deliberately not included

- Does not add route-shape mismatch fallback-to-not-found yet.
- Does not add manifest conflict resolution.
- Does not change the generic prefetch fetch helper.

## Verification

After restacking and autosquashing, I verified the full stack with:

- `pnpm --filter=next build`
- `pnpm testonly packages/next/src/lib/output-export-dynamic-fallback.test.ts packages/next/src/lib/output-export-fallback-routes.test.ts packages/next/src/export/helpers/output-export-fallback.test.ts packages/next/src/server/request/fallback-params.test.ts`
- `pnpm testonly packages/next/src/client/output-export-fallback.test.ts packages/next/src/client/components/router-reducer/fetch-server-response.test.ts packages/next/src/client/components/router-reducer/create-initial-router-state.test.ts packages/next/src/client/components/segment-cache/cache.test.ts packages/next/src/client/components/segment-cache/vary-path.test.ts`
- `pnpm testonly packages/next/src/client/components/router-reducer/compute-changed-path.test.ts packages/next/src/client/flight-data-helpers.test.ts packages/next/src/server/app-render/postponed-state.test.ts`
- `pnpm test-start-turbo test/e2e/app-dir-export/test/dynamic-fallback-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-route-shapes-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-cache-components-basepath.test.ts test/e2e/app-dir-export/test/dynamic-fallback-optimizations-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-known-params-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-conflict.test.ts`
- `pnpm test-start-turbo test/e2e/app-dir/output-export-dynamic-fallbacks/output-export-dynamic-fallbacks.test.ts test/e2e/app-dir-export/test/output-export-server-io.test.ts test/e2e/app-dir-export/test/output-export-server-io-use-cache.test.ts test/e2e/app-dir-export/test/dynamic-fallback-server-params.test.ts`

<!-- NEXT_JS_LLM_PR -->
