### PR TITLE
offline navigations: persist initial-load navigation data (11/25)

### DIFF
--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -68,14 +68,19 @@ function neverResolveOfflineNavigationResponse(): Promise<Response> {
   return new Promise<Response>(() => {})
 }
 
-function createOfflineNavigationClientResumeFetch():
-  | Promise<Response>
+type OfflineNavigationFallbackResponse = {
+  requestKind: 'client-resume' | 'initial-load'
+  response: Response
+}
+
+function createOfflineNavigationFallbackResponse():
+  | Promise<OfflineNavigationFallbackResponse>
   | undefined {
   if (!isOfflineNavigationFallbackDocument()) {
     return undefined
   }
 
-  return (async () => {
+  return (async (): Promise<OfflineNavigationFallbackResponse> => {
     const {
       createOfflineNavigationRSCResponse,
       isOfflineNavigationRSCResponsePayload,
@@ -94,27 +99,44 @@ function createOfflineNavigationClientResumeFetch():
 
     if (
       !isOfflineNavigationRSCResponsePayload(payload) ||
-      payload.requestKind !== 'client-resume'
+      (payload.requestKind !== 'client-resume' &&
+        payload.requestKind !== 'initial-load')
     ) {
       showOfflineNavigationCacheMiss()
-      return neverResolveOfflineNavigationResponse()
+      return {
+        requestKind: 'client-resume',
+        response: await neverResolveOfflineNavigationResponse(),
+      }
     }
 
-    return createOfflineNavigationRSCResponse(payload)
-  })().catch(() => {
+    const requestKind: OfflineNavigationFallbackResponse['requestKind'] =
+      payload.requestKind === 'initial-load' ? 'initial-load' : 'client-resume'
+
+    return {
+      requestKind,
+      response: createOfflineNavigationRSCResponse(payload),
+    }
+  })().catch(async (): Promise<OfflineNavigationFallbackResponse> => {
     showOfflineNavigationCacheMiss()
-    return neverResolveOfflineNavigationResponse()
+    return {
+      requestKind: 'client-resume',
+      response: await neverResolveOfflineNavigationResponse(),
+    }
   })
 }
 
+const offlineNavigationFallbackResponse =
+  createOfflineNavigationFallbackResponse()
 const offlineNavigationClientResumeFetch =
-  createOfflineNavigationClientResumeFetch()
+  offlineNavigationFallbackResponse?.then(({ response }) => response)
 
+const hasClientResumeShell =
+  // @ts-expect-error
+  Boolean(window.__NEXT_CLIENT_RESUME)
 const hasLockedStaticShell =
   Boolean(instantTestStaticFetch) ||
   Boolean(offlineNavigationClientResumeFetch) ||
-  // @ts-expect-error
-  Boolean(window.__NEXT_CLIENT_RESUME)
+  hasClientResumeShell
 
 const encoder = new TextEncoder()
 
@@ -268,6 +290,19 @@ if (process.env.NODE_ENV !== 'production') {
 // know if `l` is present until React decodes the payload, so always tee and
 // cancel the clone if not needed.
 let initialFlightStreamForCache: ReadableStream<Uint8Array> | null = null
+let initialFlightStreamForOfflineNavigationCache: ReadableStream<Uint8Array> | null =
+  null
+if (
+  process.env.__NEXT_OFFLINE_NAVIGATIONS &&
+  process.env.NODE_ENV === 'production' &&
+  process.env.__NEXT_CONFIG_OUTPUT !== 'export' &&
+  !process.env.__NEXT_DEV_SERVER &&
+  !hasLockedStaticShell
+) {
+  const [forApp, forOfflineNavigationCache] = readable.tee()
+  readable = forApp
+  initialFlightStreamForOfflineNavigationCache = forOfflineNavigationCache
+}
 if (
   process.env.__NEXT_CACHE_COMPONENTS &&
   process.env.__NEXT_EXPERIMENTAL_CACHED_NAVIGATIONS &&
@@ -323,12 +358,17 @@ if (instantTestStaticFetch) {
       debugChannel,
       unstable_allowPartialStream: true,
     })
-  ).then(async (fallbackInitialRSCPayload) =>
-    createInitialRSCPayloadFromFallbackPrerender(
-      await offlineNavigationClientResumeFetch,
+  ).then(async (fallbackInitialRSCPayload) => {
+    const fallbackResponse = await offlineNavigationFallbackResponse!
+    if (fallbackResponse.requestKind === 'initial-load') {
+      return fallbackInitialRSCPayload
+    }
+
+    return createInitialRSCPayloadFromFallbackPrerender(
+      fallbackResponse.response,
       fallbackInitialRSCPayload
     )
-  )
+  })
 } else if (
   // @ts-expect-error
   window.__NEXT_CLIENT_RESUME
@@ -482,6 +522,7 @@ export async function hydrate(
       navigatedAt: initialTimestamp,
       initialRSCPayload,
       initialFlightStreamForCache,
+      initialFlightStreamForOfflineNavigationCache,
       location: window.location,
     }),
     instrumentationHooks

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -21,11 +21,13 @@ import {
 import { decodeStaticStage } from './fetch-server-response'
 import { discoverKnownRoute } from '../segment-cache/optimistic-routes'
 import type { NormalizedSearch } from '../segment-cache/cache-key'
+import { RSC_CONTENT_TYPE_HEADER } from '../app-router-headers'
 
 export interface InitialRouterStateParameters {
   navigatedAt: number
   initialRSCPayload: InitialRSCPayload
   initialFlightStreamForCache?: ReadableStream<Uint8Array> | null
+  initialFlightStreamForOfflineNavigationCache?: ReadableStream<Uint8Array> | null
   location: Location | null
 }
 
@@ -33,6 +35,7 @@ export function createInitialRouterState({
   navigatedAt,
   initialRSCPayload,
   initialFlightStreamForCache,
+  initialFlightStreamForOfflineNavigationCache,
   location,
 }: InitialRouterStateParameters): AppRouterState {
   const {
@@ -88,6 +91,12 @@ export function createInitialRouterState({
     acc
   )
   const metadataVaryPath = acc.metadataVaryPath
+  const initialStaleAt =
+    location === null ||
+    initialSeedData === null ||
+    initialStaticStageByteLength !== undefined
+      ? null
+      : getStaleAt(navigatedAt, initialStaleTime)
   const initialTask = createInitialCacheNodeForHydration(
     navigatedAt,
     initialRouteTree,
@@ -157,7 +166,7 @@ export function createInitialRouterState({
         // hydration and write it into the cache directly.
         const now = Date.now()
 
-        getStaleAt(now, initialStaleTime)
+        initialStaleAt!
           .then((staleAt) => {
             writeStaticStageResponseIntoCache(
               now,
@@ -216,6 +225,18 @@ export function createInitialRouterState({
     }
   }
 
+  persistInitialOfflineNavigationResponse({
+    initialCouldBeIntercepted,
+    initialDynamicStaleTimeSeconds,
+    initialFlightStreamForOfflineNavigationCache,
+    initialRuntimePrefetchStream,
+    initialStaleAt,
+    initialStaticStageByteLength,
+    initialSupportsPerSegmentPrefetching,
+    location,
+    navigatedAt,
+  })
+
   // NOTE: We intentionally don't check if any data needs to be fetched from the
   // server. We assume the initial hydration payload is sufficient to render
   // the page.
@@ -258,4 +279,83 @@ export function createInitialRouterState({
   }
 
   return initialState
+}
+
+function persistInitialOfflineNavigationResponse({
+  initialCouldBeIntercepted,
+  initialDynamicStaleTimeSeconds,
+  initialFlightStreamForOfflineNavigationCache,
+  initialRuntimePrefetchStream,
+  initialStaleAt,
+  initialStaticStageByteLength,
+  initialSupportsPerSegmentPrefetching,
+  location,
+  navigatedAt,
+}: {
+  initialCouldBeIntercepted: boolean
+  initialDynamicStaleTimeSeconds: number | undefined
+  initialFlightStreamForOfflineNavigationCache:
+    | ReadableStream<Uint8Array>
+    | null
+    | undefined
+  initialRuntimePrefetchStream: ReadableStream<Uint8Array> | undefined
+  initialStaleAt: Promise<number> | null
+  initialStaticStageByteLength: Promise<number> | undefined
+  initialSupportsPerSegmentPrefetching: boolean
+  location: Location | null
+  navigatedAt: number
+}): void {
+  if (initialFlightStreamForOfflineNavigationCache == null) {
+    return
+  }
+
+  if (
+    !process.env.__NEXT_OFFLINE_NAVIGATIONS ||
+    process.env.__NEXT_DEV_SERVER ||
+    process.env.NODE_ENV !== 'production' ||
+    process.env.__NEXT_CONFIG_OUTPUT === 'export' ||
+    location === null ||
+    !initialSupportsPerSegmentPrefetching ||
+    initialCouldBeIntercepted ||
+    initialDynamicStaleTimeSeconds !== undefined ||
+    initialRuntimePrefetchStream !== undefined ||
+    initialStaleAt === null ||
+    initialStaticStageByteLength !== undefined
+  ) {
+    initialFlightStreamForOfflineNavigationCache.cancel()
+    return
+  }
+
+  const response = new Response(initialFlightStreamForOfflineNavigationCache, {
+    headers: { 'content-type': RSC_CONTENT_TYPE_HEADER },
+    status: 200,
+    statusText: 'OK',
+  })
+  Object.defineProperty(response, 'url', {
+    value: createHrefFromUrl(location),
+  })
+
+  const {
+    createOfflineNavigationRSCResponsePayload,
+    writeOfflineNavigationRSCResponseCacheEntry,
+  } =
+    require('./offline-navigation-cache') as typeof import('./offline-navigation-cache')
+
+  const payload = createOfflineNavigationRSCResponsePayload(
+    response,
+    'initial-load'
+  ).catch(() => null)
+
+  void (async () => {
+    const staleAt = await initialStaleAt
+    await writeOfflineNavigationRSCResponseCacheEntry({
+      expiresAt: staleAt,
+      payload,
+      staleAt,
+      url: createHrefFromUrl(location),
+      now: navigatedAt,
+    })
+  })().catch(() => {
+    // The page already rendered. Offline persistence must not affect boot.
+  })
 }

--- a/packages/next/src/client/components/router-reducer/offline-navigation-cache.test.ts
+++ b/packages/next/src/client/components/router-reducer/offline-navigation-cache.test.ts
@@ -203,6 +203,19 @@ describe('offline navigation cache', () => {
     })
   })
 
+  it('accepts initial load RSC responses for offline document boot', async () => {
+    const payload = await createOfflineNavigationRSCResponsePayload(
+      new Response('0:["$","payload"]'),
+      'initial-load'
+    )
+
+    expect(isOfflineNavigationRSCResponsePayload(payload)).toBe(true)
+    expect(payload).toMatchObject({
+      kind: 'rsc-response',
+      requestKind: 'initial-load',
+    })
+  })
+
   it('deletes exact URL entries', async () => {
     const storage = new MemoryOfflineNavigationCacheStorage()
     const cache = createOfflineNavigationCache(storage)

--- a/packages/next/src/client/components/router-reducer/offline-navigation-cache.ts
+++ b/packages/next/src/client/components/router-reducer/offline-navigation-cache.ts
@@ -12,6 +12,7 @@ type OfflineNavigationRSCResponseRequestKind =
   | 'navigation'
   | 'route-prefetch'
   | 'client-resume'
+  | 'initial-load'
 
 export type OfflineNavigationCacheEntry = {
   version: typeof ENTRY_VERSION
@@ -217,7 +218,8 @@ export function isOfflineNavigationRSCResponsePayload(
     candidate.kind === 'rsc-response' &&
     (candidate.requestKind === 'navigation' ||
       candidate.requestKind === 'route-prefetch' ||
-      candidate.requestKind === 'client-resume') &&
+      candidate.requestKind === 'client-resume' ||
+      candidate.requestKind === 'initial-load') &&
     typeof candidate.url === 'string' &&
     typeof candidate.status === 'number' &&
     typeof candidate.statusText === 'string' &&

--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -50,6 +50,60 @@ describe('offlineNavigations build artifacts', () => {
     }
   }
 
+  async function readPersistedOfflineNavigationEntry(
+    browser: Awaited<ReturnType<typeof next.browser>>,
+    urlSubstring: string
+  ) {
+    return browser.eval(async (substring) => {
+      const database = await new Promise<IDBDatabase>((resolve, reject) => {
+        const request = indexedDB.open('next-offline-navigation-cache', 1)
+        request.onupgradeneeded = () => {
+          const database = request.result
+          if (!database.objectStoreNames.contains('navigation-data')) {
+            database.createObjectStore('navigation-data', {
+              keyPath: ['buildId', 'url'],
+            })
+          }
+        }
+        request.onsuccess = () => resolve(request.result)
+        request.onerror = () => reject(request.error)
+      })
+
+      try {
+        const entries = await new Promise<any[]>((resolve, reject) => {
+          const transaction = database.transaction(
+            'navigation-data',
+            'readonly'
+          )
+          const request = transaction.objectStore('navigation-data').getAll()
+          request.onsuccess = () => resolve(request.result)
+          request.onerror = () => reject(request.error)
+        })
+        const entry = entries.find((entry) => entry.url.includes(substring))
+        if (!entry) {
+          return null
+        }
+
+        return {
+          buildId: entry.buildId,
+          expiresAt: entry.expiresAt,
+          kind: entry.kind,
+          payload: {
+            bodyLength: entry.payload.body.byteLength,
+            kind: entry.payload.kind,
+            requestKind: entry.payload.requestKind,
+            status: entry.payload.status,
+          },
+          staleAt: entry.staleAt,
+          url: entry.url,
+          version: entry.version,
+        }
+      } finally {
+        database.close()
+      }
+    }, urlSubstring)
+  }
+
   it('emits request-invariant offline navigation artifacts when enabled', async () => {
     const buildResult = await next.build()
     expect(buildResult.exitCode).toBe(0)
@@ -210,18 +264,6 @@ describe('offlineNavigations build artifacts', () => {
         )
       })
 
-      await browser.eval((messageType) => {
-        localStorage.removeItem('__nextOfflineNavigationMessage')
-        navigator.serviceWorker.addEventListener('message', (event) => {
-          if (event.data?.type === messageType) {
-            localStorage.setItem(
-              '__nextOfflineNavigationMessage',
-              JSON.stringify(event.data)
-            )
-          }
-        })
-      }, OFFLINE_NAVIGATION_FALLBACK_SERVED)
-
       const cacheState = await browser.eval(async () => {
         const cacheNames = (await caches.keys()).filter((cacheName) =>
           cacheName.startsWith('next-offline-navigation-v1:')
@@ -258,60 +300,67 @@ describe('offlineNavigations build artifacts', () => {
         ])
       )
 
-      await browser.elementById('prefetch-offline-navigation').click()
       await retry(async () => {
-        const persistedEntry = await browser.eval(async () => {
-          const database = await new Promise<IDBDatabase>((resolve, reject) => {
-            const request = indexedDB.open('next-offline-navigation-cache', 1)
-            request.onupgradeneeded = () => {
-              const database = request.result
-              if (!database.objectStoreNames.contains('navigation-data')) {
-                database.createObjectStore('navigation-data', {
-                  keyPath: ['buildId', 'url'],
-                })
-              }
-            }
-            request.onsuccess = () => resolve(request.result)
-            request.onerror = () => reject(request.error)
-          })
+        const initialLoadEntry = await readPersistedOfflineNavigationEntry(
+          browser,
+          '/docs/'
+        )
+        expect(initialLoadEntry).toEqual({
+          buildId: navigationBuildId,
+          expiresAt: expect.any(Number),
+          kind: 'exact-url',
+          payload: {
+            bodyLength: expect.any(Number),
+            kind: 'rsc-response',
+            requestKind: 'initial-load',
+            status: 200,
+          },
+          staleAt: expect.any(Number),
+          url: expect.stringContaining('/docs/'),
+          version: 1,
+        })
+        expect(initialLoadEntry!.payload.bodyLength).toBeGreaterThan(0)
+      })
 
-          try {
-            const entries = await new Promise<any[]>((resolve, reject) => {
-              const transaction = database.transaction(
-                'navigation-data',
-                'readonly'
-              )
-              const request = transaction
-                .objectStore('navigation-data')
-                .getAll()
-              request.onsuccess = () => resolve(request.result)
-              request.onerror = () => reject(request.error)
-            })
-            const entry = entries.find((entry) =>
-              entry.url.includes('/docs/prefetched')
+      await page!.context().setOffline(true)
+      const initialLoadOfflineResponse = await page!.goto(`${next.url}/docs/`, {
+        waitUntil: 'domcontentloaded',
+      })
+      expect(initialLoadOfflineResponse?.status()).toBe(200)
+      await retry(async () => {
+        expect(await browser.elementByCss('p').text()).toBe(
+          'offline navigations page'
+        )
+      })
+      expect(await browser.elementById('offline-status').text()).toBe('offline')
+      await page!.context().setOffline(false)
+      await browser.eval(() => {
+        window.dispatchEvent(new Event('online'))
+      })
+      await retry(async () => {
+        expect(await browser.elementById('offline-status').text()).toBe(
+          'online'
+        )
+      })
+
+      await browser.eval((messageType) => {
+        localStorage.removeItem('__nextOfflineNavigationMessage')
+        navigator.serviceWorker.addEventListener('message', (event) => {
+          if (event.data?.type === messageType) {
+            localStorage.setItem(
+              '__nextOfflineNavigationMessage',
+              JSON.stringify(event.data)
             )
-            if (!entry) {
-              return null
-            }
-
-            return {
-              buildId: entry.buildId,
-              expiresAt: entry.expiresAt,
-              kind: entry.kind,
-              payload: {
-                bodyLength: entry.payload.body.byteLength,
-                kind: entry.payload.kind,
-                requestKind: entry.payload.requestKind,
-                status: entry.payload.status,
-              },
-              staleAt: entry.staleAt,
-              url: entry.url,
-              version: entry.version,
-            }
-          } finally {
-            database.close()
           }
         })
+      }, OFFLINE_NAVIGATION_FALLBACK_SERVED)
+
+      await browser.elementById('prefetch-offline-navigation').click()
+      await retry(async () => {
+        const persistedEntry = await readPersistedOfflineNavigationEntry(
+          browser,
+          '/docs/prefetched'
+        )
         expect(persistedEntry).toEqual({
           buildId: navigationBuildId,
           expiresAt: expect.any(Number),


### PR DESCRIPTION
## Stack Position

11/25 in the offline navigations first-usable stack.

This stack turns `experimental.offlineNavigations` into a usable cache-components experiment for regular apps. The service worker owns document survival only. Cache Storage owns generated fallback artifacts. The cache-components client router owns IndexedDB, route semantics, replay, visible misses, and invalidation. Output export, dev simulation, custom miss UI, and broad production-hardening matrices are intentionally deferred.

Review guide: https://gist.github.com/feedthejim/b3d9fe26a7c05655fd57adcce371b93d

## Full Stack

1. offline navigations: add cache-components flag (1/25)
2. offline navigations: emit fallback document (2/25)
3. offline navigations: emit fallback manifest (3/25)
4. offline navigations: register pass-through service worker (4/25)
5. offline navigations: cache fallback artifacts (5/25)
6. offline navigations: serve fallback document (6/25)
7. offline navigations: bridge fallback state to useOffline (7/25)
8. offline navigations: add navigation cache primitives (8/25)
9. offline navigations: persist exact-url navigation data (9/25)
10. offline navigations: boot fallback from exact-url data (10/25)
11. offline navigations: persist initial-load navigation data (11/25) ← this PR
12. offline navigations: centralize cache eligibility (12/25)
13. offline navigations: replay request-sensitive exact urls (13/25)
14. offline navigations: wire exact-url invalidation (14/25)
15. offline navigations: harden fallback diagnostics and misses (15/25)
16. offline navigations: cover exact-url app replay basics (16/25)
17. offline navigations: define persistent router schema (17/25)
18. offline navigations: persist route records and known routes (18/25)
19. offline navigations: persist segment and head records (19/25)
20. offline navigations: hydrate persisted router caches (20/25)
21. offline navigations: reconstruct prefetched routes offline (21/25)
22. offline navigations: replay dynamic routes from known routes (22/25)
23. offline navigations: mirror router cache invalidation (23/25)
24. offline navigations: cover mutation invalidation (24/25)
25. offline navigations: add app cache reset API (25/25)

## What This PR Does

Persists the initial document load RSC payload so a page can be replayed later without requiring a prior soft navigation.

## What Works After This PR

Pages loaded normally in this browser can become offline-replayable exact URLs.

## Reviewer Focus

Initial-load response capture, cache key normalization, and interaction with existing exact-URL payload validation.

## Not In This PR

Route/segment replay and broader URL identity matrices remain later.

## Proof in This PR

- Relevant coverage: Initial-load replay assertions in the production fixture plus stack-level build/e2e verification.
- Restack verification run at the cleaned stack tip:
  - `pnpm --filter=next build`
  - `NEXT_SKIP_ISOLATE=1 NEXT_TEST_MODE=start pnpm testheadless test/production/app-dir/offline-navigations/offline-navigations.test.ts`
  - `NEXT_TEST_MODE=start pnpm testheadless test/production/app-dir/offline-navigations/offline-navigations.test.ts`
  - `IS_WEBPACK_TEST=1 NEXT_TEST_MODE=start pnpm testheadless test/production/app-dir/offline-navigations/offline-navigations.test.ts`

## Deferred Coverage

Route/segment replay and broader URL identity matrices remain later.

<!-- NEXT_JS_LLM_PR -->
