### PR TITLE
(19/19) Cover export fallback route edge cases

### DIFF
--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/app/docs/[...slug]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/app/docs/[...slug]/page.js
@@ -1,0 +1,12 @@
+import { Suspense } from 'react'
+import DocsCatchAllClient from './slug-client'
+
+export default function DocsCatchAllPage() {
+  return (
+    <main>
+      <Suspense fallback={<h1>Loading docs catch-all...</h1>}>
+        <DocsCatchAllClient />
+      </Suspense>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/app/docs/[...slug]/slug-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/app/docs/[...slug]/slug-client.js
@@ -1,0 +1,15 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function DocsCatchAllClient() {
+  const params = useParams()
+
+  return (
+    <h1>
+      {Array.isArray(params.slug)
+        ? `catchall:${params.slug.join('/')}`
+        : 'catchall:missing'}
+    </h1>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/app/docs/[section]/[page]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/app/docs/[section]/[page]/page.js
@@ -1,0 +1,16 @@
+import { Suspense } from 'react'
+import DocsSectionPageClient from './params-client'
+
+export function generateStaticParams() {
+  return [{ section: 'api', page: 'reference' }]
+}
+
+export default function DocsSectionPage() {
+  return (
+    <main>
+      <Suspense fallback={<h1>Loading docs section page...</h1>}>
+        <DocsSectionPageClient />
+      </Suspense>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/app/docs/[section]/[page]/params-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/app/docs/[section]/[page]/params-client.js
@@ -1,0 +1,13 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function DocsSectionPageClient() {
+  const params = useParams()
+
+  return (
+    <h1>
+      {params.section}:{params.page}
+    </h1>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/app/docs/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/app/docs/page.js
@@ -1,0 +1,3 @@
+export default function DocsIndexPage() {
+  return <h1>Docs</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/app/layout.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/app/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/app/page.js
@@ -1,0 +1,10 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <main>
+      <h1>Home</h1>
+      <Link href="/docs/guides/export/fallback">Visit docs fallback route</Link>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/next.config.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  output: 'export',
+  cacheComponents: true,
+  experimental: {
+    outputExportDynamicFallbacks: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-internal-path-conflict/app/docs/[...slug]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-internal-path-conflict/app/docs/[...slug]/page.js
@@ -1,0 +1,12 @@
+import { Suspense } from 'react'
+import DocsCatchAllClient from './slug-client'
+
+export default function DocsCatchAllPage() {
+  return (
+    <main>
+      <Suspense fallback={<h1>Loading docs catch-all...</h1>}>
+        <DocsCatchAllClient />
+      </Suspense>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-internal-path-conflict/app/docs/[...slug]/slug-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-internal-path-conflict/app/docs/[...slug]/slug-client.js
@@ -1,0 +1,8 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function DocsCatchAllClient() {
+  const { slug } = useParams()
+  return <h1>{`catchall:${slug.join('/')}`}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-internal-path-conflict/app/docs/[section]/[page]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-internal-path-conflict/app/docs/[section]/[page]/page.js
@@ -1,0 +1,16 @@
+import { Suspense } from 'react'
+import DocsSectionPageClient from './params-client'
+
+export function generateStaticParams() {
+  return [{ section: 'api', page: 'reference' }]
+}
+
+export default function DocsSectionPage() {
+  return (
+    <main>
+      <Suspense fallback={<h1>Loading docs section page...</h1>}>
+        <DocsSectionPageClient />
+      </Suspense>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-internal-path-conflict/app/docs/[section]/[page]/params-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-internal-path-conflict/app/docs/[section]/[page]/params-client.js
@@ -1,0 +1,8 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function DocsSectionPageClient() {
+  const { section, page } = useParams()
+  return <h1>{`${section}:${page}`}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-internal-path-conflict/app/docs/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-internal-path-conflict/app/docs/page.js
@@ -1,0 +1,3 @@
+export default function DocsPage() {
+  return <p>docs</p>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-internal-path-conflict/app/layout.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-internal-path-conflict/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-internal-path-conflict/app/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-internal-path-conflict/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>home</p>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-internal-path-conflict/next.config.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-internal-path-conflict/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  output: 'export',
+  cacheComponents: true,
+  experimental: {
+    outputExportDynamicFallbacks: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-internal-path-conflict/public/docs/__fallback/__route_0.html
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-internal-path-conflict/public/docs/__fallback/__route_0.html
@@ -1,0 +1,1 @@
+reserved fallback variant path

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/another/[slug]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/another/[slug]/page.js
@@ -1,0 +1,25 @@
+import Link from 'next/link'
+import { Suspense } from 'react'
+import SlugClient from './slug-client'
+
+export function generateStaticParams() {
+  return [{ slug: 'first' }, { slug: 'second' }]
+}
+
+export default function Page() {
+  return (
+    <main>
+      <Suspense fallback={<h1>Loading slug...</h1>}>
+        <SlugClient />
+      </Suspense>
+      <ul>
+        <li>
+          <Link href="/another">Visit another page</Link>
+        </li>
+        <li>
+          <Link href="/another/third">Visit another third (fallback)</Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/another/[slug]/slug-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/another/[slug]/slug-client.js
@@ -1,0 +1,9 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function SlugClient() {
+  const params = useParams()
+
+  return <h1>{params.slug}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/another/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/another/page.js
@@ -1,0 +1,26 @@
+import Link from 'next/link'
+
+export default function Another() {
+  return (
+    <main>
+      <h1>Another</h1>
+      <ul>
+        <li>
+          <Link href="/">Visit the home page</Link>
+        </li>
+        <li>
+          <Link href="/another">another page</Link>
+        </li>
+        <li>
+          <Link href="/another/first">another first page</Link>
+        </li>
+        <li>
+          <Link href="/another/second">another second page</Link>
+        </li>
+        <li>
+          <Link href="/another/third">another third page</Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/layout.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/not-found.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/not-found.js
@@ -1,0 +1,3 @@
+export default function NotFound() {
+  return <h1>My custom not found page</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/org/[org]/chat/[thread]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/org/[org]/chat/[thread]/page.js
@@ -1,0 +1,30 @@
+import Link from 'next/link'
+import { Suspense } from 'react'
+import OrgThreadClient from './thread-client'
+
+export function generateStaticParams() {
+  return [
+    { org: 'acme', thread: 'thread-123' },
+    { org: 'acme', thread: 'thread-456' },
+  ]
+}
+
+export default function OrgThreadPage() {
+  return (
+    <>
+      <Suspense fallback={<h1>Loading org thread...</h1>}>
+        <OrgThreadClient />
+      </Suspense>
+      <ul>
+        <li>
+          <Link href="/org">Visit org index</Link>
+        </li>
+        <li>
+          <Link href="/org/acme/chat/thread-789">
+            Visit fallback org chat thread
+          </Link>
+        </li>
+      </ul>
+    </>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/org/[org]/chat/[thread]/thread-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/org/[org]/chat/[thread]/thread-client.js
@@ -1,0 +1,13 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function OrgThreadClient() {
+  const params = useParams()
+
+  return (
+    <h1>
+      {params.org}:{params.thread}
+    </h1>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/org/[org]/layout.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/org/[org]/layout.js
@@ -1,0 +1,13 @@
+import { Suspense } from 'react'
+import OrgClient from './org-client'
+
+export default function OrgLayout({ children }) {
+  return (
+    <main>
+      <Suspense fallback={<p id="org-name">Loading org...</p>}>
+        <OrgClient />
+      </Suspense>
+      {children}
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/org/[org]/org-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/org/[org]/org-client.js
@@ -1,0 +1,9 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function OrgClient() {
+  const params = useParams()
+
+  return <p id="org-name">Org {params.org}</p>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/org/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/org/page.js
@@ -7,11 +7,13 @@ export default function OrgIndexPage() {
       <ul>
         <li>
           <Link href="/org/acme/chat/thread-123">
-            Visit org chat thread 123
+            Visit known org chat thread
           </Link>
         </li>
         <li>
-          <Link href="/org/acme/missing-one">Visit missing org route</Link>
+          <Link href="/org/acme/chat/thread-789">
+            Visit fallback org chat thread
+          </Link>
         </li>
       </ul>
     </main>

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/next.config.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/next.config.js
@@ -1,0 +1,11 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  output: 'export',
+  trailingSlash: true,
+  cacheComponents: true,
+  experimental: {
+    outputExportDynamicFallbacks: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir-export/test/dynamic-fallback-conflict.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-fallback-conflict.test.ts
@@ -1,0 +1,155 @@
+import { join } from 'path'
+import fs from 'fs-extra'
+import { nextTestSetup } from 'e2e-utils'
+import webdriver from 'next-webdriver'
+import { retry } from 'next-test-utils'
+import { buildAndStartOutputExportServer } from './utils'
+
+describe('app dir - output export fallback conflicts', () => {
+  const { next, skipped } = nextTestSetup({
+    files: join(__dirname, '..', 'fixtures', 'dynamic-fallback-conflict'),
+    skipStart: true,
+    skipDeployment: true,
+    disableAutoSkewProtection: true,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  let port: number
+  let stopOrKill: (() => Promise<void>) | undefined
+  let getRequests: () => string[]
+  let clearRequests: () => void
+
+  beforeAll(async () => {
+    ;({ port, stopOrKill, getRequests, clearRequests } =
+      await buildAndStartOutputExportServer(next, {
+        useFallbackDocument: true,
+      }))
+  })
+
+  afterAll(async () => {
+    await stopOrKill?.()
+  })
+
+  it('emits fallback metadata and branch-specific fallback artifacts', async () => {
+    const outDir = join(next.testDir, 'out')
+    const manifestPath = join(outDir, 'docs', '__fallback.meta.json')
+    const knownSpecificParamExists =
+      (await fs.pathExists(
+        join(outDir, 'docs', 'api', 'reference', 'index.html')
+      )) || (await fs.pathExists(join(outDir, 'docs', 'api', 'reference.html')))
+    const unknownSpecificParamExists =
+      (await fs.pathExists(
+        join(outDir, 'docs', 'api', 'guide', 'index.html')
+      )) || (await fs.pathExists(join(outDir, 'docs', 'api', 'guide.html')))
+
+    expect(await fs.pathExists(join(outDir, '_fallback.html'))).toBe(true)
+    expect(await fs.pathExists(manifestPath)).toBe(true)
+    expect(knownSpecificParamExists).toBe(true)
+    expect(unknownSpecificParamExists).toBe(false)
+
+    const manifest = await fs.readJson(manifestPath)
+    expect(manifest).toEqual({
+      version: 1,
+      routes: [
+        {
+          route: '/docs/[section]/[page]',
+          fallbackPath: '/docs/__fallback/__route_0',
+        },
+        {
+          route: '/docs/[...slug]',
+          fallbackPath: '/docs/__fallback/__route_1',
+        },
+      ],
+    })
+
+    for (const entry of manifest.routes) {
+      const relativeFallbackPath = entry.fallbackPath.slice(1)
+      const hasBranchPayload =
+        (await fs.pathExists(join(outDir, `${relativeFallbackPath}.txt`))) ||
+        (await fs.pathExists(join(outDir, relativeFallbackPath, 'index.txt')))
+
+      expect(hasBranchPayload).toBe(true)
+    }
+  })
+
+  it('keeps known params prerendered while unknown params on the same branch fall back', async () => {
+    const browser = await webdriver(port, '/docs/api/reference/')
+
+    try {
+      await retry(async () => {
+        expect(await browser.elementByCss('h1').text()).toBe('api:reference')
+      })
+
+      await browser.get(`http://localhost:${port}/docs/api/guide/`)
+      await retry(async () => {
+        expect(await browser.elementByCss('h1').text()).toBe('api:guide')
+      })
+    } finally {
+      await browser.close()
+    }
+  })
+
+  it('prefers the more specific route when multiple fallback branches match', async () => {
+    clearRequests()
+    const browser = await webdriver(port, '/docs/api/guide/')
+
+    try {
+      await retry(async () => {
+        expect(await browser.elementByCss('h1').text()).toBe('api:guide')
+      })
+
+      expect(
+        getRequests().some((requestPath) =>
+          requestPath.startsWith('/docs/__fallback/__route_0.html')
+        )
+      ).toBe(false)
+    } finally {
+      await browser.close()
+    }
+  })
+
+  it('falls through to the catch-all branch when the specific route does not match', async () => {
+    const browser = await webdriver(port, '/docs/guides/export/fallback/')
+
+    try {
+      await retry(async () => {
+        expect(await browser.elementByCss('h1').text()).toBe(
+          'catchall:guides/export/fallback'
+        )
+      })
+    } finally {
+      await browser.close()
+    }
+  })
+})
+
+describe('app dir - output export fallback internal path collisions', () => {
+  const { next, skipped } = nextTestSetup({
+    files: join(
+      __dirname,
+      '..',
+      'fixtures',
+      'dynamic-fallback-internal-path-conflict'
+    ),
+    skipStart: true,
+    skipDeployment: true,
+    disableAutoSkewProtection: true,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  it('errors when a multi-route fallback artifact path is already occupied', async () => {
+    const { exitCode, cliOutput } = await next.build()
+
+    expect(exitCode).toBe(1)
+    expect(cliOutput).toContain(
+      'conflicts with the internal "__fallback" path used by dynamic route fallbacks in static export mode'
+    )
+    expect(cliOutput).toContain('/docs/__fallback/__route_0')
+  })
+})

--- a/test/e2e/app-dir-export/test/dynamic-fallback-known-params-cache-components.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-fallback-known-params-cache-components.test.ts
@@ -1,0 +1,256 @@
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+import webdriver from 'next-webdriver'
+import fs from 'fs-extra'
+import { buildAndStartOutputExportServer } from './utils'
+
+const { next, skipped, isNextDev } = nextTestSetup({
+  files: join(
+    __dirname,
+    '..',
+    'fixtures',
+    'dynamic-fallback-known-params-cache-components'
+  ),
+  skipDeployment: true,
+  skipStart: true,
+  disableAutoSkewProtection: true,
+})
+
+if (skipped) {
+  it('skips unsupported mode', () => {})
+} else {
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  describeProduction(
+    'app dir - output export dynamic routes with Cache Components and known prerenders',
+    () => {
+      let port: number
+      let stopOrKill: (() => Promise<void>) | undefined
+
+      beforeAll(async () => {
+        ;({ port, stopOrKill } = await buildAndStartOutputExportServer(next, {
+          useFallbackDocument: true,
+        }))
+      })
+
+      afterAll(async () => {
+        if (stopOrKill) {
+          await stopOrKill()
+        }
+        await next.destroy()
+      })
+
+      it('emits both prerendered known params and fallback artifacts', async () => {
+        const outDir = join(next.testDir, 'out')
+
+        expect(await fs.pathExists(join(outDir, '_fallback.html'))).toBe(true)
+        expect(
+          await fs.pathExists(
+            join(outDir, 'another', '__fallback', 'index.txt')
+          )
+        ).toBe(true)
+        expect(
+          await fs.pathExists(join(outDir, 'org', '__fallback', 'index.txt'))
+        ).toBe(true)
+        expect(
+          await fs.pathExists(join(outDir, 'another', 'first', 'index.html'))
+        ).toBe(true)
+        expect(
+          await fs.pathExists(join(outDir, 'another', 'second', 'index.html'))
+        ).toBe(true)
+        expect(
+          await fs.pathExists(join(outDir, 'another', 'third', 'index.html'))
+        ).toBe(false)
+        expect(
+          await fs.pathExists(
+            join(outDir, 'org', 'acme', 'chat', 'thread-123', 'index.html')
+          )
+        ).toBe(true)
+        expect(
+          await fs.pathExists(
+            join(outDir, 'org', 'acme', 'chat', 'thread-789', 'index.html')
+          )
+        ).toBe(false)
+      })
+
+      it('serves both prerendered and fallback params', async () => {
+        const browser = await webdriver(port, '/another/first/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('first')
+          })
+
+          await browser.get(`http://localhost:${port}/another/third/`)
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('third')
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('serves both prerendered and fallback params for nested dynamic routes', async () => {
+        const browser = await webdriver(port, '/org/acme/chat/thread-123/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('#org-name').text()).toBe(
+              'Org acme'
+            )
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'acme:thread-123'
+            )
+          })
+
+          await browser.get(
+            `http://localhost:${port}/org/acme/chat/thread-789/`
+          )
+          await retry(async () => {
+            expect(await browser.elementByCss('#org-name').text()).toBe(
+              'Org acme'
+            )
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'acme:thread-789'
+            )
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('client navigates from a prerendered page to a fallback route', async () => {
+        // Start on a prerendered page (known from generateStaticParams)
+        const browser = await webdriver(port, '/another/first/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('first')
+          })
+
+          // Client navigate to an unenumerated slug (fallback)
+          await browser.elementByCss('a[href="/another/third/"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('third')
+          })
+
+          // Navigate back to the prerendered page
+          await browser.elementByCss('a[href="/another/"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('Another')
+          })
+
+          // Navigate to a different prerendered page
+          await browser.elementByCss('a[href="/another/first/"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('first')
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('client navigates from a fallback route to a prerendered page', async () => {
+        // Start on a fallback route (not in generateStaticParams)
+        const browser = await webdriver(port, '/org/acme/chat/thread-789/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'acme:thread-789'
+            )
+          })
+
+          // Client navigate to a prerendered page (known from generateStaticParams)
+          await browser.elementByCss('a[href="/org/"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('Org index')
+          })
+
+          await browser
+            .elementByCss('a[href="/org/acme/chat/thread-123/"]')
+            .click()
+          await retry(async () => {
+            expect(await browser.elementByCss('#org-name').text()).toBe(
+              'Org acme'
+            )
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'acme:thread-123'
+            )
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('navigates from a known prerendered param to an unknown param via client nav then back', async () => {
+        const browser = await webdriver(port, '/org/acme/chat/thread-123/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'acme:thread-123'
+            )
+          })
+
+          // Client navigate to a fallback param
+          await browser
+            .elementByCss('a[href="/org/acme/chat/thread-789/"]')
+            .click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'acme:thread-789'
+            )
+          })
+
+          // Browser back to the prerendered page
+          await browser.back()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'acme:thread-123'
+            )
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('preserves history across prerendered and fallback routes with search params', async () => {
+        const browser = await webdriver(port, '/another/first/?mode=known')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('first')
+            expect(await browser.eval('window.location.search')).toBe(
+              '?mode=known'
+            )
+          })
+
+          await browser.elementByCss('a[href="/another/third/"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('third')
+            expect(await browser.eval('window.location.pathname')).toBe(
+              '/another/third/'
+            )
+          })
+
+          await browser.back()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('first')
+            expect(await browser.eval('window.location.search')).toBe(
+              '?mode=known'
+            )
+          })
+
+          await browser.forward()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('third')
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+    }
+  )
+}

--- a/test/e2e/app-dir-export/test/dynamic-fallback-route-shapes-cache-components.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-fallback-route-shapes-cache-components.test.ts
@@ -1,0 +1,239 @@
+import { join } from 'path'
+import { createNext, isNextDeploy, isNextDev, NextInstance } from 'e2e-utils'
+import fs from 'fs-extra'
+import { retry } from 'next-test-utils'
+import webdriver from 'next-webdriver'
+import { buildAndStartOutputExportServer } from './utils'
+
+if (isNextDeploy) {
+  it('skips deploy mode', () => {})
+} else {
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  describeProduction(
+    'app dir - output export fallback route shapes with Cache Components',
+    () => {
+      let next: NextInstance
+      let port: number
+      let stopOrKill: (() => Promise<void>) | undefined
+
+      beforeAll(async () => {
+        next = await createNext({
+          files: join(
+            __dirname,
+            '..',
+            'fixtures',
+            'dynamic-fallback-cache-components'
+          ),
+          skipStart: true,
+          disableAutoSkewProtection: true,
+        })
+        ;({ port, stopOrKill } = await buildAndStartOutputExportServer(next, {
+          useFallbackDocument: true,
+        }))
+      })
+
+      afterAll(async () => {
+        if (stopOrKill) {
+          await stopOrKill()
+        }
+        await next.destroy()
+      })
+
+      it('emits fallback artifacts for catch-all, optional, grouped, parallel, and nested multi-segment route shapes', async () => {
+        const outDir = join(next.testDir, 'out')
+
+        expect(
+          await fs.pathExists(join(outDir, 'docs', '__fallback', 'index.txt'))
+        ).toBe(true)
+        expect(
+          await fs.pathExists(
+            join(outDir, 'optional', '__fallback', 'index.txt')
+          )
+        ).toBe(true)
+        expect(
+          await fs.pathExists(
+            join(outDir, 'grouped', '__fallback', 'index.txt')
+          )
+        ).toBe(true)
+        expect(
+          await fs.pathExists(join(outDir, 'inbox', '__fallback', 'index.txt'))
+        ).toBe(true)
+        expect(
+          await fs.pathExists(join(outDir, 'org', '__fallback', 'index.txt'))
+        ).toBe(true)
+      })
+
+      it('renders catch-all fallback routes on hard load and client navigation', async () => {
+        const browser = await webdriver(port, '/docs/guides/export/fallback/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'guides/export/fallback'
+            )
+          })
+
+          await browser.elementByCss('a[href="/docs/"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('Docs')
+          })
+
+          await browser.eval('window.__routeShapeSentinel = 1')
+          await browser
+            .elementByCss('a[href="/docs/guides/export/fallback/"]')
+            .click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'guides/export/fallback'
+            )
+            expect(await browser.eval('window.__routeShapeSentinel')).toBe(1)
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('renders optional catch-all fallback routes for empty and nested params', async () => {
+        const browser = await webdriver(port, '/optional/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'optional index'
+            )
+          })
+
+          await browser.elementByCss('a[href="/optional/deep/path/"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('deep/path')
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('renders grouped dynamic fallback routes', async () => {
+        const browser = await webdriver(port, '/grouped/from-group/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('from-group')
+          })
+
+          await browser.elementByCss('a[href="/grouped/"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'Grouped index'
+            )
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('renders fallback params consistently across parallel routes', async () => {
+        const browser = await webdriver(port, '/inbox/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('Inbox')
+            expect(await browser.elementByCss('#modal-thread').text()).toBe(
+              'No modal'
+            )
+          })
+
+          await browser.elementByCss('a[href="/inbox/thread-123/"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('thread-123')
+            expect(await browser.elementByCss('#modal-thread').text()).toBe(
+              'Modal thread-123'
+            )
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+      it('renders nested fallback params across multiple dynamic segments with optimistic routing', async () => {
+        const browser = await webdriver(port, '/org/umbrella/chat/thread-789/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('#org-name').text()).toBe(
+              'Org umbrella'
+            )
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'umbrella:thread-789'
+            )
+          })
+
+          await browser.elementByCss('a[href="/org/"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('Org index')
+          })
+
+          await browser
+            .elementByCss('a[href="/org/acme/chat/thread-123/"]')
+            .click()
+          await retry(async () => {
+            expect(await browser.elementByCss('#org-name').text()).toBe(
+              'Org acme'
+            )
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'acme:thread-123'
+            )
+          })
+
+          await browser
+            .elementByCss('a[href="/org/acme/chat/thread-456/"]')
+            .click()
+          await retry(async () => {
+            expect(await browser.elementByCss('#org-name').text()).toBe(
+              'Org acme'
+            )
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'acme:thread-456'
+            )
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('renders the global not-found route instead of a mismatched fallback shell', async () => {
+        const browser = await webdriver(port, '/org/acme/missing-one/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'My custom not found page'
+            )
+            expect(await browser.hasElementByCss('#org-section')).toBe(false)
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('client navigates to the global not-found route instead of caching a mismatched fallback shell', async () => {
+        const browser = await webdriver(port, '/org/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('Org index')
+          })
+
+          await browser.elementByCss('a[href="/org/acme/missing-one/"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'My custom not found page'
+            )
+            expect(await browser.hasElementByCss('#org-section')).toBe(false)
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+    }
+  )
+}


### PR DESCRIPTION
## Stack position

Part 19 of 19 in the output export dynamic fallback stack.

Previous PR: #93575 (18/19)
Next PR: none, this is the top of the stack.

## Context

The stack is split so build-time output can land behind `experimental.outputExportDynamicFallbacks` before the client router behavior is enabled. The target behavior is for `output: 'export'` apps with parameterized App Router routes to emit fallback HTML/RSC artifacts that a later client can resolve for hard loads and soft navigations.

This PR scope: E2E coverage for route conflicts, known params, and mismatched fallback shapes.

This final PR covers the route edges that are easiest to break after the core flow works: known prerenders mixed with fallback params, conflicting route manifests, and not-found behavior for mismatched route shapes.

## What changed

- Covers known prerendered params alongside fallback params.
- Covers route manifest conflicts and internal fallback path conflicts.
- Covers both hard-load and client-navigation not-found behavior when a fallback shell would have the wrong route shape.

## Deliberately not included

- Does not add new feature code.
- Does not broaden the already-large client implementation PRs.
- Does not rely on duplicate tests from earlier e2e suites.

## Verification

After restacking and autosquashing, I verified the full stack with:

- `pnpm --filter=next build`
- `pnpm testonly packages/next/src/lib/output-export-dynamic-fallback.test.ts packages/next/src/lib/output-export-fallback-routes.test.ts packages/next/src/export/helpers/output-export-fallback.test.ts packages/next/src/server/request/fallback-params.test.ts`
- `pnpm testonly packages/next/src/client/output-export-fallback.test.ts packages/next/src/client/components/router-reducer/fetch-server-response.test.ts packages/next/src/client/components/router-reducer/create-initial-router-state.test.ts packages/next/src/client/components/segment-cache/cache.test.ts packages/next/src/client/components/segment-cache/vary-path.test.ts`
- `pnpm testonly packages/next/src/client/components/router-reducer/compute-changed-path.test.ts packages/next/src/client/flight-data-helpers.test.ts packages/next/src/server/app-render/postponed-state.test.ts`
- `pnpm test-start-turbo test/e2e/app-dir-export/test/dynamic-fallback-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-route-shapes-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-cache-components-basepath.test.ts test/e2e/app-dir-export/test/dynamic-fallback-optimizations-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-known-params-cache-components.test.ts test/e2e/app-dir-export/test/dynamic-fallback-conflict.test.ts`
- `pnpm test-start-turbo test/e2e/app-dir/output-export-dynamic-fallbacks/output-export-dynamic-fallbacks.test.ts test/e2e/app-dir-export/test/output-export-server-io.test.ts test/e2e/app-dir-export/test/output-export-server-io-use-cache.test.ts test/e2e/app-dir-export/test/dynamic-fallback-server-params.test.ts`

<!-- NEXT_JS_LLM_PR -->
