### PR TITLE
(1/1) Cover expired head record offline navigation misses

### DIFF
--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -1682,6 +1682,172 @@ describe('offlineNavigations build artifacts', () => {
     }
   })
 
+  it('misses and deletes expired persisted head records during fallback boot', async () => {
+    if (shouldSkipReplayWithCachedNavigations) {
+      return
+    }
+
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    await next.start({ skipBuild: true })
+
+    let page: Playwright.Page | undefined
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
+
+      await browser.elementById('prefetch-offline-navigation').click()
+      await retry(async () => {
+        const routeRecords =
+          await readPersistedOfflineNavigationRouteRecords(browser)
+        expect(
+          routeRecords.some((record) =>
+            record.route.pathname.includes('/prefetched')
+          )
+        ).toBe(true)
+
+        const segmentRecords =
+          await readPersistedOfflineNavigationSegmentRecords(browser)
+        expect(
+          segmentRecords.some(
+            (record) =>
+              record.key.includes('prefetched') &&
+              record.segment.requestKey.endsWith('/__PAGE__')
+          )
+        ).toBe(true)
+        expect(
+          segmentRecords.some(
+            (record) => record.segment.requestKey === '/_head'
+          )
+        ).toBe(true)
+      })
+
+      const deletedExactEntries = await deletePersistedOfflineNavigationEntries(
+        browser,
+        '/docs/prefetched'
+      )
+      expect(deletedExactEntries).toBeGreaterThan(0)
+      await retry(async () => {
+        const deletedEntry = await readPersistedOfflineNavigationEntry(
+          browser,
+          '/docs/prefetched'
+        )
+        expect(deletedEntry).toBe(null)
+      })
+
+      const expiredHeadRecords =
+        await expirePersistedOfflineNavigationSegmentRecords(browser, {
+          keySubstring: '',
+          requestKeySuffix: '/_head',
+        })
+      expect(expiredHeadRecords).toEqual({
+        count: expect.any(Number),
+        expiresAt: expect.any(Number),
+        keys: expect.any(Array),
+        requestKeys: expect.arrayContaining(['/_head']),
+      })
+      expect(expiredHeadRecords.count).toBeGreaterThan(0)
+      await retry(async () => {
+        const segmentRecords =
+          await readPersistedOfflineNavigationSegmentRecords(browser)
+        const headRecords = segmentRecords.filter(
+          (record) => record.segment.requestKey === '/_head'
+        )
+        expect(headRecords).toHaveLength(expiredHeadRecords.count)
+        expect(
+          headRecords.every(
+            (record) =>
+              record.expiresAt === expiredHeadRecords.expiresAt &&
+              record.expiresAt <= Date.now()
+          )
+        ).toBe(true)
+        expect(
+          segmentRecords.some(
+            (record) =>
+              record.key.includes('prefetched') &&
+              record.segment.requestKey.endsWith('/__PAGE__')
+          )
+        ).toBe(true)
+      })
+
+      await next.stop()
+      await page!.context().setOffline(true)
+      const expiredHeadResponse = await page!.goto(
+        `${next.url}/docs/prefetched`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(expiredHeadResponse?.status()).toBe(200)
+
+      await retry(async () => {
+        const diagnostics = await browser.eval(() => {
+          const win = window as typeof window & {
+            __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?: Array<{
+              reason?: string
+              type?: string
+              url?: string
+            }>
+          }
+          return win.__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__ ?? []
+        })
+        expect(diagnostics).toContainEqual(
+          expect.objectContaining({
+            reason: 'missing-head',
+            type: 'router-cache-reconstruction-miss',
+            url: `${next.url}/docs/prefetched`,
+          })
+        )
+        expect(diagnostics).toContainEqual(
+          expect.objectContaining({
+            reason: 'missing-entry',
+            type: 'cache-miss',
+            url: `${next.url}/docs/prefetched`,
+          })
+        )
+      })
+      await retry(async () => {
+        expect(
+          await browser.eval(() => {
+            const cacheMiss = document.getElementById(
+              '__NEXT_OFFLINE_NAVIGATION_CACHE_MISS'
+            )
+            return cacheMiss === null
+              ? null
+              : {
+                  hidden: cacheMiss.hidden,
+                  reason: cacheMiss.getAttribute(
+                    'data-next-offline-navigation-cache-reason'
+                  ),
+                  text: cacheMiss.textContent,
+                }
+          })
+        ).toEqual({
+          hidden: false,
+          reason: 'missing-entry',
+          text: 'This page is not available offline.',
+        })
+      })
+      await retry(async () => {
+        const segmentRecords =
+          await readPersistedOfflineNavigationSegmentRecords(browser)
+        expect(
+          segmentRecords.some(
+            (record) => record.segment.requestKey === '/_head'
+          )
+        ).toBe(false)
+      })
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
   it('misses persisted router records after router refresh invalidation', async () => {
     if (shouldSkipReplayWithCachedNavigations) {
       return


### PR DESCRIPTION
## Why

This is a focused follow-up to the expired route-record and page-segment stress PRs. It covers the separate head reconstruction branch: a route can have valid route and page segment records but still must miss if the persisted head record is expired.

That distinction matters because fallback boot reconstructs the cache-components route in two phases: route/segment seed data first, then head data. We want e2e coverage that the `missing-head` reason is observable and does not collapse into an unrelated cache miss.

## What changed

- Reuses the segment-record expiration helper from the previous PR.
- Adds an e2e that prefetches `/docs/prefetched`, deletes the exact-URL entry, expires persisted `/_head` records, stops the server, and hard-loads the route offline.
- Asserts fallback boot emits `router-cache-reconstruction-miss` with `missing-head`, reaches visible cache-miss UI, and deletes the expired head record from IndexedDB.

## Stack position

Base: `feedthejim/offline-navigations-expired-segment-record-stress`

This PR is test-only. The prior slices cover expired exact URL, expired route, and expired page segment records. This one completes the current route/head freshness trio by covering the distinct `missing-head` reconstruction path.

## Still intentionally not covered here

- Expired parent layout, default slot, and parallel route segment records
- Stale-but-not-expired freshness policy boundaries
- Segment schema, build, deployment, route epoch, and app/session scope mismatch matrices
- Output export artifact freshness

Those stay as separate stress slices so each PR keeps a single reviewable claim.

## Verification

- `pnpm prettier --with-node-modules --ignore-path .prettierignore --write test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `npx eslint --config eslint.config.mjs --fix test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `git diff --check`
- `NEXT_SKIP_ISOLATE=1 pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "misses and deletes expired persisted head records during fallback boot"`
- `pnpm test-start-webpack test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "misses and deletes expired persisted head records during fallback boot"`

Note: the focused test commands printed the existing stale package-build warning because this stack has only test-file changes on top of the last package build. The fixture production build ran in both modes and passed.

<!-- NEXT_JS_LLM_PR -->