### PR TITLE
(1/1) Clean up stale offline navigation workers

### DIFF
--- a/packages/next/src/build/offline-navigation-service-worker.ts
+++ b/packages/next/src/build/offline-navigation-service-worker.ts
@@ -58,6 +58,18 @@ async function cacheOfflineNavigationResources(){
   const fallbackResponse=await fetchRequiredResource(manifest.fallbackDocument.href);
   await cache.put(manifest.fallbackDocument.href,fallbackResponse);
 }
+async function unregisterOfflineNavigationServiceWorker(){
+  const metadata=self.__NEXT_OFFLINE_NAVIGATION_SW;
+  await caches.delete(metadata.cacheNamespace);
+  await self.registration.unregister();
+}
+async function refreshOfflineNavigationResources(){
+  try{
+    await cacheOfflineNavigationResources();
+  }catch(err){
+    await unregisterOfflineNavigationServiceWorker();
+  }
+}
 function isDocumentNavigationRequest(request){
   if(request.method!=='GET'||request.mode!=='navigate'||request.destination!=='document'){
     return false;
@@ -74,7 +86,7 @@ async function isValidFallbackDocumentResponse(response,metadata){
 }
 async function fetchDocumentNavigation(request){
   try{
-    return await fetch(request);
+    return {fromNetwork:true,response:await fetch(request)};
   }catch(err){
     const metadata=self.__NEXT_OFFLINE_NAVIGATION_SW;
     const cache=await caches.open(metadata.cacheNamespace);
@@ -86,7 +98,7 @@ async function fetchDocumentNavigation(request){
         reason:'network-error',
         url:request.url
       });
-      return fallbackResponse;
+      return {fromNetwork:false,response:fallbackResponse};
     }
     throw err;
   }
@@ -115,7 +127,13 @@ self.addEventListener('activate',(event)=>{
 });
 self.addEventListener('fetch',(event)=>{
   if(isDocumentNavigationRequest(event.request)){
-    event.respondWith(fetchDocumentNavigation(event.request));
+    const navigationResult=fetchDocumentNavigation(event.request);
+    event.respondWith(navigationResult.then((result)=>result.response));
+    event.waitUntil(navigationResult.then((result)=>{
+      if(result.fromNetwork){
+        return refreshOfflineNavigationResources();
+      }
+    }).catch(()=>{}));
   }
 });
 `

--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -667,6 +667,10 @@ describe('offlineNavigations build artifacts', () => {
       `"manifestHref":"/docs/_next/static/${buildId}/_offline-navigation-manifest.json"`
     )
     expect(serviceWorkerScript).toContain('cacheOfflineNavigationResources')
+    expect(serviceWorkerScript).toContain('refreshOfflineNavigationResources')
+    expect(serviceWorkerScript).toContain(
+      'unregisterOfflineNavigationServiceWorker'
+    )
     expect(serviceWorkerScript).toContain('caches.delete')
     expect(serviceWorkerScript).toContain(OFFLINE_NAVIGATION_FALLBACK_SERVED)
     expect(serviceWorkerScript).toContain('isDocumentNavigationRequest')
@@ -6044,6 +6048,184 @@ describe('offlineNavigations build artifacts', () => {
         if (page) {
           await page.context().setOffline(false)
         }
+        await next.stop()
+      }
+    }
+  })
+
+  it('cleans up stale service worker artifacts when offlineNavigations is disabled', async () => {
+    if (shouldSkipReplayWithCachedNavigations) {
+      return
+    }
+
+    const enabledBuildResult = await next.build()
+    expect(enabledBuildResult.exitCode).toBe(0)
+
+    const { buildId } = await getOfflineNavigationArtifactPaths()
+    await next.start({ skipBuild: true })
+
+    const previousForcedPort = next.forcedPort
+    let isStarted = true
+    let page: Playwright.Page | undefined
+    const fallbackMessages: Array<unknown> = []
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
+
+      const enabledCacheState = await browser.eval(async (currentBuildId) => {
+        const cacheNames = await caches.keys()
+        return {
+          cacheNames: cacheNames.filter((cacheName) =>
+            cacheName.startsWith('next-offline-navigation-v1:')
+          ),
+          controlled: Boolean(navigator.serviceWorker.controller),
+          registrations: (await navigator.serviceWorker.getRegistrations()).map(
+            (registration) => ({
+              active: registration.active?.scriptURL ?? null,
+              scope: registration.scope,
+            })
+          ),
+          expectedCacheName: `next-offline-navigation-v1:${currentBuildId}:/docs`,
+        }
+      }, buildId)
+      expect(enabledCacheState).toMatchObject({
+        cacheNames: [enabledCacheState.expectedCacheName],
+        controlled: true,
+      })
+      expect(enabledCacheState.registrations).toEqual(
+        expect.arrayContaining([
+          {
+            active: expect.stringContaining(
+              '/docs/_next/static/_offline-navigation-service-worker.js'
+            ),
+            scope: `${next.url}/docs/`,
+          },
+        ])
+      )
+
+      next.forcedPort = next.appPort
+      await next.stop()
+      isStarted = false
+
+      await next.patchFile(
+        'next.config.js',
+        (content) =>
+          content.replace(
+            'offlineNavigations: true',
+            'offlineNavigations: false'
+          ),
+        async () => {
+          const disabledBuildResult = await next.build()
+          expect(disabledBuildResult.exitCode).toBe(0)
+
+          const { fallbackDocument, manifest, serviceWorker } =
+            await getOfflineNavigationArtifactPaths()
+          expect(existsSync(fallbackDocument.absolutePath)).toBe(false)
+          expect(existsSync(manifest.absolutePath)).toBe(false)
+          expect(existsSync(serviceWorker.absolutePath)).toBe(false)
+
+          await next.start({ skipBuild: true })
+          isStarted = true
+
+          try {
+            await page!.goto(`${next.url}/docs?offline-navigation-disabled=1`, {
+              waitUntil: 'domcontentloaded',
+            })
+            await retry(async () => {
+              expect(await browser.elementByCss('p').text()).toBe(
+                'offline navigations page'
+              )
+            })
+
+            await page!.exposeFunction(
+              '__nextRecordOfflineNavigationFlagDisabledMessage',
+              (message: unknown) => {
+                fallbackMessages.push(message)
+              }
+            )
+            await browser.eval((messageType) => {
+              const win = window as typeof window & {
+                __nextRecordOfflineNavigationFlagDisabledMessage?: (
+                  message: unknown
+                ) => void
+              }
+              navigator.serviceWorker.addEventListener('message', (event) => {
+                if (event.data?.type === messageType) {
+                  win.__nextRecordOfflineNavigationFlagDisabledMessage?.(
+                    event.data
+                  )
+                }
+              })
+            }, OFFLINE_NAVIGATION_FALLBACK_SERVED)
+
+            await retry(
+              async () => {
+                const cleanupState = await browser.eval(async () => {
+                  const cacheNames = await caches.keys()
+                  const registrations =
+                    await navigator.serviceWorker.getRegistrations()
+                  return {
+                    cacheNames: cacheNames.filter((cacheName) =>
+                      cacheName.startsWith('next-offline-navigation-v1:')
+                    ),
+                    registrations: registrations
+                      .filter((registration) =>
+                        registration.scope.endsWith('/docs/')
+                      )
+                      .map((registration) => ({
+                        active: registration.active?.scriptURL ?? null,
+                        installing: registration.installing?.state ?? null,
+                        scope: registration.scope,
+                        waiting: registration.waiting?.state ?? null,
+                      })),
+                  }
+                })
+
+                expect(cleanupState.cacheNames).toEqual([])
+                expect(
+                  cleanupState.registrations.every(
+                    (registration) => registration.active === null
+                  )
+                ).toBe(true)
+              },
+              10000,
+              500
+            )
+
+            await page!.context().setOffline(true)
+            let navigationError: string | null = null
+            try {
+              await page!.goto(
+                `${next.url}/docs/prefetched?flag-disabled-cleanup=1`,
+                { waitUntil: 'domcontentloaded' }
+              )
+            } catch (error) {
+              navigationError = String(error)
+            }
+
+            expect(navigationError).toMatch(
+              /ERR_FAILED|ERR_INTERNET_DISCONNECTED|NS_ERROR_OFFLINE|offline/i
+            )
+            expect(fallbackMessages).toEqual([])
+          } finally {
+            if (page) {
+              await page.context().setOffline(false)
+            }
+            await next.stop()
+            isStarted = false
+          }
+        }
+      )
+    } finally {
+      next.forcedPort = previousForcedPort
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      if (isStarted) {
         await next.stop()
       }
     }


### PR DESCRIPTION
## Stack position

This PR sits directly on top of #93694, `(1/1) Cover offline manifest install failures`. The previous slice proves a worker whose manifest dependency is damaged before install fails closed and never activates.

This slice handles the next service-worker lifecycle boundary: a user had `experimental.offlineNavigations` enabled, installed the generated worker, then deploys a build where `offlineNavigations` is disabled and no offline navigation artifacts are emitted.

## Why

Disabling the flag should not leave an old generated worker serving stale fallback HTML. At the same time, disabled builds should not need a new client-side cleanup path that runs for apps that never opted into the feature.

This PR keeps the cleanup responsibility inside the generated worker from the enabled build. On successful online document navigations, the worker refreshes its required offline-navigation resources in `waitUntil`. If the current deployment no longer has those resources, the old worker fails closed by deleting its own Cache Storage namespace and unregistering itself. Offline fallback responses do not trigger this cleanup path.

## What changed

- Adds generated-worker cleanup helpers for stale offline navigation registrations.
- Keeps document navigation network-first and continues to serve fallback only on document network failure.
- Refreshes required worker resources after successful online document responses.
- Deletes only the current worker cache namespace and unregisters when that refresh fails.
- Adds an e2e that installs the worker with the flag enabled, rebuilds the same app with `offlineNavigations` disabled, proves the disabled build emits no artifacts, verifies the old cache namespace is removed, and verifies a later offline document navigation fails normally without `fallback-served`.

## What this intentionally does not cover

- Multi-tab old/new controller update races.
- Runtime chunk, CSS, build manifest, or asset damage after fallback document boot.
- Client router exact URL or route/segment replay behavior.

Those remain separate stress rows so this PR is reviewable around one lifecycle contract.

## Verification

- `pnpm prettier --with-node-modules --ignore-path .prettierignore --write packages/next/src/build/offline-navigation-service-worker.ts test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `npx eslint --config eslint.config.mjs --fix packages/next/src/build/offline-navigation-service-worker.ts test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `git diff --check -- packages/next/src/build/offline-navigation-service-worker.ts test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `NEXT_SKIP_ISOLATE=1 pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "emits request-invariant offline navigation artifacts when enabled|cleans up stale service worker artifacts when offlineNavigations is disabled"`
- `pnpm test-start-webpack test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "emits request-invariant offline navigation artifacts when enabled|cleans up stale service worker artifacts when offlineNavigations is disabled"`
- `pnpm --filter=next build`

<!-- NEXT_JS_LLM_PR -->