### PR TITLE
(3/6) Cover redirecting server action offline invalidation

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1190,5 +1190,6 @@
   "1189": "Route \"%s\" accessed header \"%s\" which is not defined in the \\`unstable_samples\\` of \\`unstable_instant\\`. Add it to the sample's \\`headers\\` array, or \\`[\"%s\", null]\\` if it should be absent.",
   "1190": "Route \"%s\" accessed param \"%s\" which is not defined in the \\`unstable_samples\\` of \\`unstable_instant\\`. Add it to the sample's \\`params\\` object.",
   "1191": "Route \"%s\" called %s but param%s %s %s not defined in the \\`unstable_samples\\` of \\`unstable_instant\\`. %s requires all route params to be provided.",
-  "1192": "Route \"%s\" accessed root param \"%s\" which is not defined in the \\`unstable_samples\\` of \\`unstable_instant\\`. Add it to the sample's \\`params\\` object."
+  "1192": "Route \"%s\" accessed root param \"%s\" which is not defined in the \\`unstable_samples\\` of \\`unstable_instant\\`. Add it to the sample's \\`params\\` object.",
+  "1193": "\\`experimental.offlineNavigations\\` requires \\`cacheComponents\\` to be enabled. Please update your %s accordingly."
 }

--- a/packages/next/src/build/define-env.ts
+++ b/packages/next/src/build/define-env.ts
@@ -246,7 +246,12 @@ export function getDefineEnv({
     'process.env.__NEXT_DYNAMIC_ON_HOVER': Boolean(
       config.experimental.dynamicOnHover
     ),
-    'process.env.__NEXT_USE_OFFLINE': Boolean(config.experimental.useOffline),
+    'process.env.__NEXT_OFFLINE_NAVIGATIONS': Boolean(
+      config.experimental.offlineNavigations
+    ),
+    'process.env.__NEXT_USE_OFFLINE': Boolean(
+      config.experimental.useOffline || config.experimental.offlineNavigations
+    ),
     'process.env.__NEXT_PREFETCH_INLINING': Boolean(
       config.experimental.prefetchInlining
     ),

--- a/packages/next/src/build/define-env.ts
+++ b/packages/next/src/build/define-env.ts
@@ -384,7 +384,9 @@ export function getDefineEnv({
     'process.env.__NEXT_GESTURE_TRANSITION':
       config.experimental.gestureTransition ?? false,
     'process.env.__NEXT_OPTIMISTIC_ROUTING':
-      config.experimental.optimisticRouting ?? false,
+      config.experimental.optimisticRouting ||
+      config.experimental.offlineNavigations ||
+      false,
     'process.env.__NEXT_VARY_PARAMS': config.experimental.varyParams ?? false,
     'process.env.__NEXT_EXPOSE_TESTING_API':
       dev || config.experimental.exposeTestingApiInProductionBuild === true,

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -233,6 +233,10 @@ import {
   createOfflineNavigationFallbackDocument,
   getOfflineNavigationFallbackFilePath,
 } from './offline-navigation-fallback'
+import {
+  createOfflineNavigationManifest,
+  getOfflineNavigationManifestFilePath,
+} from './offline-navigation-manifest'
 
 type Fallback = null | boolean | string
 
@@ -4097,7 +4101,7 @@ export default async function build(
 
       if (config.experimental.offlineNavigations && appDir) {
         await nextBuildSpan
-          .traceChild('write-offline-navigation-fallback')
+          .traceChild('write-offline-navigation-artifacts')
           .traceAsyncFn(async () => {
             const fallbackDocument = createOfflineNavigationFallbackDocument({
               assetPrefix: config.assetPrefix,
@@ -4116,6 +4120,17 @@ export default async function build(
             )
             await mkdir(path.dirname(fallbackPath), { recursive: true })
             await writeFileUtf8(fallbackPath, fallbackDocument)
+
+            await writeManifest(
+              path.join(distDir, getOfflineNavigationManifestFilePath(buildId)),
+              createOfflineNavigationManifest({
+                assetPrefix: config.assetPrefix,
+                basePath: config.basePath,
+                buildId,
+                output: config.output,
+                trailingSlash: config.trailingSlash,
+              })
+            )
           })
       }
 

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -4145,6 +4145,7 @@ export default async function build(
               serviceWorkerPath,
               createOfflineNavigationServiceWorker({
                 buildId,
+                cacheNamespace: manifest.cacheNamespace,
                 manifestHref: manifest.manifest.href,
               })
             )

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -237,6 +237,10 @@ import {
   createOfflineNavigationManifest,
   getOfflineNavigationManifestFilePath,
 } from './offline-navigation-manifest'
+import {
+  createOfflineNavigationServiceWorker,
+  getOfflineNavigationServiceWorkerFilePath,
+} from './offline-navigation-service-worker'
 
 type Fallback = null | boolean | string
 
@@ -4118,17 +4122,30 @@ export default async function build(
               distDir,
               getOfflineNavigationFallbackFilePath(buildId)
             )
+            const manifestPath = path.join(
+              distDir,
+              getOfflineNavigationManifestFilePath(buildId)
+            )
+            const serviceWorkerPath = path.join(
+              distDir,
+              getOfflineNavigationServiceWorkerFilePath()
+            )
+            const manifest = createOfflineNavigationManifest({
+              assetPrefix: config.assetPrefix,
+              basePath: config.basePath,
+              buildId,
+              output: config.output,
+              trailingSlash: config.trailingSlash,
+            })
+
             await mkdir(path.dirname(fallbackPath), { recursive: true })
             await writeFileUtf8(fallbackPath, fallbackDocument)
-
-            await writeManifest(
-              path.join(distDir, getOfflineNavigationManifestFilePath(buildId)),
-              createOfflineNavigationManifest({
-                assetPrefix: config.assetPrefix,
-                basePath: config.basePath,
+            await writeManifest(manifestPath, manifest)
+            await writeFileUtf8(
+              serviceWorkerPath,
+              createOfflineNavigationServiceWorker({
                 buildId,
-                output: config.output,
-                trailingSlash: config.trailingSlash,
+                manifestHref: manifest.manifest.href,
               })
             )
           })

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -229,6 +229,10 @@ import {
 } from '../server/lib/router-utils/build-prefetch-segment-data-route'
 import { generateRoutesManifest } from './generate-routes-manifest'
 import { validateAppPaths } from './validate-app-paths'
+import {
+  createOfflineNavigationFallbackDocument,
+  getOfflineNavigationFallbackFilePath,
+} from './offline-navigation-fallback'
 
 type Fallback = null | boolean | string
 
@@ -4090,6 +4094,30 @@ export default async function build(
       }
 
       // #endregion
+
+      if (config.experimental.offlineNavigations && appDir) {
+        await nextBuildSpan
+          .traceChild('write-offline-navigation-fallback')
+          .traceAsyncFn(async () => {
+            const fallbackDocument = createOfflineNavigationFallbackDocument({
+              assetPrefix: config.assetPrefix,
+              buildId,
+              buildManifest,
+              crossOrigin: config.crossOrigin,
+            })
+
+            if (fallbackDocument === null) {
+              return
+            }
+
+            const fallbackPath = path.join(
+              distDir,
+              getOfflineNavigationFallbackFilePath(buildId)
+            )
+            await mkdir(path.dirname(fallbackPath), { recursive: true })
+            await writeFileUtf8(fallbackPath, fallbackDocument)
+          })
+      }
 
       await writeImagesManifest(distDir, config)
       await writeManifest(path.join(distDir, EXPORT_MARKER), {

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -4146,6 +4146,7 @@ export default async function build(
               createOfflineNavigationServiceWorker({
                 buildId,
                 cacheNamespace: manifest.cacheNamespace,
+                fallbackDocumentHref: manifest.fallbackDocument.href,
                 manifestHref: manifest.manifest.href,
               })
             )

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -4112,6 +4112,7 @@ export default async function build(
               buildId,
               buildManifest,
               crossOrigin: config.crossOrigin,
+              deploymentId: config.deploymentId,
             })
 
             if (fallbackDocument === null) {

--- a/packages/next/src/build/offline-navigation-fallback.ts
+++ b/packages/next/src/build/offline-navigation-fallback.ts
@@ -38,11 +38,13 @@ export function createOfflineNavigationFallbackDocument({
   buildId,
   buildManifest,
   crossOrigin,
+  deploymentId,
 }: {
   assetPrefix: string
   buildId: string
   buildManifest: BuildManifest
   crossOrigin: '' | 'anonymous' | 'use-credentials' | undefined
+  deploymentId: string | undefined
 }): string | null {
   const rootMainFiles = buildManifest.rootMainFiles.filter((file) =>
     file.endsWith('.js')
@@ -74,11 +76,15 @@ export function createOfflineNavigationFallbackDocument({
     source: 'offline-navigation-fallback',
   }
 
+  const deploymentIdAttribute = deploymentId
+    ? ` data-dpl-id="${htmlEscapeAttributeString(deploymentId)}"`
+    : ''
+
   return `<!DOCTYPE html><html data-next-offline-navigation-fallback="" data-build-id="${htmlEscapeAttributeString(
     buildId
-  )}"><head><meta charSet="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><meta name="next-offline-navigation-fallback" content="1"><meta name="next-build-id" content="${htmlEscapeAttributeString(
+  )}"${deploymentIdAttribute}><head><meta charSet="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><meta name="next-offline-navigation-fallback" content="1"><meta name="next-build-id" content="${htmlEscapeAttributeString(
     buildId
   )}"><script id="__NEXT_OFFLINE_NAVIGATION_FALLBACK" type="application/json">${htmlEscapeJsonString(
     JSON.stringify(metadata)
-  )}</script></head><body><div id="__next"></div><script>self.__next_f=self.__next_f||[];self.__next_f.push([0])</script>${polyfillScripts}${bootstrapScripts}</body></html>`
+  )}</script></head><body><div id="__next"></div><p id="__NEXT_OFFLINE_NAVIGATION_CACHE_MISS" hidden>This page is not available offline.</p><script>self.__next_f=self.__next_f||[];self.__next_f.push([0])</script>${polyfillScripts}${bootstrapScripts}</body></html>`
 }

--- a/packages/next/src/build/offline-navigation-fallback.ts
+++ b/packages/next/src/build/offline-navigation-fallback.ts
@@ -1,0 +1,84 @@
+import path from 'node:path'
+
+import type { BuildManifest } from '../server/get-page-files'
+import { encodeURIPath } from '../shared/lib/encode-uri-path'
+import {
+  htmlEscapeAttributeString,
+  htmlEscapeJsonString,
+} from '../shared/lib/htmlescape'
+import { CLIENT_STATIC_FILES_PATH } from '../shared/lib/constants'
+
+export const OFFLINE_NAVIGATION_FALLBACK_HTML =
+  '_offline-navigation-fallback.html'
+
+export function getOfflineNavigationFallbackFilePath(buildId: string): string {
+  return path.join(
+    CLIENT_STATIC_FILES_PATH,
+    buildId,
+    OFFLINE_NAVIGATION_FALLBACK_HTML
+  )
+}
+
+function getAssetHref(assetPrefix: string, file: string): string {
+  return `${assetPrefix}/_next/${encodeURIPath(file)}`
+}
+
+function getScriptAttributes(
+  crossOrigin: '' | 'anonymous' | 'use-credentials' | undefined
+): string {
+  if (!crossOrigin) {
+    return ''
+  }
+
+  return ` crossOrigin="${htmlEscapeAttributeString(crossOrigin)}"`
+}
+
+export function createOfflineNavigationFallbackDocument({
+  assetPrefix,
+  buildId,
+  buildManifest,
+  crossOrigin,
+}: {
+  assetPrefix: string
+  buildId: string
+  buildManifest: BuildManifest
+  crossOrigin: '' | 'anonymous' | 'use-credentials' | undefined
+}): string | null {
+  const rootMainFiles = buildManifest.rootMainFiles.filter((file) =>
+    file.endsWith('.js')
+  )
+
+  if (rootMainFiles.length === 0) {
+    return null
+  }
+
+  const polyfillScripts = buildManifest.polyfillFiles
+    .filter((file) => file.endsWith('.js') && !file.endsWith('.module.js'))
+    .map((file) => {
+      return `<script src="${htmlEscapeAttributeString(
+        getAssetHref(assetPrefix, file)
+      )}" noModule${getScriptAttributes(crossOrigin)}></script>`
+    })
+    .join('')
+
+  const bootstrapScripts = rootMainFiles
+    .map((file) => {
+      return `<script src="${htmlEscapeAttributeString(
+        getAssetHref(assetPrefix, file)
+      )}" async${getScriptAttributes(crossOrigin)}></script>`
+    })
+    .join('')
+
+  const metadata = {
+    buildId,
+    source: 'offline-navigation-fallback',
+  }
+
+  return `<!DOCTYPE html><html data-next-offline-navigation-fallback="" data-build-id="${htmlEscapeAttributeString(
+    buildId
+  )}"><head><meta charSet="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><meta name="next-offline-navigation-fallback" content="1"><meta name="next-build-id" content="${htmlEscapeAttributeString(
+    buildId
+  )}"><script id="__NEXT_OFFLINE_NAVIGATION_FALLBACK" type="application/json">${htmlEscapeJsonString(
+    JSON.stringify(metadata)
+  )}</script></head><body><div id="__next"></div><script>self.__next_f=self.__next_f||[];self.__next_f.push([0])</script>${polyfillScripts}${bootstrapScripts}</body></html>`
+}

--- a/packages/next/src/build/offline-navigation-manifest.ts
+++ b/packages/next/src/build/offline-navigation-manifest.ts
@@ -4,6 +4,7 @@ import type { NextConfigComplete } from '../server/config-shared'
 import { CLIENT_STATIC_FILES_PATH } from '../shared/lib/constants'
 import { encodeURIPath } from '../shared/lib/encode-uri-path'
 import { getOfflineNavigationFallbackFilePath } from './offline-navigation-fallback'
+import { getOfflineNavigationServiceWorkerFilePath } from './offline-navigation-service-worker'
 
 export const OFFLINE_NAVIGATION_MANIFEST = '_offline-navigation-manifest.json'
 
@@ -21,6 +22,10 @@ export interface OfflineNavigationManifest {
     href: string
   }
   fallbackDocument: {
+    path: string
+    href: string
+  }
+  serviceWorker: {
     path: string
     href: string
   }
@@ -57,6 +62,7 @@ export function createOfflineNavigationManifest({
 }): OfflineNavigationManifest {
   const manifestPath = getOfflineNavigationManifestFilePath(buildId)
   const fallbackDocumentPath = getOfflineNavigationFallbackFilePath(buildId)
+  const serviceWorkerPath = getOfflineNavigationServiceWorkerFilePath()
 
   return {
     version: 1,
@@ -74,6 +80,10 @@ export function createOfflineNavigationManifest({
     fallbackDocument: {
       path: fallbackDocumentPath,
       href: getStaticHref(basePath, fallbackDocumentPath),
+    },
+    serviceWorker: {
+      path: serviceWorkerPath,
+      href: getStaticHref(basePath, serviceWorkerPath),
     },
   }
 }

--- a/packages/next/src/build/offline-navigation-manifest.ts
+++ b/packages/next/src/build/offline-navigation-manifest.ts
@@ -1,0 +1,79 @@
+import path from 'node:path'
+
+import type { NextConfigComplete } from '../server/config-shared'
+import { CLIENT_STATIC_FILES_PATH } from '../shared/lib/constants'
+import { encodeURIPath } from '../shared/lib/encode-uri-path'
+import { getOfflineNavigationFallbackFilePath } from './offline-navigation-fallback'
+
+export const OFFLINE_NAVIGATION_MANIFEST = '_offline-navigation-manifest.json'
+
+export interface OfflineNavigationManifest {
+  version: 1
+  buildId: string
+  basePath: string
+  assetPrefix: string
+  trailingSlash: boolean
+  output: NonNullable<NextConfigComplete['output']> | 'default'
+  scope: string
+  cacheNamespace: string
+  manifest: {
+    path: string
+    href: string
+  }
+  fallbackDocument: {
+    path: string
+    href: string
+  }
+}
+
+export function getOfflineNavigationManifestFilePath(buildId: string): string {
+  return path.join(
+    CLIENT_STATIC_FILES_PATH,
+    buildId,
+    OFFLINE_NAVIGATION_MANIFEST
+  )
+}
+
+function getStaticHref(basePath: string, filePath: string): string {
+  return `${basePath}/_next/${encodeURIPath(filePath)}`
+}
+
+function getScope(basePath: string): string {
+  return basePath ? `${basePath}/` : '/'
+}
+
+export function createOfflineNavigationManifest({
+  assetPrefix,
+  basePath,
+  buildId,
+  output,
+  trailingSlash,
+}: {
+  assetPrefix: string
+  basePath: string
+  buildId: string
+  output: NextConfigComplete['output']
+  trailingSlash: boolean
+}): OfflineNavigationManifest {
+  const manifestPath = getOfflineNavigationManifestFilePath(buildId)
+  const fallbackDocumentPath = getOfflineNavigationFallbackFilePath(buildId)
+
+  return {
+    version: 1,
+    buildId,
+    basePath,
+    assetPrefix,
+    trailingSlash,
+    output: output ?? 'default',
+    scope: getScope(basePath),
+    cacheNamespace: `next-offline-navigation-v1:${buildId}:${basePath || '/'}`,
+    manifest: {
+      path: manifestPath,
+      href: getStaticHref(basePath, manifestPath),
+    },
+    fallbackDocument: {
+      path: fallbackDocumentPath,
+      href: getStaticHref(basePath, fallbackDocumentPath),
+    },
+  }
+}

--- a/packages/next/src/build/offline-navigation-service-worker.ts
+++ b/packages/next/src/build/offline-navigation-service-worker.ts
@@ -2,6 +2,7 @@ import path from 'node:path'
 
 import { CLIENT_STATIC_FILES_PATH } from '../shared/lib/constants'
 import { OFFLINE_NAVIGATION_SERVICE_WORKER } from '../shared/lib/offline-navigation'
+import { OFFLINE_NAVIGATION_FALLBACK_SERVED } from '../shared/lib/offline-navigation-constants'
 
 export function getOfflineNavigationServiceWorkerFilePath(): string {
   return path.join(CLIENT_STATIC_FILES_PATH, OFFLINE_NAVIGATION_SERVICE_WORKER)
@@ -25,6 +26,9 @@ export function createOfflineNavigationServiceWorker({
     manifestHref,
     source: 'offline-navigation-service-worker',
   })
+  const fallbackServedMessageType = JSON.stringify(
+    OFFLINE_NAVIGATION_FALLBACK_SERVED
+  )
 
   return `self.__NEXT_OFFLINE_NAVIGATION_SW=${metadata};
 const CACHE_PREFIX='next-offline-navigation-v1:';
@@ -69,10 +73,20 @@ async function fetchDocumentNavigation(request){
     const cache=await caches.open(metadata.cacheNamespace);
     const fallbackResponse=await cache.match(metadata.fallbackDocumentHref);
     if(fallbackResponse){
+      await notifyClients({
+        type:${fallbackServedMessageType},
+        buildId:metadata.buildId,
+        reason:'network-error',
+        url:request.url
+      });
       return fallbackResponse;
     }
     throw err;
   }
+}
+async function notifyClients(message){
+  const clients=await self.clients.matchAll({type:'window',includeUncontrolled:true});
+  await Promise.all(clients.map((client)=>client.postMessage(message)));
 }
 self.addEventListener('install',(event)=>{
   event.waitUntil((async()=>{

--- a/packages/next/src/build/offline-navigation-service-worker.ts
+++ b/packages/next/src/build/offline-navigation-service-worker.ts
@@ -10,15 +10,18 @@ export function getOfflineNavigationServiceWorkerFilePath(): string {
 export function createOfflineNavigationServiceWorker({
   buildId,
   cacheNamespace,
+  fallbackDocumentHref,
   manifestHref,
 }: {
   buildId: string
   cacheNamespace: string
+  fallbackDocumentHref: string
   manifestHref: string
 }): string {
   const metadata = JSON.stringify({
     buildId,
     cacheNamespace,
+    fallbackDocumentHref,
     manifestHref,
     source: 'offline-navigation-service-worker',
   })
@@ -51,6 +54,26 @@ async function cacheOfflineNavigationResources(){
   const fallbackResponse=await fetchRequiredResource(manifest.fallbackDocument.href);
   await cache.put(manifest.fallbackDocument.href,fallbackResponse);
 }
+function isDocumentNavigationRequest(request){
+  if(request.method!=='GET'||request.mode!=='navigate'||request.destination!=='document'){
+    return false;
+  }
+  const url=new URL(request.url);
+  return url.origin===self.location.origin;
+}
+async function fetchDocumentNavigation(request){
+  try{
+    return await fetch(request);
+  }catch(err){
+    const metadata=self.__NEXT_OFFLINE_NAVIGATION_SW;
+    const cache=await caches.open(metadata.cacheNamespace);
+    const fallbackResponse=await cache.match(metadata.fallbackDocumentHref);
+    if(fallbackResponse){
+      return fallbackResponse;
+    }
+    throw err;
+  }
+}
 self.addEventListener('install',(event)=>{
   event.waitUntil((async()=>{
     await cacheOfflineNavigationResources();
@@ -68,6 +91,11 @@ self.addEventListener('activate',(event)=>{
     }));
     await self.clients.claim();
   })());
+});
+self.addEventListener('fetch',(event)=>{
+  if(isDocumentNavigationRequest(event.request)){
+    event.respondWith(fetchDocumentNavigation(event.request));
+  }
 });
 `
 }

--- a/packages/next/src/build/offline-navigation-service-worker.ts
+++ b/packages/next/src/build/offline-navigation-service-worker.ts
@@ -9,19 +9,65 @@ export function getOfflineNavigationServiceWorkerFilePath(): string {
 
 export function createOfflineNavigationServiceWorker({
   buildId,
+  cacheNamespace,
   manifestHref,
 }: {
   buildId: string
+  cacheNamespace: string
   manifestHref: string
 }): string {
   const metadata = JSON.stringify({
     buildId,
+    cacheNamespace,
     manifestHref,
     source: 'offline-navigation-service-worker',
   })
 
   return `self.__NEXT_OFFLINE_NAVIGATION_SW=${metadata};
-self.addEventListener('install',(event)=>{event.waitUntil(self.skipWaiting())});
-self.addEventListener('activate',(event)=>{event.waitUntil(self.clients.claim())});
+const CACHE_PREFIX='next-offline-navigation-v1:';
+function withDeploymentQuery(href){
+  const url=new URL(href,self.location.origin);
+  const deploymentParams=new URLSearchParams(self.location.search);
+  deploymentParams.forEach((value,key)=>{
+    if(!url.searchParams.has(key)){
+      url.searchParams.set(key,value);
+    }
+  });
+  return url.href;
+}
+async function fetchRequiredResource(href){
+  const response=await fetch(withDeploymentQuery(href),{cache:'no-store'});
+  if(!response.ok){
+    throw new Error('Failed to cache offline navigation resource: '+href);
+  }
+  return response;
+}
+async function cacheOfflineNavigationResources(){
+  const metadata=self.__NEXT_OFFLINE_NAVIGATION_SW;
+  const cache=await caches.open(metadata.cacheNamespace);
+  const manifestResponse=await fetchRequiredResource(metadata.manifestHref);
+  const manifest=await manifestResponse.clone().json();
+  await cache.put(metadata.manifestHref,manifestResponse);
+  const fallbackResponse=await fetchRequiredResource(manifest.fallbackDocument.href);
+  await cache.put(manifest.fallbackDocument.href,fallbackResponse);
+}
+self.addEventListener('install',(event)=>{
+  event.waitUntil((async()=>{
+    await cacheOfflineNavigationResources();
+    await self.skipWaiting();
+  })());
+});
+self.addEventListener('activate',(event)=>{
+  event.waitUntil((async()=>{
+    const metadata=self.__NEXT_OFFLINE_NAVIGATION_SW;
+    const cacheNames=await caches.keys();
+    await Promise.all(cacheNames.map((cacheName)=>{
+      if(cacheName.startsWith(CACHE_PREFIX)&&cacheName!==metadata.cacheNamespace){
+        return caches.delete(cacheName);
+      }
+    }));
+    await self.clients.claim();
+  })());
+});
 `
 }

--- a/packages/next/src/build/offline-navigation-service-worker.ts
+++ b/packages/next/src/build/offline-navigation-service-worker.ts
@@ -1,0 +1,27 @@
+import path from 'node:path'
+
+import { CLIENT_STATIC_FILES_PATH } from '../shared/lib/constants'
+import { OFFLINE_NAVIGATION_SERVICE_WORKER } from '../shared/lib/offline-navigation'
+
+export function getOfflineNavigationServiceWorkerFilePath(): string {
+  return path.join(CLIENT_STATIC_FILES_PATH, OFFLINE_NAVIGATION_SERVICE_WORKER)
+}
+
+export function createOfflineNavigationServiceWorker({
+  buildId,
+  manifestHref,
+}: {
+  buildId: string
+  manifestHref: string
+}): string {
+  const metadata = JSON.stringify({
+    buildId,
+    manifestHref,
+    source: 'offline-navigation-service-worker',
+  })
+
+  return `self.__NEXT_OFFLINE_NAVIGATION_SW=${metadata};
+self.addEventListener('install',(event)=>{event.waitUntil(self.skipWaiting())});
+self.addEventListener('activate',(event)=>{event.waitUntil(self.clients.claim())});
+`
+}

--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -890,7 +890,8 @@ export async function handler(
             staleTimes: nextConfig.experimental.staleTimes,
             dynamicOnHover: Boolean(nextConfig.experimental.dynamicOnHover),
             optimisticRouting: Boolean(
-              nextConfig.experimental.optimisticRouting
+              nextConfig.experimental.optimisticRouting ||
+                nextConfig.experimental.offlineNavigations
             ),
             inlineCss: Boolean(nextConfig.experimental.inlineCss),
             prefetchInlining: nextConfig.experimental.prefetchInlining ?? false,

--- a/packages/next/src/build/templates/edge-ssr-app.ts
+++ b/packages/next/src/build/templates/edge-ssr-app.ts
@@ -165,7 +165,10 @@ async function requestHandler(
         expireTime: nextConfig.expireTime,
         staleTimes: nextConfig.experimental.staleTimes,
         dynamicOnHover: Boolean(nextConfig.experimental.dynamicOnHover),
-        optimisticRouting: Boolean(nextConfig.experimental.optimisticRouting),
+        optimisticRouting: Boolean(
+          nextConfig.experimental.optimisticRouting ||
+            nextConfig.experimental.offlineNavigations
+        ),
         inlineCss: Boolean(nextConfig.experimental.inlineCss),
         prefetchInlining: nextConfig.experimental.prefetchInlining ?? false,
         authInterrupts: Boolean(nextConfig.experimental.authInterrupts),

--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -76,6 +76,19 @@ type OfflineNavigationFallbackDiagnostic =
       buildId: string | undefined
       reason: OfflineNavigationCacheMissReason
     }
+  | {
+      type: 'router-cache-hydration'
+      url: string
+      buildId: string | undefined
+      routes: {
+        hydrated: number
+        skipped: number
+      }
+      segments: {
+        hydrated: number
+        skipped: number
+      }
+    }
 
 declare global {
   interface Window {
@@ -597,6 +610,7 @@ export async function hydrate(
   } else {
     setNavigationBuildId(getDeploymentId()!)
   }
+  const buildId = initialRSCPayload.b ?? getDeploymentId()
 
   if (
     process.env.__NEXT_OFFLINE_NAVIGATIONS &&
@@ -605,6 +619,28 @@ export async function hydrate(
     const { registerOfflineNavigationServiceWorker } =
       require('./offline-navigation-service-worker') as typeof import('./offline-navigation-service-worker')
     registerOfflineNavigationServiceWorker()
+  }
+
+  if (
+    process.env.__NEXT_OFFLINE_NAVIGATIONS &&
+    !process.env.__NEXT_DEV_SERVER &&
+    offlineNavigationClientResumeFetch
+  ) {
+    try {
+      const { hydrateOfflineNavigationRouterCache } =
+        require('./components/segment-cache/cache') as typeof import('./components/segment-cache/cache')
+      const result = await hydrateOfflineNavigationRouterCache()
+      reportOfflineNavigationFallbackDiagnostic({
+        type: 'router-cache-hydration',
+        url: location.href,
+        buildId,
+        routes: result.routes,
+        segments: result.segments,
+      })
+    } catch {
+      // The exact URL fallback already booted. Router cache hydration should
+      // only improve later navigations, never block the current render.
+    }
   }
 
   const initialTimestamp = Date.now()

--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -376,6 +376,15 @@ export async function hydrate(
     setNavigationBuildId(getDeploymentId()!)
   }
 
+  if (
+    process.env.__NEXT_OFFLINE_NAVIGATIONS &&
+    !process.env.__NEXT_DEV_SERVER
+  ) {
+    const { registerOfflineNavigationServiceWorker } =
+      require('./offline-navigation-service-worker') as typeof import('./offline-navigation-service-worker')
+    registerOfflineNavigationServiceWorker()
+  }
+
   const initialTimestamp = Date.now()
   const actionQueue: AppRouterActionQueue = createMutableActionQueue(
     createInitialRouterState({

--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -20,6 +20,7 @@ import {
   createMutableActionQueue,
 } from './components/app-router-instance'
 import AppRouter from './components/app-router'
+import DefaultGlobalError from './components/builtin/global-error'
 import type { InitialRSCPayload } from '../shared/lib/app-router-types'
 import { createInitialRouterState } from './components/router-reducer/create-initial-router-state'
 import { MissingSlotContext } from '../shared/lib/app-router-context.shared-runtime'
@@ -63,12 +64,17 @@ type OfflineNavigationCacheMissReason =
   | 'unsupported-request-kind'
   | 'read-error'
 
+type OfflineNavigationFallbackRequestKind =
+  | 'client-resume'
+  | 'initial-load'
+  | 'router-cache'
+
 type OfflineNavigationFallbackDiagnostic =
   | {
       type: 'cache-hit'
       url: string
       buildId: string | undefined
-      requestKind: OfflineNavigationFallbackResponse['requestKind']
+      requestKind: OfflineNavigationFallbackRequestKind
     }
   | {
       type: 'cache-miss'
@@ -88,6 +94,12 @@ type OfflineNavigationFallbackDiagnostic =
         hydrated: number
         skipped: number
       }
+    }
+  | {
+      type: 'router-cache-reconstruction-miss'
+      url: string
+      buildId: string | undefined
+      reason: string
     }
 
 declare global {
@@ -109,7 +121,7 @@ function reportOfflineNavigationFallbackDiagnostic(
 }
 
 function showOfflineNavigationCacheHit(
-  requestKind: OfflineNavigationFallbackResponse['requestKind'],
+  requestKind: OfflineNavigationFallbackRequestKind,
   buildId: string | undefined
 ): void {
   document.documentElement.setAttribute(
@@ -157,8 +169,8 @@ function showOfflineNavigationCacheMiss(
   })
 }
 
-function neverResolveOfflineNavigationResponse(): Promise<Response> {
-  return new Promise<Response>(() => {})
+function neverResolveInitialRSCPayload(): Promise<InitialRSCPayload> {
+  return new Promise<InitialRSCPayload>(() => {})
 }
 
 type OfflineNavigationFallbackResponse = {
@@ -166,14 +178,30 @@ type OfflineNavigationFallbackResponse = {
   response: Response
 }
 
-function createOfflineNavigationFallbackResponse():
-  | Promise<OfflineNavigationFallbackResponse>
+type OfflineNavigationFallbackBootstrap =
+  | {
+      kind: 'rsc-response'
+      response: OfflineNavigationFallbackResponse
+      buildId: string | undefined
+    }
+  | {
+      kind: 'router-cache'
+      initialRSCPayload: InitialRSCPayload
+      buildId: string | undefined
+    }
+  | {
+      kind: 'cache-miss'
+      buildId: string | undefined
+    }
+
+function createOfflineNavigationFallbackBootstrap():
+  | Promise<OfflineNavigationFallbackBootstrap>
   | undefined {
   if (!isOfflineNavigationFallbackDocument()) {
     return undefined
   }
 
-  return (async (): Promise<OfflineNavigationFallbackResponse> => {
+  return (async (): Promise<OfflineNavigationFallbackBootstrap> => {
     const {
       createOfflineNavigationRSCResponse,
       isOfflineNavigationRSCResponsePayload,
@@ -191,13 +219,54 @@ function createOfflineNavigationFallbackResponse():
     const payload = entry?.payload
 
     if (!isOfflineNavigationRSCResponsePayload(payload)) {
+      if (payload === undefined) {
+        const {
+          createOfflineNavigationInitialRSCPayloadFromRouterCache,
+          hydrateOfflineNavigationRouterCache,
+        } =
+          require('./components/segment-cache/cache') as typeof import('./components/segment-cache/cache')
+
+        const hydrationResult = await hydrateOfflineNavigationRouterCache({
+          buildId,
+        })
+        reportOfflineNavigationFallbackDiagnostic({
+          type: 'router-cache-hydration',
+          url: location.href,
+          buildId,
+          routes: hydrationResult.routes,
+          segments: hydrationResult.segments,
+        })
+
+        const reconstruction =
+          createOfflineNavigationInitialRSCPayloadFromRouterCache({
+            buildId,
+            globalErrorState: [DefaultGlobalError, undefined],
+            now: Date.now(),
+            url: location.href,
+          })
+        if (reconstruction.status === 'fulfilled') {
+          showOfflineNavigationCacheHit('router-cache', buildId)
+          return {
+            kind: 'router-cache',
+            initialRSCPayload: reconstruction.initialRSCPayload,
+            buildId,
+          }
+        }
+        reportOfflineNavigationFallbackDiagnostic({
+          type: 'router-cache-reconstruction-miss',
+          url: location.href,
+          buildId,
+          reason: reconstruction.reason,
+        })
+      }
+
       showOfflineNavigationCacheMiss(
         payload === undefined ? 'missing-entry' : 'invalid-payload',
         buildId
       )
       return {
-        requestKind: 'client-resume',
-        response: await neverResolveOfflineNavigationResponse(),
+        kind: 'cache-miss',
+        buildId,
       }
     }
 
@@ -207,8 +276,8 @@ function createOfflineNavigationFallbackResponse():
     ) {
       showOfflineNavigationCacheMiss('unsupported-request-kind', buildId)
       return {
-        requestKind: 'client-resume',
-        response: await neverResolveOfflineNavigationResponse(),
+        kind: 'cache-miss',
+        buildId,
       }
     }
 
@@ -217,29 +286,37 @@ function createOfflineNavigationFallbackResponse():
 
     showOfflineNavigationCacheHit(requestKind, buildId)
     return {
-      requestKind,
-      response: createOfflineNavigationRSCResponse(payload),
+      kind: 'rsc-response',
+      buildId,
+      response: {
+        requestKind,
+        response: createOfflineNavigationRSCResponse(payload),
+      },
     }
-  })().catch(async (): Promise<OfflineNavigationFallbackResponse> => {
+  })().catch((): OfflineNavigationFallbackBootstrap => {
     showOfflineNavigationCacheMiss('read-error', undefined)
     return {
-      requestKind: 'client-resume',
-      response: await neverResolveOfflineNavigationResponse(),
+      kind: 'cache-miss',
+      buildId: undefined,
     }
   })
 }
 
-const offlineNavigationFallbackResponse =
-  createOfflineNavigationFallbackResponse()
-const offlineNavigationClientResumeFetch =
-  offlineNavigationFallbackResponse?.then(({ response }) => response)
+const offlineNavigationFallbackBootstrap =
+  createOfflineNavigationFallbackBootstrap()
+
+if (process.env.__NEXT_USE_OFFLINE && offlineNavigationFallbackBootstrap) {
+  const { notifyOffline } =
+    require('./components/offline') as typeof import('./components/offline')
+  notifyOffline()
+}
 
 const hasClientResumeShell =
   // @ts-expect-error
   Boolean(window.__NEXT_CLIENT_RESUME)
 const hasLockedStaticShell =
   Boolean(instantTestStaticFetch) ||
-  Boolean(offlineNavigationClientResumeFetch) ||
+  Boolean(offlineNavigationFallbackBootstrap) ||
   hasClientResumeShell
 
 const encoder = new TextEncoder()
@@ -410,7 +487,7 @@ if (
 if (
   process.env.__NEXT_CACHE_COMPONENTS &&
   process.env.__NEXT_EXPERIMENTAL_CACHED_NAVIGATIONS &&
-  !offlineNavigationClientResumeFetch
+  !offlineNavigationFallbackBootstrap
 ) {
   const [forReact, forCache] = readable.tee()
   readable = forReact
@@ -454,25 +531,39 @@ if (instantTestStaticFetch) {
       initialRSCPayload
     )
   })
-} else if (offlineNavigationClientResumeFetch) {
-  initialServerResponse = Promise.resolve(
-    createFromFetch<InitialRSCPayload>(offlineNavigationClientResumeFetch, {
-      callServer,
-      findSourceMapURL,
-      debugChannel,
-      unstable_allowPartialStream: true,
-    })
-  ).then(async (fallbackInitialRSCPayload) => {
-    const fallbackResponse = await offlineNavigationFallbackResponse!
-    if (fallbackResponse.requestKind === 'initial-load') {
-      return fallbackInitialRSCPayload
-    }
+} else if (offlineNavigationFallbackBootstrap) {
+  initialServerResponse = offlineNavigationFallbackBootstrap.then(
+    async (bootstrap) => {
+      if (bootstrap.kind === 'cache-miss') {
+        return await neverResolveInitialRSCPayload()
+      }
 
-    return createInitialRSCPayloadFromFallbackPrerender(
-      fallbackResponse.response,
-      fallbackInitialRSCPayload
-    )
-  })
+      if (bootstrap.kind === 'router-cache') {
+        return bootstrap.initialRSCPayload
+      }
+
+      const fallbackResponse = bootstrap.response
+      const fallbackInitialRSCPayload =
+        await createFromFetch<InitialRSCPayload>(
+          Promise.resolve(fallbackResponse.response),
+          {
+            callServer,
+            findSourceMapURL,
+            debugChannel,
+            unstable_allowPartialStream: true,
+          }
+        )
+
+      if (fallbackResponse.requestKind === 'initial-load') {
+        return fallbackInitialRSCPayload
+      }
+
+      return createInitialRSCPayloadFromFallbackPrerender(
+        fallbackResponse.response,
+        fallbackInitialRSCPayload
+      )
+    }
+  )
 } else if (
   // @ts-expect-error
   window.__NEXT_CLIENT_RESUME
@@ -598,7 +689,7 @@ export async function hydrate(
   if (process.env.__NEXT_USE_OFFLINE) {
     const { notifyOffline } =
       require('./components/offline') as typeof import('./components/offline')
-    if (offlineNavigationClientResumeFetch) {
+    if (offlineNavigationFallbackBootstrap) {
       notifyOffline()
     }
   }
@@ -624,19 +715,22 @@ export async function hydrate(
   if (
     process.env.__NEXT_OFFLINE_NAVIGATIONS &&
     !process.env.__NEXT_DEV_SERVER &&
-    offlineNavigationClientResumeFetch
+    offlineNavigationFallbackBootstrap
   ) {
     try {
-      const { hydrateOfflineNavigationRouterCache } =
-        require('./components/segment-cache/cache') as typeof import('./components/segment-cache/cache')
-      const result = await hydrateOfflineNavigationRouterCache()
-      reportOfflineNavigationFallbackDiagnostic({
-        type: 'router-cache-hydration',
-        url: location.href,
-        buildId,
-        routes: result.routes,
-        segments: result.segments,
-      })
+      const bootstrap = await offlineNavigationFallbackBootstrap
+      if (bootstrap.kind === 'rsc-response') {
+        const { hydrateOfflineNavigationRouterCache } =
+          require('./components/segment-cache/cache') as typeof import('./components/segment-cache/cache')
+        const result = await hydrateOfflineNavigationRouterCache({ buildId })
+        reportOfflineNavigationFallbackDiagnostic({
+          type: 'router-cache-hydration',
+          url: location.href,
+          buildId,
+          routes: result.routes,
+          segments: result.segments,
+        })
+      }
     } catch {
       // The exact URL fallback already booted. Router cache hydration should
       // only improve later navigations, never block the current render.

--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -55,13 +55,93 @@ function isOfflineNavigationFallbackDocument(): boolean {
   )
 }
 
-function showOfflineNavigationCacheMiss(): void {
+const OFFLINE_NAVIGATION_DIAGNOSTIC_LIMIT = 32
+
+type OfflineNavigationCacheMissReason =
+  | 'missing-entry'
+  | 'invalid-payload'
+  | 'unsupported-request-kind'
+  | 'read-error'
+
+type OfflineNavigationFallbackDiagnostic =
+  | {
+      type: 'cache-hit'
+      url: string
+      buildId: string | undefined
+      requestKind: OfflineNavigationFallbackResponse['requestKind']
+    }
+  | {
+      type: 'cache-miss'
+      url: string
+      buildId: string | undefined
+      reason: OfflineNavigationCacheMissReason
+    }
+
+declare global {
+  interface Window {
+    __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?:
+      | OfflineNavigationFallbackDiagnostic[]
+      | undefined
+  }
+}
+
+function reportOfflineNavigationFallbackDiagnostic(
+  diagnostic: OfflineNavigationFallbackDiagnostic
+): void {
+  const diagnostics = (window.__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__ ??= [])
+  if (diagnostics.length >= OFFLINE_NAVIGATION_DIAGNOSTIC_LIMIT) {
+    diagnostics.shift()
+  }
+  diagnostics.push(diagnostic)
+}
+
+function showOfflineNavigationCacheHit(
+  requestKind: OfflineNavigationFallbackResponse['requestKind'],
+  buildId: string | undefined
+): void {
+  document.documentElement.setAttribute(
+    'data-next-offline-navigation-cache',
+    'hit'
+  )
+  document.documentElement.removeAttribute(
+    'data-next-offline-navigation-cache-reason'
+  )
+  reportOfflineNavigationFallbackDiagnostic({
+    type: 'cache-hit',
+    url: location.href,
+    buildId,
+    requestKind,
+  })
+}
+
+function showOfflineNavigationCacheMiss(
+  reason: OfflineNavigationCacheMissReason,
+  buildId: string | undefined
+): void {
+  document.documentElement.setAttribute(
+    'data-next-offline-navigation-cache',
+    'miss'
+  )
+  document.documentElement.setAttribute(
+    'data-next-offline-navigation-cache-reason',
+    reason
+  )
   const cacheMissElement = document.getElementById(
     '__NEXT_OFFLINE_NAVIGATION_CACHE_MISS'
   )
   if (cacheMissElement !== null) {
     cacheMissElement.hidden = false
+    cacheMissElement.setAttribute(
+      'data-next-offline-navigation-cache-reason',
+      reason
+    )
   }
+  reportOfflineNavigationFallbackDiagnostic({
+    type: 'cache-miss',
+    url: location.href,
+    buildId,
+    reason,
+  })
 }
 
 function neverResolveOfflineNavigationResponse(): Promise<Response> {
@@ -97,12 +177,22 @@ function createOfflineNavigationFallbackResponse():
     })
     const payload = entry?.payload
 
+    if (!isOfflineNavigationRSCResponsePayload(payload)) {
+      showOfflineNavigationCacheMiss(
+        payload === undefined ? 'missing-entry' : 'invalid-payload',
+        buildId
+      )
+      return {
+        requestKind: 'client-resume',
+        response: await neverResolveOfflineNavigationResponse(),
+      }
+    }
+
     if (
-      !isOfflineNavigationRSCResponsePayload(payload) ||
-      (payload.requestKind !== 'client-resume' &&
-        payload.requestKind !== 'initial-load')
+      payload.requestKind !== 'client-resume' &&
+      payload.requestKind !== 'initial-load'
     ) {
-      showOfflineNavigationCacheMiss()
+      showOfflineNavigationCacheMiss('unsupported-request-kind', buildId)
       return {
         requestKind: 'client-resume',
         response: await neverResolveOfflineNavigationResponse(),
@@ -112,12 +202,13 @@ function createOfflineNavigationFallbackResponse():
     const requestKind: OfflineNavigationFallbackResponse['requestKind'] =
       payload.requestKind === 'initial-load' ? 'initial-load' : 'client-resume'
 
+    showOfflineNavigationCacheHit(requestKind, buildId)
     return {
       requestKind,
       response: createOfflineNavigationRSCResponse(payload),
     }
   })().catch(async (): Promise<OfflineNavigationFallbackResponse> => {
-    showOfflineNavigationCacheMiss()
+    showOfflineNavigationCacheMiss('read-error', undefined)
     return {
       requestKind: 'client-resume',
       response: await neverResolveOfflineNavigationResponse(),

--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -45,6 +45,77 @@ const instantTestStaticFetch: Promise<Response> | undefined =
     ? (self.__next_instant_test as unknown as Promise<Response>)
     : undefined
 
+function isOfflineNavigationFallbackDocument(): boolean {
+  return Boolean(
+    process.env.__NEXT_OFFLINE_NAVIGATIONS &&
+      !process.env.__NEXT_DEV_SERVER &&
+      document.documentElement.hasAttribute(
+        'data-next-offline-navigation-fallback'
+      )
+  )
+}
+
+function showOfflineNavigationCacheMiss(): void {
+  const cacheMissElement = document.getElementById(
+    '__NEXT_OFFLINE_NAVIGATION_CACHE_MISS'
+  )
+  if (cacheMissElement !== null) {
+    cacheMissElement.hidden = false
+  }
+}
+
+function neverResolveOfflineNavigationResponse(): Promise<Response> {
+  return new Promise<Response>(() => {})
+}
+
+function createOfflineNavigationClientResumeFetch():
+  | Promise<Response>
+  | undefined {
+  if (!isOfflineNavigationFallbackDocument()) {
+    return undefined
+  }
+
+  return (async () => {
+    const {
+      createOfflineNavigationRSCResponse,
+      isOfflineNavigationRSCResponsePayload,
+      readOfflineNavigationCacheEntry,
+    } =
+      require('./components/router-reducer/offline-navigation-cache') as typeof import('./components/router-reducer/offline-navigation-cache')
+
+    const buildId =
+      getDeploymentId() ??
+      document.documentElement.getAttribute('data-build-id') ??
+      undefined
+    const entry = await readOfflineNavigationCacheEntry(location.href, {
+      buildId,
+    })
+    const payload = entry?.payload
+
+    if (
+      !isOfflineNavigationRSCResponsePayload(payload) ||
+      payload.requestKind !== 'client-resume'
+    ) {
+      showOfflineNavigationCacheMiss()
+      return neverResolveOfflineNavigationResponse()
+    }
+
+    return createOfflineNavigationRSCResponse(payload)
+  })().catch(() => {
+    showOfflineNavigationCacheMiss()
+    return neverResolveOfflineNavigationResponse()
+  })
+}
+
+const offlineNavigationClientResumeFetch =
+  createOfflineNavigationClientResumeFetch()
+
+const hasLockedStaticShell =
+  Boolean(instantTestStaticFetch) ||
+  Boolean(offlineNavigationClientResumeFetch) ||
+  // @ts-expect-error
+  Boolean(window.__NEXT_CLIENT_RESUME)
+
 const encoder = new TextEncoder()
 
 let initialServerDataBuffer: (string | Uint8Array)[] | undefined = undefined
@@ -128,14 +199,11 @@ function nextServerDataRegisterWriter(ctr: ReadableStreamDefaultController) {
       ctr.enqueue(typeof val === 'string' ? encoder.encode(val) : val)
     })
     if (initialServerDataLoaded && !initialServerDataFlushed) {
-      // Instant Navigation Testing API: don't close or error the inline
-      // Flight stream. The static shell has no inline Flight data, so the
-      // stream is empty. Closing it would cause React to log an error about
-      // missing data. Leaving it open lets React treat any holes as
-      // "still suspended." Hydration uses the separately fetched RSC payload
-      // (self.__next_instant_test), not this stream.
+      // Locked static shells do not have a real inline Flight stream. Closing
+      // or erroring this stream causes React to report a missing-data failure,
+      // but the actual hydration data arrives through a separate response.
       if (isStreamErrorOrUnfinished(ctr)) {
-        if (!instantTestStaticFetch) {
+        if (!hasLockedStaticShell) {
           ctr.error(
             new Error(
               'The connection to the page was unexpectedly closed, possibly due to the stop button being clicked, loss of Wi-Fi, or an unstable internet connection.'
@@ -155,7 +223,11 @@ function nextServerDataRegisterWriter(ctr: ReadableStreamDefaultController) {
 
 // When `DOMContentLoaded`, we can close all pending writers to finish hydration.
 const DOMContentLoaded = function () {
-  if (initialServerDataWriter && !initialServerDataFlushed) {
+  if (
+    initialServerDataWriter &&
+    !initialServerDataFlushed &&
+    !hasLockedStaticShell
+  ) {
     initialServerDataWriter.close()
     initialServerDataFlushed = true
     initialServerDataBuffer = undefined
@@ -198,7 +270,8 @@ if (process.env.NODE_ENV !== 'production') {
 let initialFlightStreamForCache: ReadableStream<Uint8Array> | null = null
 if (
   process.env.__NEXT_CACHE_COMPONENTS &&
-  process.env.__NEXT_EXPERIMENTAL_CACHED_NAVIGATIONS
+  process.env.__NEXT_EXPERIMENTAL_CACHED_NAVIGATIONS &&
+  !offlineNavigationClientResumeFetch
 ) {
   const [forReact, forCache] = readable.tee()
   readable = forReact
@@ -242,6 +315,20 @@ if (instantTestStaticFetch) {
       initialRSCPayload
     )
   })
+} else if (offlineNavigationClientResumeFetch) {
+  initialServerResponse = Promise.resolve(
+    createFromFetch<InitialRSCPayload>(offlineNavigationClientResumeFetch, {
+      callServer,
+      findSourceMapURL,
+      debugChannel,
+      unstable_allowPartialStream: true,
+    })
+  ).then(async (fallbackInitialRSCPayload) =>
+    createInitialRSCPayloadFromFallbackPrerender(
+      await offlineNavigationClientResumeFetch,
+      fallbackInitialRSCPayload
+    )
+  )
 } else if (
   // @ts-expect-error
   window.__NEXT_CLIENT_RESUME
@@ -365,7 +452,11 @@ export async function hydrate(
   // Initialize the offline module to register browser event listeners
   // (offline/online) before any components hydrate.
   if (process.env.__NEXT_USE_OFFLINE) {
-    require('./components/offline') as typeof import('./components/offline')
+    const { notifyOffline } =
+      require('./components/offline') as typeof import('./components/offline')
+    if (offlineNavigationClientResumeFetch) {
+      notifyOffline()
+    }
   }
 
   // setNavigationBuildId should be called only once, during JS initialization
@@ -411,9 +502,13 @@ export async function hydrate(
     </StrictModeIfEnabled>
   )
 
-  if (document.documentElement.id === '__next_error__') {
+  if (
+    document.documentElement.id === '__next_error__' ||
+    isOfflineNavigationFallbackDocument()
+  ) {
     let element = reactEl
-    // Server rendering failed, fall back to client-side rendering
+    // Error documents and generated offline navigation fallback documents do
+    // not contain route HTML that can be hydrated.
     if (process.env.NODE_ENV !== 'production') {
       const { RootLevelDevOverlayElement } =
         require('../next-devtools/userspace/app/client-entry') as typeof import('../next-devtools/userspace/app/client-entry')

--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -68,14 +68,19 @@ function neverResolveOfflineNavigationResponse(): Promise<Response> {
   return new Promise<Response>(() => {})
 }
 
-function createOfflineNavigationClientResumeFetch():
-  | Promise<Response>
+type OfflineNavigationFallbackResponse = {
+  requestKind: 'client-resume' | 'initial-load'
+  response: Response
+}
+
+function createOfflineNavigationFallbackResponse():
+  | Promise<OfflineNavigationFallbackResponse>
   | undefined {
   if (!isOfflineNavigationFallbackDocument()) {
     return undefined
   }
 
-  return (async () => {
+  return (async (): Promise<OfflineNavigationFallbackResponse> => {
     const {
       createOfflineNavigationRSCResponse,
       isOfflineNavigationRSCResponsePayload,
@@ -94,27 +99,44 @@ function createOfflineNavigationClientResumeFetch():
 
     if (
       !isOfflineNavigationRSCResponsePayload(payload) ||
-      payload.requestKind !== 'client-resume'
+      (payload.requestKind !== 'client-resume' &&
+        payload.requestKind !== 'initial-load')
     ) {
       showOfflineNavigationCacheMiss()
-      return neverResolveOfflineNavigationResponse()
+      return {
+        requestKind: 'client-resume',
+        response: await neverResolveOfflineNavigationResponse(),
+      }
     }
 
-    return createOfflineNavigationRSCResponse(payload)
-  })().catch(() => {
+    const requestKind: OfflineNavigationFallbackResponse['requestKind'] =
+      payload.requestKind === 'initial-load' ? 'initial-load' : 'client-resume'
+
+    return {
+      requestKind,
+      response: createOfflineNavigationRSCResponse(payload),
+    }
+  })().catch(async (): Promise<OfflineNavigationFallbackResponse> => {
     showOfflineNavigationCacheMiss()
-    return neverResolveOfflineNavigationResponse()
+    return {
+      requestKind: 'client-resume',
+      response: await neverResolveOfflineNavigationResponse(),
+    }
   })
 }
 
+const offlineNavigationFallbackResponse =
+  createOfflineNavigationFallbackResponse()
 const offlineNavigationClientResumeFetch =
-  createOfflineNavigationClientResumeFetch()
+  offlineNavigationFallbackResponse?.then(({ response }) => response)
 
+const hasClientResumeShell =
+  // @ts-expect-error
+  Boolean(window.__NEXT_CLIENT_RESUME)
 const hasLockedStaticShell =
   Boolean(instantTestStaticFetch) ||
   Boolean(offlineNavigationClientResumeFetch) ||
-  // @ts-expect-error
-  Boolean(window.__NEXT_CLIENT_RESUME)
+  hasClientResumeShell
 
 const encoder = new TextEncoder()
 
@@ -268,6 +290,19 @@ if (process.env.NODE_ENV !== 'production') {
 // know if `l` is present until React decodes the payload, so always tee and
 // cancel the clone if not needed.
 let initialFlightStreamForCache: ReadableStream<Uint8Array> | null = null
+let initialFlightStreamForOfflineNavigationCache: ReadableStream<Uint8Array> | null =
+  null
+if (
+  process.env.__NEXT_OFFLINE_NAVIGATIONS &&
+  process.env.NODE_ENV === 'production' &&
+  process.env.__NEXT_CONFIG_OUTPUT !== 'export' &&
+  !process.env.__NEXT_DEV_SERVER &&
+  !hasLockedStaticShell
+) {
+  const [forApp, forOfflineNavigationCache] = readable.tee()
+  readable = forApp
+  initialFlightStreamForOfflineNavigationCache = forOfflineNavigationCache
+}
 if (
   process.env.__NEXT_CACHE_COMPONENTS &&
   process.env.__NEXT_EXPERIMENTAL_CACHED_NAVIGATIONS &&
@@ -323,12 +358,17 @@ if (instantTestStaticFetch) {
       debugChannel,
       unstable_allowPartialStream: true,
     })
-  ).then(async (fallbackInitialRSCPayload) =>
-    createInitialRSCPayloadFromFallbackPrerender(
-      await offlineNavigationClientResumeFetch,
+  ).then(async (fallbackInitialRSCPayload) => {
+    const fallbackResponse = await offlineNavigationFallbackResponse!
+    if (fallbackResponse.requestKind === 'initial-load') {
+      return fallbackInitialRSCPayload
+    }
+
+    return createInitialRSCPayloadFromFallbackPrerender(
+      fallbackResponse.response,
       fallbackInitialRSCPayload
     )
-  )
+  })
 } else if (
   // @ts-expect-error
   window.__NEXT_CLIENT_RESUME
@@ -482,6 +522,7 @@ export async function hydrate(
       navigatedAt: initialTimestamp,
       initialRSCPayload,
       initialFlightStreamForCache,
+      initialFlightStreamForOfflineNavigationCache,
       location: window.location,
     }),
     instrumentationHooks

--- a/packages/next/src/client/components/offline.ts
+++ b/packages/next/src/client/components/offline.ts
@@ -77,7 +77,7 @@ export function getOffline(): OfflineState | null {
  * Enters the offline state if not already in it, and starts the
  * connectivity polling loop.
  */
-function notifyOffline(): OfflineState {
+export function notifyOffline(): OfflineState {
   if (offlineState !== null) {
     return offlineState
   }

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -227,7 +227,6 @@ export function createInitialRouterState({
 
   persistInitialOfflineNavigationResponse({
     initialCouldBeIntercepted,
-    initialDynamicStaleTimeSeconds,
     initialFlightStreamForOfflineNavigationCache,
     initialRuntimePrefetchStream,
     initialStaleAt,
@@ -283,7 +282,6 @@ export function createInitialRouterState({
 
 function persistInitialOfflineNavigationResponse({
   initialCouldBeIntercepted,
-  initialDynamicStaleTimeSeconds,
   initialFlightStreamForOfflineNavigationCache,
   initialRuntimePrefetchStream,
   initialStaleAt,
@@ -293,7 +291,6 @@ function persistInitialOfflineNavigationResponse({
   navigatedAt,
 }: {
   initialCouldBeIntercepted: boolean
-  initialDynamicStaleTimeSeconds: number | undefined
   initialFlightStreamForOfflineNavigationCache:
     | ReadableStream<Uint8Array>
     | null
@@ -309,19 +306,29 @@ function persistInitialOfflineNavigationResponse({
     return
   }
 
-  if (
-    !process.env.__NEXT_OFFLINE_NAVIGATIONS ||
-    process.env.__NEXT_DEV_SERVER ||
-    process.env.NODE_ENV !== 'production' ||
-    process.env.__NEXT_CONFIG_OUTPUT === 'export' ||
-    location === null ||
-    !initialSupportsPerSegmentPrefetching ||
-    initialCouldBeIntercepted ||
-    initialDynamicStaleTimeSeconds !== undefined ||
-    initialRuntimePrefetchStream !== undefined ||
-    initialStaleAt === null ||
-    initialStaticStageByteLength !== undefined
-  ) {
+  if (location === null || initialStaleAt === null) {
+    initialFlightStreamForOfflineNavigationCache.cancel()
+    return
+  }
+
+  const url = createHrefFromUrl(location)
+
+  const {
+    createOfflineNavigationRSCResponsePayload,
+    getOfflineNavigationRSCResponseCacheSkipReason,
+    writeOfflineNavigationRSCResponseCacheEntry,
+  } =
+    require('./offline-navigation-cache') as typeof import('./offline-navigation-cache')
+
+  const skipReason = getOfflineNavigationRSCResponseCacheSkipReason({
+    requestKind: 'initial-load',
+    hasPartialResponse: initialStaticStageByteLength !== undefined,
+    hasRuntimePrefetch: initialRuntimePrefetchStream !== undefined,
+    isInterception: initialCouldBeIntercepted,
+    supportsPerSegmentPrefetching: initialSupportsPerSegmentPrefetching,
+    url,
+  })
+  if (skipReason !== null) {
     initialFlightStreamForOfflineNavigationCache.cancel()
     return
   }
@@ -332,14 +339,8 @@ function persistInitialOfflineNavigationResponse({
     statusText: 'OK',
   })
   Object.defineProperty(response, 'url', {
-    value: createHrefFromUrl(location),
+    value: url,
   })
-
-  const {
-    createOfflineNavigationRSCResponsePayload,
-    writeOfflineNavigationRSCResponseCacheEntry,
-  } =
-    require('./offline-navigation-cache') as typeof import('./offline-navigation-cache')
 
   const payload = createOfflineNavigationRSCResponsePayload(
     response,
@@ -352,7 +353,7 @@ function persistInitialOfflineNavigationResponse({
       expiresAt: staleAt,
       payload,
       staleAt,
-      url: createHrefFromUrl(location),
+      url,
       now: navigatedAt,
     })
   })().catch(() => {

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -21,11 +21,13 @@ import {
 import { decodeStaticStage } from './fetch-server-response'
 import { discoverKnownRoute } from '../segment-cache/optimistic-routes'
 import type { NormalizedSearch } from '../segment-cache/cache-key'
+import { RSC_CONTENT_TYPE_HEADER } from '../app-router-headers'
 
 export interface InitialRouterStateParameters {
   navigatedAt: number
   initialRSCPayload: InitialRSCPayload
   initialFlightStreamForCache?: ReadableStream<Uint8Array> | null
+  initialFlightStreamForOfflineNavigationCache?: ReadableStream<Uint8Array> | null
   location: Location | null
 }
 
@@ -33,6 +35,7 @@ export function createInitialRouterState({
   navigatedAt,
   initialRSCPayload,
   initialFlightStreamForCache,
+  initialFlightStreamForOfflineNavigationCache,
   location,
 }: InitialRouterStateParameters): AppRouterState {
   const {
@@ -88,6 +91,12 @@ export function createInitialRouterState({
     acc
   )
   const metadataVaryPath = acc.metadataVaryPath
+  const initialStaleAt =
+    location === null ||
+    initialSeedData === null ||
+    initialStaticStageByteLength !== undefined
+      ? null
+      : getStaleAt(navigatedAt, initialStaleTime)
   const initialTask = createInitialCacheNodeForHydration(
     navigatedAt,
     initialRouteTree,
@@ -157,7 +166,7 @@ export function createInitialRouterState({
         // hydration and write it into the cache directly.
         const now = Date.now()
 
-        getStaleAt(now, initialStaleTime)
+        initialStaleAt!
           .then((staleAt) => {
             writeStaticStageResponseIntoCache(
               now,
@@ -216,6 +225,18 @@ export function createInitialRouterState({
     }
   }
 
+  persistInitialOfflineNavigationResponse({
+    initialCouldBeIntercepted,
+    initialDynamicStaleTimeSeconds,
+    initialFlightStreamForOfflineNavigationCache,
+    initialRuntimePrefetchStream,
+    initialStaleAt,
+    initialStaticStageByteLength,
+    initialSupportsPerSegmentPrefetching,
+    location,
+    navigatedAt,
+  })
+
   // NOTE: We intentionally don't check if any data needs to be fetched from the
   // server. We assume the initial hydration payload is sufficient to render
   // the page.
@@ -258,4 +279,83 @@ export function createInitialRouterState({
   }
 
   return initialState
+}
+
+function persistInitialOfflineNavigationResponse({
+  initialCouldBeIntercepted,
+  initialDynamicStaleTimeSeconds,
+  initialFlightStreamForOfflineNavigationCache,
+  initialRuntimePrefetchStream,
+  initialStaleAt,
+  initialStaticStageByteLength,
+  initialSupportsPerSegmentPrefetching,
+  location,
+  navigatedAt,
+}: {
+  initialCouldBeIntercepted: boolean
+  initialDynamicStaleTimeSeconds: number | undefined
+  initialFlightStreamForOfflineNavigationCache:
+    | ReadableStream<Uint8Array>
+    | null
+    | undefined
+  initialRuntimePrefetchStream: ReadableStream<Uint8Array> | undefined
+  initialStaleAt: Promise<number> | null
+  initialStaticStageByteLength: Promise<number> | undefined
+  initialSupportsPerSegmentPrefetching: boolean
+  location: Location | null
+  navigatedAt: number
+}): void {
+  if (initialFlightStreamForOfflineNavigationCache == null) {
+    return
+  }
+
+  if (
+    !process.env.__NEXT_OFFLINE_NAVIGATIONS ||
+    process.env.__NEXT_DEV_SERVER ||
+    process.env.NODE_ENV !== 'production' ||
+    process.env.__NEXT_CONFIG_OUTPUT === 'export' ||
+    location === null ||
+    !initialSupportsPerSegmentPrefetching ||
+    initialCouldBeIntercepted ||
+    initialDynamicStaleTimeSeconds !== undefined ||
+    initialRuntimePrefetchStream !== undefined ||
+    initialStaleAt === null ||
+    initialStaticStageByteLength !== undefined
+  ) {
+    initialFlightStreamForOfflineNavigationCache.cancel()
+    return
+  }
+
+  const response = new Response(initialFlightStreamForOfflineNavigationCache, {
+    headers: { 'content-type': RSC_CONTENT_TYPE_HEADER },
+    status: 200,
+    statusText: 'OK',
+  })
+  Object.defineProperty(response, 'url', {
+    value: createHrefFromUrl(location),
+  })
+
+  const {
+    createOfflineNavigationRSCResponsePayload,
+    writeOfflineNavigationRSCResponseCacheEntry,
+  } =
+    require('./offline-navigation-cache') as typeof import('./offline-navigation-cache')
+
+  const payload = createOfflineNavigationRSCResponsePayload(
+    response,
+    'initial-load'
+  ).catch(() => null)
+
+  void (async () => {
+    const staleAt = await initialStaleAt
+    await writeOfflineNavigationRSCResponseCacheEntry({
+      expiresAt: staleAt,
+      payload,
+      staleAt,
+      url: createHrefFromUrl(location),
+      now: navigatedAt,
+    })
+  })().catch(() => {
+    // The page already rendered. Offline persistence must not affect boot.
+  })
 }

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -50,8 +50,10 @@ import {
 import { UnknownDynamicStaleTime } from '../segment-cache/bfcache'
 import {
   createOfflineNavigationRSCResponsePayload,
+  getOfflineNavigationRSCResponseCacheSkipReason,
   writeOfflineNavigationRSCResponseCacheEntry,
   type OfflineNavigationRSCResponsePayload,
+  type OfflineNavigationRSCResponseRequestKind,
 } from './offline-navigation-cache'
 
 const createFromReadableStream =
@@ -371,6 +373,7 @@ export type RSCResponse<T> = {
   url: string
   flightResponsePromise: (Promise<T> & { _debugInfo?: Array<any> }) | null
   cacheData: Promise<FetchResponseCacheData | null>
+  offlineNavigationCacheRequestKind: OfflineNavigationRSCResponseRequestKind | null
   offlineNavigationCachePayload: Promise<OfflineNavigationRSCResponsePayload | null> | null
 }
 
@@ -552,8 +555,13 @@ export async function createFetch<T>(
   let fetchUrl = new URL(url)
   await setCacheBustingSearchParam(fetchUrl, headers)
   let processed = fetch(fetchUrl, fetchOptions).then(processFetch)
+  const offlineNavigationCacheRequestKind =
+    getOfflineNavigationCacheRequestKind(headers)
   let offlineNavigationCachePayload =
-    createOfflineNavigationCachePayloadFromProcessedResponse(processed, headers)
+    createOfflineNavigationCachePayloadFromProcessedResponse(
+      processed,
+      offlineNavigationCacheRequestKind
+    )
   let fetchPromise = processed.then(({ response }) => response)
 
   // Immediately pass the fetch promise to the Flight client so that the debug
@@ -627,7 +635,7 @@ export async function createFetch<T>(
       offlineNavigationCachePayload =
         createOfflineNavigationCachePayloadFromProcessedResponse(
           processed,
-          headers
+          offlineNavigationCacheRequestKind
         )
       fetchPromise = processed.then(({ response }) => response)
       flightResponsePromise = shouldImmediatelyDecode
@@ -668,6 +676,7 @@ export async function createFetch<T>(
 
     cacheData: processed.then(({ cacheData }) => cacheData),
 
+    offlineNavigationCacheRequestKind,
     offlineNavigationCachePayload,
   }
 
@@ -717,9 +726,8 @@ function createOfflineNavigationCachePayloadFromProcessedResponse(
     response: Response
     cacheData: FetchResponseCacheData | null
   }>,
-  headers: RequestHeaders
+  requestKind: OfflineNavigationRSCResponseRequestKind | null
 ): Promise<OfflineNavigationRSCResponsePayload | null> | null {
-  const requestKind = getOfflineNavigationCacheRequestKind(headers)
   if (requestKind === null) {
     return null
   }
@@ -752,17 +760,18 @@ function persistOfflineNavigationResponse({
   postponed: boolean
   response: RSCResponse<NavigationFlightResponse>
 }): void {
-  if (
-    response.offlineNavigationCachePayload === null ||
-    !flightResponse.S ||
-    flightResponse.d !== undefined ||
-    flightResponse.p !== undefined ||
-    interception ||
-    isHmrRefresh ||
-    postponed ||
-    response.redirected ||
-    canonicalUrl.origin !== location.origin
-  ) {
+  const skipReason = getOfflineNavigationRSCResponseCacheSkipReason({
+    requestKind: response.offlineNavigationCacheRequestKind,
+    hasCachePayload: response.offlineNavigationCachePayload !== null,
+    supportsPerSegmentPrefetching: flightResponse.S,
+    hasRuntimePrefetch: flightResponse.p !== undefined,
+    isHmrRefresh: isHmrRefresh === true,
+    isInterception: interception,
+    isPostponed: postponed,
+    isRedirected: response.redirected,
+    url: canonicalUrl,
+  })
+  if (skipReason !== null) {
     return
   }
 

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -685,7 +685,7 @@ export async function createFetch<T>(
 
 function getOfflineNavigationCacheRequestKind(
   headers: RequestHeaders
-): 'navigation' | 'route-prefetch' | 'client-resume' | null {
+): OfflineNavigationRSCResponseRequestKind | null {
   if (
     !process.env.__NEXT_OFFLINE_NAVIGATIONS ||
     process.env.__NEXT_DEV_SERVER ||
@@ -705,8 +705,12 @@ function getOfflineNavigationCacheRequestKind(
 
   if (
     headers[NEXT_ROUTER_PREFETCH_HEADER] !== undefined &&
-    headers[NEXT_ROUTER_SEGMENT_PREFETCH_HEADER] === undefined
+    headers[NEXT_ROUTER_SEGMENT_PREFETCH_HEADER] !== undefined
   ) {
+    return 'segment-prefetch'
+  }
+
+  if (headers[NEXT_ROUTER_PREFETCH_HEADER] !== undefined) {
     return 'route-prefetch'
   }
 

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -16,8 +16,8 @@ import type {
 } from '../../../shared/lib/app-router-types'
 
 import {
-  type NEXT_ROUTER_PREFETCH_HEADER,
-  type NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
+  NEXT_ROUTER_PREFETCH_HEADER,
+  NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
   type NEXT_INSTANT_PREFETCH_HEADER,
   NEXT_ROUTER_STATE_TREE_HEADER,
   NEXT_RSC_UNION_QUERY,
@@ -45,8 +45,14 @@ import { NEXT_NAV_DEPLOYMENT_ID_HEADER } from '../../../lib/constants'
 import {
   stripIsPartialByte,
   createNonTaskyPrefetchResponseStream,
+  getStaleAt,
 } from '../segment-cache/cache'
 import { UnknownDynamicStaleTime } from '../segment-cache/bfcache'
+import {
+  createOfflineNavigationRSCResponsePayload,
+  writeOfflineNavigationRSCResponseCacheEntry,
+  type OfflineNavigationRSCResponsePayload,
+} from './offline-navigation-cache'
 
 const createFromReadableStream =
   createFromReadableStreamBrowser as (typeof import('react-server-dom-webpack/client.browser'))['createFromReadableStream']
@@ -275,6 +281,16 @@ export async function fetchServerResponse(
       return doMpaNavigation(normalizedFlightData)
     }
 
+    persistOfflineNavigationResponse({
+      canonicalUrl,
+      flightResponse,
+      interception,
+      isHmrRefresh: options.isHmrRefresh,
+      originalUrl,
+      postponed,
+      response: res,
+    })
+
     const staticStageData =
       cacheData !== null
         ? await resolveStaticStageData(cacheData, flightResponse, headers)
@@ -355,6 +371,7 @@ export type RSCResponse<T> = {
   url: string
   flightResponsePromise: (Promise<T> & { _debugInfo?: Array<any> }) | null
   cacheData: Promise<FetchResponseCacheData | null>
+  offlineNavigationCachePayload: Promise<OfflineNavigationRSCResponsePayload | null> | null
 }
 
 type FetchResponseCacheData = {
@@ -535,6 +552,8 @@ export async function createFetch<T>(
   let fetchUrl = new URL(url)
   await setCacheBustingSearchParam(fetchUrl, headers)
   let processed = fetch(fetchUrl, fetchOptions).then(processFetch)
+  let offlineNavigationCachePayload =
+    createOfflineNavigationCachePayloadFromProcessedResponse(processed, headers)
   let fetchPromise = processed.then(({ response }) => response)
 
   // Immediately pass the fetch promise to the Flight client so that the debug
@@ -605,6 +624,11 @@ export async function createFetch<T>(
       fetchUrl = new URL(responseUrl)
       await setCacheBustingSearchParam(fetchUrl, headers)
       processed = fetch(fetchUrl, fetchOptions).then(processFetch)
+      offlineNavigationCachePayload =
+        createOfflineNavigationCachePayloadFromProcessedResponse(
+          processed,
+          headers
+        )
       fetchPromise = processed.then(({ response }) => response)
       flightResponsePromise = shouldImmediatelyDecode
         ? createFromNextFetch<T>(fetchPromise, headers)
@@ -643,9 +667,118 @@ export async function createFetch<T>(
     flightResponsePromise: flightResponsePromise,
 
     cacheData: processed.then(({ cacheData }) => cacheData),
+
+    offlineNavigationCachePayload,
   }
 
   return rscResponse
+}
+
+function getOfflineNavigationCacheRequestKind(
+  headers: RequestHeaders
+): 'navigation' | 'route-prefetch' | 'client-resume' | null {
+  if (
+    !process.env.__NEXT_OFFLINE_NAVIGATIONS ||
+    process.env.__NEXT_DEV_SERVER ||
+    process.env.NODE_ENV !== 'production' ||
+    process.env.__NEXT_CONFIG_OUTPUT === 'export' ||
+    headers[NEXT_HMR_REFRESH_HEADER]
+  ) {
+    return null
+  }
+
+  if (
+    headers[NEXT_ROUTER_PREFETCH_HEADER] !== undefined &&
+    headers[NEXT_ROUTER_SEGMENT_PREFETCH_HEADER] === '/_full'
+  ) {
+    return 'client-resume'
+  }
+
+  if (
+    headers[NEXT_ROUTER_PREFETCH_HEADER] !== undefined &&
+    headers[NEXT_ROUTER_SEGMENT_PREFETCH_HEADER] === undefined
+  ) {
+    return 'route-prefetch'
+  }
+
+  if (
+    headers[NEXT_ROUTER_STATE_TREE_HEADER] !== undefined &&
+    headers[NEXT_ROUTER_PREFETCH_HEADER] === undefined &&
+    headers[NEXT_ROUTER_SEGMENT_PREFETCH_HEADER] === undefined
+  ) {
+    return 'navigation'
+  }
+
+  return null
+}
+
+function createOfflineNavigationCachePayloadFromProcessedResponse(
+  processed: Promise<{
+    response: Response
+    cacheData: FetchResponseCacheData | null
+  }>,
+  headers: RequestHeaders
+): Promise<OfflineNavigationRSCResponsePayload | null> | null {
+  const requestKind = getOfflineNavigationCacheRequestKind(headers)
+  if (requestKind === null) {
+    return null
+  }
+
+  return processed
+    .then(({ response }) => {
+      if (!response.ok || !response.body) {
+        return null
+      }
+
+      return createOfflineNavigationRSCResponsePayload(response, requestKind)
+    })
+    .catch(() => null)
+}
+
+function persistOfflineNavigationResponse({
+  canonicalUrl,
+  flightResponse,
+  interception,
+  isHmrRefresh,
+  originalUrl,
+  postponed,
+  response,
+}: {
+  canonicalUrl: URL
+  flightResponse: NavigationFlightResponse
+  interception: boolean
+  isHmrRefresh: boolean | undefined
+  originalUrl: URL
+  postponed: boolean
+  response: RSCResponse<NavigationFlightResponse>
+}): void {
+  if (
+    response.offlineNavigationCachePayload === null ||
+    !flightResponse.S ||
+    flightResponse.d !== undefined ||
+    flightResponse.p !== undefined ||
+    interception ||
+    isHmrRefresh ||
+    postponed ||
+    response.redirected ||
+    canonicalUrl.origin !== location.origin
+  ) {
+    return
+  }
+
+  void (async () => {
+    const now = Date.now()
+    const staleAt = await getStaleAt(now, flightResponse.s, response)
+    await writeOfflineNavigationRSCResponseCacheEntry({
+      buildId:
+        response.headers.get(NEXT_NAV_DEPLOYMENT_ID_HEADER) ?? flightResponse.b,
+      expiresAt: staleAt,
+      payload: response.offlineNavigationCachePayload!,
+      staleAt,
+      url: originalUrl,
+      now,
+    })
+  })()
 }
 
 export function createFromNextReadableStream<T>(

--- a/packages/next/src/client/components/router-reducer/offline-navigation-cache.test.ts
+++ b/packages/next/src/client/components/router-reducer/offline-navigation-cache.test.ts
@@ -337,6 +337,15 @@ describe('offline navigation cache', () => {
     expect(getCacheSkipReason()).toBe(null)
   })
 
+  it('allows initial-load RSC responses without per-segment prefetch support', () => {
+    expect(
+      getCacheSkipReason({
+        requestKind: 'initial-load',
+        supportsPerSegmentPrefetching: false,
+      })
+    ).toBe(null)
+  })
+
   it('deletes exact URL entries', async () => {
     const storage = new MemoryOfflineNavigationCacheStorage()
     const cache = createOfflineNavigationCache(storage)

--- a/packages/next/src/client/components/router-reducer/offline-navigation-cache.test.ts
+++ b/packages/next/src/client/components/router-reducer/offline-navigation-cache.test.ts
@@ -3,6 +3,7 @@ import {
   createOfflineNavigationRSCResponse,
   createOfflineNavigationRSCResponsePayload,
   deleteOfflineNavigationCacheEntry,
+  isOfflineNavigationRSCResponsePayload,
   normalizeOfflineNavigationCacheUrl,
   readOfflineNavigationCacheEntry,
   writeOfflineNavigationCacheEntry,
@@ -71,6 +72,26 @@ describe('offline navigation cache', () => {
     ).toBe('https://example.com/dashboard?tab=activity')
   })
 
+  it('normalizes exact URL keys with the configured trailing slash', () => {
+    const originalTrailingSlash = process.env.__NEXT_TRAILING_SLASH
+    process.env.__NEXT_TRAILING_SLASH = 'true'
+
+    try {
+      expect(
+        normalizeOfflineNavigationCacheUrl('https://example.com/dashboard')
+      ).toBe('https://example.com/dashboard/')
+      expect(
+        normalizeOfflineNavigationCacheUrl('https://example.com/feed.xml')
+      ).toBe('https://example.com/feed.xml')
+    } finally {
+      if (originalTrailingSlash === undefined) {
+        delete process.env.__NEXT_TRAILING_SLASH
+      } else {
+        process.env.__NEXT_TRAILING_SLASH = originalTrailingSlash
+      }
+    }
+  })
+
   it('writes and reads exact URL entries for the current build', async () => {
     const storage = new MemoryOfflineNavigationCacheStorage()
     const cache = createOfflineNavigationCache(storage)
@@ -132,9 +153,13 @@ describe('offline navigation cache', () => {
       ]),
     })
 
-    await expect(
-      createOfflineNavigationRSCResponse(payload).text()
-    ).resolves.toBe('0:["$","payload"]')
+    const restoredResponse = createOfflineNavigationRSCResponse(payload)
+    expect(restoredResponse.url).toBe('https://example.com/dashboard?_rsc=abc')
+    await expect(restoredResponse.text()).resolves.toBe('0:["$","payload"]')
+    expect(isOfflineNavigationRSCResponsePayload(payload)).toBe(true)
+    expect(
+      isOfflineNavigationRSCResponsePayload({ ...payload, body: null })
+    ).toBe(false)
   })
 
   it('writes RSC response payloads through the exact URL cache', async () => {

--- a/packages/next/src/client/components/router-reducer/offline-navigation-cache.test.ts
+++ b/packages/next/src/client/components/router-reducer/offline-navigation-cache.test.ts
@@ -203,6 +203,19 @@ describe('offline navigation cache', () => {
     })
   })
 
+  it('accepts initial load RSC responses for offline document boot', async () => {
+    const payload = await createOfflineNavigationRSCResponsePayload(
+      new Response('0:["$","payload"]'),
+      'initial-load'
+    )
+
+    expect(isOfflineNavigationRSCResponsePayload(payload)).toBe(true)
+    expect(payload).toMatchObject({
+      kind: 'rsc-response',
+      requestKind: 'initial-load',
+    })
+  })
+
   it('deletes exact URL entries', async () => {
     const storage = new MemoryOfflineNavigationCacheStorage()
     const cache = createOfflineNavigationCache(storage)

--- a/packages/next/src/client/components/router-reducer/offline-navigation-cache.test.ts
+++ b/packages/next/src/client/components/router-reducer/offline-navigation-cache.test.ts
@@ -1,0 +1,283 @@
+import {
+  createOfflineNavigationCache,
+  deleteOfflineNavigationCacheEntry,
+  normalizeOfflineNavigationCacheUrl,
+  readOfflineNavigationCacheEntry,
+  writeOfflineNavigationCacheEntry,
+  type OfflineNavigationCacheEntry,
+  type OfflineNavigationCacheStorage,
+} from './offline-navigation-cache'
+
+type CacheKey = [buildId: string, url: string]
+
+class MemoryOfflineNavigationCacheStorage
+  implements OfflineNavigationCacheStorage
+{
+  entries = new Map<string, OfflineNavigationCacheEntry>()
+
+  async get(key: CacheKey): Promise<OfflineNavigationCacheEntry | undefined> {
+    return this.entries.get(this.getKey(key))
+  }
+
+  async put(entry: OfflineNavigationCacheEntry): Promise<void> {
+    this.entries.set(this.getKey([entry.buildId, entry.url]), entry)
+  }
+
+  async delete(key: CacheKey): Promise<void> {
+    this.entries.delete(this.getKey(key))
+  }
+
+  async deleteBuild(buildId: string): Promise<void> {
+    for (const [key, entry] of this.entries) {
+      if (entry.buildId === buildId) {
+        this.entries.delete(key)
+      }
+    }
+  }
+
+  private getKey(key: CacheKey): string {
+    return `${key[0]}\0${key[1]}`
+  }
+}
+
+class FailingOfflineNavigationCacheStorage
+  implements OfflineNavigationCacheStorage
+{
+  async get(): Promise<OfflineNavigationCacheEntry | undefined> {
+    throw new Error('get failed')
+  }
+
+  async put(): Promise<void> {
+    throw new Error('put failed')
+  }
+
+  async delete(): Promise<void> {
+    throw new Error('delete failed')
+  }
+
+  async deleteBuild(): Promise<void> {
+    throw new Error('delete build failed')
+  }
+}
+
+describe('offline navigation cache', () => {
+  it('normalizes exact URL keys without fragments', () => {
+    expect(
+      normalizeOfflineNavigationCacheUrl(
+        'https://example.com/dashboard?tab=activity#settings'
+      )
+    ).toBe('https://example.com/dashboard?tab=activity')
+  })
+
+  it('writes and reads exact URL entries for the current build', async () => {
+    const storage = new MemoryOfflineNavigationCacheStorage()
+    const cache = createOfflineNavigationCache(storage)
+
+    await expect(
+      cache.write({
+        buildId: 'build-a',
+        url: 'https://example.com/dashboard?tab=activity#settings',
+        now: 100,
+        staleAt: 200,
+        expiresAt: 300,
+        payload: { tree: 'payload' },
+      })
+    ).resolves.toBe(true)
+
+    await expect(
+      cache.read('https://example.com/dashboard?tab=activity', {
+        buildId: 'build-a',
+        now: 150,
+      })
+    ).resolves.toEqual({
+      version: 1,
+      kind: 'exact-url',
+      buildId: 'build-a',
+      url: 'https://example.com/dashboard?tab=activity',
+      createdAt: 100,
+      staleAt: 200,
+      expiresAt: 300,
+      payload: { tree: 'payload' },
+    })
+  })
+
+  it('deletes exact URL entries', async () => {
+    const storage = new MemoryOfflineNavigationCacheStorage()
+    const cache = createOfflineNavigationCache(storage)
+    const url = 'https://example.com/dashboard'
+
+    await cache.write({
+      buildId: 'build-a',
+      url,
+      now: 100,
+      staleAt: 200,
+      expiresAt: 300,
+      payload: 'payload',
+    })
+    await expect(cache.delete(url, { buildId: 'build-a' })).resolves.toBe(true)
+    await expect(cache.read(url, { buildId: 'build-a' })).resolves.toBe(null)
+  })
+
+  it('ignores and deletes entries whose stored build id does not match', async () => {
+    const storage = new MemoryOfflineNavigationCacheStorage()
+    const cache = createOfflineNavigationCache(storage)
+    const url = 'https://example.com/dashboard'
+
+    await storage.put({
+      version: 1,
+      kind: 'exact-url',
+      buildId: 'build-b',
+      url,
+      createdAt: 100,
+      staleAt: 200,
+      expiresAt: 300,
+      payload: 'payload',
+    })
+    storage.entries.set(
+      `build-a\0${url}`,
+      storage.entries.get(`build-b\0${url}`)!
+    )
+
+    await expect(
+      cache.read(url, {
+        buildId: 'build-a',
+        now: 150,
+      })
+    ).resolves.toBe(null)
+    expect(storage.entries.has(`build-a\0${url}`)).toBe(false)
+  })
+
+  it('expires entries past their hard expiry time', async () => {
+    const storage = new MemoryOfflineNavigationCacheStorage()
+    const cache = createOfflineNavigationCache(storage)
+    const url = 'https://example.com/dashboard'
+
+    await cache.write({
+      buildId: 'build-a',
+      url,
+      now: 100,
+      staleAt: 150,
+      expiresAt: 200,
+      payload: 'payload',
+    })
+
+    await expect(
+      cache.read(url, {
+        buildId: 'build-a',
+        now: 250,
+      })
+    ).resolves.toBe(null)
+    expect(storage.entries.size).toBe(0)
+  })
+
+  it('can delete all entries for a build without touching other builds', async () => {
+    const storage = new MemoryOfflineNavigationCacheStorage()
+    const cache = createOfflineNavigationCache(storage)
+
+    await cache.write({
+      buildId: 'build-a',
+      url: 'https://example.com/a',
+      staleAt: 200,
+      expiresAt: 300,
+      payload: 'a',
+    })
+    await cache.write({
+      buildId: 'build-b',
+      url: 'https://example.com/b',
+      staleAt: 200,
+      expiresAt: 300,
+      payload: 'b',
+    })
+
+    await expect(cache.deleteBuild('build-a')).resolves.toBe(true)
+    await expect(
+      cache.read('https://example.com/a', { buildId: 'build-a', now: 150 })
+    ).resolves.toBe(null)
+    await expect(
+      cache.read('https://example.com/b', { buildId: 'build-b', now: 150 })
+    ).resolves.toMatchObject({ payload: 'b' })
+  })
+
+  it('treats missing build ids as no-ops', async () => {
+    const storage = new MemoryOfflineNavigationCacheStorage()
+    const cache = createOfflineNavigationCache(storage)
+
+    await expect(
+      cache.write({
+        url: 'https://example.com/dashboard',
+        staleAt: 200,
+        expiresAt: 300,
+        payload: 'payload',
+      })
+    ).resolves.toBe(false)
+    await expect(cache.read('https://example.com/dashboard')).resolves.toBe(
+      null
+    )
+    await expect(cache.delete('https://example.com/dashboard')).resolves.toBe(
+      false
+    )
+    await expect(cache.deleteBuild()).resolves.toBe(false)
+  })
+
+  it('treats storage failures as non-fatal misses', async () => {
+    const cache = createOfflineNavigationCache(
+      new FailingOfflineNavigationCacheStorage()
+    )
+
+    await expect(
+      cache.write({
+        buildId: 'build-a',
+        url: 'https://example.com/dashboard',
+        staleAt: 200,
+        expiresAt: 300,
+        payload: 'payload',
+      })
+    ).resolves.toBe(false)
+    await expect(
+      cache.read('https://example.com/dashboard', { buildId: 'build-a' })
+    ).resolves.toBe(null)
+    await expect(
+      cache.delete('https://example.com/dashboard', { buildId: 'build-a' })
+    ).resolves.toBe(false)
+    await expect(cache.deleteBuild('build-a')).resolves.toBe(false)
+  })
+
+  it('is a no-op when IndexedDB is unavailable', async () => {
+    const originalIndexedDB = Object.getOwnPropertyDescriptor(
+      globalThis,
+      'indexedDB'
+    )
+    Object.defineProperty(globalThis, 'indexedDB', {
+      configurable: true,
+      value: undefined,
+    })
+
+    try {
+      await expect(
+        writeOfflineNavigationCacheEntry({
+          buildId: 'build-a',
+          url: 'https://example.com/dashboard',
+          staleAt: 200,
+          expiresAt: 300,
+          payload: 'payload',
+        })
+      ).resolves.toBe(false)
+      await expect(
+        readOfflineNavigationCacheEntry('https://example.com/dashboard', {
+          buildId: 'build-a',
+        })
+      ).resolves.toBe(null)
+      await expect(
+        deleteOfflineNavigationCacheEntry('https://example.com/dashboard', {
+          buildId: 'build-a',
+        })
+      ).resolves.toBe(false)
+    } finally {
+      if (originalIndexedDB) {
+        Object.defineProperty(globalThis, 'indexedDB', originalIndexedDB)
+      } else {
+        delete (globalThis as { indexedDB?: IDBFactory }).indexedDB
+      }
+    }
+  })
+})

--- a/packages/next/src/client/components/router-reducer/offline-navigation-cache.test.ts
+++ b/packages/next/src/client/components/router-reducer/offline-navigation-cache.test.ts
@@ -166,6 +166,23 @@ describe('offline navigation cache', () => {
     ).toBe('https://example.com/dashboard?tab=activity')
   })
 
+  it('preserves encoded query values and duplicate search param order', () => {
+    const first = normalizeOfflineNavigationCacheUrl(
+      'https://example.com/docs/url-stress/space%20value/?token=a%2Bb&tag=one&tag=two#section-1'
+    )
+    const reordered = normalizeOfflineNavigationCacheUrl(
+      'https://example.com/docs/url-stress/space%20value/?tag=one&tag=two&token=a%2Bb#section-1'
+    )
+
+    expect(first).toBe(
+      'https://example.com/docs/url-stress/space%20value?token=a%2Bb&tag=one&tag=two'
+    )
+    expect(reordered).toBe(
+      'https://example.com/docs/url-stress/space%20value?tag=one&tag=two&token=a%2Bb'
+    )
+    expect(first).not.toBe(reordered)
+  })
+
   it('normalizes exact URL keys with the configured trailing slash', () => {
     const originalTrailingSlash = process.env.__NEXT_TRAILING_SLASH
     process.env.__NEXT_TRAILING_SLASH = 'true'

--- a/packages/next/src/client/components/router-reducer/offline-navigation-cache.test.ts
+++ b/packages/next/src/client/components/router-reducer/offline-navigation-cache.test.ts
@@ -51,6 +51,16 @@ class MemoryOfflineNavigationCacheStorage
         this.entries.delete(key)
       }
     }
+    for (const [key, entry] of this.routeEntries) {
+      if (entry.buildId === buildId) {
+        this.routeEntries.delete(key)
+      }
+    }
+    for (const [key, entry] of this.segmentEntries) {
+      if (entry.buildId === buildId) {
+        this.segmentEntries.delete(key)
+      }
+    }
   }
 
   async getCacheEpoch(): Promise<number> {
@@ -892,6 +902,7 @@ describe('offline navigation cache', () => {
   it('can delete all entries for a build without touching other builds', async () => {
     const storage = new MemoryOfflineNavigationCacheStorage()
     const cache = createOfflineNavigationCache(storage)
+    const routerCache = createOfflineNavigationRouterCache(storage)
 
     await cache.write({
       buildId: 'build-a',
@@ -907,6 +918,72 @@ describe('offline navigation cache', () => {
       expiresAt: 300,
       payload: 'b',
     })
+    await routerCache.writeRoute({
+      buildId: 'build-a',
+      key: 'route:/a',
+      staleAt: 200,
+      expiresAt: 300,
+      route: {
+        pathname: '/a',
+        search: '',
+        nextUrl: null,
+        canonicalUrl: '/a',
+        renderedSearch: '',
+        couldBeIntercepted: false,
+        supportsPerSegmentPrefetching: true,
+        hasDynamicRewrite: false,
+      },
+      routeVaryPath: [],
+      tree: null,
+      metadata: null,
+    })
+    await routerCache.writeRoute({
+      buildId: 'build-b',
+      key: 'route:/b',
+      staleAt: 200,
+      expiresAt: 300,
+      route: {
+        pathname: '/b',
+        search: '',
+        nextUrl: null,
+        canonicalUrl: '/b',
+        renderedSearch: '',
+        couldBeIntercepted: false,
+        supportsPerSegmentPrefetching: true,
+        hasDynamicRewrite: false,
+      },
+      routeVaryPath: [],
+      tree: null,
+      metadata: null,
+    })
+    await routerCache.writeSegment({
+      buildId: 'build-a',
+      key: 'segment:/a',
+      staleAt: 200,
+      expiresAt: 300,
+      segment: {
+        requestKey: 'children/page',
+        fetchStrategy: 1,
+        isPartial: false,
+        payloadIndex: 0,
+      },
+      segmentVaryPath: [],
+      payload: null,
+    })
+    await routerCache.writeSegment({
+      buildId: 'build-b',
+      key: 'segment:/b',
+      staleAt: 200,
+      expiresAt: 300,
+      segment: {
+        requestKey: 'children/page',
+        fetchStrategy: 1,
+        isPartial: false,
+        payloadIndex: 0,
+      },
+      segmentVaryPath: [],
+      payload: null,
+    })
 
     await expect(cache.deleteBuild('build-a')).resolves.toBe(true)
     await expect(
@@ -915,6 +992,18 @@ describe('offline navigation cache', () => {
     await expect(
       cache.read('https://example.com/b', { buildId: 'build-b', now: 150 })
     ).resolves.toMatchObject({ payload: 'b' })
+    await expect(
+      routerCache.readRoute('route:/a', { buildId: 'build-a', now: 150 })
+    ).resolves.toBe(null)
+    await expect(
+      routerCache.readRoute('route:/b', { buildId: 'build-b', now: 150 })
+    ).resolves.toMatchObject({ key: 'route:/b' })
+    await expect(
+      routerCache.readSegment('segment:/a', { buildId: 'build-a', now: 150 })
+    ).resolves.toBe(null)
+    await expect(
+      routerCache.readSegment('segment:/b', { buildId: 'build-b', now: 150 })
+    ).resolves.toMatchObject({ key: 'segment:/b' })
   })
 
   it('treats missing build ids as no-ops', async () => {

--- a/packages/next/src/client/components/router-reducer/offline-navigation-cache.test.ts
+++ b/packages/next/src/client/components/router-reducer/offline-navigation-cache.test.ts
@@ -4,6 +4,7 @@ import {
   createOfflineNavigationRSCResponsePayload,
   deleteOfflineNavigationCacheEntry,
   getOfflineNavigationRSCResponseCacheSkipReason,
+  invalidateOfflineNavigationCacheEntries,
   isOfflineNavigationRSCResponsePayload,
   normalizeOfflineNavigationCacheUrl,
   readOfflineNavigationCacheEntry,
@@ -20,6 +21,7 @@ class MemoryOfflineNavigationCacheStorage
   implements OfflineNavigationCacheStorage
 {
   entries = new Map<string, OfflineNavigationCacheEntry>()
+  cacheEpoch = 0
 
   async get(key: CacheKey): Promise<OfflineNavigationCacheEntry | undefined> {
     return this.entries.get(this.getKey(key))
@@ -39,6 +41,15 @@ class MemoryOfflineNavigationCacheStorage
         this.entries.delete(key)
       }
     }
+  }
+
+  async getCacheEpoch(): Promise<number> {
+    return this.cacheEpoch
+  }
+
+  async incrementCacheEpoch(): Promise<number> {
+    this.cacheEpoch++
+    return this.cacheEpoch
   }
 
   private getKey(key: CacheKey): string {
@@ -63,6 +74,14 @@ class FailingOfflineNavigationCacheStorage
 
   async deleteBuild(): Promise<void> {
     throw new Error('delete build failed')
+  }
+
+  async getCacheEpoch(): Promise<number> {
+    throw new Error('get epoch failed')
+  }
+
+  async incrementCacheEpoch(): Promise<number> {
+    throw new Error('increment epoch failed')
   }
 }
 
@@ -188,10 +207,11 @@ describe('offline navigation cache', () => {
         now: 150,
       })
     ).resolves.toEqual({
-      version: 1,
+      version: 2,
       kind: 'exact-url',
       buildId: 'build-a',
       url: 'https://example.com/dashboard?tab=activity',
+      cacheEpoch: 0,
       createdAt: 100,
       staleAt: 200,
       expiresAt: 300,
@@ -267,6 +287,7 @@ describe('offline navigation cache', () => {
       })
     ).resolves.toMatchObject({
       buildId: 'build-a',
+      cacheEpoch: 0,
       createdAt: 100,
       payload: {
         kind: 'rsc-response',
@@ -363,16 +384,59 @@ describe('offline navigation cache', () => {
     await expect(cache.read(url, { buildId: 'build-a' })).resolves.toBe(null)
   })
 
+  it('invalidates exact URL entries with a durable cache epoch', async () => {
+    const storage = new MemoryOfflineNavigationCacheStorage()
+    const cache = createOfflineNavigationCache(storage)
+    const url = 'https://example.com/dashboard'
+
+    await cache.write({
+      buildId: 'build-a',
+      url,
+      now: 100,
+      staleAt: 200,
+      expiresAt: 300,
+      payload: 'stale payload',
+    })
+    await expect(
+      cache.read(url, { buildId: 'build-a', now: 150 })
+    ).resolves.toMatchObject({
+      cacheEpoch: 0,
+      payload: 'stale payload',
+    })
+
+    await expect(cache.invalidate()).resolves.toBe(true)
+    await expect(
+      cache.read(url, { buildId: 'build-a', now: 150 })
+    ).resolves.toBe(null)
+    expect(storage.entries.size).toBe(0)
+
+    await cache.write({
+      buildId: 'build-a',
+      url,
+      now: 175,
+      staleAt: 250,
+      expiresAt: 350,
+      payload: 'fresh payload',
+    })
+    await expect(
+      cache.read(url, { buildId: 'build-a', now: 200 })
+    ).resolves.toMatchObject({
+      cacheEpoch: 1,
+      payload: 'fresh payload',
+    })
+  })
+
   it('ignores and deletes entries whose stored build id does not match', async () => {
     const storage = new MemoryOfflineNavigationCacheStorage()
     const cache = createOfflineNavigationCache(storage)
     const url = 'https://example.com/dashboard'
 
     await storage.put({
-      version: 1,
+      version: 2,
       kind: 'exact-url',
       buildId: 'build-b',
       url,
+      cacheEpoch: 0,
       createdAt: 100,
       staleAt: 200,
       expiresAt: 300,
@@ -485,6 +549,7 @@ describe('offline navigation cache', () => {
       cache.delete('https://example.com/dashboard', { buildId: 'build-a' })
     ).resolves.toBe(false)
     await expect(cache.deleteBuild('build-a')).resolves.toBe(false)
+    await expect(cache.invalidate()).resolves.toBe(false)
   })
 
   it('is a no-op when IndexedDB is unavailable', async () => {
@@ -517,6 +582,9 @@ describe('offline navigation cache', () => {
           buildId: 'build-a',
         })
       ).resolves.toBe(false)
+      await expect(invalidateOfflineNavigationCacheEntries()).resolves.toBe(
+        false
+      )
     } finally {
       if (originalIndexedDB) {
         Object.defineProperty(globalThis, 'indexedDB', originalIndexedDB)

--- a/packages/next/src/client/components/router-reducer/offline-navigation-cache.test.ts
+++ b/packages/next/src/client/components/router-reducer/offline-navigation-cache.test.ts
@@ -68,6 +68,12 @@ class MemoryOfflineNavigationCacheStorage
     return this.routeEntries.get(this.getKey(key))
   }
 
+  async getRoutes(buildId: string): Promise<OfflineNavigationRouteRecord[]> {
+    return Array.from(this.routeEntries.values()).filter(
+      (entry) => entry.buildId === buildId
+    )
+  }
+
   async putRoute(entry: OfflineNavigationRouteRecord): Promise<void> {
     this.routeEntries.set(this.getKey([entry.buildId, entry.key]), entry)
   }
@@ -89,6 +95,14 @@ class MemoryOfflineNavigationCacheStorage
     key: RouterCacheKey
   ): Promise<OfflineNavigationSegmentRecord | undefined> {
     return this.segmentEntries.get(this.getKey(key))
+  }
+
+  async getSegments(
+    buildId: string
+  ): Promise<OfflineNavigationSegmentRecord[]> {
+    return Array.from(this.segmentEntries.values()).filter(
+      (entry) => entry.buildId === buildId
+    )
   }
 
   async putSegment(entry: OfflineNavigationSegmentRecord): Promise<void> {
@@ -144,6 +158,10 @@ class FailingOfflineNavigationCacheStorage
     throw new Error('get route failed')
   }
 
+  async getRoutes(): Promise<OfflineNavigationRouteRecord[]> {
+    throw new Error('get routes failed')
+  }
+
   async putRoute(): Promise<void> {
     throw new Error('put route failed')
   }
@@ -162,6 +180,10 @@ class FailingOfflineNavigationCacheStorage
 
   async getSegment(): Promise<OfflineNavigationSegmentRecord | undefined> {
     throw new Error('get segment failed')
+  }
+
+  async getSegments(): Promise<OfflineNavigationSegmentRecord[]> {
+    throw new Error('get segments failed')
   }
 
   async putSegment(): Promise<void> {
@@ -708,6 +730,110 @@ describe('offline navigation cache', () => {
         now: 150,
       })
     ).resolves.toBe(null)
+  })
+
+  it('lists only fresh current-epoch route and segment records', async () => {
+    const storage = new MemoryOfflineNavigationCacheStorage()
+    const cache = createOfflineNavigationRouterCache(storage)
+    const routeVaryPath = serializeOfflineNavigationVaryPath({
+      id: null,
+      value: '/dashboard',
+      parent: null,
+    })
+    const segmentVaryPath = serializeOfflineNavigationVaryPath({
+      id: null,
+      value: 'children/page',
+      parent: null,
+    })
+
+    await cache.writeRoute({
+      buildId: 'build-a',
+      key: 'route:/dashboard',
+      now: 100,
+      staleAt: 200,
+      expiresAt: 300,
+      route: {
+        pathname: '/dashboard',
+        search: '',
+        nextUrl: null,
+        canonicalUrl: '/dashboard',
+        renderedSearch: '',
+        couldBeIntercepted: false,
+        supportsPerSegmentPrefetching: true,
+        hasDynamicRewrite: false,
+      },
+      routeVaryPath,
+      tree: { segment: 'dashboard' },
+      metadata: { segment: 'metadata' },
+    })
+    await cache.writeRoute({
+      buildId: 'build-a',
+      key: 'route:/expired',
+      now: 100,
+      staleAt: 110,
+      expiresAt: 120,
+      route: {
+        pathname: '/expired',
+        search: '',
+        nextUrl: null,
+        canonicalUrl: '/expired',
+        renderedSearch: '',
+        couldBeIntercepted: false,
+        supportsPerSegmentPrefetching: true,
+        hasDynamicRewrite: false,
+      },
+      routeVaryPath,
+      tree: { segment: 'expired' },
+      metadata: { segment: 'metadata' },
+    })
+    await cache.writeSegment({
+      buildId: 'build-a',
+      key: 'segment:/dashboard:children/page',
+      now: 100,
+      staleAt: 200,
+      expiresAt: 300,
+      segment: {
+        requestKey: 'children/page',
+        fetchStrategy: 1,
+        isPartial: false,
+        payloadIndex: 0,
+      },
+      segmentVaryPath,
+      payload: { kind: 'segment-payload' },
+    })
+    await cache.writeSegment({
+      buildId: 'build-a',
+      key: 'segment:/expired:children/page',
+      now: 100,
+      staleAt: 110,
+      expiresAt: 120,
+      segment: {
+        requestKey: 'children/page',
+        fetchStrategy: 1,
+        isPartial: false,
+        payloadIndex: 0,
+      },
+      segmentVaryPath,
+      payload: { kind: 'expired-payload' },
+    })
+
+    await expect(
+      cache.readRoutes({ buildId: 'build-a', now: 150 })
+    ).resolves.toMatchObject([{ key: 'route:/dashboard' }])
+    await expect(
+      cache.readSegments({ buildId: 'build-a', now: 150 })
+    ).resolves.toMatchObject([{ key: 'segment:/dashboard:children/page' }])
+    expect(storage.routeEntries.has('build-a\0route:/expired')).toBe(false)
+    expect(
+      storage.segmentEntries.has('build-a\0segment:/expired:children/page')
+    ).toBe(false)
+
+    await expect(
+      cache.readRoutes({ buildId: 'build-b', now: 150 })
+    ).resolves.toEqual([])
+    await expect(
+      cache.readSegments({ buildId: 'build-b', now: 150 })
+    ).resolves.toEqual([])
   })
 
   it('ignores and deletes entries whose stored build id does not match', async () => {

--- a/packages/next/src/client/components/router-reducer/offline-navigation-cache.test.ts
+++ b/packages/next/src/client/components/router-reducer/offline-navigation-cache.test.ts
@@ -3,10 +3,13 @@ import {
   createOfflineNavigationRSCResponse,
   createOfflineNavigationRSCResponsePayload,
   deleteOfflineNavigationCacheEntry,
+  getOfflineNavigationRSCResponseCacheSkipReason,
   isOfflineNavigationRSCResponsePayload,
   normalizeOfflineNavigationCacheUrl,
   readOfflineNavigationCacheEntry,
   writeOfflineNavigationCacheEntry,
+  type OfflineNavigationRSCResponseCacheEligibility,
+  type OfflineNavigationRSCResponseCacheSkipReason,
   type OfflineNavigationCacheEntry,
   type OfflineNavigationCacheStorage,
 } from './offline-navigation-cache'
@@ -61,6 +64,78 @@ class FailingOfflineNavigationCacheStorage
   async deleteBuild(): Promise<void> {
     throw new Error('delete build failed')
   }
+}
+
+type OfflineNavigationEnvKey =
+  | '__NEXT_CONFIG_OUTPUT'
+  | '__NEXT_DEV_SERVER'
+  | '__NEXT_OFFLINE_NAVIGATIONS'
+  | 'NODE_ENV'
+
+const offlineNavigationEnvKeys: Array<OfflineNavigationEnvKey> = [
+  '__NEXT_CONFIG_OUTPUT',
+  '__NEXT_DEV_SERVER',
+  '__NEXT_OFFLINE_NAVIGATIONS',
+  'NODE_ENV',
+]
+
+function withOfflineNavigationCacheEnv<T>(
+  env: Partial<Record<OfflineNavigationEnvKey, string | undefined>>,
+  test: () => T
+): T {
+  const originalEnv: Partial<
+    Record<OfflineNavigationEnvKey, string | undefined>
+  > = {}
+
+  for (const key of offlineNavigationEnvKeys) {
+    originalEnv[key] = process.env[key]
+  }
+
+  const writableEnv = process.env as Record<string, string | undefined>
+
+  for (const key of offlineNavigationEnvKeys) {
+    const value = env[key]
+    if (value === undefined) {
+      delete writableEnv[key]
+    } else {
+      writableEnv[key] = value
+    }
+  }
+
+  try {
+    return test()
+  } finally {
+    for (const key of offlineNavigationEnvKeys) {
+      const value = originalEnv[key]
+      if (value === undefined) {
+        delete writableEnv[key]
+      } else {
+        writableEnv[key] = value
+      }
+    }
+  }
+}
+
+function getCacheSkipReason(
+  eligibility: Partial<OfflineNavigationRSCResponseCacheEligibility> = {},
+  env: Partial<Record<OfflineNavigationEnvKey, string | undefined>> = {}
+) {
+  return withOfflineNavigationCacheEnv(
+    {
+      __NEXT_CONFIG_OUTPUT: undefined,
+      __NEXT_DEV_SERVER: undefined,
+      __NEXT_OFFLINE_NAVIGATIONS: 'true',
+      NODE_ENV: 'production',
+      ...env,
+    },
+    () =>
+      getOfflineNavigationRSCResponseCacheSkipReason({
+        origin: 'https://example.com',
+        requestKind: 'navigation',
+        url: 'https://example.com/dashboard',
+        ...eligibility,
+      })
+  )
 }
 
 describe('offline navigation cache', () => {
@@ -214,6 +289,52 @@ describe('offline navigation cache', () => {
       kind: 'rsc-response',
       requestKind: 'initial-load',
     })
+  })
+
+  it('returns cache eligibility skip reasons for unsupported RSC responses', () => {
+    const cases: Array<{
+      expected: OfflineNavigationRSCResponseCacheSkipReason
+      eligibility?: Partial<OfflineNavigationRSCResponseCacheEligibility>
+      env?: Partial<Record<OfflineNavigationEnvKey, string | undefined>>
+    }> = [
+      {
+        expected: 'disabled',
+        env: { __NEXT_OFFLINE_NAVIGATIONS: undefined },
+      },
+      { expected: 'dev-server', env: { __NEXT_DEV_SERVER: 'true' } },
+      { expected: 'not-production', env: { NODE_ENV: 'development' } },
+      { expected: 'output-export', env: { __NEXT_CONFIG_OUTPUT: 'export' } },
+      { expected: 'unsupported-request', eligibility: { requestKind: null } },
+      { expected: 'missing-payload', eligibility: { hasCachePayload: false } },
+      {
+        expected: 'cross-origin',
+        eligibility: { url: 'https://external.example/dashboard' },
+      },
+      {
+        expected: 'unsupported-segment-prefetching',
+        eligibility: { supportsPerSegmentPrefetching: false },
+      },
+      {
+        expected: 'runtime-prefetch',
+        eligibility: { hasRuntimePrefetch: true },
+      },
+      {
+        expected: 'partial-response',
+        eligibility: { hasPartialResponse: true },
+      },
+      { expected: 'hmr-refresh', eligibility: { isHmrRefresh: true } },
+      { expected: 'interception', eligibility: { isInterception: true } },
+      { expected: 'postponed', eligibility: { isPostponed: true } },
+      { expected: 'redirected', eligibility: { isRedirected: true } },
+    ]
+
+    for (const { expected, eligibility, env } of cases) {
+      expect(getCacheSkipReason(eligibility, env)).toBe(expected)
+    }
+  })
+
+  it('allows eligible same-origin RSC responses in production', () => {
+    expect(getCacheSkipReason()).toBe(null)
   })
 
   it('deletes exact URL entries', async () => {

--- a/packages/next/src/client/components/router-reducer/offline-navigation-cache.test.ts
+++ b/packages/next/src/client/components/router-reducer/offline-navigation-cache.test.ts
@@ -411,6 +411,12 @@ describe('offline navigation cache', () => {
     expect(
       isOfflineNavigationRSCResponsePayload({ ...payload, body: null })
     ).toBe(false)
+    expect(
+      isOfflineNavigationRSCResponsePayload({
+        ...payload,
+        requestKind: 'segment-prefetch',
+      })
+    ).toBe(true)
   })
 
   it('writes RSC response payloads through the exact URL cache', async () => {
@@ -637,6 +643,7 @@ describe('offline navigation cache', () => {
           requestKey: 'children/page',
           fetchStrategy: 1,
           isPartial: false,
+          payloadIndex: 0,
         },
         segmentVaryPath,
         payload: { kind: 'segment-payload' },
@@ -671,6 +678,7 @@ describe('offline navigation cache', () => {
       kind: 'segment',
       segment: {
         requestKey: 'children/page',
+        payloadIndex: 0,
       },
       segmentVaryPath,
       version: 1,
@@ -867,6 +875,7 @@ describe('offline navigation cache', () => {
           requestKey: 'children/page',
           fetchStrategy: 1,
           isPartial: false,
+          payloadIndex: 0,
         },
         segmentVaryPath: [],
         payload: null,

--- a/packages/next/src/client/components/router-reducer/offline-navigation-cache.test.ts
+++ b/packages/next/src/client/components/router-reducer/offline-navigation-cache.test.ts
@@ -1,5 +1,7 @@
 import {
   createOfflineNavigationCache,
+  createOfflineNavigationRSCResponse,
+  createOfflineNavigationRSCResponsePayload,
   deleteOfflineNavigationCacheEntry,
   normalizeOfflineNavigationCacheUrl,
   readOfflineNavigationCacheEntry,
@@ -98,6 +100,81 @@ describe('offline navigation cache', () => {
       staleAt: 200,
       expiresAt: 300,
       payload: { tree: 'payload' },
+    })
+  })
+
+  it('serializes RSC response payloads for persisted navigation entries', async () => {
+    const response = new Response('0:["$","payload"]', {
+      headers: {
+        'content-type': 'text/x-component',
+        'x-nextjs-stale-time': '60',
+      },
+      status: 200,
+      statusText: 'OK',
+    })
+    Object.defineProperty(response, 'url', {
+      value: 'https://example.com/dashboard?_rsc=abc',
+    })
+
+    const payload = await createOfflineNavigationRSCResponsePayload(
+      response,
+      'route-prefetch'
+    )
+    expect(payload).toMatchObject({
+      version: 1,
+      kind: 'rsc-response',
+      requestKind: 'route-prefetch',
+      status: 200,
+      statusText: 'OK',
+      headers: expect.arrayContaining([
+        ['content-type', 'text/x-component'],
+        ['x-nextjs-stale-time', '60'],
+      ]),
+    })
+
+    await expect(
+      createOfflineNavigationRSCResponse(payload).text()
+    ).resolves.toBe('0:["$","payload"]')
+  })
+
+  it('writes RSC response payloads through the exact URL cache', async () => {
+    const storage = new MemoryOfflineNavigationCacheStorage()
+    const cache = createOfflineNavigationCache(storage)
+    const payload = createOfflineNavigationRSCResponsePayload(
+      new Response('0:["$","payload"]'),
+      'navigation'
+    )
+
+    await expect(payload).resolves.toMatchObject({
+      kind: 'rsc-response',
+      requestKind: 'navigation',
+    })
+    await expect(
+      cache.write({
+        buildId: 'build-a',
+        expiresAt: 300,
+        payload: await payload,
+        staleAt: 200,
+        url: 'https://example.com/dashboard#section',
+        now: 100,
+      })
+    ).resolves.toBe(true)
+
+    await expect(
+      cache.read('https://example.com/dashboard', {
+        buildId: 'build-a',
+        now: 150,
+      })
+    ).resolves.toMatchObject({
+      buildId: 'build-a',
+      createdAt: 100,
+      payload: {
+        kind: 'rsc-response',
+        requestKind: 'navigation',
+      },
+      staleAt: 200,
+      expiresAt: 300,
+      url: 'https://example.com/dashboard',
     })
   })
 

--- a/packages/next/src/client/components/router-reducer/offline-navigation-cache.test.ts
+++ b/packages/next/src/client/components/router-reducer/offline-navigation-cache.test.ts
@@ -2,26 +2,36 @@ import {
   createOfflineNavigationCache,
   createOfflineNavigationRSCResponse,
   createOfflineNavigationRSCResponsePayload,
+  createOfflineNavigationRouterCache,
+  createOfflineNavigationVaryPathKey,
   deleteOfflineNavigationCacheEntry,
   getOfflineNavigationRSCResponseCacheSkipReason,
   invalidateOfflineNavigationCacheEntries,
   isOfflineNavigationRSCResponsePayload,
   normalizeOfflineNavigationCacheUrl,
   readOfflineNavigationCacheEntry,
+  serializeOfflineNavigationVaryPath,
   writeOfflineNavigationCacheEntry,
   type OfflineNavigationRSCResponseCacheEligibility,
   type OfflineNavigationRSCResponseCacheSkipReason,
   type OfflineNavigationCacheEntry,
   type OfflineNavigationCacheStorage,
+  type OfflineNavigationRouteRecord,
+  type OfflineNavigationSegmentRecord,
 } from './offline-navigation-cache'
 
 type CacheKey = [buildId: string, url: string]
+type RouterCacheKey = [buildId: string, key: string]
 
 class MemoryOfflineNavigationCacheStorage
   implements OfflineNavigationCacheStorage
 {
   entries = new Map<string, OfflineNavigationCacheEntry>()
+  routeEntries = new Map<string, OfflineNavigationRouteRecord>()
+  segmentEntries = new Map<string, OfflineNavigationSegmentRecord>()
   cacheEpoch = 0
+  routeCacheEpoch = 0
+  segmentCacheEpoch = 0
 
   async get(key: CacheKey): Promise<OfflineNavigationCacheEntry | undefined> {
     return this.entries.get(this.getKey(key))
@@ -50,6 +60,52 @@ class MemoryOfflineNavigationCacheStorage
   async incrementCacheEpoch(): Promise<number> {
     this.cacheEpoch++
     return this.cacheEpoch
+  }
+
+  async getRoute(
+    key: RouterCacheKey
+  ): Promise<OfflineNavigationRouteRecord | undefined> {
+    return this.routeEntries.get(this.getKey(key))
+  }
+
+  async putRoute(entry: OfflineNavigationRouteRecord): Promise<void> {
+    this.routeEntries.set(this.getKey([entry.buildId, entry.key]), entry)
+  }
+
+  async deleteRoute(key: RouterCacheKey): Promise<void> {
+    this.routeEntries.delete(this.getKey(key))
+  }
+
+  async getRouteCacheEpoch(): Promise<number> {
+    return this.routeCacheEpoch
+  }
+
+  async incrementRouteCacheEpoch(): Promise<number> {
+    this.routeCacheEpoch++
+    return this.routeCacheEpoch
+  }
+
+  async getSegment(
+    key: RouterCacheKey
+  ): Promise<OfflineNavigationSegmentRecord | undefined> {
+    return this.segmentEntries.get(this.getKey(key))
+  }
+
+  async putSegment(entry: OfflineNavigationSegmentRecord): Promise<void> {
+    this.segmentEntries.set(this.getKey([entry.buildId, entry.key]), entry)
+  }
+
+  async deleteSegment(key: RouterCacheKey): Promise<void> {
+    this.segmentEntries.delete(this.getKey(key))
+  }
+
+  async getSegmentCacheEpoch(): Promise<number> {
+    return this.segmentCacheEpoch
+  }
+
+  async incrementSegmentCacheEpoch(): Promise<number> {
+    this.segmentCacheEpoch++
+    return this.segmentCacheEpoch
   }
 
   private getKey(key: CacheKey): string {
@@ -82,6 +138,46 @@ class FailingOfflineNavigationCacheStorage
 
   async incrementCacheEpoch(): Promise<number> {
     throw new Error('increment epoch failed')
+  }
+
+  async getRoute(): Promise<OfflineNavigationRouteRecord | undefined> {
+    throw new Error('get route failed')
+  }
+
+  async putRoute(): Promise<void> {
+    throw new Error('put route failed')
+  }
+
+  async deleteRoute(): Promise<void> {
+    throw new Error('delete route failed')
+  }
+
+  async getRouteCacheEpoch(): Promise<number> {
+    throw new Error('get route epoch failed')
+  }
+
+  async incrementRouteCacheEpoch(): Promise<number> {
+    throw new Error('increment route epoch failed')
+  }
+
+  async getSegment(): Promise<OfflineNavigationSegmentRecord | undefined> {
+    throw new Error('get segment failed')
+  }
+
+  async putSegment(): Promise<void> {
+    throw new Error('put segment failed')
+  }
+
+  async deleteSegment(): Promise<void> {
+    throw new Error('delete segment failed')
+  }
+
+  async getSegmentCacheEpoch(): Promise<number> {
+    throw new Error('get segment epoch failed')
+  }
+
+  async incrementSegmentCacheEpoch(): Promise<number> {
+    throw new Error('increment segment epoch failed')
   }
 }
 
@@ -181,6 +277,49 @@ describe('offline navigation cache', () => {
       'https://example.com/docs/url-stress/space%20value?tag=one&tag=two&token=a%2Bb'
     )
     expect(first).not.toBe(reordered)
+  })
+
+  it('serializes vary paths into stable router record keys', () => {
+    const fallback = {}
+    const varyPath = {
+      id: null,
+      value: 'children/page',
+      parent: {
+        id: '?',
+        value: fallback,
+        parent: {
+          id: 'slug',
+          value: 'hello',
+          parent: null,
+        },
+      },
+    }
+
+    expect(serializeOfflineNavigationVaryPath(varyPath)).toEqual([
+      {
+        id: null,
+        value: {
+          kind: 'value',
+          value: 'children/page',
+        },
+      },
+      {
+        id: '?',
+        value: {
+          kind: 'fallback',
+        },
+      },
+      {
+        id: 'slug',
+        value: {
+          kind: 'value',
+          value: 'hello',
+        },
+      },
+    ])
+    expect(createOfflineNavigationVaryPathKey(varyPath)).toBe(
+      '[{"id":null,"value":{"kind":"value","value":"children/page"}},{"id":"?","value":{"kind":"fallback"}},{"id":"slug","value":{"kind":"value","value":"hello"}}]'
+    )
   })
 
   it('normalizes exact URL keys with the configured trailing slash', () => {
@@ -443,6 +582,126 @@ describe('offline navigation cache', () => {
     })
   })
 
+  it('stores route and segment records with independent durable epochs', async () => {
+    const storage = new MemoryOfflineNavigationCacheStorage()
+    const cache = createOfflineNavigationRouterCache(storage)
+    const routeVaryPath = serializeOfflineNavigationVaryPath({
+      id: null,
+      value: '/dashboard',
+      parent: {
+        id: '?',
+        value: '',
+        parent: {
+          id: null,
+          value: null,
+          parent: null,
+        },
+      },
+    })
+    const segmentVaryPath = serializeOfflineNavigationVaryPath({
+      id: null,
+      value: 'children/page',
+      parent: null,
+    })
+
+    await expect(
+      cache.writeRoute({
+        buildId: 'build-a',
+        key: 'route:/dashboard',
+        now: 100,
+        staleAt: 200,
+        expiresAt: 300,
+        route: {
+          pathname: '/dashboard',
+          search: '',
+          nextUrl: null,
+          canonicalUrl: '/dashboard',
+          renderedSearch: '',
+          couldBeIntercepted: false,
+          supportsPerSegmentPrefetching: true,
+          hasDynamicRewrite: false,
+        },
+        routeVaryPath,
+        tree: { segment: 'dashboard' },
+        metadata: { segment: 'metadata' },
+      })
+    ).resolves.toBe(true)
+    await expect(
+      cache.writeSegment({
+        buildId: 'build-a',
+        key: 'segment:/dashboard:children/page',
+        now: 100,
+        staleAt: 200,
+        expiresAt: 300,
+        segment: {
+          requestKey: 'children/page',
+          fetchStrategy: 1,
+          isPartial: false,
+        },
+        segmentVaryPath,
+        payload: { kind: 'segment-payload' },
+      })
+    ).resolves.toBe(true)
+
+    await expect(
+      cache.readRoute('route:/dashboard', {
+        buildId: 'build-a',
+        now: 150,
+      })
+    ).resolves.toMatchObject({
+      buildId: 'build-a',
+      cacheEpoch: 0,
+      key: 'route:/dashboard',
+      kind: 'route',
+      route: {
+        pathname: '/dashboard',
+      },
+      routeVaryPath,
+      version: 1,
+    })
+    await expect(
+      cache.readSegment('segment:/dashboard:children/page', {
+        buildId: 'build-a',
+        now: 150,
+      })
+    ).resolves.toMatchObject({
+      buildId: 'build-a',
+      cacheEpoch: 0,
+      key: 'segment:/dashboard:children/page',
+      kind: 'segment',
+      segment: {
+        requestKey: 'children/page',
+      },
+      segmentVaryPath,
+      version: 1,
+    })
+
+    await expect(cache.invalidateRoutes()).resolves.toBe(true)
+    await expect(
+      cache.readRoute('route:/dashboard', {
+        buildId: 'build-a',
+        now: 150,
+      })
+    ).resolves.toBe(null)
+    await expect(
+      cache.readSegment('segment:/dashboard:children/page', {
+        buildId: 'build-a',
+        now: 150,
+      })
+    ).resolves.toMatchObject({
+      cacheEpoch: 0,
+      key: 'segment:/dashboard:children/page',
+    })
+
+    await expect(cache.invalidateSegments()).resolves.toBe(true)
+    await expect(
+      cache.readSegment('segment:/dashboard:children/page', {
+        buildId: 'build-a',
+        now: 150,
+      })
+    ).resolves.toBe(null)
+  })
+
   it('ignores and deletes entries whose stored build id does not match', async () => {
     const storage = new MemoryOfflineNavigationCacheStorage()
     const cache = createOfflineNavigationCache(storage)
@@ -549,6 +808,9 @@ describe('offline navigation cache', () => {
     const cache = createOfflineNavigationCache(
       new FailingOfflineNavigationCacheStorage()
     )
+    const routerCache = createOfflineNavigationRouterCache(
+      new FailingOfflineNavigationCacheStorage()
+    )
 
     await expect(
       cache.write({
@@ -567,6 +829,56 @@ describe('offline navigation cache', () => {
     ).resolves.toBe(false)
     await expect(cache.deleteBuild('build-a')).resolves.toBe(false)
     await expect(cache.invalidate()).resolves.toBe(false)
+    await expect(
+      routerCache.writeRoute({
+        buildId: 'build-a',
+        key: 'route:/dashboard',
+        staleAt: 200,
+        expiresAt: 300,
+        route: {
+          pathname: '/dashboard',
+          search: '',
+          nextUrl: null,
+          canonicalUrl: '/dashboard',
+          renderedSearch: '',
+          couldBeIntercepted: false,
+          supportsPerSegmentPrefetching: true,
+          hasDynamicRewrite: false,
+        },
+        routeVaryPath: [],
+        tree: null,
+        metadata: null,
+      })
+    ).resolves.toBe(false)
+    await expect(
+      routerCache.readRoute('route:/dashboard', { buildId: 'build-a' })
+    ).resolves.toBe(null)
+    await expect(
+      routerCache.deleteRoute('route:/dashboard', { buildId: 'build-a' })
+    ).resolves.toBe(false)
+    await expect(routerCache.invalidateRoutes()).resolves.toBe(false)
+    await expect(
+      routerCache.writeSegment({
+        buildId: 'build-a',
+        key: 'segment:/dashboard',
+        staleAt: 200,
+        expiresAt: 300,
+        segment: {
+          requestKey: 'children/page',
+          fetchStrategy: 1,
+          isPartial: false,
+        },
+        segmentVaryPath: [],
+        payload: null,
+      })
+    ).resolves.toBe(false)
+    await expect(
+      routerCache.readSegment('segment:/dashboard', { buildId: 'build-a' })
+    ).resolves.toBe(null)
+    await expect(
+      routerCache.deleteSegment('segment:/dashboard', { buildId: 'build-a' })
+    ).resolves.toBe(false)
+    await expect(routerCache.invalidateSegments()).resolves.toBe(false)
   })
 
   it('is a no-op when IndexedDB is unavailable', async () => {

--- a/packages/next/src/client/components/router-reducer/offline-navigation-cache.ts
+++ b/packages/next/src/client/components/router-reducer/offline-navigation-cache.ts
@@ -4,8 +4,13 @@ const DATABASE_NAME = 'next-offline-navigation-cache'
 const DATABASE_VERSION = 1
 const STORE_NAME = 'navigation-data'
 const ENTRY_VERSION = 1
+const RSC_RESPONSE_PAYLOAD_VERSION = 1
 
 type OfflineNavigationCacheKey = [buildId: string, url: string]
+type OfflineNavigationRSCResponseRequestKind =
+  | 'navigation'
+  | 'route-prefetch'
+  | 'client-resume'
 
 export type OfflineNavigationCacheEntry = {
   version: typeof ENTRY_VERSION
@@ -16,6 +21,17 @@ export type OfflineNavigationCacheEntry = {
   staleAt: number
   expiresAt: number
   payload: unknown
+}
+
+export type OfflineNavigationRSCResponsePayload = {
+  version: typeof RSC_RESPONSE_PAYLOAD_VERSION
+  kind: 'rsc-response'
+  requestKind: OfflineNavigationRSCResponseRequestKind
+  url: string
+  status: number
+  statusText: string
+  headers: Array<[string, string]>
+  body: ArrayBuffer
 }
 
 export type OfflineNavigationCacheWrite = {
@@ -30,6 +46,15 @@ export type OfflineNavigationCacheWrite = {
 export type OfflineNavigationCacheReadOptions = {
   buildId?: string
   now?: number
+}
+
+export type OfflineNavigationRSCResponseCacheWrite = {
+  url: string | URL
+  staleAt: number
+  expiresAt: number
+  buildId?: string
+  now?: number
+  payload: Promise<OfflineNavigationRSCResponsePayload | null>
 }
 
 export type OfflineNavigationCacheStorage = {
@@ -146,6 +171,48 @@ export function createOfflineNavigationCache(
       }, false)
     },
   }
+}
+
+export async function createOfflineNavigationRSCResponsePayload(
+  response: Response,
+  requestKind: OfflineNavigationRSCResponseRequestKind
+): Promise<OfflineNavigationRSCResponsePayload> {
+  const clone = response.clone()
+  return {
+    version: RSC_RESPONSE_PAYLOAD_VERSION,
+    kind: 'rsc-response',
+    requestKind,
+    url: clone.url,
+    status: clone.status,
+    statusText: clone.statusText,
+    headers: Array.from(clone.headers.entries()),
+    body: await clone.arrayBuffer(),
+  }
+}
+
+export function createOfflineNavigationRSCResponse(
+  payload: OfflineNavigationRSCResponsePayload
+): Response {
+  return new Response(payload.body.slice(0), {
+    status: payload.status,
+    statusText: payload.statusText,
+    headers: payload.headers,
+  })
+}
+
+export async function writeOfflineNavigationRSCResponseCacheEntry({
+  payload,
+  ...entry
+}: OfflineNavigationRSCResponseCacheWrite): Promise<boolean> {
+  const resolvedPayload = await payload
+  if (resolvedPayload === null) {
+    return false
+  }
+
+  return writeOfflineNavigationCacheEntry({
+    ...entry,
+    payload: resolvedPayload,
+  })
 }
 
 function getCacheBuildId(buildId: string | undefined): string | null {

--- a/packages/next/src/client/components/router-reducer/offline-navigation-cache.ts
+++ b/packages/next/src/client/components/router-reducer/offline-navigation-cache.ts
@@ -1,0 +1,299 @@
+import { getNavigationBuildId } from '../../navigation-build-id'
+
+const DATABASE_NAME = 'next-offline-navigation-cache'
+const DATABASE_VERSION = 1
+const STORE_NAME = 'navigation-data'
+const ENTRY_VERSION = 1
+
+type OfflineNavigationCacheKey = [buildId: string, url: string]
+
+export type OfflineNavigationCacheEntry = {
+  version: typeof ENTRY_VERSION
+  kind: 'exact-url'
+  buildId: string
+  url: string
+  createdAt: number
+  staleAt: number
+  expiresAt: number
+  payload: unknown
+}
+
+export type OfflineNavigationCacheWrite = {
+  url: string | URL
+  staleAt: number
+  expiresAt: number
+  payload: unknown
+  buildId?: string
+  now?: number
+}
+
+export type OfflineNavigationCacheReadOptions = {
+  buildId?: string
+  now?: number
+}
+
+export type OfflineNavigationCacheStorage = {
+  get(
+    key: OfflineNavigationCacheKey
+  ): Promise<OfflineNavigationCacheEntry | undefined>
+  put(entry: OfflineNavigationCacheEntry): Promise<void>
+  delete(key: OfflineNavigationCacheKey): Promise<void>
+  deleteBuild(buildId: string): Promise<void>
+}
+
+export type OfflineNavigationCache = {
+  read: (
+    url: string | URL,
+    options?: OfflineNavigationCacheReadOptions
+  ) => Promise<OfflineNavigationCacheEntry | null>
+  write: (entry: OfflineNavigationCacheWrite) => Promise<boolean>
+  delete: (
+    url: string | URL,
+    options?: OfflineNavigationCacheReadOptions
+  ) => Promise<boolean>
+  deleteBuild: (buildId?: string) => Promise<boolean>
+}
+
+export function normalizeOfflineNavigationCacheUrl(url: string | URL): string {
+  const normalized =
+    typeof url === 'string'
+      ? new URL(
+          url,
+          typeof window === 'undefined' ? undefined : window.location.href
+        )
+      : new URL(url.href)
+
+  normalized.hash = ''
+  return normalized.href
+}
+
+export function createOfflineNavigationCache(
+  storage: OfflineNavigationCacheStorage
+): OfflineNavigationCache {
+  return {
+    read: async (url, options) => {
+      return runOfflineNavigationCacheOperation(async () => {
+        const buildId = getCacheBuildId(options?.buildId)
+        if (buildId === null) {
+          return null
+        }
+
+        const cacheUrl = normalizeOfflineNavigationCacheUrl(url)
+        const key: OfflineNavigationCacheKey = [buildId, cacheUrl]
+        const entry = await storage.get(key)
+        if (!entry) {
+          return null
+        }
+
+        if (
+          entry.version !== ENTRY_VERSION ||
+          entry.kind !== 'exact-url' ||
+          entry.buildId !== buildId ||
+          entry.url !== cacheUrl
+        ) {
+          await storage.delete(key)
+          return null
+        }
+
+        if (entry.expiresAt <= (options?.now ?? Date.now())) {
+          await storage.delete(key)
+          return null
+        }
+
+        return entry
+      }, null)
+    },
+    write: async (entry) => {
+      return runOfflineNavigationCacheOperation(async () => {
+        const buildId = getCacheBuildId(entry.buildId)
+        if (buildId === null) {
+          return false
+        }
+
+        await storage.put({
+          version: ENTRY_VERSION,
+          kind: 'exact-url',
+          buildId,
+          url: normalizeOfflineNavigationCacheUrl(entry.url),
+          createdAt: entry.now ?? Date.now(),
+          staleAt: entry.staleAt,
+          expiresAt: entry.expiresAt,
+          payload: entry.payload,
+        })
+        return true
+      }, false)
+    },
+    delete: async (url, options) => {
+      return runOfflineNavigationCacheOperation(async () => {
+        const buildId = getCacheBuildId(options?.buildId)
+        if (buildId === null) {
+          return false
+        }
+
+        await storage.delete([buildId, normalizeOfflineNavigationCacheUrl(url)])
+        return true
+      }, false)
+    },
+    deleteBuild: async (buildId) => {
+      return runOfflineNavigationCacheOperation(async () => {
+        const cacheBuildId = getCacheBuildId(buildId)
+        if (cacheBuildId === null) {
+          return false
+        }
+
+        await storage.deleteBuild(cacheBuildId)
+        return true
+      }, false)
+    },
+  }
+}
+
+function getCacheBuildId(buildId: string | undefined): string | null {
+  const cacheBuildId = buildId ?? getNavigationBuildId()
+  return cacheBuildId === '' ? null : cacheBuildId
+}
+
+async function runOfflineNavigationCacheOperation<T>(
+  operation: () => Promise<T>,
+  fallback: T
+): Promise<T> {
+  try {
+    return await operation()
+  } catch {
+    return fallback
+  }
+}
+
+function getIndexedDB(): IDBFactory | null {
+  return typeof indexedDB === 'undefined' ? null : indexedDB
+}
+
+function requestToPromise<T>(request: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result)
+    request.onerror = () => reject(request.error ?? new Error())
+  })
+}
+
+function waitForTransaction(transaction: IDBTransaction): Promise<void> {
+  return new Promise((resolve, reject) => {
+    transaction.oncomplete = () => resolve()
+    transaction.onabort = () => reject(transaction.error ?? new Error())
+    transaction.onerror = () => reject(transaction.error ?? new Error())
+  })
+}
+
+class IndexedDBOfflineNavigationCacheStorage
+  implements OfflineNavigationCacheStorage
+{
+  private databasePromise: Promise<IDBDatabase | null> | null = null
+
+  async get(
+    key: OfflineNavigationCacheKey
+  ): Promise<OfflineNavigationCacheEntry | undefined> {
+    const database = await this.getDatabase()
+    if (database === null) {
+      return undefined
+    }
+
+    return requestToPromise(
+      database
+        .transaction(STORE_NAME, 'readonly')
+        .objectStore(STORE_NAME)
+        .get(key)
+    )
+  }
+
+  async put(entry: OfflineNavigationCacheEntry): Promise<void> {
+    const database = await this.getDatabase()
+    if (database === null) {
+      throw new Error()
+    }
+
+    const transaction = database.transaction(STORE_NAME, 'readwrite')
+    transaction.objectStore(STORE_NAME).put(entry)
+    await waitForTransaction(transaction)
+  }
+
+  async delete(key: OfflineNavigationCacheKey): Promise<void> {
+    const database = await this.getDatabase()
+    if (database === null) {
+      throw new Error()
+    }
+
+    const transaction = database.transaction(STORE_NAME, 'readwrite')
+    transaction.objectStore(STORE_NAME).delete(key)
+    await waitForTransaction(transaction)
+  }
+
+  async deleteBuild(buildId: string): Promise<void> {
+    const database = await this.getDatabase()
+    if (database === null) {
+      throw new Error()
+    }
+
+    const transaction = database.transaction(STORE_NAME, 'readwrite')
+    const store = transaction.objectStore(STORE_NAME)
+    const cursorRequest = store.openCursor()
+    await new Promise<void>((resolve, reject) => {
+      cursorRequest.onsuccess = () => {
+        const cursor = cursorRequest.result
+        if (cursor === null) {
+          resolve()
+          return
+        }
+
+        if ((cursor.value as OfflineNavigationCacheEntry).buildId === buildId) {
+          cursor.delete()
+        }
+        cursor.continue()
+      }
+      cursorRequest.onerror = () => reject(cursorRequest.error ?? new Error())
+    })
+    await waitForTransaction(transaction)
+  }
+
+  private async getDatabase(): Promise<IDBDatabase | null> {
+    if (this.databasePromise === null) {
+      this.databasePromise = this.openDatabase().catch((error) => {
+        this.databasePromise = null
+        throw error
+      })
+    }
+    return this.databasePromise
+  }
+
+  private async openDatabase(): Promise<IDBDatabase | null> {
+    const idb = getIndexedDB()
+    if (idb === null) {
+      return null
+    }
+
+    const request = idb.open(DATABASE_NAME, DATABASE_VERSION)
+    request.onupgradeneeded = () => {
+      const database = request.result
+      if (!database.objectStoreNames.contains(STORE_NAME)) {
+        database.createObjectStore(STORE_NAME, {
+          keyPath: ['buildId', 'url'],
+        })
+      }
+    }
+
+    const database = await requestToPromise(request)
+    database.onversionchange = () => {
+      database.close()
+      this.databasePromise = null
+    }
+    return database
+  }
+}
+
+const offlineNavigationCache = createOfflineNavigationCache(
+  new IndexedDBOfflineNavigationCacheStorage()
+)
+
+export const readOfflineNavigationCacheEntry = offlineNavigationCache.read
+export const writeOfflineNavigationCacheEntry = offlineNavigationCache.write
+export const deleteOfflineNavigationCacheEntry = offlineNavigationCache.delete
+export const deleteOfflineNavigationCacheEntriesForBuild =
+  offlineNavigationCache.deleteBuild

--- a/packages/next/src/client/components/router-reducer/offline-navigation-cache.ts
+++ b/packages/next/src/client/components/router-reducer/offline-navigation-cache.ts
@@ -2,14 +2,21 @@ import { getNavigationBuildId } from '../../navigation-build-id'
 import { normalizePathTrailingSlash } from '../../normalize-trailing-slash'
 
 const DATABASE_NAME = 'next-offline-navigation-cache'
-const DATABASE_VERSION = 2
-const STORE_NAME = 'navigation-data'
+const DATABASE_VERSION = 3
+const EXACT_URL_STORE_NAME = 'navigation-data'
+const ROUTE_STORE_NAME = 'route-data'
+const SEGMENT_STORE_NAME = 'segment-data'
 const METADATA_STORE_NAME = 'metadata'
 const EXACT_URL_CACHE_EPOCH_KEY = 'exact-url-cache-epoch'
+const ROUTE_CACHE_EPOCH_KEY = 'route-cache-epoch'
+const SEGMENT_CACHE_EPOCH_KEY = 'segment-cache-epoch'
 const ENTRY_VERSION = 2
+const ROUTE_RECORD_VERSION = 1
+const SEGMENT_RECORD_VERSION = 1
 const RSC_RESPONSE_PAYLOAD_VERSION = 1
 
 type OfflineNavigationCacheKey = [buildId: string, url: string]
+type OfflineNavigationRouterCacheKey = [buildId: string, key: string]
 export type OfflineNavigationRSCResponseRequestKind =
   | 'navigation'
   | 'route-prefetch'
@@ -58,6 +65,71 @@ export type OfflineNavigationCacheEntry = {
   payload: unknown
 }
 
+export type OfflineNavigationSerializedVaryPathValue =
+  | {
+      kind: 'value'
+      value: string | null
+    }
+  | {
+      kind: 'fallback'
+    }
+
+export type OfflineNavigationSerializedVaryPathPart = {
+  id: string | null
+  value: OfflineNavigationSerializedVaryPathValue
+}
+
+export type OfflineNavigationSerializedVaryPath =
+  OfflineNavigationSerializedVaryPathPart[]
+
+export type OfflineNavigationSerializableVaryPath = {
+  id: string | null
+  value: string | null | object
+  parent: OfflineNavigationSerializableVaryPath | null
+}
+
+export type OfflineNavigationRouteRecord = {
+  version: typeof ROUTE_RECORD_VERSION
+  kind: 'route'
+  buildId: string
+  key: string
+  cacheEpoch: number
+  createdAt: number
+  staleAt: number
+  expiresAt: number
+  route: {
+    pathname: string
+    search: string
+    nextUrl: string | null
+    canonicalUrl: string
+    renderedSearch: string
+    couldBeIntercepted: boolean
+    supportsPerSegmentPrefetching: boolean
+    hasDynamicRewrite: boolean
+  }
+  routeVaryPath: OfflineNavigationSerializedVaryPath
+  tree: unknown
+  metadata: unknown
+}
+
+export type OfflineNavigationSegmentRecord = {
+  version: typeof SEGMENT_RECORD_VERSION
+  kind: 'segment'
+  buildId: string
+  key: string
+  cacheEpoch: number
+  createdAt: number
+  staleAt: number
+  expiresAt: number
+  segment: {
+    requestKey: string
+    fetchStrategy: number
+    isPartial: boolean
+  }
+  segmentVaryPath: OfflineNavigationSerializedVaryPath
+  payload: unknown
+}
+
 export type OfflineNavigationRSCResponsePayload = {
   version: typeof RSC_RESPONSE_PAYLOAD_VERSION
   kind: 'rsc-response'
@@ -92,6 +164,22 @@ export type OfflineNavigationRSCResponseCacheWrite = {
   payload: Promise<OfflineNavigationRSCResponsePayload | null>
 }
 
+export type OfflineNavigationRouteRecordWrite = Omit<
+  OfflineNavigationRouteRecord,
+  'buildId' | 'cacheEpoch' | 'createdAt' | 'kind' | 'version'
+> & {
+  buildId?: string
+  now?: number
+}
+
+export type OfflineNavigationSegmentRecordWrite = Omit<
+  OfflineNavigationSegmentRecord,
+  'buildId' | 'cacheEpoch' | 'createdAt' | 'kind' | 'version'
+> & {
+  buildId?: string
+  now?: number
+}
+
 export type OfflineNavigationCacheStorage = {
   get(
     key: OfflineNavigationCacheKey
@@ -101,6 +189,20 @@ export type OfflineNavigationCacheStorage = {
   deleteBuild(buildId: string): Promise<void>
   getCacheEpoch(): Promise<number>
   incrementCacheEpoch(): Promise<number>
+  getRoute(
+    key: OfflineNavigationRouterCacheKey
+  ): Promise<OfflineNavigationRouteRecord | undefined>
+  putRoute(entry: OfflineNavigationRouteRecord): Promise<void>
+  deleteRoute(key: OfflineNavigationRouterCacheKey): Promise<void>
+  getRouteCacheEpoch(): Promise<number>
+  incrementRouteCacheEpoch(): Promise<number>
+  getSegment(
+    key: OfflineNavigationRouterCacheKey
+  ): Promise<OfflineNavigationSegmentRecord | undefined>
+  putSegment(entry: OfflineNavigationSegmentRecord): Promise<void>
+  deleteSegment(key: OfflineNavigationRouterCacheKey): Promise<void>
+  getSegmentCacheEpoch(): Promise<number>
+  incrementSegmentCacheEpoch(): Promise<number>
 }
 
 export type OfflineNavigationCache = {
@@ -117,6 +219,29 @@ export type OfflineNavigationCache = {
   invalidate: () => Promise<boolean>
 }
 
+export type OfflineNavigationRouterCache = {
+  readRoute: (
+    key: string,
+    options?: OfflineNavigationCacheReadOptions
+  ) => Promise<OfflineNavigationRouteRecord | null>
+  writeRoute: (entry: OfflineNavigationRouteRecordWrite) => Promise<boolean>
+  deleteRoute: (
+    key: string,
+    options?: OfflineNavigationCacheReadOptions
+  ) => Promise<boolean>
+  invalidateRoutes: () => Promise<boolean>
+  readSegment: (
+    key: string,
+    options?: OfflineNavigationCacheReadOptions
+  ) => Promise<OfflineNavigationSegmentRecord | null>
+  writeSegment: (entry: OfflineNavigationSegmentRecordWrite) => Promise<boolean>
+  deleteSegment: (
+    key: string,
+    options?: OfflineNavigationCacheReadOptions
+  ) => Promise<boolean>
+  invalidateSegments: () => Promise<boolean>
+}
+
 export function normalizeOfflineNavigationCacheUrl(url: string | URL): string {
   const normalized =
     typeof url === 'string'
@@ -129,6 +254,37 @@ export function normalizeOfflineNavigationCacheUrl(url: string | URL): string {
   normalized.hash = ''
   normalized.pathname = normalizePathTrailingSlash(normalized.pathname)
   return normalized.href
+}
+
+export function serializeOfflineNavigationVaryPath(
+  varyPath: OfflineNavigationSerializableVaryPath | null
+): OfflineNavigationSerializedVaryPath {
+  const parts: OfflineNavigationSerializedVaryPath = []
+  let current = varyPath
+
+  while (current !== null) {
+    parts.push({
+      id: current.id,
+      value:
+        current.value === null || typeof current.value === 'string'
+          ? {
+              kind: 'value',
+              value: current.value,
+            }
+          : {
+              kind: 'fallback',
+            },
+    })
+    current = current.parent
+  }
+
+  return parts
+}
+
+export function createOfflineNavigationVaryPathKey(
+  varyPath: OfflineNavigationSerializableVaryPath | null
+): string {
+  return JSON.stringify(serializeOfflineNavigationVaryPath(varyPath))
 }
 
 export function createOfflineNavigationCache(
@@ -217,6 +373,164 @@ export function createOfflineNavigationCache(
     invalidate: async () => {
       return runOfflineNavigationCacheOperation(async () => {
         await storage.incrementCacheEpoch()
+        return true
+      }, false)
+    },
+  }
+}
+
+export function createOfflineNavigationRouterCache(
+  storage: OfflineNavigationCacheStorage
+): OfflineNavigationRouterCache {
+  return {
+    readRoute: async (key, options) => {
+      return runOfflineNavigationCacheOperation(async () => {
+        const buildId = getCacheBuildId(options?.buildId)
+        if (buildId === null) {
+          return null
+        }
+
+        const cacheKey: OfflineNavigationRouterCacheKey = [buildId, key]
+        const [entry, cacheEpoch] = await Promise.all([
+          storage.getRoute(cacheKey),
+          storage.getRouteCacheEpoch(),
+        ])
+        if (!entry) {
+          return null
+        }
+
+        if (
+          entry.version !== ROUTE_RECORD_VERSION ||
+          entry.kind !== 'route' ||
+          entry.buildId !== buildId ||
+          entry.key !== key ||
+          entry.cacheEpoch !== cacheEpoch
+        ) {
+          await storage.deleteRoute(cacheKey)
+          return null
+        }
+
+        if (entry.expiresAt <= (options?.now ?? Date.now())) {
+          await storage.deleteRoute(cacheKey)
+          return null
+        }
+
+        return entry
+      }, null)
+    },
+    writeRoute: async (entry) => {
+      return runOfflineNavigationCacheOperation(async () => {
+        const buildId = getCacheBuildId(entry.buildId)
+        if (buildId === null) {
+          return false
+        }
+
+        await storage.putRoute({
+          version: ROUTE_RECORD_VERSION,
+          kind: 'route',
+          buildId,
+          key: entry.key,
+          cacheEpoch: await storage.getRouteCacheEpoch(),
+          createdAt: entry.now ?? Date.now(),
+          staleAt: entry.staleAt,
+          expiresAt: entry.expiresAt,
+          route: entry.route,
+          routeVaryPath: entry.routeVaryPath,
+          tree: entry.tree,
+          metadata: entry.metadata,
+        })
+        return true
+      }, false)
+    },
+    deleteRoute: async (key, options) => {
+      return runOfflineNavigationCacheOperation(async () => {
+        const buildId = getCacheBuildId(options?.buildId)
+        if (buildId === null) {
+          return false
+        }
+
+        await storage.deleteRoute([buildId, key])
+        return true
+      }, false)
+    },
+    invalidateRoutes: async () => {
+      return runOfflineNavigationCacheOperation(async () => {
+        await storage.incrementRouteCacheEpoch()
+        return true
+      }, false)
+    },
+    readSegment: async (key, options) => {
+      return runOfflineNavigationCacheOperation(async () => {
+        const buildId = getCacheBuildId(options?.buildId)
+        if (buildId === null) {
+          return null
+        }
+
+        const cacheKey: OfflineNavigationRouterCacheKey = [buildId, key]
+        const [entry, cacheEpoch] = await Promise.all([
+          storage.getSegment(cacheKey),
+          storage.getSegmentCacheEpoch(),
+        ])
+        if (!entry) {
+          return null
+        }
+
+        if (
+          entry.version !== SEGMENT_RECORD_VERSION ||
+          entry.kind !== 'segment' ||
+          entry.buildId !== buildId ||
+          entry.key !== key ||
+          entry.cacheEpoch !== cacheEpoch
+        ) {
+          await storage.deleteSegment(cacheKey)
+          return null
+        }
+
+        if (entry.expiresAt <= (options?.now ?? Date.now())) {
+          await storage.deleteSegment(cacheKey)
+          return null
+        }
+
+        return entry
+      }, null)
+    },
+    writeSegment: async (entry) => {
+      return runOfflineNavigationCacheOperation(async () => {
+        const buildId = getCacheBuildId(entry.buildId)
+        if (buildId === null) {
+          return false
+        }
+
+        await storage.putSegment({
+          version: SEGMENT_RECORD_VERSION,
+          kind: 'segment',
+          buildId,
+          key: entry.key,
+          cacheEpoch: await storage.getSegmentCacheEpoch(),
+          createdAt: entry.now ?? Date.now(),
+          staleAt: entry.staleAt,
+          expiresAt: entry.expiresAt,
+          segment: entry.segment,
+          segmentVaryPath: entry.segmentVaryPath,
+          payload: entry.payload,
+        })
+        return true
+      }, false)
+    },
+    deleteSegment: async (key, options) => {
+      return runOfflineNavigationCacheOperation(async () => {
+        const buildId = getCacheBuildId(options?.buildId)
+        if (buildId === null) {
+          return false
+        }
+
+        await storage.deleteSegment([buildId, key])
+        return true
+      }, false)
+    },
+    invalidateSegments: async () => {
+      return runOfflineNavigationCacheOperation(async () => {
+        await storage.incrementSegmentCacheEpoch()
         return true
       }, false)
     },
@@ -402,6 +716,16 @@ function waitForTransaction(transaction: IDBTransaction): Promise<void> {
   })
 }
 
+function ensureObjectStore(
+  database: IDBDatabase,
+  storeName: string,
+  keyPath: string | string[]
+): void {
+  if (!database.objectStoreNames.contains(storeName)) {
+    database.createObjectStore(storeName, { keyPath })
+  }
+}
+
 class IndexedDBOfflineNavigationCacheStorage
   implements OfflineNavigationCacheStorage
 {
@@ -410,39 +734,15 @@ class IndexedDBOfflineNavigationCacheStorage
   async get(
     key: OfflineNavigationCacheKey
   ): Promise<OfflineNavigationCacheEntry | undefined> {
-    const database = await this.getDatabase()
-    if (database === null) {
-      return undefined
-    }
-
-    return requestToPromise(
-      database
-        .transaction(STORE_NAME, 'readonly')
-        .objectStore(STORE_NAME)
-        .get(key)
-    )
+    return this.getFromStore(EXACT_URL_STORE_NAME, key)
   }
 
   async put(entry: OfflineNavigationCacheEntry): Promise<void> {
-    const database = await this.getDatabase()
-    if (database === null) {
-      throw new Error()
-    }
-
-    const transaction = database.transaction(STORE_NAME, 'readwrite')
-    transaction.objectStore(STORE_NAME).put(entry)
-    await waitForTransaction(transaction)
+    await this.putIntoStore(EXACT_URL_STORE_NAME, entry)
   }
 
   async delete(key: OfflineNavigationCacheKey): Promise<void> {
-    const database = await this.getDatabase()
-    if (database === null) {
-      throw new Error()
-    }
-
-    const transaction = database.transaction(STORE_NAME, 'readwrite')
-    transaction.objectStore(STORE_NAME).delete(key)
-    await waitForTransaction(transaction)
+    await this.deleteFromStore(EXACT_URL_STORE_NAME, key)
   }
 
   async deleteBuild(buildId: string): Promise<void> {
@@ -451,8 +751,8 @@ class IndexedDBOfflineNavigationCacheStorage
       throw new Error()
     }
 
-    const transaction = database.transaction(STORE_NAME, 'readwrite')
-    const store = transaction.objectStore(STORE_NAME)
+    const transaction = database.transaction(EXACT_URL_STORE_NAME, 'readwrite')
+    const store = transaction.objectStore(EXACT_URL_STORE_NAME)
     const cursorRequest = store.openCursor()
     await new Promise<void>((resolve, reject) => {
       cursorRequest.onsuccess = () => {
@@ -473,6 +773,100 @@ class IndexedDBOfflineNavigationCacheStorage
   }
 
   async getCacheEpoch(): Promise<number> {
+    return this.getEpoch(EXACT_URL_CACHE_EPOCH_KEY)
+  }
+
+  async incrementCacheEpoch(): Promise<number> {
+    return this.incrementEpoch(EXACT_URL_CACHE_EPOCH_KEY)
+  }
+
+  async getRoute(
+    key: OfflineNavigationRouterCacheKey
+  ): Promise<OfflineNavigationRouteRecord | undefined> {
+    return this.getFromStore(ROUTE_STORE_NAME, key)
+  }
+
+  async putRoute(entry: OfflineNavigationRouteRecord): Promise<void> {
+    await this.putIntoStore(ROUTE_STORE_NAME, entry)
+  }
+
+  async deleteRoute(key: OfflineNavigationRouterCacheKey): Promise<void> {
+    await this.deleteFromStore(ROUTE_STORE_NAME, key)
+  }
+
+  async getRouteCacheEpoch(): Promise<number> {
+    return this.getEpoch(ROUTE_CACHE_EPOCH_KEY)
+  }
+
+  async incrementRouteCacheEpoch(): Promise<number> {
+    return this.incrementEpoch(ROUTE_CACHE_EPOCH_KEY)
+  }
+
+  async getSegment(
+    key: OfflineNavigationRouterCacheKey
+  ): Promise<OfflineNavigationSegmentRecord | undefined> {
+    return this.getFromStore(SEGMENT_STORE_NAME, key)
+  }
+
+  async putSegment(entry: OfflineNavigationSegmentRecord): Promise<void> {
+    await this.putIntoStore(SEGMENT_STORE_NAME, entry)
+  }
+
+  async deleteSegment(key: OfflineNavigationRouterCacheKey): Promise<void> {
+    await this.deleteFromStore(SEGMENT_STORE_NAME, key)
+  }
+
+  async getSegmentCacheEpoch(): Promise<number> {
+    return this.getEpoch(SEGMENT_CACHE_EPOCH_KEY)
+  }
+
+  async incrementSegmentCacheEpoch(): Promise<number> {
+    return this.incrementEpoch(SEGMENT_CACHE_EPOCH_KEY)
+  }
+
+  private async getFromStore<T>(
+    storeName: string,
+    key: IDBValidKey | IDBKeyRange
+  ): Promise<T | undefined> {
+    const database = await this.getDatabase()
+    if (database === null) {
+      return undefined
+    }
+
+    return requestToPromise(
+      database
+        .transaction(storeName, 'readonly')
+        .objectStore(storeName)
+        .get(key)
+    )
+  }
+
+  private async putIntoStore(storeName: string, entry: unknown): Promise<void> {
+    const database = await this.getDatabase()
+    if (database === null) {
+      throw new Error()
+    }
+
+    const transaction = database.transaction(storeName, 'readwrite')
+    transaction.objectStore(storeName).put(entry)
+    await waitForTransaction(transaction)
+  }
+
+  private async deleteFromStore(
+    storeName: string,
+    key: IDBValidKey | IDBKeyRange
+  ): Promise<void> {
+    const database = await this.getDatabase()
+    if (database === null) {
+      throw new Error()
+    }
+
+    const transaction = database.transaction(storeName, 'readwrite')
+    transaction.objectStore(storeName).delete(key)
+    await waitForTransaction(transaction)
+  }
+
+  private async getEpoch(key: string): Promise<number> {
     const database = await this.getDatabase()
     if (database === null) {
       return 0
@@ -482,12 +876,12 @@ class IndexedDBOfflineNavigationCacheStorage
       database
         .transaction(METADATA_STORE_NAME, 'readonly')
         .objectStore(METADATA_STORE_NAME)
-        .get(EXACT_URL_CACHE_EPOCH_KEY)
+        .get(key)
     )
     return typeof epoch === 'number' ? epoch : 0
   }
 
-  async incrementCacheEpoch(): Promise<number> {
+  private async incrementEpoch(key: string): Promise<number> {
     const database = await this.getDatabase()
     if (database === null) {
       throw new Error()
@@ -495,9 +889,9 @@ class IndexedDBOfflineNavigationCacheStorage
 
     const transaction = database.transaction(METADATA_STORE_NAME, 'readwrite')
     const store = transaction.objectStore(METADATA_STORE_NAME)
-    const epoch = await requestToPromise(store.get(EXACT_URL_CACHE_EPOCH_KEY))
+    const epoch = await requestToPromise(store.get(key))
     const nextEpoch = (typeof epoch === 'number' ? epoch : 0) + 1
-    store.put(nextEpoch, EXACT_URL_CACHE_EPOCH_KEY)
+    store.put(nextEpoch, key)
     await waitForTransaction(transaction)
     return nextEpoch
   }
@@ -521,11 +915,9 @@ class IndexedDBOfflineNavigationCacheStorage
     const request = idb.open(DATABASE_NAME, DATABASE_VERSION)
     request.onupgradeneeded = () => {
       const database = request.result
-      if (!database.objectStoreNames.contains(STORE_NAME)) {
-        database.createObjectStore(STORE_NAME, {
-          keyPath: ['buildId', 'url'],
-        })
-      }
+      ensureObjectStore(database, EXACT_URL_STORE_NAME, ['buildId', 'url'])
+      ensureObjectStore(database, ROUTE_STORE_NAME, ['buildId', 'key'])
+      ensureObjectStore(database, SEGMENT_STORE_NAME, ['buildId', 'key'])
       if (!database.objectStoreNames.contains(METADATA_STORE_NAME)) {
         database.createObjectStore(METADATA_STORE_NAME)
       }
@@ -540,8 +932,13 @@ class IndexedDBOfflineNavigationCacheStorage
   }
 }
 
-const offlineNavigationCache = createOfflineNavigationCache(
+const offlineNavigationCacheStorage =
   new IndexedDBOfflineNavigationCacheStorage()
+const offlineNavigationCache = createOfflineNavigationCache(
+  offlineNavigationCacheStorage
+)
+const offlineNavigationRouterCache = createOfflineNavigationRouterCache(
+  offlineNavigationCacheStorage
 )
 
 export const readOfflineNavigationCacheEntry = offlineNavigationCache.read
@@ -551,3 +948,19 @@ export const deleteOfflineNavigationCacheEntriesForBuild =
   offlineNavigationCache.deleteBuild
 export const invalidateOfflineNavigationCacheEntries =
   offlineNavigationCache.invalidate
+export const readOfflineNavigationRouteRecord =
+  offlineNavigationRouterCache.readRoute
+export const writeOfflineNavigationRouteRecord =
+  offlineNavigationRouterCache.writeRoute
+export const deleteOfflineNavigationRouteRecord =
+  offlineNavigationRouterCache.deleteRoute
+export const invalidateOfflineNavigationRouteRecords =
+  offlineNavigationRouterCache.invalidateRoutes
+export const readOfflineNavigationSegmentRecord =
+  offlineNavigationRouterCache.readSegment
+export const writeOfflineNavigationSegmentRecord =
+  offlineNavigationRouterCache.writeSegment
+export const deleteOfflineNavigationSegmentRecord =
+  offlineNavigationRouterCache.deleteSegment
+export const invalidateOfflineNavigationSegmentRecords =
+  offlineNavigationRouterCache.invalidateSegments

--- a/packages/next/src/client/components/router-reducer/offline-navigation-cache.ts
+++ b/packages/next/src/client/components/router-reducer/offline-navigation-cache.ts
@@ -1,4 +1,5 @@
 import { getNavigationBuildId } from '../../navigation-build-id'
+import { normalizePathTrailingSlash } from '../../normalize-trailing-slash'
 
 const DATABASE_NAME = 'next-offline-navigation-cache'
 const DATABASE_VERSION = 1
@@ -89,6 +90,7 @@ export function normalizeOfflineNavigationCacheUrl(url: string | URL): string {
       : new URL(url.href)
 
   normalized.hash = ''
+  normalized.pathname = normalizePathTrailingSlash(normalized.pathname)
   return normalized.href
 }
 
@@ -182,7 +184,7 @@ export async function createOfflineNavigationRSCResponsePayload(
     version: RSC_RESPONSE_PAYLOAD_VERSION,
     kind: 'rsc-response',
     requestKind,
-    url: clone.url,
+    url: response.url,
     status: clone.status,
     statusText: clone.statusText,
     headers: Array.from(clone.headers.entries()),
@@ -193,11 +195,35 @@ export async function createOfflineNavigationRSCResponsePayload(
 export function createOfflineNavigationRSCResponse(
   payload: OfflineNavigationRSCResponsePayload
 ): Response {
-  return new Response(payload.body.slice(0), {
+  const response = new Response(payload.body.slice(0), {
     status: payload.status,
     statusText: payload.statusText,
     headers: payload.headers,
   })
+  Object.defineProperty(response, 'url', { value: payload.url })
+  return response
+}
+
+export function isOfflineNavigationRSCResponsePayload(
+  payload: unknown
+): payload is OfflineNavigationRSCResponsePayload {
+  if (payload === null || typeof payload !== 'object') {
+    return false
+  }
+
+  const candidate = payload as Partial<OfflineNavigationRSCResponsePayload>
+  return (
+    candidate.version === RSC_RESPONSE_PAYLOAD_VERSION &&
+    candidate.kind === 'rsc-response' &&
+    (candidate.requestKind === 'navigation' ||
+      candidate.requestKind === 'route-prefetch' ||
+      candidate.requestKind === 'client-resume') &&
+    typeof candidate.url === 'string' &&
+    typeof candidate.status === 'number' &&
+    typeof candidate.statusText === 'string' &&
+    Array.isArray(candidate.headers) &&
+    candidate.body instanceof ArrayBuffer
+  )
 }
 
 export async function writeOfflineNavigationRSCResponseCacheEntry({

--- a/packages/next/src/client/components/router-reducer/offline-navigation-cache.ts
+++ b/packages/next/src/client/components/router-reducer/offline-navigation-cache.ts
@@ -825,6 +825,28 @@ function ensureObjectStore(
   }
 }
 
+async function deleteBuildEntriesFromObjectStore(
+  store: IDBObjectStore,
+  buildId: string
+): Promise<void> {
+  const cursorRequest = store.openCursor()
+  await new Promise<void>((resolve, reject) => {
+    cursorRequest.onsuccess = () => {
+      const cursor = cursorRequest.result
+      if (cursor === null) {
+        resolve()
+        return
+      }
+
+      if ((cursor.value as { buildId?: unknown }).buildId === buildId) {
+        cursor.delete()
+      }
+      cursor.continue()
+    }
+    cursorRequest.onerror = () => reject(cursorRequest.error ?? new Error())
+  })
+}
+
 class IndexedDBOfflineNavigationCacheStorage
   implements OfflineNavigationCacheStorage
 {
@@ -850,24 +872,19 @@ class IndexedDBOfflineNavigationCacheStorage
       throw new Error()
     }
 
-    const transaction = database.transaction(EXACT_URL_STORE_NAME, 'readwrite')
-    const store = transaction.objectStore(EXACT_URL_STORE_NAME)
-    const cursorRequest = store.openCursor()
-    await new Promise<void>((resolve, reject) => {
-      cursorRequest.onsuccess = () => {
-        const cursor = cursorRequest.result
-        if (cursor === null) {
-          resolve()
-          return
-        }
-
-        if ((cursor.value as OfflineNavigationCacheEntry).buildId === buildId) {
-          cursor.delete()
-        }
-        cursor.continue()
-      }
-      cursorRequest.onerror = () => reject(cursorRequest.error ?? new Error())
-    })
+    const transaction = database.transaction(
+      [EXACT_URL_STORE_NAME, ROUTE_STORE_NAME, SEGMENT_STORE_NAME],
+      'readwrite'
+    )
+    await Promise.all(
+      [EXACT_URL_STORE_NAME, ROUTE_STORE_NAME, SEGMENT_STORE_NAME].map(
+        (storeName) =>
+          deleteBuildEntriesFromObjectStore(
+            transaction.objectStore(storeName),
+            buildId
+          )
+      )
+    )
     await waitForTransaction(transaction)
   }
 

--- a/packages/next/src/client/components/router-reducer/offline-navigation-cache.ts
+++ b/packages/next/src/client/components/router-reducer/offline-navigation-cache.ts
@@ -281,7 +281,7 @@ export function getOfflineNavigationRSCResponseCacheSkipReason({
     return 'cross-origin'
   }
 
-  if (!supportsPerSegmentPrefetching) {
+  if (!supportsPerSegmentPrefetching && requestKind !== 'initial-load') {
     return 'unsupported-segment-prefetching'
   }
 

--- a/packages/next/src/client/components/router-reducer/offline-navigation-cache.ts
+++ b/packages/next/src/client/components/router-reducer/offline-navigation-cache.ts
@@ -2,9 +2,11 @@ import { getNavigationBuildId } from '../../navigation-build-id'
 import { normalizePathTrailingSlash } from '../../normalize-trailing-slash'
 
 const DATABASE_NAME = 'next-offline-navigation-cache'
-const DATABASE_VERSION = 1
+const DATABASE_VERSION = 2
 const STORE_NAME = 'navigation-data'
-const ENTRY_VERSION = 1
+const METADATA_STORE_NAME = 'metadata'
+const EXACT_URL_CACHE_EPOCH_KEY = 'exact-url-cache-epoch'
+const ENTRY_VERSION = 2
 const RSC_RESPONSE_PAYLOAD_VERSION = 1
 
 type OfflineNavigationCacheKey = [buildId: string, url: string]
@@ -49,6 +51,7 @@ export type OfflineNavigationCacheEntry = {
   kind: 'exact-url'
   buildId: string
   url: string
+  cacheEpoch: number
   createdAt: number
   staleAt: number
   expiresAt: number
@@ -96,6 +99,8 @@ export type OfflineNavigationCacheStorage = {
   put(entry: OfflineNavigationCacheEntry): Promise<void>
   delete(key: OfflineNavigationCacheKey): Promise<void>
   deleteBuild(buildId: string): Promise<void>
+  getCacheEpoch(): Promise<number>
+  incrementCacheEpoch(): Promise<number>
 }
 
 export type OfflineNavigationCache = {
@@ -109,6 +114,7 @@ export type OfflineNavigationCache = {
     options?: OfflineNavigationCacheReadOptions
   ) => Promise<boolean>
   deleteBuild: (buildId?: string) => Promise<boolean>
+  invalidate: () => Promise<boolean>
 }
 
 export function normalizeOfflineNavigationCacheUrl(url: string | URL): string {
@@ -138,7 +144,10 @@ export function createOfflineNavigationCache(
 
         const cacheUrl = normalizeOfflineNavigationCacheUrl(url)
         const key: OfflineNavigationCacheKey = [buildId, cacheUrl]
-        const entry = await storage.get(key)
+        const [entry, cacheEpoch] = await Promise.all([
+          storage.get(key),
+          storage.getCacheEpoch(),
+        ])
         if (!entry) {
           return null
         }
@@ -147,7 +156,8 @@ export function createOfflineNavigationCache(
           entry.version !== ENTRY_VERSION ||
           entry.kind !== 'exact-url' ||
           entry.buildId !== buildId ||
-          entry.url !== cacheUrl
+          entry.url !== cacheUrl ||
+          entry.cacheEpoch !== cacheEpoch
         ) {
           await storage.delete(key)
           return null
@@ -173,6 +183,7 @@ export function createOfflineNavigationCache(
           kind: 'exact-url',
           buildId,
           url: normalizeOfflineNavigationCacheUrl(entry.url),
+          cacheEpoch: await storage.getCacheEpoch(),
           createdAt: entry.now ?? Date.now(),
           staleAt: entry.staleAt,
           expiresAt: entry.expiresAt,
@@ -200,6 +211,12 @@ export function createOfflineNavigationCache(
         }
 
         await storage.deleteBuild(cacheBuildId)
+        return true
+      }, false)
+    },
+    invalidate: async () => {
+      return runOfflineNavigationCacheOperation(async () => {
+        await storage.incrementCacheEpoch()
         return true
       }, false)
     },
@@ -455,6 +472,36 @@ class IndexedDBOfflineNavigationCacheStorage
     await waitForTransaction(transaction)
   }
 
+  async getCacheEpoch(): Promise<number> {
+    const database = await this.getDatabase()
+    if (database === null) {
+      return 0
+    }
+
+    const epoch = await requestToPromise(
+      database
+        .transaction(METADATA_STORE_NAME, 'readonly')
+        .objectStore(METADATA_STORE_NAME)
+        .get(EXACT_URL_CACHE_EPOCH_KEY)
+    )
+    return typeof epoch === 'number' ? epoch : 0
+  }
+
+  async incrementCacheEpoch(): Promise<number> {
+    const database = await this.getDatabase()
+    if (database === null) {
+      throw new Error()
+    }
+
+    const transaction = database.transaction(METADATA_STORE_NAME, 'readwrite')
+    const store = transaction.objectStore(METADATA_STORE_NAME)
+    const epoch = await requestToPromise(store.get(EXACT_URL_CACHE_EPOCH_KEY))
+    const nextEpoch = (typeof epoch === 'number' ? epoch : 0) + 1
+    store.put(nextEpoch, EXACT_URL_CACHE_EPOCH_KEY)
+    await waitForTransaction(transaction)
+    return nextEpoch
+  }
+
   private async getDatabase(): Promise<IDBDatabase | null> {
     if (this.databasePromise === null) {
       this.databasePromise = this.openDatabase().catch((error) => {
@@ -479,6 +526,9 @@ class IndexedDBOfflineNavigationCacheStorage
           keyPath: ['buildId', 'url'],
         })
       }
+      if (!database.objectStoreNames.contains(METADATA_STORE_NAME)) {
+        database.createObjectStore(METADATA_STORE_NAME)
+      }
     }
 
     const database = await requestToPromise(request)
@@ -499,3 +549,5 @@ export const writeOfflineNavigationCacheEntry = offlineNavigationCache.write
 export const deleteOfflineNavigationCacheEntry = offlineNavigationCache.delete
 export const deleteOfflineNavigationCacheEntriesForBuild =
   offlineNavigationCache.deleteBuild
+export const invalidateOfflineNavigationCacheEntries =
+  offlineNavigationCache.invalidate

--- a/packages/next/src/client/components/router-reducer/offline-navigation-cache.ts
+++ b/packages/next/src/client/components/router-reducer/offline-navigation-cache.ts
@@ -20,6 +20,7 @@ type OfflineNavigationRouterCacheKey = [buildId: string, key: string]
 export type OfflineNavigationRSCResponseRequestKind =
   | 'navigation'
   | 'route-prefetch'
+  | 'segment-prefetch'
   | 'client-resume'
   | 'initial-load'
 
@@ -125,6 +126,7 @@ export type OfflineNavigationSegmentRecord = {
     requestKey: string
     fetchStrategy: number
     isPartial: boolean
+    payloadIndex: number
   }
   segmentVaryPath: OfflineNavigationSerializedVaryPath
   payload: unknown
@@ -656,6 +658,7 @@ export function isOfflineNavigationRSCResponsePayload(
     candidate.kind === 'rsc-response' &&
     (candidate.requestKind === 'navigation' ||
       candidate.requestKind === 'route-prefetch' ||
+      candidate.requestKind === 'segment-prefetch' ||
       candidate.requestKind === 'client-resume' ||
       candidate.requestKind === 'initial-load') &&
     typeof candidate.url === 'string' &&

--- a/packages/next/src/client/components/router-reducer/offline-navigation-cache.ts
+++ b/packages/next/src/client/components/router-reducer/offline-navigation-cache.ts
@@ -194,6 +194,7 @@ export type OfflineNavigationCacheStorage = {
   getRoute(
     key: OfflineNavigationRouterCacheKey
   ): Promise<OfflineNavigationRouteRecord | undefined>
+  getRoutes(buildId: string): Promise<OfflineNavigationRouteRecord[]>
   putRoute(entry: OfflineNavigationRouteRecord): Promise<void>
   deleteRoute(key: OfflineNavigationRouterCacheKey): Promise<void>
   getRouteCacheEpoch(): Promise<number>
@@ -201,6 +202,7 @@ export type OfflineNavigationCacheStorage = {
   getSegment(
     key: OfflineNavigationRouterCacheKey
   ): Promise<OfflineNavigationSegmentRecord | undefined>
+  getSegments(buildId: string): Promise<OfflineNavigationSegmentRecord[]>
   putSegment(entry: OfflineNavigationSegmentRecord): Promise<void>
   deleteSegment(key: OfflineNavigationRouterCacheKey): Promise<void>
   getSegmentCacheEpoch(): Promise<number>
@@ -226,6 +228,9 @@ export type OfflineNavigationRouterCache = {
     key: string,
     options?: OfflineNavigationCacheReadOptions
   ) => Promise<OfflineNavigationRouteRecord | null>
+  readRoutes: (
+    options?: OfflineNavigationCacheReadOptions
+  ) => Promise<OfflineNavigationRouteRecord[]>
   writeRoute: (entry: OfflineNavigationRouteRecordWrite) => Promise<boolean>
   deleteRoute: (
     key: string,
@@ -236,6 +241,9 @@ export type OfflineNavigationRouterCache = {
     key: string,
     options?: OfflineNavigationCacheReadOptions
   ) => Promise<OfflineNavigationSegmentRecord | null>
+  readSegments: (
+    options?: OfflineNavigationCacheReadOptions
+  ) => Promise<OfflineNavigationSegmentRecord[]>
   writeSegment: (entry: OfflineNavigationSegmentRecordWrite) => Promise<boolean>
   deleteSegment: (
     key: string,
@@ -401,24 +409,50 @@ export function createOfflineNavigationRouterCache(
           return null
         }
 
-        if (
-          entry.version !== ROUTE_RECORD_VERSION ||
-          entry.kind !== 'route' ||
-          entry.buildId !== buildId ||
-          entry.key !== key ||
-          entry.cacheEpoch !== cacheEpoch
-        ) {
-          await storage.deleteRoute(cacheKey)
-          return null
-        }
-
-        if (entry.expiresAt <= (options?.now ?? Date.now())) {
+        if (!isUsableRouteRecord(entry, buildId, key, cacheEpoch, options)) {
           await storage.deleteRoute(cacheKey)
           return null
         }
 
         return entry
       }, null)
+    },
+    readRoutes: async (options) => {
+      return runOfflineNavigationCacheOperation(async () => {
+        const buildId = getCacheBuildId(options?.buildId)
+        if (buildId === null) {
+          return []
+        }
+
+        const [entries, cacheEpoch] = await Promise.all([
+          storage.getRoutes(buildId),
+          storage.getRouteCacheEpoch(),
+        ])
+        const usableEntries: OfflineNavigationRouteRecord[] = []
+        await Promise.all(
+          entries.map(async (entry) => {
+            if (
+              isUsableRouteRecord(
+                entry,
+                buildId,
+                entry.key,
+                cacheEpoch,
+                options
+              )
+            ) {
+              usableEntries.push(entry)
+            } else {
+              if (
+                typeof entry.buildId === 'string' &&
+                typeof entry.key === 'string'
+              ) {
+                await storage.deleteRoute([entry.buildId, entry.key])
+              }
+            }
+          })
+        )
+        return usableEntries
+      }, [])
     },
     writeRoute: async (entry) => {
       return runOfflineNavigationCacheOperation(async () => {
@@ -477,24 +511,50 @@ export function createOfflineNavigationRouterCache(
           return null
         }
 
-        if (
-          entry.version !== SEGMENT_RECORD_VERSION ||
-          entry.kind !== 'segment' ||
-          entry.buildId !== buildId ||
-          entry.key !== key ||
-          entry.cacheEpoch !== cacheEpoch
-        ) {
-          await storage.deleteSegment(cacheKey)
-          return null
-        }
-
-        if (entry.expiresAt <= (options?.now ?? Date.now())) {
+        if (!isUsableSegmentRecord(entry, buildId, key, cacheEpoch, options)) {
           await storage.deleteSegment(cacheKey)
           return null
         }
 
         return entry
       }, null)
+    },
+    readSegments: async (options) => {
+      return runOfflineNavigationCacheOperation(async () => {
+        const buildId = getCacheBuildId(options?.buildId)
+        if (buildId === null) {
+          return []
+        }
+
+        const [entries, cacheEpoch] = await Promise.all([
+          storage.getSegments(buildId),
+          storage.getSegmentCacheEpoch(),
+        ])
+        const usableEntries: OfflineNavigationSegmentRecord[] = []
+        await Promise.all(
+          entries.map(async (entry) => {
+            if (
+              isUsableSegmentRecord(
+                entry,
+                buildId,
+                entry.key,
+                cacheEpoch,
+                options
+              )
+            ) {
+              usableEntries.push(entry)
+            } else {
+              if (
+                typeof entry.buildId === 'string' &&
+                typeof entry.key === 'string'
+              ) {
+                await storage.deleteSegment([entry.buildId, entry.key])
+              }
+            }
+          })
+        )
+        return usableEntries
+      }, [])
     },
     writeSegment: async (entry) => {
       return runOfflineNavigationCacheOperation(async () => {
@@ -537,6 +597,42 @@ export function createOfflineNavigationRouterCache(
       }, false)
     },
   }
+}
+
+function isUsableRouteRecord(
+  entry: OfflineNavigationRouteRecord,
+  buildId: string,
+  key: string,
+  cacheEpoch: number,
+  options: OfflineNavigationCacheReadOptions | undefined
+): boolean {
+  return (
+    entry.version === ROUTE_RECORD_VERSION &&
+    entry.kind === 'route' &&
+    entry.buildId === buildId &&
+    typeof entry.key === 'string' &&
+    entry.key === key &&
+    entry.cacheEpoch === cacheEpoch &&
+    entry.expiresAt > (options?.now ?? Date.now())
+  )
+}
+
+function isUsableSegmentRecord(
+  entry: OfflineNavigationSegmentRecord,
+  buildId: string,
+  key: string,
+  cacheEpoch: number,
+  options: OfflineNavigationCacheReadOptions | undefined
+): boolean {
+  return (
+    entry.version === SEGMENT_RECORD_VERSION &&
+    entry.kind === 'segment' &&
+    entry.buildId === buildId &&
+    typeof entry.key === 'string' &&
+    entry.key === key &&
+    entry.cacheEpoch === cacheEpoch &&
+    entry.expiresAt > (options?.now ?? Date.now())
+  )
 }
 
 export async function createOfflineNavigationRSCResponsePayload(
@@ -789,6 +885,10 @@ class IndexedDBOfflineNavigationCacheStorage
     return this.getFromStore(ROUTE_STORE_NAME, key)
   }
 
+  async getRoutes(buildId: string): Promise<OfflineNavigationRouteRecord[]> {
+    return this.getBuildEntriesFromStore(ROUTE_STORE_NAME, buildId)
+  }
+
   async putRoute(entry: OfflineNavigationRouteRecord): Promise<void> {
     await this.putIntoStore(ROUTE_STORE_NAME, entry)
   }
@@ -809,6 +909,12 @@ class IndexedDBOfflineNavigationCacheStorage
     key: OfflineNavigationRouterCacheKey
   ): Promise<OfflineNavigationSegmentRecord | undefined> {
     return this.getFromStore(SEGMENT_STORE_NAME, key)
+  }
+
+  async getSegments(
+    buildId: string
+  ): Promise<OfflineNavigationSegmentRecord[]> {
+    return this.getBuildEntriesFromStore(SEGMENT_STORE_NAME, buildId)
   }
 
   async putSegment(entry: OfflineNavigationSegmentRecord): Promise<void> {
@@ -842,6 +948,39 @@ class IndexedDBOfflineNavigationCacheStorage
         .objectStore(storeName)
         .get(key)
     )
+  }
+
+  private async getBuildEntriesFromStore<T extends { buildId: string }>(
+    storeName: string,
+    buildId: string
+  ): Promise<T[]> {
+    const database = await this.getDatabase()
+    if (database === null) {
+      return []
+    }
+
+    const transaction = database.transaction(storeName, 'readonly')
+    const store = transaction.objectStore(storeName)
+    const cursorRequest = store.openCursor()
+    const entries: T[] = []
+    await new Promise<void>((resolve, reject) => {
+      cursorRequest.onsuccess = () => {
+        const cursor = cursorRequest.result
+        if (cursor === null) {
+          resolve()
+          return
+        }
+
+        const entry = cursor.value as T
+        if (entry.buildId === buildId) {
+          entries.push(entry)
+        }
+        cursor.continue()
+      }
+      cursorRequest.onerror = () => reject(cursorRequest.error ?? new Error())
+    })
+    await waitForTransaction(transaction)
+    return entries
   }
 
   private async putIntoStore(storeName: string, entry: unknown): Promise<void> {
@@ -953,6 +1092,8 @@ export const invalidateOfflineNavigationCacheEntries =
   offlineNavigationCache.invalidate
 export const readOfflineNavigationRouteRecord =
   offlineNavigationRouterCache.readRoute
+export const readOfflineNavigationRouteRecords =
+  offlineNavigationRouterCache.readRoutes
 export const writeOfflineNavigationRouteRecord =
   offlineNavigationRouterCache.writeRoute
 export const deleteOfflineNavigationRouteRecord =
@@ -961,6 +1102,8 @@ export const invalidateOfflineNavigationRouteRecords =
   offlineNavigationRouterCache.invalidateRoutes
 export const readOfflineNavigationSegmentRecord =
   offlineNavigationRouterCache.readSegment
+export const readOfflineNavigationSegmentRecords =
+  offlineNavigationRouterCache.readSegments
 export const writeOfflineNavigationSegmentRecord =
   offlineNavigationRouterCache.writeSegment
 export const deleteOfflineNavigationSegmentRecord =

--- a/packages/next/src/client/components/router-reducer/offline-navigation-cache.ts
+++ b/packages/next/src/client/components/router-reducer/offline-navigation-cache.ts
@@ -12,6 +12,7 @@ type OfflineNavigationRSCResponseRequestKind =
   | 'navigation'
   | 'route-prefetch'
   | 'client-resume'
+  | 'initial-load'
 
 export type OfflineNavigationCacheEntry = {
   version: typeof ENTRY_VERSION
@@ -217,7 +218,8 @@ export function isOfflineNavigationRSCResponsePayload(
     candidate.kind === 'rsc-response' &&
     (candidate.requestKind === 'navigation' ||
       candidate.requestKind === 'route-prefetch' ||
-      candidate.requestKind === 'client-resume') &&
+      candidate.requestKind === 'client-resume' ||
+      candidate.requestKind === 'initial-load') &&
     typeof candidate.url === 'string' &&
     typeof candidate.status === 'number' &&
     typeof candidate.statusText === 'string' &&

--- a/packages/next/src/client/components/router-reducer/offline-navigation-cache.ts
+++ b/packages/next/src/client/components/router-reducer/offline-navigation-cache.ts
@@ -8,11 +8,41 @@ const ENTRY_VERSION = 1
 const RSC_RESPONSE_PAYLOAD_VERSION = 1
 
 type OfflineNavigationCacheKey = [buildId: string, url: string]
-type OfflineNavigationRSCResponseRequestKind =
+export type OfflineNavigationRSCResponseRequestKind =
   | 'navigation'
   | 'route-prefetch'
   | 'client-resume'
   | 'initial-load'
+
+export type OfflineNavigationRSCResponseCacheSkipReason =
+  | 'disabled'
+  | 'dev-server'
+  | 'not-production'
+  | 'output-export'
+  | 'unsupported-request'
+  | 'missing-payload'
+  | 'cross-origin'
+  | 'unsupported-segment-prefetching'
+  | 'runtime-prefetch'
+  | 'partial-response'
+  | 'hmr-refresh'
+  | 'interception'
+  | 'postponed'
+  | 'redirected'
+
+export type OfflineNavigationRSCResponseCacheEligibility = {
+  requestKind: OfflineNavigationRSCResponseRequestKind | null
+  url: string | URL
+  origin?: string
+  hasCachePayload?: boolean
+  supportsPerSegmentPrefetching?: boolean
+  hasRuntimePrefetch?: boolean
+  hasPartialResponse?: boolean
+  isHmrRefresh?: boolean
+  isInterception?: boolean
+  isPostponed?: boolean
+  isRedirected?: boolean
+}
 
 export type OfflineNavigationCacheEntry = {
   version: typeof ENTRY_VERSION
@@ -203,6 +233,83 @@ export function createOfflineNavigationRSCResponse(
   })
   Object.defineProperty(response, 'url', { value: payload.url })
   return response
+}
+
+export function getOfflineNavigationRSCResponseCacheSkipReason({
+  requestKind,
+  url,
+  origin,
+  hasCachePayload = true,
+  supportsPerSegmentPrefetching = true,
+  hasRuntimePrefetch = false,
+  hasPartialResponse = false,
+  isHmrRefresh = false,
+  isInterception = false,
+  isPostponed = false,
+  isRedirected = false,
+}: OfflineNavigationRSCResponseCacheEligibility): OfflineNavigationRSCResponseCacheSkipReason | null {
+  if (!process.env.__NEXT_OFFLINE_NAVIGATIONS) {
+    return 'disabled'
+  }
+
+  if (process.env.__NEXT_DEV_SERVER) {
+    return 'dev-server'
+  }
+
+  if (process.env.NODE_ENV !== 'production') {
+    return 'not-production'
+  }
+
+  if (process.env.__NEXT_CONFIG_OUTPUT === 'export') {
+    return 'output-export'
+  }
+
+  if (requestKind === null) {
+    return 'unsupported-request'
+  }
+
+  if (!hasCachePayload) {
+    return 'missing-payload'
+  }
+
+  const currentOrigin =
+    origin ?? (typeof location === 'undefined' ? null : location.origin)
+  if (
+    currentOrigin !== null &&
+    new URL(url, currentOrigin).origin !== currentOrigin
+  ) {
+    return 'cross-origin'
+  }
+
+  if (!supportsPerSegmentPrefetching) {
+    return 'unsupported-segment-prefetching'
+  }
+
+  if (hasRuntimePrefetch) {
+    return 'runtime-prefetch'
+  }
+
+  if (hasPartialResponse) {
+    return 'partial-response'
+  }
+
+  if (isHmrRefresh) {
+    return 'hmr-refresh'
+  }
+
+  if (isInterception) {
+    return 'interception'
+  }
+
+  if (isPostponed) {
+    return 'postponed'
+  }
+
+  if (isRedirected) {
+    return 'redirected'
+  }
+
+  return null
 }
 
 export function isOfflineNavigationRSCResponsePayload(

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -125,7 +125,11 @@ import { PAGE_SEGMENT_KEY } from '../../../shared/lib/segment'
 import { FetchStrategy } from './types'
 import { createPromiseWithResolvers } from '../../../shared/lib/promise-with-resolvers'
 import { readFromBFCache, UnknownDynamicStaleTime } from './bfcache'
-import { discoverKnownRoute, matchKnownRoute } from './optimistic-routes'
+import {
+  discoverKnownRoute,
+  matchKnownRoute,
+  restoreKnownRouteFromCacheEntry,
+} from './optimistic-routes'
 import { convertServerPatchToFullTree, type NavigationSeed } from './navigation'
 import { getNavigationBuildId } from '../../navigation-build-id'
 import { NEXT_NAV_DEPLOYMENT_ID_HEADER } from '../../../lib/constants'
@@ -1442,7 +1446,14 @@ export async function hydrateOfflineNavigationRouterCacheFromRecords(
   }
 
   for (const record of routeRecords) {
-    if (writeOfflineNavigationRouteRecordIntoCache(now, record)) {
+    const entry = writeOfflineNavigationRouteRecordIntoCache(now, record)
+    if (entry !== null) {
+      restoreKnownRouteFromCacheEntry(
+        now,
+        record.route.pathname,
+        record.route.nextUrl,
+        entry
+      )
       result.routes.hydrated++
     } else {
       result.routes.skipped++
@@ -1463,7 +1474,7 @@ export async function hydrateOfflineNavigationRouterCacheFromRecords(
 export function writeOfflineNavigationRouteRecordIntoCache(
   now: number,
   record: OfflineNavigationRouteRecord
-): boolean {
+): FulfilledRouteCacheEntry | null {
   const route = record.route
   if (
     record.staleAt <= now ||
@@ -1473,16 +1484,19 @@ export function writeOfflineNavigationRouteRecordIntoCache(
     record.metadata === null ||
     typeof route.canonicalUrl !== 'string' ||
     typeof route.renderedSearch !== 'string' ||
+    typeof route.pathname !== 'string' ||
+    typeof route.search !== 'string' ||
+    (route.nextUrl !== null && typeof route.nextUrl !== 'string') ||
     typeof route.couldBeIntercepted !== 'boolean' ||
     typeof route.supportsPerSegmentPrefetching !== 'boolean' ||
     typeof route.hasDynamicRewrite !== 'boolean'
   ) {
-    return false
+    return null
   }
 
   const varyPath = deserializeOfflineNavigationVaryPath(record.routeVaryPath)
   if (varyPath === null) {
-    return false
+    return null
   }
 
   const fulfilledEntry: FulfilledRouteCacheEntry = {
@@ -1507,7 +1521,7 @@ export function writeOfflineNavigationRouteRecordIntoCache(
     fulfilledEntry,
     isRevalidation
   )
-  return true
+  return fulfilledEntry
 }
 
 export async function writeOfflineNavigationSegmentRecordIntoCache(

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -59,9 +59,13 @@ import {
 } from './vary-path'
 import { createHrefFromUrl } from '../router-reducer/create-href-from-url'
 import {
+  createOfflineNavigationVaryPathKey,
   invalidateOfflineNavigationCacheEntries,
   getOfflineNavigationRSCResponseCacheSkipReason,
+  serializeOfflineNavigationVaryPath,
   writeOfflineNavigationRSCResponseCacheEntry,
+  writeOfflineNavigationSegmentRecord,
+  type OfflineNavigationRSCResponsePayload,
 } from '../router-reducer/offline-navigation-cache'
 import type {
   NormalizedPathname,
@@ -2150,7 +2154,17 @@ export async function fetchSegmentsOnCacheMiss(
       }
 
       // Set the fulfilled entry into the canonical cache slot.
-      upsertSegmentEntry(now, canonicalVaryPath, fulfilled)
+      const upserted = upsertSegmentEntry(now, canonicalVaryPath, fulfilled)
+      if (upserted !== null && upserted.status === EntryStatus.Fulfilled) {
+        persistOfflineNavigationSegmentRecord(
+          now,
+          node.tree,
+          canonicalVaryPath,
+          upserted,
+          dataIndex,
+          response.offlineNavigationCachePayload
+        )
+      }
 
       node = node.parent
       dataIndex++
@@ -2967,6 +2981,48 @@ export function canNewFetchStrategyProvideMoreContent(
   newStrategy: FetchStrategy
 ): boolean {
   return currentStrategy < newStrategy
+}
+
+function persistOfflineNavigationSegmentRecord(
+  now: number,
+  tree: RouteTree,
+  varyPath: SegmentVaryPath,
+  entry: FulfilledSegmentCacheEntry,
+  payloadIndex: number,
+  payload: Promise<OfflineNavigationRSCResponsePayload | null> | null
+): void {
+  if (
+    !process.env.__NEXT_OFFLINE_NAVIGATIONS ||
+    process.env.__NEXT_DEV_SERVER ||
+    process.env.NODE_ENV !== 'production' ||
+    process.env.__NEXT_CONFIG_OUTPUT === 'export' ||
+    entry.staleAt <= now ||
+    payload === null
+  ) {
+    return
+  }
+
+  void (async () => {
+    const resolvedPayload = await payload
+    if (resolvedPayload === null) {
+      return
+    }
+
+    await writeOfflineNavigationSegmentRecord({
+      key: createOfflineNavigationVaryPathKey(varyPath),
+      now,
+      staleAt: entry.staleAt,
+      expiresAt: entry.staleAt,
+      segment: {
+        requestKey: tree.requestKey,
+        fetchStrategy: entry.fetchStrategy,
+        isPartial: entry.isPartial,
+        payloadIndex,
+      },
+      segmentVaryPath: serializeOfflineNavigationVaryPath(varyPath),
+      payload: resolvedPayload,
+    })
+  })()
 }
 
 /**

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -65,6 +65,8 @@ import {
   createOfflineNavigationRSCResponse,
   createOfflineNavigationVaryPathKey,
   invalidateOfflineNavigationCacheEntries,
+  invalidateOfflineNavigationRouteRecords,
+  invalidateOfflineNavigationSegmentRecords,
   getOfflineNavigationRSCResponseCacheSkipReason,
   isOfflineNavigationRSCResponsePayload,
   readOfflineNavigationRouteRecords,
@@ -411,7 +413,7 @@ export function invalidateEntirePrefetchCache(
 ): void {
   currentRouteCacheVersion++
   currentSegmentCacheVersion++
-  invalidatePersistentOfflineNavigationCache()
+  invalidatePersistentOfflineNavigationCache('entire')
 
   pingVisibleLinks(nextUrl, tree)
   pingInvalidationListeners(nextUrl, tree)
@@ -429,7 +431,7 @@ export function invalidateRouteCacheEntries(
   tree: FlightRouterState
 ): void {
   currentRouteCacheVersion++
-  invalidatePersistentOfflineNavigationCache()
+  invalidatePersistentOfflineNavigationCache('route')
 
   pingVisibleLinks(nextUrl, tree)
   pingInvalidationListeners(nextUrl, tree)
@@ -447,13 +449,20 @@ export function invalidateSegmentCacheEntries(
   tree: FlightRouterState
 ): void {
   currentSegmentCacheVersion++
-  invalidatePersistentOfflineNavigationCache()
+  invalidatePersistentOfflineNavigationCache('segment')
 
   pingVisibleLinks(nextUrl, tree)
   pingInvalidationListeners(nextUrl, tree)
 }
 
-function invalidatePersistentOfflineNavigationCache(): void {
+type PersistentOfflineNavigationCacheInvalidation =
+  | 'entire'
+  | 'route'
+  | 'segment'
+
+function invalidatePersistentOfflineNavigationCache(
+  kind: PersistentOfflineNavigationCacheInvalidation
+): void {
   if (
     !process.env.__NEXT_OFFLINE_NAVIGATIONS ||
     process.env.__NEXT_DEV_SERVER ||
@@ -464,6 +473,12 @@ function invalidatePersistentOfflineNavigationCache(): void {
   }
 
   void invalidateOfflineNavigationCacheEntries()
+  if (kind === 'entire' || kind === 'route') {
+    void invalidateOfflineNavigationRouteRecords()
+  }
+  if (kind === 'entire' || kind === 'segment') {
+    void invalidateOfflineNavigationSegmentRecords()
+  }
 }
 
 function attachInvalidationListener(task: PrefetchTask): void {

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -6,6 +6,8 @@ import type {
 import type {
   CacheNodeSeedData,
   FlightData,
+  HeadData,
+  InitialRSCPayload,
   Segment as FlightRouterStateSegment,
 } from '../../../shared/lib/app-router-types'
 import { PrefetchHint } from '../../../shared/lib/app-router-types'
@@ -127,6 +129,7 @@ import { discoverKnownRoute, matchKnownRoute } from './optimistic-routes'
 import { convertServerPatchToFullTree, type NavigationSeed } from './navigation'
 import { getNavigationBuildId } from '../../navigation-build-id'
 import { NEXT_NAV_DEPLOYMENT_ID_HEADER } from '../../../lib/constants'
+import { normalizePathTrailingSlash } from '../../normalize-trailing-slash'
 
 /**
  * Ensures a minimum stale time of 30s to avoid issues where the server sends a too
@@ -309,6 +312,30 @@ export type OfflineNavigationRouterCacheHydrationResult = {
     skipped: number
   }
 }
+
+export type OfflineNavigationRouterCacheReconstructionResult =
+  | {
+      status: 'fulfilled'
+      initialRSCPayload: InitialRSCPayload
+      route: {
+        canonicalUrl: string
+        renderedSearch: string
+      }
+      segments: {
+        restored: number
+      }
+      head: {
+        restored: number
+      }
+    }
+  | {
+      status: 'miss'
+      reason:
+        | 'missing-route'
+        | 'unsupported-route'
+        | 'missing-segment'
+        | 'missing-head'
+    }
 
 export type NonEmptySegmentCacheEntry = Exclude<
   SegmentCacheEntry,
@@ -1201,11 +1228,16 @@ export function markRouteEntryAsDynamicRewrite(
   // before we knew it had a dynamic rewrite.
 }
 
-export async function hydrateOfflineNavigationRouterCache(): Promise<OfflineNavigationRouterCacheHydrationResult> {
-  const now = Date.now()
+export async function hydrateOfflineNavigationRouterCache({
+  buildId,
+  now = Date.now(),
+}: {
+  buildId?: string
+  now?: number
+} = {}): Promise<OfflineNavigationRouterCacheHydrationResult> {
   const [routeRecords, segmentRecords] = await Promise.all([
-    readOfflineNavigationRouteRecords({ now }),
-    readOfflineNavigationSegmentRecords({ now }),
+    readOfflineNavigationRouteRecords({ buildId, now }),
+    readOfflineNavigationSegmentRecords({ buildId, now }),
   ])
 
   return hydrateOfflineNavigationRouterCacheFromRecords(
@@ -1213,6 +1245,184 @@ export async function hydrateOfflineNavigationRouterCache(): Promise<OfflineNavi
     routeRecords,
     segmentRecords
   )
+}
+
+export function createOfflineNavigationInitialRSCPayloadFromRouterCache({
+  buildId,
+  globalErrorState,
+  now,
+  url,
+}: {
+  buildId: string | undefined
+  globalErrorState: InitialRSCPayload['G']
+  now: number
+  url: string
+}): OfflineNavigationRouterCacheReconstructionResult {
+  const requestUrl = new URL(url, location.href)
+  requestUrl.pathname = normalizePathTrailingSlash(requestUrl.pathname)
+  const routeEntry = readRouteCacheEntry(
+    now,
+    createPrefetchRequestKey(requestUrl.href, null)
+  )
+  if (routeEntry === null || routeEntry.status !== EntryStatus.Fulfilled) {
+    return {
+      status: 'miss',
+      reason: 'missing-route',
+    }
+  }
+
+  if (
+    routeEntry.couldBeIntercepted ||
+    routeEntry.hasDynamicRewrite ||
+    !routeEntry.supportsPerSegmentPrefetching
+  ) {
+    return {
+      status: 'miss',
+      reason: 'unsupported-route',
+    }
+  }
+
+  const seedResult = createOfflineNavigationSeedDataFromRouterCache(
+    now,
+    routeEntry.tree
+  )
+  if (seedResult.status === 'miss') {
+    return seedResult
+  }
+
+  const metadataVaryPath = routeEntry.metadata.varyPath as PageVaryPath | null
+  if (metadataVaryPath === null) {
+    return {
+      status: 'miss',
+      reason: 'missing-head',
+    }
+  }
+
+  const headResult = readOfflineNavigationHeadFromRouterCache(
+    now,
+    metadataVaryPath
+  )
+  if (headResult.status === 'miss') {
+    return headResult
+  }
+
+  const initialRSCPayload: InitialRSCPayload = {
+    c: routeEntry.canonicalUrl.split('/'),
+    q: routeEntry.renderedSearch,
+    i: routeEntry.couldBeIntercepted,
+    f: [
+      [
+        convertRouteTreeToFlightRouterState(routeEntry.tree),
+        seedResult.seedData,
+        headResult.head,
+        false,
+      ],
+    ],
+    m: undefined,
+    G: globalErrorState,
+    S: routeEntry.supportsPerSegmentPrefetching,
+    h: null,
+  }
+  if (buildId !== undefined) {
+    initialRSCPayload.b = buildId
+  }
+
+  return {
+    status: 'fulfilled',
+    initialRSCPayload,
+    route: {
+      canonicalUrl: routeEntry.canonicalUrl,
+      renderedSearch: routeEntry.renderedSearch,
+    },
+    segments: {
+      restored: seedResult.segments,
+    },
+    head: {
+      restored: 1,
+    },
+  }
+}
+
+type OfflineNavigationSeedDataResult =
+  | {
+      status: 'fulfilled'
+      seedData: CacheNodeSeedData
+      segments: number
+    }
+  | Extract<
+      OfflineNavigationRouterCacheReconstructionResult,
+      { status: 'miss' }
+    >
+
+function createOfflineNavigationSeedDataFromRouterCache(
+  now: number,
+  tree: RouteTree
+): OfflineNavigationSeedDataResult {
+  const segmentEntry = readSegmentCacheEntry(now, tree.varyPath)
+  if (segmentEntry === null || segmentEntry.status !== EntryStatus.Fulfilled) {
+    return {
+      status: 'miss',
+      reason: 'missing-segment',
+    }
+  }
+
+  const parallelRoutes: CacheNodeSeedData[1] = {}
+  let restoredSegments = 1
+  if (tree.slots !== null) {
+    for (const parallelRouteKey in tree.slots) {
+      const childResult = createOfflineNavigationSeedDataFromRouterCache(
+        now,
+        tree.slots[parallelRouteKey]
+      )
+      if (childResult.status === 'miss') {
+        return childResult
+      }
+
+      parallelRoutes[parallelRouteKey] = childResult.seedData
+      restoredSegments += childResult.segments
+    }
+  }
+
+  return {
+    status: 'fulfilled',
+    seedData: [
+      segmentEntry.rsc,
+      parallelRoutes,
+      null,
+      segmentEntry.isPartial,
+      null,
+    ],
+    segments: restoredSegments,
+  }
+}
+
+function readOfflineNavigationHeadFromRouterCache(
+  now: number,
+  metadataVaryPath: PageVaryPath
+):
+  | {
+      status: 'fulfilled'
+      head: HeadData
+    }
+  | Extract<
+      OfflineNavigationRouterCacheReconstructionResult,
+      { status: 'miss' }
+    > {
+  const metadataEntry = readSegmentCacheEntry(now, metadataVaryPath)
+  if (
+    metadataEntry === null ||
+    metadataEntry.status !== EntryStatus.Fulfilled
+  ) {
+    return {
+      status: 'miss',
+      reason: 'missing-head',
+    }
+  }
+
+  return {
+    status: 'fulfilled',
+    head: metadataEntry.rsc,
+  }
 }
 
 export async function hydrateOfflineNavigationRouterCacheFromRecords(

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -39,6 +39,7 @@ import {
   type PrefetchSubtaskResult,
 } from './scheduler'
 import {
+  type VaryPath,
   type RouteVaryPath,
   type SegmentVaryPath,
   type PartialSegmentVaryPath,
@@ -59,13 +60,20 @@ import {
 } from './vary-path'
 import { createHrefFromUrl } from '../router-reducer/create-href-from-url'
 import {
+  createOfflineNavigationRSCResponse,
   createOfflineNavigationVaryPathKey,
   invalidateOfflineNavigationCacheEntries,
   getOfflineNavigationRSCResponseCacheSkipReason,
+  isOfflineNavigationRSCResponsePayload,
+  readOfflineNavigationRouteRecords,
+  readOfflineNavigationSegmentRecords,
   serializeOfflineNavigationVaryPath,
   writeOfflineNavigationRSCResponseCacheEntry,
   writeOfflineNavigationSegmentRecord,
+  type OfflineNavigationRouteRecord,
   type OfflineNavigationRSCResponsePayload,
+  type OfflineNavigationSegmentRecord,
+  type OfflineNavigationSerializedVaryPath,
 } from '../router-reducer/offline-navigation-cache'
 import type {
   NormalizedPathname,
@@ -87,6 +95,7 @@ import {
   setInCacheMap,
   setSizeInCacheMap,
   deleteFromCacheMap,
+  Fallback,
   isValueExpired,
   type CacheMap,
   type UnknownMapEntry,
@@ -289,6 +298,17 @@ export type SegmentCacheEntry =
   | PendingSegmentCacheEntry
   | RejectedSegmentCacheEntry
   | FulfilledSegmentCacheEntry
+
+export type OfflineNavigationRouterCacheHydrationResult = {
+  routes: {
+    hydrated: number
+    skipped: number
+  }
+  segments: {
+    hydrated: number
+    skipped: number
+  }
+}
 
 export type NonEmptySegmentCacheEntry = Exclude<
   SegmentCacheEntry,
@@ -1179,6 +1199,205 @@ export function markRouteEntryAsDynamicRewrite(
   // Note: The caller is responsible for also calling invalidateRouteCacheEntries
   // to invalidate other entries that may have been derived from this template
   // before we knew it had a dynamic rewrite.
+}
+
+export async function hydrateOfflineNavigationRouterCache(): Promise<OfflineNavigationRouterCacheHydrationResult> {
+  const now = Date.now()
+  const [routeRecords, segmentRecords] = await Promise.all([
+    readOfflineNavigationRouteRecords({ now }),
+    readOfflineNavigationSegmentRecords({ now }),
+  ])
+
+  return hydrateOfflineNavigationRouterCacheFromRecords(
+    now,
+    routeRecords,
+    segmentRecords
+  )
+}
+
+export async function hydrateOfflineNavigationRouterCacheFromRecords(
+  now: number,
+  routeRecords: OfflineNavigationRouteRecord[],
+  segmentRecords: OfflineNavigationSegmentRecord[]
+): Promise<OfflineNavigationRouterCacheHydrationResult> {
+  const result: OfflineNavigationRouterCacheHydrationResult = {
+    routes: {
+      hydrated: 0,
+      skipped: 0,
+    },
+    segments: {
+      hydrated: 0,
+      skipped: 0,
+    },
+  }
+
+  for (const record of routeRecords) {
+    if (writeOfflineNavigationRouteRecordIntoCache(now, record)) {
+      result.routes.hydrated++
+    } else {
+      result.routes.skipped++
+    }
+  }
+
+  for (const record of segmentRecords) {
+    if (await writeOfflineNavigationSegmentRecordIntoCache(now, record)) {
+      result.segments.hydrated++
+    } else {
+      result.segments.skipped++
+    }
+  }
+
+  return result
+}
+
+export function writeOfflineNavigationRouteRecordIntoCache(
+  now: number,
+  record: OfflineNavigationRouteRecord
+): boolean {
+  const route = record.route
+  if (
+    record.staleAt <= now ||
+    route === null ||
+    typeof route !== 'object' ||
+    record.tree === null ||
+    record.metadata === null ||
+    typeof route.canonicalUrl !== 'string' ||
+    typeof route.renderedSearch !== 'string' ||
+    typeof route.couldBeIntercepted !== 'boolean' ||
+    typeof route.supportsPerSegmentPrefetching !== 'boolean' ||
+    typeof route.hasDynamicRewrite !== 'boolean'
+  ) {
+    return false
+  }
+
+  const varyPath = deserializeOfflineNavigationVaryPath(record.routeVaryPath)
+  if (varyPath === null) {
+    return false
+  }
+
+  const fulfilledEntry: FulfilledRouteCacheEntry = {
+    status: EntryStatus.Fulfilled,
+    blockedTasks: null,
+    canonicalUrl: route.canonicalUrl,
+    renderedSearch: route.renderedSearch as NormalizedSearch,
+    tree: record.tree as RouteTree,
+    metadata: record.metadata as RouteTree,
+    couldBeIntercepted: route.couldBeIntercepted,
+    supportsPerSegmentPrefetching: route.supportsPerSegmentPrefetching,
+    hasDynamicRewrite: route.hasDynamicRewrite,
+    ref: null,
+    size: 0,
+    staleAt: record.staleAt,
+    version: getCurrentRouteCacheVersion(),
+  }
+  const isRevalidation = false
+  setInCacheMap(
+    routeCacheMap,
+    varyPath as RouteVaryPath,
+    fulfilledEntry,
+    isRevalidation
+  )
+  return true
+}
+
+export async function writeOfflineNavigationSegmentRecordIntoCache(
+  now: number,
+  record: OfflineNavigationSegmentRecord
+): Promise<boolean> {
+  const segment = record.segment
+  if (
+    record.staleAt <= now ||
+    segment === null ||
+    typeof segment !== 'object' ||
+    !isOfflineNavigationRSCResponsePayload(record.payload) ||
+    record.payload.requestKind !== 'segment-prefetch' ||
+    !isOfflineNavigationFetchStrategy(segment.fetchStrategy) ||
+    typeof segment.isPartial !== 'boolean' ||
+    typeof segment.payloadIndex !== 'number' ||
+    segment.payloadIndex < 0
+  ) {
+    return false
+  }
+
+  const response = createOfflineNavigationRSCResponse(record.payload)
+  if (response.body === null) {
+    return false
+  }
+
+  const varyPath = deserializeOfflineNavigationVaryPath(record.segmentVaryPath)
+  if (varyPath === null) {
+    return false
+  }
+
+  let serverResponse: SegmentPrefetchResponse
+  try {
+    serverResponse =
+      await createFromNextReadableStream<SegmentPrefetchResponse>(
+        response.body,
+        undefined,
+        { allowPartialStream: true }
+      )
+  } catch {
+    return false
+  }
+
+  const segmentData = serverResponse.data[segment.payloadIndex]
+  if (segmentData === undefined || segmentData === null) {
+    return false
+  }
+
+  const pendingEntry = upgradeToPendingSegment(
+    createDetachedSegmentCacheEntry(now),
+    segment.fetchStrategy
+  )
+  const fulfilledEntry = fulfillSegmentCacheEntry(
+    pendingEntry,
+    segmentData.rsc,
+    record.staleAt,
+    segment.isPartial
+  )
+  const isRevalidation = false
+  setInCacheMap(
+    segmentCacheMap,
+    varyPath as SegmentVaryPath,
+    fulfilledEntry,
+    isRevalidation
+  )
+  return true
+}
+
+function isOfflineNavigationFetchStrategy(
+  fetchStrategy: number
+): fetchStrategy is FetchStrategy {
+  return (
+    fetchStrategy === FetchStrategy.LoadingBoundary ||
+    fetchStrategy === FetchStrategy.PPR ||
+    fetchStrategy === FetchStrategy.PPRRuntime ||
+    fetchStrategy === FetchStrategy.Full
+  )
+}
+
+function deserializeOfflineNavigationVaryPath(
+  serialized: OfflineNavigationSerializedVaryPath
+): VaryPath | null {
+  if (!Array.isArray(serialized) || serialized.length === 0) {
+    return null
+  }
+
+  let parent: VaryPath | null = null
+  for (let i = serialized.length - 1; i >= 0; i--) {
+    const part = serialized[i]
+    if (part.value.kind !== 'value' && part.value.kind !== 'fallback') {
+      return null
+    }
+
+    parent = {
+      id: part.id,
+      value: part.value.kind === 'fallback' ? Fallback : part.value.value,
+      parent,
+    }
+  }
+  return parent
 }
 
 function fulfillSegmentCacheEntry(

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -59,6 +59,7 @@ import {
 } from './vary-path'
 import { createHrefFromUrl } from '../router-reducer/create-href-from-url'
 import {
+  invalidateOfflineNavigationCacheEntries,
   getOfflineNavigationRSCResponseCacheSkipReason,
   writeOfflineNavigationRSCResponseCacheEntry,
 } from '../router-reducer/offline-navigation-cache'
@@ -355,6 +356,7 @@ export function invalidateEntirePrefetchCache(
 ): void {
   currentRouteCacheVersion++
   currentSegmentCacheVersion++
+  invalidatePersistentOfflineNavigationCache()
 
   pingVisibleLinks(nextUrl, tree)
   pingInvalidationListeners(nextUrl, tree)
@@ -372,6 +374,7 @@ export function invalidateRouteCacheEntries(
   tree: FlightRouterState
 ): void {
   currentRouteCacheVersion++
+  invalidatePersistentOfflineNavigationCache()
 
   pingVisibleLinks(nextUrl, tree)
   pingInvalidationListeners(nextUrl, tree)
@@ -389,9 +392,23 @@ export function invalidateSegmentCacheEntries(
   tree: FlightRouterState
 ): void {
   currentSegmentCacheVersion++
+  invalidatePersistentOfflineNavigationCache()
 
   pingVisibleLinks(nextUrl, tree)
   pingInvalidationListeners(nextUrl, tree)
+}
+
+function invalidatePersistentOfflineNavigationCache(): void {
+  if (
+    !process.env.__NEXT_OFFLINE_NAVIGATIONS ||
+    process.env.__NEXT_DEV_SERVER ||
+    process.env.NODE_ENV !== 'production' ||
+    process.env.__NEXT_CONFIG_OUTPUT === 'export'
+  ) {
+    return
+  }
+
+  void invalidateOfflineNavigationCacheEntries()
 }
 
 function attachInvalidationListener(task: PrefetchTask): void {

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -58,6 +58,7 @@ import {
   getRenderedSearchFromVaryPath,
 } from './vary-path'
 import { createHrefFromUrl } from '../router-reducer/create-href-from-url'
+import { writeOfflineNavigationRSCResponseCacheEntry } from '../router-reducer/offline-navigation-cache'
 import type {
   NormalizedPathname,
   NormalizedSearch,
@@ -1577,6 +1578,57 @@ export function convertRouteTreeToFlightRouterState(
   return flightRouterState
 }
 
+function persistOfflineNavigationClientResumePrefetchResponse({
+  buildId,
+  couldBeIntercepted,
+  url,
+}: {
+  buildId: string | undefined
+  couldBeIntercepted: boolean
+  url: URL
+}): void {
+  if (
+    !process.env.__NEXT_OFFLINE_NAVIGATIONS ||
+    process.env.__NEXT_DEV_SERVER ||
+    process.env.NODE_ENV !== 'production' ||
+    process.env.__NEXT_CONFIG_OUTPUT === 'export' ||
+    couldBeIntercepted ||
+    url.origin !== location.origin
+  ) {
+    return
+  }
+
+  void (async () => {
+    try {
+      const headers: RequestHeaders = {
+        [RSC_HEADER]: '1',
+        [NEXT_ROUTER_PREFETCH_HEADER]: '1',
+        [NEXT_ROUTER_SEGMENT_PREFETCH_HEADER]: '/_full',
+      }
+      addInstantPrefetchHeaderIfLocked(headers)
+
+      const response = await fetchPrefetchResponse(url, headers)
+      if (
+        response === null ||
+        response.offlineNavigationCachePayload === null ||
+        response.redirected ||
+        response.headers.get('vary')?.includes(NEXT_URL)
+      ) {
+        return
+      }
+
+      const staleAt = getStaleAtFromHeader(Date.now(), response)
+      await writeOfflineNavigationRSCResponseCacheEntry({
+        buildId: response.headers.get(NEXT_NAV_DEPLOYMENT_ID_HEADER) ?? buildId,
+        expiresAt: staleAt,
+        payload: response.offlineNavigationCachePayload,
+        staleAt,
+        url,
+      })
+    } catch {}
+  })()
+}
+
 export async function fetchRouteOnCacheMiss(
   entry: PendingRouteCacheEntry,
   key: RouteCacheKey
@@ -1777,6 +1829,14 @@ export async function fetchRouteOnCacheMiss(
         routeIsPPREnabled,
         false // hasDynamicRewrite
       )
+
+      persistOfflineNavigationClientResumePrefetchResponse({
+        buildId:
+          response.headers.get(NEXT_NAV_DEPLOYMENT_ID_HEADER) ??
+          serverData.buildId,
+        couldBeIntercepted,
+        url: urlAfterRedirects,
+      })
     } else {
       // PPR is not enabled for this route. The server responds with a
       // different format (FlightRouterState) that we need to convert.
@@ -1827,6 +1887,13 @@ export async function fetchRouteOnCacheMiss(
         pathname,
         nextUrl
       )
+
+      persistOfflineNavigationClientResumePrefetchResponse({
+        buildId:
+          response.headers.get(NEXT_NAV_DEPLOYMENT_ID_HEADER) ?? serverData.b,
+        couldBeIntercepted,
+        url: urlAfterRedirects,
+      })
     }
 
     if (!couldBeIntercepted) {

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -58,7 +58,10 @@ import {
   getRenderedSearchFromVaryPath,
 } from './vary-path'
 import { createHrefFromUrl } from '../router-reducer/create-href-from-url'
-import { writeOfflineNavigationRSCResponseCacheEntry } from '../router-reducer/offline-navigation-cache'
+import {
+  getOfflineNavigationRSCResponseCacheSkipReason,
+  writeOfflineNavigationRSCResponseCacheEntry,
+} from '../router-reducer/offline-navigation-cache'
 import type {
   NormalizedPathname,
   NormalizedSearch,
@@ -1608,12 +1611,23 @@ function persistOfflineNavigationClientResumePrefetchResponse({
       addInstantPrefetchHeaderIfLocked(headers)
 
       const response = await fetchPrefetchResponse(url, headers)
-      if (
-        response === null ||
-        response.offlineNavigationCachePayload === null ||
-        response.redirected ||
-        response.headers.get('vary')?.includes(NEXT_URL)
-      ) {
+      if (response === null) {
+        return
+      }
+
+      const skipReason = getOfflineNavigationRSCResponseCacheSkipReason({
+        requestKind: response.offlineNavigationCacheRequestKind,
+        hasCachePayload: response.offlineNavigationCachePayload !== null,
+        isInterception: response.headers.get('vary')?.includes(NEXT_URL),
+        isRedirected: response.redirected,
+        url,
+      })
+      if (skipReason !== null) {
+        return
+      }
+
+      const payload = response.offlineNavigationCachePayload
+      if (payload === null) {
         return
       }
 
@@ -1621,7 +1635,7 @@ function persistOfflineNavigationClientResumePrefetchResponse({
       await writeOfflineNavigationRSCResponseCacheEntry({
         buildId: response.headers.get(NEXT_NAV_DEPLOYMENT_ID_HEADER) ?? buildId,
         expiresAt: staleAt,
-        payload: response.offlineNavigationCachePayload,
+        payload,
         staleAt,
         url,
       })

--- a/packages/next/src/client/components/segment-cache/optimistic-routes.ts
+++ b/packages/next/src/client/components/segment-cache/optimistic-routes.ts
@@ -54,6 +54,8 @@ import {
   createMetadataRouteTree,
 } from './cache'
 import { isValueExpired } from './cache-map'
+import { hasBasePath } from '../../has-base-path'
+import { removeBasePath } from '../../remove-base-path'
 import { doesStaticSegmentAppearInURL } from '../../route-params'
 import type {
   NormalizedNextUrl,
@@ -186,6 +188,10 @@ function createEmptyPart(): KnownRoutePart {
 // The root of the known route tree.
 let knownRouteTreeRoot: KnownRoutePart = createEmptyPart()
 
+function removeBasePathIfPresent(pathname: string): string {
+  return hasBasePath(pathname) ? removeBasePath(pathname) : pathname
+}
+
 /**
  * Learns a route pattern from a server response and inserts it into the cache.
  *
@@ -218,7 +224,8 @@ export function discoverKnownRoute(
 ): FulfilledRouteCacheEntry {
   const tree = routeTree
 
-  const pathnameParts = pathname.split('/').filter((p) => p !== '')
+  const routePathname = removeBasePathIfPresent(pathname)
+  const pathnameParts = routePathname.split('/').filter((p) => p !== '')
   const firstPart = pathnameParts.length > 0 ? pathnameParts[0] : null
   const remainingParts = pathnameParts.length > 0 ? pathnameParts.slice(1) : []
   let fulfilledEntry: FulfilledRouteCacheEntry
@@ -323,6 +330,36 @@ function persistOfflineNavigationRouteRecord(
     tree: entry.tree,
     metadata: entry.metadata,
   })
+}
+
+export function restoreKnownRouteFromCacheEntry(
+  now: number,
+  pathname: string,
+  nextUrl: string | null,
+  entry: FulfilledRouteCacheEntry
+): void {
+  const routePathname = removeBasePathIfPresent(pathname)
+  const pathnameParts = routePathname.split('/').filter((p) => p !== '')
+  const firstPart = pathnameParts.length > 0 ? pathnameParts[0] : null
+  const remainingParts = pathnameParts.length > 0 ? pathnameParts.slice(1) : []
+  const metadataVaryPath = entry.metadata.varyPath as PageVaryPath
+
+  discoverKnownRoutePart(
+    knownRouteTreeRoot,
+    entry.tree,
+    firstPart,
+    remainingParts,
+    entry,
+    now,
+    pathname,
+    nextUrl,
+    entry.tree,
+    metadataVaryPath,
+    entry.couldBeIntercepted,
+    entry.canonicalUrl,
+    entry.supportsPerSegmentPrefetching,
+    entry.hasDynamicRewrite
+  )
 }
 
 /**
@@ -574,7 +611,8 @@ export function matchKnownRoute(
   pathname: string,
   search: NormalizedSearch
 ): FulfilledRouteCacheEntry | null {
-  const pathnameParts = pathname.split('/').filter((p) => p !== '')
+  const routePathname = removeBasePathIfPresent(pathname)
+  const pathnameParts = routePathname.split('/').filter((p) => p !== '')
   const resolvedParams: ResolvedParams = new Map()
   const match = matchKnownRoutePart(
     now,

--- a/packages/next/src/client/components/segment-cache/optimistic-routes.ts
+++ b/packages/next/src/client/components/segment-cache/optimistic-routes.ts
@@ -55,15 +55,25 @@ import {
 } from './cache'
 import { isValueExpired } from './cache-map'
 import { doesStaticSegmentAppearInURL } from '../../route-params'
-import type { NormalizedPathname, NormalizedSearch } from './cache-key'
+import type {
+  NormalizedNextUrl,
+  NormalizedPathname,
+  NormalizedSearch,
+} from './cache-key'
 import {
   appendLayoutVaryPath,
   finalizeLayoutVaryPath,
   finalizePageVaryPath,
   finalizeMetadataVaryPath,
+  getFulfilledRouteVaryPath,
   type PartialSegmentVaryPath,
   type PageVaryPath,
 } from './vary-path'
+import {
+  createOfflineNavigationVaryPathKey,
+  serializeOfflineNavigationVaryPath,
+  writeOfflineNavigationRouteRecord,
+} from '../router-reducer/offline-navigation-cache'
 
 /**
  * The known route tree is analogous to a route table. A different routing
@@ -211,10 +221,11 @@ export function discoverKnownRoute(
   const pathnameParts = pathname.split('/').filter((p) => p !== '')
   const firstPart = pathnameParts.length > 0 ? pathnameParts[0] : null
   const remainingParts = pathnameParts.length > 0 ? pathnameParts.slice(1) : []
+  let fulfilledEntry: FulfilledRouteCacheEntry
 
   if (pendingEntry !== null) {
     // Fulfill the pending entry first
-    const fulfilledEntry = fulfillRouteCacheEntry(
+    fulfilledEntry = fulfillRouteCacheEntry(
       now,
       pendingEntry,
       tree,
@@ -245,27 +256,73 @@ export function discoverKnownRoute(
       supportsPerSegmentPrefetching,
       hasDynamicRewrite
     )
-    return fulfilledEntry
+  } else {
+    // No pending entry - discoverKnownRoutePart will create one and insert it
+    // into the cache, or return an existing pattern if one exists.
+    fulfilledEntry = discoverKnownRoutePart(
+      knownRouteTreeRoot,
+      tree,
+      firstPart,
+      remainingParts,
+      null,
+      now,
+      pathname,
+      nextUrl,
+      tree,
+      metadataVaryPath,
+      couldBeIntercepted,
+      canonicalUrl,
+      supportsPerSegmentPrefetching,
+      hasDynamicRewrite
+    )
   }
 
-  // No pending entry - discoverKnownRoutePart will create one and insert it
-  // into the cache, or return an existing pattern if one exists.
-  return discoverKnownRoutePart(
-    knownRouteTreeRoot,
-    tree,
-    firstPart,
-    remainingParts,
-    null,
-    now,
-    pathname,
-    nextUrl,
-    tree,
-    metadataVaryPath,
-    couldBeIntercepted,
-    canonicalUrl,
-    supportsPerSegmentPrefetching,
-    hasDynamicRewrite
+  persistOfflineNavigationRouteRecord(now, pathname, nextUrl, fulfilledEntry)
+  return fulfilledEntry
+}
+
+function persistOfflineNavigationRouteRecord(
+  now: number,
+  pathname: string,
+  nextUrl: string | null,
+  entry: FulfilledRouteCacheEntry
+): void {
+  if (
+    !process.env.__NEXT_OFFLINE_NAVIGATIONS ||
+    process.env.__NEXT_DEV_SERVER ||
+    process.env.NODE_ENV !== 'production' ||
+    process.env.__NEXT_CONFIG_OUTPUT === 'export' ||
+    entry.staleAt <= now
+  ) {
+    return
+  }
+
+  const routeVaryPath = getFulfilledRouteVaryPath(
+    pathname as NormalizedPathname,
+    entry.renderedSearch,
+    nextUrl as NormalizedNextUrl | null,
+    entry.couldBeIntercepted
   )
+
+  void writeOfflineNavigationRouteRecord({
+    key: createOfflineNavigationVaryPathKey(routeVaryPath),
+    now,
+    staleAt: entry.staleAt,
+    expiresAt: entry.staleAt,
+    route: {
+      pathname,
+      search: entry.renderedSearch,
+      nextUrl,
+      canonicalUrl: entry.canonicalUrl,
+      renderedSearch: entry.renderedSearch,
+      couldBeIntercepted: entry.couldBeIntercepted,
+      supportsPerSegmentPrefetching: entry.supportsPerSegmentPrefetching,
+      hasDynamicRewrite: entry.hasDynamicRewrite,
+    },
+    routeVaryPath: serializeOfflineNavigationVaryPath(routeVaryPath),
+    tree: entry.tree,
+    metadata: entry.metadata,
+  })
 }
 
 /**

--- a/packages/next/src/client/components/use-offline.tsx
+++ b/packages/next/src/client/components/use-offline.tsx
@@ -15,12 +15,14 @@ const OfflineContext = createContext<boolean>(false)
 // (via dispatchOfflineChange) to update the React tree.
 let setOptimistic: ((value: boolean) => void) | null = null
 let setCanonical: ((value: boolean) => void) | null = null
+let offlineSnapshot = false
 
 /**
  * Called by the offline module when the offline state changes.
  * Dispatches into React via startTransition + useOptimistic.
  */
 export function dispatchOfflineChange(isOffline: boolean): void {
+  offlineSnapshot = isOffline
   const canonical = setCanonical
   const optimistic = setOptimistic
   if (canonical === null || optimistic === null) {
@@ -33,7 +35,7 @@ export function dispatchOfflineChange(isOffline: boolean): void {
 }
 
 export function OfflineProvider({ children }: { children: React.ReactNode }) {
-  const [canonicalOffline, setCanonicalOffline] = useState(false)
+  const [canonicalOffline, setCanonicalOffline] = useState(offlineSnapshot)
   const [isOffline, setOptimisticOffline] = useOptimistic(canonicalOffline)
 
   setOptimistic = setOptimisticOffline

--- a/packages/next/src/client/offline-navigation-service-worker.ts
+++ b/packages/next/src/client/offline-navigation-service-worker.ts
@@ -1,0 +1,35 @@
+import { getDeploymentIdQuery } from '../shared/lib/deployment-id'
+
+const OFFLINE_NAVIGATION_SERVICE_WORKER =
+  '_offline-navigation-service-worker.js'
+
+function getBasePath(): string {
+  return (process.env.__NEXT_ROUTER_BASEPATH as string) || ''
+}
+
+function getServiceWorkerHref(): string {
+  return `${getBasePath()}/_next/static/${OFFLINE_NAVIGATION_SERVICE_WORKER}${getDeploymentIdQuery()}`
+}
+
+function getServiceWorkerScope(): string {
+  const basePath = getBasePath()
+  return basePath ? `${basePath}/` : '/'
+}
+
+export function registerOfflineNavigationServiceWorker(): void {
+  if (
+    process.env.__NEXT_DEV_SERVER ||
+    typeof window === 'undefined' ||
+    !window.isSecureContext ||
+    !('serviceWorker' in navigator)
+  ) {
+    return
+  }
+
+  navigator.serviceWorker
+    .register(getServiceWorkerHref(), {
+      scope: getServiceWorkerScope(),
+      updateViaCache: 'none',
+    })
+    .catch(() => {})
+}

--- a/packages/next/src/client/offline-navigation-service-worker.ts
+++ b/packages/next/src/client/offline-navigation-service-worker.ts
@@ -1,7 +1,17 @@
 import { getDeploymentIdQuery } from '../shared/lib/deployment-id'
+import { OFFLINE_NAVIGATION_FALLBACK_SERVED } from '../shared/lib/offline-navigation-constants'
 
 const OFFLINE_NAVIGATION_SERVICE_WORKER =
   '_offline-navigation-service-worker.js'
+
+let isListeningForServiceWorkerMessages = false
+
+type OfflineNavigationFallbackServedMessage = {
+  type: typeof OFFLINE_NAVIGATION_FALLBACK_SERVED
+  buildId?: string
+  reason?: 'network-error'
+  url?: string
+}
 
 function getBasePath(): string {
   return (process.env.__NEXT_ROUTER_BASEPATH as string) || ''
@@ -16,6 +26,38 @@ function getServiceWorkerScope(): string {
   return basePath ? `${basePath}/` : '/'
 }
 
+function listenForOfflineNavigationMessages(): void {
+  if (isListeningForServiceWorkerMessages) {
+    return
+  }
+  isListeningForServiceWorkerMessages = true
+
+  navigator.serviceWorker.addEventListener('message', (event) => {
+    handleOfflineNavigationServiceWorkerMessage(event.data)
+  })
+}
+
+export function handleOfflineNavigationServiceWorkerMessage(data: unknown) {
+  if (!isOfflineNavigationFallbackServedMessage(data)) {
+    return
+  }
+
+  const { notifyOffline } =
+    require('./components/offline') as typeof import('./components/offline')
+  notifyOffline()
+}
+
+function isOfflineNavigationFallbackServedMessage(
+  data: unknown
+): data is OfflineNavigationFallbackServedMessage {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    (data as Partial<OfflineNavigationFallbackServedMessage>).type ===
+      OFFLINE_NAVIGATION_FALLBACK_SERVED
+  )
+}
+
 export function registerOfflineNavigationServiceWorker(): void {
   if (
     process.env.__NEXT_DEV_SERVER ||
@@ -25,6 +67,8 @@ export function registerOfflineNavigationServiceWorker(): void {
   ) {
     return
   }
+
+  listenForOfflineNavigationMessages()
 
   navigator.serviceWorker
     .register(getServiceWorkerHref(), {

--- a/packages/next/src/client/route-params.ts
+++ b/packages/next/src/client/route-params.ts
@@ -10,6 +10,8 @@ import {
   NEXT_REWRITTEN_QUERY_HEADER,
   NEXT_RSC_UNION_QUERY,
 } from './components/app-router-headers'
+import { hasBasePath } from './has-base-path'
+import { removeBasePath } from './remove-base-path'
 import type {
   NormalizedPathname,
   NormalizedSearch,
@@ -44,9 +46,11 @@ export function getRenderedPathname(
   // page will be different from the pathname in the request URL. In this case,
   // the response will include a header that gives the rewritten pathname.
   const rewrittenPath = response.headers.get(NEXT_REWRITTEN_PATH_HEADER)
-  return (rewrittenPath ??
-    urlToUrlWithoutFlightMarker(new URL(response.url))
-      .pathname) as NormalizedPathname
+  const pathname =
+    rewrittenPath ?? urlToUrlWithoutFlightMarker(new URL(response.url)).pathname
+  return (
+    hasBasePath(pathname) ? removeBasePath(pathname) : pathname
+  ) as NormalizedPathname
 }
 
 // Pathname parts come from `URL.pathname.split('/')`, so they are already

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -510,7 +510,10 @@ async function exportAppImpl(
       clientParamParsingOrigins:
         nextConfig.experimental.clientParamParsingOrigins,
       dynamicOnHover: nextConfig.experimental.dynamicOnHover ?? false,
-      optimisticRouting: nextConfig.experimental.optimisticRouting ?? false,
+      optimisticRouting:
+        nextConfig.experimental.optimisticRouting ||
+        nextConfig.experimental.offlineNavigations ||
+        false,
       inlineCss: nextConfig.experimental.inlineCss ?? false,
       prefetchInlining: nextConfig.experimental.prefetchInlining ?? false,
       authInterrupts: !!nextConfig.experimental.authInterrupts,

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -578,7 +578,9 @@ export default abstract class Server<
           this.nextConfig.experimental.clientParamParsingOrigins,
         dynamicOnHover: this.nextConfig.experimental.dynamicOnHover ?? false,
         optimisticRouting:
-          this.nextConfig.experimental.optimisticRouting ?? false,
+          this.nextConfig.experimental.optimisticRouting ||
+          this.nextConfig.experimental.offlineNavigations ||
+          false,
         inlineCss: this.nextConfig.experimental.inlineCss ?? false,
         prefetchInlining:
           this.nextConfig.experimental.prefetchInlining ?? false,

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -222,6 +222,7 @@ export const experimentalSchema = {
   cachedNavigations: z.boolean().optional(),
   partialFallbacks: z.boolean().optional(),
   dynamicOnHover: z.boolean().optional(),
+  offlineNavigations: z.boolean().optional(),
   useOffline: z.boolean().optional(),
   optimisticRouting: z.boolean().optional(),
   varyParams: z.boolean().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -429,6 +429,7 @@ export interface ExperimentalConfig {
    */
   partialFallbacks?: boolean
   dynamicOnHover?: boolean
+  offlineNavigations?: boolean
   useOffline?: boolean
   optimisticRouting?: boolean
   varyParams?: boolean
@@ -1913,6 +1914,7 @@ export const defaultConfig = Object.freeze({
     cachedNavigations: false,
     partialFallbacks: true,
     dynamicOnHover: false,
+    offlineNavigations: false,
     useOffline: false,
     varyParams: false,
     prefetchInlining: true,
@@ -2059,6 +2061,7 @@ export interface NextConfigRuntime {
     | 'serverActions'
     | 'staleTimes'
     | 'dynamicOnHover'
+    | 'offlineNavigations'
     | 'useOffline'
     | 'optimisticRouting'
     | 'inlineCss'
@@ -2127,6 +2130,7 @@ export function getNextConfigRuntime(
     serverActions: ex.serverActions,
     staleTimes: ex.staleTimes,
     dynamicOnHover: ex.dynamicOnHover,
+    offlineNavigations: ex.offlineNavigations,
     useOffline: ex.useOffline,
     optimisticRouting: ex.optimisticRouting,
     inlineCss: ex.inlineCss,

--- a/packages/next/src/server/config.test.ts
+++ b/packages/next/src/server/config.test.ts
@@ -73,6 +73,37 @@ describe('loadConfig', () => {
     })
   })
 
+  describe('experimental.offlineNavigations', () => {
+    it('implies experimental.useOffline', async () => {
+      const result = await loadConfig(PHASE_PRODUCTION_BUILD, __dirname, {
+        customConfig: {
+          cacheComponents: true,
+          experimental: {
+            offlineNavigations: true,
+            useOffline: false,
+          },
+        },
+      })
+
+      expect(result.experimental.offlineNavigations).toBe(true)
+      expect(result.experimental.useOffline).toBe(true)
+    })
+
+    it('requires cacheComponents', async () => {
+      await expect(
+        loadConfig(PHASE_PRODUCTION_BUILD, __dirname, {
+          customConfig: {
+            experimental: {
+              offlineNavigations: true,
+            },
+          },
+        })
+      ).rejects.toThrow(
+        /`experimental\.offlineNavigations` requires `cacheComponents`/
+      )
+    })
+  })
+
   describe('canary-only features', () => {
     beforeAll(() => {
       process.env.__NEXT_VERSION = '14.2.0'

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -406,6 +406,16 @@ function assignDefaultsAndValidate(
     }
   }
 
+  if (result.experimental.offlineNavigations) {
+    if (!result.cacheComponents) {
+      throw new Error(
+        `\`experimental.offlineNavigations\` requires \`cacheComponents\` to be enabled. Please update your ${configFileName} accordingly.`
+      )
+    }
+
+    result.experimental.useOffline = true
+  }
+
   // ensure correct default is set for api-resolver revalidate handling
   if (!result.experimental.trustHostHeader && ciEnvironment.hasNextSupport) {
     result.experimental.trustHostHeader = true

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -13,6 +13,7 @@ import loadConfig, { type ConfiguredExperimentalFeature } from '../config'
 import { serveStatic } from '../serve-static'
 import setupDebug from 'next/dist/compiled/debug'
 import * as Log from '../../build/output/log'
+import { OFFLINE_NAVIGATION_SERVICE_WORKER } from '../../shared/lib/offline-navigation'
 import { DecodeError } from '../../shared/lib/utils'
 import { findPagesDir } from '../../lib/find-pages-dir'
 import { setupFsCheck } from './router-utils/filesystem'
@@ -524,6 +525,17 @@ export async function initialize(opts: {
         }
 
         if (
+          matchedOutput.type === 'nextStaticFolder' &&
+          matchedOutput.itemPath.endsWith(
+            `/${OFFLINE_NAVIGATION_SERVICE_WORKER}`
+          )
+        ) {
+          res.setHeader('Cache-Control', 'no-cache, must-revalidate')
+          res.setHeader(
+            'Service-Worker-Allowed',
+            config.basePath ? `${config.basePath}/` : '/'
+          )
+        } else if (
           !res.getHeader('cache-control') &&
           matchedOutput.type === 'nextStaticFolder'
         ) {

--- a/packages/next/src/shared/lib/offline-navigation-constants.ts
+++ b/packages/next/src/shared/lib/offline-navigation-constants.ts
@@ -1,0 +1,2 @@
+export const OFFLINE_NAVIGATION_FALLBACK_SERVED =
+  'next-offline-navigation-fallback-served'

--- a/packages/next/src/shared/lib/offline-navigation.ts
+++ b/packages/next/src/shared/lib/offline-navigation.ts
@@ -1,0 +1,2 @@
+export const OFFLINE_NAVIGATION_SERVICE_WORKER =
+  '_offline-navigation-service-worker.js'

--- a/test/production/app-dir/offline-navigations/app/api/server-error/route.ts
+++ b/test/production/app-dir/offline-navigations/app/api/server-error/route.ts
@@ -1,0 +1,9 @@
+export function GET() {
+  return new Response('offline navigation server error', {
+    status: 500,
+  })
+}
+
+export function POST() {
+  return new Response('offline navigation post response')
+}

--- a/test/production/app-dir/offline-navigations/app/dynamic-prefetch/[value]/dynamic-prefetch-value.tsx
+++ b/test/production/app-dir/offline-navigations/app/dynamic-prefetch/[value]/dynamic-prefetch-value.tsx
@@ -1,0 +1,9 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export function DynamicPrefetchValue() {
+  const params = useParams<{ value: string }>()
+
+  return <p id="dynamic-prefetch-page">dynamic prefetch path: {params.value}</p>
+}

--- a/test/production/app-dir/offline-navigations/app/dynamic-prefetch/[value]/page.tsx
+++ b/test/production/app-dir/offline-navigations/app/dynamic-prefetch/[value]/page.tsx
@@ -1,0 +1,18 @@
+import { Suspense } from 'react'
+import { OfflineStatus } from '../../offline-status'
+import { DynamicPrefetchValue } from './dynamic-prefetch-value'
+
+export function generateStaticParams() {
+  return [{ value: '__TEST__' }]
+}
+
+export default function DynamicPrefetchPage() {
+  return (
+    <>
+      <Suspense fallback={<p>loading dynamic prefetch value</p>}>
+        <DynamicPrefetchValue />
+      </Suspense>
+      <OfflineStatus />
+    </>
+  )
+}

--- a/test/production/app-dir/offline-navigations/app/layout.tsx
+++ b/test/production/app-dir/offline-navigations/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/offline-navigations/app/offline-status.tsx
+++ b/test/production/app-dir/offline-navigations/app/offline-status.tsx
@@ -1,0 +1,8 @@
+'use client'
+
+import { useOffline } from 'next/offline'
+
+export function OfflineStatus() {
+  const isOffline = useOffline()
+  return <p id="offline-status">{isOffline ? 'offline' : 'online'}</p>
+}

--- a/test/production/app-dir/offline-navigations/app/page.tsx
+++ b/test/production/app-dir/offline-navigations/app/page.tsx
@@ -1,5 +1,10 @@
 import { OfflineStatus } from './offline-status'
-import { PrefetchButton, RefreshButton } from './prefetch-button'
+import {
+  DynamicPatternSourcePrefetchButton,
+  DynamicPatternTargetPrefetchButton,
+  PrefetchButton,
+  RefreshButton,
+} from './prefetch-button'
 
 export default function Page() {
   return (
@@ -7,6 +12,8 @@ export default function Page() {
       <p>offline navigations page</p>
       <OfflineStatus />
       <PrefetchButton />
+      <DynamicPatternSourcePrefetchButton />
+      <DynamicPatternTargetPrefetchButton />
       <RefreshButton />
     </>
   )

--- a/test/production/app-dir/offline-navigations/app/page.tsx
+++ b/test/production/app-dir/offline-navigations/app/page.tsx
@@ -1,5 +1,5 @@
 import { OfflineStatus } from './offline-status'
-import { PrefetchButton } from './prefetch-button'
+import { PrefetchButton, RefreshButton } from './prefetch-button'
 
 export default function Page() {
   return (
@@ -7,6 +7,7 @@ export default function Page() {
       <p>offline navigations page</p>
       <OfflineStatus />
       <PrefetchButton />
+      <RefreshButton />
     </>
   )
 }

--- a/test/production/app-dir/offline-navigations/app/page.tsx
+++ b/test/production/app-dir/offline-navigations/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>offline navigations page</p>
+}

--- a/test/production/app-dir/offline-navigations/app/page.tsx
+++ b/test/production/app-dir/offline-navigations/app/page.tsx
@@ -1,4 +1,5 @@
 import { cacheLife, cacheTag, updateTag } from 'next/cache'
+import { redirect } from 'next/navigation'
 import { OfflineStatus } from './offline-status'
 import {
   DynamicPatternSourcePrefetchButton,
@@ -20,6 +21,12 @@ async function invalidateOfflineNavigationAction() {
   updateTag('offline-navigation-action')
 }
 
+async function redirectAfterOfflineNavigationInvalidationAction() {
+  'use server'
+  updateTag('offline-navigation-action')
+  redirect('/?offline-navigation-redirect=1')
+}
+
 export default function Page() {
   return (
     <>
@@ -29,6 +36,14 @@ export default function Page() {
       <form action={invalidateOfflineNavigationAction}>
         <button id="invalidate-offline-navigation-action" type="submit">
           Invalidate offline navigation action
+        </button>
+      </form>
+      <form action={redirectAfterOfflineNavigationInvalidationAction}>
+        <button
+          id="redirect-after-offline-navigation-invalidation"
+          type="submit"
+        >
+          Redirect after offline navigation invalidation
         </button>
       </form>
       <PrefetchButton />

--- a/test/production/app-dir/offline-navigations/app/page.tsx
+++ b/test/production/app-dir/offline-navigations/app/page.tsx
@@ -1,3 +1,10 @@
+import { OfflineStatus } from './offline-status'
+
 export default function Page() {
-  return <p>offline navigations page</p>
+  return (
+    <>
+      <p>offline navigations page</p>
+      <OfflineStatus />
+    </>
+  )
 }

--- a/test/production/app-dir/offline-navigations/app/page.tsx
+++ b/test/production/app-dir/offline-navigations/app/page.tsx
@@ -1,3 +1,4 @@
+import { cacheLife, cacheTag, updateTag } from 'next/cache'
 import { OfflineStatus } from './offline-status'
 import {
   DynamicPatternSourcePrefetchButton,
@@ -6,11 +7,30 @@ import {
   RefreshButton,
 } from './prefetch-button'
 
+async function ActionInvalidationMarker() {
+  'use cache'
+  cacheLife('max')
+  cacheTag('offline-navigation-action')
+
+  return <p id="action-invalidation-marker">action invalidation marker</p>
+}
+
+async function invalidateOfflineNavigationAction() {
+  'use server'
+  updateTag('offline-navigation-action')
+}
+
 export default function Page() {
   return (
     <>
       <p>offline navigations page</p>
       <OfflineStatus />
+      <ActionInvalidationMarker />
+      <form action={invalidateOfflineNavigationAction}>
+        <button id="invalidate-offline-navigation-action" type="submit">
+          Invalidate offline navigation action
+        </button>
+      </form>
       <PrefetchButton />
       <DynamicPatternSourcePrefetchButton />
       <DynamicPatternTargetPrefetchButton />

--- a/test/production/app-dir/offline-navigations/app/page.tsx
+++ b/test/production/app-dir/offline-navigations/app/page.tsx
@@ -1,10 +1,12 @@
 import { OfflineStatus } from './offline-status'
+import { PrefetchButton } from './prefetch-button'
 
 export default function Page() {
   return (
     <>
       <p>offline navigations page</p>
       <OfflineStatus />
+      <PrefetchButton />
     </>
   )
 }

--- a/test/production/app-dir/offline-navigations/app/prefetch-button.tsx
+++ b/test/production/app-dir/offline-navigations/app/prefetch-button.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+
+export function PrefetchButton() {
+  const router = useRouter()
+  return (
+    <button
+      id="prefetch-offline-navigation"
+      onClick={() => router.prefetch('/prefetched')}
+    >
+      Prefetch offline navigation
+    </button>
+  )
+}

--- a/test/production/app-dir/offline-navigations/app/prefetch-button.tsx
+++ b/test/production/app-dir/offline-navigations/app/prefetch-button.tsx
@@ -13,3 +13,12 @@ export function PrefetchButton() {
     </button>
   )
 }
+
+export function RefreshButton() {
+  const router = useRouter()
+  return (
+    <button id="refresh-offline-navigation" onClick={() => router.refresh()}>
+      Refresh offline navigation
+    </button>
+  )
+}

--- a/test/production/app-dir/offline-navigations/app/prefetch-button.tsx
+++ b/test/production/app-dir/offline-navigations/app/prefetch-button.tsx
@@ -14,6 +14,30 @@ export function PrefetchButton() {
   )
 }
 
+export function DynamicPatternSourcePrefetchButton() {
+  const router = useRouter()
+  return (
+    <button
+      id="prefetch-dynamic-pattern-source"
+      onClick={() => router.prefetch('/dynamic-prefetch/learned')}
+    >
+      Prefetch dynamic pattern source
+    </button>
+  )
+}
+
+export function DynamicPatternTargetPrefetchButton() {
+  const router = useRouter()
+  return (
+    <button
+      id="prefetch-dynamic-pattern-target"
+      onClick={() => router.prefetch('/dynamic-prefetch/replayed')}
+    >
+      Prefetch dynamic pattern target
+    </button>
+  )
+}
+
 export function RefreshButton() {
   const router = useRouter()
   return (

--- a/test/production/app-dir/offline-navigations/app/prefetched/page.tsx
+++ b/test/production/app-dir/offline-navigations/app/prefetched/page.tsx
@@ -1,3 +1,10 @@
+import { OfflineStatus } from '../offline-status'
+
 export default function PrefetchedPage() {
-  return <p id="prefetched-page">prefetched page</p>
+  return (
+    <>
+      <p id="prefetched-page">prefetched page</p>
+      <OfflineStatus />
+    </>
+  )
 }

--- a/test/production/app-dir/offline-navigations/app/prefetched/page.tsx
+++ b/test/production/app-dir/offline-navigations/app/prefetched/page.tsx
@@ -1,0 +1,3 @@
+export default function PrefetchedPage() {
+  return <p id="prefetched-page">prefetched page</p>
+}

--- a/test/production/app-dir/offline-navigations/app/request-sensitive/page.tsx
+++ b/test/production/app-dir/offline-navigations/app/request-sensitive/page.tsx
@@ -1,0 +1,17 @@
+import { cookies } from 'next/headers'
+import { OfflineStatus } from '../offline-status'
+
+export const unstable_instant = false
+export const unstable_prefetch = 'force-disabled'
+
+export default async function RequestSensitivePage() {
+  const cookieStore = await cookies()
+  const session = cookieStore.get('offline-session')?.value ?? 'missing'
+
+  return (
+    <>
+      <p id="request-sensitive-page">request sensitive session: {session}</p>
+      <OfflineStatus />
+    </>
+  )
+}

--- a/test/production/app-dir/offline-navigations/app/url-stress/[value]/hash-indicator.tsx
+++ b/test/production/app-dir/offline-navigations/app/url-stress/[value]/hash-indicator.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+export function HashIndicator() {
+  const [hash, setHash] = useState('')
+
+  useEffect(() => {
+    const updateHash = () => setHash(window.location.hash)
+    updateHash()
+    window.addEventListener('hashchange', updateHash)
+
+    return () => {
+      window.removeEventListener('hashchange', updateHash)
+    }
+  }, [])
+
+  return <p id="url-stress-hash">url stress hash: {hash}</p>
+}

--- a/test/production/app-dir/offline-navigations/app/url-stress/[value]/page.tsx
+++ b/test/production/app-dir/offline-navigations/app/url-stress/[value]/page.tsx
@@ -1,0 +1,36 @@
+import { OfflineStatus } from '../../offline-status'
+import { HashIndicator } from './hash-indicator'
+
+type PageProps = {
+  params: Promise<{ value: string }>
+  searchParams: Promise<{
+    tag?: string | string[]
+    token?: string
+  }>
+}
+
+export const unstable_instant = false
+
+export default async function UrlStressPage({
+  params,
+  searchParams,
+}: PageProps) {
+  const { value } = await params
+  const query = await searchParams
+  const tags =
+    query.tag === undefined
+      ? []
+      : Array.isArray(query.tag)
+        ? query.tag
+        : [query.tag]
+
+  return (
+    <>
+      <p id="url-stress-page">url stress path: {value}</p>
+      <p id="url-stress-token">url stress token: {query.token ?? 'missing'}</p>
+      <p id="url-stress-tags">url stress tags: {tags.join(',')}</p>
+      <HashIndicator />
+      <OfflineStatus />
+    </>
+  )
+}

--- a/test/production/app-dir/offline-navigations/next.config.js
+++ b/test/production/app-dir/offline-navigations/next.config.js
@@ -3,9 +3,12 @@
  */
 const nextConfig = {
   cacheComponents: true,
+  assetPrefix: 'https://cdn.example.com/app-assets',
+  basePath: '/docs',
   experimental: {
     offlineNavigations: true,
   },
+  trailingSlash: true,
 }
 
 module.exports = nextConfig

--- a/test/production/app-dir/offline-navigations/next.config.js
+++ b/test/production/app-dir/offline-navigations/next.config.js
@@ -3,7 +3,7 @@
  */
 const nextConfig = {
   cacheComponents: true,
-  assetPrefix: 'https://cdn.example.com/app-assets',
+  assetPrefix: '/app-assets',
   basePath: '/docs',
   experimental: {
     offlineNavigations: true,

--- a/test/production/app-dir/offline-navigations/next.config.js
+++ b/test/production/app-dir/offline-navigations/next.config.js
@@ -1,0 +1,11 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+  experimental: {
+    offlineNavigations: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -338,6 +338,18 @@ describe('offlineNavigations build artifacts', () => {
         )
       })
       expect(await browser.elementById('offline-status').text()).toBe('offline')
+      expect(
+        await browser.eval(() => {
+          const win = window as typeof window & {
+            __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?: Array<unknown>
+          }
+          return win.__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?.at(-1)
+        })
+      ).toMatchObject({
+        type: 'cache-hit',
+        requestKind: 'initial-load',
+        url: `${next.url}/docs/`,
+      })
       await page!.context().setOffline(false)
       await browser.eval(() => {
         window.dispatchEvent(new Event('online'))
@@ -420,6 +432,18 @@ describe('offlineNavigations build artifacts', () => {
         )
       })
       expect(await browser.elementById('offline-status').text()).toBe('offline')
+      expect(
+        await browser.eval(() => {
+          const win = window as typeof window & {
+            __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?: Array<unknown>
+          }
+          return win.__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?.at(-1)
+        })
+      ).toMatchObject({
+        type: 'cache-hit',
+        requestKind: 'client-resume',
+        url: `${next.url}/docs/prefetched`,
+      })
       const cachedServiceWorkerMessage = await browser.eval(() => {
         const message = localStorage.getItem('__nextOfflineNavigationMessage')
         return message === null ? null : JSON.parse(message)
@@ -443,7 +467,61 @@ describe('offlineNavigations build artifacts', () => {
       })
       expect(nonNavigationResult).toBe('rejected')
 
+      await browser.eval(
+        async ({ buildId: entryBuildId, url }) => {
+          const database = await new Promise<IDBDatabase>((resolve, reject) => {
+            const request = indexedDB.open('next-offline-navigation-cache', 2)
+            request.onsuccess = () => resolve(request.result)
+            request.onerror = () => reject(request.error)
+          })
+
+          try {
+            const transaction = database.transaction(
+              'navigation-data',
+              'readwrite'
+            )
+            transaction.objectStore('navigation-data').put({
+              version: 2,
+              kind: 'exact-url',
+              buildId: entryBuildId,
+              url,
+              cacheEpoch: 1,
+              createdAt: Date.now(),
+              staleAt: Date.now() + 60_000,
+              expiresAt: Date.now() + 60_000,
+              payload: { kind: 'not-rsc-response' },
+            })
+            await new Promise<void>((resolve, reject) => {
+              transaction.oncomplete = () => resolve()
+              transaction.onerror = () => reject(transaction.error)
+              transaction.onabort = () => reject(transaction.error)
+            })
+          } finally {
+            database.close()
+          }
+        },
+        {
+          buildId: navigationBuildId,
+          url: `${next.url}/docs/malformed-offline-entry/`,
+        }
+      )
+
       await next.stop()
+      const malformedResponse = await page!.goto(
+        `${next.url}/docs/malformed-offline-entry/`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(malformedResponse?.status()).toBe(200)
+      await retry(async () => {
+        expect(
+          await browser.eval(() =>
+            document.documentElement.getAttribute(
+              'data-next-offline-navigation-cache-reason'
+            )
+          )
+        ).toBe('invalid-payload')
+      })
+
       const offlineResponse = await page!.goto(
         `${next.url}/docs/offline-navigation-cache-miss`,
         { waitUntil: 'domcontentloaded' }
@@ -466,13 +544,41 @@ describe('offlineNavigations build artifacts', () => {
               ? null
               : {
                   hidden: cacheMiss.hidden,
+                  reason: cacheMiss.getAttribute(
+                    'data-next-offline-navigation-cache-reason'
+                  ),
                   text: cacheMiss.textContent,
                 }
           })
         ).toEqual({
           hidden: false,
+          reason: 'missing-entry',
           text: 'This page is not available offline.',
         })
+      })
+      expect(
+        await browser.eval(() => ({
+          cache: document.documentElement.getAttribute(
+            'data-next-offline-navigation-cache'
+          ),
+          reason: document.documentElement.getAttribute(
+            'data-next-offline-navigation-cache-reason'
+          ),
+          diagnostic:
+            (
+              window as typeof window & {
+                __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?: Array<unknown>
+              }
+            ).__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?.at(-1) ?? null,
+        }))
+      ).toMatchObject({
+        cache: 'miss',
+        reason: 'missing-entry',
+        diagnostic: {
+          type: 'cache-miss',
+          reason: 'missing-entry',
+          url: `${next.url}/docs/offline-navigation-cache-miss`,
+        },
       })
       await page!.context().setOffline(false)
 

--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -1403,6 +1403,182 @@ describe('offlineNavigations build artifacts', () => {
     }
   })
 
+  it('misses persisted router records after server action invalidation', async () => {
+    if (shouldSkipReplayWithCachedNavigations) {
+      return
+    }
+
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    await next.start({ skipBuild: true })
+
+    let page: Playwright.Page | undefined
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
+
+      await browser.elementById('prefetch-offline-navigation').click()
+      await retry(async () => {
+        const routeRecords =
+          await readPersistedOfflineNavigationRouteRecords(browser)
+        expect(
+          routeRecords.some((record) =>
+            record.route.pathname.includes('/prefetched')
+          )
+        ).toBe(true)
+
+        const segmentRecords =
+          await readPersistedOfflineNavigationSegmentRecords(browser)
+        expect(
+          segmentRecords.some(
+            (record) => record.payload.requestKind === 'segment-prefetch'
+          )
+        ).toBe(true)
+        expect(
+          segmentRecords.some(
+            (record) => record.segment.requestKey === '/_head'
+          )
+        ).toBe(true)
+      })
+
+      const deletedExactEntries = await deletePersistedOfflineNavigationEntries(
+        browser,
+        '/docs/prefetched'
+      )
+      expect(deletedExactEntries).toBeGreaterThan(0)
+
+      await page!.context().setOffline(true)
+      const cachedRouterRecordsResponse = await page!.goto(
+        `${next.url}/docs/prefetched`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(cachedRouterRecordsResponse?.status()).toBe(200)
+      await retry(async () => {
+        expect(await browser.elementById('prefetched-page').text()).toBe(
+          'prefetched page'
+        )
+        const diagnostics = await browser.eval(() => {
+          const win = window as typeof window & {
+            __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?: Array<{
+              requestKind?: string
+              type?: string
+              url?: string
+            }>
+          }
+          return win.__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__ ?? []
+        })
+        expect(diagnostics).toContainEqual(
+          expect.objectContaining({
+            requestKind: 'router-cache',
+            type: 'cache-hit',
+            url: `${next.url}/docs/prefetched`,
+          })
+        )
+      })
+
+      await page!.context().setOffline(false)
+      await browser.eval(() => {
+        window.dispatchEvent(new Event('online'))
+      })
+      const onlineRootResponse = await page!.goto(`${next.url}/docs`, {
+        waitUntil: 'domcontentloaded',
+      })
+      expect(onlineRootResponse?.status()).toBe(200)
+      await retry(async () => {
+        expect(
+          await browser.elementById('action-invalidation-marker').text()
+        ).toBe('action invalidation marker')
+      })
+
+      await browser.elementById('invalidate-offline-navigation-action').click()
+      await retry(async () => {
+        expect(
+          await readPersistedOfflineNavigationMetadata(
+            browser,
+            'exact-url-cache-epoch'
+          )
+        ).toBeGreaterThan(0)
+        expect(
+          await readPersistedOfflineNavigationMetadata(
+            browser,
+            'route-cache-epoch'
+          )
+        ).toBeGreaterThan(0)
+        expect(
+          await readPersistedOfflineNavigationMetadata(
+            browser,
+            'segment-cache-epoch'
+          )
+        ).toBeGreaterThan(0)
+      })
+
+      await page!.context().setOffline(true)
+      const invalidatedRouterRecordsResponse = await page!.goto(
+        `${next.url}/docs/prefetched`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(invalidatedRouterRecordsResponse?.status()).toBe(200)
+      await retry(async () => {
+        const diagnostics = await browser.eval(() => {
+          const win = window as typeof window & {
+            __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?: Array<{
+              reason?: string
+              type?: string
+              url?: string
+            }>
+          }
+          return win.__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__ ?? []
+        })
+        expect(diagnostics).toContainEqual(
+          expect.objectContaining({
+            reason: 'missing-route',
+            type: 'router-cache-reconstruction-miss',
+            url: `${next.url}/docs/prefetched`,
+          })
+        )
+        expect(diagnostics).toContainEqual(
+          expect.objectContaining({
+            reason: 'missing-entry',
+            type: 'cache-miss',
+            url: `${next.url}/docs/prefetched`,
+          })
+        )
+      })
+      await retry(async () => {
+        expect(
+          await browser.eval(() => {
+            const cacheMiss = document.getElementById(
+              '__NEXT_OFFLINE_NAVIGATION_CACHE_MISS'
+            )
+            return cacheMiss === null
+              ? null
+              : {
+                  hidden: cacheMiss.hidden,
+                  reason: cacheMiss.getAttribute(
+                    'data-next-offline-navigation-cache-reason'
+                  ),
+                  text: cacheMiss.textContent,
+                }
+          })
+        ).toEqual({
+          hidden: false,
+          reason: 'missing-entry',
+          text: 'This page is not available offline.',
+        })
+      })
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
   it('replays a dynamic route from persisted known route patterns', async () => {
     if (shouldSkipReplayWithCachedNavigations) {
       return

--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -62,7 +62,11 @@ describe('offlineNavigations build artifacts', () => {
 
     expect(html).toContain('data-next-offline-navigation-fallback')
     expect(html).toContain('id="__NEXT_OFFLINE_NAVIGATION_FALLBACK"')
+    expect(html).toContain('id="__NEXT_OFFLINE_NAVIGATION_CACHE_MISS"')
     expect(html).toContain(`"buildId":"${buildId}"`)
+    if (next.deploymentId) {
+      expect(html).toContain(`data-dpl-id="${next.deploymentId}"`)
+    }
     expect(html).toContain('self.__next_f')
     expect(html).toContain('/app-assets/_next/static/')
     expect(html).not.toContain('offline navigations page')
@@ -326,6 +330,28 @@ describe('offlineNavigations build artifacts', () => {
       })
 
       await page!.context().setOffline(true)
+      const cachedOfflineResponse = await page!.goto(
+        `${next.url}/docs/prefetched`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(cachedOfflineResponse?.status()).toBe(200)
+      await retry(async () => {
+        expect(await browser.elementById('prefetched-page').text()).toBe(
+          'prefetched page'
+        )
+      })
+      expect(await browser.elementById('offline-status').text()).toBe('offline')
+      const cachedServiceWorkerMessage = await browser.eval(() => {
+        const message = localStorage.getItem('__nextOfflineNavigationMessage')
+        return message === null ? null : JSON.parse(message)
+      })
+      expect(cachedServiceWorkerMessage).toMatchObject({
+        type: OFFLINE_NAVIGATION_FALLBACK_SERVED,
+        buildId,
+        reason: 'network-error',
+        url: `${next.url}/docs/prefetched`,
+      })
+
       const nonNavigationResult = await browser.eval(async () => {
         try {
           await fetch('/docs?__next_offline_probe=1', {
@@ -338,6 +364,7 @@ describe('offlineNavigations build artifacts', () => {
       })
       expect(nonNavigationResult).toBe('rejected')
 
+      await next.stop()
       const offlineResponse = await page!.goto(
         `${next.url}/docs/offline-navigation-cache-miss`,
         { waitUntil: 'domcontentloaded' }
@@ -350,15 +377,23 @@ describe('offlineNavigations build artifacts', () => {
           )
         )
       ).toBe(true)
-      const serviceWorkerMessage = await browser.eval(() => {
-        const message = localStorage.getItem('__nextOfflineNavigationMessage')
-        return message === null ? null : JSON.parse(message)
-      })
-      expect(serviceWorkerMessage).toMatchObject({
-        type: OFFLINE_NAVIGATION_FALLBACK_SERVED,
-        buildId,
-        reason: 'network-error',
-        url: `${next.url}/docs/offline-navigation-cache-miss`,
+      await retry(async () => {
+        expect(
+          await browser.eval(() => {
+            const cacheMiss = document.getElementById(
+              '__NEXT_OFFLINE_NAVIGATION_CACHE_MISS'
+            )
+            return cacheMiss === null
+              ? null
+              : {
+                  hidden: cacheMiss.hidden,
+                  text: cacheMiss.textContent,
+                }
+          })
+        ).toEqual({
+          hidden: false,
+          text: 'This page is not available offline.',
+        })
       })
       await page!.context().setOffline(false)
 

--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -56,12 +56,22 @@ describe('offlineNavigations build artifacts', () => {
   ) {
     return browser.eval(async (substring) => {
       const database = await new Promise<IDBDatabase>((resolve, reject) => {
-        const request = indexedDB.open('next-offline-navigation-cache', 2)
+        const request = indexedDB.open('next-offline-navigation-cache', 3)
         request.onupgradeneeded = () => {
           const database = request.result
           if (!database.objectStoreNames.contains('navigation-data')) {
             database.createObjectStore('navigation-data', {
               keyPath: ['buildId', 'url'],
+            })
+          }
+          if (!database.objectStoreNames.contains('route-data')) {
+            database.createObjectStore('route-data', {
+              keyPath: ['buildId', 'key'],
+            })
+          }
+          if (!database.objectStoreNames.contains('segment-data')) {
+            database.createObjectStore('segment-data', {
+              keyPath: ['buildId', 'key'],
             })
           }
           if (!database.objectStoreNames.contains('metadata')) {
@@ -494,7 +504,7 @@ describe('offlineNavigations build artifacts', () => {
       await browser.eval(
         async ({ buildId: entryBuildId, url }) => {
           const database = await new Promise<IDBDatabase>((resolve, reject) => {
-            const request = indexedDB.open('next-offline-navigation-cache', 2)
+            const request = indexedDB.open('next-offline-navigation-cache', 3)
             request.onsuccess = () => resolve(request.result)
             request.onerror = () => reject(request.error)
           })
@@ -533,7 +543,7 @@ describe('offlineNavigations build artifacts', () => {
       await browser.eval(
         async ({ buildId: entryBuildId, url }) => {
           const database = await new Promise<IDBDatabase>((resolve, reject) => {
-            const request = indexedDB.open('next-offline-navigation-cache', 2)
+            const request = indexedDB.open('next-offline-navigation-cache', 3)
             request.onsuccess = () => resolve(request.result)
             request.onerror = () => reject(request.error)
           })

--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -196,6 +196,54 @@ describe('offlineNavigations build artifacts', () => {
     })
   }
 
+  async function deletePersistedOfflineNavigationSegmentRecords(
+    browser: Awaited<ReturnType<typeof next.browser>>,
+    options: {
+      keySubstring: string
+      requestKeySuffix: string
+    }
+  ) {
+    return browser.eval(async ({ keySubstring, requestKeySuffix }) => {
+      const database = await new Promise<IDBDatabase>((resolve, reject) => {
+        const request = indexedDB.open('next-offline-navigation-cache', 3)
+        request.onsuccess = () => resolve(request.result)
+        request.onerror = () => reject(request.error)
+      })
+
+      try {
+        const entries = await new Promise<any[]>((resolve, reject) => {
+          const transaction = database.transaction('segment-data', 'readonly')
+          const request = transaction.objectStore('segment-data').getAll()
+          request.onsuccess = () => resolve(request.result)
+          request.onerror = () => reject(request.error)
+        })
+        const matchingEntries = entries.filter(
+          (entry) =>
+            entry.key.includes(keySubstring) &&
+            entry.segment.requestKey.endsWith(requestKeySuffix)
+        )
+
+        if (matchingEntries.length === 0) {
+          return 0
+        }
+
+        const transaction = database.transaction('segment-data', 'readwrite')
+        const store = transaction.objectStore('segment-data')
+        for (const entry of matchingEntries) {
+          store.delete([entry.buildId, entry.key])
+        }
+        await new Promise<void>((resolve, reject) => {
+          transaction.oncomplete = () => resolve()
+          transaction.onerror = () => reject(transaction.error)
+          transaction.onabort = () => reject(transaction.error)
+        })
+        return matchingEntries.length
+      } finally {
+        database.close()
+      }
+    }, options)
+  }
+
   async function deletePersistedOfflineNavigationEntries(
     browser: Awaited<ReturnType<typeof next.browser>>,
     urlSubstring: string
@@ -240,6 +288,64 @@ describe('offlineNavigations build artifacts', () => {
         database.close()
       }
     }, urlSubstring)
+  }
+
+  async function prefetchDynamicPatternReplayData(
+    browser: Awaited<ReturnType<typeof next.browser>>
+  ) {
+    await browser.elementById('prefetch-dynamic-pattern-source').click()
+    await retry(async () => {
+      const routeRecords =
+        await readPersistedOfflineNavigationRouteRecords(browser)
+      expect(
+        routeRecords.some((record) =>
+          record.route.pathname.includes('/dynamic-prefetch/learned')
+        )
+      ).toBe(true)
+    })
+
+    await browser.elementById('prefetch-dynamic-pattern-target').click()
+    await retry(async () => {
+      const exactEntry = await readPersistedOfflineNavigationEntry(
+        browser,
+        '/docs/dynamic-prefetch/replayed'
+      )
+      expect(exactEntry).toBe(null)
+
+      const routeRecords =
+        await readPersistedOfflineNavigationRouteRecords(browser)
+      expect(
+        routeRecords.some((record) =>
+          record.route.pathname.includes('/dynamic-prefetch/learned')
+        )
+      ).toBe(true)
+      expect(
+        routeRecords.some((record) =>
+          record.route.pathname.includes('/dynamic-prefetch/replayed')
+        )
+      ).toBe(false)
+
+      const segmentRecords =
+        await readPersistedOfflineNavigationSegmentRecords(browser)
+      const replayedSegmentRecords = segmentRecords.filter((record) =>
+        record.key.includes('replayed')
+      )
+      expect(
+        segmentRecords.some(
+          (record) => record.payload.requestKind === 'segment-prefetch'
+        )
+      ).toBe(true)
+      expect(
+        replayedSegmentRecords.some((record) =>
+          record.segment.requestKey.endsWith('/__PAGE__')
+        )
+      ).toBe(true)
+      expect(
+        replayedSegmentRecords.some(
+          (record) => record.segment.requestKey === '/_head'
+        )
+      ).toBe(true)
+    })
   }
 
   async function cleanupOfflineNavigationState(
@@ -1073,54 +1179,7 @@ describe('offlineNavigations build artifacts', () => {
         ).toBe(true)
       })
 
-      await browser.elementById('prefetch-dynamic-pattern-source').click()
-      await retry(async () => {
-        const routeRecords =
-          await readPersistedOfflineNavigationRouteRecords(browser)
-        expect(
-          routeRecords.some((record) =>
-            record.route.pathname.includes('/dynamic-prefetch/learned')
-          )
-        ).toBe(true)
-      })
-
-      await browser.elementById('prefetch-dynamic-pattern-target').click()
-      await retry(async () => {
-        const exactEntry = await readPersistedOfflineNavigationEntry(
-          browser,
-          '/docs/dynamic-prefetch/replayed'
-        )
-        expect(exactEntry).toBe(null)
-
-        const routeRecords =
-          await readPersistedOfflineNavigationRouteRecords(browser)
-        expect(
-          routeRecords.some((record) =>
-            record.route.pathname.includes('/dynamic-prefetch/replayed')
-          )
-        ).toBe(false)
-
-        const segmentRecords =
-          await readPersistedOfflineNavigationSegmentRecords(browser)
-        const replayedSegmentRecords = segmentRecords.filter((record) =>
-          record.key.includes('replayed')
-        )
-        expect(
-          segmentRecords.some(
-            (record) => record.payload.requestKind === 'segment-prefetch'
-          )
-        ).toBe(true)
-        expect(
-          replayedSegmentRecords.some((record) =>
-            record.segment.requestKey.endsWith('/__PAGE__')
-          )
-        ).toBe(true)
-        expect(
-          replayedSegmentRecords.some(
-            (record) => record.segment.requestKey === '/_head'
-          )
-        ).toBe(true)
-      })
+      await prefetchDynamicPatternReplayData(browser)
 
       await next.stop()
       await page!.context().setOffline(true)
@@ -1153,6 +1212,108 @@ describe('offlineNavigations build artifacts', () => {
         expect(await browser.elementById('dynamic-prefetch-page').text()).toBe(
           'dynamic prefetch path: replayed'
         )
+      })
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
+  it('misses dynamic route pattern replay when a required segment record is missing', async () => {
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    await next.start({ skipBuild: true })
+
+    let page: Playwright.Page | undefined
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await retry(async () => {
+        expect(
+          await browser.eval(() => Boolean(navigator.serviceWorker.controller))
+        ).toBe(true)
+      })
+
+      await prefetchDynamicPatternReplayData(browser)
+
+      const deletedSegments =
+        await deletePersistedOfflineNavigationSegmentRecords(browser, {
+          keySubstring: 'replayed',
+          requestKeySuffix: '/__PAGE__',
+        })
+      expect(deletedSegments).toBeGreaterThan(0)
+      await retry(async () => {
+        const segmentRecords =
+          await readPersistedOfflineNavigationSegmentRecords(browser)
+        expect(
+          segmentRecords.some(
+            (record) =>
+              record.key.includes('replayed') &&
+              record.segment.requestKey.endsWith('/__PAGE__')
+          )
+        ).toBe(false)
+      })
+
+      await next.stop()
+      await page!.context().setOffline(true)
+      const missingSegmentResponse = await page!.goto(
+        `${next.url}/docs/dynamic-prefetch/replayed#missing-segment`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(missingSegmentResponse?.status()).toBe(200)
+      await retry(async () => {
+        const diagnostics = await browser.eval(() => {
+          const win = window as typeof window & {
+            __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?: Array<{
+              type?: string
+              reason?: string
+              url?: string
+            }>
+          }
+          return win.__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__ ?? []
+        })
+        expect(diagnostics).toContainEqual(
+          expect.objectContaining({
+            type: 'router-cache-reconstruction-miss',
+            reason: 'missing-segment',
+            url: `${next.url}/docs/dynamic-prefetch/replayed#missing-segment`,
+          })
+        )
+        expect(diagnostics).toContainEqual(
+          expect.objectContaining({
+            type: 'cache-miss',
+            reason: 'missing-entry',
+            url: `${next.url}/docs/dynamic-prefetch/replayed#missing-segment`,
+          })
+        )
+      })
+      await retry(async () => {
+        expect(
+          await browser.eval(() => {
+            const cacheMiss = document.getElementById(
+              '__NEXT_OFFLINE_NAVIGATION_CACHE_MISS'
+            )
+            return cacheMiss === null
+              ? null
+              : {
+                  hidden: cacheMiss.hidden,
+                  reason: cacheMiss.getAttribute(
+                    'data-next-offline-navigation-cache-reason'
+                  ),
+                  text: cacheMiss.textContent,
+                }
+          })
+        ).toEqual({
+          hidden: false,
+          reason: 'missing-entry',
+          text: 'This page is not available offline.',
+        })
       })
     } finally {
       if (page) {

--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -196,6 +196,52 @@ describe('offlineNavigations build artifacts', () => {
     })
   }
 
+  async function deletePersistedOfflineNavigationEntries(
+    browser: Awaited<ReturnType<typeof next.browser>>,
+    urlSubstring: string
+  ) {
+    return browser.eval(async (substring) => {
+      const database = await new Promise<IDBDatabase>((resolve, reject) => {
+        const request = indexedDB.open('next-offline-navigation-cache', 3)
+        request.onsuccess = () => resolve(request.result)
+        request.onerror = () => reject(request.error)
+      })
+
+      try {
+        const entries = await new Promise<any[]>((resolve, reject) => {
+          const transaction = database.transaction(
+            'navigation-data',
+            'readonly'
+          )
+          const request = transaction.objectStore('navigation-data').getAll()
+          request.onsuccess = () => resolve(request.result)
+          request.onerror = () => reject(request.error)
+        })
+        const matchingEntries = entries.filter((entry) =>
+          entry.url.includes(substring)
+        )
+
+        if (matchingEntries.length === 0) {
+          return 0
+        }
+
+        const transaction = database.transaction('navigation-data', 'readwrite')
+        const store = transaction.objectStore('navigation-data')
+        for (const entry of matchingEntries) {
+          store.delete([entry.buildId, entry.url])
+        }
+        await new Promise<void>((resolve, reject) => {
+          transaction.oncomplete = () => resolve()
+          transaction.onerror = () => reject(transaction.error)
+          transaction.onabort = () => reject(transaction.error)
+        })
+        return matchingEntries.length
+      } finally {
+        database.close()
+      }
+    }, urlSubstring)
+  }
+
   async function cleanupOfflineNavigationState(
     browser: Awaited<ReturnType<typeof next.browser>>
   ) {
@@ -887,6 +933,117 @@ describe('offlineNavigations build artifacts', () => {
         const registrations = await navigator.serviceWorker.getRegistrations()
         await Promise.all(
           registrations.map((registration) => registration.unregister())
+        )
+      })
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
+  it('reconstructs a fully prefetched route from persisted router records', async () => {
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    await next.start({ skipBuild: true })
+
+    let page: Playwright.Page | undefined
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await retry(async () => {
+        expect(
+          await browser.eval(() => Boolean(navigator.serviceWorker.controller))
+        ).toBe(true)
+      })
+
+      await browser.elementById('prefetch-offline-navigation').click()
+      await retry(async () => {
+        const exactEntry = await readPersistedOfflineNavigationEntry(
+          browser,
+          '/docs/prefetched'
+        )
+        expect(exactEntry).toEqual(
+          expect.objectContaining({
+            kind: 'exact-url',
+            payload: expect.objectContaining({
+              kind: 'rsc-response',
+              requestKind: 'client-resume',
+            }),
+          })
+        )
+      })
+      await retry(async () => {
+        const routeRecords =
+          await readPersistedOfflineNavigationRouteRecords(browser)
+        expect(
+          routeRecords.some((record) =>
+            record.route.pathname.includes('/prefetched')
+          )
+        ).toBe(true)
+
+        const segmentRecords =
+          await readPersistedOfflineNavigationSegmentRecords(browser)
+        expect(
+          segmentRecords.some(
+            (record) => record.payload.requestKind === 'segment-prefetch'
+          )
+        ).toBe(true)
+        expect(
+          segmentRecords.some(
+            (record) => record.segment.requestKey === '/_head'
+          )
+        ).toBe(true)
+      })
+
+      const deletedExactEntries = await deletePersistedOfflineNavigationEntries(
+        browser,
+        '/docs/prefetched'
+      )
+      expect(deletedExactEntries).toBeGreaterThan(0)
+      await retry(async () => {
+        const deletedEntry = await readPersistedOfflineNavigationEntry(
+          browser,
+          '/docs/prefetched'
+        )
+        expect(deletedEntry).toBe(null)
+      })
+
+      await next.stop()
+      await page!.context().setOffline(true)
+      const routerCacheOnlyResponse = await page!.goto(
+        `${next.url}/docs/prefetched`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(routerCacheOnlyResponse?.status()).toBe(200)
+      await retry(async () => {
+        const routerCacheDiagnostics = await browser.eval(() => {
+          const win = window as typeof window & {
+            __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?: Array<{
+              type?: string
+              requestKind?: string
+              url?: string
+              reason?: string
+            }>
+          }
+          return win.__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__ ?? []
+        })
+        expect(routerCacheDiagnostics).toContainEqual(
+          expect.objectContaining({
+            type: 'cache-hit',
+            requestKind: 'router-cache',
+            url: `${next.url}/docs/prefetched`,
+          })
+        )
+      })
+      await retry(async () => {
+        expect(await browser.elementById('prefetched-page').text()).toBe(
+          'prefetched page'
         )
       })
     } finally {

--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -473,6 +473,102 @@ describe('offlineNavigations build artifacts', () => {
     }
   })
 
+  it('replays request-sensitive exact URLs from browser-private storage', async () => {
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    const { buildId } = await getOfflineNavigationArtifactPaths()
+    const navigationBuildId = next.deploymentId ?? buildId
+    await next.start({ skipBuild: true })
+
+    let page: Playwright.Page | undefined
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await retry(async () => {
+        expect(
+          await browser.eval(() => Boolean(navigator.serviceWorker.controller))
+        ).toBe(true)
+      })
+
+      await browser.eval(() => {
+        document.cookie = 'offline-session=alpha; path=/; SameSite=Lax'
+      })
+      const onlineResponse = await page!.goto(
+        `${next.url}/docs/request-sensitive/`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(onlineResponse?.status()).toBe(200)
+      await retry(async () => {
+        expect(await browser.elementById('request-sensitive-page').text()).toBe(
+          'request sensitive session: alpha'
+        )
+      })
+
+      await retry(async () => {
+        const entry = await readPersistedOfflineNavigationEntry(
+          browser,
+          '/docs/request-sensitive'
+        )
+        expect(entry).toEqual({
+          buildId: navigationBuildId,
+          expiresAt: expect.any(Number),
+          kind: 'exact-url',
+          payload: {
+            bodyLength: expect.any(Number),
+            kind: 'rsc-response',
+            requestKind: 'initial-load',
+            status: 200,
+          },
+          staleAt: expect.any(Number),
+          url: expect.stringContaining('/docs/request-sensitive'),
+          version: 1,
+        })
+        expect(entry!.payload.bodyLength).toBeGreaterThan(0)
+      })
+
+      await page!.context().setOffline(true)
+      const offlineResponse = await page!.goto(
+        `${next.url}/docs/request-sensitive/`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(offlineResponse?.status()).toBe(200)
+      await retry(async () => {
+        expect(await browser.elementById('request-sensitive-page').text()).toBe(
+          'request sensitive session: alpha'
+        )
+      })
+      expect(await browser.elementById('offline-status').text()).toBe('offline')
+
+      await page!.context().setOffline(false)
+      await browser.eval(async () => {
+        window.dispatchEvent(new Event('online'))
+
+        const cacheNames = await caches.keys()
+        await Promise.all(
+          cacheNames
+            .filter((cacheName) =>
+              cacheName.startsWith('next-offline-navigation-v1:')
+            )
+            .map((cacheName) => caches.delete(cacheName))
+        )
+
+        const registrations = await navigator.serviceWorker.getRegistrations()
+        await Promise.all(
+          registrations.map((registration) => registration.unregister())
+        )
+      })
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
   it('does not emit offline navigation artifacts when disabled', async () => {
     await next.patchFile('next.config.js', (content) =>
       content.replace('offlineNavigations: true', 'offlineNavigations: false')

--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -65,8 +65,13 @@ describe('offlineNavigations build artifacts', () => {
 
     expect(serviceWorkerScript).toContain(`"buildId":"${buildId}"`)
     expect(serviceWorkerScript).toContain(
+      `"cacheNamespace":"next-offline-navigation-v1:${buildId}:/docs"`
+    )
+    expect(serviceWorkerScript).toContain(
       `"manifestHref":"/docs/_next/static/${buildId}/_offline-navigation-manifest.json"`
     )
+    expect(serviceWorkerScript).toContain('cacheOfflineNavigationResources')
+    expect(serviceWorkerScript).toContain('caches.delete')
     expect(serviceWorkerScript).toContain('skipWaiting')
     expect(serviceWorkerScript).toContain('clients.claim')
     expect(serviceWorkerScript).not.toContain('respondWith')
@@ -99,6 +104,7 @@ describe('offlineNavigations build artifacts', () => {
     const buildResult = await next.build()
     expect(buildResult.exitCode).toBe(0)
 
+    const { buildId } = await getOfflineNavigationArtifactPaths()
     await next.start({ skipBuild: true })
 
     try {
@@ -139,10 +145,55 @@ describe('offlineNavigations build artifacts', () => {
         })
       })
 
+      const cacheState = await browser.eval(async () => {
+        const cacheNames = (await caches.keys()).filter((cacheName) =>
+          cacheName.startsWith('next-offline-navigation-v1:')
+        )
+        const entries: Array<{ cacheName: string; pathname: string }> = []
+
+        for (const cacheName of cacheNames) {
+          const cache = await caches.open(cacheName)
+          const requests = await cache.keys()
+
+          for (const request of requests) {
+            entries.push({
+              cacheName,
+              pathname: new URL(request.url).pathname,
+            })
+          }
+        }
+
+        return { cacheNames, entries }
+      })
+
+      const cacheName = `next-offline-navigation-v1:${buildId}:/docs`
+      expect(cacheState.cacheNames).toContain(cacheName)
+      expect(cacheState.entries).toEqual(
+        expect.arrayContaining([
+          {
+            cacheName,
+            pathname: `/docs/_next/static/${buildId}/_offline-navigation-manifest.json`,
+          },
+          {
+            cacheName,
+            pathname: `/docs/_next/static/${buildId}/_offline-navigation-fallback.html`,
+          },
+        ])
+      )
+
       await browser.eval(async () => {
         if (!('serviceWorker' in navigator)) {
           return
         }
+
+        const cacheNames = await caches.keys()
+        await Promise.all(
+          cacheNames
+            .filter((cacheName) =>
+              cacheName.startsWith('next-offline-navigation-v1:')
+            )
+            .map((cacheName) => caches.delete(cacheName))
+        )
 
         const registrations = await navigator.serviceWorker.getRegistrations()
         await Promise.all(

--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -2,6 +2,7 @@ import { existsSync } from 'fs'
 import { join } from 'path'
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
+import type * as Playwright from 'playwright'
 
 describe('offlineNavigations build artifacts', () => {
   const { next } = nextTestSetup({
@@ -68,13 +69,17 @@ describe('offlineNavigations build artifacts', () => {
       `"cacheNamespace":"next-offline-navigation-v1:${buildId}:/docs"`
     )
     expect(serviceWorkerScript).toContain(
+      `"fallbackDocumentHref":"/docs/_next/static/${buildId}/_offline-navigation-fallback.html"`
+    )
+    expect(serviceWorkerScript).toContain(
       `"manifestHref":"/docs/_next/static/${buildId}/_offline-navigation-manifest.json"`
     )
     expect(serviceWorkerScript).toContain('cacheOfflineNavigationResources')
     expect(serviceWorkerScript).toContain('caches.delete')
+    expect(serviceWorkerScript).toContain('isDocumentNavigationRequest')
     expect(serviceWorkerScript).toContain('skipWaiting')
     expect(serviceWorkerScript).toContain('clients.claim')
-    expect(serviceWorkerScript).not.toContain('respondWith')
+    expect(serviceWorkerScript).toContain('respondWith')
 
     expect(manifestJson).toEqual({
       version: 1,
@@ -107,6 +112,7 @@ describe('offlineNavigations build artifacts', () => {
     const { buildId } = await getOfflineNavigationArtifactPaths()
     await next.start({ skipBuild: true })
 
+    let page: Playwright.Page | undefined
     try {
       const swResponse = await next.fetch(
         `/docs/_next/static/_offline-navigation-service-worker.js${next.getDeploymentIdQuery()}`
@@ -117,7 +123,11 @@ describe('offlineNavigations build artifacts', () => {
       )
       expect(swResponse.headers.get('service-worker-allowed')).toBe('/docs/')
 
-      const browser = await next.browser('/docs')
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
       await retry(async () => {
         const registration = await browser.eval(async () => {
           if (!('serviceWorker' in navigator)) {
@@ -143,6 +153,11 @@ describe('offlineNavigations build artifacts', () => {
           scope: `${next.url}/docs/`,
           scriptURL: `${next.url}/docs/_next/static/_offline-navigation-service-worker.js${next.getDeploymentIdQuery()}`,
         })
+      })
+      await retry(async () => {
+        expect(
+          await browser.eval(() => Boolean(navigator.serviceWorker.controller))
+        ).toBe(true)
       })
 
       const cacheState = await browser.eval(async () => {
@@ -181,6 +196,33 @@ describe('offlineNavigations build artifacts', () => {
         ])
       )
 
+      await page!.context().setOffline(true)
+      const nonNavigationResult = await browser.eval(async () => {
+        try {
+          await fetch('/docs?__next_offline_probe=1', {
+            headers: { rsc: '1' },
+          })
+          return 'resolved'
+        } catch {
+          return 'rejected'
+        }
+      })
+      expect(nonNavigationResult).toBe('rejected')
+
+      const offlineResponse = await page!.goto(
+        `${next.url}/docs/offline-navigation-cache-miss`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(offlineResponse?.status()).toBe(200)
+      expect(
+        await browser.eval(() =>
+          document.documentElement.hasAttribute(
+            'data-next-offline-navigation-fallback'
+          )
+        )
+      ).toBe(true)
+      await page!.context().setOffline(false)
+
       await browser.eval(async () => {
         if (!('serviceWorker' in navigator)) {
           return
@@ -201,6 +243,9 @@ describe('offlineNavigations build artifacts', () => {
         )
       })
     } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
       await next.stop()
     }
   })

--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -56,13 +56,16 @@ describe('offlineNavigations build artifacts', () => {
   ) {
     return browser.eval(async (substring) => {
       const database = await new Promise<IDBDatabase>((resolve, reject) => {
-        const request = indexedDB.open('next-offline-navigation-cache', 1)
+        const request = indexedDB.open('next-offline-navigation-cache', 2)
         request.onupgradeneeded = () => {
           const database = request.result
           if (!database.objectStoreNames.contains('navigation-data')) {
             database.createObjectStore('navigation-data', {
               keyPath: ['buildId', 'url'],
             })
+          }
+          if (!database.objectStoreNames.contains('metadata')) {
+            database.createObjectStore('metadata')
           }
         }
         request.onsuccess = () => resolve(request.result)
@@ -86,6 +89,7 @@ describe('offlineNavigations build artifacts', () => {
 
         return {
           buildId: entry.buildId,
+          cacheEpoch: entry.cacheEpoch,
           expiresAt: entry.expiresAt,
           kind: entry.kind,
           payload: {
@@ -307,6 +311,7 @@ describe('offlineNavigations build artifacts', () => {
         )
         expect(initialLoadEntry).toEqual({
           buildId: navigationBuildId,
+          cacheEpoch: 0,
           expiresAt: expect.any(Number),
           kind: 'exact-url',
           payload: {
@@ -317,7 +322,7 @@ describe('offlineNavigations build artifacts', () => {
           },
           staleAt: expect.any(Number),
           url: expect.stringContaining('/docs/'),
-          version: 1,
+          version: 2,
         })
         expect(initialLoadEntry!.payload.bodyLength).toBeGreaterThan(0)
       })
@@ -343,6 +348,30 @@ describe('offlineNavigations build artifacts', () => {
         )
       })
 
+      await browser.elementById('refresh-offline-navigation').click()
+      await retry(async () => {
+        const refreshedEntry = await readPersistedOfflineNavigationEntry(
+          browser,
+          '/docs/'
+        )
+        expect(refreshedEntry).toEqual({
+          buildId: navigationBuildId,
+          cacheEpoch: 1,
+          expiresAt: expect.any(Number),
+          kind: 'exact-url',
+          payload: {
+            bodyLength: expect.any(Number),
+            kind: 'rsc-response',
+            requestKind: 'navigation',
+            status: 200,
+          },
+          staleAt: expect.any(Number),
+          url: expect.stringContaining('/docs/'),
+          version: 2,
+        })
+        expect(refreshedEntry!.payload.bodyLength).toBeGreaterThan(0)
+      })
+
       await browser.eval((messageType) => {
         localStorage.removeItem('__nextOfflineNavigationMessage')
         navigator.serviceWorker.addEventListener('message', (event) => {
@@ -363,6 +392,7 @@ describe('offlineNavigations build artifacts', () => {
         )
         expect(persistedEntry).toEqual({
           buildId: navigationBuildId,
+          cacheEpoch: 1,
           expiresAt: expect.any(Number),
           kind: 'exact-url',
           payload: {
@@ -373,7 +403,7 @@ describe('offlineNavigations build artifacts', () => {
           },
           staleAt: expect.any(Number),
           url: expect.stringContaining('/docs/prefetched'),
-          version: 1,
+          version: 2,
         })
         expect(persistedEntry!.payload.bodyLength).toBeGreaterThan(0)
       })
@@ -515,6 +545,7 @@ describe('offlineNavigations build artifacts', () => {
         )
         expect(entry).toEqual({
           buildId: navigationBuildId,
+          cacheEpoch: expect.any(Number),
           expiresAt: expect.any(Number),
           kind: 'exact-url',
           payload: {
@@ -525,7 +556,7 @@ describe('offlineNavigations build artifacts', () => {
           },
           staleAt: expect.any(Number),
           url: expect.stringContaining('/docs/request-sensitive'),
-          version: 1,
+          version: 2,
         })
         expect(entry!.payload.bodyLength).toBeGreaterThan(0)
       })

--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -1,6 +1,7 @@
 import { existsSync } from 'fs'
 import { join } from 'path'
 import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
 
 describe('offlineNavigations build artifacts', () => {
   const { next } = nextTestSetup({
@@ -23,6 +24,15 @@ describe('offlineNavigations build artifacts', () => {
         ),
         relativePath: `.next/static/${buildId}/_offline-navigation-fallback.html`,
       },
+      serviceWorker: {
+        absolutePath: join(
+          next.testDir,
+          '.next',
+          'static',
+          '_offline-navigation-service-worker.js'
+        ),
+        relativePath: `.next/static/_offline-navigation-service-worker.js`,
+      },
       manifest: {
         absolutePath: join(
           next.testDir,
@@ -40,23 +50,32 @@ describe('offlineNavigations build artifacts', () => {
     const buildResult = await next.build()
     expect(buildResult.exitCode).toBe(0)
 
-    const { buildId, fallbackDocument, manifest } =
+    const { buildId, fallbackDocument, manifest, serviceWorker } =
       await getOfflineNavigationArtifactPaths()
     const html = await next.readFile(fallbackDocument.relativePath)
     const manifestJson = JSON.parse(await next.readFile(manifest.relativePath))
+    const serviceWorkerScript = await next.readFile(serviceWorker.relativePath)
 
     expect(html).toContain('data-next-offline-navigation-fallback')
     expect(html).toContain('id="__NEXT_OFFLINE_NAVIGATION_FALLBACK"')
     expect(html).toContain(`"buildId":"${buildId}"`)
     expect(html).toContain('self.__next_f')
-    expect(html).toContain('https://cdn.example.com/app-assets/_next/static/')
+    expect(html).toContain('/app-assets/_next/static/')
     expect(html).not.toContain('offline navigations page')
+
+    expect(serviceWorkerScript).toContain(`"buildId":"${buildId}"`)
+    expect(serviceWorkerScript).toContain(
+      `"manifestHref":"/docs/_next/static/${buildId}/_offline-navigation-manifest.json"`
+    )
+    expect(serviceWorkerScript).toContain('skipWaiting')
+    expect(serviceWorkerScript).toContain('clients.claim')
+    expect(serviceWorkerScript).not.toContain('respondWith')
 
     expect(manifestJson).toEqual({
       version: 1,
       buildId,
       basePath: '/docs',
-      assetPrefix: 'https://cdn.example.com/app-assets',
+      assetPrefix: '/app-assets',
       trailingSlash: true,
       output: 'default',
       scope: '/docs/',
@@ -69,7 +88,70 @@ describe('offlineNavigations build artifacts', () => {
         path: `static/${buildId}/_offline-navigation-fallback.html`,
         href: `/docs/_next/static/${buildId}/_offline-navigation-fallback.html`,
       },
+      serviceWorker: {
+        path: `static/_offline-navigation-service-worker.js`,
+        href: `/docs/_next/static/_offline-navigation-service-worker.js`,
+      },
     })
+  })
+
+  it('registers the pass-through service worker when enabled', async () => {
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    await next.start({ skipBuild: true })
+
+    try {
+      const swResponse = await next.fetch(
+        `/docs/_next/static/_offline-navigation-service-worker.js${next.getDeploymentIdQuery()}`
+      )
+      expect(swResponse.status).toBe(200)
+      expect(swResponse.headers.get('cache-control')).toBe(
+        'no-cache, must-revalidate'
+      )
+      expect(swResponse.headers.get('service-worker-allowed')).toBe('/docs/')
+
+      const browser = await next.browser('/docs')
+      await retry(async () => {
+        const registration = await browser.eval(async () => {
+          if (!('serviceWorker' in navigator)) {
+            return null
+          }
+
+          const registrations = await navigator.serviceWorker.getRegistrations()
+          const registration = registrations.find((registration) =>
+            registration.scope.endsWith('/docs/')
+          )
+
+          if (!registration) {
+            return null
+          }
+
+          return {
+            scope: registration.scope,
+            scriptURL: registration.active?.scriptURL ?? null,
+          }
+        })
+
+        expect(registration).toEqual({
+          scope: `${next.url}/docs/`,
+          scriptURL: `${next.url}/docs/_next/static/_offline-navigation-service-worker.js${next.getDeploymentIdQuery()}`,
+        })
+      })
+
+      await browser.eval(async () => {
+        if (!('serviceWorker' in navigator)) {
+          return
+        }
+
+        const registrations = await navigator.serviceWorker.getRegistrations()
+        await Promise.all(
+          registrations.map((registration) => registration.unregister())
+        )
+      })
+    } finally {
+      await next.stop()
+    }
   })
 
   it('does not emit offline navigation artifacts when disabled', async () => {
@@ -80,9 +162,10 @@ describe('offlineNavigations build artifacts', () => {
     const buildResult = await next.build()
     expect(buildResult.exitCode).toBe(0)
 
-    const { fallbackDocument, manifest } =
+    const { fallbackDocument, manifest, serviceWorker } =
       await getOfflineNavigationArtifactPaths()
     expect(existsSync(fallbackDocument.absolutePath)).toBe(false)
     expect(existsSync(manifest.absolutePath)).toBe(false)
+    expect(existsSync(serviceWorker.absolutePath)).toBe(false)
   })
 })

--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -196,6 +196,30 @@ describe('offlineNavigations build artifacts', () => {
     })
   }
 
+  async function readPersistedOfflineNavigationMetadata(
+    browser: Awaited<ReturnType<typeof next.browser>>,
+    key: string
+  ) {
+    return browser.eval(async (metadataKey) => {
+      const database = await new Promise<IDBDatabase>((resolve, reject) => {
+        const request = indexedDB.open('next-offline-navigation-cache', 3)
+        request.onsuccess = () => resolve(request.result)
+        request.onerror = () => reject(request.error)
+      })
+
+      try {
+        return await new Promise<unknown>((resolve, reject) => {
+          const transaction = database.transaction('metadata', 'readonly')
+          const request = transaction.objectStore('metadata').get(metadataKey)
+          request.onsuccess = () => resolve(request.result)
+          request.onerror = () => reject(request.error)
+        })
+      } finally {
+        database.close()
+      }
+    }, key)
+  }
+
   async function deletePersistedOfflineNavigationSegmentRecords(
     browser: Awaited<ReturnType<typeof next.browser>>,
     options: {
@@ -723,7 +747,7 @@ describe('offlineNavigations build artifacts', () => {
         expect(headRecord).toEqual(
           expect.objectContaining({
             buildId: navigationBuildId,
-            cacheEpoch: 0,
+            cacheEpoch: 1,
             kind: 'segment',
             payload: {
               bodyLength: expect.any(Number),
@@ -746,7 +770,7 @@ describe('offlineNavigations build artifacts', () => {
         expect(pageRecord).toEqual(
           expect.objectContaining({
             buildId: navigationBuildId,
-            cacheEpoch: 0,
+            cacheEpoch: 1,
             kind: 'segment',
             payload: {
               bodyLength: expect.any(Number),
@@ -1151,6 +1175,176 @@ describe('offlineNavigations build artifacts', () => {
         expect(await browser.elementById('prefetched-page').text()).toBe(
           'prefetched page'
         )
+      })
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
+  it('misses persisted router records after router refresh invalidation', async () => {
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    await next.start({ skipBuild: true })
+
+    let page: Playwright.Page | undefined
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await retry(async () => {
+        expect(
+          await browser.eval(() => Boolean(navigator.serviceWorker.controller))
+        ).toBe(true)
+      })
+
+      await browser.elementById('prefetch-offline-navigation').click()
+      await retry(async () => {
+        const routeRecords =
+          await readPersistedOfflineNavigationRouteRecords(browser)
+        expect(
+          routeRecords.some((record) =>
+            record.route.pathname.includes('/prefetched')
+          )
+        ).toBe(true)
+
+        const segmentRecords =
+          await readPersistedOfflineNavigationSegmentRecords(browser)
+        expect(
+          segmentRecords.some(
+            (record) => record.payload.requestKind === 'segment-prefetch'
+          )
+        ).toBe(true)
+        expect(
+          segmentRecords.some(
+            (record) => record.segment.requestKey === '/_head'
+          )
+        ).toBe(true)
+      })
+
+      const deletedExactEntries = await deletePersistedOfflineNavigationEntries(
+        browser,
+        '/docs/prefetched'
+      )
+      expect(deletedExactEntries).toBeGreaterThan(0)
+
+      await page!.context().setOffline(true)
+      const cachedRouterRecordsResponse = await page!.goto(
+        `${next.url}/docs/prefetched`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(cachedRouterRecordsResponse?.status()).toBe(200)
+      await retry(async () => {
+        expect(await browser.elementById('prefetched-page').text()).toBe(
+          'prefetched page'
+        )
+        const diagnostics = await browser.eval(() => {
+          const win = window as typeof window & {
+            __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?: Array<{
+              requestKind?: string
+              type?: string
+              url?: string
+            }>
+          }
+          return win.__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__ ?? []
+        })
+        expect(diagnostics).toContainEqual(
+          expect.objectContaining({
+            requestKind: 'router-cache',
+            type: 'cache-hit',
+            url: `${next.url}/docs/prefetched`,
+          })
+        )
+      })
+
+      await page!.context().setOffline(false)
+      await browser.eval(() => {
+        window.dispatchEvent(new Event('online'))
+      })
+      const onlineRootResponse = await page!.goto(`${next.url}/docs`, {
+        waitUntil: 'domcontentloaded',
+      })
+      expect(onlineRootResponse?.status()).toBe(200)
+      await retry(async () => {
+        expect(await browser.elementByCss('p').text()).toBe(
+          'offline navigations page'
+        )
+      })
+
+      await browser.elementById('refresh-offline-navigation').click()
+      await retry(async () => {
+        expect(
+          await readPersistedOfflineNavigationMetadata(
+            browser,
+            'exact-url-cache-epoch'
+          )
+        ).toBeGreaterThan(0)
+        expect(
+          await readPersistedOfflineNavigationMetadata(
+            browser,
+            'segment-cache-epoch'
+          )
+        ).toBeGreaterThan(0)
+      })
+
+      await page!.context().setOffline(true)
+      const invalidatedRouterRecordsResponse = await page!.goto(
+        `${next.url}/docs/prefetched`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(invalidatedRouterRecordsResponse?.status()).toBe(200)
+      await retry(async () => {
+        const diagnostics = await browser.eval(() => {
+          const win = window as typeof window & {
+            __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?: Array<{
+              reason?: string
+              type?: string
+              url?: string
+            }>
+          }
+          return win.__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__ ?? []
+        })
+        expect(diagnostics).toContainEqual(
+          expect.objectContaining({
+            reason: 'missing-segment',
+            type: 'router-cache-reconstruction-miss',
+            url: `${next.url}/docs/prefetched`,
+          })
+        )
+        expect(diagnostics).toContainEqual(
+          expect.objectContaining({
+            reason: 'missing-entry',
+            type: 'cache-miss',
+            url: `${next.url}/docs/prefetched`,
+          })
+        )
+      })
+      await retry(async () => {
+        expect(
+          await browser.eval(() => {
+            const cacheMiss = document.getElementById(
+              '__NEXT_OFFLINE_NAVIGATION_CACHE_MISS'
+            )
+            return cacheMiss === null
+              ? null
+              : {
+                  hidden: cacheMiss.hidden,
+                  reason: cacheMiss.getAttribute(
+                    'data-next-offline-navigation-cache-reason'
+                  ),
+                  text: cacheMiss.textContent,
+                }
+          })
+        ).toEqual({
+          hidden: false,
+          reason: 'missing-entry',
+          text: 'This page is not available offline.',
+        })
       })
     } finally {
       if (page) {

--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -2,44 +2,77 @@ import { existsSync } from 'fs'
 import { join } from 'path'
 import { nextTestSetup } from 'e2e-utils'
 
-describe('offlineNavigations fallback document', () => {
+describe('offlineNavigations build artifacts', () => {
   const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,
   })
 
-  async function getFallbackDocumentPath() {
+  async function getOfflineNavigationArtifactPaths() {
     const buildId = (await next.readFile('.next/BUILD_ID')).trim()
 
     return {
       buildId,
-      absolutePath: join(
-        next.testDir,
-        '.next',
-        'static',
-        buildId,
-        '_offline-navigation-fallback.html'
-      ),
-      relativePath: `.next/static/${buildId}/_offline-navigation-fallback.html`,
+      fallbackDocument: {
+        absolutePath: join(
+          next.testDir,
+          '.next',
+          'static',
+          buildId,
+          '_offline-navigation-fallback.html'
+        ),
+        relativePath: `.next/static/${buildId}/_offline-navigation-fallback.html`,
+      },
+      manifest: {
+        absolutePath: join(
+          next.testDir,
+          '.next',
+          'static',
+          buildId,
+          '_offline-navigation-manifest.json'
+        ),
+        relativePath: `.next/static/${buildId}/_offline-navigation-manifest.json`,
+      },
     }
   }
 
-  it('emits a request-invariant fallback document when enabled', async () => {
+  it('emits request-invariant offline navigation artifacts when enabled', async () => {
     const buildResult = await next.build()
     expect(buildResult.exitCode).toBe(0)
 
-    const { buildId, relativePath } = await getFallbackDocumentPath()
-    const html = await next.readFile(relativePath)
+    const { buildId, fallbackDocument, manifest } =
+      await getOfflineNavigationArtifactPaths()
+    const html = await next.readFile(fallbackDocument.relativePath)
+    const manifestJson = JSON.parse(await next.readFile(manifest.relativePath))
 
     expect(html).toContain('data-next-offline-navigation-fallback')
     expect(html).toContain('id="__NEXT_OFFLINE_NAVIGATION_FALLBACK"')
     expect(html).toContain(`"buildId":"${buildId}"`)
     expect(html).toContain('self.__next_f')
-    expect(html).toContain('/_next/static/')
+    expect(html).toContain('https://cdn.example.com/app-assets/_next/static/')
     expect(html).not.toContain('offline navigations page')
+
+    expect(manifestJson).toEqual({
+      version: 1,
+      buildId,
+      basePath: '/docs',
+      assetPrefix: 'https://cdn.example.com/app-assets',
+      trailingSlash: true,
+      output: 'default',
+      scope: '/docs/',
+      cacheNamespace: `next-offline-navigation-v1:${buildId}:/docs`,
+      manifest: {
+        path: `static/${buildId}/_offline-navigation-manifest.json`,
+        href: `/docs/_next/static/${buildId}/_offline-navigation-manifest.json`,
+      },
+      fallbackDocument: {
+        path: `static/${buildId}/_offline-navigation-fallback.html`,
+        href: `/docs/_next/static/${buildId}/_offline-navigation-fallback.html`,
+      },
+    })
   })
 
-  it('does not emit a fallback document when disabled', async () => {
+  it('does not emit offline navigation artifacts when disabled', async () => {
     await next.patchFile('next.config.js', (content) =>
       content.replace('offlineNavigations: true', 'offlineNavigations: false')
     )
@@ -47,7 +80,9 @@ describe('offlineNavigations fallback document', () => {
     const buildResult = await next.build()
     expect(buildResult.exitCode).toBe(0)
 
-    const { absolutePath } = await getFallbackDocumentPath()
-    expect(existsSync(absolutePath)).toBe(false)
+    const { fallbackDocument, manifest } =
+      await getOfflineNavigationArtifactPaths()
+    expect(existsSync(fallbackDocument.absolutePath)).toBe(false)
+    expect(existsSync(manifest.absolutePath)).toBe(false)
   })
 })

--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -6,6 +6,11 @@ import type * as Playwright from 'playwright'
 
 const OFFLINE_NAVIGATION_FALLBACK_SERVED =
   'next-offline-navigation-fallback-served'
+// cachedNavigations changes the runtime cache shape in ways the durable offline
+// replay format does not model yet. Keep artifact and service worker coverage
+// in that CI mode, but leave replay behavior to standard cache-components runs.
+const shouldSkipReplayWithCachedNavigations =
+  process.env.__NEXT_EXPERIMENTAL_CACHED_NAVIGATIONS === 'true'
 
 describe('offlineNavigations build artifacts', () => {
   const { next } = nextTestSetup({
@@ -396,6 +401,54 @@ describe('offlineNavigations build artifacts', () => {
     })
   }
 
+  async function waitForOfflineNavigationServiceWorker(
+    browser: Awaited<ReturnType<typeof next.browser>>,
+    page: Playwright.Page
+  ) {
+    await retry(
+      async () => {
+        const state = await browser.eval(async () => {
+          if (!('serviceWorker' in navigator)) {
+            return {
+              controlled: false,
+              hasActiveRegistration: false,
+            }
+          }
+
+          const registrations = await navigator.serviceWorker.getRegistrations()
+          return {
+            controlled: Boolean(navigator.serviceWorker.controller),
+            hasActiveRegistration: registrations.some(
+              (registration) =>
+                registration.scope.endsWith('/docs/') &&
+                registration.active !== null
+            ),
+          }
+        })
+
+        expect(state.hasActiveRegistration).toBe(true)
+      },
+      10000,
+      500
+    )
+
+    if (
+      !(await browser.eval(() => Boolean(navigator.serviceWorker.controller)))
+    ) {
+      await page.reload({ waitUntil: 'domcontentloaded' })
+    }
+
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(() => Boolean(navigator.serviceWorker.controller))
+        ).toBe(true)
+      },
+      10000,
+      500
+    )
+  }
+
   it('emits request-invariant offline navigation artifacts when enabled', async () => {
     const buildResult = await next.build()
     expect(buildResult.exitCode).toBe(0)
@@ -509,11 +562,7 @@ describe('offlineNavigations build artifacts', () => {
           scriptURL: `${next.url}/docs/_next/static/_offline-navigation-service-worker.js${next.getDeploymentIdQuery()}`,
         })
       })
-      await retry(async () => {
-        expect(
-          await browser.eval(() => Boolean(navigator.serviceWorker.controller))
-        ).toBe(true)
-      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
       expect(await browser.elementById('offline-status').text()).toBe('online')
 
       await browser.eval((messageType) => {
@@ -1074,6 +1123,10 @@ describe('offlineNavigations build artifacts', () => {
   })
 
   it('reconstructs a fully prefetched route from persisted router records', async () => {
+    if (shouldSkipReplayWithCachedNavigations) {
+      return
+    }
+
     const buildResult = await next.build()
     expect(buildResult.exitCode).toBe(0)
 
@@ -1086,11 +1139,7 @@ describe('offlineNavigations build artifacts', () => {
           page = p
         },
       })
-      await retry(async () => {
-        expect(
-          await browser.eval(() => Boolean(navigator.serviceWorker.controller))
-        ).toBe(true)
-      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
 
       await browser.elementById('prefetch-offline-navigation').click()
       await retry(async () => {
@@ -1185,6 +1234,10 @@ describe('offlineNavigations build artifacts', () => {
   })
 
   it('misses persisted router records after router refresh invalidation', async () => {
+    if (shouldSkipReplayWithCachedNavigations) {
+      return
+    }
+
     const buildResult = await next.build()
     expect(buildResult.exitCode).toBe(0)
 
@@ -1197,11 +1250,7 @@ describe('offlineNavigations build artifacts', () => {
           page = p
         },
       })
-      await retry(async () => {
-        expect(
-          await browser.eval(() => Boolean(navigator.serviceWorker.controller))
-        ).toBe(true)
-      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
 
       await browser.elementById('prefetch-offline-navigation').click()
       await retry(async () => {
@@ -1355,6 +1404,10 @@ describe('offlineNavigations build artifacts', () => {
   })
 
   it('replays a dynamic route from persisted known route patterns', async () => {
+    if (shouldSkipReplayWithCachedNavigations) {
+      return
+    }
+
     const buildResult = await next.build()
     expect(buildResult.exitCode).toBe(0)
 
@@ -1367,11 +1420,7 @@ describe('offlineNavigations build artifacts', () => {
           page = p
         },
       })
-      await retry(async () => {
-        expect(
-          await browser.eval(() => Boolean(navigator.serviceWorker.controller))
-        ).toBe(true)
-      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
 
       await prefetchDynamicPatternReplayData(browser)
 
@@ -1428,11 +1477,7 @@ describe('offlineNavigations build artifacts', () => {
           page = p
         },
       })
-      await retry(async () => {
-        expect(
-          await browser.eval(() => Boolean(navigator.serviceWorker.controller))
-        ).toBe(true)
-      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
 
       await prefetchDynamicPatternReplayData(browser)
 
@@ -1518,6 +1563,10 @@ describe('offlineNavigations build artifacts', () => {
   })
 
   it('replays request-sensitive exact URLs from browser-private storage', async () => {
+    if (shouldSkipReplayWithCachedNavigations) {
+      return
+    }
+
     const buildResult = await next.build()
     expect(buildResult.exitCode).toBe(0)
 
@@ -1532,11 +1581,7 @@ describe('offlineNavigations build artifacts', () => {
           page = p
         },
       })
-      await retry(async () => {
-        expect(
-          await browser.eval(() => Boolean(navigator.serviceWorker.controller))
-        ).toBe(true)
-      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
 
       await browser.eval(() => {
         document.cookie = 'offline-session=alpha; path=/; SameSite=Lax'
@@ -1615,6 +1660,10 @@ describe('offlineNavigations build artifacts', () => {
   })
 
   it('covers exact URL shape and pass-through stress cases', async () => {
+    if (shouldSkipReplayWithCachedNavigations) {
+      return
+    }
+
     const buildResult = await next.build()
     expect(buildResult.exitCode).toBe(0)
 
@@ -1629,11 +1678,7 @@ describe('offlineNavigations build artifacts', () => {
           page = p
         },
       })
-      await retry(async () => {
-        expect(
-          await browser.eval(() => Boolean(navigator.serviceWorker.controller))
-        ).toBe(true)
-      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
 
       const notFoundResponse = await page!.goto(
         `${next.url}/docs/missing-offline-navigation-route/`,

--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -453,9 +453,13 @@ describe('offlineNavigations build artifacts', () => {
       expect(
         await browser.eval(() => {
           const win = window as typeof window & {
-            __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?: Array<unknown>
+            __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?: Array<{
+              type?: string
+            }>
           }
-          return win.__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?.at(-1)
+          return win.__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?.find(
+            (diagnostic) => diagnostic.type === 'cache-hit'
+          )
         })
       ).toMatchObject({
         type: 'cache-hit',
@@ -623,14 +627,47 @@ describe('offlineNavigations build artifacts', () => {
       expect(
         await browser.eval(() => {
           const win = window as typeof window & {
-            __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?: Array<unknown>
+            __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?: Array<{
+              type?: string
+            }>
           }
-          return win.__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?.at(-1)
+          return win.__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?.find(
+            (diagnostic) => diagnostic.type === 'cache-hit'
+          )
         })
       ).toMatchObject({
         type: 'cache-hit',
         requestKind: 'client-resume',
         url: `${next.url}/docs/prefetched`,
+      })
+      await retry(async () => {
+        const hydrationDiagnostic = await browser.eval(() => {
+          const win = window as typeof window & {
+            __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?: Array<{
+              type?: string
+              routes?: { hydrated: number; skipped: number }
+              segments?: { hydrated: number; skipped: number }
+            }>
+          }
+          return win.__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__
+            ?.filter(
+              (diagnostic) => diagnostic.type === 'router-cache-hydration'
+            )
+            .at(-1)
+        })
+        expect(hydrationDiagnostic).toMatchObject({
+          type: 'router-cache-hydration',
+          routes: {
+            hydrated: expect.any(Number),
+            skipped: 0,
+          },
+          segments: {
+            hydrated: expect.any(Number),
+            skipped: 0,
+          },
+        })
+        expect(hydrationDiagnostic!.routes!.hydrated).toBeGreaterThan(0)
+        expect(hydrationDiagnostic!.segments!.hydrated).toBeGreaterThan(0)
       })
       const cachedServiceWorkerMessage = await browser.eval(() => {
         const message = localStorage.getItem('__nextOfflineNavigationMessage')

--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -118,6 +118,43 @@ describe('offlineNavigations build artifacts', () => {
     }, urlSubstring)
   }
 
+  async function readPersistedOfflineNavigationRouteRecords(
+    browser: Awaited<ReturnType<typeof next.browser>>
+  ) {
+    return browser.eval(async () => {
+      const database = await new Promise<IDBDatabase>((resolve, reject) => {
+        const request = indexedDB.open('next-offline-navigation-cache', 3)
+        request.onsuccess = () => resolve(request.result)
+        request.onerror = () => reject(request.error)
+      })
+
+      try {
+        const entries = await new Promise<any[]>((resolve, reject) => {
+          const transaction = database.transaction('route-data', 'readonly')
+          const request = transaction.objectStore('route-data').getAll()
+          request.onsuccess = () => resolve(request.result)
+          request.onerror = () => reject(request.error)
+        })
+
+        return entries.map((entry) => ({
+          buildId: entry.buildId,
+          cacheEpoch: entry.cacheEpoch,
+          expiresAt: entry.expiresAt,
+          hasMetadata: entry.metadata !== null,
+          hasTree: entry.tree !== null,
+          key: entry.key,
+          kind: entry.kind,
+          route: entry.route,
+          routeVaryPath: entry.routeVaryPath,
+          staleAt: entry.staleAt,
+          version: entry.version,
+        }))
+      } finally {
+        database.close()
+      }
+    })
+  }
+
   async function cleanupOfflineNavigationState(
     browser: Awaited<ReturnType<typeof next.browser>>
   ) {
@@ -452,6 +489,27 @@ describe('offlineNavigations build artifacts', () => {
           version: 2,
         })
         expect(persistedEntry!.payload.bodyLength).toBeGreaterThan(0)
+      })
+      await retry(async () => {
+        const routeRecords =
+          await readPersistedOfflineNavigationRouteRecords(browser)
+        const prefetchedRouteRecord = routeRecords.find((record) =>
+          record.route.pathname.includes('/prefetched')
+        )
+        expect(prefetchedRouteRecord).toEqual(
+          expect.objectContaining({
+            buildId: navigationBuildId,
+            cacheEpoch: 0,
+            hasMetadata: true,
+            hasTree: true,
+            kind: 'route',
+            route: expect.objectContaining({
+              supportsPerSegmentPrefetching: true,
+            }),
+            routeVaryPath: expect.any(Array),
+            version: 1,
+          })
+        )
       })
 
       await page!.context().setOffline(true)

--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -155,6 +155,47 @@ describe('offlineNavigations build artifacts', () => {
     })
   }
 
+  async function readPersistedOfflineNavigationSegmentRecords(
+    browser: Awaited<ReturnType<typeof next.browser>>
+  ) {
+    return browser.eval(async () => {
+      const database = await new Promise<IDBDatabase>((resolve, reject) => {
+        const request = indexedDB.open('next-offline-navigation-cache', 3)
+        request.onsuccess = () => resolve(request.result)
+        request.onerror = () => reject(request.error)
+      })
+
+      try {
+        const entries = await new Promise<any[]>((resolve, reject) => {
+          const transaction = database.transaction('segment-data', 'readonly')
+          const request = transaction.objectStore('segment-data').getAll()
+          request.onsuccess = () => resolve(request.result)
+          request.onerror = () => reject(request.error)
+        })
+
+        return entries.map((entry) => ({
+          buildId: entry.buildId,
+          cacheEpoch: entry.cacheEpoch,
+          expiresAt: entry.expiresAt,
+          key: entry.key,
+          kind: entry.kind,
+          payload: {
+            bodyLength: entry.payload?.body?.byteLength,
+            kind: entry.payload?.kind,
+            requestKind: entry.payload?.requestKind,
+            status: entry.payload?.status,
+          },
+          segment: entry.segment,
+          segmentVaryPath: entry.segmentVaryPath,
+          staleAt: entry.staleAt,
+          version: entry.version,
+        }))
+      } finally {
+        database.close()
+      }
+    })
+  }
+
   async function cleanupOfflineNavigationState(
     browser: Awaited<ReturnType<typeof next.browser>>
   ) {
@@ -510,6 +551,61 @@ describe('offlineNavigations build artifacts', () => {
             version: 1,
           })
         )
+      })
+      await retry(async () => {
+        const segmentRecords =
+          await readPersistedOfflineNavigationSegmentRecords(browser)
+        const headRecord = segmentRecords.find(
+          (record) => record.segment.requestKey === '/_head'
+        )
+        const pageRecord = segmentRecords.find(
+          (record) =>
+            record.segment.requestKey !== '/_head' &&
+            record.payload.requestKind === 'segment-prefetch'
+        )
+
+        expect(headRecord).toEqual(
+          expect.objectContaining({
+            buildId: navigationBuildId,
+            cacheEpoch: 0,
+            kind: 'segment',
+            payload: {
+              bodyLength: expect.any(Number),
+              kind: 'rsc-response',
+              requestKind: 'segment-prefetch',
+              status: 200,
+            },
+            segment: expect.objectContaining({
+              fetchStrategy: expect.any(Number),
+              isPartial: expect.any(Boolean),
+              payloadIndex: expect.any(Number),
+              requestKey: '/_head',
+            }),
+            segmentVaryPath: expect.any(Array),
+            version: 1,
+          })
+        )
+        expect(headRecord!.payload.bodyLength).toBeGreaterThan(0)
+
+        expect(pageRecord).toEqual(
+          expect.objectContaining({
+            buildId: navigationBuildId,
+            cacheEpoch: 0,
+            kind: 'segment',
+            payload: {
+              bodyLength: expect.any(Number),
+              kind: 'rsc-response',
+              requestKind: 'segment-prefetch',
+              status: 200,
+            },
+            segment: expect.objectContaining({
+              payloadIndex: expect.any(Number),
+            }),
+            segmentVaryPath: expect.any(Array),
+            version: 1,
+          })
+        )
+        expect(pageRecord!.payload.bodyLength).toBeGreaterThan(0)
       })
 
       await page!.context().setOffline(true)

--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -1054,6 +1054,114 @@ describe('offlineNavigations build artifacts', () => {
     }
   })
 
+  it('replays a dynamic route from persisted known route patterns', async () => {
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    await next.start({ skipBuild: true })
+
+    let page: Playwright.Page | undefined
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await retry(async () => {
+        expect(
+          await browser.eval(() => Boolean(navigator.serviceWorker.controller))
+        ).toBe(true)
+      })
+
+      await browser.elementById('prefetch-dynamic-pattern-source').click()
+      await retry(async () => {
+        const routeRecords =
+          await readPersistedOfflineNavigationRouteRecords(browser)
+        expect(
+          routeRecords.some((record) =>
+            record.route.pathname.includes('/dynamic-prefetch/learned')
+          )
+        ).toBe(true)
+      })
+
+      await browser.elementById('prefetch-dynamic-pattern-target').click()
+      await retry(async () => {
+        const exactEntry = await readPersistedOfflineNavigationEntry(
+          browser,
+          '/docs/dynamic-prefetch/replayed'
+        )
+        expect(exactEntry).toBe(null)
+
+        const routeRecords =
+          await readPersistedOfflineNavigationRouteRecords(browser)
+        expect(
+          routeRecords.some((record) =>
+            record.route.pathname.includes('/dynamic-prefetch/replayed')
+          )
+        ).toBe(false)
+
+        const segmentRecords =
+          await readPersistedOfflineNavigationSegmentRecords(browser)
+        const replayedSegmentRecords = segmentRecords.filter((record) =>
+          record.key.includes('replayed')
+        )
+        expect(
+          segmentRecords.some(
+            (record) => record.payload.requestKind === 'segment-prefetch'
+          )
+        ).toBe(true)
+        expect(
+          replayedSegmentRecords.some((record) =>
+            record.segment.requestKey.endsWith('/__PAGE__')
+          )
+        ).toBe(true)
+        expect(
+          replayedSegmentRecords.some(
+            (record) => record.segment.requestKey === '/_head'
+          )
+        ).toBe(true)
+      })
+
+      await next.stop()
+      await page!.context().setOffline(true)
+      const dynamicReplayResponse = await page!.goto(
+        `${next.url}/docs/dynamic-prefetch/replayed#restored`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(dynamicReplayResponse?.status()).toBe(200)
+      await retry(async () => {
+        const routerCacheDiagnostics = await browser.eval(() => {
+          const win = window as typeof window & {
+            __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?: Array<{
+              type?: string
+              requestKind?: string
+              url?: string
+              reason?: string
+            }>
+          }
+          return win.__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__ ?? []
+        })
+        expect(routerCacheDiagnostics).toContainEqual(
+          expect.objectContaining({
+            type: 'cache-hit',
+            requestKind: 'router-cache',
+            url: `${next.url}/docs/dynamic-prefetch/replayed#restored`,
+          })
+        )
+      })
+      await retry(async () => {
+        expect(await browser.elementById('dynamic-prefetch-page').text()).toBe(
+          'dynamic prefetch path: replayed'
+        )
+      })
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
   it('replays request-sensitive exact URLs from browser-private storage', async () => {
     const buildResult = await next.build()
     expect(buildResult.exitCode).toBe(0)

--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -1,0 +1,53 @@
+import { existsSync } from 'fs'
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+
+describe('offlineNavigations fallback document', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    skipStart: true,
+  })
+
+  async function getFallbackDocumentPath() {
+    const buildId = (await next.readFile('.next/BUILD_ID')).trim()
+
+    return {
+      buildId,
+      absolutePath: join(
+        next.testDir,
+        '.next',
+        'static',
+        buildId,
+        '_offline-navigation-fallback.html'
+      ),
+      relativePath: `.next/static/${buildId}/_offline-navigation-fallback.html`,
+    }
+  }
+
+  it('emits a request-invariant fallback document when enabled', async () => {
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    const { buildId, relativePath } = await getFallbackDocumentPath()
+    const html = await next.readFile(relativePath)
+
+    expect(html).toContain('data-next-offline-navigation-fallback')
+    expect(html).toContain('id="__NEXT_OFFLINE_NAVIGATION_FALLBACK"')
+    expect(html).toContain(`"buildId":"${buildId}"`)
+    expect(html).toContain('self.__next_f')
+    expect(html).toContain('/_next/static/')
+    expect(html).not.toContain('offline navigations page')
+  })
+
+  it('does not emit a fallback document when disabled', async () => {
+    await next.patchFile('next.config.js', (content) =>
+      content.replace('offlineNavigations: true', 'offlineNavigations: false')
+    )
+
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    const { absolutePath } = await getFallbackDocumentPath()
+    expect(existsSync(absolutePath)).toBe(false)
+  })
+})

--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -114,6 +114,7 @@ describe('offlineNavigations build artifacts', () => {
     expect(buildResult.exitCode).toBe(0)
 
     const { buildId } = await getOfflineNavigationArtifactPaths()
+    const navigationBuildId = next.deploymentId ?? buildId
     await next.start({ skipBuild: true })
 
     let page: Playwright.Page | undefined
@@ -252,6 +253,77 @@ describe('offlineNavigations build artifacts', () => {
           },
         ])
       )
+
+      await browser.elementById('prefetch-offline-navigation').click()
+      await retry(async () => {
+        const persistedEntry = await browser.eval(async () => {
+          const database = await new Promise<IDBDatabase>((resolve, reject) => {
+            const request = indexedDB.open('next-offline-navigation-cache', 1)
+            request.onupgradeneeded = () => {
+              const database = request.result
+              if (!database.objectStoreNames.contains('navigation-data')) {
+                database.createObjectStore('navigation-data', {
+                  keyPath: ['buildId', 'url'],
+                })
+              }
+            }
+            request.onsuccess = () => resolve(request.result)
+            request.onerror = () => reject(request.error)
+          })
+
+          try {
+            const entries = await new Promise<any[]>((resolve, reject) => {
+              const transaction = database.transaction(
+                'navigation-data',
+                'readonly'
+              )
+              const request = transaction
+                .objectStore('navigation-data')
+                .getAll()
+              request.onsuccess = () => resolve(request.result)
+              request.onerror = () => reject(request.error)
+            })
+            const entry = entries.find((entry) =>
+              entry.url.includes('/docs/prefetched')
+            )
+            if (!entry) {
+              return null
+            }
+
+            return {
+              buildId: entry.buildId,
+              expiresAt: entry.expiresAt,
+              kind: entry.kind,
+              payload: {
+                bodyLength: entry.payload.body.byteLength,
+                kind: entry.payload.kind,
+                requestKind: entry.payload.requestKind,
+                status: entry.payload.status,
+              },
+              staleAt: entry.staleAt,
+              url: entry.url,
+              version: entry.version,
+            }
+          } finally {
+            database.close()
+          }
+        })
+        expect(persistedEntry).toEqual({
+          buildId: navigationBuildId,
+          expiresAt: expect.any(Number),
+          kind: 'exact-url',
+          payload: {
+            bodyLength: expect.any(Number),
+            kind: 'rsc-response',
+            requestKind: 'client-resume',
+            status: 200,
+          },
+          staleAt: expect.any(Number),
+          url: expect.stringContaining('/docs/prefetched'),
+          version: 1,
+        })
+        expect(persistedEntry!.payload.bodyLength).toBeGreaterThan(0)
+      })
 
       await page!.context().setOffline(true)
       const nonNavigationResult = await browser.eval(async () => {

--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -1579,6 +1579,185 @@ describe('offlineNavigations build artifacts', () => {
     }
   })
 
+  it('misses persisted router records after redirecting server action invalidation', async () => {
+    if (shouldSkipReplayWithCachedNavigations) {
+      return
+    }
+
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    await next.start({ skipBuild: true })
+
+    let page: Playwright.Page | undefined
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
+
+      await browser.elementById('prefetch-offline-navigation').click()
+      await retry(async () => {
+        const routeRecords =
+          await readPersistedOfflineNavigationRouteRecords(browser)
+        expect(
+          routeRecords.some((record) =>
+            record.route.pathname.includes('/prefetched')
+          )
+        ).toBe(true)
+
+        const segmentRecords =
+          await readPersistedOfflineNavigationSegmentRecords(browser)
+        expect(
+          segmentRecords.some(
+            (record) => record.payload.requestKind === 'segment-prefetch'
+          )
+        ).toBe(true)
+        expect(
+          segmentRecords.some(
+            (record) => record.segment.requestKey === '/_head'
+          )
+        ).toBe(true)
+      })
+
+      const deletedExactEntries = await deletePersistedOfflineNavigationEntries(
+        browser,
+        '/docs/prefetched'
+      )
+      expect(deletedExactEntries).toBeGreaterThan(0)
+
+      await page!.context().setOffline(true)
+      const cachedRouterRecordsResponse = await page!.goto(
+        `${next.url}/docs/prefetched`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(cachedRouterRecordsResponse?.status()).toBe(200)
+      await retry(async () => {
+        expect(await browser.elementById('prefetched-page').text()).toBe(
+          'prefetched page'
+        )
+        const diagnostics = await browser.eval(() => {
+          const win = window as typeof window & {
+            __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?: Array<{
+              requestKind?: string
+              type?: string
+              url?: string
+            }>
+          }
+          return win.__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__ ?? []
+        })
+        expect(diagnostics).toContainEqual(
+          expect.objectContaining({
+            requestKind: 'router-cache',
+            type: 'cache-hit',
+            url: `${next.url}/docs/prefetched`,
+          })
+        )
+      })
+
+      await page!.context().setOffline(false)
+      await browser.eval(() => {
+        window.dispatchEvent(new Event('online'))
+      })
+      const onlineRootResponse = await page!.goto(`${next.url}/docs`, {
+        waitUntil: 'domcontentloaded',
+      })
+      expect(onlineRootResponse?.status()).toBe(200)
+      await retry(async () => {
+        expect(
+          await browser.elementById('action-invalidation-marker').text()
+        ).toBe('action invalidation marker')
+      })
+
+      await browser
+        .elementById('redirect-after-offline-navigation-invalidation')
+        .click()
+      await retry(async () => {
+        expect(page!.url()).toContain('offline-navigation-redirect=1')
+        expect(
+          await readPersistedOfflineNavigationMetadata(
+            browser,
+            'exact-url-cache-epoch'
+          )
+        ).toBeGreaterThan(0)
+        expect(
+          await readPersistedOfflineNavigationMetadata(
+            browser,
+            'route-cache-epoch'
+          )
+        ).toBeGreaterThan(0)
+        expect(
+          await readPersistedOfflineNavigationMetadata(
+            browser,
+            'segment-cache-epoch'
+          )
+        ).toBeGreaterThan(0)
+      })
+
+      await page!.context().setOffline(true)
+      const invalidatedRouterRecordsResponse = await page!.goto(
+        `${next.url}/docs/prefetched`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(invalidatedRouterRecordsResponse?.status()).toBe(200)
+      await retry(async () => {
+        const diagnostics = await browser.eval(() => {
+          const win = window as typeof window & {
+            __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?: Array<{
+              reason?: string
+              type?: string
+              url?: string
+            }>
+          }
+          return win.__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__ ?? []
+        })
+        expect(diagnostics).toContainEqual(
+          expect.objectContaining({
+            reason: 'missing-route',
+            type: 'router-cache-reconstruction-miss',
+            url: `${next.url}/docs/prefetched`,
+          })
+        )
+        expect(diagnostics).toContainEqual(
+          expect.objectContaining({
+            reason: 'missing-entry',
+            type: 'cache-miss',
+            url: `${next.url}/docs/prefetched`,
+          })
+        )
+      })
+      await retry(async () => {
+        expect(
+          await browser.eval(() => {
+            const cacheMiss = document.getElementById(
+              '__NEXT_OFFLINE_NAVIGATION_CACHE_MISS'
+            )
+            return cacheMiss === null
+              ? null
+              : {
+                  hidden: cacheMiss.hidden,
+                  reason: cacheMiss.getAttribute(
+                    'data-next-offline-navigation-cache-reason'
+                  ),
+                  text: cacheMiss.textContent,
+                }
+          })
+        ).toEqual({
+          hidden: false,
+          reason: 'missing-entry',
+          text: 'This page is not available offline.',
+        })
+      })
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
   it('replays a dynamic route from persisted known route patterns', async () => {
     if (shouldSkipReplayWithCachedNavigations) {
       return

--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -4,6 +4,9 @@ import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 import type * as Playwright from 'playwright'
 
+const OFFLINE_NAVIGATION_FALLBACK_SERVED =
+  'next-offline-navigation-fallback-served'
+
 describe('offlineNavigations build artifacts', () => {
   const { next } = nextTestSetup({
     files: __dirname,
@@ -76,6 +79,7 @@ describe('offlineNavigations build artifacts', () => {
     )
     expect(serviceWorkerScript).toContain('cacheOfflineNavigationResources')
     expect(serviceWorkerScript).toContain('caches.delete')
+    expect(serviceWorkerScript).toContain(OFFLINE_NAVIGATION_FALLBACK_SERVED)
     expect(serviceWorkerScript).toContain('isDocumentNavigationRequest')
     expect(serviceWorkerScript).toContain('skipWaiting')
     expect(serviceWorkerScript).toContain('clients.claim')
@@ -159,6 +163,59 @@ describe('offlineNavigations build artifacts', () => {
           await browser.eval(() => Boolean(navigator.serviceWorker.controller))
         ).toBe(true)
       })
+      expect(await browser.elementById('offline-status').text()).toBe('online')
+
+      await browser.eval((messageType) => {
+        const win = window as typeof window & {
+          __restoreOfflineNavigationFetch?: () => void
+        }
+        const originalFetch = window.fetch
+        win.__restoreOfflineNavigationFetch = () => {
+          window.fetch = originalFetch
+          delete win.__restoreOfflineNavigationFetch
+        }
+        window.fetch = async () => {
+          throw new TypeError('offline navigation test')
+        }
+        navigator.serviceWorker.dispatchEvent(
+          new MessageEvent('message', {
+            data: {
+              type: messageType,
+              reason: 'network-error',
+              url: location.href,
+            },
+          })
+        )
+      }, OFFLINE_NAVIGATION_FALLBACK_SERVED)
+      await retry(async () => {
+        expect(await browser.elementById('offline-status').text()).toBe(
+          'offline'
+        )
+      })
+      await browser.eval(() => {
+        const win = window as typeof window & {
+          __restoreOfflineNavigationFetch?: () => void
+        }
+        win.__restoreOfflineNavigationFetch?.()
+        window.dispatchEvent(new Event('online'))
+      })
+      await retry(async () => {
+        expect(await browser.elementById('offline-status').text()).toBe(
+          'online'
+        )
+      })
+
+      await browser.eval((messageType) => {
+        localStorage.removeItem('__nextOfflineNavigationMessage')
+        navigator.serviceWorker.addEventListener('message', (event) => {
+          if (event.data?.type === messageType) {
+            localStorage.setItem(
+              '__nextOfflineNavigationMessage',
+              JSON.stringify(event.data)
+            )
+          }
+        })
+      }, OFFLINE_NAVIGATION_FALLBACK_SERVED)
 
       const cacheState = await browser.eval(async () => {
         const cacheNames = (await caches.keys()).filter((cacheName) =>
@@ -221,6 +278,16 @@ describe('offlineNavigations build artifacts', () => {
           )
         )
       ).toBe(true)
+      const serviceWorkerMessage = await browser.eval(() => {
+        const message = localStorage.getItem('__nextOfflineNavigationMessage')
+        return message === null ? null : JSON.parse(message)
+      })
+      expect(serviceWorkerMessage).toMatchObject({
+        type: OFFLINE_NAVIGATION_FALLBACK_SERVED,
+        buildId,
+        reason: 'network-error',
+        url: `${next.url}/docs/offline-navigation-cache-miss`,
+      })
       await page!.context().setOffline(false)
 
       await browser.eval(async () => {

--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -50,6 +50,60 @@ describe('offlineNavigations build artifacts', () => {
     }
   }
 
+  async function readPersistedOfflineNavigationEntry(
+    browser: Awaited<ReturnType<typeof next.browser>>,
+    urlSubstring: string
+  ) {
+    return browser.eval(async (substring) => {
+      const database = await new Promise<IDBDatabase>((resolve, reject) => {
+        const request = indexedDB.open('next-offline-navigation-cache', 1)
+        request.onupgradeneeded = () => {
+          const database = request.result
+          if (!database.objectStoreNames.contains('navigation-data')) {
+            database.createObjectStore('navigation-data', {
+              keyPath: ['buildId', 'url'],
+            })
+          }
+        }
+        request.onsuccess = () => resolve(request.result)
+        request.onerror = () => reject(request.error)
+      })
+
+      try {
+        const entries = await new Promise<any[]>((resolve, reject) => {
+          const transaction = database.transaction(
+            'navigation-data',
+            'readonly'
+          )
+          const request = transaction.objectStore('navigation-data').getAll()
+          request.onsuccess = () => resolve(request.result)
+          request.onerror = () => reject(request.error)
+        })
+        const entry = entries.find((entry) => entry.url.includes(substring))
+        if (!entry) {
+          return null
+        }
+
+        return {
+          buildId: entry.buildId,
+          expiresAt: entry.expiresAt,
+          kind: entry.kind,
+          payload: {
+            bodyLength: entry.payload.body.byteLength,
+            kind: entry.payload.kind,
+            requestKind: entry.payload.requestKind,
+            status: entry.payload.status,
+          },
+          staleAt: entry.staleAt,
+          url: entry.url,
+          version: entry.version,
+        }
+      } finally {
+        database.close()
+      }
+    }, urlSubstring)
+  }
+
   it('emits request-invariant offline navigation artifacts when enabled', async () => {
     const buildResult = await next.build()
     expect(buildResult.exitCode).toBe(0)
@@ -210,18 +264,6 @@ describe('offlineNavigations build artifacts', () => {
         )
       })
 
-      await browser.eval((messageType) => {
-        localStorage.removeItem('__nextOfflineNavigationMessage')
-        navigator.serviceWorker.addEventListener('message', (event) => {
-          if (event.data?.type === messageType) {
-            localStorage.setItem(
-              '__nextOfflineNavigationMessage',
-              JSON.stringify(event.data)
-            )
-          }
-        })
-      }, OFFLINE_NAVIGATION_FALLBACK_SERVED)
-
       const cacheState = await browser.eval(async () => {
         const cacheNames = (await caches.keys()).filter((cacheName) =>
           cacheName.startsWith('next-offline-navigation-v1:')
@@ -258,60 +300,67 @@ describe('offlineNavigations build artifacts', () => {
         ])
       )
 
-      await browser.elementById('prefetch-offline-navigation').click()
       await retry(async () => {
-        const persistedEntry = await browser.eval(async () => {
-          const database = await new Promise<IDBDatabase>((resolve, reject) => {
-            const request = indexedDB.open('next-offline-navigation-cache', 1)
-            request.onupgradeneeded = () => {
-              const database = request.result
-              if (!database.objectStoreNames.contains('navigation-data')) {
-                database.createObjectStore('navigation-data', {
-                  keyPath: ['buildId', 'url'],
-                })
-              }
-            }
-            request.onsuccess = () => resolve(request.result)
-            request.onerror = () => reject(request.error)
-          })
+        const initialLoadEntry = await readPersistedOfflineNavigationEntry(
+          browser,
+          '/docs/'
+        )
+        expect(initialLoadEntry).toEqual({
+          buildId: navigationBuildId,
+          expiresAt: expect.any(Number),
+          kind: 'exact-url',
+          payload: {
+            bodyLength: expect.any(Number),
+            kind: 'rsc-response',
+            requestKind: 'initial-load',
+            status: 200,
+          },
+          staleAt: expect.any(Number),
+          url: expect.stringContaining('/docs/'),
+          version: 1,
+        })
+        expect(initialLoadEntry!.payload.bodyLength).toBeGreaterThan(0)
+      })
 
-          try {
-            const entries = await new Promise<any[]>((resolve, reject) => {
-              const transaction = database.transaction(
-                'navigation-data',
-                'readonly'
-              )
-              const request = transaction
-                .objectStore('navigation-data')
-                .getAll()
-              request.onsuccess = () => resolve(request.result)
-              request.onerror = () => reject(request.error)
-            })
-            const entry = entries.find((entry) =>
-              entry.url.includes('/docs/prefetched')
+      await page!.context().setOffline(true)
+      const initialLoadOfflineResponse = await page!.goto(`${next.url}/docs/`, {
+        waitUntil: 'domcontentloaded',
+      })
+      expect(initialLoadOfflineResponse?.status()).toBe(200)
+      await retry(async () => {
+        expect(await browser.elementByCss('p').text()).toBe(
+          'offline navigations page'
+        )
+      })
+      expect(await browser.elementById('offline-status').text()).toBe('offline')
+      await page!.context().setOffline(false)
+      await browser.eval(() => {
+        window.dispatchEvent(new Event('online'))
+      })
+      await retry(async () => {
+        expect(await browser.elementById('offline-status').text()).toBe(
+          'online'
+        )
+      })
+
+      await browser.eval((messageType) => {
+        localStorage.removeItem('__nextOfflineNavigationMessage')
+        navigator.serviceWorker.addEventListener('message', (event) => {
+          if (event.data?.type === messageType) {
+            localStorage.setItem(
+              '__nextOfflineNavigationMessage',
+              JSON.stringify(event.data)
             )
-            if (!entry) {
-              return null
-            }
-
-            return {
-              buildId: entry.buildId,
-              expiresAt: entry.expiresAt,
-              kind: entry.kind,
-              payload: {
-                bodyLength: entry.payload.body.byteLength,
-                kind: entry.payload.kind,
-                requestKind: entry.payload.requestKind,
-                status: entry.payload.status,
-              },
-              staleAt: entry.staleAt,
-              url: entry.url,
-              version: entry.version,
-            }
-          } finally {
-            database.close()
           }
         })
+      }, OFFLINE_NAVIGATION_FALLBACK_SERVED)
+
+      await browser.elementById('prefetch-offline-navigation').click()
+      await retry(async () => {
+        const persistedEntry = await readPersistedOfflineNavigationEntry(
+          browser,
+          '/docs/prefetched'
+        )
         expect(persistedEntry).toEqual({
           buildId: navigationBuildId,
           expiresAt: expect.any(Number),

--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -108,6 +108,30 @@ describe('offlineNavigations build artifacts', () => {
     }, urlSubstring)
   }
 
+  async function cleanupOfflineNavigationState(
+    browser: Awaited<ReturnType<typeof next.browser>>
+  ) {
+    await browser.eval(async () => {
+      if (!('serviceWorker' in navigator)) {
+        return
+      }
+
+      const cacheNames = await caches.keys()
+      await Promise.all(
+        cacheNames
+          .filter((cacheName) =>
+            cacheName.startsWith('next-offline-navigation-v1:')
+          )
+          .map((cacheName) => caches.delete(cacheName))
+      )
+
+      const registrations = await navigator.serviceWorker.getRegistrations()
+      await Promise.all(
+        registrations.map((registration) => registration.unregister())
+      )
+    })
+  }
+
   it('emits request-invariant offline navigation artifacts when enabled', async () => {
     const buildResult = await next.build()
     expect(buildResult.exitCode).toBe(0)
@@ -506,6 +530,54 @@ describe('offlineNavigations build artifacts', () => {
         }
       )
 
+      await browser.eval(
+        async ({ buildId: entryBuildId, url }) => {
+          const database = await new Promise<IDBDatabase>((resolve, reject) => {
+            const request = indexedDB.open('next-offline-navigation-cache', 2)
+            request.onsuccess = () => resolve(request.result)
+            request.onerror = () => reject(request.error)
+          })
+
+          try {
+            const transaction = database.transaction(
+              'navigation-data',
+              'readwrite'
+            )
+            transaction.objectStore('navigation-data').put({
+              version: 2,
+              kind: 'exact-url',
+              buildId: entryBuildId,
+              url,
+              cacheEpoch: 1,
+              createdAt: Date.now(),
+              staleAt: Date.now() + 60_000,
+              expiresAt: Date.now() + 60_000,
+              payload: {
+                version: 1,
+                kind: 'rsc-response',
+                requestKind: 'route-prefetch',
+                url,
+                status: 200,
+                statusText: 'OK',
+                headers: [['content-type', 'text/x-component']],
+                body: new TextEncoder().encode('0:["$","payload"]').buffer,
+              },
+            })
+            await new Promise<void>((resolve, reject) => {
+              transaction.oncomplete = () => resolve()
+              transaction.onerror = () => reject(transaction.error)
+              transaction.onabort = () => reject(transaction.error)
+            })
+          } finally {
+            database.close()
+          }
+        },
+        {
+          buildId: navigationBuildId,
+          url: `${next.url}/docs/unsupported-offline-entry/`,
+        }
+      )
+
       await next.stop()
       const malformedResponse = await page!.goto(
         `${next.url}/docs/malformed-offline-entry/`,
@@ -520,6 +592,21 @@ describe('offlineNavigations build artifacts', () => {
             )
           )
         ).toBe('invalid-payload')
+      })
+
+      const unsupportedResponse = await page!.goto(
+        `${next.url}/docs/unsupported-offline-entry/`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(unsupportedResponse?.status()).toBe(200)
+      await retry(async () => {
+        expect(
+          await browser.eval(() =>
+            document.documentElement.getAttribute(
+              'data-next-offline-navigation-cache-reason'
+            )
+          )
+        ).toBe('unsupported-request-kind')
       })
 
       const offlineResponse = await page!.goto(
@@ -698,6 +785,187 @@ describe('offlineNavigations build artifacts', () => {
           registrations.map((registration) => registration.unregister())
         )
       })
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
+  it('covers exact URL shape and pass-through stress cases', async () => {
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    const { buildId } = await getOfflineNavigationArtifactPaths()
+    const navigationBuildId = next.deploymentId ?? buildId
+    await next.start({ skipBuild: true })
+
+    let page: Playwright.Page | undefined
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await retry(async () => {
+        expect(
+          await browser.eval(() => Boolean(navigator.serviceWorker.controller))
+        ).toBe(true)
+      })
+
+      const notFoundResponse = await page!.goto(
+        `${next.url}/docs/missing-offline-navigation-route/`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(notFoundResponse?.status()).toBe(404)
+      expect(
+        await browser.eval(() =>
+          document.documentElement.hasAttribute(
+            'data-next-offline-navigation-fallback'
+          )
+        )
+      ).toBe(false)
+
+      const serverErrorResponse = await page!.goto(
+        `${next.url}/docs/api/server-error`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(serverErrorResponse?.status()).toBe(500)
+      expect(await browser.eval(() => document.body.textContent)).toContain(
+        'offline navigation server error'
+      )
+      expect(
+        await browser.eval(() =>
+          document.documentElement.hasAttribute(
+            'data-next-offline-navigation-fallback'
+          )
+        )
+      ).toBe(false)
+
+      const cachedUrl = `${next.url}/docs/url-stress/space%20value/?token=a%2Bb&tag=one&tag=two#section-1`
+      const onlineResponse = await page!.goto(cachedUrl, {
+        waitUntil: 'domcontentloaded',
+      })
+      expect(onlineResponse?.status()).toBe(200)
+      await retry(async () => {
+        expect(await browser.elementById('url-stress-page').text()).toBe(
+          'url stress path: space%20value'
+        )
+        expect(await browser.elementById('url-stress-token').text()).toBe(
+          'url stress token: a+b'
+        )
+        expect(await browser.elementById('url-stress-tags').text()).toBe(
+          'url stress tags: one,two'
+        )
+        expect(await browser.elementById('url-stress-hash').text()).toBe(
+          'url stress hash: #section-1'
+        )
+      })
+
+      await retry(async () => {
+        const entry = await readPersistedOfflineNavigationEntry(
+          browser,
+          '/docs/url-stress/space%20value/'
+        )
+        expect(entry).toEqual({
+          buildId: navigationBuildId,
+          cacheEpoch: 0,
+          expiresAt: expect.any(Number),
+          kind: 'exact-url',
+          payload: {
+            bodyLength: expect.any(Number),
+            kind: 'rsc-response',
+            requestKind: 'initial-load',
+            status: 200,
+          },
+          staleAt: expect.any(Number),
+          url: `${next.url}/docs/url-stress/space%20value/?token=a%2Bb&tag=one&tag=two`,
+          version: 2,
+        })
+        expect(entry!.payload.bodyLength).toBeGreaterThan(0)
+      })
+
+      const rootResponse = await page!.goto(`${next.url}/docs/`, {
+        waitUntil: 'domcontentloaded',
+      })
+      expect(rootResponse?.status()).toBe(200)
+
+      await next.stop()
+      await page!.context().setOffline(true)
+      const hashVariantResponse = await page!.goto(
+        `${next.url}/docs/url-stress/space%20value/?token=a%2Bb&tag=one&tag=two#section-2`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(hashVariantResponse?.status()).toBe(200)
+      await retry(async () => {
+        expect(await browser.elementById('url-stress-page').text()).toBe(
+          'url stress path: space%20value'
+        )
+        expect(await browser.elementById('url-stress-hash').text()).toBe(
+          'url stress hash: #section-2'
+        )
+      })
+      expect(await browser.elementById('offline-status').text()).toBe('offline')
+
+      const reorderedSearchResponse = await page!.goto(
+        `${next.url}/docs/url-stress/space%20value/?tag=one&tag=two&token=a%2Bb#section-3`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(reorderedSearchResponse?.status()).toBe(200)
+      await retry(async () => {
+        expect(
+          await browser.eval(() =>
+            document.documentElement.getAttribute(
+              'data-next-offline-navigation-cache-reason'
+            )
+          )
+        ).toBe('missing-entry')
+      })
+      expect(
+        await browser.eval(() => {
+          const win = window as typeof window & {
+            __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?: Array<unknown>
+          }
+          return win.__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?.at(-1)
+        })
+      ).toMatchObject({
+        type: 'cache-miss',
+        reason: 'missing-entry',
+        url: `${next.url}/docs/url-stress/space%20value/?tag=one&tag=two&token=a%2Bb#section-3`,
+      })
+
+      const passThroughResults = await browser.eval(async () => {
+        const results: Record<string, string> = {}
+
+        for (const [key, input, init] of [
+          ['rsc', '/docs?__next_offline_probe=1', { headers: { rsc: '1' } }],
+          [
+            'post',
+            '/docs/api/server-error',
+            { method: 'POST', body: 'offline navigation post' },
+          ],
+        ] as const) {
+          try {
+            await fetch(input, init)
+            results[key] = 'resolved'
+          } catch {
+            results[key] = 'rejected'
+          }
+        }
+
+        return results
+      })
+      expect(passThroughResults).toEqual({
+        post: 'rejected',
+        rsc: 'rejected',
+      })
+
+      await page!.context().setOffline(false)
+      await browser.eval(() => {
+        window.dispatchEvent(new Event('online'))
+      })
+      await cleanupOfflineNavigationState(browser)
     } finally {
       if (page) {
         await page.context().setOffline(false)


### PR DESCRIPTION
## Where this sits in the stack

This is PR 3 of 6 in the production-hardening stack for `experimental.offlineNavigations`.

Stack order:

1. #93650, `(1/6) Mirror offline router cache invalidation`
2. #93651, `(2/6) Cover server action offline cache invalidation`
3. This PR, `(3/6) Cover redirecting server action offline invalidation`

The foundation and route-replay stacks already taught the fallback document how to restore a route from persisted cache-components router data. The first two hardening PRs made durable IndexedDB invalidation mirror the live router cache for `router.refresh()` and a non-redirecting server action mutation. This PR covers the redirecting server action branch, where the action invalidates cached data and also drives an App Router redirect.

## What changes

- Adds a test fixture server action that calls `updateTag('offline-navigation-action')` and then `redirect('/?offline-navigation-redirect=1')`.
- Adds production e2e coverage that:
  - prefetches `/docs/prefetched` so route and segment records are persisted
  - deletes the exact URL entry so the first offline reload must come from persisted router records
  - proves offline route/segment replay succeeds before invalidation
  - goes back online and submits the redirecting server action
  - asserts exact URL, route, and segment durable epochs were bumped
  - hard-loads `/docs/prefetched` offline again and asserts route reconstruction now misses with `missing-route`, then falls back to visible cache-miss UI

## What works after this PR

A server action that both revalidates cache-components data and redirects cannot leave stale durable offline navigation records replayable after the redirect path runs.

## What intentionally does not work yet

This does not add new product behavior. It is coverage for an already-intended invalidation invariant.

Still deferred to later hardening slices:

- dedicated `revalidateTag()` and `revalidatePath()` coverage outside the `updateTag()` path
- cookie mutation and app/session scope invalidation coverage
- concurrent write/invalidation race stress
- custom app-provided offline/cache-miss UI
- output-export bridge coverage

## Reviewer focus

The main thing to check is the e2e shape: the test must first prove router-cache replay works with the exact URL entry deleted, then perform the redirecting invalidation online, then prove the same offline hard reload misses because the durable router records were invalidated.

The service worker remains document-survival-only. This PR does not add route matching, RSC parsing, or IndexedDB ownership to the worker.

## Verification

- `NEXT_SKIP_ISOLATE=1 pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "misses persisted router records after redirecting server action invalidation"`
- `pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "misses persisted router records after redirecting server action invalidation"`
- `pnpm test-start-webpack test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "misses persisted router records after redirecting server action invalidation"`
- `NEXT_SKIP_ISOLATE=1 pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `pnpm prettier --with-node-modules --ignore-path .prettierignore --write test/production/app-dir/offline-navigations/app/page.tsx test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `git diff --check`

<!-- NEXT_JS_LLM_PR -->

