### PR TITLE
offline navigations: cache fallback and current-build assets (4/21)

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -231,10 +231,12 @@ import { generateRoutesManifest } from './generate-routes-manifest'
 import { validateAppPaths } from './validate-app-paths'
 import {
   createOfflineNavigationFallbackDocument,
+  getOfflineNavigationFallbackDocumentHref,
   getOfflineNavigationFallbackFilePath,
 } from './offline-navigation-fallback'
 import {
   createOfflineNavigationServiceWorker,
+  getOfflineNavigationCacheNamespace,
   getOfflineNavigationServiceWorkerFilePath,
 } from './offline-navigation-service-worker'
 
@@ -4122,12 +4124,25 @@ export default async function build(
               distDir,
               getOfflineNavigationServiceWorkerFilePath()
             )
+            const cacheNamespace = getOfflineNavigationCacheNamespace({
+              basePath: config.basePath,
+              buildId,
+            })
+            const fallbackDocumentHref =
+              getOfflineNavigationFallbackDocumentHref({
+                basePath: config.basePath,
+                buildId,
+              })
 
             await mkdir(path.dirname(fallbackPath), { recursive: true })
             await writeFileUtf8(fallbackPath, fallbackDocument.html)
             await writeFileUtf8(
               serviceWorkerPath,
-              createOfflineNavigationServiceWorker()
+              createOfflineNavigationServiceWorker({
+                cacheNamespace,
+                fallbackAssetHrefs: fallbackDocument.assetHrefs,
+                fallbackDocumentHref,
+              })
             )
           })
       }

--- a/packages/next/src/build/offline-navigation-service-worker.ts
+++ b/packages/next/src/build/offline-navigation-service-worker.ts
@@ -1,33 +1,211 @@
 import path from 'node:path'
 
 import { CLIENT_STATIC_FILES_PATH } from '../shared/lib/constants'
-import { OFFLINE_NAVIGATION_SERVICE_WORKER } from '../shared/lib/offline-navigation'
+import {
+  OFFLINE_NAVIGATION_CACHE_PREFIX,
+  OFFLINE_NAVIGATION_CACHE_STATIC_ASSETS,
+  OFFLINE_NAVIGATION_SERVICE_WORKER,
+  OFFLINE_NAVIGATION_SERVICE_WORKER_METADATA_GLOBAL,
+} from '../shared/lib/offline-navigation-constants'
 
 export function getOfflineNavigationServiceWorkerFilePath(): string {
   return path.join(CLIENT_STATIC_FILES_PATH, OFFLINE_NAVIGATION_SERVICE_WORKER)
 }
 
-function renderServiceWorkerMetadata(metadata: unknown): string {
-  return `self.__NEXT_OFFLINE_NAVIGATION_SW=${JSON.stringify(metadata)};`
+export function getOfflineNavigationCacheNamespace({
+  basePath,
+  buildId,
+}: {
+  basePath: string
+  buildId: string
+}): string {
+  return `${OFFLINE_NAVIGATION_CACHE_PREFIX}${buildId}:${basePath || '/'}`
 }
 
-const serviceWorkerInstallListener =
-  "self.addEventListener('install',(event)=>{event.waitUntil(self.skipWaiting())});"
+const serviceWorkerMetadataReference = `self.${OFFLINE_NAVIGATION_SERVICE_WORKER_METADATA_GLOBAL}`
 
-const serviceWorkerActivateListener =
-  "self.addEventListener('activate',(event)=>{event.waitUntil(self.clients.claim())});"
+function renderServiceWorkerMetadata(metadata: unknown): string {
+  return `${serviceWorkerMetadataReference}=${JSON.stringify(metadata)};`
+}
 
-// Generate an app-local service worker for offline navigations. This slice is
-// pass-through: it only installs and claims clients so later slices can add
-// cache population and fallback document handling.
-export function createOfflineNavigationServiceWorker(): string {
-  const metadata = {
-    source: 'offline-navigation-service-worker',
-  }
+function readServiceWorkerMetadataSource(): string {
+  return `const metadata=${serviceWorkerMetadataReference};`
+}
 
+const cachePrefixSource = `const CACHE_PREFIX=${JSON.stringify(
+  OFFLINE_NAVIGATION_CACHE_PREFIX
+)};`
+
+const hrefNormalizationSource = [
+  'function normalizeHref(href){',
+  'const url=new URL(href,self.location.origin);',
+  "url.search='';",
+  "url.hash='';",
+  'return url.href;',
+  '}',
+  'function withDeploymentQuery(href){',
+  'const url=new URL(normalizeHref(href));',
+  'const deploymentParams=new URLSearchParams(self.location.search);',
+  'deploymentParams.forEach((value,key)=>{',
+  'if(!url.searchParams.has(key)){url.searchParams.set(key,value);}',
+  '});',
+  'return url.href;',
+  '}',
+].join('')
+
+const requiredResourceCachingSource = [
+  'async function fetchRequiredResource(href,withDeploymentId){',
+  'const normalizedHref=normalizeHref(href);',
+  'const resourceHref=withDeploymentId?withDeploymentQuery(normalizedHref):normalizedHref;',
+  'let response;',
+  "try{response=await fetch(resourceHref,{cache:'no-store'});}",
+  'catch(err){',
+  'if(withDeploymentId){throw err;}',
+  "response=await fetch(resourceHref,{cache:'no-store',mode:'no-cors'});",
+  '}',
+  "if(!response.ok&&response.type!=='opaque'){",
+  "throw new Error('Failed to cache offline navigation resource: '+href);",
+  '}',
+  'return response;',
+  '}',
+  'async function cacheOfflineNavigationResources(){',
+  readServiceWorkerMetadataSource(),
+  'const cache=await caches.open(metadata.cacheNamespace);',
+  'const fallbackResponse=await fetchRequiredResource(metadata.fallbackDocumentHref,true);',
+  'await cache.put(normalizeHref(metadata.fallbackDocumentHref),fallbackResponse);',
+  'await Promise.all(metadata.fallbackAssetHrefs.map(async(href)=>{',
+  'const response=await fetchRequiredResource(href,false);',
+  'await cache.put(normalizeHref(href),response);',
+  '}));',
+  '}',
+].join('')
+
+const assetCacheKeySource = [
+  'function getFallbackAssetCacheKey(request){',
+  "if(request.method!=='GET'){return null;}",
+  'const requestHref=normalizeHref(request.url);',
+  readServiceWorkerMetadataSource(),
+  'return metadata.fallbackAssetHrefs.some((href)=>normalizeHref(href)===requestHref)?requestHref:null;',
+  '}',
+  'function getManagedStaticAssetCacheKey(request){',
+  "if(request.method!=='GET'){return null;}",
+  'return getManagedStaticAssetCacheKeyFromHref(request.url);',
+  '}',
+  'function getManagedStaticAssetCacheKeyFromHref(href){',
+  'let url;',
+  'try{url=new URL(href,self.location.origin);}',
+  'catch(err){return null;}',
+  "if(!url.pathname.includes('/_next/static/')||url.pathname.includes('/_offline-navigation-')){return null;}",
+  "url.search='';",
+  "url.hash='';",
+  'return url.href;',
+  '}',
+  'function getStaticAssetPromotionRequestHref(href){',
+  'let url;',
+  'try{url=new URL(href,self.location.origin);}',
+  'catch(err){return null;}',
+  'if(url.origin!==self.location.origin||getManagedStaticAssetCacheKeyFromHref(url.href)===null){return null;}',
+  "url.hash='';",
+  'return url.href;',
+  '}',
+].join('')
+
+const staticAssetFetchSource = [
+  'async function fetchManagedStaticAsset(request){',
+  'const cacheKey=getFallbackAssetCacheKey(request)||getManagedStaticAssetCacheKey(request);',
+  'if(cacheKey===null){return fetch(request);}',
+  readServiceWorkerMetadataSource(),
+  'const cache=await caches.open(metadata.cacheNamespace);',
+  'const cachedResponse=await cache.match(cacheKey);',
+  'if(cachedResponse){return cachedResponse;}',
+  'const response=await fetch(request);',
+  "if(response.ok||response.type==='opaque'){await cache.put(cacheKey,response.clone());}",
+  'return response;',
+  '}',
+].join('')
+
+const currentAssetPromotionSource = [
+  'async function cacheCurrentStaticAssets(hrefs){',
+  'if(!Array.isArray(hrefs)||hrefs.length===0){return;}',
+  readServiceWorkerMetadataSource(),
+  'const cache=await caches.open(metadata.cacheNamespace);',
+  'await Promise.all(hrefs.slice(0,128).map(async(href)=>{',
+  "if(typeof href!=='string'||href.length>4096){return;}",
+  'const cacheKey=getManagedStaticAssetCacheKeyFromHref(href);',
+  'if(cacheKey===null){return;}',
+  'const cachedResponse=await cache.match(cacheKey);',
+  'if(cachedResponse){return;}',
+  'const requestHref=getStaticAssetPromotionRequestHref(href);',
+  'if(requestHref===null){return;}',
+  'let response;',
+  "try{response=await fetch(requestHref,{cache:'only-if-cached',mode:'same-origin'});}",
+  'catch(err){return;}',
+  'if(response.ok){await cache.put(cacheKey,response);}',
+  '}));',
+  '}',
+].join('')
+
+const installAndActivateListenersSource = [
+  "self.addEventListener('install',(event)=>{",
+  'event.waitUntil((async()=>{',
+  'await cacheOfflineNavigationResources();',
+  'await self.skipWaiting();',
+  '})());',
+  '});',
+  "self.addEventListener('activate',(event)=>{",
+  'event.waitUntil((async()=>{',
+  readServiceWorkerMetadataSource(),
+  'const cacheNames=await caches.keys();',
+  'await Promise.all(cacheNames.map((cacheName)=>{',
+  'if(cacheName.startsWith(CACHE_PREFIX)&&cacheName!==metadata.cacheNamespace){',
+  'return caches.delete(cacheName);',
+  '}',
+  '}));',
+  'await self.clients.claim();',
+  '})());',
+  '});',
+].join('')
+
+const fetchListenerSource = [
+  "self.addEventListener('fetch',(event)=>{",
+  'if(getFallbackAssetCacheKey(event.request)!==null||getManagedStaticAssetCacheKey(event.request)!==null){',
+  'event.respondWith(fetchManagedStaticAsset(event.request));',
+  '}',
+  '});',
+].join('')
+
+function renderMessageListener(messageType: string): string {
+  return `self.addEventListener('message',(event)=>{const data=event.data;if(data&&data.type===${JSON.stringify(
+    messageType
+  )}){event.waitUntil(cacheCurrentStaticAssets(data.hrefs));}});`
+}
+
+// Offline navigations use a generated, app-local service worker for the
+// document fallback and the bootstrap assets referenced by that fallback. It
+// does not interpret route data; later client-router slices own route replay.
+export function createOfflineNavigationServiceWorker({
+  cacheNamespace,
+  fallbackAssetHrefs,
+  fallbackDocumentHref,
+}: {
+  cacheNamespace: string
+  fallbackAssetHrefs: string[]
+  fallbackDocumentHref: string
+}): string {
   return [
-    renderServiceWorkerMetadata(metadata),
-    serviceWorkerInstallListener,
-    serviceWorkerActivateListener,
+    renderServiceWorkerMetadata({
+      cacheNamespace,
+      fallbackAssetHrefs,
+      fallbackDocumentHref,
+    }),
+    cachePrefixSource,
+    hrefNormalizationSource,
+    requiredResourceCachingSource,
+    assetCacheKeySource,
+    staticAssetFetchSource,
+    currentAssetPromotionSource,
+    installAndActivateListenersSource,
+    fetchListenerSource,
+    renderMessageListener(OFFLINE_NAVIGATION_CACHE_STATIC_ASSETS),
   ].join('')
 }

--- a/packages/next/src/client/offline-navigation-service-worker.ts
+++ b/packages/next/src/client/offline-navigation-service-worker.ts
@@ -1,5 +1,15 @@
 import { getDeploymentIdQuery } from '../shared/lib/deployment-id'
-import { OFFLINE_NAVIGATION_SERVICE_WORKER } from '../shared/lib/offline-navigation-constants'
+import {
+  OFFLINE_NAVIGATION_CACHE_STATIC_ASSETS,
+  OFFLINE_NAVIGATION_SERVICE_WORKER,
+} from '../shared/lib/offline-navigation-constants'
+
+let isSyncingCurrentStaticAssets = false
+
+type OfflineNavigationCacheStaticAssetsMessage = {
+  type: typeof OFFLINE_NAVIGATION_CACHE_STATIC_ASSETS
+  hrefs: string[]
+}
 
 function getBasePath(): string {
   return (process.env.__NEXT_ROUTER_BASEPATH as string) || ''
@@ -14,6 +24,90 @@ function getServiceWorkerScope(): string {
   return basePath ? `${basePath}/` : '/'
 }
 
+function isNextStaticAssetHref(href: string): boolean {
+  try {
+    const url = new URL(href, window.location.href)
+    return (
+      url.pathname.includes('/_next/static/') &&
+      !url.pathname.includes('/_offline-navigation-')
+    )
+  } catch {
+    return false
+  }
+}
+
+function getCurrentNextStaticAssetHrefs(): string[] {
+  const hrefs = new Set<string>()
+
+  for (const element of document.querySelectorAll('script[src],link[href]')) {
+    let href: string | null = null
+    if (element instanceof HTMLScriptElement) {
+      href = element.src
+    } else if (element instanceof HTMLLinkElement) {
+      href = element.href
+    }
+
+    if (href !== null && isNextStaticAssetHref(href)) {
+      hrefs.add(href)
+    }
+  }
+
+  for (const entry of performance.getEntriesByType('resource')) {
+    if (isNextStaticAssetHref(entry.name)) {
+      hrefs.add(entry.name)
+    }
+  }
+
+  return Array.from(hrefs)
+}
+
+function postCurrentNextStaticAssetsToServiceWorker(): void {
+  const controller = navigator.serviceWorker.controller
+  if (controller === null) {
+    return
+  }
+
+  const hrefs = getCurrentNextStaticAssetHrefs()
+  if (hrefs.length === 0) {
+    return
+  }
+
+  const message: OfflineNavigationCacheStaticAssetsMessage = {
+    type: OFFLINE_NAVIGATION_CACHE_STATIC_ASSETS,
+    hrefs,
+  }
+  controller.postMessage(message)
+}
+
+function syncCurrentNextStaticAssetsWithServiceWorker(): void {
+  if (isSyncingCurrentStaticAssets) {
+    return
+  }
+  isSyncingCurrentStaticAssets = true
+
+  const post = () => postCurrentNextStaticAssetsToServiceWorker()
+
+  // The first page load may fetch bootstrap scripts, CSS, and viewport
+  // prefetch chunks before the generated worker controls the page. Once it is
+  // controlling, hand those already-observed static resources to the worker so
+  // offline replay does not depend on the browser HTTP cache.
+  if (navigator.serviceWorker.controller !== null) {
+    post()
+  } else {
+    navigator.serviceWorker.addEventListener('controllerchange', post, {
+      once: true,
+    })
+  }
+
+  if (document.readyState === 'complete') {
+    post()
+  } else {
+    window.addEventListener('load', post, { once: true })
+  }
+
+  navigator.serviceWorker.ready.then(post).catch(() => {})
+}
+
 export function registerOfflineNavigationServiceWorker(): void {
   if (
     process.env.__NEXT_DEV_SERVER ||
@@ -23,6 +117,8 @@ export function registerOfflineNavigationServiceWorker(): void {
   ) {
     return
   }
+
+  syncCurrentNextStaticAssetsWithServiceWorker()
 
   // Registration is best-effort: a failed service worker install should not
   // affect the current online page load.

--- a/packages/next/src/shared/lib/offline-navigation-constants.ts
+++ b/packages/next/src/shared/lib/offline-navigation-constants.ts
@@ -2,6 +2,11 @@ export const OFFLINE_NAVIGATION_SERVICE_WORKER =
   '_offline-navigation-service-worker.js'
 export const OFFLINE_NAVIGATION_FALLBACK_HTML =
   '_offline-navigation-fallback.html'
+export const OFFLINE_NAVIGATION_CACHE_PREFIX = 'next-offline-navigation-v1:'
+export const OFFLINE_NAVIGATION_CACHE_STATIC_ASSETS =
+  'next-offline-navigation-cache-static-assets'
+export const OFFLINE_NAVIGATION_SERVICE_WORKER_METADATA_GLOBAL =
+  '__NEXT_OFFLINE_NAVIGATION_SW'
 export const OFFLINE_NAVIGATION_FALLBACK_DOCUMENT_ATTRIBUTE =
   'data-next-offline-navigation-fallback'
 export const OFFLINE_NAVIGATION_FALLBACK_SCRIPT_ID =

--- a/test/e2e/app-dir/offline-navigations-deploy/app/layout.tsx
+++ b/test/e2e/app-dir/offline-navigations-deploy/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/offline-navigations-deploy/app/offline-status.tsx
+++ b/test/e2e/app-dir/offline-navigations-deploy/app/offline-status.tsx
@@ -1,0 +1,8 @@
+'use client'
+
+import { useOffline } from 'next/offline'
+
+export function OfflineStatus() {
+  const isOffline = useOffline()
+  return <p id="offline-status">{isOffline ? 'offline' : 'online'}</p>
+}

--- a/test/e2e/app-dir/offline-navigations-deploy/app/page.tsx
+++ b/test/e2e/app-dir/offline-navigations-deploy/app/page.tsx
@@ -1,0 +1,10 @@
+import { OfflineStatus } from './offline-status'
+
+export default function Page() {
+  return (
+    <>
+      <p id="offline-navigations-page">offline navigations deploy page</p>
+      <OfflineStatus />
+    </>
+  )
+}

--- a/test/e2e/app-dir/offline-navigations-deploy/next.config.js
+++ b/test/e2e/app-dir/offline-navigations-deploy/next.config.js
@@ -1,0 +1,15 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+  assetPrefix: '/app-assets',
+  basePath: '/docs',
+  experimental: {
+    exposeTestingApiInProductionBuild: true,
+    offlineNavigations: true,
+  },
+  trailingSlash: true,
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/offline-navigations-deploy/offline-navigations-deploy.test.ts
+++ b/test/e2e/app-dir/offline-navigations-deploy/offline-navigations-deploy.test.ts
@@ -1,0 +1,195 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+import type * as Playwright from 'playwright'
+
+describe('offlineNavigations deploy-safe runtime behavior', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: __dirname,
+  })
+
+  if (isNextDev) {
+    it('skipped in dev', () => {})
+    return
+  }
+
+  async function waitForOfflineNavigationServiceWorker(
+    browser: Awaited<ReturnType<typeof next.browser>>,
+    page: Playwright.Page
+  ) {
+    await retry(
+      async () => {
+        const state = await browser.eval(async () => {
+          if (!('serviceWorker' in navigator)) {
+            return {
+              controlled: false,
+              hasActiveRegistration: false,
+            }
+          }
+
+          const registrations = await navigator.serviceWorker.getRegistrations()
+          return {
+            controlled: Boolean(navigator.serviceWorker.controller),
+            hasActiveRegistration: registrations.some(
+              (registration) =>
+                registration.scope.endsWith('/docs/') &&
+                registration.active !== null
+            ),
+          }
+        })
+
+        expect(state.hasActiveRegistration).toBe(true)
+      },
+      10000,
+      500
+    )
+
+    if (
+      !(await browser.eval(() => Boolean(navigator.serviceWorker.controller)))
+    ) {
+      await page.reload({ waitUntil: 'domcontentloaded' })
+    }
+
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(() => Boolean(navigator.serviceWorker.controller))
+        ).toBe(true)
+      },
+      10000,
+      500
+    )
+  }
+
+  async function readOfflineNavigationCacheState(
+    browser: Awaited<ReturnType<typeof next.browser>>
+  ) {
+    return browser.eval(async () => {
+      const cacheNames = (await caches.keys()).filter((cacheName) =>
+        cacheName.startsWith('next-offline-navigation-v1:')
+      )
+      const entries: Array<{
+        cacheName: string
+        pathname: string
+        search: string
+      }> = []
+
+      for (const cacheName of cacheNames) {
+        const cache = await caches.open(cacheName)
+        const requests = await cache.keys()
+
+        for (const request of requests) {
+          const url = new URL(request.url)
+          entries.push({
+            cacheName,
+            pathname: url.pathname,
+            search: url.search,
+          })
+        }
+      }
+
+      return { cacheNames, entries }
+    })
+  }
+
+  it('registers the service worker and serves current-build assets from Cache Storage', async () => {
+    let page: Playwright.Page | undefined
+    try {
+      const serviceWorkerResponse = await next.fetch(
+        `/docs/_next/static/_offline-navigation-service-worker.js${next.getDeploymentIdQuery()}`
+      )
+      expect(serviceWorkerResponse.status).toBe(200)
+      expect(serviceWorkerResponse.headers.get('service-worker-allowed')).toBe(
+        '/docs/'
+      )
+
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
+      expect(await browser.elementById('offline-status').text()).toBe('online')
+
+      await retry(async () => {
+        const registration = await browser.eval(async () => {
+          if (!('serviceWorker' in navigator)) {
+            return null
+          }
+
+          const registrations = await navigator.serviceWorker.getRegistrations()
+          const registration = registrations.find((entry) =>
+            entry.scope.endsWith('/docs/')
+          )
+
+          if (!registration) {
+            return null
+          }
+
+          const scriptURL = new URL(registration.active?.scriptURL ?? '')
+          return {
+            pathname: scriptURL.pathname,
+            search: scriptURL.search,
+            scope: registration.scope,
+          }
+        })
+
+        expect(registration).toEqual({
+          pathname: '/docs/_next/static/_offline-navigation-service-worker.js',
+          search: next.getDeploymentIdQuery(),
+          scope: `${next.url}/docs/`,
+        })
+      })
+
+      const staticAssetPathname = await retry(async () => {
+        const cacheState = await readOfflineNavigationCacheState(browser)
+        expect(cacheState.cacheNames).toEqual(
+          expect.arrayContaining([
+            expect.stringMatching(/^next-offline-navigation-v1:/),
+          ])
+        )
+        expect(cacheState.entries).toEqual(
+          expect.arrayContaining([
+            {
+              cacheName: expect.stringMatching(/^next-offline-navigation-v1:/),
+              pathname: expect.stringMatching(
+                /^\/docs\/_next\/static\/.+\/_offline-navigation-fallback\.html$/
+              ),
+              search: '',
+            },
+            {
+              cacheName: expect.stringMatching(/^next-offline-navigation-v1:/),
+              pathname: expect.stringMatching(
+                /^\/app-assets\/_next\/static\/(?:immutable\/)?chunks\/.+\.js$/
+              ),
+              search: '',
+            },
+          ])
+        )
+
+        return cacheState.entries.find((entry) =>
+          /^\/app-assets\/_next\/static\/(?:immutable\/)?chunks\/.+\.js$/.test(
+            entry.pathname
+          )
+        )!.pathname
+      })
+
+      await page!.context().setOffline(true)
+      const assetResponse = await browser.eval(async (pathname) => {
+        const response = await fetch(`${pathname}?dpl=offline-navigation-test`)
+        return {
+          ok: response.ok,
+          status: response.status,
+        }
+      }, staticAssetPathname)
+      expect(assetResponse).toEqual({
+        ok: true,
+        status: 200,
+      })
+      await page!.context().setOffline(false)
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+    }
+  })
+})

--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -3,6 +3,9 @@ import { join } from 'path'
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
+const OFFLINE_NAVIGATION_CACHE_STATIC_ASSETS =
+  'next-offline-navigation-cache-static-assets'
+
 describe('offlineNavigations build artifacts', () => {
   const { next } = nextTestSetup({
     files: __dirname,
@@ -45,7 +48,32 @@ describe('offlineNavigations build artifacts', () => {
       .sort()
   }
 
-  it('emits a request-invariant offline navigation fallback document when enabled', async () => {
+  async function readOfflineNavigationCacheState(
+    browser: Awaited<ReturnType<typeof next.browser>>
+  ) {
+    return browser.eval(async () => {
+      const cacheNames = (await caches.keys()).filter((cacheName) =>
+        cacheName.startsWith('next-offline-navigation-v1:')
+      )
+      const entries: Array<{ cacheName: string; pathname: string }> = []
+
+      for (const cacheName of cacheNames) {
+        const cache = await caches.open(cacheName)
+        const requests = await cache.keys()
+
+        for (const request of requests) {
+          entries.push({
+            cacheName,
+            pathname: new URL(request.url).pathname,
+          })
+        }
+      }
+
+      return { cacheNames, entries }
+    })
+  }
+
+  it('emits request-invariant offline navigation artifacts when enabled', async () => {
     const buildResult = await next.build()
     expect(buildResult.exitCode).toBe(0)
 
@@ -71,19 +99,38 @@ describe('offlineNavigations build artifacts', () => {
     expect(html.length).toBeLessThan(4096)
 
     expect(serviceWorkerScript).toContain(
-      '"source":"offline-navigation-service-worker"'
+      `"cacheNamespace":"next-offline-navigation-v1:${buildId}:/docs"`
+    )
+    expect(serviceWorkerScript).toContain(
+      `"fallbackDocumentHref":"/docs/_next/static/${buildId}/_offline-navigation-fallback.html"`
+    )
+    expect(serviceWorkerScript).toContain(
+      '"fallbackAssetHrefs":["/app-assets/_next/static/'
+    )
+    expect(serviceWorkerScript).not.toContain('"source"')
+    expect(serviceWorkerScript).toContain('cacheOfflineNavigationResources')
+    expect(serviceWorkerScript).toContain('cacheCurrentStaticAssets')
+    expect(serviceWorkerScript).toContain('fetchManagedStaticAsset')
+    expect(serviceWorkerScript).toContain('getManagedStaticAssetCacheKey')
+    expect(serviceWorkerScript).toContain("cache:'only-if-cached'")
+    expect(serviceWorkerScript).toContain("mode:'same-origin'")
+    expect(serviceWorkerScript).not.toContain("cache:'force-cache'")
+    expect(serviceWorkerScript).toContain('caches.delete')
+    expect(serviceWorkerScript).toContain(
+      OFFLINE_NAVIGATION_CACHE_STATIC_ASSETS
     )
     expect(serviceWorkerScript).toContain('skipWaiting')
     expect(serviceWorkerScript).toContain('clients.claim')
-    expect(serviceWorkerScript).not.toContain('respondWith')
     expect(serviceWorkerScript).not.toContain('\n')
-    expect(serviceWorkerScript.length).toBeLessThan(512)
+    expect(serviceWorkerScript).toContain('respondWith')
+    expect(serviceWorkerScript.length).toBeLessThan(6000)
   })
 
-  it('registers the pass-through service worker when enabled', async () => {
+  it('registers the service worker and caches offline resources when enabled', async () => {
     const buildResult = await next.build()
     expect(buildResult.exitCode).toBe(0)
 
+    const { buildId } = await getOfflineNavigationArtifactPaths()
     await next.start({ skipBuild: true })
 
     try {
@@ -124,10 +171,39 @@ describe('offlineNavigations build artifacts', () => {
         })
       })
 
+      const cacheName = `next-offline-navigation-v1:${buildId}:/docs`
+      await retry(async () => {
+        const cacheState = await readOfflineNavigationCacheState(browser)
+        expect(cacheState.cacheNames).toContain(cacheName)
+        expect(cacheState.entries).toEqual(
+          expect.arrayContaining([
+            {
+              cacheName,
+              pathname: `/docs/_next/static/${buildId}/_offline-navigation-fallback.html`,
+            },
+            {
+              cacheName,
+              pathname: expect.stringMatching(
+                /^\/app-assets\/_next\/static\/(?:immutable\/)?chunks\/.+\.js$/
+              ),
+            },
+          ])
+        )
+      })
+
       await browser.eval(async () => {
         if (!('serviceWorker' in navigator)) {
           return
         }
+
+        const cacheNames = await caches.keys()
+        await Promise.all(
+          cacheNames
+            .filter((cacheName) =>
+              cacheName.startsWith('next-offline-navigation-v1:')
+            )
+            .map((cacheName) => caches.delete(cacheName))
+        )
 
         const registrations = await navigator.serviceWorker.getRegistrations()
         await Promise.all(


### PR DESCRIPTION
This is PR 4 of 21 in the offline navigations plus output-export fallback stack.

This stack introduces a generated fallback entrypoint and then layers the client behavior on the existing App Router, cached navigations, optimistic routing, Cache Components, and Segment Cache primitives. The offline navigations chapter adds a managed service worker and persisted Segment Cache replay. The output-export chapter emits static fallback HTML/RSC artifacts so parameterized routes can load and navigate without enumerating every param at build time.

Review guide: https://gist.github.com/feedthejim/bb440153d29dce019d1d26b6643e2a48

## Where This Sits
This PR is in the offline navigations chapter.
Previous PR: #93625 `offline navigations: register pass-through worker (3/21)`.
Next PR: #93627 `offline navigations: serve fallback document offline (5/21)`.

## What Changes
- Teaches the generated worker to cache the fallback document and current-build static assets.
- Centralizes the generated worker metadata surface used by the worker and tests.

## Reviewer Focus
- The worker should stay network-first for documents and should not become a general app service worker.
- Generated metadata should stay compact, private, and build-scoped.

## Proof In This PR
- Offline navigation production tests assert the worker metadata references the fallback document and build assets.
- Artifact checks assert the worker and fallback document are absent when the flag is disabled.

Latest local stack verification after autosquash included:
- `git diff --check`
- `pnpm --filter=next types`
- `pnpm testonly packages/next/src/client/components/segment-cache/offline-navigation-cache.test.ts packages/next/src/client/components/segment-cache/cache.test.ts packages/next/src/client/output-export-fallback.test.ts packages/next/src/export/helpers/output-export-fallback.test.ts packages/next/src/lib/output-export-fallback-routes.test.ts packages/next/src/client/components/router-reducer/fetch-server-response.test.ts`
- `HEADLESS=true pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `HEADLESS=true pnpm test-start-turbo test/e2e/app-dir-export/test/dynamic-fallback*.test.ts`

## Deferred Coverage
Actually serving the fallback document for offline document requests is deferred to the next PR.

## Disabled-Flag Posture
Worker generation and metadata are gated by the flag; disabled apps should not emit the worker or its cache metadata.

## Full Stack
1. [offline navigations: add gated build primitives (1/21)](https://github.com/vercel/next.js/pull/93736)
2. [offline navigations: generate fallback document artifacts (2/21)](https://github.com/vercel/next.js/pull/93737)
3. [offline navigations: register pass-through worker (3/21)](https://github.com/vercel/next.js/pull/93625)
4. **Current PR:** [offline navigations: cache fallback and current-build assets (4/21)](https://github.com/vercel/next.js/pull/93626)
5. [offline navigations: serve fallback document offline (5/21)](https://github.com/vercel/next.js/pull/93627)
6. [offline navigations: add Segment Cache persistence primitives (6/21)](https://github.com/vercel/next.js/pull/93630)
7. [offline navigations: persist cached Segment Cache records (7/21)](https://github.com/vercel/next.js/pull/93640)
8. [offline navigations: bootstrap fallback from Segment Cache records (8/21)](https://github.com/vercel/next.js/pull/93644)
9. [offline navigations: support dynamic route patterns (9/21)](https://github.com/vercel/next.js/pull/93647)
10. [offline navigations: add docs and examples (10/21)](https://github.com/vercel/next.js/pull/93738)
11. [output export fallbacks: add gated build primitives (11/21)](https://github.com/vercel/next.js/pull/93744)
12. [output export fallbacks: emit fallback HTML artifacts (12/21)](https://github.com/vercel/next.js/pull/93745)
13. [output export fallbacks: emit fallback RSC artifacts (13/21)](https://github.com/vercel/next.js/pull/93746)
14. [output export fallbacks: enforce server-only boundaries (14/21)](https://github.com/vercel/next.js/pull/93747)
15. [output export fallbacks: bootstrap hard loads from artifacts (15/21)](https://github.com/vercel/next.js/pull/93748)
16. [output export fallbacks: resolve soft navigations through cached routes (16/21)](https://github.com/vercel/next.js/pull/93749)
17. [output export fallbacks: resolve fallback artifacts from route manifests (17/21)](https://github.com/vercel/next.js/pull/93779)
18. [output export fallbacks: validate fallback Flight responses (18/21)](https://github.com/vercel/next.js/pull/93750)
19. [output export fallbacks: store fallback data in Segment Cache (19/21)](https://github.com/vercel/next.js/pull/93774)
20. [output export fallbacks: support known params and export variants (20/21)](https://github.com/vercel/next.js/pull/93751)
21. [output export fallbacks: add docs and review guide (21/21)](https://github.com/vercel/next.js/pull/93752)

<!-- NEXT_JS_LLM_PR -->
