### PR TITLE
(1/1) Cover exact URL query identity offline misses

### DIFF
--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -3569,6 +3569,146 @@ describe('offlineNavigations build artifacts', () => {
     }
   })
 
+  it('misses exact-URL replay for query identity collision variants', async () => {
+    if (shouldSkipReplayWithCachedNavigations) {
+      return
+    }
+
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    const { buildId } = await getOfflineNavigationArtifactPaths()
+    const navigationBuildId = next.deploymentId ?? buildId
+    await next.start({ skipBuild: true })
+
+    let page: Playwright.Page | undefined
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
+
+      const cachedUrl = `${next.url}/docs/url-stress/space%20value/?token=a%2Bb&tag=one&tag=two`
+      const onlineResponse = await page!.goto(cachedUrl, {
+        waitUntil: 'domcontentloaded',
+      })
+      expect(onlineResponse?.status()).toBe(200)
+      await retry(async () => {
+        expect(await browser.elementById('url-stress-page').text()).toBe(
+          'url stress path: space%20value'
+        )
+        expect(await browser.elementById('url-stress-token').text()).toBe(
+          'url stress token: a+b'
+        )
+        expect(await browser.elementById('url-stress-tags').text()).toBe(
+          'url stress tags: one,two'
+        )
+      })
+
+      await retry(async () => {
+        const entry = await readPersistedOfflineNavigationEntry(
+          browser,
+          '/docs/url-stress/space%20value/'
+        )
+        expect(entry).toEqual({
+          buildId: navigationBuildId,
+          cacheEpoch: 0,
+          expiresAt: expect.any(Number),
+          kind: 'exact-url',
+          payload: {
+            bodyLength: expect.any(Number),
+            kind: 'rsc-response',
+            requestKind: 'initial-load',
+            status: 200,
+          },
+          staleAt: expect.any(Number),
+          url: cachedUrl,
+          version: 2,
+        })
+      })
+
+      const collisionVariants = [
+        {
+          name: 'plus-as-space',
+          url: `${next.url}/docs/url-stress/space%20value/?token=a+b&tag=one&tag=two`,
+        },
+        {
+          name: 'duplicate-param-order',
+          url: `${next.url}/docs/url-stress/space%20value/?token=a%2Bb&tag=two&tag=one`,
+        },
+      ]
+
+      await next.stop()
+      await page!.context().setOffline(true)
+
+      for (const variant of collisionVariants) {
+        const response = await page!.goto(variant.url, {
+          waitUntil: 'domcontentloaded',
+        })
+        expect(response?.status()).toBe(200)
+
+        await retry(async () => {
+          expect(
+            await browser.eval(() => {
+              const cacheMiss = document.getElementById(
+                '__NEXT_OFFLINE_NAVIGATION_CACHE_MISS'
+              )
+              return cacheMiss === null
+                ? null
+                : {
+                    hidden: cacheMiss.hidden,
+                    reason: cacheMiss.getAttribute(
+                      'data-next-offline-navigation-cache-reason'
+                    ),
+                    text: cacheMiss.textContent,
+                  }
+            })
+          ).toEqual({
+            hidden: false,
+            reason: 'missing-entry',
+            text: 'This page is not available offline.',
+          })
+        })
+
+        expect(
+          await browser.eval(() => ({
+            cache: document.documentElement.getAttribute(
+              'data-next-offline-navigation-cache'
+            ),
+            reason: document.documentElement.getAttribute(
+              'data-next-offline-navigation-cache-reason'
+            ),
+            renderedRoute:
+              document.getElementById('url-stress-page')?.textContent ?? null,
+            diagnostic:
+              (
+                window as typeof window & {
+                  __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?: Array<unknown>
+                }
+              ).__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?.at(-1) ?? null,
+          }))
+        ).toMatchObject({
+          cache: 'miss',
+          reason: 'missing-entry',
+          renderedRoute: null,
+          diagnostic: {
+            type: 'cache-miss',
+            buildId: navigationBuildId,
+            reason: 'missing-entry',
+            url: variant.url,
+          },
+        })
+      }
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
   it('shows cache miss when IndexedDB is unavailable during fallback boot', async () => {
     const buildResult = await next.build()
     expect(buildResult.exitCode).toBe(0)


### PR DESCRIPTION
## Stack position

This is a one-PR URL-identity stress slice stacked on top of #93667, `(1/1) Handle malformed exact URL RSC payload offline misses`.

The previous payload-damage slices prove fallback boot rejects incompatible or malformed exact-URL data. This PR moves to the next exact-URL correctness contract: nearby query strings must not collide and replay the wrong cached response.

## What this covers

Exact-URL offline replay is intentionally keyed by the normalized request URL, with the hash excluded but the query string preserved. This matters for duplicate params and encoding differences where two URLs may look similar but produce different app data.

The e2e first loads and persists:

`/docs/url-stress/space%20value/?token=a%2Bb&tag=one&tag=two`

Then it stops the server, goes offline, and hard-loads two nearby variants:

- `token=a+b`, which is not the same URL as `token=a%2Bb`
- reversed duplicate query param order, `tag=two&tag=one`

Both variants must miss visibly with `missing-entry` and must not render the cached route data from the original URL.

## What works after this PR

- Exact-URL replay cannot accidentally collapse `+` and `%2B` query encodings.
- Exact-URL replay cannot accidentally collapse duplicate query params with different order.
- Miss diagnostics include the current build ID, requested URL, and `missing-entry` reason.
- The test asserts the app route content is absent on miss, so fallback UI cannot be mistaken for a replay hit.

## What intentionally does not work yet

- This does not cover every URL identity case in the plan. Base path, asset prefix, hash behavior, and basic reordered query coverage already exist elsewhere; encoded path variants, canonical redirects, trailing slash matrix, and deployment URL changes still need their own slices if they are not already covered by the owning implementation PRs.
- This does not change runtime behavior or storage schema.

## Reviewer focus

Please focus on whether these two collision variants protect the exact-URL cache key contract without expanding the implementation surface. This PR is test-only.

## Verification

- `pnpm prettier --with-node-modules --ignore-path .prettierignore --write test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `npx eslint --config eslint.config.mjs --fix test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `git diff --check`
- `NEXT_SKIP_ISOLATE=1 pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "misses exact-URL replay for query identity collision variants"`
- `pnpm test-start-webpack test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "misses exact-URL replay for query identity collision variants"`

## Known risks and deferred coverage

CI for the parent stress stack currently has an unrelated Turbopack dev failure in `test/development/app-dir/hmr-deleted-page/hmr-deleted-page.test.ts`. This PR's owned production offline-navigation focused runs passed locally in Turbopack and packed webpack modes.

<!-- NEXT_JS_LLM_PR -->
