### PR TITLE
(1/1) Cover expired exact URL offline navigation misses

### DIFF
--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -3200,6 +3200,178 @@ describe('offlineNavigations build artifacts', () => {
     }
   })
 
+  it('misses and deletes expired persisted exact-URL data during fallback boot', async () => {
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    const { buildId } = await getOfflineNavigationArtifactPaths()
+    const navigationBuildId = next.deploymentId ?? buildId
+    await next.start({ skipBuild: true })
+
+    let page: Playwright.Page | undefined
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
+
+      await retry(async () => {
+        const initialLoadEntry = await readPersistedOfflineNavigationEntry(
+          browser,
+          '/docs/'
+        )
+        expect(initialLoadEntry).toEqual(
+          expect.objectContaining({
+            buildId: navigationBuildId,
+            kind: 'exact-url',
+            payload: expect.objectContaining({
+              kind: 'rsc-response',
+              requestKind: 'initial-load',
+            }),
+          })
+        )
+      })
+
+      const expiredUrl = `${next.url}/docs/expired-offline-entry/`
+      const expiredEntry = await browser.eval(
+        async ({ currentBuildId, url }) => {
+          const database = await new Promise<IDBDatabase>((resolve, reject) => {
+            const request = indexedDB.open('next-offline-navigation-cache', 3)
+            request.onsuccess = () => resolve(request.result)
+            request.onerror = () => reject(request.error)
+          })
+
+          try {
+            const readTransaction = database.transaction(
+              'navigation-data',
+              'readonly'
+            )
+            const entries = await new Promise<any[]>((resolve, reject) => {
+              const request = readTransaction
+                .objectStore('navigation-data')
+                .getAll()
+              request.onsuccess = () => resolve(request.result)
+              request.onerror = () => reject(request.error)
+            })
+            const sourceEntry = entries.find((entry) =>
+              entry.url.endsWith('/docs/')
+            )
+            if (!sourceEntry) {
+              return null
+            }
+
+            const expiredAt = Date.now() - 1_000
+            const writeTransaction = database.transaction(
+              'navigation-data',
+              'readwrite'
+            )
+            writeTransaction.objectStore('navigation-data').put({
+              ...sourceEntry,
+              buildId: currentBuildId,
+              url,
+              staleAt: expiredAt,
+              expiresAt: expiredAt,
+            })
+            await new Promise<void>((resolve, reject) => {
+              writeTransaction.oncomplete = () => resolve()
+              writeTransaction.onerror = () => reject(writeTransaction.error)
+              writeTransaction.onabort = () => reject(writeTransaction.error)
+            })
+
+            return {
+              buildId: currentBuildId,
+              expiresAt: expiredAt,
+              url,
+            }
+          } finally {
+            database.close()
+          }
+        },
+        {
+          currentBuildId: navigationBuildId,
+          url: expiredUrl,
+        }
+      )
+      expect(expiredEntry).toEqual({
+        buildId: navigationBuildId,
+        expiresAt: expect.any(Number),
+        url: expiredUrl,
+      })
+
+      await next.stop()
+      await page!.context().setOffline(true)
+      const response = await page!.goto(expiredUrl, {
+        waitUntil: 'domcontentloaded',
+      })
+      expect(response?.status()).toBe(200)
+
+      await retry(async () => {
+        expect(
+          await browser.eval(() => {
+            const cacheMiss = document.getElementById(
+              '__NEXT_OFFLINE_NAVIGATION_CACHE_MISS'
+            )
+            return cacheMiss === null
+              ? null
+              : {
+                  hidden: cacheMiss.hidden,
+                  reason: cacheMiss.getAttribute(
+                    'data-next-offline-navigation-cache-reason'
+                  ),
+                  text: cacheMiss.textContent,
+                }
+          })
+        ).toEqual({
+          hidden: false,
+          reason: 'missing-entry',
+          text: 'This page is not available offline.',
+        })
+      })
+
+      expect(
+        await browser.eval(() => ({
+          cache: document.documentElement.getAttribute(
+            'data-next-offline-navigation-cache'
+          ),
+          reason: document.documentElement.getAttribute(
+            'data-next-offline-navigation-cache-reason'
+          ),
+          diagnostic:
+            (
+              window as typeof window & {
+                __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?: Array<unknown>
+              }
+            ).__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?.at(-1) ?? null,
+        }))
+      ).toMatchObject({
+        cache: 'miss',
+        reason: 'missing-entry',
+        diagnostic: {
+          type: 'cache-miss',
+          buildId: navigationBuildId,
+          reason: 'missing-entry',
+          url: expiredUrl,
+        },
+      })
+
+      await retry(async () => {
+        expect(
+          await readPersistedOfflineNavigationEntry(
+            browser,
+            '/docs/expired-offline-entry/'
+          )
+        ).toBe(null)
+      })
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
   it('does not emit offline navigation artifacts when disabled', async () => {
     await next.patchFile('next.config.js', (content) =>
       content.replace('offlineNavigations: true', 'offlineNavigations: false')


### PR DESCRIPTION
## Stack position

This is PR 1/1 in a standalone `offlineNavigations` exact-URL freshness stress coverage slice.

It sits after #93659, which covered current-build namespace isolation. This PR is test-only and covers the next fallback-boot invariant: even when an exact-URL payload is otherwise valid and belongs to the current build, it must not replay after its expiration time.

## Why this exists

Offline navigation data is durable browser storage, but it still needs to follow the same freshness model as the cache-components router cache. Expired data should miss visibly and be cleaned up, rather than becoming a stale offline-only route replay.

This is especially important before adding output-export and broader production hardening, because the fallback document should treat persistent storage as a scoped, freshness-checked router cache mirror, not as an eternal archive.

## What changed

- Added a production e2e that waits for a real exact-URL initial-load entry to be persisted.
- Copies that valid current-build RSC payload to a new URL with an expired `staleAt`/`expiresAt` timestamp.
- Stops the app server, switches the browser offline, and hard-loads the expired URL through the fallback document.
- Asserts fallback boot renders visible `missing-entry` cache-miss UI with structured diagnostics.
- Asserts the expired exact-URL entry is deleted from IndexedDB after the miss.

## Not included

- No runtime changes.
- No route/segment expired-record matrix yet.
- No stale-but-not-expired policy change.
- No quota or LRU behavior.

## Reviewer focus

- This should read as a test-only PR.
- The copied payload is intentionally valid and uses the current build ID. The miss should happen because the entry is expired.
- The final IndexedDB assertion is the cleanup check: expired exact-URL entries should be removed during fallback boot.

## Verification

- `pnpm prettier --with-node-modules --ignore-path .prettierignore --write test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `npx eslint --config eslint.config.mjs --fix test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `git diff --check`
- `NEXT_SKIP_ISOLATE=1 pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "misses and deletes expired persisted exact-URL data during fallback boot"`
- `pnpm test-start-webpack test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "misses and deletes expired persisted exact-URL data during fallback boot"`

<!-- NEXT_JS_LLM_PR -->