### PR TITLE
[ci] Ensure graphite_ci_optimizer fails open even if github fails to fetch the action

### DIFF
--- a/.github/workflows/graphite_ci_optimizer.yml
+++ b/.github/workflows/graphite_ci_optimizer.yml
@@ -36,10 +36,14 @@ jobs:
     name: Graphite CI Optimizer
     runs-on: ubuntu-latest
     outputs:
+      # `== 'true'` comparison: If `step.check-skip` fails (`continue-on-error`), that output will
+      # be an empty string, which sets our `skip` output to `'false'`.
       skip: ${{ env.HAS_BYPASS_LABEL == 'false' && steps.check-skip.outputs.skip == 'true' }}
     steps:
       - name: Optimize CI
         id: check-skip
+        # Graphite's action is designed to fail open, but still sometimes fails if GH's infra flakes
+        continue-on-error: true
         uses: withgraphite/graphite-ci-action@ee395f3a78254c006d11339669c6cabddf196f72 # main
         with:
           graphite_token: ${{ secrets.GRAPHITE_TOKEN }}


### PR DESCRIPTION
Thread here: https://vercel.slack.com/archives/C08V7CU57E1/p1778186281862589?thread_ts=1778182852.380899&cid=C08V7CU57E1

Sometimes GitHub can fail to fetch and run an action due to general infra flakiness. That can cause this workflow to fail-closed, even though the action itself is designed to fail-open.

![Screenshot 2026-05-07 at 2.03.36 PM.png](https://app.graphite.com/user-attachments/assets/61b749f8-549c-4945-9384-adae58a7fb1d.png)

Reduce the chance that this can fail-closed due to infra flakiness by setting `continue-on-error`.