### PR TITLE
offline navigations: support dynamic route patterns (9/21)

### DIFF
--- a/packages/next/src/build/define-env.ts
+++ b/packages/next/src/build/define-env.ts
@@ -384,7 +384,9 @@ export function getDefineEnv({
     'process.env.__NEXT_GESTURE_TRANSITION':
       config.experimental.gestureTransition ?? false,
     'process.env.__NEXT_OPTIMISTIC_ROUTING':
-      config.experimental.optimisticRouting ?? false,
+      config.experimental.optimisticRouting ||
+      config.experimental.offlineNavigations ||
+      false,
     'process.env.__NEXT_VARY_PARAMS': config.experimental.varyParams ?? false,
     'process.env.__NEXT_EXPOSE_TESTING_API':
       dev || config.experimental.exposeTestingApiInProductionBuild === true,

--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -890,7 +890,8 @@ export async function handler(
             staleTimes: nextConfig.experimental.staleTimes,
             dynamicOnHover: Boolean(nextConfig.experimental.dynamicOnHover),
             optimisticRouting: Boolean(
-              nextConfig.experimental.optimisticRouting
+              nextConfig.experimental.optimisticRouting ||
+                nextConfig.experimental.offlineNavigations
             ),
             inlineCss: Boolean(nextConfig.experimental.inlineCss),
             prefetchInlining: nextConfig.experimental.prefetchInlining ?? false,

--- a/packages/next/src/build/templates/edge-ssr-app.ts
+++ b/packages/next/src/build/templates/edge-ssr-app.ts
@@ -165,7 +165,10 @@ async function requestHandler(
         expireTime: nextConfig.expireTime,
         staleTimes: nextConfig.experimental.staleTimes,
         dynamicOnHover: Boolean(nextConfig.experimental.dynamicOnHover),
-        optimisticRouting: Boolean(nextConfig.experimental.optimisticRouting),
+        optimisticRouting: Boolean(
+          nextConfig.experimental.optimisticRouting ||
+            nextConfig.experimental.offlineNavigations
+        ),
         inlineCss: Boolean(nextConfig.experimental.inlineCss),
         prefetchInlining: nextConfig.experimental.prefetchInlining ?? false,
         authInterrupts: Boolean(nextConfig.experimental.authInterrupts),

--- a/packages/next/src/client/route-params.ts
+++ b/packages/next/src/client/route-params.ts
@@ -10,6 +10,8 @@ import {
   NEXT_REWRITTEN_QUERY_HEADER,
   NEXT_RSC_UNION_QUERY,
 } from './components/app-router-headers'
+import { hasBasePath } from './has-base-path'
+import { removeBasePath } from './remove-base-path'
 import type {
   NormalizedPathname,
   NormalizedSearch,
@@ -44,9 +46,14 @@ export function getRenderedPathname(
   // page will be different from the pathname in the request URL. In this case,
   // the response will include a header that gives the rewritten pathname.
   const rewrittenPath = response.headers.get(NEXT_REWRITTEN_PATH_HEADER)
-  return (rewrittenPath ??
-    urlToUrlWithoutFlightMarker(new URL(response.url))
-      .pathname) as NormalizedPathname
+  const pathname =
+    rewrittenPath ?? urlToUrlWithoutFlightMarker(new URL(response.url)).pathname
+  // `response.url` is browser-visible, so it may still include the configured
+  // basePath. Route trees and dynamic param matching use app pathnames without
+  // basePath, matching the server-side params contract.
+  return (
+    hasBasePath(pathname) ? removeBasePath(pathname) : pathname
+  ) as NormalizedPathname
 }
 
 // Pathname parts come from `URL.pathname.split('/')`, so they are already

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -510,7 +510,10 @@ async function exportAppImpl(
       clientParamParsingOrigins:
         nextConfig.experimental.clientParamParsingOrigins,
       dynamicOnHover: nextConfig.experimental.dynamicOnHover ?? false,
-      optimisticRouting: nextConfig.experimental.optimisticRouting ?? false,
+      optimisticRouting:
+        nextConfig.experimental.optimisticRouting ||
+        nextConfig.experimental.offlineNavigations ||
+        false,
       inlineCss: nextConfig.experimental.inlineCss ?? false,
       prefetchInlining: nextConfig.experimental.prefetchInlining ?? false,
       authInterrupts: !!nextConfig.experimental.authInterrupts,

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -578,7 +578,9 @@ export default abstract class Server<
           this.nextConfig.experimental.clientParamParsingOrigins,
         dynamicOnHover: this.nextConfig.experimental.dynamicOnHover ?? false,
         optimisticRouting:
-          this.nextConfig.experimental.optimisticRouting ?? false,
+          this.nextConfig.experimental.optimisticRouting ||
+          this.nextConfig.experimental.offlineNavigations ||
+          false,
         inlineCss: this.nextConfig.experimental.inlineCss ?? false,
         prefetchInlining:
           this.nextConfig.experimental.prefetchInlining ?? false,

--- a/test/production/app-dir/offline-navigations/app/dynamic-prefetch/[value]/dynamic-prefetch-value.tsx
+++ b/test/production/app-dir/offline-navigations/app/dynamic-prefetch/[value]/dynamic-prefetch-value.tsx
@@ -1,0 +1,9 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export function DynamicPrefetchValue() {
+  const params = useParams<{ value: string }>()
+
+  return <p id="dynamic-prefetch-page">dynamic prefetch path: {params.value}</p>
+}

--- a/test/production/app-dir/offline-navigations/app/dynamic-prefetch/[value]/page.tsx
+++ b/test/production/app-dir/offline-navigations/app/dynamic-prefetch/[value]/page.tsx
@@ -1,0 +1,18 @@
+import { Suspense } from 'react'
+import { OfflineStatus } from '../../offline-status'
+import { DynamicPrefetchValue } from './dynamic-prefetch-value'
+
+export function generateStaticParams() {
+  return [{ value: '__TEST__' }]
+}
+
+export default function DynamicPrefetchPage() {
+  return (
+    <>
+      <Suspense fallback={<p>loading dynamic prefetch value</p>}>
+        <DynamicPrefetchValue />
+      </Suspense>
+      <OfflineStatus />
+    </>
+  )
+}

--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -353,6 +353,58 @@ describe('offlineNavigations build artifacts', () => {
     })
   }
 
+  async function prefetchDynamicPatternReplayData(
+    browser: Awaited<ReturnType<typeof next.browser>>
+  ) {
+    await browser.elementById('prefetch-dynamic-pattern-source').click()
+    await retry(async () => {
+      const routeRecords =
+        await readPersistedOfflineNavigationRouteRecords(browser)
+      expect(
+        routeRecords.some((record) =>
+          record.route.pathname.includes('/dynamic-prefetch/learned')
+        )
+      ).toBe(true)
+    })
+
+    await browser.elementById('prefetch-dynamic-pattern-target').click()
+    await retry(async () => {
+      const routeRecords =
+        await readPersistedOfflineNavigationRouteRecords(browser)
+      expect(
+        routeRecords.some((record) =>
+          record.route.pathname.includes('/dynamic-prefetch/learned')
+        )
+      ).toBe(true)
+      expect(
+        routeRecords.some((record) =>
+          record.route.pathname.includes('/dynamic-prefetch/replayed')
+        )
+      ).toBe(false)
+
+      const segmentRecords =
+        await readPersistedOfflineNavigationSegmentRecords(browser)
+      const replayedSegmentRecords = segmentRecords.filter((record) =>
+        record.key.includes('replayed')
+      )
+      expect(
+        segmentRecords.some(
+          (record) => record.payload.requestKind === 'segment-prefetch'
+        )
+      ).toBe(true)
+      expect(
+        replayedSegmentRecords.some((record) =>
+          getPersistedSegmentRequestKey(record)?.endsWith('/__PAGE__')
+        )
+      ).toBe(true)
+      expect(
+        replayedSegmentRecords.some((record) =>
+          isPersistedHeadSegmentRecord(record)
+        )
+      ).toBe(true)
+    })
+  }
+
   async function cleanupOfflineNavigationState(
     browser: Awaited<ReturnType<typeof next.browser>>
   ) {
@@ -1368,6 +1420,131 @@ describe('offlineNavigations build artifacts', () => {
         window.dispatchEvent(new Event('online'))
       })
       await cleanupOfflineNavigationState(browser)
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
+  it('replays a dynamic route from persisted known route patterns', async () => {
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    await next.start({ skipBuild: true })
+
+    let page: Playwright.Page | undefined
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
+
+      await prefetchDynamicPatternReplayData(browser)
+      await retry(async () => {
+        const routeRecords =
+          await readPersistedOfflineNavigationRouteRecords(browser)
+        expect(
+          routeRecords.some((record) =>
+            record.route.pathname.includes('/dynamic-prefetch/replayed')
+          )
+        ).toBe(false)
+      })
+      await retry(async () => {
+        const cacheState = await readOfflineNavigationCacheState(browser)
+        expect(cacheState.entries).toEqual(
+          expect.arrayContaining([
+            {
+              cacheName: expect.stringMatching(/^next-offline-navigation-v1:/),
+              pathname: expect.stringMatching(
+                /^\/app-assets\/_next\/static\/(?:immutable\/)?chunks\/.+\.js$/
+              ),
+            },
+          ])
+        )
+      })
+
+      const session = await (
+        page!.context() as Playwright.BrowserContext & {
+          newCDPSession: (page: Playwright.Page) => Promise<{
+            send: (method: string) => Promise<void>
+            detach: () => Promise<void>
+          }>
+        }
+      ).newCDPSession(page!)
+
+      try {
+        await session.send('Network.clearBrowserCache')
+      } finally {
+        await session.detach()
+      }
+
+      await next.stop()
+      await page!.context().setOffline(true)
+      const dynamicReplayResponse = await page!.goto(
+        `${next.url}/docs/dynamic-prefetch/replayed#restored`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(dynamicReplayResponse?.status()).toBe(200)
+      await retry(async () => {
+        expect(await browser.elementById('dynamic-prefetch-page').text()).toBe(
+          'dynamic prefetch path: replayed'
+        )
+      })
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
+  it('misses dynamic route pattern replay when a required segment record is missing', async () => {
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    await next.start({ skipBuild: true })
+
+    let page: Playwright.Page | undefined
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
+
+      await prefetchDynamicPatternReplayData(browser)
+
+      const deletedSegments =
+        await deletePersistedOfflineNavigationSegmentRecords(browser, {
+          keySubstring: 'replayed',
+          requestKeySuffix: '/__PAGE__',
+        })
+      expect(deletedSegments).toBeGreaterThan(0)
+      await retry(async () => {
+        const segmentRecords =
+          await readPersistedOfflineNavigationSegmentRecords(browser)
+        expect(
+          segmentRecords.some(
+            (record) =>
+              record.key.includes('replayed') &&
+              getPersistedSegmentRequestKey(record)?.endsWith('/__PAGE__')
+          )
+        ).toBe(false)
+      })
+
+      await next.stop()
+      await page!.context().setOffline(true)
+      const missingSegmentResponse = await page!.goto(
+        `${next.url}/docs/dynamic-prefetch/replayed#missing-segment`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(missingSegmentResponse?.status()).toBe(200)
+      await expectOfflineNavigationCacheMiss(browser, 'missing-segment')
     } finally {
       if (page) {
         await page.context().setOffline(false)


### PR DESCRIPTION
This is PR 9 of 21 in the offline navigations plus output-export fallback stack.

This stack introduces a generated fallback entrypoint and then layers the client behavior on the existing App Router, cached navigations, optimistic routing, Cache Components, and Segment Cache primitives. The offline navigations chapter adds a managed service worker and persisted Segment Cache replay. The output-export chapter emits static fallback HTML/RSC artifacts so parameterized routes can load and navigate without enumerating every param at build time.

Review guide: https://gist.github.com/feedthejim/bb440153d29dce019d1d26b6643e2a48

## Where This Sits
This PR is in the offline navigations chapter.
Previous PR: #93644 `offline navigations: bootstrap fallback from Segment Cache records (8/21)`.
Next PR: #93738 `offline navigations: add docs and examples (10/21)`.

## What Changes
- Persists the route pattern information needed to replay dynamic routes from cached Segment Cache records.
- Keeps missing-record behavior safe when a dynamic route is only partially prefetched.

## Reviewer Focus
- Dynamic replay should still reuse the existing router and Segment Cache representation.
- Missing data should produce an offline miss, not a stale or mismatched page.

## Proof In This PR
- Offline production e2e covers dynamic route replay from prefetched records.
- Negative rows cover missing required records during fallback boot.

Latest local stack verification after autosquash included:
- `git diff --check`
- `pnpm --filter=next types`
- `pnpm testonly packages/next/src/client/components/segment-cache/offline-navigation-cache.test.ts packages/next/src/client/components/segment-cache/cache.test.ts packages/next/src/client/output-export-fallback.test.ts packages/next/src/export/helpers/output-export-fallback.test.ts packages/next/src/lib/output-export-fallback-routes.test.ts packages/next/src/client/components/router-reducer/fetch-server-response.test.ts`
- `HEADLESS=true pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `HEADLESS=true pnpm test-start-turbo test/e2e/app-dir-export/test/dynamic-fallback*.test.ts`

## Deferred Coverage
Public docs and examples are deferred to the docs PR.

## Disabled-Flag Posture
Dynamic pattern persistence is behind the same offline navigations flag as the persistence layer.

## Full Stack
1. [offline navigations: add gated build primitives (1/21)](https://github.com/vercel/next.js/pull/93736)
2. [offline navigations: generate fallback document artifacts (2/21)](https://github.com/vercel/next.js/pull/93737)
3. [offline navigations: register pass-through worker (3/21)](https://github.com/vercel/next.js/pull/93625)
4. [offline navigations: cache fallback and current-build assets (4/21)](https://github.com/vercel/next.js/pull/93626)
5. [offline navigations: serve fallback document offline (5/21)](https://github.com/vercel/next.js/pull/93627)
6. [offline navigations: add Segment Cache persistence primitives (6/21)](https://github.com/vercel/next.js/pull/93630)
7. [offline navigations: persist cached Segment Cache records (7/21)](https://github.com/vercel/next.js/pull/93640)
8. [offline navigations: bootstrap fallback from Segment Cache records (8/21)](https://github.com/vercel/next.js/pull/93644)
9. **Current PR:** [offline navigations: support dynamic route patterns (9/21)](https://github.com/vercel/next.js/pull/93647)
10. [offline navigations: add docs and examples (10/21)](https://github.com/vercel/next.js/pull/93738)
11. [output export fallbacks: add gated build primitives (11/21)](https://github.com/vercel/next.js/pull/93744)
12. [output export fallbacks: emit fallback HTML artifacts (12/21)](https://github.com/vercel/next.js/pull/93745)
13. [output export fallbacks: emit fallback RSC artifacts (13/21)](https://github.com/vercel/next.js/pull/93746)
14. [output export fallbacks: enforce server-only boundaries (14/21)](https://github.com/vercel/next.js/pull/93747)
15. [output export fallbacks: bootstrap hard loads from artifacts (15/21)](https://github.com/vercel/next.js/pull/93748)
16. [output export fallbacks: resolve soft navigations through cached routes (16/21)](https://github.com/vercel/next.js/pull/93749)
17. [output export fallbacks: resolve fallback artifacts from route manifests (17/21)](https://github.com/vercel/next.js/pull/93779)
18. [output export fallbacks: validate fallback Flight responses (18/21)](https://github.com/vercel/next.js/pull/93750)
19. [output export fallbacks: store fallback data in Segment Cache (19/21)](https://github.com/vercel/next.js/pull/93774)
20. [output export fallbacks: support known params and export variants (20/21)](https://github.com/vercel/next.js/pull/93751)
21. [output export fallbacks: add docs and review guide (21/21)](https://github.com/vercel/next.js/pull/93752)

<!-- NEXT_JS_LLM_PR -->
