### PR TITLE
(1/1) Cover offline navigation IDB unavailable fallback

### DIFF
--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -2954,6 +2954,94 @@ describe('offlineNavigations build artifacts', () => {
     }
   })
 
+  it('shows cache miss when IndexedDB is unavailable during fallback boot', async () => {
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    await next.start({ skipBuild: true })
+
+    let page: Playwright.Page | undefined
+    try {
+      const browser = await next.browser('/docs', {
+        async beforePageLoad(p: Playwright.Page) {
+          page = p
+          await p.addInitScript(() => {
+            Object.defineProperty(window, 'indexedDB', {
+              configurable: true,
+              value: undefined,
+            })
+          })
+        },
+      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
+      expect(await browser.eval(() => typeof indexedDB)).toBe('undefined')
+
+      await next.stop()
+      await page!.context().setOffline(true)
+      const response = await page!.goto(`${next.url}/docs/idb-unavailable/`, {
+        waitUntil: 'domcontentloaded',
+      })
+      expect(response?.status()).toBe(200)
+
+      await retry(async () => {
+        expect(
+          await browser.eval(() => {
+            const cacheMiss = document.getElementById(
+              '__NEXT_OFFLINE_NAVIGATION_CACHE_MISS'
+            )
+            return cacheMiss === null
+              ? null
+              : {
+                  fallback: document.documentElement.hasAttribute(
+                    'data-next-offline-navigation-fallback'
+                  ),
+                  hidden: cacheMiss.hidden,
+                  reason: cacheMiss.getAttribute(
+                    'data-next-offline-navigation-cache-reason'
+                  ),
+                  text: cacheMiss.textContent,
+                }
+          })
+        ).toEqual({
+          fallback: true,
+          hidden: false,
+          reason: 'missing-entry',
+          text: 'This page is not available offline.',
+        })
+      })
+
+      expect(
+        await browser.eval(() => ({
+          cache: document.documentElement.getAttribute(
+            'data-next-offline-navigation-cache'
+          ),
+          reason: document.documentElement.getAttribute(
+            'data-next-offline-navigation-cache-reason'
+          ),
+          diagnostic:
+            (
+              window as typeof window & {
+                __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?: Array<unknown>
+              }
+            ).__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?.at(-1) ?? null,
+        }))
+      ).toMatchObject({
+        cache: 'miss',
+        reason: 'missing-entry',
+        diagnostic: {
+          type: 'cache-miss',
+          reason: 'missing-entry',
+          url: `${next.url}/docs/idb-unavailable/`,
+        },
+      })
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
   it('does not emit offline navigation artifacts when disabled', async () => {
     await next.patchFile('next.config.js', (content) =>
       content.replace('offlineNavigations: true', 'offlineNavigations: false')


### PR DESCRIPTION
## Stack position

This is PR 1/1 in a standalone `offlineNavigations` storage-failure stress coverage slice.

It sits after #93657, which tightened the service-worker pass-through boundary. This PR is test-only and covers the next production-hardening invariant: if durable browser storage is unavailable during fallback boot, the generated fallback document must settle to visible cache-miss UI instead of hanging or crashing.

## Why this exists

The offline navigation design treats IndexedDB as the client-owned durable router cache. Real browsers can still make IDB unavailable because of private-mode-like restrictions, storage failures, user settings, or transient platform failures. The feature should degrade to a deterministic miss, because guessing or blanking during an offline document reload is worse than showing the app/user that the route is unavailable offline.

## What changed

- Added a production e2e that disables `window.indexedDB` with an init script before app code runs.
- Verifies the service worker still installs and can serve the generated fallback document.
- Stops the app server, switches the browser offline, and hard-loads a route with no available durable storage.
- Asserts the fallback document renders visible cache-miss UI with `missing-entry` diagnostics.

## Not included

- No runtime changes.
- No quota-exceeded simulation.
- No IDB blocked/versionchange stress.
- No migration failure coverage.

Those remain separate storage hardening slices.

## Reviewer focus

- This should read as a test-only PR.
- The key assertion is that an unavailable IDB path produces a named visible miss, not a hidden fallback shell or an uncaught boot error.
- The test intentionally disables IDB before both the online setup page and the offline fallback document so it exercises the same browser condition throughout.

## Verification

- `pnpm prettier --with-node-modules --ignore-path .prettierignore --write test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `npx eslint --config eslint.config.mjs --fix test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `git diff --check`
- `NEXT_SKIP_ISOLATE=1 pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "shows cache miss when IndexedDB is unavailable during fallback boot"`
- `pnpm test-start-webpack test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "shows cache miss when IndexedDB is unavailable during fallback boot"`

Note: the focused Turbopack run reported a stale package-build warning, but this PR changes only the e2e test file. The packed webpack run also passed through an isolated package install.

<!-- NEXT_JS_LLM_PR -->