### PR TITLE
offline navigations: serve fallback document offline (5/21)

### DIFF
--- a/packages/next/src/build/offline-navigation-service-worker.ts
+++ b/packages/next/src/build/offline-navigation-service-worker.ts
@@ -4,6 +4,7 @@ import { CLIENT_STATIC_FILES_PATH } from '../shared/lib/constants'
 import {
   OFFLINE_NAVIGATION_CACHE_PREFIX,
   OFFLINE_NAVIGATION_CACHE_STATIC_ASSETS,
+  OFFLINE_NAVIGATION_FALLBACK_SERVED,
   OFFLINE_NAVIGATION_SERVICE_WORKER,
   OFFLINE_NAVIGATION_SERVICE_WORKER_METADATA_GLOBAL,
 } from '../shared/lib/offline-navigation-constants'
@@ -166,9 +167,40 @@ const installAndActivateListenersSource = [
   '});',
 ].join('')
 
+function renderDocumentNavigationSource(
+  fallbackServedMessageType: string
+): string {
+  return [
+    'function isDocumentNavigationRequest(request){',
+    "if(request.method!=='GET'||request.mode!=='navigate'||request.destination!=='document'){return false;}",
+    'const url=new URL(request.url);',
+    'return url.origin===self.location.origin;',
+    '}',
+    'async function fetchDocumentNavigation(request){',
+    'try{return await fetch(request);}',
+    'catch(err){',
+    readServiceWorkerMetadataSource(),
+    'const cache=await caches.open(metadata.cacheNamespace);',
+    'const fallbackResponse=await cache.match(normalizeHref(metadata.fallbackDocumentHref));',
+    'if(fallbackResponse){',
+    `await notifyClients({type:${JSON.stringify(fallbackServedMessageType)}});`,
+    'return fallbackResponse;',
+    '}',
+    'throw err;',
+    '}',
+    '}',
+    'async function notifyClients(message){',
+    "const clients=await self.clients.matchAll({type:'window',includeUncontrolled:true});",
+    'await Promise.all(clients.map((client)=>client.postMessage(message)));',
+    '}',
+  ].join('')
+}
+
 const fetchListenerSource = [
   "self.addEventListener('fetch',(event)=>{",
-  'if(getFallbackAssetCacheKey(event.request)!==null||getManagedStaticAssetCacheKey(event.request)!==null){',
+  'if(isDocumentNavigationRequest(event.request)){',
+  'event.respondWith(fetchDocumentNavigation(event.request));',
+  '}else if(getFallbackAssetCacheKey(event.request)!==null||getManagedStaticAssetCacheKey(event.request)!==null){',
   'event.respondWith(fetchManagedStaticAsset(event.request));',
   '}',
   '});',
@@ -181,8 +213,9 @@ function renderMessageListener(messageType: string): string {
 }
 
 // Offline navigations use a generated, app-local service worker for the
-// document fallback and the bootstrap assets referenced by that fallback. It
-// does not interpret route data; later client-router slices own route replay.
+// document fallback and the bootstrap assets referenced by that fallback. It is
+// network-first for regular document loads; the client bootstrap owns route
+// data after the fallback document loads.
 export function createOfflineNavigationServiceWorker({
   cacheNamespace,
   fallbackAssetHrefs,
@@ -204,6 +237,7 @@ export function createOfflineNavigationServiceWorker({
     assetCacheKeySource,
     staticAssetFetchSource,
     currentAssetPromotionSource,
+    renderDocumentNavigationSource(OFFLINE_NAVIGATION_FALLBACK_SERVED),
     installAndActivateListenersSource,
     fetchListenerSource,
     renderMessageListener(OFFLINE_NAVIGATION_CACHE_STATIC_ASSETS),

--- a/packages/next/src/client/components/offline.ts
+++ b/packages/next/src/client/components/offline.ts
@@ -77,7 +77,7 @@ export function getOffline(): OfflineState | null {
  * Enters the offline state if not already in it, and starts the
  * connectivity polling loop.
  */
-function notifyOffline(): OfflineState {
+export function notifyOffline(): OfflineState {
   if (offlineState !== null) {
     return offlineState
   }

--- a/packages/next/src/client/offline-navigation-service-worker.ts
+++ b/packages/next/src/client/offline-navigation-service-worker.ts
@@ -1,10 +1,16 @@
 import { getDeploymentIdQuery } from '../shared/lib/deployment-id'
 import {
   OFFLINE_NAVIGATION_CACHE_STATIC_ASSETS,
+  OFFLINE_NAVIGATION_FALLBACK_SERVED,
   OFFLINE_NAVIGATION_SERVICE_WORKER,
 } from '../shared/lib/offline-navigation-constants'
 
+let isListeningForServiceWorkerMessages = false
 let isSyncingCurrentStaticAssets = false
+
+type OfflineNavigationFallbackServedMessage = {
+  type: typeof OFFLINE_NAVIGATION_FALLBACK_SERVED
+}
 
 type OfflineNavigationCacheStaticAssetsMessage = {
   type: typeof OFFLINE_NAVIGATION_CACHE_STATIC_ASSETS
@@ -22,6 +28,41 @@ function getServiceWorkerHref(): string {
 function getServiceWorkerScope(): string {
   const basePath = getBasePath()
   return basePath ? `${basePath}/` : '/'
+}
+
+// The generated worker posts this message when it had to serve the fallback
+// document. Treat it as the same user-visible offline transition as the
+// browser's native offline event.
+function listenForOfflineNavigationMessages(): void {
+  if (isListeningForServiceWorkerMessages) {
+    return
+  }
+  isListeningForServiceWorkerMessages = true
+
+  navigator.serviceWorker.addEventListener('message', (event) => {
+    handleOfflineNavigationServiceWorkerMessage(event.data)
+  })
+}
+
+export function handleOfflineNavigationServiceWorkerMessage(data: unknown) {
+  if (!isOfflineNavigationFallbackServedMessage(data)) {
+    return
+  }
+
+  const { notifyOffline } =
+    require('./components/offline') as typeof import('./components/offline')
+  notifyOffline()
+}
+
+function isOfflineNavigationFallbackServedMessage(
+  data: unknown
+): data is OfflineNavigationFallbackServedMessage {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    (data as Partial<OfflineNavigationFallbackServedMessage>).type ===
+      OFFLINE_NAVIGATION_FALLBACK_SERVED
+  )
 }
 
 function isNextStaticAssetHref(href: string): boolean {
@@ -118,6 +159,7 @@ export function registerOfflineNavigationServiceWorker(): void {
     return
   }
 
+  listenForOfflineNavigationMessages()
   syncCurrentNextStaticAssetsWithServiceWorker()
 
   // Registration is best-effort: a failed service worker install should not

--- a/packages/next/src/shared/lib/offline-navigation-constants.ts
+++ b/packages/next/src/shared/lib/offline-navigation-constants.ts
@@ -3,6 +3,8 @@ export const OFFLINE_NAVIGATION_SERVICE_WORKER =
 export const OFFLINE_NAVIGATION_FALLBACK_HTML =
   '_offline-navigation-fallback.html'
 export const OFFLINE_NAVIGATION_CACHE_PREFIX = 'next-offline-navigation-v1:'
+export const OFFLINE_NAVIGATION_FALLBACK_SERVED =
+  'next-offline-navigation-fallback-served'
 export const OFFLINE_NAVIGATION_CACHE_STATIC_ASSETS =
   'next-offline-navigation-cache-static-assets'
 export const OFFLINE_NAVIGATION_SERVICE_WORKER_METADATA_GLOBAL =

--- a/test/production/app-dir/offline-navigations/app/offline-status.tsx
+++ b/test/production/app-dir/offline-navigations/app/offline-status.tsx
@@ -1,0 +1,8 @@
+'use client'
+
+import { useOffline } from 'next/offline'
+
+export function OfflineStatus() {
+  const isOffline = useOffline()
+  return <p id="offline-status">{isOffline ? 'offline' : 'online'}</p>
+}

--- a/test/production/app-dir/offline-navigations/app/page.tsx
+++ b/test/production/app-dir/offline-navigations/app/page.tsx
@@ -1,3 +1,10 @@
+import { OfflineStatus } from './offline-status'
+
 export default function Page() {
-  return <p>offline navigations page</p>
+  return (
+    <>
+      <p>offline navigations page</p>
+      <OfflineStatus />
+    </>
+  )
 }

--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -2,6 +2,10 @@ import { existsSync, readdirSync } from 'fs'
 import { join } from 'path'
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
+import type * as Playwright from 'playwright'
+
+const OFFLINE_NAVIGATION_FALLBACK_SERVED =
+  'next-offline-navigation-fallback-served'
 
 const OFFLINE_NAVIGATION_CACHE_STATIC_ASSETS =
   'next-offline-navigation-cache-static-assets'
@@ -119,11 +123,13 @@ describe('offlineNavigations build artifacts', () => {
     expect(serviceWorkerScript).toContain(
       OFFLINE_NAVIGATION_CACHE_STATIC_ASSETS
     )
+    expect(serviceWorkerScript).toContain(OFFLINE_NAVIGATION_FALLBACK_SERVED)
+    expect(serviceWorkerScript).toContain('isDocumentNavigationRequest')
     expect(serviceWorkerScript).toContain('skipWaiting')
     expect(serviceWorkerScript).toContain('clients.claim')
     expect(serviceWorkerScript).not.toContain('\n')
     expect(serviceWorkerScript).toContain('respondWith')
-    expect(serviceWorkerScript.length).toBeLessThan(6000)
+    expect(serviceWorkerScript.length).toBeLessThan(8000)
   })
 
   it('registers the service worker and caches offline resources when enabled', async () => {
@@ -133,6 +139,7 @@ describe('offlineNavigations build artifacts', () => {
     const { buildId } = await getOfflineNavigationArtifactPaths()
     await next.start({ skipBuild: true })
 
+    let page: Playwright.Page | undefined
     try {
       const swResponse = await next.fetch(
         `/docs/_next/static/_offline-navigation-service-worker.js${next.getDeploymentIdQuery()}`
@@ -143,7 +150,11 @@ describe('offlineNavigations build artifacts', () => {
       )
       expect(swResponse.headers.get('service-worker-allowed')).toBe('/docs/')
 
-      const browser = await next.browser('/docs')
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
       await retry(async () => {
         const registration = await browser.eval(async () => {
           if (!('serviceWorker' in navigator)) {
@@ -170,6 +181,62 @@ describe('offlineNavigations build artifacts', () => {
           scriptURL: `${next.url}/docs/_next/static/_offline-navigation-service-worker.js${next.getDeploymentIdQuery()}`,
         })
       })
+      await retry(async () => {
+        expect(
+          await browser.eval(() => Boolean(navigator.serviceWorker.controller))
+        ).toBe(true)
+      })
+      expect(await browser.elementById('offline-status').text()).toBe('online')
+
+      await browser.eval((messageType) => {
+        const win = window as typeof window & {
+          __restoreOfflineNavigationFetch?: () => void
+        }
+        const originalFetch = window.fetch
+        win.__restoreOfflineNavigationFetch = () => {
+          window.fetch = originalFetch
+          delete win.__restoreOfflineNavigationFetch
+        }
+        window.fetch = async () => {
+          throw new TypeError('offline navigation test')
+        }
+        navigator.serviceWorker.dispatchEvent(
+          new MessageEvent('message', {
+            data: {
+              type: messageType,
+            },
+          })
+        )
+      }, OFFLINE_NAVIGATION_FALLBACK_SERVED)
+      await retry(async () => {
+        expect(await browser.elementById('offline-status').text()).toBe(
+          'offline'
+        )
+      })
+      await browser.eval(() => {
+        const win = window as typeof window & {
+          __restoreOfflineNavigationFetch?: () => void
+        }
+        win.__restoreOfflineNavigationFetch?.()
+        window.dispatchEvent(new Event('online'))
+      })
+      await retry(async () => {
+        expect(await browser.elementById('offline-status').text()).toBe(
+          'online'
+        )
+      })
+
+      await browser.eval((messageType) => {
+        localStorage.removeItem('__nextOfflineNavigationMessage')
+        navigator.serviceWorker.addEventListener('message', (event) => {
+          if (event.data?.type === messageType) {
+            localStorage.setItem(
+              '__nextOfflineNavigationMessage',
+              JSON.stringify(event.data)
+            )
+          }
+        })
+      }, OFFLINE_NAVIGATION_FALLBACK_SERVED)
 
       const cacheName = `next-offline-navigation-v1:${buildId}:/docs`
       await retry(async () => {
@@ -191,6 +258,40 @@ describe('offlineNavigations build artifacts', () => {
         )
       })
 
+      await page!.context().setOffline(true)
+      const nonNavigationResult = await browser.eval(async () => {
+        try {
+          await fetch('/docs?__next_offline_probe=1', {
+            headers: { rsc: '1' },
+          })
+          return 'resolved'
+        } catch {
+          return 'rejected'
+        }
+      })
+      expect(nonNavigationResult).toBe('rejected')
+
+      const offlineResponse = await page!.goto(
+        `${next.url}/docs/offline-navigation-cache-miss`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(offlineResponse?.status()).toBe(200)
+      expect(
+        await browser.eval(() =>
+          document.documentElement.hasAttribute(
+            'data-next-offline-navigation-fallback'
+          )
+        )
+      ).toBe(true)
+      const serviceWorkerMessage = await browser.eval(() => {
+        const message = localStorage.getItem('__nextOfflineNavigationMessage')
+        return message === null ? null : JSON.parse(message)
+      })
+      expect(serviceWorkerMessage).toMatchObject({
+        type: OFFLINE_NAVIGATION_FALLBACK_SERVED,
+      })
+      await page!.context().setOffline(false)
+
       await browser.eval(async () => {
         if (!('serviceWorker' in navigator)) {
           return
@@ -211,6 +312,9 @@ describe('offlineNavigations build artifacts', () => {
         )
       })
     } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
       await next.stop()
     }
   })


### PR DESCRIPTION
This is PR 5 of 21 in the offline navigations plus output-export fallback stack.

This stack introduces a generated fallback entrypoint and then layers the client behavior on the existing App Router, cached navigations, optimistic routing, Cache Components, and Segment Cache primitives. The offline navigations chapter adds a managed service worker and persisted Segment Cache replay. The output-export chapter emits static fallback HTML/RSC artifacts so parameterized routes can load and navigate without enumerating every param at build time.

Review guide: https://gist.github.com/feedthejim/bb440153d29dce019d1d26b6643e2a48

## Where This Sits
This PR is in the offline navigations chapter.
Previous PR: #93626 `offline navigations: cache fallback and current-build assets (4/21)`.
Next PR: #93630 `offline navigations: add Segment Cache persistence primitives (6/21)`.

## What Changes
- Uses the cached fallback document for offline document requests after the network path fails.
- Preserves online network-first semantics for normal document loads.

## Reviewer Focus
- The service worker should only answer failed document navigations with the fallback document.
- The client bootstrap still does not reconstruct route data from persisted Segment Cache records yet.

## Proof In This PR
- Offline production e2e covers network-first document behavior and fallback document serving while offline.
- Cache-miss UI remains visible when the fallback document loads without persisted route data.

Latest local stack verification after autosquash included:
- `git diff --check`
- `pnpm --filter=next types`
- `pnpm testonly packages/next/src/client/components/segment-cache/offline-navigation-cache.test.ts packages/next/src/client/components/segment-cache/cache.test.ts packages/next/src/client/output-export-fallback.test.ts packages/next/src/export/helpers/output-export-fallback.test.ts packages/next/src/lib/output-export-fallback-routes.test.ts packages/next/src/client/components/router-reducer/fetch-server-response.test.ts`
- `HEADLESS=true pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `HEADLESS=true pnpm test-start-turbo test/e2e/app-dir-export/test/dynamic-fallback*.test.ts`

## Deferred Coverage
Persisting and hydrating Segment Cache records for a real offline page replay is deferred.

## Disabled-Flag Posture
All worker response behavior is gated by generated worker emission, which only happens when the flag is enabled.

## Full Stack
1. [offline navigations: add gated build primitives (1/21)](https://github.com/vercel/next.js/pull/93736)
2. [offline navigations: generate fallback document artifacts (2/21)](https://github.com/vercel/next.js/pull/93737)
3. [offline navigations: register pass-through worker (3/21)](https://github.com/vercel/next.js/pull/93625)
4. [offline navigations: cache fallback and current-build assets (4/21)](https://github.com/vercel/next.js/pull/93626)
5. **Current PR:** [offline navigations: serve fallback document offline (5/21)](https://github.com/vercel/next.js/pull/93627)
6. [offline navigations: add Segment Cache persistence primitives (6/21)](https://github.com/vercel/next.js/pull/93630)
7. [offline navigations: persist cached Segment Cache records (7/21)](https://github.com/vercel/next.js/pull/93640)
8. [offline navigations: bootstrap fallback from Segment Cache records (8/21)](https://github.com/vercel/next.js/pull/93644)
9. [offline navigations: support dynamic route patterns (9/21)](https://github.com/vercel/next.js/pull/93647)
10. [offline navigations: add docs and examples (10/21)](https://github.com/vercel/next.js/pull/93738)
11. [output export fallbacks: add gated build primitives (11/21)](https://github.com/vercel/next.js/pull/93744)
12. [output export fallbacks: emit fallback HTML artifacts (12/21)](https://github.com/vercel/next.js/pull/93745)
13. [output export fallbacks: emit fallback RSC artifacts (13/21)](https://github.com/vercel/next.js/pull/93746)
14. [output export fallbacks: enforce server-only boundaries (14/21)](https://github.com/vercel/next.js/pull/93747)
15. [output export fallbacks: bootstrap hard loads from artifacts (15/21)](https://github.com/vercel/next.js/pull/93748)
16. [output export fallbacks: resolve soft navigations through cached routes (16/21)](https://github.com/vercel/next.js/pull/93749)
17. [output export fallbacks: resolve fallback artifacts from route manifests (17/21)](https://github.com/vercel/next.js/pull/93779)
18. [output export fallbacks: validate fallback Flight responses (18/21)](https://github.com/vercel/next.js/pull/93750)
19. [output export fallbacks: store fallback data in Segment Cache (19/21)](https://github.com/vercel/next.js/pull/93774)
20. [output export fallbacks: support known params and export variants (20/21)](https://github.com/vercel/next.js/pull/93751)
21. [output export fallbacks: add docs and review guide (21/21)](https://github.com/vercel/next.js/pull/93752)

<!-- NEXT_JS_LLM_PR -->
