### PR TITLE
[backport][test] Pin package manager to patch versions

### DIFF
--- a/test/e2e/app-dir/nx-handling/nx-handling.test.ts
+++ b/test/e2e/app-dir/nx-handling/nx-handling.test.ts
@@ -11,6 +11,7 @@ describe('nx-handling', () => {
       name: '@nx-next/source',
       version: '0.0.0',
       private: true,
+      packageManager: 'npm@10.9.2',
       scripts: {
         build: 'rm -rf dist; nx run next-nx-test:build',
         dev: 'nx run next-nx-test:dev',

--- a/test/e2e/handle-non-hoisted-swc-helpers/index.test.ts
+++ b/test/e2e/handle-non-hoisted-swc-helpers/index.test.ts
@@ -1,4 +1,4 @@
-import { createNext } from 'e2e-utils'
+import { createNext, isNextDev } from 'e2e-utils'
 import { NextInstance } from 'e2e-utils'
 import { renderViaHTTP } from 'next-test-utils'
 
@@ -24,8 +24,18 @@ describe('handle-non-hoisted-swc-helpers', () => {
           }
         `,
       },
+      packageJson: {
+        packageManager: 'npm@10.9.2',
+        scripts: {
+          build: 'next build',
+          dev: 'next dev',
+          start: 'next start',
+        },
+      },
       installCommand:
         'npm install; mkdir -p node_modules/next/node_modules/@swc; mv node_modules/@swc/helpers node_modules/next/node_modules/@swc/',
+      buildCommand: 'npm run build',
+      startCommand: isNextDev ? 'npm run dev' : 'npm run start',
       dependencies: {},
     })
   })

--- a/test/e2e/yarn-pnp/test/utils.ts
+++ b/test/e2e/yarn-pnp/test/utils.ts
@@ -49,6 +49,11 @@ export function runTests(
           },
           {} as { [key: string]: FileRef }
         ),
+        packageJson: {
+          // Bootstrap with classic yarn; the install command below runs
+          // `yarn set version berry` which rewrites this to the berry version.
+          packageManager: 'yarn@1.22.22',
+        },
         dependencies: {
           ...packageJson.dependencies,
           ...packageJson.devDependencies,

--- a/test/integration/create-next-app/package-manager/pnpm.test.ts
+++ b/test/integration/create-next-app/package-manager/pnpm.test.ts
@@ -1,4 +1,5 @@
 import {
+  command,
   DEFAULT_FILES,
   FULL_EXAMPLE_PATH,
   projectFilesShouldExist,
@@ -9,6 +10,11 @@ import {
 const lockFile = 'pnpm-lock.yaml'
 const files = [...DEFAULT_FILES, lockFile]
 
+// Match the monorepo's pinned pnpm so CNA's `pnpm install` doesn't drift to
+// whichever version corepack happens to fetch as "latest" at test time.
+const rootPackageManager: string =
+  require('../../../../package.json').packageManager
+
 describe('create-next-app with package manager pnpm', () => {
   let nextTgzFilename: string
 
@@ -16,6 +22,8 @@ describe('create-next-app with package manager pnpm', () => {
     if (!process.env.NEXT_TEST_PKG_PATHS) {
       throw new Error('This test needs to be run with `node run-tests.js`.')
     }
+
+    await command('corepack', ['prepare', '--activate', rootPackageManager])
 
     const pkgPaths = new Map<string, string>(
       JSON.parse(process.env.NEXT_TEST_PKG_PATHS)

--- a/test/lib/create-next-install.js
+++ b/test/lib/create-next-install.js
@@ -9,6 +9,7 @@ const { linkPackages } =
 
 const PREFER_OFFLINE = process.env.NEXT_TEST_PREFER_OFFLINE === '1'
 const useRspack = process.env.NEXT_TEST_USE_RSPACK === '1'
+const ROOT_PACKAGE_MANAGER = require('../../package.json').packageManager
 
 async function installDependencies(cwd, tmpDir) {
   const args = [
@@ -176,6 +177,10 @@ async function createNextInstall({
         path.join(installDir, 'package.json'),
         JSON.stringify(
           {
+            // Pin packageManager so corepack doesn't auto-inject a reference
+            // to the latest version (and rewrite this file mid-test).
+            // Callers can override via packageJson.packageManager.
+            packageManager: ROOT_PACKAGE_MANAGER,
             ...packageJson,
             scripts,
             dependencies: combinedDependencies,

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -64,6 +64,9 @@ const nextjsReactPeerVersion = "19.1.0";
 const latestSupportedTypeScriptVersion = '5.8.2'
 const latestSupportedNodeTypesVersion = '20.17.6'
 
+const ROOT_PACKAGE_MANAGER: string =
+  require('../../../package.json').packageManager
+
 export class NextInstance {
   protected files: ResolvedFileConfig
   protected overrideFiles: ResolvedFileConfig
@@ -228,6 +231,10 @@ export class NextInstance {
             path.join(this.testDir, 'package.json'),
             JSON.stringify(
               {
+                // Pin packageManager so corepack doesn't auto-inject a reference
+                // to the latest version (and rewrite this file mid-test).
+                // Callers can override via packageJson.packageManager.
+                packageManager: ROOT_PACKAGE_MANAGER,
                 ...this.packageJson,
                 dependencies: {
                   ...finalDependencies,


### PR DESCRIPTION
Backports https://github.com/vercel/next.js/pull/93592


Stats is not needed since on older branches we already pinned: https://github.com/vercel/next.js/blob/2252a2182b95877d03f80f782dc0e32992482db6/.github/actions/next-stats-action/package.json

Stats being broken despite is a known issue.