### PR TITLE
(1/1) Cover incompatible exact URL payload version offline misses

### DIFF
--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -3982,6 +3982,174 @@ describe('offlineNavigations build artifacts', () => {
     }
   })
 
+  it('misses exact-URL data with an incompatible RSC response payload version during fallback boot', async () => {
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    const { buildId } = await getOfflineNavigationArtifactPaths()
+    const navigationBuildId = next.deploymentId ?? buildId
+    await next.start({ skipBuild: true })
+
+    let page: Playwright.Page | undefined
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
+
+      await retry(async () => {
+        const initialLoadEntry = await readPersistedOfflineNavigationEntry(
+          browser,
+          '/docs/'
+        )
+        expect(initialLoadEntry).toEqual(
+          expect.objectContaining({
+            buildId: navigationBuildId,
+            kind: 'exact-url',
+            payload: expect.objectContaining({
+              kind: 'rsc-response',
+              requestKind: 'initial-load',
+            }),
+          })
+        )
+      })
+
+      const incompatiblePayloadUrl = `${next.url}/docs/incompatible-payload-version-offline-entry/`
+      const incompatiblePayloadEntry = await browser.eval(
+        async ({ currentBuildId, url }) => {
+          const database = await new Promise<IDBDatabase>((resolve, reject) => {
+            const request = indexedDB.open('next-offline-navigation-cache', 3)
+            request.onsuccess = () => resolve(request.result)
+            request.onerror = () => reject(request.error)
+          })
+
+          try {
+            const readTransaction = database.transaction(
+              'navigation-data',
+              'readonly'
+            )
+            const entries = await new Promise<any[]>((resolve, reject) => {
+              const request = readTransaction
+                .objectStore('navigation-data')
+                .getAll()
+              request.onsuccess = () => resolve(request.result)
+              request.onerror = () => reject(request.error)
+            })
+            const sourceEntry = entries.find((entry) =>
+              entry.url.endsWith('/docs/')
+            )
+            if (!sourceEntry) {
+              return null
+            }
+
+            const payloadVersion = 999
+            const writeTransaction = database.transaction(
+              'navigation-data',
+              'readwrite'
+            )
+            writeTransaction.objectStore('navigation-data').put({
+              ...sourceEntry,
+              buildId: currentBuildId,
+              url,
+              payload: {
+                ...sourceEntry.payload,
+                url,
+                version: payloadVersion,
+              },
+            })
+            await new Promise<void>((resolve, reject) => {
+              writeTransaction.oncomplete = () => resolve()
+              writeTransaction.onerror = () => reject(writeTransaction.error)
+              writeTransaction.onabort = () => reject(writeTransaction.error)
+            })
+
+            return {
+              buildId: currentBuildId,
+              payloadKind: sourceEntry.payload.kind,
+              payloadVersion,
+              url,
+            }
+          } finally {
+            database.close()
+          }
+        },
+        {
+          currentBuildId: navigationBuildId,
+          url: incompatiblePayloadUrl,
+        }
+      )
+      expect(incompatiblePayloadEntry).toEqual({
+        buildId: navigationBuildId,
+        payloadKind: 'rsc-response',
+        payloadVersion: 999,
+        url: incompatiblePayloadUrl,
+      })
+
+      await next.stop()
+      await page!.context().setOffline(true)
+      const response = await page!.goto(incompatiblePayloadUrl, {
+        waitUntil: 'domcontentloaded',
+      })
+      expect(response?.status()).toBe(200)
+
+      await retry(async () => {
+        expect(
+          await browser.eval(() => {
+            const cacheMiss = document.getElementById(
+              '__NEXT_OFFLINE_NAVIGATION_CACHE_MISS'
+            )
+            return cacheMiss === null
+              ? null
+              : {
+                  hidden: cacheMiss.hidden,
+                  reason: cacheMiss.getAttribute(
+                    'data-next-offline-navigation-cache-reason'
+                  ),
+                  text: cacheMiss.textContent,
+                }
+          })
+        ).toEqual({
+          hidden: false,
+          reason: 'invalid-payload',
+          text: 'This page is not available offline.',
+        })
+      })
+
+      expect(
+        await browser.eval(() => ({
+          cache: document.documentElement.getAttribute(
+            'data-next-offline-navigation-cache'
+          ),
+          reason: document.documentElement.getAttribute(
+            'data-next-offline-navigation-cache-reason'
+          ),
+          diagnostic:
+            (
+              window as typeof window & {
+                __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?: Array<unknown>
+              }
+            ).__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?.at(-1) ?? null,
+        }))
+      ).toMatchObject({
+        cache: 'miss',
+        reason: 'invalid-payload',
+        diagnostic: {
+          type: 'cache-miss',
+          buildId: navigationBuildId,
+          reason: 'invalid-payload',
+          url: incompatiblePayloadUrl,
+        },
+      })
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
   it('misses and deletes expired persisted exact-URL data during fallback boot', async () => {
     const buildResult = await next.build()
     expect(buildResult.exitCode).toBe(0)


### PR DESCRIPTION
## Stack position

This is a one-PR stress-test slice stacked on top of #93664, `(1/1) Cover missing exact URL body offline navigation misses`.

The surrounding offline navigation stack is proving the cache-components-only architecture where the service worker only keeps document navigations alive, while the client runtime owns IndexedDB replay decisions. This PR does not add a new feature path. It adds another destructive exact-URL payload compatibility case for the fallback boot contract introduced earlier in the stack.

## What this covers

When the fallback document boots offline, it may find an exact-URL IndexedDB entry for the requested URL. That entry is only replayable if the stored RSC response payload still matches the payload schema the current runtime knows how to restore.

This PR copies a valid initial-load exact-URL RSC payload, changes only the RSC response payload `version`, stops the server, goes offline, and hard-loads the damaged URL. The expected behavior is a visible cache miss with an `invalid-payload` diagnostic, not an attempted replay from an incompatible schema and not a silent blank page.

## What works after this PR

- Exact-URL fallback boot has e2e coverage for an incompatible RSC payload version.
- The test proves the service worker still serves the generated fallback document while the app server is unavailable.
- The client rejects the damaged payload with the same visible cache-miss path used for other invalid exact-URL payloads.
- Diagnostics include the current build ID, requested URL, and `invalid-payload` reason.

## What intentionally does not work yet

- This does not cover truncated RSC framing, unsupported response shapes, or deployment-ID mismatch. Those remain separate payload-damage stress cases.
- This does not add route/segment schema mismatch coverage. Route and segment records have separate stores and should stay in their own stress slices.
- This does not change any runtime behavior, storage schema, or service-worker logic.

## Reviewer focus

Please focus on whether this test protects the right production contract: fallback boot must not replay exact-URL data whose payload schema is incompatible with the current client runtime.

The PR is intentionally test-only so it can be reviewed independently from implementation changes.

## Verification

- `pnpm prettier --with-node-modules --ignore-path .prettierignore --write test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `npx eslint --config eslint.config.mjs --fix test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `git diff --check`
- `NEXT_SKIP_ISOLATE=1 pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "misses exact-URL data with an incompatible RSC response payload version during fallback boot"`
- `pnpm test-start-webpack test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "misses exact-URL data with an incompatible RSC response payload version during fallback boot"`

## Known risks and deferred coverage

CI for the parent stress stack currently has an unrelated Turbopack dev failure in `test/development/app-dir/hmr-deleted-page/hmr-deleted-page.test.ts`. This PR's owned production offline-navigation focused runs passed locally in Turbopack and packed webpack modes.

<!-- NEXT_JS_LLM_PR -->
