### PR TITLE
Fix "type: module" in project dir when using standalone or adapters

### DIFF
--- a/crates/next-api/src/next_server_nft.rs
+++ b/crates/next-api/src/next_server_nft.rs
@@ -118,9 +118,6 @@ impl Asset for ServerNftJsonAsset {
                 .try_join()
                 .await?;
 
-        // A few hardcoded files (not recursive)
-        server_output_assets.push("./package.json".into());
-
         let next_dir = get_next_package(this.project.project_path().owned().await?).await?;
         for ty in ["app-page", "pages"] {
             let dir = next_dir.join(&format!("dist/server/route-modules/{ty}"))?;

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1852,6 +1852,11 @@ export default async function build(
             appDir: dir,
             relativeAppDir: path.relative(outputFileTracingRoot, dir),
             files: [
+              // Marks distDir as commonjs so server output is loaded correctly
+              // when the user's project package.json is "type": "module".
+              // See `writeFileUtf8(path.join(distDir, 'package.json'), '{"type": "commonjs"}')`
+              // earlier in this file.
+              'package.json',
               ROUTES_MANIFEST,
               path.relative(distDir, pagesManifestPath),
               BUILD_MANIFEST,

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1852,10 +1852,18 @@ export default async function build(
             appDir: dir,
             relativeAppDir: path.relative(outputFileTracingRoot, dir),
             files: [
-              // Marks distDir as commonjs so server output is loaded correctly
+              // Marks distDir as commonjs so server output is loaded as CJS
               // when the user's project package.json is "type": "module".
-              // See `writeFileUtf8(path.join(distDir, 'package.json'), '{"type": "commonjs"}')`
-              // earlier in this file.
+              // See `writeFileUtf8(path.join(distDir, 'package.json'),
+              // '{"type": "commonjs"}')` earlier in this file.
+              //
+              // Standalone already picks this up via `next-server.js.nft.json`
+              // (nft traces it as `./package.json`), but per-page nft files do
+              // not include it. The adapter codepath (`handleBuildComplete`)
+              // builds each page's `assets` from `requiredServerFiles` plus
+              // the per-page trace, so without listing it here the boundary
+              // is missing from adapter outputs and Node walks up to the
+              // user's `"type": "module"` package.json at runtime.
               'package.json',
               ROUTES_MANIFEST,
               path.relative(distDir, pagesManifestPath),

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1852,18 +1852,8 @@ export default async function build(
             appDir: dir,
             relativeAppDir: path.relative(outputFileTracingRoot, dir),
             files: [
-              // Marks distDir as commonjs so server output is loaded as CJS
-              // when the user's project package.json is "type": "module".
-              // See `writeFileUtf8(path.join(distDir, 'package.json'),
-              // '{"type": "commonjs"}')` earlier in this file.
-              //
-              // Standalone already picks this up via `next-server.js.nft.json`
-              // (nft traces it as `./package.json`), but per-page nft files do
-              // not include it. The adapter codepath (`handleBuildComplete`)
-              // builds each page's `assets` from `requiredServerFiles` plus
-              // the per-page trace, so without listing it here the boundary
-              // is missing from adapter outputs and Node walks up to the
-              // user's `"type": "module"` package.json at runtime.
+              // distDir `{"type":"commonjs"}` boundary so `.next/server/**/*.js`
+              // is loaded as CJS when the user's project is "type": "module".
               'package.json',
               ROUTES_MANIFEST,
               path.relative(distDir, pagesManifestPath),

--- a/test/production/required-server-files-package-boundary/app/layout.tsx
+++ b/test/production/required-server-files-package-boundary/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/required-server-files-package-boundary/app/page.tsx
+++ b/test/production/required-server-files-package-boundary/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/production/required-server-files-package-boundary/my-adapter.mjs
+++ b/test/production/required-server-files-package-boundary/my-adapter.mjs
@@ -1,0 +1,25 @@
+import fs from 'fs'
+import path from 'path'
+
+/** @type {import('next').NextAdapter } */
+const myAdapter = {
+  name: 'package-boundary-test-adapter',
+  onBuildComplete: async (ctx) => {
+    // Capture every page output's assets so the test can assert the distDir
+    // package.json boundary marker is reachable from the page bundle's
+    // function root. Without this, Node walks up to the user's
+    // "type": "module" package.json and loads `.next/server/**/*.js` as ESM.
+    const pageAssets = {}
+
+    for (const output of [...ctx.outputs.pages, ...ctx.outputs.appPages]) {
+      pageAssets[output.id] = Object.keys(output.assets || {}).sort()
+    }
+
+    await fs.promises.writeFile(
+      path.join(ctx.distDir, 'adapter-page-assets.json'),
+      JSON.stringify(pageAssets, null, 2)
+    )
+  },
+}
+
+export default myAdapter

--- a/test/production/required-server-files-package-boundary/next.config.mjs
+++ b/test/production/required-server-files-package-boundary/next.config.mjs
@@ -1,0 +1,9 @@
+import Module from 'module'
+const require = Module.createRequire(import.meta.url)
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  adapterPath: require.resolve('./my-adapter.mjs'),
+}
+
+export default nextConfig

--- a/test/production/required-server-files-package-boundary/required-server-files-package-boundary.test.ts
+++ b/test/production/required-server-files-package-boundary/required-server-files-package-boundary.test.ts
@@ -1,7 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 import { join } from 'path'
 
-describe('required-server-files manifest - distDir package.json boundary', () => {
+describe('distDir package.json commonjs boundary', () => {
   const { next } = nextTestSetup({
     files: __dirname,
     // Use "type": "module" in the project package.json so the boundary file
@@ -22,11 +22,27 @@ describe('required-server-files manifest - distDir package.json boundary', () =>
     const manifest = JSON.parse(
       await next.readFile('.next/required-server-files.json')
     )
-    // Adapters (e.g. the Vercel adapter) and the standalone build both copy
-    // every entry in `requiredServerFiles.files` into their server output.
-    // The distDir `package.json` boundary marker must be in this list so
-    // `.next/server/**/*.js` continues to load as CJS in deployed
-    // environments where the user has `"type": "module"`.
+    // Adapters consume `requiredServerFiles.files` to seed the per-page
+    // shared assets. The boundary marker must be in this list because
+    // per-page nft traces do not include it.
     expect(manifest.files).toContain(join('.next', 'package.json'))
+  })
+
+  it('includes the distDir package.json in every adapter page output assets', async () => {
+    // The adapter writes per-page asset keys to `.next/adapter-page-assets.json`
+    // during onBuildComplete. The fix in `build/index.ts` ensures the boundary
+    // is in `requiredServerFiles.files`, which `handleBuildComplete` then
+    // merges into every page output's `assets` map.
+    const pageAssets = JSON.parse(
+      await next.readFile('.next/adapter-page-assets.json')
+    )
+
+    const pageIds = Object.keys(pageAssets)
+    expect(pageIds.length).toBeGreaterThan(0)
+
+    const boundaryPath = join('.next', 'package.json')
+    for (const pageId of pageIds) {
+      expect(pageAssets[pageId]).toContain(boundaryPath)
+    }
   })
 })

--- a/test/production/required-server-files-package-boundary/required-server-files-package-boundary.test.ts
+++ b/test/production/required-server-files-package-boundary/required-server-files-package-boundary.test.ts
@@ -1,0 +1,32 @@
+import { nextTestSetup } from 'e2e-utils'
+import { join } from 'path'
+
+describe('required-server-files manifest - distDir package.json boundary', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    // Use "type": "module" in the project package.json so the boundary file
+    // is what determines whether `.next/server/**/*.js` is loaded as CJS.
+    packageJson: {
+      type: 'module',
+    },
+  })
+
+  it('writes the distDir package.json with the commonjs boundary', async () => {
+    const distPackageJson = JSON.parse(
+      await next.readFile('.next/package.json')
+    )
+    expect(distPackageJson).toEqual({ type: 'commonjs' })
+  })
+
+  it('lists the distDir package.json in required-server-files.json', async () => {
+    const manifest = JSON.parse(
+      await next.readFile('.next/required-server-files.json')
+    )
+    // Adapters (e.g. the Vercel adapter) and the standalone build both copy
+    // every entry in `requiredServerFiles.files` into their server output.
+    // The distDir `package.json` boundary marker must be in this list so
+    // `.next/server/**/*.js` continues to load as CJS in deployed
+    // environments where the user has `"type": "module"`.
+    expect(manifest.files).toContain(join('.next', 'package.json'))
+  })
+})

--- a/test/production/standalone-mode/type-module/index.test.ts
+++ b/test/production/standalone-mode/type-module/index.test.ts
@@ -22,6 +22,17 @@ describe('type-module', () => {
 
     expect(fs.existsSync(join(standalonePath, 'package.json'))).toBe(true)
 
+    // The distDir package.json acts as a commonjs boundary marker so that
+    // server bundles in `.next/server/**/*.js` are loaded as CJS even when
+    // the user's project has `"type": "module"`. Without this file, Node
+    // walks up to the project package.json and tries to load the server
+    // bundles as ESM, which fails at runtime.
+    const distPackageJsonPath = join(standalonePath, '.next', 'package.json')
+    expect(fs.existsSync(distPackageJsonPath)).toBe(true)
+    expect(JSON.parse(await fs.readFile(distPackageJsonPath, 'utf8'))).toEqual({
+      type: 'commonjs',
+    })
+
     const serverFile = join(standalonePath, 'server.js')
 
     const appPort = await findPort()
@@ -32,8 +43,16 @@ describe('type-module', () => {
       undefined,
       { cwd: next.testDir }
     )
-    const res = await fetchViaHTTP(appPort, '/')
-    expect(await res.text()).toContain('hello world')
+    const staticRes = await fetchViaHTTP(appPort, '/')
+    expect(await staticRes.text()).toContain('hello world')
+
+    // Hitting a server-rendered page forces Node to actually load
+    // `.next/server/pages/dynamic.js` at runtime, which only succeeds when
+    // the distDir commonjs boundary is in place.
+    const dynamicRes = await fetchViaHTTP(appPort, '/dynamic')
+    expect(dynamicRes.status).toBe(200)
+    expect(await dynamicRes.text()).toContain('dynamic-rendered-at-runtime')
+
     await killApp(server)
   })
 })

--- a/test/production/standalone-mode/type-module/index.test.ts
+++ b/test/production/standalone-mode/type-module/index.test.ts
@@ -1,6 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 import { join } from 'path'
 import fs from 'fs-extra'
+import cheerio from 'cheerio'
 import {
   fetchViaHTTP,
   findPort,
@@ -51,7 +52,8 @@ describe('type-module', () => {
     // the distDir commonjs boundary is in place.
     const dynamicRes = await fetchViaHTTP(appPort, '/dynamic')
     expect(dynamicRes.status).toBe(200)
-    expect(await dynamicRes.text()).toContain('dynamic-rendered-at-runtime')
+    const $ = cheerio.load(await dynamicRes.text())
+    expect($('#content').text()).toBe('dynamic-rendered-at-runtime')
 
     await killApp(server)
   })

--- a/test/production/standalone-mode/type-module/pages/dynamic.js
+++ b/test/production/standalone-mode/type-module/pages/dynamic.js
@@ -1,0 +1,7 @@
+export default function Dynamic({ now }) {
+  return <p id="content">dynamic-{now}</p>
+}
+
+export async function getServerSideProps() {
+  return { props: { now: 'rendered-at-runtime' } }
+}

--- a/test/production/standalone-mode/type-module/pages/dynamic.js
+++ b/test/production/standalone-mode/type-module/pages/dynamic.js
@@ -1,5 +1,5 @@
 export default function Dynamic({ now }) {
-  return <p id="content">dynamic-{now}</p>
+  return <p id="content">{`dynamic-${now}`}</p>
 }
 
 export async function getServerSideProps() {

--- a/test/production/standalone-mode/type-module/pages/dynamic.js
+++ b/test/production/standalone-mode/type-module/pages/dynamic.js
@@ -1,5 +1,5 @@
 export default function Dynamic({ now }) {
-  return <p id="content">{`dynamic-${now}`}</p>
+  return <p id="content">dynamic-{now}</p>
 }
 
 export async function getServerSideProps() {


### PR DESCRIPTION
### What?

Add `.next/package.json` (the distDir commonjs boundary marker) to the `required-server-files.json` manifest.

### Why?

`next build` writes `.next/package.json` with `{"type": "commonjs"}` so that everything in `.next/**` is loaded as CJS even when the user's project `package.json` has `"type": "module"`. Without that file, Node walks up to the project `package.json` when loading `.next/server/**/*.js` and tries to evaluate the compiled server bundles as ESM, which fails at runtime.

This file is necessary on disk in every server deployment artifact (the standalone bundle, every adapter Node function), but it was not declared in `required-server-files.json`. As a result, adapters consuming `requiredServerFiles.files` did not include the boundary file.

`.next/package.json` is conceptually a required server file: any deployment that wants to run `.next/server/**/*.js` correctly under a `"type": "module"` project must ship it. Declaring it in the manifest is the right place to express that contract once for every consumer.

This error case would only happen if the project package.json gets included into the Node.js functions. For example when file tracing analysis (node-file-trace) decides it needs to include it (i.e. glob patterns or such).

### How?

Add `'package.json'` to the `requiredServerFilesManifest.files` array in `packages/next/src/build/index.ts`. Every entry in that array is joined with `config.distDir`, so this resolves to `.next/package.json`.
Both existing consumers pick it up automatically with no further changes:
- `packages/next/src/build/adapter/build-complete.ts` iterates `requiredServerFiles` into `sharedNodeAssets`, which is merged into every Node function's `output.assets` regardless of bundler. The Vercel adapter (and any other adapter) gets the file for free.
- `copyTracedFiles` in `packages/next/src/build/utils.ts` iterates `requiredServerFiles.files` and copies each entry into `.next/standalone/<relative>`, so the standalone output now contains `.next/standalone/.next/package.json`.

### Tests
- `test/production/required-server-files-package-boundary/` — a focused, non-standalone test that builds a `"type": "module"` app and asserts:
  - `.next/package.json` is `{"type": "commonjs"}` on disk
  - `.next/required-server-files.json` lists `.next/package.json`
- `test/production/standalone-mode/type-module/` — extended with a `pages/dynamic.js` that uses `getServerSideProps`. The test now:
  - Asserts `.next/standalone/.next/package.json` exists with `{"type": "commonjs"}`
  - Boots the standalone `server.js` and fetches `/dynamic`, which forces Node to actually evaluate `.next/server/pages/dynamic.js` at runtime — the exact code path the boundary file makes work
