### PR TITLE
(1/1) Cover workspace metadata offline replay

### DIFF
--- a/test/production/app-dir/offline-navigations/app/workspace/[workspace]/channel/[channel]/thread/[thread]/page.tsx
+++ b/test/production/app-dir/offline-navigations/app/workspace/[workspace]/channel/[channel]/thread/[thread]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from 'next'
 import { OfflineStatus } from '../../../../../../offline-status'
 
 type WorkspaceThreadPageProps = {
@@ -21,6 +22,17 @@ export default async function WorkspaceThreadPage({
       <OfflineStatus />
     </>
   )
+}
+
+export async function generateMetadata({
+  params,
+}: WorkspaceThreadPageProps): Promise<Metadata> {
+  const { channel, thread, workspace } = await params
+
+  return {
+    title: `Workspace ${workspace} thread ${channel}/${thread}`,
+    description: `Offline workspace thread ${workspace}/${channel}/${thread}`,
+  }
 }
 
 export function generateStaticParams({

--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -1545,6 +1545,138 @@ describe('offlineNavigations build artifacts', () => {
     }
   })
 
+  it('restores workspace shell metadata from persisted router records', async () => {
+    if (shouldSkipReplayWithCachedNavigations) {
+      return
+    }
+
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    await next.start({ skipBuild: true })
+
+    const workspaceRoute = '/workspace/acme/channel/general/thread/123'
+    const workspaceUrlPath = `/docs${workspaceRoute}`
+    let page: Playwright.Page | undefined
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
+
+      await browser.elementById('prefetch-workspace-shell').click()
+      await retry(async () => {
+        const exactEntry = await readPersistedOfflineNavigationEntry(
+          browser,
+          workspaceUrlPath
+        )
+        expect(exactEntry).toEqual(
+          expect.objectContaining({
+            kind: 'exact-url',
+            payload: expect.objectContaining({
+              kind: 'rsc-response',
+              requestKind: 'client-resume',
+            }),
+          })
+        )
+      })
+      await retry(async () => {
+        const routeRecords =
+          await readPersistedOfflineNavigationRouteRecords(browser)
+        expect(
+          routeRecords.some((record) =>
+            record.route.pathname.includes(workspaceRoute)
+          )
+        ).toBe(true)
+
+        const segmentRecords =
+          await readPersistedOfflineNavigationSegmentRecords(browser)
+        expect(
+          segmentRecords.some(
+            (record) =>
+              record.key.includes('workspace') &&
+              record.payload.requestKind === 'segment-prefetch'
+          )
+        ).toBe(true)
+        expect(
+          segmentRecords.some(
+            (record) => record.segment.requestKey === '/_head'
+          )
+        ).toBe(true)
+      })
+
+      const deletedExactEntries = await deletePersistedOfflineNavigationEntries(
+        browser,
+        workspaceUrlPath
+      )
+      expect(deletedExactEntries).toBeGreaterThan(0)
+      await retry(async () => {
+        const deletedEntry = await readPersistedOfflineNavigationEntry(
+          browser,
+          workspaceUrlPath
+        )
+        expect(deletedEntry).toBe(null)
+      })
+
+      await next.stop()
+      await page!.context().setOffline(true)
+      const workspaceResponse = await page!.goto(
+        `${next.url}${workspaceUrlPath}`,
+        {
+          waitUntil: 'domcontentloaded',
+        }
+      )
+      expect(workspaceResponse?.status()).toBe(200)
+      await retry(async () => {
+        const routerCacheDiagnostics = await browser.eval(() => {
+          const win = window as typeof window & {
+            __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?: Array<{
+              type?: string
+              requestKind?: string
+              url?: string
+              reason?: string
+            }>
+          }
+          return win.__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__ ?? []
+        })
+        expect(routerCacheDiagnostics).toContainEqual(
+          expect.objectContaining({
+            type: 'cache-hit',
+            requestKind: 'router-cache',
+            url: `${next.url}${workspaceUrlPath}`,
+          })
+        )
+      })
+      await retry(async () => {
+        expect(await browser.elementById('workspace-thread-page').text()).toBe(
+          'workspace thread: acme/general/123'
+        )
+        expect(await browser.elementById('offline-status').text()).toBe(
+          'offline'
+        )
+        expect(
+          await browser.eval(() => ({
+            description:
+              document
+                .querySelector('meta[name="description"]')
+                ?.getAttribute('content') ?? null,
+            title: document.title,
+          }))
+        ).toEqual({
+          description: 'Offline workspace thread acme/general/123',
+          title: 'Workspace acme thread general/123',
+        })
+      })
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
   it('misses a workspace shell route when a required default slot record is missing during fallback boot', async () => {
     if (shouldSkipReplayWithCachedNavigations) {
       return


### PR DESCRIPTION
## Stack Position

This is a focused stress PR stacked on #93678, `(1/1) Cover session reset offline navigation misses`. It covers the positive metadata/head portion of the `META-01` stress row and the complex app-shell follow-up for `SHELL-01`.

The earlier workspace-shell PRs proved that a fully prefetched app shell can replay from persisted route and segment records and that missing layout/default/parallel/page records miss visibly. This PR adds the next narrow claim: the same route/segment replay path also restores route-owned metadata instead of leaving stale fallback document head state behind.

## What Changed

- Adds `generateMetadata()` to the workspace thread fixture route.
- The fixture now emits a dynamic title and meta description derived from `workspace`, `channel`, and `thread` params.
- Adds `restores workspace shell metadata from persisted router records`.

## Behavior Covered

The new e2e:

1. Prefetches `/workspace/acme/channel/general/thread/123`.
2. Asserts the exact URL record, route record, workspace segment record, and `/_head` record exist.
3. Deletes the exact URL record so fallback boot cannot pass through the simpler exact URL replay path.
4. Stops the server and hard-loads the route offline.
5. Asserts a `router-cache` cache-hit diagnostic for the requested URL.
6. Asserts the workspace route UI renders with `useOffline()` reporting offline.
7. Asserts `document.title` and `meta[name="description"]` match the route metadata.

That gives reviewers a direct browser-level proof that route/segment replay includes the head record, not only the visible page body.

## Intentionally Not Covered Yet

- Canonical link restoration.
- Head deduplication and ordering.
- Stale head record behavior.
- CSS, font preload, and runtime chunk coherence.
- Blank-root or missing-runtime red-team cases.

Those stay in later `META-*`, `ASSET-*`, and runtime integrity stress slices so this PR remains one claim.

## Verification

- `pnpm prettier --with-node-modules --ignore-path .prettierignore --write test/production/app-dir/offline-navigations/app/workspace/[workspace]/channel/[channel]/thread/[thread]/page.tsx test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `npx eslint --config eslint.config.mjs --fix test/production/app-dir/offline-navigations/app/workspace/[workspace]/channel/[channel]/thread/[thread]/page.tsx test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `git diff --check -- test/production/app-dir/offline-navigations/app/workspace/[workspace]/channel/[channel]/thread/[thread]/page.tsx test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `NEXT_SKIP_ISOLATE=1 pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "restores workspace shell metadata from persisted router records"`
- `pnpm test-start-webpack test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "restores workspace shell metadata from persisted router records"`
- `NEXT_SKIP_ISOLATE=1 pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "workspace shell"`

<!-- NEXT_JS_LLM_PR -->