### PR TITLE
(1/1) Cover session reset offline navigation misses

### DIFF
--- a/test/production/app-dir/offline-navigations/app/page.tsx
+++ b/test/production/app-dir/offline-navigations/app/page.tsx
@@ -14,6 +14,7 @@ import {
   DynamicPatternTargetPrefetchButton,
   PrefetchButton,
   RefreshButton,
+  ResetOfflineNavigationSessionButton,
   WorkspaceShellPrefetchButton,
 } from './prefetch-button'
 
@@ -95,6 +96,7 @@ export default function Page() {
       <WorkspaceShellPrefetchButton />
       <RefreshButton />
       <ClearOfflineNavigationCacheButton />
+      <ResetOfflineNavigationSessionButton />
     </>
   )
 }

--- a/test/production/app-dir/offline-navigations/app/prefetch-button.tsx
+++ b/test/production/app-dir/offline-navigations/app/prefetch-button.tsx
@@ -81,3 +81,23 @@ export function ClearOfflineNavigationCacheButton() {
     </>
   )
 }
+
+export function ResetOfflineNavigationSessionButton() {
+  const [result, setResult] = useState('idle')
+  return (
+    <>
+      <button
+        id="reset-offline-navigation-session"
+        onClick={async () => {
+          document.cookie = 'offline-session=; Max-Age=0; path=/; SameSite=Lax'
+          setResult(
+            (await clearOfflineNavigationCache()) ? 'cleared' : 'not-cleared'
+          )
+        }}
+      >
+        Reset offline navigation session
+      </button>
+      <p id="reset-offline-navigation-session-result">{result}</p>
+    </>
+  )
+}

--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -4778,6 +4778,196 @@ describe('offlineNavigations build artifacts', () => {
     }
   })
 
+  it('misses request-sensitive exact URLs after an app-owned session reset', async () => {
+    if (shouldSkipReplayWithCachedNavigations) {
+      return
+    }
+
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    const { buildId } = await getOfflineNavigationArtifactPaths()
+    const navigationBuildId = next.deploymentId ?? buildId
+    await next.start({ skipBuild: true })
+
+    let page: Playwright.Page | undefined
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
+
+      await browser.eval(() => {
+        document.cookie = 'offline-session=alpha; path=/; SameSite=Lax'
+      })
+      const onlineResponse = await page!.goto(
+        `${next.url}/docs/request-sensitive/`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(onlineResponse?.status()).toBe(200)
+      await retry(async () => {
+        expect(await browser.elementById('request-sensitive-page').text()).toBe(
+          'request sensitive session: alpha'
+        )
+      })
+
+      let cachedEntryEpoch = -1
+      await retry(async () => {
+        const entry = await readPersistedOfflineNavigationEntry(
+          browser,
+          '/docs/request-sensitive'
+        )
+        expect(entry).toEqual(
+          expect.objectContaining({
+            buildId: navigationBuildId,
+            cacheEpoch: expect.any(Number),
+            kind: 'exact-url',
+            payload: expect.objectContaining({
+              kind: 'rsc-response',
+              requestKind: 'initial-load',
+              status: 200,
+            }),
+            url: expect.stringContaining('/docs/request-sensitive'),
+          })
+        )
+        expect(entry!.payload.bodyLength).toBeGreaterThan(0)
+        cachedEntryEpoch = entry!.cacheEpoch
+      })
+
+      await page!.context().setOffline(true)
+      const sameSessionOfflineResponse = await page!.goto(
+        `${next.url}/docs/request-sensitive/`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(sameSessionOfflineResponse?.status()).toBe(200)
+      await retry(async () => {
+        expect(await browser.elementById('request-sensitive-page').text()).toBe(
+          'request sensitive session: alpha'
+        )
+        expect(await browser.elementById('offline-status').text()).toBe(
+          'offline'
+        )
+      })
+
+      await page!.context().setOffline(false)
+      await browser.eval(() => {
+        window.dispatchEvent(new Event('online'))
+      })
+      const onlineRootResponse = await page!.goto(`${next.url}/docs`, {
+        waitUntil: 'domcontentloaded',
+      })
+      expect(onlineRootResponse?.status()).toBe(200)
+      await retry(async () => {
+        expect(
+          await browser.elementById('reset-offline-navigation-session').text()
+        ).toBe('Reset offline navigation session')
+      })
+
+      await browser.elementById('reset-offline-navigation-session').click()
+      await retry(async () => {
+        expect(
+          await browser
+            .elementById('reset-offline-navigation-session-result')
+            .text()
+        ).toBe('cleared')
+        expect(
+          await browser.eval(() => document.cookie.includes('offline-session='))
+        ).toBe(false)
+        expect(
+          await readPersistedOfflineNavigationMetadata(
+            browser,
+            'exact-url-cache-epoch'
+          )
+        ).toBeGreaterThan(cachedEntryEpoch)
+        expect(
+          await readPersistedOfflineNavigationMetadata(
+            browser,
+            'route-cache-epoch'
+          )
+        ).toBeGreaterThan(0)
+        expect(
+          await readPersistedOfflineNavigationMetadata(
+            browser,
+            'segment-cache-epoch'
+          )
+        ).toBeGreaterThan(0)
+      })
+
+      await retry(async () => {
+        const oldEntry = await readPersistedOfflineNavigationEntry(
+          browser,
+          '/docs/request-sensitive'
+        )
+        expect(oldEntry).toEqual(
+          expect.objectContaining({
+            cacheEpoch: cachedEntryEpoch,
+            url: expect.stringContaining('/docs/request-sensitive'),
+          })
+        )
+      })
+
+      await page!.context().setOffline(true)
+      const resetOfflineResponse = await page!.goto(
+        `${next.url}/docs/request-sensitive/`,
+        { waitUntil: 'domcontentloaded' }
+      )
+      expect(resetOfflineResponse?.status()).toBe(200)
+      await retry(async () => {
+        const diagnostics = await browser.eval(() => {
+          const win = window as typeof window & {
+            __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?: Array<{
+              reason?: string
+              type?: string
+              url?: string
+            }>
+          }
+          return win.__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__ ?? []
+        })
+        expect(diagnostics).toContainEqual(
+          expect.objectContaining({
+            reason: 'missing-entry',
+            type: 'cache-miss',
+            url: `${next.url}/docs/request-sensitive/`,
+          })
+        )
+      })
+      await retry(async () => {
+        expect(
+          await browser.eval(() => {
+            const cacheMiss = document.getElementById(
+              '__NEXT_OFFLINE_NAVIGATION_CACHE_MISS'
+            )
+            return cacheMiss === null
+              ? null
+              : {
+                  hidden: cacheMiss.hidden,
+                  reason: cacheMiss.getAttribute(
+                    'data-next-offline-navigation-cache-reason'
+                  ),
+                  text: cacheMiss.textContent,
+                }
+          })
+        ).toEqual({
+          hidden: false,
+          reason: 'missing-entry',
+          text: 'This page is not available offline.',
+        })
+      })
+      expect(
+        await browser.eval(() =>
+          Boolean(document.getElementById('request-sensitive-page'))
+        )
+      ).toBe(false)
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
   it('covers exact URL shape and pass-through stress cases', async () => {
     if (shouldSkipReplayWithCachedNavigations) {
       return


### PR DESCRIPTION
## Stack Position

This is a test-only stress PR stacked on #93677, `(1/1) Cover missing root layout offline navigation misses`. It is the `stress-session-reset` follow-up from the offline navigations production plan and covers scenario `SESSION-02b`: same-browser request-sensitive exact URL replay after an explicit app-owned session reset.

This PR does not change production code. It only adds fixture UI and one focused production e2e so reviewers can evaluate this policy boundary separately from the broader route graph and service worker work.

## Why This Exists

The browser-private replay policy intentionally does not treat cookie or auth usage as a blanket reason to skip offline replay. If this browser already received a fresh payload, an offline navigation may replay it for the same build and same app/session scope.

The important safety boundary is what happens after the app knows the session scope changed. This PR proves the current reset primitive can make previously replayable exact URL data unreachable without relying on deletion of the raw record.

## What Changed

- Adds `ResetOfflineNavigationSessionButton` to the offline navigation fixture.
- The button clears the fixture `offline-session` cookie and calls `clearOfflineNavigationCache()`.
- Adds the button to the fixture root page so the e2e can trigger an app-owned reset through browser UI.
- Adds `misses request-sensitive exact URLs after an app-owned session reset`.

## Behavior Covered

The e2e walks the full contract in one browser profile:

1. Load `/docs/request-sensitive/` online with `offline-session=alpha`.
2. Assert an exact URL initial-load record was persisted with the current build/deployment ID.
3. Go offline and hard-load the same URL, proving same-session personalized data can replay and `useOffline()` reports offline.
4. Reconnect, click the reset button, and assert the session cookie is gone.
5. Assert exact URL, route, and segment cache epochs advanced.
6. Assert the old raw exact URL entry can still exist with its old epoch.
7. Go offline and hard-load the same URL again.
8. Assert fallback boot now renders visible cache-miss UI with `missing-entry` and does not render the personalized page.

This protects the intended production posture: same-browser personalized replay is allowed while scope is stable, and explicit app-owned scope reset makes old data unreachable.

## Intentionally Not Covered Yet

- Account switch.
- Workspace switch.
- Entitlement or session-version rotation.
- Multi-profile isolation.
- Races where reset overlaps a write or fallback boot.

Those remain separate stress rows so this PR stays reviewable.

## Verification

- `pnpm prettier --with-node-modules --ignore-path .prettierignore --write test/production/app-dir/offline-navigations/app/prefetch-button.tsx test/production/app-dir/offline-navigations/app/page.tsx test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `npx eslint --config eslint.config.mjs --fix test/production/app-dir/offline-navigations/app/prefetch-button.tsx test/production/app-dir/offline-navigations/app/page.tsx test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `git diff --check -- test/production/app-dir/offline-navigations/app/prefetch-button.tsx test/production/app-dir/offline-navigations/app/page.tsx test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `NEXT_SKIP_ISOLATE=1 pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "misses request-sensitive exact URLs after an app-owned session reset"`
- `pnpm test-start-webpack test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "misses request-sensitive exact URLs after an app-owned session reset"`

<!-- NEXT_JS_LLM_PR -->