### PR TITLE
(1/1) Cover online app error fallback boundaries

### DIFF
--- a/test/production/app-dir/offline-navigations/app/app-not-found/page.tsx
+++ b/test/production/app-dir/offline-navigations/app/app-not-found/page.tsx
@@ -1,0 +1,10 @@
+import { notFound } from 'next/navigation'
+import { connection } from 'next/server'
+
+export const unstable_instant = false
+export const unstable_prefetch = 'force-disabled'
+
+export default async function AppNotFoundPage(): Promise<never> {
+  await connection()
+  notFound()
+}

--- a/test/production/app-dir/offline-navigations/app/throws-error/page.tsx
+++ b/test/production/app-dir/offline-navigations/app/throws-error/page.tsx
@@ -1,0 +1,9 @@
+import { connection } from 'next/server'
+
+export const unstable_instant = false
+export const unstable_prefetch = 'force-disabled'
+
+export default async function ThrowsErrorPage(): Promise<never> {
+  await connection()
+  throw new Error('offline navigation thrown page error')
+}

--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -5338,6 +5338,101 @@ describe('offlineNavigations build artifacts', () => {
     }
   })
 
+  it('does not serve fallback HTML for online app error responses', async () => {
+    if (shouldSkipReplayWithCachedNavigations) {
+      return
+    }
+
+    const buildResult = await next.build()
+    expect(buildResult.exitCode).toBe(0)
+
+    await next.start({ skipBuild: true })
+
+    let page: Playwright.Page | undefined
+    try {
+      const browser = await next.browser('/docs', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await waitForOfflineNavigationServiceWorker(browser, page!)
+
+      const fallbackMessageStorageKey =
+        '__nextOfflineNavigationOnlineErrorMessages'
+      await browser.eval(
+        ({ messageType, storageKey }) => {
+          localStorage.removeItem(storageKey)
+          navigator.serviceWorker.addEventListener('message', (event) => {
+            if (event.data?.type === messageType) {
+              const messages = JSON.parse(
+                localStorage.getItem(storageKey) ?? '[]'
+              )
+              messages.push(event.data)
+              localStorage.setItem(storageKey, JSON.stringify(messages))
+            }
+          })
+        },
+        {
+          messageType: OFFLINE_NAVIGATION_FALLBACK_SERVED,
+          storageKey: fallbackMessageStorageKey,
+        }
+      )
+
+      for (const errorRoute of [
+        {
+          expectedBody: '404',
+          statuses: [200, 404],
+          url: `${next.url}/docs/app-not-found/`,
+        },
+        {
+          expectedBody: null,
+          statuses: [200, 500],
+          url: `${next.url}/docs/throws-error/`,
+        },
+      ]) {
+        const response = await page!.goto(errorRoute.url, {
+          waitUntil: 'domcontentloaded',
+        })
+        expect(errorRoute.statuses).toContain(response?.status())
+
+        expect(
+          await browser.eval((storageKey) => {
+            return {
+              body: document.body.textContent,
+              cache: document.documentElement.getAttribute(
+                'data-next-offline-navigation-cache'
+              ),
+              fallback: document.documentElement.hasAttribute(
+                'data-next-offline-navigation-fallback'
+              ),
+              fallbackMessages: JSON.parse(
+                localStorage.getItem(storageKey) ?? '[]'
+              ),
+              missVisible:
+                document.getElementById('__NEXT_OFFLINE_NAVIGATION_CACHE_MISS')
+                  ?.hidden === false,
+            }
+          }, fallbackMessageStorageKey)
+        ).toMatchObject({
+          cache: null,
+          fallback: false,
+          fallbackMessages: [],
+          missVisible: false,
+        })
+        if (errorRoute.expectedBody !== null) {
+          expect(await browser.eval(() => document.body.textContent)).toContain(
+            errorRoute.expectedBody
+          )
+        }
+      }
+    } finally {
+      if (page) {
+        await page.context().setOffline(false)
+      }
+      await next.stop()
+    }
+  })
+
   it('does not serve fallback HTML to offline non-document request shapes', async () => {
     if (shouldSkipReplayWithCachedNavigations) {
       return


### PR DESCRIPTION
## Stack position

This PR sits on top of #93697. It is a focused `HTTP-04` stress slice for online application errors in the offlineNavigations production-hardening stack.

The service worker should only serve the generated fallback document for same-origin document network failures. Online application errors, including app `notFound()` boundaries and thrown page errors, must pass through as the app's real online result.

## Why

A common service-worker bug is treating any bad-looking document response as a reason to serve fallback HTML. That would be wrong for Next apps: an online `notFound()` boundary or thrown page error is still a real app response, not an offline navigation miss.

This PR adds direct browser coverage so the fallback path cannot accidentally start intercepting online application error states.

## What changed

- Adds two tiny fixture routes:
  - `/docs/app-not-found/`, a dynamic route that calls `notFound()`.
  - `/docs/throws-error/`, a dynamic route that throws during render.
- Adds a production e2e that installs the offline navigation service worker, navigates to both routes while online, and asserts:
  - the page is not the generated offline fallback document,
  - no fallback cache state is set,
  - no cache-miss UI appears,
  - no `fallback-served` service-worker message is emitted.

## Review focus

The test intentionally accepts either `200` or error status for streamed app-level errors, because the important contract here is not the exact HTTP status. The important contract is that the online app error response remains owned by the app/router and does not become service-worker fallback HTML.

## Intentionally not covered yet

Download/content-disposition navigations, navigation preload races, aborted document requests, and a broader matrix of online error variants still belong in follow-up request-boundary stress slices.

## Verification

- `pnpm prettier --with-node-modules --ignore-path .prettierignore --write test/production/app-dir/offline-navigations/app/app-not-found/page.tsx test/production/app-dir/offline-navigations/app/throws-error/page.tsx test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `npx eslint --config eslint.config.mjs --fix test/production/app-dir/offline-navigations/app/app-not-found/page.tsx test/production/app-dir/offline-navigations/app/throws-error/page.tsx test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `git diff --check -- test/production/app-dir/offline-navigations/app/app-not-found/page.tsx test/production/app-dir/offline-navigations/app/throws-error/page.tsx test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `NEXT_SKIP_ISOLATE=1 pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "does not serve fallback HTML for online app error responses"`
- `pnpm test-start-webpack test/production/app-dir/offline-navigations/offline-navigations.test.ts -t "does not serve fallback HTML for online app error responses"`

The thrown-page route logs the expected app render error during the test. The assertions prove the response is not the generated offline fallback and no fallback-served message is emitted.

<!-- NEXT_JS_LLM_PR -->
