### PR TITLE
(1/1) Cover stale exact URL offline replay

### DIFF
--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -4638,6 +4638,168 @@ describe('offlineNavigations build artifacts', () => {
     }
   })
 
+  it('replays stale-but-not-expired exact-URL data during fallback boot', async () => {
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    const { buildId } = await getOfflineNavigationArtifactPaths()
+    const navigationBuildId = next.deploymentId ?? buildId
+    await next.start({ skipBuild: true })
+
+    let page: Playwright.Page | undefined
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
+
+      await retry(async () => {
+        const initialLoadEntry = await readPersistedOfflineNavigationEntry(
+          browser,
+          '/docs/'
+        )
+        expect(initialLoadEntry).toEqual(
+          expect.objectContaining({
+            buildId: navigationBuildId,
+            kind: 'exact-url',
+            payload: expect.objectContaining({
+              kind: 'rsc-response',
+              requestKind: 'initial-load',
+            }),
+          })
+        )
+      })
+
+      const staleUrl = `${next.url}/docs/stale-but-replayable-offline-entry/`
+      const staleEntry = await browser.eval(
+        async ({ currentBuildId, url }) => {
+          const database = await new Promise<IDBDatabase>((resolve, reject) => {
+            const request = indexedDB.open('next-offline-navigation-cache', 3)
+            request.onsuccess = () => resolve(request.result)
+            request.onerror = () => reject(request.error)
+          })
+
+          try {
+            const readTransaction = database.transaction(
+              'navigation-data',
+              'readonly'
+            )
+            const entries = await new Promise<any[]>((resolve, reject) => {
+              const request = readTransaction
+                .objectStore('navigation-data')
+                .getAll()
+              request.onsuccess = () => resolve(request.result)
+              request.onerror = () => reject(request.error)
+            })
+            const sourceEntry = entries.find(
+              (entry) =>
+                entry.buildId === currentBuildId && entry.url.endsWith('/docs/')
+            )
+            if (!sourceEntry) {
+              return null
+            }
+
+            const staleAt = Date.now() - 1_000
+            const expiresAt = Date.now() + 60_000
+            const writeTransaction = database.transaction(
+              'navigation-data',
+              'readwrite'
+            )
+            writeTransaction.objectStore('navigation-data').put({
+              ...sourceEntry,
+              url,
+              staleAt,
+              expiresAt,
+              payload: {
+                ...sourceEntry.payload,
+                url,
+              },
+            })
+            await new Promise<void>((resolve, reject) => {
+              writeTransaction.oncomplete = () => resolve()
+              writeTransaction.onerror = () => reject(writeTransaction.error)
+              writeTransaction.onabort = () => reject(writeTransaction.error)
+            })
+
+            return {
+              buildId: currentBuildId,
+              expiresAt,
+              staleAt,
+              url,
+            }
+          } finally {
+            database.close()
+          }
+        },
+        {
+          currentBuildId: navigationBuildId,
+          url: staleUrl,
+        }
+      )
+      expect(staleEntry).toEqual({
+        buildId: navigationBuildId,
+        expiresAt: expect.any(Number),
+        staleAt: expect.any(Number),
+        url: staleUrl,
+      })
+      expect(staleEntry!.staleAt).toBeLessThan(Date.now())
+      expect(staleEntry!.expiresAt).toBeGreaterThan(Date.now())
+
+      const awayResponse = await page!.goto(`${next.url}/docs/prefetched`, {
+        waitUntil: 'domcontentloaded',
+      })
+      expect(awayResponse?.status()).toBe(200)
+      await retry(async () => {
+        expect(await browser.elementById('prefetched-page').text()).toBe(
+          'prefetched page'
+        )
+      })
+
+      await next.stop()
+      await page!.context().setOffline(true)
+      const response = await page!.goto(staleUrl, {
+        waitUntil: 'domcontentloaded',
+      })
+      expect(response?.status()).toBe(200)
+
+      await retry(async () => {
+        expect(await browser.elementByCss('p').text()).toBe(
+          'offline navigations page'
+        )
+      })
+      await retry(async () => {
+        expect(await browser.elementById('offline-status').text()).toBe(
+          'offline'
+        )
+      })
+
+      expect(
+        await browser.eval(() => {
+          const win = window as typeof window & {
+            __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?: Array<{
+              type?: string
+            }>
+          }
+          return win.__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?.find(
+            (diagnostic) => diagnostic.type === 'cache-hit'
+          )
+        })
+      ).toMatchObject({
+        type: 'cache-hit',
+        buildId: navigationBuildId,
+        requestKind: 'initial-load',
+        url: staleUrl,
+      })
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
   it('misses and deletes expired persisted exact-URL data during fallback boot', async () => {
     const buildResult = await next.build()
     expect(buildResult.exitCode).toBe(0)


### PR DESCRIPTION
## Stack position

This is a one-PR freshness-policy stress slice stacked on top of #93668, `(1/1) Cover exact URL query identity offline misses`.

The previous slices cover exact-URL payload damage and URL identity misses. This PR covers the positive side of freshness: stale-but-not-expired exact-URL data should still replay offline in the current v1 policy, while hard-expired entries are already covered by #93660.

## What this covers

The test starts from a valid initial-load exact-URL RSC payload, copies it to a never-loaded URL, mutates `staleAt` into the past while keeping `expiresAt` in the future, then navigates away online. After stopping the server and going offline, it hard-loads the never-loaded URL.

The expected behavior is a real fallback-document boot that renders from the stale-but-not-expired exact-URL data, reports `useOffline()` as offline, and emits a `cache-hit` diagnostic for the requested URL.

## What works after this PR

- Exact-URL replay has e2e coverage for stale-but-not-expired records.
- The test proves the URL was never loaded as an HTML document, so the result cannot be browser HTTP cache reuse.
- The paired hard-expired exact-URL miss remains covered in #93660.

## What intentionally does not work yet

- This does not define every future stale policy. It documents the current v1 behavior: replay while offline until hard expiry.
- Route, segment, and head stale-but-not-expired behavior still need their own cache-components route-cache slices.
- Clock skew and controlled-clock boundary tests remain separate `CACHE-01`/`EXACT-09` follow-ups.

## Reviewer focus

Please focus on whether this test captures the intended v1 offline freshness contract without changing runtime behavior: stale-but-not-expired exact-URL data is allowed to replay in browser-private storage, hard-expired data is not.

## Verification

- `pnpm prettier --with-node-modules --ignore-path .prettierignore --write test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `npx eslint --config eslint.config.mjs --fix test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `git diff --check`
- `NEXT_SKIP_ISOLATE=1 pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "replays stale-but-not-expired exact-URL data during fallback boot"`
- `pnpm test-start-webpack test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "replays stale-but-not-expired exact-URL data during fallback boot"`

## Known risks and deferred coverage

CI for the parent stress stack currently has an unrelated Turbopack dev failure in `test/development/app-dir/hmr-deleted-page/hmr-deleted-page.test.ts`. This PR's owned production offline-navigation focused runs passed locally in Turbopack and packed webpack modes.

<!-- NEXT_JS_LLM_PR -->
