### PR TITLE
(1/1) Cover offline route handler mutation boundaries

### DIFF
--- a/test/production/app-dir/offline-navigations/app/api/offline-mutation/route.ts
+++ b/test/production/app-dir/offline-navigations/app/api/offline-mutation/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server'
+
+export function POST() {
+  const response = new NextResponse('offline navigation mutation response')
+  response.cookies.set('offline-navigation-route-mutation', 'online', {
+    path: '/',
+    sameSite: 'lax',
+  })
+  return response
+}

--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -5661,6 +5661,164 @@ describe('offlineNavigations build artifacts', () => {
     }
   })
 
+  it('does not reach route handler mutation side effects while offline', async () => {
+    if (shouldSkipReplayWithCachedNavigations) {
+      return
+    }
+
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    await next.start({ skipBuild: true })
+
+    let page: Playwright.Page | undefined
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
+
+      await retry(async () => {
+        expect(await browser.elementByCss('p').text()).toBe(
+          'offline navigations page'
+        )
+      })
+
+      await browser.eval(
+        ({ action, messageType }) => {
+          document.cookie =
+            'offline-navigation-route-mutation=; Max-Age=0; path=/'
+          localStorage.removeItem('__nextOfflineNavigationRouteHandlerMessages')
+          navigator.serviceWorker.addEventListener('message', (event) => {
+            if (event.data?.type === messageType) {
+              const messages = JSON.parse(
+                localStorage.getItem(
+                  '__nextOfflineNavigationRouteHandlerMessages'
+                ) ?? '[]'
+              )
+              messages.push(event.data)
+              localStorage.setItem(
+                '__nextOfflineNavigationRouteHandlerMessages',
+                JSON.stringify(messages)
+              )
+            }
+          })
+
+          const iframe = document.createElement('iframe')
+          iframe.hidden = true
+          iframe.id = 'offline-navigation-route-handler-target'
+          iframe.name = 'offline-navigation-route-handler-target'
+          document.body.appendChild(iframe)
+
+          const form = document.createElement('form')
+          form.action = action
+          form.id = 'offline-navigation-route-handler-form'
+          form.method = 'post'
+          form.target = iframe.name
+
+          const input = document.createElement('input')
+          input.name = 'offline-navigation-route-handler-value'
+          input.value = 'offline navigation route handler mutation'
+          form.appendChild(input)
+
+          document.body.appendChild(form)
+        },
+        {
+          action: `${next.url}/docs/api/offline-mutation/`,
+          messageType: OFFLINE_NAVIGATION_FALLBACK_SERVED,
+        }
+      )
+
+      const mutationUrl = `${next.url}/docs/api/offline-mutation/`
+      const offlineMutationRequest = page!.waitForEvent('request', {
+        predicate(request) {
+          return (
+            request.method() === 'POST' && request.url().startsWith(mutationUrl)
+          )
+        },
+      })
+
+      await page!.context().setOffline(true)
+      await browser.eval(() => {
+        const form = document.getElementById(
+          'offline-navigation-route-handler-form'
+        ) as HTMLFormElement
+        form.requestSubmit()
+      })
+
+      const request = await offlineMutationRequest
+      expect(request.method()).toBe('POST')
+      expect(request.url()).toContain('/docs/api/offline-mutation')
+
+      expect(
+        await browser.eval((targetUrl) => {
+          const iframe = document.getElementById(
+            'offline-navigation-route-handler-target'
+          ) as HTMLIFrameElement | null
+          let iframeUrl: string | null = null
+
+          try {
+            iframeUrl = iframe?.contentWindow?.location.href ?? null
+          } catch {
+            iframeUrl = 'inaccessible'
+          }
+
+          return {
+            cookie: document.cookie.includes(
+              'offline-navigation-route-mutation=online'
+            ),
+            fallbackMessages: JSON.parse(
+              localStorage.getItem(
+                '__nextOfflineNavigationRouteHandlerMessages'
+              ) ?? '[]'
+            ),
+            iframeReachedTarget: iframeUrl === targetUrl,
+            pageText: document.querySelector('p')?.textContent ?? null,
+          }
+        }, mutationUrl)
+      ).toEqual({
+        cookie: false,
+        fallbackMessages: [],
+        iframeReachedTarget: false,
+        pageText: 'offline navigations page',
+      })
+
+      await page!.context().setOffline(false)
+      await browser.eval(() => {
+        window.dispatchEvent(new Event('online'))
+      })
+
+      const onlineMutationResponse = page!.waitForResponse((response) => {
+        return (
+          response.request().method() === 'POST' &&
+          response.url().startsWith(mutationUrl)
+        )
+      })
+      await browser.eval(() => {
+        const form = document.getElementById(
+          'offline-navigation-route-handler-form'
+        ) as HTMLFormElement
+        form.requestSubmit()
+      })
+
+      expect((await onlineMutationResponse).status()).toBe(200)
+      await retry(async () => {
+        expect(
+          await browser.eval(() =>
+            document.cookie.includes('offline-navigation-route-mutation=online')
+          )
+        ).toBe(true)
+      })
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
   it('misses exact-URL replay for query identity collision variants', async () => {
     if (shouldSkipReplayWithCachedNavigations) {
       return


### PR DESCRIPTION
## Stack Position

This is a focused request-shape stress PR stacked on #93687, `(1/1) Cover offline redirecting server action boundaries`.

It covers the fourth small `MUTATION-01` row from the offline navigations stress plan: route-handler mutation side effects while offline. This PR only changes the offline navigation test fixture and e2e coverage. It does not change service worker routing, fallback boot, or production mutation behavior.

## What Changed

- Adds a fixture route handler at `/docs/api/offline-mutation/` that sets a test cookie on POST.
- Adds `does not reach route handler mutation side effects while offline` to the offline navigations production e2e suite.
- Uses a real browser form POST targeted at a hidden iframe so the app page remains inspectable after the offline submission.

## Behavior Covered

The e2e:

1. Builds and starts the offline navigations fixture.
2. Loads `/docs` online and waits for the generated service worker.
3. Registers a listener for `next-offline-navigation-fallback-served` messages.
4. Creates a plain POST form targeting the mutation route handler.
5. Switches the browser context offline.
6. Submits the form and asserts the POST was issued but failed with an offline network error.
7. Asserts no fallback-served message was emitted to the app page.
8. Asserts the iframe did not reach the fallback target document.
9. Asserts the mutation cookie was not set while offline.
10. Reconnects, submits the same form online, and asserts the route handler sets the cookie.

This protects the service worker boundary while proving the fixture still exercises a real mutation path when online.

## Intentionally Not Covered Yet

- Automatic reconnect retry UI for failed offline mutations.
- Successful online retry invalidating durable offline records before a later offline replay.

## Verification

- `pnpm prettier --with-node-modules --ignore-path .prettierignore --write test/production/app-dir/offline-navigations/offline-navigations.test.ts test/production/app-dir/offline-navigations/app/api/offline-mutation/route.ts`
- `npx eslint --config eslint.config.mjs --fix test/production/app-dir/offline-navigations/offline-navigations.test.ts test/production/app-dir/offline-navigations/app/api/offline-mutation/route.ts`
- `git diff --check -- test/production/app-dir/offline-navigations/offline-navigations.test.ts test/production/app-dir/offline-navigations/app/api/offline-mutation/route.ts`
- `NEXT_SKIP_ISOLATE=1 pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "does not reach route handler mutation side effects while offline"`
- `pnpm test-start-webpack test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "does not reach route handler mutation side effects while offline"`
- `pnpm --filter=next build`
- commit hook: lint-staged reran prettier and eslint for the touched files

<!-- NEXT_JS_LLM_PR -->