### PR TITLE
docs: escape literal triple-backticks in contribution guide

### DIFF
--- a/docs/04-community/01-contribution-guide.mdx
+++ b/docs/04-community/01-contribution-guide.mdx
@@ -243,17 +243,17 @@ Most examples in the docs are written in `tsx` and `jsx`, and a few in `bash`. H
 
 When writing JavaScript code blocks, we use the following language and extension combinations.
 
-|                                | Language | Extension |
-| ------------------------------ | -------- | --------- |
-| JavaScript files with JSX code | ```jsx   | .js       |
-| JavaScript files without JSX   | ```js    | .js       |
-| TypeScript files with JSX      | ```tsx   | .tsx      |
-| TypeScript files without JSX   | ```ts    | .ts       |
+|                                | Language   | Extension |
+| ------------------------------ | ---------- | --------- |
+| JavaScript files with JSX code | ` ```jsx ` | .js       |
+| JavaScript files without JSX   | ` ```js `  | .js       |
+| TypeScript files with JSX      | ` ```tsx ` | .tsx      |
+| TypeScript files without JSX   | ` ```ts `  | .ts       |
 
 > **Good to know**:
 >
 > - Make sure to use **`.js`** extension for JavaScript files with **JSX** code.
-> - For example, ```jsx filename="app/layout.js"
+> - For example, ` ```jsx filename="app/layout.js" `
 
 ### TS and JS Switcher
 


### PR DESCRIPTION
Updates: https://nextjs.org/docs/community/contribution-guide#language-and-filename

to:


<img width="1335" height="690" alt="Screenshot 2026-05-07 at 14 26 35" src="https://github.com/user-attachments/assets/588799a3-1a0e-4696-9600-627df270f48e" />

