### PR TITLE
offline navigations: handle exact-url eligibility and invalidation (8/13)

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -4112,6 +4112,7 @@ export default async function build(
               buildId,
               buildManifest,
               crossOrigin: config.crossOrigin,
+              deploymentId: config.deploymentId,
             })
 
             if (fallbackDocument === null) {

--- a/packages/next/src/build/offline-navigation-fallback.ts
+++ b/packages/next/src/build/offline-navigation-fallback.ts
@@ -34,18 +34,20 @@ function getScriptAttributes(
 }
 
 // Generate the build-scoped HTML entrypoint used by offline document fallback
-// handling. It intentionally contains only the app bootstrap, not route HTML,
-// so the artifact stays request-invariant.
+// handling. It intentionally contains only the app bootstrap, not route HTML;
+// exact-URL route data is restored by the client after this document loads.
 export function createOfflineNavigationFallbackDocument({
   assetPrefix,
   buildId,
   buildManifest,
   crossOrigin,
+  deploymentId,
 }: {
   assetPrefix: string
   buildId: string
   buildManifest: BuildManifest
   crossOrigin: '' | 'anonymous' | 'use-credentials' | undefined
+  deploymentId: string | undefined
 }): string | null {
   const rootMainFiles = buildManifest.rootMainFiles.filter((file) =>
     file.endsWith('.js')
@@ -77,11 +79,15 @@ export function createOfflineNavigationFallbackDocument({
     source: 'offline-navigation-fallback',
   }
 
+  const deploymentIdAttribute = deploymentId
+    ? ` data-dpl-id="${htmlEscapeAttributeString(deploymentId)}"`
+    : ''
+
   return `<!DOCTYPE html><html data-next-offline-navigation-fallback="" data-build-id="${htmlEscapeAttributeString(
     buildId
-  )}"><head><meta charSet="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><meta name="next-offline-navigation-fallback" content="1"><meta name="next-build-id" content="${htmlEscapeAttributeString(
+  )}"${deploymentIdAttribute}><head><meta charSet="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><meta name="next-offline-navigation-fallback" content="1"><meta name="next-build-id" content="${htmlEscapeAttributeString(
     buildId
   )}"><script id="__NEXT_OFFLINE_NAVIGATION_FALLBACK" type="application/json">${htmlEscapeJsonString(
     JSON.stringify(metadata)
-  )}</script></head><body><div id="__next"></div><script>self.__next_f=self.__next_f||[];self.__next_f.push([0])</script>${polyfillScripts}${bootstrapScripts}</body></html>`
+  )}</script></head><body><div id="__next"></div><p id="__NEXT_OFFLINE_NAVIGATION_CACHE_MISS" hidden>This page is not available offline.</p><script>self.__next_f=self.__next_f||[];self.__next_f.push([0])</script>${polyfillScripts}${bootstrapScripts}</body></html>`
 }

--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -55,13 +55,93 @@ function isOfflineNavigationFallbackDocument(): boolean {
   )
 }
 
-function showOfflineNavigationCacheMiss(): void {
+const OFFLINE_NAVIGATION_DIAGNOSTIC_LIMIT = 32
+
+type OfflineNavigationCacheMissReason =
+  | 'missing-entry'
+  | 'invalid-payload'
+  | 'unsupported-request-kind'
+  | 'read-error'
+
+type OfflineNavigationFallbackDiagnostic =
+  | {
+      type: 'cache-hit'
+      url: string
+      buildId: string | undefined
+      requestKind: OfflineNavigationFallbackResponse['requestKind']
+    }
+  | {
+      type: 'cache-miss'
+      url: string
+      buildId: string | undefined
+      reason: OfflineNavigationCacheMissReason
+    }
+
+declare global {
+  interface Window {
+    __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?:
+      | OfflineNavigationFallbackDiagnostic[]
+      | undefined
+  }
+}
+
+function reportOfflineNavigationFallbackDiagnostic(
+  diagnostic: OfflineNavigationFallbackDiagnostic
+): void {
+  const diagnostics = (window.__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__ ??= [])
+  if (diagnostics.length >= OFFLINE_NAVIGATION_DIAGNOSTIC_LIMIT) {
+    diagnostics.shift()
+  }
+  diagnostics.push(diagnostic)
+}
+
+function showOfflineNavigationCacheHit(
+  requestKind: OfflineNavigationFallbackResponse['requestKind'],
+  buildId: string | undefined
+): void {
+  document.documentElement.setAttribute(
+    'data-next-offline-navigation-cache',
+    'hit'
+  )
+  document.documentElement.removeAttribute(
+    'data-next-offline-navigation-cache-reason'
+  )
+  reportOfflineNavigationFallbackDiagnostic({
+    type: 'cache-hit',
+    url: location.href,
+    buildId,
+    requestKind,
+  })
+}
+
+function showOfflineNavigationCacheMiss(
+  reason: OfflineNavigationCacheMissReason,
+  buildId: string | undefined
+): void {
+  document.documentElement.setAttribute(
+    'data-next-offline-navigation-cache',
+    'miss'
+  )
+  document.documentElement.setAttribute(
+    'data-next-offline-navigation-cache-reason',
+    reason
+  )
   const cacheMissElement = document.getElementById(
     '__NEXT_OFFLINE_NAVIGATION_CACHE_MISS'
   )
   if (cacheMissElement !== null) {
     cacheMissElement.hidden = false
+    cacheMissElement.setAttribute(
+      'data-next-offline-navigation-cache-reason',
+      reason
+    )
   }
+  reportOfflineNavigationFallbackDiagnostic({
+    type: 'cache-miss',
+    url: location.href,
+    buildId,
+    reason,
+  })
 }
 
 function neverResolveOfflineNavigationResponse(): Promise<Response> {
@@ -98,12 +178,22 @@ function createOfflineNavigationFallbackResponse():
       })
       const payload = entry?.payload
 
+      if (!isOfflineNavigationRSCResponsePayload(payload)) {
+        showOfflineNavigationCacheMiss(
+          payload === undefined ? 'missing-entry' : 'invalid-payload',
+          buildId
+        )
+        return {
+          requestKind: 'client-resume',
+          response: await neverResolveOfflineNavigationResponse(),
+        }
+      }
+
       if (
-        !isOfflineNavigationRSCResponsePayload(payload) ||
-        (payload.requestKind !== 'client-resume' &&
-          payload.requestKind !== 'initial-load')
+        payload.requestKind !== 'client-resume' &&
+        payload.requestKind !== 'initial-load'
       ) {
-        showOfflineNavigationCacheMiss()
+        showOfflineNavigationCacheMiss('unsupported-request-kind', buildId)
         return {
           requestKind: 'client-resume',
           response: await neverResolveOfflineNavigationResponse(),
@@ -115,12 +205,13 @@ function createOfflineNavigationFallbackResponse():
           ? 'initial-load'
           : 'client-resume'
 
+      showOfflineNavigationCacheHit(requestKind, buildId)
       return {
         requestKind,
         response: createOfflineNavigationRSCResponse(payload),
       }
     })().catch(async (): Promise<OfflineNavigationFallbackResponse> => {
-      showOfflineNavigationCacheMiss()
+      showOfflineNavigationCacheMiss('read-error', undefined)
       return {
         requestKind: 'client-resume',
         response: await neverResolveOfflineNavigationResponse(),

--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -45,6 +45,103 @@ const instantTestStaticFetch: Promise<Response> | undefined =
     ? (self.__next_instant_test as unknown as Promise<Response>)
     : undefined
 
+function isOfflineNavigationFallbackDocument(): boolean {
+  return Boolean(
+    process.env.__NEXT_OFFLINE_NAVIGATIONS &&
+      !process.env.__NEXT_DEV_SERVER &&
+      document.documentElement.hasAttribute(
+        'data-next-offline-navigation-fallback'
+      )
+  )
+}
+
+function showOfflineNavigationCacheMiss(): void {
+  const cacheMissElement = document.getElementById(
+    '__NEXT_OFFLINE_NAVIGATION_CACHE_MISS'
+  )
+  if (cacheMissElement !== null) {
+    cacheMissElement.hidden = false
+  }
+}
+
+function neverResolveOfflineNavigationResponse(): Promise<Response> {
+  return new Promise<Response>(() => {})
+}
+
+type OfflineNavigationFallbackResponse = {
+  requestKind: 'client-resume' | 'initial-load'
+  response: Response
+}
+
+function createOfflineNavigationFallbackResponse():
+  | Promise<OfflineNavigationFallbackResponse>
+  | undefined {
+  if (process.env.__NEXT_OFFLINE_NAVIGATIONS) {
+    if (!isOfflineNavigationFallbackDocument()) {
+      return undefined
+    }
+
+    return (async (): Promise<OfflineNavigationFallbackResponse> => {
+      const {
+        createOfflineNavigationRSCResponse,
+        isOfflineNavigationRSCResponsePayload,
+        readOfflineNavigationCacheEntry,
+      } =
+        require('./components/router-reducer/offline-navigation-cache') as typeof import('./components/router-reducer/offline-navigation-cache')
+
+      const buildId =
+        getDeploymentId() ??
+        document.documentElement.getAttribute('data-build-id') ??
+        undefined
+      const entry = await readOfflineNavigationCacheEntry(location.href, {
+        buildId,
+      })
+      const payload = entry?.payload
+
+      if (
+        !isOfflineNavigationRSCResponsePayload(payload) ||
+        (payload.requestKind !== 'client-resume' &&
+          payload.requestKind !== 'initial-load')
+      ) {
+        showOfflineNavigationCacheMiss()
+        return {
+          requestKind: 'client-resume',
+          response: await neverResolveOfflineNavigationResponse(),
+        }
+      }
+
+      const requestKind: OfflineNavigationFallbackResponse['requestKind'] =
+        payload.requestKind === 'initial-load'
+          ? 'initial-load'
+          : 'client-resume'
+
+      return {
+        requestKind,
+        response: createOfflineNavigationRSCResponse(payload),
+      }
+    })().catch(async (): Promise<OfflineNavigationFallbackResponse> => {
+      showOfflineNavigationCacheMiss()
+      return {
+        requestKind: 'client-resume',
+        response: await neverResolveOfflineNavigationResponse(),
+      }
+    })
+  } else {
+    return undefined
+  }
+}
+
+const offlineNavigationFallbackResponse =
+  createOfflineNavigationFallbackResponse()
+const offlineNavigationClientResumeFetch =
+  offlineNavigationFallbackResponse?.then(({ response }) => response)
+
+const hasClientResumeShell = Boolean(window.__NEXT_CLIENT_RESUME)
+const hasLockedStaticShell =
+  Boolean(instantTestStaticFetch) ||
+  Boolean(offlineNavigationClientResumeFetch) ||
+  hasClientResumeShell
+
 const encoder = new TextEncoder()
 
 let initialServerDataBuffer: (string | Uint8Array)[] | undefined = undefined
@@ -73,6 +170,7 @@ declare global {
      */
     __next_r?: string
     __next_f: NextFlight
+    __NEXT_CLIENT_RESUME?: Promise<Response>
   }
 }
 
@@ -128,14 +226,11 @@ function nextServerDataRegisterWriter(ctr: ReadableStreamDefaultController) {
       ctr.enqueue(typeof val === 'string' ? encoder.encode(val) : val)
     })
     if (initialServerDataLoaded && !initialServerDataFlushed) {
-      // Instant Navigation Testing API: don't close or error the inline
-      // Flight stream. The static shell has no inline Flight data, so the
-      // stream is empty. Closing it would cause React to log an error about
-      // missing data. Leaving it open lets React treat any holes as
-      // "still suspended." Hydration uses the separately fetched RSC payload
-      // (self.__next_instant_test), not this stream.
+      // Locked static shells do not have a real inline Flight stream. Closing
+      // or erroring this stream causes React to report a missing-data failure,
+      // but the actual hydration data arrives through a separate response.
       if (isStreamErrorOrUnfinished(ctr)) {
-        if (!instantTestStaticFetch) {
+        if (!hasLockedStaticShell) {
           ctr.error(
             new Error(
               'The connection to the page was unexpectedly closed, possibly due to the stop button being clicked, loss of Wi-Fi, or an unstable internet connection.'
@@ -155,7 +250,11 @@ function nextServerDataRegisterWriter(ctr: ReadableStreamDefaultController) {
 
 // When `DOMContentLoaded`, we can close all pending writers to finish hydration.
 const DOMContentLoaded = function () {
-  if (initialServerDataWriter && !initialServerDataFlushed) {
+  if (
+    initialServerDataWriter &&
+    !initialServerDataFlushed &&
+    !hasLockedStaticShell
+  ) {
     initialServerDataWriter.close()
     initialServerDataFlushed = true
     initialServerDataBuffer = undefined
@@ -187,7 +286,7 @@ let readable: ReadableStream<Uint8Array> = new ReadableStream({
   },
 })
 if (process.env.NODE_ENV !== 'production') {
-  // @ts-expect-error
+  // @ts-expect-error name is a dev-only debugging affordance.
   readable.name = 'hydration'
 }
 
@@ -196,9 +295,25 @@ if (process.env.NODE_ENV !== 'production') {
 // know if `l` is present until React decodes the payload, so always tee and
 // cancel the clone if not needed.
 let initialFlightStreamForCache: ReadableStream<Uint8Array> | null = null
+let initialFlightStreamForOfflineNavigationCache: ReadableStream<Uint8Array> | null =
+  null
+if (
+  process.env.__NEXT_OFFLINE_NAVIGATIONS &&
+  process.env.NODE_ENV === 'production' &&
+  process.env.__NEXT_CONFIG_OUTPUT !== 'export' &&
+  !process.env.__NEXT_DEV_SERVER &&
+  !hasLockedStaticShell
+) {
+  // Normal online loads should hydrate from the original stream while a tee
+  // persists the same RSC payload for future offline reloads.
+  const [forApp, forOfflineNavigationCache] = readable.tee()
+  readable = forApp
+  initialFlightStreamForOfflineNavigationCache = forOfflineNavigationCache
+}
 if (
   process.env.__NEXT_CACHE_COMPONENTS &&
-  process.env.__NEXT_EXPERIMENTAL_CACHED_NAVIGATIONS
+  process.env.__NEXT_EXPERIMENTAL_CACHED_NAVIGATIONS &&
+  !offlineNavigationClientResumeFetch
 ) {
   const [forReact, forCache] = readable.tee()
   readable = forReact
@@ -242,13 +357,27 @@ if (instantTestStaticFetch) {
       initialRSCPayload
     )
   })
-} else if (
-  // @ts-expect-error
-  window.__NEXT_CLIENT_RESUME
-) {
-  const clientResumeFetch: Promise<Response> =
-    // @ts-expect-error
-    window.__NEXT_CLIENT_RESUME
+} else if (offlineNavigationClientResumeFetch) {
+  initialServerResponse = Promise.resolve(
+    createFromFetch<InitialRSCPayload>(offlineNavigationClientResumeFetch, {
+      callServer,
+      findSourceMapURL,
+      debugChannel,
+      unstable_allowPartialStream: true,
+    })
+  ).then(async (fallbackInitialRSCPayload) => {
+    const fallbackResponse = await offlineNavigationFallbackResponse!
+    if (fallbackResponse.requestKind === 'initial-load') {
+      return fallbackInitialRSCPayload
+    }
+
+    return createInitialRSCPayloadFromFallbackPrerender(
+      fallbackResponse.response,
+      fallbackInitialRSCPayload
+    )
+  })
+} else if (window.__NEXT_CLIENT_RESUME) {
+  const clientResumeFetch: Promise<Response> = window.__NEXT_CLIENT_RESUME
   initialServerResponse = Promise.resolve(
     createFromFetch<InitialRSCPayload>(clientResumeFetch, {
       callServer,
@@ -365,7 +494,11 @@ export async function hydrate(
   // Initialize the offline module to register browser event listeners
   // (offline/online) before any components hydrate.
   if (process.env.__NEXT_USE_OFFLINE) {
-    require('./components/offline') as typeof import('./components/offline')
+    const { notifyOffline } =
+      require('./components/offline') as typeof import('./components/offline')
+    if (offlineNavigationClientResumeFetch) {
+      notifyOffline()
+    }
   }
 
   // setNavigationBuildId should be called only once, during JS initialization
@@ -392,6 +525,7 @@ export async function hydrate(
       navigatedAt: initialTimestamp,
       initialRSCPayload,
       initialFlightStreamForCache,
+      initialFlightStreamForOfflineNavigationCache,
       location: window.location,
     }),
     instrumentationHooks
@@ -412,9 +546,13 @@ export async function hydrate(
     </StrictModeIfEnabled>
   )
 
-  if (document.documentElement.id === '__next_error__') {
+  if (
+    document.documentElement.id === '__next_error__' ||
+    isOfflineNavigationFallbackDocument()
+  ) {
     let element = reactEl
-    // Server rendering failed, fall back to client-side rendering
+    // Error documents and generated offline navigation fallback documents do
+    // not contain route HTML that can be hydrated.
     if (process.env.NODE_ENV !== 'production') {
       const { RootLevelDevOverlayElement } =
         require('../next-devtools/userspace/app/client-entry') as typeof import('../next-devtools/userspace/app/client-entry')

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -227,7 +227,6 @@ export function createInitialRouterState({
 
   persistInitialOfflineNavigationResponse({
     initialCouldBeIntercepted,
-    initialDynamicStaleTimeSeconds,
     initialFlightStreamForOfflineNavigationCache,
     initialRuntimePrefetchStream,
     initialStaleAt,
@@ -283,7 +282,6 @@ export function createInitialRouterState({
 
 function persistInitialOfflineNavigationResponse({
   initialCouldBeIntercepted,
-  initialDynamicStaleTimeSeconds,
   initialFlightStreamForOfflineNavigationCache,
   initialRuntimePrefetchStream,
   initialStaleAt,
@@ -293,7 +291,6 @@ function persistInitialOfflineNavigationResponse({
   navigatedAt,
 }: {
   initialCouldBeIntercepted: boolean
-  initialDynamicStaleTimeSeconds: number | undefined
   initialFlightStreamForOfflineNavigationCache:
     | ReadableStream<Uint8Array>
     | null
@@ -308,23 +305,38 @@ function persistInitialOfflineNavigationResponse({
   // Online document loads can seed the exact-URL offline cache by teeing the
   // inline RSC stream. This gives the generated fallback document something
   // to replay later even if the user never performed a soft navigation.
+  //
+  // Keep the cache module behind the compile-time flag. Once enabled, the
+  // shared skip-reason helper keeps initial loads and soft navigations aligned
+  // on which RSC responses are complete enough to persist.
   if (process.env.__NEXT_OFFLINE_NAVIGATIONS) {
     if (initialFlightStreamForOfflineNavigationCache == null) {
       return
     }
 
-    if (
-      process.env.__NEXT_DEV_SERVER ||
-      process.env.NODE_ENV !== 'production' ||
-      process.env.__NEXT_CONFIG_OUTPUT === 'export' ||
-      location === null ||
-      !initialSupportsPerSegmentPrefetching ||
-      initialCouldBeIntercepted ||
-      initialDynamicStaleTimeSeconds !== undefined ||
-      initialRuntimePrefetchStream !== undefined ||
-      initialStaleAt === null ||
-      initialStaticStageByteLength !== undefined
-    ) {
+    if (location === null || initialStaleAt === null) {
+      initialFlightStreamForOfflineNavigationCache.cancel()
+      return
+    }
+
+    const url = createHrefFromUrl(location)
+
+    const {
+      createOfflineNavigationRSCResponsePayload,
+      getOfflineNavigationRSCResponseCacheSkipReason,
+      writeOfflineNavigationRSCResponseCacheEntry,
+    } =
+      require('./offline-navigation-cache') as typeof import('./offline-navigation-cache')
+
+    const skipReason = getOfflineNavigationRSCResponseCacheSkipReason({
+      requestKind: 'initial-load',
+      hasPartialResponse: initialStaticStageByteLength !== undefined,
+      hasRuntimePrefetch: initialRuntimePrefetchStream !== undefined,
+      isInterception: initialCouldBeIntercepted,
+      supportsPerSegmentPrefetching: initialSupportsPerSegmentPrefetching,
+      url,
+    })
+    if (skipReason !== null) {
       initialFlightStreamForOfflineNavigationCache.cancel()
       return
     }
@@ -338,14 +350,8 @@ function persistInitialOfflineNavigationResponse({
       }
     )
     Object.defineProperty(response, 'url', {
-      value: createHrefFromUrl(location),
+      value: url,
     })
-
-    const {
-      createOfflineNavigationRSCResponsePayload,
-      writeOfflineNavigationRSCResponseCacheEntry,
-    } =
-      require('./offline-navigation-cache') as typeof import('./offline-navigation-cache')
 
     const payload = createOfflineNavigationRSCResponsePayload(
       response,
@@ -358,14 +364,13 @@ function persistInitialOfflineNavigationResponse({
         expiresAt: staleAt,
         payload,
         staleAt,
-        url: createHrefFromUrl(location),
+        url,
         now: navigatedAt,
       })
     })().catch(() => {
       // The page already rendered. Offline persistence must not affect boot.
     })
   } else {
-    initialFlightStreamForOfflineNavigationCache?.cancel()
     return
   }
 }

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -21,11 +21,13 @@ import {
 import { decodeStaticStage } from './fetch-server-response'
 import { discoverKnownRoute } from '../segment-cache/optimistic-routes'
 import type { NormalizedSearch } from '../segment-cache/cache-key'
+import { RSC_CONTENT_TYPE_HEADER } from '../app-router-headers'
 
 export interface InitialRouterStateParameters {
   navigatedAt: number
   initialRSCPayload: InitialRSCPayload
   initialFlightStreamForCache?: ReadableStream<Uint8Array> | null
+  initialFlightStreamForOfflineNavigationCache?: ReadableStream<Uint8Array> | null
   location: Location | null
 }
 
@@ -33,6 +35,7 @@ export function createInitialRouterState({
   navigatedAt,
   initialRSCPayload,
   initialFlightStreamForCache,
+  initialFlightStreamForOfflineNavigationCache,
   location,
 }: InitialRouterStateParameters): AppRouterState {
   const {
@@ -88,6 +91,12 @@ export function createInitialRouterState({
     acc
   )
   const metadataVaryPath = acc.metadataVaryPath
+  const initialStaleAt =
+    location === null ||
+    initialSeedData === null ||
+    initialStaticStageByteLength !== undefined
+      ? null
+      : getStaleAt(navigatedAt, initialStaleTime)
   const initialTask = createInitialCacheNodeForHydration(
     navigatedAt,
     initialRouteTree,
@@ -157,7 +166,7 @@ export function createInitialRouterState({
         // hydration and write it into the cache directly.
         const now = Date.now()
 
-        getStaleAt(now, initialStaleTime)
+        initialStaleAt!
           .then((staleAt) => {
             writeStaticStageResponseIntoCache(
               now,
@@ -216,6 +225,18 @@ export function createInitialRouterState({
     }
   }
 
+  persistInitialOfflineNavigationResponse({
+    initialCouldBeIntercepted,
+    initialDynamicStaleTimeSeconds,
+    initialFlightStreamForOfflineNavigationCache,
+    initialRuntimePrefetchStream,
+    initialStaleAt,
+    initialStaticStageByteLength,
+    initialSupportsPerSegmentPrefetching,
+    location,
+    navigatedAt,
+  })
+
   // NOTE: We intentionally don't check if any data needs to be fetched from the
   // server. We assume the initial hydration payload is sufficient to render
   // the page.
@@ -258,4 +279,93 @@ export function createInitialRouterState({
   }
 
   return initialState
+}
+
+function persistInitialOfflineNavigationResponse({
+  initialCouldBeIntercepted,
+  initialDynamicStaleTimeSeconds,
+  initialFlightStreamForOfflineNavigationCache,
+  initialRuntimePrefetchStream,
+  initialStaleAt,
+  initialStaticStageByteLength,
+  initialSupportsPerSegmentPrefetching,
+  location,
+  navigatedAt,
+}: {
+  initialCouldBeIntercepted: boolean
+  initialDynamicStaleTimeSeconds: number | undefined
+  initialFlightStreamForOfflineNavigationCache:
+    | ReadableStream<Uint8Array>
+    | null
+    | undefined
+  initialRuntimePrefetchStream: ReadableStream<Uint8Array> | undefined
+  initialStaleAt: Promise<number> | null
+  initialStaticStageByteLength: Promise<number> | undefined
+  initialSupportsPerSegmentPrefetching: boolean
+  location: Location | null
+  navigatedAt: number
+}): void {
+  // Online document loads can seed the exact-URL offline cache by teeing the
+  // inline RSC stream. This gives the generated fallback document something
+  // to replay later even if the user never performed a soft navigation.
+  if (process.env.__NEXT_OFFLINE_NAVIGATIONS) {
+    if (initialFlightStreamForOfflineNavigationCache == null) {
+      return
+    }
+
+    if (
+      process.env.__NEXT_DEV_SERVER ||
+      process.env.NODE_ENV !== 'production' ||
+      process.env.__NEXT_CONFIG_OUTPUT === 'export' ||
+      location === null ||
+      !initialSupportsPerSegmentPrefetching ||
+      initialCouldBeIntercepted ||
+      initialDynamicStaleTimeSeconds !== undefined ||
+      initialRuntimePrefetchStream !== undefined ||
+      initialStaleAt === null ||
+      initialStaticStageByteLength !== undefined
+    ) {
+      initialFlightStreamForOfflineNavigationCache.cancel()
+      return
+    }
+
+    const response = new Response(
+      initialFlightStreamForOfflineNavigationCache,
+      {
+        headers: { 'content-type': RSC_CONTENT_TYPE_HEADER },
+        status: 200,
+        statusText: 'OK',
+      }
+    )
+    Object.defineProperty(response, 'url', {
+      value: createHrefFromUrl(location),
+    })
+
+    const {
+      createOfflineNavigationRSCResponsePayload,
+      writeOfflineNavigationRSCResponseCacheEntry,
+    } =
+      require('./offline-navigation-cache') as typeof import('./offline-navigation-cache')
+
+    const payload = createOfflineNavigationRSCResponsePayload(
+      response,
+      'initial-load'
+    ).catch(() => null)
+
+    void (async () => {
+      const staleAt = await initialStaleAt
+      await writeOfflineNavigationRSCResponseCacheEntry({
+        expiresAt: staleAt,
+        payload,
+        staleAt,
+        url: createHrefFromUrl(location),
+        now: navigatedAt,
+      })
+    })().catch(() => {
+      // The page already rendered. Offline persistence must not affect boot.
+    })
+  } else {
+    initialFlightStreamForOfflineNavigationCache?.cancel()
+    return
+  }
 }

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -48,7 +48,10 @@ import {
   getStaleAt,
 } from '../segment-cache/cache'
 import { UnknownDynamicStaleTime } from '../segment-cache/bfcache'
-import type { OfflineNavigationRSCResponsePayload } from './offline-navigation-cache'
+import type {
+  OfflineNavigationRSCResponsePayload,
+  OfflineNavigationRSCResponseRequestKind,
+} from './offline-navigation-cache'
 
 const createFromReadableStream =
   createFromReadableStreamBrowser as (typeof import('react-server-dom-webpack/client.browser'))['createFromReadableStream']
@@ -387,6 +390,7 @@ export type RSCResponse<T> = {
   url: string
   flightResponsePromise: (Promise<T> & { _debugInfo?: Array<any> }) | null
   cacheData: Promise<FetchResponseCacheData | null>
+  offlineNavigationCacheRequestKind: OfflineNavigationRSCResponseRequestKind | null
   offlineNavigationCachePayload: Promise<OfflineNavigationRSCResponsePayload | null> | null
 }
 
@@ -568,8 +572,13 @@ export async function createFetch<T>(
   let fetchUrl = new URL(url)
   await setCacheBustingSearchParam(fetchUrl, headers)
   let processed = fetch(fetchUrl, fetchOptions).then(processFetch)
+  const offlineNavigationCacheRequestKind =
+    getOfflineNavigationCacheRequestKind(headers)
   let offlineNavigationCachePayload =
-    createOfflineNavigationCachePayloadFromProcessedResponse(processed, headers)
+    createOfflineNavigationCachePayloadFromProcessedResponse(
+      processed,
+      offlineNavigationCacheRequestKind
+    )
   let fetchPromise = processed.then(({ response }) => response)
 
   // Immediately pass the fetch promise to the Flight client so that the debug
@@ -643,7 +652,7 @@ export async function createFetch<T>(
       offlineNavigationCachePayload =
         createOfflineNavigationCachePayloadFromProcessedResponse(
           processed,
-          headers
+          offlineNavigationCacheRequestKind
         )
       fetchPromise = processed.then(({ response }) => response)
       flightResponsePromise = shouldImmediatelyDecode
@@ -684,6 +693,7 @@ export async function createFetch<T>(
 
     cacheData: processed.then(({ cacheData }) => cacheData),
 
+    offlineNavigationCacheRequestKind,
     offlineNavigationCachePayload,
   }
 
@@ -733,10 +743,9 @@ function createOfflineNavigationCachePayloadFromProcessedResponse(
     response: Response
     cacheData: FetchResponseCacheData | null
   }>,
-  headers: RequestHeaders
+  requestKind: OfflineNavigationRSCResponseRequestKind | null
 ): Promise<OfflineNavigationRSCResponsePayload | null> | null {
   const offlineNavigationCache = getOfflineNavigationCacheModule()
-  const requestKind = getOfflineNavigationCacheRequestKind(headers)
   if (requestKind === null || offlineNavigationCache === null) {
     return null
   }
@@ -775,22 +784,27 @@ function persistOfflineNavigationResponse({
   // Soft navigations are persisted after the router has accepted the response,
   // so normal navigation remains the source of truth and offline persistence is
   // only a best-effort side effect.
+  //
+  // The shared helper deliberately treats unsupported or incomplete responses
+  // as cache misses. It must not change the already-accepted navigation.
   const offlineNavigationCache = getOfflineNavigationCacheModule()
   if (offlineNavigationCache === null) {
     return
   }
 
-  if (
-    response.offlineNavigationCachePayload === null ||
-    !flightResponse.S ||
-    flightResponse.d !== undefined ||
-    flightResponse.p !== undefined ||
-    interception ||
-    isHmrRefresh ||
-    postponed ||
-    response.redirected ||
-    canonicalUrl.origin !== location.origin
-  ) {
+  const skipReason =
+    offlineNavigationCache.getOfflineNavigationRSCResponseCacheSkipReason({
+      requestKind: response.offlineNavigationCacheRequestKind,
+      hasCachePayload: response.offlineNavigationCachePayload !== null,
+      supportsPerSegmentPrefetching: flightResponse.S,
+      hasRuntimePrefetch: flightResponse.p !== undefined,
+      isHmrRefresh: isHmrRefresh === true,
+      isInterception: interception,
+      isPostponed: postponed,
+      isRedirected: response.redirected,
+      url: canonicalUrl,
+    })
+  if (skipReason !== null) {
     return
   }
 

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -16,8 +16,8 @@ import type {
 } from '../../../shared/lib/app-router-types'
 
 import {
-  type NEXT_ROUTER_PREFETCH_HEADER,
-  type NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
+  NEXT_ROUTER_PREFETCH_HEADER,
+  NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
   type NEXT_INSTANT_PREFETCH_HEADER,
   NEXT_ROUTER_STATE_TREE_HEADER,
   NEXT_RSC_UNION_QUERY,
@@ -45,13 +45,35 @@ import { NEXT_NAV_DEPLOYMENT_ID_HEADER } from '../../../lib/constants'
 import {
   stripIsPartialByte,
   createNonTaskyPrefetchResponseStream,
+  getStaleAt,
 } from '../segment-cache/cache'
 import { UnknownDynamicStaleTime } from '../segment-cache/bfcache'
+import type { OfflineNavigationRSCResponsePayload } from './offline-navigation-cache'
 
 const createFromReadableStream =
   createFromReadableStreamBrowser as (typeof import('react-server-dom-webpack/client.browser'))['createFromReadableStream']
 const createFromFetch =
   createFromFetchBrowser as (typeof import('react-server-dom-webpack/client.browser'))['createFromFetch']
+
+let offlineNavigationCacheModule:
+  | typeof import('./offline-navigation-cache')
+  | undefined
+
+// Keep the runtime require inside a compile-time flag branch so disabled builds
+// do not pull the offline cache module into client chunks.
+function getOfflineNavigationCacheModule():
+  | typeof import('./offline-navigation-cache')
+  | null {
+  if (process.env.__NEXT_OFFLINE_NAVIGATIONS) {
+    if (offlineNavigationCacheModule === undefined) {
+      offlineNavigationCacheModule =
+        require('./offline-navigation-cache') as typeof import('./offline-navigation-cache')
+    }
+    return offlineNavigationCacheModule
+  } else {
+    return null
+  }
+}
 
 let createDebugChannel:
   | typeof import('../../dev/debug-channel').createDebugChannel
@@ -275,6 +297,16 @@ export async function fetchServerResponse(
       return doMpaNavigation(normalizedFlightData)
     }
 
+    persistOfflineNavigationResponse({
+      canonicalUrl,
+      flightResponse,
+      interception,
+      isHmrRefresh: options.isHmrRefresh,
+      originalUrl,
+      postponed,
+      response: res,
+    })
+
     const staticStageData =
       cacheData !== null
         ? await resolveStaticStageData(cacheData, flightResponse, headers)
@@ -355,6 +387,7 @@ export type RSCResponse<T> = {
   url: string
   flightResponsePromise: (Promise<T> & { _debugInfo?: Array<any> }) | null
   cacheData: Promise<FetchResponseCacheData | null>
+  offlineNavigationCachePayload: Promise<OfflineNavigationRSCResponsePayload | null> | null
 }
 
 type FetchResponseCacheData = {
@@ -535,6 +568,8 @@ export async function createFetch<T>(
   let fetchUrl = new URL(url)
   await setCacheBustingSearchParam(fetchUrl, headers)
   let processed = fetch(fetchUrl, fetchOptions).then(processFetch)
+  let offlineNavigationCachePayload =
+    createOfflineNavigationCachePayloadFromProcessedResponse(processed, headers)
   let fetchPromise = processed.then(({ response }) => response)
 
   // Immediately pass the fetch promise to the Flight client so that the debug
@@ -605,6 +640,11 @@ export async function createFetch<T>(
       fetchUrl = new URL(responseUrl)
       await setCacheBustingSearchParam(fetchUrl, headers)
       processed = fetch(fetchUrl, fetchOptions).then(processFetch)
+      offlineNavigationCachePayload =
+        createOfflineNavigationCachePayloadFromProcessedResponse(
+          processed,
+          headers
+        )
       fetchPromise = processed.then(({ response }) => response)
       flightResponsePromise = shouldImmediatelyDecode
         ? createFromNextFetch<T>(fetchPromise, headers)
@@ -643,9 +683,130 @@ export async function createFetch<T>(
     flightResponsePromise: flightResponsePromise,
 
     cacheData: processed.then(({ cacheData }) => cacheData),
+
+    offlineNavigationCachePayload,
   }
 
   return rscResponse
+}
+
+function getOfflineNavigationCacheRequestKind(
+  headers: RequestHeaders
+): 'navigation' | 'route-prefetch' | 'client-resume' | null {
+  if (
+    !process.env.__NEXT_OFFLINE_NAVIGATIONS ||
+    process.env.__NEXT_DEV_SERVER ||
+    process.env.NODE_ENV !== 'production' ||
+    process.env.__NEXT_CONFIG_OUTPUT === 'export' ||
+    headers[NEXT_HMR_REFRESH_HEADER]
+  ) {
+    return null
+  }
+
+  if (
+    headers[NEXT_ROUTER_PREFETCH_HEADER] !== undefined &&
+    headers[NEXT_ROUTER_SEGMENT_PREFETCH_HEADER] === '/_full'
+  ) {
+    return 'client-resume'
+  }
+
+  if (
+    headers[NEXT_ROUTER_PREFETCH_HEADER] !== undefined &&
+    headers[NEXT_ROUTER_SEGMENT_PREFETCH_HEADER] === undefined
+  ) {
+    return 'route-prefetch'
+  }
+
+  if (
+    headers[NEXT_ROUTER_STATE_TREE_HEADER] !== undefined &&
+    headers[NEXT_ROUTER_PREFETCH_HEADER] === undefined &&
+    headers[NEXT_ROUTER_SEGMENT_PREFETCH_HEADER] === undefined
+  ) {
+    return 'navigation'
+  }
+
+  return null
+}
+
+function createOfflineNavigationCachePayloadFromProcessedResponse(
+  processed: Promise<{
+    response: Response
+    cacheData: FetchResponseCacheData | null
+  }>,
+  headers: RequestHeaders
+): Promise<OfflineNavigationRSCResponsePayload | null> | null {
+  const offlineNavigationCache = getOfflineNavigationCacheModule()
+  const requestKind = getOfflineNavigationCacheRequestKind(headers)
+  if (requestKind === null || offlineNavigationCache === null) {
+    return null
+  }
+
+  return processed
+    .then(({ response }) => {
+      if (!response.ok || !response.body) {
+        return null
+      }
+
+      return offlineNavigationCache.createOfflineNavigationRSCResponsePayload(
+        response,
+        requestKind
+      )
+    })
+    .catch(() => null)
+}
+
+function persistOfflineNavigationResponse({
+  canonicalUrl,
+  flightResponse,
+  interception,
+  isHmrRefresh,
+  originalUrl,
+  postponed,
+  response,
+}: {
+  canonicalUrl: URL
+  flightResponse: NavigationFlightResponse
+  interception: boolean
+  isHmrRefresh: boolean | undefined
+  originalUrl: URL
+  postponed: boolean
+  response: RSCResponse<NavigationFlightResponse>
+}): void {
+  // Soft navigations are persisted after the router has accepted the response,
+  // so normal navigation remains the source of truth and offline persistence is
+  // only a best-effort side effect.
+  const offlineNavigationCache = getOfflineNavigationCacheModule()
+  if (offlineNavigationCache === null) {
+    return
+  }
+
+  if (
+    response.offlineNavigationCachePayload === null ||
+    !flightResponse.S ||
+    flightResponse.d !== undefined ||
+    flightResponse.p !== undefined ||
+    interception ||
+    isHmrRefresh ||
+    postponed ||
+    response.redirected ||
+    canonicalUrl.origin !== location.origin
+  ) {
+    return
+  }
+
+  void (async () => {
+    const now = Date.now()
+    const staleAt = await getStaleAt(now, flightResponse.s, response)
+    await offlineNavigationCache.writeOfflineNavigationRSCResponseCacheEntry({
+      buildId:
+        response.headers.get(NEXT_NAV_DEPLOYMENT_ID_HEADER) ?? flightResponse.b,
+      expiresAt: staleAt,
+      payload: response.offlineNavigationCachePayload!,
+      staleAt,
+      url: originalUrl,
+      now,
+    })
+  })()
 }
 
 export function createFromNextReadableStream<T>(

--- a/packages/next/src/client/components/router-reducer/offline-navigation-cache.test.ts
+++ b/packages/next/src/client/components/router-reducer/offline-navigation-cache.test.ts
@@ -3,10 +3,14 @@ import {
   createOfflineNavigationRSCResponse,
   createOfflineNavigationRSCResponsePayload,
   deleteOfflineNavigationCacheEntry,
+  getOfflineNavigationRSCResponseCacheSkipReason,
+  invalidateOfflineNavigationCacheEntries,
   isOfflineNavigationRSCResponsePayload,
   normalizeOfflineNavigationCacheUrl,
   readOfflineNavigationCacheEntry,
   writeOfflineNavigationCacheEntry,
+  type OfflineNavigationRSCResponseCacheEligibility,
+  type OfflineNavigationRSCResponseCacheSkipReason,
   type OfflineNavigationCacheEntry,
   type OfflineNavigationCacheStorage,
 } from './offline-navigation-cache'
@@ -17,6 +21,7 @@ class MemoryOfflineNavigationCacheStorage
   implements OfflineNavigationCacheStorage
 {
   entries = new Map<string, OfflineNavigationCacheEntry>()
+  cacheEpoch = 0
 
   async get(key: CacheKey): Promise<OfflineNavigationCacheEntry | undefined> {
     return this.entries.get(this.getKey(key))
@@ -36,6 +41,15 @@ class MemoryOfflineNavigationCacheStorage
         this.entries.delete(key)
       }
     }
+  }
+
+  async getCacheEpoch(): Promise<number> {
+    return this.cacheEpoch
+  }
+
+  async incrementCacheEpoch(): Promise<number> {
+    this.cacheEpoch++
+    return this.cacheEpoch
   }
 
   private getKey(key: CacheKey): string {
@@ -61,6 +75,86 @@ class FailingOfflineNavigationCacheStorage
   async deleteBuild(): Promise<void> {
     throw new Error('delete build failed')
   }
+
+  async getCacheEpoch(): Promise<number> {
+    throw new Error('get epoch failed')
+  }
+
+  async incrementCacheEpoch(): Promise<number> {
+    throw new Error('increment epoch failed')
+  }
+}
+
+type OfflineNavigationEnvKey =
+  | '__NEXT_CONFIG_OUTPUT'
+  | '__NEXT_DEV_SERVER'
+  | '__NEXT_OFFLINE_NAVIGATIONS'
+  | 'NODE_ENV'
+
+const offlineNavigationEnvKeys: Array<OfflineNavigationEnvKey> = [
+  '__NEXT_CONFIG_OUTPUT',
+  '__NEXT_DEV_SERVER',
+  '__NEXT_OFFLINE_NAVIGATIONS',
+  'NODE_ENV',
+]
+
+function withOfflineNavigationCacheEnv<T>(
+  env: Partial<Record<OfflineNavigationEnvKey, string | undefined>>,
+  test: () => T
+): T {
+  const originalEnv: Partial<
+    Record<OfflineNavigationEnvKey, string | undefined>
+  > = {}
+
+  for (const key of offlineNavigationEnvKeys) {
+    originalEnv[key] = process.env[key]
+  }
+
+  const writableEnv = process.env as Record<string, string | undefined>
+
+  for (const key of offlineNavigationEnvKeys) {
+    const value = env[key]
+    if (value === undefined) {
+      delete writableEnv[key]
+    } else {
+      writableEnv[key] = value
+    }
+  }
+
+  try {
+    return test()
+  } finally {
+    for (const key of offlineNavigationEnvKeys) {
+      const value = originalEnv[key]
+      if (value === undefined) {
+        delete writableEnv[key]
+      } else {
+        writableEnv[key] = value
+      }
+    }
+  }
+}
+
+function getCacheSkipReason(
+  eligibility: Partial<OfflineNavigationRSCResponseCacheEligibility> = {},
+  env: Partial<Record<OfflineNavigationEnvKey, string | undefined>> = {}
+) {
+  return withOfflineNavigationCacheEnv(
+    {
+      __NEXT_CONFIG_OUTPUT: undefined,
+      __NEXT_DEV_SERVER: undefined,
+      __NEXT_OFFLINE_NAVIGATIONS: 'true',
+      NODE_ENV: 'production',
+      ...env,
+    },
+    () =>
+      getOfflineNavigationRSCResponseCacheSkipReason({
+        origin: 'https://example.com',
+        requestKind: 'navigation',
+        url: 'https://example.com/dashboard',
+        ...eligibility,
+      })
+  )
 }
 
 describe('offline navigation cache', () => {
@@ -70,6 +164,23 @@ describe('offline navigation cache', () => {
         'https://example.com/dashboard?tab=activity#settings'
       )
     ).toBe('https://example.com/dashboard?tab=activity')
+  })
+
+  it('preserves encoded query values and duplicate search param order', () => {
+    const first = normalizeOfflineNavigationCacheUrl(
+      'https://example.com/docs/url-stress/space%20value/?token=a%2Bb&tag=one&tag=two#section-1'
+    )
+    const reordered = normalizeOfflineNavigationCacheUrl(
+      'https://example.com/docs/url-stress/space%20value/?tag=one&tag=two&token=a%2Bb#section-1'
+    )
+
+    expect(first).toBe(
+      'https://example.com/docs/url-stress/space%20value?token=a%2Bb&tag=one&tag=two'
+    )
+    expect(reordered).toBe(
+      'https://example.com/docs/url-stress/space%20value?tag=one&tag=two&token=a%2Bb'
+    )
+    expect(first).not.toBe(reordered)
   })
 
   it('normalizes exact URL keys with the configured trailing slash', () => {
@@ -113,10 +224,11 @@ describe('offline navigation cache', () => {
         now: 150,
       })
     ).resolves.toEqual({
-      version: 1,
+      version: 2,
       kind: 'exact-url',
       buildId: 'build-a',
       url: 'https://example.com/dashboard?tab=activity',
+      cacheEpoch: 0,
       createdAt: 100,
       staleAt: 200,
       expiresAt: 300,
@@ -192,6 +304,7 @@ describe('offline navigation cache', () => {
       })
     ).resolves.toMatchObject({
       buildId: 'build-a',
+      cacheEpoch: 0,
       createdAt: 100,
       payload: {
         kind: 'rsc-response',
@@ -216,6 +329,61 @@ describe('offline navigation cache', () => {
     })
   })
 
+  it('returns cache eligibility skip reasons for unsupported RSC responses', () => {
+    const cases: Array<{
+      expected: OfflineNavigationRSCResponseCacheSkipReason
+      eligibility?: Partial<OfflineNavigationRSCResponseCacheEligibility>
+      env?: Partial<Record<OfflineNavigationEnvKey, string | undefined>>
+    }> = [
+      {
+        expected: 'disabled',
+        env: { __NEXT_OFFLINE_NAVIGATIONS: undefined },
+      },
+      { expected: 'dev-server', env: { __NEXT_DEV_SERVER: 'true' } },
+      { expected: 'not-production', env: { NODE_ENV: 'development' } },
+      { expected: 'output-export', env: { __NEXT_CONFIG_OUTPUT: 'export' } },
+      { expected: 'unsupported-request', eligibility: { requestKind: null } },
+      { expected: 'missing-payload', eligibility: { hasCachePayload: false } },
+      {
+        expected: 'cross-origin',
+        eligibility: { url: 'https://external.example/dashboard' },
+      },
+      {
+        expected: 'unsupported-segment-prefetching',
+        eligibility: { supportsPerSegmentPrefetching: false },
+      },
+      {
+        expected: 'runtime-prefetch',
+        eligibility: { hasRuntimePrefetch: true },
+      },
+      {
+        expected: 'partial-response',
+        eligibility: { hasPartialResponse: true },
+      },
+      { expected: 'hmr-refresh', eligibility: { isHmrRefresh: true } },
+      { expected: 'interception', eligibility: { isInterception: true } },
+      { expected: 'postponed', eligibility: { isPostponed: true } },
+      { expected: 'redirected', eligibility: { isRedirected: true } },
+    ]
+
+    for (const { expected, eligibility, env } of cases) {
+      expect(getCacheSkipReason(eligibility, env)).toBe(expected)
+    }
+  })
+
+  it('allows eligible same-origin RSC responses in production', () => {
+    expect(getCacheSkipReason()).toBe(null)
+  })
+
+  it('allows initial-load RSC responses without per-segment prefetch support', () => {
+    expect(
+      getCacheSkipReason({
+        requestKind: 'initial-load',
+        supportsPerSegmentPrefetching: false,
+      })
+    ).toBe(null)
+  })
+
   it('deletes exact URL entries', async () => {
     const storage = new MemoryOfflineNavigationCacheStorage()
     const cache = createOfflineNavigationCache(storage)
@@ -233,16 +401,59 @@ describe('offline navigation cache', () => {
     await expect(cache.read(url, { buildId: 'build-a' })).resolves.toBe(null)
   })
 
+  it('invalidates exact URL entries with a durable cache epoch', async () => {
+    const storage = new MemoryOfflineNavigationCacheStorage()
+    const cache = createOfflineNavigationCache(storage)
+    const url = 'https://example.com/dashboard'
+
+    await cache.write({
+      buildId: 'build-a',
+      url,
+      now: 100,
+      staleAt: 200,
+      expiresAt: 300,
+      payload: 'stale payload',
+    })
+    await expect(
+      cache.read(url, { buildId: 'build-a', now: 150 })
+    ).resolves.toMatchObject({
+      cacheEpoch: 0,
+      payload: 'stale payload',
+    })
+
+    await expect(cache.invalidate()).resolves.toBe(true)
+    await expect(
+      cache.read(url, { buildId: 'build-a', now: 150 })
+    ).resolves.toBe(null)
+    expect(storage.entries.size).toBe(0)
+
+    await cache.write({
+      buildId: 'build-a',
+      url,
+      now: 175,
+      staleAt: 250,
+      expiresAt: 350,
+      payload: 'fresh payload',
+    })
+    await expect(
+      cache.read(url, { buildId: 'build-a', now: 200 })
+    ).resolves.toMatchObject({
+      cacheEpoch: 1,
+      payload: 'fresh payload',
+    })
+  })
+
   it('ignores and deletes entries whose stored build id does not match', async () => {
     const storage = new MemoryOfflineNavigationCacheStorage()
     const cache = createOfflineNavigationCache(storage)
     const url = 'https://example.com/dashboard'
 
     await storage.put({
-      version: 1,
+      version: 2,
       kind: 'exact-url',
       buildId: 'build-b',
       url,
+      cacheEpoch: 0,
       createdAt: 100,
       staleAt: 200,
       expiresAt: 300,
@@ -355,6 +566,7 @@ describe('offline navigation cache', () => {
       cache.delete('https://example.com/dashboard', { buildId: 'build-a' })
     ).resolves.toBe(false)
     await expect(cache.deleteBuild('build-a')).resolves.toBe(false)
+    await expect(cache.invalidate()).resolves.toBe(false)
   })
 
   it('is a no-op when IndexedDB is unavailable', async () => {
@@ -387,6 +599,9 @@ describe('offline navigation cache', () => {
           buildId: 'build-a',
         })
       ).resolves.toBe(false)
+      await expect(invalidateOfflineNavigationCacheEntries()).resolves.toBe(
+        false
+      )
     } finally {
       if (originalIndexedDB) {
         Object.defineProperty(globalThis, 'indexedDB', originalIndexedDB)

--- a/packages/next/src/client/components/router-reducer/offline-navigation-cache.test.ts
+++ b/packages/next/src/client/components/router-reducer/offline-navigation-cache.test.ts
@@ -1,6 +1,9 @@
 import {
   createOfflineNavigationCache,
+  createOfflineNavigationRSCResponse,
+  createOfflineNavigationRSCResponsePayload,
   deleteOfflineNavigationCacheEntry,
+  isOfflineNavigationRSCResponsePayload,
   normalizeOfflineNavigationCacheUrl,
   readOfflineNavigationCacheEntry,
   writeOfflineNavigationCacheEntry,
@@ -69,6 +72,26 @@ describe('offline navigation cache', () => {
     ).toBe('https://example.com/dashboard?tab=activity')
   })
 
+  it('normalizes exact URL keys with the configured trailing slash', () => {
+    const originalTrailingSlash = process.env.__NEXT_TRAILING_SLASH
+    process.env.__NEXT_TRAILING_SLASH = 'true'
+
+    try {
+      expect(
+        normalizeOfflineNavigationCacheUrl('https://example.com/dashboard')
+      ).toBe('https://example.com/dashboard/')
+      expect(
+        normalizeOfflineNavigationCacheUrl('https://example.com/feed.xml')
+      ).toBe('https://example.com/feed.xml')
+    } finally {
+      if (originalTrailingSlash === undefined) {
+        delete process.env.__NEXT_TRAILING_SLASH
+      } else {
+        process.env.__NEXT_TRAILING_SLASH = originalTrailingSlash
+      }
+    }
+  })
+
   it('writes and reads exact URL entries for the current build', async () => {
     const storage = new MemoryOfflineNavigationCacheStorage()
     const cache = createOfflineNavigationCache(storage)
@@ -98,6 +121,98 @@ describe('offline navigation cache', () => {
       staleAt: 200,
       expiresAt: 300,
       payload: { tree: 'payload' },
+    })
+  })
+
+  it('serializes RSC response payloads for persisted navigation entries', async () => {
+    const response = new Response('0:["$","payload"]', {
+      headers: {
+        'content-type': 'text/x-component',
+        'x-nextjs-stale-time': '60',
+      },
+      status: 200,
+      statusText: 'OK',
+    })
+    Object.defineProperty(response, 'url', {
+      value: 'https://example.com/dashboard?_rsc=abc',
+    })
+
+    const payload = await createOfflineNavigationRSCResponsePayload(
+      response,
+      'route-prefetch'
+    )
+    expect(payload).toMatchObject({
+      version: 1,
+      kind: 'rsc-response',
+      requestKind: 'route-prefetch',
+      status: 200,
+      statusText: 'OK',
+      headers: expect.arrayContaining([
+        ['content-type', 'text/x-component'],
+        ['x-nextjs-stale-time', '60'],
+      ]),
+    })
+
+    const restoredResponse = createOfflineNavigationRSCResponse(payload)
+    expect(restoredResponse.url).toBe('https://example.com/dashboard?_rsc=abc')
+    await expect(restoredResponse.text()).resolves.toBe('0:["$","payload"]')
+    expect(isOfflineNavigationRSCResponsePayload(payload)).toBe(true)
+    expect(
+      isOfflineNavigationRSCResponsePayload({ ...payload, body: null })
+    ).toBe(false)
+  })
+
+  it('writes RSC response payloads through the exact URL cache', async () => {
+    const storage = new MemoryOfflineNavigationCacheStorage()
+    const cache = createOfflineNavigationCache(storage)
+    const payload = createOfflineNavigationRSCResponsePayload(
+      new Response('0:["$","payload"]'),
+      'navigation'
+    )
+
+    await expect(payload).resolves.toMatchObject({
+      kind: 'rsc-response',
+      requestKind: 'navigation',
+    })
+    await expect(
+      cache.write({
+        buildId: 'build-a',
+        expiresAt: 300,
+        payload: await payload,
+        staleAt: 200,
+        url: 'https://example.com/dashboard#section',
+        now: 100,
+      })
+    ).resolves.toBe(true)
+
+    await expect(
+      cache.read('https://example.com/dashboard', {
+        buildId: 'build-a',
+        now: 150,
+      })
+    ).resolves.toMatchObject({
+      buildId: 'build-a',
+      createdAt: 100,
+      payload: {
+        kind: 'rsc-response',
+        requestKind: 'navigation',
+      },
+      staleAt: 200,
+      expiresAt: 300,
+      url: 'https://example.com/dashboard',
+    })
+  })
+
+  it('accepts initial load RSC responses for offline document boot', async () => {
+    const payload = await createOfflineNavigationRSCResponsePayload(
+      new Response('0:["$","payload"]'),
+      'initial-load'
+    )
+
+    expect(isOfflineNavigationRSCResponsePayload(payload)).toBe(true)
+    expect(payload).toMatchObject({
+      kind: 'rsc-response',
+      requestKind: 'initial-load',
     })
   })
 

--- a/packages/next/src/client/components/router-reducer/offline-navigation-cache.ts
+++ b/packages/next/src/client/components/router-reducer/offline-navigation-cache.ts
@@ -1,4 +1,5 @@
 import { getNavigationBuildId } from '../../navigation-build-id'
+import { normalizePathTrailingSlash } from '../../normalize-trailing-slash'
 
 // Durable exact-URL RSC response storage for offline navigations. IndexedDB is
 // used instead of the service worker CacheStorage because the router needs
@@ -7,8 +8,14 @@ const DATABASE_NAME = 'next-offline-navigation-cache'
 const DATABASE_VERSION = 1
 const STORE_NAME = 'navigation-data'
 const ENTRY_VERSION = 1
+const RSC_RESPONSE_PAYLOAD_VERSION = 1
 
 type OfflineNavigationCacheKey = [buildId: string, url: string]
+type OfflineNavigationRSCResponseRequestKind =
+  | 'navigation'
+  | 'route-prefetch'
+  | 'client-resume'
+  | 'initial-load'
 
 export type OfflineNavigationCacheEntry = {
   version: typeof ENTRY_VERSION
@@ -19,6 +26,17 @@ export type OfflineNavigationCacheEntry = {
   staleAt: number
   expiresAt: number
   payload: unknown
+}
+
+export type OfflineNavigationRSCResponsePayload = {
+  version: typeof RSC_RESPONSE_PAYLOAD_VERSION
+  kind: 'rsc-response'
+  requestKind: OfflineNavigationRSCResponseRequestKind
+  url: string
+  status: number
+  statusText: string
+  headers: Array<[string, string]>
+  body: ArrayBuffer
 }
 
 export type OfflineNavigationCacheWrite = {
@@ -33,6 +51,15 @@ export type OfflineNavigationCacheWrite = {
 export type OfflineNavigationCacheReadOptions = {
   buildId?: string
   now?: number
+}
+
+export type OfflineNavigationRSCResponseCacheWrite = {
+  url: string | URL
+  staleAt: number
+  expiresAt: number
+  buildId?: string
+  now?: number
+  payload: Promise<OfflineNavigationRSCResponsePayload | null>
 }
 
 export type OfflineNavigationCacheStorage = {
@@ -67,6 +94,7 @@ export function normalizeOfflineNavigationCacheUrl(url: string | URL): string {
       : new URL(url.href)
 
   normalized.hash = ''
+  normalized.pathname = normalizePathTrailingSlash(normalized.pathname)
   return normalized.href
 }
 
@@ -149,6 +177,73 @@ export function createOfflineNavigationCache(
       }, false)
     },
   }
+}
+
+export async function createOfflineNavigationRSCResponsePayload(
+  response: Response,
+  requestKind: OfflineNavigationRSCResponseRequestKind
+): Promise<OfflineNavigationRSCResponsePayload> {
+  const clone = response.clone()
+  return {
+    version: RSC_RESPONSE_PAYLOAD_VERSION,
+    kind: 'rsc-response',
+    requestKind,
+    url: response.url,
+    status: clone.status,
+    statusText: clone.statusText,
+    headers: Array.from(clone.headers.entries()),
+    body: await clone.arrayBuffer(),
+  }
+}
+
+export function createOfflineNavigationRSCResponse(
+  payload: OfflineNavigationRSCResponsePayload
+): Response {
+  const response = new Response(payload.body.slice(0), {
+    status: payload.status,
+    statusText: payload.statusText,
+    headers: payload.headers,
+  })
+  Object.defineProperty(response, 'url', { value: payload.url })
+  return response
+}
+
+export function isOfflineNavigationRSCResponsePayload(
+  payload: unknown
+): payload is OfflineNavigationRSCResponsePayload {
+  if (payload === null || typeof payload !== 'object') {
+    return false
+  }
+
+  const candidate = payload as Partial<OfflineNavigationRSCResponsePayload>
+  return (
+    candidate.version === RSC_RESPONSE_PAYLOAD_VERSION &&
+    candidate.kind === 'rsc-response' &&
+    (candidate.requestKind === 'navigation' ||
+      candidate.requestKind === 'route-prefetch' ||
+      candidate.requestKind === 'client-resume' ||
+      candidate.requestKind === 'initial-load') &&
+    typeof candidate.url === 'string' &&
+    typeof candidate.status === 'number' &&
+    typeof candidate.statusText === 'string' &&
+    Array.isArray(candidate.headers) &&
+    candidate.body instanceof ArrayBuffer
+  )
+}
+
+export async function writeOfflineNavigationRSCResponseCacheEntry({
+  payload,
+  ...entry
+}: OfflineNavigationRSCResponseCacheWrite): Promise<boolean> {
+  const resolvedPayload = await payload
+  if (resolvedPayload === null) {
+    return false
+  }
+
+  return writeOfflineNavigationCacheEntry({
+    ...entry,
+    payload: resolvedPayload,
+  })
 }
 
 function getCacheBuildId(buildId: string | undefined): string | null {

--- a/packages/next/src/client/components/router-reducer/offline-navigation-cache.ts
+++ b/packages/next/src/client/components/router-reducer/offline-navigation-cache.ts
@@ -5,23 +5,56 @@ import { normalizePathTrailingSlash } from '../../normalize-trailing-slash'
 // used instead of the service worker CacheStorage because the router needs
 // structured records tied to the current Next.js build.
 const DATABASE_NAME = 'next-offline-navigation-cache'
-const DATABASE_VERSION = 1
+const DATABASE_VERSION = 2
 const STORE_NAME = 'navigation-data'
-const ENTRY_VERSION = 1
+const METADATA_STORE_NAME = 'metadata'
+const EXACT_URL_CACHE_EPOCH_KEY = 'exact-url-cache-epoch'
+const ENTRY_VERSION = 2
 const RSC_RESPONSE_PAYLOAD_VERSION = 1
 
 type OfflineNavigationCacheKey = [buildId: string, url: string]
-type OfflineNavigationRSCResponseRequestKind =
+export type OfflineNavigationRSCResponseRequestKind =
   | 'navigation'
   | 'route-prefetch'
   | 'client-resume'
   | 'initial-load'
+
+export type OfflineNavigationRSCResponseCacheSkipReason =
+  | 'disabled'
+  | 'dev-server'
+  | 'not-production'
+  | 'output-export'
+  | 'unsupported-request'
+  | 'missing-payload'
+  | 'cross-origin'
+  | 'unsupported-segment-prefetching'
+  | 'runtime-prefetch'
+  | 'partial-response'
+  | 'hmr-refresh'
+  | 'interception'
+  | 'postponed'
+  | 'redirected'
+
+export type OfflineNavigationRSCResponseCacheEligibility = {
+  requestKind: OfflineNavigationRSCResponseRequestKind | null
+  url: string | URL
+  origin?: string
+  hasCachePayload?: boolean
+  supportsPerSegmentPrefetching?: boolean
+  hasRuntimePrefetch?: boolean
+  hasPartialResponse?: boolean
+  isHmrRefresh?: boolean
+  isInterception?: boolean
+  isPostponed?: boolean
+  isRedirected?: boolean
+}
 
 export type OfflineNavigationCacheEntry = {
   version: typeof ENTRY_VERSION
   kind: 'exact-url'
   buildId: string
   url: string
+  cacheEpoch: number
   createdAt: number
   staleAt: number
   expiresAt: number
@@ -69,6 +102,8 @@ export type OfflineNavigationCacheStorage = {
   put(entry: OfflineNavigationCacheEntry): Promise<void>
   delete(key: OfflineNavigationCacheKey): Promise<void>
   deleteBuild(buildId: string): Promise<void>
+  getCacheEpoch(): Promise<number>
+  incrementCacheEpoch(): Promise<number>
 }
 
 export type OfflineNavigationCache = {
@@ -82,6 +117,7 @@ export type OfflineNavigationCache = {
     options?: OfflineNavigationCacheReadOptions
   ) => Promise<boolean>
   deleteBuild: (buildId?: string) => Promise<boolean>
+  invalidate: () => Promise<boolean>
 }
 
 export function normalizeOfflineNavigationCacheUrl(url: string | URL): string {
@@ -111,7 +147,10 @@ export function createOfflineNavigationCache(
 
         const cacheUrl = normalizeOfflineNavigationCacheUrl(url)
         const key: OfflineNavigationCacheKey = [buildId, cacheUrl]
-        const entry = await storage.get(key)
+        const [entry, cacheEpoch] = await Promise.all([
+          storage.get(key),
+          storage.getCacheEpoch(),
+        ])
         if (!entry) {
           return null
         }
@@ -120,7 +159,8 @@ export function createOfflineNavigationCache(
           entry.version !== ENTRY_VERSION ||
           entry.kind !== 'exact-url' ||
           entry.buildId !== buildId ||
-          entry.url !== cacheUrl
+          entry.url !== cacheUrl ||
+          entry.cacheEpoch !== cacheEpoch
         ) {
           await storage.delete(key)
           return null
@@ -146,6 +186,7 @@ export function createOfflineNavigationCache(
           kind: 'exact-url',
           buildId,
           url: normalizeOfflineNavigationCacheUrl(entry.url),
+          cacheEpoch: await storage.getCacheEpoch(),
           createdAt: entry.now ?? Date.now(),
           staleAt: entry.staleAt,
           expiresAt: entry.expiresAt,
@@ -173,6 +214,12 @@ export function createOfflineNavigationCache(
         }
 
         await storage.deleteBuild(cacheBuildId)
+        return true
+      }, false)
+    },
+    invalidate: async () => {
+      return runOfflineNavigationCacheOperation(async () => {
+        await storage.incrementCacheEpoch()
         return true
       }, false)
     },
@@ -206,6 +253,87 @@ export function createOfflineNavigationRSCResponse(
   })
   Object.defineProperty(response, 'url', { value: payload.url })
   return response
+}
+
+export function getOfflineNavigationRSCResponseCacheSkipReason({
+  requestKind,
+  url,
+  origin,
+  hasCachePayload = true,
+  supportsPerSegmentPrefetching = true,
+  hasRuntimePrefetch = false,
+  hasPartialResponse = false,
+  isHmrRefresh = false,
+  isInterception = false,
+  isPostponed = false,
+  isRedirected = false,
+}: OfflineNavigationRSCResponseCacheEligibility): OfflineNavigationRSCResponseCacheSkipReason | null {
+  // Persist only response shapes the offline bootstrap can replay without
+  // issuing follow-up network requests or guessing request context. This is
+  // about replay completeness, not a privacy boundary; entries are still scoped
+  // to the current browser profile and build.
+  if (!process.env.__NEXT_OFFLINE_NAVIGATIONS) {
+    return 'disabled'
+  }
+
+  if (process.env.__NEXT_DEV_SERVER) {
+    return 'dev-server'
+  }
+
+  if (process.env.NODE_ENV !== 'production') {
+    return 'not-production'
+  }
+
+  if (process.env.__NEXT_CONFIG_OUTPUT === 'export') {
+    return 'output-export'
+  }
+
+  if (requestKind === null) {
+    return 'unsupported-request'
+  }
+
+  if (!hasCachePayload) {
+    return 'missing-payload'
+  }
+
+  const currentOrigin =
+    origin ?? (typeof location === 'undefined' ? null : location.origin)
+  if (
+    currentOrigin !== null &&
+    new URL(url, currentOrigin).origin !== currentOrigin
+  ) {
+    return 'cross-origin'
+  }
+
+  if (!supportsPerSegmentPrefetching && requestKind !== 'initial-load') {
+    return 'unsupported-segment-prefetching'
+  }
+
+  if (hasRuntimePrefetch) {
+    return 'runtime-prefetch'
+  }
+
+  if (hasPartialResponse) {
+    return 'partial-response'
+  }
+
+  if (isHmrRefresh) {
+    return 'hmr-refresh'
+  }
+
+  if (isInterception) {
+    return 'interception'
+  }
+
+  if (isPostponed) {
+    return 'postponed'
+  }
+
+  if (isRedirected) {
+    return 'redirected'
+  }
+
+  return null
 }
 
 export function isOfflineNavigationRSCResponsePayload(
@@ -353,6 +481,36 @@ class IndexedDBOfflineNavigationCacheStorage
     await waitForTransaction(transaction)
   }
 
+  async getCacheEpoch(): Promise<number> {
+    const database = await this.getDatabase()
+    if (database === null) {
+      return 0
+    }
+
+    const epoch = await requestToPromise(
+      database
+        .transaction(METADATA_STORE_NAME, 'readonly')
+        .objectStore(METADATA_STORE_NAME)
+        .get(EXACT_URL_CACHE_EPOCH_KEY)
+    )
+    return typeof epoch === 'number' ? epoch : 0
+  }
+
+  async incrementCacheEpoch(): Promise<number> {
+    const database = await this.getDatabase()
+    if (database === null) {
+      throw new Error()
+    }
+
+    const transaction = database.transaction(METADATA_STORE_NAME, 'readwrite')
+    const store = transaction.objectStore(METADATA_STORE_NAME)
+    const epoch = await requestToPromise(store.get(EXACT_URL_CACHE_EPOCH_KEY))
+    const nextEpoch = (typeof epoch === 'number' ? epoch : 0) + 1
+    store.put(nextEpoch, EXACT_URL_CACHE_EPOCH_KEY)
+    await waitForTransaction(transaction)
+    return nextEpoch
+  }
+
   private async getDatabase(): Promise<IDBDatabase | null> {
     if (this.databasePromise === null) {
       this.databasePromise = this.openDatabase().catch((error) => {
@@ -377,6 +535,9 @@ class IndexedDBOfflineNavigationCacheStorage
           keyPath: ['buildId', 'url'],
         })
       }
+      if (!database.objectStoreNames.contains(METADATA_STORE_NAME)) {
+        database.createObjectStore(METADATA_STORE_NAME)
+      }
     }
 
     const database = await requestToPromise(request)
@@ -397,3 +558,5 @@ export const writeOfflineNavigationCacheEntry = offlineNavigationCache.write
 export const deleteOfflineNavigationCacheEntry = offlineNavigationCache.delete
 export const deleteOfflineNavigationCacheEntriesForBuild =
   offlineNavigationCache.deleteBuild
+export const invalidateOfflineNavigationCacheEntries =
+  offlineNavigationCache.invalidate

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -110,6 +110,26 @@ import { convertServerPatchToFullTree, type NavigationSeed } from './navigation'
 import { getNavigationBuildId } from '../../navigation-build-id'
 import { NEXT_NAV_DEPLOYMENT_ID_HEADER } from '../../../lib/constants'
 
+let offlineNavigationCacheModule:
+  | typeof import('../router-reducer/offline-navigation-cache')
+  | undefined
+
+// Keep the runtime require inside a compile-time flag branch so disabled builds
+// do not pull the offline cache module into client chunks.
+function getOfflineNavigationCacheModule():
+  | typeof import('../router-reducer/offline-navigation-cache')
+  | null {
+  if (process.env.__NEXT_OFFLINE_NAVIGATIONS) {
+    if (offlineNavigationCacheModule === undefined) {
+      offlineNavigationCacheModule =
+        require('../router-reducer/offline-navigation-cache') as typeof import('../router-reducer/offline-navigation-cache')
+    }
+    return offlineNavigationCacheModule
+  } else {
+    return null
+  }
+}
+
 /**
  * Ensures a minimum stale time of 30s to avoid issues where the server sends a too
  * short-lived stale time, which would prevent anything from being prefetched.
@@ -1577,6 +1597,62 @@ export function convertRouteTreeToFlightRouterState(
   return flightRouterState
 }
 
+function persistOfflineNavigationClientResumePrefetchResponse({
+  buildId,
+  couldBeIntercepted,
+  url,
+}: {
+  buildId: string | undefined
+  couldBeIntercepted: boolean
+  url: URL
+}): void {
+  if (
+    !process.env.__NEXT_OFFLINE_NAVIGATIONS ||
+    process.env.__NEXT_DEV_SERVER ||
+    process.env.NODE_ENV !== 'production' ||
+    process.env.__NEXT_CONFIG_OUTPUT === 'export' ||
+    couldBeIntercepted ||
+    url.origin !== location.origin
+  ) {
+    return
+  }
+
+  const offlineNavigationCache = getOfflineNavigationCacheModule()
+  if (offlineNavigationCache === null) {
+    return
+  }
+
+  void (async () => {
+    try {
+      const headers: RequestHeaders = {
+        [RSC_HEADER]: '1',
+        [NEXT_ROUTER_PREFETCH_HEADER]: '1',
+        [NEXT_ROUTER_SEGMENT_PREFETCH_HEADER]: '/_full',
+      }
+      addInstantPrefetchHeaderIfLocked(headers)
+
+      const response = await fetchPrefetchResponse(url, headers)
+      if (
+        response === null ||
+        response.offlineNavigationCachePayload === null ||
+        response.redirected ||
+        response.headers.get('vary')?.includes(NEXT_URL)
+      ) {
+        return
+      }
+
+      const staleAt = getStaleAtFromHeader(Date.now(), response)
+      await offlineNavigationCache.writeOfflineNavigationRSCResponseCacheEntry({
+        buildId: response.headers.get(NEXT_NAV_DEPLOYMENT_ID_HEADER) ?? buildId,
+        expiresAt: staleAt,
+        payload: response.offlineNavigationCachePayload,
+        staleAt,
+        url,
+      })
+    } catch {}
+  })()
+}
+
 export async function fetchRouteOnCacheMiss(
   entry: PendingRouteCacheEntry,
   key: RouteCacheKey
@@ -1777,6 +1853,14 @@ export async function fetchRouteOnCacheMiss(
         routeIsPPREnabled,
         false // hasDynamicRewrite
       )
+
+      persistOfflineNavigationClientResumePrefetchResponse({
+        buildId:
+          response.headers.get(NEXT_NAV_DEPLOYMENT_ID_HEADER) ??
+          serverData.buildId,
+        couldBeIntercepted,
+        url: urlAfterRedirects,
+      })
     } else {
       // PPR is not enabled for this route. The server responds with a
       // different format (FlightRouterState) that we need to convert.
@@ -1827,6 +1911,13 @@ export async function fetchRouteOnCacheMiss(
         pathname,
         nextUrl
       )
+
+      persistOfflineNavigationClientResumePrefetchResponse({
+        buildId:
+          response.headers.get(NEXT_NAV_DEPLOYMENT_ID_HEADER) ?? serverData.b,
+        couldBeIntercepted,
+        url: urlAfterRedirects,
+      })
     }
 
     if (!couldBeIntercepted) {

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -371,6 +371,7 @@ export function invalidateEntirePrefetchCache(
 ): void {
   currentRouteCacheVersion++
   currentSegmentCacheVersion++
+  invalidatePersistentOfflineNavigationCache()
 
   pingVisibleLinks(nextUrl, tree)
   pingInvalidationListeners(nextUrl, tree)
@@ -388,6 +389,7 @@ export function invalidateRouteCacheEntries(
   tree: FlightRouterState
 ): void {
   currentRouteCacheVersion++
+  invalidatePersistentOfflineNavigationCache()
 
   pingVisibleLinks(nextUrl, tree)
   pingInvalidationListeners(nextUrl, tree)
@@ -405,9 +407,28 @@ export function invalidateSegmentCacheEntries(
   tree: FlightRouterState
 ): void {
   currentSegmentCacheVersion++
+  invalidatePersistentOfflineNavigationCache()
 
   pingVisibleLinks(nextUrl, tree)
   pingInvalidationListeners(nextUrl, tree)
+}
+
+function invalidatePersistentOfflineNavigationCache(): void {
+  if (
+    !process.env.__NEXT_OFFLINE_NAVIGATIONS ||
+    process.env.__NEXT_DEV_SERVER ||
+    process.env.NODE_ENV !== 'production' ||
+    process.env.__NEXT_CONFIG_OUTPUT === 'export'
+  ) {
+    return
+  }
+
+  const offlineNavigationCache = getOfflineNavigationCacheModule()
+  if (offlineNavigationCache === null) {
+    return
+  }
+
+  void offlineNavigationCache.invalidateOfflineNavigationCacheEntries()
 }
 
 function attachInvalidationListener(task: PrefetchTask): void {
@@ -1632,12 +1653,24 @@ function persistOfflineNavigationClientResumePrefetchResponse({
       addInstantPrefetchHeaderIfLocked(headers)
 
       const response = await fetchPrefetchResponse(url, headers)
-      if (
-        response === null ||
-        response.offlineNavigationCachePayload === null ||
-        response.redirected ||
-        response.headers.get('vary')?.includes(NEXT_URL)
-      ) {
+      if (response === null) {
+        return
+      }
+
+      const skipReason =
+        offlineNavigationCache.getOfflineNavigationRSCResponseCacheSkipReason({
+          requestKind: response.offlineNavigationCacheRequestKind,
+          hasCachePayload: response.offlineNavigationCachePayload !== null,
+          isInterception: response.headers.get('vary')?.includes(NEXT_URL),
+          isRedirected: response.redirected,
+          url,
+        })
+      if (skipReason !== null) {
+        return
+      }
+
+      const payload = response.offlineNavigationCachePayload
+      if (payload === null) {
         return
       }
 
@@ -1645,7 +1678,7 @@ function persistOfflineNavigationClientResumePrefetchResponse({
       await offlineNavigationCache.writeOfflineNavigationRSCResponseCacheEntry({
         buildId: response.headers.get(NEXT_NAV_DEPLOYMENT_ID_HEADER) ?? buildId,
         expiresAt: staleAt,
-        payload: response.offlineNavigationCachePayload,
+        payload,
         staleAt,
         url,
       })

--- a/packages/next/src/client/components/use-offline.tsx
+++ b/packages/next/src/client/components/use-offline.tsx
@@ -15,12 +15,14 @@ const OfflineContext = createContext<boolean>(false)
 // (via dispatchOfflineChange) to update the React tree.
 let setOptimistic: ((value: boolean) => void) | null = null
 let setCanonical: ((value: boolean) => void) | null = null
+let offlineSnapshot = false
 
 /**
  * Called by the offline module when the offline state changes.
  * Dispatches into React via startTransition + useOptimistic.
  */
 export function dispatchOfflineChange(isOffline: boolean): void {
+  offlineSnapshot = isOffline
   const canonical = setCanonical
   const optimistic = setOptimistic
   if (canonical === null || optimistic === null) {
@@ -33,7 +35,7 @@ export function dispatchOfflineChange(isOffline: boolean): void {
 }
 
 export function OfflineProvider({ children }: { children: React.ReactNode }) {
-  const [canonicalOffline, setCanonicalOffline] = useState(false)
+  const [canonicalOffline, setCanonicalOffline] = useState(offlineSnapshot)
   const [isOffline, setOptimisticOffline] = useOptimistic(canonicalOffline)
 
   setOptimistic = setOptimisticOffline

--- a/test/production/app-dir/offline-navigations/app/page.tsx
+++ b/test/production/app-dir/offline-navigations/app/page.tsx
@@ -1,5 +1,5 @@
 import { OfflineStatus } from './offline-status'
-import { PrefetchButton } from './prefetch-button'
+import { PrefetchButton, RefreshButton } from './prefetch-button'
 
 export default function Page() {
   return (
@@ -7,6 +7,7 @@ export default function Page() {
       <p>offline navigations page</p>
       <OfflineStatus />
       <PrefetchButton />
+      <RefreshButton />
     </>
   )
 }

--- a/test/production/app-dir/offline-navigations/app/page.tsx
+++ b/test/production/app-dir/offline-navigations/app/page.tsx
@@ -1,10 +1,12 @@
 import { OfflineStatus } from './offline-status'
+import { PrefetchButton } from './prefetch-button'
 
 export default function Page() {
   return (
     <>
       <p>offline navigations page</p>
       <OfflineStatus />
+      <PrefetchButton />
     </>
   )
 }

--- a/test/production/app-dir/offline-navigations/app/prefetch-button.tsx
+++ b/test/production/app-dir/offline-navigations/app/prefetch-button.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+
+export function PrefetchButton() {
+  const router = useRouter()
+  return (
+    <button
+      id="prefetch-offline-navigation"
+      onClick={() => router.prefetch('/prefetched')}
+    >
+      Prefetch offline navigation
+    </button>
+  )
+}

--- a/test/production/app-dir/offline-navigations/app/prefetch-button.tsx
+++ b/test/production/app-dir/offline-navigations/app/prefetch-button.tsx
@@ -13,3 +13,12 @@ export function PrefetchButton() {
     </button>
   )
 }
+
+export function RefreshButton() {
+  const router = useRouter()
+  return (
+    <button id="refresh-offline-navigation" onClick={() => router.refresh()}>
+      Refresh offline navigation
+    </button>
+  )
+}

--- a/test/production/app-dir/offline-navigations/app/prefetched/page.tsx
+++ b/test/production/app-dir/offline-navigations/app/prefetched/page.tsx
@@ -1,0 +1,10 @@
+import { OfflineStatus } from '../offline-status'
+
+export default function PrefetchedPage() {
+  return (
+    <>
+      <p id="prefetched-page">prefetched page</p>
+      <OfflineStatus />
+    </>
+  )
+}

--- a/test/production/app-dir/offline-navigations/app/request-sensitive/page.tsx
+++ b/test/production/app-dir/offline-navigations/app/request-sensitive/page.tsx
@@ -1,0 +1,17 @@
+import { cookies } from 'next/headers'
+import { OfflineStatus } from '../offline-status'
+
+export const unstable_instant = false
+export const unstable_prefetch = 'force-disabled'
+
+export default async function RequestSensitivePage() {
+  const cookieStore = await cookies()
+  const session = cookieStore.get('offline-session')?.value ?? 'missing'
+
+  return (
+    <>
+      <p id="request-sensitive-page">request sensitive session: {session}</p>
+      <OfflineStatus />
+    </>
+  )
+}

--- a/test/production/app-dir/offline-navigations/app/url-stress/[value]/hash-indicator.tsx
+++ b/test/production/app-dir/offline-navigations/app/url-stress/[value]/hash-indicator.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+export function HashIndicator() {
+  const [hash, setHash] = useState('')
+
+  useEffect(() => {
+    const updateHash = () => setHash(window.location.hash)
+    updateHash()
+    window.addEventListener('hashchange', updateHash)
+
+    return () => {
+      window.removeEventListener('hashchange', updateHash)
+    }
+  }, [])
+
+  return <p id="url-stress-hash">url stress hash: {hash}</p>
+}

--- a/test/production/app-dir/offline-navigations/app/url-stress/[value]/page.tsx
+++ b/test/production/app-dir/offline-navigations/app/url-stress/[value]/page.tsx
@@ -1,0 +1,36 @@
+import { OfflineStatus } from '../../offline-status'
+import { HashIndicator } from './hash-indicator'
+
+type PageProps = {
+  params: Promise<{ value: string }>
+  searchParams: Promise<{
+    tag?: string | string[]
+    token?: string
+  }>
+}
+
+export const unstable_instant = false
+
+export default async function UrlStressPage({
+  params,
+  searchParams,
+}: PageProps) {
+  const { value } = await params
+  const query = await searchParams
+  const tags =
+    query.tag === undefined
+      ? []
+      : Array.isArray(query.tag)
+        ? query.tag
+        : [query.tag]
+
+  return (
+    <>
+      <p id="url-stress-page">url stress path: {value}</p>
+      <p id="url-stress-token">url stress token: {query.token ?? 'missing'}</p>
+      <p id="url-stress-tags">url stress tags: {tags.join(',')}</p>
+      <HashIndicator />
+      <OfflineStatus />
+    </>
+  )
+}

--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -56,13 +56,16 @@ describe('offlineNavigations build artifacts', () => {
   ) {
     return browser.eval(async (substring) => {
       const database = await new Promise<IDBDatabase>((resolve, reject) => {
-        const request = indexedDB.open('next-offline-navigation-cache', 1)
+        const request = indexedDB.open('next-offline-navigation-cache', 2)
         request.onupgradeneeded = () => {
           const database = request.result
           if (!database.objectStoreNames.contains('navigation-data')) {
             database.createObjectStore('navigation-data', {
               keyPath: ['buildId', 'url'],
             })
+          }
+          if (!database.objectStoreNames.contains('metadata')) {
+            database.createObjectStore('metadata')
           }
         }
         request.onsuccess = () => resolve(request.result)
@@ -86,6 +89,7 @@ describe('offlineNavigations build artifacts', () => {
 
         return {
           buildId: entry.buildId,
+          cacheEpoch: entry.cacheEpoch,
           expiresAt: entry.expiresAt,
           kind: entry.kind,
           payload: {
@@ -102,6 +106,30 @@ describe('offlineNavigations build artifacts', () => {
         database.close()
       }
     }, urlSubstring)
+  }
+
+  async function cleanupOfflineNavigationState(
+    browser: Awaited<ReturnType<typeof next.browser>>
+  ) {
+    await browser.eval(async () => {
+      if (!('serviceWorker' in navigator)) {
+        return
+      }
+
+      const cacheNames = await caches.keys()
+      await Promise.all(
+        cacheNames
+          .filter((cacheName) =>
+            cacheName.startsWith('next-offline-navigation-v1:')
+          )
+          .map((cacheName) => caches.delete(cacheName))
+      )
+
+      const registrations = await navigator.serviceWorker.getRegistrations()
+      await Promise.all(
+        registrations.map((registration) => registration.unregister())
+      )
+    })
   }
 
   it('emits request-invariant offline navigation artifacts when enabled', async () => {
@@ -307,6 +335,7 @@ describe('offlineNavigations build artifacts', () => {
         )
         expect(initialLoadEntry).toEqual({
           buildId: navigationBuildId,
+          cacheEpoch: 0,
           expiresAt: expect.any(Number),
           kind: 'exact-url',
           payload: {
@@ -317,7 +346,7 @@ describe('offlineNavigations build artifacts', () => {
           },
           staleAt: expect.any(Number),
           url: expect.stringContaining('/docs/'),
-          version: 1,
+          version: 2,
         })
         expect(initialLoadEntry!.payload.bodyLength).toBeGreaterThan(0)
       })
@@ -333,6 +362,18 @@ describe('offlineNavigations build artifacts', () => {
         )
       })
       expect(await browser.elementById('offline-status').text()).toBe('offline')
+      expect(
+        await browser.eval(() => {
+          const win = window as typeof window & {
+            __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?: Array<unknown>
+          }
+          return win.__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?.at(-1)
+        })
+      ).toMatchObject({
+        type: 'cache-hit',
+        requestKind: 'initial-load',
+        url: `${next.url}/docs/`,
+      })
       await page!.context().setOffline(false)
       await browser.eval(() => {
         window.dispatchEvent(new Event('online'))
@@ -341,6 +382,30 @@ describe('offlineNavigations build artifacts', () => {
         expect(await browser.elementById('offline-status').text()).toBe(
           'online'
         )
+      })
+
+      await browser.elementById('refresh-offline-navigation').click()
+      await retry(async () => {
+        const refreshedEntry = await readPersistedOfflineNavigationEntry(
+          browser,
+          '/docs/'
+        )
+        expect(refreshedEntry).toEqual({
+          buildId: navigationBuildId,
+          cacheEpoch: 1,
+          expiresAt: expect.any(Number),
+          kind: 'exact-url',
+          payload: {
+            bodyLength: expect.any(Number),
+            kind: 'rsc-response',
+            requestKind: 'navigation',
+            status: 200,
+          },
+          staleAt: expect.any(Number),
+          url: expect.stringContaining('/docs/'),
+          version: 2,
+        })
+        expect(refreshedEntry!.payload.bodyLength).toBeGreaterThan(0)
       })
 
       await browser.eval((messageType) => {
@@ -363,6 +428,7 @@ describe('offlineNavigations build artifacts', () => {
         )
         expect(persistedEntry).toEqual({
           buildId: navigationBuildId,
+          cacheEpoch: 1,
           expiresAt: expect.any(Number),
           kind: 'exact-url',
           payload: {
@@ -373,7 +439,7 @@ describe('offlineNavigations build artifacts', () => {
           },
           staleAt: expect.any(Number),
           url: expect.stringContaining('/docs/prefetched'),
-          version: 1,
+          version: 2,
         })
         expect(persistedEntry!.payload.bodyLength).toBeGreaterThan(0)
       })
@@ -390,6 +456,18 @@ describe('offlineNavigations build artifacts', () => {
         )
       })
       expect(await browser.elementById('offline-status').text()).toBe('offline')
+      expect(
+        await browser.eval(() => {
+          const win = window as typeof window & {
+            __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?: Array<unknown>
+          }
+          return win.__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?.at(-1)
+        })
+      ).toMatchObject({
+        type: 'cache-hit',
+        requestKind: 'client-resume',
+        url: `${next.url}/docs/prefetched`,
+      })
       const cachedServiceWorkerMessage = await browser.eval(() => {
         const message = localStorage.getItem('__nextOfflineNavigationMessage')
         return message === null ? null : JSON.parse(message)
@@ -413,7 +491,124 @@ describe('offlineNavigations build artifacts', () => {
       })
       expect(nonNavigationResult).toBe('rejected')
 
+      await browser.eval(
+        async ({ buildId: entryBuildId, url }) => {
+          const database = await new Promise<IDBDatabase>((resolve, reject) => {
+            const request = indexedDB.open('next-offline-navigation-cache', 2)
+            request.onsuccess = () => resolve(request.result)
+            request.onerror = () => reject(request.error)
+          })
+
+          try {
+            const transaction = database.transaction(
+              'navigation-data',
+              'readwrite'
+            )
+            transaction.objectStore('navigation-data').put({
+              version: 2,
+              kind: 'exact-url',
+              buildId: entryBuildId,
+              url,
+              cacheEpoch: 1,
+              createdAt: Date.now(),
+              staleAt: Date.now() + 60_000,
+              expiresAt: Date.now() + 60_000,
+              payload: { kind: 'not-rsc-response' },
+            })
+            await new Promise<void>((resolve, reject) => {
+              transaction.oncomplete = () => resolve()
+              transaction.onerror = () => reject(transaction.error)
+              transaction.onabort = () => reject(transaction.error)
+            })
+          } finally {
+            database.close()
+          }
+        },
+        {
+          buildId: navigationBuildId,
+          url: `${next.url}/docs/malformed-offline-entry/`,
+        }
+      )
+
+      await browser.eval(
+        async ({ buildId: entryBuildId, url }) => {
+          const database = await new Promise<IDBDatabase>((resolve, reject) => {
+            const request = indexedDB.open('next-offline-navigation-cache', 2)
+            request.onsuccess = () => resolve(request.result)
+            request.onerror = () => reject(request.error)
+          })
+
+          try {
+            const transaction = database.transaction(
+              'navigation-data',
+              'readwrite'
+            )
+            transaction.objectStore('navigation-data').put({
+              version: 2,
+              kind: 'exact-url',
+              buildId: entryBuildId,
+              url,
+              cacheEpoch: 1,
+              createdAt: Date.now(),
+              staleAt: Date.now() + 60_000,
+              expiresAt: Date.now() + 60_000,
+              payload: {
+                version: 1,
+                kind: 'rsc-response',
+                requestKind: 'route-prefetch',
+                url,
+                status: 200,
+                statusText: 'OK',
+                headers: [['content-type', 'text/x-component']],
+                body: new TextEncoder().encode('0:["$","payload"]').buffer,
+              },
+            })
+            await new Promise<void>((resolve, reject) => {
+              transaction.oncomplete = () => resolve()
+              transaction.onerror = () => reject(transaction.error)
+              transaction.onabort = () => reject(transaction.error)
+            })
+          } finally {
+            database.close()
+          }
+        },
+        {
+          buildId: navigationBuildId,
+          url: `${next.url}/docs/unsupported-offline-entry/`,
+        }
+      )
+
       await next.stop()
+      const malformedResponse = await page!.goto(
+        `${next.url}/docs/malformed-offline-entry/`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(malformedResponse?.status()).toBe(200)
+      await retry(async () => {
+        expect(
+          await browser.eval(() =>
+            document.documentElement.getAttribute(
+              'data-next-offline-navigation-cache-reason'
+            )
+          )
+        ).toBe('invalid-payload')
+      })
+
+      const unsupportedResponse = await page!.goto(
+        `${next.url}/docs/unsupported-offline-entry/`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(unsupportedResponse?.status()).toBe(200)
+      await retry(async () => {
+        expect(
+          await browser.eval(() =>
+            document.documentElement.getAttribute(
+              'data-next-offline-navigation-cache-reason'
+            )
+          )
+        ).toBe('unsupported-request-kind')
+      })
+
       const offlineResponse = await page!.goto(
         `${next.url}/docs/offline-navigation-cache-miss`,
         { waitUntil: 'domcontentloaded' }
@@ -436,13 +631,41 @@ describe('offlineNavigations build artifacts', () => {
               ? null
               : {
                   hidden: cacheMiss.hidden,
+                  reason: cacheMiss.getAttribute(
+                    'data-next-offline-navigation-cache-reason'
+                  ),
                   text: cacheMiss.textContent,
                 }
           })
         ).toEqual({
           hidden: false,
+          reason: 'missing-entry',
           text: 'This page is not available offline.',
         })
+      })
+      expect(
+        await browser.eval(() => ({
+          cache: document.documentElement.getAttribute(
+            'data-next-offline-navigation-cache'
+          ),
+          reason: document.documentElement.getAttribute(
+            'data-next-offline-navigation-cache-reason'
+          ),
+          diagnostic:
+            (
+              window as typeof window & {
+                __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?: Array<unknown>
+              }
+            ).__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?.at(-1) ?? null,
+        }))
+      ).toMatchObject({
+        cache: 'miss',
+        reason: 'missing-entry',
+        diagnostic: {
+          type: 'cache-miss',
+          reason: 'missing-entry',
+          url: `${next.url}/docs/offline-navigation-cache-miss`,
+        },
       })
       await page!.context().setOffline(false)
 
@@ -465,6 +688,228 @@ describe('offlineNavigations build artifacts', () => {
           registrations.map((registration) => registration.unregister())
         )
       })
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
+  it('misses hard-loaded request-sensitive URLs without cached router records', async () => {
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    await next.start({ skipBuild: true })
+
+    let page: Playwright.Page | undefined
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await retry(async () => {
+        expect(
+          await browser.eval(() => Boolean(navigator.serviceWorker.controller))
+        ).toBe(true)
+      })
+
+      await browser.eval(() => {
+        document.cookie = 'offline-session=alpha; path=/; SameSite=Lax'
+      })
+      const onlineResponse = await page!.goto(
+        `${next.url}/docs/request-sensitive/`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(onlineResponse?.status()).toBe(200)
+      await retry(async () => {
+        expect(await browser.elementById('request-sensitive-page').text()).toBe(
+          'request sensitive session: alpha'
+        )
+      })
+
+      await retry(async () => {
+        expect(
+          await readPersistedOfflineNavigationEntry(
+            browser,
+            '/docs/request-sensitive'
+          )
+        ).toBe(null)
+      })
+
+      await page!.context().setOffline(true)
+      const offlineResponse = await page!.goto(
+        `${next.url}/docs/request-sensitive/`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(offlineResponse?.status()).toBe(200)
+      await retry(async () => {
+        expect(
+          await browser
+            .elementById('__NEXT_OFFLINE_NAVIGATION_CACHE_MISS')
+            .text()
+        ).toContain('This page is not available offline.')
+        expect(
+          await browser.eval(() =>
+            document.documentElement.getAttribute(
+              'data-next-offline-navigation-cache-reason'
+            )
+          )
+        ).toBe('missing-entry')
+      })
+
+      expect(
+        await browser.eval(() => {
+          const win = window as typeof window & {
+            __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?: Array<unknown>
+          }
+          return win.__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?.at(-1)
+        })
+      ).toMatchObject({
+        type: 'cache-miss',
+        reason: 'missing-entry',
+        url: `${next.url}/docs/request-sensitive/`,
+      })
+
+      await page!.context().setOffline(false)
+      await browser.eval(async () => {
+        window.dispatchEvent(new Event('online'))
+
+        const cacheNames = await caches.keys()
+        await Promise.all(
+          cacheNames
+            .filter((cacheName) =>
+              cacheName.startsWith('next-offline-navigation-v1:')
+            )
+            .map((cacheName) => caches.delete(cacheName))
+        )
+
+        const registrations = await navigator.serviceWorker.getRegistrations()
+        await Promise.all(
+          registrations.map((registration) => registration.unregister())
+        )
+      })
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
+  it('covers exact URL shape stress cases', async () => {
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    await next.start({ skipBuild: true })
+
+    let page: Playwright.Page | undefined
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await retry(async () => {
+        expect(
+          await browser.eval(() => Boolean(navigator.serviceWorker.controller))
+        ).toBe(true)
+      })
+
+      const cachedUrl = `${next.url}/docs/url-stress/space%20value/?token=a%2Bb&tag=one&tag=two#section-1`
+      const onlineResponse = await page!.goto(cachedUrl, {
+        waitUntil: 'domcontentloaded',
+      })
+      expect(onlineResponse?.status()).toBe(200)
+      await retry(async () => {
+        expect(await browser.elementById('url-stress-page').text()).toBe(
+          'url stress path: space%20value'
+        )
+        expect(await browser.elementById('url-stress-token').text()).toBe(
+          'url stress token: a+b'
+        )
+        expect(await browser.elementById('url-stress-tags').text()).toBe(
+          'url stress tags: one,two'
+        )
+        expect(await browser.elementById('url-stress-hash').text()).toBe(
+          'url stress hash: #section-1'
+        )
+      })
+
+      await retry(async () => {
+        const entry = await readPersistedOfflineNavigationEntry(
+          browser,
+          '/docs/url-stress/space%20value/'
+        )
+        expect(entry).toBe(null)
+      })
+
+      const rootResponse = await page!.goto(`${next.url}/docs/`, {
+        waitUntil: 'domcontentloaded',
+      })
+      expect(rootResponse?.status()).toBe(200)
+
+      await next.stop()
+      await page!.context().setOffline(true)
+      const offlineResponse = await page!.goto(cachedUrl, {
+        waitUntil: 'domcontentloaded',
+      })
+      expect(offlineResponse?.status()).toBe(200)
+      await retry(async () => {
+        expect(
+          await browser.eval(() =>
+            document.documentElement.getAttribute(
+              'data-next-offline-navigation-cache-reason'
+            )
+          )
+        ).toBe('missing-entry')
+      })
+      expect(
+        await browser.eval(() => {
+          const win = window as typeof window & {
+            __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?: Array<unknown>
+          }
+          return win.__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?.at(-1)
+        })
+      ).toMatchObject({
+        type: 'cache-miss',
+        reason: 'missing-entry',
+        url: `${next.url}/docs/url-stress/space%20value/?token=a%2Bb&tag=one&tag=two#section-1`,
+      })
+
+      const reorderedSearchResponse = await page!.goto(
+        `${next.url}/docs/url-stress/space%20value/?tag=one&tag=two&token=a%2Bb#section-3`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(reorderedSearchResponse?.status()).toBe(200)
+      await retry(async () => {
+        expect(
+          await browser.eval(() =>
+            document.documentElement.getAttribute(
+              'data-next-offline-navigation-cache-reason'
+            )
+          )
+        ).toBe('missing-entry')
+      })
+      expect(
+        await browser.eval(() => {
+          const win = window as typeof window & {
+            __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?: Array<unknown>
+          }
+          return win.__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?.at(-1)
+        })
+      ).toMatchObject({
+        type: 'cache-miss',
+        reason: 'missing-entry',
+        url: `${next.url}/docs/url-stress/space%20value/?tag=one&tag=two&token=a%2Bb#section-3`,
+      })
+
+      await page!.context().setOffline(false)
+      await browser.eval(() => {
+        window.dispatchEvent(new Event('online'))
+      })
+      await cleanupOfflineNavigationState(browser)
     } finally {
       if (page) {
         await page.context().setOffline(false)

--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -50,6 +50,60 @@ describe('offlineNavigations build artifacts', () => {
     }
   }
 
+  async function readPersistedOfflineNavigationEntry(
+    browser: Awaited<ReturnType<typeof next.browser>>,
+    urlSubstring: string
+  ) {
+    return browser.eval(async (substring) => {
+      const database = await new Promise<IDBDatabase>((resolve, reject) => {
+        const request = indexedDB.open('next-offline-navigation-cache', 1)
+        request.onupgradeneeded = () => {
+          const database = request.result
+          if (!database.objectStoreNames.contains('navigation-data')) {
+            database.createObjectStore('navigation-data', {
+              keyPath: ['buildId', 'url'],
+            })
+          }
+        }
+        request.onsuccess = () => resolve(request.result)
+        request.onerror = () => reject(request.error)
+      })
+
+      try {
+        const entries = await new Promise<any[]>((resolve, reject) => {
+          const transaction = database.transaction(
+            'navigation-data',
+            'readonly'
+          )
+          const request = transaction.objectStore('navigation-data').getAll()
+          request.onsuccess = () => resolve(request.result)
+          request.onerror = () => reject(request.error)
+        })
+        const entry = entries.find((entry) => entry.url.includes(substring))
+        if (!entry) {
+          return null
+        }
+
+        return {
+          buildId: entry.buildId,
+          expiresAt: entry.expiresAt,
+          kind: entry.kind,
+          payload: {
+            bodyLength: entry.payload.body.byteLength,
+            kind: entry.payload.kind,
+            requestKind: entry.payload.requestKind,
+            status: entry.payload.status,
+          },
+          staleAt: entry.staleAt,
+          url: entry.url,
+          version: entry.version,
+        }
+      } finally {
+        database.close()
+      }
+    }, urlSubstring)
+  }
+
   it('emits request-invariant offline navigation artifacts when enabled', async () => {
     const buildResult = await next.build()
     expect(buildResult.exitCode).toBe(0)
@@ -62,7 +116,11 @@ describe('offlineNavigations build artifacts', () => {
 
     expect(html).toContain('data-next-offline-navigation-fallback')
     expect(html).toContain('id="__NEXT_OFFLINE_NAVIGATION_FALLBACK"')
+    expect(html).toContain('id="__NEXT_OFFLINE_NAVIGATION_CACHE_MISS"')
     expect(html).toContain(`"buildId":"${buildId}"`)
+    if (next.deploymentId) {
+      expect(html).toContain(`data-dpl-id="${next.deploymentId}"`)
+    }
     expect(html).toContain('self.__next_f')
     expect(html).toContain('/app-assets/_next/static/')
     expect(html).not.toContain('offline navigations page')
@@ -114,6 +172,7 @@ describe('offlineNavigations build artifacts', () => {
     expect(buildResult.exitCode).toBe(0)
 
     const { buildId } = await getOfflineNavigationArtifactPaths()
+    const navigationBuildId = next.deploymentId ?? buildId
     await next.start({ skipBuild: true })
 
     let page: Playwright.Page | undefined
@@ -205,18 +264,6 @@ describe('offlineNavigations build artifacts', () => {
         )
       })
 
-      await browser.eval((messageType) => {
-        localStorage.removeItem('__nextOfflineNavigationMessage')
-        navigator.serviceWorker.addEventListener('message', (event) => {
-          if (event.data?.type === messageType) {
-            localStorage.setItem(
-              '__nextOfflineNavigationMessage',
-              JSON.stringify(event.data)
-            )
-          }
-        })
-      }, OFFLINE_NAVIGATION_FALLBACK_SERVED)
-
       const cacheState = await browser.eval(async () => {
         const cacheNames = (await caches.keys()).filter((cacheName) =>
           cacheName.startsWith('next-offline-navigation-v1:')
@@ -253,7 +300,107 @@ describe('offlineNavigations build artifacts', () => {
         ])
       )
 
+      await retry(async () => {
+        const initialLoadEntry = await readPersistedOfflineNavigationEntry(
+          browser,
+          '/docs/'
+        )
+        expect(initialLoadEntry).toEqual({
+          buildId: navigationBuildId,
+          expiresAt: expect.any(Number),
+          kind: 'exact-url',
+          payload: {
+            bodyLength: expect.any(Number),
+            kind: 'rsc-response',
+            requestKind: 'initial-load',
+            status: 200,
+          },
+          staleAt: expect.any(Number),
+          url: expect.stringContaining('/docs/'),
+          version: 1,
+        })
+        expect(initialLoadEntry!.payload.bodyLength).toBeGreaterThan(0)
+      })
+
       await page!.context().setOffline(true)
+      const initialLoadOfflineResponse = await page!.goto(`${next.url}/docs/`, {
+        waitUntil: 'domcontentloaded',
+      })
+      expect(initialLoadOfflineResponse?.status()).toBe(200)
+      await retry(async () => {
+        expect(await browser.elementByCss('p').text()).toBe(
+          'offline navigations page'
+        )
+      })
+      expect(await browser.elementById('offline-status').text()).toBe('offline')
+      await page!.context().setOffline(false)
+      await browser.eval(() => {
+        window.dispatchEvent(new Event('online'))
+      })
+      await retry(async () => {
+        expect(await browser.elementById('offline-status').text()).toBe(
+          'online'
+        )
+      })
+
+      await browser.eval((messageType) => {
+        localStorage.removeItem('__nextOfflineNavigationMessage')
+        navigator.serviceWorker.addEventListener('message', (event) => {
+          if (event.data?.type === messageType) {
+            localStorage.setItem(
+              '__nextOfflineNavigationMessage',
+              JSON.stringify(event.data)
+            )
+          }
+        })
+      }, OFFLINE_NAVIGATION_FALLBACK_SERVED)
+
+      await browser.elementById('prefetch-offline-navigation').click()
+      await retry(async () => {
+        const persistedEntry = await readPersistedOfflineNavigationEntry(
+          browser,
+          '/docs/prefetched'
+        )
+        expect(persistedEntry).toEqual({
+          buildId: navigationBuildId,
+          expiresAt: expect.any(Number),
+          kind: 'exact-url',
+          payload: {
+            bodyLength: expect.any(Number),
+            kind: 'rsc-response',
+            requestKind: 'client-resume',
+            status: 200,
+          },
+          staleAt: expect.any(Number),
+          url: expect.stringContaining('/docs/prefetched'),
+          version: 1,
+        })
+        expect(persistedEntry!.payload.bodyLength).toBeGreaterThan(0)
+      })
+
+      await page!.context().setOffline(true)
+      const cachedOfflineResponse = await page!.goto(
+        `${next.url}/docs/prefetched`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(cachedOfflineResponse?.status()).toBe(200)
+      await retry(async () => {
+        expect(await browser.elementById('prefetched-page').text()).toBe(
+          'prefetched page'
+        )
+      })
+      expect(await browser.elementById('offline-status').text()).toBe('offline')
+      const cachedServiceWorkerMessage = await browser.eval(() => {
+        const message = localStorage.getItem('__nextOfflineNavigationMessage')
+        return message === null ? null : JSON.parse(message)
+      })
+      expect(cachedServiceWorkerMessage).toMatchObject({
+        type: OFFLINE_NAVIGATION_FALLBACK_SERVED,
+        buildId,
+        reason: 'network-error',
+        url: `${next.url}/docs/prefetched`,
+      })
+
       const nonNavigationResult = await browser.eval(async () => {
         try {
           await fetch('/docs?__next_offline_probe=1', {
@@ -266,6 +413,7 @@ describe('offlineNavigations build artifacts', () => {
       })
       expect(nonNavigationResult).toBe('rejected')
 
+      await next.stop()
       const offlineResponse = await page!.goto(
         `${next.url}/docs/offline-navigation-cache-miss`,
         { waitUntil: 'domcontentloaded' }
@@ -278,15 +426,23 @@ describe('offlineNavigations build artifacts', () => {
           )
         )
       ).toBe(true)
-      const serviceWorkerMessage = await browser.eval(() => {
-        const message = localStorage.getItem('__nextOfflineNavigationMessage')
-        return message === null ? null : JSON.parse(message)
-      })
-      expect(serviceWorkerMessage).toMatchObject({
-        type: OFFLINE_NAVIGATION_FALLBACK_SERVED,
-        buildId,
-        reason: 'network-error',
-        url: `${next.url}/docs/offline-navigation-cache-miss`,
+      await retry(async () => {
+        expect(
+          await browser.eval(() => {
+            const cacheMiss = document.getElementById(
+              '__NEXT_OFFLINE_NAVIGATION_CACHE_MISS'
+            )
+            return cacheMiss === null
+              ? null
+              : {
+                  hidden: cacheMiss.hidden,
+                  text: cacheMiss.textContent,
+                }
+          })
+        ).toEqual({
+          hidden: false,
+          text: 'This page is not available offline.',
+        })
       })
       await page!.context().setOffline(false)
 


### PR DESCRIPTION
## Stack Position

This is PR 8/13 in the compressed offline navigations stack. Chapter: Exact URL replay.

Review guide: https://gist.github.com/feedthejim/b3d9fe26a7c05655fd57adcce371b93d

## Full Stack

1. [#93622](https://github.com/vercel/next.js/pull/93622) offline navigations: add gated build primitives (1/13)
2. [#93624](https://github.com/vercel/next.js/pull/93624) offline navigations: emit fallback manifest data (2/13)
3. [#93625](https://github.com/vercel/next.js/pull/93625) offline navigations: register pass-through worker (3/13)
4. [#93626](https://github.com/vercel/next.js/pull/93626) offline navigations: cache fallback artifacts (4/13)
5. [#93627](https://github.com/vercel/next.js/pull/93627) offline navigations: serve fallback document offline (5/13)
6. [#93630](https://github.com/vercel/next.js/pull/93630) offline navigations: add persistent navigation cache (6/13)
7. [#93631](https://github.com/vercel/next.js/pull/93631) offline navigations: replay exact-url navigations (7/13)
8. [#93635](https://github.com/vercel/next.js/pull/93635) offline navigations: handle exact-url eligibility and invalidation (8/13) **current**
9. [#93640](https://github.com/vercel/next.js/pull/93640) offline navigations: persist router records (9/13)
10. [#93644](https://github.com/vercel/next.js/pull/93644) offline navigations: hydrate router cache from persisted records (10/13)
11. [#93646](https://github.com/vercel/next.js/pull/93646) offline navigations: reconstruct prefetched routes offline (11/13)
12. [#93647](https://github.com/vercel/next.js/pull/93647) offline navigations: support dynamic route patterns (12/13)
13. [#93650](https://github.com/vercel/next.js/pull/93650) offline navigations: wire invalidation and reset APIs (13/13)

## Context

The original offline navigations work was split into 25 staging PRs, which made the review surface too noisy. This compressed stack keeps the same first-usable feature at the tip, but groups the work by reviewer-facing behavior: build artifacts first, exact URL replay next, then route-record replay and invalidation.

The architecture boundary is intentional: the generated service worker keeps the app bootable by serving the fallback document, while the cache-components client router owns IndexedDB, replay eligibility, route reconstruction, visible misses, and invalidation.

Folded source PRs: #93636, #93637, #93638, plus remaining exact-URL coverage from #93639.

## What This PR Does

- Centralizes cache eligibility and visible miss reasons for exact URL replay.
- Supports same-browser request-sensitive replay while records are fresh and scoped to the current browser/build.
- Adds exact URL invalidation so stale records are not replayed after router cache changes.

## What Works After This PR

After this PR, exact URL replay is the first usable client behavior: fresh compatible records replay, unsupported or invalid records visibly miss, and invalidated records are unreachable.

## What Intentionally Does Not Work Yet

A route that was prefetched but never loaded as an exact URL still cannot be reconstructed offline.

## Reviewer Focus

Eligibility rules, diagnostics, request-sensitive semantics, freshness/schema/build guards, and exact URL invalidation.

## Proof in This PR

- Focused production e2e passed in Turbopack and webpack modes.
- The suite includes request-sensitive replay, exact URL shape stress, and visible miss paths.
- The cache unit suite covers skip reasons, exact URL invalidation epochs, and expiry.
- `git diff --check canary..HEAD` passed.
- `git diff --stat HEAD f60949e313` and `git diff --name-status HEAD f60949e313` produced no output, so the compressed tip preserves the previous staging tip.
- `pnpm --filter=next build` passed.
- `NEXT_TEST_MODE=start pnpm testheadless test/production/app-dir/offline-navigations/offline-navigations.test.ts` passed, 12/12.
- `IS_WEBPACK_TEST=1 NEXT_TEST_MODE=start pnpm testheadless test/production/app-dir/offline-navigations/offline-navigations.test.ts` passed, 12/12.

## Deferred Coverage

Persistent route, segment, and head records start in PR 9/13.

<!-- NEXT_JS_LLM_PR -->
