### PR TITLE
(1/1) Cover offline manifest cache damage

### DIFF
--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -5728,6 +5728,189 @@ describe('offlineNavigations build artifacts', () => {
     }
   })
 
+  it('serves fallback HTML when the cached manifest is missing or corrupted', async () => {
+    if (shouldSkipReplayWithCachedNavigations) {
+      return
+    }
+
+    for (const manifestDamage of [
+      {
+        kind: 'missing',
+        targetPath: '/docs/prefetched?missing-manifest-cache=1',
+      },
+      {
+        kind: 'corrupted',
+        targetPath: '/docs/prefetched?corrupted-manifest-cache=1',
+      },
+    ]) {
+      const buildResult = await next.build()
+      expect(buildResult.exitCode).toBe(0)
+
+      const { buildId } = await getOfflineNavigationArtifactPaths()
+      await next.start({ skipBuild: true })
+
+      let page: Playwright.Page | undefined
+      try {
+        const browser = await next.browser('/docs', {
+          beforePageLoad(p: Playwright.Page) {
+            page = p
+          },
+        })
+        await waitForOfflineNavigationServiceWorker(browser, page!)
+
+        await retry(async () => {
+          expect(await browser.elementByCss('p').text()).toBe(
+            'offline navigations page'
+          )
+        })
+
+        const fallbackMessageStorageKey = `__nextOfflineNavigationManifestDamageMessages:${manifestDamage.kind}`
+        await browser.eval(
+          ({ messageType, storageKey }) => {
+            localStorage.removeItem(storageKey)
+            navigator.serviceWorker.addEventListener('message', (event) => {
+              if (event.data?.type === messageType) {
+                const messages = JSON.parse(
+                  localStorage.getItem(storageKey) ?? '[]'
+                )
+                messages.push(event.data)
+                localStorage.setItem(storageKey, JSON.stringify(messages))
+              }
+            })
+          },
+          {
+            messageType: OFFLINE_NAVIGATION_FALLBACK_SERVED,
+            storageKey: fallbackMessageStorageKey,
+          }
+        )
+
+        const cacheDamageState = await browser.eval(
+          async ({ currentBuildId, damageKind }) => {
+            const cacheName = `next-offline-navigation-v1:${currentBuildId}:/docs`
+            const fallbackPath = `/docs/_next/static/${currentBuildId}/_offline-navigation-fallback.html`
+            const manifestPath = `/docs/_next/static/${currentBuildId}/_offline-navigation-manifest.json`
+            const cache = await caches.open(cacheName)
+            const originalManifest = await cache.match(manifestPath)
+
+            if (damageKind === 'missing') {
+              await cache.delete(manifestPath)
+            } else {
+              await cache.put(
+                manifestPath,
+                new Response('{"corruptedOfflineNavigationManifest":true}', {
+                  headers: {
+                    'content-type': 'application/json',
+                  },
+                })
+              )
+            }
+
+            const damagedManifest = await cache.match(manifestPath)
+
+            return {
+              damagedManifestText:
+                damagedManifest === undefined
+                  ? null
+                  : await damagedManifest.text(),
+              hadManifest: Boolean(originalManifest),
+              hasFallback: Boolean(await cache.match(fallbackPath)),
+            }
+          },
+          {
+            currentBuildId: buildId,
+            damageKind: manifestDamage.kind,
+          }
+        )
+        expect(cacheDamageState).toEqual({
+          damagedManifestText:
+            manifestDamage.kind === 'missing'
+              ? null
+              : '{"corruptedOfflineNavigationManifest":true}',
+          hadManifest: true,
+          hasFallback: true,
+        })
+
+        await page!.context().setOffline(true)
+        const targetUrl = `${next.url}${manifestDamage.targetPath}`
+        const offlineResponse = await page!.goto(targetUrl, {
+          waitUntil: 'domcontentloaded',
+        })
+        expect(offlineResponse?.status()).toBe(200)
+
+        await retry(async () => {
+          expect(
+            await browser.eval(() =>
+              document.documentElement.getAttribute(
+                'data-next-offline-navigation-cache-reason'
+              )
+            )
+          ).toBe('missing-entry')
+        })
+
+        expect(
+          await browser.eval((storageKey) => {
+            const cacheMiss = document.getElementById(
+              '__NEXT_OFFLINE_NAVIGATION_CACHE_MISS'
+            )
+            const win = window as typeof window & {
+              __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?: Array<unknown>
+            }
+
+            return {
+              cache: document.documentElement.getAttribute(
+                'data-next-offline-navigation-cache'
+              ),
+              diagnostic:
+                win.__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?.at(-1) ?? null,
+              fallback: document.documentElement.hasAttribute(
+                'data-next-offline-navigation-fallback'
+              ),
+              fallbackMessages: JSON.parse(
+                localStorage.getItem(storageKey) ?? '[]'
+              ),
+              miss:
+                cacheMiss === null
+                  ? null
+                  : {
+                      hidden: cacheMiss.hidden,
+                      reason: cacheMiss.getAttribute(
+                        'data-next-offline-navigation-cache-reason'
+                      ),
+                      text: cacheMiss.textContent,
+                    },
+            }
+          }, fallbackMessageStorageKey)
+        ).toMatchObject({
+          cache: 'miss',
+          diagnostic: {
+            reason: 'missing-entry',
+            type: 'cache-miss',
+            url: targetUrl,
+          },
+          fallback: true,
+          fallbackMessages: [
+            {
+              buildId,
+              reason: 'network-error',
+              type: OFFLINE_NAVIGATION_FALLBACK_SERVED,
+              url: targetUrl,
+            },
+          ],
+          miss: {
+            hidden: false,
+            reason: 'missing-entry',
+            text: 'This page is not available offline.',
+          },
+        })
+      } finally {
+        if (page) {
+          await page.context().setOffline(false)
+        }
+        await next.stop()
+      }
+    }
+  })
+
   it('does not serve fallback HTML to offline server action submissions', async () => {
     if (shouldSkipReplayWithCachedNavigations) {
       return


### PR DESCRIPTION
## Stack position

This is a focused service-worker cache-damage stress slice on top of #93692, `feedthejim/offline-navigations-corrupted-fallback-cache-stress`.

The parent PR validates that the worker does not serve a corrupted fallback document. This PR covers the adjacent post-install manifest cases: the cached offline-navigation manifest is missing or corrupted, while the generated fallback document itself is still intact.

## Why this slice exists

The manifest is required for install/update caching, but document fallback at request time should not turn into a router or depend on reparsing a cached manifest. Once the worker is installed, document fallback should be driven by the generated worker metadata and the cached fallback document.

So this PR proves a different contract from #93691 and #93692:

- Missing fallback document: fail normally, no fake fallback boot.
- Corrupted fallback document: fail normally, no fake fallback boot.
- Missing or corrupted cached manifest after install: still serve the valid fallback document, then let the client-owned offline restore path produce the visible cache miss.

## What changed

- Adds an e2e that runs both post-install manifest damage variants:
  - delete the cached `_offline-navigation-manifest.json`, and
  - replace it with corrupted JSON.
- In both cases, the test keeps the cached fallback HTML intact.
- It then takes the browser offline and hard-navigates to a route without durable route data.
- It asserts the browser receives the generated fallback HTML, the worker emits `fallback-served`, and the client reaches visible `missing-entry` cache-miss UI with diagnostics.

## What this intentionally does not cover

- Deleted fallback document, covered by #93691.
- Corrupted fallback document, covered by #93692.
- Install-time manifest fetch or JSON failure.
- Service worker update failures.
- Flag-disable cleanup and unregister behavior.
- Runtime chunk, CSS, font, or build-manifest damage after a valid fallback document has been served.

Those remain separate stress slices because they exercise different ownership boundaries.

## Verification

- `pnpm prettier --with-node-modules --ignore-path .prettierignore --write test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `npx eslint --config eslint.config.mjs --fix test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `git diff --check -- test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `NEXT_SKIP_ISOLATE=1 pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "serves fallback HTML when the cached manifest is missing or corrupted"`
- `pnpm test-start-webpack test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "serves fallback HTML when the cached manifest is missing or corrupted"`
- `pnpm --filter=next build`

<!-- NEXT_JS_LLM_PR -->
