### PR TITLE
(1/1) Cover stale offline manifest refreshes

### DIFF
--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -6231,6 +6231,151 @@ describe('offlineNavigations build artifacts', () => {
     }
   })
 
+  it('does not serve stale fallback HTML when a later manifest refresh is corrupted', async () => {
+    if (shouldSkipReplayWithCachedNavigations) {
+      return
+    }
+
+    const initialBuildResult = await next.build()
+    expect(initialBuildResult.exitCode).toBe(0)
+
+    const initialArtifacts = await getOfflineNavigationArtifactPaths()
+    await next.start({ skipBuild: true })
+
+    const previousForcedPort = next.forcedPort
+    let isStarted = true
+    let page: Playwright.Page | undefined
+    const fallbackMessages: Array<unknown> = []
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
+
+      const initialState = await browser.eval(async (currentBuildId) => {
+        const cacheNames = await caches.keys()
+        return {
+          cacheNames: cacheNames.filter((cacheName) =>
+            cacheName.startsWith('next-offline-navigation-v1:')
+          ),
+          controlled: Boolean(navigator.serviceWorker.controller),
+          expectedCacheName: `next-offline-navigation-v1:${currentBuildId}:/docs`,
+        }
+      }, initialArtifacts.buildId)
+      expect(initialState).toEqual({
+        cacheNames: [initialState.expectedCacheName],
+        controlled: true,
+        expectedCacheName: `next-offline-navigation-v1:${initialArtifacts.buildId}:/docs`,
+      })
+
+      next.forcedPort = next.appPort
+      await next.stop()
+      isStarted = false
+
+      const updateBuildResult = await next.build()
+      expect(updateBuildResult.exitCode).toBe(0)
+
+      const updatedArtifacts = await getOfflineNavigationArtifactPaths()
+      writeFileSync(
+        updatedArtifacts.manifest.absolutePath,
+        'not updated offline navigation manifest'
+      )
+
+      await next.start({ skipBuild: true })
+      isStarted = true
+
+      try {
+        const updatedManifestResponse = await next.fetch(
+          `/docs/_next/static/${updatedArtifacts.buildId}/_offline-navigation-manifest.json${next.getDeploymentIdQuery()}`
+        )
+        expect(updatedManifestResponse.status).toBe(200)
+        expect(await updatedManifestResponse.text()).toBe(
+          'not updated offline navigation manifest'
+        )
+
+        await page!.goto(
+          `${next.url}/docs?offline-navigation-update-failed=1`,
+          {
+            waitUntil: 'domcontentloaded',
+          }
+        )
+        await retry(async () => {
+          expect(await browser.elementByCss('p').text()).toBe(
+            'offline navigations page'
+          )
+        })
+
+        await page!.exposeFunction(
+          '__nextRecordOfflineNavigationUpdateDamageMessage',
+          (message: unknown) => {
+            fallbackMessages.push(message)
+          }
+        )
+        await browser.eval((messageType) => {
+          const win = window as typeof window & {
+            __nextRecordOfflineNavigationUpdateDamageMessage?: (
+              message: unknown
+            ) => void
+          }
+          navigator.serviceWorker.addEventListener('message', (event) => {
+            if (event.data?.type === messageType) {
+              win.__nextRecordOfflineNavigationUpdateDamageMessage?.(event.data)
+            }
+          })
+        }, OFFLINE_NAVIGATION_FALLBACK_SERVED)
+
+        await retry(
+          async () => {
+            const cleanupState = await browser.eval(async () => {
+              const cacheNames = await caches.keys()
+              return {
+                cacheNames: cacheNames.filter((cacheName) =>
+                  cacheName.startsWith('next-offline-navigation-v1:')
+                ),
+              }
+            })
+
+            expect(cleanupState.cacheNames).toEqual([])
+          },
+          10000,
+          500
+        )
+
+        await page!.context().setOffline(true)
+        let navigationError: string | null = null
+        try {
+          await page!.goto(
+            `${next.url}/docs/prefetched?update-manifest-failure=1`,
+            { waitUntil: 'domcontentloaded' }
+          )
+        } catch (error) {
+          navigationError = String(error)
+        }
+
+        expect(navigationError).toMatch(
+          /ERR_FAILED|ERR_INTERNET_DISCONNECTED|NS_ERROR_OFFLINE|offline/i
+        )
+        expect(fallbackMessages).toEqual([])
+      } finally {
+        if (page) {
+          await page.context().setOffline(false)
+        }
+        await next.stop()
+        isStarted = false
+      }
+    } finally {
+      next.forcedPort = previousForcedPort
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      if (isStarted) {
+        await next.stop()
+      }
+    }
+  })
+
   it('does not serve fallback HTML to offline server action submissions', async () => {
     if (shouldSkipReplayWithCachedNavigations) {
       return


### PR DESCRIPTION
## Stack position

This PR sits directly on top of #93695, `(1/1) Clean up stale offline navigation workers`. The previous PR adds the cleanup primitive in the generated worker: after successful online document responses, the worker refreshes its required offline resources and fails closed if they are unavailable or invalid.

This PR is a test-only stress slice for that primitive. It covers the old-controller case where the worker was already active, then the generated manifest becomes corrupted before a later online navigation.

## Why

Install-time manifest failure is covered by #93694. Flag-disabled cleanup is covered by #93695. This slice proves the same cleanup behavior protects a stale active worker during a later manifest refresh, so it cannot keep serving old fallback HTML after its required manifest is no longer valid.

The review question is narrow: if an already-active generated worker sees a corrupted manifest during a later online refresh, does it lose the ability to serve stale offline fallback?

## What changed

- Adds a production e2e that first installs and controls the page with a valid offline navigation worker.
- Rebuilds the app on the same origin, corrupts the generated manifest file, and starts the app again.
- Navigates online so the old worker attempts to refresh its required resources.
- Verifies the offline-navigation Cache Storage namespace is deleted.
- Verifies a later offline document navigation fails normally and emits no `next-offline-navigation-fallback-served` message.

## What this intentionally does not cover

- Multi-tab old/new controller races.
- Runtime JS, CSS, font, or build-manifest damage after fallback document boot.
- Client router exact URL or route/segment replay behavior.

Those remain separate production-hardening slices.

## Verification

- `pnpm prettier --with-node-modules --ignore-path .prettierignore --write test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `npx eslint --config eslint.config.mjs --fix test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `git diff --check -- test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `NEXT_SKIP_ISOLATE=1 pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "does not serve stale fallback HTML when a later manifest refresh is corrupted"`
- `pnpm test-start-webpack test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "does not serve stale fallback HTML when a later manifest refresh is corrupted"`

<!-- NEXT_JS_LLM_PR -->