### PR TITLE
(1/1) Cover expired segment record offline navigation misses

### DIFF
--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -376,6 +376,70 @@ describe('offlineNavigations build artifacts', () => {
     }, pathnameSubstring)
   }
 
+  async function expirePersistedOfflineNavigationSegmentRecords(
+    browser: Awaited<ReturnType<typeof next.browser>>,
+    options: {
+      keySubstring: string
+      requestKeySuffix: string
+    }
+  ) {
+    return browser.eval(async ({ keySubstring, requestKeySuffix }) => {
+      const database = await new Promise<IDBDatabase>((resolve, reject) => {
+        const request = indexedDB.open('next-offline-navigation-cache', 3)
+        request.onsuccess = () => resolve(request.result)
+        request.onerror = () => reject(request.error)
+      })
+
+      try {
+        const entries = await new Promise<any[]>((resolve, reject) => {
+          const transaction = database.transaction('segment-data', 'readonly')
+          const request = transaction.objectStore('segment-data').getAll()
+          request.onsuccess = () => resolve(request.result)
+          request.onerror = () => reject(request.error)
+        })
+        const matchingEntries = entries.filter(
+          (entry) =>
+            entry.key.includes(keySubstring) &&
+            entry.segment.requestKey.endsWith(requestKeySuffix)
+        )
+
+        if (matchingEntries.length === 0) {
+          return {
+            count: 0,
+            expiresAt: null,
+            keys: [],
+            requestKeys: [],
+          }
+        }
+
+        const expiredAt = Date.now() - 1_000
+        const transaction = database.transaction('segment-data', 'readwrite')
+        const store = transaction.objectStore('segment-data')
+        for (const entry of matchingEntries) {
+          store.put({
+            ...entry,
+            staleAt: expiredAt,
+            expiresAt: expiredAt,
+          })
+        }
+        await new Promise<void>((resolve, reject) => {
+          transaction.oncomplete = () => resolve()
+          transaction.onerror = () => reject(transaction.error)
+          transaction.onabort = () => reject(transaction.error)
+        })
+
+        return {
+          count: matchingEntries.length,
+          expiresAt: expiredAt,
+          keys: matchingEntries.map((entry) => entry.key),
+          requestKeys: matchingEntries.map((entry) => entry.segment.requestKey),
+        }
+      } finally {
+        database.close()
+      }
+    }, options)
+  }
+
   async function prefetchDynamicPatternReplayData(
     browser: Awaited<ReturnType<typeof next.browser>>
   ) {
@@ -1435,6 +1499,178 @@ describe('offlineNavigations build artifacts', () => {
         expect(
           routeRecords.some((record) =>
             record.route.pathname.includes('/prefetched')
+          )
+        ).toBe(false)
+      })
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
+  it('misses and deletes expired persisted segment records during fallback boot', async () => {
+    if (shouldSkipReplayWithCachedNavigations) {
+      return
+    }
+
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    await next.start({ skipBuild: true })
+
+    let page: Playwright.Page | undefined
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
+
+      await browser.elementById('prefetch-offline-navigation').click()
+      await retry(async () => {
+        const routeRecords =
+          await readPersistedOfflineNavigationRouteRecords(browser)
+        expect(
+          routeRecords.some((record) =>
+            record.route.pathname.includes('/prefetched')
+          )
+        ).toBe(true)
+
+        const segmentRecords =
+          await readPersistedOfflineNavigationSegmentRecords(browser)
+        expect(
+          segmentRecords.some(
+            (record) =>
+              record.key.includes('prefetched') &&
+              record.segment.requestKey.endsWith('/__PAGE__')
+          )
+        ).toBe(true)
+        expect(
+          segmentRecords.some(
+            (record) => record.segment.requestKey === '/_head'
+          )
+        ).toBe(true)
+      })
+
+      const deletedExactEntries = await deletePersistedOfflineNavigationEntries(
+        browser,
+        '/docs/prefetched'
+      )
+      expect(deletedExactEntries).toBeGreaterThan(0)
+      await retry(async () => {
+        const deletedEntry = await readPersistedOfflineNavigationEntry(
+          browser,
+          '/docs/prefetched'
+        )
+        expect(deletedEntry).toBe(null)
+      })
+
+      const expiredSegmentRecords =
+        await expirePersistedOfflineNavigationSegmentRecords(browser, {
+          keySubstring: 'prefetched',
+          requestKeySuffix: '/__PAGE__',
+        })
+      expect(expiredSegmentRecords).toEqual({
+        count: expect.any(Number),
+        expiresAt: expect.any(Number),
+        keys: expect.arrayContaining([expect.stringContaining('prefetched')]),
+        requestKeys: expect.arrayContaining([
+          expect.stringContaining('/__PAGE__'),
+        ]),
+      })
+      expect(expiredSegmentRecords.count).toBeGreaterThan(0)
+      await retry(async () => {
+        const segmentRecords =
+          await readPersistedOfflineNavigationSegmentRecords(browser)
+        const prefetchedPageSegmentRecords = segmentRecords.filter(
+          (record) =>
+            record.key.includes('prefetched') &&
+            record.segment.requestKey.endsWith('/__PAGE__')
+        )
+        expect(prefetchedPageSegmentRecords).toHaveLength(
+          expiredSegmentRecords.count
+        )
+        expect(
+          prefetchedPageSegmentRecords.every(
+            (record) =>
+              record.expiresAt === expiredSegmentRecords.expiresAt &&
+              record.expiresAt <= Date.now()
+          )
+        ).toBe(true)
+        expect(
+          segmentRecords.some(
+            (record) => record.segment.requestKey === '/_head'
+          )
+        ).toBe(true)
+      })
+
+      await next.stop()
+      await page!.context().setOffline(true)
+      const expiredSegmentResponse = await page!.goto(
+        `${next.url}/docs/prefetched`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(expiredSegmentResponse?.status()).toBe(200)
+
+      await retry(async () => {
+        const diagnostics = await browser.eval(() => {
+          const win = window as typeof window & {
+            __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?: Array<{
+              reason?: string
+              type?: string
+              url?: string
+            }>
+          }
+          return win.__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__ ?? []
+        })
+        expect(diagnostics).toContainEqual(
+          expect.objectContaining({
+            reason: 'missing-segment',
+            type: 'router-cache-reconstruction-miss',
+            url: `${next.url}/docs/prefetched`,
+          })
+        )
+        expect(diagnostics).toContainEqual(
+          expect.objectContaining({
+            reason: 'missing-entry',
+            type: 'cache-miss',
+            url: `${next.url}/docs/prefetched`,
+          })
+        )
+      })
+      await retry(async () => {
+        expect(
+          await browser.eval(() => {
+            const cacheMiss = document.getElementById(
+              '__NEXT_OFFLINE_NAVIGATION_CACHE_MISS'
+            )
+            return cacheMiss === null
+              ? null
+              : {
+                  hidden: cacheMiss.hidden,
+                  reason: cacheMiss.getAttribute(
+                    'data-next-offline-navigation-cache-reason'
+                  ),
+                  text: cacheMiss.textContent,
+                }
+          })
+        ).toEqual({
+          hidden: false,
+          reason: 'missing-entry',
+          text: 'This page is not available offline.',
+        })
+      })
+      await retry(async () => {
+        const segmentRecords =
+          await readPersistedOfflineNavigationSegmentRecords(browser)
+        expect(
+          segmentRecords.some(
+            (record) =>
+              record.key.includes('prefetched') &&
+              record.segment.requestKey.endsWith('/__PAGE__')
           )
         ).toBe(false)
       })


### PR DESCRIPTION
## Why

This is the next narrow stress slice in the `offlineNavigations` stack, directly on top of the expired route-record PR. It covers the page-segment half of `GRAPH-04b`: a route must not reconstruct offline from an expired persisted segment record, even when the route record and head record are still present.

The important contract is still the same: the service worker only serves the fallback document. The cache-components client router owns IndexedDB route and segment freshness. If a required segment is expired, fallback boot must miss visibly instead of rendering partial or stale UI.

## What changed

- Adds a test helper that expires selected persisted `segment-data` records in IndexedDB.
- Adds an e2e that prefetches `/docs/prefetched`, deletes the exact-URL entry, expires the prefetched page segment, stops the server, and hard-loads the route offline.
- Asserts fallback boot emits `router-cache-reconstruction-miss` with `missing-segment`, reaches visible cache-miss UI, and deletes the expired page segment from IndexedDB.

## Stack position

Base: `feedthejim/offline-navigations-expired-route-record-stress`

This PR is intentionally test-only. The prior PR covers expired route records with `missing-route`; this PR covers expired page segment records with `missing-segment`. Keeping those separate should make the freshness behavior easier to review.

## Still intentionally not covered here

- Expired head records, which should exercise the `missing-head` path
- Expired parent layout, default slot, and parallel route segment records
- Stale-but-not-expired freshness policy boundaries
- Segment schema, build, deployment, route epoch, and app/session scope mismatch matrices
- Output export artifact freshness

Those stay as separate stress slices so the route graph completeness matrix remains reviewable.

## Verification

- `pnpm prettier --with-node-modules --ignore-path .prettierignore --write test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `npx eslint --config eslint.config.mjs --fix test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `git diff --check`
- `NEXT_SKIP_ISOLATE=1 pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "misses and deletes expired persisted segment records during fallback boot"`
- `pnpm test-start-webpack test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "misses and deletes expired persisted segment records during fallback boot"`

Note: the focused test commands printed the existing stale package-build warning because this stack has only test-file changes on top of the last package build. The fixture production build ran in both modes and passed.

<!-- NEXT_JS_LLM_PR -->