### PR TITLE
(1/1) Cover workspace shell offline navigation replay

### DIFF
--- a/test/production/app-dir/offline-navigations/app/page.tsx
+++ b/test/production/app-dir/offline-navigations/app/page.tsx
@@ -14,6 +14,7 @@ import {
   DynamicPatternTargetPrefetchButton,
   PrefetchButton,
   RefreshButton,
+  WorkspaceShellPrefetchButton,
 } from './prefetch-button'
 
 async function ActionInvalidationMarker() {
@@ -91,6 +92,7 @@ export default function Page() {
       <PrefetchButton />
       <DynamicPatternSourcePrefetchButton />
       <DynamicPatternTargetPrefetchButton />
+      <WorkspaceShellPrefetchButton />
       <RefreshButton />
       <ClearOfflineNavigationCacheButton />
     </>

--- a/test/production/app-dir/offline-navigations/app/prefetch-button.tsx
+++ b/test/production/app-dir/offline-navigations/app/prefetch-button.tsx
@@ -40,6 +40,20 @@ export function DynamicPatternTargetPrefetchButton() {
   )
 }
 
+export function WorkspaceShellPrefetchButton() {
+  const router = useRouter()
+  return (
+    <button
+      id="prefetch-workspace-shell"
+      onClick={() =>
+        router.prefetch('/workspace/acme/channel/general/thread/123')
+      }
+    >
+      Prefetch workspace shell
+    </button>
+  )
+}
+
 export function RefreshButton() {
   const router = useRouter()
   return (

--- a/test/production/app-dir/offline-navigations/app/workspace/[workspace]/@activity/channel/[channel]/thread/[thread]/page.tsx
+++ b/test/production/app-dir/offline-navigations/app/workspace/[workspace]/@activity/channel/[channel]/thread/[thread]/page.tsx
@@ -1,0 +1,33 @@
+type WorkspaceActivityProps = {
+  params: Promise<{
+    channel: string
+    thread: string
+  }>
+}
+
+export default async function WorkspaceActivity({
+  params,
+}: WorkspaceActivityProps) {
+  const { channel, thread } = await params
+
+  return (
+    <p id="workspace-activity-page">
+      workspace activity: {channel}/{thread}
+    </p>
+  )
+}
+
+export function generateStaticParams({
+  params,
+}: {
+  params: { workspace: string }
+}) {
+  return params.workspace === 'acme'
+    ? [
+        {
+          channel: 'general',
+          thread: '123',
+        },
+      ]
+    : []
+}

--- a/test/production/app-dir/offline-navigations/app/workspace/[workspace]/@activity/default.tsx
+++ b/test/production/app-dir/offline-navigations/app/workspace/[workspace]/@activity/default.tsx
@@ -1,0 +1,3 @@
+export default function WorkspaceActivityDefault() {
+  return <p id="workspace-activity-default">workspace activity default</p>
+}

--- a/test/production/app-dir/offline-navigations/app/workspace/[workspace]/@sidebar/default.tsx
+++ b/test/production/app-dir/offline-navigations/app/workspace/[workspace]/@sidebar/default.tsx
@@ -1,0 +1,3 @@
+export default function WorkspaceSidebarDefault() {
+  return <p id="workspace-sidebar-default">workspace sidebar default</p>
+}

--- a/test/production/app-dir/offline-navigations/app/workspace/[workspace]/channel/[channel]/thread/[thread]/page.tsx
+++ b/test/production/app-dir/offline-navigations/app/workspace/[workspace]/channel/[channel]/thread/[thread]/page.tsx
@@ -1,0 +1,39 @@
+import { OfflineStatus } from '../../../../../../offline-status'
+
+type WorkspaceThreadPageProps = {
+  params: Promise<{
+    channel: string
+    thread: string
+    workspace: string
+  }>
+}
+
+export default async function WorkspaceThreadPage({
+  params,
+}: WorkspaceThreadPageProps) {
+  const { channel, thread, workspace } = await params
+
+  return (
+    <>
+      <p id="workspace-thread-page">
+        workspace thread: {workspace}/{channel}/{thread}
+      </p>
+      <OfflineStatus />
+    </>
+  )
+}
+
+export function generateStaticParams({
+  params,
+}: {
+  params: { workspace: string }
+}) {
+  return params.workspace === 'acme'
+    ? [
+        {
+          channel: 'general',
+          thread: '123',
+        },
+      ]
+    : []
+}

--- a/test/production/app-dir/offline-navigations/app/workspace/[workspace]/layout.tsx
+++ b/test/production/app-dir/offline-navigations/app/workspace/[workspace]/layout.tsx
@@ -1,0 +1,32 @@
+import { ReactNode } from 'react'
+
+type WorkspaceLayoutProps = {
+  activity: ReactNode
+  children: ReactNode
+  params: Promise<{
+    workspace: string
+  }>
+  sidebar: ReactNode
+}
+
+export default async function WorkspaceLayout({
+  activity,
+  children,
+  params,
+  sidebar,
+}: WorkspaceLayoutProps) {
+  const { workspace } = await params
+
+  return (
+    <section id="workspace-shell-layout">
+      <p id="workspace-shell-layout-name">workspace layout: {workspace}</p>
+      <nav id="workspace-shell-sidebar">{sidebar}</nav>
+      <aside id="workspace-shell-activity">{activity}</aside>
+      <main id="workspace-shell-content">{children}</main>
+    </section>
+  )
+}
+
+export function generateStaticParams() {
+  return [{ workspace: 'acme' }]
+}

--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -1404,6 +1404,132 @@ describe('offlineNavigations build artifacts', () => {
     }
   })
 
+  it('reconstructs a prefetched workspace shell route from persisted router records', async () => {
+    if (shouldSkipReplayWithCachedNavigations) {
+      return
+    }
+
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    await next.start({ skipBuild: true })
+
+    const workspaceRoute = '/workspace/acme/channel/general/thread/123'
+    const workspaceUrlPath = `/docs${workspaceRoute}`
+    let page: Playwright.Page | undefined
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
+
+      await browser.elementById('prefetch-workspace-shell').click()
+      await retry(async () => {
+        const exactEntry = await readPersistedOfflineNavigationEntry(
+          browser,
+          workspaceUrlPath
+        )
+        expect(exactEntry).toEqual(
+          expect.objectContaining({
+            kind: 'exact-url',
+            payload: expect.objectContaining({
+              kind: 'rsc-response',
+              requestKind: 'client-resume',
+            }),
+          })
+        )
+      })
+      await retry(async () => {
+        const routeRecords =
+          await readPersistedOfflineNavigationRouteRecords(browser)
+        expect(
+          routeRecords.some((record) =>
+            record.route.pathname.includes(workspaceRoute)
+          )
+        ).toBe(true)
+
+        const segmentRecords =
+          await readPersistedOfflineNavigationSegmentRecords(browser)
+        expect(
+          segmentRecords.some(
+            (record) =>
+              record.key.includes('workspace') &&
+              record.payload.requestKind === 'segment-prefetch'
+          )
+        ).toBe(true)
+        expect(
+          segmentRecords.some(
+            (record) => record.segment.requestKey === '/_head'
+          )
+        ).toBe(true)
+      })
+
+      const deletedExactEntries = await deletePersistedOfflineNavigationEntries(
+        browser,
+        workspaceUrlPath
+      )
+      expect(deletedExactEntries).toBeGreaterThan(0)
+      await retry(async () => {
+        const deletedEntry = await readPersistedOfflineNavigationEntry(
+          browser,
+          workspaceUrlPath
+        )
+        expect(deletedEntry).toBe(null)
+      })
+
+      await next.stop()
+      await page!.context().setOffline(true)
+      const workspaceResponse = await page!.goto(
+        `${next.url}${workspaceUrlPath}`,
+        {
+          waitUntil: 'domcontentloaded',
+        }
+      )
+      expect(workspaceResponse?.status()).toBe(200)
+      await retry(async () => {
+        const routerCacheDiagnostics = await browser.eval(() => {
+          const win = window as typeof window & {
+            __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?: Array<{
+              type?: string
+              requestKind?: string
+              url?: string
+              reason?: string
+            }>
+          }
+          return win.__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__ ?? []
+        })
+        expect(routerCacheDiagnostics).toContainEqual(
+          expect.objectContaining({
+            type: 'cache-hit',
+            requestKind: 'router-cache',
+            url: `${next.url}${workspaceUrlPath}`,
+          })
+        )
+      })
+      await retry(async () => {
+        expect(
+          await browser.elementById('workspace-shell-layout-name').text()
+        ).toBe('workspace layout: acme')
+        expect(await browser.elementById('workspace-thread-page').text()).toBe(
+          'workspace thread: acme/general/123'
+        )
+        expect(
+          await browser.elementById('workspace-sidebar-default').text()
+        ).toBe('workspace sidebar default')
+        expect(
+          await browser.elementById('workspace-activity-page').text()
+        ).toBe('workspace activity: general/123')
+      })
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
   it('misses and deletes expired persisted route records during fallback boot', async () => {
     if (shouldSkipReplayWithCachedNavigations) {
       return


### PR DESCRIPTION
## Stack Position

This is a focused stress-test slice stacked on top of `feedthejim/offline-navigations-missing-page-segment-stress`.

It continues the route-graph hardening work for offlineNavigations. The previous slices cover missing route, head, and regular page segment records. This PR adds a denser workspace-shell fixture and proves the positive replay path before we start deleting nested layout/default/parallel-slot records in follow-up PRs.

## Why This Exists

The existing fixture only had a simple root layout and page routes. That was enough for exact-URL, route-record, head, and page-segment coverage, but not enough to honestly test complex app-shell reconstruction.

This PR adds a small cache-components-compatible route shape:

- `/workspace/[workspace]/layout.tsx`
- a default `@sidebar` slot
- an `@activity` parallel slot for the thread route
- `/workspace/[workspace]/channel/[channel]/thread/[thread]/page.tsx`
- static params for the concrete `/workspace/acme/channel/general/thread/123` test route

The e2e then proves:

- the route can be prefetched online
- exact-URL data for the document URL is deleted before reload
- route, segment, and head records remain available
- the server is stopped and the browser is offline
- fallback boot renders from `router-cache`
- the workspace layout, page segment, default sidebar slot, and activity parallel slot all render together

## Reviewer Focus

Please focus on whether this is a good minimal fixture for later destructive route-graph tests.

The point of this PR is not to finish every `SHELL-01` negative case. It establishes the positive replay contract for a realistic nested app shell so follow-up PRs can delete one required layout or slot record at a time and prove the miss reason.

## What This Does Not Cover Yet

Remaining follow-ups still need focused destructive coverage for:

- missing root shell/layout record
- missing nested workspace layout record
- missing default sidebar slot record
- missing activity parallel slot record
- metadata/head/style ordering for the workspace shell
- app/session scope rotation on a workspace-like route

## Verification

- `pnpm prettier --with-node-modules --ignore-path .prettierignore --write test/production/app-dir/offline-navigations/offline-navigations.test.ts test/production/app-dir/offline-navigations/app/page.tsx test/production/app-dir/offline-navigations/app/prefetch-button.tsx test/production/app-dir/offline-navigations/app/workspace/[workspace]/layout.tsx test/production/app-dir/offline-navigations/app/workspace/[workspace]/@sidebar/default.tsx test/production/app-dir/offline-navigations/app/workspace/[workspace]/@activity/channel/[channel]/thread/[thread]/page.tsx test/production/app-dir/offline-navigations/app/workspace/[workspace]/@activity/default.tsx test/production/app-dir/offline-navigations/app/workspace/[workspace]/channel/[channel]/thread/[thread]/page.tsx`
- `npx eslint --config eslint.config.mjs --fix test/production/app-dir/offline-navigations/offline-navigations.test.ts test/production/app-dir/offline-navigations/app/page.tsx test/production/app-dir/offline-navigations/app/prefetch-button.tsx test/production/app-dir/offline-navigations/app/workspace/[workspace]/layout.tsx test/production/app-dir/offline-navigations/app/workspace/[workspace]/@sidebar/default.tsx test/production/app-dir/offline-navigations/app/workspace/[workspace]/@activity/channel/[channel]/thread/[thread]/page.tsx test/production/app-dir/offline-navigations/app/workspace/[workspace]/@activity/default.tsx test/production/app-dir/offline-navigations/app/workspace/[workspace]/channel/[channel]/thread/[thread]/page.tsx`
- `git diff --check`
- `NEXT_SKIP_ISOLATE=1 pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "reconstructs a prefetched workspace shell route from persisted router records"`
- `pnpm test-start-webpack test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "reconstructs a prefetched workspace shell route from persisted router records"`

<!-- NEXT_JS_LLM_PR -->
