### PR TITLE
Draft: Turbopack: Add FsError type, return it from write/write_link effects

### DIFF
--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -1186,7 +1186,7 @@ impl Project {
     pub async fn issue_filter(self: Vc<Self>) -> Result<Vc<IssueFilter>> {
         let ignore_rules = self.next_config().turbopack_ignore_issue_rules().await?;
         Ok(IssueFilter::warnings_and_foreign_errors()
-            .with_ignore_rules(ignore_rules.to_vec())
+            .with_ignore_rules(ReadRef::into_owned(ignore_rules))
             .cell())
     }
 

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -1605,7 +1605,7 @@ pub struct OptionSubResourceIntegrity(Option<SubResourceIntegrity>);
 pub struct OptionFileSystemPath(Option<FileSystemPath>);
 
 #[turbo_tasks::value(transparent)]
-pub struct IgnoreIssues(Vec<IgnoreIssue>);
+pub struct IgnoreIssues(Box<[IgnoreIssue]>);
 
 #[turbo_tasks::value(transparent)]
 pub struct OptionJsonValue(
@@ -2531,7 +2531,7 @@ impl NextConfig {
                         .transpose()?,
                 })
             })
-            .collect::<Result<Vec<_>>>()?;
+            .collect::<Result<_>>()?;
         Ok(Vc::cell(rules))
     }
 

--- a/crates/next-napi-bindings/src/next_api/analyze.rs
+++ b/crates/next-napi-bindings/src/next_api/analyze.rs
@@ -29,7 +29,7 @@ pub async fn write_analyze_data_with_issues_operation(
     let filter = project.project().issue_filter().await?;
 
     let (_analyze_data, issues, effects) =
-        strongly_consistent_catch_collectables(analyze_data_op, &*filter).await?;
+        strongly_consistent_catch_collectables(analyze_data_op, &filter).await?;
 
     Ok(WriteAnalyzeResult { issues, effects }.cell())
 }

--- a/crates/next-napi-bindings/src/next_api/analyze.rs
+++ b/crates/next-napi-bindings/src/next_api/analyze.rs
@@ -26,10 +26,10 @@ pub async fn write_analyze_data_with_issues_operation(
     app_dir_only: bool,
 ) -> Result<Vc<WriteAnalyzeResult>> {
     let analyze_data_op = write_analyze_data_with_issues_operation_inner(project, app_dir_only);
-    let filter = project.project().issue_filter();
+    let filter = project.project().issue_filter().await?;
 
     let (_analyze_data, issues, effects) =
-        strongly_consistent_catch_collectables(analyze_data_op, filter).await?;
+        strongly_consistent_catch_collectables(analyze_data_op, &*filter).await?;
 
     Ok(WriteAnalyzeResult { issues, effects }.cell())
 }

--- a/crates/next-napi-bindings/src/next_api/endpoint.rs
+++ b/crates/next-napi-bindings/src/next_api/endpoint.rs
@@ -107,16 +107,16 @@ impl Deref for ExternalEndpoint {
 /// `node_modules` reshuffle), this falls back to a default filter rather than
 /// propagating the error.  In this scenario we believe the caller will already be observing the
 /// same error
-async fn issue_filter_from_endpoint(endpoint_op: OperationVc<OptionEndpoint>) -> Vc<IssueFilter> {
-    match endpoint_op.connect().await {
-        Ok(endpoint_option) => {
-            if let Some(ep) = &*endpoint_option {
-                ep.project().issue_filter()
-            } else {
-                IssueFilter::warnings_and_foreign_errors().cell()
-            }
-        }
-        Err(_) => IssueFilter::warnings_and_foreign_errors().cell(),
+async fn issue_filter_from_endpoint(
+    endpoint_op: OperationVc<OptionEndpoint>,
+) -> ReadRef<IssueFilter> {
+    if let Ok(ep_option) = endpoint_op.connect().await
+        && let Some(ep) = &*ep_option
+        && let Ok(filter) = ep.project().issue_filter().await
+    {
+        filter
+    } else {
+        ReadRef::new_owned(IssueFilter::warnings_and_foreign_errors())
     }
 }
 
@@ -134,7 +134,7 @@ async fn get_written_endpoint_with_issues_operation(
     let write_to_disk_op = endpoint_write_to_disk_operation(endpoint_op);
     let filter = issue_filter_from_endpoint(endpoint_op).await;
     let (written, issues, effects) =
-        strongly_consistent_catch_collectables(write_to_disk_op, filter).await?;
+        strongly_consistent_catch_collectables(write_to_disk_op, &*filter).await?;
     Ok(WrittenEndpointWithIssues {
         written,
         issues,
@@ -244,7 +244,7 @@ async fn subscribe_issues_and_diags_operation(
     // payload, but we still need the catch path to avoid the FATAL.
     let filter = issue_filter_from_endpoint(endpoint_op).await;
     let (changed_value, issues, effects) =
-        strongly_consistent_catch_collectables(changed_op, filter).await?;
+        strongly_consistent_catch_collectables(changed_op, &*filter).await?;
     Ok(EndpointIssuesAndDiags {
         changed: changed_value,
         issues: if should_include_issues {

--- a/crates/next-napi-bindings/src/next_api/endpoint.rs
+++ b/crates/next-napi-bindings/src/next_api/endpoint.rs
@@ -134,7 +134,7 @@ async fn get_written_endpoint_with_issues_operation(
     let write_to_disk_op = endpoint_write_to_disk_operation(endpoint_op);
     let filter = issue_filter_from_endpoint(endpoint_op).await;
     let (written, issues, effects) =
-        strongly_consistent_catch_collectables(write_to_disk_op, &*filter).await?;
+        strongly_consistent_catch_collectables(write_to_disk_op, &filter).await?;
     Ok(WrittenEndpointWithIssues {
         written,
         issues,
@@ -244,7 +244,7 @@ async fn subscribe_issues_and_diags_operation(
     // payload, but we still need the catch path to avoid the FATAL.
     let filter = issue_filter_from_endpoint(endpoint_op).await;
     let (changed_value, issues, effects) =
-        strongly_consistent_catch_collectables(changed_op, &*filter).await?;
+        strongly_consistent_catch_collectables(changed_op, &filter).await?;
     Ok(EndpointIssuesAndDiags {
         changed: changed_value,
         issues: if should_include_issues {

--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -998,7 +998,7 @@ async fn get_entrypoints_with_issues_operation(
         EntrypointsOperation::new(project_container_entrypoints_operation(container));
     let filter = container.project().issue_filter().await?;
     let (entrypoints, issues, effects) =
-        strongly_consistent_catch_collectables(entrypoints_operation, &*filter).await?;
+        strongly_consistent_catch_collectables(entrypoints_operation, &filter).await?;
     Ok(EntrypointsWithIssues {
         entrypoints,
         issues,
@@ -1554,7 +1554,7 @@ async fn get_all_written_entrypoints_with_issues_operation(
     ));
     let filter = container.project().issue_filter().await?;
     let (entrypoints, issues, effects) =
-        strongly_consistent_catch_collectables(entrypoints_operation, &*filter).await?;
+        strongly_consistent_catch_collectables(entrypoints_operation, &filter).await?;
     Ok(AllWrittenEntrypointsWithIssues {
         entrypoints,
         issues,
@@ -1637,7 +1637,7 @@ async fn emit_all_output_assets_once_with_issues_operation(
     ));
     let filter = container.project().issue_filter().await?;
     let (_, issues, effects) =
-        strongly_consistent_catch_collectables(entrypoints_operation, &*filter).await?;
+        strongly_consistent_catch_collectables(entrypoints_operation, &filter).await?;
 
     Ok(OperationResult { issues, effects }.cell())
 }
@@ -1822,7 +1822,7 @@ async fn hmr_update_with_issues_operation(
     // failures to trigger their recovery paths
     let update = update_op.read_strongly_consistent().await?;
     let filter = project.issue_filter().await?;
-    let issues = get_issues(update_op, &*filter).await?;
+    let issues = get_issues(update_op, &filter).await?;
     let effects = Arc::new(take_effects(update_op).await?);
     Ok(HmrUpdateWithIssues {
         update,
@@ -1964,7 +1964,7 @@ async fn get_hmr_chunk_names_with_issues_operation(
     // failure from the dev server log.
     let hmr_chunk_names = hmr_chunk_names_op.read_strongly_consistent().await?;
     let filter = container.project().issue_filter().await?;
-    let issues = get_issues(hmr_chunk_names_op, &*filter).await?;
+    let issues = get_issues(hmr_chunk_names_op, &filter).await?;
     let effects = Arc::new(take_effects(hmr_chunk_names_op).await?);
     Ok(HmrChunkNamesWithIssues {
         chunk_names: hmr_chunk_names,
@@ -2508,7 +2508,7 @@ async fn get_all_compilation_issues_operation(
 ) -> Result<Vc<OperationResult>> {
     let inner_op = get_all_compilation_issues_inner_operation(container);
     let filter = container.project().issue_filter().await?;
-    let (_, issues, effects) = strongly_consistent_catch_collectables(inner_op, &*filter).await?;
+    let (_, issues, effects) = strongly_consistent_catch_collectables(inner_op, &filter).await?;
     Ok(OperationResult { issues, effects }.cell())
 }
 

--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -62,7 +62,7 @@ use turbo_tasks_fs::{
 use turbo_unix_path::{get_relative_path_to, sys_to_unix, unix_to_sys};
 use turbopack_core::{
     PROJECT_FILESYSTEM_NAME, SOURCE_URL_PROTOCOL,
-    issue::{IssueFilter, PlainIssue},
+    issue::PlainIssue,
     output::{OutputAsset, OutputAssets},
     source_map::{SourceMap, Token},
     version::{PartialUpdate, TotalUpdate, Update, VersionState},
@@ -98,11 +98,6 @@ const SLOW_FILESYSTEM_THRESHOLD: Duration = Duration::from_millis(200);
 static SOURCE_MAP_PREFIX: LazyLock<String> = LazyLock::new(|| format!("{SOURCE_URL_PROTOCOL}///"));
 static SOURCE_MAP_PREFIX_PROJECT: LazyLock<String> =
     LazyLock::new(|| format!("{SOURCE_URL_PROTOCOL}///[{PROJECT_FILESYSTEM_NAME}]/"));
-
-/// Get the `Vc<IssueFilter>` for a `ProjectContainer`.
-fn issue_filter_from_container(container: ResolvedVc<ProjectContainer>) -> Vc<IssueFilter> {
-    container.project().issue_filter()
-}
 
 #[napi(object)]
 #[derive(Clone, Debug)]
@@ -1001,9 +996,9 @@ async fn get_entrypoints_with_issues_operation(
 ) -> Result<Vc<EntrypointsWithIssues>> {
     let entrypoints_operation =
         EntrypointsOperation::new(project_container_entrypoints_operation(container));
-    let filter = issue_filter_from_container(container);
+    let filter = container.project().issue_filter().await?;
     let (entrypoints, issues, effects) =
-        strongly_consistent_catch_collectables(entrypoints_operation, filter).await?;
+        strongly_consistent_catch_collectables(entrypoints_operation, &*filter).await?;
     Ok(EntrypointsWithIssues {
         entrypoints,
         issues,
@@ -1557,9 +1552,9 @@ async fn get_all_written_entrypoints_with_issues_operation(
         app_dir_only,
         write_phase,
     ));
-    let filter = issue_filter_from_container(container);
+    let filter = container.project().issue_filter().await?;
     let (entrypoints, issues, effects) =
-        strongly_consistent_catch_collectables(entrypoints_operation, filter).await?;
+        strongly_consistent_catch_collectables(entrypoints_operation, &*filter).await?;
     Ok(AllWrittenEntrypointsWithIssues {
         entrypoints,
         issues,
@@ -1640,9 +1635,9 @@ async fn emit_all_output_assets_once_with_issues_operation(
         app_dir_only,
         has_deferred_entrypoints,
     ));
-    let filter = issue_filter_from_container(container);
+    let filter = container.project().issue_filter().await?;
     let (_, issues, effects) =
-        strongly_consistent_catch_collectables(entrypoints_operation, filter).await?;
+        strongly_consistent_catch_collectables(entrypoints_operation, &*filter).await?;
 
     Ok(OperationResult { issues, effects }.cell())
 }
@@ -1826,8 +1821,8 @@ async fn hmr_update_with_issues_operation(
     // `subscribeToClientHmrEvents`) rely on this read *throwing* on build-graph
     // failures to trigger their recovery paths
     let update = update_op.read_strongly_consistent().await?;
-    let filter = project.issue_filter();
-    let issues = get_issues(update_op, filter).await?;
+    let filter = project.issue_filter().await?;
+    let issues = get_issues(update_op, &*filter).await?;
     let effects = Arc::new(take_effects(update_op).await?);
     Ok(HmrUpdateWithIssues {
         update,
@@ -1968,8 +1963,8 @@ async fn get_hmr_chunk_names_with_issues_operation(
     // list keeps the loop running but with stale state, and obscures the real
     // failure from the dev server log.
     let hmr_chunk_names = hmr_chunk_names_op.read_strongly_consistent().await?;
-    let filter = issue_filter_from_container(container);
-    let issues = get_issues(hmr_chunk_names_op, filter).await?;
+    let filter = container.project().issue_filter().await?;
+    let issues = get_issues(hmr_chunk_names_op, &*filter).await?;
     let effects = Arc::new(take_effects(hmr_chunk_names_op).await?);
     Ok(HmrChunkNamesWithIssues {
         chunk_names: hmr_chunk_names,
@@ -2512,8 +2507,8 @@ async fn get_all_compilation_issues_operation(
     container: ResolvedVc<ProjectContainer>,
 ) -> Result<Vc<OperationResult>> {
     let inner_op = get_all_compilation_issues_inner_operation(container);
-    let filter = issue_filter_from_container(container);
-    let (_, issues, effects) = strongly_consistent_catch_collectables(inner_op, filter).await?;
+    let filter = container.project().issue_filter().await?;
+    let (_, issues, effects) = strongly_consistent_catch_collectables(inner_op, &*filter).await?;
     Ok(OperationResult { issues, effects }.cell())
 }
 

--- a/crates/next-napi-bindings/src/next_api/utils.rs
+++ b/crates/next-napi-bindings/src/next_api/utils.rs
@@ -107,7 +107,7 @@ pub fn root_task_dispose(
 /// [consume]: turbo_tasks::CollectiblesSource::take_collectibles
 pub async fn get_issues<T: Send>(
     source: OperationVc<T>,
-    filter: Vc<IssueFilter>,
+    filter: &IssueFilter,
 ) -> Result<Arc<Vec<ReadRef<PlainIssue>>>> {
     Ok(Arc::new(
         source.peek_issues().get_plain_issues(filter).await?,
@@ -447,7 +447,7 @@ pub fn subscribe<T: 'static + Send + Sync, F: Future<Output = Result<T>> + Send,
 // propagate any actual error results.
 pub async fn strongly_consistent_catch_collectables<R: VcValueType + Send>(
     source_op: OperationVc<R>,
-    filter: Vc<IssueFilter>,
+    filter: &IssueFilter,
 ) -> Result<(
     Option<ReadRef<R>>,
     Arc<Vec<ReadRef<PlainIssue>>>,

--- a/turbopack/crates/turbo-tasks-fs/src/error.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/error.rs
@@ -1,0 +1,277 @@
+use core::mem::discriminant;
+#[cfg(windows)]
+use std::io::ErrorKind;
+use std::{
+    borrow::Cow,
+    fmt::{self, Display},
+    io,
+};
+
+use bincode::{Decode, Encode};
+use turbo_tasks::{NonLocalValue, ReadRef, trace::TraceRawVcs};
+
+use crate::{FileSystemPath, LinkContent};
+
+pub type FsResult<T, E = FileSystemError> = Result<T, E>;
+
+#[cfg(windows)]
+const ERROR_INVALID_FUNCTION: i32 = 1;
+
+#[derive(Debug, Eq, PartialEq, TraceRawVcs, NonLocalValue, Encode, Decode)]
+pub struct FileSystemError {
+    pub operation: FileSystemErrorOperation,
+    pub path: FileSystemPath,
+    pub source: FileSystemErrorSource,
+}
+
+impl FileSystemError {
+    // It might be possible for this to return a `StyledString`, but we'd need to move
+    // `StyledString` into a standalone crate.
+    pub fn hint(&self) -> Option<Cow<'static, str>> {
+        #[cfg(windows)]
+        use std::io::ErrorKind;
+        match (&self.operation, &self.source) {
+            #[cfg(windows)]
+            (
+                FileSystemErrorOperation::Link {
+                    creation_method: LinkCreationMethod::Symbolic,
+                    ..
+                },
+                FileSystemErrorSource::Io(err),
+            ) if err.kind() == ErrorKind::PermissionDenied => Some(Cow::Borrowed(
+                "Creating file symlinks on Windows require developer mode or admin permissions:\n\
+                 https://learn.microsoft.com/en-us/windows/advanced-settings/developer-mode",
+            )),
+            #[cfg(windows)]
+            (
+                FileSystemErrorOperation::Link {
+                    creation_method: LinkCreationMethod::Junction,
+                    ..
+                },
+                FileSystemErrorSource::Io(err),
+            ) if err.raw_os_error() == Some(ERROR_INVALID_FUNCTION) => Some(Cow::Borrowed(
+                "Creating junction points on Windows requires support from the filesystem. Check \
+                 that you're using an NTFS filesystem.",
+            )),
+            _ => None,
+        }
+    }
+}
+
+impl std::error::Error for FileSystemError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match &self.source {
+            FileSystemErrorSource::Io(err) => Some(err as &dyn std::error::Error),
+            FileSystemErrorSource::Anyhow(err) => err.source(),
+            _ => None,
+        }
+    }
+}
+
+/// Note: The `Display` implementation for `FileSystemError` exists as a fallback, but is not
+/// typically used in Turbopack. Turbopack should usually transform `FileSystemError`s into an
+/// `Issue` and use that for display purposes.
+///
+/// There is an implementation of `Issue` for `FileSystemError` in
+/// `turbopack-core/src/issue/fs_error.rs`.
+///
+/// Some of the `Display` implementations of the fields on `FileSystemError` are used by the `Issue`
+/// implementation.
+impl Display for FileSystemError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Failed to {} at {}: {}",
+            self.operation, self.path, self.source,
+        )
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, TraceRawVcs, NonLocalValue, Encode, Decode)]
+pub enum FileSystemErrorOperation {
+    Write,
+    Link {
+        creation_method: LinkCreationMethod,
+        content: ReadRef<LinkContent>,
+    },
+}
+
+impl Display for FileSystemErrorOperation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Write => write!(f, "write to file"),
+            Self::Link {
+                creation_method,
+                content,
+            } => match &**content {
+                LinkContent::Link { target, .. } => {
+                    write!(f, "create a {creation_method} pointing to {target}")
+                }
+                LinkContent::Invalid => {
+                    write!(f, "create a {creation_method} (invalid target)")
+                }
+                LinkContent::NotFound => {
+                    write!(f, "remove a {creation_method}")
+                }
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, TraceRawVcs, NonLocalValue, Encode, Decode)]
+pub enum LinkCreationMethod {
+    Symbolic,
+    #[cfg(windows)]
+    Junction,
+    /// The creation method could not be determined.
+    Unknown,
+}
+
+impl Display for LinkCreationMethod {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Symbolic => write!(f, "symbolic link"),
+            #[cfg(windows)]
+            Self::Junction => write!(f, "junction point"),
+            Self::Unknown => write!(f, "link"),
+        }
+    }
+}
+
+#[derive(Debug, TraceRawVcs, NonLocalValue, Encode, Decode)]
+pub enum FileSystemErrorSource {
+    Io(
+        #[bincode(with = "bincode_io_error")]
+        #[turbo_tasks(trace_ignore)]
+        io::Error,
+    ),
+    InvalidLinkTarget,
+    /// Path segment exceeds the maximum length (typically 255 bytes on Unix)
+    PathSegmentTooLong {
+        max_length: usize,
+    },
+    /// Full path exceeds the maximum length
+    PathTooLong {
+        max_length: usize,
+    },
+    /// A catch-all for other errors that haven't been migrated to use structured errors yet.
+    Anyhow(#[bincode(with = "bincode_anyhow_error")] anyhow::Error),
+}
+
+impl PartialEq for FileSystemErrorSource {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Io(l), Self::Io(r)) => l.to_string() == r.to_string(),
+            (
+                Self::PathSegmentTooLong { max_length: l },
+                Self::PathSegmentTooLong { max_length: r },
+            ) => l == r,
+            (Self::PathTooLong { max_length: l }, Self::PathTooLong { max_length: r }) => l == r,
+            (Self::Anyhow(l), Self::Anyhow(r)) => l.to_string() == r.to_string(),
+            _ => discriminant(self) == discriminant(other),
+        }
+    }
+}
+
+impl Eq for FileSystemErrorSource {}
+
+impl Display for FileSystemErrorSource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            FileSystemErrorSource::Io(err) => err.fmt(f),
+            FileSystemErrorSource::InvalidLinkTarget => write!(f, "link target is invalid"),
+            FileSystemErrorSource::PathSegmentTooLong { max_length } => {
+                write!(f, "path segment is too long (exceeds {max_length} bytes)")
+            }
+            FileSystemErrorSource::PathTooLong { max_length } => {
+                write!(f, "path is too long (exceeds {max_length} bytes)")
+            }
+            FileSystemErrorSource::Anyhow(err) => err.fmt(f),
+        }
+    }
+}
+
+/// Best effort string-based serialization for `io::Error`. Most of the functions that construct an
+/// `FileSystemError` are either effects or are marked as session-dependent, so most io errors won't
+/// be serialized.
+mod bincode_io_error {
+
+    use std::io;
+
+    use bincode::{
+        Decode, Encode,
+        de::{BorrowDecoder, Decoder},
+        enc::Encoder,
+        error::{DecodeError, EncodeError},
+    };
+
+    pub fn encode<E: Encoder>(err: &io::Error, encoder: &mut E) -> Result<(), EncodeError> {
+        err.to_string().encode(encoder)
+    }
+
+    pub fn decode<Context, D: Decoder<Context = Context>>(
+        decoder: &mut D,
+    ) -> Result<io::Error, DecodeError> {
+        let message = String::decode(decoder)?;
+        Ok(io::Error::other(message))
+    }
+
+    pub fn borrow_decode<'de, Context, D: BorrowDecoder<'de, Context = Context>>(
+        decoder: &mut D,
+    ) -> Result<io::Error, DecodeError> {
+        decode(decoder)
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use std::io::{self, ErrorKind};
+
+        use bincode::{Decode, Encode, decode_from_slice, encode_to_vec};
+
+        #[derive(Encode, Decode)]
+        struct Wrapper(#[bincode(with = "super")] io::Error);
+
+        #[test]
+        fn test_roundtrip() {
+            let cfg = bincode::config::standard();
+
+            let err1 = Wrapper(io::Error::new(ErrorKind::NotFound, "file not found"));
+            let err2: Wrapper = decode_from_slice(&encode_to_vec(&err1, cfg).unwrap(), cfg)
+                .unwrap()
+                .0;
+
+            // The `Display` implementation is equivalent
+            assert_eq!(err1.0.to_string(), err2.0.to_string());
+            // The kind becomes Other after roundtrip
+            assert_eq!(err2.0.kind(), ErrorKind::Other);
+        }
+    }
+}
+
+/// Best effort string-based serialization for `anyhow::Error`.
+mod bincode_anyhow_error {
+    use anyhow::anyhow;
+    use bincode::{
+        Decode, Encode,
+        de::{BorrowDecoder, Decoder},
+        enc::Encoder,
+        error::{DecodeError, EncodeError},
+    };
+
+    pub fn encode<E: Encoder>(err: &anyhow::Error, encoder: &mut E) -> Result<(), EncodeError> {
+        err.to_string().encode(encoder)
+    }
+
+    pub fn decode<Context, D: Decoder<Context = Context>>(
+        decoder: &mut D,
+    ) -> Result<anyhow::Error, DecodeError> {
+        let message = String::decode(decoder)?;
+        Ok(anyhow!(message))
+    }
+
+    pub fn borrow_decode<'de, Context, D: BorrowDecoder<'de, Context = Context>>(
+        decoder: &mut D,
+    ) -> Result<anyhow::Error, DecodeError> {
+        decode(decoder)
+    }
+}

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -15,6 +15,7 @@
 
 pub mod attach;
 pub mod embed;
+pub mod error;
 pub mod glob;
 mod globset;
 pub mod invalidation;
@@ -34,9 +35,8 @@ use std::{
     borrow::Cow,
     cmp::{Ordering, min},
     env,
-    error::Error as StdError,
     fmt::{self, Debug, Formatter},
-    fs::FileType,
+    fs::{FileType, create_dir_all},
     future::Future,
     io::{self, BufRead, BufReader, ErrorKind, Read, Write as _},
     mem::take,
@@ -76,6 +76,7 @@ use turbo_unix_path::{
 
 use crate::{
     attach::AttachedFileSystem,
+    error::{FileSystemError, FileSystemErrorOperation, FileSystemErrorSource, LinkCreationMethod},
     glob::Glob,
     invalidation::Write,
     invalidator_map::InvalidatorMap,
@@ -85,7 +86,6 @@ use crate::{
     read_glob::{read_glob, track_glob},
     retry::{can_retry, retry_blocking, retry_blocking_custom},
     rope::{Rope, RopeReader},
-    util::extract_disk_access,
     watcher::DiskWatcher,
 };
 pub use crate::{read_glob::ReadGlobResult, virtual_fs::VirtualFileSystem};
@@ -114,59 +114,53 @@ pub use crate::{read_glob::ReadGlobResult, virtual_fs::VirtualFileSystem};
 /// 255 characters, because it is the shortest of the three options.
 ///
 /// [PATH_MAX]: https://eklitzke.org/path-max-is-tricky
-pub fn validate_path_length(path: &Path) -> Result<Cow<'_, Path>> {
-    /// Here we check if the path is too long for windows, and if so, attempt to canonicalize it
-    /// to a UNC path.
-    fn validate_path_length_inner(path: &Path) -> Result<Cow<'_, Path>> {
-        if cfg!(windows) {
-            const MAX_PATH_LENGTH_WINDOWS: usize = 260;
-            const UNC_PREFIX: &str = "\\\\?\\";
+fn validate_path_length(path: &Path) -> Result<Cow<'_, Path>, FileSystemErrorSource> {
+    // Here we check if the path is too long for windows, and if so, attempt to canonicalize it
+    // to a UNC path.
+    if cfg!(windows) {
+        const MAX_PATH_LENGTH_WINDOWS: usize = 260;
+        const UNC_PREFIX: &str = "\\\\?\\";
 
-            if path.starts_with(UNC_PREFIX) {
-                return Ok(path.into());
-            }
-
-            if path.as_os_str().len() > MAX_PATH_LENGTH_WINDOWS {
-                let new_path = std::fs::canonicalize(path).map_err(|err| {
-                    anyhow!(err).context("file is too long, and could not be normalized")
-                })?;
-                return Ok(new_path.into());
-            }
-
-            Ok(path.into())
-        } else {
-            /// here we are only going to check if the total length exceeds, or the last segment
-            /// exceeds. This heuristic is primarily to avoid long file names, and it makes the
-            /// operation much cheaper.
-            const MAX_FILE_NAME_LENGTH_UNIX: usize = 255;
-            // macOS reports a limit of 1024, but I (@arlyon) have had issues with paths above 1016
-            // so we subtract a bit to be safe. on most linux distros this is likely a lot larger
-            // than 1024, but macOS is *special*
-            const MAX_PATH_LENGTH: usize = 1024 - 8;
-
-            // check the last segment (file name)
-            if path
-                .file_name()
-                .map(|n| n.as_encoded_bytes().len())
-                .unwrap_or(0)
-                > MAX_FILE_NAME_LENGTH_UNIX
-            {
-                anyhow::bail!(
-                    "file name is too long (exceeds {} bytes)",
-                    MAX_FILE_NAME_LENGTH_UNIX,
-                );
-            }
-
-            if path.as_os_str().len() > MAX_PATH_LENGTH {
-                anyhow::bail!("path is too long (exceeds {MAX_PATH_LENGTH} bytes)");
-            }
-
-            Ok(path.into())
+        if path.starts_with(UNC_PREFIX) {
+            return Ok(path.into());
         }
-    }
 
-    validate_path_length_inner(path)
-        .with_context(|| format!("path length for file {path:?} exceeds max length of filesystem"))
+        if path.as_os_str().len() > MAX_PATH_LENGTH_WINDOWS {
+            let new_path = std::fs::canonicalize(path).map_err(FileSystemErrorSource::Io)?;
+            return Ok(new_path.into());
+        }
+
+        Ok(path.into())
+    } else {
+        // Here we are only going to check if the total length exceeds, or the last segment exceeds.
+        // This heuristic is primarily to avoid long file names, and it makes the operation much
+        // cheaper.
+        const MAX_FILE_NAME_LENGTH_UNIX: usize = 255;
+        // macOS reports a limit of 1024, but I (@arlyon) have had issues with paths above 1016
+        // so we subtract a bit to be safe. on most linux distros this is likely a lot larger
+        // than 1024, but macOS is *special*
+        const MAX_PATH_LENGTH: usize = 1024 - 8;
+
+        // check the last segment (file name)
+        if path
+            .file_name()
+            .map(|n| n.as_encoded_bytes().len())
+            .unwrap_or(0)
+            > MAX_FILE_NAME_LENGTH_UNIX
+        {
+            return Err(FileSystemErrorSource::PathSegmentTooLong {
+                max_length: MAX_FILE_NAME_LENGTH_UNIX,
+            });
+        }
+
+        if path.as_os_str().len() > MAX_PATH_LENGTH {
+            return Err(FileSystemErrorSource::PathTooLong {
+                max_length: MAX_PATH_LENGTH,
+            });
+        }
+
+        Ok(path.into())
+    }
 }
 
 trait ConcurrencyLimitedExt {
@@ -487,7 +481,7 @@ impl DiskFileSystemInner {
         let root_path = self.root_path().to_path_buf();
 
         // create the directory for the filesystem on disk, if it doesn't exist
-        retry_blocking(|| std::fs::create_dir_all(&root_path))
+        retry_blocking(|| create_dir_all(&root_path))
             .instrument(tracing::info_span!("create root directory", name = ?root_path))
             .concurrency_limited(&self.write_semaphore)
             .await?;
@@ -939,13 +933,14 @@ impl FileSystem for DiskFileSystem {
         #[derive(TraceRawVcs, NonLocalValue)]
         struct WriteEffect {
             full_path: PathBuf,
+            fs_path: FileSystemPath,
             inner: Arc<DiskFileSystemInner>,
             content: ReadRef<PersistedFileContent>,
             content_hash: u128,
         }
 
         impl Effect for WriteEffect {
-            type Error = AnyhowWrapper;
+            type Error = FileSystemError;
 
             fn key(&self) -> Box<[u8]> {
                 self.full_path.as_os_str().as_encoded_bytes().into()
@@ -959,15 +954,14 @@ impl FileSystem for DiskFileSystem {
                 &self.inner.effect_state_storage
             }
 
-            async fn apply(&self) -> Result<(), AnyhowWrapper> {
-                self.apply_inner().await.map_err(AnyhowWrapper::from)
-            }
-        }
+            async fn apply(&self) -> Result<(), Self::Error> {
+                let make_err = |source: FileSystemErrorSource| FileSystemError {
+                    operation: FileSystemErrorOperation::Write,
+                    path: self.fs_path.clone(),
+                    source,
+                };
 
-        impl WriteEffect {
-            async fn apply_inner(&self) -> anyhow::Result<()> {
-                let full_path = validate_path_length(&self.full_path)?;
-
+                let full_path = validate_path_length(&self.full_path).map_err(&make_err)?;
                 let _lock = self.inner.lock_path(&full_path).await;
 
                 // We perform an untracked comparison here, so that this write is not dependent
@@ -980,7 +974,8 @@ impl FileSystem for DiskFileSystem {
                     .streaming_compare(&full_path)
                     .instrument(tracing::info_span!("read file before write", name = ?full_path))
                     .concurrency_limited(&self.inner.read_semaphore)
-                    .await?;
+                    .await
+                    .map_err(|err| make_err(FileSystemErrorSource::Io(err)))?;
                 if compare == FileComparison::Equal {
                     return Ok(());
                 }
@@ -1033,33 +1028,21 @@ impl FileSystem for DiskFileSystem {
                                 Err(e) if e.kind() == ErrorKind::NotFound => {
                                     // The parent directory doesn't exist. Create it and retry once.
                                     if let Some(parent) = full_path.parent() {
-                                        retry_blocking(|| std::fs::create_dir_all(parent))
+                                        retry_blocking(|| create_dir_all(parent))
                                             .instrument(tracing::info_span!(
                                                 "create directory",
                                                 name = ?parent
                                             ))
-                                            .await
-                                            .with_context(|| {
-                                                format!(
-                                                    "failed to create directory {parent:?} for \
-                                                     write to {full_path:?}",
-                                                )
-                                            })?;
+                                            .await?
                                     }
-                                    do_write().await.with_context(|| {
-                                        format!("failed to write to {full_path:?}")
-                                    })?;
+                                    do_write().await
                                 }
-                                result => {
-                                    result.with_context(|| {
-                                        format!("failed to write to {full_path:?}")
-                                    })?;
-                                }
+                                result => result,
                             }
-                            anyhow::Ok(())
                         }
                         .concurrency_limited(&self.inner.write_semaphore)
-                        .await?;
+                        .await
+                        .map_err(|err| make_err(FileSystemErrorSource::Io(err)))?;
                     }
                     PersistedFileContent::NotFound => {
                         retry_blocking(|| std::fs::remove_file(&full_path))
@@ -1073,7 +1056,7 @@ impl FileSystem for DiskFileSystem {
                                     Err(err)
                                 }
                             })
-                            .with_context(|| format!("removing {full_path:?} failed"))?;
+                            .map_err(|err| make_err(FileSystemErrorSource::Io(err)))?;
                     }
                 }
 
@@ -1087,6 +1070,7 @@ impl FileSystem for DiskFileSystem {
         let content_hash = u128::from_le_bytes(hash_xxh3_hash128(&*content));
         emit_effect(WriteEffect {
             full_path,
+            fs_path,
             inner,
             content,
             content_hash,
@@ -1101,7 +1085,6 @@ impl FileSystem for DiskFileSystem {
         // effect and does not need to be re-executed in the next session. All side effects are
         // re-executed in general.
 
-        // Check if path is denied - if so, return an error
         if self.inner.is_path_denied(&fs_path) {
             turbobail!("Cannot write link to denied path: {fs_path}");
         }
@@ -1114,13 +1097,14 @@ impl FileSystem for DiskFileSystem {
         #[derive(TraceRawVcs, NonLocalValue)]
         struct WriteLinkEffect {
             full_path: PathBuf,
+            fs_path: FileSystemPath,
             inner: Arc<DiskFileSystemInner>,
             content: ReadRef<LinkContent>,
             content_hash: u128,
         }
 
         impl Effect for WriteLinkEffect {
-            type Error = AnyhowWrapper;
+            type Error = FileSystemError;
 
             fn key(&self) -> Box<[u8]> {
                 self.full_path.as_os_str().as_encoded_bytes().into()
@@ -1134,14 +1118,23 @@ impl FileSystem for DiskFileSystem {
                 &self.inner.effect_state_storage
             }
 
-            async fn apply(&self) -> Result<(), AnyhowWrapper> {
-                self.apply_inner().await.map_err(AnyhowWrapper::from)
-            }
-        }
+            async fn apply(&self) -> Result<(), Self::Error> {
+                // Helper to construct link errors
+                let make_link_err = |source: FileSystemErrorSource,
+                                     creation_method: LinkCreationMethod|
+                 -> FileSystemError {
+                    FileSystemError {
+                        operation: FileSystemErrorOperation::Link {
+                            creation_method,
+                            content: self.content.clone(),
+                        },
+                        path: self.fs_path.clone(),
+                        source,
+                    }
+                };
 
-        impl WriteLinkEffect {
-            async fn apply_inner(&self) -> anyhow::Result<()> {
-                let full_path = validate_path_length(&self.full_path)?;
+                let full_path = validate_path_length(&self.full_path)
+                    .map_err(|source| make_link_err(source, LinkCreationMethod::Unknown))?;
 
                 let _lock = self.inner.lock_path(&full_path).await;
 
@@ -1211,6 +1204,16 @@ impl FileSystem for DiskFileSystem {
                     } => {
                         let full_path = full_path.into_owned();
 
+                        // Determine the creation method for error reporting
+                        #[cfg(not(windows))]
+                        let creation_method = LinkCreationMethod::Symbolic;
+                        #[cfg(windows)]
+                        let creation_method = if is_directory {
+                            LinkCreationMethod::Junction
+                        } else {
+                            LinkCreationMethod::Symbolic
+                        };
+
                         #[derive(thiserror::Error, Debug)]
                         #[error("{msg}: {source}")]
                         struct SymlinkCreationError {
@@ -1235,126 +1238,86 @@ impl FileSystem for DiskFileSystem {
                                 })?;
                                 has_old_content = false;
                             }
-                            #[cfg(not(windows))]
-                            let io_result = std::os::unix::fs::symlink(&target, &full_path);
-                            #[cfg(windows)]
-                            let io_result = if is_directory {
-                                std::os::windows::fs::junction_point(&target, &full_path)
-                            } else {
-                                std::os::windows::fs::symlink_file(&target, &full_path)
-                            };
-                            io_result.map_err(|err| {
-                                if err.kind() == ErrorKind::AlreadyExists {
+                            let mut created_parent_directories = false;
+                            loop {
+                                #[cfg(not(windows))]
+                                let io_result = std::os::unix::fs::symlink(&target, &full_path);
+                                #[cfg(windows)]
+                                let io_result = if is_directory {
+                                    std::os::windows::fs::junction_point(&target, &full_path)
+                                } else {
+                                    std::os::windows::fs::symlink_file(&target, &full_path)
+                                };
+                                let Err(err) = io_result else {
+                                    return Ok(());
+                                };
+                                match err.kind() {
                                     // try to remove the symlink on the next iteration of the loop
-                                    has_old_content = true;
+                                    ErrorKind::AlreadyExists => {
+                                        has_old_content = true;
+                                    }
+                                    // the parent directory may not exist, create it if needed
+                                    ErrorKind::NotFound
+                                        if !created_parent_directories
+                                            && let Some(parent) = full_path.parent() =>
+                                    {
+                                        if let Err(err) = create_dir_all(parent) {
+                                            return Err(SymlinkCreationError {
+                                                msg: "creation of parent directory for symlink or \
+                                                      junction point failed",
+                                                source: err,
+                                            });
+                                        }
+                                        // retry link creation immediately, it will likely succeed
+                                        created_parent_directories = true;
+                                        continue;
+                                    }
+                                    _ => {}
                                 }
-                                SymlinkCreationError {
+                                return Err(SymlinkCreationError {
                                     msg: "creation of a new symbolic link or junction point failed",
                                     source: err,
-                                }
-                            })
+                                });
+                            }
                         };
                         fn can_retry_link(err: &SymlinkCreationError) -> bool {
-                            err.source.kind() == ErrorKind::AlreadyExists || can_retry(&err.source)
+                            matches!(
+                                err.source.kind(),
+                                ErrorKind::AlreadyExists | ErrorKind::NotFound
+                            ) || can_retry(&err.source)
                         }
-                        let err_context = || {
-                            #[cfg(not(windows))]
-                            let message = format!(
-                                "failed to create symlink at {full_path:?} pointing to {target:?}"
-                            );
-                            #[cfg(windows)]
-                            let message = if is_directory {
-                                format!(
-                                    "failed to create junction point at {full_path:?} pointing to \
-                                     {target:?}"
+                        retry_blocking_custom(try_create_link, can_retry_link)
+                            .instrument(tracing::info_span!(
+                                "write symlink",
+                                name = ?full_path,
+                                target = ?target,
+                            ))
+                            .concurrency_limited(&self.inner.write_semaphore)
+                            .await
+                            .map_err(|err| {
+                                make_link_err(
+                                    FileSystemErrorSource::Io(err.source),
+                                    creation_method,
                                 )
-                            } else {
-                                format!(
-                                    "failed to create symlink at {full_path:?} pointing to \
-                                     {target:?}\n\
-                                    (Note: creating file symlinks on Windows require developer \
-                                     mode or admin permissions: \
-                                     https://learn.microsoft.com/en-us/windows/advanced-settings/developer-mode)",
-                                )
-                            };
-                            message
-                        };
-                        async {
-                            let write_result =
-                                retry_blocking_custom(try_create_link, can_retry_link)
-                                    .instrument(tracing::info_span!(
-                                        "write symlink",
-                                        name = ?full_path,
-                                        target = ?target,
-                                    ))
-                                    .await;
-
-                            match write_result {
-                                Err(ref e) if e.source.kind() == ErrorKind::NotFound => {
-                                    // Parent directory doesn't exist. Create it and retry once.
-                                    if let Some(parent) = full_path.parent() {
-                                        retry_blocking(|| std::fs::create_dir_all(parent))
-                                            .instrument(tracing::info_span!(
-                                                "create directory",
-                                                name = ?parent
-                                            ))
-                                            .await
-                                            .with_context(|| {
-                                                format!(
-                                                    "failed to create directory {parent:?} for \
-                                                     write link to {full_path:?}",
-                                                )
-                                            })?;
-                                    }
-                                    // After the first attempt, any pre-existing link was already
-                                    // removed (has_old_content is now false), so just create.
-                                    retry_blocking_custom(
-                                        || {
-                                            #[cfg(not(windows))]
-                                            let io_result =
-                                                std::os::unix::fs::symlink(&target, &full_path);
-                                            #[cfg(windows)]
-                                            let io_result = if is_directory {
-                                                std::os::windows::fs::junction_point(
-                                                    &target, &full_path,
-                                                )
-                                            } else {
-                                                std::os::windows::fs::symlink_file(
-                                                    &target, &full_path,
-                                                )
-                                            };
-                                            io_result.map_err(|err| SymlinkCreationError {
-                                                msg: "creation of a new symbolic link or junction \
-                                                      point failed",
-                                                source: err,
-                                            })
-                                        },
-                                        |e: &SymlinkCreationError| can_retry(&e.source),
-                                    )
-                                    .instrument(tracing::info_span!(
-                                        "write symlink",
-                                        name = ?full_path,
-                                        target = ?target,
-                                    ))
-                                    .await
-                                    .with_context(err_context)?;
-                                }
-                                result => result.with_context(err_context)?,
-                            }
-                            anyhow::Ok(())
-                        }
-                        .concurrency_limited(&self.inner.write_semaphore)
-                        .await?;
+                            })?;
                     }
                     OsSpecificLinkContent::Invalid => {
-                        bail!("invalid symlink target: {full_path:?}");
+                        return Err(make_link_err(
+                            FileSystemErrorSource::InvalidLinkTarget,
+                            LinkCreationMethod::Unknown,
+                        ));
                     }
                     OsSpecificLinkContent::NotFound => {
                         retry_blocking(|| remove_symbolic_link_dir_helper(&full_path))
                             .instrument(tracing::info_span!("remove symlink", name = ?full_path))
                             .concurrency_limited(&self.inner.write_semaphore)
                             .await
-                            .with_context(|| format!("removing {full_path:?} failed"))?;
+                            .map_err(|err| {
+                                make_link_err(
+                                    FileSystemErrorSource::Io(err),
+                                    LinkCreationMethod::Unknown,
+                                )
+                            })?;
                     }
                 }
 
@@ -1368,6 +1331,7 @@ impl FileSystem for DiskFileSystem {
         let content_hash = u128::from_le_bytes(hash_xxh3_hash128(&*content));
         emit_effect(WriteLinkEffect {
             full_path,
+            fs_path,
             inner,
             content,
             content_hash,
@@ -2015,27 +1979,35 @@ pub enum PersistedFileContent {
 }
 
 impl PersistedFileContent {
-    /// Performs a comparison of self's data against a disk file's streamed read.
-    async fn streaming_compare(&self, path: &Path) -> Result<FileComparison> {
-        let old_file =
-            extract_disk_access(retry_blocking(|| std::fs::File::open(path)).await, path)?;
-        let Some(old_file) = old_file else {
-            return Ok(match self {
-                PersistedFileContent::NotFound => FileComparison::Equal,
-                _ => FileComparison::Create,
-            });
+    /// Performs a comparison of self's data against a disk file's streamed
+    /// read.
+    async fn streaming_compare(&self, path: &Path) -> io::Result<FileComparison> {
+        let old_file = match retry_blocking(|| std::fs::File::open(path)).await {
+            Ok(file) => file,
+            Err(e) if matches!(e.kind(), ErrorKind::NotFound | ErrorKind::InvalidFilename) => {
+                return Ok(match self {
+                    PersistedFileContent::NotFound => FileComparison::Equal,
+                    _ => FileComparison::Create,
+                });
+            }
+            Err(e) => return Err(e),
         };
+
         // We know old file exists, does the new file?
         let PersistedFileContent::Content(new_file) = self else {
             return Ok(FileComparison::NotEqual);
         };
 
-        let old_meta = extract_disk_access(retry_blocking(|| old_file.metadata()).await, path)?;
-        let Some(old_meta) = old_meta else {
-            // If we failed to get meta, then the old file has been deleted between the
-            // handle open. In which case, we just pretend the file never existed.
-            return Ok(FileComparison::Create);
+        let old_meta = match retry_blocking(|| old_file.metadata()).await {
+            Ok(meta) => meta,
+            Err(e) if matches!(e.kind(), ErrorKind::NotFound | ErrorKind::InvalidFilename) => {
+                // If we failed to get meta, then the old file has been deleted between the
+                // handle open. In which case, we just pretend the file never existed.
+                return Ok(FileComparison::Create);
+            }
+            Err(e) => return Err(e),
         };
+
         // If the meta is different, we need to rewrite the file to update it.
         if new_file.meta != old_meta.into() {
             return Ok(FileComparison::NotEqual);
@@ -2905,35 +2877,6 @@ async fn realpath_with_links(path: FileSystemPath) -> Result<Vc<RealPathResult>>
         symlinks: symlinks.into_iter().collect(),
     }
     .cell())
-}
-
-/// Wrapper to convert [`anyhow::Error`] to `impl std::error::Error` for use in [`Effect::apply`].
-// TODO(bgw): use a structured error type instead of anyhow for write/write_link
-#[derive(TraceRawVcs, NonLocalValue)]
-pub(crate) struct AnyhowWrapper(anyhow::Error);
-
-impl fmt::Display for AnyhowWrapper {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(&self.0, f)
-    }
-}
-
-impl fmt::Debug for AnyhowWrapper {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Debug::fmt(&self.0, f)
-    }
-}
-
-impl StdError for AnyhowWrapper {
-    fn source(&self) -> Option<&(dyn StdError + 'static)> {
-        self.0.source()
-    }
-}
-
-impl From<anyhow::Error> for AnyhowWrapper {
-    fn from(err: anyhow::Error) -> Self {
-        AnyhowWrapper(err)
-    }
 }
 
 #[cfg(test)]

--- a/turbopack/crates/turbo-tasks-fs/src/util.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/util.rs
@@ -1,24 +1,9 @@
-use std::{
-    io::{self, ErrorKind},
-    path::{Path, PathBuf},
-};
+use std::path::PathBuf;
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Context, Result};
 use turbo_tasks::ResolvedVc;
 
 use crate::{DiskFileSystem, FileSystemPath};
-
-/// Converts a disk access `Result<T>` into a `Result<Some<T>>`, where a [`ErrorKind::NotFound`] (or
-/// [`ErrorKind::InvalidFilename`]) error results in a [`None`] value. This is purely to reduce
-/// boilerplate code comparing [`ErrorKind::NotFound`] errors against all other errors.
-pub fn extract_disk_access<T>(value: io::Result<T>, path: &Path) -> Result<Option<T>> {
-    match value {
-        Ok(v) => Ok(Some(v)),
-        Err(e) if matches!(e.kind(), ErrorKind::NotFound | ErrorKind::InvalidFilename) => Ok(None),
-        // ast-grep-ignore: no-context-format
-        Err(e) => Err(anyhow!(e).context(format!("reading file {}", path.display()))),
-    }
-}
 
 pub async fn uri_from_file(root: FileSystemPath, path: Option<&str>) -> Result<String> {
     let root_fs = root.fs;

--- a/turbopack/crates/turbopack-cli-utils/src/issue.rs
+++ b/turbopack/crates/turbopack-cli-utils/src/issue.rs
@@ -395,7 +395,7 @@ impl IssueReporter for ConsoleUi {
         } = self.options;
         let mut grouped_issues: GroupedIssues = FxHashMap::default();
 
-        let plain_issues = issues.get_plain_issues(IssueFilter::everything()).await?;
+        let plain_issues = issues.get_plain_issues(&IssueFilter::everything()).await?;
         let issues = plain_issues
             .iter()
             .map(|plain_issue| {

--- a/turbopack/crates/turbopack-core/src/issue/fs_error.rs
+++ b/turbopack/crates/turbopack-core/src/issue/fs_error.rs
@@ -1,0 +1,43 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use turbo_rcstr::{RcStr, rcstr};
+use turbo_tasks_fs::{FileSystemPath, error::FileSystemError};
+
+use crate::issue::{Issue, IssueStage, StyledString};
+
+#[turbo_tasks::value(shared)]
+pub struct FileSystemErrorIssue(pub(crate) Arc<FileSystemError>);
+
+#[async_trait]
+#[turbo_tasks::value_impl]
+impl Issue for FileSystemErrorIssue {
+    async fn file_path(&self) -> Result<FileSystemPath> {
+        Ok(self.0.path.clone())
+    }
+
+    fn stage(&self) -> IssueStage {
+        IssueStage::WriteOutput
+    }
+
+    async fn title(&self) -> Result<StyledString> {
+        Ok(StyledString::Text(rcstr!("File system operation failed")))
+    }
+
+    async fn description(&self) -> Result<Option<StyledString>> {
+        let mut stack = vec![StyledString::Line(vec![
+            StyledString::Text(rcstr!("Failed to ")),
+            StyledString::Text(RcStr::from(self.0.operation.to_string())),
+            StyledString::Text(rcstr!(": ")),
+            StyledString::Text(RcStr::from(self.0.source.to_string())),
+        ])];
+        if let Some(hint) = self.0.hint() {
+            stack.extend([
+                StyledString::Line(Vec::new()), // empty line
+                StyledString::Text(RcStr::from(hint)),
+            ]);
+        }
+        Ok(Some(StyledString::Stack(stack)))
+    }
+}

--- a/turbopack/crates/turbopack-core/src/issue/mod.rs
+++ b/turbopack/crates/turbopack-core/src/issue/mod.rs
@@ -301,85 +301,12 @@ impl IssueFilter {
     /// Returns true if the issue is allowed by this filter.
     #[turbo_tasks::function]
     pub async fn matches(&self, issue: ResolvedVc<Box<dyn Issue>>) -> Result<Vc<bool>> {
-        let has_no_ignore_rules = self.ignore_rules.is_empty();
-        let is_everything = self.severity == IssueSeverity::Info
-            && self.foreign_severity == IssueSeverity::Info
-            && has_no_ignore_rules;
-
-        if is_everything {
-            return Ok(Vc::cell(true));
-        }
-
-        let trait_ref = issue.into_trait_ref().await?;
-
-        // Fetch the file path once — it's used by both severity and ignore-rule
-        // checks.
-        let file_path = trait_ref.file_path().await?;
-
-        // Check severity first — this is cheap and avoids fetching
-        // title/description for issues that would be filtered out anyway.
-        let severity = trait_ref.severity();
-        // NOTE: Lower severities are _more_ severe
-        let severity_allowed = if severity <= self.severity || severity <= self.foreign_severity {
-            // we need to check the path to see if it is foreign or not.  Only await the
-            // path if it might possibly matter
-            if severity <= self.severity && severity <= self.foreign_severity {
-                // it matches no matter where the path is
-                true
-            } else if ContextCondition::InNodeModules.matches(&file_path) {
-                severity <= self.foreign_severity
-            } else {
-                severity <= self.severity
-            }
-        } else {
-            // it is too low severity to match either way
-            false
-        };
-
-        if !severity_allowed {
-            return Ok(Vc::cell(false));
-        }
-
-        // Check ignore rules — if any rule matches, the issue is dropped.
-        // Title and description are fetched lazily: only when a rule's path
-        // matches and the rule also specifies a title/description pattern.
-        if !has_no_ignore_rules {
-            let file_path_str = file_path.to_string();
-            let mut title_str: Option<String> = None;
-            let mut description_text: Option<Option<String>> = None;
-
-            for rule in &self.ignore_rules {
-                if !rule.path.matches(&file_path_str) {
-                    continue;
-                }
-                if let Some(ref title_pat) = rule.title {
-                    if title_str.is_none() {
-                        title_str = Some(trait_ref.title().await?.to_unstyled_string());
-                    }
-                    if !title_pat.matches(title_str.as_deref().unwrap()) {
-                        continue;
-                    }
-                }
-                if let Some(ref desc_pat) = rule.description {
-                    if description_text.is_none() {
-                        description_text = Some(
-                            trait_ref
-                                .description()
-                                .await?
-                                .map(|s| s.to_unstyled_string()),
-                        );
-                    }
-                    match description_text.as_ref().unwrap().as_deref() {
-                        Some(desc) if desc_pat.matches(desc) => {}
-                        _ => continue,
-                    }
-                }
-                // All specified fields matched — ignore this issue.
-                return Ok(Vc::cell(false));
-            }
-        }
-
-        Ok(Vc::cell(true))
+        Ok(Vc::cell(
+            self.matches_all_fast_path()
+                || self
+                    .matches_ref_slow_path(&*issue.into_trait_ref().await?)
+                    .await?,
+        ))
     }
 }
 
@@ -398,6 +325,83 @@ impl IssueFilter {
         self.ignore_rules = rules;
         self
     }
+
+    pub async fn matches_ref(&self, issue: &dyn Issue) -> Result<bool> {
+        Ok(self.matches_all_fast_path() || self.matches_ref_slow_path(issue).await?)
+    }
+
+    fn matches_all_fast_path(&self) -> bool {
+        self.severity == IssueSeverity::Info
+            && self.foreign_severity == IssueSeverity::Info
+            && self.ignore_rules.is_empty()
+    }
+
+    async fn matches_ref_slow_path(&self, issue: &dyn Issue) -> Result<bool> {
+        // Fetch the file path once — it's used by both severity and ignore-rule
+        // checks.
+        let file_path = issue.file_path().await?;
+
+        // Check severity first — this is cheap and avoids fetching
+        // title/description for issues that would be filtered out anyway.
+        let severity = issue.severity();
+        // NOTE: Lower severities are _more_ severe
+        let severity_allowed = if severity <= self.severity || severity <= self.foreign_severity {
+            // we need to check the path to see if it is foreign or not.  Only await the
+            // path if it might possibly matter
+            if severity <= self.severity && severity <= self.foreign_severity {
+                // it matches no matter where the path is
+                true
+            } else if ContextCondition::InNodeModules.matches(&file_path) {
+                severity <= self.foreign_severity
+            } else {
+                severity <= self.severity
+            }
+        } else {
+            // it is too low severity to match either way
+            false
+        };
+
+        if !severity_allowed {
+            return Ok(false);
+        }
+
+        // Check ignore rules — if any rule matches, the issue is dropped.
+        // Title and description are fetched lazily: only when a rule's path
+        // matches and the rule also specifies a title/description pattern.
+        if !self.ignore_rules.is_empty() {
+            let file_path_str = file_path.to_string();
+            let mut title_str: Option<String> = None;
+            let mut description_text: Option<Option<String>> = None;
+
+            for rule in &self.ignore_rules {
+                if !rule.path.matches(&file_path_str) {
+                    continue;
+                }
+                if let Some(ref title_pat) = rule.title {
+                    if title_str.is_none() {
+                        title_str = Some(issue.title().await?.to_unstyled_string());
+                    }
+                    if !title_pat.matches(title_str.as_deref().unwrap()) {
+                        continue;
+                    }
+                }
+                if let Some(ref desc_pat) = rule.description {
+                    if description_text.is_none() {
+                        description_text =
+                            Some(issue.description().await?.map(|s| s.to_unstyled_string()));
+                    }
+                    match description_text.as_ref().unwrap().as_deref() {
+                        Some(desc) if desc_pat.matches(desc) => {}
+                        _ => continue,
+                    }
+                }
+                // All specified fields matched — ignore this issue.
+                return Ok(false);
+            }
+        }
+
+        Ok(true)
+    }
 }
 
 /// A list of issues captured with [`CollectibleIssuesExt::peek_issues`].
@@ -415,15 +419,12 @@ impl CapturedIssues {
     }
 
     // Returns all the issues as formatted `PlainIssues`.
-    pub async fn get_plain_issues(
-        &self,
-        filter: Vc<IssueFilter>,
-    ) -> Result<Vec<ReadRef<PlainIssue>>> {
+    pub async fn get_plain_issues(&self, filter: &IssueFilter) -> Result<Vec<ReadRef<PlainIssue>>> {
         let mut list = self
             .issues
             .iter()
             .map(async |issue| {
-                if *filter.matches(**issue).await? {
+                if *filter.matches_ref(**issue).await? {
                     Ok(Some(
                         PlainIssue::from_issue(**issue, Some(*self.tracer)).await?,
                     ))
@@ -975,12 +976,24 @@ impl PlainIssue {
         issue: ResolvedVc<Box<dyn Issue>>,
         import_tracer: Option<ResolvedVc<DelegatingImportTracer>>,
     ) -> Result<Vc<Self>> {
-        let trait_ref = issue.into_trait_ref().await?;
+        Ok(
+            Self::from_issue_ref(&*issue.into_trait_ref().await?, import_tracer)
+                .await?
+                .cell(),
+        )
+    }
+}
+
+impl PlainIssue {
+    pub async fn from_issue_ref(
+        trait_ref: &dyn Issue,
+        import_tracer: Option<ResolvedVc<DelegatingImportTracer>>,
+    ) -> Result<Self> {
         let severity = trait_ref.severity();
         let file_path = trait_ref.file_path().await?;
         let file_path_str = file_path.to_string_ref().await?;
 
-        Ok(Self::cell(Self {
+        Ok(Self {
             severity,
             file_path: file_path_str,
             stage: trait_ref.stage(),
@@ -1015,7 +1028,7 @@ impl PlainIssue {
                 }
                 None => vec![],
             },
-        }))
+        })
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/issue/mod.rs
+++ b/turbopack/crates/turbopack-core/src/issue/mod.rs
@@ -1,5 +1,6 @@
 pub mod analyze;
 pub mod code_gen;
+pub mod fs_error;
 pub mod module;
 pub mod resolve;
 
@@ -863,6 +864,7 @@ pub enum IssueStage {
     Bindings,
     CodeGen,
     Emit,
+    WriteOutput,
     Unsupported,
     Misc,
     Other(RcStr),
@@ -884,6 +886,7 @@ impl Display for IssueStage {
             IssueStage::Emit => write!(f, "emit"),
             IssueStage::Unsupported => write!(f, "unsupported"),
             IssueStage::AppStructure => write!(f, "app structure"),
+            IssueStage::WriteOutput => write!(f, "write output"),
             IssueStage::Misc => write!(f, "misc"),
             IssueStage::Other(s) => write!(f, "{s}"),
         }

--- a/turbopack/crates/turbopack-core/src/issue/mod.rs
+++ b/turbopack/crates/turbopack-core/src/issue/mod.rs
@@ -282,7 +282,7 @@ pub struct IssueFilter {
     /// The minimum severity for issues in node_modules
     foreign_severity: IssueSeverity,
     /// Issues matching any of these rules are ignored (dropped from results).
-    ignore_rules: Vec<IgnoreIssue>,
+    ignore_rules: Box<[IgnoreIssue]>,
 }
 
 impl IssueFilter {
@@ -291,7 +291,7 @@ impl IssueFilter {
         IssueFilter {
             severity: IssueSeverity::Info,
             foreign_severity: IssueSeverity::Info,
-            ignore_rules: Vec::new(),
+            ignore_rules: Box::from([]),
         }
     }
 
@@ -300,12 +300,12 @@ impl IssueFilter {
         IssueFilter {
             severity: IssueSeverity::Warning,
             foreign_severity: IssueSeverity::Error,
-            ignore_rules: Vec::new(),
+            ignore_rules: Box::from([]),
         }
     }
 
     /// Set the ignore rules for this filter.
-    pub fn with_ignore_rules(mut self, rules: Vec<IgnoreIssue>) -> Self {
+    pub fn with_ignore_rules(mut self, rules: Box<[IgnoreIssue]>) -> Self {
         self.ignore_rules = rules;
         self
     }

--- a/turbopack/crates/turbopack-core/src/issue/mod.rs
+++ b/turbopack/crates/turbopack-core/src/issue/mod.rs
@@ -285,32 +285,16 @@ pub struct IssueFilter {
     ignore_rules: Vec<IgnoreIssue>,
 }
 
-#[turbo_tasks::value_impl]
 impl IssueFilter {
     /// A filter that lets everything through.
-    #[turbo_tasks::function]
-    pub fn everything() -> Vc<Self> {
+    pub fn everything() -> Self {
         IssueFilter {
             severity: IssueSeverity::Info,
             foreign_severity: IssueSeverity::Info,
             ignore_rules: Vec::new(),
         }
-        .cell()
     }
 
-    /// Returns true if the issue is allowed by this filter.
-    #[turbo_tasks::function]
-    pub async fn matches(&self, issue: ResolvedVc<Box<dyn Issue>>) -> Result<Vc<bool>> {
-        Ok(Vc::cell(
-            self.matches_all_fast_path()
-                || self
-                    .matches_ref_slow_path(&*issue.into_trait_ref().await?)
-                    .await?,
-        ))
-    }
-}
-
-impl IssueFilter {
     /// Construct a filter with the standard warning/foreign-error severities.
     pub fn warnings_and_foreign_errors() -> Self {
         IssueFilter {
@@ -324,6 +308,14 @@ impl IssueFilter {
     pub fn with_ignore_rules(mut self, rules: Vec<IgnoreIssue>) -> Self {
         self.ignore_rules = rules;
         self
+    }
+
+    /// Returns true if the issue is allowed by this filter.
+    pub async fn matches(&self, issue: ResolvedVc<Box<dyn Issue>>) -> Result<bool> {
+        Ok(self.matches_all_fast_path()
+            || self
+                .matches_ref_slow_path(&*issue.into_trait_ref().await?)
+                .await?)
     }
 
     pub async fn matches_ref(&self, issue: &dyn Issue) -> Result<bool> {
@@ -424,7 +416,7 @@ impl CapturedIssues {
             .issues
             .iter()
             .map(async |issue| {
-                if *filter.matches_ref(**issue).await? {
+                if filter.matches(*issue).await? {
                     Ok(Some(
                         PlainIssue::from_issue(**issue, Some(*self.tracer)).await?,
                     ))

--- a/turbopack/crates/turbopack-dev-server/src/update/stream.rs
+++ b/turbopack/crates/turbopack-dev-server/src/update/stream.rs
@@ -90,7 +90,7 @@ impl GetContentFn {
 async fn peek_issues<T: Send>(source: OperationVc<T>) -> Result<Vec<ReadRef<PlainIssue>>> {
     let captured = source.peek_issues();
 
-    captured.get_plain_issues(IssueFilter::everything()).await
+    captured.get_plain_issues(&IssueFilter::everything()).await
 }
 
 fn extend_issues(issues: &mut Vec<ReadRef<PlainIssue>>, new_issues: Vec<ReadRef<PlainIssue>>) {

--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -638,7 +638,7 @@ async fn snapshot_issues(
 
     let plain_issues = run_result_op
         .peek_issues()
-        .get_plain_issues(IssueFilter::everything())
+        .get_plain_issues(&IssueFilter::everything())
         .await?;
 
     turbopack_test_utils::snapshot::snapshot_issues(plain_issues, path.join("issues")?, &REPO_ROOT)

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -234,7 +234,7 @@ async fn run(resource: PathBuf) -> Result<()> {
 
             let plain_issues = out_op
                 .peek_issues()
-                .get_plain_issues(IssueFilter::everything())
+                .get_plain_issues(&IssueFilter::everything())
                 .await?;
 
             snapshot_issues(plain_issues, out_vc.join("issues")?, &REPO_ROOT)


### PR DESCRIPTION
This was previously https://github.com/vercel/next.js/pull/89326 but I had to recreate the branch due to branch protection rules.

We'd like to create `Issue`s when IO operations fail, so `FsError` is basically that:
- `FsError` is a structured error type, so we can track things like `FileSystemPath` (note: this type contains a `Vc`).
- There's an implementation of `Issue` on `FsError`. This implementation lives in `turbopack-core` due to crate-ordering issues.

## What's missing

- At the top-level, when we apply effects, we need to also need to attempt to downcast errors and collect them as issues to avoid surfacing the `FsError`s as an internal error.
- We also want to emit issues for failed reads and other filesystem operations.