### PR TITLE
(1/1) Cover missing head record offline navigation misses

### DIFF
--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -1722,6 +1722,164 @@ describe('offlineNavigations build artifacts', () => {
     }
   })
 
+  it('misses persisted router records when a required head record is missing during fallback boot', async () => {
+    if (shouldSkipReplayWithCachedNavigations) {
+      return
+    }
+
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    await next.start({ skipBuild: true })
+
+    let page: Playwright.Page | undefined
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
+
+      await browser.elementById('prefetch-offline-navigation').click()
+      await retry(async () => {
+        const routeRecords =
+          await readPersistedOfflineNavigationRouteRecords(browser)
+        expect(
+          routeRecords.some((record) =>
+            record.route.pathname.includes('/prefetched')
+          )
+        ).toBe(true)
+
+        const segmentRecords =
+          await readPersistedOfflineNavigationSegmentRecords(browser)
+        expect(
+          segmentRecords.some(
+            (record) =>
+              record.key.includes('prefetched') &&
+              record.segment.requestKey.endsWith('/__PAGE__')
+          )
+        ).toBe(true)
+        expect(
+          segmentRecords.some(
+            (record) => record.segment.requestKey === '/_head'
+          )
+        ).toBe(true)
+      })
+
+      const deletedExactEntries = await deletePersistedOfflineNavigationEntries(
+        browser,
+        '/docs/prefetched'
+      )
+      expect(deletedExactEntries).toBeGreaterThan(0)
+      await retry(async () => {
+        const deletedEntry = await readPersistedOfflineNavigationEntry(
+          browser,
+          '/docs/prefetched'
+        )
+        expect(deletedEntry).toBe(null)
+      })
+
+      const deletedHeadRecords =
+        await deletePersistedOfflineNavigationSegmentRecords(browser, {
+          keySubstring: '',
+          requestKeySuffix: '/_head',
+        })
+      expect(deletedHeadRecords).toBeGreaterThan(0)
+      await retry(async () => {
+        const routeRecords =
+          await readPersistedOfflineNavigationRouteRecords(browser)
+        expect(
+          routeRecords.some((record) =>
+            record.route.pathname.includes('/prefetched')
+          )
+        ).toBe(true)
+
+        const segmentRecords =
+          await readPersistedOfflineNavigationSegmentRecords(browser)
+        expect(
+          segmentRecords.some(
+            (record) =>
+              record.key.includes('prefetched') &&
+              record.segment.requestKey.endsWith('/__PAGE__')
+          )
+        ).toBe(true)
+        expect(
+          segmentRecords.some(
+            (record) => record.segment.requestKey === '/_head'
+          )
+        ).toBe(false)
+      })
+
+      await next.stop()
+      await page!.context().setOffline(true)
+      const missingHeadResponse = await page!.goto(
+        `${next.url}/docs/prefetched`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(missingHeadResponse?.status()).toBe(200)
+
+      await retry(async () => {
+        const diagnostics = await browser.eval(() => {
+          const win = window as typeof window & {
+            __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?: Array<{
+              reason?: string
+              type?: string
+              url?: string
+            }>
+          }
+          return win.__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__ ?? []
+        })
+        expect(diagnostics).toContainEqual(
+          expect.objectContaining({
+            reason: 'missing-head',
+            type: 'router-cache-reconstruction-miss',
+            url: `${next.url}/docs/prefetched`,
+          })
+        )
+        expect(diagnostics).toContainEqual(
+          expect.objectContaining({
+            reason: 'missing-entry',
+            type: 'cache-miss',
+            url: `${next.url}/docs/prefetched`,
+          })
+        )
+      })
+      await retry(async () => {
+        expect(
+          await browser.eval(() => {
+            const cacheMiss = document.getElementById(
+              '__NEXT_OFFLINE_NAVIGATION_CACHE_MISS'
+            )
+            return cacheMiss === null
+              ? null
+              : {
+                  hidden: cacheMiss.hidden,
+                  reason: cacheMiss.getAttribute(
+                    'data-next-offline-navigation-cache-reason'
+                  ),
+                  text: cacheMiss.textContent,
+                }
+          })
+        ).toEqual({
+          hidden: false,
+          reason: 'missing-entry',
+          text: 'This page is not available offline.',
+        })
+      })
+      expect(
+        await browser.eval(() =>
+          Boolean(document.getElementById('prefetched-page'))
+        )
+      ).toBe(false)
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
   it('misses and deletes expired persisted segment records during fallback boot', async () => {
     if (shouldSkipReplayWithCachedNavigations) {
       return


### PR DESCRIPTION
## Stack Position

This is a focused stress-test slice stacked on top of `feedthejim/offline-navigations-missing-route-record-stress`.

It continues the `GRAPH-02b` route-graph completeness matrix for offlineNavigations. The previous slice covers a deleted persisted route record. This slice covers a deleted persisted head record while route and page segment records are still present.

## Why This Exists

Route/segment replay needs complete route graph data. A page segment by itself is not enough if the matching head record is missing, and this test makes that behavior explicit without relying on exact-URL replay.

The test flow is intentionally destructive:

- prefetch `/docs/prefetched` so route, page segment, and head records exist
- delete the exact-URL entry for `/docs/prefetched`
- delete the persisted `/_head` record
- verify the route and page segment records are still present
- stop the server and hard-load the route offline
- assert a visible cache miss and structured `missing-head` diagnostics
- assert the prefetched page does not render

## Reviewer Focus

Please focus on whether this proves the missing-head-record contract distinctly from the existing expired-head-record coverage.

The existing expired-head test proves cleanup of stale head data. This PR proves the absent-record path: the client router must reject an otherwise present route/segment replay set if the required head record was never available.

## What This Does Not Cover Yet

This does not finish the whole `GRAPH-02b` matrix. Remaining route-graph missing-record rows still need focused slices:

- missing root layout record
- missing nested layout record
- missing page segment record outside the existing dynamic-pattern case
- missing default slot record
- missing parallel slot record

## Verification

- `pnpm prettier --with-node-modules --ignore-path .prettierignore --write test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `npx eslint --config eslint.config.mjs --fix test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `git diff --check`
- `NEXT_SKIP_ISOLATE=1 pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "misses persisted router records when a required head record is missing during fallback boot"`
- `pnpm test-start-webpack test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "misses persisted router records when a required head record is missing during fallback boot"`

<!-- NEXT_JS_LLM_PR -->
