### PR TITLE
offline navigations: bridge fallback state to useOffline (7/25)

### DIFF
--- a/packages/next/src/build/offline-navigation-service-worker.ts
+++ b/packages/next/src/build/offline-navigation-service-worker.ts
@@ -2,6 +2,7 @@ import path from 'node:path'
 
 import { CLIENT_STATIC_FILES_PATH } from '../shared/lib/constants'
 import { OFFLINE_NAVIGATION_SERVICE_WORKER } from '../shared/lib/offline-navigation'
+import { OFFLINE_NAVIGATION_FALLBACK_SERVED } from '../shared/lib/offline-navigation-constants'
 
 export function getOfflineNavigationServiceWorkerFilePath(): string {
   return path.join(CLIENT_STATIC_FILES_PATH, OFFLINE_NAVIGATION_SERVICE_WORKER)
@@ -25,6 +26,9 @@ export function createOfflineNavigationServiceWorker({
     manifestHref,
     source: 'offline-navigation-service-worker',
   })
+  const fallbackServedMessageType = JSON.stringify(
+    OFFLINE_NAVIGATION_FALLBACK_SERVED
+  )
 
   return `self.__NEXT_OFFLINE_NAVIGATION_SW=${metadata};
 const CACHE_PREFIX='next-offline-navigation-v1:';
@@ -69,10 +73,20 @@ async function fetchDocumentNavigation(request){
     const cache=await caches.open(metadata.cacheNamespace);
     const fallbackResponse=await cache.match(metadata.fallbackDocumentHref);
     if(fallbackResponse){
+      await notifyClients({
+        type:${fallbackServedMessageType},
+        buildId:metadata.buildId,
+        reason:'network-error',
+        url:request.url
+      });
       return fallbackResponse;
     }
     throw err;
   }
+}
+async function notifyClients(message){
+  const clients=await self.clients.matchAll({type:'window',includeUncontrolled:true});
+  await Promise.all(clients.map((client)=>client.postMessage(message)));
 }
 self.addEventListener('install',(event)=>{
   event.waitUntil((async()=>{

--- a/packages/next/src/client/components/offline.ts
+++ b/packages/next/src/client/components/offline.ts
@@ -77,7 +77,7 @@ export function getOffline(): OfflineState | null {
  * Enters the offline state if not already in it, and starts the
  * connectivity polling loop.
  */
-function notifyOffline(): OfflineState {
+export function notifyOffline(): OfflineState {
   if (offlineState !== null) {
     return offlineState
   }

--- a/packages/next/src/client/offline-navigation-service-worker.ts
+++ b/packages/next/src/client/offline-navigation-service-worker.ts
@@ -1,7 +1,17 @@
 import { getDeploymentIdQuery } from '../shared/lib/deployment-id'
+import { OFFLINE_NAVIGATION_FALLBACK_SERVED } from '../shared/lib/offline-navigation-constants'
 
 const OFFLINE_NAVIGATION_SERVICE_WORKER =
   '_offline-navigation-service-worker.js'
+
+let isListeningForServiceWorkerMessages = false
+
+type OfflineNavigationFallbackServedMessage = {
+  type: typeof OFFLINE_NAVIGATION_FALLBACK_SERVED
+  buildId?: string
+  reason?: 'network-error'
+  url?: string
+}
 
 function getBasePath(): string {
   return (process.env.__NEXT_ROUTER_BASEPATH as string) || ''
@@ -16,6 +26,38 @@ function getServiceWorkerScope(): string {
   return basePath ? `${basePath}/` : '/'
 }
 
+function listenForOfflineNavigationMessages(): void {
+  if (isListeningForServiceWorkerMessages) {
+    return
+  }
+  isListeningForServiceWorkerMessages = true
+
+  navigator.serviceWorker.addEventListener('message', (event) => {
+    handleOfflineNavigationServiceWorkerMessage(event.data)
+  })
+}
+
+export function handleOfflineNavigationServiceWorkerMessage(data: unknown) {
+  if (!isOfflineNavigationFallbackServedMessage(data)) {
+    return
+  }
+
+  const { notifyOffline } =
+    require('./components/offline') as typeof import('./components/offline')
+  notifyOffline()
+}
+
+function isOfflineNavigationFallbackServedMessage(
+  data: unknown
+): data is OfflineNavigationFallbackServedMessage {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    (data as Partial<OfflineNavigationFallbackServedMessage>).type ===
+      OFFLINE_NAVIGATION_FALLBACK_SERVED
+  )
+}
+
 export function registerOfflineNavigationServiceWorker(): void {
   if (
     process.env.__NEXT_DEV_SERVER ||
@@ -25,6 +67,8 @@ export function registerOfflineNavigationServiceWorker(): void {
   ) {
     return
   }
+
+  listenForOfflineNavigationMessages()
 
   navigator.serviceWorker
     .register(getServiceWorkerHref(), {

--- a/packages/next/src/shared/lib/offline-navigation-constants.ts
+++ b/packages/next/src/shared/lib/offline-navigation-constants.ts
@@ -1,0 +1,2 @@
+export const OFFLINE_NAVIGATION_FALLBACK_SERVED =
+  'next-offline-navigation-fallback-served'

--- a/test/production/app-dir/offline-navigations/app/offline-status.tsx
+++ b/test/production/app-dir/offline-navigations/app/offline-status.tsx
@@ -1,0 +1,8 @@
+'use client'
+
+import { useOffline } from 'next/offline'
+
+export function OfflineStatus() {
+  const isOffline = useOffline()
+  return <p id="offline-status">{isOffline ? 'offline' : 'online'}</p>
+}

--- a/test/production/app-dir/offline-navigations/app/page.tsx
+++ b/test/production/app-dir/offline-navigations/app/page.tsx
@@ -1,3 +1,10 @@
+import { OfflineStatus } from './offline-status'
+
 export default function Page() {
-  return <p>offline navigations page</p>
+  return (
+    <>
+      <p>offline navigations page</p>
+      <OfflineStatus />
+    </>
+  )
 }

--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -4,6 +4,9 @@ import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 import type * as Playwright from 'playwright'
 
+const OFFLINE_NAVIGATION_FALLBACK_SERVED =
+  'next-offline-navigation-fallback-served'
+
 describe('offlineNavigations build artifacts', () => {
   const { next } = nextTestSetup({
     files: __dirname,
@@ -76,6 +79,7 @@ describe('offlineNavigations build artifacts', () => {
     )
     expect(serviceWorkerScript).toContain('cacheOfflineNavigationResources')
     expect(serviceWorkerScript).toContain('caches.delete')
+    expect(serviceWorkerScript).toContain(OFFLINE_NAVIGATION_FALLBACK_SERVED)
     expect(serviceWorkerScript).toContain('isDocumentNavigationRequest')
     expect(serviceWorkerScript).toContain('skipWaiting')
     expect(serviceWorkerScript).toContain('clients.claim')
@@ -159,6 +163,59 @@ describe('offlineNavigations build artifacts', () => {
           await browser.eval(() => Boolean(navigator.serviceWorker.controller))
         ).toBe(true)
       })
+      expect(await browser.elementById('offline-status').text()).toBe('online')
+
+      await browser.eval((messageType) => {
+        const win = window as typeof window & {
+          __restoreOfflineNavigationFetch?: () => void
+        }
+        const originalFetch = window.fetch
+        win.__restoreOfflineNavigationFetch = () => {
+          window.fetch = originalFetch
+          delete win.__restoreOfflineNavigationFetch
+        }
+        window.fetch = async () => {
+          throw new TypeError('offline navigation test')
+        }
+        navigator.serviceWorker.dispatchEvent(
+          new MessageEvent('message', {
+            data: {
+              type: messageType,
+              reason: 'network-error',
+              url: location.href,
+            },
+          })
+        )
+      }, OFFLINE_NAVIGATION_FALLBACK_SERVED)
+      await retry(async () => {
+        expect(await browser.elementById('offline-status').text()).toBe(
+          'offline'
+        )
+      })
+      await browser.eval(() => {
+        const win = window as typeof window & {
+          __restoreOfflineNavigationFetch?: () => void
+        }
+        win.__restoreOfflineNavigationFetch?.()
+        window.dispatchEvent(new Event('online'))
+      })
+      await retry(async () => {
+        expect(await browser.elementById('offline-status').text()).toBe(
+          'online'
+        )
+      })
+
+      await browser.eval((messageType) => {
+        localStorage.removeItem('__nextOfflineNavigationMessage')
+        navigator.serviceWorker.addEventListener('message', (event) => {
+          if (event.data?.type === messageType) {
+            localStorage.setItem(
+              '__nextOfflineNavigationMessage',
+              JSON.stringify(event.data)
+            )
+          }
+        })
+      }, OFFLINE_NAVIGATION_FALLBACK_SERVED)
 
       const cacheState = await browser.eval(async () => {
         const cacheNames = (await caches.keys()).filter((cacheName) =>
@@ -221,6 +278,16 @@ describe('offlineNavigations build artifacts', () => {
           )
         )
       ).toBe(true)
+      const serviceWorkerMessage = await browser.eval(() => {
+        const message = localStorage.getItem('__nextOfflineNavigationMessage')
+        return message === null ? null : JSON.parse(message)
+      })
+      expect(serviceWorkerMessage).toMatchObject({
+        type: OFFLINE_NAVIGATION_FALLBACK_SERVED,
+        buildId,
+        reason: 'network-error',
+        url: `${next.url}/docs/offline-navigation-cache-miss`,
+      })
       await page!.context().setOffline(false)
 
       await browser.eval(async () => {


### PR DESCRIPTION
## Stack Position

7/25 in the offline navigations first-usable stack.

This stack turns `experimental.offlineNavigations` into a usable cache-components experiment for regular apps. The service worker owns document survival only. Cache Storage owns generated fallback artifacts. The cache-components client router owns IndexedDB, route semantics, replay, visible misses, and invalidation. Output export, dev simulation, custom miss UI, and broad production-hardening matrices are intentionally deferred.

Review guide: https://gist.github.com/feedthejim/b3d9fe26a7c05655fd57adcce371b93d

## Full Stack

1. offline navigations: add cache-components flag (1/25)
2. offline navigations: emit fallback document (2/25)
3. offline navigations: emit fallback manifest (3/25)
4. offline navigations: register pass-through service worker (4/25)
5. offline navigations: cache fallback artifacts (5/25)
6. offline navigations: serve fallback document (6/25)
7. offline navigations: bridge fallback state to useOffline (7/25) ← this PR
8. offline navigations: add navigation cache primitives (8/25)
9. offline navigations: persist exact-url navigation data (9/25)
10. offline navigations: boot fallback from exact-url data (10/25)
11. offline navigations: persist initial-load navigation data (11/25)
12. offline navigations: centralize cache eligibility (12/25)
13. offline navigations: replay request-sensitive exact urls (13/25)
14. offline navigations: wire exact-url invalidation (14/25)
15. offline navigations: harden fallback diagnostics and misses (15/25)
16. offline navigations: cover exact-url app replay basics (16/25)
17. offline navigations: define persistent router schema (17/25)
18. offline navigations: persist route records and known routes (18/25)
19. offline navigations: persist segment and head records (19/25)
20. offline navigations: hydrate persisted router caches (20/25)
21. offline navigations: reconstruct prefetched routes offline (21/25)
22. offline navigations: replay dynamic routes from known routes (22/25)
23. offline navigations: mirror router cache invalidation (23/25)
24. offline navigations: cover mutation invalidation (24/25)
25. offline navigations: add app cache reset API (25/25)

## What This PR Does

Bridges fallback-boot and worker messages into the existing `useOffline` state.

## What Works After This PR

`useOffline()` reflects offline fallback boot state for the covered paths, which gives app code a stable signal without making the service worker a router.

## Reviewer Focus

`useOffline` state transitions, fallback boot messages, online recovery, and avoiding a separate public service-worker flag.

## Not In This PR

Custom cache-miss UI and dev offline simulation are deferred.

## Proof in This PR

- Relevant coverage: `useOffline` assertions in the production fixture plus stack-level build/e2e verification.
- Restack verification run at the cleaned stack tip:
  - `pnpm --filter=next build`
  - `NEXT_SKIP_ISOLATE=1 NEXT_TEST_MODE=start pnpm testheadless test/production/app-dir/offline-navigations/offline-navigations.test.ts`
  - `NEXT_TEST_MODE=start pnpm testheadless test/production/app-dir/offline-navigations/offline-navigations.test.ts`
  - `IS_WEBPACK_TEST=1 NEXT_TEST_MODE=start pnpm testheadless test/production/app-dir/offline-navigations/offline-navigations.test.ts`

## Deferred Coverage

Custom cache-miss UI and dev offline simulation are deferred.

<!-- NEXT_JS_LLM_PR -->
