### PR TITLE
(1/1) Cover expired route record offline navigation misses

### DIFF
--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -319,6 +319,63 @@ describe('offlineNavigations build artifacts', () => {
     }, urlSubstring)
   }
 
+  async function expirePersistedOfflineNavigationRouteRecords(
+    browser: Awaited<ReturnType<typeof next.browser>>,
+    pathnameSubstring: string
+  ) {
+    return browser.eval(async (substring) => {
+      const database = await new Promise<IDBDatabase>((resolve, reject) => {
+        const request = indexedDB.open('next-offline-navigation-cache', 3)
+        request.onsuccess = () => resolve(request.result)
+        request.onerror = () => reject(request.error)
+      })
+
+      try {
+        const entries = await new Promise<any[]>((resolve, reject) => {
+          const transaction = database.transaction('route-data', 'readonly')
+          const request = transaction.objectStore('route-data').getAll()
+          request.onsuccess = () => resolve(request.result)
+          request.onerror = () => reject(request.error)
+        })
+        const matchingEntries = entries.filter((entry) =>
+          entry.route.pathname.includes(substring)
+        )
+
+        if (matchingEntries.length === 0) {
+          return {
+            count: 0,
+            expiresAt: null,
+            keys: [],
+          }
+        }
+
+        const expiredAt = Date.now() - 1_000
+        const transaction = database.transaction('route-data', 'readwrite')
+        const store = transaction.objectStore('route-data')
+        for (const entry of matchingEntries) {
+          store.put({
+            ...entry,
+            staleAt: expiredAt,
+            expiresAt: expiredAt,
+          })
+        }
+        await new Promise<void>((resolve, reject) => {
+          transaction.oncomplete = () => resolve()
+          transaction.onerror = () => reject(transaction.error)
+          transaction.onabort = () => reject(transaction.error)
+        })
+
+        return {
+          count: matchingEntries.length,
+          expiresAt: expiredAt,
+          keys: matchingEntries.map((entry) => entry.key),
+        }
+      } finally {
+        database.close()
+      }
+    }, pathnameSubstring)
+  }
+
   async function prefetchDynamicPatternReplayData(
     browser: Awaited<ReturnType<typeof next.browser>>
   ) {
@@ -1224,6 +1281,162 @@ describe('offlineNavigations build artifacts', () => {
         expect(await browser.elementById('prefetched-page').text()).toBe(
           'prefetched page'
         )
+      })
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
+  it('misses and deletes expired persisted route records during fallback boot', async () => {
+    if (shouldSkipReplayWithCachedNavigations) {
+      return
+    }
+
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    await next.start({ skipBuild: true })
+
+    let page: Playwright.Page | undefined
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
+
+      await browser.elementById('prefetch-offline-navigation').click()
+      await retry(async () => {
+        const routeRecords =
+          await readPersistedOfflineNavigationRouteRecords(browser)
+        expect(
+          routeRecords.some((record) =>
+            record.route.pathname.includes('/prefetched')
+          )
+        ).toBe(true)
+
+        const segmentRecords =
+          await readPersistedOfflineNavigationSegmentRecords(browser)
+        expect(
+          segmentRecords.some(
+            (record) => record.payload.requestKind === 'segment-prefetch'
+          )
+        ).toBe(true)
+        expect(
+          segmentRecords.some(
+            (record) => record.segment.requestKey === '/_head'
+          )
+        ).toBe(true)
+      })
+
+      const deletedExactEntries = await deletePersistedOfflineNavigationEntries(
+        browser,
+        '/docs/prefetched'
+      )
+      expect(deletedExactEntries).toBeGreaterThan(0)
+      await retry(async () => {
+        const deletedEntry = await readPersistedOfflineNavigationEntry(
+          browser,
+          '/docs/prefetched'
+        )
+        expect(deletedEntry).toBe(null)
+      })
+
+      const expiredRouteRecords =
+        await expirePersistedOfflineNavigationRouteRecords(
+          browser,
+          '/prefetched'
+        )
+      expect(expiredRouteRecords).toEqual({
+        count: expect.any(Number),
+        expiresAt: expect.any(Number),
+        keys: expect.arrayContaining([expect.stringContaining('/prefetched')]),
+      })
+      expect(expiredRouteRecords.count).toBeGreaterThan(0)
+      await retry(async () => {
+        const routeRecords =
+          await readPersistedOfflineNavigationRouteRecords(browser)
+        const prefetchedRouteRecords = routeRecords.filter((record) =>
+          record.route.pathname.includes('/prefetched')
+        )
+        expect(prefetchedRouteRecords).toHaveLength(expiredRouteRecords.count)
+        expect(
+          prefetchedRouteRecords.every(
+            (record) =>
+              record.expiresAt === expiredRouteRecords.expiresAt &&
+              record.expiresAt <= Date.now()
+          )
+        ).toBe(true)
+      })
+
+      await next.stop()
+      await page!.context().setOffline(true)
+      const expiredRouteResponse = await page!.goto(
+        `${next.url}/docs/prefetched`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(expiredRouteResponse?.status()).toBe(200)
+
+      await retry(async () => {
+        const diagnostics = await browser.eval(() => {
+          const win = window as typeof window & {
+            __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?: Array<{
+              reason?: string
+              type?: string
+              url?: string
+            }>
+          }
+          return win.__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__ ?? []
+        })
+        expect(diagnostics).toContainEqual(
+          expect.objectContaining({
+            reason: 'missing-route',
+            type: 'router-cache-reconstruction-miss',
+            url: `${next.url}/docs/prefetched`,
+          })
+        )
+        expect(diagnostics).toContainEqual(
+          expect.objectContaining({
+            reason: 'missing-entry',
+            type: 'cache-miss',
+            url: `${next.url}/docs/prefetched`,
+          })
+        )
+      })
+      await retry(async () => {
+        expect(
+          await browser.eval(() => {
+            const cacheMiss = document.getElementById(
+              '__NEXT_OFFLINE_NAVIGATION_CACHE_MISS'
+            )
+            return cacheMiss === null
+              ? null
+              : {
+                  hidden: cacheMiss.hidden,
+                  reason: cacheMiss.getAttribute(
+                    'data-next-offline-navigation-cache-reason'
+                  ),
+                  text: cacheMiss.textContent,
+                }
+          })
+        ).toEqual({
+          hidden: false,
+          reason: 'missing-entry',
+          text: 'This page is not available offline.',
+        })
+      })
+      await retry(async () => {
+        const routeRecords =
+          await readPersistedOfflineNavigationRouteRecords(browser)
+        expect(
+          routeRecords.some((record) =>
+            record.route.pathname.includes('/prefetched')
+          )
+        ).toBe(false)
       })
     } finally {
       if (page) {


### PR DESCRIPTION
## Why

This is a small test-only stress slice in the `offlineNavigations` stack. It sits directly after the expired exact-URL stress PR and covers the next P0 freshness case from the advanced e2e matrix: expired persisted route records must not be replayed during fallback boot.

The production contract here is that the service worker only gets the app to the fallback document. Once the app boots, the cache-components client router owns the IndexedDB route records and must reject stale or expired route data before rendering. A visible miss is the correct result when the route record is expired, even if the matching segment and head records are still present.

## What changed

- Adds a test helper that expires selected persisted `route-data` records in IndexedDB.
- Adds an e2e that prefetches `/docs/prefetched`, deletes the exact-URL entry, expires the route record, stops the server, and hard-loads the URL offline.
- Asserts the fallback boot emits `router-cache-reconstruction-miss` with `missing-route`, reaches visible cache-miss UI, and deletes the expired route record from IndexedDB.

## Stack position

Base: `feedthejim/offline-navigations-expired-exact-url-stress`

This PR is intentionally narrow and test-only. It does not add new route persistence behavior. It verifies the route-record expiration behavior that already exists in the client router cache read path, using a full browser fallback boot so we know the app cannot accidentally replay expired durable route data.

## Still intentionally not covered here

- Expired segment and head records
- Stale-but-not-expired route policy boundaries
- Route epoch, schema, build, deployment, basePath, assetPrefix, and app/session scope mismatch matrix
- Output export artifact freshness

Those are separate stress slices so reviewers can inspect one failure mode at a time.

## Verification

- `pnpm prettier --with-node-modules --ignore-path .prettierignore --write test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `npx eslint --config eslint.config.mjs --fix test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `git diff --check`
- `NEXT_SKIP_ISOLATE=1 pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "misses and deletes expired persisted route records during fallback boot"`
- `pnpm test-start-webpack test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "misses and deletes expired persisted route records during fallback boot"`

<!-- NEXT_JS_LLM_PR -->