### PR TITLE
(1/1) Cover missing fallback cache boundaries

### DIFF
--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -5533,6 +5533,93 @@ describe('offlineNavigations build artifacts', () => {
     }
   })
 
+  it('does not fake fallback boot when the cached fallback document is missing', async () => {
+    if (shouldSkipReplayWithCachedNavigations) {
+      return
+    }
+
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    const { buildId } = await getOfflineNavigationArtifactPaths()
+    await next.start({ skipBuild: true })
+
+    let page: Playwright.Page | undefined
+    const fallbackMessages: Array<unknown> = []
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
+
+      await retry(async () => {
+        expect(await browser.elementByCss('p').text()).toBe(
+          'offline navigations page'
+        )
+      })
+
+      await page!.exposeFunction(
+        '__nextRecordOfflineNavigationCacheDamageMessage',
+        (message: unknown) => {
+          fallbackMessages.push(message)
+        }
+      )
+      await browser.eval((messageType) => {
+        const win = window as typeof window & {
+          __nextRecordOfflineNavigationCacheDamageMessage?: (
+            message: unknown
+          ) => void
+        }
+        navigator.serviceWorker.addEventListener('message', (event) => {
+          if (event.data?.type === messageType) {
+            win.__nextRecordOfflineNavigationCacheDamageMessage?.(event.data)
+          }
+        })
+      }, OFFLINE_NAVIGATION_FALLBACK_SERVED)
+
+      const cacheDamageState = await browser.eval(async (currentBuildId) => {
+        const cacheName = `next-offline-navigation-v1:${currentBuildId}:/docs`
+        const fallbackPath = `/docs/_next/static/${currentBuildId}/_offline-navigation-fallback.html`
+        const manifestPath = `/docs/_next/static/${currentBuildId}/_offline-navigation-manifest.json`
+        const cache = await caches.open(cacheName)
+
+        return {
+          deletedFallback: await cache.delete(fallbackPath),
+          hasFallback: Boolean(await cache.match(fallbackPath)),
+          hasManifest: Boolean(await cache.match(manifestPath)),
+        }
+      }, buildId)
+      expect(cacheDamageState).toEqual({
+        deletedFallback: true,
+        hasFallback: false,
+        hasManifest: true,
+      })
+
+      await page!.context().setOffline(true)
+      let navigationError: string | null = null
+      try {
+        await page!.goto(
+          `${next.url}/docs/prefetched?missing-fallback-cache=1`,
+          { waitUntil: 'domcontentloaded' }
+        )
+      } catch (error) {
+        navigationError = String(error)
+      }
+
+      expect(navigationError).toMatch(
+        /ERR_FAILED|ERR_INTERNET_DISCONNECTED|NS_ERROR_OFFLINE|offline/i
+      )
+      expect(fallbackMessages).toEqual([])
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
   it('does not serve fallback HTML to offline server action submissions', async () => {
     if (shouldSkipReplayWithCachedNavigations) {
       return


### PR DESCRIPTION
## Stack position

This is a focused stress-test slice on top of #93690, `feedthejim/offline-navigations-request-shape-boundary-stress`.

The previous PR proves the generated service worker does not serve fallback HTML for additional offline non-document request shapes. This PR moves to the next service-worker hardening case: what happens when the worker has its manifest but no longer has the generated fallback document that it must serve for offline document navigations.

## Why this slice exists

The offline navigation architecture keeps the service worker deliberately small. The worker owns document survival only: when a same-origin document navigation fails because the network is unavailable, it may serve the generated fallback HTML. It should not become a router, synthesize fallback boot, or infer route data from other caches.

That means the fallback document Cache Storage entry is critical. If it is missing, the worker should not pretend it served fallback HTML. A normal failed navigation is safer than a fake fallback boot that could hide a corrupted cache state or make later router-cache assertions pass for the wrong reason.

## What changed

- Adds an e2e that builds and starts the offlineNavigations fixture.
- Waits for the generated service worker and confirms the `/docs` page loaded normally.
- Deletes only `/_next/static/<buildId>/_offline-navigation-fallback.html` from the expected `next-offline-navigation-v1:<buildId>:/docs` cache.
- Confirms the offline-navigation manifest is still cached, so the damaged state is specifically the missing fallback document.
- Puts the browser offline and hard-navigates to a document URL.
- Asserts the navigation fails as a browser/network failure and no `fallback-served` message is emitted.

## What this intentionally does not cover

- Corrupted fallback HTML.
- Missing or corrupted offline-navigation manifest.
- Service worker install or update failures.
- Flag-disable cleanup and unregister behavior.
- Runtime chunk, CSS, or build-manifest damage after the fallback document has been served.

Those remain separate stress slices in the service-worker cache damage and lifecycle queue so each PR has one reviewable claim.

## Verification

- `pnpm prettier --with-node-modules --ignore-path .prettierignore --write test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `npx eslint --config eslint.config.mjs --fix test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `git diff --check -- test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `NEXT_SKIP_ISOLATE=1 pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "does not fake fallback boot when the cached fallback document is missing"`
- `pnpm test-start-webpack test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "does not fake fallback boot when the cached fallback document is missing"`

<!-- NEXT_JS_LLM_PR -->
