### PR TITLE
[ci] Ensure builds in Docker images have Git access to workspace

### DIFF
--- a/crates/next-napi-bindings/build.rs
+++ b/crates/next-napi-bindings/build.rs
@@ -67,7 +67,12 @@ fn main() -> anyhow::Result<()> {
             "cargo:warning=git HEAD: {}",
             str::from_utf8(&out.stdout).unwrap()
         ),
-        _ => println!("cargo:warning=`git rev-parse HEAD` failed"),
+        Ok(out) => println!(
+            "cargo:warning=`git rev-parse HEAD` failed with status {}: {}",
+            out.status,
+            str::from_utf8(&out.stderr).unwrap()
+        ),
+        Err(e) => println!("cargo:warning=`git rev-parse HEAD` could not be spawned: {e}"),
     }
 
     if !is_macos_target {

--- a/scripts/docker-native-build.sh
+++ b/scripts/docker-native-build.sh
@@ -16,6 +16,12 @@
 
 set -xeo pipefail
 
+# The workspace is bind-mounted from the host, so its .git is owned by the
+# host runner UID while this container runs as root. Without this, git 2.35.2+
+# refuses to operate ("dubious ownership"), which breaks vergen-gitcl in
+# crates/next-napi-bindings/build.rs.
+git config --global --add safe.directory /build
+
 BUILD_TASK="${BUILD_TASK:-build-native-release}"
 
 # Node.js (installed via nodesource) is used only as a build tool (runs


### PR DESCRIPTION
Since switching to GH hosted runners, Linux builds were broken with just warning.

The issue comes from a change in Git 2.35 which started to refuse working on Git directories that were owner by a different uid. Our [self-hosted runners used 2.34.1](https://github.com/vercel/next.js/actions/runs/24619032350/job/71986251846#step:4:31) whereas GH hosted runners use [2.50](https://github.com/vercel/next.js/actions/runs/25435823240/job/74613469020?pr=93539#step:3:32).

Adding `/build` as a safe directory fixes the issue.

## Test plan

Without adding the safe directory we actually get the dubious ownership error:

> warning: next-napi-bindings@0.0.0: `git rev-parse HEAD` failed with status exit status: 128: fatal: detected dubious ownership in repository at '/build'
-- https://github.com/vercel/next.js/actions/runs/25483622900/job/74773786959#step:14:732

With the fix
[pending...](https://github.com/vercel/next.js/actions/runs/25484026686)