### PR TITLE
(18/19) Cover export fallback cache component navigations

### DIFF
--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/another/[slug]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/another/[slug]/page.js
@@ -1,0 +1,21 @@
+import Link from 'next/link'
+import { Suspense } from 'react'
+import SlugClient from './slug-client'
+
+export default function Page() {
+  return (
+    <main>
+      <Suspense fallback={<h1>Loading slug...</h1>}>
+        <SlugClient />
+      </Suspense>
+      <ul>
+        <li>
+          <Link href="/another">Visit another page</Link>
+        </li>
+        <li>
+          <Link href="/org/acme/chat/thread-flat">Visit org thread</Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/another/[slug]/slug-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/another/[slug]/slug-client.js
@@ -1,0 +1,9 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function SlugClient() {
+  const params = useParams()
+
+  return <h1>{params.slug}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/another/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/another/page.js
@@ -1,0 +1,20 @@
+import Link from 'next/link'
+
+export default function Another() {
+  return (
+    <main>
+      <h1>Another</h1>
+      <ul>
+        <li>
+          <Link href="/">Visit the home page</Link>
+        </li>
+        <li>
+          <Link href="/another">another page</Link>
+        </li>
+        <li>
+          <Link href="/another/third">another third page</Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/layout.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/not-found.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/not-found.js
@@ -1,0 +1,3 @@
+export default function NotFound() {
+  return <h1>My custom not found page</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/org/[org]/chat/[thread]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/org/[org]/chat/[thread]/page.js
@@ -1,0 +1,18 @@
+import Link from 'next/link'
+import { Suspense } from 'react'
+import OrgThreadClient from './thread-client'
+
+export default function OrgThreadPage() {
+  return (
+    <>
+      <Suspense fallback={<h1>Loading org thread...</h1>}>
+        <OrgThreadClient />
+      </Suspense>
+      <ul>
+        <li>
+          <Link href="/org">Visit org index</Link>
+        </li>
+      </ul>
+    </>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/org/[org]/chat/[thread]/thread-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/org/[org]/chat/[thread]/thread-client.js
@@ -1,0 +1,13 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function OrgThreadClient() {
+  const params = useParams()
+
+  return (
+    <h1>
+      {params.org}:{params.thread}
+    </h1>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/org/[org]/layout.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/org/[org]/layout.js
@@ -1,0 +1,13 @@
+import { Suspense } from 'react'
+import OrgClient from './org-client'
+
+export default function OrgLayout({ children }) {
+  return (
+    <main>
+      <Suspense fallback={<p id="org-name">Loading org...</p>}>
+        <OrgClient />
+      </Suspense>
+      {children}
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/org/[org]/org-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/org/[org]/org-client.js
@@ -1,0 +1,9 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function OrgClient() {
+  const params = useParams()
+
+  return <p id="org-name">Org {params.org}</p>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/org/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/app/org/page.js
@@ -1,0 +1,16 @@
+import Link from 'next/link'
+
+export default function OrgIndexPage() {
+  return (
+    <main>
+      <h1>Org index</h1>
+      <ul>
+        <li>
+          <Link href="/org/acme/chat/thread-123">
+            Visit org chat thread 123
+          </Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/next.config.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components-flat/next.config.js
@@ -1,0 +1,11 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  output: 'export',
+  trailingSlash: false,
+  cacheComponents: true,
+  experimental: {
+    outputExportDynamicFallbacks: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/(grouped)/grouped/[slug]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/(grouped)/grouped/[slug]/page.js
@@ -1,0 +1,18 @@
+import Link from 'next/link'
+import { Suspense } from 'react'
+import GroupedSlugClient from './slug-client'
+
+export default function GroupedSlugPage() {
+  return (
+    <main>
+      <Suspense fallback={<h1>Loading grouped slug...</h1>}>
+        <GroupedSlugClient />
+      </Suspense>
+      <ul>
+        <li>
+          <Link href="/grouped">Visit grouped index</Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/(grouped)/grouped/[slug]/slug-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/(grouped)/grouped/[slug]/slug-client.js
@@ -1,0 +1,9 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function GroupedSlugClient() {
+  const params = useParams()
+
+  return <h1>{params.slug}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/(grouped)/grouped/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/(grouped)/grouped/page.js
@@ -1,0 +1,14 @@
+import Link from 'next/link'
+
+export default function GroupedIndexPage() {
+  return (
+    <main>
+      <h1>Grouped index</h1>
+      <ul>
+        <li>
+          <Link href="/grouped/from-group">Visit grouped fallback page</Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/another/[slug]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/another/[slug]/page.js
@@ -1,0 +1,23 @@
+import Link from 'next/link'
+import { Suspense } from 'react'
+import SlugClient from './slug-client'
+
+export default function Page() {
+  return (
+    <main>
+      <Suspense fallback={<h1>Loading slug...</h1>}>
+        <SlugClient />
+      </Suspense>
+      <ul>
+        <li>
+          <Link href="/another">Visit another page</Link>
+        </li>
+        <li>
+          <Link href="/org/acme/chat/thread-cross">
+            Visit org thread (cross-subtree)
+          </Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/another/[slug]/slug-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/another/[slug]/slug-client.js
@@ -1,0 +1,9 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function SlugClient() {
+  const params = useParams()
+
+  return <h1>{params.slug}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/another/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/another/page.js
@@ -1,0 +1,20 @@
+import Link from 'next/link'
+
+export default function Another() {
+  return (
+    <main>
+      <h1>Another</h1>
+      <ul>
+        <li>
+          <Link href="/">Visit the home page</Link>
+        </li>
+        <li>
+          <Link href="/another">another page</Link>
+        </li>
+        <li>
+          <Link href="/another/third">another third page</Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/components/link-accordion.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/components/link-accordion.js
@@ -1,0 +1,26 @@
+'use client'
+
+import Link from 'next/link'
+import { useState } from 'react'
+
+export function LinkAccordion({ href, children, prefetch }) {
+  const [isVisible, setIsVisible] = useState(false)
+
+  return (
+    <>
+      <input
+        type="checkbox"
+        checked={isVisible}
+        onChange={() => setIsVisible(!isVisible)}
+        data-link-accordion={href}
+      />
+      {isVisible ? (
+        <Link href={href} prefetch={prefetch} data-accordion-link={href}>
+          {children}
+        </Link>
+      ) : (
+        `${children} (link is hidden)`
+      )}
+    </>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/docs/[...slug]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/docs/[...slug]/page.js
@@ -1,0 +1,18 @@
+import Link from 'next/link'
+import { Suspense } from 'react'
+import DocsSlugClient from './slug-client'
+
+export default function DocsCatchAllPage() {
+  return (
+    <main>
+      <Suspense fallback={<h1>Loading docs...</h1>}>
+        <DocsSlugClient />
+      </Suspense>
+      <ul>
+        <li>
+          <Link href="/docs">Visit docs index</Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/docs/[...slug]/slug-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/docs/[...slug]/slug-client.js
@@ -1,0 +1,11 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function DocsSlugClient() {
+  const params = useParams()
+
+  return (
+    <h1>{Array.isArray(params.slug) ? params.slug.join('/') : 'missing'}</h1>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/docs/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/docs/page.js
@@ -1,0 +1,19 @@
+import Link from 'next/link'
+
+export default function DocsIndex() {
+  return (
+    <main>
+      <h1>Docs</h1>
+      <ul>
+        <li>
+          <Link href="/docs/reference/export">docs reference page</Link>
+        </li>
+        <li>
+          <Link href="/docs/guides/export/fallback">
+            docs export fallback page
+          </Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/docs/reference/[topic]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/docs/reference/[topic]/page.js
@@ -1,0 +1,18 @@
+import Link from 'next/link'
+import { Suspense } from 'react'
+import ReferenceTopicClient from './topic-client'
+
+export default function DocsReferenceTopicPage() {
+  return (
+    <main>
+      <Suspense fallback={<h1>Loading reference...</h1>}>
+        <ReferenceTopicClient />
+      </Suspense>
+      <ul>
+        <li>
+          <Link href="/docs">Visit docs index</Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/docs/reference/[topic]/topic-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/docs/reference/[topic]/topic-client.js
@@ -1,0 +1,9 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function ReferenceTopicClient() {
+  const params = useParams()
+
+  return <h1>{`reference:${params.topic ?? 'missing'}`}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/hydrated/[thread]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/hydrated/[thread]/page.js
@@ -1,0 +1,29 @@
+import Link from 'next/link'
+import { Suspense } from 'react'
+import { LinkAccordion } from '../../components/link-accordion'
+import HydratedThreadClient from './thread-client'
+
+export default function HydratedThreadPage() {
+  return (
+    <>
+      <Suspense fallback={<h1>Loading hydrated thread...</h1>}>
+        <HydratedThreadClient />
+      </Suspense>
+      <ul>
+        <li>
+          <Link href="/">Visit the home page</Link>
+        </li>
+        <li>
+          <LinkAccordion href="/hydrated/second">
+            Visit hydrated thread second
+          </LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/hydrated/third">
+            Visit hydrated thread third
+          </LinkAccordion>
+        </li>
+      </ul>
+    </>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/hydrated/[thread]/thread-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/hydrated/[thread]/thread-client.js
@@ -1,0 +1,9 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function HydratedThreadClient() {
+  const params = useParams()
+
+  return <h1>{params.thread}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/inbox/@modal/[thread]/modal-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/inbox/@modal/[thread]/modal-client.js
@@ -1,0 +1,9 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function InboxModalClient() {
+  const params = useParams()
+
+  return <p id="modal-thread">Modal {params.thread}</p>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/inbox/@modal/[thread]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/inbox/@modal/[thread]/page.js
@@ -1,0 +1,10 @@
+import { Suspense } from 'react'
+import InboxModalClient from './modal-client'
+
+export default function InboxModalPage() {
+  return (
+    <Suspense fallback={<p id="modal-thread">Loading modal...</p>}>
+      <InboxModalClient />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/inbox/@modal/default.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/inbox/@modal/default.js
@@ -1,0 +1,3 @@
+export default function InboxModalDefault() {
+  return <p id="modal-thread">No modal</p>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/inbox/[thread]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/inbox/[thread]/page.js
@@ -1,0 +1,18 @@
+import Link from 'next/link'
+import { Suspense } from 'react'
+import InboxThreadClient from './thread-client'
+
+export default function InboxThreadPage() {
+  return (
+    <>
+      <Suspense fallback={<h1>Loading inbox thread...</h1>}>
+        <InboxThreadClient />
+      </Suspense>
+      <ul>
+        <li>
+          <Link href="/inbox">Visit inbox index</Link>
+        </li>
+      </ul>
+    </>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/inbox/[thread]/thread-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/inbox/[thread]/thread-client.js
@@ -1,0 +1,9 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function InboxThreadClient() {
+  const params = useParams()
+
+  return <h1>{params.thread}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/inbox/layout.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/inbox/layout.js
@@ -1,0 +1,8 @@
+export default function InboxLayout({ children, modal }) {
+  return (
+    <main>
+      {children}
+      <section id="modal-slot">{modal}</section>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/inbox/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/inbox/page.js
@@ -1,0 +1,14 @@
+import Link from 'next/link'
+
+export default function InboxIndexPage() {
+  return (
+    <main>
+      <h1>Inbox</h1>
+      <ul>
+        <li>
+          <Link href="/inbox/thread-123">Visit inbox thread</Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/isolated/[slug]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/isolated/[slug]/page.js
@@ -1,0 +1,12 @@
+import { Suspense } from 'react'
+import IsolatedSlugClient from './slug-client'
+
+export default function Page() {
+  return (
+    <main>
+      <Suspense fallback={<h1>Loading isolated slug...</h1>}>
+        <IsolatedSlugClient />
+      </Suspense>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/isolated/[slug]/slug-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/isolated/[slug]/slug-client.js
@@ -1,0 +1,8 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function IsolatedSlugClient() {
+  const params = useParams()
+  return <h1>{params.slug}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/isolated/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/isolated/page.js
@@ -1,0 +1,26 @@
+import { LinkAccordion } from '../components/link-accordion'
+
+export default function Isolated() {
+  return (
+    <main>
+      <h1>Isolated</h1>
+      <ul>
+        <li>
+          <LinkAccordion href="/isolated/third" prefetch={true}>
+            prefetched isolated third page
+          </LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/isolated/fourth" prefetch={true}>
+            prefetched isolated fourth page
+          </LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/isolated/third/extra" prefetch={true}>
+            invalid isolated third page
+          </LinkAccordion>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/layout.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/not-found.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/not-found.js
@@ -1,0 +1,3 @@
+export default function NotFound() {
+  return <h1>My custom not found page</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/optional/[[...slug]]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/optional/[[...slug]]/page.js
@@ -1,0 +1,18 @@
+import Link from 'next/link'
+import { Suspense } from 'react'
+import OptionalSlugClient from './slug-client'
+
+export default function OptionalCatchAllPage() {
+  return (
+    <main>
+      <Suspense fallback={<h1>Loading optional...</h1>}>
+        <OptionalSlugClient />
+      </Suspense>
+      <ul>
+        <li>
+          <Link href="/optional/deep/path">Visit optional deep path</Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/optional/[[...slug]]/slug-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/optional/[[...slug]]/slug-client.js
@@ -1,0 +1,10 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function OptionalSlugClient() {
+  const params = useParams()
+  const slug = params.slug
+
+  return <h1>{Array.isArray(slug) ? slug.join('/') : 'optional index'}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/org/[org]/chat/[thread]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/org/[org]/chat/[thread]/page.js
@@ -1,0 +1,23 @@
+import Link from 'next/link'
+import { Suspense } from 'react'
+import OrgThreadClient from './thread-client'
+
+export default function OrgThreadPage() {
+  return (
+    <>
+      <Suspense fallback={<h1>Loading org thread...</h1>}>
+        <OrgThreadClient />
+      </Suspense>
+      <ul>
+        <li>
+          <Link href="/org">Visit org index</Link>
+        </li>
+        <li>
+          <Link href="/org/acme/chat/thread-456">
+            Visit org chat thread 456
+          </Link>
+        </li>
+      </ul>
+    </>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/org/[org]/chat/[thread]/thread-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/org/[org]/chat/[thread]/thread-client.js
@@ -1,0 +1,13 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function OrgThreadClient() {
+  const params = useParams()
+
+  return (
+    <h1>
+      {params.org}:{params.thread}
+    </h1>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/org/[org]/layout.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/org/[org]/layout.js
@@ -1,0 +1,13 @@
+import { Suspense } from 'react'
+import OrgClient from './org-client'
+
+export default function OrgLayout({ children }) {
+  return (
+    <main>
+      <Suspense fallback={<p id="org-name">Loading org...</p>}>
+        <OrgClient />
+      </Suspense>
+      {children}
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/org/[org]/org-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/org/[org]/org-client.js
@@ -1,0 +1,9 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function OrgClient() {
+  const params = useParams()
+
+  return <p id="org-name">Org {params.org}</p>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/org/layout.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/org/layout.js
@@ -1,0 +1,8 @@
+export default function OrgSectionLayout({ children }) {
+  return (
+    <section>
+      <p id="org-section">Org section layout</p>
+      {children}
+    </section>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/org/not-found.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/org/not-found.js
@@ -1,0 +1,16 @@
+import Link from 'next/link'
+
+export default function OrgNotFound() {
+  return (
+    <main>
+      <h1>Org section not found</h1>
+      <ul>
+        <li>
+          <Link href="/org/acme/missing-two">
+            Visit another missing org route
+          </Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/org/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/org/page.js
@@ -1,0 +1,16 @@
+import Link from 'next/link'
+
+export default function OrgIndexPage() {
+  return (
+    <main>
+      <h1>Org index</h1>
+      <ul>
+        <li>
+          <Link href="/org/acme/chat/thread-123">
+            Visit org chat thread 123
+          </Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/page.js
@@ -1,0 +1,14 @@
+import Link from 'next/link'
+
+export default function Home() {
+  return (
+    <main>
+      <h1>Home</h1>
+      <ul>
+        <li>
+          <Link href="/hydrated/first">Visit hydrated thread first</Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/next.config.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/next.config.js
@@ -1,0 +1,12 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  output: 'export',
+  trailingSlash: true,
+  cacheComponents: true,
+  experimental: {
+    outputExportDynamicFallbacks: true,
+    optimisticRouting: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir-export/test/dynamic-fallback-cache-components-basepath.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-fallback-cache-components-basepath.test.ts
@@ -1,0 +1,112 @@
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+import webdriver from 'next-webdriver'
+import { buildAndStartOutputExportServer } from './utils'
+
+const { next, skipped, isNextDev } = nextTestSetup({
+  files: join(__dirname, '..', 'fixtures', 'dynamic-fallback-cache-components'),
+  skipDeployment: true,
+  skipStart: true,
+  disableAutoSkewProtection: true,
+})
+
+if (skipped) {
+  describe.skip('app dir - output export dynamic routes with Cache Components and basePath', () => {})
+} else {
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  describeProduction(
+    'app dir - output export dynamic routes with Cache Components and basePath',
+    () => {
+      let port: number
+      let stopOrKill: (() => Promise<void>) | undefined
+      let getRequests: () => string[]
+      let clearRequests: () => void
+
+      beforeAll(async () => {
+        await next.patchFile('next.config.js', (content) =>
+          content.replace(
+            'cacheComponents: true,',
+            "cacheComponents: true,\n  basePath: '/base',"
+          )
+        )
+        ;({ port, stopOrKill, getRequests, clearRequests } =
+          await buildAndStartOutputExportServer(next, {
+            basePath: '/base',
+            useFallbackDocument: true,
+          }))
+      })
+
+      afterAll(async () => {
+        await stopOrKill?.()
+        await next.destroy()
+      })
+
+      it('renders an unenumerated dynamic route after removing basePath from fallback params', async () => {
+        const browser = await webdriver(port, '/base/another/third/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('third')
+            expect(await browser.eval('window.location.pathname')).toBe(
+              '/base/another/third/'
+            )
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('client navigates to an unenumerated dynamic route under the basePath', async () => {
+        const browser = await webdriver(port, '/base/another/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('Another')
+            expect(await browser.eval('window.location.pathname')).toBe(
+              '/base/another/'
+            )
+          })
+
+          await browser.elementByCss('a[href^="/base/another/third"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('third')
+            expect(await browser.eval('window.location.pathname')).toBe(
+              '/base/another/third/'
+            )
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('keeps unmatched fallback not-found fetches under the basePath', async () => {
+        clearRequests()
+        const browser = await webdriver(port, '/base/missing/route/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'My custom not found page'
+            )
+          })
+
+          const requests = getRequests()
+          expect(
+            requests.some((requestPath) =>
+              requestPath.startsWith('/base/_not-found/index.txt')
+            )
+          ).toBe(true)
+          expect(
+            requests.some((requestPath) =>
+              requestPath.startsWith('/_not-found.txt')
+            )
+          ).toBe(false)
+        } finally {
+          await browser.close()
+        }
+      })
+    }
+  )
+}

--- a/test/e2e/app-dir-export/test/dynamic-fallback-cache-components-flat.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-fallback-cache-components-flat.test.ts
@@ -1,0 +1,121 @@
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+import webdriver from 'next-webdriver'
+import fs from 'fs-extra'
+import { buildAndStartOutputExportServer } from './utils'
+
+const { next, skipped, isNextDev } = nextTestSetup({
+  files: join(
+    __dirname,
+    '..',
+    'fixtures',
+    'dynamic-fallback-cache-components-flat'
+  ),
+  skipDeployment: true,
+  skipStart: true,
+  disableAutoSkewProtection: true,
+})
+
+if (skipped) {
+  it('skips unsupported mode', () => {})
+} else {
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  describeProduction(
+    'app dir - output export dynamic routes with Cache Components without trailing slashes',
+    () => {
+      let port: number
+      let stopOrKill: (() => Promise<void>) | undefined
+
+      beforeAll(async () => {
+        ;({ port, stopOrKill } = await buildAndStartOutputExportServer(next, {
+          useFallbackDocument: true,
+        }))
+      })
+
+      afterAll(async () => {
+        if (stopOrKill) {
+          await stopOrKill()
+        }
+        await next.destroy()
+      })
+
+      it('writes flat fallback artifacts for trailingSlash false', async () => {
+        const outDir = join(next.testDir, 'out')
+
+        expect(await fs.pathExists(join(outDir, '_fallback.html'))).toBe(true)
+        expect(
+          await fs.pathExists(join(outDir, 'another', '__fallback.html'))
+        ).toBe(true)
+        expect(
+          await fs.pathExists(join(outDir, 'another', '__fallback.txt'))
+        ).toBe(true)
+        expect(await fs.pathExists(join(outDir, 'org', '__fallback.txt'))).toBe(
+          true
+        )
+        expect(
+          await fs.pathExists(
+            join(outDir, 'another', '__fallback', 'index.html')
+          )
+        ).toBe(false)
+      })
+
+      it('renders an unenumerated slug on hard load and client navigation without adding a trailing slash', async () => {
+        const browser = await webdriver(port, '/another/third')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('third')
+            expect(await browser.eval('window.location.pathname')).toBe(
+              '/another/third'
+            )
+          })
+
+          await browser.elementByCss('a[href="/another"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('Another')
+            expect(await browser.eval('window.location.pathname')).toBe(
+              '/another'
+            )
+          })
+
+          await browser.elementByCss('a[href="/another/third"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('third')
+            expect(await browser.eval('window.location.pathname')).toBe(
+              '/another/third'
+            )
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('preserves search params and hash for nested fallback routes without trailing slashes', async () => {
+        const browser = await webdriver(
+          port,
+          '/org/umbrella/chat/thread-flat?view=full#messages'
+        )
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('#org-name').text()).toBe(
+              'Org umbrella'
+            )
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'umbrella:thread-flat'
+            )
+            expect(
+              await browser.eval(
+                'window.location.pathname + window.location.search + window.location.hash'
+              )
+            ).toBe('/org/umbrella/chat/thread-flat?view=full#messages')
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+    }
+  )
+}

--- a/test/e2e/app-dir-export/test/dynamic-fallback-cache-components.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-fallback-cache-components.test.ts
@@ -1,0 +1,390 @@
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+import webdriver from 'next-webdriver'
+import type * as Playwright from 'playwright'
+import { createRouterAct } from 'router-act'
+import fs from 'fs-extra'
+import { buildAndStartOutputExportServer } from './utils'
+
+const { next, skipped, isNextDev } = nextTestSetup({
+  files: join(__dirname, '..', 'fixtures', 'dynamic-fallback-cache-components'),
+  skipDeployment: true,
+  skipStart: true,
+  disableAutoSkewProtection: true,
+})
+
+if (skipped) {
+  it('skips unsupported mode', () => {})
+} else {
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  describeProduction(
+    'app dir - output export dynamic routes with Cache Components',
+    () => {
+      let port: number
+      let stopOrKill: (() => Promise<void>) | undefined
+      let getRequests: () => string[]
+      let clearRequests: () => void
+
+      beforeAll(async () => {
+        ;({ port, stopOrKill, getRequests, clearRequests } =
+          await buildAndStartOutputExportServer(next, {
+            useFallbackDocument: true,
+          }))
+      })
+
+      afterAll(async () => {
+        if (stopOrKill) {
+          await stopOrKill()
+        }
+        await next.destroy()
+      })
+
+      it('writes fallback artifacts instead of per-param prerenders', async () => {
+        const outDir = join(next.testDir, 'out')
+
+        expect(await fs.pathExists(join(outDir, '_fallback.html'))).toBe(true)
+        expect(
+          await fs.readFile(join(outDir, '_fallback.html'), 'utf8')
+        ).toContain('__NEXT_EXPORT_FALLBACK=1')
+        expect(
+          await fs.pathExists(
+            join(outDir, 'another', '__fallback', 'index.html')
+          )
+        ).toBe(true)
+        expect(
+          await fs.pathExists(
+            join(outDir, 'another', '__fallback', 'index.txt')
+          )
+        ).toBe(true)
+        expect(
+          await fs.pathExists(join(outDir, 'another', 'first', 'index.html'))
+        ).toBe(false)
+      })
+
+      it('renders an unenumerated slug on hard load and client navigation', async () => {
+        clearRequests()
+        const browser = await webdriver(port, '/another/third/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('third')
+          })
+
+          expect(
+            getRequests().some((requestPath) =>
+              requestPath.startsWith('/another/__fallback/index.html')
+            )
+          ).toBe(false)
+
+          await browser.elementByCss('a[href="/another/"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('Another')
+          })
+
+          await browser.elementByCss('a[href="/another/third/"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('third')
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('prefetches fallback payloads for unknown-param links before navigation', async () => {
+        let act!: ReturnType<typeof createRouterAct>
+        const browser = await webdriver(port, '/isolated/', {
+          beforePageLoad(page: Playwright.Page) {
+            act = createRouterAct(page)
+          },
+        })
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('Isolated')
+          })
+
+          await act(async () => {
+            const toggle = await browser.elementByCss(
+              'input[data-link-accordion="/isolated/third"]'
+            )
+            await toggle.click()
+          })
+
+          clearRequests()
+
+          await browser
+            .elementByCss('a[data-accordion-link="/isolated/third"]')
+            .click()
+
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('third')
+          })
+
+          const clickRequests = getRequests()
+          expect(
+            clickRequests.some((requestPath) =>
+              requestPath.startsWith('/isolated/__fallback.meta.json')
+            )
+          ).toBe(false)
+          expect(
+            clickRequests.some((requestPath) =>
+              requestPath.startsWith('/isolated/__fallback/index.txt')
+            )
+          ).toBe(false)
+          expect(
+            clickRequests.some((requestPath) =>
+              requestPath.startsWith('/isolated/third/index.txt')
+            )
+          ).toBe(false)
+          expect(
+            clickRequests.some((requestPath) =>
+              requestPath.startsWith('/isolated/third/__next.')
+            )
+          ).toBe(false)
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('dedupes fallback artifact prefetches across sibling unknown-param links', async () => {
+        let act!: ReturnType<typeof createRouterAct>
+        const browser = await webdriver(port, '/isolated/', {
+          beforePageLoad(page: Playwright.Page) {
+            act = createRouterAct(page)
+          },
+        })
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('Isolated')
+          })
+
+          clearRequests()
+
+          await act(async () => {
+            await browser
+              .elementByCss('input[data-link-accordion="/isolated/third"]')
+              .click()
+            await browser
+              .elementByCss('input[data-link-accordion="/isolated/fourth"]')
+              .click()
+          })
+
+          const prefetchRequests = getRequests().filter((requestPath) =>
+            requestPath.startsWith('/isolated/__fallback/index.txt')
+          )
+
+          expect(prefetchRequests).toHaveLength(1)
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('renders the app not-found page when no fallback route matches', async () => {
+        const browser = await webdriver(port, '/missing/route/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'My custom not found page'
+            )
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('renders not-found for a prefetched invalid fallback route shape', async () => {
+        let act!: ReturnType<typeof createRouterAct>
+        const browser = await webdriver(port, '/isolated/', {
+          beforePageLoad(page: Playwright.Page) {
+            act = createRouterAct(page)
+          },
+        })
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('Isolated')
+          })
+
+          await act(async () => {
+            const toggle = await browser.elementByCss(
+              'input[data-link-accordion="/isolated/third/extra"]'
+            )
+            await toggle.click()
+          })
+
+          const prefetchRequests = getRequests()
+          expect(
+            prefetchRequests.some((requestPath) =>
+              requestPath.startsWith('/isolated/__fallback/index.txt')
+            )
+          ).toBe(true)
+
+          clearRequests()
+
+          await browser
+            .elementByCss('a[data-accordion-link="/isolated/third/extra"]')
+            .click()
+
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'My custom not found page'
+            )
+          })
+
+          const clickRequests = getRequests()
+          expect(
+            clickRequests.some((requestPath) =>
+              requestPath.startsWith('/_not-found/index.txt')
+            )
+          ).toBe(true)
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('generates _fallback.html from a PPR shell instead of index.html', async () => {
+        const outDir = join(next.testDir, 'out')
+        const fallbackHtml = await fs.readFile(
+          join(outDir, '_fallback.html'),
+          'utf8'
+        )
+
+        expect(fallbackHtml).toContain('__NEXT_EXPORT_FALLBACK=1')
+        expect(fallbackHtml).not.toContain('>Home<')
+        expect(fallbackHtml).toContain('__next-export-fallback-style')
+      })
+
+      it('supports browser back/forward between fallback routes', async () => {
+        const browser = await webdriver(port, '/another/slug-a/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('slug-a')
+          })
+
+          await browser.elementByCss('a[href="/another/"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('Another')
+          })
+
+          await browser.back()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('slug-a')
+          })
+
+          await browser.forward()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('Another')
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('handles consecutive hard navigations to different params', async () => {
+        const browser = await webdriver(port, '/another/param-one/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('param-one')
+          })
+
+          await browser.get(`http://localhost:${port}/another/param-two/`)
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('param-two')
+          })
+
+          await browser.get(`http://localhost:${port}/another/param-three/`)
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('param-three')
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('preserves search params and hash across fallback hard loads', async () => {
+        const browser = await webdriver(
+          port,
+          '/another/query-param/?tab=notes#anchor'
+        )
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('query-param')
+            expect(
+              await browser.eval(
+                'window.location.pathname + window.location.search + window.location.hash'
+              )
+            ).toBe('/another/query-param/?tab=notes#anchor')
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('supports a longer history sequence across static and fallback routes', async () => {
+        const browser = await webdriver(port, '/another/history-one/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('history-one')
+          })
+
+          await browser.elementByCss('a[href="/another/"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('Another')
+          })
+
+          await browser.elementByCss('a[href="/another/third/"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('third')
+          })
+
+          await browser.back()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('Another')
+          })
+
+          await browser.back()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('history-one')
+          })
+
+          await browser.forward()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('Another')
+          })
+
+          await browser.forward()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('third')
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('shows Suspense fallback UI during hard load of a fallback route', async () => {
+        const browser = await webdriver(port, '/another/suspense-test/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'suspense-test'
+            )
+          })
+
+          const html = await browser.eval('document.documentElement.innerHTML')
+          expect(html).not.toContain('Loading slug...')
+        } finally {
+          await browser.close()
+        }
+      })
+    }
+  )
+}

--- a/test/e2e/app-dir-export/test/dynamic-fallback-optimizations-cache-components.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-fallback-optimizations-cache-components.test.ts
@@ -1,0 +1,300 @@
+import { join } from 'path'
+import { createNext, isNextDeploy, isNextDev, NextInstance } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+import webdriver from 'next-webdriver'
+import type * as Playwright from 'playwright'
+import { createRouterAct } from 'router-act'
+import { buildAndStartOutputExportServer } from './utils'
+
+if (isNextDeploy) {
+  it('skips deploy mode', () => {})
+} else {
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  describeProduction(
+    'app dir - output export dynamic route optimizations with Cache Components',
+    () => {
+      let next: NextInstance
+      let port: number
+      let stopOrKill: (() => Promise<void>) | undefined
+      let getRequests: () => string[]
+      let clearRequests: () => void
+
+      beforeAll(async () => {
+        next = await createNext({
+          files: join(
+            __dirname,
+            '..',
+            'fixtures',
+            'dynamic-fallback-cache-components'
+          ),
+          skipStart: true,
+          disableAutoSkewProtection: true,
+        })
+        ;({ port, stopOrKill, getRequests, clearRequests } =
+          await buildAndStartOutputExportServer(next, {
+            useFallbackDocument: true,
+          }))
+      })
+
+      afterAll(async () => {
+        if (stopOrKill) {
+          await stopOrKill()
+        }
+        await next.destroy()
+      })
+
+      it('falls through from a concrete route-tree probe to the hydrated fallback tree', async () => {
+        let act!: ReturnType<typeof createRouterAct>
+        const browser = await webdriver(port, '/hydrated/first/', {
+          beforePageLoad(page: Playwright.Page) {
+            act = createRouterAct(page)
+          },
+        })
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('first')
+          })
+
+          await act(async () => {}, 'no-requests')
+          clearRequests()
+
+          await act(async () => {
+            await browser
+              .elementByCss('input[data-link-accordion="/hydrated/second"]')
+              .click()
+          })
+
+          const prefetchRequests = getRequests()
+
+          expect(prefetchRequests.length).toBeGreaterThan(0)
+          expect(
+            prefetchRequests.some((requestPath) =>
+              requestPath.startsWith('/hydrated/second/?_rsc=')
+            )
+          ).toBe(false)
+          expect(
+            prefetchRequests.some((requestPath) =>
+              requestPath.startsWith('/hydrated/second/index.txt')
+            )
+          ).toBe(false)
+          expect(
+            prefetchRequests.some((requestPath) =>
+              requestPath.startsWith('/hydrated/second/__fallback/index.txt')
+            )
+          ).toBe(true)
+          expect(
+            prefetchRequests.some((requestPath) =>
+              requestPath.startsWith('/hydrated/second/__fallback.meta.json')
+            )
+          ).toBe(true)
+          expect(
+            prefetchRequests.some((requestPath) =>
+              requestPath.startsWith('/hydrated/__fallback/__next.')
+            )
+          ).toBe(true)
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('keeps shared hydrated fallback endpoints after revisiting a cached fallback route', async () => {
+        let act!: ReturnType<typeof createRouterAct>
+        const browser = await webdriver(port, '/hydrated/first/', {
+          beforePageLoad(page: Playwright.Page) {
+            act = createRouterAct(page)
+          },
+        })
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('first')
+          })
+
+          await browser.elementByCss('a[href="/"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('Home')
+          })
+
+          clearRequests()
+
+          await browser.elementByCss('a[href^="/hydrated/first"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('first')
+          })
+
+          await act(async () => {}, 'no-requests')
+          clearRequests()
+
+          await browser
+            .elementByCss('input[data-link-accordion="/hydrated/second"]')
+            .click()
+
+          await retry(async () => {
+            const prefetchRequests = getRequests()
+
+            expect(
+              prefetchRequests.some((requestPath) =>
+                requestPath.startsWith('/hydrated/second/?_rsc=')
+              )
+            ).toBe(false)
+            expect(
+              prefetchRequests.some((requestPath) =>
+                requestPath.startsWith('/hydrated/second/__next.')
+              )
+            ).toBe(false)
+            expect(
+              prefetchRequests.length === 0 ||
+                prefetchRequests.some((requestPath) =>
+                  requestPath.startsWith('/hydrated/__fallback/__next.')
+                )
+            ).toBe(true)
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('reuses the same hydrated fallback tree endpoint across sibling prefetches', async () => {
+        let act!: ReturnType<typeof createRouterAct>
+        const browser = await webdriver(port, '/hydrated/first/', {
+          beforePageLoad(page: Playwright.Page) {
+            act = createRouterAct(page)
+          },
+        })
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('first')
+          })
+
+          clearRequests()
+
+          await act(async () => {
+            await browser
+              .elementByCss('input[data-link-accordion="/hydrated/second"]')
+              .click()
+            await browser
+              .elementByCss('input[data-link-accordion="/hydrated/third"]')
+              .click()
+          })
+
+          const prefetchRequests = getRequests()
+          const fallbackTreeRequests = prefetchRequests.filter((requestPath) =>
+            requestPath.startsWith('/hydrated/__fallback/__next.')
+          )
+
+          expect(
+            prefetchRequests.some((requestPath) =>
+              requestPath.startsWith('/hydrated/second/?_rsc=')
+            )
+          ).toBe(false)
+          expect(
+            prefetchRequests.some((requestPath) =>
+              requestPath.startsWith('/hydrated/third/?_rsc=')
+            )
+          ).toBe(false)
+          expect(
+            prefetchRequests.some((requestPath) =>
+              requestPath.startsWith('/hydrated/second/index.txt')
+            )
+          ).toBe(false)
+          expect(
+            prefetchRequests.some((requestPath) =>
+              requestPath.startsWith('/hydrated/third/index.txt')
+            )
+          ).toBe(false)
+          expect(fallbackTreeRequests.length).toBeGreaterThanOrEqual(1)
+          expect(
+            fallbackTreeRequests.every((requestPath) =>
+              requestPath.startsWith('/hydrated/__fallback/__next.')
+            )
+          ).toBe(true)
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('keeps shared hydrated segment requests on the fallback artifact during sibling prefetches', async () => {
+        let act!: ReturnType<typeof createRouterAct>
+        const browser = await webdriver(port, '/hydrated/first/', {
+          beforePageLoad(page: Playwright.Page) {
+            act = createRouterAct(page)
+          },
+        })
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('first')
+          })
+
+          await act(async () => {}, 'no-requests')
+          clearRequests()
+
+          await act(async () => {
+            await browser
+              .elementByCss('input[data-link-accordion="/hydrated/second"]')
+              .click()
+          })
+
+          const prefetchRequests = getRequests()
+          const sharedFallbackSegmentRequests = prefetchRequests.filter(
+            (requestPath) =>
+              requestPath.startsWith('/hydrated/__fallback/__next.')
+          )
+
+          expect(sharedFallbackSegmentRequests.length).toBeGreaterThan(0)
+          expect(
+            prefetchRequests.some((requestPath) =>
+              requestPath.startsWith('/hydrated/second/__next.')
+            )
+          ).toBe(false)
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('loads nested fallback routes without concrete retries or extra probes', async () => {
+        clearRequests()
+        const browser = await webdriver(port, '/org/umbrella/chat/thread-789/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('#org-name').text()).toBe(
+              'Org umbrella'
+            )
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'umbrella:thread-789'
+            )
+          })
+
+          const requests = getRequests()
+
+          expect(
+            requests.some((requestPath) =>
+              requestPath.startsWith('/org/umbrella/chat/thread-789/?_rsc=')
+            )
+          ).toBe(false)
+          expect(
+            requests.some((requestPath) =>
+              requestPath.startsWith('/org/__fallback.txt')
+            )
+          ).toBe(false)
+          expect(
+            requests.filter((requestPath) =>
+              requestPath.startsWith('/org/__fallback.meta.json')
+            )
+          ).toHaveLength(1)
+          expect(
+            requests.filter((requestPath) =>
+              requestPath.startsWith('/org/__fallback/index.txt')
+            )
+          ).toHaveLength(1)
+        } finally {
+          await browser.close()
+        }
+      })
+    }
+  )
+}


### PR DESCRIPTION
## Stack position

Part 18 of 19 in the output export dynamic fallback stack.

Previous PR: #93574 (17/19)
Next PR: #93576 (19/19)

## Context

The stack is split so build-time output can land behind `experimental.outputExportDynamicFallbacks` before the client router behavior is enabled. The target behavior is for `output: 'export'` apps with parameterized App Router routes to emit fallback HTML/RSC artifacts that a later client can resolve for hard loads and soft navigations.

This PR scope: E2E coverage for common Cache Components fallback navigations.

After the build and client machinery exists, this PR proves the main user flows work in a browser: hard loads, soft navigations, basePath, prefetch, dedupe, and hydrated fallback artifact reuse.

## What changed

- Adds Cache Components fixtures for unknown dynamic params, nested routes, grouped routes, optional catch-all routes, and basePath.
- Covers hard-load and client-navigation behavior for unenumerated params.
- Covers fallback artifact prefetching and deduping without duplicate optimization tests.

## Deliberately not included

- Does not cover route conflict and known-param edge cases. PR19 does that.
- Does not add new client code.
- Does not keep duplicate tests that were already covered by the main cache-components suite.

## Verification

After restacking and autosquashing, I verified the full stack with:

- `pnpm --filter=next build`
- `pnpm testonly packages/next/src/lib/output-export-dynamic-fallback.test.ts packages/next/src/lib/output-export-fallback-routes.test.ts packages/next/src/export/helpers/output-export-fallback.test.ts packages/next/src/server/request/fallback-params.test.ts`
- `pnpm testonly packages/next/src/client/output-export-fallback.test.ts packages/next/src/client/components/router-reducer/fetch-server-response.test.ts packages/next/src/client/components/router-reducer/create-initial-router-state.test.ts packages/next/src/client/components/segment-cache/cache.test.ts packages/next/src/client/components/segment-cache/vary-path.test.ts`
- `pnpm testonly packages/next/src/client/components/router-reducer/compute-changed-path.test.ts packages/next/src/client/flight-data-helpers.test.ts packages/next/src/server/app-render/postponed-state.test.ts`
- `pnpm test-start-turbo test/e2e/app-dir-export/test/dynamic-fallback-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-route-shapes-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-cache-components-basepath.test.ts test/e2e/app-dir-export/test/dynamic-fallback-optimizations-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-known-params-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-conflict.test.ts`
- `pnpm test-start-turbo test/e2e/app-dir/output-export-dynamic-fallbacks/output-export-dynamic-fallbacks.test.ts test/e2e/app-dir-export/test/output-export-server-io.test.ts test/e2e/app-dir-export/test/output-export-server-io-use-cache.test.ts test/e2e/app-dir-export/test/dynamic-fallback-server-params.test.ts`

<!-- NEXT_JS_LLM_PR -->
