### PR TITLE
(1/1) Cover offline request shape boundaries

### DIFF
--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -5326,6 +5326,213 @@ describe('offlineNavigations build artifacts', () => {
     }
   })
 
+  it('does not serve fallback HTML to offline non-document request shapes', async () => {
+    if (shouldSkipReplayWithCachedNavigations) {
+      return
+    }
+
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    const { buildId } = await getOfflineNavigationArtifactPaths()
+    await next.start({ skipBuild: true })
+
+    const requestShapes: Array<{
+      expected: {
+        accept?: string
+        key: string
+        method: string
+        range?: string
+        url: string
+      }
+      init: RequestInit
+      input: string
+      key: string
+    }> = [
+      {
+        expected: {
+          key: 'head',
+          method: 'HEAD',
+          url: '/docs/api/server-error?offline-request-shape=head',
+        },
+        init: { cache: 'no-store', method: 'HEAD' },
+        input: '/docs/api/server-error?offline-request-shape=head',
+        key: 'head',
+      },
+      {
+        expected: {
+          key: 'options',
+          method: 'OPTIONS',
+          url: '/docs/api/server-error?offline-request-shape=options',
+        },
+        init: { cache: 'no-store', method: 'OPTIONS' },
+        input: '/docs/api/server-error?offline-request-shape=options',
+        key: 'options',
+      },
+      {
+        expected: {
+          accept: 'text/html',
+          key: 'accept-html-fetch',
+          method: 'GET',
+          url: '/docs/api/server-error?offline-request-shape=accept-html-fetch',
+        },
+        init: { cache: 'no-store', headers: { accept: 'text/html' } },
+        input: '/docs/api/server-error?offline-request-shape=accept-html-fetch',
+        key: 'accept-html-fetch',
+      },
+      {
+        expected: {
+          key: 'range',
+          method: 'GET',
+          range: 'bytes=0-16',
+          url: `/docs/_next/static/${buildId}/_offline-navigation-manifest.json?offline-request-shape=range`,
+        },
+        init: { cache: 'no-store', headers: { range: 'bytes=0-16' } },
+        input: `/docs/_next/static/${buildId}/_offline-navigation-manifest.json?offline-request-shape=range`,
+        key: 'range',
+      },
+      {
+        expected: {
+          key: 'delete',
+          method: 'DELETE',
+          url: '/docs/api/server-error?offline-request-shape=delete',
+        },
+        init: { cache: 'no-store', method: 'DELETE' },
+        input: '/docs/api/server-error?offline-request-shape=delete',
+        key: 'delete',
+      },
+      {
+        expected: {
+          key: 'post-custom-header',
+          method: 'POST',
+          url: '/docs/api/server-error?offline-request-shape=post-custom-header',
+        },
+        init: {
+          body: 'offline navigation request shape',
+          cache: 'no-store',
+          headers: {
+            'content-type': 'text/plain',
+            'x-offline-navigation-request-shape': '1',
+          },
+          method: 'POST',
+        },
+        input:
+          '/docs/api/server-error?offline-request-shape=post-custom-header',
+        key: 'post-custom-header',
+      },
+    ]
+    let page: Playwright.Page | undefined
+    const observedRequests: Array<{
+      accept?: string
+      key: string
+      method: string
+      range?: string
+      url: string
+    }> = []
+    const requestShapeParam = 'offline-request-shape'
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
+
+      const onRequest = (request: Playwright.Request) => {
+        const url = new URL(request.url())
+        const key = url.searchParams.get(requestShapeParam)
+        if (!key) {
+          return
+        }
+
+        const headers = request.headers()
+        const observedRequest: {
+          accept?: string
+          key: string
+          method: string
+          range?: string
+          url: string
+        } = {
+          key,
+          method: request.method(),
+          url: `${url.pathname}?${url.searchParams.toString()}`,
+        }
+        if (headers.accept) {
+          observedRequest.accept = headers.accept
+        }
+        if (headers.range) {
+          observedRequest.range = headers.range
+        }
+        observedRequests.push(observedRequest)
+      }
+      page!.on('request', onRequest)
+
+      await page!.context().setOffline(true)
+      const passThroughResults = await browser.eval(
+        async ({ messageType, requests }) => {
+          localStorage.removeItem('__nextOfflineNavigationRequestShapeMessages')
+          navigator.serviceWorker.addEventListener('message', (event) => {
+            if (event.data?.type === messageType) {
+              const messages = JSON.parse(
+                localStorage.getItem(
+                  '__nextOfflineNavigationRequestShapeMessages'
+                ) ?? '[]'
+              )
+              messages.push(event.data)
+              localStorage.setItem(
+                '__nextOfflineNavigationRequestShapeMessages',
+                JSON.stringify(messages)
+              )
+            }
+          })
+
+          const results: Record<string, string> = {}
+
+          for (const { key, input, init } of requests) {
+            try {
+              await fetch(input, init)
+              results[key] = 'resolved'
+            } catch {
+              results[key] = 'rejected'
+            }
+          }
+
+          return {
+            fallbackMessages: JSON.parse(
+              localStorage.getItem(
+                '__nextOfflineNavigationRequestShapeMessages'
+              ) ?? '[]'
+            ),
+            results,
+          }
+        },
+        {
+          messageType: OFFLINE_NAVIGATION_FALLBACK_SERVED,
+          requests: requestShapes,
+        }
+      )
+
+      page!.off('request', onRequest)
+
+      await retry(async () => {
+        expect(observedRequests).toEqual(
+          requestShapes.map(({ expected }) => expected)
+        )
+      })
+      expect(passThroughResults).toEqual({
+        fallbackMessages: [],
+        results: Object.fromEntries(
+          requestShapes.map(({ key }) => [key, 'rejected'])
+        ),
+      })
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
   it('does not serve fallback HTML to offline server action submissions', async () => {
     if (shouldSkipReplayWithCachedNavigations) {
       return


### PR DESCRIPTION
## Why

This is a small test-only stress slice on top of the offline mutation-boundary PRs. It covers the next P0 request-boundary case from `.private-investigation/offline-navigations-production-plan.md`: the generated service worker should only serve fallback HTML for failed same-origin document navigations.

The earlier pass-through stress coverage already checks broad non-document requests like RSC fetches, API fetches, POST fetches, and static manifest fetches. This PR adds a narrower matrix for request shapes that are easy to accidentally misclassify when the request looks document-ish or unusual.

## Stack Position

Base PR: #93688, `(1/1) Cover offline route handler mutation boundaries`

This PR is intentionally independent from the route replay and output-export work. It does not change implementation behavior. It only adds browser-backed coverage around the service-worker boundary contract introduced earlier in the offlineNavigations stack.

## What Changed

Adds one production e2e:

- `does not serve fallback HTML to offline non-document request shapes`

The test boots the fixture app, waits for the offline navigation service worker, sets the browser offline, then issues these exact same-origin request shapes from the page:

- `HEAD` route handler request
- `OPTIONS` route handler request
- `DELETE` route handler request
- custom-header `POST` route handler request
- `GET` fetch with `Accept: text/html`
- static manifest fetch with a `Range` header

For each shape, the test asserts two things:

- Playwright observed the exact method, URL, and relevant headers.
- No `next-offline-navigation-fallback-served` service-worker message was posted.

That avoids the false-positive pattern where a test passes because some unrelated request failed first after going offline.

## Intentionally Not Covered Here

This PR does not cover download navigations, navigation preload, aborted document requests, service-worker cache corruption, or server-stopped non-document request paths. Those stay as separate stress slices in the plan so this PR remains reviewable.

## Verification

- `pnpm prettier --with-node-modules --ignore-path .prettierignore --write test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `npx eslint --config eslint.config.mjs --fix test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `git diff --check -- test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `NEXT_SKIP_ISOLATE=1 pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "does not serve fallback HTML to offline non-document request shapes"`
- `pnpm test-start-webpack test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "does not serve fallback HTML to offline non-document request shapes"`

<!-- NEXT_JS_LLM_PR -->
