### PR TITLE
(1/1) Cover fallback runtime bootstrap failures

### DIFF
--- a/packages/next/src/build/offline-navigation-fallback.ts
+++ b/packages/next/src/build/offline-navigation-fallback.ts
@@ -33,6 +33,10 @@ function getScriptAttributes(
   return ` crossOrigin="${htmlEscapeAttributeString(crossOrigin)}"`
 }
 
+function createRuntimeWatchdogScript(): string {
+  return `<script>(function(){var doc=document.documentElement;var reason='runtime-error';var done=false;function finish(){done=true;removeEventListener('error',onError,true);clearTimeout(timer);delete self.__NEXT_OFFLINE_NAVIGATION_FALLBACK_WATCHDOG_CANCEL__}function reportRuntimeFailure(){if(done||doc.hasAttribute('data-next-offline-navigation-cache'))return;finish();doc.setAttribute('data-next-offline-navigation-cache','miss');doc.setAttribute('data-next-offline-navigation-cache-reason',reason);var miss=document.getElementById('__NEXT_OFFLINE_NAVIGATION_CACHE_MISS');if(miss){miss.hidden=false;miss.setAttribute('data-next-offline-navigation-cache-reason',reason)}var diagnostics=self.__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__=self.__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__||[];if(diagnostics.length>=32){diagnostics.shift()}diagnostics.push({type:'cache-miss',url:location.href,buildId:doc.getAttribute('data-dpl-id')||doc.getAttribute('data-build-id')||undefined,reason:reason})}function onError(event){var target=event&&event.target;if(target&&target.tagName==='SCRIPT'&&target.src&&target.src.indexOf('/_next/static/')!==-1){reportRuntimeFailure()}}var timer=setTimeout(reportRuntimeFailure,4000);self.__NEXT_OFFLINE_NAVIGATION_FALLBACK_WATCHDOG_CANCEL__=finish;addEventListener('error',onError,true)})()</script>`
+}
+
 export function createOfflineNavigationFallbackDocument({
   assetPrefix,
   buildId,
@@ -86,5 +90,5 @@ export function createOfflineNavigationFallbackDocument({
     buildId
   )}"><script id="__NEXT_OFFLINE_NAVIGATION_FALLBACK" type="application/json">${htmlEscapeJsonString(
     JSON.stringify(metadata)
-  )}</script></head><body><div id="__next"></div><p id="__NEXT_OFFLINE_NAVIGATION_CACHE_MISS" hidden>This page is not available offline.</p><script>self.__next_f=self.__next_f||[];self.__next_f.push([0])</script>${polyfillScripts}${bootstrapScripts}</body></html>`
+  )}</script></head><body><div id="__next"></div><p id="__NEXT_OFFLINE_NAVIGATION_CACHE_MISS" hidden>This page is not available offline.</p><script>self.__next_f=self.__next_f||[];self.__next_f.push([0])</script>${createRuntimeWatchdogScript()}${polyfillScripts}${bootstrapScripts}</body></html>`
 }

--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -62,6 +62,7 @@ type OfflineNavigationCacheMissReason =
   | 'missing-entry'
   | 'invalid-payload'
   | 'unsupported-request-kind'
+  | 'runtime-error'
   | 'read-error'
 
 type OfflineNavigationFallbackRequestKind =
@@ -107,6 +108,18 @@ declare global {
     __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?:
       | OfflineNavigationFallbackDiagnostic[]
       | undefined
+    __NEXT_OFFLINE_NAVIGATION_FALLBACK_WATCHDOG_CANCEL__?:
+      | (() => void)
+      | undefined
+  }
+}
+
+function cancelOfflineNavigationFallbackRuntimeWatchdog(): void {
+  const cancelRuntimeWatchdog =
+    window.__NEXT_OFFLINE_NAVIGATION_FALLBACK_WATCHDOG_CANCEL__
+  if (typeof cancelRuntimeWatchdog === 'function') {
+    cancelRuntimeWatchdog()
+    window.__NEXT_OFFLINE_NAVIGATION_FALLBACK_WATCHDOG_CANCEL__ = undefined
   }
 }
 
@@ -304,6 +317,10 @@ function createOfflineNavigationFallbackBootstrap():
 
 const offlineNavigationFallbackBootstrap =
   createOfflineNavigationFallbackBootstrap()
+
+if (offlineNavigationFallbackBootstrap) {
+  cancelOfflineNavigationFallbackRuntimeWatchdog()
+}
 
 if (process.env.__NEXT_USE_OFFLINE && offlineNavigationFallbackBootstrap) {
   const { notifyOffline } =

--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -648,6 +648,10 @@ describe('offlineNavigations build artifacts', () => {
     expect(html).toContain('data-next-offline-navigation-fallback')
     expect(html).toContain('id="__NEXT_OFFLINE_NAVIGATION_FALLBACK"')
     expect(html).toContain('id="__NEXT_OFFLINE_NAVIGATION_CACHE_MISS"')
+    expect(html).toContain(
+      '__NEXT_OFFLINE_NAVIGATION_FALLBACK_WATCHDOG_CANCEL__'
+    )
+    expect(html).toContain('runtime-error')
     expect(html).toContain(`"buildId":"${buildId}"`)
     if (next.deploymentId) {
       expect(html).toContain(`data-dpl-id="${next.deploymentId}"`)
@@ -5724,6 +5728,187 @@ describe('offlineNavigations build artifacts', () => {
         /ERR_FAILED|ERR_INTERNET_DISCONNECTED|NS_ERROR_OFFLINE|offline/i
       )
       expect(fallbackMessages).toEqual([])
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
+  it('shows cache miss when fallback runtime scripts fail to load', async () => {
+    if (shouldSkipReplayWithCachedNavigations) {
+      return
+    }
+
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    const { buildId } = await getOfflineNavigationArtifactPaths()
+    const diagnosticBuildId = next.deploymentId ?? buildId
+    await next.start({ skipBuild: true })
+
+    let page: Playwright.Page | undefined
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
+
+      await retry(async () => {
+        expect(await browser.elementByCss('p').text()).toBe(
+          'offline navigations page'
+        )
+      })
+
+      const fallbackMessageStorageKey =
+        '__nextOfflineNavigationRuntimeFailureMessages'
+      await browser.eval(
+        ({ messageType, storageKey }) => {
+          localStorage.removeItem(storageKey)
+          navigator.serviceWorker.addEventListener('message', (event) => {
+            if (event.data?.type === messageType) {
+              const messages = JSON.parse(
+                localStorage.getItem(storageKey) ?? '[]'
+              )
+              messages.push(event.data)
+              localStorage.setItem(storageKey, JSON.stringify(messages))
+            }
+          })
+        },
+        {
+          messageType: OFFLINE_NAVIGATION_FALLBACK_SERVED,
+          storageKey: fallbackMessageStorageKey,
+        }
+      )
+
+      const runtimeDamageState = await browser.eval(async (currentBuildId) => {
+        const cacheName = `next-offline-navigation-v1:${currentBuildId}:/docs`
+        const fallbackPath = `/docs/_next/static/${currentBuildId}/_offline-navigation-fallback.html`
+        const cache = await caches.open(cacheName)
+        const originalFallback = await cache.match(fallbackPath)
+        const originalFallbackHtml = await originalFallback?.text()
+        if (!originalFallbackHtml) {
+          return {
+            damagedRuntimeScriptCount: 0,
+            hasBuildId: false,
+            hasFallback: false,
+            hasFallbackMarker: false,
+          }
+        }
+
+        const damagedFallbackHtml = originalFallbackHtml.replace(
+          /src="[^"]*\/_next\/static\/[^"]+\.js"/g,
+          'src="/app-assets/_next/static/chunks/missing-offline-runtime.js"'
+        )
+        await cache.put(
+          fallbackPath,
+          new Response(damagedFallbackHtml, {
+            headers: {
+              'content-type': 'text/html; charset=utf-8',
+            },
+          })
+        )
+
+        return {
+          damagedRuntimeScriptCount:
+            damagedFallbackHtml.match(/missing-offline-runtime\.js/g)?.length ??
+            0,
+          hasBuildId: damagedFallbackHtml.includes(
+            `"buildId":"${currentBuildId}"`
+          ),
+          hasFallback: true,
+          hasFallbackMarker: damagedFallbackHtml.includes(
+            'data-next-offline-navigation-fallback'
+          ),
+        }
+      }, buildId)
+      expect(runtimeDamageState).toMatchObject({
+        hasBuildId: true,
+        hasFallback: true,
+        hasFallbackMarker: true,
+      })
+      expect(runtimeDamageState.damagedRuntimeScriptCount).toBeGreaterThan(0)
+
+      await page!.context().setOffline(true)
+      const targetUrl = `${next.url}/docs/prefetched?missing-runtime-script=1`
+      const offlineResponse = await page!.goto(targetUrl, {
+        waitUntil: 'domcontentloaded',
+      })
+      expect(offlineResponse?.status()).toBe(200)
+
+      await retry(async () => {
+        expect(
+          await browser.eval(() =>
+            document.documentElement.getAttribute(
+              'data-next-offline-navigation-cache'
+            )
+          )
+        ).toBe('miss')
+      })
+
+      expect(
+        await browser.eval((storageKey) => {
+          const cacheMiss = document.getElementById(
+            '__NEXT_OFFLINE_NAVIGATION_CACHE_MISS'
+          )
+          const win = window as typeof window & {
+            __NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?: Array<unknown>
+          }
+
+          return {
+            cache: document.documentElement.getAttribute(
+              'data-next-offline-navigation-cache'
+            ),
+            diagnostic:
+              win.__NEXT_OFFLINE_NAVIGATION_DIAGNOSTICS__?.at(-1) ?? null,
+            fallback: document.documentElement.hasAttribute(
+              'data-next-offline-navigation-fallback'
+            ),
+            fallbackMessages: JSON.parse(
+              localStorage.getItem(storageKey) ?? '[]'
+            ),
+            miss:
+              cacheMiss === null
+                ? null
+                : {
+                    hidden: cacheMiss.hidden,
+                    reason: cacheMiss.getAttribute(
+                      'data-next-offline-navigation-cache-reason'
+                    ),
+                    text: cacheMiss.textContent,
+                  },
+            reason: document.documentElement.getAttribute(
+              'data-next-offline-navigation-cache-reason'
+            ),
+          }
+        }, fallbackMessageStorageKey)
+      ).toMatchObject({
+        cache: 'miss',
+        diagnostic: {
+          buildId: diagnosticBuildId,
+          reason: 'runtime-error',
+          type: 'cache-miss',
+          url: targetUrl,
+        },
+        fallback: true,
+        fallbackMessages: [
+          {
+            buildId,
+            reason: 'network-error',
+            type: OFFLINE_NAVIGATION_FALLBACK_SERVED,
+            url: targetUrl,
+          },
+        ],
+        miss: {
+          hidden: false,
+          reason: 'runtime-error',
+          text: 'This page is not available offline.',
+        },
+        reason: 'runtime-error',
+      })
     } finally {
       if (page) {
         await page.context().setOffline(false)


### PR DESCRIPTION
## Stack position

This PR sits on top of #93696, after the service-worker manifest refresh failure stress slice. It is a focused production-hardening slice for the `ASSET-01` / `RUNTIME-01` runtime bootstrap gap in the offlineNavigations stress plan.

The service worker still only owns document survival. This PR does not teach the service worker to route, inspect RSC, or resolve assets. It covers the narrower case where the generated fallback HTML is served correctly, but the app runtime scripts referenced by that fallback cannot execute.

## Why

Before this slice, a fallback document could be served from the service worker and still leave the user on a blank fallback root if the client runtime never loaded. That is a dangerous false positive for offline navigations: the service worker did its job, but the app never reached either a cache hit or a visible cache miss.

For production apps, a missing or stale runtime chunk should be observable as a bounded fallback boot failure. It should not look like a pending cache hit, and it should not require route-data logic in the service worker.

## What changed

- Adds a small inline watchdog to the generated offline navigation fallback document.
- The watchdog reveals the existing generated cache-miss UI and records a `runtime-error` diagnostic if the app runtime never starts or a root `/_next/static/*.js` script fails to load.
- The real app runtime cancels that watchdog as soon as `app-index` starts executing, so normal exact-URL and route/segment fallback boot still own their own hit/miss diagnostics.
- Adds a production e2e that corrupts the cached fallback document so its runtime script URLs point at a missing chunk, then hard-loads offline through the service worker and proves the page reaches a visible `runtime-error` miss instead of a blank root.

## Review focus

The important boundary is that the fallback document only handles the "runtime never started" case. Once `app-index` executes, the existing client-owned offline navigation bootstrap remains responsible for exact URL replay, route/segment replay, IndexedDB reads, and normal cache hit/miss diagnostics.

## Intentionally not covered yet

This is not the full runtime/bootstrap matrix. Follow-up stress slices still need to cover stale runtime chunks after build updates, CSS/font preload failures, build-manifest skew, cross-origin `assetPrefix` runtime failures, and old/new controller races.

## Verification

- `pnpm prettier --with-node-modules --ignore-path .prettierignore --write packages/next/src/build/offline-navigation-fallback.ts packages/next/src/client/app-index.tsx test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `npx eslint --config eslint.config.mjs --fix packages/next/src/build/offline-navigation-fallback.ts packages/next/src/client/app-index.tsx test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `git diff --check -- packages/next/src/build/offline-navigation-fallback.ts packages/next/src/client/app-index.tsx test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `NEXT_SKIP_ISOLATE=1 pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "emits request-invariant offline navigation artifacts when enabled|shows cache miss when fallback runtime scripts fail to load"`
- `pnpm test-start-webpack test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "emits request-invariant offline navigation artifacts when enabled|shows cache miss when fallback runtime scripts fail to load"`
- `pnpm --filter=next build`

`pnpm --filter=next build` passed with existing Rspack/devtools warnings. The background `pnpm --filter=next dev` watcher later exited with the known `RspackResolver(NotFound("../../runtime-reacts.external"))` failure after the explicit build completed; the focused tests and explicit build above passed.

<!-- NEXT_JS_LLM_PR -->
