### PR TITLE
Turbopack: skip unsupported pseudo CSS warnings

### DIFF
--- a/test/development/app-dir/css-unsupported-pseudo/app/layout.tsx
+++ b/test/development/app-dir/css-unsupported-pseudo/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/css-unsupported-pseudo/app/page-with-pseudo/page.tsx
+++ b/test/development/app-dir/css-unsupported-pseudo/app/page-with-pseudo/page.tsx
@@ -1,0 +1,5 @@
+import './style.css'
+
+export default function Page() {
+  return <p className="box">unsupported pseudo page</p>
+}

--- a/test/development/app-dir/css-unsupported-pseudo/app/page-with-pseudo/style.css
+++ b/test/development/app-dir/css-unsupported-pseudo/app/page-with-pseudo/style.css
@@ -1,0 +1,11 @@
+.box {
+  color: red;
+}
+
+.box:target-current {
+  color: green;
+}
+
+.box::-webkit-scrollbar {
+  width: 0;
+}

--- a/test/development/app-dir/css-unsupported-pseudo/app/page.tsx
+++ b/test/development/app-dir/css-unsupported-pseudo/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/development/app-dir/css-unsupported-pseudo/css-unsupported-pseudo.test.ts
+++ b/test/development/app-dir/css-unsupported-pseudo/css-unsupported-pseudo.test.ts
@@ -1,0 +1,28 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+import stripAnsi from 'strip-ansi'
+
+;(process.env.IS_TURBOPACK_TEST ? describe : describe.skip)(
+  'css-unsupported-pseudo',
+  () => {
+    const { next, skipped } = nextTestSetup({ files: __dirname })
+
+    if (skipped) return
+
+    it('should not surface parser warnings for unrecognized pseudo-class/element selectors', async () => {
+      const outputIndex = next.cliOutput.length
+      const res = await next.fetch('/page-with-pseudo')
+      expect(res.status).toBe(200)
+
+      await retry(async () => {
+        const output = stripAnsi(next.cliOutput.slice(outputIndex))
+        expect(output).toContain('GET /page-with-pseudo')
+      })
+
+      const output = stripAnsi(next.cliOutput.slice(outputIndex))
+      expect(output).not.toContain('Parsing CSS source code failed')
+      expect(output).not.toContain('not recognized as a valid pseudo-class')
+      expect(output).not.toContain('not recognized as a valid pseudo-element')
+    })
+  }
+)

--- a/turbopack/crates/turbopack-css/src/process.rs
+++ b/turbopack/crates/turbopack-css/src/process.rs
@@ -489,16 +489,20 @@ async fn process_content(
         ) {
             Ok(mut ss) => {
                 for err in warnings.read().unwrap().iter() {
-                    // Unsupported pseudo-classes/elements are common in real-world CSS
-                    // (vendor prefixes, custom frameworks) and do not prevent the
-                    // stylesheet from being used — treat them as recoverable warnings.
-                    // All other previously-ignored parser warnings are also surfaced.
-                    let severity = match err.kind {
+                    // Skip recoverable warnings for unrecognized pseudo-class/element
+                    // names — lightningcss's table lags Baseline CSS and vendor
+                    // prefixes, producing false positives for valid modern selectors.
+                    if matches!(
+                        err.kind,
                         lightningcss::error::ParserError::SelectorError(
                             lightningcss::error::SelectorError::UnsupportedPseudoClass(_)
-                            | lightningcss::error::SelectorError::UnsupportedPseudoElement(_),
-                        ) => IssueSeverity::Warning,
+                                | lightningcss::error::SelectorError::UnsupportedPseudoElement(_),
+                        )
+                    ) {
+                        continue;
+                    }
 
+                    let severity = match err.kind {
                         lightningcss::error::ParserError::UnexpectedToken(_)
                         | lightningcss::error::ParserError::UnexpectedImportRule
                         | lightningcss::error::ParserError::SelectorError(..)


### PR DESCRIPTION
Fixes #93419.

lightningcss flags pseudo-class/element names it doesn't recognize, but its table lags real-world CSS — `:target-current` (Baseline 2024) and vendor prefixes like `::-webkit-scrollbar` surface as parser warnings in `next dev` even though the stylesheet works. Webpack mode silently ignores these; match that here. Other parser warnings continue to surface.

<!-- NEXT_JS_LLM_PR -->
