### PR TITLE
(13/19) Resolve export fallback route manifests on the client

### DIFF
--- a/packages/next/src/client/output-export-fallback.ts
+++ b/packages/next/src/client/output-export-fallback.ts
@@ -1,38 +1,32 @@
-import { getOutputExportFallbackPath } from '../lib/output-export-dynamic-fallback'
+import {
+  getOutputExportFallbackMetadataPath,
+  getOutputExportFallbackPath,
+  type OutputExportFallbackManifestEntry,
+} from '../lib/output-export-dynamic-fallback'
+import { addPathPrefix } from '../shared/lib/router/utils/add-path-prefix'
+import { removePathPrefix } from '../shared/lib/router/utils/remove-path-prefix'
 import { RSC_CONTENT_TYPE_HEADER } from './components/app-router-headers'
+import { getRouteMatcher } from '../shared/lib/router/utils/route-matcher'
+import { getRouteRegex } from '../shared/lib/router/utils/route-regex'
+import { normalizePathTrailingSlash } from './normalize-trailing-slash'
+
+type OutputExportFallbackManifest = {
+  version: 1
+  routes: OutputExportFallbackManifestEntry[]
+}
+
+type OutputExportFallbackCacheStore = {
+  manifests: Map<string, Promise<OutputExportFallbackManifest | null>>
+  dataResponses: Map<string, Promise<OutputExportCachedResponse | null>>
+  dataUrls: Map<string, string>
+  basePaths: Map<string, string>
+}
 
 type OutputExportCachedResponse = {
   body: ArrayBuffer
   headers: Array<[string, string]>
   status: number
   statusText: string
-}
-
-type OutputExportFallbackCacheStore = {
-  dataResponses: Map<string, Promise<OutputExportCachedResponse | null>>
-  dataUrls: Map<string, string>
-  basePaths: Map<string, string>
-}
-
-function getOutputExportFallbackCacheStore(): OutputExportFallbackCacheStore {
-  const globalWithCache = globalThis as typeof globalThis & {
-    __NEXT_OUTPUT_EXPORT_FALLBACK_CACHE_STORE?: OutputExportFallbackCacheStore
-  }
-  const existing = globalWithCache.__NEXT_OUTPUT_EXPORT_FALLBACK_CACHE_STORE
-  if (existing !== undefined) {
-    return existing
-  }
-
-  const cacheStore = {
-    dataResponses: new Map<
-      string,
-      Promise<OutputExportCachedResponse | null>
-    >(),
-    dataUrls: new Map<string, string>(),
-    basePaths: new Map<string, string>(),
-  }
-  globalWithCache.__NEXT_OUTPUT_EXPORT_FALLBACK_CACHE_STORE = cacheStore
-  return cacheStore
 }
 
 function getOutputExportCandidatePrefixes(pathname: string): string[] {
@@ -48,9 +42,58 @@ function getOutputExportCandidatePrefixes(pathname: string): string[] {
   return candidates
 }
 
+function getOutputExportFallbackCacheStore(): OutputExportFallbackCacheStore {
+  const globalWithCache = globalThis as typeof globalThis & {
+    __NEXT_OUTPUT_EXPORT_FALLBACK_CACHE_STORE?: OutputExportFallbackCacheStore
+  }
+  const existing = globalWithCache.__NEXT_OUTPUT_EXPORT_FALLBACK_CACHE_STORE
+  if (existing !== undefined) {
+    return existing
+  }
+
+  const cacheStore = {
+    manifests: new Map<string, Promise<OutputExportFallbackManifest | null>>(),
+    dataResponses: new Map<
+      string,
+      Promise<OutputExportCachedResponse | null>
+    >(),
+    dataUrls: new Map<string, string>(),
+    basePaths: new Map<string, string>(),
+  }
+  globalWithCache.__NEXT_OUTPUT_EXPORT_FALLBACK_CACHE_STORE = cacheStore
+  return cacheStore
+}
+
 export function getOutputExportFallbackCandidates(pathname: string): string[] {
   return getOutputExportCandidatePrefixes(pathname).map((prefix) =>
     getOutputExportFallbackPath(prefix)
+  )
+}
+
+function getOutputExportNotFoundPath(prefix: string): string {
+  return prefix.length > 0 ? `/${prefix}/_not-found` : '/_not-found'
+}
+
+export function getOutputExportNotFoundCandidates(pathname: string): string[] {
+  return getOutputExportCandidatePrefixes(pathname).map((prefix) =>
+    getOutputExportNotFoundPath(prefix)
+  )
+}
+
+export function getConfiguredOutputExportNotFoundCandidate(
+  pathname: string
+): string {
+  const configuredPath = normalizeOutputExportRouteDirectory(
+    normalizePathTrailingSlash(
+      addPathPrefix('/_not-found', process.env.__NEXT_ROUTER_BASEPATH || '')
+    )
+  )
+
+  return (
+    getOutputExportNotFoundCandidates(pathname).find(
+      (candidate) =>
+        normalizeOutputExportRouteDirectory(candidate) === configuredPath
+    ) ?? getOutputExportNotFoundPath('')
   )
 }
 
@@ -72,20 +115,64 @@ export function isOutputExportFlightContentType(contentType: string): boolean {
   )
 }
 
-function getConfiguredOutputExportDataUrl(
-  url: URL,
-  prefersTrailingSlash: boolean
-): URL {
-  const trailingSlash = process.env.__NEXT_TRAILING_SLASH
-  const configuredUrl = new URL(url)
-  const useTrailingSlash =
-    trailingSlash == null
-      ? prefersTrailingSlash
-      : String(trailingSlash) === 'true'
-  if (useTrailingSlash && !configuredUrl.pathname.endsWith('/')) {
-    configuredUrl.pathname = `${configuredUrl.pathname}/`
+export function clearOutputExportFallbackManifestCache(): void {
+  const cacheStore = getOutputExportFallbackCacheStore()
+  cacheStore.manifests.clear()
+  cacheStore.dataResponses.clear()
+  cacheStore.dataUrls.clear()
+  cacheStore.basePaths.clear()
+}
+
+function getOutputExportFallbackMetadataUrl(url: URL): URL {
+  const nextUrl = new URL(url)
+  nextUrl.pathname = getOutputExportFallbackMetadataPath(nextUrl.pathname)
+  return nextUrl
+}
+
+function matchOutputExportFallbackManifestEntry(
+  entry: OutputExportFallbackManifestEntry,
+  pathname: string
+): boolean {
+  const basePath = process.env.__NEXT_ROUTER_BASEPATH || ''
+  const matcher = getRouteMatcher(getRouteRegex(entry.route))
+  return matcher(removePathPrefix(pathname, basePath)) !== false
+}
+
+async function fetchOutputExportFallbackManifest(
+  fallbackUrl: URL,
+  init?: RequestInit
+): Promise<OutputExportFallbackManifest | null> {
+  const metadataUrl = getOutputExportFallbackMetadataUrl(fallbackUrl)
+  const cacheKey = metadataUrl.href
+  const manifestCache = getOutputExportFallbackCacheStore().manifests
+  const cached = manifestCache.get(cacheKey)
+  if (cached !== undefined) {
+    return cached
   }
-  return addOutputExportDataSuffix(configuredUrl)
+
+  const manifestPromise = fetch(metadataUrl, init)
+    .then(async (metadataResponse) => {
+      if (!metadataResponse.ok) {
+        return null
+      }
+
+      const contentType = metadataResponse.headers.get('content-type') || ''
+      if (
+        !contentType.startsWith('application/json') &&
+        !contentType.startsWith('text/json')
+      ) {
+        return null
+      }
+
+      return metadataResponse.json()
+    })
+    .catch((error) => {
+      manifestCache.delete(cacheKey)
+      throw error
+    })
+
+  manifestCache.set(cacheKey, manifestPromise)
+  return manifestPromise
 }
 
 function getOutputExportDataCandidates(url: URL): URL[] {
@@ -100,6 +187,22 @@ function getOutputExportDataCandidates(url: URL): URL[] {
   const trailingSlash = addOutputExportDataSuffix(trailingSlashUrl)
 
   return [direct, trailingSlash]
+}
+
+function getConfiguredOutputExportDataUrl(
+  url: URL,
+  prefersTrailingSlash: boolean
+): URL {
+  const trailingSlash = process.env.__NEXT_TRAILING_SLASH
+  const configuredUrl = new URL(url)
+  const useTrailingSlash =
+    trailingSlash == null
+      ? prefersTrailingSlash
+      : String(trailingSlash) === 'true'
+  if (useTrailingSlash && !configuredUrl.pathname.endsWith('/')) {
+    configuredUrl.pathname = `${configuredUrl.pathname}/`
+  }
+  return addOutputExportDataSuffix(configuredUrl)
 }
 
 function normalizeOutputExportRouteDirectory(pathname: string): string {
@@ -175,6 +278,20 @@ export function getCachedOutputExportFallbackRequestUrl(url: URL): URL | null {
   return nextUrl
 }
 
+async function fetchOutputExportDataResult(
+  renderedUrl: URL,
+  init?: RequestInit
+): Promise<{ response: Response; dataUrl: URL } | null> {
+  for (const dataUrl of getOutputExportDataCandidates(renderedUrl)) {
+    const response = await fetchOutputExportDataResponseByUrl(dataUrl, init)
+    if (response !== null) {
+      return { response, dataUrl }
+    }
+  }
+
+  return null
+}
+
 async function fetchConfiguredOutputExportDataResult(
   renderedUrl: URL,
   prefersTrailingSlash: boolean,
@@ -245,6 +362,59 @@ async function fetchOutputExportDataResponseByUrl(
   })
 }
 
+export async function fetchOutputExportDataResponse(
+  renderedUrl: URL,
+  init?: RequestInit
+): Promise<Response | null> {
+  const result = await fetchOutputExportDataResult(renderedUrl, init)
+  return result?.response ?? null
+}
+
+export async function fetchOutputExportNotFoundDataResponse(
+  renderedUrl: URL,
+  init?: RequestInit
+): Promise<Response | null> {
+  for (const candidate of getOutputExportNotFoundCandidates(
+    renderedUrl.pathname
+  )) {
+    const candidateUrl = new URL(renderedUrl)
+    candidateUrl.pathname = candidate
+
+    const result = await fetchOutputExportDataResult(candidateUrl, init)
+    if (result !== null) {
+      cacheOutputExportFallbackDataUrl(
+        renderedUrl,
+        candidateUrl,
+        result.dataUrl
+      )
+      return result.response
+    }
+  }
+
+  return null
+}
+
+export async function fetchOutputExportNotFoundResponse(
+  renderedUrl: URL,
+  init?: RequestInit
+): Promise<Response> {
+  // The raw fallback should preserve the configured app root (for example a
+  // basePath) without probing deeper missing prefixes that may be served by an
+  // HTML fallback document instead of the RSC not-found payload.
+  const candidateUrl = new URL(renderedUrl)
+  candidateUrl.pathname = getConfiguredOutputExportNotFoundCandidate(
+    renderedUrl.pathname
+  )
+  const configuredDataUrl = getConfiguredOutputExportDataUrl(
+    candidateUrl,
+    renderedUrl.pathname.endsWith('/')
+  )
+
+  cacheOutputExportFallbackDataUrl(renderedUrl, candidateUrl, configuredDataUrl)
+
+  return fetch(configuredDataUrl, init)
+}
+
 export async function fetchOutputExportFallbackResponse(
   renderedUrl: URL,
   init?: RequestInit
@@ -257,19 +427,73 @@ export async function fetchOutputExportFallbackResponse(
     const candidateUrl = new URL(renderedUrl)
     candidateUrl.pathname = candidate
 
-    const result = await fetchConfiguredOutputExportDataResult(
+    const directResult = await fetchConfiguredOutputExportDataResult(
       candidateUrl,
       prefersTrailingSlash,
       init
     )
-    if (result) {
+    const fallbackManifest = await fetchOutputExportFallbackManifest(
+      candidateUrl,
+      init
+    )
+    if (fallbackManifest !== null) {
+      for (const entry of fallbackManifest.routes) {
+        if (
+          !matchOutputExportFallbackManifestEntry(entry, renderedUrl.pathname)
+        ) {
+          continue
+        }
+
+        const branchFallbackUrl = new URL(renderedUrl)
+        const basePath = process.env.__NEXT_ROUTER_BASEPATH || ''
+        branchFallbackUrl.pathname = addPathPrefix(
+          removePathPrefix(entry.fallbackPath, basePath),
+          basePath
+        )
+
+        if (directResult) {
+          cacheOutputExportFallbackDataUrl(
+            renderedUrl,
+            branchFallbackUrl,
+            directResult.dataUrl
+          )
+          return {
+            response: directResult.response,
+            renderedUrl,
+            fallbackUrl: branchFallbackUrl,
+          }
+        }
+
+        const result = await fetchConfiguredOutputExportDataResult(
+          branchFallbackUrl,
+          prefersTrailingSlash,
+          init
+        )
+        if (result) {
+          cacheOutputExportFallbackDataUrl(
+            renderedUrl,
+            branchFallbackUrl,
+            result.dataUrl
+          )
+          return {
+            response: result.response,
+            renderedUrl,
+            fallbackUrl: branchFallbackUrl,
+          }
+        }
+      }
+
+      continue
+    }
+
+    if (directResult) {
       cacheOutputExportFallbackDataUrl(
         renderedUrl,
         candidateUrl,
-        result.dataUrl
+        directResult.dataUrl
       )
       return {
-        response: result.response,
+        response: directResult.response,
         renderedUrl,
         fallbackUrl: candidateUrl,
       }


### PR DESCRIPTION
## Stack position

Part 13 of 19 in the output export dynamic fallback stack.

Previous PR: #93570 (12/19)
Next PR: #93563 (14/19)

## Context

The stack is split so build-time output can land behind `experimental.outputExportDynamicFallbacks` before the client router behavior is enabled. The target behavior is for `output: 'export'` apps with parameterized App Router routes to emit fallback HTML/RSC artifacts that a later client can resolve for hard loads and soft navigations.

This PR scope: Client-side fallback manifest lookup.

Build-time route metadata from PR4 is only useful once the client can read it. This PR teaches the client resolver to use fallback manifests to choose the right artifact for conflicting dynamic route shapes.

## What changed

- Fetches and caches fallback metadata manifests.
- Matches the requested pathname against manifest route entries, including basePath handling.
- Caches resolved fallback data URLs for later RSC and segment requests.
- Removes the unused `stripOutputExportDataSuffix` helper and its dead unit coverage.

## Deliberately not included

- Does not validate filled fallback data against the rendered route shape yet.
- Does not add e2e coverage for every conflict case. Later PRs cover that.
- Does not keep dead helper API surface around without callers.

## Verification

After restacking and autosquashing, I verified the full stack with:

- `pnpm --filter=next build`
- `pnpm testonly packages/next/src/lib/output-export-dynamic-fallback.test.ts packages/next/src/lib/output-export-fallback-routes.test.ts packages/next/src/export/helpers/output-export-fallback.test.ts packages/next/src/server/request/fallback-params.test.ts`
- `pnpm testonly packages/next/src/client/output-export-fallback.test.ts packages/next/src/client/components/router-reducer/fetch-server-response.test.ts packages/next/src/client/components/router-reducer/create-initial-router-state.test.ts packages/next/src/client/components/segment-cache/cache.test.ts packages/next/src/client/components/segment-cache/vary-path.test.ts`
- `pnpm testonly packages/next/src/client/components/router-reducer/compute-changed-path.test.ts packages/next/src/client/flight-data-helpers.test.ts packages/next/src/server/app-render/postponed-state.test.ts`
- `pnpm test-start-turbo test/e2e/app-dir-export/test/dynamic-fallback-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-route-shapes-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-cache-components-basepath.test.ts test/e2e/app-dir-export/test/dynamic-fallback-optimizations-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-known-params-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-conflict.test.ts`
- `pnpm test-start-turbo test/e2e/app-dir/output-export-dynamic-fallbacks/output-export-dynamic-fallbacks.test.ts test/e2e/app-dir-export/test/output-export-server-io.test.ts test/e2e/app-dir-export/test/output-export-server-io-use-cache.test.ts test/e2e/app-dir-export/test/dynamic-fallback-server-params.test.ts`

<!-- NEXT_JS_LLM_PR -->
