### PR TITLE
offline navigations: emit fallback manifest data (2/13)

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -233,6 +233,10 @@ import {
   createOfflineNavigationFallbackDocument,
   getOfflineNavigationFallbackFilePath,
 } from './offline-navigation-fallback'
+import {
+  createOfflineNavigationManifest,
+  getOfflineNavigationManifestFilePath,
+} from './offline-navigation-manifest'
 
 type Fallback = null | boolean | string
 
@@ -4097,7 +4101,7 @@ export default async function build(
 
       if (config.experimental.offlineNavigations && appDir) {
         await nextBuildSpan
-          .traceChild('write-offline-navigation-fallback')
+          .traceChild('write-offline-navigation-artifacts')
           .traceAsyncFn(async () => {
             const fallbackDocument = createOfflineNavigationFallbackDocument({
               assetPrefix: config.assetPrefix,
@@ -4116,6 +4120,17 @@ export default async function build(
             )
             await mkdir(path.dirname(fallbackPath), { recursive: true })
             await writeFileUtf8(fallbackPath, fallbackDocument)
+
+            await writeManifest(
+              path.join(distDir, getOfflineNavigationManifestFilePath(buildId)),
+              createOfflineNavigationManifest({
+                assetPrefix: config.assetPrefix,
+                basePath: config.basePath,
+                buildId,
+                output: config.output,
+                trailingSlash: config.trailingSlash,
+              })
+            )
           })
       }
 

--- a/packages/next/src/build/offline-navigation-manifest.ts
+++ b/packages/next/src/build/offline-navigation-manifest.ts
@@ -1,0 +1,84 @@
+import path from 'node:path'
+
+import type { NextConfigComplete } from '../server/config-shared'
+import { CLIENT_STATIC_FILES_PATH } from '../shared/lib/constants'
+import { encodeURIPath } from '../shared/lib/encode-uri-path'
+import { getOfflineNavigationFallbackFilePath } from './offline-navigation-fallback'
+
+export const OFFLINE_NAVIGATION_MANIFEST = '_offline-navigation-manifest.json'
+
+export interface OfflineNavigationManifest {
+  version: 1
+  buildId: string
+  basePath: string
+  assetPrefix: string
+  trailingSlash: boolean
+  output: NonNullable<NextConfigComplete['output']> | 'default'
+  scope: string
+  cacheNamespace: string
+  manifest: {
+    path: string
+    href: string
+  }
+  fallbackDocument: {
+    path: string
+    href: string
+  }
+}
+
+export function getOfflineNavigationManifestFilePath(buildId: string): string {
+  return path.join(
+    CLIENT_STATIC_FILES_PATH,
+    buildId,
+    OFFLINE_NAVIGATION_MANIFEST
+  )
+}
+
+function getStaticHref(basePath: string, filePath: string): string {
+  return `${basePath}/_next/${encodeURIPath(filePath)}`
+}
+
+function getScope(basePath: string): string {
+  return basePath ? `${basePath}/` : '/'
+}
+
+// Describe the build-scoped offline navigation artifacts with URLs that honor
+// the app basePath. Later slices use this manifest as the service worker's
+// source of truth for what bootstrap artifacts to cache.
+export function createOfflineNavigationManifest({
+  assetPrefix,
+  basePath,
+  buildId,
+  output,
+  trailingSlash,
+}: {
+  assetPrefix: string
+  basePath: string
+  buildId: string
+  output: NextConfigComplete['output']
+  trailingSlash: boolean
+}): OfflineNavigationManifest {
+  const manifestPath = getOfflineNavigationManifestFilePath(buildId)
+  const fallbackDocumentPath = getOfflineNavigationFallbackFilePath(buildId)
+
+  return {
+    version: 1,
+    buildId,
+    basePath,
+    assetPrefix,
+    trailingSlash,
+    output: output ?? 'default',
+    scope: getScope(basePath),
+    // Scope caches by build and basePath so a new deployment never reuses an
+    // older fallback document.
+    cacheNamespace: `next-offline-navigation-v1:${buildId}:${basePath || '/'}`,
+    manifest: {
+      path: manifestPath,
+      href: getStaticHref(basePath, manifestPath),
+    },
+    fallbackDocument: {
+      path: fallbackDocumentPath,
+      href: getStaticHref(basePath, fallbackDocumentPath),
+    },
+  }
+}

--- a/test/production/app-dir/offline-navigations/next.config.js
+++ b/test/production/app-dir/offline-navigations/next.config.js
@@ -3,9 +3,12 @@
  */
 const nextConfig = {
   cacheComponents: true,
+  assetPrefix: 'https://cdn.example.com/app-assets',
+  basePath: '/docs',
   experimental: {
     offlineNavigations: true,
   },
+  trailingSlash: true,
 }
 
 module.exports = nextConfig

--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -2,44 +2,77 @@ import { existsSync } from 'fs'
 import { join } from 'path'
 import { nextTestSetup } from 'e2e-utils'
 
-describe('offlineNavigations fallback document', () => {
+describe('offlineNavigations build artifacts', () => {
   const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,
   })
 
-  async function getFallbackDocumentPath() {
+  async function getOfflineNavigationArtifactPaths() {
     const buildId = (await next.readFile('.next/BUILD_ID')).trim()
 
     return {
       buildId,
-      absolutePath: join(
-        next.testDir,
-        '.next',
-        'static',
-        buildId,
-        '_offline-navigation-fallback.html'
-      ),
-      relativePath: `.next/static/${buildId}/_offline-navigation-fallback.html`,
+      fallbackDocument: {
+        absolutePath: join(
+          next.testDir,
+          '.next',
+          'static',
+          buildId,
+          '_offline-navigation-fallback.html'
+        ),
+        relativePath: `.next/static/${buildId}/_offline-navigation-fallback.html`,
+      },
+      manifest: {
+        absolutePath: join(
+          next.testDir,
+          '.next',
+          'static',
+          buildId,
+          '_offline-navigation-manifest.json'
+        ),
+        relativePath: `.next/static/${buildId}/_offline-navigation-manifest.json`,
+      },
     }
   }
 
-  it('emits a request-invariant fallback document when enabled', async () => {
+  it('emits request-invariant offline navigation artifacts when enabled', async () => {
     const buildResult = await next.build()
     expect(buildResult.exitCode).toBe(0)
 
-    const { buildId, relativePath } = await getFallbackDocumentPath()
-    const html = await next.readFile(relativePath)
+    const { buildId, fallbackDocument, manifest } =
+      await getOfflineNavigationArtifactPaths()
+    const html = await next.readFile(fallbackDocument.relativePath)
+    const manifestJson = JSON.parse(await next.readFile(manifest.relativePath))
 
     expect(html).toContain('data-next-offline-navigation-fallback')
     expect(html).toContain('id="__NEXT_OFFLINE_NAVIGATION_FALLBACK"')
     expect(html).toContain(`"buildId":"${buildId}"`)
     expect(html).toContain('self.__next_f')
-    expect(html).toContain('/_next/static/')
+    expect(html).toContain('https://cdn.example.com/app-assets/_next/static/')
     expect(html).not.toContain('offline navigations page')
+
+    expect(manifestJson).toEqual({
+      version: 1,
+      buildId,
+      basePath: '/docs',
+      assetPrefix: 'https://cdn.example.com/app-assets',
+      trailingSlash: true,
+      output: 'default',
+      scope: '/docs/',
+      cacheNamespace: `next-offline-navigation-v1:${buildId}:/docs`,
+      manifest: {
+        path: `static/${buildId}/_offline-navigation-manifest.json`,
+        href: `/docs/_next/static/${buildId}/_offline-navigation-manifest.json`,
+      },
+      fallbackDocument: {
+        path: `static/${buildId}/_offline-navigation-fallback.html`,
+        href: `/docs/_next/static/${buildId}/_offline-navigation-fallback.html`,
+      },
+    })
   })
 
-  it('does not emit a fallback document when disabled', async () => {
+  it('does not emit offline navigation artifacts when disabled', async () => {
     await next.patchFile('next.config.js', (content) =>
       content.replace('offlineNavigations: true', 'offlineNavigations: false')
     )
@@ -47,7 +80,9 @@ describe('offlineNavigations fallback document', () => {
     const buildResult = await next.build()
     expect(buildResult.exitCode).toBe(0)
 
-    const { absolutePath } = await getFallbackDocumentPath()
-    expect(existsSync(absolutePath)).toBe(false)
+    const { fallbackDocument, manifest } =
+      await getOfflineNavigationArtifactPaths()
+    expect(existsSync(fallbackDocument.absolutePath)).toBe(false)
+    expect(existsSync(manifest.absolutePath)).toBe(false)
   })
 })


### PR DESCRIPTION
## Stack Position

This is PR 2/13 in the compressed offline navigations stack. Chapter: Build artifacts and worker boundary.

Review guide: https://gist.github.com/feedthejim/b3d9fe26a7c05655fd57adcce371b93d

## Full Stack

1. [#93622](https://github.com/vercel/next.js/pull/93622) offline navigations: add gated build primitives (1/13)
2. [#93624](https://github.com/vercel/next.js/pull/93624) offline navigations: emit fallback manifest data (2/13) **current**
3. [#93625](https://github.com/vercel/next.js/pull/93625) offline navigations: register pass-through worker (3/13)
4. [#93626](https://github.com/vercel/next.js/pull/93626) offline navigations: cache fallback artifacts (4/13)
5. [#93627](https://github.com/vercel/next.js/pull/93627) offline navigations: serve fallback document offline (5/13)
6. [#93630](https://github.com/vercel/next.js/pull/93630) offline navigations: add persistent navigation cache (6/13)
7. [#93631](https://github.com/vercel/next.js/pull/93631) offline navigations: replay exact-url navigations (7/13)
8. [#93635](https://github.com/vercel/next.js/pull/93635) offline navigations: handle exact-url eligibility and invalidation (8/13)
9. [#93640](https://github.com/vercel/next.js/pull/93640) offline navigations: persist router records (9/13)
10. [#93644](https://github.com/vercel/next.js/pull/93644) offline navigations: hydrate router cache from persisted records (10/13)
11. [#93646](https://github.com/vercel/next.js/pull/93646) offline navigations: reconstruct prefetched routes offline (11/13)
12. [#93647](https://github.com/vercel/next.js/pull/93647) offline navigations: support dynamic route patterns (12/13)
13. [#93650](https://github.com/vercel/next.js/pull/93650) offline navigations: wire invalidation and reset APIs (13/13)

## Context

The original offline navigations work was split into 25 staging PRs, which made the review surface too noisy. This compressed stack keeps the same first-usable feature at the tip, but groups the work by reviewer-facing behavior: build artifacts first, exact URL replay next, then route-record replay and invalidation.

The architecture boundary is intentional: the generated service worker keeps the app bootable by serving the fallback document, while the cache-components client router owns IndexedDB, replay eligibility, route reconstruction, visible misses, and invalidation.

Folded source PRs: None.

## What This PR Does

- Emits the offline-navigation manifest data behind the experimental flag.
- Records the build/deployment identity and fallback artifact metadata that the worker and client will consume later.
- Keeps this as build output only, without changing runtime routing behavior.

## What Works After This PR

After this PR, an enabled build can produce the manifest data needed to resolve the generated fallback entrypoint later.

## What Intentionally Does Not Work Yet

There is still no registered worker, no artifact caching, and no offline document response.

## Reviewer Focus

Manifest shape, path stability, build-only scope, and whether the output is minimal enough for later clients to consume.

## Proof in This PR

- `NEXT_TEST_MODE=start pnpm testheadless test/production/app-dir/offline-navigations/offline-navigations.test.ts` passed at the compressed tip.
- The production e2e includes `emits request-invariant offline navigation artifacts when enabled`.
- `git diff --check canary..HEAD` passed.
- `git diff --stat HEAD f60949e313` and `git diff --name-status HEAD f60949e313` produced no output, so the compressed tip preserves the previous staging tip.
- `pnpm --filter=next build` passed.
- `NEXT_TEST_MODE=start pnpm testheadless test/production/app-dir/offline-navigations/offline-navigations.test.ts` passed, 12/12.
- `IS_WEBPACK_TEST=1 NEXT_TEST_MODE=start pnpm testheadless test/production/app-dir/offline-navigations/offline-navigations.test.ts` passed, 12/12.

## Deferred Coverage

Worker registration, Cache Storage population, and route replay are deferred.

<!-- NEXT_JS_LLM_PR -->
