### PR TITLE
(1/1) Cover incompatible exact URL entry version offline misses

### DIFF
--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -4150,6 +4150,183 @@ describe('offlineNavigations build artifacts', () => {
     }
   })
 
+  it('misses and deletes exact-URL data with an incompatible entry version during fallback boot', async () => {
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    const { buildId } = await getOfflineNavigationArtifactPaths()
+    const navigationBuildId = next.deploymentId ?? buildId
+    await next.start({ skipBuild: true })
+
+    let page: Playwright.Page | undefined
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
+
+      await retry(async () => {
+        const initialLoadEntry = await readPersistedOfflineNavigationEntry(
+          browser,
+          '/docs/'
+        )
+        expect(initialLoadEntry).toEqual(
+          expect.objectContaining({
+            buildId: navigationBuildId,
+            kind: 'exact-url',
+            payload: expect.objectContaining({
+              kind: 'rsc-response',
+              requestKind: 'initial-load',
+            }),
+          })
+        )
+      })
+
+      const incompatibleEntryUrl = `${next.url}/docs/incompatible-entry-version-offline-entry/`
+      const incompatibleEntry = await browser.eval(
+        async ({ currentBuildId, url }) => {
+          const database = await new Promise<IDBDatabase>((resolve, reject) => {
+            const request = indexedDB.open('next-offline-navigation-cache', 3)
+            request.onsuccess = () => resolve(request.result)
+            request.onerror = () => reject(request.error)
+          })
+
+          try {
+            const readTransaction = database.transaction(
+              'navigation-data',
+              'readonly'
+            )
+            const entries = await new Promise<any[]>((resolve, reject) => {
+              const request = readTransaction
+                .objectStore('navigation-data')
+                .getAll()
+              request.onsuccess = () => resolve(request.result)
+              request.onerror = () => reject(request.error)
+            })
+            const sourceEntry = entries.find((entry) =>
+              entry.url.endsWith('/docs/')
+            )
+            if (!sourceEntry) {
+              return null
+            }
+
+            const entryVersion = 999
+            const writeTransaction = database.transaction(
+              'navigation-data',
+              'readwrite'
+            )
+            writeTransaction.objectStore('navigation-data').put({
+              ...sourceEntry,
+              version: entryVersion,
+              buildId: currentBuildId,
+              url,
+              payload: {
+                ...sourceEntry.payload,
+                url,
+              },
+            })
+            await new Promise<void>((resolve, reject) => {
+              writeTransaction.oncomplete = () => resolve()
+              writeTransaction.onerror = () => reject(writeTransaction.error)
+              writeTransaction.onabort = () => reject(writeTransaction.error)
+            })
+
+            return {
+              buildId: currentBuildId,
+              entryVersion,
+              payloadKind: sourceEntry.payload.kind,
+              url,
+            }
+          } finally {
+            database.close()
+          }
+        },
+        {
+          currentBuildId: navigationBuildId,
+          url: incompatibleEntryUrl,
+        }
+      )
+      expect(incompatibleEntry).toEqual({
+        buildId: navigationBuildId,
+        entryVersion: 999,
+        payloadKind: 'rsc-response',
+        url: incompatibleEntryUrl,
+      })
+
+      await next.stop()
+      await page!.context().setOffline(true)
+      const response = await page!.goto(incompatibleEntryUrl, {
+        waitUntil: 'domcontentloaded',
+      })
+      expect(response?.status()).toBe(200)
+
+      await retry(async () => {
+        expect(
+          await browser.eval(() => {
+            const cacheMiss = document.getElementById(
+              '__NEXT_OFFLINE_NAVIGATION_CACHE_MISS'
+            )
+            return cacheMiss === null
+              ? null
+              : {
+                  hidden: cacheMiss.hidden,
+                  reason: cacheMiss.getAttribute(
+                    'data-next-offline-navigation-cache-reason'
+                  ),
+                  text: cacheMiss.textContent,
+                }
+          })
+        ).toEqual({
+          hidden: false,
+          reason: 'missing-entry',
+          text: 'This page is not available offline.',
+        })
+      })
+
+      expect(
+        await browser.eval(() => ({
+          cache: document.documentElement.getAttribute(
+            'data-next-offline-navigation-cache'
+          ),
+          reason: document.documentElement.getAttribute(
+            'data-next-offline-navigation-cache-reason'
+          ),
+          diagnostic:
+            (
+              window as typeof window & {
+                __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?: Array<unknown>
+              }
+            ).__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?.at(-1) ?? null,
+        }))
+      ).toMatchObject({
+        cache: 'miss',
+        reason: 'missing-entry',
+        diagnostic: {
+          type: 'cache-miss',
+          buildId: navigationBuildId,
+          reason: 'missing-entry',
+          url: incompatibleEntryUrl,
+        },
+      })
+
+      await retry(async () => {
+        expect(
+          await readPersistedOfflineNavigationEntry(
+            browser,
+            '/docs/incompatible-entry-version-offline-entry/'
+          )
+        ).toBe(null)
+      })
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
   it('misses and deletes expired persisted exact-URL data during fallback boot', async () => {
     const buildResult = await next.build()
     expect(buildResult.exitCode).toBe(0)


### PR DESCRIPTION
## Stack position

This is a one-PR stress-test slice stacked on top of #93665, `(1/1) Cover incompatible exact URL payload version offline misses`.

The previous PR covers the inner RSC response payload schema. This PR covers the outer exact-URL IndexedDB entry schema. Keeping them separate makes the review question narrow: does fallback boot delete an incompatible durable entry before it can be treated as replayable data?

## What this covers

The exact-URL store has an entry-level schema version in addition to the stored RSC response payload shape. If that outer entry version does not match the current runtime, the client should treat the entry as incompatible, delete it, and render the normal offline cache-miss UI.

This test copies a valid initial-load exact-URL entry, changes only the outer entry `version`, stops the app server, goes offline, and hard-loads the damaged URL. The expected result is a visible `missing-entry` miss with current-build diagnostics, followed by deletion of the incompatible IndexedDB record.

## What works after this PR

- Fallback boot has e2e coverage for incompatible exact-URL entry versions.
- The incompatible record is deleted during the read path.
- The app shows deterministic cache-miss UI instead of replaying stale or schema-incompatible data.
- The diagnostic records the current build ID, requested URL, and `missing-entry` reason.

## What intentionally does not work yet

- This does not cover route or segment record schema mismatch. Those stores have separate replay paths and should be tested in route/segment stress slices.
- This does not cover truncated RSC body framing or deployment-ID mismatch.
- This does not change production behavior, storage schema, or service-worker behavior.

## Reviewer focus

Please focus on the entry-level compatibility contract: an exact-URL record whose outer schema is incompatible must not survive fallback boot or produce a replay hit.

The PR is intentionally test-only and stacked directly after the payload-version test so the two schema layers are easy to review separately.

## Verification

- `pnpm prettier --with-node-modules --ignore-path .prettierignore --write test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `npx eslint --config eslint.config.mjs --fix test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `git diff --check`
- `NEXT_SKIP_ISOLATE=1 pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "misses and deletes exact-URL data with an incompatible entry version during fallback boot"`
- `pnpm test-start-webpack test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "misses and deletes exact-URL data with an incompatible entry version during fallback boot"`

## Known risks and deferred coverage

CI for the parent stress stack currently has an unrelated Turbopack dev failure in `test/development/app-dir/hmr-deleted-page/hmr-deleted-page.test.ts`. This PR's owned production offline-navigation focused runs passed locally in Turbopack and packed webpack modes.

<!-- NEXT_JS_LLM_PR -->
