### PR TITLE
offline navigations: bootstrap fallback from Segment Cache records (8/21)

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -4110,6 +4110,7 @@ export default async function build(
               buildId,
               buildManifest,
               crossOrigin: config.crossOrigin,
+              deploymentId: config.deploymentId,
             })
 
             if (fallbackDocument === null) {

--- a/packages/next/src/build/offline-navigation-fallback.ts
+++ b/packages/next/src/build/offline-navigation-fallback.ts
@@ -10,6 +10,7 @@ import { CLIENT_STATIC_FILES_PATH } from '../shared/lib/constants'
 import { createInitialInlinedFlightDataScriptContent } from '../shared/lib/inlined-flight-data'
 import {
   OFFLINE_NAVIGATION_BUILD_ID_META_NAME,
+  OFFLINE_NAVIGATION_CACHE_MISS_ELEMENT_ID,
   OFFLINE_NAVIGATION_FALLBACK_DOCUMENT_ATTRIBUTE,
   OFFLINE_NAVIGATION_FALLBACK_HTML,
   OFFLINE_NAVIGATION_FALLBACK_META_NAME,
@@ -83,6 +84,10 @@ function renderInitialFlightBootstrapScript(): string {
   return `<script>${createInitialInlinedFlightDataScriptContent(null)}</script>`
 }
 
+function renderOfflineNavigationCacheMissElement(): string {
+  return `<p id="${OFFLINE_NAVIGATION_CACHE_MISS_ELEMENT_ID}" hidden>This page is not available offline.</p>`
+}
+
 export interface OfflineNavigationFallbackDocument {
   html: string
   assetHrefs: string[]
@@ -91,19 +96,24 @@ export interface OfflineNavigationFallbackDocument {
 function renderFallbackDocument({
   bootstrapScripts,
   buildId,
+  deploymentId,
   metadata,
   polyfillScripts,
 }: {
   bootstrapScripts: string
   buildId: string
+  deploymentId: string | undefined
   metadata: unknown
   polyfillScripts: string
 }): string {
   const escapedBuildId = htmlEscapeAttributeString(buildId)
+  const deploymentIdAttribute = deploymentId
+    ? ` data-dpl-id="${htmlEscapeAttributeString(deploymentId)}"`
+    : ''
 
   return [
     '<!DOCTYPE html>',
-    `<html ${OFFLINE_NAVIGATION_FALLBACK_DOCUMENT_ATTRIBUTE}="" data-build-id="${escapedBuildId}">`,
+    `<html ${OFFLINE_NAVIGATION_FALLBACK_DOCUMENT_ATTRIBUTE}="" data-build-id="${escapedBuildId}"${deploymentIdAttribute}>`,
     '<head>',
     '<meta charSet="utf-8">',
     '<meta name="viewport" content="width=device-width, initial-scale=1">',
@@ -113,6 +123,7 @@ function renderFallbackDocument({
     '</head>',
     '<body>',
     '<div id="__next"></div>',
+    renderOfflineNavigationCacheMissElement(),
     renderInitialFlightBootstrapScript(),
     polyfillScripts,
     bootstrapScripts,
@@ -122,18 +133,21 @@ function renderFallbackDocument({
 }
 
 // Generate the build-scoped HTML entrypoint used by offline document fallback
-// handling. It intentionally contains only the app bootstrap, not route HTML,
-// so the artifact stays request-invariant.
+// handling. It intentionally contains only the app bootstrap, not route HTML;
+// route data is restored by the client from persisted Segment Cache records
+// after this document loads.
 export function createOfflineNavigationFallbackDocument({
   assetPrefix,
   buildId,
   buildManifest,
   crossOrigin,
+  deploymentId,
 }: {
   assetPrefix: string
   buildId: string
   buildManifest: BuildManifest
   crossOrigin: '' | 'anonymous' | 'use-credentials' | undefined
+  deploymentId: string | undefined
 }): OfflineNavigationFallbackDocument | null {
   const rootMainFiles = buildManifest.rootMainFiles.filter((file) =>
     file.endsWith('.js')
@@ -178,6 +192,7 @@ export function createOfflineNavigationFallbackDocument({
     html: renderFallbackDocument({
       bootstrapScripts,
       buildId,
+      deploymentId,
       metadata,
       polyfillScripts,
     }),

--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -45,6 +45,37 @@ const instantTestStaticFetch: Promise<Response> | undefined =
     ? (self.__next_instant_test as unknown as Promise<Response>)
     : undefined
 
+type OfflineNavigationBootstrapModule =
+  typeof import('./offline-navigation-bootstrap')
+
+let offlineNavigationBootstrap: OfflineNavigationBootstrapModule | null
+let offlineNavigationFallbackBootstrap: ReturnType<
+  OfflineNavigationBootstrapModule['createOfflineNavigationFallbackBootstrap']
+>
+if (process.env.__NEXT_OFFLINE_NAVIGATIONS) {
+  offlineNavigationBootstrap =
+    (require('./offline-navigation-bootstrap') as typeof import('./offline-navigation-bootstrap'))
+  offlineNavigationFallbackBootstrap =
+    offlineNavigationBootstrap.createOfflineNavigationFallbackBootstrap()
+} else {
+  offlineNavigationBootstrap = null
+  offlineNavigationFallbackBootstrap = undefined
+}
+
+if (process.env.__NEXT_USE_OFFLINE) {
+  offlineNavigationBootstrap?.notifyOfflineNavigationFallback(
+    offlineNavigationFallbackBootstrap
+  )
+} else {
+  // Keep the offline event module out of disabled client bundles.
+}
+
+const hasClientResumeShell = Boolean(window.__NEXT_CLIENT_RESUME)
+const hasLockedStaticShell =
+  Boolean(instantTestStaticFetch) ||
+  Boolean(offlineNavigationFallbackBootstrap) ||
+  hasClientResumeShell
+
 const encoder = new TextEncoder()
 
 let initialServerDataBuffer: (string | Uint8Array)[] | undefined = undefined
@@ -73,6 +104,7 @@ declare global {
      */
     __next_r?: string
     __next_f: NextFlight
+    __NEXT_CLIENT_RESUME?: Promise<Response>
   }
 }
 
@@ -128,14 +160,13 @@ function nextServerDataRegisterWriter(ctr: ReadableStreamDefaultController) {
       ctr.enqueue(typeof val === 'string' ? encoder.encode(val) : val)
     })
     if (initialServerDataLoaded && !initialServerDataFlushed) {
-      // Instant Navigation Testing API: don't close or error the inline
-      // Flight stream. The static shell has no inline Flight data, so the
-      // stream is empty. Closing it would cause React to log an error about
-      // missing data. Leaving it open lets React treat any holes as
-      // "still suspended." Hydration uses the separately fetched RSC payload
-      // (self.__next_instant_test), not this stream.
+      // Locked static shells do not have a real inline Flight stream. Closing
+      // or erroring this stream causes React to report a missing-data failure,
+      // but the actual hydration data arrives through a separate response:
+      // the instant test fetch, client resume fetch, or
+      // offline Segment Cache reconstruction.
       if (isStreamErrorOrUnfinished(ctr)) {
-        if (!instantTestStaticFetch) {
+        if (!hasLockedStaticShell) {
           ctr.error(
             new Error(
               'The connection to the page was unexpectedly closed, possibly due to the stop button being clicked, loss of Wi-Fi, or an unstable internet connection.'
@@ -155,7 +186,11 @@ function nextServerDataRegisterWriter(ctr: ReadableStreamDefaultController) {
 
 // When `DOMContentLoaded`, we can close all pending writers to finish hydration.
 const DOMContentLoaded = function () {
-  if (initialServerDataWriter && !initialServerDataFlushed) {
+  if (
+    initialServerDataWriter &&
+    !initialServerDataFlushed &&
+    !hasLockedStaticShell
+  ) {
     initialServerDataWriter.close()
     initialServerDataFlushed = true
     initialServerDataBuffer = undefined
@@ -187,7 +222,7 @@ let readable: ReadableStream<Uint8Array> = new ReadableStream({
   },
 })
 if (process.env.NODE_ENV !== 'production') {
-  // @ts-expect-error
+  // @ts-expect-error name is a dev-only debugging affordance.
   readable.name = 'hydration'
 }
 
@@ -198,7 +233,8 @@ if (process.env.NODE_ENV !== 'production') {
 let initialFlightStreamForCache: ReadableStream<Uint8Array> | null = null
 if (
   process.env.__NEXT_CACHE_COMPONENTS &&
-  process.env.__NEXT_EXPERIMENTAL_CACHED_NAVIGATIONS
+  process.env.__NEXT_EXPERIMENTAL_CACHED_NAVIGATIONS &&
+  !offlineNavigationFallbackBootstrap
 ) {
   const [forReact, forCache] = readable.tee()
   readable = forReact
@@ -242,13 +278,13 @@ if (instantTestStaticFetch) {
       initialRSCPayload
     )
   })
-} else if (
-  // @ts-expect-error
-  window.__NEXT_CLIENT_RESUME
-) {
-  const clientResumeFetch: Promise<Response> =
-    // @ts-expect-error
-    window.__NEXT_CLIENT_RESUME
+} else if (offlineNavigationFallbackBootstrap) {
+  initialServerResponse =
+    offlineNavigationBootstrap!.getOfflineNavigationInitialRSCPayload(
+      offlineNavigationFallbackBootstrap
+    )
+} else if (window.__NEXT_CLIENT_RESUME) {
+  const clientResumeFetch: Promise<Response> = window.__NEXT_CLIENT_RESUME
   initialServerResponse = Promise.resolve(
     createFromFetch<InitialRSCPayload>(clientResumeFetch, {
       callServer,
@@ -362,12 +398,6 @@ export async function hydrate(
   }
   const initialRSCPayload = await initialServerResponse
 
-  // Initialize the offline module to register browser event listeners
-  // (offline/online) before any components hydrate.
-  if (process.env.__NEXT_USE_OFFLINE) {
-    require('./components/offline') as typeof import('./components/offline')
-  }
-
   // setNavigationBuildId should be called only once, during JS initialization
   // and before any components have hydrated.
   if (initialRSCPayload.b) {
@@ -377,11 +407,7 @@ export async function hydrate(
   }
 
   if (process.env.__NEXT_OFFLINE_NAVIGATIONS) {
-    if (!process.env.__NEXT_DEV_SERVER) {
-      const { registerOfflineNavigationServiceWorker } =
-        require('./offline-navigation-service-worker') as typeof import('./offline-navigation-service-worker')
-      registerOfflineNavigationServiceWorker()
-    }
+    offlineNavigationBootstrap?.registerOfflineNavigationServiceWorker()
   } else {
     // Keep the service worker module out of disabled client bundles.
   }
@@ -412,9 +438,13 @@ export async function hydrate(
     </StrictModeIfEnabled>
   )
 
-  if (document.documentElement.id === '__next_error__') {
+  if (
+    document.documentElement.id === '__next_error__' ||
+    offlineNavigationBootstrap?.isOfflineNavigationFallbackDocument()
+  ) {
     let element = reactEl
-    // Server rendering failed, fall back to client-side rendering
+    // Error documents and generated offline navigation fallback documents do
+    // not contain route HTML that can be hydrated.
     if (process.env.NODE_ENV !== 'production') {
       const { RootLevelDevOverlayElement } =
         require('../next-devtools/userspace/app/client-entry') as typeof import('../next-devtools/userspace/app/client-entry')

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -88,6 +88,12 @@ export function createInitialRouterState({
     acc
   )
   const metadataVaryPath = acc.metadataVaryPath
+  const initialStaleAt =
+    location === null ||
+    initialSeedData === null ||
+    initialStaticStageByteLength !== undefined
+      ? null
+      : getStaleAt(navigatedAt, initialStaleTime)
   const initialTask = createInitialCacheNodeForHydration(
     navigatedAt,
     initialRouteTree,
@@ -157,7 +163,7 @@ export function createInitialRouterState({
         // hydration and write it into the cache directly.
         const now = Date.now()
 
-        getStaleAt(now, initialStaleTime)
+        initialStaleAt!
           .then((staleAt) => {
             writeStaticStageResponseIntoCache(
               now,

--- a/packages/next/src/client/components/use-offline.tsx
+++ b/packages/next/src/client/components/use-offline.tsx
@@ -15,12 +15,14 @@ const OfflineContext = createContext<boolean>(false)
 // (via dispatchOfflineChange) to update the React tree.
 let setOptimistic: ((value: boolean) => void) | null = null
 let setCanonical: ((value: boolean) => void) | null = null
+let offlineSnapshot = false
 
 /**
  * Called by the offline module when the offline state changes.
  * Dispatches into React via startTransition + useOptimistic.
  */
 export function dispatchOfflineChange(isOffline: boolean): void {
+  offlineSnapshot = isOffline
   const canonical = setCanonical
   const optimistic = setOptimistic
   if (canonical === null || optimistic === null) {
@@ -33,7 +35,7 @@ export function dispatchOfflineChange(isOffline: boolean): void {
 }
 
 export function OfflineProvider({ children }: { children: React.ReactNode }) {
-  const [canonicalOffline, setCanonicalOffline] = useState(false)
+  const [canonicalOffline, setCanonicalOffline] = useState(offlineSnapshot)
   const [isOffline, setOptimisticOffline] = useOptimistic(canonicalOffline)
 
   setOptimistic = setOptimisticOffline

--- a/packages/next/src/client/offline-navigation-bootstrap.ts
+++ b/packages/next/src/client/offline-navigation-bootstrap.ts
@@ -1,0 +1,169 @@
+import type { InitialRSCPayload } from '../shared/lib/app-router-types'
+import { getDeploymentId } from '../shared/lib/deployment-id'
+import {
+  OFFLINE_NAVIGATION_CACHE_MISS_ELEMENT_ID,
+  OFFLINE_NAVIGATION_CACHE_REASON_ATTRIBUTE,
+  OFFLINE_NAVIGATION_CACHE_STATUS_ATTRIBUTE,
+  OFFLINE_NAVIGATION_FALLBACK_DOCUMENT_ATTRIBUTE,
+} from '../shared/lib/offline-navigation-constants'
+import DefaultGlobalError from './components/builtin/global-error'
+
+type OfflineNavigationCacheMissReason =
+  | 'missing-route'
+  | 'unsupported-route'
+  | 'missing-segment'
+  | 'missing-head'
+  | 'read-error'
+
+export type OfflineNavigationFallbackBootstrap =
+  | {
+      kind: 'segment-cache'
+      initialRSCPayload: InitialRSCPayload
+      buildId: string | undefined
+    }
+  | {
+      kind: 'cache-miss'
+      buildId: string | undefined
+    }
+
+export function isOfflineNavigationFallbackDocument(): boolean {
+  return Boolean(
+    !process.env.__NEXT_DEV_SERVER &&
+      document.documentElement.hasAttribute(
+        OFFLINE_NAVIGATION_FALLBACK_DOCUMENT_ATTRIBUTE
+      )
+  )
+}
+
+// Private test markers for the offline navigation e2e suite. These are only
+// emitted when the production testing API is explicitly enabled.
+function showOfflineNavigationCacheHit(): void {
+  if (process.env.__NEXT_EXPOSE_TESTING_API) {
+    document.documentElement.setAttribute(
+      OFFLINE_NAVIGATION_CACHE_STATUS_ATTRIBUTE,
+      'hit'
+    )
+    document.documentElement.removeAttribute(
+      OFFLINE_NAVIGATION_CACHE_REASON_ATTRIBUTE
+    )
+  }
+}
+
+function showOfflineNavigationCacheMiss(
+  reason: OfflineNavigationCacheMissReason
+): void {
+  if (process.env.__NEXT_EXPOSE_TESTING_API) {
+    document.documentElement.setAttribute(
+      OFFLINE_NAVIGATION_CACHE_STATUS_ATTRIBUTE,
+      'miss'
+    )
+    document.documentElement.setAttribute(
+      OFFLINE_NAVIGATION_CACHE_REASON_ATTRIBUTE,
+      reason
+    )
+  }
+  const cacheMissElement = document.getElementById(
+    OFFLINE_NAVIGATION_CACHE_MISS_ELEMENT_ID
+  )
+  if (cacheMissElement !== null) {
+    cacheMissElement.hidden = false
+    if (process.env.__NEXT_EXPOSE_TESTING_API) {
+      cacheMissElement.setAttribute(
+        OFFLINE_NAVIGATION_CACHE_REASON_ATTRIBUTE,
+        reason
+      )
+    }
+  }
+}
+
+function neverResolveInitialRSCPayload(): Promise<InitialRSCPayload> {
+  return new Promise<InitialRSCPayload>(() => {})
+}
+
+// The generated fallback document has no inline Flight data for the current
+// URL. Hydrate the persisted Segment Cache records, then reconstruct the
+// initial payload from the in-memory Segment Cache.
+export function createOfflineNavigationFallbackBootstrap():
+  | Promise<OfflineNavigationFallbackBootstrap>
+  | undefined {
+  if (!isOfflineNavigationFallbackDocument()) {
+    return undefined
+  }
+
+  return (async (): Promise<OfflineNavigationFallbackBootstrap> => {
+    const {
+      createOfflineNavigationInitialRSCPayloadFromSegmentCache,
+      hydrateOfflineNavigationSegmentCache,
+    } =
+      require('./components/segment-cache/cache') as typeof import('./components/segment-cache/cache')
+
+    const buildId =
+      getDeploymentId() ??
+      document.documentElement.getAttribute('data-build-id') ??
+      undefined
+    await hydrateOfflineNavigationSegmentCache({
+      buildId,
+    })
+
+    const reconstruction =
+      createOfflineNavigationInitialRSCPayloadFromSegmentCache({
+        buildId,
+        globalErrorState: [DefaultGlobalError, undefined],
+        now: Date.now(),
+        url: location.href,
+      })
+    if (reconstruction.status === 'fulfilled') {
+      showOfflineNavigationCacheHit()
+      return {
+        kind: 'segment-cache',
+        initialRSCPayload: reconstruction.initialRSCPayload,
+        buildId,
+      }
+    }
+    showOfflineNavigationCacheMiss(reconstruction.reason)
+    return {
+      kind: 'cache-miss',
+      buildId,
+    }
+  })().catch((): OfflineNavigationFallbackBootstrap => {
+    showOfflineNavigationCacheMiss('read-error')
+    return {
+      kind: 'cache-miss',
+      buildId: undefined,
+    }
+  })
+}
+
+export function getOfflineNavigationInitialRSCPayload(
+  bootstrap: Promise<OfflineNavigationFallbackBootstrap>
+): Promise<InitialRSCPayload> {
+  return bootstrap.then(async (result) => {
+    if (result.kind === 'segment-cache') {
+      return result.initialRSCPayload
+    }
+
+    return await neverResolveInitialRSCPayload()
+  })
+}
+
+export function notifyOfflineNavigationFallback(
+  bootstrap: Promise<OfflineNavigationFallbackBootstrap> | undefined
+): void {
+  if (bootstrap === undefined) {
+    return
+  }
+
+  const { notifyOffline } =
+    require('./components/offline') as typeof import('./components/offline')
+  notifyOffline()
+}
+
+export function registerOfflineNavigationServiceWorker(): void {
+  if (process.env.__NEXT_DEV_SERVER) {
+    return
+  } else {
+    const { registerOfflineNavigationServiceWorker: registerServiceWorker } =
+      require('./offline-navigation-service-worker') as typeof import('./offline-navigation-service-worker')
+    registerServiceWorker()
+  }
+}

--- a/packages/next/src/shared/lib/offline-navigation-constants.ts
+++ b/packages/next/src/shared/lib/offline-navigation-constants.ts
@@ -11,8 +11,14 @@ export const OFFLINE_NAVIGATION_SERVICE_WORKER_METADATA_GLOBAL =
   '__NEXT_OFFLINE_NAVIGATION_SW'
 export const OFFLINE_NAVIGATION_FALLBACK_DOCUMENT_ATTRIBUTE =
   'data-next-offline-navigation-fallback'
+export const OFFLINE_NAVIGATION_CACHE_STATUS_ATTRIBUTE =
+  'data-next-offline-navigation-cache'
+export const OFFLINE_NAVIGATION_CACHE_REASON_ATTRIBUTE =
+  'data-next-offline-navigation-cache-reason'
 export const OFFLINE_NAVIGATION_FALLBACK_SCRIPT_ID =
   '__NEXT_OFFLINE_NAVIGATION_FALLBACK'
+export const OFFLINE_NAVIGATION_CACHE_MISS_ELEMENT_ID =
+  '__NEXT_OFFLINE_NAVIGATION_CACHE_MISS'
 export const OFFLINE_NAVIGATION_FALLBACK_META_NAME =
   'next-offline-navigation-fallback'
 export const OFFLINE_NAVIGATION_BUILD_ID_META_NAME = 'next-build-id'

--- a/test/e2e/app-dir/offline-navigations-deploy/app/page.tsx
+++ b/test/e2e/app-dir/offline-navigations-deploy/app/page.tsx
@@ -1,9 +1,13 @@
+import Link from 'next/link'
 import { OfflineStatus } from './offline-status'
 
 export default function Page() {
   return (
     <>
       <p id="offline-navigations-page">offline navigations deploy page</p>
+      <Link id="viewport-prefetch-offline-navigation" href="/viewport-prefetch">
+        Viewport prefetch offline navigation
+      </Link>
       <OfflineStatus />
     </>
   )

--- a/test/e2e/app-dir/offline-navigations-deploy/app/viewport-prefetch/page.tsx
+++ b/test/e2e/app-dir/offline-navigations-deploy/app/viewport-prefetch/page.tsx
@@ -1,0 +1,3 @@
+export default function ViewportPrefetchPage() {
+  return <p id="viewport-prefetch-page">viewport prefetch page</p>
+}

--- a/test/e2e/app-dir/offline-navigations-deploy/offline-navigations-deploy.test.ts
+++ b/test/e2e/app-dir/offline-navigations-deploy/offline-navigations-deploy.test.ts
@@ -91,6 +91,97 @@ describe('offlineNavigations deploy-safe runtime behavior', () => {
     })
   }
 
+  async function readPersistedOfflineNavigationRouteRecords(
+    browser: Awaited<ReturnType<typeof next.browser>>
+  ) {
+    return browser.eval(async () => {
+      const database = await new Promise<IDBDatabase>((resolve, reject) => {
+        const request = indexedDB.open('next-offline-navigation-cache', 1)
+        request.onupgradeneeded = () => {
+          const database = request.result
+          if (!database.objectStoreNames.contains('route-data')) {
+            database.createObjectStore('route-data', {
+              keyPath: ['buildId', 'key'],
+            })
+          }
+          if (!database.objectStoreNames.contains('segment-data')) {
+            database.createObjectStore('segment-data', {
+              keyPath: ['buildId', 'key'],
+            })
+          }
+          if (!database.objectStoreNames.contains('metadata')) {
+            database.createObjectStore('metadata')
+          }
+        }
+        request.onsuccess = () => resolve(request.result)
+        request.onerror = () => reject(request.error)
+      })
+
+      try {
+        const entries = await new Promise<any[]>((resolve, reject) => {
+          const transaction = database.transaction('route-data', 'readonly')
+          const request = transaction.objectStore('route-data').getAll()
+          request.onsuccess = () => resolve(request.result)
+          request.onerror = () => reject(request.error)
+        })
+
+        return entries.map((entry) => ({
+          key: entry.key,
+          route: entry.route,
+        }))
+      } finally {
+        database.close()
+      }
+    })
+  }
+
+  async function readPersistedOfflineNavigationSegmentRecords(
+    browser: Awaited<ReturnType<typeof next.browser>>
+  ) {
+    return browser.eval(async () => {
+      const database = await new Promise<IDBDatabase>((resolve, reject) => {
+        const request = indexedDB.open('next-offline-navigation-cache', 1)
+        request.onupgradeneeded = () => {
+          const database = request.result
+          if (!database.objectStoreNames.contains('route-data')) {
+            database.createObjectStore('route-data', {
+              keyPath: ['buildId', 'key'],
+            })
+          }
+          if (!database.objectStoreNames.contains('segment-data')) {
+            database.createObjectStore('segment-data', {
+              keyPath: ['buildId', 'key'],
+            })
+          }
+          if (!database.objectStoreNames.contains('metadata')) {
+            database.createObjectStore('metadata')
+          }
+        }
+        request.onsuccess = () => resolve(request.result)
+        request.onerror = () => reject(request.error)
+      })
+
+      try {
+        const entries = await new Promise<any[]>((resolve, reject) => {
+          const transaction = database.transaction('segment-data', 'readonly')
+          const request = transaction.objectStore('segment-data').getAll()
+          request.onsuccess = () => resolve(request.result)
+          request.onerror = () => reject(request.error)
+        })
+
+        return entries.map((entry) => ({
+          key: entry.key,
+          payload: {
+            requestKind: entry.payload?.requestKind,
+          },
+          segment: entry.segment,
+        }))
+      } finally {
+        database.close()
+      }
+    })
+  }
+
   it('registers the service worker and serves current-build assets from Cache Storage', async () => {
     let page: Playwright.Page | undefined
     try {
@@ -186,6 +277,53 @@ describe('offlineNavigations deploy-safe runtime behavior', () => {
         status: 200,
       })
       await page!.context().setOffline(false)
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+    }
+  })
+
+  it('recovers a viewport-prefetched route while offline', async () => {
+    let page: Playwright.Page | undefined
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
+
+      await retry(async () => {
+        const routeRecords =
+          await readPersistedOfflineNavigationRouteRecords(browser)
+        expect(
+          routeRecords.some((record) =>
+            record.route.pathname.includes('/viewport-prefetch')
+          )
+        ).toBe(true)
+
+        const segmentRecords =
+          await readPersistedOfflineNavigationSegmentRecords(browser)
+        expect(
+          segmentRecords.some(
+            (record) =>
+              record.key.includes('viewport-prefetch') &&
+              record.payload.requestKind === 'segment-prefetch'
+          )
+        ).toBe(true)
+      })
+
+      await page!.context().setOffline(true)
+      const response = await page!.goto(`${next.url}/docs/viewport-prefetch/`, {
+        waitUntil: 'domcontentloaded',
+      })
+      expect(response?.status()).toBe(200)
+      await retry(async () => {
+        expect(await browser.elementById('viewport-prefetch-page').text()).toBe(
+          'viewport prefetch page'
+        )
+      })
     } finally {
       if (page) {
         await page.context().setOffline(false)

--- a/test/production/app-dir/offline-navigations/app/page.tsx
+++ b/test/production/app-dir/offline-navigations/app/page.tsx
@@ -1,10 +1,44 @@
+import { cacheLife, cacheTag, updateTag } from 'next/cache'
+import Link from 'next/link'
 import { OfflineStatus } from './offline-status'
+import {
+  DynamicPatternSourcePrefetchButton,
+  DynamicPatternTargetPrefetchButton,
+  PrefetchButton,
+  RefreshButton,
+} from './prefetch-button'
+
+async function ActionInvalidationMarker() {
+  'use cache'
+  cacheLife('max')
+  cacheTag('offline-navigation-action')
+
+  return <p id="action-invalidation-marker">action invalidation marker</p>
+}
+
+async function invalidateOfflineNavigationAction() {
+  'use server'
+  updateTag('offline-navigation-action')
+}
 
 export default function Page() {
   return (
     <>
       <p>offline navigations page</p>
+      <Link id="viewport-prefetch-offline-navigation" href="/viewport-prefetch">
+        Viewport prefetch offline navigation
+      </Link>
       <OfflineStatus />
+      <ActionInvalidationMarker />
+      <form action={invalidateOfflineNavigationAction}>
+        <button id="invalidate-offline-navigation-action" type="submit">
+          Invalidate offline navigation action
+        </button>
+      </form>
+      <PrefetchButton />
+      <DynamicPatternSourcePrefetchButton />
+      <DynamicPatternTargetPrefetchButton />
+      <RefreshButton />
     </>
   )
 }

--- a/test/production/app-dir/offline-navigations/app/prefetch-button.tsx
+++ b/test/production/app-dir/offline-navigations/app/prefetch-button.tsx
@@ -1,0 +1,48 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+
+export function PrefetchButton() {
+  const router = useRouter()
+  return (
+    <button
+      id="prefetch-offline-navigation"
+      onClick={() => router.prefetch('/prefetched')}
+    >
+      Prefetch offline navigation
+    </button>
+  )
+}
+
+export function DynamicPatternSourcePrefetchButton() {
+  const router = useRouter()
+  return (
+    <button
+      id="prefetch-dynamic-pattern-source"
+      onClick={() => router.prefetch('/dynamic-prefetch/learned')}
+    >
+      Prefetch dynamic pattern source
+    </button>
+  )
+}
+
+export function DynamicPatternTargetPrefetchButton() {
+  const router = useRouter()
+  return (
+    <button
+      id="prefetch-dynamic-pattern-target"
+      onClick={() => router.prefetch('/dynamic-prefetch/replayed')}
+    >
+      Prefetch dynamic pattern target
+    </button>
+  )
+}
+
+export function RefreshButton() {
+  const router = useRouter()
+  return (
+    <button id="refresh-offline-navigation" onClick={() => router.refresh()}>
+      Refresh offline navigation
+    </button>
+  )
+}

--- a/test/production/app-dir/offline-navigations/app/prefetched/page.tsx
+++ b/test/production/app-dir/offline-navigations/app/prefetched/page.tsx
@@ -1,0 +1,10 @@
+import { OfflineStatus } from '../offline-status'
+
+export default function PrefetchedPage() {
+  return (
+    <>
+      <p id="prefetched-page">prefetched page</p>
+      <OfflineStatus />
+    </>
+  )
+}

--- a/test/production/app-dir/offline-navigations/app/request-sensitive/page.tsx
+++ b/test/production/app-dir/offline-navigations/app/request-sensitive/page.tsx
@@ -1,0 +1,17 @@
+import { cookies } from 'next/headers'
+import { OfflineStatus } from '../offline-status'
+
+export const unstable_instant = false
+export const unstable_prefetch = 'force-disabled'
+
+export default async function RequestSensitivePage() {
+  const cookieStore = await cookies()
+  const session = cookieStore.get('offline-session')?.value ?? 'missing'
+
+  return (
+    <>
+      <p id="request-sensitive-page">request sensitive session: {session}</p>
+      <OfflineStatus />
+    </>
+  )
+}

--- a/test/production/app-dir/offline-navigations/app/url-stress/[value]/hash-indicator.tsx
+++ b/test/production/app-dir/offline-navigations/app/url-stress/[value]/hash-indicator.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+export function HashIndicator() {
+  const [hash, setHash] = useState('')
+
+  useEffect(() => {
+    const updateHash = () => setHash(window.location.hash)
+    updateHash()
+    window.addEventListener('hashchange', updateHash)
+
+    return () => {
+      window.removeEventListener('hashchange', updateHash)
+    }
+  }, [])
+
+  return <p id="url-stress-hash">url stress hash: {hash}</p>
+}

--- a/test/production/app-dir/offline-navigations/app/url-stress/[value]/page.tsx
+++ b/test/production/app-dir/offline-navigations/app/url-stress/[value]/page.tsx
@@ -1,0 +1,36 @@
+import { OfflineStatus } from '../../offline-status'
+import { HashIndicator } from './hash-indicator'
+
+type PageProps = {
+  params: Promise<{ value: string }>
+  searchParams: Promise<{
+    tag?: string | string[]
+    token?: string
+  }>
+}
+
+export const unstable_instant = false
+
+export default async function UrlStressPage({
+  params,
+  searchParams,
+}: PageProps) {
+  const { value } = await params
+  const query = await searchParams
+  const tags =
+    query.tag === undefined
+      ? []
+      : Array.isArray(query.tag)
+        ? query.tag
+        : [query.tag]
+
+  return (
+    <>
+      <p id="url-stress-page">url stress path: {value}</p>
+      <p id="url-stress-token">url stress token: {query.token ?? 'missing'}</p>
+      <p id="url-stress-tags">url stress tags: {tags.join(',')}</p>
+      <HashIndicator />
+      <OfflineStatus />
+    </>
+  )
+}

--- a/test/production/app-dir/offline-navigations/app/viewport-prefetch/page.tsx
+++ b/test/production/app-dir/offline-navigations/app/viewport-prefetch/page.tsx
@@ -1,0 +1,3 @@
+export default function ViewportPrefetchPage() {
+  return <p id="viewport-prefetch-page">viewport prefetch page</p>
+}

--- a/test/production/app-dir/offline-navigations/next.config.js
+++ b/test/production/app-dir/offline-navigations/next.config.js
@@ -6,6 +6,7 @@ const nextConfig = {
   assetPrefix: '/app-assets',
   basePath: '/docs',
   experimental: {
+    exposeTestingApiInProductionBuild: true,
     offlineNavigations: true,
   },
   trailingSlash: true,

--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync } from 'fs'
+import { existsSync, readdirSync, readFileSync, statSync } from 'fs'
 import { join } from 'path'
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
@@ -52,6 +52,282 @@ describe('offlineNavigations build artifacts', () => {
       .sort()
   }
 
+  function getStaticClientChunkFiles(directory: string): string[] {
+    if (!existsSync(directory)) {
+      return []
+    }
+
+    return readdirSync(directory).flatMap((entry) => {
+      const absolutePath = join(directory, entry)
+      const stat = statSync(absolutePath)
+      if (stat.isDirectory()) {
+        return getStaticClientChunkFiles(absolutePath)
+      }
+      return absolutePath.endsWith('.js') ? [absolutePath] : []
+    })
+  }
+
+  function getStaticClientChunkForbiddenMatches(
+    directory: string,
+    forbidden: string[]
+  ): Array<{ file: string; token: string; snippet: string }> {
+    const matches: Array<{ file: string; token: string; snippet: string }> = []
+    for (const file of getStaticClientChunkFiles(directory)) {
+      const contents = readFileSync(file, 'utf8')
+      for (const token of forbidden) {
+        const index = contents.indexOf(token)
+        if (index === -1) {
+          continue
+        }
+        matches.push({
+          file,
+          token,
+          snippet: contents.slice(
+            Math.max(0, index - 120),
+            Math.min(contents.length, index + token.length + 120)
+          ),
+        })
+      }
+    }
+    return matches
+  }
+
+  async function readPersistedOfflineNavigationRouteRecords(
+    browser: Awaited<ReturnType<typeof next.browser>>
+  ) {
+    return browser.eval(async () => {
+      const database = await new Promise<IDBDatabase>((resolve, reject) => {
+        const request = indexedDB.open('next-offline-navigation-cache', 1)
+        request.onupgradeneeded = () => {
+          const database = request.result
+          if (!database.objectStoreNames.contains('route-data')) {
+            database.createObjectStore('route-data', {
+              keyPath: ['buildId', 'key'],
+            })
+          }
+          if (!database.objectStoreNames.contains('segment-data')) {
+            database.createObjectStore('segment-data', {
+              keyPath: ['buildId', 'key'],
+            })
+          }
+          if (!database.objectStoreNames.contains('metadata')) {
+            database.createObjectStore('metadata')
+          }
+        }
+        request.onsuccess = () => resolve(request.result)
+        request.onerror = () => reject(request.error)
+      })
+
+      try {
+        const entries = await new Promise<any[]>((resolve, reject) => {
+          const transaction = database.transaction('route-data', 'readonly')
+          const request = transaction.objectStore('route-data').getAll()
+          request.onsuccess = () => resolve(request.result)
+          request.onerror = () => reject(request.error)
+        })
+
+        return entries.map((entry) => ({
+          buildId: entry.buildId,
+          cacheVersion: entry.cacheVersion,
+          hasMetadata: entry.metadata !== null,
+          hasTree: entry.tree !== null,
+          key: entry.key,
+          kind: entry.kind,
+          route: entry.route,
+          routeVaryPath: entry.routeVaryPath,
+          staleAt: entry.staleAt,
+          version: entry.version,
+        }))
+      } finally {
+        database.close()
+      }
+    })
+  }
+
+  async function readPersistedOfflineNavigationSegmentRecords(
+    browser: Awaited<ReturnType<typeof next.browser>>
+  ) {
+    return browser.eval(async () => {
+      const database = await new Promise<IDBDatabase>((resolve, reject) => {
+        const request = indexedDB.open('next-offline-navigation-cache', 1)
+        request.onupgradeneeded = () => {
+          const database = request.result
+          if (!database.objectStoreNames.contains('route-data')) {
+            database.createObjectStore('route-data', {
+              keyPath: ['buildId', 'key'],
+            })
+          }
+          if (!database.objectStoreNames.contains('segment-data')) {
+            database.createObjectStore('segment-data', {
+              keyPath: ['buildId', 'key'],
+            })
+          }
+          if (!database.objectStoreNames.contains('metadata')) {
+            database.createObjectStore('metadata')
+          }
+        }
+        request.onsuccess = () => resolve(request.result)
+        request.onerror = () => reject(request.error)
+      })
+
+      try {
+        const entries = await new Promise<any[]>((resolve, reject) => {
+          const transaction = database.transaction('segment-data', 'readonly')
+          const request = transaction.objectStore('segment-data').getAll()
+          request.onsuccess = () => resolve(request.result)
+          request.onerror = () => reject(request.error)
+        })
+
+        return entries.map((entry) => ({
+          buildId: entry.buildId,
+          cacheVersion: entry.cacheVersion,
+          key: entry.key,
+          kind: entry.kind,
+          payload: {
+            bodyLength: entry.payload?.body?.byteLength,
+            kind: entry.payload?.kind,
+            requestKind: entry.payload?.requestKind,
+          },
+          segment: entry.segment,
+          segmentVaryPath: entry.segmentVaryPath,
+          staleAt: entry.staleAt,
+          version: entry.version,
+        }))
+      } finally {
+        database.close()
+      }
+    })
+  }
+
+  async function readPersistedOfflineNavigationMetadata(
+    browser: Awaited<ReturnType<typeof next.browser>>,
+    key: string
+  ) {
+    return browser.eval(async (metadataKey) => {
+      const database = await new Promise<IDBDatabase>((resolve, reject) => {
+        const request = indexedDB.open('next-offline-navigation-cache', 1)
+        request.onupgradeneeded = () => {
+          const database = request.result
+          if (!database.objectStoreNames.contains('route-data')) {
+            database.createObjectStore('route-data', {
+              keyPath: ['buildId', 'key'],
+            })
+          }
+          if (!database.objectStoreNames.contains('segment-data')) {
+            database.createObjectStore('segment-data', {
+              keyPath: ['buildId', 'key'],
+            })
+          }
+          if (!database.objectStoreNames.contains('metadata')) {
+            database.createObjectStore('metadata')
+          }
+        }
+        request.onsuccess = () => resolve(request.result)
+        request.onerror = () => reject(request.error)
+      })
+
+      try {
+        return await new Promise<unknown>((resolve, reject) => {
+          const transaction = database.transaction('metadata', 'readonly')
+          const request = transaction.objectStore('metadata').get(metadataKey)
+          request.onsuccess = () => resolve(request.result)
+          request.onerror = () => reject(request.error)
+        })
+      } finally {
+        database.close()
+      }
+    }, key)
+  }
+
+  function getPersistedSegmentRequestKey(record: {
+    segmentVaryPath?: Array<{
+      value?: { kind?: string; value?: unknown }
+    }>
+  }): string | null {
+    const requestKey = record.segmentVaryPath?.[0]?.value
+    return requestKey?.kind === 'value' && typeof requestKey.value === 'string'
+      ? requestKey.value
+      : null
+  }
+
+  function isPersistedHeadSegmentRecord(record: {
+    segmentVaryPath?: Array<{
+      value?: { kind?: string; value?: unknown }
+    }>
+  }): boolean {
+    return getPersistedSegmentRequestKey(record)?.endsWith('/_head') ?? false
+  }
+
+  async function deletePersistedOfflineNavigationSegmentRecords(
+    browser: Awaited<ReturnType<typeof next.browser>>,
+    options: {
+      keySubstring: string
+      requestKeySuffix: string
+    }
+  ) {
+    return browser.eval(async ({ keySubstring, requestKeySuffix }) => {
+      const database = await new Promise<IDBDatabase>((resolve, reject) => {
+        const request = indexedDB.open('next-offline-navigation-cache', 1)
+        request.onupgradeneeded = () => {
+          const database = request.result
+          if (!database.objectStoreNames.contains('route-data')) {
+            database.createObjectStore('route-data', {
+              keyPath: ['buildId', 'key'],
+            })
+          }
+          if (!database.objectStoreNames.contains('segment-data')) {
+            database.createObjectStore('segment-data', {
+              keyPath: ['buildId', 'key'],
+            })
+          }
+          if (!database.objectStoreNames.contains('metadata')) {
+            database.createObjectStore('metadata')
+          }
+        }
+        request.onsuccess = () => resolve(request.result)
+        request.onerror = () => reject(request.error)
+      })
+
+      try {
+        const entries = await new Promise<any[]>((resolve, reject) => {
+          const transaction = database.transaction('segment-data', 'readonly')
+          const request = transaction.objectStore('segment-data').getAll()
+          request.onsuccess = () => resolve(request.result)
+          request.onerror = () => reject(request.error)
+        })
+        const matchingEntries = entries.filter((entry) => {
+          const requestKey = entry.segmentVaryPath?.[0]?.value
+          const requestKeyValue =
+            requestKey?.kind === 'value' && typeof requestKey.value === 'string'
+              ? requestKey.value
+              : ''
+          return (
+            entry.key.includes(keySubstring) &&
+            requestKeyValue.endsWith(requestKeySuffix)
+          )
+        })
+
+        if (matchingEntries.length === 0) {
+          return 0
+        }
+
+        const transaction = database.transaction('segment-data', 'readwrite')
+        const store = transaction.objectStore('segment-data')
+        for (const entry of matchingEntries) {
+          store.delete([entry.buildId, entry.key])
+        }
+        await new Promise<void>((resolve, reject) => {
+          transaction.oncomplete = () => resolve()
+          transaction.onerror = () => reject(transaction.error)
+          transaction.onabort = () => reject(transaction.error)
+        })
+        return matchingEntries.length
+      } finally {
+        database.close()
+      }
+    }, options)
+  }
+
   async function readOfflineNavigationCacheState(
     browser: Awaited<ReturnType<typeof next.browser>>
   ) {
@@ -77,6 +353,118 @@ describe('offlineNavigations build artifacts', () => {
     })
   }
 
+  async function cleanupOfflineNavigationState(
+    browser: Awaited<ReturnType<typeof next.browser>>
+  ) {
+    await browser.eval(async () => {
+      if (!('serviceWorker' in navigator)) {
+        return
+      }
+
+      const cacheNames = await caches.keys()
+      await Promise.all(
+        cacheNames
+          .filter((cacheName) =>
+            cacheName.startsWith('next-offline-navigation-v1:')
+          )
+          .map((cacheName) => caches.delete(cacheName))
+      )
+
+      const registrations = await navigator.serviceWorker.getRegistrations()
+      await Promise.all(
+        registrations.map((registration) => registration.unregister())
+      )
+    })
+  }
+
+  async function waitForOfflineNavigationServiceWorker(
+    browser: Awaited<ReturnType<typeof next.browser>>,
+    page: Playwright.Page
+  ) {
+    await retry(
+      async () => {
+        const state = await browser.eval(async () => {
+          if (!('serviceWorker' in navigator)) {
+            return {
+              controlled: false,
+              hasActiveRegistration: false,
+            }
+          }
+
+          const registrations = await navigator.serviceWorker.getRegistrations()
+          return {
+            controlled: Boolean(navigator.serviceWorker.controller),
+            hasActiveRegistration: registrations.some(
+              (registration) =>
+                registration.scope.endsWith('/docs/') &&
+                registration.active !== null
+            ),
+          }
+        })
+
+        expect(state.hasActiveRegistration).toBe(true)
+      },
+      10000,
+      500
+    )
+
+    if (
+      !(await browser.eval(() => Boolean(navigator.serviceWorker.controller)))
+    ) {
+      await page.reload({ waitUntil: 'domcontentloaded' })
+    }
+
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(() => Boolean(navigator.serviceWorker.controller))
+        ).toBe(true)
+      },
+      10000,
+      500
+    )
+  }
+
+  async function expectOfflineNavigationCacheMiss(
+    browser: Awaited<ReturnType<typeof next.browser>>,
+    reason: string
+  ) {
+    await retry(async () => {
+      expect(
+        await browser.eval(() => {
+          const cacheMiss = document.getElementById(
+            '__NEXT_OFFLINE_NAVIGATION_CACHE_MISS'
+          )
+          return {
+            cache: document.documentElement.getAttribute(
+              'data-next-offline-navigation-cache'
+            ),
+            reason: document.documentElement.getAttribute(
+              'data-next-offline-navigation-cache-reason'
+            ),
+            miss: cacheMiss
+              ? {
+                  hidden: cacheMiss.hidden,
+                  reason: cacheMiss.getAttribute(
+                    'data-next-offline-navigation-cache-reason'
+                  ),
+                  text: cacheMiss.textContent,
+                }
+              : null,
+          }
+        })
+      ).toEqual({
+        cache: 'miss',
+        reason,
+        miss: {
+          hidden: false,
+          reason,
+          text: 'This page is not available offline.',
+        },
+      })
+    })
+  }
+
   it('emits request-invariant offline navigation artifacts when enabled', async () => {
     const buildResult = await next.build()
     expect(buildResult.exitCode).toBe(0)
@@ -92,8 +480,12 @@ describe('offlineNavigations build artifacts', () => {
 
     expect(html).toContain('data-next-offline-navigation-fallback')
     expect(html).toContain('id="__NEXT_OFFLINE_NAVIGATION_FALLBACK"')
+    expect(html).toContain('id="__NEXT_OFFLINE_NAVIGATION_CACHE_MISS"')
     expect(html).toContain(`"buildId":"${buildId}"`)
     expect(html).not.toContain('"source"')
+    if (next.deploymentId) {
+      expect(html).toContain(`data-dpl-id="${next.deploymentId}"`)
+    }
     expect(html).toContain(
       '<script>(self.__next_f=self.__next_f||[]).push([0])</script>'
     )
@@ -137,6 +529,7 @@ describe('offlineNavigations build artifacts', () => {
     expect(buildResult.exitCode).toBe(0)
 
     const { buildId } = await getOfflineNavigationArtifactPaths()
+    const navigationBuildId = next.deploymentId ?? buildId
     await next.start({ skipBuild: true })
 
     let page: Playwright.Page | undefined
@@ -181,11 +574,7 @@ describe('offlineNavigations build artifacts', () => {
           scriptURL: `${next.url}/docs/_next/static/_offline-navigation-service-worker.js${next.getDeploymentIdQuery()}`,
         })
       })
-      await retry(async () => {
-        expect(
-          await browser.eval(() => Boolean(navigator.serviceWorker.controller))
-        ).toBe(true)
-      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
       expect(await browser.elementById('offline-status').text()).toBe('online')
 
       await browser.eval((messageType) => {
@@ -226,18 +615,6 @@ describe('offlineNavigations build artifacts', () => {
         )
       })
 
-      await browser.eval((messageType) => {
-        localStorage.removeItem('__nextOfflineNavigationMessage')
-        navigator.serviceWorker.addEventListener('message', (event) => {
-          if (event.data?.type === messageType) {
-            localStorage.setItem(
-              '__nextOfflineNavigationMessage',
-              JSON.stringify(event.data)
-            )
-          }
-        })
-      }, OFFLINE_NAVIGATION_FALLBACK_SERVED)
-
       const cacheName = `next-offline-navigation-v1:${buildId}:/docs`
       await retry(async () => {
         const cacheState = await readOfflineNavigationCacheState(browser)
@@ -258,7 +635,113 @@ describe('offlineNavigations build artifacts', () => {
         )
       })
 
+      await browser.eval((messageType) => {
+        localStorage.removeItem('__nextOfflineNavigationMessage')
+        navigator.serviceWorker.addEventListener('message', (event) => {
+          if (event.data?.type === messageType) {
+            localStorage.setItem(
+              '__nextOfflineNavigationMessage',
+              JSON.stringify(event.data)
+            )
+          }
+        })
+      }, OFFLINE_NAVIGATION_FALLBACK_SERVED)
+
+      await browser.elementById('prefetch-offline-navigation').click()
+      await retry(async () => {
+        const routeRecords =
+          await readPersistedOfflineNavigationRouteRecords(browser)
+        const prefetchedRouteRecord = routeRecords.find((record) =>
+          record.route.pathname.includes('/prefetched')
+        )
+        expect(prefetchedRouteRecord).toEqual(
+          expect.objectContaining({
+            buildId: navigationBuildId,
+            cacheVersion: 0,
+            hasMetadata: true,
+            hasTree: true,
+            kind: 'route',
+            route: expect.objectContaining({
+              supportsPerSegmentPrefetching: true,
+            }),
+            routeVaryPath: expect.any(Array),
+            version: 1,
+          })
+        )
+      })
+      await retry(async () => {
+        const segmentRecords =
+          await readPersistedOfflineNavigationSegmentRecords(browser)
+        const headRecord = segmentRecords.find((record) =>
+          isPersistedHeadSegmentRecord(record)
+        )
+        const pageRecord = segmentRecords.find(
+          (record) =>
+            !isPersistedHeadSegmentRecord(record) &&
+            record.payload.requestKind === 'segment-prefetch'
+        )
+
+        expect(headRecord).toEqual(
+          expect.objectContaining({
+            buildId: navigationBuildId,
+            cacheVersion: 0,
+            kind: 'segment',
+            payload: {
+              bodyLength: expect.any(Number),
+              kind: 'rsc-response',
+              requestKind: 'segment-prefetch',
+            },
+            segment: expect.objectContaining({
+              fetchStrategy: expect.any(Number),
+              isPartial: expect.any(Boolean),
+              payloadIndex: expect.any(Number),
+            }),
+            segmentVaryPath: expect.any(Array),
+            version: 1,
+          })
+        )
+        expect(headRecord!.payload.bodyLength).toBeGreaterThan(0)
+
+        expect(pageRecord).toEqual(
+          expect.objectContaining({
+            buildId: navigationBuildId,
+            cacheVersion: 0,
+            kind: 'segment',
+            payload: {
+              bodyLength: expect.any(Number),
+              kind: 'rsc-response',
+              requestKind: 'segment-prefetch',
+            },
+            segment: expect.objectContaining({
+              payloadIndex: expect.any(Number),
+            }),
+            segmentVaryPath: expect.any(Array),
+            version: 1,
+          })
+        )
+        expect(pageRecord!.payload.bodyLength).toBeGreaterThan(0)
+      })
+
       await page!.context().setOffline(true)
+      const cachedOfflineResponse = await page!.goto(
+        `${next.url}/docs/prefetched`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(cachedOfflineResponse?.status()).toBe(200)
+      await retry(async () => {
+        expect(await browser.elementById('prefetched-page').text()).toBe(
+          'prefetched page'
+        )
+      })
+      expect(await browser.elementById('offline-status').text()).toBe('offline')
+      const cachedServiceWorkerMessage = await browser.eval(() => {
+        const message = localStorage.getItem('__nextOfflineNavigationMessage')
+        return message === null ? null : JSON.parse(message)
+      })
+      expect(cachedServiceWorkerMessage).toEqual({
+        type: OFFLINE_NAVIGATION_FALLBACK_SERVED,
+      })
+
       const nonNavigationResult = await browser.eval(async () => {
         try {
           await fetch('/docs?__next_offline_probe=1', {
@@ -271,6 +754,7 @@ describe('offlineNavigations build artifacts', () => {
       })
       expect(nonNavigationResult).toBe('rejected')
 
+      await next.stop()
       const offlineResponse = await page!.goto(
         `${next.url}/docs/offline-navigation-cache-miss`,
         { waitUntil: 'domcontentloaded' }
@@ -290,6 +774,7 @@ describe('offlineNavigations build artifacts', () => {
       expect(serviceWorkerMessage).toMatchObject({
         type: OFFLINE_NAVIGATION_FALLBACK_SERVED,
       })
+      await expectOfflineNavigationCacheMiss(browser, 'missing-route')
       await page!.context().setOffline(false)
 
       await browser.eval(async () => {
@@ -319,6 +804,578 @@ describe('offlineNavigations build artifacts', () => {
     }
   })
 
+  it('reconstructs a fully prefetched route from persisted Segment Cache records', async () => {
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    await next.start({ skipBuild: true })
+
+    let page: Playwright.Page | undefined
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
+
+      await browser.elementById('prefetch-offline-navigation').click()
+      await retry(async () => {
+        const routeRecords =
+          await readPersistedOfflineNavigationRouteRecords(browser)
+        expect(
+          routeRecords.some((record) =>
+            record.route.pathname.includes('/prefetched')
+          )
+        ).toBe(true)
+
+        const segmentRecords =
+          await readPersistedOfflineNavigationSegmentRecords(browser)
+        expect(
+          segmentRecords.some(
+            (record) => record.payload.requestKind === 'segment-prefetch'
+          )
+        ).toBe(true)
+        expect(
+          segmentRecords.some((record) => isPersistedHeadSegmentRecord(record))
+        ).toBe(true)
+      })
+
+      await next.stop()
+      await page!.context().setOffline(true)
+      const segmentCacheOnlyResponse = await page!.goto(
+        `${next.url}/docs/prefetched`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(segmentCacheOnlyResponse?.status()).toBe(200)
+      await retry(async () => {
+        expect(await browser.elementById('prefetched-page').text()).toBe(
+          'prefetched page'
+        )
+      })
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
+  it('reconstructs a viewport-prefetched route from persisted Segment Cache records', async () => {
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    await next.start({ skipBuild: true })
+
+    let page: Playwright.Page | undefined
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
+
+      await retry(async () => {
+        const routeRecords =
+          await readPersistedOfflineNavigationRouteRecords(browser)
+        expect(
+          routeRecords.some((record) =>
+            record.route.pathname.includes('/viewport-prefetch')
+          )
+        ).toBe(true)
+
+        const segmentRecords =
+          await readPersistedOfflineNavigationSegmentRecords(browser)
+        expect(
+          segmentRecords.some(
+            (record) =>
+              record.key.includes('viewport-prefetch') &&
+              record.payload.requestKind === 'segment-prefetch'
+          )
+        ).toBe(true)
+      })
+
+      await retry(async () => {
+        const cacheState = await readOfflineNavigationCacheState(browser)
+        expect(cacheState.entries).toEqual(
+          expect.arrayContaining([
+            {
+              cacheName: expect.stringMatching(/^next-offline-navigation-v1:/),
+              pathname: expect.stringMatching(
+                /^\/app-assets\/_next\/static\/(?:immutable\/)?chunks\/.+\.js$/
+              ),
+            },
+          ])
+        )
+      })
+
+      const session = await (
+        page!.context() as Playwright.BrowserContext & {
+          newCDPSession: (page: Playwright.Page) => Promise<{
+            send: (method: string) => Promise<void>
+            detach: () => Promise<void>
+          }>
+        }
+      ).newCDPSession(page!)
+
+      try {
+        await session.send('Network.clearBrowserCache')
+      } finally {
+        await session.detach()
+      }
+
+      await next.stop()
+      await page!.context().setOffline(true)
+      const viewportPrefetchResponse = await page!.goto(
+        `${next.url}/docs/viewport-prefetch`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(viewportPrefetchResponse?.status()).toBe(200)
+      await retry(async () => {
+        expect(await browser.elementById('viewport-prefetch-page').text()).toBe(
+          'viewport prefetch page'
+        )
+      })
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
+  it('misses persisted Segment Cache records when a required head record is missing during fallback boot', async () => {
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    await next.start({ skipBuild: true })
+
+    let page: Playwright.Page | undefined
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
+
+      await browser.elementById('prefetch-offline-navigation').click()
+      await retry(async () => {
+        const routeRecords =
+          await readPersistedOfflineNavigationRouteRecords(browser)
+        expect(
+          routeRecords.some((record) =>
+            record.route.pathname.includes('/prefetched')
+          )
+        ).toBe(true)
+
+        const segmentRecords =
+          await readPersistedOfflineNavigationSegmentRecords(browser)
+        expect(
+          segmentRecords.some(
+            (record) =>
+              record.key.includes('prefetched') &&
+              getPersistedSegmentRequestKey(record)?.endsWith('/__PAGE__') ===
+                true
+          )
+        ).toBe(true)
+        expect(
+          segmentRecords.some((record) => isPersistedHeadSegmentRecord(record))
+        ).toBe(true)
+      })
+
+      const deletedHeadRecords =
+        await deletePersistedOfflineNavigationSegmentRecords(browser, {
+          keySubstring: '',
+          requestKeySuffix: '/_head',
+        })
+      expect(deletedHeadRecords).toBeGreaterThan(0)
+      await retry(async () => {
+        const routeRecords =
+          await readPersistedOfflineNavigationRouteRecords(browser)
+        expect(
+          routeRecords.some((record) =>
+            record.route.pathname.includes('/prefetched')
+          )
+        ).toBe(true)
+
+        const segmentRecords =
+          await readPersistedOfflineNavigationSegmentRecords(browser)
+        expect(
+          segmentRecords.some(
+            (record) =>
+              record.key.includes('prefetched') &&
+              getPersistedSegmentRequestKey(record)?.endsWith('/__PAGE__') ===
+                true
+          )
+        ).toBe(true)
+        expect(
+          segmentRecords.some((record) => isPersistedHeadSegmentRecord(record))
+        ).toBe(false)
+      })
+
+      await next.stop()
+      await page!.context().setOffline(true)
+      const missingHeadResponse = await page!.goto(
+        `${next.url}/docs/prefetched`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(missingHeadResponse?.status()).toBe(200)
+
+      await expectOfflineNavigationCacheMiss(browser, 'missing-head')
+      expect(
+        await browser.eval(() =>
+          Boolean(document.getElementById('prefetched-page'))
+        )
+      ).toBe(false)
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
+  it('misses persisted Segment Cache records after router refresh invalidation', async () => {
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    await next.start({ skipBuild: true })
+
+    let page: Playwright.Page | undefined
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
+
+      await browser.elementById('prefetch-offline-navigation').click()
+      await retry(async () => {
+        const routeRecords =
+          await readPersistedOfflineNavigationRouteRecords(browser)
+        expect(
+          routeRecords.some((record) =>
+            record.route.pathname.includes('/prefetched')
+          )
+        ).toBe(true)
+
+        const segmentRecords =
+          await readPersistedOfflineNavigationSegmentRecords(browser)
+        expect(
+          segmentRecords.some(
+            (record) => record.payload.requestKind === 'segment-prefetch'
+          )
+        ).toBe(true)
+        expect(
+          segmentRecords.some((record) => isPersistedHeadSegmentRecord(record))
+        ).toBe(true)
+      })
+
+      await page!.context().setOffline(true)
+      const cachedRouterRecordsResponse = await page!.goto(
+        `${next.url}/docs/prefetched`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(cachedRouterRecordsResponse?.status()).toBe(200)
+      await retry(async () => {
+        expect(await browser.elementById('prefetched-page').text()).toBe(
+          'prefetched page'
+        )
+      })
+
+      await page!.context().setOffline(false)
+      await browser.eval(() => {
+        window.dispatchEvent(new Event('online'))
+      })
+      const onlineRootResponse = await page!.goto(`${next.url}/docs`, {
+        waitUntil: 'domcontentloaded',
+      })
+      expect(onlineRootResponse?.status()).toBe(200)
+      await retry(async () => {
+        expect(await browser.elementByCss('p').text()).toBe(
+          'offline navigations page'
+        )
+      })
+
+      await browser.elementById('refresh-offline-navigation').click()
+      await retry(async () => {
+        expect(
+          await readPersistedOfflineNavigationMetadata(
+            browser,
+            'segment-cache-version'
+          )
+        ).toBeGreaterThan(0)
+      })
+
+      await page!.context().setOffline(true)
+      const invalidatedRouterRecordsResponse = await page!.goto(
+        `${next.url}/docs/prefetched`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(invalidatedRouterRecordsResponse?.status()).toBe(200)
+      await expectOfflineNavigationCacheMiss(browser, 'missing-segment')
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
+  it('misses persisted Segment Cache records after server action invalidation', async () => {
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    await next.start({ skipBuild: true })
+
+    let page: Playwright.Page | undefined
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
+
+      await browser.elementById('prefetch-offline-navigation').click()
+      await retry(async () => {
+        const routeRecords =
+          await readPersistedOfflineNavigationRouteRecords(browser)
+        expect(
+          routeRecords.some((record) =>
+            record.route.pathname.includes('/prefetched')
+          )
+        ).toBe(true)
+
+        const segmentRecords =
+          await readPersistedOfflineNavigationSegmentRecords(browser)
+        expect(
+          segmentRecords.some(
+            (record) => record.payload.requestKind === 'segment-prefetch'
+          )
+        ).toBe(true)
+        expect(
+          segmentRecords.some((record) => isPersistedHeadSegmentRecord(record))
+        ).toBe(true)
+      })
+
+      await page!.context().setOffline(true)
+      const cachedRouterRecordsResponse = await page!.goto(
+        `${next.url}/docs/prefetched`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(cachedRouterRecordsResponse?.status()).toBe(200)
+      await retry(async () => {
+        expect(await browser.elementById('prefetched-page').text()).toBe(
+          'prefetched page'
+        )
+      })
+
+      await page!.context().setOffline(false)
+      await browser.eval(() => {
+        window.dispatchEvent(new Event('online'))
+      })
+      const onlineRootResponse = await page!.goto(`${next.url}/docs`, {
+        waitUntil: 'domcontentloaded',
+      })
+      expect(onlineRootResponse?.status()).toBe(200)
+      await retry(async () => {
+        expect(
+          await browser.elementById('action-invalidation-marker').text()
+        ).toBe('action invalidation marker')
+      })
+
+      await browser.elementById('invalidate-offline-navigation-action').click()
+      await retry(async () => {
+        expect(
+          await readPersistedOfflineNavigationMetadata(
+            browser,
+            'route-cache-version'
+          )
+        ).toBeGreaterThan(0)
+        expect(
+          await readPersistedOfflineNavigationMetadata(
+            browser,
+            'segment-cache-version'
+          )
+        ).toBeGreaterThan(0)
+      })
+
+      await page!.context().setOffline(true)
+      const invalidatedRouterRecordsResponse = await page!.goto(
+        `${next.url}/docs/prefetched`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(invalidatedRouterRecordsResponse?.status()).toBe(200)
+      await expectOfflineNavigationCacheMiss(browser, 'missing-route')
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
+  it('misses hard-loaded request-sensitive URLs without cached Segment Cache records', async () => {
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    await next.start({ skipBuild: true })
+
+    let page: Playwright.Page | undefined
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
+
+      await browser.eval(() => {
+        document.cookie = 'offline-session=alpha; path=/; SameSite=Lax'
+      })
+      const onlineResponse = await page!.goto(
+        `${next.url}/docs/request-sensitive/`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(onlineResponse?.status()).toBe(200)
+      await retry(async () => {
+        expect(await browser.elementById('request-sensitive-page').text()).toBe(
+          'request sensitive session: alpha'
+        )
+      })
+
+      await retry(async () => {
+        const segmentRecords =
+          await readPersistedOfflineNavigationSegmentRecords(browser)
+        expect(
+          segmentRecords.some((record) =>
+            record.key.includes('request-sensitive')
+          )
+        ).toBe(false)
+      })
+
+      await page!.context().setOffline(true)
+      const offlineResponse = await page!.goto(
+        `${next.url}/docs/request-sensitive/`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(offlineResponse?.status()).toBe(200)
+      await expectOfflineNavigationCacheMiss(browser, 'missing-segment')
+
+      await page!.context().setOffline(false)
+      await browser.eval(async () => {
+        window.dispatchEvent(new Event('online'))
+
+        const cacheNames = await caches.keys()
+        await Promise.all(
+          cacheNames
+            .filter((cacheName) =>
+              cacheName.startsWith('next-offline-navigation-v1:')
+            )
+            .map((cacheName) => caches.delete(cacheName))
+        )
+
+        const registrations = await navigator.serviceWorker.getRegistrations()
+        await Promise.all(
+          registrations.map((registration) => registration.unregister())
+        )
+      })
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
+  it('misses hard-loaded URL shape stress cases without complete Segment Cache records', async () => {
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    await next.start({ skipBuild: true })
+
+    let page: Playwright.Page | undefined
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
+
+      const cachedUrl = `${next.url}/docs/url-stress/space%20value/?token=a%2Bb&tag=one&tag=two#section-1`
+      const onlineResponse = await page!.goto(cachedUrl, {
+        waitUntil: 'domcontentloaded',
+      })
+      expect(onlineResponse?.status()).toBe(200)
+      await retry(async () => {
+        expect(await browser.elementById('url-stress-page').text()).toBe(
+          'url stress path: space%20value'
+        )
+        expect(await browser.elementById('url-stress-token').text()).toBe(
+          'url stress token: a+b'
+        )
+        expect(await browser.elementById('url-stress-tags').text()).toBe(
+          'url stress tags: one,two'
+        )
+        expect(await browser.elementById('url-stress-hash').text()).toBe(
+          'url stress hash: #section-1'
+        )
+      })
+
+      await retry(async () => {
+        const routeRecords =
+          await readPersistedOfflineNavigationRouteRecords(browser)
+        expect(
+          routeRecords.some((record) =>
+            record.route.pathname.includes('/url-stress')
+          )
+        ).toBe(true)
+
+        const segmentRecords =
+          await readPersistedOfflineNavigationSegmentRecords(browser)
+        expect(
+          segmentRecords.some((record) => record.key.includes('url-stress'))
+        ).toBe(false)
+      })
+
+      const rootResponse = await page!.goto(`${next.url}/docs/`, {
+        waitUntil: 'domcontentloaded',
+      })
+      expect(rootResponse?.status()).toBe(200)
+
+      await next.stop()
+      await page!.context().setOffline(true)
+      const offlineResponse = await page!.goto(cachedUrl, {
+        waitUntil: 'domcontentloaded',
+      })
+      expect(offlineResponse?.status()).toBe(200)
+      await expectOfflineNavigationCacheMiss(browser, 'missing-segment')
+
+      const reorderedSearchResponse = await page!.goto(
+        `${next.url}/docs/url-stress/space%20value/?tag=one&tag=two&token=a%2Bb#section-3`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(reorderedSearchResponse?.status()).toBe(200)
+      await expectOfflineNavigationCacheMiss(browser, 'missing-segment')
+
+      await page!.context().setOffline(false)
+      await browser.eval(() => {
+        window.dispatchEvent(new Event('online'))
+      })
+      await cleanupOfflineNavigationState(browser)
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
   it('does not emit offline navigation artifacts when disabled', async () => {
     await next.patchFile('next.config.js', (content) =>
       content.replace('offlineNavigations: true', 'offlineNavigations: false')
@@ -339,5 +1396,17 @@ describe('offlineNavigations build artifacts', () => {
       )
     ).toBe(false)
     expect(existsSync(serviceWorker.absolutePath)).toBe(false)
+
+    expect(
+      getStaticClientChunkForbiddenMatches(
+        join(next.testDir, '.next', 'static', 'chunks'),
+        [
+          'next-offline-navigation-cache',
+          'offline-navigation-cache',
+          'data-next-offline-navigation',
+          '_offline-navigation',
+        ]
+      )
+    ).toEqual([])
   })
 })


### PR DESCRIPTION
This is PR 8 of 21 in the offline navigations plus output-export fallback stack.

This stack introduces a generated fallback entrypoint and then layers the client behavior on the existing App Router, cached navigations, optimistic routing, Cache Components, and Segment Cache primitives. The offline navigations chapter adds a managed service worker and persisted Segment Cache replay. The output-export chapter emits static fallback HTML/RSC artifacts so parameterized routes can load and navigate without enumerating every param at build time.

Review guide: https://gist.github.com/feedthejim/bb440153d29dce019d1d26b6643e2a48

## Where This Sits
This PR is in the offline navigations chapter.
Previous PR: #93640 `offline navigations: persist cached Segment Cache records (7/21)`.
Next PR: #93647 `offline navigations: support dynamic route patterns (9/21)`.

## What Changes
- Moves offline fallback bootstrapping into a dedicated feature module.
- Hydrates persisted Segment Cache records and reconstructs the initial RSC payload for hard-load fallback documents.

## Reviewer Focus
- `app-index.tsx` should only contain a small compile-time gated handoff.
- Cache-hit and cache-miss behavior should be user-visible and covered by e2e, not only private test markers.

## Proof In This PR
- Offline production e2e covers hard-load cache hits, missing-record misses, and persisted record invalidation.
- Focused unit coverage verifies the persisted Segment Cache record shape used by bootstrap.

Latest local stack verification after autosquash included:
- `git diff --check`
- `pnpm --filter=next types`
- `pnpm testonly packages/next/src/client/components/segment-cache/offline-navigation-cache.test.ts packages/next/src/client/components/segment-cache/cache.test.ts packages/next/src/client/output-export-fallback.test.ts packages/next/src/export/helpers/output-export-fallback.test.ts packages/next/src/lib/output-export-fallback-routes.test.ts packages/next/src/client/components/router-reducer/fetch-server-response.test.ts`
- `HEADLESS=true pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `HEADLESS=true pnpm test-start-turbo test/e2e/app-dir-export/test/dynamic-fallback*.test.ts`

## Deferred Coverage
Dynamic route pattern replay is widened in the next PR.

## Disabled-Flag Posture
The bootstrap module is required only under `__NEXT_OFFLINE_NAVIGATIONS`; disabled bundles should not include or execute it.

## Full Stack
1. [offline navigations: add gated build primitives (1/21)](https://github.com/vercel/next.js/pull/93736)
2. [offline navigations: generate fallback document artifacts (2/21)](https://github.com/vercel/next.js/pull/93737)
3. [offline navigations: register pass-through worker (3/21)](https://github.com/vercel/next.js/pull/93625)
4. [offline navigations: cache fallback and current-build assets (4/21)](https://github.com/vercel/next.js/pull/93626)
5. [offline navigations: serve fallback document offline (5/21)](https://github.com/vercel/next.js/pull/93627)
6. [offline navigations: add Segment Cache persistence primitives (6/21)](https://github.com/vercel/next.js/pull/93630)
7. [offline navigations: persist cached Segment Cache records (7/21)](https://github.com/vercel/next.js/pull/93640)
8. **Current PR:** [offline navigations: bootstrap fallback from Segment Cache records (8/21)](https://github.com/vercel/next.js/pull/93644)
9. [offline navigations: support dynamic route patterns (9/21)](https://github.com/vercel/next.js/pull/93647)
10. [offline navigations: add docs and examples (10/21)](https://github.com/vercel/next.js/pull/93738)
11. [output export fallbacks: add gated build primitives (11/21)](https://github.com/vercel/next.js/pull/93744)
12. [output export fallbacks: emit fallback HTML artifacts (12/21)](https://github.com/vercel/next.js/pull/93745)
13. [output export fallbacks: emit fallback RSC artifacts (13/21)](https://github.com/vercel/next.js/pull/93746)
14. [output export fallbacks: enforce server-only boundaries (14/21)](https://github.com/vercel/next.js/pull/93747)
15. [output export fallbacks: bootstrap hard loads from artifacts (15/21)](https://github.com/vercel/next.js/pull/93748)
16. [output export fallbacks: resolve soft navigations through cached routes (16/21)](https://github.com/vercel/next.js/pull/93749)
17. [output export fallbacks: resolve fallback artifacts from route manifests (17/21)](https://github.com/vercel/next.js/pull/93779)
18. [output export fallbacks: validate fallback Flight responses (18/21)](https://github.com/vercel/next.js/pull/93750)
19. [output export fallbacks: store fallback data in Segment Cache (19/21)](https://github.com/vercel/next.js/pull/93774)
20. [output export fallbacks: support known params and export variants (20/21)](https://github.com/vercel/next.js/pull/93751)
21. [output export fallbacks: add docs and review guide (21/21)](https://github.com/vercel/next.js/pull/93752)

<!-- NEXT_JS_LLM_PR -->
