### PR TITLE
(1/1) Cover missing exact URL body offline navigation misses

### DIFF
--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -3815,6 +3815,173 @@ describe('offlineNavigations build artifacts', () => {
     }
   })
 
+  it('misses exact-URL data with a missing RSC response body during fallback boot', async () => {
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    const { buildId } = await getOfflineNavigationArtifactPaths()
+    const navigationBuildId = next.deploymentId ?? buildId
+    await next.start({ skipBuild: true })
+
+    let page: Playwright.Page | undefined
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
+
+      await retry(async () => {
+        const initialLoadEntry = await readPersistedOfflineNavigationEntry(
+          browser,
+          '/docs/'
+        )
+        expect(initialLoadEntry).toEqual(
+          expect.objectContaining({
+            buildId: navigationBuildId,
+            kind: 'exact-url',
+            payload: expect.objectContaining({
+              kind: 'rsc-response',
+              requestKind: 'initial-load',
+            }),
+          })
+        )
+      })
+
+      const missingBodyUrl = `${next.url}/docs/missing-body-offline-entry/`
+      const missingBodyEntry = await browser.eval(
+        async ({ currentBuildId, url }) => {
+          const database = await new Promise<IDBDatabase>((resolve, reject) => {
+            const request = indexedDB.open('next-offline-navigation-cache', 3)
+            request.onsuccess = () => resolve(request.result)
+            request.onerror = () => reject(request.error)
+          })
+
+          try {
+            const readTransaction = database.transaction(
+              'navigation-data',
+              'readonly'
+            )
+            const entries = await new Promise<any[]>((resolve, reject) => {
+              const request = readTransaction
+                .objectStore('navigation-data')
+                .getAll()
+              request.onsuccess = () => resolve(request.result)
+              request.onerror = () => reject(request.error)
+            })
+            const sourceEntry = entries.find((entry) =>
+              entry.url.endsWith('/docs/')
+            )
+            if (!sourceEntry) {
+              return null
+            }
+
+            const writeTransaction = database.transaction(
+              'navigation-data',
+              'readwrite'
+            )
+            writeTransaction.objectStore('navigation-data').put({
+              ...sourceEntry,
+              buildId: currentBuildId,
+              url,
+              payload: {
+                ...sourceEntry.payload,
+                url,
+                body: null,
+              },
+            })
+            await new Promise<void>((resolve, reject) => {
+              writeTransaction.oncomplete = () => resolve()
+              writeTransaction.onerror = () => reject(writeTransaction.error)
+              writeTransaction.onabort = () => reject(writeTransaction.error)
+            })
+
+            return {
+              buildId: currentBuildId,
+              payloadBody: null,
+              payloadKind: sourceEntry.payload.kind,
+              url,
+            }
+          } finally {
+            database.close()
+          }
+        },
+        {
+          currentBuildId: navigationBuildId,
+          url: missingBodyUrl,
+        }
+      )
+      expect(missingBodyEntry).toEqual({
+        buildId: navigationBuildId,
+        payloadBody: null,
+        payloadKind: 'rsc-response',
+        url: missingBodyUrl,
+      })
+
+      await next.stop()
+      await page!.context().setOffline(true)
+      const response = await page!.goto(missingBodyUrl, {
+        waitUntil: 'domcontentloaded',
+      })
+      expect(response?.status()).toBe(200)
+
+      await retry(async () => {
+        expect(
+          await browser.eval(() => {
+            const cacheMiss = document.getElementById(
+              '__NEXT_OFFLINE_NAVIGATION_CACHE_MISS'
+            )
+            return cacheMiss === null
+              ? null
+              : {
+                  hidden: cacheMiss.hidden,
+                  reason: cacheMiss.getAttribute(
+                    'data-next-offline-navigation-cache-reason'
+                  ),
+                  text: cacheMiss.textContent,
+                }
+          })
+        ).toEqual({
+          hidden: false,
+          reason: 'invalid-payload',
+          text: 'This page is not available offline.',
+        })
+      })
+
+      expect(
+        await browser.eval(() => ({
+          cache: document.documentElement.getAttribute(
+            'data-next-offline-navigation-cache'
+          ),
+          reason: document.documentElement.getAttribute(
+            'data-next-offline-navigation-cache-reason'
+          ),
+          diagnostic:
+            (
+              window as typeof window & {
+                __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?: Array<unknown>
+              }
+            ).__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?.at(-1) ?? null,
+        }))
+      ).toMatchObject({
+        cache: 'miss',
+        reason: 'invalid-payload',
+        diagnostic: {
+          type: 'cache-miss',
+          buildId: navigationBuildId,
+          reason: 'invalid-payload',
+          url: missingBodyUrl,
+        },
+      })
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
   it('misses and deletes expired persisted exact-URL data during fallback boot', async () => {
     const buildResult = await next.build()
     expect(buildResult.exitCode).toBe(0)


### PR DESCRIPTION
## Why

This is a narrow `EXACT-05a` payload-damage stress slice in the `offlineNavigations` stack. Earlier coverage already checks a broad malformed payload and unsupported request kind inside the service-worker stress test, but this PR isolates one concrete exact-URL payload-capability failure: the persisted RSC response shape is otherwise fresh and current-build, but the response body is missing.

The client fallback bootstrap should reject that payload as `invalid-payload`, show visible cache-miss UI, and avoid trying to render stale or partial route data.

## What changed

- Adds an e2e that starts from a valid initial-load exact-URL entry, copies it to a new URL, and changes only `payload.body` to `null`.
- Stops the server, hard-loads the damaged URL offline, and asserts the fallback document boots to visible cache-miss UI.
- Asserts the public diagnostic reason is `invalid-payload` for the requested URL and current build/deployment namespace.

## Stack position

Base: `feedthejim/offline-navigations-expired-head-record-stress`

This PR is test-only. It follows the route/segment/head freshness stress slices and starts the exact-URL payload damage queue with one reviewable failure mode.

## Still intentionally not covered here

- Truncated but non-null RSC framing
- Exact-URL schema mismatch
- Deployment ID mismatch
- Unsupported exact-URL response shapes beyond the existing broad malformed/unsupported coverage
- Output export artifact corruption

Those stay as separate stress slices so each PR owns one concrete claim.

## Verification

- `pnpm prettier --with-node-modules --ignore-path .prettierignore --write test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `npx eslint --config eslint.config.mjs --fix test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `git diff --check`
- `NEXT_SKIP_ISOLATE=1 pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "misses exact-URL data with a missing RSC response body during fallback boot"`
- `pnpm test-start-webpack test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "misses exact-URL data with a missing RSC response body during fallback boot"`

Note: the focused test commands printed the existing stale package-build warning because this stack has only test-file changes on top of the last package build. The fixture production build ran in both modes and passed.

<!-- NEXT_JS_LLM_PR -->