### PR TITLE
offline navigations: persist segment and head records (19/25)

### DIFF
--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -685,7 +685,7 @@ export async function createFetch<T>(
 
 function getOfflineNavigationCacheRequestKind(
   headers: RequestHeaders
-): 'navigation' | 'route-prefetch' | 'client-resume' | null {
+): OfflineNavigationRSCResponseRequestKind | null {
   if (
     !process.env.__NEXT_OFFLINE_NAVIGATIONS ||
     process.env.__NEXT_DEV_SERVER ||
@@ -705,8 +705,12 @@ function getOfflineNavigationCacheRequestKind(
 
   if (
     headers[NEXT_ROUTER_PREFETCH_HEADER] !== undefined &&
-    headers[NEXT_ROUTER_SEGMENT_PREFETCH_HEADER] === undefined
+    headers[NEXT_ROUTER_SEGMENT_PREFETCH_HEADER] !== undefined
   ) {
+    return 'segment-prefetch'
+  }
+
+  if (headers[NEXT_ROUTER_PREFETCH_HEADER] !== undefined) {
     return 'route-prefetch'
   }
 

--- a/packages/next/src/client/components/router-reducer/offline-navigation-cache.test.ts
+++ b/packages/next/src/client/components/router-reducer/offline-navigation-cache.test.ts
@@ -411,6 +411,12 @@ describe('offline navigation cache', () => {
     expect(
       isOfflineNavigationRSCResponsePayload({ ...payload, body: null })
     ).toBe(false)
+    expect(
+      isOfflineNavigationRSCResponsePayload({
+        ...payload,
+        requestKind: 'segment-prefetch',
+      })
+    ).toBe(true)
   })
 
   it('writes RSC response payloads through the exact URL cache', async () => {
@@ -637,6 +643,7 @@ describe('offline navigation cache', () => {
           requestKey: 'children/page',
           fetchStrategy: 1,
           isPartial: false,
+          payloadIndex: 0,
         },
         segmentVaryPath,
         payload: { kind: 'segment-payload' },
@@ -671,6 +678,7 @@ describe('offline navigation cache', () => {
       kind: 'segment',
       segment: {
         requestKey: 'children/page',
+        payloadIndex: 0,
       },
       segmentVaryPath,
       version: 1,
@@ -867,6 +875,7 @@ describe('offline navigation cache', () => {
           requestKey: 'children/page',
           fetchStrategy: 1,
           isPartial: false,
+          payloadIndex: 0,
         },
         segmentVaryPath: [],
         payload: null,

--- a/packages/next/src/client/components/router-reducer/offline-navigation-cache.ts
+++ b/packages/next/src/client/components/router-reducer/offline-navigation-cache.ts
@@ -20,6 +20,7 @@ type OfflineNavigationRouterCacheKey = [buildId: string, key: string]
 export type OfflineNavigationRSCResponseRequestKind =
   | 'navigation'
   | 'route-prefetch'
+  | 'segment-prefetch'
   | 'client-resume'
   | 'initial-load'
 
@@ -125,6 +126,7 @@ export type OfflineNavigationSegmentRecord = {
     requestKey: string
     fetchStrategy: number
     isPartial: boolean
+    payloadIndex: number
   }
   segmentVaryPath: OfflineNavigationSerializedVaryPath
   payload: unknown
@@ -656,6 +658,7 @@ export function isOfflineNavigationRSCResponsePayload(
     candidate.kind === 'rsc-response' &&
     (candidate.requestKind === 'navigation' ||
       candidate.requestKind === 'route-prefetch' ||
+      candidate.requestKind === 'segment-prefetch' ||
       candidate.requestKind === 'client-resume' ||
       candidate.requestKind === 'initial-load') &&
     typeof candidate.url === 'string' &&

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -59,9 +59,13 @@ import {
 } from './vary-path'
 import { createHrefFromUrl } from '../router-reducer/create-href-from-url'
 import {
+  createOfflineNavigationVaryPathKey,
   invalidateOfflineNavigationCacheEntries,
   getOfflineNavigationRSCResponseCacheSkipReason,
+  serializeOfflineNavigationVaryPath,
   writeOfflineNavigationRSCResponseCacheEntry,
+  writeOfflineNavigationSegmentRecord,
+  type OfflineNavigationRSCResponsePayload,
 } from '../router-reducer/offline-navigation-cache'
 import type {
   NormalizedPathname,
@@ -2150,7 +2154,17 @@ export async function fetchSegmentsOnCacheMiss(
       }
 
       // Set the fulfilled entry into the canonical cache slot.
-      upsertSegmentEntry(now, canonicalVaryPath, fulfilled)
+      const upserted = upsertSegmentEntry(now, canonicalVaryPath, fulfilled)
+      if (upserted !== null && upserted.status === EntryStatus.Fulfilled) {
+        persistOfflineNavigationSegmentRecord(
+          now,
+          node.tree,
+          canonicalVaryPath,
+          upserted,
+          dataIndex,
+          response.offlineNavigationCachePayload
+        )
+      }
 
       node = node.parent
       dataIndex++
@@ -2967,6 +2981,48 @@ export function canNewFetchStrategyProvideMoreContent(
   newStrategy: FetchStrategy
 ): boolean {
   return currentStrategy < newStrategy
+}
+
+function persistOfflineNavigationSegmentRecord(
+  now: number,
+  tree: RouteTree,
+  varyPath: SegmentVaryPath,
+  entry: FulfilledSegmentCacheEntry,
+  payloadIndex: number,
+  payload: Promise<OfflineNavigationRSCResponsePayload | null> | null
+): void {
+  if (
+    !process.env.__NEXT_OFFLINE_NAVIGATIONS ||
+    process.env.__NEXT_DEV_SERVER ||
+    process.env.NODE_ENV !== 'production' ||
+    process.env.__NEXT_CONFIG_OUTPUT === 'export' ||
+    entry.staleAt <= now ||
+    payload === null
+  ) {
+    return
+  }
+
+  void (async () => {
+    const resolvedPayload = await payload
+    if (resolvedPayload === null) {
+      return
+    }
+
+    await writeOfflineNavigationSegmentRecord({
+      key: createOfflineNavigationVaryPathKey(varyPath),
+      now,
+      staleAt: entry.staleAt,
+      expiresAt: entry.staleAt,
+      segment: {
+        requestKey: tree.requestKey,
+        fetchStrategy: entry.fetchStrategy,
+        isPartial: entry.isPartial,
+        payloadIndex,
+      },
+      segmentVaryPath: serializeOfflineNavigationVaryPath(varyPath),
+      payload: resolvedPayload,
+    })
+  })()
 }
 
 /**

--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -155,6 +155,47 @@ describe('offlineNavigations build artifacts', () => {
     })
   }
 
+  async function readPersistedOfflineNavigationSegmentRecords(
+    browser: Awaited<ReturnType<typeof next.browser>>
+  ) {
+    return browser.eval(async () => {
+      const database = await new Promise<IDBDatabase>((resolve, reject) => {
+        const request = indexedDB.open('next-offline-navigation-cache', 3)
+        request.onsuccess = () => resolve(request.result)
+        request.onerror = () => reject(request.error)
+      })
+
+      try {
+        const entries = await new Promise<any[]>((resolve, reject) => {
+          const transaction = database.transaction('segment-data', 'readonly')
+          const request = transaction.objectStore('segment-data').getAll()
+          request.onsuccess = () => resolve(request.result)
+          request.onerror = () => reject(request.error)
+        })
+
+        return entries.map((entry) => ({
+          buildId: entry.buildId,
+          cacheEpoch: entry.cacheEpoch,
+          expiresAt: entry.expiresAt,
+          key: entry.key,
+          kind: entry.kind,
+          payload: {
+            bodyLength: entry.payload?.body?.byteLength,
+            kind: entry.payload?.kind,
+            requestKind: entry.payload?.requestKind,
+            status: entry.payload?.status,
+          },
+          segment: entry.segment,
+          segmentVaryPath: entry.segmentVaryPath,
+          staleAt: entry.staleAt,
+          version: entry.version,
+        }))
+      } finally {
+        database.close()
+      }
+    })
+  }
+
   async function cleanupOfflineNavigationState(
     browser: Awaited<ReturnType<typeof next.browser>>
   ) {
@@ -510,6 +551,61 @@ describe('offlineNavigations build artifacts', () => {
             version: 1,
           })
         )
+      })
+      await retry(async () => {
+        const segmentRecords =
+          await readPersistedOfflineNavigationSegmentRecords(browser)
+        const headRecord = segmentRecords.find(
+          (record) => record.segment.requestKey === '/_head'
+        )
+        const pageRecord = segmentRecords.find(
+          (record) =>
+            record.segment.requestKey !== '/_head' &&
+            record.payload.requestKind === 'segment-prefetch'
+        )
+
+        expect(headRecord).toEqual(
+          expect.objectContaining({
+            buildId: navigationBuildId,
+            cacheEpoch: 0,
+            kind: 'segment',
+            payload: {
+              bodyLength: expect.any(Number),
+              kind: 'rsc-response',
+              requestKind: 'segment-prefetch',
+              status: 200,
+            },
+            segment: expect.objectContaining({
+              fetchStrategy: expect.any(Number),
+              isPartial: expect.any(Boolean),
+              payloadIndex: expect.any(Number),
+              requestKey: '/_head',
+            }),
+            segmentVaryPath: expect.any(Array),
+            version: 1,
+          })
+        )
+        expect(headRecord!.payload.bodyLength).toBeGreaterThan(0)
+
+        expect(pageRecord).toEqual(
+          expect.objectContaining({
+            buildId: navigationBuildId,
+            cacheEpoch: 0,
+            kind: 'segment',
+            payload: {
+              bodyLength: expect.any(Number),
+              kind: 'rsc-response',
+              requestKind: 'segment-prefetch',
+              status: 200,
+            },
+            segment: expect.objectContaining({
+              payloadIndex: expect.any(Number),
+            }),
+            segmentVaryPath: expect.any(Array),
+            version: 1,
+          })
+        )
+        expect(pageRecord!.payload.bodyLength).toBeGreaterThan(0)
       })
 
       await page!.context().setOffline(true)


### PR DESCRIPTION
## Stack Position

19/25 in the offline navigations first-usable stack.

This stack turns `experimental.offlineNavigations` into a usable cache-components experiment for regular apps. The service worker owns document survival only. Cache Storage owns generated fallback artifacts. The cache-components client router owns IndexedDB, route semantics, replay, visible misses, and invalidation. Output export, dev simulation, custom miss UI, and broad production-hardening matrices are intentionally deferred.

Review guide: https://gist.github.com/feedthejim/b3d9fe26a7c05655fd57adcce371b93d

## Full Stack

1. offline navigations: add cache-components flag (1/25)
2. offline navigations: emit fallback document (2/25)
3. offline navigations: emit fallback manifest (3/25)
4. offline navigations: register pass-through service worker (4/25)
5. offline navigations: cache fallback artifacts (5/25)
6. offline navigations: serve fallback document (6/25)
7. offline navigations: bridge fallback state to useOffline (7/25)
8. offline navigations: add navigation cache primitives (8/25)
9. offline navigations: persist exact-url navigation data (9/25)
10. offline navigations: boot fallback from exact-url data (10/25)
11. offline navigations: persist initial-load navigation data (11/25)
12. offline navigations: centralize cache eligibility (12/25)
13. offline navigations: replay request-sensitive exact urls (13/25)
14. offline navigations: wire exact-url invalidation (14/25)
15. offline navigations: harden fallback diagnostics and misses (15/25)
16. offline navigations: cover exact-url app replay basics (16/25)
17. offline navigations: define persistent router schema (17/25)
18. offline navigations: persist route records and known routes (18/25)
19. offline navigations: persist segment and head records (19/25) ← this PR
20. offline navigations: hydrate persisted router caches (20/25)
21. offline navigations: reconstruct prefetched routes offline (21/25)
22. offline navigations: replay dynamic routes from known routes (22/25)
23. offline navigations: mirror router cache invalidation (23/25)
24. offline navigations: cover mutation invalidation (24/25)
25. offline navigations: add app cache reset API (25/25)

## What This PR Does

Persists fulfilled segment and head records that correspond to cache-components router cache entries.

## What Works After This PR

Prefetched route parts can be stored durably with enough metadata for later reconstruction.

## Reviewer Focus

Segment/head payload metadata, request keys, vary paths, stale/expire fields, and avoiding partial or unsupported records.

## Not In This PR

Metadata/style/Suspense ordering and broad route graph completeness are follow-ups.

## Proof in This PR

- Relevant coverage: Segment/head persistence assertions in the production fixture plus stack-level build/e2e verification.
- Restack verification run at the cleaned stack tip:
  - `pnpm --filter=next build`
  - `NEXT_SKIP_ISOLATE=1 NEXT_TEST_MODE=start pnpm testheadless test/production/app-dir/offline-navigations/offline-navigations.test.ts`
  - `NEXT_TEST_MODE=start pnpm testheadless test/production/app-dir/offline-navigations/offline-navigations.test.ts`
  - `IS_WEBPACK_TEST=1 NEXT_TEST_MODE=start pnpm testheadless test/production/app-dir/offline-navigations/offline-navigations.test.ts`

## Deferred Coverage

Metadata/style/Suspense ordering and broad route graph completeness are follow-ups.

<!-- NEXT_JS_LLM_PR -->
