### PR TITLE
(4/6) Cover revalidatePath offline invalidation

### DIFF
--- a/test/production/app-dir/offline-navigations/app/page.tsx
+++ b/test/production/app-dir/offline-navigations/app/page.tsx
@@ -1,4 +1,4 @@
-import { cacheLife, cacheTag, updateTag } from 'next/cache'
+import { cacheLife, cacheTag, revalidatePath, updateTag } from 'next/cache'
 import { redirect } from 'next/navigation'
 import { OfflineStatus } from './offline-status'
 import {
@@ -27,6 +27,11 @@ async function redirectAfterOfflineNavigationInvalidationAction() {
   redirect('/?offline-navigation-redirect=1')
 }
 
+async function revalidateOfflineNavigationPathAction() {
+  'use server'
+  revalidatePath('/prefetched')
+}
+
 export default function Page() {
   return (
     <>
@@ -44,6 +49,11 @@ export default function Page() {
           type="submit"
         >
           Redirect after offline navigation invalidation
+        </button>
+      </form>
+      <form action={revalidateOfflineNavigationPathAction}>
+        <button id="revalidate-offline-navigation-path" type="submit">
+          Revalidate offline navigation path
         </button>
       </form>
       <PrefetchButton />

--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -1758,6 +1758,182 @@ describe('offlineNavigations build artifacts', () => {
     }
   })
 
+  it('misses persisted router records after revalidatePath invalidation', async () => {
+    if (shouldSkipReplayWithCachedNavigations) {
+      return
+    }
+
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    await next.start({ skipBuild: true })
+
+    let page: Playwright.Page | undefined
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
+
+      await browser.elementById('prefetch-offline-navigation').click()
+      await retry(async () => {
+        const routeRecords =
+          await readPersistedOfflineNavigationRouteRecords(browser)
+        expect(
+          routeRecords.some((record) =>
+            record.route.pathname.includes('/prefetched')
+          )
+        ).toBe(true)
+
+        const segmentRecords =
+          await readPersistedOfflineNavigationSegmentRecords(browser)
+        expect(
+          segmentRecords.some(
+            (record) => record.payload.requestKind === 'segment-prefetch'
+          )
+        ).toBe(true)
+        expect(
+          segmentRecords.some(
+            (record) => record.segment.requestKey === '/_head'
+          )
+        ).toBe(true)
+      })
+
+      const deletedExactEntries = await deletePersistedOfflineNavigationEntries(
+        browser,
+        '/docs/prefetched'
+      )
+      expect(deletedExactEntries).toBeGreaterThan(0)
+
+      await page!.context().setOffline(true)
+      const cachedRouterRecordsResponse = await page!.goto(
+        `${next.url}/docs/prefetched`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(cachedRouterRecordsResponse?.status()).toBe(200)
+      await retry(async () => {
+        expect(await browser.elementById('prefetched-page').text()).toBe(
+          'prefetched page'
+        )
+        const diagnostics = await browser.eval(() => {
+          const win = window as typeof window & {
+            __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?: Array<{
+              requestKind?: string
+              type?: string
+              url?: string
+            }>
+          }
+          return win.__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__ ?? []
+        })
+        expect(diagnostics).toContainEqual(
+          expect.objectContaining({
+            requestKind: 'router-cache',
+            type: 'cache-hit',
+            url: `${next.url}/docs/prefetched`,
+          })
+        )
+      })
+
+      await page!.context().setOffline(false)
+      await browser.eval(() => {
+        window.dispatchEvent(new Event('online'))
+      })
+      const onlineRootResponse = await page!.goto(`${next.url}/docs`, {
+        waitUntil: 'domcontentloaded',
+      })
+      expect(onlineRootResponse?.status()).toBe(200)
+      await retry(async () => {
+        expect(
+          await browser.elementById('action-invalidation-marker').text()
+        ).toBe('action invalidation marker')
+      })
+
+      await browser.elementById('revalidate-offline-navigation-path').click()
+      await retry(async () => {
+        expect(
+          await readPersistedOfflineNavigationMetadata(
+            browser,
+            'exact-url-cache-epoch'
+          )
+        ).toBeGreaterThan(0)
+        expect(
+          await readPersistedOfflineNavigationMetadata(
+            browser,
+            'route-cache-epoch'
+          )
+        ).toBeGreaterThan(0)
+        expect(
+          await readPersistedOfflineNavigationMetadata(
+            browser,
+            'segment-cache-epoch'
+          )
+        ).toBeGreaterThan(0)
+      })
+
+      await page!.context().setOffline(true)
+      const invalidatedRouterRecordsResponse = await page!.goto(
+        `${next.url}/docs/prefetched`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(invalidatedRouterRecordsResponse?.status()).toBe(200)
+      await retry(async () => {
+        const diagnostics = await browser.eval(() => {
+          const win = window as typeof window & {
+            __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?: Array<{
+              reason?: string
+              type?: string
+              url?: string
+            }>
+          }
+          return win.__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__ ?? []
+        })
+        expect(diagnostics).toContainEqual(
+          expect.objectContaining({
+            reason: 'missing-route',
+            type: 'router-cache-reconstruction-miss',
+            url: `${next.url}/docs/prefetched`,
+          })
+        )
+        expect(diagnostics).toContainEqual(
+          expect.objectContaining({
+            reason: 'missing-entry',
+            type: 'cache-miss',
+            url: `${next.url}/docs/prefetched`,
+          })
+        )
+      })
+      await retry(async () => {
+        expect(
+          await browser.eval(() => {
+            const cacheMiss = document.getElementById(
+              '__NEXT_OFFLINE_NAVIGATION_CACHE_MISS'
+            )
+            return cacheMiss === null
+              ? null
+              : {
+                  hidden: cacheMiss.hidden,
+                  reason: cacheMiss.getAttribute(
+                    'data-next-offline-navigation-cache-reason'
+                  ),
+                  text: cacheMiss.textContent,
+                }
+          })
+        ).toEqual({
+          hidden: false,
+          reason: 'missing-entry',
+          text: 'This page is not available offline.',
+        })
+      })
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
   it('replays a dynamic route from persisted known route patterns', async () => {
     if (shouldSkipReplayWithCachedNavigations) {
       return


### PR DESCRIPTION
## Where this sits in the stack

This is PR 4 of 6 in the production-hardening stack for `experimental.offlineNavigations`.

Stack order:

1. #93650, `(1/6) Mirror offline router cache invalidation`
2. #93651, `(2/6) Cover server action offline cache invalidation`
3. #93652, `(3/6) Cover redirecting server action offline invalidation`
4. This PR, `(4/6) Cover revalidatePath offline invalidation`

The preceding hardening PRs prove durable offline navigation records are invalidated for `router.refresh()`, a non-redirecting `updateTag()` server action, and a redirecting `updateTag()` server action. This PR adds explicit coverage for the path revalidation path so reviewers do not have to infer that `revalidatePath()` is protected by the broader server-action case.

## What changes

- Adds a fixture server action that calls `revalidatePath('/prefetched')`.
- Adds production e2e coverage that:
  - prefetches `/docs/prefetched` so route and segment records exist in IndexedDB
  - deletes the exact URL entry, forcing the first offline hard reload to use persisted route/segment records
  - proves the route replays offline from the router cache before invalidation
  - goes online and runs the `revalidatePath('/prefetched')` action
  - asserts exact URL, route, and segment durable epochs were bumped
  - hard-loads `/docs/prefetched` offline again and asserts reconstruction misses with `missing-route`, followed by visible cache-miss UI

## What works after this PR

`revalidatePath()` server-action invalidation cannot leave stale exact URL or route/segment offline navigation records replayable after the corresponding live router cache is invalidated.

## What intentionally does not work yet

This PR does not introduce path-granular offline dependency tracking. Until exact URL and route/segment records carry more granular dependency metadata, path revalidation continues to bump the durable exact URL, route, and segment epochs conservatively.

Still deferred to later slices:

- dedicated `revalidateTag()` coverage
- cookie mutation and app/session scope invalidation coverage
- concurrent write/invalidation race stress
- storage quota and lifecycle hardening
- output-export bridge coverage

## Reviewer focus

The test structure is the important part: it first proves the route can replay from persisted route/segment records with the exact URL entry removed, then runs `revalidatePath()` online, then proves the same offline route no longer replays.

The service worker remains document-survival-only. The invalidation and replay decisions stay in the cache-components client router and IndexedDB cache code.

## Verification

- `NEXT_SKIP_ISOLATE=1 pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "misses persisted router records after revalidatePath invalidation"`
- `pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "misses persisted router records after revalidatePath invalidation"`
- `pnpm test-start-webpack test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "misses persisted router records after revalidatePath invalidation"`
- `NEXT_SKIP_ISOLATE=1 pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `pnpm prettier --with-node-modules --ignore-path .prettierignore --write test/production/app-dir/offline-navigations/app/page.tsx test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `git diff --check`

<!-- NEXT_JS_LLM_PR -->

