### PR TITLE
(1/1) Cover missing parallel slot offline navigation misses

### DIFF
--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -229,48 +229,54 @@ describe('offlineNavigations build artifacts', () => {
     browser: Awaited<ReturnType<typeof next.browser>>,
     options: {
       keySubstring: string
+      requestKeySubstring?: string
       requestKeySuffix: string
     }
   ) {
-    return browser.eval(async ({ keySubstring, requestKeySuffix }) => {
-      const database = await new Promise<IDBDatabase>((resolve, reject) => {
-        const request = indexedDB.open('next-offline-navigation-cache', 3)
-        request.onsuccess = () => resolve(request.result)
-        request.onerror = () => reject(request.error)
-      })
-
-      try {
-        const entries = await new Promise<any[]>((resolve, reject) => {
-          const transaction = database.transaction('segment-data', 'readonly')
-          const request = transaction.objectStore('segment-data').getAll()
+    return browser.eval(
+      async ({ keySubstring, requestKeySubstring, requestKeySuffix }) => {
+        const database = await new Promise<IDBDatabase>((resolve, reject) => {
+          const request = indexedDB.open('next-offline-navigation-cache', 3)
           request.onsuccess = () => resolve(request.result)
           request.onerror = () => reject(request.error)
         })
-        const matchingEntries = entries.filter(
-          (entry) =>
-            entry.key.includes(keySubstring) &&
-            entry.segment.requestKey.endsWith(requestKeySuffix)
-        )
 
-        if (matchingEntries.length === 0) {
-          return 0
-        }
+        try {
+          const entries = await new Promise<any[]>((resolve, reject) => {
+            const transaction = database.transaction('segment-data', 'readonly')
+            const request = transaction.objectStore('segment-data').getAll()
+            request.onsuccess = () => resolve(request.result)
+            request.onerror = () => reject(request.error)
+          })
+          const matchingEntries = entries.filter(
+            (entry) =>
+              entry.key.includes(keySubstring) &&
+              (requestKeySubstring === undefined ||
+                entry.segment.requestKey.includes(requestKeySubstring)) &&
+              entry.segment.requestKey.endsWith(requestKeySuffix)
+          )
 
-        const transaction = database.transaction('segment-data', 'readwrite')
-        const store = transaction.objectStore('segment-data')
-        for (const entry of matchingEntries) {
-          store.delete([entry.buildId, entry.key])
+          if (matchingEntries.length === 0) {
+            return 0
+          }
+
+          const transaction = database.transaction('segment-data', 'readwrite')
+          const store = transaction.objectStore('segment-data')
+          for (const entry of matchingEntries) {
+            store.delete([entry.buildId, entry.key])
+          }
+          await new Promise<void>((resolve, reject) => {
+            transaction.oncomplete = () => resolve()
+            transaction.onerror = () => reject(transaction.error)
+            transaction.onabort = () => reject(transaction.error)
+          })
+          return matchingEntries.length
+        } finally {
+          database.close()
         }
-        await new Promise<void>((resolve, reject) => {
-          transaction.oncomplete = () => resolve()
-          transaction.onerror = () => reject(transaction.error)
-          transaction.onabort = () => reject(transaction.error)
-        })
-        return matchingEntries.length
-      } finally {
-        database.close()
-      }
-    }, options)
+      },
+      options
+    )
   }
 
   async function deletePersistedOfflineNavigationEntries(
@@ -1654,6 +1660,193 @@ describe('offlineNavigations build artifacts', () => {
         }
       )
       expect(missingDefaultSlotResponse?.status()).toBe(200)
+
+      await retry(async () => {
+        const diagnostics = await browser.eval(() => {
+          const win = window as typeof window & {
+            __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?: Array<{
+              reason?: string
+              type?: string
+              url?: string
+            }>
+          }
+          return win.__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__ ?? []
+        })
+        expect(diagnostics).toContainEqual(
+          expect.objectContaining({
+            reason: 'missing-segment',
+            type: 'router-cache-reconstruction-miss',
+            url: `${next.url}${workspaceUrlPath}`,
+          })
+        )
+        expect(diagnostics).toContainEqual(
+          expect.objectContaining({
+            reason: 'missing-entry',
+            type: 'cache-miss',
+            url: `${next.url}${workspaceUrlPath}`,
+          })
+        )
+      })
+      await retry(async () => {
+        expect(
+          await browser.eval(() => {
+            const cacheMiss = document.getElementById(
+              '__NEXT_OFFLINE_NAVIGATION_CACHE_MISS'
+            )
+            return cacheMiss === null
+              ? null
+              : {
+                  hidden: cacheMiss.hidden,
+                  reason: cacheMiss.getAttribute(
+                    'data-next-offline-navigation-cache-reason'
+                  ),
+                  text: cacheMiss.textContent,
+                }
+          })
+        ).toEqual({
+          hidden: false,
+          reason: 'missing-entry',
+          text: 'This page is not available offline.',
+        })
+      })
+      expect(
+        await browser.eval(() =>
+          Boolean(document.getElementById('workspace-thread-page'))
+        )
+      ).toBe(false)
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
+  it('misses a workspace shell route when a required parallel slot record is missing during fallback boot', async () => {
+    if (shouldSkipReplayWithCachedNavigations) {
+      return
+    }
+
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    await next.start({ skipBuild: true })
+
+    const workspaceRoute = '/workspace/acme/channel/general/thread/123'
+    const workspaceUrlPath = `/docs${workspaceRoute}`
+    let page: Playwright.Page | undefined
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
+
+      await browser.elementById('prefetch-workspace-shell').click()
+      await retry(async () => {
+        const routeRecords =
+          await readPersistedOfflineNavigationRouteRecords(browser)
+        expect(
+          routeRecords.some((record) =>
+            record.route.pathname.includes(workspaceRoute)
+          )
+        ).toBe(true)
+
+        const segmentRecords =
+          await readPersistedOfflineNavigationSegmentRecords(browser)
+        expect(
+          segmentRecords.some((record) =>
+            record.segment.requestKey.endsWith('/@sidebar/__DEFAULT__')
+          )
+        ).toBe(true)
+        expect(
+          segmentRecords.some(
+            (record) =>
+              record.segment.requestKey.includes('/@activity/') &&
+              record.segment.requestKey.endsWith('/__PAGE__')
+          )
+        ).toBe(true)
+        expect(
+          segmentRecords.some(
+            (record) =>
+              record.key.includes('workspace') &&
+              record.segment.requestKey.endsWith('/__PAGE__')
+          )
+        ).toBe(true)
+        expect(
+          segmentRecords.some(
+            (record) => record.segment.requestKey === '/_head'
+          )
+        ).toBe(true)
+      })
+
+      const deletedExactEntries = await deletePersistedOfflineNavigationEntries(
+        browser,
+        workspaceUrlPath
+      )
+      expect(deletedExactEntries).toBeGreaterThan(0)
+      await retry(async () => {
+        const deletedEntry = await readPersistedOfflineNavigationEntry(
+          browser,
+          workspaceUrlPath
+        )
+        expect(deletedEntry).toBe(null)
+      })
+
+      const deletedParallelSlotRecords =
+        await deletePersistedOfflineNavigationSegmentRecords(browser, {
+          keySubstring: 'workspace',
+          requestKeySubstring: '/@activity/',
+          requestKeySuffix: '/__PAGE__',
+        })
+      expect(deletedParallelSlotRecords).toBeGreaterThan(0)
+      await retry(async () => {
+        const routeRecords =
+          await readPersistedOfflineNavigationRouteRecords(browser)
+        expect(
+          routeRecords.some((record) =>
+            record.route.pathname.includes(workspaceRoute)
+          )
+        ).toBe(true)
+
+        const segmentRecords =
+          await readPersistedOfflineNavigationSegmentRecords(browser)
+        expect(
+          segmentRecords.some((record) =>
+            record.segment.requestKey.endsWith('/@sidebar/__DEFAULT__')
+          )
+        ).toBe(true)
+        expect(
+          segmentRecords.some(
+            (record) =>
+              record.segment.requestKey.includes('/@activity/') &&
+              record.segment.requestKey.endsWith('/__PAGE__')
+          )
+        ).toBe(false)
+        expect(
+          segmentRecords.some(
+            (record) =>
+              record.key.includes('workspace') &&
+              record.segment.requestKey.endsWith('/__PAGE__')
+          )
+        ).toBe(true)
+        expect(
+          segmentRecords.some(
+            (record) => record.segment.requestKey === '/_head'
+          )
+        ).toBe(true)
+      })
+
+      await next.stop()
+      await page!.context().setOffline(true)
+      const missingParallelSlotResponse = await page!.goto(
+        `${next.url}${workspaceUrlPath}`,
+        {
+          waitUntil: 'domcontentloaded',
+        }
+      )
+      expect(missingParallelSlotResponse?.status()).toBe(200)
 
       await retry(async () => {
         const diagnostics = await browser.eval(() => {


### PR DESCRIPTION
## Stack position

This is a test-only stress slice on top of #93674, which covers the destructive missing default-slot case for the Slack-like workspace shell fixture introduced in #93673.

Stack context:

1. #93670 covers a missing persisted route record.
2. #93671 covers a missing persisted head record.
3. #93672 covers a missing persisted page segment record.
4. #93673 proves the complex workspace shell can replay when all required route, segment, slot, and head records are present.
5. #93674 covers a missing required default sidebar slot record.
6. This PR covers the paired missing required activity parallel-slot record.

## What changed

Adds one focused production e2e for `offlineNavigations` with Cache Components:

- online-loads `/docs` and waits for the offline navigation service worker
- prefetches `/docs/workspace/acme/channel/general/thread/123`
- verifies the durable route record, page segment, default sidebar slot, activity parallel slot, and head record were persisted
- deletes the exact URL entry so the hard reload must use route/segment reconstruction
- deletes only the `@activity` parallel-slot page segment record
- stops the server, puts the browser offline, and hard-loads the workspace route
- asserts the fallback boot emits `router-cache-reconstruction-miss` with `missing-segment`, falls back to visible `missing-entry` UI, and does not render the workspace page

The test-only IndexedDB deletion helper now accepts an optional `requestKeySubstring` so this PR can target the activity parallel slot without also deleting the main page segment.

## Why this is separate

#93673 proves the full shell can replay, and #93674 proves a missing default slot misses safely. This PR keeps the parallel-route failure mode isolated so reviewers can answer one question: if a required parallel slot record is absent, do we miss instead of rendering a partial shell with the primary page or another slot still present?

This also advances the advanced e2e stress matrix in `.private-investigation/offline-navigations-production-plan.md`: route, head, page segment, default slot, and parallel slot deletions now each have focused browser-backed negative coverage.

## Reviewer focus

Please focus on the false-positive guards:

- the exact URL entry is deleted first, so the test cannot pass through direct exact-URL replay
- the route, page segment, default sidebar slot, and head records are asserted present after the activity slot is deleted
- the expected result is a structured `missing-segment` reconstruction miss plus visible `missing-entry` UI, not a partially rendered workspace page

## Intentionally not covered here

Still pending in later stress slices:

- missing root layout record
- missing nested workspace layout record
- metadata/head style ordering integrity on successful replay
- app/session or workspace-scope partitioning

## Verification

- `pnpm prettier --with-node-modules --ignore-path .prettierignore --write test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `npx eslint --config eslint.config.mjs --fix test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `git diff --check -- test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `NEXT_SKIP_ISOLATE=1 pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "misses a workspace shell route when a required parallel slot record is missing during fallback boot"`
- `NEXT_SKIP_ISOLATE=1 pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "required (default|parallel) slot record"`
- `pnpm test-start-webpack test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "required (default|parallel) slot record"`

<!-- NEXT_JS_LLM_PR -->
