### PR TITLE
(1/1) Handle malformed exact URL RSC payload offline misses

### DIFF
--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -543,8 +543,9 @@ if (instantTestStaticFetch) {
       }
 
       const fallbackResponse = bootstrap.response
-      const fallbackInitialRSCPayload =
-        await createFromFetch<InitialRSCPayload>(
+      let fallbackInitialRSCPayload: InitialRSCPayload
+      try {
+        fallbackInitialRSCPayload = await createFromFetch<InitialRSCPayload>(
           Promise.resolve(fallbackResponse.response),
           {
             callServer,
@@ -553,6 +554,10 @@ if (instantTestStaticFetch) {
             unstable_allowPartialStream: true,
           }
         )
+      } catch {
+        showOfflineNavigationCacheMiss('invalid-payload', bootstrap.buildId)
+        return await neverResolveInitialRSCPayload()
+      }
 
       if (fallbackResponse.requestKind === 'initial-load') {
         return fallbackInitialRSCPayload

--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -4327,6 +4327,177 @@ describe('offlineNavigations build artifacts', () => {
     }
   })
 
+  it('misses exact-URL data with a malformed RSC response body during fallback boot', async () => {
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    const { buildId } = await getOfflineNavigationArtifactPaths()
+    const navigationBuildId = next.deploymentId ?? buildId
+    await next.start({ skipBuild: true })
+
+    let page: Playwright.Page | undefined
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
+
+      await retry(async () => {
+        const initialLoadEntry = await readPersistedOfflineNavigationEntry(
+          browser,
+          '/docs/'
+        )
+        expect(initialLoadEntry).toEqual(
+          expect.objectContaining({
+            buildId: navigationBuildId,
+            kind: 'exact-url',
+            payload: expect.objectContaining({
+              kind: 'rsc-response',
+              requestKind: 'initial-load',
+            }),
+          })
+        )
+      })
+
+      const malformedBodyUrl = `${next.url}/docs/malformed-rsc-body-offline-entry/`
+      const malformedBodyEntry = await browser.eval(
+        async ({ currentBuildId, url }) => {
+          const database = await new Promise<IDBDatabase>((resolve, reject) => {
+            const request = indexedDB.open('next-offline-navigation-cache', 3)
+            request.onsuccess = () => resolve(request.result)
+            request.onerror = () => reject(request.error)
+          })
+
+          try {
+            const readTransaction = database.transaction(
+              'navigation-data',
+              'readonly'
+            )
+            const entries = await new Promise<any[]>((resolve, reject) => {
+              const request = readTransaction
+                .objectStore('navigation-data')
+                .getAll()
+              request.onsuccess = () => resolve(request.result)
+              request.onerror = () => reject(request.error)
+            })
+            const sourceEntry = entries.find((entry) =>
+              entry.url.endsWith('/docs/')
+            )
+            if (!sourceEntry) {
+              return null
+            }
+
+            const malformedBody = new TextEncoder().encode(
+              '0:{"unterminated"\n'
+            )
+            const writeTransaction = database.transaction(
+              'navigation-data',
+              'readwrite'
+            )
+            writeTransaction.objectStore('navigation-data').put({
+              ...sourceEntry,
+              buildId: currentBuildId,
+              url,
+              payload: {
+                ...sourceEntry.payload,
+                url,
+                body: malformedBody.buffer,
+              },
+            })
+            await new Promise<void>((resolve, reject) => {
+              writeTransaction.oncomplete = () => resolve()
+              writeTransaction.onerror = () => reject(writeTransaction.error)
+              writeTransaction.onabort = () => reject(writeTransaction.error)
+            })
+
+            return {
+              bodyLength: malformedBody.byteLength,
+              buildId: currentBuildId,
+              payloadKind: sourceEntry.payload.kind,
+              url,
+            }
+          } finally {
+            database.close()
+          }
+        },
+        {
+          currentBuildId: navigationBuildId,
+          url: malformedBodyUrl,
+        }
+      )
+      expect(malformedBodyEntry).toEqual({
+        bodyLength: expect.any(Number),
+        buildId: navigationBuildId,
+        payloadKind: 'rsc-response',
+        url: malformedBodyUrl,
+      })
+      expect(malformedBodyEntry!.bodyLength).toBeGreaterThan(0)
+
+      await next.stop()
+      await page!.context().setOffline(true)
+      const response = await page!.goto(malformedBodyUrl, {
+        waitUntil: 'domcontentloaded',
+      })
+      expect(response?.status()).toBe(200)
+
+      await retry(async () => {
+        expect(
+          await browser.eval(() => {
+            const cacheMiss = document.getElementById(
+              '__NEXT_OFFLINE_NAVIGATION_CACHE_MISS'
+            )
+            return cacheMiss === null
+              ? null
+              : {
+                  hidden: cacheMiss.hidden,
+                  reason: cacheMiss.getAttribute(
+                    'data-next-offline-navigation-cache-reason'
+                  ),
+                  text: cacheMiss.textContent,
+                }
+          })
+        ).toEqual({
+          hidden: false,
+          reason: 'invalid-payload',
+          text: 'This page is not available offline.',
+        })
+      })
+
+      expect(
+        await browser.eval(() => ({
+          cache: document.documentElement.getAttribute(
+            'data-next-offline-navigation-cache'
+          ),
+          reason: document.documentElement.getAttribute(
+            'data-next-offline-navigation-cache-reason'
+          ),
+          diagnostic:
+            (
+              window as typeof window & {
+                __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?: Array<unknown>
+              }
+            ).__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?.at(-1) ?? null,
+        }))
+      ).toMatchObject({
+        cache: 'miss',
+        reason: 'invalid-payload',
+        diagnostic: {
+          type: 'cache-miss',
+          buildId: navigationBuildId,
+          reason: 'invalid-payload',
+          url: malformedBodyUrl,
+        },
+      })
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
   it('misses and deletes expired persisted exact-URL data during fallback boot', async () => {
     const buildResult = await next.build()
     expect(buildResult.exitCode).toBe(0)


### PR DESCRIPTION
## Stack position

This is a one-PR payload-damage slice stacked on top of #93666, `(1/1) Cover incompatible exact URL entry version offline misses`.

The previous two slices cover schema compatibility before React tries to consume the cached response. This PR covers the next failure boundary: a valid-shaped exact-URL entry whose RSC response bytes are malformed.

## What this changes

Fallback boot already validates that an exact-URL payload has the expected RSC response shape. A corrupt body can still pass that shape check because the body is an `ArrayBuffer`, then fail when React parses the Flight response.

This PR catches that parse failure in the fallback bootstrap path, switches the document to visible `invalid-payload` cache-miss UI, and returns the same never-resolving placeholder payload used by other cache-miss states. This avoids treating a malformed cached response as a successful replay and avoids leaving the generated fallback document blank or stuck without a reason.

## What this covers

The e2e copies a valid initial-load exact-URL RSC payload, replaces the body with a malformed complete Flight row, stops the server, goes offline, and hard-loads the damaged URL. The expected result is a visible `invalid-payload` miss with the current build ID and requested URL in diagnostics.

## What works after this PR

- Valid-shaped but malformed exact-URL RSC response bodies miss visibly during fallback boot.
- The miss reason is `invalid-payload`, consistent with other payload compatibility failures.
- The service worker still only serves the fallback document; the client bootstrap owns the payload validation and parse failure behavior.

## What intentionally does not work yet

- Incomplete partial streams that React treats as allowed partial data are not reclassified here. This PR is specifically about corrupt complete RSC rows that reject during parsing.
- Deployment-ID mismatch and route/segment malformed payloads remain separate stress slices.
- This does not change the IndexedDB schema or service-worker behavior.

## Reviewer focus

Please focus on the small bootstrap change in `app-index.tsx`: the catch is scoped to offline fallback exact-URL RSC parsing, and it falls back to the existing cache-miss mechanism rather than inventing a new render path.

## Verification

- `pnpm prettier --with-node-modules --ignore-path .prettierignore --write packages/next/src/client/app-index.tsx test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `npx eslint --config eslint.config.mjs --fix packages/next/src/client/app-index.tsx test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `pnpm --filter=next build`
- `git diff --check`
- `NEXT_SKIP_ISOLATE=1 pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "misses exact-URL data with a malformed RSC response body during fallback boot"`
- `pnpm test-start-webpack test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "misses exact-URL data with a malformed RSC response body during fallback boot"`

## Known risks and deferred coverage

CI for the parent stress stack currently has an unrelated Turbopack dev failure in `test/development/app-dir/hmr-deleted-page/hmr-deleted-page.test.ts`. This PR's owned production offline-navigation focused runs passed locally in Turbopack and packed webpack modes.

<!-- NEXT_JS_LLM_PR -->
