### PR TITLE
offline navigations: emit fallback document (2/25)

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -229,6 +229,10 @@ import {
 } from '../server/lib/router-utils/build-prefetch-segment-data-route'
 import { generateRoutesManifest } from './generate-routes-manifest'
 import { validateAppPaths } from './validate-app-paths'
+import {
+  createOfflineNavigationFallbackDocument,
+  getOfflineNavigationFallbackFilePath,
+} from './offline-navigation-fallback'
 
 type Fallback = null | boolean | string
 
@@ -4090,6 +4094,30 @@ export default async function build(
       }
 
       // #endregion
+
+      if (config.experimental.offlineNavigations && appDir) {
+        await nextBuildSpan
+          .traceChild('write-offline-navigation-fallback')
+          .traceAsyncFn(async () => {
+            const fallbackDocument = createOfflineNavigationFallbackDocument({
+              assetPrefix: config.assetPrefix,
+              buildId,
+              buildManifest,
+              crossOrigin: config.crossOrigin,
+            })
+
+            if (fallbackDocument === null) {
+              return
+            }
+
+            const fallbackPath = path.join(
+              distDir,
+              getOfflineNavigationFallbackFilePath(buildId)
+            )
+            await mkdir(path.dirname(fallbackPath), { recursive: true })
+            await writeFileUtf8(fallbackPath, fallbackDocument)
+          })
+      }
 
       await writeImagesManifest(distDir, config)
       await writeManifest(path.join(distDir, EXPORT_MARKER), {

--- a/packages/next/src/build/offline-navigation-fallback.ts
+++ b/packages/next/src/build/offline-navigation-fallback.ts
@@ -1,0 +1,84 @@
+import path from 'node:path'
+
+import type { BuildManifest } from '../server/get-page-files'
+import { encodeURIPath } from '../shared/lib/encode-uri-path'
+import {
+  htmlEscapeAttributeString,
+  htmlEscapeJsonString,
+} from '../shared/lib/htmlescape'
+import { CLIENT_STATIC_FILES_PATH } from '../shared/lib/constants'
+
+export const OFFLINE_NAVIGATION_FALLBACK_HTML =
+  '_offline-navigation-fallback.html'
+
+export function getOfflineNavigationFallbackFilePath(buildId: string): string {
+  return path.join(
+    CLIENT_STATIC_FILES_PATH,
+    buildId,
+    OFFLINE_NAVIGATION_FALLBACK_HTML
+  )
+}
+
+function getAssetHref(assetPrefix: string, file: string): string {
+  return `${assetPrefix}/_next/${encodeURIPath(file)}`
+}
+
+function getScriptAttributes(
+  crossOrigin: '' | 'anonymous' | 'use-credentials' | undefined
+): string {
+  if (!crossOrigin) {
+    return ''
+  }
+
+  return ` crossOrigin="${htmlEscapeAttributeString(crossOrigin)}"`
+}
+
+export function createOfflineNavigationFallbackDocument({
+  assetPrefix,
+  buildId,
+  buildManifest,
+  crossOrigin,
+}: {
+  assetPrefix: string
+  buildId: string
+  buildManifest: BuildManifest
+  crossOrigin: '' | 'anonymous' | 'use-credentials' | undefined
+}): string | null {
+  const rootMainFiles = buildManifest.rootMainFiles.filter((file) =>
+    file.endsWith('.js')
+  )
+
+  if (rootMainFiles.length === 0) {
+    return null
+  }
+
+  const polyfillScripts = buildManifest.polyfillFiles
+    .filter((file) => file.endsWith('.js') && !file.endsWith('.module.js'))
+    .map((file) => {
+      return `<script src="${htmlEscapeAttributeString(
+        getAssetHref(assetPrefix, file)
+      )}" noModule${getScriptAttributes(crossOrigin)}></script>`
+    })
+    .join('')
+
+  const bootstrapScripts = rootMainFiles
+    .map((file) => {
+      return `<script src="${htmlEscapeAttributeString(
+        getAssetHref(assetPrefix, file)
+      )}" async${getScriptAttributes(crossOrigin)}></script>`
+    })
+    .join('')
+
+  const metadata = {
+    buildId,
+    source: 'offline-navigation-fallback',
+  }
+
+  return `<!DOCTYPE html><html data-next-offline-navigation-fallback="" data-build-id="${htmlEscapeAttributeString(
+    buildId
+  )}"><head><meta charSet="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><meta name="next-offline-navigation-fallback" content="1"><meta name="next-build-id" content="${htmlEscapeAttributeString(
+    buildId
+  )}"><script id="__NEXT_OFFLINE_NAVIGATION_FALLBACK" type="application/json">${htmlEscapeJsonString(
+    JSON.stringify(metadata)
+  )}</script></head><body><div id="__next"></div><script>self.__next_f=self.__next_f||[];self.__next_f.push([0])</script>${polyfillScripts}${bootstrapScripts}</body></html>`
+}

--- a/test/production/app-dir/offline-navigations/app/layout.tsx
+++ b/test/production/app-dir/offline-navigations/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/offline-navigations/app/page.tsx
+++ b/test/production/app-dir/offline-navigations/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>offline navigations page</p>
+}

--- a/test/production/app-dir/offline-navigations/next.config.js
+++ b/test/production/app-dir/offline-navigations/next.config.js
@@ -1,0 +1,11 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+  experimental: {
+    offlineNavigations: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -1,0 +1,53 @@
+import { existsSync } from 'fs'
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+
+describe('offlineNavigations fallback document', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    skipStart: true,
+  })
+
+  async function getFallbackDocumentPath() {
+    const buildId = (await next.readFile('.next/BUILD_ID')).trim()
+
+    return {
+      buildId,
+      absolutePath: join(
+        next.testDir,
+        '.next',
+        'static',
+        buildId,
+        '_offline-navigation-fallback.html'
+      ),
+      relativePath: `.next/static/${buildId}/_offline-navigation-fallback.html`,
+    }
+  }
+
+  it('emits a request-invariant fallback document when enabled', async () => {
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    const { buildId, relativePath } = await getFallbackDocumentPath()
+    const html = await next.readFile(relativePath)
+
+    expect(html).toContain('data-next-offline-navigation-fallback')
+    expect(html).toContain('id="__NEXT_OFFLINE_NAVIGATION_FALLBACK"')
+    expect(html).toContain(`"buildId":"${buildId}"`)
+    expect(html).toContain('self.__next_f')
+    expect(html).toContain('/_next/static/')
+    expect(html).not.toContain('offline navigations page')
+  })
+
+  it('does not emit a fallback document when disabled', async () => {
+    await next.patchFile('next.config.js', (content) =>
+      content.replace('offlineNavigations: true', 'offlineNavigations: false')
+    )
+
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    const { absolutePath } = await getFallbackDocumentPath()
+    expect(existsSync(absolutePath)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Stack Position

2/25 in the offline navigations first-usable stack.

This stack turns `experimental.offlineNavigations` into a usable cache-components experiment for regular apps. The service worker owns document survival only. Cache Storage owns generated fallback artifacts. The cache-components client router owns IndexedDB, route semantics, replay, visible misses, and invalidation. Output export, dev simulation, custom miss UI, and broad production-hardening matrices are intentionally deferred.

Review guide: https://gist.github.com/feedthejim/b3d9fe26a7c05655fd57adcce371b93d

## Full Stack

1. offline navigations: add cache-components flag (1/25)
2. offline navigations: emit fallback document (2/25) ← this PR
3. offline navigations: emit fallback manifest (3/25)
4. offline navigations: register pass-through service worker (4/25)
5. offline navigations: cache fallback artifacts (5/25)
6. offline navigations: serve fallback document (6/25)
7. offline navigations: bridge fallback state to useOffline (7/25)
8. offline navigations: add navigation cache primitives (8/25)
9. offline navigations: persist exact-url navigation data (9/25)
10. offline navigations: boot fallback from exact-url data (10/25)
11. offline navigations: persist initial-load navigation data (11/25)
12. offline navigations: centralize cache eligibility (12/25)
13. offline navigations: replay request-sensitive exact urls (13/25)
14. offline navigations: wire exact-url invalidation (14/25)
15. offline navigations: harden fallback diagnostics and misses (15/25)
16. offline navigations: cover exact-url app replay basics (16/25)
17. offline navigations: define persistent router schema (17/25)
18. offline navigations: persist route records and known routes (18/25)
19. offline navigations: persist segment and head records (19/25)
20. offline navigations: hydrate persisted router caches (20/25)
21. offline navigations: reconstruct prefetched routes offline (21/25)
22. offline navigations: replay dynamic routes from known routes (22/25)
23. offline navigations: mirror router cache invalidation (23/25)
24. offline navigations: cover mutation invalidation (24/25)
25. offline navigations: add app cache reset API (25/25)

## What This PR Does

Introduces the generated fallback HTML document that can later bootstrap the app when a document navigation fails offline.

## What Works After This PR

Build output has the minimal request-invariant fallback document behind the flag, but it is not served or cached yet.

## Reviewer Focus

The generated document shape, build/deployment metadata, base path and asset prefix handling, and disabled-flag behavior.

## Not In This PR

Manifest generation, service worker installation, and client replay are later PRs.

## Proof in This PR

- Relevant coverage: Production artifact assertions in the offline navigations fixture plus stack-level build/e2e verification.
- Restack verification run at the cleaned stack tip:
  - `pnpm --filter=next build`
  - `NEXT_SKIP_ISOLATE=1 NEXT_TEST_MODE=start pnpm testheadless test/production/app-dir/offline-navigations/offline-navigations.test.ts`
  - `NEXT_TEST_MODE=start pnpm testheadless test/production/app-dir/offline-navigations/offline-navigations.test.ts`
  - `IS_WEBPACK_TEST=1 NEXT_TEST_MODE=start pnpm testheadless test/production/app-dir/offline-navigations/offline-navigations.test.ts`

## Deferred Coverage

Manifest generation, service worker installation, and client replay are later PRs.

<!-- NEXT_JS_LLM_PR -->
