### PR TITLE
(1/1) Cover offline redirecting server action boundaries

### DIFF
--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -5426,6 +5426,112 @@ describe('offlineNavigations build artifacts', () => {
     }
   })
 
+  it('does not serve fallback HTML to offline redirecting server action submissions', async () => {
+    if (shouldSkipReplayWithCachedNavigations) {
+      return
+    }
+
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    await next.start({ skipBuild: true })
+
+    let page: Playwright.Page | undefined
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
+
+      await retry(async () => {
+        expect(await browser.elementByCss('p').text()).toBe(
+          'offline navigations page'
+        )
+        expect(
+          await browser.elementById('action-invalidation-marker').text()
+        ).toBe('action invalidation marker')
+      })
+
+      await browser.eval((messageType) => {
+        localStorage.removeItem('__nextOfflineNavigationRedirectActionMessages')
+        navigator.serviceWorker.addEventListener('message', (event) => {
+          if (event.data?.type === messageType) {
+            const messages = JSON.parse(
+              localStorage.getItem(
+                '__nextOfflineNavigationRedirectActionMessages'
+              ) ?? '[]'
+            )
+            messages.push(event.data)
+            localStorage.setItem(
+              '__nextOfflineNavigationRedirectActionMessages',
+              JSON.stringify(messages)
+            )
+          }
+        })
+      }, OFFLINE_NAVIGATION_FALLBACK_SERVED)
+
+      const failedActionRequest = page!.waitForEvent('requestfailed', {
+        predicate(request) {
+          return (
+            request.method() === 'POST' &&
+            request.url().startsWith(`${next.url}/docs`)
+          )
+        },
+      })
+
+      await page!.context().setOffline(true)
+      await browser
+        .elementById('redirect-after-offline-navigation-invalidation')
+        .click()
+
+      const request = await failedActionRequest
+      expect(request.failure()?.errorText).toMatch(
+        /ERR_INTERNET_DISCONNECTED|NS_ERROR_OFFLINE|offline/i
+      )
+
+      expect(
+        await browser.eval(() => ({
+          cache: document.documentElement.getAttribute(
+            'data-next-offline-navigation-cache'
+          ),
+          fallback: document.documentElement.hasAttribute(
+            'data-next-offline-navigation-fallback'
+          ),
+          fallbackMessages: JSON.parse(
+            localStorage.getItem(
+              '__nextOfflineNavigationRedirectActionMessages'
+            ) ?? '[]'
+          ),
+          marker:
+            document.getElementById('action-invalidation-marker')
+              ?.textContent ?? null,
+          miss:
+            document.getElementById('__NEXT_OFFLINE_NAVIGATION_CACHE_MISS') ===
+            null
+              ? null
+              : 'present',
+          pageText: document.querySelector('p')?.textContent ?? null,
+          search: location.search,
+        }))
+      ).toEqual({
+        cache: null,
+        fallback: false,
+        fallbackMessages: [],
+        marker: 'action invalidation marker',
+        miss: null,
+        pageText: 'offline navigations page',
+        search: '',
+      })
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
   it('does not serve fallback HTML to offline form POST navigations', async () => {
     if (shouldSkipReplayWithCachedNavigations) {
       return


### PR DESCRIPTION
## Stack Position

This is a focused request-shape stress PR stacked on #93686, `(1/1) Cover offline form POST boundaries`.

It covers the third small `MUTATION-01` row from the offline navigations stress plan: redirecting server action submissions while offline. This PR is intentionally test-only. It does not change service worker routing, fallback boot, server action behavior, or redirect handling.

## What Changed

- Adds `does not serve fallback HTML to offline redirecting server action submissions` to the offline navigations production e2e suite.
- Reuses the existing redirecting server action form on the fixture root page.
- Asserts the POST fails offline before any redirect can be applied, and that generated fallback HTML/cache-miss UI is not served to the mutation.

## Behavior Covered

The e2e:

1. Builds and starts the offline navigations fixture.
2. Loads `/docs` online and waits for the generated service worker.
3. Registers a listener for `next-offline-navigation-fallback-served` messages.
4. Switches the browser context offline.
5. Submits the existing redirecting server action form.
6. Waits for the POST request to fail with an offline network error.
7. Asserts no fallback-served message was emitted.
8. Asserts generated fallback/cache-miss UI did not render.
9. Asserts the redirect search param was not applied.
10. Asserts the current app page remains intact.

This protects the service worker contract for redirecting unsafe mutations: the offline fallback is a document survival layer, not a substitute response for action POSTs, even if the online action would redirect after mutation.

## Intentionally Not Covered Yet

- Route-handler mutation side effects beyond the form POST pass-through covered in #93686.
- Reconnect retry after a failed offline mutation.
- Successful online retry invalidating durable offline records.

## Verification

- `pnpm prettier --with-node-modules --ignore-path .prettierignore --write test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `npx eslint --config eslint.config.mjs --fix test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `git diff --check -- test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `NEXT_SKIP_ISOLATE=1 pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "does not serve fallback HTML to offline redirecting server action submissions"`
- `pnpm test-start-webpack test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "does not serve fallback HTML to offline redirecting server action submissions"`
- `pnpm --filter=next build`
- clean rerun after build: `NEXT_SKIP_ISOLATE=1 pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "does not serve fallback HTML to offline redirecting server action submissions"`
- commit hook: lint-staged reran prettier and eslint for the touched file

<!-- NEXT_JS_LLM_PR -->