### PR TITLE
offline navigations: add Segment Cache persistence primitives (6/21)

### DIFF
--- a/packages/next/src/client/components/segment-cache/offline-navigation-cache.test.ts
+++ b/packages/next/src/client/components/segment-cache/offline-navigation-cache.test.ts
@@ -1,0 +1,573 @@
+import {
+  createOfflineNavigationRSCResponse,
+  createOfflineNavigationRSCResponsePayload,
+  createOfflineNavigationSegmentCachePersistence,
+  createOfflineNavigationVaryPathKey,
+  deleteOfflineNavigationCacheEntriesForBuild,
+  isOfflineNavigationRSCResponsePayload,
+  serializeOfflineNavigationVaryPath,
+  type OfflineNavigationCacheStorage,
+  type OfflineNavigationRouteRecord,
+  type OfflineNavigationRouteRecordWrite,
+  type OfflineNavigationSegmentRecord,
+  type OfflineNavigationSegmentRecordWrite,
+} from './offline-navigation-cache'
+
+type SegmentCacheKey = [buildId: string, key: string]
+
+class MemoryOfflineNavigationCacheStorage
+  implements OfflineNavigationCacheStorage
+{
+  routeEntries = new Map<string, OfflineNavigationRouteRecord>()
+  segmentEntries = new Map<string, OfflineNavigationSegmentRecord>()
+  routeCacheVersion = 0
+  segmentCacheVersion = 0
+
+  async deleteBuild(buildId: string): Promise<void> {
+    for (const [key, entry] of this.routeEntries) {
+      if (entry.buildId === buildId) {
+        this.routeEntries.delete(key)
+      }
+    }
+    for (const [key, entry] of this.segmentEntries) {
+      if (entry.buildId === buildId) {
+        this.segmentEntries.delete(key)
+      }
+    }
+  }
+
+  async getRoute(
+    key: SegmentCacheKey
+  ): Promise<OfflineNavigationRouteRecord | undefined> {
+    return this.routeEntries.get(this.getKey(key))
+  }
+
+  async getRoutes(buildId: string): Promise<OfflineNavigationRouteRecord[]> {
+    return Array.from(this.routeEntries.values()).filter(
+      (entry) => entry.buildId === buildId
+    )
+  }
+
+  async putRoute(entry: OfflineNavigationRouteRecord): Promise<void> {
+    this.routeEntries.set(this.getKey([entry.buildId, entry.key]), entry)
+  }
+
+  async deleteRoute(key: SegmentCacheKey): Promise<void> {
+    this.routeEntries.delete(this.getKey(key))
+  }
+
+  async getRouteCacheVersion(): Promise<number> {
+    return this.routeCacheVersion
+  }
+
+  async incrementRouteCacheVersion(): Promise<number> {
+    this.routeCacheVersion++
+    return this.routeCacheVersion
+  }
+
+  async getSegment(
+    key: SegmentCacheKey
+  ): Promise<OfflineNavigationSegmentRecord | undefined> {
+    return this.segmentEntries.get(this.getKey(key))
+  }
+
+  async getSegments(
+    buildId: string
+  ): Promise<OfflineNavigationSegmentRecord[]> {
+    return Array.from(this.segmentEntries.values()).filter(
+      (entry) => entry.buildId === buildId
+    )
+  }
+
+  async putSegment(entry: OfflineNavigationSegmentRecord): Promise<void> {
+    this.segmentEntries.set(this.getKey([entry.buildId, entry.key]), entry)
+  }
+
+  async deleteSegment(key: SegmentCacheKey): Promise<void> {
+    this.segmentEntries.delete(this.getKey(key))
+  }
+
+  async getSegmentCacheVersion(): Promise<number> {
+    return this.segmentCacheVersion
+  }
+
+  async incrementSegmentCacheVersion(): Promise<number> {
+    this.segmentCacheVersion++
+    return this.segmentCacheVersion
+  }
+
+  private getKey(key: SegmentCacheKey): string {
+    return `${key[0]}\0${key[1]}`
+  }
+}
+
+class FailingOfflineNavigationCacheStorage
+  implements OfflineNavigationCacheStorage
+{
+  async deleteBuild(): Promise<void> {
+    throw new Error('delete build failed')
+  }
+
+  async getRoute(): Promise<OfflineNavigationRouteRecord | undefined> {
+    throw new Error('get route failed')
+  }
+
+  async getRoutes(): Promise<OfflineNavigationRouteRecord[]> {
+    throw new Error('get routes failed')
+  }
+
+  async putRoute(): Promise<void> {
+    throw new Error('put route failed')
+  }
+
+  async deleteRoute(): Promise<void> {
+    throw new Error('delete route failed')
+  }
+
+  async getRouteCacheVersion(): Promise<number> {
+    throw new Error('get route cache version failed')
+  }
+
+  async incrementRouteCacheVersion(): Promise<number> {
+    throw new Error('increment route cache version failed')
+  }
+
+  async getSegment(): Promise<OfflineNavigationSegmentRecord | undefined> {
+    throw new Error('get segment failed')
+  }
+
+  async getSegments(): Promise<OfflineNavigationSegmentRecord[]> {
+    throw new Error('get segments failed')
+  }
+
+  async putSegment(): Promise<void> {
+    throw new Error('put segment failed')
+  }
+
+  async deleteSegment(): Promise<void> {
+    throw new Error('delete segment failed')
+  }
+
+  async getSegmentCacheVersion(): Promise<number> {
+    throw new Error('get segment cache version failed')
+  }
+
+  async incrementSegmentCacheVersion(): Promise<number> {
+    throw new Error('increment segment cache version failed')
+  }
+}
+
+function createRouteRecord(
+  key: string,
+  pathname: string,
+  overrides: Partial<OfflineNavigationRouteRecordWrite> = {}
+): OfflineNavigationRouteRecordWrite {
+  return {
+    buildId: 'build-a',
+    key,
+    staleAt: 200,
+    route: {
+      pathname,
+      nextUrl: null,
+      canonicalUrl: pathname,
+      renderedSearch: '',
+      couldBeIntercepted: false,
+      supportsPerSegmentPrefetching: true,
+      hasDynamicRewrite: false,
+    },
+    routeVaryPath: [],
+    tree: { segment: pathname },
+    metadata: { head: pathname },
+    ...overrides,
+  }
+}
+
+function createSegmentRecord(
+  key: string,
+  overrides: Partial<OfflineNavigationSegmentRecordWrite> = {}
+): OfflineNavigationSegmentRecordWrite {
+  return {
+    buildId: 'build-a',
+    key,
+    staleAt: 200,
+    segment: {
+      fetchStrategy: 1,
+      isPartial: false,
+      payloadIndex: 0,
+    },
+    segmentVaryPath: [],
+    payload: { kind: 'segment-payload' },
+    ...overrides,
+  }
+}
+
+describe('offline navigation cache', () => {
+  it('serializes vary paths into stable persisted record keys', () => {
+    const fallback = {}
+    const varyPath = {
+      id: null,
+      value: 'children/page',
+      parent: {
+        id: '?',
+        value: fallback,
+        parent: {
+          id: 'slug',
+          value: 'hello',
+          parent: null,
+        },
+      },
+    }
+
+    expect(serializeOfflineNavigationVaryPath(varyPath)).toEqual([
+      {
+        id: null,
+        value: {
+          kind: 'value',
+          value: 'children/page',
+        },
+      },
+      {
+        id: '?',
+        value: {
+          kind: 'fallback',
+        },
+      },
+      {
+        id: 'slug',
+        value: {
+          kind: 'value',
+          value: 'hello',
+        },
+      },
+    ])
+    expect(createOfflineNavigationVaryPathKey(varyPath)).toBe(
+      '[{"id":null,"value":{"kind":"value","value":"children/page"}},{"id":"?","value":{"kind":"fallback"}},{"id":"slug","value":{"kind":"value","value":"hello"}}]'
+    )
+  })
+
+  it('serializes segment-prefetch RSC payloads for persisted segment records', async () => {
+    const response = new Response('0:["$","payload"]', {
+      headers: {
+        'content-type': 'text/x-component',
+        'x-nextjs-stale-time': '60',
+      },
+      status: 200,
+      statusText: 'OK',
+    })
+
+    const payload = await createOfflineNavigationRSCResponsePayload(
+      response,
+      'segment-prefetch'
+    )
+    expect(payload).toMatchObject({
+      version: 1,
+      kind: 'rsc-response',
+      requestKind: 'segment-prefetch',
+    })
+
+    const restoredResponse = createOfflineNavigationRSCResponse(payload)
+    await expect(restoredResponse.text()).resolves.toBe('0:["$","payload"]')
+    expect(isOfflineNavigationRSCResponsePayload(payload)).toBe(true)
+    expect(
+      isOfflineNavigationRSCResponsePayload({ ...payload, body: null })
+    ).toBe(false)
+    expect(
+      isOfflineNavigationRSCResponsePayload({
+        ...payload,
+        requestKind: 'route-prefetch',
+      })
+    ).toBe(false)
+  })
+
+  it('stores route and segment records with independent durable cache versions', async () => {
+    const storage = new MemoryOfflineNavigationCacheStorage()
+    const cache = createOfflineNavigationSegmentCachePersistence(storage)
+    const routeVaryPath = serializeOfflineNavigationVaryPath({
+      id: null,
+      value: '/dashboard',
+      parent: {
+        id: '?',
+        value: '',
+        parent: {
+          id: null,
+          value: null,
+          parent: null,
+        },
+      },
+    })
+    const segmentVaryPath = serializeOfflineNavigationVaryPath({
+      id: null,
+      value: 'children/page',
+      parent: null,
+    })
+
+    await expect(
+      cache.writeRoute(
+        createRouteRecord('route:/dashboard', '/dashboard', {
+          routeVaryPath,
+        })
+      )
+    ).resolves.toBe(true)
+    await expect(
+      cache.writeSegment(
+        createSegmentRecord('segment:/dashboard:children/page', {
+          segmentVaryPath,
+        })
+      )
+    ).resolves.toBe(true)
+
+    await expect(
+      cache.readRoute('route:/dashboard', {
+        buildId: 'build-a',
+        now: 150,
+      })
+    ).resolves.toMatchObject({
+      buildId: 'build-a',
+      cacheVersion: 0,
+      key: 'route:/dashboard',
+      kind: 'route',
+      route: {
+        pathname: '/dashboard',
+      },
+      routeVaryPath,
+      version: 1,
+    })
+    await expect(
+      cache.readSegment('segment:/dashboard:children/page', {
+        buildId: 'build-a',
+        now: 150,
+      })
+    ).resolves.toMatchObject({
+      buildId: 'build-a',
+      cacheVersion: 0,
+      key: 'segment:/dashboard:children/page',
+      kind: 'segment',
+      segment: {
+        payloadIndex: 0,
+      },
+      segmentVaryPath,
+      version: 1,
+    })
+
+    await expect(cache.invalidateRoutes()).resolves.toBe(true)
+    await expect(
+      cache.readRoute('route:/dashboard', {
+        buildId: 'build-a',
+        now: 150,
+      })
+    ).resolves.toBe(null)
+    await expect(
+      cache.readSegment('segment:/dashboard:children/page', {
+        buildId: 'build-a',
+        now: 150,
+      })
+    ).resolves.toMatchObject({
+      cacheVersion: 0,
+      key: 'segment:/dashboard:children/page',
+    })
+
+    await expect(cache.invalidateSegments()).resolves.toBe(true)
+    await expect(
+      cache.readSegment('segment:/dashboard:children/page', {
+        buildId: 'build-a',
+        now: 150,
+      })
+    ).resolves.toBe(null)
+  })
+
+  it('lists only fresh current-version route and segment records', async () => {
+    const storage = new MemoryOfflineNavigationCacheStorage()
+    const cache = createOfflineNavigationSegmentCachePersistence(storage)
+
+    await cache.writeRoute(createRouteRecord('route:/dashboard', '/dashboard'))
+    await cache.writeRoute(
+      createRouteRecord('route:/expired', '/expired', {
+        staleAt: 110,
+      })
+    )
+    await cache.writeSegment(
+      createSegmentRecord('segment:/dashboard:children/page')
+    )
+    await cache.writeSegment(
+      createSegmentRecord('segment:/expired:children/page', {
+        staleAt: 110,
+      })
+    )
+
+    await expect(
+      cache.readRoutes({ buildId: 'build-a', now: 150 })
+    ).resolves.toMatchObject([{ key: 'route:/dashboard' }])
+    await expect(
+      cache.readSegments({ buildId: 'build-a', now: 150 })
+    ).resolves.toMatchObject([{ key: 'segment:/dashboard:children/page' }])
+    expect(storage.routeEntries.has('build-a\0route:/expired')).toBe(false)
+    expect(
+      storage.segmentEntries.has('build-a\0segment:/expired:children/page')
+    ).toBe(false)
+
+    await expect(
+      cache.readRoutes({ buildId: 'build-b', now: 150 })
+    ).resolves.toEqual([])
+    await expect(
+      cache.readSegments({ buildId: 'build-b', now: 150 })
+    ).resolves.toEqual([])
+  })
+
+  it('ignores and deletes route and segment records whose stored build id does not match', async () => {
+    const storage = new MemoryOfflineNavigationCacheStorage()
+    const cache = createOfflineNavigationSegmentCachePersistence(storage)
+
+    await storage.putRoute({
+      version: 1,
+      kind: 'route',
+      buildId: 'build-b',
+      key: 'route:/dashboard',
+      cacheVersion: 0,
+      staleAt: 200,
+      route: createRouteRecord('route:/dashboard', '/dashboard').route,
+      routeVaryPath: [],
+      tree: null,
+      metadata: null,
+    })
+    storage.routeEntries.set(
+      'build-a\0route:/dashboard',
+      storage.routeEntries.get('build-b\0route:/dashboard')!
+    )
+    await storage.putSegment({
+      version: 1,
+      kind: 'segment',
+      buildId: 'build-b',
+      key: 'segment:/dashboard',
+      cacheVersion: 0,
+      staleAt: 200,
+      segment: createSegmentRecord('segment:/dashboard').segment,
+      segmentVaryPath: [],
+      payload: null,
+    })
+    storage.segmentEntries.set(
+      'build-a\0segment:/dashboard',
+      storage.segmentEntries.get('build-b\0segment:/dashboard')!
+    )
+
+    await expect(
+      cache.readRoute('route:/dashboard', {
+        buildId: 'build-a',
+        now: 150,
+      })
+    ).resolves.toBe(null)
+    await expect(
+      cache.readSegment('segment:/dashboard', {
+        buildId: 'build-a',
+        now: 150,
+      })
+    ).resolves.toBe(null)
+    expect(storage.routeEntries.has('build-a\0route:/dashboard')).toBe(false)
+    expect(storage.segmentEntries.has('build-a\0segment:/dashboard')).toBe(
+      false
+    )
+  })
+
+  it('can delete all route and segment records for a build without touching other builds', async () => {
+    const storage = new MemoryOfflineNavigationCacheStorage()
+    const cache = createOfflineNavigationSegmentCachePersistence(storage)
+
+    await cache.writeRoute(createRouteRecord('route:/a', '/a'))
+    await cache.writeRoute(
+      createRouteRecord('route:/b', '/b', { buildId: 'build-b' })
+    )
+    await cache.writeSegment(createSegmentRecord('segment:/a'))
+    await cache.writeSegment(
+      createSegmentRecord('segment:/b', { buildId: 'build-b' })
+    )
+
+    await expect(cache.deleteBuild('build-a')).resolves.toBe(true)
+    await expect(
+      cache.readRoute('route:/a', { buildId: 'build-a', now: 150 })
+    ).resolves.toBe(null)
+    await expect(
+      cache.readRoute('route:/b', { buildId: 'build-b', now: 150 })
+    ).resolves.toMatchObject({ key: 'route:/b' })
+    await expect(
+      cache.readSegment('segment:/a', { buildId: 'build-a', now: 150 })
+    ).resolves.toBe(null)
+    await expect(
+      cache.readSegment('segment:/b', { buildId: 'build-b', now: 150 })
+    ).resolves.toMatchObject({ key: 'segment:/b' })
+  })
+
+  it('treats missing build ids as no-ops', async () => {
+    const storage = new MemoryOfflineNavigationCacheStorage()
+    const cache = createOfflineNavigationSegmentCachePersistence(storage)
+
+    await expect(
+      cache.writeRoute(
+        createRouteRecord('route:/dashboard', '/dashboard', { buildId: '' })
+      )
+    ).resolves.toBe(false)
+    await expect(
+      cache.writeSegment(
+        createSegmentRecord('segment:/dashboard', { buildId: '' })
+      )
+    ).resolves.toBe(false)
+    await expect(cache.readRoute('route:/dashboard')).resolves.toBe(null)
+    await expect(cache.readSegment('segment:/dashboard')).resolves.toBe(null)
+    await expect(cache.deleteRoute('route:/dashboard')).resolves.toBe(false)
+    await expect(cache.deleteSegment('segment:/dashboard')).resolves.toBe(false)
+    await expect(cache.deleteBuild()).resolves.toBe(false)
+  })
+
+  it('treats storage failures as non-fatal misses', async () => {
+    const cache = createOfflineNavigationSegmentCachePersistence(
+      new FailingOfflineNavigationCacheStorage()
+    )
+
+    await expect(
+      cache.writeRoute(createRouteRecord('route:/dashboard', '/dashboard'))
+    ).resolves.toBe(false)
+    await expect(
+      cache.readRoute('route:/dashboard', { buildId: 'build-a' })
+    ).resolves.toBe(null)
+    await expect(cache.readRoutes({ buildId: 'build-a' })).resolves.toEqual([])
+    await expect(
+      cache.deleteRoute('route:/dashboard', { buildId: 'build-a' })
+    ).resolves.toBe(false)
+    await expect(cache.invalidateRoutes()).resolves.toBe(false)
+    await expect(
+      cache.writeSegment(createSegmentRecord('segment:/dashboard'))
+    ).resolves.toBe(false)
+    await expect(
+      cache.readSegment('segment:/dashboard', { buildId: 'build-a' })
+    ).resolves.toBe(null)
+    await expect(cache.readSegments({ buildId: 'build-a' })).resolves.toEqual(
+      []
+    )
+    await expect(
+      cache.deleteSegment('segment:/dashboard', { buildId: 'build-a' })
+    ).resolves.toBe(false)
+    await expect(cache.invalidateSegments()).resolves.toBe(false)
+    await expect(cache.deleteBuild('build-a')).resolves.toBe(false)
+  })
+
+  it('is a no-op when IndexedDB is unavailable', async () => {
+    const originalIndexedDB = Object.getOwnPropertyDescriptor(
+      globalThis,
+      'indexedDB'
+    )
+    Object.defineProperty(globalThis, 'indexedDB', {
+      configurable: true,
+      value: undefined,
+    })
+
+    try {
+      await expect(
+        deleteOfflineNavigationCacheEntriesForBuild('build-a')
+      ).resolves.toBe(false)
+    } finally {
+      if (originalIndexedDB) {
+        Object.defineProperty(globalThis, 'indexedDB', originalIndexedDB)
+      } else {
+        delete (globalThis as { indexedDB?: IDBFactory }).indexedDB
+      }
+    }
+  })
+})

--- a/packages/next/src/client/components/segment-cache/offline-navigation-cache.ts
+++ b/packages/next/src/client/components/segment-cache/offline-navigation-cache.ts
@@ -1,0 +1,815 @@
+import { getNavigationBuildId } from '../../navigation-build-id'
+// Durable storage for offline navigations mirrors the in-memory Segment Cache.
+// Route records describe the route tree that can be reconstructed for a URL.
+// Segment records carry the prefetched RSC payloads that fill that tree after a
+// hard reload through the offline fallback document.
+//
+// IndexedDB is used instead of the service worker CacheStorage because the
+// the client needs structured records, independent route and segment
+// invalidation, and RSC response bodies tied to the current Next.js build.
+const DATABASE_NAME = 'next-offline-navigation-cache'
+const DATABASE_VERSION = 1
+const ROUTE_STORE_NAME = 'route-data'
+const SEGMENT_STORE_NAME = 'segment-data'
+const METADATA_STORE_NAME = 'metadata'
+const ROUTE_CACHE_VERSION_KEY = 'route-cache-version'
+const SEGMENT_CACHE_VERSION_KEY = 'segment-cache-version'
+const ROUTE_RECORD_VERSION = 1
+const SEGMENT_RECORD_VERSION = 1
+const RSC_RESPONSE_PAYLOAD_VERSION = 1
+
+type OfflineNavigationSegmentCacheKey = [buildId: string, key: string]
+export type OfflineNavigationRSCResponseRequestKind = 'segment-prefetch'
+
+export type OfflineNavigationSerializedVaryPathValue =
+  | {
+      kind: 'value'
+      value: string | null
+    }
+  | {
+      kind: 'fallback'
+    }
+
+export type OfflineNavigationSerializedVaryPathPart = {
+  id: string | null
+  value: OfflineNavigationSerializedVaryPathValue
+}
+
+export type OfflineNavigationSerializedVaryPath =
+  OfflineNavigationSerializedVaryPathPart[]
+
+export type OfflineNavigationSerializableVaryPath = {
+  id: string | null
+  value: string | null | object
+  parent: OfflineNavigationSerializableVaryPath | null
+}
+
+export type OfflineNavigationRouteRecord = {
+  version: typeof ROUTE_RECORD_VERSION
+  kind: 'route'
+  buildId: string
+  key: string
+  cacheVersion: number
+  staleAt: number
+  // `pathname` and `nextUrl` duplicate part of `routeVaryPath`, but the route
+  // hydration step also needs them to rebuild the known-route trie used for
+  // dynamic route matching. Keep them as the small route index, not as a second
+  // router state model.
+  route: {
+    pathname: string
+    nextUrl: string | null
+    canonicalUrl: string
+    renderedSearch: string
+    couldBeIntercepted: boolean
+    supportsPerSegmentPrefetching: boolean
+    hasDynamicRewrite: boolean
+  }
+  routeVaryPath: OfflineNavigationSerializedVaryPath
+  tree: unknown
+  metadata: unknown
+}
+
+export type OfflineNavigationSegmentRecord = {
+  version: typeof SEGMENT_RECORD_VERSION
+  kind: 'segment'
+  buildId: string
+  key: string
+  cacheVersion: number
+  staleAt: number
+  segment: {
+    fetchStrategy: number
+    isPartial: boolean
+    payloadIndex: number
+  }
+  segmentVaryPath: OfflineNavigationSerializedVaryPath
+  payload: unknown
+}
+
+export type OfflineNavigationRSCResponsePayload = {
+  version: typeof RSC_RESPONSE_PAYLOAD_VERSION
+  kind: 'rsc-response'
+  requestKind: OfflineNavigationRSCResponseRequestKind
+  body: ArrayBuffer
+}
+
+export type OfflineNavigationCacheReadOptions = {
+  buildId?: string
+  now?: number
+}
+
+export type OfflineNavigationRouteRecordWrite = Omit<
+  OfflineNavigationRouteRecord,
+  'buildId' | 'cacheVersion' | 'kind' | 'version'
+> & {
+  buildId?: string
+}
+
+export type OfflineNavigationSegmentRecordWrite = Omit<
+  OfflineNavigationSegmentRecord,
+  'buildId' | 'cacheVersion' | 'kind' | 'version'
+> & {
+  buildId?: string
+}
+
+export type OfflineNavigationCacheStorage = {
+  deleteBuild(buildId: string): Promise<void>
+  getRoute(
+    key: OfflineNavigationSegmentCacheKey
+  ): Promise<OfflineNavigationRouteRecord | undefined>
+  getRoutes(buildId: string): Promise<OfflineNavigationRouteRecord[]>
+  putRoute(entry: OfflineNavigationRouteRecord): Promise<void>
+  deleteRoute(key: OfflineNavigationSegmentCacheKey): Promise<void>
+  getRouteCacheVersion(): Promise<number>
+  incrementRouteCacheVersion(): Promise<number>
+  getSegment(
+    key: OfflineNavigationSegmentCacheKey
+  ): Promise<OfflineNavigationSegmentRecord | undefined>
+  getSegments(buildId: string): Promise<OfflineNavigationSegmentRecord[]>
+  putSegment(entry: OfflineNavigationSegmentRecord): Promise<void>
+  deleteSegment(key: OfflineNavigationSegmentCacheKey): Promise<void>
+  getSegmentCacheVersion(): Promise<number>
+  incrementSegmentCacheVersion(): Promise<number>
+}
+
+export type OfflineNavigationSegmentCachePersistence = {
+  readRoute: (
+    key: string,
+    options?: OfflineNavigationCacheReadOptions
+  ) => Promise<OfflineNavigationRouteRecord | null>
+  readRoutes: (
+    options?: OfflineNavigationCacheReadOptions
+  ) => Promise<OfflineNavigationRouteRecord[]>
+  writeRoute: (entry: OfflineNavigationRouteRecordWrite) => Promise<boolean>
+  deleteRoute: (
+    key: string,
+    options?: OfflineNavigationCacheReadOptions
+  ) => Promise<boolean>
+  invalidateRoutes: () => Promise<boolean>
+  readSegment: (
+    key: string,
+    options?: OfflineNavigationCacheReadOptions
+  ) => Promise<OfflineNavigationSegmentRecord | null>
+  readSegments: (
+    options?: OfflineNavigationCacheReadOptions
+  ) => Promise<OfflineNavigationSegmentRecord[]>
+  writeSegment: (entry: OfflineNavigationSegmentRecordWrite) => Promise<boolean>
+  deleteSegment: (
+    key: string,
+    options?: OfflineNavigationCacheReadOptions
+  ) => Promise<boolean>
+  invalidateSegments: () => Promise<boolean>
+  deleteBuild: (buildId?: string) => Promise<boolean>
+}
+
+// Segment Cache keys are linked lists called "vary paths". Each node represents
+// one input that can affect a cache entry, like pathname, search params,
+// Next-Url, or a dynamic route param. The in-memory cache can use an object
+// identity as the generic "fallback" marker; persisted records need a structured
+// marker so the same key can be rebuilt after a reload.
+export function serializeOfflineNavigationVaryPath(
+  varyPath: OfflineNavigationSerializableVaryPath | null
+): OfflineNavigationSerializedVaryPath {
+  const parts: OfflineNavigationSerializedVaryPath = []
+  let current = varyPath
+
+  while (current !== null) {
+    parts.push({
+      id: current.id,
+      value:
+        current.value === null || typeof current.value === 'string'
+          ? {
+              kind: 'value',
+              value: current.value,
+            }
+          : {
+              kind: 'fallback',
+            },
+    })
+    current = current.parent
+  }
+
+  return parts
+}
+
+export function createOfflineNavigationVaryPathKey(
+  varyPath: OfflineNavigationSerializableVaryPath | null
+): string {
+  return JSON.stringify(serializeOfflineNavigationVaryPath(varyPath))
+}
+
+// Route records and segment records are invalidated independently, mirroring the
+// in-memory route and segment cache versions. A write stores the current
+// persisted cache version on the record; invalidation bumps the version instead
+// of scanning and deleting every entry. Old-version records miss on read.
+export function createOfflineNavigationSegmentCachePersistence(
+  storage: OfflineNavigationCacheStorage
+): OfflineNavigationSegmentCachePersistence {
+  return {
+    readRoute: async (key, options) => {
+      return runOfflineNavigationCacheOperation(async () => {
+        const buildId = getCacheBuildId(options?.buildId)
+        if (buildId === null) {
+          return null
+        }
+
+        const cacheKey: OfflineNavigationSegmentCacheKey = [buildId, key]
+        const [entry, cacheVersion] = await Promise.all([
+          storage.getRoute(cacheKey),
+          storage.getRouteCacheVersion(),
+        ])
+        if (!entry) {
+          return null
+        }
+
+        if (!isUsableRouteRecord(entry, buildId, key, cacheVersion, options)) {
+          await storage.deleteRoute(cacheKey)
+          return null
+        }
+
+        return entry
+      }, null)
+    },
+    readRoutes: async (options) => {
+      return runOfflineNavigationCacheOperation(async () => {
+        const buildId = getCacheBuildId(options?.buildId)
+        if (buildId === null) {
+          return []
+        }
+
+        const [entries, cacheVersion] = await Promise.all([
+          storage.getRoutes(buildId),
+          storage.getRouteCacheVersion(),
+        ])
+        const usableEntries: OfflineNavigationRouteRecord[] = []
+        await Promise.all(
+          entries.map(async (entry) => {
+            if (
+              isUsableRouteRecord(
+                entry,
+                buildId,
+                entry.key,
+                cacheVersion,
+                options
+              )
+            ) {
+              usableEntries.push(entry)
+            } else {
+              if (
+                typeof entry.buildId === 'string' &&
+                typeof entry.key === 'string'
+              ) {
+                await storage.deleteRoute([entry.buildId, entry.key])
+              }
+            }
+          })
+        )
+        return usableEntries
+      }, [])
+    },
+    writeRoute: async (entry) => {
+      return runOfflineNavigationCacheOperation(async () => {
+        const buildId = getCacheBuildId(entry.buildId)
+        if (buildId === null) {
+          return false
+        }
+
+        await storage.putRoute({
+          version: ROUTE_RECORD_VERSION,
+          kind: 'route',
+          buildId,
+          key: entry.key,
+          cacheVersion: await storage.getRouteCacheVersion(),
+          staleAt: entry.staleAt,
+          route: entry.route,
+          routeVaryPath: entry.routeVaryPath,
+          tree: entry.tree,
+          metadata: entry.metadata,
+        })
+        return true
+      }, false)
+    },
+    deleteRoute: async (key, options) => {
+      return runOfflineNavigationCacheOperation(async () => {
+        const buildId = getCacheBuildId(options?.buildId)
+        if (buildId === null) {
+          return false
+        }
+
+        await storage.deleteRoute([buildId, key])
+        return true
+      }, false)
+    },
+    invalidateRoutes: async () => {
+      return runOfflineNavigationCacheOperation(async () => {
+        await storage.incrementRouteCacheVersion()
+        return true
+      }, false)
+    },
+    readSegment: async (key, options) => {
+      return runOfflineNavigationCacheOperation(async () => {
+        const buildId = getCacheBuildId(options?.buildId)
+        if (buildId === null) {
+          return null
+        }
+
+        const cacheKey: OfflineNavigationSegmentCacheKey = [buildId, key]
+        const [entry, cacheVersion] = await Promise.all([
+          storage.getSegment(cacheKey),
+          storage.getSegmentCacheVersion(),
+        ])
+        if (!entry) {
+          return null
+        }
+
+        if (
+          !isUsableSegmentRecord(entry, buildId, key, cacheVersion, options)
+        ) {
+          await storage.deleteSegment(cacheKey)
+          return null
+        }
+
+        return entry
+      }, null)
+    },
+    readSegments: async (options) => {
+      return runOfflineNavigationCacheOperation(async () => {
+        const buildId = getCacheBuildId(options?.buildId)
+        if (buildId === null) {
+          return []
+        }
+
+        const [entries, cacheVersion] = await Promise.all([
+          storage.getSegments(buildId),
+          storage.getSegmentCacheVersion(),
+        ])
+        const usableEntries: OfflineNavigationSegmentRecord[] = []
+        await Promise.all(
+          entries.map(async (entry) => {
+            if (
+              isUsableSegmentRecord(
+                entry,
+                buildId,
+                entry.key,
+                cacheVersion,
+                options
+              )
+            ) {
+              usableEntries.push(entry)
+            } else {
+              if (
+                typeof entry.buildId === 'string' &&
+                typeof entry.key === 'string'
+              ) {
+                await storage.deleteSegment([entry.buildId, entry.key])
+              }
+            }
+          })
+        )
+        return usableEntries
+      }, [])
+    },
+    writeSegment: async (entry) => {
+      return runOfflineNavigationCacheOperation(async () => {
+        const buildId = getCacheBuildId(entry.buildId)
+        if (buildId === null) {
+          return false
+        }
+
+        await storage.putSegment({
+          version: SEGMENT_RECORD_VERSION,
+          kind: 'segment',
+          buildId,
+          key: entry.key,
+          cacheVersion: await storage.getSegmentCacheVersion(),
+          staleAt: entry.staleAt,
+          segment: entry.segment,
+          segmentVaryPath: entry.segmentVaryPath,
+          payload: entry.payload,
+        })
+        return true
+      }, false)
+    },
+    deleteSegment: async (key, options) => {
+      return runOfflineNavigationCacheOperation(async () => {
+        const buildId = getCacheBuildId(options?.buildId)
+        if (buildId === null) {
+          return false
+        }
+
+        await storage.deleteSegment([buildId, key])
+        return true
+      }, false)
+    },
+    invalidateSegments: async () => {
+      return runOfflineNavigationCacheOperation(async () => {
+        await storage.incrementSegmentCacheVersion()
+        return true
+      }, false)
+    },
+    deleteBuild: async (buildId) => {
+      return runOfflineNavigationCacheOperation(async () => {
+        const cacheBuildId = getCacheBuildId(buildId)
+        if (cacheBuildId === null) {
+          return false
+        }
+
+        await storage.deleteBuild(cacheBuildId)
+        return true
+      }, false)
+    },
+  }
+}
+
+function isUsableRouteRecord(
+  entry: OfflineNavigationRouteRecord,
+  buildId: string,
+  key: string,
+  cacheVersion: number,
+  options: OfflineNavigationCacheReadOptions | undefined
+): boolean {
+  return (
+    entry.version === ROUTE_RECORD_VERSION &&
+    entry.kind === 'route' &&
+    entry.buildId === buildId &&
+    typeof entry.key === 'string' &&
+    entry.key === key &&
+    entry.cacheVersion === cacheVersion &&
+    entry.staleAt > (options?.now ?? Date.now())
+  )
+}
+
+function isUsableSegmentRecord(
+  entry: OfflineNavigationSegmentRecord,
+  buildId: string,
+  key: string,
+  cacheVersion: number,
+  options: OfflineNavigationCacheReadOptions | undefined
+): boolean {
+  return (
+    entry.version === SEGMENT_RECORD_VERSION &&
+    entry.kind === 'segment' &&
+    entry.buildId === buildId &&
+    typeof entry.key === 'string' &&
+    entry.key === key &&
+    entry.cacheVersion === cacheVersion &&
+    entry.staleAt > (options?.now ?? Date.now())
+  )
+}
+
+export async function createOfflineNavigationRSCResponsePayload(
+  response: Response,
+  requestKind: OfflineNavigationRSCResponseRequestKind
+): Promise<OfflineNavigationRSCResponsePayload> {
+  // Response bodies are one-shot streams, but IndexedDB stores structured data.
+  // Persist the body as an ArrayBuffer so a later hard reload can recreate a
+  // Response and feed it through the same RSC decoder as a network prefetch.
+  const clone = response.clone()
+  return {
+    version: RSC_RESPONSE_PAYLOAD_VERSION,
+    kind: 'rsc-response',
+    requestKind,
+    body: await clone.arrayBuffer(),
+  }
+}
+
+export function createOfflineNavigationRSCResponse(
+  payload: OfflineNavigationRSCResponsePayload
+): Response {
+  return new Response(payload.body.slice(0))
+}
+
+export function isOfflineNavigationRSCResponsePayload(
+  payload: unknown
+): payload is OfflineNavigationRSCResponsePayload {
+  if (payload === null || typeof payload !== 'object') {
+    return false
+  }
+
+  const candidate = payload as Partial<OfflineNavigationRSCResponsePayload>
+  return (
+    candidate.version === RSC_RESPONSE_PAYLOAD_VERSION &&
+    candidate.kind === 'rsc-response' &&
+    candidate.requestKind === 'segment-prefetch' &&
+    candidate.body instanceof ArrayBuffer
+  )
+}
+
+function getCacheBuildId(buildId: string | undefined): string | null {
+  const cacheBuildId = buildId ?? getNavigationBuildId()
+  return cacheBuildId === '' ? null : cacheBuildId
+}
+
+async function runOfflineNavigationCacheOperation<T>(
+  operation: () => Promise<T>,
+  fallback: T
+): Promise<T> {
+  // Offline cache persistence must never affect normal navigation. Treat any
+  // storage failure as a cache miss and let the router continue.
+  try {
+    return await operation()
+  } catch {
+    return fallback
+  }
+}
+
+function getIndexedDB(): IDBFactory | null {
+  return typeof indexedDB === 'undefined' ? null : indexedDB
+}
+
+function requestToPromise<T>(request: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result)
+    request.onerror = () => reject(request.error ?? new Error())
+  })
+}
+
+function waitForTransaction(transaction: IDBTransaction): Promise<void> {
+  return new Promise((resolve, reject) => {
+    transaction.oncomplete = () => resolve()
+    transaction.onabort = () => reject(transaction.error ?? new Error())
+    transaction.onerror = () => reject(transaction.error ?? new Error())
+  })
+}
+
+function ensureObjectStore(
+  database: IDBDatabase,
+  storeName: string,
+  keyPath: string | string[]
+): void {
+  if (!database.objectStoreNames.contains(storeName)) {
+    database.createObjectStore(storeName, { keyPath })
+  }
+}
+
+async function deleteBuildEntriesFromObjectStore(
+  store: IDBObjectStore,
+  buildId: string
+): Promise<void> {
+  const cursorRequest = store.openCursor()
+  await new Promise<void>((resolve, reject) => {
+    cursorRequest.onsuccess = () => {
+      const cursor = cursorRequest.result
+      if (cursor === null) {
+        resolve()
+        return
+      }
+
+      if ((cursor.value as { buildId?: unknown }).buildId === buildId) {
+        cursor.delete()
+      }
+      cursor.continue()
+    }
+    cursorRequest.onerror = () => reject(cursorRequest.error ?? new Error())
+  })
+}
+
+class IndexedDBOfflineNavigationCacheStorage
+  implements OfflineNavigationCacheStorage
+{
+  private databasePromise: Promise<IDBDatabase | null> | null = null
+
+  async deleteBuild(buildId: string): Promise<void> {
+    const database = await this.getDatabase()
+    if (database === null) {
+      throw new Error()
+    }
+
+    const transaction = database.transaction(
+      [ROUTE_STORE_NAME, SEGMENT_STORE_NAME],
+      'readwrite'
+    )
+    await Promise.all(
+      [ROUTE_STORE_NAME, SEGMENT_STORE_NAME].map((storeName) =>
+        deleteBuildEntriesFromObjectStore(
+          transaction.objectStore(storeName),
+          buildId
+        )
+      )
+    )
+    await waitForTransaction(transaction)
+  }
+
+  async getRoute(
+    key: OfflineNavigationSegmentCacheKey
+  ): Promise<OfflineNavigationRouteRecord | undefined> {
+    return this.getFromStore(ROUTE_STORE_NAME, key)
+  }
+
+  async getRoutes(buildId: string): Promise<OfflineNavigationRouteRecord[]> {
+    return this.getBuildEntriesFromStore(ROUTE_STORE_NAME, buildId)
+  }
+
+  async putRoute(entry: OfflineNavigationRouteRecord): Promise<void> {
+    await this.putIntoStore(ROUTE_STORE_NAME, entry)
+  }
+
+  async deleteRoute(key: OfflineNavigationSegmentCacheKey): Promise<void> {
+    await this.deleteFromStore(ROUTE_STORE_NAME, key)
+  }
+
+  async getRouteCacheVersion(): Promise<number> {
+    return this.getCacheVersion(ROUTE_CACHE_VERSION_KEY)
+  }
+
+  async incrementRouteCacheVersion(): Promise<number> {
+    return this.incrementCacheVersion(ROUTE_CACHE_VERSION_KEY)
+  }
+
+  async getSegment(
+    key: OfflineNavigationSegmentCacheKey
+  ): Promise<OfflineNavigationSegmentRecord | undefined> {
+    return this.getFromStore(SEGMENT_STORE_NAME, key)
+  }
+
+  async getSegments(
+    buildId: string
+  ): Promise<OfflineNavigationSegmentRecord[]> {
+    return this.getBuildEntriesFromStore(SEGMENT_STORE_NAME, buildId)
+  }
+
+  async putSegment(entry: OfflineNavigationSegmentRecord): Promise<void> {
+    await this.putIntoStore(SEGMENT_STORE_NAME, entry)
+  }
+
+  async deleteSegment(key: OfflineNavigationSegmentCacheKey): Promise<void> {
+    await this.deleteFromStore(SEGMENT_STORE_NAME, key)
+  }
+
+  async getSegmentCacheVersion(): Promise<number> {
+    return this.getCacheVersion(SEGMENT_CACHE_VERSION_KEY)
+  }
+
+  async incrementSegmentCacheVersion(): Promise<number> {
+    return this.incrementCacheVersion(SEGMENT_CACHE_VERSION_KEY)
+  }
+
+  private async getFromStore<T>(
+    storeName: string,
+    key: IDBValidKey | IDBKeyRange
+  ): Promise<T | undefined> {
+    const database = await this.getDatabase()
+    if (database === null) {
+      return undefined
+    }
+
+    return requestToPromise(
+      database
+        .transaction(storeName, 'readonly')
+        .objectStore(storeName)
+        .get(key)
+    )
+  }
+
+  private async getBuildEntriesFromStore<T extends { buildId: string }>(
+    storeName: string,
+    buildId: string
+  ): Promise<T[]> {
+    const database = await this.getDatabase()
+    if (database === null) {
+      return []
+    }
+
+    const transaction = database.transaction(storeName, 'readonly')
+    const store = transaction.objectStore(storeName)
+    const cursorRequest = store.openCursor()
+    const entries: T[] = []
+    await new Promise<void>((resolve, reject) => {
+      cursorRequest.onsuccess = () => {
+        const cursor = cursorRequest.result
+        if (cursor === null) {
+          resolve()
+          return
+        }
+
+        const entry = cursor.value as T
+        if (entry.buildId === buildId) {
+          entries.push(entry)
+        }
+        cursor.continue()
+      }
+      cursorRequest.onerror = () => reject(cursorRequest.error ?? new Error())
+    })
+    await waitForTransaction(transaction)
+    return entries
+  }
+
+  private async putIntoStore(storeName: string, entry: unknown): Promise<void> {
+    const database = await this.getDatabase()
+    if (database === null) {
+      throw new Error()
+    }
+
+    const transaction = database.transaction(storeName, 'readwrite')
+    transaction.objectStore(storeName).put(entry)
+    await waitForTransaction(transaction)
+  }
+
+  private async deleteFromStore(
+    storeName: string,
+    key: IDBValidKey | IDBKeyRange
+  ): Promise<void> {
+    const database = await this.getDatabase()
+    if (database === null) {
+      throw new Error()
+    }
+
+    const transaction = database.transaction(storeName, 'readwrite')
+    transaction.objectStore(storeName).delete(key)
+    await waitForTransaction(transaction)
+  }
+
+  private async getCacheVersion(key: string): Promise<number> {
+    const database = await this.getDatabase()
+    if (database === null) {
+      return 0
+    }
+
+    const cacheVersion = await requestToPromise(
+      database
+        .transaction(METADATA_STORE_NAME, 'readonly')
+        .objectStore(METADATA_STORE_NAME)
+        .get(key)
+    )
+    return typeof cacheVersion === 'number' ? cacheVersion : 0
+  }
+
+  private async incrementCacheVersion(key: string): Promise<number> {
+    const database = await this.getDatabase()
+    if (database === null) {
+      throw new Error()
+    }
+
+    const transaction = database.transaction(METADATA_STORE_NAME, 'readwrite')
+    const store = transaction.objectStore(METADATA_STORE_NAME)
+    const cacheVersion = await requestToPromise(store.get(key))
+    const nextCacheVersion =
+      (typeof cacheVersion === 'number' ? cacheVersion : 0) + 1
+    store.put(nextCacheVersion, key)
+    await waitForTransaction(transaction)
+    return nextCacheVersion
+  }
+
+  private async getDatabase(): Promise<IDBDatabase | null> {
+    if (this.databasePromise === null) {
+      this.databasePromise = this.openDatabase().catch((error) => {
+        this.databasePromise = null
+        throw error
+      })
+    }
+    return this.databasePromise
+  }
+
+  private async openDatabase(): Promise<IDBDatabase | null> {
+    const idb = getIndexedDB()
+    if (idb === null) {
+      return null
+    }
+
+    const request = idb.open(DATABASE_NAME, DATABASE_VERSION)
+    request.onupgradeneeded = () => {
+      const database = request.result
+      // The build id is part of every primary key so records from an older
+      // deployment cannot be replayed into a newer client bundle.
+      ensureObjectStore(database, ROUTE_STORE_NAME, ['buildId', 'key'])
+      ensureObjectStore(database, SEGMENT_STORE_NAME, ['buildId', 'key'])
+      if (!database.objectStoreNames.contains(METADATA_STORE_NAME)) {
+        database.createObjectStore(METADATA_STORE_NAME)
+      }
+    }
+
+    const database = await requestToPromise(request)
+    database.onversionchange = () => {
+      database.close()
+      this.databasePromise = null
+    }
+    return database
+  }
+}
+
+const offlineNavigationCacheStorage =
+  new IndexedDBOfflineNavigationCacheStorage()
+const offlineNavigationSegmentCachePersistence =
+  createOfflineNavigationSegmentCachePersistence(offlineNavigationCacheStorage)
+
+export const deleteOfflineNavigationCacheEntriesForBuild =
+  offlineNavigationSegmentCachePersistence.deleteBuild
+export const readOfflineNavigationRouteRecord =
+  offlineNavigationSegmentCachePersistence.readRoute
+export const readOfflineNavigationRouteRecords =
+  offlineNavigationSegmentCachePersistence.readRoutes
+export const writeOfflineNavigationRouteRecord =
+  offlineNavigationSegmentCachePersistence.writeRoute
+export const deleteOfflineNavigationRouteRecord =
+  offlineNavigationSegmentCachePersistence.deleteRoute
+export const invalidateOfflineNavigationRouteRecords =
+  offlineNavigationSegmentCachePersistence.invalidateRoutes
+export const readOfflineNavigationSegmentRecord =
+  offlineNavigationSegmentCachePersistence.readSegment
+export const readOfflineNavigationSegmentRecords =
+  offlineNavigationSegmentCachePersistence.readSegments
+export const writeOfflineNavigationSegmentRecord =
+  offlineNavigationSegmentCachePersistence.writeSegment
+export const deleteOfflineNavigationSegmentRecord =
+  offlineNavigationSegmentCachePersistence.deleteSegment
+export const invalidateOfflineNavigationSegmentRecords =
+  offlineNavigationSegmentCachePersistence.invalidateSegments


### PR DESCRIPTION
This is PR 6 of 21 in the offline navigations plus output-export fallback stack.

This stack introduces a generated fallback entrypoint and then layers the client behavior on the existing App Router, cached navigations, optimistic routing, Cache Components, and Segment Cache primitives. The offline navigations chapter adds a managed service worker and persisted Segment Cache replay. The output-export chapter emits static fallback HTML/RSC artifacts so parameterized routes can load and navigate without enumerating every param at build time.

Review guide: https://gist.github.com/feedthejim/bb440153d29dce019d1d26b6643e2a48

## Where This Sits
This PR is in the offline navigations chapter.
Previous PR: #93627 `offline navigations: serve fallback document offline (5/21)`.
Next PR: #93640 `offline navigations: persist cached Segment Cache records (7/21)`.

## What Changes
- Adds IndexedDB-backed persistence for route and segment records owned by Segment Cache.
- Keeps the exported API narrow so this reads as persisted Segment Cache state, not a second router cache.

## Reviewer Focus
- Store shape, build scoping, and invalidation primitives.
- Names should say Segment Cache records, not router-cache records, unless referring to the existing public router cache concept.

## Proof In This PR
- `packages/next/src/client/components/segment-cache/offline-navigation-cache.test.ts` owns persistence read/write/delete semantics.
- Later e2es prove these records can bootstrap an offline document load.

Latest local stack verification after autosquash included:
- `git diff --check`
- `pnpm --filter=next types`
- `pnpm testonly packages/next/src/client/components/segment-cache/offline-navigation-cache.test.ts packages/next/src/client/components/segment-cache/cache.test.ts packages/next/src/client/output-export-fallback.test.ts packages/next/src/export/helpers/output-export-fallback.test.ts packages/next/src/lib/output-export-fallback-routes.test.ts packages/next/src/client/components/router-reducer/fetch-server-response.test.ts`
- `HEADLESS=true pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `HEADLESS=true pnpm test-start-turbo test/e2e/app-dir-export/test/dynamic-fallback*.test.ts`

## Deferred Coverage
Writing records from normal prefetches and hydrating them during fallback boot are deferred.

## Disabled-Flag Posture
The module is only loaded behind `__NEXT_OFFLINE_NAVIGATIONS`; disabled apps should not open the database.

## Full Stack
1. [offline navigations: add gated build primitives (1/21)](https://github.com/vercel/next.js/pull/93736)
2. [offline navigations: generate fallback document artifacts (2/21)](https://github.com/vercel/next.js/pull/93737)
3. [offline navigations: register pass-through worker (3/21)](https://github.com/vercel/next.js/pull/93625)
4. [offline navigations: cache fallback and current-build assets (4/21)](https://github.com/vercel/next.js/pull/93626)
5. [offline navigations: serve fallback document offline (5/21)](https://github.com/vercel/next.js/pull/93627)
6. **Current PR:** [offline navigations: add Segment Cache persistence primitives (6/21)](https://github.com/vercel/next.js/pull/93630)
7. [offline navigations: persist cached Segment Cache records (7/21)](https://github.com/vercel/next.js/pull/93640)
8. [offline navigations: bootstrap fallback from Segment Cache records (8/21)](https://github.com/vercel/next.js/pull/93644)
9. [offline navigations: support dynamic route patterns (9/21)](https://github.com/vercel/next.js/pull/93647)
10. [offline navigations: add docs and examples (10/21)](https://github.com/vercel/next.js/pull/93738)
11. [output export fallbacks: add gated build primitives (11/21)](https://github.com/vercel/next.js/pull/93744)
12. [output export fallbacks: emit fallback HTML artifacts (12/21)](https://github.com/vercel/next.js/pull/93745)
13. [output export fallbacks: emit fallback RSC artifacts (13/21)](https://github.com/vercel/next.js/pull/93746)
14. [output export fallbacks: enforce server-only boundaries (14/21)](https://github.com/vercel/next.js/pull/93747)
15. [output export fallbacks: bootstrap hard loads from artifacts (15/21)](https://github.com/vercel/next.js/pull/93748)
16. [output export fallbacks: resolve soft navigations through cached routes (16/21)](https://github.com/vercel/next.js/pull/93749)
17. [output export fallbacks: resolve fallback artifacts from route manifests (17/21)](https://github.com/vercel/next.js/pull/93779)
18. [output export fallbacks: validate fallback Flight responses (18/21)](https://github.com/vercel/next.js/pull/93750)
19. [output export fallbacks: store fallback data in Segment Cache (19/21)](https://github.com/vercel/next.js/pull/93774)
20. [output export fallbacks: support known params and export variants (20/21)](https://github.com/vercel/next.js/pull/93751)
21. [output export fallbacks: add docs and review guide (21/21)](https://github.com/vercel/next.js/pull/93752)

<!-- NEXT_JS_LLM_PR -->
