### PR TITLE
(1/1) Cover offline navigation build namespace misses

### DIFF
--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -3042,6 +3042,164 @@ describe('offlineNavigations build artifacts', () => {
     }
   })
 
+  it('ignores persisted offline navigation data from another build', async () => {
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    const { buildId } = await getOfflineNavigationArtifactPaths()
+    const navigationBuildId = next.deploymentId ?? buildId
+    await next.start({ skipBuild: true })
+
+    let page: Playwright.Page | undefined
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
+
+      await retry(async () => {
+        const initialLoadEntry = await readPersistedOfflineNavigationEntry(
+          browser,
+          '/docs/'
+        )
+        expect(initialLoadEntry).toEqual(
+          expect.objectContaining({
+            buildId: navigationBuildId,
+            kind: 'exact-url',
+            payload: expect.objectContaining({
+              kind: 'rsc-response',
+              requestKind: 'initial-load',
+            }),
+          })
+        )
+      })
+
+      const staleEntry = await browser.eval(
+        async ({ currentBuildId, staleUrl }) => {
+          const database = await new Promise<IDBDatabase>((resolve, reject) => {
+            const request = indexedDB.open('next-offline-navigation-cache', 3)
+            request.onsuccess = () => resolve(request.result)
+            request.onerror = () => reject(request.error)
+          })
+
+          try {
+            const readTransaction = database.transaction(
+              'navigation-data',
+              'readonly'
+            )
+            const entries = await new Promise<any[]>((resolve, reject) => {
+              const request = readTransaction
+                .objectStore('navigation-data')
+                .getAll()
+              request.onsuccess = () => resolve(request.result)
+              request.onerror = () => reject(request.error)
+            })
+            const sourceEntry = entries.find((entry) =>
+              entry.url.endsWith('/docs/')
+            )
+            if (!sourceEntry) {
+              return null
+            }
+
+            const staleBuildId = `${currentBuildId}:stale`
+            const writeTransaction = database.transaction(
+              'navigation-data',
+              'readwrite'
+            )
+            writeTransaction.objectStore('navigation-data').put({
+              ...sourceEntry,
+              buildId: staleBuildId,
+              url: staleUrl,
+            })
+            await new Promise<void>((resolve, reject) => {
+              writeTransaction.oncomplete = () => resolve()
+              writeTransaction.onerror = () => reject(writeTransaction.error)
+              writeTransaction.onabort = () => reject(writeTransaction.error)
+            })
+
+            return {
+              buildId: staleBuildId,
+              url: staleUrl,
+            }
+          } finally {
+            database.close()
+          }
+        },
+        {
+          currentBuildId: navigationBuildId,
+          staleUrl: `${next.url}/docs/stale-build/`,
+        }
+      )
+      expect(staleEntry).toEqual({
+        buildId: `${navigationBuildId}:stale`,
+        url: `${next.url}/docs/stale-build/`,
+      })
+
+      await next.stop()
+      await page!.context().setOffline(true)
+      const response = await page!.goto(`${next.url}/docs/stale-build/`, {
+        waitUntil: 'domcontentloaded',
+      })
+      expect(response?.status()).toBe(200)
+
+      await retry(async () => {
+        expect(
+          await browser.eval(() => {
+            const cacheMiss = document.getElementById(
+              '__NEXT_OFFLINE_NAVIGATION_CACHE_MISS'
+            )
+            return cacheMiss === null
+              ? null
+              : {
+                  hidden: cacheMiss.hidden,
+                  reason: cacheMiss.getAttribute(
+                    'data-next-offline-navigation-cache-reason'
+                  ),
+                  text: cacheMiss.textContent,
+                }
+          })
+        ).toEqual({
+          hidden: false,
+          reason: 'missing-entry',
+          text: 'This page is not available offline.',
+        })
+      })
+
+      expect(
+        await browser.eval(() => ({
+          cache: document.documentElement.getAttribute(
+            'data-next-offline-navigation-cache'
+          ),
+          reason: document.documentElement.getAttribute(
+            'data-next-offline-navigation-cache-reason'
+          ),
+          diagnostic:
+            (
+              window as typeof window & {
+                __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?: Array<unknown>
+              }
+            ).__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?.at(-1) ?? null,
+        }))
+      ).toMatchObject({
+        cache: 'miss',
+        reason: 'missing-entry',
+        diagnostic: {
+          type: 'cache-miss',
+          buildId: navigationBuildId,
+          reason: 'missing-entry',
+          url: `${next.url}/docs/stale-build/`,
+        },
+      })
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
   it('does not emit offline navigation artifacts when disabled', async () => {
     await next.patchFile('next.config.js', (content) =>
       content.replace('offlineNavigations: true', 'offlineNavigations: false')


### PR DESCRIPTION
## Stack position

This is PR 1/1 in a standalone `offlineNavigations` build-namespace stress coverage slice.

It sits after #93658, which covered the IDB-unavailable fallback boot path. This PR is test-only and covers another production-hardening invariant: persisted data from a previous build/deployment namespace must not be replayed into the current fallback boot.

## Why this exists

Offline navigation data is durable browser storage. A user can have records from an older build sitting in IndexedDB when a newer build is loaded. The fallback document must scope lookups to the current build/deployment ID and miss visibly if only stale-build data exists for the requested URL.

That matters for correctness, but it also keeps the architecture aligned with the cache-components router cache: durable replay is a mirror of the current router cache namespace, not a cross-build best-effort cache.

## What changed

- Added a production e2e that first waits for the current build to persist a valid exact-URL initial-load entry.
- Copies that valid payload to a different URL under a fake stale build ID.
- Stops the app server, switches the browser offline, and hard-loads the stale-build URL.
- Asserts fallback boot uses the current build namespace, ignores the stale record, and renders visible `missing-entry` cache-miss UI with structured diagnostics.

## Not included

- No runtime changes.
- No physical old-build cleanup changes. #93650 covers build-scoped cleanup at the storage layer.
- No deployment-ID skew/multi-tab upgrade test yet.
- No route/segment stale-build record matrix yet.

## Reviewer focus

- This should read as a test-only PR.
- The copied payload is intentionally valid. The miss should happen because of the build namespace, not because the payload is malformed.
- The diagnostic should report the current build/deployment ID, proving the fallback boot is scoped to the active build.

## Verification

- `pnpm prettier --with-node-modules --ignore-path .prettierignore --write test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `npx eslint --config eslint.config.mjs --fix test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `git diff --check`
- `NEXT_SKIP_ISOLATE=1 pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "ignores persisted offline navigation data from another build"`
- `pnpm test-start-webpack test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "ignores persisted offline navigation data from another build"`

<!-- NEXT_JS_LLM_PR -->