### PR TITLE
Use Next.js version as Turbopack persistent cache versioning key

### DIFF
--- a/crates/next-napi-bindings/build.rs
+++ b/crates/next-napi-bindings/build.rs
@@ -5,7 +5,6 @@ use serde_json::Value;
 fn main() -> anyhow::Result<()> {
     println!("cargo:rerun-if-env-changed=CI");
     println!("cargo:rerun-if-env-changed=CARGO_CFG_TARGET_OS");
-    let is_ci = env::var("CI").is_ok_and(|value| !value.is_empty());
     let is_macos_target = env::var("CARGO_CFG_TARGET_OS").is_ok_and(|value| value == "macos");
 
     let nextjs_version = {
@@ -50,11 +49,6 @@ fn main() -> anyhow::Result<()> {
     // commit hash as a version is okay.
     let git = vergen_gitcl::GitclBuilder::default()
         .dirty(/* include_untracked */ true)
-        .describe(
-            /* tags */ true,
-            /* dirty */ !is_ci, // suppress the dirty suffix in CI
-            /* matches */ Some("v[0-9]*"), // find the last version tag
-        )
         .sha(/* short */ true)
         .build()?;
     vergen_gitcl::Emitter::default()

--- a/crates/next-napi-bindings/build.rs
+++ b/crates/next-napi-bindings/build.rs
@@ -55,6 +55,7 @@ fn main() -> anyhow::Result<()> {
             /* dirty */ !is_ci, // suppress the dirty suffix in CI
             /* matches */ Some("v[0-9]*"), // find the last version tag
         )
+        .sha(/* short */ true)
         .build()?;
     vergen_gitcl::Emitter::default()
         .add_instructions(&cargo)?

--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -569,6 +569,7 @@ pub fn project_new(
             let skip_compaction = turbo_engine_options.skip_compaction.unwrap_or(false);
             let turbo_tasks = create_turbo_tasks(
                 PathBuf::from(&options.dist_dir),
+                &options.next_version,
                 options.is_persistent_caching_enabled,
                 memory_limit,
                 dependency_tracking,
@@ -2595,8 +2596,9 @@ pub async fn project_get_all_compilation_issues(
 ///
 /// The `path` should point to the `<distDir>/cache/turbopack` directory.
 #[napi]
-pub async fn turbopack_database_compact(path: String) -> napi::Result<()> {
-    let version_info = crate::next_api::turbopack_ctx::git_version_info();
+pub async fn turbopack_database_compact(path: String, next_version: String) -> napi::Result<()> {
+    let describe = crate::next_api::turbopack_ctx::cache_describe(&next_version);
+    let version_info = crate::next_api::turbopack_ctx::git_version_info(&describe);
     let is_ci = std::env::var("CI").is_ok_and(|v| !v.is_empty());
     turbo_tasks_backend::compact_database(&PathBuf::from(path), &version_info, is_ci)
         .map_err(|e| napi::Error::from_reason(format!("Database compaction failed: {e}")))?;

--- a/crates/next-napi-bindings/src/next_api/turbopack_ctx.rs
+++ b/crates/next-napi-bindings/src/next_api/turbopack_ctx.rs
@@ -208,13 +208,19 @@ impl NapiNextTurbopackCallbacks {
     }
 }
 
-/// Returns version info derived from compile-time git metadata.
+/// Returns the cache version `describe` string for the given Next.js version, of the form
+/// `v<next_version>-<git_short_sha>` (e.g. `v16.0.1-canary.13-94e9fa6`).
+pub fn cache_describe(next_version: &str) -> String {
+    format!("v{next_version}-{}", env!("VERGEN_GIT_SHA"))
+}
+
+/// Returns version info derived from the supplied Next.js version and compile-time git metadata.
 ///
 /// The `dirty` flag is only set when not running in CI (`CI` env var unset at build time) and the
 /// working tree was dirty at build time.
-pub fn git_version_info() -> GitVersionInfo<'static> {
+pub fn git_version_info(describe: &str) -> GitVersionInfo<'_> {
     GitVersionInfo {
-        describe: env!("VERGEN_GIT_DESCRIBE"),
+        describe,
         dirty: option_env!("CI").is_none_or(|value| value.is_empty())
             && env!("VERGEN_GIT_DIRTY") == "true",
     }
@@ -222,6 +228,7 @@ pub fn git_version_info() -> GitVersionInfo<'static> {
 
 pub fn create_turbo_tasks(
     output_path: PathBuf,
+    next_version: &str,
     persistent_caching: bool,
     _memory_limit: usize,
     dependency_tracking: bool,
@@ -230,7 +237,8 @@ pub fn create_turbo_tasks(
     skip_compaction: bool,
 ) -> Result<NextTurboTasks> {
     Ok(if persistent_caching {
-        let version_info = git_version_info();
+        let describe = cache_describe(next_version);
+        let version_info = git_version_info(&describe);
         let (backing_storage, cache_state) = turbo_backing_storage(
             &output_path.join("cache/turbopack"),
             &version_info,

--- a/crates/next-napi-bindings/src/next_api/turbopack_ctx.rs
+++ b/crates/next-napi-bindings/src/next_api/turbopack_ctx.rs
@@ -402,7 +402,7 @@ pub fn log_internal_error_and_inform(internal_error: &anyhow::Error) {
     );
     let version_str = format!(
         "Turbopack version: `{}`\nNext.js version: `{}`",
-        env!("VERGEN_GIT_DESCRIBE"),
+        env!("VERGEN_GIT_SHA"),
         env!("NEXTJS_VERSION")
     );
     let bug_report_url = format!(

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -491,7 +491,10 @@ export declare function projectGetAllCompilationIssues(project: {
  *
  * The `path` should point to the `<distDir>/cache/turbopack` directory.
  */
-export declare function turbopackDatabaseCompact(path: string): Promise<void>
+export declare function turbopackDatabaseCompact(
+  path: string,
+  nextVersion: string
+): Promise<void>
 /**
  * A version of [`NapiNextTurbopackCallbacks`] that can accepted as an argument to a napi function.
  *

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -1410,7 +1410,7 @@ async function loadWasm(importPath = '') {
             `Only WebAssembly (WASM) bindings were loaded, and Turbopack requires native bindings.`
         )
       },
-      databaseCompact(_path: string): Promise<void> {
+      databaseCompact(_path: string, _nextVersion: string): Promise<void> {
         throw new Error(
           'Turbopack database compaction is not supported on this platform'
         )
@@ -1659,8 +1659,11 @@ function loadNative(importPath?: string): Binding {
         queryTraceSpans(handle, options) {
           return (customBindings ?? bindings).queryTraceSpans(handle, options)
         },
-        databaseCompact(dbPath: string) {
-          return (customBindings ?? bindings).turbopackDatabaseCompact(dbPath)
+        databaseCompact(dbPath: string, dbNextVersion: string) {
+          return (customBindings ?? bindings).turbopackDatabaseCompact(
+            dbPath,
+            dbNextVersion
+          )
         },
       },
       mdx: {

--- a/packages/next/src/build/swc/types.ts
+++ b/packages/next/src/build/swc/types.ts
@@ -40,7 +40,7 @@ export interface Binding {
       handle: TraceServerHandle,
       options: TraceQueryOptions
     ): TraceQueryResult
-    databaseCompact(path: string): Promise<void>
+    databaseCompact(path: string, nextVersion: string): Promise<void>
 
     nextBuild?: any
   }

--- a/packages/next/src/cli/next-post-build.ts
+++ b/packages/next/src/cli/next-post-build.ts
@@ -38,7 +38,10 @@ const nextPostBuild = async (
   }
 
   const bindings = await loadBindings(config.experimental?.useWasmBinary)
-  await bindings.turbo.databaseCompact(cachePath)
+  await bindings.turbo.databaseCompact(
+    cachePath,
+    process.env.__NEXT_VERSION as string
+  )
   console.log('Turbopack database compaction complete.')
 }
 


### PR DESCRIPTION
### What?

The Turbopack persistent cache directory under `.next/cache/turbopack/<version>/` is now versioned by the Next.js package version concatenated with the git short SHA, instead of `git describe`.

Example: `v16.0.1-canary.13-94e9fa6`

### Why?

The previous version key came from `VERGEN_GIT_DESCRIBE` (`git describe --match 'v[0-9]' --dirty`), which depends on having an annotated `v*` tag reachable from the build commit. That ties the cache version to local git tag state and breaks down for builds against forks, shallow clones, or branches without a recent matching tag.

The Next.js package version from `packages/next/package.json` is the value users actually care about for cache compatibility, and it is already plumbed through to the Rust side as `ProjectOptions::next_version` (sourced from `process.env.__NEXT_VERSION`). Combining it with the git short SHA keeps per-commit cache uniqueness while removing the dependency on git tags.

### How?

**Rust (`crates/next-napi-bindings`)**

- `build.rs`: also emit `VERGEN_GIT_SHA` (short form) via `vergen_gitcl`. `VERGEN_GIT_DESCRIBE` is still emitted and is still used for the bug-report URL / panic log.
- `src/next_api/turbopack_ctx.rs`:
  - New `cache_describe(next_version)` returns `format!("v{next_version}-{}", env!("VERGEN_GIT_SHA"))`.
  - `git_version_info` now takes the pre-built `describe` string instead of reading `VERGEN_GIT_DESCRIBE` itself. `dirty` handling is unchanged (still derived from `VERGEN_GIT_DIRTY`, still suppressed in CI), so `handle_db_versioning`'s dirty-repo behavior is preserved.
  - `create_turbo_tasks` takes `next_version: &str` and threads it through.
- `src/next_api/project.rs`:
  - `project_new` passes `options.next_version` into `create_turbo_tasks`. No new field is needed on `NapiProjectOptions` — the `nextVersion` field already exists and is already populated by all three call sites.
  - `turbopack_database_compact` (the napi `databaseCompact` function used by `next-post-build`) gains a `next_version: String` parameter so post-build compaction targets the same versioned directory.

**JS (`packages/next`)**

- `src/build/swc/types.ts`, `generated-native.d.ts`, `index.ts`: update the `databaseCompact(path, nextVersion)` signature on both the native and WASM-fallback paths.
- `src/cli/next-post-build.ts`: passes `process.env.__NEXT_VERSION` through to `bindings.turbo.databaseCompact`.

`turbopack/crates/turbopack-cli` (the standalone Turbopack CLI) is intentionally left on `VERGEN_GIT_DESCRIBE` — it is not tied to a Next.js package version.
