### PR TITLE
(1/1) Cover offline server action boundaries

### DIFF
--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -5326,6 +5326,106 @@ describe('offlineNavigations build artifacts', () => {
     }
   })
 
+  it('does not serve fallback HTML to offline server action submissions', async () => {
+    if (shouldSkipReplayWithCachedNavigations) {
+      return
+    }
+
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    await next.start({ skipBuild: true })
+
+    let page: Playwright.Page | undefined
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
+
+      await retry(async () => {
+        expect(await browser.elementByCss('p').text()).toBe(
+          'offline navigations page'
+        )
+        expect(
+          await browser.elementById('action-invalidation-marker').text()
+        ).toBe('action invalidation marker')
+      })
+
+      await browser.eval((messageType) => {
+        localStorage.removeItem('__nextOfflineNavigationActionMessages')
+        navigator.serviceWorker.addEventListener('message', (event) => {
+          if (event.data?.type === messageType) {
+            const messages = JSON.parse(
+              localStorage.getItem('__nextOfflineNavigationActionMessages') ??
+                '[]'
+            )
+            messages.push(event.data)
+            localStorage.setItem(
+              '__nextOfflineNavigationActionMessages',
+              JSON.stringify(messages)
+            )
+          }
+        })
+      }, OFFLINE_NAVIGATION_FALLBACK_SERVED)
+
+      const failedActionRequest = page!.waitForEvent('requestfailed', {
+        predicate(request) {
+          return (
+            request.method() === 'POST' &&
+            request.url().startsWith(`${next.url}/docs`)
+          )
+        },
+      })
+
+      await page!.context().setOffline(true)
+      await browser.elementById('invalidate-offline-navigation-action').click()
+
+      const request = await failedActionRequest
+      expect(request.failure()?.errorText).toMatch(
+        /ERR_INTERNET_DISCONNECTED|NS_ERROR_OFFLINE|offline/i
+      )
+
+      expect(
+        await browser.eval(() => ({
+          cache: document.documentElement.getAttribute(
+            'data-next-offline-navigation-cache'
+          ),
+          fallback: document.documentElement.hasAttribute(
+            'data-next-offline-navigation-fallback'
+          ),
+          fallbackMessages: JSON.parse(
+            localStorage.getItem('__nextOfflineNavigationActionMessages') ??
+              '[]'
+          ),
+          marker:
+            document.getElementById('action-invalidation-marker')
+              ?.textContent ?? null,
+          miss:
+            document.getElementById('__NEXT_OFFLINE_NAVIGATION_CACHE_MISS') ===
+            null
+              ? null
+              : 'present',
+          pageText: document.querySelector('p')?.textContent ?? null,
+        }))
+      ).toEqual({
+        cache: null,
+        fallback: false,
+        fallbackMessages: [],
+        marker: 'action invalidation marker',
+        miss: null,
+        pageText: 'offline navigations page',
+      })
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
   it('misses exact-URL replay for query identity collision variants', async () => {
     if (shouldSkipReplayWithCachedNavigations) {
       return


### PR DESCRIPTION
## Stack Position

This is a focused request-shape stress PR stacked on #93683, `(1/1) Cover encoded slash offline misses`.

It covers the first `MUTATION-01` row from the offline navigations stress plan: server action submissions while the browser is offline. This PR is intentionally test-only. It does not change service worker routing, fallback boot, or server action behavior.

## What Changed

- Adds `does not serve fallback HTML to offline server action submissions` to the offline navigations production e2e suite.
- Reuses the existing server action invalidation form on the fixture root page.
- Asserts the mutation request fails as a POST network request while offline, rather than being answered by generated fallback HTML.

## Behavior Covered

The e2e:

1. Builds and starts the offline navigations fixture.
2. Loads `/docs` online and waits for the generated service worker.
3. Registers a listener for `next-offline-navigation-fallback-served` messages.
4. Switches the browser context offline.
5. Submits the existing `invalidateOfflineNavigationAction` server action form.
6. Waits for the POST request to fail with an offline network error.
7. Asserts no fallback-served message was emitted.
8. Asserts generated fallback/cache-miss UI did not render.
9. Asserts the current app page remains intact.

This protects the service worker contract: failed same-origin document navigations may receive the fallback document, but server action POSTs are unsafe app mutations and must pass through or fail normally.

## Intentionally Not Covered Yet

- Plain non-JS form POST fallback behavior.
- Redirecting server action while offline.
- Route-handler mutation POSTs beyond the existing fetch POST pass-through probe.
- Reconnect retry after a failed offline mutation.
- Successful online retry invalidating durable offline records.

## Verification

- `pnpm prettier --with-node-modules --ignore-path .prettierignore --write test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `npx eslint --config eslint.config.mjs --fix test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `git diff --check -- test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `NEXT_SKIP_ISOLATE=1 pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "does not serve fallback HTML to offline server action submissions"`
- `pnpm test-start-webpack test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "does not serve fallback HTML to offline server action submissions"`
- commit hook: lint-staged reran prettier and eslint for the touched file

<!-- NEXT_JS_LLM_PR -->