### PR TITLE
(1/1) Cover encoded slash offline misses

### DIFF
--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -5592,6 +5592,132 @@ describe('offlineNavigations build artifacts', () => {
     }
   })
 
+  it('misses exact-URL replay for encoded slash path identity variants', async () => {
+    if (shouldSkipReplayWithCachedNavigations) {
+      return
+    }
+
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    const { buildId } = await getOfflineNavigationArtifactPaths()
+    const navigationBuildId = next.deploymentId ?? buildId
+    await next.start({ skipBuild: true })
+
+    let page: Playwright.Page | undefined
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
+
+      const cachedUrl = `${next.url}/docs/url-stress/a%2Fb/?token=encoded-slash`
+      const onlineResponse = await page!.goto(cachedUrl, {
+        waitUntil: 'domcontentloaded',
+      })
+      expect(onlineResponse?.status()).toBe(200)
+      await retry(async () => {
+        expect(await browser.elementById('url-stress-page').text()).toBe(
+          'url stress path: a%2Fb'
+        )
+        expect(await browser.elementById('url-stress-token').text()).toBe(
+          'url stress token: encoded-slash'
+        )
+      })
+
+      await retry(async () => {
+        const entry = await readPersistedOfflineNavigationEntry(
+          browser,
+          '/docs/url-stress/a%2Fb/'
+        )
+        expect(entry).toEqual({
+          buildId: navigationBuildId,
+          cacheEpoch: 0,
+          expiresAt: expect.any(Number),
+          kind: 'exact-url',
+          payload: {
+            bodyLength: expect.any(Number),
+            kind: 'rsc-response',
+            requestKind: 'initial-load',
+            status: 200,
+          },
+          staleAt: expect.any(Number),
+          url: cachedUrl,
+          version: 2,
+        })
+      })
+
+      const pathCollisionUrl = `${next.url}/docs/url-stress/a/b/?token=encoded-slash`
+
+      await next.stop()
+      await page!.context().setOffline(true)
+
+      const response = await page!.goto(pathCollisionUrl, {
+        waitUntil: 'domcontentloaded',
+      })
+      expect(response?.status()).toBe(200)
+
+      await retry(async () => {
+        expect(
+          await browser.eval(() => {
+            const cacheMiss = document.getElementById(
+              '__NEXT_OFFLINE_NAVIGATION_CACHE_MISS'
+            )
+            return cacheMiss === null
+              ? null
+              : {
+                  hidden: cacheMiss.hidden,
+                  reason: cacheMiss.getAttribute(
+                    'data-next-offline-navigation-cache-reason'
+                  ),
+                  text: cacheMiss.textContent,
+                }
+          })
+        ).toEqual({
+          hidden: false,
+          reason: 'missing-entry',
+          text: 'This page is not available offline.',
+        })
+      })
+
+      expect(
+        await browser.eval(() => ({
+          cache: document.documentElement.getAttribute(
+            'data-next-offline-navigation-cache'
+          ),
+          reason: document.documentElement.getAttribute(
+            'data-next-offline-navigation-cache-reason'
+          ),
+          renderedRoute:
+            document.getElementById('url-stress-page')?.textContent ?? null,
+          diagnostic:
+            (
+              window as typeof window & {
+                __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?: Array<unknown>
+              }
+            ).__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?.at(-1) ?? null,
+        }))
+      ).toMatchObject({
+        cache: 'miss',
+        reason: 'missing-entry',
+        renderedRoute: null,
+        diagnostic: {
+          type: 'cache-miss',
+          buildId: navigationBuildId,
+          reason: 'missing-entry',
+          url: pathCollisionUrl,
+        },
+      })
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
   it('misses exact-URL replay for path case identity collision variants', async () => {
     if (shouldSkipReplayWithCachedNavigations) {
       return


### PR DESCRIPTION
## Stack Position

This is a focused URL-identity stress PR stacked on #93682, `(1/1) Cover trailing slash offline replay`. It covers the next small `EXACT-04` row: encoded slash path identity.

This PR is intentionally test-only. It does not change the offline navigation keying implementation; it adds browser coverage for a path variant that is easy to accidentally normalize incorrectly.

## What Changed

- Adds `misses exact-URL replay for encoded slash path identity variants`.
- Uses the existing `url-stress/[value]` fixture route.

## Behavior Covered

The e2e:

1. Loads `/docs/url-stress/a%2Fb/?token=encoded-slash` online.
2. Asserts the route rendered the encoded slash path value and the exact URL initial-load record was persisted for the encoded URL.
3. Stops the server and switches the browser offline.
4. Hard-loads nearby real-slash `/docs/url-stress/a/b/?token=encoded-slash`.
5. Asserts the fallback boot renders visible `missing-entry` UI.
6. Asserts the cache diagnostic is for the requested real-slash URL.
7. Asserts no `url-stress-page` content rendered, so the test cannot pass by replaying the cached encoded-slash route.

This protects the exact URL cache contract: `%2F` inside a path segment and a real `/` path separator are not interchangeable. A future route-identity layer can model canonicalization explicitly, but the exact URL fallback must not guess.

## Intentionally Not Covered Yet

- Canonical redirect identity.
- Deployment URL changes.
- `trailingSlash: false` fixture parity.
- Remaining basePath and assetPrefix URL identity combinations.

Those stay separate so this PR remains one reviewable claim.

## Verification

- `pnpm prettier --with-node-modules --ignore-path .prettierignore --write test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `npx eslint --config eslint.config.mjs --fix test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `git diff --check -- test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `pnpm --filter=next build`
- `NEXT_SKIP_ISOLATE=1 pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "misses exact-URL replay for encoded slash path identity variants"`
- `pnpm test-start-webpack test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "misses exact-URL replay for encoded slash path identity variants"`

<!-- NEXT_JS_LLM_PR -->