### PR TITLE
offline navigations: cover persisted router replay (10/11)

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1190,5 +1190,6 @@
   "1189": "Route \"%s\" accessed header \"%s\" which is not defined in the \\`unstable_samples\\` of \\`unstable_instant\\`. Add it to the sample's \\`headers\\` array, or \\`[\"%s\", null]\\` if it should be absent.",
   "1190": "Route \"%s\" accessed param \"%s\" which is not defined in the \\`unstable_samples\\` of \\`unstable_instant\\`. Add it to the sample's \\`params\\` object.",
   "1191": "Route \"%s\" called %s but param%s %s %s not defined in the \\`unstable_samples\\` of \\`unstable_instant\\`. %s requires all route params to be provided.",
-  "1192": "Route \"%s\" accessed root param \"%s\" which is not defined in the \\`unstable_samples\\` of \\`unstable_instant\\`. Add it to the sample's \\`params\\` object."
+  "1192": "Route \"%s\" accessed root param \"%s\" which is not defined in the \\`unstable_samples\\` of \\`unstable_instant\\`. Add it to the sample's \\`params\\` object.",
+  "1193": "\\`experimental.offlineNavigations\\` requires \\`cacheComponents\\` to be enabled. Please update your %s accordingly."
 }

--- a/packages/next/src/build/define-env.ts
+++ b/packages/next/src/build/define-env.ts
@@ -246,7 +246,12 @@ export function getDefineEnv({
     'process.env.__NEXT_DYNAMIC_ON_HOVER': Boolean(
       config.experimental.dynamicOnHover
     ),
-    'process.env.__NEXT_USE_OFFLINE': Boolean(config.experimental.useOffline),
+    'process.env.__NEXT_OFFLINE_NAVIGATIONS': Boolean(
+      config.experimental.offlineNavigations
+    ),
+    'process.env.__NEXT_USE_OFFLINE': Boolean(
+      config.experimental.useOffline || config.experimental.offlineNavigations
+    ),
     'process.env.__NEXT_PREFETCH_INLINING': Boolean(
       config.experimental.prefetchInlining
     ),

--- a/packages/next/src/build/define-env.ts
+++ b/packages/next/src/build/define-env.ts
@@ -384,7 +384,9 @@ export function getDefineEnv({
     'process.env.__NEXT_GESTURE_TRANSITION':
       config.experimental.gestureTransition ?? false,
     'process.env.__NEXT_OPTIMISTIC_ROUTING':
-      config.experimental.optimisticRouting ?? false,
+      config.experimental.optimisticRouting ||
+      config.experimental.offlineNavigations ||
+      false,
     'process.env.__NEXT_VARY_PARAMS': config.experimental.varyParams ?? false,
     'process.env.__NEXT_EXPOSE_TESTING_API':
       dev || config.experimental.exposeTestingApiInProductionBuild === true,

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -233,6 +233,10 @@ import {
   createOfflineNavigationFallbackDocument,
   getOfflineNavigationFallbackFilePath,
 } from './offline-navigation-fallback'
+import {
+  createOfflineNavigationManifest,
+  getOfflineNavigationManifestFilePath,
+} from './offline-navigation-manifest'
 
 type Fallback = null | boolean | string
 
@@ -4097,7 +4101,7 @@ export default async function build(
 
       if (config.experimental.offlineNavigations && appDir) {
         await nextBuildSpan
-          .traceChild('write-offline-navigation-fallback')
+          .traceChild('write-offline-navigation-artifacts')
           .traceAsyncFn(async () => {
             const fallbackDocument = createOfflineNavigationFallbackDocument({
               assetPrefix: config.assetPrefix,
@@ -4116,6 +4120,17 @@ export default async function build(
             )
             await mkdir(path.dirname(fallbackPath), { recursive: true })
             await writeFileUtf8(fallbackPath, fallbackDocument)
+
+            await writeManifest(
+              path.join(distDir, getOfflineNavigationManifestFilePath(buildId)),
+              createOfflineNavigationManifest({
+                assetPrefix: config.assetPrefix,
+                basePath: config.basePath,
+                buildId,
+                output: config.output,
+                trailingSlash: config.trailingSlash,
+              })
+            )
           })
       }
 

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -4145,6 +4145,7 @@ export default async function build(
               serviceWorkerPath,
               createOfflineNavigationServiceWorker({
                 cacheNamespace: manifest.cacheNamespace,
+                fallbackDocumentHref: manifest.fallbackDocument.href,
                 manifestHref: manifest.manifest.href,
               })
             )

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -4144,6 +4144,7 @@ export default async function build(
             await writeFileUtf8(
               serviceWorkerPath,
               createOfflineNavigationServiceWorker({
+                cacheNamespace: manifest.cacheNamespace,
                 manifestHref: manifest.manifest.href,
               })
             )

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -229,6 +229,10 @@ import {
 } from '../server/lib/router-utils/build-prefetch-segment-data-route'
 import { generateRoutesManifest } from './generate-routes-manifest'
 import { validateAppPaths } from './validate-app-paths'
+import {
+  createOfflineNavigationFallbackDocument,
+  getOfflineNavigationFallbackFilePath,
+} from './offline-navigation-fallback'
 
 type Fallback = null | boolean | string
 
@@ -4090,6 +4094,30 @@ export default async function build(
       }
 
       // #endregion
+
+      if (config.experimental.offlineNavigations && appDir) {
+        await nextBuildSpan
+          .traceChild('write-offline-navigation-fallback')
+          .traceAsyncFn(async () => {
+            const fallbackDocument = createOfflineNavigationFallbackDocument({
+              assetPrefix: config.assetPrefix,
+              buildId,
+              buildManifest,
+              crossOrigin: config.crossOrigin,
+            })
+
+            if (fallbackDocument === null) {
+              return
+            }
+
+            const fallbackPath = path.join(
+              distDir,
+              getOfflineNavigationFallbackFilePath(buildId)
+            )
+            await mkdir(path.dirname(fallbackPath), { recursive: true })
+            await writeFileUtf8(fallbackPath, fallbackDocument)
+          })
+      }
 
       await writeImagesManifest(distDir, config)
       await writeManifest(path.join(distDir, EXPORT_MARKER), {

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -237,6 +237,10 @@ import {
   createOfflineNavigationManifest,
   getOfflineNavigationManifestFilePath,
 } from './offline-navigation-manifest'
+import {
+  createOfflineNavigationServiceWorker,
+  getOfflineNavigationServiceWorkerFilePath,
+} from './offline-navigation-service-worker'
 
 type Fallback = null | boolean | string
 
@@ -4118,17 +4122,29 @@ export default async function build(
               distDir,
               getOfflineNavigationFallbackFilePath(buildId)
             )
+            const manifestPath = path.join(
+              distDir,
+              getOfflineNavigationManifestFilePath(buildId)
+            )
+            const serviceWorkerPath = path.join(
+              distDir,
+              getOfflineNavigationServiceWorkerFilePath()
+            )
+            const manifest = createOfflineNavigationManifest({
+              assetPrefix: config.assetPrefix,
+              basePath: config.basePath,
+              buildId,
+              output: config.output,
+              trailingSlash: config.trailingSlash,
+            })
+
             await mkdir(path.dirname(fallbackPath), { recursive: true })
             await writeFileUtf8(fallbackPath, fallbackDocument)
-
-            await writeManifest(
-              path.join(distDir, getOfflineNavigationManifestFilePath(buildId)),
-              createOfflineNavigationManifest({
-                assetPrefix: config.assetPrefix,
-                basePath: config.basePath,
-                buildId,
-                output: config.output,
-                trailingSlash: config.trailingSlash,
+            await writeManifest(manifestPath, manifest)
+            await writeFileUtf8(
+              serviceWorkerPath,
+              createOfflineNavigationServiceWorker({
+                manifestHref: manifest.manifest.href,
               })
             )
           })

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -4112,6 +4112,7 @@ export default async function build(
               buildId,
               buildManifest,
               crossOrigin: config.crossOrigin,
+              deploymentId: config.deploymentId,
             })
 
             if (fallbackDocument === null) {

--- a/packages/next/src/build/offline-navigation-fallback.ts
+++ b/packages/next/src/build/offline-navigation-fallback.ts
@@ -34,18 +34,21 @@ function getScriptAttributes(
 }
 
 // Generate the build-scoped HTML entrypoint used by offline document fallback
-// handling. It intentionally contains only the app bootstrap, not route HTML,
-// so the artifact stays request-invariant.
+// handling. It intentionally contains only the app bootstrap, not route HTML;
+// route data is restored by the client from persisted router-cache records
+// after this document loads.
 export function createOfflineNavigationFallbackDocument({
   assetPrefix,
   buildId,
   buildManifest,
   crossOrigin,
+  deploymentId,
 }: {
   assetPrefix: string
   buildId: string
   buildManifest: BuildManifest
   crossOrigin: '' | 'anonymous' | 'use-credentials' | undefined
+  deploymentId: string | undefined
 }): string | null {
   const rootMainFiles = buildManifest.rootMainFiles.filter((file) =>
     file.endsWith('.js')
@@ -77,11 +80,15 @@ export function createOfflineNavigationFallbackDocument({
     source: 'offline-navigation-fallback',
   }
 
+  const deploymentIdAttribute = deploymentId
+    ? ` data-dpl-id="${htmlEscapeAttributeString(deploymentId)}"`
+    : ''
+
   return `<!DOCTYPE html><html data-next-offline-navigation-fallback="" data-build-id="${htmlEscapeAttributeString(
     buildId
-  )}"><head><meta charSet="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><meta name="next-offline-navigation-fallback" content="1"><meta name="next-build-id" content="${htmlEscapeAttributeString(
+  )}"${deploymentIdAttribute}><head><meta charSet="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><meta name="next-offline-navigation-fallback" content="1"><meta name="next-build-id" content="${htmlEscapeAttributeString(
     buildId
   )}"><script id="__NEXT_OFFLINE_NAVIGATION_FALLBACK" type="application/json">${htmlEscapeJsonString(
     JSON.stringify(metadata)
-  )}</script></head><body><div id="__next"></div><script>self.__next_f=self.__next_f||[];self.__next_f.push([0])</script>${polyfillScripts}${bootstrapScripts}</body></html>`
+  )}</script></head><body><div id="__next"></div><p id="__NEXT_OFFLINE_NAVIGATION_CACHE_MISS" hidden>This page is not available offline.</p><script>self.__next_f=self.__next_f||[];self.__next_f.push([0])</script>${polyfillScripts}${bootstrapScripts}</body></html>`
 }

--- a/packages/next/src/build/offline-navigation-fallback.ts
+++ b/packages/next/src/build/offline-navigation-fallback.ts
@@ -1,0 +1,87 @@
+import path from 'node:path'
+
+import type { BuildManifest } from '../server/get-page-files'
+import { encodeURIPath } from '../shared/lib/encode-uri-path'
+import {
+  htmlEscapeAttributeString,
+  htmlEscapeJsonString,
+} from '../shared/lib/htmlescape'
+import { CLIENT_STATIC_FILES_PATH } from '../shared/lib/constants'
+
+export const OFFLINE_NAVIGATION_FALLBACK_HTML =
+  '_offline-navigation-fallback.html'
+
+export function getOfflineNavigationFallbackFilePath(buildId: string): string {
+  return path.join(
+    CLIENT_STATIC_FILES_PATH,
+    buildId,
+    OFFLINE_NAVIGATION_FALLBACK_HTML
+  )
+}
+
+function getAssetHref(assetPrefix: string, file: string): string {
+  return `${assetPrefix}/_next/${encodeURIPath(file)}`
+}
+
+function getScriptAttributes(
+  crossOrigin: '' | 'anonymous' | 'use-credentials' | undefined
+): string {
+  if (!crossOrigin) {
+    return ''
+  }
+
+  return ` crossOrigin="${htmlEscapeAttributeString(crossOrigin)}"`
+}
+
+// Generate the build-scoped HTML entrypoint used by offline document fallback
+// handling. It intentionally contains only the app bootstrap, not route HTML,
+// so the artifact stays request-invariant.
+export function createOfflineNavigationFallbackDocument({
+  assetPrefix,
+  buildId,
+  buildManifest,
+  crossOrigin,
+}: {
+  assetPrefix: string
+  buildId: string
+  buildManifest: BuildManifest
+  crossOrigin: '' | 'anonymous' | 'use-credentials' | undefined
+}): string | null {
+  const rootMainFiles = buildManifest.rootMainFiles.filter((file) =>
+    file.endsWith('.js')
+  )
+
+  if (rootMainFiles.length === 0) {
+    return null
+  }
+
+  const polyfillScripts = buildManifest.polyfillFiles
+    .filter((file) => file.endsWith('.js') && !file.endsWith('.module.js'))
+    .map((file) => {
+      return `<script src="${htmlEscapeAttributeString(
+        getAssetHref(assetPrefix, file)
+      )}" noModule${getScriptAttributes(crossOrigin)}></script>`
+    })
+    .join('')
+
+  const bootstrapScripts = rootMainFiles
+    .map((file) => {
+      return `<script src="${htmlEscapeAttributeString(
+        getAssetHref(assetPrefix, file)
+      )}" async${getScriptAttributes(crossOrigin)}></script>`
+    })
+    .join('')
+
+  const metadata = {
+    buildId,
+    source: 'offline-navigation-fallback',
+  }
+
+  return `<!DOCTYPE html><html data-next-offline-navigation-fallback="" data-build-id="${htmlEscapeAttributeString(
+    buildId
+  )}"><head><meta charSet="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><meta name="next-offline-navigation-fallback" content="1"><meta name="next-build-id" content="${htmlEscapeAttributeString(
+    buildId
+  )}"><script id="__NEXT_OFFLINE_NAVIGATION_FALLBACK" type="application/json">${htmlEscapeJsonString(
+    JSON.stringify(metadata)
+  )}</script></head><body><div id="__next"></div><script>self.__next_f=self.__next_f||[];self.__next_f.push([0])</script>${polyfillScripts}${bootstrapScripts}</body></html>`
+}

--- a/packages/next/src/build/offline-navigation-manifest.ts
+++ b/packages/next/src/build/offline-navigation-manifest.ts
@@ -4,6 +4,7 @@ import type { NextConfigComplete } from '../server/config-shared'
 import { CLIENT_STATIC_FILES_PATH } from '../shared/lib/constants'
 import { encodeURIPath } from '../shared/lib/encode-uri-path'
 import { getOfflineNavigationFallbackFilePath } from './offline-navigation-fallback'
+import { getOfflineNavigationServiceWorkerFilePath } from './offline-navigation-service-worker'
 
 export const OFFLINE_NAVIGATION_MANIFEST = '_offline-navigation-manifest.json'
 
@@ -21,6 +22,10 @@ export interface OfflineNavigationManifest {
     href: string
   }
   fallbackDocument: {
+    path: string
+    href: string
+  }
+  serviceWorker: {
     path: string
     href: string
   }
@@ -60,6 +65,7 @@ export function createOfflineNavigationManifest({
 }): OfflineNavigationManifest {
   const manifestPath = getOfflineNavigationManifestFilePath(buildId)
   const fallbackDocumentPath = getOfflineNavigationFallbackFilePath(buildId)
+  const serviceWorkerPath = getOfflineNavigationServiceWorkerFilePath()
 
   return {
     version: 1,
@@ -79,6 +85,10 @@ export function createOfflineNavigationManifest({
     fallbackDocument: {
       path: fallbackDocumentPath,
       href: getStaticHref(basePath, fallbackDocumentPath),
+    },
+    serviceWorker: {
+      path: serviceWorkerPath,
+      href: getStaticHref(basePath, serviceWorkerPath),
     },
   }
 }

--- a/packages/next/src/build/offline-navigation-manifest.ts
+++ b/packages/next/src/build/offline-navigation-manifest.ts
@@ -1,0 +1,84 @@
+import path from 'node:path'
+
+import type { NextConfigComplete } from '../server/config-shared'
+import { CLIENT_STATIC_FILES_PATH } from '../shared/lib/constants'
+import { encodeURIPath } from '../shared/lib/encode-uri-path'
+import { getOfflineNavigationFallbackFilePath } from './offline-navigation-fallback'
+
+export const OFFLINE_NAVIGATION_MANIFEST = '_offline-navigation-manifest.json'
+
+export interface OfflineNavigationManifest {
+  version: 1
+  buildId: string
+  basePath: string
+  assetPrefix: string
+  trailingSlash: boolean
+  output: NonNullable<NextConfigComplete['output']> | 'default'
+  scope: string
+  cacheNamespace: string
+  manifest: {
+    path: string
+    href: string
+  }
+  fallbackDocument: {
+    path: string
+    href: string
+  }
+}
+
+export function getOfflineNavigationManifestFilePath(buildId: string): string {
+  return path.join(
+    CLIENT_STATIC_FILES_PATH,
+    buildId,
+    OFFLINE_NAVIGATION_MANIFEST
+  )
+}
+
+function getStaticHref(basePath: string, filePath: string): string {
+  return `${basePath}/_next/${encodeURIPath(filePath)}`
+}
+
+function getScope(basePath: string): string {
+  return basePath ? `${basePath}/` : '/'
+}
+
+// Describe the build-scoped offline navigation artifacts with URLs that honor
+// the app basePath. Later slices use this manifest as the service worker's
+// source of truth for what bootstrap artifacts to cache.
+export function createOfflineNavigationManifest({
+  assetPrefix,
+  basePath,
+  buildId,
+  output,
+  trailingSlash,
+}: {
+  assetPrefix: string
+  basePath: string
+  buildId: string
+  output: NextConfigComplete['output']
+  trailingSlash: boolean
+}): OfflineNavigationManifest {
+  const manifestPath = getOfflineNavigationManifestFilePath(buildId)
+  const fallbackDocumentPath = getOfflineNavigationFallbackFilePath(buildId)
+
+  return {
+    version: 1,
+    buildId,
+    basePath,
+    assetPrefix,
+    trailingSlash,
+    output: output ?? 'default',
+    scope: getScope(basePath),
+    // Scope caches by build and basePath so each deployment uses its own
+    // fallback document.
+    cacheNamespace: `next-offline-navigation-v1:${buildId}:${basePath || '/'}`,
+    manifest: {
+      path: manifestPath,
+      href: getStaticHref(basePath, manifestPath),
+    },
+    fallbackDocument: {
+      path: fallbackDocumentPath,
+      href: getStaticHref(basePath, fallbackDocumentPath),
+    },
+  }
+}

--- a/packages/next/src/build/offline-navigation-manifest.ts
+++ b/packages/next/src/build/offline-navigation-manifest.ts
@@ -47,9 +47,10 @@ function getScope(basePath: string): string {
   return basePath ? `${basePath}/` : '/'
 }
 
-// Describe the build-scoped offline navigation artifacts with URLs that honor
-// the app basePath. Later slices use this manifest as the service worker's
-// source of truth for what bootstrap artifacts to cache.
+// The generated service worker reads this manifest to cache only the
+// build-scoped bootstrap artifacts. RSC navigation data is persisted by the
+// client router in IndexedDB, so it can follow router cache invalidation
+// instead of being managed by CacheStorage.
 export function createOfflineNavigationManifest({
   assetPrefix,
   basePath,

--- a/packages/next/src/build/offline-navigation-service-worker.ts
+++ b/packages/next/src/build/offline-navigation-service-worker.ts
@@ -7,21 +7,67 @@ export function getOfflineNavigationServiceWorkerFilePath(): string {
   return path.join(CLIENT_STATIC_FILES_PATH, OFFLINE_NAVIGATION_SERVICE_WORKER)
 }
 
-// Generate an app-local service worker for offline navigations. This slice is
-// pass-through: it only installs and claims clients so later slices can add
-// cache population and fallback document handling.
+// Offline navigations use a generated, app-local service worker. It caches the
+// bootstrap manifest and fallback document during installation; document
+// navigations still go to the network until fallback handling is enabled.
 export function createOfflineNavigationServiceWorker({
+  cacheNamespace,
   manifestHref,
 }: {
+  cacheNamespace: string
   manifestHref: string
 }): string {
   const metadata = JSON.stringify({
+    cacheNamespace,
     manifestHref,
     source: 'offline-navigation-service-worker',
   })
 
   return `self.__NEXT_OFFLINE_NAVIGATION_SW=${metadata};
-self.addEventListener('install',(event)=>{event.waitUntil(self.skipWaiting())});
-self.addEventListener('activate',(event)=>{event.waitUntil(self.clients.claim())});
+const CACHE_PREFIX='next-offline-navigation-v1:';
+function withDeploymentQuery(href){
+  const url=new URL(href,self.location.origin);
+  const deploymentParams=new URLSearchParams(self.location.search);
+  deploymentParams.forEach((value,key)=>{
+    if(!url.searchParams.has(key)){
+      url.searchParams.set(key,value);
+    }
+  });
+  return url.href;
+}
+async function fetchRequiredResource(href){
+  const response=await fetch(withDeploymentQuery(href),{cache:'no-store'});
+  if(!response.ok){
+    throw new Error('Failed to cache offline navigation resource: '+href);
+  }
+  return response;
+}
+async function cacheOfflineNavigationResources(){
+  const metadata=self.__NEXT_OFFLINE_NAVIGATION_SW;
+  const cache=await caches.open(metadata.cacheNamespace);
+  const manifestResponse=await fetchRequiredResource(metadata.manifestHref);
+  const manifest=await manifestResponse.clone().json();
+  await cache.put(metadata.manifestHref,manifestResponse);
+  const fallbackResponse=await fetchRequiredResource(manifest.fallbackDocument.href);
+  await cache.put(manifest.fallbackDocument.href,fallbackResponse);
+}
+self.addEventListener('install',(event)=>{
+  event.waitUntil((async()=>{
+    await cacheOfflineNavigationResources();
+    await self.skipWaiting();
+  })());
+});
+self.addEventListener('activate',(event)=>{
+  event.waitUntil((async()=>{
+    const metadata=self.__NEXT_OFFLINE_NAVIGATION_SW;
+    const cacheNames=await caches.keys();
+    await Promise.all(cacheNames.map((cacheName)=>{
+      if(cacheName.startsWith(CACHE_PREFIX)&&cacheName!==metadata.cacheNamespace){
+        return caches.delete(cacheName);
+      }
+    }));
+    await self.clients.claim();
+  })());
+});
 `
 }

--- a/packages/next/src/build/offline-navigation-service-worker.ts
+++ b/packages/next/src/build/offline-navigation-service-worker.ts
@@ -10,7 +10,8 @@ export function getOfflineNavigationServiceWorkerFilePath(): string {
 
 // Offline navigations use a generated, app-local service worker as a document
 // fallback only. It is network-first for regular loads and only serves the
-// fallback document after the network request fails.
+// fallback document after the network request fails; route data is restored
+// later by the client from the durable router cache.
 export function createOfflineNavigationServiceWorker({
   cacheNamespace,
   fallbackDocumentHref,

--- a/packages/next/src/build/offline-navigation-service-worker.ts
+++ b/packages/next/src/build/offline-navigation-service-worker.ts
@@ -2,26 +2,33 @@ import path from 'node:path'
 
 import { CLIENT_STATIC_FILES_PATH } from '../shared/lib/constants'
 import { OFFLINE_NAVIGATION_SERVICE_WORKER } from '../shared/lib/offline-navigation'
+import { OFFLINE_NAVIGATION_FALLBACK_SERVED } from '../shared/lib/offline-navigation-constants'
 
 export function getOfflineNavigationServiceWorkerFilePath(): string {
   return path.join(CLIENT_STATIC_FILES_PATH, OFFLINE_NAVIGATION_SERVICE_WORKER)
 }
 
-// Offline navigations use a generated, app-local service worker. It caches the
-// bootstrap manifest and fallback document during installation; document
-// navigations still go to the network until fallback handling is enabled.
+// Offline navigations use a generated, app-local service worker as a document
+// fallback only. It is network-first for regular loads and only serves the
+// fallback document after the network request fails.
 export function createOfflineNavigationServiceWorker({
   cacheNamespace,
+  fallbackDocumentHref,
   manifestHref,
 }: {
   cacheNamespace: string
+  fallbackDocumentHref: string
   manifestHref: string
 }): string {
   const metadata = JSON.stringify({
     cacheNamespace,
+    fallbackDocumentHref,
     manifestHref,
     source: 'offline-navigation-service-worker',
   })
+  const fallbackServedMessageType = JSON.stringify(
+    OFFLINE_NAVIGATION_FALLBACK_SERVED
+  )
 
   return `self.__NEXT_OFFLINE_NAVIGATION_SW=${metadata};
 const CACHE_PREFIX='next-offline-navigation-v1:';
@@ -51,6 +58,33 @@ async function cacheOfflineNavigationResources(){
   const fallbackResponse=await fetchRequiredResource(manifest.fallbackDocument.href);
   await cache.put(manifest.fallbackDocument.href,fallbackResponse);
 }
+function isDocumentNavigationRequest(request){
+  if(request.method!=='GET'||request.mode!=='navigate'||request.destination!=='document'){
+    return false;
+  }
+  const url=new URL(request.url);
+  return url.origin===self.location.origin;
+}
+async function fetchDocumentNavigation(request){
+  try{
+    return await fetch(request);
+  }catch(err){
+    const metadata=self.__NEXT_OFFLINE_NAVIGATION_SW;
+    const cache=await caches.open(metadata.cacheNamespace);
+    const fallbackResponse=await cache.match(metadata.fallbackDocumentHref);
+    if(fallbackResponse){
+      await notifyClients({
+        type:${fallbackServedMessageType}
+      });
+      return fallbackResponse;
+    }
+    throw err;
+  }
+}
+async function notifyClients(message){
+  const clients=await self.clients.matchAll({type:'window',includeUncontrolled:true});
+  await Promise.all(clients.map((client)=>client.postMessage(message)));
+}
 self.addEventListener('install',(event)=>{
   event.waitUntil((async()=>{
     await cacheOfflineNavigationResources();
@@ -68,6 +102,11 @@ self.addEventListener('activate',(event)=>{
     }));
     await self.clients.claim();
   })());
+});
+self.addEventListener('fetch',(event)=>{
+  if(isDocumentNavigationRequest(event.request)){
+    event.respondWith(fetchDocumentNavigation(event.request));
+  }
 });
 `
 }

--- a/packages/next/src/build/offline-navigation-service-worker.ts
+++ b/packages/next/src/build/offline-navigation-service-worker.ts
@@ -1,0 +1,27 @@
+import path from 'node:path'
+
+import { CLIENT_STATIC_FILES_PATH } from '../shared/lib/constants'
+import { OFFLINE_NAVIGATION_SERVICE_WORKER } from '../shared/lib/offline-navigation'
+
+export function getOfflineNavigationServiceWorkerFilePath(): string {
+  return path.join(CLIENT_STATIC_FILES_PATH, OFFLINE_NAVIGATION_SERVICE_WORKER)
+}
+
+// Generate an app-local service worker for offline navigations. This slice is
+// pass-through: it only installs and claims clients so later slices can add
+// cache population and fallback document handling.
+export function createOfflineNavigationServiceWorker({
+  manifestHref,
+}: {
+  manifestHref: string
+}): string {
+  const metadata = JSON.stringify({
+    manifestHref,
+    source: 'offline-navigation-service-worker',
+  })
+
+  return `self.__NEXT_OFFLINE_NAVIGATION_SW=${metadata};
+self.addEventListener('install',(event)=>{event.waitUntil(self.skipWaiting())});
+self.addEventListener('activate',(event)=>{event.waitUntil(self.clients.claim())});
+`
+}

--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -890,7 +890,8 @@ export async function handler(
             staleTimes: nextConfig.experimental.staleTimes,
             dynamicOnHover: Boolean(nextConfig.experimental.dynamicOnHover),
             optimisticRouting: Boolean(
-              nextConfig.experimental.optimisticRouting
+              nextConfig.experimental.optimisticRouting ||
+                nextConfig.experimental.offlineNavigations
             ),
             inlineCss: Boolean(nextConfig.experimental.inlineCss),
             prefetchInlining: nextConfig.experimental.prefetchInlining ?? false,

--- a/packages/next/src/build/templates/edge-ssr-app.ts
+++ b/packages/next/src/build/templates/edge-ssr-app.ts
@@ -165,7 +165,10 @@ async function requestHandler(
         expireTime: nextConfig.expireTime,
         staleTimes: nextConfig.experimental.staleTimes,
         dynamicOnHover: Boolean(nextConfig.experimental.dynamicOnHover),
-        optimisticRouting: Boolean(nextConfig.experimental.optimisticRouting),
+        optimisticRouting: Boolean(
+          nextConfig.experimental.optimisticRouting ||
+            nextConfig.experimental.offlineNavigations
+        ),
         inlineCss: Boolean(nextConfig.experimental.inlineCss),
         prefetchInlining: nextConfig.experimental.prefetchInlining ?? false,
         authInterrupts: Boolean(nextConfig.experimental.authInterrupts),

--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -20,6 +20,7 @@ import {
   createMutableActionQueue,
 } from './components/app-router-instance'
 import AppRouter from './components/app-router'
+import DefaultGlobalError from './components/builtin/global-error'
 import type { InitialRSCPayload } from '../shared/lib/app-router-types'
 import { createInitialRouterState } from './components/router-reducer/create-initial-router-state'
 import { MissingSlotContext } from '../shared/lib/app-router-context.shared-runtime'
@@ -44,6 +45,156 @@ const instantTestStaticFetch: Promise<Response> | undefined =
   self.__next_instant_test
     ? (self.__next_instant_test as unknown as Promise<Response>)
     : undefined
+
+function isOfflineNavigationFallbackDocument(): boolean {
+  return Boolean(
+    process.env.__NEXT_OFFLINE_NAVIGATIONS &&
+      !process.env.__NEXT_DEV_SERVER &&
+      document.documentElement.hasAttribute(
+        'data-next-offline-navigation-fallback'
+      )
+  )
+}
+
+type OfflineNavigationCacheMissReason =
+  | 'missing-route'
+  | 'unsupported-route'
+  | 'missing-segment'
+  | 'missing-head'
+  | 'read-error'
+
+// Private test markers for the offline navigation e2e suite. These are only
+// emitted when the production testing API is explicitly enabled.
+function showOfflineNavigationCacheHit(): void {
+  if (process.env.__NEXT_EXPOSE_TESTING_API) {
+    document.documentElement.setAttribute(
+      'data-next-offline-navigation-cache',
+      'hit'
+    )
+    document.documentElement.removeAttribute(
+      'data-next-offline-navigation-cache-reason'
+    )
+  }
+}
+
+function showOfflineNavigationCacheMiss(
+  reason: OfflineNavigationCacheMissReason
+): void {
+  if (process.env.__NEXT_EXPOSE_TESTING_API) {
+    document.documentElement.setAttribute(
+      'data-next-offline-navigation-cache',
+      'miss'
+    )
+    document.documentElement.setAttribute(
+      'data-next-offline-navigation-cache-reason',
+      reason
+    )
+  }
+  const cacheMissElement = document.getElementById(
+    '__NEXT_OFFLINE_NAVIGATION_CACHE_MISS'
+  )
+  if (cacheMissElement !== null) {
+    cacheMissElement.hidden = false
+    if (process.env.__NEXT_EXPOSE_TESTING_API) {
+      cacheMissElement.setAttribute(
+        'data-next-offline-navigation-cache-reason',
+        reason
+      )
+    }
+  }
+}
+
+function neverResolveInitialRSCPayload(): Promise<InitialRSCPayload> {
+  return new Promise<InitialRSCPayload>(() => {})
+}
+
+type OfflineNavigationFallbackBootstrap =
+  | {
+      kind: 'router-cache'
+      initialRSCPayload: InitialRSCPayload
+      buildId: string | undefined
+    }
+  | {
+      kind: 'cache-miss'
+      buildId: string | undefined
+    }
+
+// The generated fallback document has no inline Flight data for the current
+// URL. Hydrate the persisted router-cache records, then ask the normal router
+// cache to reconstruct the initial payload for this URL.
+function createOfflineNavigationFallbackBootstrap():
+  | Promise<OfflineNavigationFallbackBootstrap>
+  | undefined {
+  if (process.env.__NEXT_OFFLINE_NAVIGATIONS) {
+    if (!isOfflineNavigationFallbackDocument()) {
+      return undefined
+    }
+
+    return (async (): Promise<OfflineNavigationFallbackBootstrap> => {
+      const {
+        createOfflineNavigationInitialRSCPayloadFromRouterCache,
+        hydrateOfflineNavigationRouterCache,
+      } =
+        require('./components/segment-cache/cache') as typeof import('./components/segment-cache/cache')
+
+      const buildId =
+        getDeploymentId() ??
+        document.documentElement.getAttribute('data-build-id') ??
+        undefined
+      await hydrateOfflineNavigationRouterCache({
+        buildId,
+      })
+
+      const reconstruction =
+        createOfflineNavigationInitialRSCPayloadFromRouterCache({
+          buildId,
+          globalErrorState: [DefaultGlobalError, undefined],
+          now: Date.now(),
+          url: location.href,
+        })
+      if (reconstruction.status === 'fulfilled') {
+        showOfflineNavigationCacheHit()
+        return {
+          kind: 'router-cache',
+          initialRSCPayload: reconstruction.initialRSCPayload,
+          buildId,
+        }
+      }
+      showOfflineNavigationCacheMiss(reconstruction.reason)
+      return {
+        kind: 'cache-miss',
+        buildId,
+      }
+    })().catch((): OfflineNavigationFallbackBootstrap => {
+      showOfflineNavigationCacheMiss('read-error')
+      return {
+        kind: 'cache-miss',
+        buildId: undefined,
+      }
+    })
+  } else {
+    return undefined
+  }
+}
+
+const offlineNavigationFallbackBootstrap =
+  createOfflineNavigationFallbackBootstrap()
+
+if (process.env.__NEXT_USE_OFFLINE) {
+  if (offlineNavigationFallbackBootstrap) {
+    const { notifyOffline } =
+      require('./components/offline') as typeof import('./components/offline')
+    notifyOffline()
+  }
+} else {
+  // Keep the offline event module out of disabled client bundles.
+}
+
+const hasClientResumeShell = Boolean(window.__NEXT_CLIENT_RESUME)
+const hasLockedStaticShell =
+  Boolean(instantTestStaticFetch) ||
+  Boolean(offlineNavigationFallbackBootstrap) ||
+  hasClientResumeShell
 
 const encoder = new TextEncoder()
 
@@ -73,6 +224,7 @@ declare global {
      */
     __next_r?: string
     __next_f: NextFlight
+    __NEXT_CLIENT_RESUME?: Promise<Response>
   }
 }
 
@@ -128,14 +280,11 @@ function nextServerDataRegisterWriter(ctr: ReadableStreamDefaultController) {
       ctr.enqueue(typeof val === 'string' ? encoder.encode(val) : val)
     })
     if (initialServerDataLoaded && !initialServerDataFlushed) {
-      // Instant Navigation Testing API: don't close or error the inline
-      // Flight stream. The static shell has no inline Flight data, so the
-      // stream is empty. Closing it would cause React to log an error about
-      // missing data. Leaving it open lets React treat any holes as
-      // "still suspended." Hydration uses the separately fetched RSC payload
-      // (self.__next_instant_test), not this stream.
+      // Locked static shells do not have a real inline Flight stream. Closing
+      // or erroring this stream causes React to report a missing-data failure,
+      // but the actual hydration data arrives through a separate response.
       if (isStreamErrorOrUnfinished(ctr)) {
-        if (!instantTestStaticFetch) {
+        if (!hasLockedStaticShell) {
           ctr.error(
             new Error(
               'The connection to the page was unexpectedly closed, possibly due to the stop button being clicked, loss of Wi-Fi, or an unstable internet connection.'
@@ -155,7 +304,11 @@ function nextServerDataRegisterWriter(ctr: ReadableStreamDefaultController) {
 
 // When `DOMContentLoaded`, we can close all pending writers to finish hydration.
 const DOMContentLoaded = function () {
-  if (initialServerDataWriter && !initialServerDataFlushed) {
+  if (
+    initialServerDataWriter &&
+    !initialServerDataFlushed &&
+    !hasLockedStaticShell
+  ) {
     initialServerDataWriter.close()
     initialServerDataFlushed = true
     initialServerDataBuffer = undefined
@@ -187,7 +340,7 @@ let readable: ReadableStream<Uint8Array> = new ReadableStream({
   },
 })
 if (process.env.NODE_ENV !== 'production') {
-  // @ts-expect-error
+  // @ts-expect-error name is a dev-only debugging affordance.
   readable.name = 'hydration'
 }
 
@@ -198,7 +351,8 @@ if (process.env.NODE_ENV !== 'production') {
 let initialFlightStreamForCache: ReadableStream<Uint8Array> | null = null
 if (
   process.env.__NEXT_CACHE_COMPONENTS &&
-  process.env.__NEXT_EXPERIMENTAL_CACHED_NAVIGATIONS
+  process.env.__NEXT_EXPERIMENTAL_CACHED_NAVIGATIONS &&
+  !offlineNavigationFallbackBootstrap
 ) {
   const [forReact, forCache] = readable.tee()
   readable = forReact
@@ -242,13 +396,18 @@ if (instantTestStaticFetch) {
       initialRSCPayload
     )
   })
-} else if (
-  // @ts-expect-error
-  window.__NEXT_CLIENT_RESUME
-) {
-  const clientResumeFetch: Promise<Response> =
-    // @ts-expect-error
-    window.__NEXT_CLIENT_RESUME
+} else if (offlineNavigationFallbackBootstrap) {
+  initialServerResponse = offlineNavigationFallbackBootstrap.then(
+    async (bootstrap) => {
+      if (bootstrap.kind === 'router-cache') {
+        return bootstrap.initialRSCPayload
+      }
+
+      return await neverResolveInitialRSCPayload()
+    }
+  )
+} else if (window.__NEXT_CLIENT_RESUME) {
+  const clientResumeFetch: Promise<Response> = window.__NEXT_CLIENT_RESUME
   initialServerResponse = Promise.resolve(
     createFromFetch<InitialRSCPayload>(clientResumeFetch, {
       callServer,
@@ -365,7 +524,11 @@ export async function hydrate(
   // Initialize the offline module to register browser event listeners
   // (offline/online) before any components hydrate.
   if (process.env.__NEXT_USE_OFFLINE) {
-    require('./components/offline') as typeof import('./components/offline')
+    const { notifyOffline } =
+      require('./components/offline') as typeof import('./components/offline')
+    if (offlineNavigationFallbackBootstrap) {
+      notifyOffline()
+    }
   }
 
   // setNavigationBuildId should be called only once, during JS initialization
@@ -412,9 +575,13 @@ export async function hydrate(
     </StrictModeIfEnabled>
   )
 
-  if (document.documentElement.id === '__next_error__') {
+  if (
+    document.documentElement.id === '__next_error__' ||
+    isOfflineNavigationFallbackDocument()
+  ) {
     let element = reactEl
-    // Server rendering failed, fall back to client-side rendering
+    // Error documents and generated offline navigation fallback documents do
+    // not contain route HTML that can be hydrated.
     if (process.env.NODE_ENV !== 'production') {
       const { RootLevelDevOverlayElement } =
         require('../next-devtools/userspace/app/client-entry') as typeof import('../next-devtools/userspace/app/client-entry')

--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -376,6 +376,16 @@ export async function hydrate(
     setNavigationBuildId(getDeploymentId()!)
   }
 
+  if (process.env.__NEXT_OFFLINE_NAVIGATIONS) {
+    if (!process.env.__NEXT_DEV_SERVER) {
+      const { registerOfflineNavigationServiceWorker } =
+        require('./offline-navigation-service-worker') as typeof import('./offline-navigation-service-worker')
+      registerOfflineNavigationServiceWorker()
+    }
+  } else {
+    // Keep the service worker module out of disabled client bundles.
+  }
+
   const initialTimestamp = Date.now()
   const actionQueue: AppRouterActionQueue = createMutableActionQueue(
     createInitialRouterState({

--- a/packages/next/src/client/components/offline.ts
+++ b/packages/next/src/client/components/offline.ts
@@ -77,7 +77,7 @@ export function getOffline(): OfflineState | null {
  * Enters the offline state if not already in it, and starts the
  * connectivity polling loop.
  */
-function notifyOffline(): OfflineState {
+export function notifyOffline(): OfflineState {
   if (offlineState !== null) {
     return offlineState
   }

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -88,6 +88,12 @@ export function createInitialRouterState({
     acc
   )
   const metadataVaryPath = acc.metadataVaryPath
+  const initialStaleAt =
+    location === null ||
+    initialSeedData === null ||
+    initialStaticStageByteLength !== undefined
+      ? null
+      : getStaleAt(navigatedAt, initialStaleTime)
   const initialTask = createInitialCacheNodeForHydration(
     navigatedAt,
     initialRouteTree,
@@ -157,7 +163,7 @@ export function createInitialRouterState({
         // hydration and write it into the cache directly.
         const now = Date.now()
 
-        getStaleAt(now, initialStaleTime)
+        initialStaleAt!
           .then((staleAt) => {
             writeStaticStageResponseIntoCache(
               now,

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -16,8 +16,8 @@ import type {
 } from '../../../shared/lib/app-router-types'
 
 import {
-  type NEXT_ROUTER_PREFETCH_HEADER,
-  type NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
+  NEXT_ROUTER_PREFETCH_HEADER,
+  NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
   type NEXT_INSTANT_PREFETCH_HEADER,
   NEXT_ROUTER_STATE_TREE_HEADER,
   NEXT_RSC_UNION_QUERY,
@@ -47,11 +47,32 @@ import {
   createNonTaskyPrefetchResponseStream,
 } from '../segment-cache/cache'
 import { UnknownDynamicStaleTime } from '../segment-cache/bfcache'
+import type { OfflineNavigationRSCResponsePayload } from './offline-navigation-cache'
 
 const createFromReadableStream =
   createFromReadableStreamBrowser as (typeof import('react-server-dom-webpack/client.browser'))['createFromReadableStream']
 const createFromFetch =
   createFromFetchBrowser as (typeof import('react-server-dom-webpack/client.browser'))['createFromFetch']
+
+let offlineNavigationCacheModule:
+  | typeof import('./offline-navigation-cache')
+  | undefined
+
+// Keep the runtime require inside a compile-time flag branch so disabled builds
+// do not pull the offline cache module into client chunks.
+function getOfflineNavigationCacheModule():
+  | typeof import('./offline-navigation-cache')
+  | null {
+  if (process.env.__NEXT_OFFLINE_NAVIGATIONS) {
+    if (offlineNavigationCacheModule === undefined) {
+      offlineNavigationCacheModule =
+        require('./offline-navigation-cache') as typeof import('./offline-navigation-cache')
+    }
+    return offlineNavigationCacheModule
+  } else {
+    return null
+  }
+}
 
 let createDebugChannel:
   | typeof import('../../dev/debug-channel').createDebugChannel
@@ -355,6 +376,11 @@ export type RSCResponse<T> = {
   url: string
   flightResponsePromise: (Promise<T> & { _debugInfo?: Array<any> }) | null
   cacheData: Promise<FetchResponseCacheData | null>
+  offlineNavigationCache?: OfflineNavigationRSCResponseCache
+}
+
+type OfflineNavigationRSCResponseCache = {
+  payload: Promise<OfflineNavigationRSCResponsePayload | null> | null
 }
 
 type FetchResponseCacheData = {
@@ -535,6 +561,19 @@ export async function createFetch<T>(
   let fetchUrl = new URL(url)
   await setCacheBustingSearchParam(fetchUrl, headers)
   let processed = fetch(fetchUrl, fetchOptions).then(processFetch)
+  let offlineNavigationCache: OfflineNavigationRSCResponseCache | undefined
+  if (process.env.__NEXT_OFFLINE_NAVIGATIONS) {
+    offlineNavigationCache = shouldPersistOfflineNavigationSegmentResponse(
+      headers
+    )
+      ? {
+          payload:
+            createOfflineNavigationCachePayloadFromProcessedResponse(processed),
+        }
+      : undefined
+  } else {
+    offlineNavigationCache = undefined
+  }
   let fetchPromise = processed.then(({ response }) => response)
 
   // Immediately pass the fetch promise to the Flight client so that the debug
@@ -605,6 +644,10 @@ export async function createFetch<T>(
       fetchUrl = new URL(responseUrl)
       await setCacheBustingSearchParam(fetchUrl, headers)
       processed = fetch(fetchUrl, fetchOptions).then(processFetch)
+      if (offlineNavigationCache !== undefined) {
+        offlineNavigationCache.payload =
+          createOfflineNavigationCachePayloadFromProcessedResponse(processed)
+      }
       fetchPromise = processed.then(({ response }) => response)
       flightResponsePromise = shouldImmediatelyDecode
         ? createFromNextFetch<T>(fetchPromise, headers)
@@ -645,7 +688,53 @@ export async function createFetch<T>(
     cacheData: processed.then(({ cacheData }) => cacheData),
   }
 
+  if (
+    process.env.__NEXT_OFFLINE_NAVIGATIONS &&
+    offlineNavigationCache !== undefined
+  ) {
+    rscResponse.offlineNavigationCache = offlineNavigationCache
+  }
+
   return rscResponse
+}
+
+function shouldPersistOfflineNavigationSegmentResponse(
+  headers: RequestHeaders
+): boolean {
+  return (
+    !process.env.__NEXT_DEV_SERVER &&
+    process.env.NODE_ENV === 'production' &&
+    process.env.__NEXT_CONFIG_OUTPUT !== 'export' &&
+    !headers[NEXT_HMR_REFRESH_HEADER] &&
+    headers[NEXT_ROUTER_PREFETCH_HEADER] !== undefined &&
+    headers[NEXT_ROUTER_SEGMENT_PREFETCH_HEADER] !== undefined &&
+    headers[NEXT_ROUTER_SEGMENT_PREFETCH_HEADER] !== '/_full'
+  )
+}
+
+function createOfflineNavigationCachePayloadFromProcessedResponse(
+  processed: Promise<{
+    response: Response
+    cacheData: FetchResponseCacheData | null
+  }>
+): Promise<OfflineNavigationRSCResponsePayload | null> | null {
+  const offlineNavigationCache = getOfflineNavigationCacheModule()
+  if (offlineNavigationCache === null) {
+    return null
+  }
+
+  return processed
+    .then(({ response }) => {
+      if (!response.ok || !response.body) {
+        return null
+      }
+
+      return offlineNavigationCache.createOfflineNavigationRSCResponsePayload(
+        response,
+        'segment-prefetch'
+      )
+    })
+    .catch(() => null)
 }
 
 export function createFromNextReadableStream<T>(

--- a/packages/next/src/client/components/router-reducer/offline-navigation-cache.test.ts
+++ b/packages/next/src/client/components/router-reducer/offline-navigation-cache.test.ts
@@ -1,0 +1,596 @@
+import {
+  createOfflineNavigationRSCResponse,
+  createOfflineNavigationRSCResponsePayload,
+  createOfflineNavigationRouterCache,
+  createOfflineNavigationVaryPathKey,
+  deleteOfflineNavigationCacheEntriesForBuild,
+  isOfflineNavigationRSCResponsePayload,
+  serializeOfflineNavigationVaryPath,
+  type OfflineNavigationCacheStorage,
+  type OfflineNavigationRouteRecord,
+  type OfflineNavigationRouteRecordWrite,
+  type OfflineNavigationSegmentRecord,
+  type OfflineNavigationSegmentRecordWrite,
+} from './offline-navigation-cache'
+
+type RouterCacheKey = [buildId: string, key: string]
+
+class MemoryOfflineNavigationCacheStorage
+  implements OfflineNavigationCacheStorage
+{
+  routeEntries = new Map<string, OfflineNavigationRouteRecord>()
+  segmentEntries = new Map<string, OfflineNavigationSegmentRecord>()
+  routeCacheEpoch = 0
+  segmentCacheEpoch = 0
+
+  async deleteBuild(buildId: string): Promise<void> {
+    for (const [key, entry] of this.routeEntries) {
+      if (entry.buildId === buildId) {
+        this.routeEntries.delete(key)
+      }
+    }
+    for (const [key, entry] of this.segmentEntries) {
+      if (entry.buildId === buildId) {
+        this.segmentEntries.delete(key)
+      }
+    }
+  }
+
+  async getRoute(
+    key: RouterCacheKey
+  ): Promise<OfflineNavigationRouteRecord | undefined> {
+    return this.routeEntries.get(this.getKey(key))
+  }
+
+  async getRoutes(buildId: string): Promise<OfflineNavigationRouteRecord[]> {
+    return Array.from(this.routeEntries.values()).filter(
+      (entry) => entry.buildId === buildId
+    )
+  }
+
+  async putRoute(entry: OfflineNavigationRouteRecord): Promise<void> {
+    this.routeEntries.set(this.getKey([entry.buildId, entry.key]), entry)
+  }
+
+  async deleteRoute(key: RouterCacheKey): Promise<void> {
+    this.routeEntries.delete(this.getKey(key))
+  }
+
+  async getRouteCacheEpoch(): Promise<number> {
+    return this.routeCacheEpoch
+  }
+
+  async incrementRouteCacheEpoch(): Promise<number> {
+    this.routeCacheEpoch++
+    return this.routeCacheEpoch
+  }
+
+  async getSegment(
+    key: RouterCacheKey
+  ): Promise<OfflineNavigationSegmentRecord | undefined> {
+    return this.segmentEntries.get(this.getKey(key))
+  }
+
+  async getSegments(
+    buildId: string
+  ): Promise<OfflineNavigationSegmentRecord[]> {
+    return Array.from(this.segmentEntries.values()).filter(
+      (entry) => entry.buildId === buildId
+    )
+  }
+
+  async putSegment(entry: OfflineNavigationSegmentRecord): Promise<void> {
+    this.segmentEntries.set(this.getKey([entry.buildId, entry.key]), entry)
+  }
+
+  async deleteSegment(key: RouterCacheKey): Promise<void> {
+    this.segmentEntries.delete(this.getKey(key))
+  }
+
+  async getSegmentCacheEpoch(): Promise<number> {
+    return this.segmentCacheEpoch
+  }
+
+  async incrementSegmentCacheEpoch(): Promise<number> {
+    this.segmentCacheEpoch++
+    return this.segmentCacheEpoch
+  }
+
+  private getKey(key: RouterCacheKey): string {
+    return `${key[0]}\0${key[1]}`
+  }
+}
+
+class FailingOfflineNavigationCacheStorage
+  implements OfflineNavigationCacheStorage
+{
+  async deleteBuild(): Promise<void> {
+    throw new Error('delete build failed')
+  }
+
+  async getRoute(): Promise<OfflineNavigationRouteRecord | undefined> {
+    throw new Error('get route failed')
+  }
+
+  async getRoutes(): Promise<OfflineNavigationRouteRecord[]> {
+    throw new Error('get routes failed')
+  }
+
+  async putRoute(): Promise<void> {
+    throw new Error('put route failed')
+  }
+
+  async deleteRoute(): Promise<void> {
+    throw new Error('delete route failed')
+  }
+
+  async getRouteCacheEpoch(): Promise<number> {
+    throw new Error('get route epoch failed')
+  }
+
+  async incrementRouteCacheEpoch(): Promise<number> {
+    throw new Error('increment route epoch failed')
+  }
+
+  async getSegment(): Promise<OfflineNavigationSegmentRecord | undefined> {
+    throw new Error('get segment failed')
+  }
+
+  async getSegments(): Promise<OfflineNavigationSegmentRecord[]> {
+    throw new Error('get segments failed')
+  }
+
+  async putSegment(): Promise<void> {
+    throw new Error('put segment failed')
+  }
+
+  async deleteSegment(): Promise<void> {
+    throw new Error('delete segment failed')
+  }
+
+  async getSegmentCacheEpoch(): Promise<number> {
+    throw new Error('get segment epoch failed')
+  }
+
+  async incrementSegmentCacheEpoch(): Promise<number> {
+    throw new Error('increment segment epoch failed')
+  }
+}
+
+function createRouteRecord(
+  key: string,
+  pathname: string,
+  overrides: Partial<OfflineNavigationRouteRecordWrite> = {}
+): OfflineNavigationRouteRecordWrite {
+  return {
+    buildId: 'build-a',
+    key,
+    now: 100,
+    staleAt: 200,
+    expiresAt: 300,
+    route: {
+      pathname,
+      search: '',
+      nextUrl: null,
+      canonicalUrl: pathname,
+      renderedSearch: '',
+      couldBeIntercepted: false,
+      supportsPerSegmentPrefetching: true,
+      hasDynamicRewrite: false,
+    },
+    routeVaryPath: [],
+    tree: { segment: pathname },
+    metadata: { head: pathname },
+    ...overrides,
+  }
+}
+
+function createSegmentRecord(
+  key: string,
+  overrides: Partial<OfflineNavigationSegmentRecordWrite> = {}
+): OfflineNavigationSegmentRecordWrite {
+  return {
+    buildId: 'build-a',
+    key,
+    now: 100,
+    staleAt: 200,
+    expiresAt: 300,
+    segment: {
+      requestKey: 'children/page',
+      fetchStrategy: 1,
+      isPartial: false,
+      payloadIndex: 0,
+    },
+    segmentVaryPath: [],
+    payload: { kind: 'segment-payload' },
+    ...overrides,
+  }
+}
+
+describe('offline navigation cache', () => {
+  it('serializes vary paths into stable router record keys', () => {
+    const fallback = {}
+    const varyPath = {
+      id: null,
+      value: 'children/page',
+      parent: {
+        id: '?',
+        value: fallback,
+        parent: {
+          id: 'slug',
+          value: 'hello',
+          parent: null,
+        },
+      },
+    }
+
+    expect(serializeOfflineNavigationVaryPath(varyPath)).toEqual([
+      {
+        id: null,
+        value: {
+          kind: 'value',
+          value: 'children/page',
+        },
+      },
+      {
+        id: '?',
+        value: {
+          kind: 'fallback',
+        },
+      },
+      {
+        id: 'slug',
+        value: {
+          kind: 'value',
+          value: 'hello',
+        },
+      },
+    ])
+    expect(createOfflineNavigationVaryPathKey(varyPath)).toBe(
+      '[{"id":null,"value":{"kind":"value","value":"children/page"}},{"id":"?","value":{"kind":"fallback"}},{"id":"slug","value":{"kind":"value","value":"hello"}}]'
+    )
+  })
+
+  it('serializes segment-prefetch RSC payloads for persisted segment records', async () => {
+    const response = new Response('0:["$","payload"]', {
+      headers: {
+        'content-type': 'text/x-component',
+        'x-nextjs-stale-time': '60',
+      },
+      status: 200,
+      statusText: 'OK',
+    })
+    Object.defineProperty(response, 'url', {
+      value: 'https://example.com/dashboard?_rsc=abc',
+    })
+
+    const payload = await createOfflineNavigationRSCResponsePayload(
+      response,
+      'segment-prefetch'
+    )
+    expect(payload).toMatchObject({
+      version: 1,
+      kind: 'rsc-response',
+      requestKind: 'segment-prefetch',
+      status: 200,
+      statusText: 'OK',
+      headers: expect.arrayContaining([
+        ['content-type', 'text/x-component'],
+        ['x-nextjs-stale-time', '60'],
+      ]),
+    })
+
+    const restoredResponse = createOfflineNavigationRSCResponse(payload)
+    expect(restoredResponse.url).toBe('https://example.com/dashboard?_rsc=abc')
+    await expect(restoredResponse.text()).resolves.toBe('0:["$","payload"]')
+    expect(isOfflineNavigationRSCResponsePayload(payload)).toBe(true)
+    expect(
+      isOfflineNavigationRSCResponsePayload({ ...payload, body: null })
+    ).toBe(false)
+    expect(
+      isOfflineNavigationRSCResponsePayload({
+        ...payload,
+        requestKind: 'route-prefetch',
+      })
+    ).toBe(false)
+  })
+
+  it('stores route and segment records with independent durable epochs', async () => {
+    const storage = new MemoryOfflineNavigationCacheStorage()
+    const cache = createOfflineNavigationRouterCache(storage)
+    const routeVaryPath = serializeOfflineNavigationVaryPath({
+      id: null,
+      value: '/dashboard',
+      parent: {
+        id: '?',
+        value: '',
+        parent: {
+          id: null,
+          value: null,
+          parent: null,
+        },
+      },
+    })
+    const segmentVaryPath = serializeOfflineNavigationVaryPath({
+      id: null,
+      value: 'children/page',
+      parent: null,
+    })
+
+    await expect(
+      cache.writeRoute(
+        createRouteRecord('route:/dashboard', '/dashboard', {
+          routeVaryPath,
+        })
+      )
+    ).resolves.toBe(true)
+    await expect(
+      cache.writeSegment(
+        createSegmentRecord('segment:/dashboard:children/page', {
+          segmentVaryPath,
+        })
+      )
+    ).resolves.toBe(true)
+
+    await expect(
+      cache.readRoute('route:/dashboard', {
+        buildId: 'build-a',
+        now: 150,
+      })
+    ).resolves.toMatchObject({
+      buildId: 'build-a',
+      cacheEpoch: 0,
+      key: 'route:/dashboard',
+      kind: 'route',
+      route: {
+        pathname: '/dashboard',
+      },
+      routeVaryPath,
+      version: 1,
+    })
+    await expect(
+      cache.readSegment('segment:/dashboard:children/page', {
+        buildId: 'build-a',
+        now: 150,
+      })
+    ).resolves.toMatchObject({
+      buildId: 'build-a',
+      cacheEpoch: 0,
+      key: 'segment:/dashboard:children/page',
+      kind: 'segment',
+      segment: {
+        requestKey: 'children/page',
+        payloadIndex: 0,
+      },
+      segmentVaryPath,
+      version: 1,
+    })
+
+    await expect(cache.invalidateRoutes()).resolves.toBe(true)
+    await expect(
+      cache.readRoute('route:/dashboard', {
+        buildId: 'build-a',
+        now: 150,
+      })
+    ).resolves.toBe(null)
+    await expect(
+      cache.readSegment('segment:/dashboard:children/page', {
+        buildId: 'build-a',
+        now: 150,
+      })
+    ).resolves.toMatchObject({
+      cacheEpoch: 0,
+      key: 'segment:/dashboard:children/page',
+    })
+
+    await expect(cache.invalidateSegments()).resolves.toBe(true)
+    await expect(
+      cache.readSegment('segment:/dashboard:children/page', {
+        buildId: 'build-a',
+        now: 150,
+      })
+    ).resolves.toBe(null)
+  })
+
+  it('lists only fresh current-epoch route and segment records', async () => {
+    const storage = new MemoryOfflineNavigationCacheStorage()
+    const cache = createOfflineNavigationRouterCache(storage)
+
+    await cache.writeRoute(createRouteRecord('route:/dashboard', '/dashboard'))
+    await cache.writeRoute(
+      createRouteRecord('route:/expired', '/expired', {
+        staleAt: 110,
+        expiresAt: 120,
+      })
+    )
+    await cache.writeSegment(
+      createSegmentRecord('segment:/dashboard:children/page')
+    )
+    await cache.writeSegment(
+      createSegmentRecord('segment:/expired:children/page', {
+        staleAt: 110,
+        expiresAt: 120,
+      })
+    )
+
+    await expect(
+      cache.readRoutes({ buildId: 'build-a', now: 150 })
+    ).resolves.toMatchObject([{ key: 'route:/dashboard' }])
+    await expect(
+      cache.readSegments({ buildId: 'build-a', now: 150 })
+    ).resolves.toMatchObject([{ key: 'segment:/dashboard:children/page' }])
+    expect(storage.routeEntries.has('build-a\0route:/expired')).toBe(false)
+    expect(
+      storage.segmentEntries.has('build-a\0segment:/expired:children/page')
+    ).toBe(false)
+
+    await expect(
+      cache.readRoutes({ buildId: 'build-b', now: 150 })
+    ).resolves.toEqual([])
+    await expect(
+      cache.readSegments({ buildId: 'build-b', now: 150 })
+    ).resolves.toEqual([])
+  })
+
+  it('ignores and deletes route and segment records whose stored build id does not match', async () => {
+    const storage = new MemoryOfflineNavigationCacheStorage()
+    const cache = createOfflineNavigationRouterCache(storage)
+
+    await storage.putRoute({
+      version: 1,
+      kind: 'route',
+      buildId: 'build-b',
+      key: 'route:/dashboard',
+      cacheEpoch: 0,
+      createdAt: 100,
+      staleAt: 200,
+      expiresAt: 300,
+      route: createRouteRecord('route:/dashboard', '/dashboard').route,
+      routeVaryPath: [],
+      tree: null,
+      metadata: null,
+    })
+    storage.routeEntries.set(
+      'build-a\0route:/dashboard',
+      storage.routeEntries.get('build-b\0route:/dashboard')!
+    )
+    await storage.putSegment({
+      version: 1,
+      kind: 'segment',
+      buildId: 'build-b',
+      key: 'segment:/dashboard',
+      cacheEpoch: 0,
+      createdAt: 100,
+      staleAt: 200,
+      expiresAt: 300,
+      segment: createSegmentRecord('segment:/dashboard').segment,
+      segmentVaryPath: [],
+      payload: null,
+    })
+    storage.segmentEntries.set(
+      'build-a\0segment:/dashboard',
+      storage.segmentEntries.get('build-b\0segment:/dashboard')!
+    )
+
+    await expect(
+      cache.readRoute('route:/dashboard', {
+        buildId: 'build-a',
+        now: 150,
+      })
+    ).resolves.toBe(null)
+    await expect(
+      cache.readSegment('segment:/dashboard', {
+        buildId: 'build-a',
+        now: 150,
+      })
+    ).resolves.toBe(null)
+    expect(storage.routeEntries.has('build-a\0route:/dashboard')).toBe(false)
+    expect(storage.segmentEntries.has('build-a\0segment:/dashboard')).toBe(
+      false
+    )
+  })
+
+  it('can delete all route and segment records for a build without touching other builds', async () => {
+    const storage = new MemoryOfflineNavigationCacheStorage()
+    const cache = createOfflineNavigationRouterCache(storage)
+
+    await cache.writeRoute(createRouteRecord('route:/a', '/a'))
+    await cache.writeRoute(
+      createRouteRecord('route:/b', '/b', { buildId: 'build-b' })
+    )
+    await cache.writeSegment(createSegmentRecord('segment:/a'))
+    await cache.writeSegment(
+      createSegmentRecord('segment:/b', { buildId: 'build-b' })
+    )
+
+    await expect(cache.deleteBuild('build-a')).resolves.toBe(true)
+    await expect(
+      cache.readRoute('route:/a', { buildId: 'build-a', now: 150 })
+    ).resolves.toBe(null)
+    await expect(
+      cache.readRoute('route:/b', { buildId: 'build-b', now: 150 })
+    ).resolves.toMatchObject({ key: 'route:/b' })
+    await expect(
+      cache.readSegment('segment:/a', { buildId: 'build-a', now: 150 })
+    ).resolves.toBe(null)
+    await expect(
+      cache.readSegment('segment:/b', { buildId: 'build-b', now: 150 })
+    ).resolves.toMatchObject({ key: 'segment:/b' })
+  })
+
+  it('treats missing build ids as no-ops', async () => {
+    const storage = new MemoryOfflineNavigationCacheStorage()
+    const cache = createOfflineNavigationRouterCache(storage)
+
+    await expect(
+      cache.writeRoute(
+        createRouteRecord('route:/dashboard', '/dashboard', { buildId: '' })
+      )
+    ).resolves.toBe(false)
+    await expect(
+      cache.writeSegment(
+        createSegmentRecord('segment:/dashboard', { buildId: '' })
+      )
+    ).resolves.toBe(false)
+    await expect(cache.readRoute('route:/dashboard')).resolves.toBe(null)
+    await expect(cache.readSegment('segment:/dashboard')).resolves.toBe(null)
+    await expect(cache.deleteRoute('route:/dashboard')).resolves.toBe(false)
+    await expect(cache.deleteSegment('segment:/dashboard')).resolves.toBe(false)
+    await expect(cache.deleteBuild()).resolves.toBe(false)
+  })
+
+  it('treats storage failures as non-fatal misses', async () => {
+    const cache = createOfflineNavigationRouterCache(
+      new FailingOfflineNavigationCacheStorage()
+    )
+
+    await expect(
+      cache.writeRoute(createRouteRecord('route:/dashboard', '/dashboard'))
+    ).resolves.toBe(false)
+    await expect(
+      cache.readRoute('route:/dashboard', { buildId: 'build-a' })
+    ).resolves.toBe(null)
+    await expect(cache.readRoutes({ buildId: 'build-a' })).resolves.toEqual([])
+    await expect(
+      cache.deleteRoute('route:/dashboard', { buildId: 'build-a' })
+    ).resolves.toBe(false)
+    await expect(cache.invalidateRoutes()).resolves.toBe(false)
+    await expect(
+      cache.writeSegment(createSegmentRecord('segment:/dashboard'))
+    ).resolves.toBe(false)
+    await expect(
+      cache.readSegment('segment:/dashboard', { buildId: 'build-a' })
+    ).resolves.toBe(null)
+    await expect(cache.readSegments({ buildId: 'build-a' })).resolves.toEqual(
+      []
+    )
+    await expect(
+      cache.deleteSegment('segment:/dashboard', { buildId: 'build-a' })
+    ).resolves.toBe(false)
+    await expect(cache.invalidateSegments()).resolves.toBe(false)
+    await expect(cache.deleteBuild('build-a')).resolves.toBe(false)
+  })
+
+  it('is a no-op when IndexedDB is unavailable', async () => {
+    const originalIndexedDB = Object.getOwnPropertyDescriptor(
+      globalThis,
+      'indexedDB'
+    )
+    Object.defineProperty(globalThis, 'indexedDB', {
+      configurable: true,
+      value: undefined,
+    })
+
+    try {
+      await expect(
+        deleteOfflineNavigationCacheEntriesForBuild('build-a')
+      ).resolves.toBe(false)
+    } finally {
+      if (originalIndexedDB) {
+        Object.defineProperty(globalThis, 'indexedDB', originalIndexedDB)
+      } else {
+        delete (globalThis as { indexedDB?: IDBFactory }).indexedDB
+      }
+    }
+  })
+})

--- a/packages/next/src/client/components/router-reducer/offline-navigation-cache.ts
+++ b/packages/next/src/client/components/router-reducer/offline-navigation-cache.ts
@@ -1,0 +1,824 @@
+import { getNavigationBuildId } from '../../navigation-build-id'
+// Durable storage for offline navigations mirrors the client router cache:
+// route records describe which route can be reconstructed, and segment records
+// carry the RSC payloads needed to fulfill that route after a hard reload.
+//
+// IndexedDB is used instead of the service worker CacheStorage because the
+// router needs structured records, independent route and segment invalidation,
+// and RSC response bodies tied to the current Next.js build.
+const DATABASE_NAME = 'next-offline-navigation-cache'
+const DATABASE_VERSION = 1
+const ROUTE_STORE_NAME = 'route-data'
+const SEGMENT_STORE_NAME = 'segment-data'
+const METADATA_STORE_NAME = 'metadata'
+const ROUTE_CACHE_EPOCH_KEY = 'route-cache-epoch'
+const SEGMENT_CACHE_EPOCH_KEY = 'segment-cache-epoch'
+const ROUTE_RECORD_VERSION = 1
+const SEGMENT_RECORD_VERSION = 1
+const RSC_RESPONSE_PAYLOAD_VERSION = 1
+
+type OfflineNavigationRouterCacheKey = [buildId: string, key: string]
+export type OfflineNavigationRSCResponseRequestKind = 'segment-prefetch'
+
+export type OfflineNavigationSerializedVaryPathValue =
+  | {
+      kind: 'value'
+      value: string | null
+    }
+  | {
+      kind: 'fallback'
+    }
+
+export type OfflineNavigationSerializedVaryPathPart = {
+  id: string | null
+  value: OfflineNavigationSerializedVaryPathValue
+}
+
+export type OfflineNavigationSerializedVaryPath =
+  OfflineNavigationSerializedVaryPathPart[]
+
+export type OfflineNavigationSerializableVaryPath = {
+  id: string | null
+  value: string | null | object
+  parent: OfflineNavigationSerializableVaryPath | null
+}
+
+export type OfflineNavigationRouteRecord = {
+  version: typeof ROUTE_RECORD_VERSION
+  kind: 'route'
+  buildId: string
+  key: string
+  cacheEpoch: number
+  createdAt: number
+  staleAt: number
+  expiresAt: number
+  route: {
+    pathname: string
+    search: string
+    nextUrl: string | null
+    canonicalUrl: string
+    renderedSearch: string
+    couldBeIntercepted: boolean
+    supportsPerSegmentPrefetching: boolean
+    hasDynamicRewrite: boolean
+  }
+  routeVaryPath: OfflineNavigationSerializedVaryPath
+  tree: unknown
+  metadata: unknown
+}
+
+export type OfflineNavigationSegmentRecord = {
+  version: typeof SEGMENT_RECORD_VERSION
+  kind: 'segment'
+  buildId: string
+  key: string
+  cacheEpoch: number
+  createdAt: number
+  staleAt: number
+  expiresAt: number
+  segment: {
+    requestKey: string
+    fetchStrategy: number
+    isPartial: boolean
+    payloadIndex: number
+  }
+  segmentVaryPath: OfflineNavigationSerializedVaryPath
+  payload: unknown
+}
+
+export type OfflineNavigationRSCResponsePayload = {
+  version: typeof RSC_RESPONSE_PAYLOAD_VERSION
+  kind: 'rsc-response'
+  requestKind: OfflineNavigationRSCResponseRequestKind
+  url: string
+  status: number
+  statusText: string
+  headers: Array<[string, string]>
+  body: ArrayBuffer
+}
+
+export type OfflineNavigationCacheReadOptions = {
+  buildId?: string
+  now?: number
+}
+
+export type OfflineNavigationRouteRecordWrite = Omit<
+  OfflineNavigationRouteRecord,
+  'buildId' | 'cacheEpoch' | 'createdAt' | 'kind' | 'version'
+> & {
+  buildId?: string
+  now?: number
+}
+
+export type OfflineNavigationSegmentRecordWrite = Omit<
+  OfflineNavigationSegmentRecord,
+  'buildId' | 'cacheEpoch' | 'createdAt' | 'kind' | 'version'
+> & {
+  buildId?: string
+  now?: number
+}
+
+export type OfflineNavigationCacheStorage = {
+  deleteBuild(buildId: string): Promise<void>
+  getRoute(
+    key: OfflineNavigationRouterCacheKey
+  ): Promise<OfflineNavigationRouteRecord | undefined>
+  getRoutes(buildId: string): Promise<OfflineNavigationRouteRecord[]>
+  putRoute(entry: OfflineNavigationRouteRecord): Promise<void>
+  deleteRoute(key: OfflineNavigationRouterCacheKey): Promise<void>
+  getRouteCacheEpoch(): Promise<number>
+  incrementRouteCacheEpoch(): Promise<number>
+  getSegment(
+    key: OfflineNavigationRouterCacheKey
+  ): Promise<OfflineNavigationSegmentRecord | undefined>
+  getSegments(buildId: string): Promise<OfflineNavigationSegmentRecord[]>
+  putSegment(entry: OfflineNavigationSegmentRecord): Promise<void>
+  deleteSegment(key: OfflineNavigationRouterCacheKey): Promise<void>
+  getSegmentCacheEpoch(): Promise<number>
+  incrementSegmentCacheEpoch(): Promise<number>
+}
+
+export type OfflineNavigationRouterCache = {
+  readRoute: (
+    key: string,
+    options?: OfflineNavigationCacheReadOptions
+  ) => Promise<OfflineNavigationRouteRecord | null>
+  readRoutes: (
+    options?: OfflineNavigationCacheReadOptions
+  ) => Promise<OfflineNavigationRouteRecord[]>
+  writeRoute: (entry: OfflineNavigationRouteRecordWrite) => Promise<boolean>
+  deleteRoute: (
+    key: string,
+    options?: OfflineNavigationCacheReadOptions
+  ) => Promise<boolean>
+  invalidateRoutes: () => Promise<boolean>
+  readSegment: (
+    key: string,
+    options?: OfflineNavigationCacheReadOptions
+  ) => Promise<OfflineNavigationSegmentRecord | null>
+  readSegments: (
+    options?: OfflineNavigationCacheReadOptions
+  ) => Promise<OfflineNavigationSegmentRecord[]>
+  writeSegment: (entry: OfflineNavigationSegmentRecordWrite) => Promise<boolean>
+  deleteSegment: (
+    key: string,
+    options?: OfflineNavigationCacheReadOptions
+  ) => Promise<boolean>
+  invalidateSegments: () => Promise<boolean>
+  deleteBuild: (buildId?: string) => Promise<boolean>
+}
+
+export function serializeOfflineNavigationVaryPath(
+  varyPath: OfflineNavigationSerializableVaryPath | null
+): OfflineNavigationSerializedVaryPath {
+  const parts: OfflineNavigationSerializedVaryPath = []
+  let current = varyPath
+
+  while (current !== null) {
+    parts.push({
+      id: current.id,
+      value:
+        current.value === null || typeof current.value === 'string'
+          ? {
+              kind: 'value',
+              value: current.value,
+            }
+          : {
+              kind: 'fallback',
+            },
+    })
+    current = current.parent
+  }
+
+  return parts
+}
+
+export function createOfflineNavigationVaryPathKey(
+  varyPath: OfflineNavigationSerializableVaryPath | null
+): string {
+  return JSON.stringify(serializeOfflineNavigationVaryPath(varyPath))
+}
+
+export function createOfflineNavigationRouterCache(
+  storage: OfflineNavigationCacheStorage
+): OfflineNavigationRouterCache {
+  return {
+    readRoute: async (key, options) => {
+      return runOfflineNavigationCacheOperation(async () => {
+        const buildId = getCacheBuildId(options?.buildId)
+        if (buildId === null) {
+          return null
+        }
+
+        const cacheKey: OfflineNavigationRouterCacheKey = [buildId, key]
+        const [entry, cacheEpoch] = await Promise.all([
+          storage.getRoute(cacheKey),
+          storage.getRouteCacheEpoch(),
+        ])
+        if (!entry) {
+          return null
+        }
+
+        if (!isUsableRouteRecord(entry, buildId, key, cacheEpoch, options)) {
+          await storage.deleteRoute(cacheKey)
+          return null
+        }
+
+        return entry
+      }, null)
+    },
+    readRoutes: async (options) => {
+      return runOfflineNavigationCacheOperation(async () => {
+        const buildId = getCacheBuildId(options?.buildId)
+        if (buildId === null) {
+          return []
+        }
+
+        const [entries, cacheEpoch] = await Promise.all([
+          storage.getRoutes(buildId),
+          storage.getRouteCacheEpoch(),
+        ])
+        const usableEntries: OfflineNavigationRouteRecord[] = []
+        await Promise.all(
+          entries.map(async (entry) => {
+            if (
+              isUsableRouteRecord(
+                entry,
+                buildId,
+                entry.key,
+                cacheEpoch,
+                options
+              )
+            ) {
+              usableEntries.push(entry)
+            } else {
+              if (
+                typeof entry.buildId === 'string' &&
+                typeof entry.key === 'string'
+              ) {
+                await storage.deleteRoute([entry.buildId, entry.key])
+              }
+            }
+          })
+        )
+        return usableEntries
+      }, [])
+    },
+    writeRoute: async (entry) => {
+      return runOfflineNavigationCacheOperation(async () => {
+        const buildId = getCacheBuildId(entry.buildId)
+        if (buildId === null) {
+          return false
+        }
+
+        await storage.putRoute({
+          version: ROUTE_RECORD_VERSION,
+          kind: 'route',
+          buildId,
+          key: entry.key,
+          cacheEpoch: await storage.getRouteCacheEpoch(),
+          createdAt: entry.now ?? Date.now(),
+          staleAt: entry.staleAt,
+          expiresAt: entry.expiresAt,
+          route: entry.route,
+          routeVaryPath: entry.routeVaryPath,
+          tree: entry.tree,
+          metadata: entry.metadata,
+        })
+        return true
+      }, false)
+    },
+    deleteRoute: async (key, options) => {
+      return runOfflineNavigationCacheOperation(async () => {
+        const buildId = getCacheBuildId(options?.buildId)
+        if (buildId === null) {
+          return false
+        }
+
+        await storage.deleteRoute([buildId, key])
+        return true
+      }, false)
+    },
+    invalidateRoutes: async () => {
+      return runOfflineNavigationCacheOperation(async () => {
+        await storage.incrementRouteCacheEpoch()
+        return true
+      }, false)
+    },
+    readSegment: async (key, options) => {
+      return runOfflineNavigationCacheOperation(async () => {
+        const buildId = getCacheBuildId(options?.buildId)
+        if (buildId === null) {
+          return null
+        }
+
+        const cacheKey: OfflineNavigationRouterCacheKey = [buildId, key]
+        const [entry, cacheEpoch] = await Promise.all([
+          storage.getSegment(cacheKey),
+          storage.getSegmentCacheEpoch(),
+        ])
+        if (!entry) {
+          return null
+        }
+
+        if (!isUsableSegmentRecord(entry, buildId, key, cacheEpoch, options)) {
+          await storage.deleteSegment(cacheKey)
+          return null
+        }
+
+        return entry
+      }, null)
+    },
+    readSegments: async (options) => {
+      return runOfflineNavigationCacheOperation(async () => {
+        const buildId = getCacheBuildId(options?.buildId)
+        if (buildId === null) {
+          return []
+        }
+
+        const [entries, cacheEpoch] = await Promise.all([
+          storage.getSegments(buildId),
+          storage.getSegmentCacheEpoch(),
+        ])
+        const usableEntries: OfflineNavigationSegmentRecord[] = []
+        await Promise.all(
+          entries.map(async (entry) => {
+            if (
+              isUsableSegmentRecord(
+                entry,
+                buildId,
+                entry.key,
+                cacheEpoch,
+                options
+              )
+            ) {
+              usableEntries.push(entry)
+            } else {
+              if (
+                typeof entry.buildId === 'string' &&
+                typeof entry.key === 'string'
+              ) {
+                await storage.deleteSegment([entry.buildId, entry.key])
+              }
+            }
+          })
+        )
+        return usableEntries
+      }, [])
+    },
+    writeSegment: async (entry) => {
+      return runOfflineNavigationCacheOperation(async () => {
+        const buildId = getCacheBuildId(entry.buildId)
+        if (buildId === null) {
+          return false
+        }
+
+        await storage.putSegment({
+          version: SEGMENT_RECORD_VERSION,
+          kind: 'segment',
+          buildId,
+          key: entry.key,
+          cacheEpoch: await storage.getSegmentCacheEpoch(),
+          createdAt: entry.now ?? Date.now(),
+          staleAt: entry.staleAt,
+          expiresAt: entry.expiresAt,
+          segment: entry.segment,
+          segmentVaryPath: entry.segmentVaryPath,
+          payload: entry.payload,
+        })
+        return true
+      }, false)
+    },
+    deleteSegment: async (key, options) => {
+      return runOfflineNavigationCacheOperation(async () => {
+        const buildId = getCacheBuildId(options?.buildId)
+        if (buildId === null) {
+          return false
+        }
+
+        await storage.deleteSegment([buildId, key])
+        return true
+      }, false)
+    },
+    invalidateSegments: async () => {
+      return runOfflineNavigationCacheOperation(async () => {
+        await storage.incrementSegmentCacheEpoch()
+        return true
+      }, false)
+    },
+    deleteBuild: async (buildId) => {
+      return runOfflineNavigationCacheOperation(async () => {
+        const cacheBuildId = getCacheBuildId(buildId)
+        if (cacheBuildId === null) {
+          return false
+        }
+
+        await storage.deleteBuild(cacheBuildId)
+        return true
+      }, false)
+    },
+  }
+}
+
+function isUsableRouteRecord(
+  entry: OfflineNavigationRouteRecord,
+  buildId: string,
+  key: string,
+  cacheEpoch: number,
+  options: OfflineNavigationCacheReadOptions | undefined
+): boolean {
+  return (
+    entry.version === ROUTE_RECORD_VERSION &&
+    entry.kind === 'route' &&
+    entry.buildId === buildId &&
+    typeof entry.key === 'string' &&
+    entry.key === key &&
+    entry.cacheEpoch === cacheEpoch &&
+    entry.expiresAt > (options?.now ?? Date.now())
+  )
+}
+
+function isUsableSegmentRecord(
+  entry: OfflineNavigationSegmentRecord,
+  buildId: string,
+  key: string,
+  cacheEpoch: number,
+  options: OfflineNavigationCacheReadOptions | undefined
+): boolean {
+  return (
+    entry.version === SEGMENT_RECORD_VERSION &&
+    entry.kind === 'segment' &&
+    entry.buildId === buildId &&
+    typeof entry.key === 'string' &&
+    entry.key === key &&
+    entry.cacheEpoch === cacheEpoch &&
+    entry.expiresAt > (options?.now ?? Date.now())
+  )
+}
+
+export async function createOfflineNavigationRSCResponsePayload(
+  response: Response,
+  requestKind: OfflineNavigationRSCResponseRequestKind
+): Promise<OfflineNavigationRSCResponsePayload> {
+  const clone = response.clone()
+  return {
+    version: RSC_RESPONSE_PAYLOAD_VERSION,
+    kind: 'rsc-response',
+    requestKind,
+    url: response.url,
+    status: clone.status,
+    statusText: clone.statusText,
+    headers: Array.from(clone.headers.entries()),
+    body: await clone.arrayBuffer(),
+  }
+}
+
+export function createOfflineNavigationRSCResponse(
+  payload: OfflineNavigationRSCResponsePayload
+): Response {
+  const response = new Response(payload.body.slice(0), {
+    status: payload.status,
+    statusText: payload.statusText,
+    headers: payload.headers,
+  })
+  Object.defineProperty(response, 'url', { value: payload.url })
+  return response
+}
+
+export function isOfflineNavigationRSCResponsePayload(
+  payload: unknown
+): payload is OfflineNavigationRSCResponsePayload {
+  if (payload === null || typeof payload !== 'object') {
+    return false
+  }
+
+  const candidate = payload as Partial<OfflineNavigationRSCResponsePayload>
+  return (
+    candidate.version === RSC_RESPONSE_PAYLOAD_VERSION &&
+    candidate.kind === 'rsc-response' &&
+    candidate.requestKind === 'segment-prefetch' &&
+    typeof candidate.url === 'string' &&
+    typeof candidate.status === 'number' &&
+    typeof candidate.statusText === 'string' &&
+    Array.isArray(candidate.headers) &&
+    candidate.body instanceof ArrayBuffer
+  )
+}
+
+function getCacheBuildId(buildId: string | undefined): string | null {
+  const cacheBuildId = buildId ?? getNavigationBuildId()
+  return cacheBuildId === '' ? null : cacheBuildId
+}
+
+async function runOfflineNavigationCacheOperation<T>(
+  operation: () => Promise<T>,
+  fallback: T
+): Promise<T> {
+  // Offline cache persistence must never affect normal navigation. Treat any
+  // storage failure as a cache miss and let the router continue.
+  try {
+    return await operation()
+  } catch {
+    return fallback
+  }
+}
+
+function getIndexedDB(): IDBFactory | null {
+  return typeof indexedDB === 'undefined' ? null : indexedDB
+}
+
+function requestToPromise<T>(request: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result)
+    request.onerror = () => reject(request.error ?? new Error())
+  })
+}
+
+function waitForTransaction(transaction: IDBTransaction): Promise<void> {
+  return new Promise((resolve, reject) => {
+    transaction.oncomplete = () => resolve()
+    transaction.onabort = () => reject(transaction.error ?? new Error())
+    transaction.onerror = () => reject(transaction.error ?? new Error())
+  })
+}
+
+function ensureObjectStore(
+  database: IDBDatabase,
+  storeName: string,
+  keyPath: string | string[]
+): void {
+  if (!database.objectStoreNames.contains(storeName)) {
+    database.createObjectStore(storeName, { keyPath })
+  }
+}
+
+async function deleteBuildEntriesFromObjectStore(
+  store: IDBObjectStore,
+  buildId: string
+): Promise<void> {
+  const cursorRequest = store.openCursor()
+  await new Promise<void>((resolve, reject) => {
+    cursorRequest.onsuccess = () => {
+      const cursor = cursorRequest.result
+      if (cursor === null) {
+        resolve()
+        return
+      }
+
+      if ((cursor.value as { buildId?: unknown }).buildId === buildId) {
+        cursor.delete()
+      }
+      cursor.continue()
+    }
+    cursorRequest.onerror = () => reject(cursorRequest.error ?? new Error())
+  })
+}
+
+class IndexedDBOfflineNavigationCacheStorage
+  implements OfflineNavigationCacheStorage
+{
+  private databasePromise: Promise<IDBDatabase | null> | null = null
+
+  async deleteBuild(buildId: string): Promise<void> {
+    const database = await this.getDatabase()
+    if (database === null) {
+      throw new Error()
+    }
+
+    const transaction = database.transaction(
+      [ROUTE_STORE_NAME, SEGMENT_STORE_NAME],
+      'readwrite'
+    )
+    await Promise.all(
+      [ROUTE_STORE_NAME, SEGMENT_STORE_NAME].map((storeName) =>
+        deleteBuildEntriesFromObjectStore(
+          transaction.objectStore(storeName),
+          buildId
+        )
+      )
+    )
+    await waitForTransaction(transaction)
+  }
+
+  async getRoute(
+    key: OfflineNavigationRouterCacheKey
+  ): Promise<OfflineNavigationRouteRecord | undefined> {
+    return this.getFromStore(ROUTE_STORE_NAME, key)
+  }
+
+  async getRoutes(buildId: string): Promise<OfflineNavigationRouteRecord[]> {
+    return this.getBuildEntriesFromStore(ROUTE_STORE_NAME, buildId)
+  }
+
+  async putRoute(entry: OfflineNavigationRouteRecord): Promise<void> {
+    await this.putIntoStore(ROUTE_STORE_NAME, entry)
+  }
+
+  async deleteRoute(key: OfflineNavigationRouterCacheKey): Promise<void> {
+    await this.deleteFromStore(ROUTE_STORE_NAME, key)
+  }
+
+  async getRouteCacheEpoch(): Promise<number> {
+    return this.getEpoch(ROUTE_CACHE_EPOCH_KEY)
+  }
+
+  async incrementRouteCacheEpoch(): Promise<number> {
+    return this.incrementEpoch(ROUTE_CACHE_EPOCH_KEY)
+  }
+
+  async getSegment(
+    key: OfflineNavigationRouterCacheKey
+  ): Promise<OfflineNavigationSegmentRecord | undefined> {
+    return this.getFromStore(SEGMENT_STORE_NAME, key)
+  }
+
+  async getSegments(
+    buildId: string
+  ): Promise<OfflineNavigationSegmentRecord[]> {
+    return this.getBuildEntriesFromStore(SEGMENT_STORE_NAME, buildId)
+  }
+
+  async putSegment(entry: OfflineNavigationSegmentRecord): Promise<void> {
+    await this.putIntoStore(SEGMENT_STORE_NAME, entry)
+  }
+
+  async deleteSegment(key: OfflineNavigationRouterCacheKey): Promise<void> {
+    await this.deleteFromStore(SEGMENT_STORE_NAME, key)
+  }
+
+  async getSegmentCacheEpoch(): Promise<number> {
+    return this.getEpoch(SEGMENT_CACHE_EPOCH_KEY)
+  }
+
+  async incrementSegmentCacheEpoch(): Promise<number> {
+    return this.incrementEpoch(SEGMENT_CACHE_EPOCH_KEY)
+  }
+
+  private async getFromStore<T>(
+    storeName: string,
+    key: IDBValidKey | IDBKeyRange
+  ): Promise<T | undefined> {
+    const database = await this.getDatabase()
+    if (database === null) {
+      return undefined
+    }
+
+    return requestToPromise(
+      database
+        .transaction(storeName, 'readonly')
+        .objectStore(storeName)
+        .get(key)
+    )
+  }
+
+  private async getBuildEntriesFromStore<T extends { buildId: string }>(
+    storeName: string,
+    buildId: string
+  ): Promise<T[]> {
+    const database = await this.getDatabase()
+    if (database === null) {
+      return []
+    }
+
+    const transaction = database.transaction(storeName, 'readonly')
+    const store = transaction.objectStore(storeName)
+    const cursorRequest = store.openCursor()
+    const entries: T[] = []
+    await new Promise<void>((resolve, reject) => {
+      cursorRequest.onsuccess = () => {
+        const cursor = cursorRequest.result
+        if (cursor === null) {
+          resolve()
+          return
+        }
+
+        const entry = cursor.value as T
+        if (entry.buildId === buildId) {
+          entries.push(entry)
+        }
+        cursor.continue()
+      }
+      cursorRequest.onerror = () => reject(cursorRequest.error ?? new Error())
+    })
+    await waitForTransaction(transaction)
+    return entries
+  }
+
+  private async putIntoStore(storeName: string, entry: unknown): Promise<void> {
+    const database = await this.getDatabase()
+    if (database === null) {
+      throw new Error()
+    }
+
+    const transaction = database.transaction(storeName, 'readwrite')
+    transaction.objectStore(storeName).put(entry)
+    await waitForTransaction(transaction)
+  }
+
+  private async deleteFromStore(
+    storeName: string,
+    key: IDBValidKey | IDBKeyRange
+  ): Promise<void> {
+    const database = await this.getDatabase()
+    if (database === null) {
+      throw new Error()
+    }
+
+    const transaction = database.transaction(storeName, 'readwrite')
+    transaction.objectStore(storeName).delete(key)
+    await waitForTransaction(transaction)
+  }
+
+  private async getEpoch(key: string): Promise<number> {
+    const database = await this.getDatabase()
+    if (database === null) {
+      return 0
+    }
+
+    const epoch = await requestToPromise(
+      database
+        .transaction(METADATA_STORE_NAME, 'readonly')
+        .objectStore(METADATA_STORE_NAME)
+        .get(key)
+    )
+    return typeof epoch === 'number' ? epoch : 0
+  }
+
+  private async incrementEpoch(key: string): Promise<number> {
+    const database = await this.getDatabase()
+    if (database === null) {
+      throw new Error()
+    }
+
+    const transaction = database.transaction(METADATA_STORE_NAME, 'readwrite')
+    const store = transaction.objectStore(METADATA_STORE_NAME)
+    const epoch = await requestToPromise(store.get(key))
+    const nextEpoch = (typeof epoch === 'number' ? epoch : 0) + 1
+    store.put(nextEpoch, key)
+    await waitForTransaction(transaction)
+    return nextEpoch
+  }
+
+  private async getDatabase(): Promise<IDBDatabase | null> {
+    if (this.databasePromise === null) {
+      this.databasePromise = this.openDatabase().catch((error) => {
+        this.databasePromise = null
+        throw error
+      })
+    }
+    return this.databasePromise
+  }
+
+  private async openDatabase(): Promise<IDBDatabase | null> {
+    const idb = getIndexedDB()
+    if (idb === null) {
+      return null
+    }
+
+    const request = idb.open(DATABASE_NAME, DATABASE_VERSION)
+    request.onupgradeneeded = () => {
+      const database = request.result
+      ensureObjectStore(database, ROUTE_STORE_NAME, ['buildId', 'key'])
+      ensureObjectStore(database, SEGMENT_STORE_NAME, ['buildId', 'key'])
+      if (!database.objectStoreNames.contains(METADATA_STORE_NAME)) {
+        database.createObjectStore(METADATA_STORE_NAME)
+      }
+    }
+
+    const database = await requestToPromise(request)
+    database.onversionchange = () => {
+      database.close()
+      this.databasePromise = null
+    }
+    return database
+  }
+}
+
+const offlineNavigationCacheStorage =
+  new IndexedDBOfflineNavigationCacheStorage()
+const offlineNavigationRouterCache = createOfflineNavigationRouterCache(
+  offlineNavigationCacheStorage
+)
+
+export const deleteOfflineNavigationCacheEntriesForBuild =
+  offlineNavigationRouterCache.deleteBuild
+export const readOfflineNavigationRouteRecord =
+  offlineNavigationRouterCache.readRoute
+export const readOfflineNavigationRouteRecords =
+  offlineNavigationRouterCache.readRoutes
+export const writeOfflineNavigationRouteRecord =
+  offlineNavigationRouterCache.writeRoute
+export const deleteOfflineNavigationRouteRecord =
+  offlineNavigationRouterCache.deleteRoute
+export const invalidateOfflineNavigationRouteRecords =
+  offlineNavigationRouterCache.invalidateRoutes
+export const readOfflineNavigationSegmentRecord =
+  offlineNavigationRouterCache.readSegment
+export const readOfflineNavigationSegmentRecords =
+  offlineNavigationRouterCache.readSegments
+export const writeOfflineNavigationSegmentRecord =
+  offlineNavigationRouterCache.writeSegment
+export const deleteOfflineNavigationSegmentRecord =
+  offlineNavigationRouterCache.deleteSegment
+export const invalidateOfflineNavigationSegmentRecords =
+  offlineNavigationRouterCache.invalidateSegments

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -6,6 +6,8 @@ import type {
 import type {
   CacheNodeSeedData,
   FlightData,
+  HeadData,
+  InitialRSCPayload,
   Segment as FlightRouterStateSegment,
 } from '../../../shared/lib/app-router-types'
 import { PrefetchHint } from '../../../shared/lib/app-router-types'
@@ -39,6 +41,7 @@ import {
   type PrefetchSubtaskResult,
 } from './scheduler'
 import {
+  type VaryPath,
   type RouteVaryPath,
   type SegmentVaryPath,
   type PartialSegmentVaryPath,
@@ -59,6 +62,12 @@ import {
 } from './vary-path'
 import { createHrefFromUrl } from '../router-reducer/create-href-from-url'
 import type {
+  OfflineNavigationRouteRecord,
+  OfflineNavigationRSCResponsePayload,
+  OfflineNavigationSegmentRecord,
+  OfflineNavigationSerializedVaryPath,
+} from '../router-reducer/offline-navigation-cache'
+import type {
   NormalizedPathname,
   NormalizedSearch,
   NormalizedNextUrl,
@@ -78,6 +87,7 @@ import {
   setInCacheMap,
   setSizeInCacheMap,
   deleteFromCacheMap,
+  Fallback,
   isValueExpired,
   type CacheMap,
   type UnknownMapEntry,
@@ -105,10 +115,35 @@ import { PAGE_SEGMENT_KEY } from '../../../shared/lib/segment'
 import { FetchStrategy } from './types'
 import { createPromiseWithResolvers } from '../../../shared/lib/promise-with-resolvers'
 import { readFromBFCache, UnknownDynamicStaleTime } from './bfcache'
-import { discoverKnownRoute, matchKnownRoute } from './optimistic-routes'
+import {
+  discoverKnownRoute,
+  matchKnownRoute,
+  restoreKnownRouteFromCacheEntry,
+} from './optimistic-routes'
 import { convertServerPatchToFullTree, type NavigationSeed } from './navigation'
 import { getNavigationBuildId } from '../../navigation-build-id'
 import { NEXT_NAV_DEPLOYMENT_ID_HEADER } from '../../../lib/constants'
+import { normalizePathTrailingSlash } from '../../normalize-trailing-slash'
+
+let offlineNavigationCacheModule:
+  | typeof import('../router-reducer/offline-navigation-cache')
+  | undefined
+
+// Keep the runtime require inside a compile-time flag branch so disabled builds
+// do not pull the offline cache module into client chunks.
+function getOfflineNavigationCacheModule():
+  | typeof import('../router-reducer/offline-navigation-cache')
+  | null {
+  if (process.env.__NEXT_OFFLINE_NAVIGATIONS) {
+    if (offlineNavigationCacheModule === undefined) {
+      offlineNavigationCacheModule =
+        require('../router-reducer/offline-navigation-cache') as typeof import('../router-reducer/offline-navigation-cache')
+    }
+    return offlineNavigationCacheModule
+  } else {
+    return null
+  }
+}
 
 /**
  * Ensures a minimum stale time of 30s to avoid issues where the server sends a too
@@ -281,6 +316,41 @@ export type SegmentCacheEntry =
   | RejectedSegmentCacheEntry
   | FulfilledSegmentCacheEntry
 
+export type OfflineNavigationRouterCacheHydrationResult = {
+  routes: {
+    hydrated: number
+    skipped: number
+  }
+  segments: {
+    hydrated: number
+    skipped: number
+  }
+}
+
+export type OfflineNavigationRouterCacheReconstructionResult =
+  | {
+      status: 'fulfilled'
+      initialRSCPayload: InitialRSCPayload
+      route: {
+        canonicalUrl: string
+        renderedSearch: string
+      }
+      segments: {
+        restored: number
+      }
+      head: {
+        restored: number
+      }
+    }
+  | {
+      status: 'miss'
+      reason:
+        | 'missing-route'
+        | 'unsupported-route'
+        | 'missing-segment'
+        | 'missing-head'
+    }
+
 export type NonEmptySegmentCacheEntry = Exclude<
   SegmentCacheEntry,
   EmptySegmentCacheEntry
@@ -351,6 +421,7 @@ export function invalidateEntirePrefetchCache(
 ): void {
   currentRouteCacheVersion++
   currentSegmentCacheVersion++
+  invalidatePersistentOfflineNavigationCache('entire')
 
   pingVisibleLinks(nextUrl, tree)
   pingInvalidationListeners(nextUrl, tree)
@@ -368,6 +439,7 @@ export function invalidateRouteCacheEntries(
   tree: FlightRouterState
 ): void {
   currentRouteCacheVersion++
+  invalidatePersistentOfflineNavigationCache('route')
 
   pingVisibleLinks(nextUrl, tree)
   pingInvalidationListeners(nextUrl, tree)
@@ -385,9 +457,43 @@ export function invalidateSegmentCacheEntries(
   tree: FlightRouterState
 ): void {
   currentSegmentCacheVersion++
+  invalidatePersistentOfflineNavigationCache('segment')
 
   pingVisibleLinks(nextUrl, tree)
   pingInvalidationListeners(nextUrl, tree)
+}
+
+type PersistentOfflineNavigationCacheInvalidation =
+  | 'entire'
+  | 'route'
+  | 'segment'
+
+function invalidatePersistentOfflineNavigationCache(
+  kind: PersistentOfflineNavigationCacheInvalidation
+): void {
+  // Mirror in-memory router cache invalidation into IndexedDB with epochs.
+  // Entries are invalidated lazily on read, which avoids blocking the current
+  // navigation on storage deletes.
+  if (
+    !process.env.__NEXT_OFFLINE_NAVIGATIONS ||
+    process.env.__NEXT_DEV_SERVER ||
+    process.env.NODE_ENV !== 'production' ||
+    process.env.__NEXT_CONFIG_OUTPUT === 'export'
+  ) {
+    return
+  }
+
+  const offlineNavigationCache = getOfflineNavigationCacheModule()
+  if (offlineNavigationCache === null) {
+    return
+  }
+
+  if (kind === 'entire' || kind === 'route') {
+    void offlineNavigationCache.invalidateOfflineNavigationRouteRecords()
+  }
+  if (kind === 'entire' || kind === 'segment') {
+    void offlineNavigationCache.invalidateOfflineNavigationSegmentRecords()
+  }
 }
 
 function attachInvalidationListener(task: PrefetchTask): void {
@@ -1154,6 +1260,429 @@ export function markRouteEntryAsDynamicRewrite(
   // Note: The caller is responsible for also calling invalidateRouteCacheEntries
   // to invalidate other entries that may have been derived from this template
   // before we knew it had a dynamic rewrite.
+}
+
+export async function hydrateOfflineNavigationRouterCache({
+  buildId,
+  now = Date.now(),
+}: {
+  buildId?: string
+  now?: number
+} = {}): Promise<OfflineNavigationRouterCacheHydrationResult> {
+  // Bring persisted route and segment records back into the in-memory router
+  // cache before trying to reconstruct an offline document navigation.
+  const offlineNavigationCache = getOfflineNavigationCacheModule()
+  if (offlineNavigationCache === null) {
+    return {
+      routes: {
+        hydrated: 0,
+        skipped: 0,
+      },
+      segments: {
+        hydrated: 0,
+        skipped: 0,
+      },
+    }
+  }
+
+  const [routeRecords, segmentRecords] = await Promise.all([
+    offlineNavigationCache.readOfflineNavigationRouteRecords({ buildId, now }),
+    offlineNavigationCache.readOfflineNavigationSegmentRecords({
+      buildId,
+      now,
+    }),
+  ])
+
+  return hydrateOfflineNavigationRouterCacheFromRecords(
+    now,
+    routeRecords,
+    segmentRecords
+  )
+}
+
+export function createOfflineNavigationInitialRSCPayloadFromRouterCache({
+  buildId,
+  globalErrorState,
+  now,
+  url,
+}: {
+  buildId: string | undefined
+  globalErrorState: InitialRSCPayload['G']
+  now: number
+  url: string
+}): OfflineNavigationRouterCacheReconstructionResult {
+  // Recreate the minimum InitialRSCPayload that app-index needs to boot from
+  // prefetched router-cache data. If any route, segment, or head record is
+  // missing, report a cache miss rather than rendering an incomplete tree.
+  const requestUrl = new URL(url, location.href)
+  requestUrl.pathname = normalizePathTrailingSlash(requestUrl.pathname)
+  const routeEntry = readRouteCacheEntry(
+    now,
+    createPrefetchRequestKey(requestUrl.href, null)
+  )
+  if (routeEntry === null || routeEntry.status !== EntryStatus.Fulfilled) {
+    return {
+      status: 'miss',
+      reason: 'missing-route',
+    }
+  }
+
+  if (
+    routeEntry.couldBeIntercepted ||
+    routeEntry.hasDynamicRewrite ||
+    !routeEntry.supportsPerSegmentPrefetching
+  ) {
+    return {
+      status: 'miss',
+      reason: 'unsupported-route',
+    }
+  }
+
+  const seedResult = createOfflineNavigationSeedDataFromRouterCache(
+    now,
+    routeEntry.tree
+  )
+  if (seedResult.status === 'miss') {
+    return seedResult
+  }
+
+  const metadataVaryPath = routeEntry.metadata.varyPath as PageVaryPath | null
+  if (metadataVaryPath === null) {
+    return {
+      status: 'miss',
+      reason: 'missing-head',
+    }
+  }
+
+  const headResult = readOfflineNavigationHeadFromRouterCache(
+    now,
+    metadataVaryPath
+  )
+  if (headResult.status === 'miss') {
+    return headResult
+  }
+
+  const initialRSCPayload: InitialRSCPayload = {
+    c: routeEntry.canonicalUrl.split('/'),
+    q: routeEntry.renderedSearch,
+    i: routeEntry.couldBeIntercepted,
+    f: [
+      [
+        convertRouteTreeToFlightRouterState(routeEntry.tree),
+        seedResult.seedData,
+        headResult.head,
+        false,
+      ],
+    ],
+    m: undefined,
+    G: globalErrorState,
+    S: routeEntry.supportsPerSegmentPrefetching,
+    h: null,
+  }
+  if (buildId !== undefined) {
+    initialRSCPayload.b = buildId
+  }
+
+  return {
+    status: 'fulfilled',
+    initialRSCPayload,
+    route: {
+      canonicalUrl: routeEntry.canonicalUrl,
+      renderedSearch: routeEntry.renderedSearch,
+    },
+    segments: {
+      restored: seedResult.segments,
+    },
+    head: {
+      restored: 1,
+    },
+  }
+}
+
+type OfflineNavigationSeedDataResult =
+  | {
+      status: 'fulfilled'
+      seedData: CacheNodeSeedData
+      segments: number
+    }
+  | Extract<
+      OfflineNavigationRouterCacheReconstructionResult,
+      { status: 'miss' }
+    >
+
+function createOfflineNavigationSeedDataFromRouterCache(
+  now: number,
+  tree: RouteTree
+): OfflineNavigationSeedDataResult {
+  const segmentEntry = readSegmentCacheEntry(now, tree.varyPath)
+  if (segmentEntry === null || segmentEntry.status !== EntryStatus.Fulfilled) {
+    return {
+      status: 'miss',
+      reason: 'missing-segment',
+    }
+  }
+
+  const parallelRoutes: CacheNodeSeedData[1] = {}
+  let restoredSegments = 1
+  if (tree.slots !== null) {
+    for (const parallelRouteKey in tree.slots) {
+      const childResult = createOfflineNavigationSeedDataFromRouterCache(
+        now,
+        tree.slots[parallelRouteKey]
+      )
+      if (childResult.status === 'miss') {
+        return childResult
+      }
+
+      parallelRoutes[parallelRouteKey] = childResult.seedData
+      restoredSegments += childResult.segments
+    }
+  }
+
+  return {
+    status: 'fulfilled',
+    seedData: [
+      segmentEntry.rsc,
+      parallelRoutes,
+      null,
+      segmentEntry.isPartial,
+      null,
+    ],
+    segments: restoredSegments,
+  }
+}
+
+function readOfflineNavigationHeadFromRouterCache(
+  now: number,
+  metadataVaryPath: PageVaryPath
+):
+  | {
+      status: 'fulfilled'
+      head: HeadData
+    }
+  | Extract<
+      OfflineNavigationRouterCacheReconstructionResult,
+      { status: 'miss' }
+    > {
+  const metadataEntry = readSegmentCacheEntry(now, metadataVaryPath)
+  if (
+    metadataEntry === null ||
+    metadataEntry.status !== EntryStatus.Fulfilled
+  ) {
+    return {
+      status: 'miss',
+      reason: 'missing-head',
+    }
+  }
+
+  return {
+    status: 'fulfilled',
+    head: metadataEntry.rsc,
+  }
+}
+
+export async function hydrateOfflineNavigationRouterCacheFromRecords(
+  now: number,
+  routeRecords: OfflineNavigationRouteRecord[],
+  segmentRecords: OfflineNavigationSegmentRecord[]
+): Promise<OfflineNavigationRouterCacheHydrationResult> {
+  const result: OfflineNavigationRouterCacheHydrationResult = {
+    routes: {
+      hydrated: 0,
+      skipped: 0,
+    },
+    segments: {
+      hydrated: 0,
+      skipped: 0,
+    },
+  }
+
+  for (const record of routeRecords) {
+    const entry = writeOfflineNavigationRouteRecordIntoCache(now, record)
+    if (entry !== null) {
+      restoreKnownRouteFromCacheEntry(
+        now,
+        record.route.pathname,
+        record.route.nextUrl,
+        entry
+      )
+      result.routes.hydrated++
+    } else {
+      result.routes.skipped++
+    }
+  }
+
+  for (const record of segmentRecords) {
+    if (await writeOfflineNavigationSegmentRecordIntoCache(now, record)) {
+      result.segments.hydrated++
+    } else {
+      result.segments.skipped++
+    }
+  }
+
+  return result
+}
+
+export function writeOfflineNavigationRouteRecordIntoCache(
+  now: number,
+  record: OfflineNavigationRouteRecord
+): FulfilledRouteCacheEntry | null {
+  const route = record.route
+  if (
+    record.staleAt <= now ||
+    route === null ||
+    typeof route !== 'object' ||
+    record.tree === null ||
+    record.metadata === null ||
+    typeof route.canonicalUrl !== 'string' ||
+    typeof route.renderedSearch !== 'string' ||
+    typeof route.pathname !== 'string' ||
+    typeof route.search !== 'string' ||
+    (route.nextUrl !== null && typeof route.nextUrl !== 'string') ||
+    typeof route.couldBeIntercepted !== 'boolean' ||
+    typeof route.supportsPerSegmentPrefetching !== 'boolean' ||
+    typeof route.hasDynamicRewrite !== 'boolean'
+  ) {
+    return null
+  }
+
+  const varyPath = deserializeOfflineNavigationVaryPath(record.routeVaryPath)
+  if (varyPath === null) {
+    return null
+  }
+
+  const fulfilledEntry: FulfilledRouteCacheEntry = {
+    status: EntryStatus.Fulfilled,
+    blockedTasks: null,
+    canonicalUrl: route.canonicalUrl,
+    renderedSearch: route.renderedSearch as NormalizedSearch,
+    tree: record.tree as RouteTree,
+    metadata: record.metadata as RouteTree,
+    couldBeIntercepted: route.couldBeIntercepted,
+    supportsPerSegmentPrefetching: route.supportsPerSegmentPrefetching,
+    hasDynamicRewrite: route.hasDynamicRewrite,
+    ref: null,
+    size: 0,
+    staleAt: record.staleAt,
+    version: getCurrentRouteCacheVersion(),
+  }
+  const isRevalidation = false
+  setInCacheMap(
+    routeCacheMap,
+    varyPath as RouteVaryPath,
+    fulfilledEntry,
+    isRevalidation
+  )
+  return fulfilledEntry
+}
+
+export async function writeOfflineNavigationSegmentRecordIntoCache(
+  now: number,
+  record: OfflineNavigationSegmentRecord
+): Promise<boolean> {
+  const offlineNavigationCache = getOfflineNavigationCacheModule()
+  if (offlineNavigationCache === null) {
+    return false
+  }
+
+  const segment = record.segment
+  if (
+    record.staleAt <= now ||
+    segment === null ||
+    typeof segment !== 'object' ||
+    !offlineNavigationCache.isOfflineNavigationRSCResponsePayload(
+      record.payload
+    ) ||
+    record.payload.requestKind !== 'segment-prefetch' ||
+    !isOfflineNavigationFetchStrategy(segment.fetchStrategy) ||
+    typeof segment.isPartial !== 'boolean' ||
+    typeof segment.payloadIndex !== 'number' ||
+    segment.payloadIndex < 0
+  ) {
+    return false
+  }
+
+  const response = offlineNavigationCache.createOfflineNavigationRSCResponse(
+    record.payload
+  )
+  if (response.body === null) {
+    return false
+  }
+
+  const varyPath = deserializeOfflineNavigationVaryPath(record.segmentVaryPath)
+  if (varyPath === null) {
+    return false
+  }
+
+  let serverResponse: SegmentPrefetchResponse
+  try {
+    serverResponse =
+      await createFromNextReadableStream<SegmentPrefetchResponse>(
+        response.body,
+        undefined,
+        { allowPartialStream: true }
+      )
+  } catch {
+    return false
+  }
+
+  const segmentData = serverResponse.data[segment.payloadIndex]
+  if (segmentData === undefined || segmentData === null) {
+    return false
+  }
+
+  const pendingEntry = upgradeToPendingSegment(
+    createDetachedSegmentCacheEntry(now),
+    segment.fetchStrategy
+  )
+  const fulfilledEntry = fulfillSegmentCacheEntry(
+    pendingEntry,
+    segmentData.rsc,
+    record.staleAt,
+    segment.isPartial
+  )
+  const isRevalidation = false
+  setInCacheMap(
+    segmentCacheMap,
+    varyPath as SegmentVaryPath,
+    fulfilledEntry,
+    isRevalidation
+  )
+  return true
+}
+
+function isOfflineNavigationFetchStrategy(
+  fetchStrategy: number
+): fetchStrategy is FetchStrategy {
+  return (
+    fetchStrategy === FetchStrategy.LoadingBoundary ||
+    fetchStrategy === FetchStrategy.PPR ||
+    fetchStrategy === FetchStrategy.PPRRuntime ||
+    fetchStrategy === FetchStrategy.Full
+  )
+}
+
+function deserializeOfflineNavigationVaryPath(
+  serialized: OfflineNavigationSerializedVaryPath
+): VaryPath | null {
+  if (!Array.isArray(serialized) || serialized.length === 0) {
+    return null
+  }
+
+  let parent: VaryPath | null = null
+  for (let i = serialized.length - 1; i >= 0; i--) {
+    const part = serialized[i]
+    if (part.value.kind !== 'value' && part.value.kind !== 'fallback') {
+      return null
+    }
+
+    parent = {
+      id: part.id,
+      value: part.value.kind === 'fallback' ? Fallback : part.value.value,
+      parent,
+    }
+  }
+  return parent
 }
 
 function fulfillSegmentCacheEntry(
@@ -2052,7 +2581,29 @@ export async function fetchSegmentsOnCacheMiss(
       }
 
       // Set the fulfilled entry into the canonical cache slot.
-      upsertSegmentEntry(now, canonicalVaryPath, fulfilled)
+      const upserted = upsertSegmentEntry(now, canonicalVaryPath, fulfilled)
+      // Cached Navigations can already have a more complete root segment in
+      // memory, causing the upsert to decline the network candidate. Persist
+      // the candidate anyway so an empty offline fallback document can restore
+      // the root layout after a hard reload.
+      const persistedEntry =
+        upserted !== null && upserted.status === EntryStatus.Fulfilled
+          ? upserted
+          : node.tree.requestKey === ROOT_SEGMENT_REQUEST_KEY
+            ? fulfilled
+            : null
+      if (persistedEntry !== null) {
+        if (process.env.__NEXT_OFFLINE_NAVIGATIONS) {
+          persistOfflineNavigationSegmentRecord(
+            now,
+            node.tree,
+            canonicalVaryPath,
+            persistedEntry,
+            dataIndex,
+            response.offlineNavigationCache?.payload ?? null
+          )
+        }
+      }
 
       node = node.parent
       dataIndex++
@@ -2869,6 +3420,58 @@ export function canNewFetchStrategyProvideMoreContent(
   newStrategy: FetchStrategy
 ): boolean {
   return currentStrategy < newStrategy
+}
+
+function persistOfflineNavigationSegmentRecord(
+  now: number,
+  tree: RouteTree,
+  varyPath: SegmentVaryPath,
+  entry: FulfilledSegmentCacheEntry,
+  payloadIndex: number,
+  payload: Promise<OfflineNavigationRSCResponsePayload | null> | null
+): void {
+  // Segment prefetch responses can bundle parent segment data. Store the
+  // response once per fulfilled segment with the payload index needed to read
+  // that segment back during router-cache hydration. Keeping each record
+  // self-contained lets the fallback bootstrap restore segments independently.
+  if (
+    !process.env.__NEXT_OFFLINE_NAVIGATIONS ||
+    process.env.__NEXT_DEV_SERVER ||
+    process.env.NODE_ENV !== 'production' ||
+    process.env.__NEXT_CONFIG_OUTPUT === 'export' ||
+    entry.staleAt <= now ||
+    payload === null
+  ) {
+    return
+  }
+
+  const offlineNavigationCache = getOfflineNavigationCacheModule()
+  if (offlineNavigationCache === null) {
+    return
+  }
+
+  void (async () => {
+    const resolvedPayload = await payload
+    if (resolvedPayload === null) {
+      return
+    }
+
+    await offlineNavigationCache.writeOfflineNavigationSegmentRecord({
+      key: offlineNavigationCache.createOfflineNavigationVaryPathKey(varyPath),
+      now,
+      staleAt: entry.staleAt,
+      expiresAt: entry.staleAt,
+      segment: {
+        requestKey: tree.requestKey,
+        fetchStrategy: entry.fetchStrategy,
+        isPartial: entry.isPartial,
+        payloadIndex,
+      },
+      segmentVaryPath:
+        offlineNavigationCache.serializeOfflineNavigationVaryPath(varyPath),
+      payload: resolvedPayload,
+    })
+  })()
 }
 
 /**

--- a/packages/next/src/client/components/segment-cache/optimistic-routes.ts
+++ b/packages/next/src/client/components/segment-cache/optimistic-routes.ts
@@ -54,16 +54,43 @@ import {
   createMetadataRouteTree,
 } from './cache'
 import { isValueExpired } from './cache-map'
+import { hasBasePath } from '../../has-base-path'
+import { removeBasePath } from '../../remove-base-path'
 import { doesStaticSegmentAppearInURL } from '../../route-params'
-import type { NormalizedPathname, NormalizedSearch } from './cache-key'
+import type {
+  NormalizedNextUrl,
+  NormalizedPathname,
+  NormalizedSearch,
+} from './cache-key'
 import {
   appendLayoutVaryPath,
   finalizeLayoutVaryPath,
   finalizePageVaryPath,
   finalizeMetadataVaryPath,
+  getFulfilledRouteVaryPath,
   type PartialSegmentVaryPath,
   type PageVaryPath,
 } from './vary-path'
+
+let offlineNavigationCacheModule:
+  | typeof import('../router-reducer/offline-navigation-cache')
+  | undefined
+
+// Keep the runtime require inside a compile-time flag branch so disabled builds
+// do not pull the offline cache module into client chunks.
+function getOfflineNavigationCacheModule():
+  | typeof import('../router-reducer/offline-navigation-cache')
+  | null {
+  if (process.env.__NEXT_OFFLINE_NAVIGATIONS) {
+    if (offlineNavigationCacheModule === undefined) {
+      offlineNavigationCacheModule =
+        require('../router-reducer/offline-navigation-cache') as typeof import('../router-reducer/offline-navigation-cache')
+    }
+    return offlineNavigationCacheModule
+  } else {
+    return null
+  }
+}
 
 /**
  * The known route tree is analogous to a route table. A different routing
@@ -176,6 +203,10 @@ function createEmptyPart(): KnownRoutePart {
 // The root of the known route tree.
 let knownRouteTreeRoot: KnownRoutePart = createEmptyPart()
 
+function removeBasePathIfPresent(pathname: string): string {
+  return hasBasePath(pathname) ? removeBasePath(pathname) : pathname
+}
+
 /**
  * Learns a route pattern from a server response and inserts it into the cache.
  *
@@ -208,13 +239,15 @@ export function discoverKnownRoute(
 ): FulfilledRouteCacheEntry {
   const tree = routeTree
 
-  const pathnameParts = pathname.split('/').filter((p) => p !== '')
+  const routePathname = removeBasePathIfPresent(pathname)
+  const pathnameParts = routePathname.split('/').filter((p) => p !== '')
   const firstPart = pathnameParts.length > 0 ? pathnameParts[0] : null
   const remainingParts = pathnameParts.length > 0 ? pathnameParts.slice(1) : []
+  let fulfilledEntry: FulfilledRouteCacheEntry
 
   if (pendingEntry !== null) {
     // Fulfill the pending entry first
-    const fulfilledEntry = fulfillRouteCacheEntry(
+    fulfilledEntry = fulfillRouteCacheEntry(
       now,
       pendingEntry,
       tree,
@@ -245,26 +278,112 @@ export function discoverKnownRoute(
       supportsPerSegmentPrefetching,
       hasDynamicRewrite
     )
-    return fulfilledEntry
+  } else {
+    // No pending entry - discoverKnownRoutePart will create one and insert it
+    // into the cache, or return an existing pattern if one exists.
+    fulfilledEntry = discoverKnownRoutePart(
+      knownRouteTreeRoot,
+      tree,
+      firstPart,
+      remainingParts,
+      null,
+      now,
+      pathname,
+      nextUrl,
+      tree,
+      metadataVaryPath,
+      couldBeIntercepted,
+      canonicalUrl,
+      supportsPerSegmentPrefetching,
+      hasDynamicRewrite
+    )
   }
 
-  // No pending entry - discoverKnownRoutePart will create one and insert it
-  // into the cache, or return an existing pattern if one exists.
-  return discoverKnownRoutePart(
+  if (process.env.__NEXT_OFFLINE_NAVIGATIONS) {
+    persistOfflineNavigationRouteRecord(now, pathname, nextUrl, fulfilledEntry)
+  }
+  return fulfilledEntry
+}
+
+function persistOfflineNavigationRouteRecord(
+  now: number,
+  pathname: string,
+  nextUrl: string | null,
+  entry: FulfilledRouteCacheEntry
+): void {
+  if (
+    !process.env.__NEXT_OFFLINE_NAVIGATIONS ||
+    process.env.__NEXT_DEV_SERVER ||
+    process.env.NODE_ENV !== 'production' ||
+    process.env.__NEXT_CONFIG_OUTPUT === 'export' ||
+    entry.staleAt <= now
+  ) {
+    return
+  }
+
+  const offlineNavigationCache = getOfflineNavigationCacheModule()
+  if (offlineNavigationCache === null) {
+    return
+  }
+
+  const routeVaryPath = getFulfilledRouteVaryPath(
+    pathname as NormalizedPathname,
+    entry.renderedSearch,
+    nextUrl as NormalizedNextUrl | null,
+    entry.couldBeIntercepted
+  )
+
+  void offlineNavigationCache.writeOfflineNavigationRouteRecord({
+    key: offlineNavigationCache.createOfflineNavigationVaryPathKey(
+      routeVaryPath
+    ),
+    now,
+    staleAt: entry.staleAt,
+    expiresAt: entry.staleAt,
+    route: {
+      pathname,
+      search: entry.renderedSearch,
+      nextUrl,
+      canonicalUrl: entry.canonicalUrl,
+      renderedSearch: entry.renderedSearch,
+      couldBeIntercepted: entry.couldBeIntercepted,
+      supportsPerSegmentPrefetching: entry.supportsPerSegmentPrefetching,
+      hasDynamicRewrite: entry.hasDynamicRewrite,
+    },
+    routeVaryPath:
+      offlineNavigationCache.serializeOfflineNavigationVaryPath(routeVaryPath),
+    tree: entry.tree,
+    metadata: entry.metadata,
+  })
+}
+
+export function restoreKnownRouteFromCacheEntry(
+  now: number,
+  pathname: string,
+  nextUrl: string | null,
+  entry: FulfilledRouteCacheEntry
+): void {
+  const routePathname = removeBasePathIfPresent(pathname)
+  const pathnameParts = routePathname.split('/').filter((p) => p !== '')
+  const firstPart = pathnameParts.length > 0 ? pathnameParts[0] : null
+  const remainingParts = pathnameParts.length > 0 ? pathnameParts.slice(1) : []
+  const metadataVaryPath = entry.metadata.varyPath as PageVaryPath
+
+  discoverKnownRoutePart(
     knownRouteTreeRoot,
-    tree,
+    entry.tree,
     firstPart,
     remainingParts,
-    null,
+    entry,
     now,
     pathname,
     nextUrl,
-    tree,
+    entry.tree,
     metadataVaryPath,
-    couldBeIntercepted,
-    canonicalUrl,
-    supportsPerSegmentPrefetching,
-    hasDynamicRewrite
+    entry.couldBeIntercepted,
+    entry.canonicalUrl,
+    entry.supportsPerSegmentPrefetching,
+    entry.hasDynamicRewrite
   )
 }
 
@@ -517,7 +636,8 @@ export function matchKnownRoute(
   pathname: string,
   search: NormalizedSearch
 ): FulfilledRouteCacheEntry | null {
-  const pathnameParts = pathname.split('/').filter((p) => p !== '')
+  const routePathname = removeBasePathIfPresent(pathname)
+  const pathnameParts = routePathname.split('/').filter((p) => p !== '')
   const resolvedParams: ResolvedParams = new Map()
   const match = matchKnownRoutePart(
     now,

--- a/packages/next/src/client/components/use-offline.tsx
+++ b/packages/next/src/client/components/use-offline.tsx
@@ -15,12 +15,14 @@ const OfflineContext = createContext<boolean>(false)
 // (via dispatchOfflineChange) to update the React tree.
 let setOptimistic: ((value: boolean) => void) | null = null
 let setCanonical: ((value: boolean) => void) | null = null
+let offlineSnapshot = false
 
 /**
  * Called by the offline module when the offline state changes.
  * Dispatches into React via startTransition + useOptimistic.
  */
 export function dispatchOfflineChange(isOffline: boolean): void {
+  offlineSnapshot = isOffline
   const canonical = setCanonical
   const optimistic = setOptimistic
   if (canonical === null || optimistic === null) {
@@ -33,7 +35,7 @@ export function dispatchOfflineChange(isOffline: boolean): void {
 }
 
 export function OfflineProvider({ children }: { children: React.ReactNode }) {
-  const [canonicalOffline, setCanonicalOffline] = useState(false)
+  const [canonicalOffline, setCanonicalOffline] = useState(offlineSnapshot)
   const [isOffline, setOptimisticOffline] = useOptimistic(canonicalOffline)
 
   setOptimistic = setOptimisticOffline

--- a/packages/next/src/client/offline-navigation-service-worker.ts
+++ b/packages/next/src/client/offline-navigation-service-worker.ts
@@ -1,5 +1,12 @@
 import { getDeploymentIdQuery } from '../shared/lib/deployment-id'
 import { OFFLINE_NAVIGATION_SERVICE_WORKER } from '../shared/lib/offline-navigation'
+import { OFFLINE_NAVIGATION_FALLBACK_SERVED } from '../shared/lib/offline-navigation-constants'
+
+let isListeningForServiceWorkerMessages = false
+
+type OfflineNavigationFallbackServedMessage = {
+  type: typeof OFFLINE_NAVIGATION_FALLBACK_SERVED
+}
 
 function getBasePath(): string {
   return (process.env.__NEXT_ROUTER_BASEPATH as string) || ''
@@ -14,6 +21,41 @@ function getServiceWorkerScope(): string {
   return basePath ? `${basePath}/` : '/'
 }
 
+// The generated worker posts this message when it had to serve the fallback
+// document. Treat it as the same user-visible offline transition as the
+// browser's native offline event.
+function listenForOfflineNavigationMessages(): void {
+  if (isListeningForServiceWorkerMessages) {
+    return
+  }
+  isListeningForServiceWorkerMessages = true
+
+  navigator.serviceWorker.addEventListener('message', (event) => {
+    handleOfflineNavigationServiceWorkerMessage(event.data)
+  })
+}
+
+export function handleOfflineNavigationServiceWorkerMessage(data: unknown) {
+  if (!isOfflineNavigationFallbackServedMessage(data)) {
+    return
+  }
+
+  const { notifyOffline } =
+    require('./components/offline') as typeof import('./components/offline')
+  notifyOffline()
+}
+
+function isOfflineNavigationFallbackServedMessage(
+  data: unknown
+): data is OfflineNavigationFallbackServedMessage {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    (data as Partial<OfflineNavigationFallbackServedMessage>).type ===
+      OFFLINE_NAVIGATION_FALLBACK_SERVED
+  )
+}
+
 export function registerOfflineNavigationServiceWorker(): void {
   if (
     process.env.__NEXT_DEV_SERVER ||
@@ -23,6 +65,8 @@ export function registerOfflineNavigationServiceWorker(): void {
   ) {
     return
   }
+
+  listenForOfflineNavigationMessages()
 
   // Registration is best-effort: a failed service worker install should not
   // affect the current online page load.

--- a/packages/next/src/client/offline-navigation-service-worker.ts
+++ b/packages/next/src/client/offline-navigation-service-worker.ts
@@ -1,0 +1,35 @@
+import { getDeploymentIdQuery } from '../shared/lib/deployment-id'
+import { OFFLINE_NAVIGATION_SERVICE_WORKER } from '../shared/lib/offline-navigation'
+
+function getBasePath(): string {
+  return (process.env.__NEXT_ROUTER_BASEPATH as string) || ''
+}
+
+function getServiceWorkerHref(): string {
+  return `${getBasePath()}/_next/static/${OFFLINE_NAVIGATION_SERVICE_WORKER}${getDeploymentIdQuery()}`
+}
+
+function getServiceWorkerScope(): string {
+  const basePath = getBasePath()
+  return basePath ? `${basePath}/` : '/'
+}
+
+export function registerOfflineNavigationServiceWorker(): void {
+  if (
+    process.env.__NEXT_DEV_SERVER ||
+    typeof window === 'undefined' ||
+    !window.isSecureContext ||
+    !('serviceWorker' in navigator)
+  ) {
+    return
+  }
+
+  // Registration is best-effort: a failed service worker install should not
+  // affect the current online page load.
+  navigator.serviceWorker
+    .register(getServiceWorkerHref(), {
+      scope: getServiceWorkerScope(),
+      updateViaCache: 'none',
+    })
+    .catch(() => {})
+}

--- a/packages/next/src/client/route-params.ts
+++ b/packages/next/src/client/route-params.ts
@@ -10,6 +10,8 @@ import {
   NEXT_REWRITTEN_QUERY_HEADER,
   NEXT_RSC_UNION_QUERY,
 } from './components/app-router-headers'
+import { hasBasePath } from './has-base-path'
+import { removeBasePath } from './remove-base-path'
 import type {
   NormalizedPathname,
   NormalizedSearch,
@@ -44,9 +46,11 @@ export function getRenderedPathname(
   // page will be different from the pathname in the request URL. In this case,
   // the response will include a header that gives the rewritten pathname.
   const rewrittenPath = response.headers.get(NEXT_REWRITTEN_PATH_HEADER)
-  return (rewrittenPath ??
-    urlToUrlWithoutFlightMarker(new URL(response.url))
-      .pathname) as NormalizedPathname
+  const pathname =
+    rewrittenPath ?? urlToUrlWithoutFlightMarker(new URL(response.url)).pathname
+  return (
+    hasBasePath(pathname) ? removeBasePath(pathname) : pathname
+  ) as NormalizedPathname
 }
 
 // Pathname parts come from `URL.pathname.split('/')`, so they are already

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -510,7 +510,10 @@ async function exportAppImpl(
       clientParamParsingOrigins:
         nextConfig.experimental.clientParamParsingOrigins,
       dynamicOnHover: nextConfig.experimental.dynamicOnHover ?? false,
-      optimisticRouting: nextConfig.experimental.optimisticRouting ?? false,
+      optimisticRouting:
+        nextConfig.experimental.optimisticRouting ||
+        nextConfig.experimental.offlineNavigations ||
+        false,
       inlineCss: nextConfig.experimental.inlineCss ?? false,
       prefetchInlining: nextConfig.experimental.prefetchInlining ?? false,
       authInterrupts: !!nextConfig.experimental.authInterrupts,

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -578,7 +578,9 @@ export default abstract class Server<
           this.nextConfig.experimental.clientParamParsingOrigins,
         dynamicOnHover: this.nextConfig.experimental.dynamicOnHover ?? false,
         optimisticRouting:
-          this.nextConfig.experimental.optimisticRouting ?? false,
+          this.nextConfig.experimental.optimisticRouting ||
+          this.nextConfig.experimental.offlineNavigations ||
+          false,
         inlineCss: this.nextConfig.experimental.inlineCss ?? false,
         prefetchInlining:
           this.nextConfig.experimental.prefetchInlining ?? false,

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -222,6 +222,7 @@ export const experimentalSchema = {
   cachedNavigations: z.boolean().optional(),
   partialFallbacks: z.boolean().optional(),
   dynamicOnHover: z.boolean().optional(),
+  offlineNavigations: z.boolean().optional(),
   useOffline: z.boolean().optional(),
   optimisticRouting: z.boolean().optional(),
   varyParams: z.boolean().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -429,6 +429,7 @@ export interface ExperimentalConfig {
    */
   partialFallbacks?: boolean
   dynamicOnHover?: boolean
+  offlineNavigations?: boolean
   useOffline?: boolean
   optimisticRouting?: boolean
   varyParams?: boolean
@@ -1913,6 +1914,7 @@ export const defaultConfig = Object.freeze({
     cachedNavigations: false,
     partialFallbacks: true,
     dynamicOnHover: false,
+    offlineNavigations: false,
     useOffline: false,
     varyParams: false,
     prefetchInlining: true,
@@ -2059,6 +2061,7 @@ export interface NextConfigRuntime {
     | 'serverActions'
     | 'staleTimes'
     | 'dynamicOnHover'
+    | 'offlineNavigations'
     | 'useOffline'
     | 'optimisticRouting'
     | 'inlineCss'
@@ -2127,6 +2130,7 @@ export function getNextConfigRuntime(
     serverActions: ex.serverActions,
     staleTimes: ex.staleTimes,
     dynamicOnHover: ex.dynamicOnHover,
+    offlineNavigations: ex.offlineNavigations,
     useOffline: ex.useOffline,
     optimisticRouting: ex.optimisticRouting,
     inlineCss: ex.inlineCss,

--- a/packages/next/src/server/config.test.ts
+++ b/packages/next/src/server/config.test.ts
@@ -73,6 +73,41 @@ describe('loadConfig', () => {
     })
   })
 
+  describe('experimental.offlineNavigations', () => {
+    it('implies the client-router features it builds on', async () => {
+      const result = await loadConfig(PHASE_PRODUCTION_BUILD, __dirname, {
+        customConfig: {
+          cacheComponents: true,
+          experimental: {
+            cachedNavigations: false,
+            offlineNavigations: true,
+            optimisticRouting: false,
+            useOffline: false,
+          },
+        },
+      })
+
+      expect(result.experimental.offlineNavigations).toBe(true)
+      expect(result.experimental.cachedNavigations).toBe(true)
+      expect(result.experimental.optimisticRouting).toBe(true)
+      expect(result.experimental.useOffline).toBe(true)
+    })
+
+    it('requires cacheComponents', async () => {
+      await expect(
+        loadConfig(PHASE_PRODUCTION_BUILD, __dirname, {
+          customConfig: {
+            experimental: {
+              offlineNavigations: true,
+            },
+          },
+        })
+      ).rejects.toThrow(
+        /`experimental\.offlineNavigations` requires `cacheComponents`/
+      )
+    })
+  })
+
   describe('canary-only features', () => {
     beforeAll(() => {
       process.env.__NEXT_VERSION = '14.2.0'

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -406,6 +406,18 @@ function assignDefaultsAndValidate(
     }
   }
 
+  if (result.experimental.offlineNavigations) {
+    if (!result.cacheComponents) {
+      throw new Error(
+        `\`experimental.offlineNavigations\` requires \`cacheComponents\` to be enabled. Please update your ${configFileName} accordingly.`
+      )
+    }
+
+    result.experimental.useOffline = true
+    result.experimental.optimisticRouting = true
+    result.experimental.cachedNavigations = true
+  }
+
   // ensure correct default is set for api-resolver revalidate handling
   if (!result.experimental.trustHostHeader && ciEnvironment.hasNextSupport) {
     result.experimental.trustHostHeader = true

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -13,6 +13,7 @@ import loadConfig, { type ConfiguredExperimentalFeature } from '../config'
 import { serveStatic } from '../serve-static'
 import setupDebug from 'next/dist/compiled/debug'
 import * as Log from '../../build/output/log'
+import { OFFLINE_NAVIGATION_SERVICE_WORKER } from '../../shared/lib/offline-navigation'
 import { DecodeError } from '../../shared/lib/utils'
 import { findPagesDir } from '../../lib/find-pages-dir'
 import { setupFsCheck } from './router-utils/filesystem'
@@ -524,6 +525,17 @@ export async function initialize(opts: {
         }
 
         if (
+          matchedOutput.type === 'nextStaticFolder' &&
+          matchedOutput.itemPath.endsWith(
+            `/${OFFLINE_NAVIGATION_SERVICE_WORKER}`
+          )
+        ) {
+          res.setHeader('Cache-Control', 'no-cache, must-revalidate')
+          res.setHeader(
+            'Service-Worker-Allowed',
+            config.basePath ? `${config.basePath}/` : '/'
+          )
+        } else if (
           !res.getHeader('cache-control') &&
           matchedOutput.type === 'nextStaticFolder'
         ) {

--- a/packages/next/src/shared/lib/offline-navigation-constants.ts
+++ b/packages/next/src/shared/lib/offline-navigation-constants.ts
@@ -1,0 +1,2 @@
+export const OFFLINE_NAVIGATION_FALLBACK_SERVED =
+  'next-offline-navigation-fallback-served'

--- a/packages/next/src/shared/lib/offline-navigation.ts
+++ b/packages/next/src/shared/lib/offline-navigation.ts
@@ -1,0 +1,2 @@
+export const OFFLINE_NAVIGATION_SERVICE_WORKER =
+  '_offline-navigation-service-worker.js'

--- a/test/production/app-dir/offline-navigations/app/dynamic-prefetch/[value]/dynamic-prefetch-value.tsx
+++ b/test/production/app-dir/offline-navigations/app/dynamic-prefetch/[value]/dynamic-prefetch-value.tsx
@@ -1,0 +1,9 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export function DynamicPrefetchValue() {
+  const params = useParams<{ value: string }>()
+
+  return <p id="dynamic-prefetch-page">dynamic prefetch path: {params.value}</p>
+}

--- a/test/production/app-dir/offline-navigations/app/dynamic-prefetch/[value]/page.tsx
+++ b/test/production/app-dir/offline-navigations/app/dynamic-prefetch/[value]/page.tsx
@@ -1,0 +1,18 @@
+import { Suspense } from 'react'
+import { OfflineStatus } from '../../offline-status'
+import { DynamicPrefetchValue } from './dynamic-prefetch-value'
+
+export function generateStaticParams() {
+  return [{ value: '__TEST__' }]
+}
+
+export default function DynamicPrefetchPage() {
+  return (
+    <>
+      <Suspense fallback={<p>loading dynamic prefetch value</p>}>
+        <DynamicPrefetchValue />
+      </Suspense>
+      <OfflineStatus />
+    </>
+  )
+}

--- a/test/production/app-dir/offline-navigations/app/layout.tsx
+++ b/test/production/app-dir/offline-navigations/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/offline-navigations/app/offline-status.tsx
+++ b/test/production/app-dir/offline-navigations/app/offline-status.tsx
@@ -1,0 +1,8 @@
+'use client'
+
+import { useOffline } from 'next/offline'
+
+export function OfflineStatus() {
+  const isOffline = useOffline()
+  return <p id="offline-status">{isOffline ? 'offline' : 'online'}</p>
+}

--- a/test/production/app-dir/offline-navigations/app/page.tsx
+++ b/test/production/app-dir/offline-navigations/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>offline navigations page</p>
+}

--- a/test/production/app-dir/offline-navigations/app/page.tsx
+++ b/test/production/app-dir/offline-navigations/app/page.tsx
@@ -1,10 +1,40 @@
+import { cacheLife, cacheTag, updateTag } from 'next/cache'
 import { OfflineStatus } from './offline-status'
+import {
+  DynamicPatternSourcePrefetchButton,
+  DynamicPatternTargetPrefetchButton,
+  PrefetchButton,
+  RefreshButton,
+} from './prefetch-button'
+
+async function ActionInvalidationMarker() {
+  'use cache'
+  cacheLife('max')
+  cacheTag('offline-navigation-action')
+
+  return <p id="action-invalidation-marker">action invalidation marker</p>
+}
+
+async function invalidateOfflineNavigationAction() {
+  'use server'
+  updateTag('offline-navigation-action')
+}
 
 export default function Page() {
   return (
     <>
       <p>offline navigations page</p>
       <OfflineStatus />
+      <ActionInvalidationMarker />
+      <form action={invalidateOfflineNavigationAction}>
+        <button id="invalidate-offline-navigation-action" type="submit">
+          Invalidate offline navigation action
+        </button>
+      </form>
+      <PrefetchButton />
+      <DynamicPatternSourcePrefetchButton />
+      <DynamicPatternTargetPrefetchButton />
+      <RefreshButton />
     </>
   )
 }

--- a/test/production/app-dir/offline-navigations/app/page.tsx
+++ b/test/production/app-dir/offline-navigations/app/page.tsx
@@ -1,3 +1,10 @@
+import { OfflineStatus } from './offline-status'
+
 export default function Page() {
-  return <p>offline navigations page</p>
+  return (
+    <>
+      <p>offline navigations page</p>
+      <OfflineStatus />
+    </>
+  )
 }

--- a/test/production/app-dir/offline-navigations/app/prefetch-button.tsx
+++ b/test/production/app-dir/offline-navigations/app/prefetch-button.tsx
@@ -1,0 +1,48 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+
+export function PrefetchButton() {
+  const router = useRouter()
+  return (
+    <button
+      id="prefetch-offline-navigation"
+      onClick={() => router.prefetch('/prefetched')}
+    >
+      Prefetch offline navigation
+    </button>
+  )
+}
+
+export function DynamicPatternSourcePrefetchButton() {
+  const router = useRouter()
+  return (
+    <button
+      id="prefetch-dynamic-pattern-source"
+      onClick={() => router.prefetch('/dynamic-prefetch/learned')}
+    >
+      Prefetch dynamic pattern source
+    </button>
+  )
+}
+
+export function DynamicPatternTargetPrefetchButton() {
+  const router = useRouter()
+  return (
+    <button
+      id="prefetch-dynamic-pattern-target"
+      onClick={() => router.prefetch('/dynamic-prefetch/replayed')}
+    >
+      Prefetch dynamic pattern target
+    </button>
+  )
+}
+
+export function RefreshButton() {
+  const router = useRouter()
+  return (
+    <button id="refresh-offline-navigation" onClick={() => router.refresh()}>
+      Refresh offline navigation
+    </button>
+  )
+}

--- a/test/production/app-dir/offline-navigations/app/prefetched/page.tsx
+++ b/test/production/app-dir/offline-navigations/app/prefetched/page.tsx
@@ -1,0 +1,10 @@
+import { OfflineStatus } from '../offline-status'
+
+export default function PrefetchedPage() {
+  return (
+    <>
+      <p id="prefetched-page">prefetched page</p>
+      <OfflineStatus />
+    </>
+  )
+}

--- a/test/production/app-dir/offline-navigations/app/request-sensitive/page.tsx
+++ b/test/production/app-dir/offline-navigations/app/request-sensitive/page.tsx
@@ -1,0 +1,17 @@
+import { cookies } from 'next/headers'
+import { OfflineStatus } from '../offline-status'
+
+export const unstable_instant = false
+export const unstable_prefetch = 'force-disabled'
+
+export default async function RequestSensitivePage() {
+  const cookieStore = await cookies()
+  const session = cookieStore.get('offline-session')?.value ?? 'missing'
+
+  return (
+    <>
+      <p id="request-sensitive-page">request sensitive session: {session}</p>
+      <OfflineStatus />
+    </>
+  )
+}

--- a/test/production/app-dir/offline-navigations/app/url-stress/[value]/hash-indicator.tsx
+++ b/test/production/app-dir/offline-navigations/app/url-stress/[value]/hash-indicator.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+export function HashIndicator() {
+  const [hash, setHash] = useState('')
+
+  useEffect(() => {
+    const updateHash = () => setHash(window.location.hash)
+    updateHash()
+    window.addEventListener('hashchange', updateHash)
+
+    return () => {
+      window.removeEventListener('hashchange', updateHash)
+    }
+  }, [])
+
+  return <p id="url-stress-hash">url stress hash: {hash}</p>
+}

--- a/test/production/app-dir/offline-navigations/app/url-stress/[value]/page.tsx
+++ b/test/production/app-dir/offline-navigations/app/url-stress/[value]/page.tsx
@@ -1,0 +1,36 @@
+import { OfflineStatus } from '../../offline-status'
+import { HashIndicator } from './hash-indicator'
+
+type PageProps = {
+  params: Promise<{ value: string }>
+  searchParams: Promise<{
+    tag?: string | string[]
+    token?: string
+  }>
+}
+
+export const unstable_instant = false
+
+export default async function UrlStressPage({
+  params,
+  searchParams,
+}: PageProps) {
+  const { value } = await params
+  const query = await searchParams
+  const tags =
+    query.tag === undefined
+      ? []
+      : Array.isArray(query.tag)
+        ? query.tag
+        : [query.tag]
+
+  return (
+    <>
+      <p id="url-stress-page">url stress path: {value}</p>
+      <p id="url-stress-token">url stress token: {query.token ?? 'missing'}</p>
+      <p id="url-stress-tags">url stress tags: {tags.join(',')}</p>
+      <HashIndicator />
+      <OfflineStatus />
+    </>
+  )
+}

--- a/test/production/app-dir/offline-navigations/next.config.js
+++ b/test/production/app-dir/offline-navigations/next.config.js
@@ -6,6 +6,7 @@ const nextConfig = {
   assetPrefix: '/app-assets',
   basePath: '/docs',
   experimental: {
+    exposeTestingApiInProductionBuild: true,
     offlineNavigations: true,
   },
   trailingSlash: true,

--- a/test/production/app-dir/offline-navigations/next.config.js
+++ b/test/production/app-dir/offline-navigations/next.config.js
@@ -3,9 +3,12 @@
  */
 const nextConfig = {
   cacheComponents: true,
+  assetPrefix: 'https://cdn.example.com/app-assets',
+  basePath: '/docs',
   experimental: {
     offlineNavigations: true,
   },
+  trailingSlash: true,
 }
 
 module.exports = nextConfig

--- a/test/production/app-dir/offline-navigations/next.config.js
+++ b/test/production/app-dir/offline-navigations/next.config.js
@@ -3,7 +3,7 @@
  */
 const nextConfig = {
   cacheComponents: true,
-  assetPrefix: 'https://cdn.example.com/app-assets',
+  assetPrefix: '/app-assets',
   basePath: '/docs',
   experimental: {
     offlineNavigations: true,

--- a/test/production/app-dir/offline-navigations/next.config.js
+++ b/test/production/app-dir/offline-navigations/next.config.js
@@ -1,0 +1,11 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+  experimental: {
+    offlineNavigations: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -2,6 +2,10 @@ import { existsSync } from 'fs'
 import { join } from 'path'
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
+import type * as Playwright from 'playwright'
+
+const OFFLINE_NAVIGATION_FALLBACK_SERVED =
+  'next-offline-navigation-fallback-served'
 
 describe('offlineNavigations build artifacts', () => {
   const { next } = nextTestSetup({
@@ -67,13 +71,18 @@ describe('offlineNavigations build artifacts', () => {
       `"cacheNamespace":"next-offline-navigation-v1:${buildId}:/docs"`
     )
     expect(serviceWorkerScript).toContain(
+      `"fallbackDocumentHref":"/docs/_next/static/${buildId}/_offline-navigation-fallback.html"`
+    )
+    expect(serviceWorkerScript).toContain(
       `"manifestHref":"/docs/_next/static/${buildId}/_offline-navigation-manifest.json"`
     )
     expect(serviceWorkerScript).toContain('cacheOfflineNavigationResources')
     expect(serviceWorkerScript).toContain('caches.delete')
+    expect(serviceWorkerScript).toContain(OFFLINE_NAVIGATION_FALLBACK_SERVED)
+    expect(serviceWorkerScript).toContain('isDocumentNavigationRequest')
     expect(serviceWorkerScript).toContain('skipWaiting')
     expect(serviceWorkerScript).toContain('clients.claim')
-    expect(serviceWorkerScript).not.toContain('respondWith')
+    expect(serviceWorkerScript).toContain('respondWith')
 
     expect(manifestJson).toEqual({
       version: 1,
@@ -106,6 +115,7 @@ describe('offlineNavigations build artifacts', () => {
     const { buildId } = await getOfflineNavigationArtifactPaths()
     await next.start({ skipBuild: true })
 
+    let page: Playwright.Page | undefined
     try {
       const swResponse = await next.fetch(
         `/docs/_next/static/_offline-navigation-service-worker.js${next.getDeploymentIdQuery()}`
@@ -116,7 +126,11 @@ describe('offlineNavigations build artifacts', () => {
       )
       expect(swResponse.headers.get('service-worker-allowed')).toBe('/docs/')
 
-      const browser = await next.browser('/docs')
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
       await retry(async () => {
         const registration = await browser.eval(async () => {
           if (!('serviceWorker' in navigator)) {
@@ -143,6 +157,62 @@ describe('offlineNavigations build artifacts', () => {
           scriptURL: `${next.url}/docs/_next/static/_offline-navigation-service-worker.js${next.getDeploymentIdQuery()}`,
         })
       })
+      await retry(async () => {
+        expect(
+          await browser.eval(() => Boolean(navigator.serviceWorker.controller))
+        ).toBe(true)
+      })
+      expect(await browser.elementById('offline-status').text()).toBe('online')
+
+      await browser.eval((messageType) => {
+        const win = window as typeof window & {
+          __restoreOfflineNavigationFetch?: () => void
+        }
+        const originalFetch = window.fetch
+        win.__restoreOfflineNavigationFetch = () => {
+          window.fetch = originalFetch
+          delete win.__restoreOfflineNavigationFetch
+        }
+        window.fetch = async () => {
+          throw new TypeError('offline navigation test')
+        }
+        navigator.serviceWorker.dispatchEvent(
+          new MessageEvent('message', {
+            data: {
+              type: messageType,
+            },
+          })
+        )
+      }, OFFLINE_NAVIGATION_FALLBACK_SERVED)
+      await retry(async () => {
+        expect(await browser.elementById('offline-status').text()).toBe(
+          'offline'
+        )
+      })
+      await browser.eval(() => {
+        const win = window as typeof window & {
+          __restoreOfflineNavigationFetch?: () => void
+        }
+        win.__restoreOfflineNavigationFetch?.()
+        window.dispatchEvent(new Event('online'))
+      })
+      await retry(async () => {
+        expect(await browser.elementById('offline-status').text()).toBe(
+          'online'
+        )
+      })
+
+      await browser.eval((messageType) => {
+        localStorage.removeItem('__nextOfflineNavigationMessage')
+        navigator.serviceWorker.addEventListener('message', (event) => {
+          if (event.data?.type === messageType) {
+            localStorage.setItem(
+              '__nextOfflineNavigationMessage',
+              JSON.stringify(event.data)
+            )
+          }
+        })
+      }, OFFLINE_NAVIGATION_FALLBACK_SERVED)
 
       const cacheState = await browser.eval(async () => {
         const cacheNames = (await caches.keys()).filter((cacheName) =>
@@ -180,6 +250,43 @@ describe('offlineNavigations build artifacts', () => {
         ])
       )
 
+      await page!.context().setOffline(true)
+      const nonNavigationResult = await browser.eval(async () => {
+        try {
+          await fetch('/docs?__next_offline_probe=1', {
+            headers: { rsc: '1' },
+          })
+          return 'resolved'
+        } catch {
+          return 'rejected'
+        }
+      })
+      expect(nonNavigationResult).toBe('rejected')
+
+      const offlineResponse = await page!.goto(
+        `${next.url}/docs/offline-navigation-cache-miss`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(offlineResponse?.status()).toBe(200)
+      expect(
+        await browser.eval(() =>
+          document.documentElement.hasAttribute(
+            'data-next-offline-navigation-fallback'
+          )
+        )
+      ).toBe(true)
+      const serviceWorkerMessage = await browser.eval(() => {
+        const message = localStorage.getItem('__nextOfflineNavigationMessage')
+        return message === null ? null : JSON.parse(message)
+      })
+      expect(serviceWorkerMessage).toMatchObject({
+        type: OFFLINE_NAVIGATION_FALLBACK_SERVED,
+        buildId,
+        reason: 'network-error',
+        url: `${next.url}/docs/offline-navigation-cache-miss`,
+      })
+      await page!.context().setOffline(false)
+
       await browser.eval(async () => {
         if (!('serviceWorker' in navigator)) {
           return
@@ -200,6 +307,9 @@ describe('offlineNavigations build artifacts', () => {
         )
       })
     } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
       await next.stop()
     }
   })

--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -2,44 +2,77 @@ import { existsSync } from 'fs'
 import { join } from 'path'
 import { nextTestSetup } from 'e2e-utils'
 
-describe('offlineNavigations fallback document', () => {
+describe('offlineNavigations build artifacts', () => {
   const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,
   })
 
-  async function getFallbackDocumentPath() {
+  async function getOfflineNavigationArtifactPaths() {
     const buildId = (await next.readFile('.next/BUILD_ID')).trim()
 
     return {
       buildId,
-      absolutePath: join(
-        next.testDir,
-        '.next',
-        'static',
-        buildId,
-        '_offline-navigation-fallback.html'
-      ),
-      relativePath: `.next/static/${buildId}/_offline-navigation-fallback.html`,
+      fallbackDocument: {
+        absolutePath: join(
+          next.testDir,
+          '.next',
+          'static',
+          buildId,
+          '_offline-navigation-fallback.html'
+        ),
+        relativePath: `.next/static/${buildId}/_offline-navigation-fallback.html`,
+      },
+      manifest: {
+        absolutePath: join(
+          next.testDir,
+          '.next',
+          'static',
+          buildId,
+          '_offline-navigation-manifest.json'
+        ),
+        relativePath: `.next/static/${buildId}/_offline-navigation-manifest.json`,
+      },
     }
   }
 
-  it('emits a request-invariant fallback document when enabled', async () => {
+  it('emits request-invariant offline navigation artifacts when enabled', async () => {
     const buildResult = await next.build()
     expect(buildResult.exitCode).toBe(0)
 
-    const { buildId, relativePath } = await getFallbackDocumentPath()
-    const html = await next.readFile(relativePath)
+    const { buildId, fallbackDocument, manifest } =
+      await getOfflineNavigationArtifactPaths()
+    const html = await next.readFile(fallbackDocument.relativePath)
+    const manifestJson = JSON.parse(await next.readFile(manifest.relativePath))
 
     expect(html).toContain('data-next-offline-navigation-fallback')
     expect(html).toContain('id="__NEXT_OFFLINE_NAVIGATION_FALLBACK"')
     expect(html).toContain(`"buildId":"${buildId}"`)
     expect(html).toContain('self.__next_f')
-    expect(html).toContain('/_next/static/')
+    expect(html).toContain('https://cdn.example.com/app-assets/_next/static/')
     expect(html).not.toContain('offline navigations page')
+
+    expect(manifestJson).toEqual({
+      version: 1,
+      buildId,
+      basePath: '/docs',
+      assetPrefix: 'https://cdn.example.com/app-assets',
+      trailingSlash: true,
+      output: 'default',
+      scope: '/docs/',
+      cacheNamespace: `next-offline-navigation-v1:${buildId}:/docs`,
+      manifest: {
+        path: `static/${buildId}/_offline-navigation-manifest.json`,
+        href: `/docs/_next/static/${buildId}/_offline-navigation-manifest.json`,
+      },
+      fallbackDocument: {
+        path: `static/${buildId}/_offline-navigation-fallback.html`,
+        href: `/docs/_next/static/${buildId}/_offline-navigation-fallback.html`,
+      },
+    })
   })
 
-  it('does not emit a fallback document when disabled', async () => {
+  it('does not emit offline navigation artifacts when disabled', async () => {
     await next.patchFile('next.config.js', (content) =>
       content.replace('offlineNavigations: true', 'offlineNavigations: false')
     )
@@ -47,7 +80,9 @@ describe('offlineNavigations fallback document', () => {
     const buildResult = await next.build()
     expect(buildResult.exitCode).toBe(0)
 
-    const { absolutePath } = await getFallbackDocumentPath()
-    expect(existsSync(absolutePath)).toBe(false)
+    const { fallbackDocument, manifest } =
+      await getOfflineNavigationArtifactPaths()
+    expect(existsSync(fallbackDocument.absolutePath)).toBe(false)
+    expect(existsSync(manifest.absolutePath)).toBe(false)
   })
 })

--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -64,8 +64,13 @@ describe('offlineNavigations build artifacts', () => {
     expect(html).not.toContain('offline navigations page')
 
     expect(serviceWorkerScript).toContain(
+      `"cacheNamespace":"next-offline-navigation-v1:${buildId}:/docs"`
+    )
+    expect(serviceWorkerScript).toContain(
       `"manifestHref":"/docs/_next/static/${buildId}/_offline-navigation-manifest.json"`
     )
+    expect(serviceWorkerScript).toContain('cacheOfflineNavigationResources')
+    expect(serviceWorkerScript).toContain('caches.delete')
     expect(serviceWorkerScript).toContain('skipWaiting')
     expect(serviceWorkerScript).toContain('clients.claim')
     expect(serviceWorkerScript).not.toContain('respondWith')
@@ -98,6 +103,7 @@ describe('offlineNavigations build artifacts', () => {
     const buildResult = await next.build()
     expect(buildResult.exitCode).toBe(0)
 
+    const { buildId } = await getOfflineNavigationArtifactPaths()
     await next.start({ skipBuild: true })
 
     try {
@@ -138,10 +144,55 @@ describe('offlineNavigations build artifacts', () => {
         })
       })
 
+      const cacheState = await browser.eval(async () => {
+        const cacheNames = (await caches.keys()).filter((cacheName) =>
+          cacheName.startsWith('next-offline-navigation-v1:')
+        )
+        const entries: Array<{ cacheName: string; pathname: string }> = []
+
+        for (const cacheName of cacheNames) {
+          const cache = await caches.open(cacheName)
+          const requests = await cache.keys()
+
+          for (const request of requests) {
+            entries.push({
+              cacheName,
+              pathname: new URL(request.url).pathname,
+            })
+          }
+        }
+
+        return { cacheNames, entries }
+      })
+
+      const cacheName = `next-offline-navigation-v1:${buildId}:/docs`
+      expect(cacheState.cacheNames).toContain(cacheName)
+      expect(cacheState.entries).toEqual(
+        expect.arrayContaining([
+          {
+            cacheName,
+            pathname: `/docs/_next/static/${buildId}/_offline-navigation-manifest.json`,
+          },
+          {
+            cacheName,
+            pathname: `/docs/_next/static/${buildId}/_offline-navigation-fallback.html`,
+          },
+        ])
+      )
+
       await browser.eval(async () => {
         if (!('serviceWorker' in navigator)) {
           return
         }
+
+        const cacheNames = await caches.keys()
+        await Promise.all(
+          cacheNames
+            .filter((cacheName) =>
+              cacheName.startsWith('next-offline-navigation-v1:')
+            )
+            .map((cacheName) => caches.delete(cacheName))
+        )
 
         const registrations = await navigator.serviceWorker.getRegistrations()
         await Promise.all(

--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -1,0 +1,53 @@
+import { existsSync } from 'fs'
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+
+describe('offlineNavigations fallback document', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    skipStart: true,
+  })
+
+  async function getFallbackDocumentPath() {
+    const buildId = (await next.readFile('.next/BUILD_ID')).trim()
+
+    return {
+      buildId,
+      absolutePath: join(
+        next.testDir,
+        '.next',
+        'static',
+        buildId,
+        '_offline-navigation-fallback.html'
+      ),
+      relativePath: `.next/static/${buildId}/_offline-navigation-fallback.html`,
+    }
+  }
+
+  it('emits a request-invariant fallback document when enabled', async () => {
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    const { buildId, relativePath } = await getFallbackDocumentPath()
+    const html = await next.readFile(relativePath)
+
+    expect(html).toContain('data-next-offline-navigation-fallback')
+    expect(html).toContain('id="__NEXT_OFFLINE_NAVIGATION_FALLBACK"')
+    expect(html).toContain(`"buildId":"${buildId}"`)
+    expect(html).toContain('self.__next_f')
+    expect(html).toContain('/_next/static/')
+    expect(html).not.toContain('offline navigations page')
+  })
+
+  it('does not emit a fallback document when disabled', async () => {
+    await next.patchFile('next.config.js', (content) =>
+      content.replace('offlineNavigations: true', 'offlineNavigations: false')
+    )
+
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    const { absolutePath } = await getFallbackDocumentPath()
+    expect(existsSync(absolutePath)).toBe(false)
+  })
+})

--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -356,6 +356,30 @@ describe('offlineNavigations build artifacts', () => {
     })
   }
 
+  async function cleanupOfflineNavigationState(
+    browser: Awaited<ReturnType<typeof next.browser>>
+  ) {
+    await browser.eval(async () => {
+      if (!('serviceWorker' in navigator)) {
+        return
+      }
+
+      const cacheNames = await caches.keys()
+      await Promise.all(
+        cacheNames
+          .filter((cacheName) =>
+            cacheName.startsWith('next-offline-navigation-v1:')
+          )
+          .map((cacheName) => caches.delete(cacheName))
+      )
+
+      const registrations = await navigator.serviceWorker.getRegistrations()
+      await Promise.all(
+        registrations.map((registration) => registration.unregister())
+      )
+    })
+  }
+
   async function waitForOfflineNavigationServiceWorker(
     browser: Awaited<ReturnType<typeof next.browser>>,
     page: Playwright.Page
@@ -1217,6 +1241,163 @@ describe('offlineNavigations build artifacts', () => {
       )
       expect(missingSegmentResponse?.status()).toBe(200)
       await expectOfflineNavigationCacheMiss(browser, 'missing-segment')
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
+  it('misses hard-loaded request-sensitive URLs without cached router records', async () => {
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    await next.start({ skipBuild: true })
+
+    let page: Playwright.Page | undefined
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
+
+      await browser.eval(() => {
+        document.cookie = 'offline-session=alpha; path=/; SameSite=Lax'
+      })
+      const onlineResponse = await page!.goto(
+        `${next.url}/docs/request-sensitive/`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(onlineResponse?.status()).toBe(200)
+      await retry(async () => {
+        expect(await browser.elementById('request-sensitive-page').text()).toBe(
+          'request sensitive session: alpha'
+        )
+      })
+
+      await retry(async () => {
+        const segmentRecords =
+          await readPersistedOfflineNavigationSegmentRecords(browser)
+        expect(
+          segmentRecords.some((record) =>
+            record.key.includes('request-sensitive')
+          )
+        ).toBe(false)
+      })
+
+      await page!.context().setOffline(true)
+      const offlineResponse = await page!.goto(
+        `${next.url}/docs/request-sensitive/`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(offlineResponse?.status()).toBe(200)
+      await expectOfflineNavigationCacheMiss(browser, 'missing-segment')
+
+      await page!.context().setOffline(false)
+      await browser.eval(async () => {
+        window.dispatchEvent(new Event('online'))
+
+        const cacheNames = await caches.keys()
+        await Promise.all(
+          cacheNames
+            .filter((cacheName) =>
+              cacheName.startsWith('next-offline-navigation-v1:')
+            )
+            .map((cacheName) => caches.delete(cacheName))
+        )
+
+        const registrations = await navigator.serviceWorker.getRegistrations()
+        await Promise.all(
+          registrations.map((registration) => registration.unregister())
+        )
+      })
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
+  it('misses hard-loaded URL shape stress cases without complete router records', async () => {
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    await next.start({ skipBuild: true })
+
+    let page: Playwright.Page | undefined
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
+
+      const cachedUrl = `${next.url}/docs/url-stress/space%20value/?token=a%2Bb&tag=one&tag=two#section-1`
+      const onlineResponse = await page!.goto(cachedUrl, {
+        waitUntil: 'domcontentloaded',
+      })
+      expect(onlineResponse?.status()).toBe(200)
+      await retry(async () => {
+        expect(await browser.elementById('url-stress-page').text()).toBe(
+          'url stress path: space%20value'
+        )
+        expect(await browser.elementById('url-stress-token').text()).toBe(
+          'url stress token: a+b'
+        )
+        expect(await browser.elementById('url-stress-tags').text()).toBe(
+          'url stress tags: one,two'
+        )
+        expect(await browser.elementById('url-stress-hash').text()).toBe(
+          'url stress hash: #section-1'
+        )
+      })
+
+      await retry(async () => {
+        const routeRecords =
+          await readPersistedOfflineNavigationRouteRecords(browser)
+        expect(
+          routeRecords.some((record) =>
+            record.route.pathname.includes('/url-stress')
+          )
+        ).toBe(true)
+
+        const segmentRecords =
+          await readPersistedOfflineNavigationSegmentRecords(browser)
+        expect(
+          segmentRecords.some((record) => record.key.includes('url-stress'))
+        ).toBe(false)
+      })
+
+      const rootResponse = await page!.goto(`${next.url}/docs/`, {
+        waitUntil: 'domcontentloaded',
+      })
+      expect(rootResponse?.status()).toBe(200)
+
+      await next.stop()
+      await page!.context().setOffline(true)
+      const offlineResponse = await page!.goto(cachedUrl, {
+        waitUntil: 'domcontentloaded',
+      })
+      expect(offlineResponse?.status()).toBe(200)
+      await expectOfflineNavigationCacheMiss(browser, 'missing-segment')
+
+      const reorderedSearchResponse = await page!.goto(
+        `${next.url}/docs/url-stress/space%20value/?tag=one&tag=two&token=a%2Bb#section-3`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(reorderedSearchResponse?.status()).toBe(200)
+      await expectOfflineNavigationCacheMiss(browser, 'missing-segment')
+
+      await page!.context().setOffline(false)
+      await browser.eval(() => {
+        window.dispatchEvent(new Event('online'))
+      })
+      await cleanupOfflineNavigationState(browser)
     } finally {
       if (page) {
         await page.context().setOffline(false)

--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -304,6 +304,58 @@ describe('offlineNavigations build artifacts', () => {
     }, options)
   }
 
+  async function prefetchDynamicPatternReplayData(
+    browser: Awaited<ReturnType<typeof next.browser>>
+  ) {
+    await browser.elementById('prefetch-dynamic-pattern-source').click()
+    await retry(async () => {
+      const routeRecords =
+        await readPersistedOfflineNavigationRouteRecords(browser)
+      expect(
+        routeRecords.some((record) =>
+          record.route.pathname.includes('/dynamic-prefetch/learned')
+        )
+      ).toBe(true)
+    })
+
+    await browser.elementById('prefetch-dynamic-pattern-target').click()
+    await retry(async () => {
+      const routeRecords =
+        await readPersistedOfflineNavigationRouteRecords(browser)
+      expect(
+        routeRecords.some((record) =>
+          record.route.pathname.includes('/dynamic-prefetch/learned')
+        )
+      ).toBe(true)
+      expect(
+        routeRecords.some((record) =>
+          record.route.pathname.includes('/dynamic-prefetch/replayed')
+        )
+      ).toBe(false)
+
+      const segmentRecords =
+        await readPersistedOfflineNavigationSegmentRecords(browser)
+      const replayedSegmentRecords = segmentRecords.filter((record) =>
+        record.key.includes('replayed')
+      )
+      expect(
+        segmentRecords.some(
+          (record) => record.payload.requestKind === 'segment-prefetch'
+        )
+      ).toBe(true)
+      expect(
+        replayedSegmentRecords.some((record) =>
+          record.segment.requestKey.endsWith('/__PAGE__')
+        )
+      ).toBe(true)
+      expect(
+        replayedSegmentRecords.some(
+          (record) => record.segment.requestKey === '/_head'
+        )
+      ).toBe(true)
+    })
+  }
+
   async function waitForOfflineNavigationServiceWorker(
     browser: Awaited<ReturnType<typeof next.browser>>,
     page: Playwright.Page
@@ -1077,6 +1129,94 @@ describe('offlineNavigations build artifacts', () => {
       )
       expect(invalidatedRouterRecordsResponse?.status()).toBe(200)
       await expectOfflineNavigationCacheMiss(browser, 'missing-route')
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
+  it('replays a dynamic route from persisted known route patterns', async () => {
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    await next.start({ skipBuild: true })
+
+    let page: Playwright.Page | undefined
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
+
+      await prefetchDynamicPatternReplayData(browser)
+
+      await next.stop()
+      await page!.context().setOffline(true)
+      const dynamicReplayResponse = await page!.goto(
+        `${next.url}/docs/dynamic-prefetch/replayed#restored`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(dynamicReplayResponse?.status()).toBe(200)
+      await retry(async () => {
+        expect(await browser.elementById('dynamic-prefetch-page').text()).toBe(
+          'dynamic prefetch path: replayed'
+        )
+      })
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
+  it('misses dynamic route pattern replay when a required segment record is missing', async () => {
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    await next.start({ skipBuild: true })
+
+    let page: Playwright.Page | undefined
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
+
+      await prefetchDynamicPatternReplayData(browser)
+
+      const deletedSegments =
+        await deletePersistedOfflineNavigationSegmentRecords(browser, {
+          keySubstring: 'replayed',
+          requestKeySuffix: '/__PAGE__',
+        })
+      expect(deletedSegments).toBeGreaterThan(0)
+      await retry(async () => {
+        const segmentRecords =
+          await readPersistedOfflineNavigationSegmentRecords(browser)
+        expect(
+          segmentRecords.some(
+            (record) =>
+              record.key.includes('replayed') &&
+              record.segment.requestKey.endsWith('/__PAGE__')
+          )
+        ).toBe(false)
+      })
+
+      await next.stop()
+      await page!.context().setOffline(true)
+      const missingSegmentResponse = await page!.goto(
+        `${next.url}/docs/dynamic-prefetch/replayed#missing-segment`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(missingSegmentResponse?.status()).toBe(200)
+      await expectOfflineNavigationCacheMiss(browser, 'missing-segment')
     } finally {
       if (page) {
         await page.context().setOffline(false)

--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -1,6 +1,7 @@
 import { existsSync } from 'fs'
 import { join } from 'path'
 import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
 
 describe('offlineNavigations build artifacts', () => {
   const { next } = nextTestSetup({
@@ -23,6 +24,15 @@ describe('offlineNavigations build artifacts', () => {
         ),
         relativePath: `.next/static/${buildId}/_offline-navigation-fallback.html`,
       },
+      serviceWorker: {
+        absolutePath: join(
+          next.testDir,
+          '.next',
+          'static',
+          '_offline-navigation-service-worker.js'
+        ),
+        relativePath: `.next/static/_offline-navigation-service-worker.js`,
+      },
       manifest: {
         absolutePath: join(
           next.testDir,
@@ -40,23 +50,31 @@ describe('offlineNavigations build artifacts', () => {
     const buildResult = await next.build()
     expect(buildResult.exitCode).toBe(0)
 
-    const { buildId, fallbackDocument, manifest } =
+    const { buildId, fallbackDocument, manifest, serviceWorker } =
       await getOfflineNavigationArtifactPaths()
     const html = await next.readFile(fallbackDocument.relativePath)
     const manifestJson = JSON.parse(await next.readFile(manifest.relativePath))
+    const serviceWorkerScript = await next.readFile(serviceWorker.relativePath)
 
     expect(html).toContain('data-next-offline-navigation-fallback')
     expect(html).toContain('id="__NEXT_OFFLINE_NAVIGATION_FALLBACK"')
     expect(html).toContain(`"buildId":"${buildId}"`)
     expect(html).toContain('self.__next_f')
-    expect(html).toContain('https://cdn.example.com/app-assets/_next/static/')
+    expect(html).toContain('/app-assets/_next/static/')
     expect(html).not.toContain('offline navigations page')
+
+    expect(serviceWorkerScript).toContain(
+      `"manifestHref":"/docs/_next/static/${buildId}/_offline-navigation-manifest.json"`
+    )
+    expect(serviceWorkerScript).toContain('skipWaiting')
+    expect(serviceWorkerScript).toContain('clients.claim')
+    expect(serviceWorkerScript).not.toContain('respondWith')
 
     expect(manifestJson).toEqual({
       version: 1,
       buildId,
       basePath: '/docs',
-      assetPrefix: 'https://cdn.example.com/app-assets',
+      assetPrefix: '/app-assets',
       trailingSlash: true,
       output: 'default',
       scope: '/docs/',
@@ -69,7 +87,70 @@ describe('offlineNavigations build artifacts', () => {
         path: `static/${buildId}/_offline-navigation-fallback.html`,
         href: `/docs/_next/static/${buildId}/_offline-navigation-fallback.html`,
       },
+      serviceWorker: {
+        path: `static/_offline-navigation-service-worker.js`,
+        href: `/docs/_next/static/_offline-navigation-service-worker.js`,
+      },
     })
+  })
+
+  it('registers the pass-through service worker when enabled', async () => {
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    await next.start({ skipBuild: true })
+
+    try {
+      const swResponse = await next.fetch(
+        `/docs/_next/static/_offline-navigation-service-worker.js${next.getDeploymentIdQuery()}`
+      )
+      expect(swResponse.status).toBe(200)
+      expect(swResponse.headers.get('cache-control')).toBe(
+        'no-cache, must-revalidate'
+      )
+      expect(swResponse.headers.get('service-worker-allowed')).toBe('/docs/')
+
+      const browser = await next.browser('/docs')
+      await retry(async () => {
+        const registration = await browser.eval(async () => {
+          if (!('serviceWorker' in navigator)) {
+            return null
+          }
+
+          const registrations = await navigator.serviceWorker.getRegistrations()
+          const registration = registrations.find((registration) =>
+            registration.scope.endsWith('/docs/')
+          )
+
+          if (!registration) {
+            return null
+          }
+
+          return {
+            scope: registration.scope,
+            scriptURL: registration.active?.scriptURL ?? null,
+          }
+        })
+
+        expect(registration).toEqual({
+          scope: `${next.url}/docs/`,
+          scriptURL: `${next.url}/docs/_next/static/_offline-navigation-service-worker.js${next.getDeploymentIdQuery()}`,
+        })
+      })
+
+      await browser.eval(async () => {
+        if (!('serviceWorker' in navigator)) {
+          return
+        }
+
+        const registrations = await navigator.serviceWorker.getRegistrations()
+        await Promise.all(
+          registrations.map((registration) => registration.unregister())
+        )
+      })
+    } finally {
+      await next.stop()
+    }
   })
 
   it('does not emit offline navigation artifacts when disabled', async () => {
@@ -80,9 +161,10 @@ describe('offlineNavigations build artifacts', () => {
     const buildResult = await next.build()
     expect(buildResult.exitCode).toBe(0)
 
-    const { fallbackDocument, manifest } =
+    const { fallbackDocument, manifest, serviceWorker } =
       await getOfflineNavigationArtifactPaths()
     expect(existsSync(fallbackDocument.absolutePath)).toBe(false)
     expect(existsSync(manifest.absolutePath)).toBe(false)
+    expect(existsSync(serviceWorker.absolutePath)).toBe(false)
   })
 })

--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -1,4 +1,4 @@
-import { existsSync } from 'fs'
+import { existsSync, readdirSync, readFileSync, statSync } from 'fs'
 import { join } from 'path'
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
@@ -50,6 +50,348 @@ describe('offlineNavigations build artifacts', () => {
     }
   }
 
+  function getStaticClientChunkFiles(directory: string): string[] {
+    if (!existsSync(directory)) {
+      return []
+    }
+
+    return readdirSync(directory).flatMap((entry) => {
+      const absolutePath = join(directory, entry)
+      const stat = statSync(absolutePath)
+      if (stat.isDirectory()) {
+        return getStaticClientChunkFiles(absolutePath)
+      }
+      return absolutePath.endsWith('.js') ? [absolutePath] : []
+    })
+  }
+
+  function getStaticClientChunkForbiddenMatches(
+    directory: string,
+    forbidden: string[]
+  ): Array<{ file: string; token: string; snippet: string }> {
+    const matches: Array<{ file: string; token: string; snippet: string }> = []
+    for (const file of getStaticClientChunkFiles(directory)) {
+      const contents = readFileSync(file, 'utf8')
+      for (const token of forbidden) {
+        const index = contents.indexOf(token)
+        if (index === -1) {
+          continue
+        }
+        matches.push({
+          file,
+          token,
+          snippet: contents.slice(
+            Math.max(0, index - 120),
+            Math.min(contents.length, index + token.length + 120)
+          ),
+        })
+      }
+    }
+    return matches
+  }
+
+  async function readPersistedOfflineNavigationRouteRecords(
+    browser: Awaited<ReturnType<typeof next.browser>>
+  ) {
+    return browser.eval(async () => {
+      const database = await new Promise<IDBDatabase>((resolve, reject) => {
+        const request = indexedDB.open('next-offline-navigation-cache', 1)
+        request.onupgradeneeded = () => {
+          const database = request.result
+          if (!database.objectStoreNames.contains('route-data')) {
+            database.createObjectStore('route-data', {
+              keyPath: ['buildId', 'key'],
+            })
+          }
+          if (!database.objectStoreNames.contains('segment-data')) {
+            database.createObjectStore('segment-data', {
+              keyPath: ['buildId', 'key'],
+            })
+          }
+          if (!database.objectStoreNames.contains('metadata')) {
+            database.createObjectStore('metadata')
+          }
+        }
+        request.onsuccess = () => resolve(request.result)
+        request.onerror = () => reject(request.error)
+      })
+
+      try {
+        const entries = await new Promise<any[]>((resolve, reject) => {
+          const transaction = database.transaction('route-data', 'readonly')
+          const request = transaction.objectStore('route-data').getAll()
+          request.onsuccess = () => resolve(request.result)
+          request.onerror = () => reject(request.error)
+        })
+
+        return entries.map((entry) => ({
+          buildId: entry.buildId,
+          cacheEpoch: entry.cacheEpoch,
+          expiresAt: entry.expiresAt,
+          hasMetadata: entry.metadata !== null,
+          hasTree: entry.tree !== null,
+          key: entry.key,
+          kind: entry.kind,
+          route: entry.route,
+          routeVaryPath: entry.routeVaryPath,
+          staleAt: entry.staleAt,
+          version: entry.version,
+        }))
+      } finally {
+        database.close()
+      }
+    })
+  }
+
+  async function readPersistedOfflineNavigationSegmentRecords(
+    browser: Awaited<ReturnType<typeof next.browser>>
+  ) {
+    return browser.eval(async () => {
+      const database = await new Promise<IDBDatabase>((resolve, reject) => {
+        const request = indexedDB.open('next-offline-navigation-cache', 1)
+        request.onupgradeneeded = () => {
+          const database = request.result
+          if (!database.objectStoreNames.contains('route-data')) {
+            database.createObjectStore('route-data', {
+              keyPath: ['buildId', 'key'],
+            })
+          }
+          if (!database.objectStoreNames.contains('segment-data')) {
+            database.createObjectStore('segment-data', {
+              keyPath: ['buildId', 'key'],
+            })
+          }
+          if (!database.objectStoreNames.contains('metadata')) {
+            database.createObjectStore('metadata')
+          }
+        }
+        request.onsuccess = () => resolve(request.result)
+        request.onerror = () => reject(request.error)
+      })
+
+      try {
+        const entries = await new Promise<any[]>((resolve, reject) => {
+          const transaction = database.transaction('segment-data', 'readonly')
+          const request = transaction.objectStore('segment-data').getAll()
+          request.onsuccess = () => resolve(request.result)
+          request.onerror = () => reject(request.error)
+        })
+
+        return entries.map((entry) => ({
+          buildId: entry.buildId,
+          cacheEpoch: entry.cacheEpoch,
+          expiresAt: entry.expiresAt,
+          key: entry.key,
+          kind: entry.kind,
+          payload: {
+            bodyLength: entry.payload?.body?.byteLength,
+            kind: entry.payload?.kind,
+            requestKind: entry.payload?.requestKind,
+            status: entry.payload?.status,
+          },
+          segment: entry.segment,
+          segmentVaryPath: entry.segmentVaryPath,
+          staleAt: entry.staleAt,
+          version: entry.version,
+        }))
+      } finally {
+        database.close()
+      }
+    })
+  }
+
+  async function readPersistedOfflineNavigationMetadata(
+    browser: Awaited<ReturnType<typeof next.browser>>,
+    key: string
+  ) {
+    return browser.eval(async (metadataKey) => {
+      const database = await new Promise<IDBDatabase>((resolve, reject) => {
+        const request = indexedDB.open('next-offline-navigation-cache', 1)
+        request.onupgradeneeded = () => {
+          const database = request.result
+          if (!database.objectStoreNames.contains('route-data')) {
+            database.createObjectStore('route-data', {
+              keyPath: ['buildId', 'key'],
+            })
+          }
+          if (!database.objectStoreNames.contains('segment-data')) {
+            database.createObjectStore('segment-data', {
+              keyPath: ['buildId', 'key'],
+            })
+          }
+          if (!database.objectStoreNames.contains('metadata')) {
+            database.createObjectStore('metadata')
+          }
+        }
+        request.onsuccess = () => resolve(request.result)
+        request.onerror = () => reject(request.error)
+      })
+
+      try {
+        return await new Promise<unknown>((resolve, reject) => {
+          const transaction = database.transaction('metadata', 'readonly')
+          const request = transaction.objectStore('metadata').get(metadataKey)
+          request.onsuccess = () => resolve(request.result)
+          request.onerror = () => reject(request.error)
+        })
+      } finally {
+        database.close()
+      }
+    }, key)
+  }
+
+  async function deletePersistedOfflineNavigationSegmentRecords(
+    browser: Awaited<ReturnType<typeof next.browser>>,
+    options: {
+      keySubstring: string
+      requestKeySuffix: string
+    }
+  ) {
+    return browser.eval(async ({ keySubstring, requestKeySuffix }) => {
+      const database = await new Promise<IDBDatabase>((resolve, reject) => {
+        const request = indexedDB.open('next-offline-navigation-cache', 1)
+        request.onupgradeneeded = () => {
+          const database = request.result
+          if (!database.objectStoreNames.contains('route-data')) {
+            database.createObjectStore('route-data', {
+              keyPath: ['buildId', 'key'],
+            })
+          }
+          if (!database.objectStoreNames.contains('segment-data')) {
+            database.createObjectStore('segment-data', {
+              keyPath: ['buildId', 'key'],
+            })
+          }
+          if (!database.objectStoreNames.contains('metadata')) {
+            database.createObjectStore('metadata')
+          }
+        }
+        request.onsuccess = () => resolve(request.result)
+        request.onerror = () => reject(request.error)
+      })
+
+      try {
+        const entries = await new Promise<any[]>((resolve, reject) => {
+          const transaction = database.transaction('segment-data', 'readonly')
+          const request = transaction.objectStore('segment-data').getAll()
+          request.onsuccess = () => resolve(request.result)
+          request.onerror = () => reject(request.error)
+        })
+        const matchingEntries = entries.filter(
+          (entry) =>
+            entry.key.includes(keySubstring) &&
+            entry.segment.requestKey.endsWith(requestKeySuffix)
+        )
+
+        if (matchingEntries.length === 0) {
+          return 0
+        }
+
+        const transaction = database.transaction('segment-data', 'readwrite')
+        const store = transaction.objectStore('segment-data')
+        for (const entry of matchingEntries) {
+          store.delete([entry.buildId, entry.key])
+        }
+        await new Promise<void>((resolve, reject) => {
+          transaction.oncomplete = () => resolve()
+          transaction.onerror = () => reject(transaction.error)
+          transaction.onabort = () => reject(transaction.error)
+        })
+        return matchingEntries.length
+      } finally {
+        database.close()
+      }
+    }, options)
+  }
+
+  async function waitForOfflineNavigationServiceWorker(
+    browser: Awaited<ReturnType<typeof next.browser>>,
+    page: Playwright.Page
+  ) {
+    await retry(
+      async () => {
+        const state = await browser.eval(async () => {
+          if (!('serviceWorker' in navigator)) {
+            return {
+              controlled: false,
+              hasActiveRegistration: false,
+            }
+          }
+
+          const registrations = await navigator.serviceWorker.getRegistrations()
+          return {
+            controlled: Boolean(navigator.serviceWorker.controller),
+            hasActiveRegistration: registrations.some(
+              (registration) =>
+                registration.scope.endsWith('/docs/') &&
+                registration.active !== null
+            ),
+          }
+        })
+
+        expect(state.hasActiveRegistration).toBe(true)
+      },
+      10000,
+      500
+    )
+
+    if (
+      !(await browser.eval(() => Boolean(navigator.serviceWorker.controller)))
+    ) {
+      await page.reload({ waitUntil: 'domcontentloaded' })
+    }
+
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(() => Boolean(navigator.serviceWorker.controller))
+        ).toBe(true)
+      },
+      10000,
+      500
+    )
+  }
+
+  async function expectOfflineNavigationCacheMiss(
+    browser: Awaited<ReturnType<typeof next.browser>>,
+    reason: string
+  ) {
+    await retry(async () => {
+      expect(
+        await browser.eval(() => {
+          const cacheMiss = document.getElementById(
+            '__NEXT_OFFLINE_NAVIGATION_CACHE_MISS'
+          )
+          return {
+            cache: document.documentElement.getAttribute(
+              'data-next-offline-navigation-cache'
+            ),
+            reason: document.documentElement.getAttribute(
+              'data-next-offline-navigation-cache-reason'
+            ),
+            miss: cacheMiss
+              ? {
+                  hidden: cacheMiss.hidden,
+                  reason: cacheMiss.getAttribute(
+                    'data-next-offline-navigation-cache-reason'
+                  ),
+                  text: cacheMiss.textContent,
+                }
+              : null,
+          }
+        })
+      ).toEqual({
+        cache: 'miss',
+        reason,
+        miss: {
+          hidden: false,
+          reason,
+          text: 'This page is not available offline.',
+        },
+      })
+    })
+  }
+
   it('emits request-invariant offline navigation artifacts when enabled', async () => {
     const buildResult = await next.build()
     expect(buildResult.exitCode).toBe(0)
@@ -62,7 +404,11 @@ describe('offlineNavigations build artifacts', () => {
 
     expect(html).toContain('data-next-offline-navigation-fallback')
     expect(html).toContain('id="__NEXT_OFFLINE_NAVIGATION_FALLBACK"')
+    expect(html).toContain('id="__NEXT_OFFLINE_NAVIGATION_CACHE_MISS"')
     expect(html).toContain(`"buildId":"${buildId}"`)
+    if (next.deploymentId) {
+      expect(html).toContain(`data-dpl-id="${next.deploymentId}"`)
+    }
     expect(html).toContain('self.__next_f')
     expect(html).toContain('/app-assets/_next/static/')
     expect(html).not.toContain('offline navigations page')
@@ -113,6 +459,7 @@ describe('offlineNavigations build artifacts', () => {
     expect(buildResult.exitCode).toBe(0)
 
     const { buildId } = await getOfflineNavigationArtifactPaths()
+    const navigationBuildId = next.deploymentId ?? buildId
     await next.start({ skipBuild: true })
 
     let page: Playwright.Page | undefined
@@ -157,11 +504,7 @@ describe('offlineNavigations build artifacts', () => {
           scriptURL: `${next.url}/docs/_next/static/_offline-navigation-service-worker.js${next.getDeploymentIdQuery()}`,
         })
       })
-      await retry(async () => {
-        expect(
-          await browser.eval(() => Boolean(navigator.serviceWorker.controller))
-        ).toBe(true)
-      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
       expect(await browser.elementById('offline-status').text()).toBe('online')
 
       await browser.eval((messageType) => {
@@ -202,18 +545,6 @@ describe('offlineNavigations build artifacts', () => {
         )
       })
 
-      await browser.eval((messageType) => {
-        localStorage.removeItem('__nextOfflineNavigationMessage')
-        navigator.serviceWorker.addEventListener('message', (event) => {
-          if (event.data?.type === messageType) {
-            localStorage.setItem(
-              '__nextOfflineNavigationMessage',
-              JSON.stringify(event.data)
-            )
-          }
-        })
-      }, OFFLINE_NAVIGATION_FALLBACK_SERVED)
-
       const cacheState = await browser.eval(async () => {
         const cacheNames = (await caches.keys()).filter((cacheName) =>
           cacheName.startsWith('next-offline-navigation-v1:')
@@ -250,7 +581,116 @@ describe('offlineNavigations build artifacts', () => {
         ])
       )
 
+      await browser.eval((messageType) => {
+        localStorage.removeItem('__nextOfflineNavigationMessage')
+        navigator.serviceWorker.addEventListener('message', (event) => {
+          if (event.data?.type === messageType) {
+            localStorage.setItem(
+              '__nextOfflineNavigationMessage',
+              JSON.stringify(event.data)
+            )
+          }
+        })
+      }, OFFLINE_NAVIGATION_FALLBACK_SERVED)
+
+      await browser.elementById('prefetch-offline-navigation').click()
+      await retry(async () => {
+        const routeRecords =
+          await readPersistedOfflineNavigationRouteRecords(browser)
+        const prefetchedRouteRecord = routeRecords.find((record) =>
+          record.route.pathname.includes('/prefetched')
+        )
+        expect(prefetchedRouteRecord).toEqual(
+          expect.objectContaining({
+            buildId: navigationBuildId,
+            cacheEpoch: 0,
+            hasMetadata: true,
+            hasTree: true,
+            kind: 'route',
+            route: expect.objectContaining({
+              supportsPerSegmentPrefetching: true,
+            }),
+            routeVaryPath: expect.any(Array),
+            version: 1,
+          })
+        )
+      })
+      await retry(async () => {
+        const segmentRecords =
+          await readPersistedOfflineNavigationSegmentRecords(browser)
+        const headRecord = segmentRecords.find(
+          (record) => record.segment.requestKey === '/_head'
+        )
+        const pageRecord = segmentRecords.find(
+          (record) =>
+            record.segment.requestKey !== '/_head' &&
+            record.payload.requestKind === 'segment-prefetch'
+        )
+
+        expect(headRecord).toEqual(
+          expect.objectContaining({
+            buildId: navigationBuildId,
+            cacheEpoch: 0,
+            kind: 'segment',
+            payload: {
+              bodyLength: expect.any(Number),
+              kind: 'rsc-response',
+              requestKind: 'segment-prefetch',
+              status: 200,
+            },
+            segment: expect.objectContaining({
+              fetchStrategy: expect.any(Number),
+              isPartial: expect.any(Boolean),
+              payloadIndex: expect.any(Number),
+              requestKey: '/_head',
+            }),
+            segmentVaryPath: expect.any(Array),
+            version: 1,
+          })
+        )
+        expect(headRecord!.payload.bodyLength).toBeGreaterThan(0)
+
+        expect(pageRecord).toEqual(
+          expect.objectContaining({
+            buildId: navigationBuildId,
+            cacheEpoch: 0,
+            kind: 'segment',
+            payload: {
+              bodyLength: expect.any(Number),
+              kind: 'rsc-response',
+              requestKind: 'segment-prefetch',
+              status: 200,
+            },
+            segment: expect.objectContaining({
+              payloadIndex: expect.any(Number),
+            }),
+            segmentVaryPath: expect.any(Array),
+            version: 1,
+          })
+        )
+        expect(pageRecord!.payload.bodyLength).toBeGreaterThan(0)
+      })
+
       await page!.context().setOffline(true)
+      const cachedOfflineResponse = await page!.goto(
+        `${next.url}/docs/prefetched`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(cachedOfflineResponse?.status()).toBe(200)
+      await retry(async () => {
+        expect(await browser.elementById('prefetched-page').text()).toBe(
+          'prefetched page'
+        )
+      })
+      expect(await browser.elementById('offline-status').text()).toBe('offline')
+      const cachedServiceWorkerMessage = await browser.eval(() => {
+        const message = localStorage.getItem('__nextOfflineNavigationMessage')
+        return message === null ? null : JSON.parse(message)
+      })
+      expect(cachedServiceWorkerMessage).toEqual({
+        type: OFFLINE_NAVIGATION_FALLBACK_SERVED,
+      })
+
       const nonNavigationResult = await browser.eval(async () => {
         try {
           await fetch('/docs?__next_offline_probe=1', {
@@ -263,6 +703,7 @@ describe('offlineNavigations build artifacts', () => {
       })
       expect(nonNavigationResult).toBe('rejected')
 
+      await next.stop()
       const offlineResponse = await page!.goto(
         `${next.url}/docs/offline-navigation-cache-miss`,
         { waitUntil: 'domcontentloaded' }
@@ -275,16 +716,7 @@ describe('offlineNavigations build artifacts', () => {
           )
         )
       ).toBe(true)
-      const serviceWorkerMessage = await browser.eval(() => {
-        const message = localStorage.getItem('__nextOfflineNavigationMessage')
-        return message === null ? null : JSON.parse(message)
-      })
-      expect(serviceWorkerMessage).toMatchObject({
-        type: OFFLINE_NAVIGATION_FALLBACK_SERVED,
-        buildId,
-        reason: 'network-error',
-        url: `${next.url}/docs/offline-navigation-cache-miss`,
-      })
+      await expectOfflineNavigationCacheMiss(browser, 'missing-route')
       await page!.context().setOffline(false)
 
       await browser.eval(async () => {
@@ -314,6 +746,345 @@ describe('offlineNavigations build artifacts', () => {
     }
   })
 
+  it('reconstructs a fully prefetched route from persisted router records', async () => {
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    await next.start({ skipBuild: true })
+
+    let page: Playwright.Page | undefined
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
+
+      await browser.elementById('prefetch-offline-navigation').click()
+      await retry(async () => {
+        const routeRecords =
+          await readPersistedOfflineNavigationRouteRecords(browser)
+        expect(
+          routeRecords.some((record) =>
+            record.route.pathname.includes('/prefetched')
+          )
+        ).toBe(true)
+
+        const segmentRecords =
+          await readPersistedOfflineNavigationSegmentRecords(browser)
+        expect(
+          segmentRecords.some(
+            (record) => record.payload.requestKind === 'segment-prefetch'
+          )
+        ).toBe(true)
+        expect(
+          segmentRecords.some(
+            (record) => record.segment.requestKey === '/_head'
+          )
+        ).toBe(true)
+      })
+
+      await next.stop()
+      await page!.context().setOffline(true)
+      const routerCacheOnlyResponse = await page!.goto(
+        `${next.url}/docs/prefetched`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(routerCacheOnlyResponse?.status()).toBe(200)
+      await retry(async () => {
+        expect(await browser.elementById('prefetched-page').text()).toBe(
+          'prefetched page'
+        )
+      })
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
+  it('misses persisted router records when a required head record is missing during fallback boot', async () => {
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    await next.start({ skipBuild: true })
+
+    let page: Playwright.Page | undefined
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
+
+      await browser.elementById('prefetch-offline-navigation').click()
+      await retry(async () => {
+        const routeRecords =
+          await readPersistedOfflineNavigationRouteRecords(browser)
+        expect(
+          routeRecords.some((record) =>
+            record.route.pathname.includes('/prefetched')
+          )
+        ).toBe(true)
+
+        const segmentRecords =
+          await readPersistedOfflineNavigationSegmentRecords(browser)
+        expect(
+          segmentRecords.some(
+            (record) =>
+              record.key.includes('prefetched') &&
+              record.segment.requestKey.endsWith('/__PAGE__')
+          )
+        ).toBe(true)
+        expect(
+          segmentRecords.some(
+            (record) => record.segment.requestKey === '/_head'
+          )
+        ).toBe(true)
+      })
+
+      const deletedHeadRecords =
+        await deletePersistedOfflineNavigationSegmentRecords(browser, {
+          keySubstring: '',
+          requestKeySuffix: '/_head',
+        })
+      expect(deletedHeadRecords).toBeGreaterThan(0)
+      await retry(async () => {
+        const routeRecords =
+          await readPersistedOfflineNavigationRouteRecords(browser)
+        expect(
+          routeRecords.some((record) =>
+            record.route.pathname.includes('/prefetched')
+          )
+        ).toBe(true)
+
+        const segmentRecords =
+          await readPersistedOfflineNavigationSegmentRecords(browser)
+        expect(
+          segmentRecords.some(
+            (record) =>
+              record.key.includes('prefetched') &&
+              record.segment.requestKey.endsWith('/__PAGE__')
+          )
+        ).toBe(true)
+        expect(
+          segmentRecords.some(
+            (record) => record.segment.requestKey === '/_head'
+          )
+        ).toBe(false)
+      })
+
+      await next.stop()
+      await page!.context().setOffline(true)
+      const missingHeadResponse = await page!.goto(
+        `${next.url}/docs/prefetched`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(missingHeadResponse?.status()).toBe(200)
+
+      await expectOfflineNavigationCacheMiss(browser, 'missing-head')
+      expect(
+        await browser.eval(() =>
+          Boolean(document.getElementById('prefetched-page'))
+        )
+      ).toBe(false)
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
+  it('misses persisted router records after router refresh invalidation', async () => {
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    await next.start({ skipBuild: true })
+
+    let page: Playwright.Page | undefined
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
+
+      await browser.elementById('prefetch-offline-navigation').click()
+      await retry(async () => {
+        const routeRecords =
+          await readPersistedOfflineNavigationRouteRecords(browser)
+        expect(
+          routeRecords.some((record) =>
+            record.route.pathname.includes('/prefetched')
+          )
+        ).toBe(true)
+
+        const segmentRecords =
+          await readPersistedOfflineNavigationSegmentRecords(browser)
+        expect(
+          segmentRecords.some(
+            (record) => record.payload.requestKind === 'segment-prefetch'
+          )
+        ).toBe(true)
+        expect(
+          segmentRecords.some(
+            (record) => record.segment.requestKey === '/_head'
+          )
+        ).toBe(true)
+      })
+
+      await page!.context().setOffline(true)
+      const cachedRouterRecordsResponse = await page!.goto(
+        `${next.url}/docs/prefetched`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(cachedRouterRecordsResponse?.status()).toBe(200)
+      await retry(async () => {
+        expect(await browser.elementById('prefetched-page').text()).toBe(
+          'prefetched page'
+        )
+      })
+
+      await page!.context().setOffline(false)
+      await browser.eval(() => {
+        window.dispatchEvent(new Event('online'))
+      })
+      const onlineRootResponse = await page!.goto(`${next.url}/docs`, {
+        waitUntil: 'domcontentloaded',
+      })
+      expect(onlineRootResponse?.status()).toBe(200)
+      await retry(async () => {
+        expect(await browser.elementByCss('p').text()).toBe(
+          'offline navigations page'
+        )
+      })
+
+      await browser.elementById('refresh-offline-navigation').click()
+      await retry(async () => {
+        expect(
+          await readPersistedOfflineNavigationMetadata(
+            browser,
+            'segment-cache-epoch'
+          )
+        ).toBeGreaterThan(0)
+      })
+
+      await page!.context().setOffline(true)
+      const invalidatedRouterRecordsResponse = await page!.goto(
+        `${next.url}/docs/prefetched`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(invalidatedRouterRecordsResponse?.status()).toBe(200)
+      await expectOfflineNavigationCacheMiss(browser, 'missing-segment')
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
+  it('misses persisted router records after server action invalidation', async () => {
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    await next.start({ skipBuild: true })
+
+    let page: Playwright.Page | undefined
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
+
+      await browser.elementById('prefetch-offline-navigation').click()
+      await retry(async () => {
+        const routeRecords =
+          await readPersistedOfflineNavigationRouteRecords(browser)
+        expect(
+          routeRecords.some((record) =>
+            record.route.pathname.includes('/prefetched')
+          )
+        ).toBe(true)
+
+        const segmentRecords =
+          await readPersistedOfflineNavigationSegmentRecords(browser)
+        expect(
+          segmentRecords.some(
+            (record) => record.payload.requestKind === 'segment-prefetch'
+          )
+        ).toBe(true)
+        expect(
+          segmentRecords.some(
+            (record) => record.segment.requestKey === '/_head'
+          )
+        ).toBe(true)
+      })
+
+      await page!.context().setOffline(true)
+      const cachedRouterRecordsResponse = await page!.goto(
+        `${next.url}/docs/prefetched`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(cachedRouterRecordsResponse?.status()).toBe(200)
+      await retry(async () => {
+        expect(await browser.elementById('prefetched-page').text()).toBe(
+          'prefetched page'
+        )
+      })
+
+      await page!.context().setOffline(false)
+      await browser.eval(() => {
+        window.dispatchEvent(new Event('online'))
+      })
+      const onlineRootResponse = await page!.goto(`${next.url}/docs`, {
+        waitUntil: 'domcontentloaded',
+      })
+      expect(onlineRootResponse?.status()).toBe(200)
+      await retry(async () => {
+        expect(
+          await browser.elementById('action-invalidation-marker').text()
+        ).toBe('action invalidation marker')
+      })
+
+      await browser.elementById('invalidate-offline-navigation-action').click()
+      await retry(async () => {
+        expect(
+          await readPersistedOfflineNavigationMetadata(
+            browser,
+            'route-cache-epoch'
+          )
+        ).toBeGreaterThan(0)
+        expect(
+          await readPersistedOfflineNavigationMetadata(
+            browser,
+            'segment-cache-epoch'
+          )
+        ).toBeGreaterThan(0)
+      })
+
+      await page!.context().setOffline(true)
+      const invalidatedRouterRecordsResponse = await page!.goto(
+        `${next.url}/docs/prefetched`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(invalidatedRouterRecordsResponse?.status()).toBe(200)
+      await expectOfflineNavigationCacheMiss(browser, 'missing-route')
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
   it('does not emit offline navigation artifacts when disabled', async () => {
     await next.patchFile('next.config.js', (content) =>
       content.replace('offlineNavigations: true', 'offlineNavigations: false')
@@ -327,5 +1098,17 @@ describe('offlineNavigations build artifacts', () => {
     expect(existsSync(fallbackDocument.absolutePath)).toBe(false)
     expect(existsSync(manifest.absolutePath)).toBe(false)
     expect(existsSync(serviceWorker.absolutePath)).toBe(false)
+
+    expect(
+      getStaticClientChunkForbiddenMatches(
+        join(next.testDir, '.next', 'static', 'chunks'),
+        [
+          'next-offline-navigation-cache',
+          'offline-navigation-cache',
+          'data-next-offline-navigation',
+          '_offline-navigation',
+        ]
+      )
+    ).toEqual([])
   })
 })


### PR DESCRIPTION
## Context

This is PR 10/11 in the offline navigations stack. The stack builds the initial experimental feature in two chapters: build and service worker artifacts first, then client router persistence and fallback bootstrap. The service worker owns bootstrap delivery only; route data stays in the Cached Navigations router cache and is persisted by the client when the flag is enabled. PR 11 adds the docs and examples layer.

Review guide: https://gist.github.com/feedthejim/007cb3a3c0dd39b3806213c4ce95d31a

## What Changed

Adds the hardening rows for the router-cache based offline navigation design. These assertions make incomplete replay state explicit: when the router cache does not contain the records needed for the URL, the app shows an offline miss.

## Reviewer Focus

Review the request-sensitive and URL-shape assertions. These should visibly miss offline rather than replaying guessed or partial UI.

## What Does Not Work Yet

Runtime replay behavior for the initial experimental scope is complete after this PR. PR 11 adds docs and examples. Static export integration, dev simulation, custom miss UI, and broader production hardening remain follow-up work.

## Proof In This PR

Adds production e2e coverage for request-sensitive hard-load misses and encoded/search/hash URL shape stress misses.

## Deferred Coverage

Docs land in PR 11. Broader production hardening can be follow-up work once this stack lands.

## Docs Status

Docs ship in #93738 (11/11).

## Stack Map

1. #93736 `offline navigations: add gated build primitives (1/11)` (sibling)
2. #93737 `offline navigations: emit fallback manifest data (2/11)` (sibling)
3. #93625 `offline navigations: register pass-through worker (3/11)` (sibling)
4. #93626 `offline navigations: cache fallback artifacts (4/11)` (sibling)
5. #93627 `offline navigations: serve fallback document offline (5/11)` (sibling)
6. #93630 `offline navigations: add router-cache persistence primitives (6/11)` (sibling)
7. #93640 `offline navigations: persist cached router records (7/11)` (sibling)
8. #93644 `offline navigations: bootstrap fallback from router records (8/11)` (sibling)
9. #93647 `offline navigations: support dynamic route patterns (9/11)` (sibling)
10. **#93650 `offline navigations: cover persisted router replay (10/11)` (current)**
11. #93738 `offline navigations: add docs and examples (11/11)` (sibling)

<!-- NEXT_JS_LLM_PR -->
