### PR TITLE
(16/19) Cover client export fallback manifest resolution

### DIFF
--- a/packages/next/src/client/output-export-fallback.test.ts
+++ b/packages/next/src/client/output-export-fallback.test.ts
@@ -1,0 +1,513 @@
+import {
+  addOutputExportDataSuffix,
+  clearOutputExportFallbackManifestCache,
+  fetchOutputExportDataResponse,
+  fetchOutputExportFallbackResponse,
+  getCachedOutputExportFallbackDataUrl,
+  getCachedOutputExportFallbackRequestUrl,
+  getOutputExportFallbackCandidates,
+} from './output-export-fallback'
+
+describe('output export fallback helpers', () => {
+  const originalFetch = global.fetch
+  const originalBasePath = process.env.__NEXT_ROUTER_BASEPATH
+  const originalTrailingSlash = process.env.__NEXT_TRAILING_SLASH
+
+  afterEach(() => {
+    global.fetch = originalFetch
+    if (originalBasePath === undefined) {
+      delete process.env.__NEXT_ROUTER_BASEPATH
+    } else {
+      process.env.__NEXT_ROUTER_BASEPATH = originalBasePath
+    }
+    if (originalTrailingSlash === undefined) {
+      delete process.env.__NEXT_TRAILING_SLASH
+    } else {
+      process.env.__NEXT_TRAILING_SLASH = originalTrailingSlash
+    }
+    clearOutputExportFallbackManifestCache()
+    jest.restoreAllMocks()
+  })
+
+  it('discovers fallback candidates from deepest static prefix to root', () => {
+    expect(getOutputExportFallbackCandidates('/org/acme/chat/123')).toEqual([
+      '/org/acme/chat/123/__fallback',
+      '/org/acme/chat/__fallback',
+      '/org/acme/__fallback',
+      '/org/__fallback',
+      '/__fallback',
+    ])
+  })
+
+  it('includes the current pathname for optional catch-all root matches', () => {
+    expect(getOutputExportFallbackCandidates('/optional/')).toEqual([
+      '/optional/__fallback',
+      '/__fallback',
+    ])
+  })
+
+  it('adds the export data suffix for flat and trailing slash routes', () => {
+    expect(
+      addOutputExportDataSuffix(new URL('https://example.com/blog/post')).href
+    ).toBe('https://example.com/blog/post.txt')
+
+    expect(
+      addOutputExportDataSuffix(new URL('https://example.com/blog/post/')).href
+    ).toBe('https://example.com/blog/post/index.txt')
+  })
+
+  it('tries both flat and trailing-slash data files', async () => {
+    const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.endsWith('/blog/post.txt')) {
+        return new Response('not found', {
+          status: 404,
+          headers: { 'content-type': 'text/html' },
+        })
+      }
+
+      return new Response('payload', {
+        status: 200,
+        headers: { 'content-type': 'text/plain' },
+      })
+    })
+
+    global.fetch = fetchMock as typeof fetch
+
+    const response = await fetchOutputExportDataResponse(
+      new URL('https://example.com/blog/post')
+    )
+
+    expect(response).not.toBeNull()
+    expect(fetchMock.mock.calls.map(([url]) => String(url))).toEqual([
+      'https://example.com/blog/post.txt',
+      'https://example.com/blog/post/index.txt',
+    ])
+  })
+
+  it('tries the direct fallback artifact before manifest lookups', async () => {
+    process.env.__NEXT_TRAILING_SLASH = 'false'
+    const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url.endsWith('/org/acme/chat/123/__fallback.txt')) {
+        return new Response('payload', {
+          status: 200,
+          headers: { 'content-type': 'text/plain' },
+        })
+      }
+
+      return new Response('not found', {
+        status: 404,
+        headers: { 'content-type': 'text/html' },
+      })
+    })
+
+    global.fetch = fetchMock as typeof fetch
+
+    const renderedUrl = new URL('https://example.com/org/acme/chat/123')
+    const result = await fetchOutputExportFallbackResponse(renderedUrl)
+
+    expect(result).not.toBeNull()
+    expect(result?.renderedUrl.href).toBe(renderedUrl.href)
+    expect(fetchMock.mock.calls.map(([url]) => String(url))).toEqual([
+      'https://example.com/org/acme/chat/123/__fallback.txt',
+      'https://example.com/org/acme/chat/123/__fallback.meta.json',
+    ])
+  })
+
+  it('uses manifest fallback base paths even when the direct artifact already exists', async () => {
+    const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url.endsWith('/hydrated/second/__fallback/index.txt')) {
+        return new Response('payload', {
+          status: 200,
+          headers: { 'content-type': 'text/plain' },
+        })
+      }
+
+      if (url.endsWith('/hydrated/second/__fallback.meta.json')) {
+        return new Response(
+          JSON.stringify({
+            version: 1,
+            routes: [
+              {
+                route: '/hydrated/[thread]',
+                fallbackPath: '/hydrated/__fallback',
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }
+        )
+      }
+
+      return new Response('not found', {
+        status: 404,
+        headers: { 'content-type': 'text/html' },
+      })
+    })
+
+    global.fetch = fetchMock as typeof fetch
+
+    const renderedUrl = new URL('https://example.com/hydrated/second/')
+    const result = await fetchOutputExportFallbackResponse(renderedUrl)
+
+    expect(result).not.toBeNull()
+    expect(result?.fallbackUrl.pathname).toBe('/hydrated/__fallback')
+    expect(fetchMock.mock.calls.map(([url]) => String(url))).toEqual([
+      'https://example.com/hydrated/second/__fallback/index.txt',
+      'https://example.com/hydrated/second/__fallback.meta.json',
+    ])
+    expect(
+      getCachedOutputExportFallbackRequestUrl(
+        new URL('https://example.com/hydrated/second/__next._tree.txt')
+      )?.href
+    ).toBe('https://example.com/hydrated/__fallback/__next._tree.txt')
+  })
+
+  it('falls through deeper prefixes before using a shallower fallback artifact', async () => {
+    process.env.__NEXT_TRAILING_SLASH = 'false'
+    const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url.endsWith('/docs/guides/export/__fallback.txt')) {
+        return new Response('not found', {
+          status: 404,
+          headers: { 'content-type': 'text/html' },
+        })
+      }
+
+      if (url.endsWith('/docs/guides/export/__fallback.meta.json')) {
+        return new Response('not found', {
+          status: 404,
+          headers: { 'content-type': 'text/html' },
+        })
+      }
+
+      if (url.endsWith('/docs/guides/__fallback.txt')) {
+        return new Response('payload', {
+          status: 200,
+          headers: { 'content-type': 'text/plain' },
+        })
+      }
+
+      return new Response('not found', {
+        status: 404,
+        headers: { 'content-type': 'text/html' },
+      })
+    })
+
+    global.fetch = fetchMock as typeof fetch
+
+    const renderedUrl = new URL('https://example.com/docs/guides/export')
+    const result = await fetchOutputExportFallbackResponse(renderedUrl)
+
+    expect(result).not.toBeNull()
+    expect(result?.renderedUrl.href).toBe(renderedUrl.href)
+    expect(result?.fallbackUrl.pathname).toBe('/docs/guides/__fallback')
+    expect(fetchMock.mock.calls.map(([url]) => String(url))).toEqual([
+      'https://example.com/docs/guides/export/__fallback.txt',
+      'https://example.com/docs/guides/export/__fallback.meta.json',
+      'https://example.com/docs/guides/__fallback.txt',
+      'https://example.com/docs/guides/__fallback.meta.json',
+    ])
+  })
+
+  it('prefers the trailing-slash fallback artifact when the request URL ends with /', async () => {
+    delete process.env.__NEXT_TRAILING_SLASH
+
+    const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url.endsWith('/org/umbrella/chat/thread-789/__fallback/index.txt')) {
+        return new Response('flight', {
+          status: 200,
+          headers: { 'content-type': 'text/x-component' },
+        })
+      }
+
+      return new Response('not found', {
+        status: 404,
+        headers: { 'content-type': 'text/html' },
+      })
+    })
+
+    global.fetch = fetchMock as typeof fetch
+
+    const renderedUrl = new URL(
+      'https://example.com/org/umbrella/chat/thread-789/'
+    )
+    const result = await fetchOutputExportFallbackResponse(renderedUrl)
+
+    expect(result).not.toBeNull()
+    expect(result?.renderedUrl.href).toBe(renderedUrl.href)
+    expect(fetchMock.mock.calls.map(([url]) => String(url))).toEqual([
+      'https://example.com/org/umbrella/chat/thread-789/__fallback/index.txt',
+      'https://example.com/org/umbrella/chat/thread-789/__fallback.meta.json',
+    ])
+  })
+
+  it('uses fallback metadata to select the most specific conflicting route', async () => {
+    process.env.__NEXT_TRAILING_SLASH = 'false'
+    const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url.endsWith('/docs/__fallback.txt')) {
+        return new Response('not found', {
+          status: 404,
+          headers: { 'content-type': 'text/html' },
+        })
+      }
+
+      if (url.endsWith('/docs/__fallback.meta.json')) {
+        return new Response(
+          JSON.stringify({
+            version: 1,
+            routes: [
+              {
+                route: '/docs/[section]/[page]',
+                fallbackPath: '/docs/__fallback/__route_0',
+              },
+              {
+                route: '/docs/[...slug]',
+                fallbackPath: '/docs/__fallback/__route_1',
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }
+        )
+      }
+
+      if (url.endsWith('/docs/__fallback/__route_0.txt')) {
+        return new Response('payload', {
+          status: 200,
+          headers: { 'content-type': 'text/plain' },
+        })
+      }
+
+      return new Response('not found', {
+        status: 404,
+        headers: { 'content-type': 'text/html' },
+      })
+    })
+
+    global.fetch = fetchMock as typeof fetch
+
+    const renderedUrl = new URL('https://example.com/docs/api/reference')
+    const result = await fetchOutputExportFallbackResponse(renderedUrl)
+
+    expect(result).not.toBeNull()
+    expect(result?.fallbackUrl.pathname).toBe('/docs/__fallback/__route_0')
+    expect(fetchMock.mock.calls.map(([url]) => String(url))).toEqual([
+      'https://example.com/docs/api/reference/__fallback.txt',
+      'https://example.com/docs/api/reference/__fallback.meta.json',
+      'https://example.com/docs/api/__fallback.txt',
+      'https://example.com/docs/api/__fallback.meta.json',
+      'https://example.com/docs/__fallback.txt',
+      'https://example.com/docs/__fallback.meta.json',
+      'https://example.com/docs/__fallback/__route_0.txt',
+    ])
+  })
+
+  it('matches and fetches conflicting fallback branches under basePath via shallower metadata', async () => {
+    process.env.__NEXT_ROUTER_BASEPATH = '/base'
+
+    const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url.endsWith('/base/docs/__fallback.meta.json')) {
+        return new Response(
+          JSON.stringify({
+            version: 1,
+            routes: [
+              {
+                route: '/docs/[section]/[page]',
+                fallbackPath: '/docs/__fallback/__route_0',
+              },
+              {
+                route: '/docs/[...slug]',
+                fallbackPath: '/docs/__fallback/__route_1',
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }
+        )
+      }
+
+      if (url.endsWith('/base/docs/__fallback/__route_0.txt')) {
+        return new Response('payload', {
+          status: 200,
+          headers: { 'content-type': 'text/plain' },
+        })
+      }
+
+      return new Response('not found', {
+        status: 404,
+        headers: { 'content-type': 'text/html' },
+      })
+    })
+
+    global.fetch = fetchMock as typeof fetch
+
+    const renderedUrl = new URL('https://example.com/base/docs/api/reference')
+    const result = await fetchOutputExportFallbackResponse(renderedUrl)
+
+    expect(result).not.toBeNull()
+    expect(result?.fallbackUrl.pathname).toBe('/base/docs/__fallback/__route_0')
+    expect(fetchMock.mock.calls.map(([url]) => String(url))).toEqual([
+      'https://example.com/base/docs/api/reference/__fallback.txt',
+      'https://example.com/base/docs/api/reference/__fallback.meta.json',
+      'https://example.com/base/docs/api/__fallback.txt',
+      'https://example.com/base/docs/api/__fallback.meta.json',
+      'https://example.com/base/docs/__fallback.txt',
+      'https://example.com/base/docs/__fallback.meta.json',
+      'https://example.com/base/docs/__fallback/__route_0.txt',
+    ])
+  })
+
+  it('caches the resolved fallback data URL for later RSC fetches', async () => {
+    process.env.__NEXT_TRAILING_SLASH = 'false'
+    const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url.endsWith('/docs/__fallback.meta.json')) {
+        return new Response(
+          JSON.stringify({
+            version: 1,
+            routes: [
+              {
+                route: '/docs/[section]/[page]',
+                fallbackPath: '/docs/__fallback/__route_0',
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }
+        )
+      }
+
+      if (url.endsWith('/docs/__fallback/__route_0.txt')) {
+        return new Response('payload', {
+          status: 200,
+          headers: { 'content-type': 'text/plain' },
+        })
+      }
+
+      return new Response('not found', {
+        status: 404,
+        headers: { 'content-type': 'text/html' },
+      })
+    })
+
+    global.fetch = fetchMock as typeof fetch
+
+    const renderedUrl = new URL('https://example.com/docs/api/reference')
+    await fetchOutputExportFallbackResponse(renderedUrl)
+
+    expect(
+      getCachedOutputExportFallbackDataUrl(
+        new URL('https://example.com/docs/api/reference.txt')
+      )?.href
+    ).toBe('https://example.com/docs/__fallback/__route_0.txt')
+    expect(
+      getCachedOutputExportFallbackDataUrl(
+        new URL('https://example.com/docs/api/reference/index.txt')
+      )?.href
+    ).toBe('https://example.com/docs/__fallback/__route_0.txt')
+    expect(
+      getCachedOutputExportFallbackRequestUrl(
+        new URL('https://example.com/docs/api/reference/__next._head.txt')
+      )?.href
+    ).toBe('https://example.com/docs/__fallback/__route_0/__next._head.txt')
+    expect(
+      getCachedOutputExportFallbackRequestUrl(
+        new URL(
+          'https://example.com/docs/api/reference/__next.docs.$d$section.$d$page.txt'
+        )
+      )?.href
+    ).toBe(
+      'https://example.com/docs/__fallback/__route_0/__next.docs.$d$section.$d$page.txt'
+    )
+  })
+
+  it('dedupes fallback artifact fetches across sibling routes', async () => {
+    process.env.__NEXT_TRAILING_SLASH = 'false'
+    const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url.endsWith('/docs/__fallback.txt')) {
+        return new Response('not found', {
+          status: 404,
+          headers: { 'content-type': 'text/html' },
+        })
+      }
+
+      if (url.endsWith('/docs/__fallback.meta.json')) {
+        return new Response(
+          JSON.stringify({
+            version: 1,
+            routes: [
+              {
+                route: '/docs/[section]/[page]',
+                fallbackPath: '/docs/__fallback/__route_0',
+              },
+              {
+                route: '/docs/[...slug]',
+                fallbackPath: '/docs/__fallback/__route_1',
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }
+        )
+      }
+
+      if (url.endsWith('/docs/__fallback/__route_0.txt')) {
+        return new Response('payload', {
+          status: 200,
+          headers: { 'content-type': 'text/plain' },
+        })
+      }
+
+      return new Response('not found', {
+        status: 404,
+        headers: { 'content-type': 'text/html' },
+      })
+    })
+
+    global.fetch = fetchMock as typeof fetch
+
+    await fetchOutputExportFallbackResponse(
+      new URL('https://example.com/docs/api/reference')
+    )
+    await fetchOutputExportFallbackResponse(
+      new URL('https://example.com/docs/api/guide')
+    )
+
+    expect(fetchMock.mock.calls.map(([url]) => String(url))).toEqual([
+      'https://example.com/docs/api/reference/__fallback.txt',
+      'https://example.com/docs/api/reference/__fallback.meta.json',
+      'https://example.com/docs/api/__fallback.txt',
+      'https://example.com/docs/api/__fallback.meta.json',
+      'https://example.com/docs/__fallback.txt',
+      'https://example.com/docs/__fallback.meta.json',
+      'https://example.com/docs/__fallback/__route_0.txt',
+      'https://example.com/docs/api/guide/__fallback.txt',
+      'https://example.com/docs/api/guide/__fallback.meta.json',
+    ])
+  })
+})


### PR DESCRIPTION
## Stack position

Part 16 of 19 in the output export dynamic fallback stack.

Previous PR: #93572 (15/19)
Next PR: #93574 (17/19)

## Context

The stack is split so build-time output can land behind `experimental.outputExportDynamicFallbacks` before the client router behavior is enabled. The target behavior is for `output: 'export'` apps with parameterized App Router routes to emit fallback HTML/RSC artifacts that a later client can resolve for hard loads and soft navigations.

This PR scope: Unit coverage for client fallback manifest lookup.

Manifest lookup is where conflicting dynamic routes, trailing slash mode, and basePath can combine. This PR keeps that resolver reviewable through focused unit coverage.

## What changed

- Covers fallback candidate ordering and data URL suffix handling.
- Covers direct fallback artifacts, manifest-selected fallback artifacts, and cached fallback request URLs.
- Covers basePath conflict matching through the remaining manifest-resolution test.

## Deliberately not included

- Does not keep duplicate tests that are already covered by the e2e basePath suite.
- Does not test dead `stripOutputExportDataSuffix` behavior because the helper was removed.
- Does not add new product behavior.

## Verification

After restacking and autosquashing, I verified the full stack with:

- `pnpm --filter=next build`
- `pnpm testonly packages/next/src/lib/output-export-dynamic-fallback.test.ts packages/next/src/lib/output-export-fallback-routes.test.ts packages/next/src/export/helpers/output-export-fallback.test.ts packages/next/src/server/request/fallback-params.test.ts`
- `pnpm testonly packages/next/src/client/output-export-fallback.test.ts packages/next/src/client/components/router-reducer/fetch-server-response.test.ts packages/next/src/client/components/router-reducer/create-initial-router-state.test.ts packages/next/src/client/components/segment-cache/cache.test.ts packages/next/src/client/components/segment-cache/vary-path.test.ts`
- `pnpm testonly packages/next/src/client/components/router-reducer/compute-changed-path.test.ts packages/next/src/client/flight-data-helpers.test.ts packages/next/src/server/app-render/postponed-state.test.ts`
- `pnpm test-start-turbo test/e2e/app-dir-export/test/dynamic-fallback-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-route-shapes-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-cache-components-basepath.test.ts test/e2e/app-dir-export/test/dynamic-fallback-optimizations-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-known-params-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-conflict.test.ts`
- `pnpm test-start-turbo test/e2e/app-dir/output-export-dynamic-fallbacks/output-export-dynamic-fallbacks.test.ts test/e2e/app-dir-export/test/output-export-server-io.test.ts test/e2e/app-dir-export/test/output-export-server-io-use-cache.test.ts test/e2e/app-dir-export/test/dynamic-fallback-server-params.test.ts`

<!-- NEXT_JS_LLM_PR -->
