### PR TITLE
(17/19) Cover client export fallback route shapes

### DIFF
--- a/packages/next/src/client/components/router-reducer/compute-changed-path.test.ts
+++ b/packages/next/src/client/components/router-reducer/compute-changed-path.test.ts
@@ -1,4 +1,4 @@
-import { computeChangedPath } from './compute-changed-path'
+import { computeChangedPath, getSelectedParams } from './compute-changed-path'
 import { PrefetchHint } from '../../../shared/lib/app-router-types'
 
 describe('computeChangedPath', () => {
@@ -57,5 +57,64 @@ describe('computeChangedPath', () => {
         ]
       )
     ).toBe('/')
+  })
+})
+
+describe('getSelectedParams', () => {
+  const originalOutput = process.env.__NEXT_CONFIG_OUTPUT
+  const originalBasePath = process.env.__NEXT_ROUTER_BASEPATH
+  const originalWindow = global.window
+
+  afterEach(() => {
+    process.env.__NEXT_CONFIG_OUTPUT = originalOutput
+    process.env.__NEXT_ROUTER_BASEPATH = originalBasePath
+    global.window = originalWindow
+  })
+
+  it('resolves deferred export fallback params from the current pathname', () => {
+    process.env.__NEXT_CONFIG_OUTPUT = 'export'
+    global.window = {
+      location: {
+        pathname: '/another/third',
+      },
+    } as Window & typeof globalThis
+
+    expect(
+      getSelectedParams([
+        '',
+        {
+          children: [
+            'another',
+            {
+              children: [['slug', '%%drp:slug:abc123%%', 'd', null], {}],
+            },
+          ],
+        },
+      ])
+    ).toEqual({ slug: 'third' })
+  })
+
+  it('resolves deferred export fallback params after removing basePath', () => {
+    process.env.__NEXT_CONFIG_OUTPUT = 'export'
+    process.env.__NEXT_ROUTER_BASEPATH = '/base'
+    global.window = {
+      location: {
+        pathname: '/base/another/third',
+      },
+    } as Window & typeof globalThis
+
+    expect(
+      getSelectedParams([
+        '',
+        {
+          children: [
+            'another',
+            {
+              children: [['slug', '%%drp:slug:abc123%%', 'd', null], {}],
+            },
+          ],
+        },
+      ])
+    ).toEqual({ slug: 'third' })
   })
 })

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.test.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.test.ts
@@ -1,0 +1,294 @@
+/**
+ * @jest-environment node
+ */
+
+import type { NavigationFlightResponse } from '../../../shared/lib/app-router-types'
+import { setNavigationBuildId } from '../../navigation-build-id'
+import { fetchServerResponse } from './fetch-server-response'
+
+const mockCreateFromReadableStream = jest.fn()
+const mockFetchOutputExportFallbackResponse = jest.fn()
+const mockFetchOutputExportNotFoundDataResponse = jest.fn()
+const mockFetchOutputExportNotFoundResponse = jest.fn()
+const mockGetCachedOutputExportFallbackBasePath = jest.fn()
+const mockGetCachedOutputExportFallbackRequestUrl = jest.fn()
+const mockGetConfiguredOutputExportNotFoundCandidate = jest.fn()
+
+jest.mock('react-server-dom-webpack/client', () => ({
+  createFromFetch: jest.fn(),
+  createFromReadableStream: (...args: Array<unknown>) =>
+    mockCreateFromReadableStream(...args),
+}))
+
+jest.mock('../../output-export-fallback', () => ({
+  addOutputExportDataSuffix: (url: URL) => {
+    const nextUrl = new URL(url)
+    nextUrl.pathname = nextUrl.pathname.endsWith('/')
+      ? `${nextUrl.pathname}index.txt`
+      : `${nextUrl.pathname}.txt`
+    return nextUrl
+  },
+  fetchOutputExportFallbackResponse: (...args: Array<unknown>) =>
+    mockFetchOutputExportFallbackResponse(...args),
+  fetchOutputExportNotFoundDataResponse: (...args: Array<unknown>) =>
+    mockFetchOutputExportNotFoundDataResponse(...args),
+  fetchOutputExportNotFoundResponse: (...args: Array<unknown>) =>
+    mockFetchOutputExportNotFoundResponse(...args),
+  getCachedOutputExportFallbackBasePath: (...args: Array<unknown>) =>
+    mockGetCachedOutputExportFallbackBasePath(...args),
+  getCachedOutputExportFallbackRequestUrl: (...args: Array<unknown>) =>
+    mockGetCachedOutputExportFallbackRequestUrl(...args),
+  getConfiguredOutputExportNotFoundCandidate: (...args: Array<unknown>) =>
+    mockGetConfiguredOutputExportNotFoundCandidate(...args),
+}))
+
+function withResponseUrl(response: Response, url: string): Response {
+  Object.defineProperty(response, 'url', { value: url })
+  Object.defineProperty(response, 'redirected', { value: false })
+  return response
+}
+
+function createFallbackNavigationFlightResponse(): NavigationFlightResponse {
+  return {
+    b: 'build-id',
+    f: [
+      [
+        'children',
+        'another',
+        'children',
+        ['slug', '%%drp:slug:abc123%%', 'd', null],
+        [
+          '',
+          {
+            children: [
+              'another',
+              {
+                children: [['slug', '%%drp:slug:abc123%%', 'd', null], {}],
+              },
+            ],
+          },
+        ],
+        null,
+        null,
+        false,
+      ],
+    ],
+    S: false,
+    q: '',
+    i: false,
+    h: null,
+  }
+}
+
+function createNotFoundNavigationFlightResponse(): NavigationFlightResponse {
+  return {
+    b: 'build-id',
+    f: [
+      [
+        'children',
+        '/_not-found',
+        ['', { children: ['/_not-found', {}] }],
+        null,
+        null,
+        false,
+      ],
+    ],
+    S: false,
+    q: '',
+    i: false,
+    h: null,
+  }
+}
+
+describe('fetchServerResponse output export fallback', () => {
+  const originalNodeEnv = process.env.NODE_ENV
+  const originalOutput = process.env.__NEXT_CONFIG_OUTPUT
+  const originalOutputExportDynamicFallbacks =
+    process.env.__NEXT_OUTPUT_EXPORT_DYNAMIC_FALLBACKS
+  const originalFetch = global.fetch
+  const originalLocation = global.location
+  const processEnv = process.env as Record<string, string | undefined>
+
+  beforeEach(() => {
+    processEnv.NODE_ENV = 'production'
+    processEnv.__NEXT_CONFIG_OUTPUT = 'export'
+    processEnv.__NEXT_OUTPUT_EXPORT_DYNAMIC_FALLBACKS = 'true'
+    global.location = new URL('https://example.com/') as unknown as Location
+    setNavigationBuildId('build-id')
+    mockCreateFromReadableStream.mockReset()
+    mockFetchOutputExportFallbackResponse.mockReset()
+    mockFetchOutputExportNotFoundDataResponse.mockReset()
+    mockFetchOutputExportNotFoundResponse.mockReset()
+    mockGetCachedOutputExportFallbackBasePath.mockReset()
+    mockGetCachedOutputExportFallbackRequestUrl.mockReset()
+    mockGetConfiguredOutputExportNotFoundCandidate.mockReset()
+    mockGetCachedOutputExportFallbackBasePath.mockReturnValue(null)
+    mockGetCachedOutputExportFallbackRequestUrl.mockReturnValue(null)
+    mockFetchOutputExportNotFoundDataResponse.mockResolvedValue(null)
+    mockFetchOutputExportNotFoundResponse.mockResolvedValue(
+      withResponseUrl(
+        new Response('not found payload', {
+          status: 200,
+          headers: { 'content-type': 'text/plain' },
+        }),
+        `${global.location.origin}/_not-found.txt`
+      )
+    )
+    mockGetConfiguredOutputExportNotFoundCandidate.mockReturnValue(
+      '/_not-found'
+    )
+  })
+
+  afterEach(() => {
+    processEnv.NODE_ENV = originalNodeEnv
+    processEnv.__NEXT_CONFIG_OUTPUT = originalOutput
+    if (originalOutputExportDynamicFallbacks === undefined) {
+      delete processEnv.__NEXT_OUTPUT_EXPORT_DYNAMIC_FALLBACKS
+    } else {
+      processEnv.__NEXT_OUTPUT_EXPORT_DYNAMIC_FALLBACKS =
+        originalOutputExportDynamicFallbacks
+    }
+    global.fetch = originalFetch
+    global.location = originalLocation
+    jest.restoreAllMocks()
+  })
+
+  it('reuses the discovered fallback response instead of fetching it again', async () => {
+    const origin = global.location.origin
+    const initialMiss = withResponseUrl(
+      new Response('not found', {
+        status: 404,
+        headers: { 'content-type': 'text/html' },
+      }),
+      `${origin}/another/third.txt`
+    )
+    const fallbackResponse = withResponseUrl(
+      new Response('fallback payload', {
+        status: 200,
+        headers: { 'content-type': 'text/plain' },
+      }),
+      `${origin}/another/__fallback/index.txt`
+    )
+
+    global.fetch = jest
+      .fn(async () => initialMiss)
+      .mockImplementationOnce(async () => initialMiss)
+      .mockImplementation(async () => {
+        throw new Error('unexpected extra fetch')
+      }) as typeof fetch
+
+    mockFetchOutputExportFallbackResponse.mockResolvedValue({
+      response: fallbackResponse,
+      renderedUrl: new URL('/another/third', origin),
+      fallbackUrl: new URL('/another/__fallback', origin),
+    })
+    mockCreateFromReadableStream.mockResolvedValue(
+      createFallbackNavigationFlightResponse()
+    )
+
+    const result = await fetchServerResponse(
+      new URL('/another/third', origin),
+      {
+        flightRouterState: ['', {}, null, null],
+        nextUrl: null,
+      }
+    )
+
+    expect(typeof result).not.toBe('string')
+    if (typeof result !== 'string') {
+      expect(result.canonicalUrl.href).toBe(`${origin}/another/third`)
+      expect(result.outputExportFallbackBasePath).toBe('/another/__fallback')
+    }
+    expect(global.fetch).toHaveBeenCalledTimes(1)
+    expect(mockFetchOutputExportFallbackResponse).toHaveBeenCalledTimes(1)
+  })
+
+  it('routes cached fallback requests explicitly through fetchServerResponse', async () => {
+    const origin = global.location.origin
+    const fallbackResponse = withResponseUrl(
+      new Response('fallback payload', {
+        status: 200,
+        headers: { 'content-type': 'text/plain' },
+      }),
+      `${origin}/another/__fallback.txt`
+    )
+    const fallbackRequestUrl = new URL('/another/__fallback.txt', origin)
+
+    global.fetch = jest.fn(async () => fallbackResponse) as typeof fetch
+    mockGetCachedOutputExportFallbackRequestUrl.mockReturnValue(
+      fallbackRequestUrl
+    )
+    mockGetCachedOutputExportFallbackBasePath.mockReturnValue(
+      '/another/__fallback'
+    )
+    mockCreateFromReadableStream.mockResolvedValue(
+      createFallbackNavigationFlightResponse()
+    )
+
+    const result = await fetchServerResponse(
+      new URL('/another/third', origin),
+      {
+        flightRouterState: ['', {}, null, null],
+        nextUrl: null,
+      }
+    )
+
+    expect(typeof result).not.toBe('string')
+    if (typeof result !== 'string') {
+      expect(result.canonicalUrl.href).toBe(`${origin}/another/third`)
+      expect(result.outputExportFallbackBasePath).toBe('/another/__fallback')
+    }
+    expect(String((global.fetch as jest.Mock).mock.calls[0][0])).toContain(
+      '/another/__fallback.txt?'
+    )
+    expect(mockFetchOutputExportFallbackResponse).not.toHaveBeenCalled()
+  })
+
+  it('validates cached fallback requests before reusing them', async () => {
+    const origin = global.location.origin
+    const fallbackResponse = withResponseUrl(
+      new Response('fallback payload', {
+        status: 200,
+        headers: { 'content-type': 'text/plain' },
+      }),
+      `${origin}/another/__fallback.txt`
+    )
+    const notFoundResponse = withResponseUrl(
+      new Response('not found payload', {
+        status: 200,
+        headers: { 'content-type': 'text/plain' },
+      }),
+      `${origin}/_not-found.txt`
+    )
+    const fallbackRequestUrl = new URL('/another/__fallback.txt', origin)
+
+    global.fetch = jest.fn(async () => fallbackResponse) as typeof fetch
+    mockGetCachedOutputExportFallbackRequestUrl.mockReturnValue(
+      fallbackRequestUrl
+    )
+    mockGetCachedOutputExportFallbackBasePath
+      .mockReturnValueOnce('/another/__fallback')
+      .mockReturnValueOnce('/_not-found')
+    mockFetchOutputExportNotFoundDataResponse.mockResolvedValue(
+      notFoundResponse
+    )
+    mockCreateFromReadableStream
+      .mockResolvedValueOnce(createFallbackNavigationFlightResponse())
+      .mockResolvedValueOnce(createNotFoundNavigationFlightResponse())
+
+    const result = await fetchServerResponse(
+      new URL('/another/third/extra', origin),
+      {
+        flightRouterState: ['', {}, null, null],
+        nextUrl: null,
+      }
+    )
+
+    expect(typeof result).not.toBe('string')
+    if (typeof result !== 'string') {
+      expect(result.canonicalUrl.href).toBe(`${origin}/another/third/extra`)
+      expect(result.outputExportFallbackBasePath).toBe('/_not-found')
+    }
+    expect(mockFetchOutputExportNotFoundDataResponse).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/next/src/client/flight-data-helpers.test.ts
+++ b/packages/next/src/client/flight-data-helpers.test.ts
@@ -1,8 +1,16 @@
-import { prepareFlightRouterStateForRequest } from './flight-data-helpers'
+import {
+  createInitialRSCPayloadFromFallbackPrerender,
+  doesFilledFallbackFlightDataMatchRenderedPathname,
+  fillInFallbackFlightData,
+  prepareFlightRouterStateForRequest,
+} from './flight-data-helpers'
 import {
   PrefetchHint,
+  type FlightData,
+  type InitialRSCPayload,
   type FlightRouterState,
 } from '../shared/lib/app-router-types'
+import type { NormalizedSearch } from './components/segment-cache/cache-key'
 
 describe('prepareFlightRouterStateForRequest', () => {
   describe('HMR refresh handling', () => {
@@ -296,5 +304,325 @@ describe('prepareFlightRouterStateForRequest', () => {
       expect(sidebarRoute[2]).toBeUndefined() // URL stripped
       expect(sidebarRoute[3]).toBeUndefined() // null marker stripped
     })
+  })
+})
+
+describe('fillInFallbackFlightData', () => {
+  const originalBasePath = process.env.__NEXT_ROUTER_BASEPATH
+
+  afterEach(() => {
+    process.env.__NEXT_ROUTER_BASEPATH = originalBasePath
+  })
+
+  it('replaces deferred route param placeholders in navigation flight data', () => {
+    const flightData = [
+      [
+        'children',
+        'another',
+        'children',
+        ['slug', '%%drp:slug:abc123%%', 'd', null],
+        [
+          '',
+          {
+            children: [
+              'another',
+              {
+                children: [['slug', '%%drp:slug:abc123%%', 'd', null], {}],
+              },
+            ],
+          },
+        ],
+        null,
+        null,
+        false,
+      ],
+    ] as FlightData
+
+    const normalizedFlightData = fillInFallbackFlightData(
+      flightData,
+      '/another/third',
+      '' as NormalizedSearch
+    )
+    const patchedFlightDataPath = normalizedFlightData[0]
+
+    expect(patchedFlightDataPath[3]).toEqual(['slug', 'third', 'd', null])
+    const patchedTree = patchedFlightDataPath[4]
+    expect(patchedTree[0]).toBe('')
+    expect(patchedTree[1].children[0]).toBe('another')
+    expect(patchedTree[1].children[1].children[0]).toEqual([
+      'slug',
+      'third',
+      'd',
+      null,
+    ])
+  })
+
+  it('fills deferred route params after removing basePath', () => {
+    process.env.__NEXT_ROUTER_BASEPATH = '/base'
+    const flightData = [
+      [
+        'children',
+        'another',
+        'children',
+        ['slug', '%%drp:slug:abc123%%', 'd', null],
+        [
+          '',
+          {
+            children: [
+              'another',
+              {
+                children: [['slug', '%%drp:slug:abc123%%', 'd', null], {}],
+              },
+            ],
+          },
+        ],
+        null,
+        null,
+        false,
+      ],
+    ] as FlightData
+
+    const normalizedFlightData = fillInFallbackFlightData(
+      flightData,
+      '/base/another/third',
+      '' as NormalizedSearch
+    )
+    const patchedFlightDataPath = normalizedFlightData[0]
+
+    expect(patchedFlightDataPath[3]).toEqual(['slug', 'third', 'd', null])
+    expect(
+      doesFilledFallbackFlightDataMatchRenderedPathname(
+        normalizedFlightData,
+        '/base/another/third'
+      )
+    ).toBe(true)
+  })
+
+  it('advances catch-all fallback params by all remaining pathname parts', () => {
+    for (const paramType of ['c', 'oc'] as const) {
+      const flightData = [
+        [
+          'children',
+          'docs',
+          'children',
+          ['slug', '%%drp:slug:abc123%%', paramType, null],
+          'children',
+          ['after', '%%drp:after:def456%%', 'd', null],
+          [
+            '',
+            {
+              children: [
+                'docs',
+                {
+                  children: [
+                    ['slug', '%%drp:slug:abc123%%', paramType, null],
+                    {
+                      children: [
+                        ['after', '%%drp:after:def456%%', 'd', null],
+                        {},
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+          null,
+          null,
+          false,
+        ],
+      ] as FlightData
+
+      const normalizedFlightData = fillInFallbackFlightData(
+        flightData,
+        '/docs/a/b/c',
+        '' as NormalizedSearch
+      )
+      const patchedFlightDataPath = normalizedFlightData[0]
+
+      expect(patchedFlightDataPath[3]).toEqual([
+        'slug',
+        'a/b/c',
+        paramType,
+        null,
+      ])
+      expect(patchedFlightDataPath[5]).toEqual(['after', '', 'd', null])
+
+      const patchedTree = patchedFlightDataPath[6]
+      expect(patchedTree[1].children[1].children[0]).toEqual([
+        'slug',
+        'a/b/c',
+        paramType,
+        null,
+      ])
+      expect(patchedTree[1].children[1].children[1].children[0]).toEqual([
+        'after',
+        '',
+        'd',
+        null,
+      ])
+    }
+  })
+})
+
+describe('createInitialRSCPayloadFromFallbackPrerender', () => {
+  it('preserves the trailing flight tuple fields while filling fallback params', () => {
+    const fallbackInitialRSCPayload: InitialRSCPayload = {
+      b: 'build-id',
+      c: ['', 'another', '%%drp:slug:abc123%%'],
+      q: '',
+      i: false,
+      f: [
+        [
+          [
+            '',
+            {
+              children: [
+                'another',
+                {
+                  children: [['slug', '%%drp:slug:abc123%%', 'd', null], {}],
+                },
+              ],
+            },
+          ],
+          null,
+          'head-node',
+          true,
+        ],
+      ],
+      m: new Set(),
+      G: [(() => null) as any, undefined],
+      S: false,
+      h: null,
+    }
+
+    const response = new Response(null, {
+      headers: { 'x-nextjs-rewritten-path': '/another/third' },
+    })
+
+    const payload = createInitialRSCPayloadFromFallbackPrerender(
+      response,
+      fallbackInitialRSCPayload,
+      new URL('https://example.com/another/third')
+    )
+
+    const patchedTree = payload.f[0][0]
+    expect(patchedTree[0]).toBe('')
+    expect(patchedTree[1].children[0]).toBe('another')
+    expect(patchedTree[1].children[1].children[0]).toEqual([
+      'slug',
+      'third',
+      'd',
+      null,
+    ])
+    expect(payload.f[0][1]).toBeNull()
+    expect(payload.f[0][2]).toBe('head-node')
+    expect(payload.f[0][3]).toBe(true)
+  })
+
+  it('prefers rewritten headers over the rendered URL override', () => {
+    const fallbackInitialRSCPayload: InitialRSCPayload = {
+      b: 'build-id',
+      c: ['', 'docs', '%%drp:slug:abc123%%'],
+      q: '',
+      i: false,
+      f: [
+        [
+          [
+            '',
+            {
+              children: [
+                'docs',
+                {
+                  children: [['slug', '%%drp:slug:abc123%%', 'd', null], {}],
+                },
+              ],
+            },
+          ],
+          null,
+          'head-node',
+          false,
+        ],
+      ],
+      m: new Set(),
+      G: [(() => null) as any, undefined],
+      S: false,
+      h: null,
+    }
+
+    const response = new Response(null, {
+      headers: {
+        'x-nextjs-rewritten-path': '/docs/rewritten',
+        'x-nextjs-rewritten-query': 'from=fetch',
+      },
+    })
+
+    const payload = createInitialRSCPayloadFromFallbackPrerender(
+      response,
+      fallbackInitialRSCPayload,
+      new URL('https://example.com/docs/original?from=document')
+    )
+
+    const patchedTree = payload.f[0][0]
+    expect(patchedTree[1].children[0]).toBe('docs')
+    expect(patchedTree[1].children[1].children[0]).toEqual([
+      'slug',
+      'rewritten',
+      'd',
+      null,
+    ])
+    expect(payload.q).toBe('?from=fetch')
+    expect(payload.c.join('/')).toBe('/docs/original?from=document')
+  })
+
+  it('falls back to the rendered URL override when no rewritten headers are present', () => {
+    const fallbackInitialRSCPayload: InitialRSCPayload = {
+      b: 'build-id',
+      c: ['', 'docs', '%%drp:slug:abc123%%'],
+      q: '',
+      i: false,
+      f: [
+        [
+          [
+            '',
+            {
+              children: [
+                'docs',
+                {
+                  children: [['slug', '%%drp:slug:abc123%%', 'd', null], {}],
+                },
+              ],
+            },
+          ],
+          null,
+          'head-node',
+          false,
+        ],
+      ],
+      m: new Set(),
+      G: [(() => null) as any, undefined],
+      S: false,
+      h: null,
+    }
+
+    const response = new Response(null, {
+      headers: {},
+    })
+
+    const payload = createInitialRSCPayloadFromFallbackPrerender(
+      response,
+      fallbackInitialRSCPayload,
+      new URL('https://example.com/docs/original?from=document')
+    )
+
+    const patchedTree = payload.f[0][0]
+    expect(patchedTree[1].children[0]).toBe('docs')
+    expect(patchedTree[1].children[1].children[0]).toEqual([
+      'slug',
+      'original',
+      'd',
+      null,
+    ])
+    expect(payload.q).toBe('?from=document')
   })
 })

--- a/packages/next/src/server/app-render/postponed-state.test.ts
+++ b/packages/next/src/server/app-render/postponed-state.test.ts
@@ -58,28 +58,25 @@ describe('getDynamicHTMLPostponedState', () => {
 
     const parsed = parsePostponedState(state, { slug: '123' }, undefined)
 
-    expect(parsed).toMatchInlineSnapshot(`
-     {
-       "data": [
-         1,
-         {
-           "123": "123",
-           "nested": {
-             "123": "123",
-           },
-         },
-       ],
-       "renderResumeDataCache": {
-         "cache": Map {
-           "1" => Promise {},
-         },
-         "decryptedBoundArgs": Map {},
-         "encryptedBoundArgs": Map {},
-         "fetch": Map {},
-       },
-       "type": 2,
-     }
-    `)
+    expect(parsed.type).toBe(DynamicState.HTML)
+    if (parsed.type !== DynamicState.HTML) {
+      return
+    }
+    expect(parsed.data).toEqual([
+      1,
+      {
+        '123': '123',
+        nested: {
+          '123': '123',
+        },
+      },
+    ])
+    expect(parsed.renderResumeDataCache.cache.get('1')).toEqual(
+      expect.any(Promise)
+    )
+    expect(parsed.renderResumeDataCache.decryptedBoundArgs).toEqual(new Map())
+    expect(parsed.renderResumeDataCache.encryptedBoundArgs).toEqual(new Map())
+    expect(parsed.renderResumeDataCache.fetch).toEqual(new Map())
 
     const value = await parsed.renderResumeDataCache.cache.get('1')
 


### PR DESCRIPTION
## Stack position

Part 17 of 19 in the output export dynamic fallback stack.

Previous PR: #93573 (16/19)
Next PR: #93575 (18/19)

## Context

The stack is split so build-time output can land behind `experimental.outputExportDynamicFallbacks` before the client router behavior is enabled. The target behavior is for `output: 'export'` apps with parameterized App Router routes to emit fallback HTML/RSC artifacts that a later client can resolve for hard loads and soft navigations.

This PR scope: Unit coverage for route-shape filling and validation.

The route-shape logic feeds both initial load and soft navigation. This PR locks down the parameter filling and pathname matching behavior before the e2e route-edge coverage.

## What changed

- Covers deferred fallback params in changed-path and selected-param helpers.
- Covers fallback Flight data filling, including basePath behavior.
- Covers explicit `fetchServerResponse` cached fallback routing after the `createFetch` cleanup.

## Deliberately not included

- Does not add browser-level route-edge tests. PR19 does that.
- Does not change build output.
- Does not reintroduce hidden shared fetch remapping.

## Verification

After restacking and autosquashing, I verified the full stack with:

- `pnpm --filter=next build`
- `pnpm testonly packages/next/src/lib/output-export-dynamic-fallback.test.ts packages/next/src/lib/output-export-fallback-routes.test.ts packages/next/src/export/helpers/output-export-fallback.test.ts packages/next/src/server/request/fallback-params.test.ts`
- `pnpm testonly packages/next/src/client/output-export-fallback.test.ts packages/next/src/client/components/router-reducer/fetch-server-response.test.ts packages/next/src/client/components/router-reducer/create-initial-router-state.test.ts packages/next/src/client/components/segment-cache/cache.test.ts packages/next/src/client/components/segment-cache/vary-path.test.ts`
- `pnpm testonly packages/next/src/client/components/router-reducer/compute-changed-path.test.ts packages/next/src/client/flight-data-helpers.test.ts packages/next/src/server/app-render/postponed-state.test.ts`
- `pnpm test-start-turbo test/e2e/app-dir-export/test/dynamic-fallback-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-route-shapes-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-cache-components-basepath.test.ts test/e2e/app-dir-export/test/dynamic-fallback-optimizations-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-known-params-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-conflict.test.ts`
- `pnpm test-start-turbo test/e2e/app-dir/output-export-dynamic-fallbacks/output-export-dynamic-fallbacks.test.ts test/e2e/app-dir-export/test/output-export-server-io.test.ts test/e2e/app-dir-export/test/output-export-server-io-use-cache.test.ts test/e2e/app-dir-export/test/dynamic-fallback-server-params.test.ts`

<!-- NEXT_JS_LLM_PR -->
