### PR TITLE
offline navigations: harden fallback diagnostics and misses (15/25)

### DIFF
--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -55,13 +55,93 @@ function isOfflineNavigationFallbackDocument(): boolean {
   )
 }
 
-function showOfflineNavigationCacheMiss(): void {
+const OFFLINE_NAVIGATION_DIAGNOSTIC_LIMIT = 32
+
+type OfflineNavigationCacheMissReason =
+  | 'missing-entry'
+  | 'invalid-payload'
+  | 'unsupported-request-kind'
+  | 'read-error'
+
+type OfflineNavigationFallbackDiagnostic =
+  | {
+      type: 'cache-hit'
+      url: string
+      buildId: string | undefined
+      requestKind: OfflineNavigationFallbackResponse['requestKind']
+    }
+  | {
+      type: 'cache-miss'
+      url: string
+      buildId: string | undefined
+      reason: OfflineNavigationCacheMissReason
+    }
+
+declare global {
+  interface Window {
+    __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?:
+      | OfflineNavigationFallbackDiagnostic[]
+      | undefined
+  }
+}
+
+function reportOfflineNavigationFallbackDiagnostic(
+  diagnostic: OfflineNavigationFallbackDiagnostic
+): void {
+  const diagnostics = (window.__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__ ??= [])
+  if (diagnostics.length >= OFFLINE_NAVIGATION_DIAGNOSTIC_LIMIT) {
+    diagnostics.shift()
+  }
+  diagnostics.push(diagnostic)
+}
+
+function showOfflineNavigationCacheHit(
+  requestKind: OfflineNavigationFallbackResponse['requestKind'],
+  buildId: string | undefined
+): void {
+  document.documentElement.setAttribute(
+    'data-next-offline-navigation-cache',
+    'hit'
+  )
+  document.documentElement.removeAttribute(
+    'data-next-offline-navigation-cache-reason'
+  )
+  reportOfflineNavigationFallbackDiagnostic({
+    type: 'cache-hit',
+    url: location.href,
+    buildId,
+    requestKind,
+  })
+}
+
+function showOfflineNavigationCacheMiss(
+  reason: OfflineNavigationCacheMissReason,
+  buildId: string | undefined
+): void {
+  document.documentElement.setAttribute(
+    'data-next-offline-navigation-cache',
+    'miss'
+  )
+  document.documentElement.setAttribute(
+    'data-next-offline-navigation-cache-reason',
+    reason
+  )
   const cacheMissElement = document.getElementById(
     '__NEXT_OFFLINE_NAVIGATION_CACHE_MISS'
   )
   if (cacheMissElement !== null) {
     cacheMissElement.hidden = false
+    cacheMissElement.setAttribute(
+      'data-next-offline-navigation-cache-reason',
+      reason
+    )
   }
+  reportOfflineNavigationFallbackDiagnostic({
+    type: 'cache-miss',
+    url: location.href,
+    buildId,
+    reason,
+  })
 }
 
 function neverResolveOfflineNavigationResponse(): Promise<Response> {
@@ -97,12 +177,22 @@ function createOfflineNavigationFallbackResponse():
     })
     const payload = entry?.payload
 
+    if (!isOfflineNavigationRSCResponsePayload(payload)) {
+      showOfflineNavigationCacheMiss(
+        payload === undefined ? 'missing-entry' : 'invalid-payload',
+        buildId
+      )
+      return {
+        requestKind: 'client-resume',
+        response: await neverResolveOfflineNavigationResponse(),
+      }
+    }
+
     if (
-      !isOfflineNavigationRSCResponsePayload(payload) ||
-      (payload.requestKind !== 'client-resume' &&
-        payload.requestKind !== 'initial-load')
+      payload.requestKind !== 'client-resume' &&
+      payload.requestKind !== 'initial-load'
     ) {
-      showOfflineNavigationCacheMiss()
+      showOfflineNavigationCacheMiss('unsupported-request-kind', buildId)
       return {
         requestKind: 'client-resume',
         response: await neverResolveOfflineNavigationResponse(),
@@ -112,12 +202,13 @@ function createOfflineNavigationFallbackResponse():
     const requestKind: OfflineNavigationFallbackResponse['requestKind'] =
       payload.requestKind === 'initial-load' ? 'initial-load' : 'client-resume'
 
+    showOfflineNavigationCacheHit(requestKind, buildId)
     return {
       requestKind,
       response: createOfflineNavigationRSCResponse(payload),
     }
   })().catch(async (): Promise<OfflineNavigationFallbackResponse> => {
-    showOfflineNavigationCacheMiss()
+    showOfflineNavigationCacheMiss('read-error', undefined)
     return {
       requestKind: 'client-resume',
       response: await neverResolveOfflineNavigationResponse(),

--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -338,6 +338,18 @@ describe('offlineNavigations build artifacts', () => {
         )
       })
       expect(await browser.elementById('offline-status').text()).toBe('offline')
+      expect(
+        await browser.eval(() => {
+          const win = window as typeof window & {
+            __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?: Array<unknown>
+          }
+          return win.__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?.at(-1)
+        })
+      ).toMatchObject({
+        type: 'cache-hit',
+        requestKind: 'initial-load',
+        url: `${next.url}/docs/`,
+      })
       await page!.context().setOffline(false)
       await browser.eval(() => {
         window.dispatchEvent(new Event('online'))
@@ -420,6 +432,18 @@ describe('offlineNavigations build artifacts', () => {
         )
       })
       expect(await browser.elementById('offline-status').text()).toBe('offline')
+      expect(
+        await browser.eval(() => {
+          const win = window as typeof window & {
+            __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?: Array<unknown>
+          }
+          return win.__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?.at(-1)
+        })
+      ).toMatchObject({
+        type: 'cache-hit',
+        requestKind: 'client-resume',
+        url: `${next.url}/docs/prefetched`,
+      })
       const cachedServiceWorkerMessage = await browser.eval(() => {
         const message = localStorage.getItem('__nextOfflineNavigationMessage')
         return message === null ? null : JSON.parse(message)
@@ -443,7 +467,61 @@ describe('offlineNavigations build artifacts', () => {
       })
       expect(nonNavigationResult).toBe('rejected')
 
+      await browser.eval(
+        async ({ buildId: entryBuildId, url }) => {
+          const database = await new Promise<IDBDatabase>((resolve, reject) => {
+            const request = indexedDB.open('next-offline-navigation-cache', 2)
+            request.onsuccess = () => resolve(request.result)
+            request.onerror = () => reject(request.error)
+          })
+
+          try {
+            const transaction = database.transaction(
+              'navigation-data',
+              'readwrite'
+            )
+            transaction.objectStore('navigation-data').put({
+              version: 2,
+              kind: 'exact-url',
+              buildId: entryBuildId,
+              url,
+              cacheEpoch: 1,
+              createdAt: Date.now(),
+              staleAt: Date.now() + 60_000,
+              expiresAt: Date.now() + 60_000,
+              payload: { kind: 'not-rsc-response' },
+            })
+            await new Promise<void>((resolve, reject) => {
+              transaction.oncomplete = () => resolve()
+              transaction.onerror = () => reject(transaction.error)
+              transaction.onabort = () => reject(transaction.error)
+            })
+          } finally {
+            database.close()
+          }
+        },
+        {
+          buildId: navigationBuildId,
+          url: `${next.url}/docs/malformed-offline-entry/`,
+        }
+      )
+
       await next.stop()
+      const malformedResponse = await page!.goto(
+        `${next.url}/docs/malformed-offline-entry/`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(malformedResponse?.status()).toBe(200)
+      await retry(async () => {
+        expect(
+          await browser.eval(() =>
+            document.documentElement.getAttribute(
+              'data-next-offline-navigation-cache-reason'
+            )
+          )
+        ).toBe('invalid-payload')
+      })
+
       const offlineResponse = await page!.goto(
         `${next.url}/docs/offline-navigation-cache-miss`,
         { waitUntil: 'domcontentloaded' }
@@ -466,13 +544,41 @@ describe('offlineNavigations build artifacts', () => {
               ? null
               : {
                   hidden: cacheMiss.hidden,
+                  reason: cacheMiss.getAttribute(
+                    'data-next-offline-navigation-cache-reason'
+                  ),
                   text: cacheMiss.textContent,
                 }
           })
         ).toEqual({
           hidden: false,
+          reason: 'missing-entry',
           text: 'This page is not available offline.',
         })
+      })
+      expect(
+        await browser.eval(() => ({
+          cache: document.documentElement.getAttribute(
+            'data-next-offline-navigation-cache'
+          ),
+          reason: document.documentElement.getAttribute(
+            'data-next-offline-navigation-cache-reason'
+          ),
+          diagnostic:
+            (
+              window as typeof window & {
+                __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?: Array<unknown>
+              }
+            ).__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?.at(-1) ?? null,
+        }))
+      ).toMatchObject({
+        cache: 'miss',
+        reason: 'missing-entry',
+        diagnostic: {
+          type: 'cache-miss',
+          reason: 'missing-entry',
+          url: `${next.url}/docs/offline-navigation-cache-miss`,
+        },
       })
       await page!.context().setOffline(false)
 


### PR DESCRIPTION
## Stack Position

15/25 in the offline navigations first-usable stack.

This stack turns `experimental.offlineNavigations` into a usable cache-components experiment for regular apps. The service worker owns document survival only. Cache Storage owns generated fallback artifacts. The cache-components client router owns IndexedDB, route semantics, replay, visible misses, and invalidation. Output export, dev simulation, custom miss UI, and broad production-hardening matrices are intentionally deferred.

Review guide: https://gist.github.com/feedthejim/b3d9fe26a7c05655fd57adcce371b93d

## Full Stack

1. offline navigations: add cache-components flag (1/25)
2. offline navigations: emit fallback document (2/25)
3. offline navigations: emit fallback manifest (3/25)
4. offline navigations: register pass-through service worker (4/25)
5. offline navigations: cache fallback artifacts (5/25)
6. offline navigations: serve fallback document (6/25)
7. offline navigations: bridge fallback state to useOffline (7/25)
8. offline navigations: add navigation cache primitives (8/25)
9. offline navigations: persist exact-url navigation data (9/25)
10. offline navigations: boot fallback from exact-url data (10/25)
11. offline navigations: persist initial-load navigation data (11/25)
12. offline navigations: centralize cache eligibility (12/25)
13. offline navigations: replay request-sensitive exact urls (13/25)
14. offline navigations: wire exact-url invalidation (14/25)
15. offline navigations: harden fallback diagnostics and misses (15/25) ← this PR
16. offline navigations: cover exact-url app replay basics (16/25)
17. offline navigations: define persistent router schema (17/25)
18. offline navigations: persist route records and known routes (18/25)
19. offline navigations: persist segment and head records (19/25)
20. offline navigations: hydrate persisted router caches (20/25)
21. offline navigations: reconstruct prefetched routes offline (21/25)
22. offline navigations: replay dynamic routes from known routes (22/25)
23. offline navigations: mirror router cache invalidation (23/25)
24. offline navigations: cover mutation invalidation (24/25)
25. offline navigations: add app cache reset API (25/25)

## What This PR Does

Improves fallback boot diagnostics and visible miss states for invalid or unavailable offline data.

## What Works After This PR

Cache misses have structured reasons and user-visible fallback UI instead of blank pages or silent failures.

## Reviewer Focus

Diagnostic shape, DOM miss markers, invalid-payload handling, and making miss reasons stable enough for tests without exposing a product API yet.

## Not In This PR

Full observability product surface and broader corruption matrices are P1/P2 follow-ups.

## Proof in This PR

- Relevant coverage: Invalid payload and visible miss assertions in the production fixture plus stack-level build/e2e verification.
- Restack verification run at the cleaned stack tip:
  - `pnpm --filter=next build`
  - `NEXT_SKIP_ISOLATE=1 NEXT_TEST_MODE=start pnpm testheadless test/production/app-dir/offline-navigations/offline-navigations.test.ts`
  - `NEXT_TEST_MODE=start pnpm testheadless test/production/app-dir/offline-navigations/offline-navigations.test.ts`
  - `IS_WEBPACK_TEST=1 NEXT_TEST_MODE=start pnpm testheadless test/production/app-dir/offline-navigations/offline-navigations.test.ts`

## Deferred Coverage

Full observability product surface and broader corruption matrices are P1/P2 follow-ups.

<!-- NEXT_JS_LLM_PR -->
