### PR TITLE
offline navigations: reconstruct prefetched routes offline (11/13)

### DIFF
--- a/packages/next/src/build/offline-navigation-fallback.ts
+++ b/packages/next/src/build/offline-navigation-fallback.ts
@@ -35,7 +35,8 @@ function getScriptAttributes(
 
 // Generate the build-scoped HTML entrypoint used by offline document fallback
 // handling. It intentionally contains only the app bootstrap, not route HTML;
-// exact-URL route data is restored by the client after this document loads.
+// route data is restored by the client from exact-URL RSC responses or
+// persisted router-cache records after this document loads.
 export function createOfflineNavigationFallbackDocument({
   assetPrefix,
   buildId,

--- a/packages/next/src/build/offline-navigation-service-worker.ts
+++ b/packages/next/src/build/offline-navigation-service-worker.ts
@@ -10,7 +10,8 @@ export function getOfflineNavigationServiceWorkerFilePath(): string {
 
 // The first version of offline navigations uses a generated, app-local service
 // worker as a document fallback only. It is network-first for regular loads and
-// only serves the fallback document after the network request fails.
+// only serves the fallback document after the network request fails; route data
+// is restored later by the client from the durable router cache.
 export function createOfflineNavigationServiceWorker({
   buildId,
   cacheNamespace,

--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -20,6 +20,7 @@ import {
   createMutableActionQueue,
 } from './components/app-router-instance'
 import AppRouter from './components/app-router'
+import DefaultGlobalError from './components/builtin/global-error'
 import type { InitialRSCPayload } from '../shared/lib/app-router-types'
 import { createInitialRouterState } from './components/router-reducer/create-initial-router-state'
 import { MissingSlotContext } from '../shared/lib/app-router-context.shared-runtime'
@@ -63,12 +64,17 @@ type OfflineNavigationCacheMissReason =
   | 'unsupported-request-kind'
   | 'read-error'
 
+type OfflineNavigationFallbackRequestKind =
+  | 'client-resume'
+  | 'initial-load'
+  | 'router-cache'
+
 type OfflineNavigationFallbackDiagnostic =
   | {
       type: 'cache-hit'
       url: string
       buildId: string | undefined
-      requestKind: OfflineNavigationFallbackResponse['requestKind']
+      requestKind: OfflineNavigationFallbackRequestKind
     }
   | {
       type: 'cache-miss'
@@ -88,6 +94,12 @@ type OfflineNavigationFallbackDiagnostic =
         hydrated: number
         skipped: number
       }
+    }
+  | {
+      type: 'router-cache-reconstruction-miss'
+      url: string
+      buildId: string | undefined
+      reason: string
     }
 
 declare global {
@@ -109,7 +121,7 @@ function reportOfflineNavigationFallbackDiagnostic(
 }
 
 function showOfflineNavigationCacheHit(
-  requestKind: OfflineNavigationFallbackResponse['requestKind'],
+  requestKind: OfflineNavigationFallbackRequestKind,
   buildId: string | undefined
 ): void {
   document.documentElement.setAttribute(
@@ -157,8 +169,8 @@ function showOfflineNavigationCacheMiss(
   })
 }
 
-function neverResolveOfflineNavigationResponse(): Promise<Response> {
-  return new Promise<Response>(() => {})
+function neverResolveInitialRSCPayload(): Promise<InitialRSCPayload> {
+  return new Promise<InitialRSCPayload>(() => {})
 }
 
 type OfflineNavigationFallbackResponse = {
@@ -166,15 +178,34 @@ type OfflineNavigationFallbackResponse = {
   response: Response
 }
 
-function createOfflineNavigationFallbackResponse():
-  | Promise<OfflineNavigationFallbackResponse>
+type OfflineNavigationFallbackBootstrap =
+  | {
+      kind: 'rsc-response'
+      response: OfflineNavigationFallbackResponse
+      buildId: string | undefined
+    }
+  | {
+      kind: 'router-cache'
+      initialRSCPayload: InitialRSCPayload
+      buildId: string | undefined
+    }
+  | {
+      kind: 'cache-miss'
+      buildId: string | undefined
+    }
+
+// The generated fallback document has no inline Flight data for the current
+// URL. Bootstrap from a durable exact-URL RSC response first, then fall back to
+// reconstructing the route from persisted segment-cache records.
+function createOfflineNavigationFallbackBootstrap():
+  | Promise<OfflineNavigationFallbackBootstrap>
   | undefined {
   if (process.env.__NEXT_OFFLINE_NAVIGATIONS) {
     if (!isOfflineNavigationFallbackDocument()) {
       return undefined
     }
 
-    return (async (): Promise<OfflineNavigationFallbackResponse> => {
+    return (async (): Promise<OfflineNavigationFallbackBootstrap> => {
       const {
         createOfflineNavigationRSCResponse,
         isOfflineNavigationRSCResponsePayload,
@@ -192,13 +223,54 @@ function createOfflineNavigationFallbackResponse():
       const payload = entry?.payload
 
       if (!isOfflineNavigationRSCResponsePayload(payload)) {
+        if (payload === undefined) {
+          const {
+            createOfflineNavigationInitialRSCPayloadFromRouterCache,
+            hydrateOfflineNavigationRouterCache,
+          } =
+            require('./components/segment-cache/cache') as typeof import('./components/segment-cache/cache')
+
+          const hydrationResult = await hydrateOfflineNavigationRouterCache({
+            buildId,
+          })
+          reportOfflineNavigationFallbackDiagnostic({
+            type: 'router-cache-hydration',
+            url: location.href,
+            buildId,
+            routes: hydrationResult.routes,
+            segments: hydrationResult.segments,
+          })
+
+          const reconstruction =
+            createOfflineNavigationInitialRSCPayloadFromRouterCache({
+              buildId,
+              globalErrorState: [DefaultGlobalError, undefined],
+              now: Date.now(),
+              url: location.href,
+            })
+          if (reconstruction.status === 'fulfilled') {
+            showOfflineNavigationCacheHit('router-cache', buildId)
+            return {
+              kind: 'router-cache',
+              initialRSCPayload: reconstruction.initialRSCPayload,
+              buildId,
+            }
+          }
+          reportOfflineNavigationFallbackDiagnostic({
+            type: 'router-cache-reconstruction-miss',
+            url: location.href,
+            buildId,
+            reason: reconstruction.reason,
+          })
+        }
+
         showOfflineNavigationCacheMiss(
           payload === undefined ? 'missing-entry' : 'invalid-payload',
           buildId
         )
         return {
-          requestKind: 'client-resume',
-          response: await neverResolveOfflineNavigationResponse(),
+          kind: 'cache-miss',
+          buildId,
         }
       }
 
@@ -208,8 +280,8 @@ function createOfflineNavigationFallbackResponse():
       ) {
         showOfflineNavigationCacheMiss('unsupported-request-kind', buildId)
         return {
-          requestKind: 'client-resume',
-          response: await neverResolveOfflineNavigationResponse(),
+          kind: 'cache-miss',
+          buildId,
         }
       }
 
@@ -220,14 +292,18 @@ function createOfflineNavigationFallbackResponse():
 
       showOfflineNavigationCacheHit(requestKind, buildId)
       return {
-        requestKind,
-        response: createOfflineNavigationRSCResponse(payload),
+        kind: 'rsc-response',
+        buildId,
+        response: {
+          requestKind,
+          response: createOfflineNavigationRSCResponse(payload),
+        },
       }
-    })().catch(async (): Promise<OfflineNavigationFallbackResponse> => {
+    })().catch((): OfflineNavigationFallbackBootstrap => {
       showOfflineNavigationCacheMiss('read-error', undefined)
       return {
-        requestKind: 'client-resume',
-        response: await neverResolveOfflineNavigationResponse(),
+        kind: 'cache-miss',
+        buildId: undefined,
       }
     })
   } else {
@@ -235,15 +311,23 @@ function createOfflineNavigationFallbackResponse():
   }
 }
 
-const offlineNavigationFallbackResponse =
-  createOfflineNavigationFallbackResponse()
-const offlineNavigationClientResumeFetch =
-  offlineNavigationFallbackResponse?.then(({ response }) => response)
+const offlineNavigationFallbackBootstrap =
+  createOfflineNavigationFallbackBootstrap()
+
+if (process.env.__NEXT_USE_OFFLINE) {
+  if (offlineNavigationFallbackBootstrap) {
+    const { notifyOffline } =
+      require('./components/offline') as typeof import('./components/offline')
+    notifyOffline()
+  }
+} else {
+  // Keep the offline event module out of disabled client bundles.
+}
 
 const hasClientResumeShell = Boolean(window.__NEXT_CLIENT_RESUME)
 const hasLockedStaticShell =
   Boolean(instantTestStaticFetch) ||
-  Boolean(offlineNavigationClientResumeFetch) ||
+  Boolean(offlineNavigationFallbackBootstrap) ||
   hasClientResumeShell
 
 const encoder = new TextEncoder()
@@ -417,7 +501,7 @@ if (
 if (
   process.env.__NEXT_CACHE_COMPONENTS &&
   process.env.__NEXT_EXPERIMENTAL_CACHED_NAVIGATIONS &&
-  !offlineNavigationClientResumeFetch
+  !offlineNavigationFallbackBootstrap
 ) {
   const [forReact, forCache] = readable.tee()
   readable = forReact
@@ -461,25 +545,39 @@ if (instantTestStaticFetch) {
       initialRSCPayload
     )
   })
-} else if (offlineNavigationClientResumeFetch) {
-  initialServerResponse = Promise.resolve(
-    createFromFetch<InitialRSCPayload>(offlineNavigationClientResumeFetch, {
-      callServer,
-      findSourceMapURL,
-      debugChannel,
-      unstable_allowPartialStream: true,
-    })
-  ).then(async (fallbackInitialRSCPayload) => {
-    const fallbackResponse = await offlineNavigationFallbackResponse!
-    if (fallbackResponse.requestKind === 'initial-load') {
-      return fallbackInitialRSCPayload
-    }
+} else if (offlineNavigationFallbackBootstrap) {
+  initialServerResponse = offlineNavigationFallbackBootstrap.then(
+    async (bootstrap) => {
+      if (bootstrap.kind === 'cache-miss') {
+        return await neverResolveInitialRSCPayload()
+      }
 
-    return createInitialRSCPayloadFromFallbackPrerender(
-      fallbackResponse.response,
-      fallbackInitialRSCPayload
-    )
-  })
+      if (bootstrap.kind === 'router-cache') {
+        return bootstrap.initialRSCPayload
+      }
+
+      const fallbackResponse = bootstrap.response
+      const fallbackInitialRSCPayload =
+        await createFromFetch<InitialRSCPayload>(
+          Promise.resolve(fallbackResponse.response),
+          {
+            callServer,
+            findSourceMapURL,
+            debugChannel,
+            unstable_allowPartialStream: true,
+          }
+        )
+
+      if (fallbackResponse.requestKind === 'initial-load') {
+        return fallbackInitialRSCPayload
+      }
+
+      return createInitialRSCPayloadFromFallbackPrerender(
+        fallbackResponse.response,
+        fallbackInitialRSCPayload
+      )
+    }
+  )
 } else if (window.__NEXT_CLIENT_RESUME) {
   const clientResumeFetch: Promise<Response> = window.__NEXT_CLIENT_RESUME
   initialServerResponse = Promise.resolve(
@@ -600,7 +698,7 @@ export async function hydrate(
   if (process.env.__NEXT_USE_OFFLINE) {
     const { notifyOffline } =
       require('./components/offline') as typeof import('./components/offline')
-    if (offlineNavigationClientResumeFetch) {
+    if (offlineNavigationFallbackBootstrap) {
       notifyOffline()
     }
   }
@@ -625,25 +723,28 @@ export async function hydrate(
   }
 
   if (process.env.__NEXT_OFFLINE_NAVIGATIONS) {
-    if (!process.env.__NEXT_DEV_SERVER && offlineNavigationClientResumeFetch) {
+    if (!process.env.__NEXT_DEV_SERVER && offlineNavigationFallbackBootstrap) {
       try {
-        const { hydrateOfflineNavigationRouterCache } =
-          require('./components/segment-cache/cache') as typeof import('./components/segment-cache/cache')
-        const result = await hydrateOfflineNavigationRouterCache()
-        reportOfflineNavigationFallbackDiagnostic({
-          type: 'router-cache-hydration',
-          url: location.href,
-          buildId,
-          routes: result.routes,
-          segments: result.segments,
-        })
+        const bootstrap = await offlineNavigationFallbackBootstrap
+        if (bootstrap.kind === 'rsc-response') {
+          const { hydrateOfflineNavigationRouterCache } =
+            require('./components/segment-cache/cache') as typeof import('./components/segment-cache/cache')
+          const result = await hydrateOfflineNavigationRouterCache({ buildId })
+          reportOfflineNavigationFallbackDiagnostic({
+            type: 'router-cache-hydration',
+            url: location.href,
+            buildId,
+            routes: result.routes,
+            segments: result.segments,
+          })
+        }
       } catch {
         // The exact URL fallback already booted. Router cache hydration should
         // only improve later navigations, never block the current render.
       }
     }
   } else {
-    // Keep router-cache hydration helpers out of disabled client bundles.
+    // Keep router-cache reconstruction helpers out of disabled client bundles.
   }
 
   const initialTimestamp = Date.now()

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -6,6 +6,8 @@ import type {
 import type {
   CacheNodeSeedData,
   FlightData,
+  HeadData,
+  InitialRSCPayload,
   Segment as FlightRouterStateSegment,
 } from '../../../shared/lib/app-router-types'
 import { PrefetchHint } from '../../../shared/lib/app-router-types'
@@ -117,6 +119,7 @@ import { discoverKnownRoute, matchKnownRoute } from './optimistic-routes'
 import { convertServerPatchToFullTree, type NavigationSeed } from './navigation'
 import { getNavigationBuildId } from '../../navigation-build-id'
 import { NEXT_NAV_DEPLOYMENT_ID_HEADER } from '../../../lib/constants'
+import { normalizePathTrailingSlash } from '../../normalize-trailing-slash'
 
 let offlineNavigationCacheModule:
   | typeof import('../router-reducer/offline-navigation-cache')
@@ -319,6 +322,30 @@ export type OfflineNavigationRouterCacheHydrationResult = {
     skipped: number
   }
 }
+
+export type OfflineNavigationRouterCacheReconstructionResult =
+  | {
+      status: 'fulfilled'
+      initialRSCPayload: InitialRSCPayload
+      route: {
+        canonicalUrl: string
+        renderedSearch: string
+      }
+      segments: {
+        restored: number
+      }
+      head: {
+        restored: number
+      }
+    }
+  | {
+      status: 'miss'
+      reason:
+        | 'missing-route'
+        | 'unsupported-route'
+        | 'missing-segment'
+        | 'missing-head'
+    }
 
 export type NonEmptySegmentCacheEntry = Exclude<
   SegmentCacheEntry,
@@ -1216,7 +1243,13 @@ export function markRouteEntryAsDynamicRewrite(
   // before we knew it had a dynamic rewrite.
 }
 
-export async function hydrateOfflineNavigationRouterCache(): Promise<OfflineNavigationRouterCacheHydrationResult> {
+export async function hydrateOfflineNavigationRouterCache({
+  buildId,
+  now = Date.now(),
+}: {
+  buildId?: string
+  now?: number
+} = {}): Promise<OfflineNavigationRouterCacheHydrationResult> {
   // Bring persisted route and segment records back into the in-memory router
   // cache before trying to reconstruct an offline document navigation.
   const offlineNavigationCache = getOfflineNavigationCacheModule()
@@ -1233,10 +1266,12 @@ export async function hydrateOfflineNavigationRouterCache(): Promise<OfflineNavi
     }
   }
 
-  const now = Date.now()
   const [routeRecords, segmentRecords] = await Promise.all([
-    offlineNavigationCache.readOfflineNavigationRouteRecords({ now }),
-    offlineNavigationCache.readOfflineNavigationSegmentRecords({ now }),
+    offlineNavigationCache.readOfflineNavigationRouteRecords({ buildId, now }),
+    offlineNavigationCache.readOfflineNavigationSegmentRecords({
+      buildId,
+      now,
+    }),
   ])
 
   return hydrateOfflineNavigationRouterCacheFromRecords(
@@ -1244,6 +1279,187 @@ export async function hydrateOfflineNavigationRouterCache(): Promise<OfflineNavi
     routeRecords,
     segmentRecords
   )
+}
+
+export function createOfflineNavigationInitialRSCPayloadFromRouterCache({
+  buildId,
+  globalErrorState,
+  now,
+  url,
+}: {
+  buildId: string | undefined
+  globalErrorState: InitialRSCPayload['G']
+  now: number
+  url: string
+}): OfflineNavigationRouterCacheReconstructionResult {
+  // Recreate the minimum InitialRSCPayload that app-index needs to boot from
+  // prefetched router-cache data. If any route, segment, or head record is
+  // missing, report a cache miss rather than rendering an incomplete tree.
+  const requestUrl = new URL(url, location.href)
+  requestUrl.pathname = normalizePathTrailingSlash(requestUrl.pathname)
+  const routeEntry = readRouteCacheEntry(
+    now,
+    createPrefetchRequestKey(requestUrl.href, null)
+  )
+  if (routeEntry === null || routeEntry.status !== EntryStatus.Fulfilled) {
+    return {
+      status: 'miss',
+      reason: 'missing-route',
+    }
+  }
+
+  if (
+    routeEntry.couldBeIntercepted ||
+    routeEntry.hasDynamicRewrite ||
+    !routeEntry.supportsPerSegmentPrefetching
+  ) {
+    return {
+      status: 'miss',
+      reason: 'unsupported-route',
+    }
+  }
+
+  const seedResult = createOfflineNavigationSeedDataFromRouterCache(
+    now,
+    routeEntry.tree
+  )
+  if (seedResult.status === 'miss') {
+    return seedResult
+  }
+
+  const metadataVaryPath = routeEntry.metadata.varyPath as PageVaryPath | null
+  if (metadataVaryPath === null) {
+    return {
+      status: 'miss',
+      reason: 'missing-head',
+    }
+  }
+
+  const headResult = readOfflineNavigationHeadFromRouterCache(
+    now,
+    metadataVaryPath
+  )
+  if (headResult.status === 'miss') {
+    return headResult
+  }
+
+  const initialRSCPayload: InitialRSCPayload = {
+    c: routeEntry.canonicalUrl.split('/'),
+    q: routeEntry.renderedSearch,
+    i: routeEntry.couldBeIntercepted,
+    f: [
+      [
+        convertRouteTreeToFlightRouterState(routeEntry.tree),
+        seedResult.seedData,
+        headResult.head,
+        false,
+      ],
+    ],
+    m: undefined,
+    G: globalErrorState,
+    S: routeEntry.supportsPerSegmentPrefetching,
+    h: null,
+  }
+  if (buildId !== undefined) {
+    initialRSCPayload.b = buildId
+  }
+
+  return {
+    status: 'fulfilled',
+    initialRSCPayload,
+    route: {
+      canonicalUrl: routeEntry.canonicalUrl,
+      renderedSearch: routeEntry.renderedSearch,
+    },
+    segments: {
+      restored: seedResult.segments,
+    },
+    head: {
+      restored: 1,
+    },
+  }
+}
+
+type OfflineNavigationSeedDataResult =
+  | {
+      status: 'fulfilled'
+      seedData: CacheNodeSeedData
+      segments: number
+    }
+  | Extract<
+      OfflineNavigationRouterCacheReconstructionResult,
+      { status: 'miss' }
+    >
+
+function createOfflineNavigationSeedDataFromRouterCache(
+  now: number,
+  tree: RouteTree
+): OfflineNavigationSeedDataResult {
+  const segmentEntry = readSegmentCacheEntry(now, tree.varyPath)
+  if (segmentEntry === null || segmentEntry.status !== EntryStatus.Fulfilled) {
+    return {
+      status: 'miss',
+      reason: 'missing-segment',
+    }
+  }
+
+  const parallelRoutes: CacheNodeSeedData[1] = {}
+  let restoredSegments = 1
+  if (tree.slots !== null) {
+    for (const parallelRouteKey in tree.slots) {
+      const childResult = createOfflineNavigationSeedDataFromRouterCache(
+        now,
+        tree.slots[parallelRouteKey]
+      )
+      if (childResult.status === 'miss') {
+        return childResult
+      }
+
+      parallelRoutes[parallelRouteKey] = childResult.seedData
+      restoredSegments += childResult.segments
+    }
+  }
+
+  return {
+    status: 'fulfilled',
+    seedData: [
+      segmentEntry.rsc,
+      parallelRoutes,
+      null,
+      segmentEntry.isPartial,
+      null,
+    ],
+    segments: restoredSegments,
+  }
+}
+
+function readOfflineNavigationHeadFromRouterCache(
+  now: number,
+  metadataVaryPath: PageVaryPath
+):
+  | {
+      status: 'fulfilled'
+      head: HeadData
+    }
+  | Extract<
+      OfflineNavigationRouterCacheReconstructionResult,
+      { status: 'miss' }
+    > {
+  const metadataEntry = readSegmentCacheEntry(now, metadataVaryPath)
+  if (
+    metadataEntry === null ||
+    metadataEntry.status !== EntryStatus.Fulfilled
+  ) {
+    return {
+      status: 'miss',
+      reason: 'missing-head',
+    }
+  }
+
+  return {
+    status: 'fulfilled',
+    head: metadataEntry.rsc,
+  }
 }
 
 export async function hydrateOfflineNavigationRouterCacheFromRecords(

--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -196,6 +196,52 @@ describe('offlineNavigations build artifacts', () => {
     })
   }
 
+  async function deletePersistedOfflineNavigationEntries(
+    browser: Awaited<ReturnType<typeof next.browser>>,
+    urlSubstring: string
+  ) {
+    return browser.eval(async (substring) => {
+      const database = await new Promise<IDBDatabase>((resolve, reject) => {
+        const request = indexedDB.open('next-offline-navigation-cache', 3)
+        request.onsuccess = () => resolve(request.result)
+        request.onerror = () => reject(request.error)
+      })
+
+      try {
+        const entries = await new Promise<any[]>((resolve, reject) => {
+          const transaction = database.transaction(
+            'navigation-data',
+            'readonly'
+          )
+          const request = transaction.objectStore('navigation-data').getAll()
+          request.onsuccess = () => resolve(request.result)
+          request.onerror = () => reject(request.error)
+        })
+        const matchingEntries = entries.filter((entry) =>
+          entry.url.includes(substring)
+        )
+
+        if (matchingEntries.length === 0) {
+          return 0
+        }
+
+        const transaction = database.transaction('navigation-data', 'readwrite')
+        const store = transaction.objectStore('navigation-data')
+        for (const entry of matchingEntries) {
+          store.delete([entry.buildId, entry.url])
+        }
+        await new Promise<void>((resolve, reject) => {
+          transaction.oncomplete = () => resolve()
+          transaction.onerror = () => reject(transaction.error)
+          transaction.onabort = () => reject(transaction.error)
+        })
+        return matchingEntries.length
+      } finally {
+        database.close()
+      }
+    }, urlSubstring)
+  }
+
   async function cleanupOfflineNavigationState(
     browser: Awaited<ReturnType<typeof next.browser>>
   ) {
@@ -887,6 +933,117 @@ describe('offlineNavigations build artifacts', () => {
         const registrations = await navigator.serviceWorker.getRegistrations()
         await Promise.all(
           registrations.map((registration) => registration.unregister())
+        )
+      })
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
+  it('reconstructs a fully prefetched route from persisted router records', async () => {
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    await next.start({ skipBuild: true })
+
+    let page: Playwright.Page | undefined
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await retry(async () => {
+        expect(
+          await browser.eval(() => Boolean(navigator.serviceWorker.controller))
+        ).toBe(true)
+      })
+
+      await browser.elementById('prefetch-offline-navigation').click()
+      await retry(async () => {
+        const exactEntry = await readPersistedOfflineNavigationEntry(
+          browser,
+          '/docs/prefetched'
+        )
+        expect(exactEntry).toEqual(
+          expect.objectContaining({
+            kind: 'exact-url',
+            payload: expect.objectContaining({
+              kind: 'rsc-response',
+              requestKind: 'client-resume',
+            }),
+          })
+        )
+      })
+      await retry(async () => {
+        const routeRecords =
+          await readPersistedOfflineNavigationRouteRecords(browser)
+        expect(
+          routeRecords.some((record) =>
+            record.route.pathname.includes('/prefetched')
+          )
+        ).toBe(true)
+
+        const segmentRecords =
+          await readPersistedOfflineNavigationSegmentRecords(browser)
+        expect(
+          segmentRecords.some(
+            (record) => record.payload.requestKind === 'segment-prefetch'
+          )
+        ).toBe(true)
+        expect(
+          segmentRecords.some(
+            (record) => record.segment.requestKey === '/_head'
+          )
+        ).toBe(true)
+      })
+
+      const deletedExactEntries = await deletePersistedOfflineNavigationEntries(
+        browser,
+        '/docs/prefetched'
+      )
+      expect(deletedExactEntries).toBeGreaterThan(0)
+      await retry(async () => {
+        const deletedEntry = await readPersistedOfflineNavigationEntry(
+          browser,
+          '/docs/prefetched'
+        )
+        expect(deletedEntry).toBe(null)
+      })
+
+      await next.stop()
+      await page!.context().setOffline(true)
+      const routerCacheOnlyResponse = await page!.goto(
+        `${next.url}/docs/prefetched`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(routerCacheOnlyResponse?.status()).toBe(200)
+      await retry(async () => {
+        const routerCacheDiagnostics = await browser.eval(() => {
+          const win = window as typeof window & {
+            __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?: Array<{
+              type?: string
+              requestKind?: string
+              url?: string
+              reason?: string
+            }>
+          }
+          return win.__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__ ?? []
+        })
+        expect(routerCacheDiagnostics).toContainEqual(
+          expect.objectContaining({
+            type: 'cache-hit',
+            requestKind: 'router-cache',
+            url: `${next.url}/docs/prefetched`,
+          })
+        )
+      })
+      await retry(async () => {
+        expect(await browser.elementById('prefetched-page').text()).toBe(
+          'prefetched page'
         )
       })
     } finally {


### PR DESCRIPTION
## Stack Position

This is PR 11/13 in the compressed offline navigations stack. Chapter: Router record replay.

Review guide: https://gist.github.com/feedthejim/b3d9fe26a7c05655fd57adcce371b93d

## Full Stack

1. [#93622](https://github.com/vercel/next.js/pull/93622) offline navigations: add gated build primitives (1/13)
2. [#93624](https://github.com/vercel/next.js/pull/93624) offline navigations: emit fallback manifest data (2/13)
3. [#93625](https://github.com/vercel/next.js/pull/93625) offline navigations: register pass-through worker (3/13)
4. [#93626](https://github.com/vercel/next.js/pull/93626) offline navigations: cache fallback artifacts (4/13)
5. [#93627](https://github.com/vercel/next.js/pull/93627) offline navigations: serve fallback document offline (5/13)
6. [#93630](https://github.com/vercel/next.js/pull/93630) offline navigations: add persistent navigation cache (6/13)
7. [#93631](https://github.com/vercel/next.js/pull/93631) offline navigations: replay exact-url navigations (7/13)
8. [#93635](https://github.com/vercel/next.js/pull/93635) offline navigations: handle exact-url eligibility and invalidation (8/13)
9. [#93640](https://github.com/vercel/next.js/pull/93640) offline navigations: persist router records (9/13)
10. [#93644](https://github.com/vercel/next.js/pull/93644) offline navigations: hydrate router cache from persisted records (10/13)
11. [#93646](https://github.com/vercel/next.js/pull/93646) offline navigations: reconstruct prefetched routes offline (11/13) **current**
12. [#93647](https://github.com/vercel/next.js/pull/93647) offline navigations: support dynamic route patterns (12/13)
13. [#93650](https://github.com/vercel/next.js/pull/93650) offline navigations: wire invalidation and reset APIs (13/13)

## Context

The original offline navigations work was split into 25 staging PRs, which made the review surface too noisy. This compressed stack keeps the same first-usable feature at the tip, but groups the work by reviewer-facing behavior: build artifacts first, exact URL replay next, then route-record replay and invalidation.

The architecture boundary is intentional: the generated service worker keeps the app bootable by serving the fallback document, while the cache-components client router owns IndexedDB, replay eligibility, route reconstruction, visible misses, and invalidation.

Folded source PRs: None.

## What This PR Does

- Reconstructs a fully prefetched route from persisted router records when exact URL data is absent.
- Uses the same cache-components route/segment/head data the regular router would use.
- Keeps missing-record cases visible instead of synthesizing partial UI.

## What Works After This PR

After this PR, a fully prefetched route can hard-load offline even if its original HTML document was never loaded.

## What Intentionally Does Not Work Yet

Dynamic route pattern matching is still limited until the next PR.

## Reviewer Focus

The handoff from persisted records to router state, exact-URL miss fallback, and destructive missing-record coverage.

## Proof in This PR

- Focused production e2e passed in Turbopack and webpack modes.
- The suite includes `reconstructs a fully prefetched route from persisted router records` and the missing head-record miss case.
- `git diff --check canary..HEAD` passed.
- `git diff --stat HEAD f60949e313` and `git diff --name-status HEAD f60949e313` produced no output, so the compressed tip preserves the previous staging tip.
- `pnpm --filter=next build` passed.
- `NEXT_TEST_MODE=start pnpm testheadless test/production/app-dir/offline-navigations/offline-navigations.test.ts` passed, 12/12.
- `IS_WEBPACK_TEST=1 NEXT_TEST_MODE=start pnpm testheadless test/production/app-dir/offline-navigations/offline-navigations.test.ts` passed, 12/12.

## Deferred Coverage

Known dynamic route patterns are owned by PR 12/13.

<!-- NEXT_JS_LLM_PR -->
