### PR TITLE
Turbopack: Match proxy matchers with webpack implementation

### DIFF
--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -183,14 +183,20 @@ impl MiddlewareEndpoint {
                         source.insert_str(0, "/:nextInternalLocale((?!_next/)[^/.]{1,})");
                     }
 
+                    // Match transport-specific route forms that resolve to the
+                    // same page:
+                    // - Pages Router data routes: /_next/data/<build-id>/...
+                    // - App Router transport routes: .rsc, ...segments/...segment.rsc
                     if is_root {
                         source.push('(');
                         if has_i18n {
                             source.push_str("|\\.json|");
                         }
-                        source.push_str("/?index|/?index\\.json)?")
+                        source.push_str("/?index|/?index\\.json|");
+                        source.push_str("/?index(?:\\.rsc|\\.segments/.+\\.segment\\.rsc)");
+                        source.push_str(")?");
                     } else {
-                        source.push_str("{(\\.json)}?")
+                        source.push_str("{(\\.json|\\.rsc|\\.segments/.+\\.segment\\.rsc)}?");
                     };
 
                     source.insert_str(0, "/:nextData(_next/data/[^/]{1,})?");

--- a/packages/next/src/build/analysis/get-page-static-info.test.ts
+++ b/packages/next/src/build/analysis/get-page-static-info.test.ts
@@ -8,7 +8,7 @@ describe('get-page-static-infos', () => {
         {
           originalSource: '/middleware/path',
           regexp:
-            '^(?:\\/(_next\\/data\\/[^/]{1,}))?\\/middleware\\/path(\\.json)?[\\/#\\?]?$',
+            '^(?:\\/(_next\\/data\\/[^/]{1,}))?\\/middleware\\/path(\\.json|\\.rsc|\\.segments\\/.+\\.segment\\.rsc)?[\\/#\\?]?$',
         },
       ]
       const result = getMiddlewareMatchers(matchers, { i18n: undefined })
@@ -21,25 +21,70 @@ describe('get-page-static-infos', () => {
         {
           originalSource: '/middleware/path',
           regexp:
-            '^(?:\\/(_next\\/data\\/[^/]{1,}))?\\/middleware\\/path(\\.json)?[\\/#\\?]?$',
+            '^(?:\\/(_next\\/data\\/[^/]{1,}))?\\/middleware\\/path(\\.json|\\.rsc|\\.segments\\/.+\\.segment\\.rsc)?[\\/#\\?]?$',
         },
         {
           originalSource: '/middleware/another-path',
           regexp:
-            '^(?:\\/(_next\\/data\\/[^/]{1,}))?\\/middleware\\/another-path(\\.json)?[\\/#\\?]?$',
+            '^(?:\\/(_next\\/data\\/[^/]{1,}))?\\/middleware\\/another-path(\\.json|\\.rsc|\\.segments\\/.+\\.segment\\.rsc)?[\\/#\\?]?$',
         },
       ]
       const result = getMiddlewareMatchers(matchers, { i18n: undefined })
       expect(result).toStrictEqual(expected)
     })
 
-    it('matches /:id and /:id.json', () => {
+    it('matches /:id and transport variants for the same route', () => {
       const matchers = ['/:id']
       const result = getMiddlewareMatchers(matchers, { i18n: undefined })[0]
         .regexp
       const regex = new RegExp(result)
       expect(regex.test('/apple')).toBe(true)
       expect(regex.test('/apple.json')).toBe(true)
+      expect(regex.test('/apple.rsc')).toBe(true)
+    })
+
+    it('matches App Router segment-prefetch routes for static matchers', () => {
+      const regex = new RegExp(
+        getMiddlewareMatchers('/dashboard', { i18n: undefined })[0].regexp
+      )
+
+      expect(regex.test('/dashboard.rsc')).toBe(true)
+      expect(
+        regex.test('/dashboard.segments/$c$children/__PAGE__.segment.rsc')
+      ).toBe(true)
+      expect(
+        regex.test('/settings.segments/$c$children/__PAGE__.segment.rsc')
+      ).toBe(false)
+    })
+
+    it('matches App Router segment-prefetch routes for nested matchers', () => {
+      const regex = new RegExp(
+        getMiddlewareMatchers('/dashboard/:path*', {
+          i18n: undefined,
+        })[0].regexp
+      )
+
+      expect(
+        regex.test(
+          '/dashboard/settings.segments/$c$children/__PAGE__.segment.rsc'
+        )
+      ).toBe(true)
+      expect(
+        regex.test(
+          '/marketing/settings.segments/$c$children/__PAGE__.segment.rsc'
+        )
+      ).toBe(false)
+    })
+
+    it('matches the root App Router segment-prefetch transport route', () => {
+      const regex = new RegExp(
+        getMiddlewareMatchers('/', { i18n: undefined })[0].regexp
+      )
+
+      expect(regex.test('/index.rsc')).toBe(true)
+      expect(
+        regex.test('/index.segments/$c$children/__PAGE__.segment.rsc')
+      ).toBe(true)
     })
   })
 })

--- a/packages/next/src/build/analysis/get-page-static-info.ts
+++ b/packages/next/src/build/analysis/get-page-static-info.ts
@@ -11,6 +11,9 @@ import {
   SERVER_RUNTIME,
   MIDDLEWARE_FILENAME,
   PROXY_FILENAME,
+  RSC_SUFFIX,
+  RSC_SEGMENT_SUFFIX,
+  RSC_SEGMENTS_DIR_SUFFIX,
 } from '../../lib/constants'
 import { tryToParsePath } from '../../lib/try-to-parse-path'
 import { isAPIRoute } from '../../lib/is-api-route'
@@ -20,6 +23,7 @@ import {
   warnAboutPreferredRegion,
 } from '../warn-about-edge-runtime'
 import { RSC_MODULE_TYPES } from '../../shared/lib/constants'
+import { escapeStringRegexp } from '../../shared/lib/escape-regexp'
 import type { RSCMeta } from '../webpack/loaders/get-module-build-info'
 import { PAGE_TYPES } from '../../lib/page-types'
 import {
@@ -110,6 +114,13 @@ export interface PagesPageStaticInfo {
 }
 
 export type PageStaticInfo = AppPageStaticInfo | PagesPageStaticInfo
+
+const APP_ROUTE_RSC_SUFFIX_MATCHER = escapeStringRegexp(RSC_SUFFIX)
+const APP_ROUTE_SEGMENT_PREFETCH_SUFFIX_MATCHER = `${escapeStringRegexp(RSC_SEGMENTS_DIR_SUFFIX)}/.+${escapeStringRegexp(RSC_SEGMENT_SUFFIX)}`
+const APP_ROUTE_TRANSPORT_SUFFIX_MATCHER = `${APP_ROUTE_RSC_SUFFIX_MATCHER}|${APP_ROUTE_SEGMENT_PREFETCH_SUFFIX_MATCHER}`
+const ROOT_APP_ROUTE_TRANSPORT_MATCHER = `/?index(?:${APP_ROUTE_TRANSPORT_SUFFIX_MATCHER})`
+const MIDDLEWARE_DATA_SUFFIX_MATCHER = `\\.json|${APP_ROUTE_TRANSPORT_SUFFIX_MATCHER}`
+const OPTIONAL_MIDDLEWARE_NEXT_DATA_PREFIX = '/:nextData(_next/data/[^/]{1,})?'
 
 const CLIENT_MODULE_LABEL =
   /\/\* __next_internal_client_entry_do_not_use__ ([^ ]*) (cjs|auto) \*\//
@@ -469,11 +480,17 @@ export function getMiddlewareMatchers(
       }`
     }
 
-    source = `/:nextData(_next/data/[^/]{1,})?${source}${
+    // Match transport-specific route forms that resolve to the same page.
+    // - Pages Router data routes: /_next/data/<build-id>/...
+    // - App Router transport routes: .rsc, ...segments/...segment.rsc
+    const sourceSuffix = `${
       isRoot
-        ? `(${nextConfig.i18n ? '|\\.json|' : ''}/?index|/?index\\.json)?`
-        : '{(\\.json)}?'
+        ? `(${
+            nextConfig.i18n ? '|\\.json|' : ''
+          }/?index|/?index\\.json|${ROOT_APP_ROUTE_TRANSPORT_MATCHER})?`
+        : `{(${MIDDLEWARE_DATA_SUFFIX_MATCHER})}?`
     }`
+    source = `${OPTIONAL_MIDDLEWARE_NEXT_DATA_PREFIX}${source}${sourceSuffix}`
 
     if (nextConfig.basePath) {
       source = `${nextConfig.basePath}${source}`

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -230,8 +230,6 @@ import {
 import { generateRoutesManifest } from './generate-routes-manifest'
 import { validateAppPaths } from './validate-app-paths'
 
-// trigger CI
-
 type Fallback = null | boolean | string
 
 export interface PrerenderManifestRoute {

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -230,6 +230,8 @@ import {
 import { generateRoutesManifest } from './generate-routes-manifest'
 import { validateAppPaths } from './validate-app-paths'
 
+// trigger CI
+
 type Fallback = null | boolean | string
 
 export interface PrerenderManifestRoute {

--- a/test/e2e/middleware-matcher/index.test.ts
+++ b/test/e2e/middleware-matcher/index.test.ts
@@ -159,19 +159,19 @@ describe('Middleware can set the matcher in its config', () => {
              "matchers": [
                {
                  "originalSource": "/",
-                 "regexp": "^(?:\\/(_next\\/data\\/[^/]{1,}))?(?:\\/(\\/?index|\\/?index\\.json))?[\\/#\\?]?$",
+                 "regexp": "^(?:\\/(_next\\/data\\/[^/]{1,}))?(?:\\/(\\/?index|\\/?index\\.json|\\/?index(?:\\.rsc|\\.segments\\/.+\\.segment\\.rsc)))?[\\/#\\?]?$",
                },
                {
                  "originalSource": "/with-middleware/:path*",
-                 "regexp": "^(?:\\/(_next\\/data\\/[^/]{1,}))?\\/with-middleware(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?(\\.json)?[\\/#\\?]?$",
+                 "regexp": "^(?:\\/(_next\\/data\\/[^/]{1,}))?\\/with-middleware(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?(\\.json|\\.rsc|\\.segments\\/.+\\.segment\\.rsc)?[\\/#\\?]?$",
                },
                {
                  "originalSource": "/another-middleware/:path*",
-                 "regexp": "^(?:\\/(_next\\/data\\/[^/]{1,}))?\\/another-middleware(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?(\\.json)?[\\/#\\?]?$",
+                 "regexp": "^(?:\\/(_next\\/data\\/[^/]{1,}))?\\/another-middleware(?:\\/((?:[^\\/#\\?]+?)(?:\\/(?:[^\\/#\\?]+?))*))?(\\.json|\\.rsc|\\.segments\\/.+\\.segment\\.rsc)?[\\/#\\?]?$",
                },
                {
                  "originalSource": "/_sites/:path((?![^/]*\\.json$)[^/]+$)",
-                 "regexp": "^(?:\\/(_next\\/data\\/[^/]{1,}))?\\/_sites(?:\\/((?![^/]*\\.json$)[^/]+$))(\\.json)?[\\/#\\?]?$",
+                 "regexp": "^(?:\\/(_next\\/data\\/[^/]{1,}))?\\/_sites(?:\\/((?![^/]*\\.json$)[^/]+$))(\\.json|\\.rsc|\\.segments\\/.+\\.segment\\.rsc)?[\\/#\\?]?$",
                },
              ],
              "name": "middleware",


### PR DESCRIPTION
## What?

Applies https://github.com/vercel/next.js/commit/d166096c399c4fc4e09cd2d1bf26dca6579a855d for canary and handles the Turbopack-side implementation for `middleware-manifest.json` which is used for edge runtime middleware.ts