### PR TITLE
(1/1) Cover trailing slash offline replay

### DIFF
--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -5718,6 +5718,121 @@ describe('offlineNavigations build artifacts', () => {
     }
   })
 
+  it('replays exact-URL data for trailing-slash normalized variants', async () => {
+    if (shouldSkipReplayWithCachedNavigations) {
+      return
+    }
+
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    const { buildId } = await getOfflineNavigationArtifactPaths()
+    const navigationBuildId = next.deploymentId ?? buildId
+    await next.start({ skipBuild: true })
+
+    let page: Playwright.Page | undefined
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
+
+      const cachedUrl = `${next.url}/docs/url-stress/trailing-slash/?token=trailing-slash`
+      const onlineResponse = await page!.goto(cachedUrl, {
+        waitUntil: 'domcontentloaded',
+      })
+      expect(onlineResponse?.status()).toBe(200)
+      await retry(async () => {
+        expect(await browser.elementById('url-stress-page').text()).toBe(
+          'url stress path: trailing-slash'
+        )
+        expect(await browser.elementById('url-stress-token').text()).toBe(
+          'url stress token: trailing-slash'
+        )
+      })
+
+      await retry(async () => {
+        const entry = await readPersistedOfflineNavigationEntry(
+          browser,
+          '/docs/url-stress/trailing-slash/'
+        )
+        expect(entry).toEqual({
+          buildId: navigationBuildId,
+          cacheEpoch: 0,
+          expiresAt: expect.any(Number),
+          kind: 'exact-url',
+          payload: {
+            bodyLength: expect.any(Number),
+            kind: 'rsc-response',
+            requestKind: 'initial-load',
+            status: 200,
+          },
+          staleAt: expect.any(Number),
+          url: cachedUrl,
+          version: 2,
+        })
+      })
+
+      const noSlashVariantUrl = `${next.url}/docs/url-stress/trailing-slash?token=trailing-slash`
+
+      await next.stop()
+      await page!.context().setOffline(true)
+
+      const response = await page!.goto(noSlashVariantUrl, {
+        waitUntil: 'domcontentloaded',
+      })
+      expect(response?.status()).toBe(200)
+
+      await retry(async () => {
+        expect(await browser.elementById('url-stress-page').text()).toBe(
+          'url stress path: trailing-slash'
+        )
+        expect(await browser.elementById('url-stress-token').text()).toBe(
+          'url stress token: trailing-slash'
+        )
+      })
+      expect(await browser.elementById('offline-status').text()).toBe('offline')
+
+      expect(
+        await browser.eval(() => ({
+          cacheMiss:
+            document.getElementById('__NEXT_OFFLINE_NAVIGATION_CACHE_MISS') ===
+            null
+              ? null
+              : 'present',
+          renderedRoute:
+            document.getElementById('url-stress-page')?.textContent ?? null,
+          diagnostic:
+            (
+              window as typeof window & {
+                __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?: Array<{
+                  type?: string
+                }>
+              }
+            ).__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?.find(
+              (diagnostic) => diagnostic.type === 'cache-hit'
+            ) ?? null,
+        }))
+      ).toMatchObject({
+        cacheMiss: null,
+        renderedRoute: 'url stress path: trailing-slash',
+        diagnostic: {
+          type: 'cache-hit',
+          buildId: navigationBuildId,
+          requestKind: 'initial-load',
+          url: noSlashVariantUrl,
+        },
+      })
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
   it('shows cache miss when IndexedDB is unavailable during fallback boot', async () => {
     const buildResult = await next.build()
     expect(buildResult.exitCode).toBe(0)


### PR DESCRIPTION
## Stack Position

This is a focused URL-identity stress PR stacked on #93681, `(1/1) Cover path case offline navigation misses`. It covers the next small `EXACT-04` row: the configured `trailingSlash` normalization case.

This PR is intentionally test-only. It does not change the offline navigation cache normalizer; it adds browser coverage for the behavior that already exists in the cache key normalization path.

## What Changed

- Adds `replays exact-URL data for trailing-slash normalized variants`.
- Uses the existing `url-stress/[value]` fixture route with `trailingSlash: true`, `basePath: '/docs'`, and `assetPrefix: '/app-assets'`.

## Behavior Covered

The e2e:

1. Loads `/docs/url-stress/trailing-slash/?token=trailing-slash` online.
2. Asserts the route rendered and the slash-normalized exact URL initial-load record was persisted.
3. Stops the server and switches the browser offline.
4. Hard-loads nearby no-slash `/docs/url-stress/trailing-slash?token=trailing-slash`.
5. Asserts the route still renders from offline exact-URL data.
6. Asserts `useOffline()` reports offline.
7. Asserts no cache-miss UI is shown.
8. Asserts the `cache-hit` diagnostic is for the requested no-slash URL.

This protects the exact URL cache contract: slash and no-slash variants may share a record only because the app config says `trailingSlash: true`. Nearby URL variants that are not described by framework config remain covered as misses in the previous `EXACT-04` stress PRs.

## Intentionally Not Covered Yet

- `trailingSlash: false` fixture parity.
- Canonical redirect identity beyond this configured normalization.
- Encoded slash variants.
- Deployment URL changes.
- Remaining basePath and assetPrefix URL identity combinations.

Those stay separate so this PR remains one reviewable claim.

## Verification

- `pnpm prettier --with-node-modules --ignore-path .prettierignore --write test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `npx eslint --config eslint.config.mjs --fix test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `git diff --check -- test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `NEXT_SKIP_ISOLATE=1 pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "replays exact-URL data for trailing-slash normalized variants"`
- `pnpm test-start-webpack test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "replays exact-URL data for trailing-slash normalized variants"`

<!-- NEXT_JS_LLM_PR -->