### PR TITLE
(15/19) Cover export fallback segment cache keying

### DIFF
--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.test.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.test.ts
@@ -1,0 +1,167 @@
+import type { InitialRSCPayload } from '../../../shared/lib/app-router-types'
+import { createInitialRouterState } from './create-initial-router-state'
+
+const mockGetFlightDataPartsFromPath = jest.fn()
+const mockCreateInitialCacheNodeForHydration = jest.fn()
+const mockConvertRootFlightRouterStateToRouteTree = jest.fn()
+const mockDiscoverKnownRoute = jest.fn()
+const mockProcessRuntimePrefetchStream = jest.fn()
+const mockWriteDynamicRenderResponseIntoCache = jest.fn()
+
+jest.mock('../../flight-data-helpers', () => ({
+  getFlightDataPartsFromPath: (...args: Array<unknown>) =>
+    mockGetFlightDataPartsFromPath(...args),
+}))
+
+jest.mock('./ppr-navigations', () => ({
+  createInitialCacheNodeForHydration: (...args: Array<unknown>) =>
+    mockCreateInitialCacheNodeForHydration(...args),
+}))
+
+jest.mock('../segment-cache/cache', () => ({
+  convertRootFlightRouterStateToRouteTree: (...args: Array<unknown>) =>
+    mockConvertRootFlightRouterStateToRouteTree(...args),
+  getStaleTimeMs: jest.fn((staleTime: number) => staleTime),
+  getStaleAt: jest.fn(),
+  processRuntimePrefetchStream: (...args: Array<unknown>) =>
+    mockProcessRuntimePrefetchStream(...args),
+  writeDynamicRenderResponseIntoCache: (...args: Array<unknown>) =>
+    mockWriteDynamicRenderResponseIntoCache(...args),
+  writeStaticStageResponseIntoCache: jest.fn(),
+}))
+
+jest.mock('../segment-cache/optimistic-routes', () => ({
+  discoverKnownRoute: (...args: Array<unknown>) =>
+    mockDiscoverKnownRoute(...args),
+}))
+
+describe('createInitialRouterState output export fallback', () => {
+  const discoveredRouteEntry = {
+    outputExportFallbackBasePath: null as string | null,
+  }
+
+  const initialRSCPayload: InitialRSCPayload = {
+    c: ['', 'hydrated', 'first'],
+    q: '',
+    i: false,
+    f: [[] as any],
+    m: new Set(),
+    G: [(() => null) as any, undefined],
+    S: false,
+    h: null,
+  }
+
+  beforeEach(() => {
+    mockGetFlightDataPartsFromPath.mockReset()
+    mockCreateInitialCacheNodeForHydration.mockReset()
+    mockConvertRootFlightRouterStateToRouteTree.mockReset()
+    mockDiscoverKnownRoute.mockReset()
+    mockProcessRuntimePrefetchStream.mockReset()
+    mockWriteDynamicRenderResponseIntoCache.mockReset()
+
+    discoveredRouteEntry.outputExportFallbackBasePath = null
+
+    mockGetFlightDataPartsFromPath.mockReturnValue({
+      tree: ['', {}],
+      seedData: null,
+      head: null,
+    })
+    mockCreateInitialCacheNodeForHydration.mockReturnValue({
+      rsc: null,
+      prefetchRsc: null,
+      prefetchHead: null,
+      head: null,
+      slots: null,
+      scrollRef: null,
+    })
+    mockConvertRootFlightRouterStateToRouteTree.mockImplementation(
+      (_tree, _renderedSearch, acc) => {
+        acc.metadataVaryPath = '__PAGE__'
+        return { path: '/hydrated/[thread]' }
+      }
+    )
+    mockDiscoverKnownRoute.mockReturnValue(discoveredRouteEntry)
+  })
+
+  it('passes the learned fallback artifact base path into route discovery', () => {
+    createInitialRouterState({
+      navigatedAt: Date.now(),
+      initialRSCPayload,
+      location: new URL(
+        'https://example.com/hydrated/first/'
+      ) as unknown as Location,
+      outputExportFallbackBasePath: '/hydrated/__fallback',
+    })
+
+    expect(mockDiscoverKnownRoute).toHaveBeenCalledWith(
+      expect.any(Number),
+      '/hydrated/first/',
+      null,
+      null,
+      { path: '/hydrated/[thread]' },
+      '__PAGE__',
+      false,
+      '/hydrated/first/',
+      false,
+      false,
+      { outputExportFallbackBasePath: '/hydrated/__fallback' }
+    )
+  })
+
+  it('passes the learned fallback artifact base path into runtime-prefetch cache writes', async () => {
+    const processedNavigationSeed = {
+      renderedSearch: '',
+      routeTree: { path: '/hydrated/[thread]' },
+      metadataVaryPath: null,
+      data: null,
+      head: null,
+      dynamicStaleAt: Date.now() + 30_000,
+      outputExportFallbackBasePath: '/hydrated/__fallback' as string | null,
+    }
+
+    mockProcessRuntimePrefetchStream.mockResolvedValue({
+      flightDatas: [],
+      navigationSeed: processedNavigationSeed,
+      buildId: undefined,
+      isResponsePartial: false,
+      headVaryParams: null,
+      staleAt: Date.now() + 30_000,
+    })
+
+    createInitialRouterState({
+      navigatedAt: Date.now(),
+      initialRSCPayload: {
+        ...initialRSCPayload,
+        p: new ReadableStream<Uint8Array>(),
+      },
+      location: new URL(
+        'https://example.com/hydrated/first/'
+      ) as unknown as Location,
+      outputExportFallbackBasePath: '/hydrated/__fallback',
+    })
+
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(mockProcessRuntimePrefetchStream).toHaveBeenCalledWith(
+      expect.any(Number),
+      expect.any(ReadableStream),
+      ['', {}],
+      '',
+      '/hydrated/__fallback'
+    )
+    expect(mockWriteDynamicRenderResponseIntoCache).toHaveBeenCalledWith(
+      expect.any(Number),
+      expect.anything(),
+      expect.any(Array),
+      undefined,
+      false,
+      null,
+      expect.any(Number),
+      expect.objectContaining({
+        outputExportFallbackBasePath: '/hydrated/__fallback',
+      }),
+      null
+    )
+  })
+})

--- a/packages/next/src/client/components/segment-cache/cache.test.ts
+++ b/packages/next/src/client/components/segment-cache/cache.test.ts
@@ -1,0 +1,233 @@
+import {
+  HEAD_REQUEST_KEY,
+  type SegmentRequestKey,
+} from '../../../shared/lib/segment-cache/segment-value-encoding'
+import type { VaryParamsThenable } from '../../../shared/lib/segment-cache/vary-params-decoding'
+import { FetchStrategy } from './types'
+import { Fallback } from './cache-map'
+import {
+  EntryStatus,
+  getOutputExportSegmentRequestUrl,
+  invalidateEntirePrefetchCache,
+  readSegmentCacheEntry,
+  readOrCreateSegmentCacheEntry,
+  upgradeToPendingSegment,
+  writeDynamicRenderResponseIntoCache,
+} from './cache'
+import { convertServerPatchToFullTree } from './navigation'
+import { finalizeMetadataVaryPath, finalizePageVaryPath } from './vary-path'
+
+describe('getOutputExportSegmentRequestUrl', () => {
+  it('uses the concrete rendered route when no fallback base path is known', () => {
+    expect(
+      getOutputExportSegmentRequestUrl(
+        new URL('https://example.com/org/acme/chat/thread-456/?mode=full'),
+        HEAD_REQUEST_KEY,
+        null
+      ).href
+    ).toBe(
+      'https://example.com/org/acme/chat/thread-456/__next._head.txt?mode=full'
+    )
+  })
+
+  it('reuses the learned fallback base path for sibling segment requests', () => {
+    expect(
+      getOutputExportSegmentRequestUrl(
+        new URL('https://example.com/org/acme/chat/thread-456/?mode=full'),
+        '/t/$d$threadId' as SegmentRequestKey,
+        '/org/__fallback'
+      ).href
+    ).toBe(
+      'https://example.com/org/__fallback/__next.t.$d$threadId.txt?mode=full'
+    )
+  })
+
+  it('keeps the matched branch fallback base path for conflicting routes', () => {
+    expect(
+      getOutputExportSegmentRequestUrl(
+        new URL('https://example.com/docs/api/reference'),
+        '/docs/$d$section/$d$page' as SegmentRequestKey,
+        '/docs/__fallback/__route_0'
+      ).href
+    ).toBe(
+      'https://example.com/docs/__fallback/__route_0/__next.docs.$d$section.$d$page.txt'
+    )
+  })
+})
+
+describe('readOrCreateSegmentCacheEntry output export fallback', () => {
+  afterEach(() => {
+    delete process.env.__NEXT_VARY_PARAMS
+    invalidateEntirePrefetchCache(null, ['', {}])
+  })
+
+  it('dedupes pending metadata entries across sibling fallback params', () => {
+    const now = Date.now()
+    const firstTree = {
+      requestKey: HEAD_REQUEST_KEY,
+      segment: HEAD_REQUEST_KEY,
+      refreshState: null,
+      varyPath: finalizeMetadataVaryPath(
+        '/hydrated/$d$thread/__PAGE__' as SegmentRequestKey,
+        '' as any,
+        {
+          id: 'thread',
+          value: 'first' as any,
+          parent: null,
+        } as any
+      ),
+      isPage: true as const,
+      slots: null,
+      prefetchHints: 0,
+    }
+    const secondTree = {
+      ...firstTree,
+      varyPath: finalizeMetadataVaryPath(
+        '/hydrated/$d$thread/__PAGE__' as SegmentRequestKey,
+        '' as any,
+        {
+          id: 'thread',
+          value: 'second' as any,
+          parent: null,
+        } as any
+      ),
+    }
+
+    const firstEntry = readOrCreateSegmentCacheEntry(
+      now,
+      FetchStrategy.PPR,
+      firstTree,
+      '/hydrated/__fallback'
+    )
+    const secondEntry = readOrCreateSegmentCacheEntry(
+      now,
+      FetchStrategy.PPR,
+      secondTree,
+      '/hydrated/__fallback'
+    )
+
+    expect(firstEntry).toBe(secondEntry)
+    const secondThreadVaryPath = secondTree.varyPath.parent?.parent
+    expect(secondThreadVaryPath).not.toBeNull()
+    if (secondThreadVaryPath === null) {
+      throw new Error('expected metadata vary path to include thread params')
+    }
+    expect(secondThreadVaryPath.value).toBe('second')
+    expect(secondThreadVaryPath.value).not.toBe(Fallback)
+  })
+
+  it('rekeys runtime-prefetched fallback segments under generic params', () => {
+    process.env.__NEXT_VARY_PARAMS = 'true'
+
+    const now = Date.now()
+    const makeTree = (thread: string) => ({
+      requestKey: '/t/$d$threadId/__PAGE__' as SegmentRequestKey,
+      segment: '/t/$d$threadId' as SegmentRequestKey,
+      refreshState: null,
+      varyPath: finalizePageVaryPath(
+        '/t/$d$threadId/__PAGE__' as SegmentRequestKey,
+        '' as any,
+        {
+          id: 'threadId',
+          value: thread as any,
+          parent: null,
+        } as any
+      ),
+      isPage: true as const,
+      slots: null,
+      prefetchHints: 0,
+    })
+
+    const firstTree = makeTree('first')
+    const secondTree = makeTree('second')
+    const emptyEntry = readOrCreateSegmentCacheEntry(
+      now,
+      FetchStrategy.PPRRuntime,
+      firstTree,
+      '/t/__fallback'
+    )
+    expect(emptyEntry.status).toBe(EntryStatus.Empty)
+    if (emptyEntry.status !== EntryStatus.Empty) {
+      throw new Error('expected a new empty segment cache entry')
+    }
+    const ownedEntry = upgradeToPendingSegment(
+      emptyEntry,
+      FetchStrategy.PPRRuntime
+    )
+    const fulfilledVaryParams = new Set(['threadId'])
+    const fulfilledVaryParamsThenable: VaryParamsThenable = {
+      status: 'fulfilled',
+      value: fulfilledVaryParams,
+      then<TResult1 = Set<string>, TResult2 = never>(
+        onfulfilled?:
+          | ((value: Set<string>) => TResult1 | PromiseLike<TResult1>)
+          | null,
+        _onrejected?:
+          | ((reason: unknown) => TResult2 | PromiseLike<TResult2>)
+          | null
+      ): PromiseLike<TResult1 | TResult2> {
+        if (onfulfilled) {
+          return Promise.resolve(onfulfilled(fulfilledVaryParams))
+        }
+        return Promise.resolve(fulfilledVaryParams as TResult1)
+      },
+    }
+
+    writeDynamicRenderResponseIntoCache(
+      now,
+      FetchStrategy.PPRRuntime,
+      [
+        {
+          segmentPath: [],
+          pathToSegment: [],
+          segment: '',
+          tree: ['', {}],
+          seedData: [
+            'runtime fallback data',
+            {},
+            null,
+            false,
+            fulfilledVaryParamsThenable,
+          ],
+          head: null,
+          isHeadPartial: false,
+          isRootRender: true,
+        },
+      ],
+      undefined,
+      false,
+      null,
+      now + 30_000,
+      {
+        renderedSearch: '',
+        routeTree: firstTree,
+        metadataVaryPath: null,
+        data: null,
+        head: null,
+        dynamicStaleAt: now + 30_000,
+        outputExportFallbackBasePath: '/t/__fallback',
+      },
+      new Map([[firstTree.requestKey, ownedEntry]])
+    )
+
+    const secondEntry = readSegmentCacheEntry(now, secondTree.varyPath)
+
+    expect(secondEntry).toBe(ownedEntry)
+    expect(secondEntry?.status).toBe(EntryStatus.Fulfilled)
+  })
+})
+
+describe('convertServerPatchToFullTree output export fallback', () => {
+  it('records the learned fallback artifact base path on the returned navigation seed', () => {
+    const navigationSeed = convertServerPatchToFullTree(
+      Date.now(),
+      ['', {}],
+      null,
+      '',
+      0,
+      '/docs/__fallback'
+    )
+
+    expect(navigationSeed.outputExportFallbackBasePath).toBe('/docs/__fallback')
+  })
+})

--- a/packages/next/src/client/components/segment-cache/vary-path.test.ts
+++ b/packages/next/src/client/components/segment-cache/vary-path.test.ts
@@ -1,0 +1,105 @@
+import { Fallback } from './cache-map'
+import { FetchStrategy } from './types'
+import {
+  HEAD_REQUEST_KEY,
+  type SegmentRequestKey,
+} from '../../../shared/lib/segment-cache/segment-value-encoding'
+import {
+  finalizeMetadataVaryPath,
+  finalizePageVaryPath,
+  getFulfilledSegmentVaryPath,
+  getSegmentVaryPathForRequest,
+} from './vary-path'
+
+function getRequiredParent<T extends { parent: unknown | null }>(
+  path: T
+): Exclude<T['parent'], null> {
+  expect(path.parent).not.toBeNull()
+  return path.parent as Exclude<T['parent'], null>
+}
+
+describe('getSegmentVaryPathForRequest output export fallback', () => {
+  it('reuses path params for normal static prefetches', () => {
+    const varyPath = finalizeMetadataVaryPath(
+      '/t/$d$threadId/__PAGE__',
+      '' as any,
+      {
+        id: 'threadId',
+        value: 'j97358' as any,
+        parent: null,
+      } as any
+    )
+
+    const requestVaryPath = getSegmentVaryPathForRequest(
+      FetchStrategy.PPR,
+      {
+        requestKey: HEAD_REQUEST_KEY,
+        segment: HEAD_REQUEST_KEY,
+        refreshState: null,
+        varyPath,
+        isPage: true,
+        slots: null,
+        prefetchHints: 0,
+      },
+      null
+    )
+
+    expect(getRequiredParent(getRequiredParent(requestVaryPath)).value).toBe(
+      'j97358'
+    )
+  })
+
+  it('treats path params as reusable for learned output export fallback routes', () => {
+    const varyPath = finalizePageVaryPath(
+      '/t/$d$threadId/__PAGE__',
+      '' as any,
+      {
+        id: 'threadId',
+        value: 'j97358' as any,
+        parent: null,
+      } as any
+    )
+
+    const requestVaryPath = getSegmentVaryPathForRequest(
+      FetchStrategy.PPR,
+      {
+        requestKey: '/t/$d$threadId/__PAGE__' as SegmentRequestKey,
+        segment: '/t/$d$threadId' as SegmentRequestKey,
+        refreshState: null,
+        varyPath,
+        isPage: true,
+        slots: null,
+        prefetchHints: 0,
+      },
+      '/t/__fallback'
+    )
+
+    expect(getRequiredParent(requestVaryPath).value).toBe(Fallback)
+    expect(getRequiredParent(getRequiredParent(requestVaryPath)).value).toBe(
+      Fallback
+    )
+  })
+
+  it('keeps fulfilled fallback segment path params generic even when vary params include them', () => {
+    const varyPath = finalizeMetadataVaryPath(
+      '/t/$d$threadId/__PAGE__',
+      '' as any,
+      {
+        id: 'threadId',
+        value: 'j97358' as any,
+        parent: null,
+      } as any
+    )
+
+    const fulfilledVaryPath = getFulfilledSegmentVaryPath(
+      varyPath,
+      new Set(['?', 'threadId']),
+      true
+    )
+
+    expect(getRequiredParent(fulfilledVaryPath).value).toBe('')
+    expect(getRequiredParent(getRequiredParent(fulfilledVaryPath)).value).toBe(
+      Fallback
+    )
+  })
+})


### PR DESCRIPTION
## Stack position

Part 15 of 19 in the output export dynamic fallback stack.

Previous PR: #93563 (14/19)
Next PR: #93573 (16/19)

## Context

The stack is split so build-time output can land behind `experimental.outputExportDynamicFallbacks` before the client router behavior is enabled. The target behavior is for `output: 'export'` apps with parameterized App Router routes to emit fallback HTML/RSC artifacts that a later client can resolve for hard loads and soft navigations.

This PR scope: Unit coverage for fallback segment-cache keying.

The segment-cache changes are subtle and easy to regress without a browser. This PR isolates the keying behavior in unit tests before the broader e2e suites.

## What changed

- Covers propagation of learned fallback base paths into initial router state.
- Covers fallback-aware route and segment vary paths.
- Covers segment-cache behavior for fallback-derived entries.

## Deliberately not included

- Does not add new runtime behavior.
- Does not cover route-manifest selection. That has its own test PR.
- Does not replace the later e2e coverage.

## Verification

After restacking and autosquashing, I verified the full stack with:

- `pnpm --filter=next build`
- `pnpm testonly packages/next/src/lib/output-export-dynamic-fallback.test.ts packages/next/src/lib/output-export-fallback-routes.test.ts packages/next/src/export/helpers/output-export-fallback.test.ts packages/next/src/server/request/fallback-params.test.ts`
- `pnpm testonly packages/next/src/client/output-export-fallback.test.ts packages/next/src/client/components/router-reducer/fetch-server-response.test.ts packages/next/src/client/components/router-reducer/create-initial-router-state.test.ts packages/next/src/client/components/segment-cache/cache.test.ts packages/next/src/client/components/segment-cache/vary-path.test.ts`
- `pnpm testonly packages/next/src/client/components/router-reducer/compute-changed-path.test.ts packages/next/src/client/flight-data-helpers.test.ts packages/next/src/server/app-render/postponed-state.test.ts`
- `pnpm test-start-turbo test/e2e/app-dir-export/test/dynamic-fallback-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-route-shapes-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-cache-components-basepath.test.ts test/e2e/app-dir-export/test/dynamic-fallback-optimizations-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-known-params-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-conflict.test.ts`
- `pnpm test-start-turbo test/e2e/app-dir/output-export-dynamic-fallbacks/output-export-dynamic-fallbacks.test.ts test/e2e/app-dir-export/test/output-export-server-io.test.ts test/e2e/app-dir-export/test/output-export-server-io-use-cache.test.ts test/e2e/app-dir-export/test/dynamic-fallback-server-params.test.ts`

<!-- NEXT_JS_LLM_PR -->
