### PR TITLE
(1/1) Cover missing workspace layout offline navigation misses

### DIFF
--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -1909,6 +1909,201 @@ describe('offlineNavigations build artifacts', () => {
     }
   })
 
+  it('misses a workspace shell route when a required nested layout record is missing during fallback boot', async () => {
+    if (shouldSkipReplayWithCachedNavigations) {
+      return
+    }
+
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    await next.start({ skipBuild: true })
+
+    const workspaceRoute = '/workspace/acme/channel/general/thread/123'
+    const workspaceUrlPath = `/docs${workspaceRoute}`
+    const workspaceLayoutRequestKey = '/workspace/$d$workspace'
+    let page: Playwright.Page | undefined
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
+
+      await browser.elementById('prefetch-workspace-shell').click()
+      await retry(async () => {
+        const routeRecords =
+          await readPersistedOfflineNavigationRouteRecords(browser)
+        expect(
+          routeRecords.some((record) =>
+            record.route.pathname.includes(workspaceRoute)
+          )
+        ).toBe(true)
+
+        const segmentRecords =
+          await readPersistedOfflineNavigationSegmentRecords(browser)
+        const segmentRequestKeys = segmentRecords.map(
+          (record) => record.segment.requestKey
+        )
+        expect(segmentRequestKeys).toContain(workspaceLayoutRequestKey)
+        expect(
+          segmentRecords.some((record) =>
+            record.segment.requestKey.endsWith('/@sidebar/__DEFAULT__')
+          )
+        ).toBe(true)
+        expect(
+          segmentRecords.some(
+            (record) =>
+              record.segment.requestKey.includes('/@activity/') &&
+              record.segment.requestKey.endsWith('/__PAGE__')
+          )
+        ).toBe(true)
+        expect(
+          segmentRecords.some(
+            (record) =>
+              record.key.includes('workspace') &&
+              record.segment.requestKey.endsWith('/__PAGE__')
+          )
+        ).toBe(true)
+        expect(
+          segmentRecords.some(
+            (record) => record.segment.requestKey === '/_head'
+          )
+        ).toBe(true)
+      })
+
+      const deletedExactEntries = await deletePersistedOfflineNavigationEntries(
+        browser,
+        workspaceUrlPath
+      )
+      expect(deletedExactEntries).toBeGreaterThan(0)
+      await retry(async () => {
+        const deletedEntry = await readPersistedOfflineNavigationEntry(
+          browser,
+          workspaceUrlPath
+        )
+        expect(deletedEntry).toBe(null)
+      })
+
+      const deletedWorkspaceLayoutRecords =
+        await deletePersistedOfflineNavigationSegmentRecords(browser, {
+          keySubstring: 'workspace',
+          requestKeySuffix: workspaceLayoutRequestKey,
+        })
+      expect(deletedWorkspaceLayoutRecords).toBeGreaterThan(0)
+      await retry(async () => {
+        const routeRecords =
+          await readPersistedOfflineNavigationRouteRecords(browser)
+        expect(
+          routeRecords.some((record) =>
+            record.route.pathname.includes(workspaceRoute)
+          )
+        ).toBe(true)
+
+        const segmentRecords =
+          await readPersistedOfflineNavigationSegmentRecords(browser)
+        const segmentRequestKeys = segmentRecords.map(
+          (record) => record.segment.requestKey
+        )
+        expect(segmentRequestKeys).not.toContain(workspaceLayoutRequestKey)
+        expect(
+          segmentRecords.some((record) =>
+            record.segment.requestKey.endsWith('/@sidebar/__DEFAULT__')
+          )
+        ).toBe(true)
+        expect(
+          segmentRecords.some(
+            (record) =>
+              record.segment.requestKey.includes('/@activity/') &&
+              record.segment.requestKey.endsWith('/__PAGE__')
+          )
+        ).toBe(true)
+        expect(
+          segmentRecords.some(
+            (record) =>
+              record.key.includes('workspace') &&
+              record.segment.requestKey.endsWith('/__PAGE__')
+          )
+        ).toBe(true)
+        expect(
+          segmentRecords.some(
+            (record) => record.segment.requestKey === '/_head'
+          )
+        ).toBe(true)
+      })
+
+      await next.stop()
+      await page!.context().setOffline(true)
+      const missingWorkspaceLayoutResponse = await page!.goto(
+        `${next.url}${workspaceUrlPath}`,
+        {
+          waitUntil: 'domcontentloaded',
+        }
+      )
+      expect(missingWorkspaceLayoutResponse?.status()).toBe(200)
+
+      await retry(async () => {
+        const diagnostics = await browser.eval(() => {
+          const win = window as typeof window & {
+            __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?: Array<{
+              reason?: string
+              type?: string
+              url?: string
+            }>
+          }
+          return win.__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__ ?? []
+        })
+        expect(diagnostics).toContainEqual(
+          expect.objectContaining({
+            reason: 'missing-segment',
+            type: 'router-cache-reconstruction-miss',
+            url: `${next.url}${workspaceUrlPath}`,
+          })
+        )
+        expect(diagnostics).toContainEqual(
+          expect.objectContaining({
+            reason: 'missing-entry',
+            type: 'cache-miss',
+            url: `${next.url}${workspaceUrlPath}`,
+          })
+        )
+      })
+      await retry(async () => {
+        expect(
+          await browser.eval(() => {
+            const cacheMiss = document.getElementById(
+              '__NEXT_OFFLINE_NAVIGATION_CACHE_MISS'
+            )
+            return cacheMiss === null
+              ? null
+              : {
+                  hidden: cacheMiss.hidden,
+                  reason: cacheMiss.getAttribute(
+                    'data-next-offline-navigation-cache-reason'
+                  ),
+                  text: cacheMiss.textContent,
+                }
+          })
+        ).toEqual({
+          hidden: false,
+          reason: 'missing-entry',
+          text: 'This page is not available offline.',
+        })
+      })
+      expect(
+        await browser.eval(() =>
+          Boolean(document.getElementById('workspace-thread-page'))
+        )
+      ).toBe(false)
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
   it('misses and deletes expired persisted route records during fallback boot', async () => {
     if (shouldSkipReplayWithCachedNavigations) {
       return


### PR DESCRIPTION
## Stack position

This is a test-only stress slice on top of #93675, which covers the destructive missing activity parallel-slot case for the Slack-like workspace shell fixture introduced in #93673.

Stack context:

1. #93670 covers a missing persisted route record.
2. #93671 covers a missing persisted head record.
3. #93672 covers a missing persisted page segment record.
4. #93673 proves the complex workspace shell can replay when all required route, segment, slot, and head records are present.
5. #93674 covers a missing required default sidebar slot record.
6. #93675 covers a missing required activity parallel-slot record.
7. This PR covers a missing required nested workspace layout record.

## What changed

Adds one focused production e2e for `offlineNavigations` with Cache Components:

- online-loads `/docs` and waits for the offline navigation service worker
- prefetches `/docs/workspace/acme/channel/general/thread/123`
- verifies the durable route record, nested workspace layout segment, page segment, default sidebar slot, activity parallel slot, and head record were persisted
- deletes the exact URL entry so the hard reload must use route/segment reconstruction
- deletes only the `/workspace/$d$workspace` layout segment record
- stops the server, puts the browser offline, and hard-loads the workspace route
- asserts the fallback boot emits `router-cache-reconstruction-miss` with `missing-segment`, falls back to visible `missing-entry` UI, and does not render the workspace page

## Why this is separate

The previous workspace-shell stress slices cover the route record, head record, page segment, default slot, and parallel slot. This PR isolates the parent layout case so reviewers can verify that the replay path treats a missing layout as fatal instead of stitching child page or slot records under an absent workspace shell.

This continues the advanced e2e stress matrix in `.private-investigation/offline-navigations-production-plan.md`: after this PR, the route-graph missing-record matrix only has the root layout row left among the core shell records.

## Reviewer focus

Please focus on the targeting and false-positive guards:

- the test asserts `/workspace/$d$workspace` exists before deleting it
- the exact URL entry is deleted first, so this cannot pass through direct exact-URL replay
- the route, page segment, default sidebar slot, activity parallel slot, and head records remain present after the nested layout is deleted
- the expected result is a structured `missing-segment` reconstruction miss plus visible `missing-entry` UI, not a partially rendered workspace page

## Intentionally not covered here

Still pending in later stress slices:

- missing root layout record
- metadata/head style ordering integrity on successful replay
- app/session or workspace-scope partitioning

## Verification

- `pnpm prettier --with-node-modules --ignore-path .prettierignore --write test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `npx eslint --config eslint.config.mjs --fix test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `git diff --check -- test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `NEXT_SKIP_ISOLATE=1 pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "misses a workspace shell route when a required nested layout record is missing during fallback boot"`
- `pnpm test-start-webpack test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "misses a workspace shell route when a required nested layout record is missing during fallback boot"`

<!-- NEXT_JS_LLM_PR -->
