### PR TITLE
Fix custom server conf propagation

### DIFF
--- a/packages/next/src/server/lib/render-server.ts
+++ b/packages/next/src/server/lib/render-server.ts
@@ -9,6 +9,7 @@ import type { OnCacheEntryHandler } from '../request-meta'
 import { interopDefault } from '../../lib/interop-default'
 import { formatDynamicImportPath } from '../../lib/format-dynamic-import-path'
 import type { ConfiguredExperimentalFeature } from '../config'
+import type { NextConfig } from '../config-shared'
 
 export type ServerInitResult = {
   requestHandler: RequestHandler
@@ -100,6 +101,7 @@ async function initializeImpl(opts: {
   startServerSpan: Span | undefined
   quiet?: boolean
   onDevServerCleanup: ((listener: () => Promise<void>) => void) | undefined
+  conf?: NextConfig
   distDir: string
   experimentalFeatures: ConfiguredExperimentalFeature[]
   cacheComponents: boolean

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -59,7 +59,11 @@ import {
   handleChromeDevtoolsWorkspaceRequest,
   isChromeDevtoolsWorkspaceUrl,
 } from './chrome-devtools-workspace'
-import { getNextConfigRuntime, type NextConfigComplete } from '../config-shared'
+import {
+  getNextConfigRuntime,
+  type NextConfig,
+  type NextConfigComplete,
+} from '../config-shared'
 
 const debug = setupDebug('next:router-server:main')
 const isNextFont = (pathname: string | null) =>
@@ -93,6 +97,7 @@ export async function initialize(opts: {
   serverFastRefresh?: boolean
   startServerSpan?: Span
   quiet?: boolean
+  conf?: NextConfig
 }): Promise<ServerInitResult> {
   if (!process.env.NODE_ENV) {
     // @ts-ignore not readonly
@@ -104,6 +109,7 @@ export async function initialize(opts: {
     opts.dev ? PHASE_DEVELOPMENT_SERVER : PHASE_PRODUCTION_SERVER,
     opts.dir,
     {
+      customConfig: opts.conf,
       silent: false,
       reportExperimentalFeatures(features) {
         experimentalFeatures = features.toSorted(({ key: a }, { key: b }) =>
@@ -753,6 +759,7 @@ export async function initialize(opts: {
     startServerSpan: opts.startServerSpan,
     quiet: opts.quiet,
     onDevServerCleanup: opts.onDevServerCleanup,
+    conf: opts.conf,
     distDir: config.distDir,
     experimentalFeatures,
     cacheComponents: config.cacheComponents,

--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -43,6 +43,7 @@ import { isIPv6 } from './is-ipv6'
 import { AsyncCallbackSet } from './async-callback-set'
 import type { NextServer } from '../next'
 import { durationToString } from '../../build/duration-to-string'
+import type { NextConfig } from '../config-shared'
 
 const debug = setupDebug('next:start-server')
 let startServerSpan: Span | undefined
@@ -143,11 +144,13 @@ export async function getRequestHandlers({
   onDevServerCleanup,
   server,
   hostname,
+  customServer,
   minimalMode,
   keepAliveTimeout,
   experimentalHttpsServer,
   serverFastRefresh,
   quiet,
+  conf,
 }: {
   dir: string
   port: number
@@ -155,11 +158,13 @@ export async function getRequestHandlers({
   onDevServerCleanup: ((listener: () => Promise<void>) => void) | undefined
   server?: import('http').Server
   hostname?: string
+  customServer?: boolean
   minimalMode?: boolean
   keepAliveTimeout?: number
   experimentalHttpsServer?: boolean
   serverFastRefresh?: boolean
   quiet?: boolean
+  conf?: NextConfig
 }): ReturnType<typeof initialize> {
   return initialize({
     dir,
@@ -169,11 +174,13 @@ export async function getRequestHandlers({
     dev: isDev,
     minimalMode,
     server,
+    customServer,
     keepAliveTimeout,
     experimentalHttpsServer,
     serverFastRefresh,
     startServerSpan,
     quiet,
+    conf,
   })
 }
 

--- a/packages/next/src/server/next.ts
+++ b/packages/next/src/server/next.ts
@@ -421,8 +421,10 @@ class NextCustomServer implements NextWrapperServer {
       isDev: !!this.options.dev,
       onDevServerCleanup,
       hostname: this.options.hostname || 'localhost',
+      customServer: true,
       minimalMode: this.options.minimalMode,
       quiet: this.options.quiet,
+      conf: this.options.conf,
     })
     this.init = initResult
   }

--- a/test/integration/custom-server/server.js
+++ b/test/integration/custom-server/server.js
@@ -26,7 +26,17 @@ const { createServer } = require(
   process.env.USE_HTTPS === 'true' ? 'https' : 'http'
 )
 
-const app = next({ dev, hostname: 'localhost', port, dir })
+const app = next({
+  dev,
+  hostname: 'localhost',
+  port,
+  dir,
+  conf: process.env.BASE_PATH
+    ? {
+        basePath: process.env.BASE_PATH,
+      }
+    : undefined,
+})
 const handleNextRequests = app.getRequestHandler()
 
 const httpOptions = {

--- a/test/integration/custom-server/test/index.test.ts
+++ b/test/integration/custom-server/test/index.test.ts
@@ -170,6 +170,18 @@ describe.each([
     })
   })
 
+  describe('with config provided through next()', () => {
+    beforeAll(() => startServer({ BASE_PATH: '/config-test' }))
+    afterAll(() => killApp(server))
+
+    it('should apply basePath routing', async () => {
+      const html = await renderViaHTTP(nextUrl, '/config-test', undefined, {
+        agent,
+      })
+      expect(html).toContain('Asset')
+    })
+  })
+
   // playwright fails with SSL error due to self-signed cert
   if (!useHttps) {
     describe('HMR with custom server', () => {


### PR DESCRIPTION
Fixes #87429

## What?

Ensures config passed through `next({ conf })` in a custom server is applied consistently across the router and render server pipeline.

## Why?

Custom server config such as `basePath` was loaded by the router server but not propagated into the internal render server. As a result, requests using `basePath` could still render with the default config and return 404.

## How?

- Pass `conf` from [NextCustomServer.prepare()](cci:1://file:///Users/kurodakayn/Coding/Projects/next.js/packages/next/src/server/next.ts:403:2-429:3) to [getRequestHandlers()](cci:1://file:///Users/kurodakayn/Coding/Projects/next.js/packages/next/src/server/lib/start-server.ts:139:0-184:1)
- Forward `conf` through [router-server.initialize()](cci:1://file:///Users/kurodakayn/Coding/Projects/next.js/packages/next/src/server/lib/render-server.ts:188:0-197:1) into `loadConfig()`
- Forward `conf` into `renderServerOpts` so the internal render server uses the same config
- Preserve the custom server marker when initializing request handlers
- Add an integration test covering `basePath` passed through `next({ conf })`

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm --filter=next build`
- `NEXT_SKIP_ISOLATE=1 NEXT_TEST_MODE=dev pnpm testheadless test/integration/custom-server/test/index.test.ts -t "with config provided through next"`
- `git diff --check`

<!-- NEXT_JS_LLM_PR -->