### PR TITLE
(1/1) Validate offline fallback cache entries

### DIFF
--- a/packages/next/src/build/offline-navigation-service-worker.ts
+++ b/packages/next/src/build/offline-navigation-service-worker.ts
@@ -65,6 +65,13 @@ function isDocumentNavigationRequest(request){
   const url=new URL(request.url);
   return url.origin===self.location.origin;
 }
+async function isValidFallbackDocumentResponse(response,metadata){
+  if(!response.ok){
+    return false;
+  }
+  const html=await response.clone().text();
+  return html.includes('data-next-offline-navigation-fallback')&&html.includes('id="__NEXT_OFFLINE_NAVIGATION_FALLBACK"')&&html.includes('"buildId":"'+metadata.buildId+'"');
+}
 async function fetchDocumentNavigation(request){
   try{
     return await fetch(request);
@@ -72,7 +79,7 @@ async function fetchDocumentNavigation(request){
     const metadata=self.__NEXT_OFFLINE_NAVIGATION_SW;
     const cache=await caches.open(metadata.cacheNamespace);
     const fallbackResponse=await cache.match(metadata.fallbackDocumentHref);
-    if(fallbackResponse){
+    if(fallbackResponse&&await isValidFallbackDocumentResponse(fallbackResponse,metadata)){
       await notifyClients({
         type:${fallbackServedMessageType},
         buildId:metadata.buildId,

--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -670,6 +670,10 @@ describe('offlineNavigations build artifacts', () => {
     expect(serviceWorkerScript).toContain('caches.delete')
     expect(serviceWorkerScript).toContain(OFFLINE_NAVIGATION_FALLBACK_SERVED)
     expect(serviceWorkerScript).toContain('isDocumentNavigationRequest')
+    expect(serviceWorkerScript).toContain('isValidFallbackDocumentResponse')
+    expect(serviceWorkerScript).toContain(
+      'data-next-offline-navigation-fallback'
+    )
     expect(serviceWorkerScript).toContain('skipWaiting')
     expect(serviceWorkerScript).toContain('clients.claim')
     expect(serviceWorkerScript).toContain('respondWith')
@@ -5602,6 +5606,110 @@ describe('offlineNavigations build artifacts', () => {
       try {
         await page!.goto(
           `${next.url}/docs/prefetched?missing-fallback-cache=1`,
+          { waitUntil: 'domcontentloaded' }
+        )
+      } catch (error) {
+        navigationError = String(error)
+      }
+
+      expect(navigationError).toMatch(
+        /ERR_FAILED|ERR_INTERNET_DISCONNECTED|NS_ERROR_OFFLINE|offline/i
+      )
+      expect(fallbackMessages).toEqual([])
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
+  it('does not fake fallback boot when the cached fallback document is corrupted', async () => {
+    if (shouldSkipReplayWithCachedNavigations) {
+      return
+    }
+
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    const { buildId } = await getOfflineNavigationArtifactPaths()
+    await next.start({ skipBuild: true })
+
+    let page: Playwright.Page | undefined
+    const fallbackMessages: Array<unknown> = []
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
+
+      await retry(async () => {
+        expect(await browser.elementByCss('p').text()).toBe(
+          'offline navigations page'
+        )
+      })
+
+      await page!.exposeFunction(
+        '__nextRecordOfflineNavigationCacheDamageMessage',
+        (message: unknown) => {
+          fallbackMessages.push(message)
+        }
+      )
+      await browser.eval((messageType) => {
+        const win = window as typeof window & {
+          __nextRecordOfflineNavigationCacheDamageMessage?: (
+            message: unknown
+          ) => void
+        }
+        navigator.serviceWorker.addEventListener('message', (event) => {
+          if (event.data?.type === messageType) {
+            win.__nextRecordOfflineNavigationCacheDamageMessage?.(event.data)
+          }
+        })
+      }, OFFLINE_NAVIGATION_FALLBACK_SERVED)
+
+      const cacheDamageState = await browser.eval(async (currentBuildId) => {
+        const cacheName = `next-offline-navigation-v1:${currentBuildId}:/docs`
+        const fallbackPath = `/docs/_next/static/${currentBuildId}/_offline-navigation-fallback.html`
+        const manifestPath = `/docs/_next/static/${currentBuildId}/_offline-navigation-manifest.json`
+        const cache = await caches.open(cacheName)
+        const originalFallback = await cache.match(fallbackPath)
+
+        await cache.put(
+          fallbackPath,
+          new Response(
+            '<!doctype html><p id="corrupted-offline-fallback">corrupted offline fallback</p>',
+            {
+              headers: {
+                'content-type': 'text/html; charset=utf-8',
+              },
+            }
+          )
+        )
+
+        const damagedFallback = await cache.match(fallbackPath)
+        const damagedFallbackText = await damagedFallback?.text()
+
+        return {
+          damagedFallbackText,
+          hadFallback: Boolean(originalFallback),
+          hasManifest: Boolean(await cache.match(manifestPath)),
+        }
+      }, buildId)
+      expect(cacheDamageState).toEqual({
+        damagedFallbackText:
+          '<!doctype html><p id="corrupted-offline-fallback">corrupted offline fallback</p>',
+        hadFallback: true,
+        hasManifest: true,
+      })
+
+      await page!.context().setOffline(true)
+      let navigationError: string | null = null
+      try {
+        await page!.goto(
+          `${next.url}/docs/prefetched?corrupted-fallback-cache=1`,
           { waitUntil: 'domcontentloaded' }
         )
       } catch (error) {


### PR DESCRIPTION
## Stack position

This is a focused service-worker cache-damage slice on top of #93691, `feedthejim/offline-navigations-missing-fallback-cache-stress`.

The parent PR covers the case where the generated fallback document is missing from Cache Storage. This PR covers the adjacent case where a response still exists at the fallback document cache key, but its bytes are not the generated offline navigation fallback document.

## Why this slice exists

The offline navigation service worker should remain deliberately small. It may serve the generated fallback document when a same-origin document navigation fails because the network is unavailable. It should not become a router, synthesize fallback boot, or announce that fallback boot happened when the cached fallback document has been poisoned or corrupted.

Before this change, the worker treated any cached response at the fallback document key as valid and posted `next-offline-navigation-fallback-served` before returning it. That could make a corrupted cache entry look like a real offline-navigation boot to tests and future diagnostics.

## What changed

- Adds a validation gate before the generated service worker serves a cached fallback document.
- The worker now checks that the cached response is OK and that the cloned HTML contains the offline fallback marker, fallback config script, and current build ID.
- Adds artifact coverage that the generated service worker includes the fallback document validation path.
- Adds an e2e that:
  - builds and starts the offlineNavigations fixture,
  - waits for the generated service worker,
  - replaces only the cached fallback HTML with same-origin corrupted HTML,
  - leaves the offline-navigation manifest cached,
  - puts the browser offline,
  - hard-navigates to a document URL,
  - asserts the navigation fails as a normal browser/network failure, and
  - asserts no `fallback-served` service-worker message is emitted.

## What this intentionally does not cover

- Deleted fallback document, covered by #93691.
- Missing or corrupted offline-navigation manifest.
- Service worker install or update cache failures.
- Flag-disable cleanup and unregister behavior.
- Runtime chunk, CSS, font, or build-manifest damage after a valid fallback document has been served.

Those remain separate stress slices so reviewers can evaluate each cache-damage contract independently.

## Verification

- `pnpm prettier --with-node-modules --ignore-path .prettierignore --write packages/next/src/build/offline-navigation-service-worker.ts test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `npx eslint --config eslint.config.mjs --fix packages/next/src/build/offline-navigation-service-worker.ts test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `git diff --check -- packages/next/src/build/offline-navigation-service-worker.ts test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `NEXT_SKIP_ISOLATE=1 pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "emits request-invariant offline navigation artifacts when enabled|does not fake fallback boot when the cached fallback document is corrupted"`
- `pnpm test-start-webpack test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "does not fake fallback boot when the cached fallback document is corrupted"`

<!-- NEXT_JS_LLM_PR -->
