### PR TITLE
(1/1) Cover missing root layout offline navigation misses

### DIFF
--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -229,12 +229,18 @@ describe('offlineNavigations build artifacts', () => {
     browser: Awaited<ReturnType<typeof next.browser>>,
     options: {
       keySubstring: string
+      requestKey?: string
       requestKeySubstring?: string
-      requestKeySuffix: string
+      requestKeySuffix?: string
     }
   ) {
     return browser.eval(
-      async ({ keySubstring, requestKeySubstring, requestKeySuffix }) => {
+      async ({
+        keySubstring,
+        requestKey,
+        requestKeySubstring,
+        requestKeySuffix,
+      }) => {
         const database = await new Promise<IDBDatabase>((resolve, reject) => {
           const request = indexedDB.open('next-offline-navigation-cache', 3)
           request.onsuccess = () => resolve(request.result)
@@ -251,9 +257,12 @@ describe('offlineNavigations build artifacts', () => {
           const matchingEntries = entries.filter(
             (entry) =>
               entry.key.includes(keySubstring) &&
-              (requestKeySubstring === undefined ||
-                entry.segment.requestKey.includes(requestKeySubstring)) &&
-              entry.segment.requestKey.endsWith(requestKeySuffix)
+              (requestKey === undefined
+                ? (requestKeySubstring === undefined ||
+                    entry.segment.requestKey.includes(requestKeySubstring)) &&
+                  (requestKeySuffix === undefined ||
+                    entry.segment.requestKey.endsWith(requestKeySuffix))
+                : entry.segment.requestKey === requestKey)
           )
 
           if (matchingEntries.length === 0) {
@@ -2042,6 +2051,204 @@ describe('offlineNavigations build artifacts', () => {
         }
       )
       expect(missingWorkspaceLayoutResponse?.status()).toBe(200)
+
+      await retry(async () => {
+        const diagnostics = await browser.eval(() => {
+          const win = window as typeof window & {
+            __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?: Array<{
+              reason?: string
+              type?: string
+              url?: string
+            }>
+          }
+          return win.__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__ ?? []
+        })
+        expect(diagnostics).toContainEqual(
+          expect.objectContaining({
+            reason: 'missing-segment',
+            type: 'router-cache-reconstruction-miss',
+            url: `${next.url}${workspaceUrlPath}`,
+          })
+        )
+        expect(diagnostics).toContainEqual(
+          expect.objectContaining({
+            reason: 'missing-entry',
+            type: 'cache-miss',
+            url: `${next.url}${workspaceUrlPath}`,
+          })
+        )
+      })
+      await retry(async () => {
+        expect(
+          await browser.eval(() => {
+            const cacheMiss = document.getElementById(
+              '__NEXT_OFFLINE_NAVIGATION_CACHE_MISS'
+            )
+            return cacheMiss === null
+              ? null
+              : {
+                  hidden: cacheMiss.hidden,
+                  reason: cacheMiss.getAttribute(
+                    'data-next-offline-navigation-cache-reason'
+                  ),
+                  text: cacheMiss.textContent,
+                }
+          })
+        ).toEqual({
+          hidden: false,
+          reason: 'missing-entry',
+          text: 'This page is not available offline.',
+        })
+      })
+      expect(
+        await browser.eval(() =>
+          Boolean(document.getElementById('workspace-thread-page'))
+        )
+      ).toBe(false)
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
+  it('misses a workspace shell route when the required root layout record is missing during fallback boot', async () => {
+    if (shouldSkipReplayWithCachedNavigations) {
+      return
+    }
+
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    await next.start({ skipBuild: true })
+
+    const workspaceRoute = '/workspace/acme/channel/general/thread/123'
+    const workspaceUrlPath = `/docs${workspaceRoute}`
+    const rootLayoutRequestKey = ''
+    const workspaceLayoutRequestKey = '/workspace/$d$workspace'
+    let page: Playwright.Page | undefined
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
+
+      await browser.elementById('prefetch-workspace-shell').click()
+      await retry(async () => {
+        const routeRecords =
+          await readPersistedOfflineNavigationRouteRecords(browser)
+        expect(
+          routeRecords.some((record) =>
+            record.route.pathname.includes(workspaceRoute)
+          )
+        ).toBe(true)
+
+        const segmentRecords =
+          await readPersistedOfflineNavigationSegmentRecords(browser)
+        const segmentRequestKeys = segmentRecords.map(
+          (record) => record.segment.requestKey
+        )
+        expect(segmentRequestKeys).toContain(rootLayoutRequestKey)
+        expect(segmentRequestKeys).toContain(workspaceLayoutRequestKey)
+        expect(
+          segmentRecords.some((record) =>
+            record.segment.requestKey.endsWith('/@sidebar/__DEFAULT__')
+          )
+        ).toBe(true)
+        expect(
+          segmentRecords.some(
+            (record) =>
+              record.segment.requestKey.includes('/@activity/') &&
+              record.segment.requestKey.endsWith('/__PAGE__')
+          )
+        ).toBe(true)
+        expect(
+          segmentRecords.some(
+            (record) =>
+              record.key.includes('workspace') &&
+              record.segment.requestKey.endsWith('/__PAGE__')
+          )
+        ).toBe(true)
+        expect(
+          segmentRecords.some(
+            (record) => record.segment.requestKey === '/_head'
+          )
+        ).toBe(true)
+      })
+
+      const deletedExactEntries = await deletePersistedOfflineNavigationEntries(
+        browser,
+        workspaceUrlPath
+      )
+      expect(deletedExactEntries).toBeGreaterThan(0)
+      await retry(async () => {
+        const deletedEntry = await readPersistedOfflineNavigationEntry(
+          browser,
+          workspaceUrlPath
+        )
+        expect(deletedEntry).toBe(null)
+      })
+
+      const deletedRootLayoutRecords =
+        await deletePersistedOfflineNavigationSegmentRecords(browser, {
+          keySubstring: '',
+          requestKey: rootLayoutRequestKey,
+        })
+      expect(deletedRootLayoutRecords).toBeGreaterThan(0)
+      await retry(async () => {
+        const routeRecords =
+          await readPersistedOfflineNavigationRouteRecords(browser)
+        expect(
+          routeRecords.some((record) =>
+            record.route.pathname.includes(workspaceRoute)
+          )
+        ).toBe(true)
+
+        const segmentRecords =
+          await readPersistedOfflineNavigationSegmentRecords(browser)
+        const segmentRequestKeys = segmentRecords.map(
+          (record) => record.segment.requestKey
+        )
+        expect(segmentRequestKeys).not.toContain(rootLayoutRequestKey)
+        expect(segmentRequestKeys).toContain(workspaceLayoutRequestKey)
+        expect(
+          segmentRecords.some((record) =>
+            record.segment.requestKey.endsWith('/@sidebar/__DEFAULT__')
+          )
+        ).toBe(true)
+        expect(
+          segmentRecords.some(
+            (record) =>
+              record.segment.requestKey.includes('/@activity/') &&
+              record.segment.requestKey.endsWith('/__PAGE__')
+          )
+        ).toBe(true)
+        expect(
+          segmentRecords.some(
+            (record) =>
+              record.key.includes('workspace') &&
+              record.segment.requestKey.endsWith('/__PAGE__')
+          )
+        ).toBe(true)
+        expect(
+          segmentRecords.some(
+            (record) => record.segment.requestKey === '/_head'
+          )
+        ).toBe(true)
+      })
+
+      await next.stop()
+      await page!.context().setOffline(true)
+      const missingRootLayoutResponse = await page!.goto(
+        `${next.url}${workspaceUrlPath}`,
+        {
+          waitUntil: 'domcontentloaded',
+        }
+      )
+      expect(missingRootLayoutResponse?.status()).toBe(200)
 
       await retry(async () => {
         const diagnostics = await browser.eval(() => {


### PR DESCRIPTION
## Stack position

This is a test-only stress slice on top of #93676, which covers the destructive missing nested workspace-layout case for the Slack-like workspace shell fixture introduced in #93673.

Stack context:

1. #93670 covers a missing persisted route record.
2. #93671 covers a missing persisted head record.
3. #93672 covers a missing persisted page segment record.
4. #93673 proves the complex workspace shell can replay when all required route, segment, slot, and head records are present.
5. #93674 covers a missing required default sidebar slot record.
6. #93675 covers a missing required activity parallel-slot record.
7. #93676 covers a missing required nested workspace layout record.
8. This PR covers a missing required root layout record.

## What changed

Adds one focused production e2e for `offlineNavigations` with Cache Components:

- online-loads `/docs` and waits for the offline navigation service worker
- prefetches `/docs/workspace/acme/channel/general/thread/123`
- verifies the durable route record, root layout segment, nested workspace layout segment, page segment, default sidebar slot, activity parallel slot, and head record were persisted
- deletes the exact URL entry so the hard reload must use route/segment reconstruction
- deletes only the root layout segment record, whose persisted request key is `''`
- stops the server, puts the browser offline, and hard-loads the workspace route
- asserts the fallback boot emits `router-cache-reconstruction-miss` with `missing-segment`, falls back to visible `missing-entry` UI, and does not render the workspace page

The test-only IndexedDB deletion helper now accepts an exact `requestKey` so the root segment can be targeted without relying on `endsWith('')`, which would match every segment.

## Why this is separate

The previous workspace-shell stress slices cover route, head, page, default slot, parallel slot, and nested layout deletion. This PR isolates the root layout case so reviewers can verify that replay cannot boot a route graph when the root app shell segment is missing, even if the nested workspace shell and page records still exist.

This completes the core missing-record matrix in `.private-investigation/offline-navigations-production-plan.md` for route, head, page segment, default slot, parallel slot, nested layout, and root layout records.

## Reviewer focus

Please focus on the targeting and false-positive guards:

- the test asserts the root segment request key `''` exists before deleting it
- the exact URL entry is deleted first, so this cannot pass through direct exact-URL replay
- the route, nested workspace layout, page segment, default sidebar slot, activity parallel slot, and head records remain present after the root layout is deleted
- the expected result is a structured `missing-segment` reconstruction miss plus visible `missing-entry` UI, not a partially rendered workspace page

## Intentionally not covered here

Still pending in later stress slices:

- metadata/head style ordering integrity on successful replay
- app/session or workspace-scope partitioning
- broader freshness, race, and storage-pressure cases

## Verification

- `pnpm prettier --with-node-modules --ignore-path .prettierignore --write test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `npx eslint --config eslint.config.mjs --fix test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `git diff --check -- test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `NEXT_SKIP_ISOLATE=1 pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "misses a workspace shell route when the required root layout record is missing during fallback boot"`
- `NEXT_SKIP_ISOLATE=1 pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "required (root|nested) layout record"`
- `pnpm test-start-webpack test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "required (root|nested) layout record"`

<!-- NEXT_JS_LLM_PR -->
