### PR TITLE
[ci] Skip installing native binaries when fetching test timings

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -145,6 +145,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: ['changes']
     if: ${{ needs.changes.outputs.docs-only == 'false' }}
+    env:
+      NEXT_SKIP_NATIVE_POSTINSTALL: 1
     steps:
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
That job doesn't need native binaries. It's also the first step that runs immediately when publishing a new version. It almost always runs before the versions are released and then fails installing native binaries e.g. https://github.com/vercel/next.js/actions/runs/25486090575/job/74781954416#step:5:244

Fetching test timings is an optional job but failing is noisy. Especially on work it doesn't need to do in the first place.