### PR TITLE
(1/1) Cover path case offline navigation misses

### DIFF
--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -5592,6 +5592,132 @@ describe('offlineNavigations build artifacts', () => {
     }
   })
 
+  it('misses exact-URL replay for path case identity collision variants', async () => {
+    if (shouldSkipReplayWithCachedNavigations) {
+      return
+    }
+
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    const { buildId } = await getOfflineNavigationArtifactPaths()
+    const navigationBuildId = next.deploymentId ?? buildId
+    await next.start({ skipBuild: true })
+
+    let page: Playwright.Page | undefined
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
+
+      const cachedUrl = `${next.url}/docs/url-stress/CaseValue/?token=case-path`
+      const onlineResponse = await page!.goto(cachedUrl, {
+        waitUntil: 'domcontentloaded',
+      })
+      expect(onlineResponse?.status()).toBe(200)
+      await retry(async () => {
+        expect(await browser.elementById('url-stress-page').text()).toBe(
+          'url stress path: CaseValue'
+        )
+        expect(await browser.elementById('url-stress-token').text()).toBe(
+          'url stress token: case-path'
+        )
+      })
+
+      await retry(async () => {
+        const entry = await readPersistedOfflineNavigationEntry(
+          browser,
+          '/docs/url-stress/CaseValue/'
+        )
+        expect(entry).toEqual({
+          buildId: navigationBuildId,
+          cacheEpoch: 0,
+          expiresAt: expect.any(Number),
+          kind: 'exact-url',
+          payload: {
+            bodyLength: expect.any(Number),
+            kind: 'rsc-response',
+            requestKind: 'initial-load',
+            status: 200,
+          },
+          staleAt: expect.any(Number),
+          url: cachedUrl,
+          version: 2,
+        })
+      })
+
+      const pathCollisionUrl = `${next.url}/docs/url-stress/casevalue/?token=case-path`
+
+      await next.stop()
+      await page!.context().setOffline(true)
+
+      const response = await page!.goto(pathCollisionUrl, {
+        waitUntil: 'domcontentloaded',
+      })
+      expect(response?.status()).toBe(200)
+
+      await retry(async () => {
+        expect(
+          await browser.eval(() => {
+            const cacheMiss = document.getElementById(
+              '__NEXT_OFFLINE_NAVIGATION_CACHE_MISS'
+            )
+            return cacheMiss === null
+              ? null
+              : {
+                  hidden: cacheMiss.hidden,
+                  reason: cacheMiss.getAttribute(
+                    'data-next-offline-navigation-cache-reason'
+                  ),
+                  text: cacheMiss.textContent,
+                }
+          })
+        ).toEqual({
+          hidden: false,
+          reason: 'missing-entry',
+          text: 'This page is not available offline.',
+        })
+      })
+
+      expect(
+        await browser.eval(() => ({
+          cache: document.documentElement.getAttribute(
+            'data-next-offline-navigation-cache'
+          ),
+          reason: document.documentElement.getAttribute(
+            'data-next-offline-navigation-cache-reason'
+          ),
+          renderedRoute:
+            document.getElementById('url-stress-page')?.textContent ?? null,
+          diagnostic:
+            (
+              window as typeof window & {
+                __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?: Array<unknown>
+              }
+            ).__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?.at(-1) ?? null,
+        }))
+      ).toMatchObject({
+        cache: 'miss',
+        reason: 'missing-entry',
+        renderedRoute: null,
+        diagnostic: {
+          type: 'cache-miss',
+          buildId: navigationBuildId,
+          reason: 'missing-entry',
+          url: pathCollisionUrl,
+        },
+      })
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
   it('shows cache miss when IndexedDB is unavailable during fallback boot', async () => {
     const buildResult = await next.build()
     expect(buildResult.exitCode).toBe(0)


### PR DESCRIPTION
## Stack Position

This is a focused URL-identity stress PR stacked on #93680, `(1/1) Cover encoded path offline navigation misses`. It covers the next small `EXACT-04` row: path case identity.

This PR is intentionally test-only. It does not change the offline navigation keying implementation; it adds an e2e that would fail if the exact URL cache normalizer accidentally treated uppercase and lowercase path spellings as interchangeable.

## What Changed

- Adds `misses exact-URL replay for path case identity collision variants`.
- Uses the existing `url-stress/[value]` fixture route.

## Behavior Covered

The e2e:

1. Loads `/docs/url-stress/CaseValue/?token=case-path` online.
2. Asserts the page rendered the uppercase path value and the exact URL initial-load record was persisted for the uppercase URL.
3. Stops the server and switches the browser offline.
4. Hard-loads nearby `/docs/url-stress/casevalue/?token=case-path`.
5. Asserts the fallback boot renders visible `missing-entry` UI.
6. Asserts the cache diagnostic is for the lowercase requested URL.
7. Asserts no `url-stress-page` content rendered, so the test cannot pass by replaying the cached uppercase-path route.

This protects the exact URL cache contract: path case remains part of the document identity unless a future route-identity layer explicitly models a canonicalization rule.

## Intentionally Not Covered Yet

- Encoded slash variants.
- Canonical redirect identity.
- Deployment URL changes.
- Remaining basePath, assetPrefix, and trailingSlash combinations beyond the current fixture settings.

Those stay as separate URL-identity stress rows so this PR remains one reviewable claim.

## Verification

- `pnpm prettier --with-node-modules --ignore-path .prettierignore --write test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `npx eslint --config eslint.config.mjs --fix test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `git diff --check -- test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `NEXT_SKIP_ISOLATE=1 pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "misses exact-URL replay for path case identity collision variants"`
- `pnpm test-start-webpack test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "misses exact-URL replay for path case identity collision variants"`

<!-- NEXT_JS_LLM_PR -->