### PR TITLE
offline navigations: add app cache reset API (25/25)

### DIFF
--- a/packages/next/offline.d.ts
+++ b/packages/next/offline.d.ts
@@ -1,1 +1,4 @@
-export { useOffline } from './dist/client/components/use-offline'
+export {
+  clearOfflineNavigationCache,
+  useOffline,
+} from './dist/client/components/use-offline'

--- a/packages/next/src/client/components/use-offline.tsx
+++ b/packages/next/src/client/components/use-offline.tsx
@@ -55,3 +55,32 @@ export function OfflineProvider({ children }: { children: React.ReactNode }) {
 export function useOffline(): boolean {
   return useContext(OfflineContext)
 }
+
+export async function clearOfflineNavigationCache(): Promise<boolean> {
+  if (process.env.__NEXT_OFFLINE_NAVIGATIONS) {
+    const {
+      invalidateOfflineNavigationCacheEntries,
+      invalidateOfflineNavigationRouteRecords,
+      invalidateOfflineNavigationSegmentRecords,
+    } =
+      require('./router-reducer/offline-navigation-cache') as typeof import('./router-reducer/offline-navigation-cache')
+
+    const [
+      exactUrlCacheInvalidated,
+      routeCacheInvalidated,
+      segmentCacheInvalidated,
+    ] = await Promise.all([
+      invalidateOfflineNavigationCacheEntries(),
+      invalidateOfflineNavigationRouteRecords(),
+      invalidateOfflineNavigationSegmentRecords(),
+    ])
+
+    return (
+      exactUrlCacheInvalidated &&
+      routeCacheInvalidated &&
+      segmentCacheInvalidated
+    )
+  } else {
+    return false
+  }
+}

--- a/test/production/app-dir/offline-navigations/app/page.tsx
+++ b/test/production/app-dir/offline-navigations/app/page.tsx
@@ -1,6 +1,7 @@
 import { cacheLife, cacheTag, updateTag } from 'next/cache'
 import { OfflineStatus } from './offline-status'
 import {
+  ClearOfflineNavigationCacheButton,
   DynamicPatternSourcePrefetchButton,
   DynamicPatternTargetPrefetchButton,
   PrefetchButton,
@@ -35,6 +36,7 @@ export default function Page() {
       <DynamicPatternSourcePrefetchButton />
       <DynamicPatternTargetPrefetchButton />
       <RefreshButton />
+      <ClearOfflineNavigationCacheButton />
     </>
   )
 }

--- a/test/production/app-dir/offline-navigations/app/prefetch-button.tsx
+++ b/test/production/app-dir/offline-navigations/app/prefetch-button.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import { useState } from 'react'
+import { clearOfflineNavigationCache } from 'next/offline'
 import { useRouter } from 'next/navigation'
 
 export function PrefetchButton() {
@@ -44,5 +46,24 @@ export function RefreshButton() {
     <button id="refresh-offline-navigation" onClick={() => router.refresh()}>
       Refresh offline navigation
     </button>
+  )
+}
+
+export function ClearOfflineNavigationCacheButton() {
+  const [result, setResult] = useState('idle')
+  return (
+    <>
+      <button
+        id="clear-offline-navigation-cache"
+        onClick={async () => {
+          setResult(
+            (await clearOfflineNavigationCache()) ? 'cleared' : 'not-cleared'
+          )
+        }}
+      >
+        Clear offline navigation cache
+      </button>
+      <p id="clear-offline-navigation-cache-result">{result}</p>
+    </>
   )
 }

--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -1736,6 +1736,187 @@ describe('offlineNavigations build artifacts', () => {
     }
   })
 
+  it('misses persisted router records after app clears offline navigation cache', async () => {
+    if (shouldSkipReplayWithCachedNavigations) {
+      return
+    }
+
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    await next.start({ skipBuild: true })
+
+    let page: Playwright.Page | undefined
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
+
+      await browser.elementById('prefetch-offline-navigation').click()
+      await retry(async () => {
+        const routeRecords =
+          await readPersistedOfflineNavigationRouteRecords(browser)
+        expect(
+          routeRecords.some((record) =>
+            record.route.pathname.includes('/prefetched')
+          )
+        ).toBe(true)
+
+        const segmentRecords =
+          await readPersistedOfflineNavigationSegmentRecords(browser)
+        expect(
+          segmentRecords.some(
+            (record) => record.payload.requestKind === 'segment-prefetch'
+          )
+        ).toBe(true)
+        expect(
+          segmentRecords.some(
+            (record) => record.segment.requestKey === '/_head'
+          )
+        ).toBe(true)
+      })
+
+      const deletedExactEntries = await deletePersistedOfflineNavigationEntries(
+        browser,
+        '/docs/prefetched'
+      )
+      expect(deletedExactEntries).toBeGreaterThan(0)
+
+      await page!.context().setOffline(true)
+      const cachedRouterRecordsResponse = await page!.goto(
+        `${next.url}/docs/prefetched`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(cachedRouterRecordsResponse?.status()).toBe(200)
+      await retry(async () => {
+        expect(await browser.elementById('prefetched-page').text()).toBe(
+          'prefetched page'
+        )
+        const diagnostics = await browser.eval(() => {
+          const win = window as typeof window & {
+            __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?: Array<{
+              requestKind?: string
+              type?: string
+              url?: string
+            }>
+          }
+          return win.__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__ ?? []
+        })
+        expect(diagnostics).toContainEqual(
+          expect.objectContaining({
+            requestKind: 'router-cache',
+            type: 'cache-hit',
+            url: `${next.url}/docs/prefetched`,
+          })
+        )
+      })
+
+      await page!.context().setOffline(false)
+      await browser.eval(() => {
+        window.dispatchEvent(new Event('online'))
+      })
+      const onlineRootResponse = await page!.goto(`${next.url}/docs`, {
+        waitUntil: 'domcontentloaded',
+      })
+      expect(onlineRootResponse?.status()).toBe(200)
+      await retry(async () => {
+        expect(await browser.elementByCss('p').text()).toBe(
+          'offline navigations page'
+        )
+      })
+
+      await browser.elementById('clear-offline-navigation-cache').click()
+      await retry(async () => {
+        expect(
+          await browser
+            .elementById('clear-offline-navigation-cache-result')
+            .text()
+        ).toBe('cleared')
+        expect(
+          await readPersistedOfflineNavigationMetadata(
+            browser,
+            'exact-url-cache-epoch'
+          )
+        ).toBeGreaterThan(0)
+        expect(
+          await readPersistedOfflineNavigationMetadata(
+            browser,
+            'route-cache-epoch'
+          )
+        ).toBeGreaterThan(0)
+        expect(
+          await readPersistedOfflineNavigationMetadata(
+            browser,
+            'segment-cache-epoch'
+          )
+        ).toBeGreaterThan(0)
+      })
+
+      await page!.context().setOffline(true)
+      const clearedRouterRecordsResponse = await page!.goto(
+        `${next.url}/docs/prefetched`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(clearedRouterRecordsResponse?.status()).toBe(200)
+      await retry(async () => {
+        const diagnostics = await browser.eval(() => {
+          const win = window as typeof window & {
+            __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?: Array<{
+              reason?: string
+              type?: string
+              url?: string
+            }>
+          }
+          return win.__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__ ?? []
+        })
+        expect(diagnostics).toContainEqual(
+          expect.objectContaining({
+            reason: 'missing-route',
+            type: 'router-cache-reconstruction-miss',
+            url: `${next.url}/docs/prefetched`,
+          })
+        )
+        expect(diagnostics).toContainEqual(
+          expect.objectContaining({
+            reason: 'missing-entry',
+            type: 'cache-miss',
+            url: `${next.url}/docs/prefetched`,
+          })
+        )
+      })
+      await retry(async () => {
+        expect(
+          await browser.eval(() => {
+            const cacheMiss = document.getElementById(
+              '__NEXT_OFFLINE_NAVIGATION_CACHE_MISS'
+            )
+            return cacheMiss === null
+              ? null
+              : {
+                  hidden: cacheMiss.hidden,
+                  reason: cacheMiss.getAttribute(
+                    'data-next-offline-navigation-cache-reason'
+                  ),
+                  text: cacheMiss.textContent,
+                }
+          })
+        ).toEqual({
+          hidden: false,
+          reason: 'missing-entry',
+          text: 'This page is not available offline.',
+        })
+      })
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
   it('replays a dynamic route from persisted known route patterns', async () => {
     if (shouldSkipReplayWithCachedNavigations) {
       return


### PR DESCRIPTION
## Stack Position

25/25 in the offline navigations first-usable stack.

This stack turns `experimental.offlineNavigations` into a usable cache-components experiment for regular apps. The service worker owns document survival only. Cache Storage owns generated fallback artifacts. The cache-components client router owns IndexedDB, route semantics, replay, visible misses, and invalidation. Output export, dev simulation, custom miss UI, and broad production-hardening matrices are intentionally deferred.

Review guide: https://gist.github.com/feedthejim/b3d9fe26a7c05655fd57adcce371b93d

## Full Stack

1. offline navigations: add cache-components flag (1/25)
2. offline navigations: emit fallback document (2/25)
3. offline navigations: emit fallback manifest (3/25)
4. offline navigations: register pass-through service worker (4/25)
5. offline navigations: cache fallback artifacts (5/25)
6. offline navigations: serve fallback document (6/25)
7. offline navigations: bridge fallback state to useOffline (7/25)
8. offline navigations: add navigation cache primitives (8/25)
9. offline navigations: persist exact-url navigation data (9/25)
10. offline navigations: boot fallback from exact-url data (10/25)
11. offline navigations: persist initial-load navigation data (11/25)
12. offline navigations: centralize cache eligibility (12/25)
13. offline navigations: replay request-sensitive exact urls (13/25)
14. offline navigations: wire exact-url invalidation (14/25)
15. offline navigations: harden fallback diagnostics and misses (15/25)
16. offline navigations: cover exact-url app replay basics (16/25)
17. offline navigations: define persistent router schema (17/25)
18. offline navigations: persist route records and known routes (18/25)
19. offline navigations: persist segment and head records (19/25)
20. offline navigations: hydrate persisted router caches (20/25)
21. offline navigations: reconstruct prefetched routes offline (21/25)
22. offline navigations: replay dynamic routes from known routes (22/25)
23. offline navigations: mirror router cache invalidation (23/25)
24. offline navigations: cover mutation invalidation (24/25)
25. offline navigations: add app cache reset API (25/25) ← this PR

## What This PR Does

Adds an app-facing reset API that clears or invalidates the durable offline navigation namespace.

## What Works After This PR

Apps have a first reset hook that can make persisted exact-url, route, and segment records unreachable after app-owned scope changes.

## Reviewer Focus

Public API shape, epoch invalidation, cleanup behavior, and the difference between this first reset API and broader session/workspace integration.

## Not In This PR

Request-sensitive session reset stress, logout/account/workspace/entitlement matrices, and real app shell scenarios are P1/P2 follow-ups.

## Proof in This PR

- Relevant coverage: `misses persisted router records after app clears offline navigation cache` plus stack-level build/e2e verification.
- Restack verification run at the cleaned stack tip:
  - `pnpm --filter=next build`
  - `NEXT_SKIP_ISOLATE=1 NEXT_TEST_MODE=start pnpm testheadless test/production/app-dir/offline-navigations/offline-navigations.test.ts`
  - `NEXT_TEST_MODE=start pnpm testheadless test/production/app-dir/offline-navigations/offline-navigations.test.ts`
  - `IS_WEBPACK_TEST=1 NEXT_TEST_MODE=start pnpm testheadless test/production/app-dir/offline-navigations/offline-navigations.test.ts`

## Deferred Coverage

Request-sensitive session reset stress, logout/account/workspace/entitlement matrices, and real app shell scenarios are P1/P2 follow-ups.

<!-- NEXT_JS_LLM_PR -->
