### PR TITLE
(1/1) Cover offline manifest install failures

### DIFF
--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -1,4 +1,4 @@
-import { existsSync } from 'fs'
+import { existsSync, unlinkSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
@@ -5902,6 +5902,144 @@ describe('offlineNavigations build artifacts', () => {
             text: 'This page is not available offline.',
           },
         })
+      } finally {
+        if (page) {
+          await page.context().setOffline(false)
+        }
+        await next.stop()
+      }
+    }
+  })
+
+  it('does not activate the service worker when install-time manifest caching fails', async () => {
+    if (shouldSkipReplayWithCachedNavigations) {
+      return
+    }
+
+    for (const manifestDamage of [
+      {
+        expectedManifestStatus: 404,
+        kind: 'missing',
+        targetPath: '/docs/prefetched?missing-install-manifest=1',
+      },
+      {
+        expectedManifestStatus: 200,
+        kind: 'corrupted',
+        targetPath: '/docs/prefetched?corrupted-install-manifest=1',
+      },
+    ] as const) {
+      const buildResult = await next.build()
+      expect(buildResult.exitCode).toBe(0)
+
+      const { buildId, manifest } = await getOfflineNavigationArtifactPaths()
+      if (manifestDamage.kind === 'missing') {
+        unlinkSync(manifest.absolutePath)
+      } else {
+        writeFileSync(manifest.absolutePath, 'not offline navigation manifest')
+      }
+
+      await next.start({ skipBuild: true })
+
+      let page: Playwright.Page | undefined
+      const fallbackMessages: Array<unknown> = []
+      try {
+        const manifestResponse = await next.fetch(
+          `/docs/_next/static/${buildId}/_offline-navigation-manifest.json${next.getDeploymentIdQuery()}`
+        )
+        expect(manifestResponse.status).toBe(
+          manifestDamage.expectedManifestStatus
+        )
+        if (manifestDamage.kind === 'corrupted') {
+          expect(await manifestResponse.text()).toBe(
+            'not offline navigation manifest'
+          )
+        }
+
+        const browser = await next.browser('/docs', {
+          beforePageLoad(p: Playwright.Page) {
+            page = p
+          },
+        })
+
+        await retry(async () => {
+          expect(await browser.elementByCss('p').text()).toBe(
+            'offline navigations page'
+          )
+        })
+
+        await page!.exposeFunction(
+          '__nextRecordOfflineNavigationInstallDamageMessage',
+          (message: unknown) => {
+            fallbackMessages.push(message)
+          }
+        )
+        await browser.eval((messageType) => {
+          const win = window as typeof window & {
+            __nextRecordOfflineNavigationInstallDamageMessage?: (
+              message: unknown
+            ) => void
+          }
+          navigator.serviceWorker.addEventListener('message', (event) => {
+            if (event.data?.type === messageType) {
+              win.__nextRecordOfflineNavigationInstallDamageMessage?.(
+                event.data
+              )
+            }
+          })
+        }, OFFLINE_NAVIGATION_FALLBACK_SERVED)
+
+        await retry(
+          async () => {
+            const serviceWorkerState = await browser.eval(async () => {
+              if (!('serviceWorker' in navigator)) {
+                return {
+                  controlled: false,
+                  registrations: [],
+                }
+              }
+
+              const registrations =
+                await navigator.serviceWorker.getRegistrations()
+              return {
+                controlled: Boolean(navigator.serviceWorker.controller),
+                registrations: registrations
+                  .filter((registration) =>
+                    registration.scope.endsWith('/docs/')
+                  )
+                  .map((registration) => ({
+                    active: registration.active?.scriptURL ?? null,
+                    installing: registration.installing?.state ?? null,
+                    scope: registration.scope,
+                    waiting: registration.waiting?.state ?? null,
+                  })),
+              }
+            })
+
+            expect(serviceWorkerState.controlled).toBe(false)
+            expect(
+              serviceWorkerState.registrations.every(
+                (registration) => registration.active === null
+              )
+            ).toBe(true)
+          },
+          10000,
+          500
+        )
+
+        await page!.context().setOffline(true)
+        let navigationError: string | null = null
+        try {
+          await page!.goto(`${next.url}${manifestDamage.targetPath}`, {
+            waitUntil: 'domcontentloaded',
+          })
+        } catch (error) {
+          navigationError = String(error)
+        }
+
+        expect(navigationError).toMatch(
+          /ERR_FAILED|ERR_INTERNET_DISCONNECTED|NS_ERROR_OFFLINE|offline/i
+        )
+        expect(fallbackMessages).toEqual([])
       } finally {
         if (page) {
           await page.context().setOffline(false)


### PR DESCRIPTION
## Stack position

This PR sits directly on top of #93693, `(1/1) Cover offline manifest cache damage`. That prior slice covers post-install Cache Storage damage where the fallback document is still valid and the cached manifest is missing or corrupted.

This PR covers the earlier install-time boundary: the generated manifest is missing or malformed before the service worker can finish installing. It is a focused service-worker lifecycle stress slice for `SW-04d-manifest-install-failure` in the private production plan.

## Why

The generated worker caches the offline navigation manifest during `install`, reads it, then uses it to cache the fallback document. If that manifest cannot be fetched or parsed, the worker should fail closed. It should not activate a broken controller, fake a fallback boot, or leave the app in a blank offline state.

The important review question is narrow: when the install-time manifest dependency is damaged, do we keep normal online navigation working and avoid claiming offline fallback ownership?

## What changed

- Adds a production e2e for missing and corrupted generated manifest files before service-worker install.
- Verifies the online app page still loads after the damaged build artifact.
- Verifies the `/docs/` service worker does not become an active controller.
- Verifies an offline document navigation fails as a normal browser network failure.
- Verifies no `next-offline-navigation-fallback-served` message is emitted.

## What this intentionally does not cover

- Service-worker update failures after a previous worker is already active.
- Flag-disable cleanup and unregister behavior.
- Runtime chunk, CSS, build manifest, or asset damage after the fallback document is served.
- Client-side exact URL or route/segment replay behavior.

Those are separate stress slices in the plan so this PR stays reviewable.

## Verification

- `pnpm prettier --with-node-modules --ignore-path .prettierignore --write test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `npx eslint --config eslint.config.mjs --fix test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `git diff --check -- test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `NEXT_SKIP_ISOLATE=1 pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "does not activate the service worker when install-time manifest caching fails"`
- `pnpm test-start-webpack test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "does not activate the service worker when install-time manifest caching fails"`

<!-- NEXT_JS_LLM_PR -->