### PR TITLE
Draft: Turbopack: Add downcasting logic for fs errors

### DIFF
--- a/crates/next-build-test/src/lib.rs
+++ b/crates/next-build-test/src/lib.rs
@@ -279,7 +279,7 @@ async fn endpoint_write_to_disk_with_apply(
         output_paths,
         effects,
     } = &*op.read_strongly_consistent().await?;
-    effects.apply().await?;
+    effects.apply_anyhow().await?;
 
     Ok(output_paths.clone())
 }

--- a/crates/next-napi-bindings/src/next_api/analyze.rs
+++ b/crates/next-napi-bindings/src/next_api/analyze.rs
@@ -8,7 +8,7 @@ use next_api::{
 };
 use turbo_tasks::{Effects, ReadRef, ResolvedVc, TryJoinIterExt, Vc};
 use turbopack_core::{
-    issue::PlainIssue,
+    issue::{IssueFilter, PlainIssue},
     output::{OutputAsset, OutputAssets},
 };
 
@@ -16,8 +16,9 @@ use crate::next_api::utils::strongly_consistent_catch_collectables;
 
 #[turbo_tasks::value(serialization = "skip")]
 pub struct WriteAnalyzeResult {
-    pub issues: Arc<Vec<ReadRef<PlainIssue>>>,
+    pub issues: Arc<[ReadRef<PlainIssue>]>,
     pub effects: Arc<Effects>,
+    pub filter: ResolvedVc<IssueFilter>,
 }
 
 #[turbo_tasks::function(operation, root)]
@@ -26,12 +27,17 @@ pub async fn write_analyze_data_with_issues_operation(
     app_dir_only: bool,
 ) -> Result<Vc<WriteAnalyzeResult>> {
     let analyze_data_op = write_analyze_data_with_issues_operation_inner(project, app_dir_only);
-    let filter = project.project().issue_filter().await?;
+    let filter = project.project().issue_filter().to_resolved().await?;
 
     let (_analyze_data, issues, effects) =
-        strongly_consistent_catch_collectables(analyze_data_op, &filter).await?;
+        strongly_consistent_catch_collectables(analyze_data_op, &*filter.await?).await?;
 
-    Ok(WriteAnalyzeResult { issues, effects }.cell())
+    Ok(WriteAnalyzeResult {
+        issues,
+        effects,
+        filter,
+    }
+    .cell())
 }
 
 #[turbo_tasks::function(operation, root)]

--- a/crates/next-napi-bindings/src/next_api/endpoint.rs
+++ b/crates/next-napi-bindings/src/next_api/endpoint.rs
@@ -128,7 +128,7 @@ struct WrittenEndpointWithIssues {
     written: Option<ReadRef<EndpointOutputPaths>>,
     issues: Arc<[ReadRef<PlainIssue>]>,
     effects: Arc<Effects>,
-    filter: ResolvedVc<IssueFilter>,
+    filter: ReadRef<IssueFilter>,
 }
 
 #[turbo_tasks::function(operation, root)]

--- a/crates/next-napi-bindings/src/next_api/endpoint.rs
+++ b/crates/next-napi-bindings/src/next_api/endpoint.rs
@@ -14,8 +14,11 @@ use next_api::{
 };
 use tracing::Instrument;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{Completion, Effects, OperationVc, ReadRef, Vc};
-use turbopack_core::issue::{IssueFilter, PlainIssue};
+use turbo_tasks::{Completion, Effects, OperationVc, ReadRef, ResolvedVc, Vc};
+use turbopack_core::{
+    effect::apply_effects_with_plain_issues,
+    issue::{IssueFilter, PlainIssue, extend_issues},
+};
 
 use crate::next_api::utils::{
     DetachedVc, NapiIssue, RootTask, TurbopackResult, strongly_consistent_catch_collectables,
@@ -123,8 +126,9 @@ async fn issue_filter_from_endpoint(
 #[turbo_tasks::value(serialization = "skip")]
 struct WrittenEndpointWithIssues {
     written: Option<ReadRef<EndpointOutputPaths>>,
-    issues: Arc<Vec<ReadRef<PlainIssue>>>,
+    issues: Arc<[ReadRef<PlainIssue>]>,
     effects: Arc<Effects>,
+    filter: ResolvedVc<IssueFilter>,
 }
 
 #[turbo_tasks::function(operation, root)]
@@ -134,11 +138,12 @@ async fn get_written_endpoint_with_issues_operation(
     let write_to_disk_op = endpoint_write_to_disk_operation(endpoint_op);
     let filter = issue_filter_from_endpoint(endpoint_op).await;
     let (written, issues, effects) =
-        strongly_consistent_catch_collectables(write_to_disk_op, &filter).await?;
+        strongly_consistent_catch_collectables(write_to_disk_op, &*filter.await?).await?;
     Ok(WrittenEndpointWithIssues {
         written,
         issues,
         effects,
+        filter,
     }
     .cell())
 }
@@ -160,12 +165,14 @@ pub async fn endpoint_write_to_disk(
                 written,
                 issues,
                 effects,
+                filter,
             } = &*written_entrypoint_with_issues_op
                 .read_strongly_consistent()
                 .await?;
-            effects.apply().await?;
+            let effect_plain_issues = apply_effects_with_plain_issues(effects, *filter).await?;
+            let issues = extend_issues(issues, &effect_plain_issues);
 
-            Ok((written.clone(), issues.clone()))
+            Ok((written.clone(), issues))
         })
         .or_else(|e| ctx.throw_turbopack_internal_result(&e.into()))
         .await?;
@@ -189,20 +196,18 @@ pub fn endpoint_server_changed_subscribe(
         func,
         move || {
             async move {
-                let issues_and_diags_op = subscribe_issues_and_diags_operation(endpoint, issues);
-                let result = issues_and_diags_op.read_strongly_consistent().await?;
-                result.effects.apply().await?;
-                Ok(result)
+                let result = subscribe_issues_and_effects_operation(endpoint, issues)
+                    .read_strongly_consistent()
+                    .await?;
+                let effect_plain_issues =
+                    apply_effects_with_plain_issues(&result.effects, result.filter).await?;
+                let issues = extend_issues(&result.issues, &effect_plain_issues);
+                Ok(issues)
             }
             .instrument(tracing::info_span!("server changes subscription"))
         },
         |ctx| {
-            let EndpointIssuesAndDiags {
-                changed: _,
-                issues,
-                effects: _,
-            } = &*ctx.value;
-
+            let issues = &ctx.value;
             Ok(vec![TurbopackResult {
                 result: (),
                 issues: issues.iter().map(|i| NapiIssue::from(&**i)).collect(),
@@ -212,13 +217,14 @@ pub fn endpoint_server_changed_subscribe(
 }
 
 #[turbo_tasks::value(shared, serialization = "skip", eq = "manual")]
-struct EndpointIssuesAndDiags {
+struct EndpointIssuesAndEffects {
     changed: Option<ReadRef<Completion>>,
-    issues: Arc<Vec<ReadRef<PlainIssue>>>,
+    issues: Arc<[ReadRef<PlainIssue>]>,
     effects: Arc<Effects>,
+    filter: ResolvedVc<IssueFilter>,
 }
 
-impl PartialEq for EndpointIssuesAndDiags {
+impl PartialEq for EndpointIssuesAndEffects {
     fn eq(&self, other: &Self) -> bool {
         (match (&self.changed, &other.changed) {
             (Some(a), Some(b)) => ReadRef::ptr_eq(a, b),
@@ -228,13 +234,13 @@ impl PartialEq for EndpointIssuesAndDiags {
     }
 }
 
-impl Eq for EndpointIssuesAndDiags {}
+impl Eq for EndpointIssuesAndEffects {}
 
 #[turbo_tasks::function(operation, root)]
-async fn subscribe_issues_and_diags_operation(
+async fn subscribe_issues_and_effects_operation(
     endpoint_op: OperationVc<OptionEndpoint>,
     should_include_issues: bool,
-) -> Result<Vc<EndpointIssuesAndDiags>> {
+) -> Result<Vc<EndpointIssuesAndEffects>> {
     let changed_op = endpoint_server_changed_operation(endpoint_op);
 
     // Use catch-collectables in both branches so transient build-graph errors
@@ -244,13 +250,13 @@ async fn subscribe_issues_and_diags_operation(
     // payload, but we still need the catch path to avoid the FATAL.
     let filter = issue_filter_from_endpoint(endpoint_op).await;
     let (changed_value, issues, effects) =
-        strongly_consistent_catch_collectables(changed_op, &filter).await?;
-    Ok(EndpointIssuesAndDiags {
+        strongly_consistent_catch_collectables(changed_op, &*filter).await?;
+    Ok(EndpointIssuesAndEffects {
         changed: changed_value,
         issues: if should_include_issues {
             issues
         } else {
-            Arc::new(vec![])
+            Arc::from([])
         },
         effects,
     }
@@ -271,9 +277,9 @@ pub fn endpoint_client_changed_subscribe(
         move || {
             async move {
                 let changed_op = endpoint_client_changed_operation(endpoint_op);
-                // We don't capture issues and diagnostics here since we don't want to be
-                // notified when they change.  We also want errors to propagate so we don't use
-                // strongly_consistent_catch_collectibles either.
+                // We don't capture issues here since we don't want to be notified when they change.
+                // We also want errors to propagate so we don't use
+                // `strongly_consistent_catch_collectibles` either.
                 //
                 // This must be a *read*, not just a resolve, because we need the root task created
                 // by `subscribe` to re-run when the `Completion`'s value changes (via equality),

--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -62,12 +62,15 @@ use turbo_tasks_fs::{
 use turbo_unix_path::{get_relative_path_to, sys_to_unix, unix_to_sys};
 use turbopack_core::{
     PROJECT_FILESYSTEM_NAME, SOURCE_URL_PROTOCOL,
-    issue::PlainIssue,
+    effect::apply_effects_with_plain_issues,
+    issue::{IssueFilter, PlainIssue, extend_issues},
     output::{OutputAsset, OutputAssets},
     source_map::{SourceMap, Token},
     version::{PartialUpdate, TotalUpdate, Update, VersionState},
 };
-use turbopack_ecmascript_hmr_protocol::{ClientUpdateInstruction, Issue, ResourceIdentifier};
+use turbopack_ecmascript_hmr_protocol::{
+    ClientUpdateInstruction, Issue as HmrIssue, ResourceIdentifier,
+};
 use turbopack_trace_utils::{
     exit::{ExitHandler, ExitReceiver},
     filter_layer::FilterLayer,
@@ -986,8 +989,9 @@ impl NapiEntrypoints {
 #[turbo_tasks::value(serialization = "skip")]
 struct EntrypointsWithIssues {
     entrypoints: Option<ReadRef<EntrypointsOperation>>,
-    issues: Arc<Vec<ReadRef<PlainIssue>>>,
+    issues: Arc<[ReadRef<PlainIssue>]>,
     effects: Arc<Effects>,
+    filter: ReadRef<IssueFilter>,
 }
 
 #[turbo_tasks::function(operation, root)]
@@ -1003,6 +1007,7 @@ async fn get_entrypoints_with_issues_operation(
         entrypoints,
         issues,
         effects,
+        filter,
     }
     .cell())
 }
@@ -1018,15 +1023,17 @@ fn project_container_entrypoints_operation(
 
 #[turbo_tasks::value(serialization = "skip")]
 struct OperationResult {
-    issues: Arc<Vec<ReadRef<PlainIssue>>>,
+    issues: Arc<[ReadRef<PlainIssue>]>,
     effects: Arc<Effects>,
+    filter: ReadRef<IssueFilter>,
 }
 
 #[turbo_tasks::value(serialization = "skip")]
 struct AllWrittenEntrypointsWithIssues {
     entrypoints: Option<ReadRef<EntrypointsOperation>>,
-    issues: Arc<Vec<ReadRef<PlainIssue>>>,
+    issues: Arc<[ReadRef<PlainIssue>]>,
     effects: Arc<Effects>,
+    filter: ReadRef<IssueFilter>,
 }
 
 #[napi(object)]
@@ -1424,17 +1431,16 @@ pub async fn project_write_all_entrypoints_to_disk(
                 entrypoints,
                 issues,
                 effects,
+                filter,
             } = &*entrypoints_with_issues_op
                 .read_strongly_consistent()
                 .await?;
 
             // Apply phase side effects. Asset emission is performed once at the end.
-            effects.apply().await?;
+            let effect_plain_issues = apply_effects_with_plain_issues(effects, *filter).await?;
+            let issues = extend_issues(issues, &effect_plain_issues);
 
-            Ok((
-                entrypoints.clone(),
-                issues.iter().cloned().collect::<Vec<_>>(),
-            ))
+            Ok((entrypoints.clone(), issues))
         })
         .or_else(|e| ctx.throw_turbopack_internal_result(&e.into()))
         .await?;
@@ -1488,17 +1494,16 @@ pub async fn project_write_all_entrypoints_to_disk(
                     entrypoints,
                     issues,
                     effects,
+                    filter,
                 } = &*entrypoints_with_issues_op
                     .read_strongly_consistent()
                     .await?;
 
                 // Apply phase side effects. Asset emission is performed once at the end.
-                effects.apply().await?;
+                let effect_plain_issues = apply_effects_with_plain_issues(effects, *filter).await?;
+                let issues = extend_issues(issues, &effect_plain_issues);
 
-                Ok((
-                    entrypoints.clone(),
-                    issues.iter().cloned().collect::<Vec<_>>(),
-                ))
+                Ok((entrypoints.clone(), issues))
             })
             .or_else(|e| ctx.throw_turbopack_internal_result(&e.into()))
             .await?;
@@ -1506,7 +1511,7 @@ pub async fn project_write_all_entrypoints_to_disk(
         if deferred_entrypoints.is_some() {
             entrypoints = deferred_entrypoints;
         }
-        issues.extend(deferred_issues);
+        issues = extend_issues(&issues, &deferred_issues);
     }
 
     let emit_issues = tt
@@ -1516,17 +1521,20 @@ pub async fn project_write_all_entrypoints_to_disk(
                 app_dir_only,
                 has_deferred_entrypoints,
             );
-            let OperationResult { issues, effects } =
-                &*emit_result_op.read_strongly_consistent().await?;
+            let OperationResult {
+                issues,
+                effects,
+                filter,
+            } = &*emit_result_op.read_strongly_consistent().await?;
 
-            effects.apply().await?;
-
-            Ok(issues.iter().cloned().collect::<Vec<_>>())
+            let effect_plain_issues = apply_effects_with_plain_issues(effects, *filter).await?;
+            let issues = extend_issues(issues, &effect_plain_issues);
+            Ok(issues)
         })
         .or_else(|e| ctx.throw_turbopack_internal_result(&e.into()))
         .await?;
 
-    issues.extend(emit_issues);
+    issues = extend_issues(&issues, &emit_issues);
 
     Ok(TurbopackResult {
         result: if let Some(entrypoints) = entrypoints {
@@ -1559,6 +1567,7 @@ async fn get_all_written_entrypoints_with_issues_operation(
         entrypoints,
         issues,
         effects,
+        filter,
     }
     .cell())
 }
@@ -1639,7 +1648,12 @@ async fn emit_all_output_assets_once_with_issues_operation(
     let (_, issues, effects) =
         strongly_consistent_catch_collectables(entrypoints_operation, &filter).await?;
 
-    Ok(OperationResult { issues, effects }.cell())
+    Ok(OperationResult {
+        issues,
+        effects,
+        filter,
+    }
+    .cell())
 }
 
 #[turbo_tasks::function(operation)]
@@ -1720,6 +1734,7 @@ pub async fn project_entrypoints(
                 entrypoints,
                 issues,
                 effects: _,
+                filter: _,
             } = &*entrypoints_with_issues_op
                 .read_strongly_consistent()
                 .await?;
@@ -1761,12 +1776,14 @@ pub fn project_entrypoints_subscribe(
                     entrypoints,
                     issues,
                     effects,
+                    filter,
                 } = &*entrypoints_with_issues_op
                     .read_strongly_consistent()
                     .await?;
 
-                effects.apply().await?;
-                Ok((entrypoints.clone(), issues.clone()))
+                let effect_plain_issues = apply_effects_with_plain_issues(effects, *filter).await?;
+                let issues = extend_issues(issues, &effect_plain_issues);
+                Ok((entrypoints.clone(), issues))
             }
             .instrument(tracing::info_span!("entrypoints subscription"))
         },
@@ -1794,8 +1811,9 @@ pub fn project_entrypoints_subscribe(
 #[turbo_tasks::value(serialization = "skip")]
 struct HmrUpdateWithIssues {
     update: ReadRef<Update>,
-    issues: Arc<Vec<ReadRef<PlainIssue>>>,
+    issues: Arc<[ReadRef<PlainIssue>]>,
     effects: Arc<Effects>,
+    filter: ReadRef<IssueFilter>,
 }
 
 #[turbo_tasks::function(operation, root)]
@@ -1828,6 +1846,7 @@ async fn hmr_update_with_issues_operation(
         update,
         issues,
         effects,
+        filter,
     }
     .cell())
 }
@@ -1875,12 +1894,15 @@ pub fn project_hmr_events(
                         update,
                         issues,
                         effects,
+                        filter,
                     } = &*update;
                     // HACK(bgw): Remove this mark call
                     mark_top_level_task();
-                    effects.apply().await?;
+                    let effect_plain_issues =
+                        apply_effects_with_plain_issues(effects, *filter).await?;
                     // HACK(bgw): Remove this unmark call
                     unmark_top_level_task_may_leak_eventually_consistent_state();
+                    let issues = extend_issues(issues, &effect_plain_issues);
                     match &**update {
                         Update::Missing | Update::None => {}
                         Update::Total(TotalUpdate { to }) => {
@@ -1890,7 +1912,7 @@ pub fn project_hmr_events(
                             state.set(to.clone()).await?;
                         }
                     }
-                    Ok((Some(update.clone()), issues.clone()))
+                    Ok((Some(update.clone()), issues))
                 }
             }
         },
@@ -1903,7 +1925,7 @@ pub fn project_hmr_events(
                 .collect();
             let update_issues = issues
                 .iter()
-                .map(|issue| Issue::from(&**issue))
+                .map(|issue| HmrIssue::from(&**issue))
                 .collect::<Vec<_>>();
 
             let identifier = ResourceIdentifier {
@@ -1938,8 +1960,9 @@ struct HmrChunkNames {
 #[turbo_tasks::value(serialization = "skip")]
 struct HmrChunkNamesWithIssues {
     chunk_names: ReadRef<Vec<RcStr>>,
-    issues: Arc<Vec<ReadRef<PlainIssue>>>,
+    issues: Arc<[ReadRef<PlainIssue>]>,
     effects: Arc<Effects>,
+    filter: ReadRef<IssueFilter>,
 }
 
 #[turbo_tasks::function(operation, root)]
@@ -1970,6 +1993,7 @@ async fn get_hmr_chunk_names_with_issues_operation(
         chunk_names: hmr_chunk_names,
         issues,
         effects,
+        filter,
     }
     .cell())
 }
@@ -1996,12 +2020,14 @@ pub fn project_hmr_chunk_names_subscribe(
                 chunk_names,
                 issues,
                 effects,
+                filter,
             } = &*hmr_chunk_names_with_issues_op
                 .read_strongly_consistent()
                 .await?;
-            effects.apply().await?;
+            let effect_plain_issues = apply_effects_with_plain_issues(effects, *filter).await?;
+            let issues = extend_issues(issues, &effect_plain_issues);
 
-            Ok((chunk_names.clone(), issues.clone()))
+            Ok((chunk_names.clone(), issues))
         },
         move |ctx| {
             let (chunk_names, issues) = ctx.value;
@@ -2469,12 +2495,16 @@ pub async fn project_write_analyze_data(
         .turbo_tasks()
         .run_once(async move {
             let analyze_data_op = write_analyze_data_with_issues_operation(container, app_dir_only);
-            let WriteAnalyzeResult { issues, effects } =
-                &*analyze_data_op.read_strongly_consistent().await?;
+            let WriteAnalyzeResult {
+                issues,
+                effects,
+                filter,
+            } = &*analyze_data_op.read_strongly_consistent().await?;
 
             // Write the files to disk
-            effects.apply().await?;
-            Ok(issues.clone())
+            let effect_plain_issues = apply_effects_with_plain_issues(effects, *filter).await?;
+            let issues = extend_issues(issues, &effect_plain_issues);
+            Ok(issues)
         })
         .await
         .map_err(|e| napi::Error::from_reason(PrettyPrintError(&e).to_string()))?;
@@ -2508,8 +2538,13 @@ async fn get_all_compilation_issues_operation(
 ) -> Result<Vc<OperationResult>> {
     let inner_op = get_all_compilation_issues_inner_operation(container);
     let filter = container.project().issue_filter().await?;
-    let (_, issues, effects) = strongly_consistent_catch_collectables(inner_op, &filter).await?;
-    Ok(OperationResult { issues, effects }.cell())
+    let (_, issues, effects) = strongly_consistent_catch_collectables(inner_op, &*filter).await?;
+    Ok(OperationResult {
+        issues,
+        effects,
+        filter,
+    }
+    .cell())
 }
 
 /// Returns the build-feature-usage telemetry summary for this project — the set of
@@ -2559,7 +2594,11 @@ pub async fn project_get_all_compilation_issues(
         .turbo_tasks()
         .run_once(async move {
             let op = get_all_compilation_issues_operation(container);
-            let OperationResult { issues, effects: _ } = &*op.read_strongly_consistent().await?;
+            let OperationResult {
+                issues,
+                effects: _,
+                filter: _,
+            } = &*op.read_strongly_consistent().await?;
             Ok(issues.clone())
         })
         .await

--- a/crates/next-napi-bindings/src/next_api/utils.rs
+++ b/crates/next-napi-bindings/src/next_api/utils.rs
@@ -108,8 +108,8 @@ pub fn root_task_dispose(
 pub async fn get_issues<T: Send>(
     source: OperationVc<T>,
     filter: &IssueFilter,
-) -> Result<Arc<Vec<ReadRef<PlainIssue>>>> {
-    Ok(Arc::new(
+) -> Result<Arc<[ReadRef<PlainIssue>]>> {
+    Ok(Arc::from(
         source.peek_issues().get_plain_issues(filter).await?,
     ))
 }
@@ -448,11 +448,7 @@ pub fn subscribe<T: 'static + Send + Sync, F: Future<Output = Result<T>> + Send,
 pub async fn strongly_consistent_catch_collectables<R: VcValueType + Send>(
     source_op: OperationVc<R>,
     filter: &IssueFilter,
-) -> Result<(
-    Option<ReadRef<R>>,
-    Arc<Vec<ReadRef<PlainIssue>>>,
-    Arc<Effects>,
-)> {
+) -> Result<(Option<ReadRef<R>>, Arc<[ReadRef<PlainIssue>]>, Arc<Effects>)> {
     let result = source_op.read_strongly_consistent().await;
     let issues = get_issues(source_op, filter).await?;
     let effects = Arc::new(take_effects(source_op).await?);

--- a/turbopack/crates/turbo-esregex/src/lib.rs
+++ b/turbopack/crates/turbo-esregex/src/lib.rs
@@ -15,7 +15,7 @@ use bincode::{
 ///
 /// Delegates to the `regex` crate when possible and `regress` otherwise.
 #[derive(Debug, Clone)]
-#[turbo_tasks::value(eq = "manual", shared, serialization = "custom")]
+#[turbo_tasks::value(eq = "manual", shared, serialization = "custom", operation)]
 pub struct EsRegex {
     #[turbo_tasks(trace_ignore)]
     delegate: EsRegexImpl,

--- a/turbopack/crates/turbo-esregex/src/lib.rs
+++ b/turbopack/crates/turbo-esregex/src/lib.rs
@@ -1,6 +1,6 @@
 #![feature(arbitrary_self_types_pointers)]
 
-use std::vec;
+use std::{hash::Hash, vec};
 
 use anyhow::{Result, bail};
 use bincode::{
@@ -10,6 +10,7 @@ use bincode::{
     error::{DecodeError, EncodeError},
     impl_borrow_decode,
 };
+use turbo_tasks::TaskInput;
 
 /// A simple regular expression implementation following ecmascript semantics
 ///
@@ -40,7 +41,21 @@ impl PartialEq for EsRegex {
         self.pattern == other.pattern && self.flags == other.flags
     }
 }
+
 impl Eq for EsRegex {}
+
+impl Hash for EsRegex {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.pattern.hash(state);
+        self.flags.hash(state);
+    }
+}
+
+impl TaskInput for EsRegex {
+    fn is_transient(&self) -> bool {
+        false
+    }
+}
 
 impl Encode for EsRegex {
     fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {

--- a/turbopack/crates/turbo-tasks-fs/src/glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/glob.rs
@@ -26,8 +26,8 @@ use crate::globset::parse;
 // Note: a/**/b does match a/b, so we need some special logic about path
 // separators
 
-#[turbo_tasks::value(eq = "manual", serialization = "custom")]
-#[derive(Debug, Clone)]
+#[turbo_tasks::value(eq = "manual", serialization = "custom", operation)]
+#[derive(Debug, Clone, Hash)]
 pub struct Glob {
     glob: RcStr,
     #[turbo_tasks(trace_ignore)]
@@ -36,6 +36,12 @@ pub struct Glob {
     regex: Regex,
     #[turbo_tasks(trace_ignore)]
     directory_match_regex: Regex,
+}
+
+impl TaskInput for Glob {
+    fn is_transient(&self) -> bool {
+        false
+    }
 }
 
 impl PartialEq for Glob {

--- a/turbopack/crates/turbo-tasks-fs/src/glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/glob.rs
@@ -1,4 +1,4 @@
-use std::fmt::Display;
+use std::{fmt::Display, hash::Hash};
 
 use anyhow::{Result, bail};
 use bincode::{
@@ -27,7 +27,7 @@ use crate::globset::parse;
 // separators
 
 #[turbo_tasks::value(eq = "manual", serialization = "custom", operation)]
-#[derive(Debug, Clone, Hash)]
+#[derive(Debug, Clone)]
 pub struct Glob {
     glob: RcStr,
     #[turbo_tasks(trace_ignore)]
@@ -41,6 +41,12 @@ pub struct Glob {
 impl TaskInput for Glob {
     fn is_transient(&self) -> bool {
         false
+    }
+}
+
+impl Hash for Glob {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.glob.hash(state);
     }
 }
 

--- a/turbopack/crates/turbo-tasks-fuzz/src/fs_watcher.rs
+++ b/turbopack/crates/turbo-tasks-fuzz/src/fs_watcher.rs
@@ -154,7 +154,7 @@ pub async fn run(args: FsWatcher) -> anyhow::Result<()> {
         .read_strongly_consistent()
         .await?;
         if track_writes {
-            effects.apply().await?;
+            effects.apply_anyhow().await?;
             let (total, mismatched) = verify_written_files(
                 &fs_root,
                 args.depth,
@@ -245,7 +245,7 @@ pub async fn run(args: FsWatcher) -> anyhow::Result<()> {
                 ""
             };
             if track_writes {
-                effects.apply().await?;
+                effects.apply_anyhow().await?;
                 let (total, mismatched) = verify_written_files(
                     &fs_root,
                     args.depth,

--- a/turbopack/crates/turbo-tasks-fuzz/src/symlink_stress.rs
+++ b/turbopack/crates/turbo-tasks-fuzz/src/symlink_stress.rs
@@ -89,7 +89,7 @@ pub async fn run(args: SymlinkStress) -> anyhow::Result<()> {
         ))
         .read_strongly_consistent()
         .await?
-        .apply()
+        .apply_anyhow()
         .await?;
 
         println!(
@@ -126,7 +126,7 @@ pub async fn run(args: SymlinkStress) -> anyhow::Result<()> {
             ))
             .read_strongly_consistent()
             .await?
-            .apply()
+            .apply_anyhow()
             .await?;
 
             total_writes += parallelism as u64;

--- a/turbopack/crates/turbo-tasks/src/effect.rs
+++ b/turbopack/crates/turbo-tasks/src/effect.rs
@@ -1,4 +1,5 @@
 use std::{
+    any::Any,
     collections::hash_map,
     error::Error as StdError,
     future::Future,
@@ -8,7 +9,7 @@ use std::{
 };
 
 use anyhow::Result;
-use futures::{StreamExt, TryStreamExt};
+use futures::StreamExt;
 use parking_lot::{Mutex, MutexGuard};
 use rustc_hash::{FxHashMap, FxHashSet};
 use tracing::Instrument;
@@ -66,8 +67,8 @@ pub trait Effect: TraceRawVcs + NonLocalValue + Send + Sync + 'static {
 /// So instead, we leave it up to the caller to figure out how to downcast these errors themselves.
 ///
 /// [`SharedError`]: crate::util::SharedError
-pub trait EffectError: StdError + TraceRawVcs + NonLocalValue + Send + Sync + 'static {}
-impl<T> EffectError for T where T: StdError + TraceRawVcs + NonLocalValue + Send + Sync + 'static {}
+pub trait EffectError: StdError + TraceRawVcs + NonLocalValue + Send + Sync + Any {}
+impl<T> EffectError for T where T: StdError + TraceRawVcs + NonLocalValue + Send + Sync + Any {}
 
 enum EffectLastApplied {
     Unapplied,
@@ -232,17 +233,11 @@ pub async fn take_effects(source: impl CollectiblesSource) -> Result<Effects> {
     })
 }
 
-#[derive(thiserror::Error, Debug, TraceRawVcs, NonLocalValue)]
+#[derive(Clone, thiserror::Error, Debug, TraceRawVcs, NonLocalValue)]
 #[error("Conflicting effects for the same key (key length: {key_len} bytes)")]
-struct ConflictingEffectError {
+pub struct ConflictingEffectError {
     key_len: usize,
 }
-
-/// Cached result of grouping effects by key and dedup/conflict detection.
-/// Each entry is (index into `effects`, per-key state entry).
-/// The `EffectStateEntry` is resolved once and cached to avoid repeated map lookups on subsequent
-/// `apply()` calls.
-type UniqueEffectIndices = Result<Vec<(usize, EffectStateEntry)>, Arc<ConflictingEffectError>>;
 
 /// Captured effects from an operation. This struct can be used to return Effects from a turbo-tasks
 /// function and apply them later.
@@ -254,9 +249,8 @@ pub struct Effects {
     /// Cached `(index, state_entry)` pairs after grouping by key and dedup/conflict detection.
     /// Computed once on first `apply()` call; reused on subsequent calls to avoid repeated
     /// key allocations and map lookups.
-    /// `Err` means a conflict was detected.
     #[turbo_tasks(debug_ignore, trace_ignore)]
-    unique_indices: OnceLock<UniqueEffectIndices>,
+    unique_indices: OnceLock<Result<Vec<(usize, EffectStateEntry)>, ConflictingEffectError>>,
 }
 
 impl PartialEq for Effects {
@@ -279,27 +273,33 @@ impl PartialEq for Effects {
 impl Eq for Effects {}
 
 impl Effects {
-    /// Applies all effects that have been captured.
+    /// Applies all effects that have been captured, and returns an [`EffectErrorCollection`].
+    ///
+    /// Most callers should use `turbopack_core::effect::apply_effects_with_plain_issues` if they
+    /// want to convert effect errors to `Issue`s
     ///
     /// On first call: groups effects by key, detects duplicates/conflicts, caches deduped indices.
     /// On subsequent calls: skips grouping (reuses cached indices), only runs per-key state checks.
     ///
-    /// `apply` must only be used in a "top-level" task (e.g. [`run_once`][crate::run_once]), after
+    /// This must only be used in a "top-level" task (e.g. [`run_once`][crate::run_once]), after
     /// [`take_effects`] is called from an [operation read with strong
     /// consistency][crate::OperationVc::read_strongly_consistent].
     ///
     /// See [`take_effects`] for example usage.
-    pub async fn apply(&self) -> Result<(), Arc<dyn EffectError>> {
+    pub async fn apply_with_raw_errors(
+        &self,
+    ) -> Result<EffectErrorCollection, ConflictingEffectError> {
         debug_assert_in_top_level_task(
             "Effects::apply must be called from a top-level task to avoid unintended \
              re-executions due to eventual consistency",
         );
         if self.effects.is_empty() {
-            return Ok(());
+            // fast path if there are no effects
+            return Ok(EffectErrorCollection(Vec::new()));
         }
-
         let span = tracing::info_span!("apply effects", count = self.effects.len());
 
+        let errors: Mutex<Vec<Arc<dyn EffectError>>> = Mutex::new(Vec::new());
         async {
             // Compute unique (index, state_entry) pairs once; reuse on later calls.
             // The EffectStateEntry is resolved from the state map on first call and cached
@@ -317,9 +317,9 @@ impl Effects {
                                 if self.effects[*entry.get()].inner.value_hash()
                                     != effect.inner.value_hash()
                                 {
-                                    return Err(Arc::new(ConflictingEffectError {
+                                    return Err(ConflictingEffectError {
                                         key_len: entry.key().len(),
-                                    }));
+                                    });
                                 }
                             }
                         }
@@ -340,13 +340,12 @@ impl Effects {
                     Ok(indices)
                 })
                 .as_ref()
-                .map_err(|err| err.clone() as Arc<_>)?;
+                .map_err(|err| -> ConflictingEffectError { err.clone() })?;
 
             // Apply effects using cached (index, state_entry) pairs.
             // Hot path: no map lookup — EffectStateEntry is cached in unique_indices.
             futures::stream::iter(unique_indices.iter())
-                .map(Ok::<_, Arc<dyn EffectError>>)
-                .try_for_each_concurrent(APPLY_EFFECTS_CONCURRENCY_LIMIT, async |(idx, entry)| {
+                .for_each_concurrent(APPLY_EFFECTS_CONCURRENCY_LIMIT, async |(idx, entry)| {
                     let effect: &dyn DynEffect = &*self.effects[*idx].inner;
 
                     // If `effect.dyn_apply` panics or the apply future is dropped before
@@ -388,7 +387,10 @@ impl Effects {
                                 EffectLastApplied::Applied { value_hash, result } => {
                                     // Fast path: check if the stored value already matches
                                     if effect.value_hash() == *value_hash {
-                                        return result.clone();
+                                        if let Err(err) = result {
+                                            errors.lock().push(err.clone());
+                                        }
+                                        return;
                                     } else {
                                         break begin_in_progress(last_applied_guard);
                                     }
@@ -427,17 +429,42 @@ impl Effects {
                     };
                     write_event.notify(usize::MAX);
 
-                    effect_result
+                    if let Err(err) = effect_result {
+                        errors.lock().push(err);
+                    }
                 })
-                .await
+                .await;
+            Ok(())
         }
         .instrument(span)
-        .await
+        .await?;
+        Ok(EffectErrorCollection(errors.into_inner()))
+    }
+
+    /// Applies all effects and returns an [`anyhow::Error`] if any effect failed. This is intended
+    /// for unit tests and toy programs. Callers in Turbopack should use
+    /// `turbopack_core::effect::apply_effects_with_plain_issues` instead.
+    ///
+    /// This is a convenience wrapper around [`Effects::apply`] that returns the first error
+    /// as an `anyhow::Error`.
+    pub async fn apply_anyhow(&self) -> Result<()> {
+        let EffectErrorCollection(errors) = self.apply_with_raw_errors().await?;
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(anyhow::anyhow!(errors.into_iter().next().unwrap()))
+        }
     }
 }
 
+/// A wrapper type around [`EffectError`] that is annotated with `#[must_use]`.
+#[must_use]
+pub struct EffectErrorCollection(pub Vec<Arc<dyn EffectError>>);
+
 #[cfg(test)]
 mod tests {
+    use std::sync::OnceLock;
+
     use crate::{CollectiblesSource, Effects, take_effects};
 
     #[test]
@@ -451,6 +478,15 @@ mod tests {
                     unique_indices: Default::default(),
                 }
                 .apply(),
+            );
+        }
+        fn check_effects_apply_anyhow() {
+            assert_sync(
+                Effects {
+                    effects: Vec::new(),
+                    unique_indices: OnceLock::new(),
+                }
+                .apply_anyhow(),
             );
         }
         fn check_take_effects<T: CollectiblesSource + Send + Sync>(t: T) {

--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -80,7 +80,10 @@ pub use crate::{
     dyn_task_inputs::{
         DynTaskInputs, OwnedStackDynTaskInputs, StackDynTaskInputs, StackDynTaskInputsSlot,
     },
-    effect::{Effect, EffectError, EffectStateStorage, Effects, emit_effect, take_effects},
+    effect::{
+        ConflictingEffectError, Effect, EffectError, EffectErrorCollection, EffectStateStorage,
+        Effects, emit_effect, take_effects,
+    },
     error::PrettyPrintError,
     id::{ExecutionId, LocalTaskId, TRANSIENT_TASK_BIT, TaskId, TraitTypeId, ValueTypeId},
     invalidation::{

--- a/turbopack/crates/turbo-tasks/src/marker_trait.rs
+++ b/turbopack/crates/turbo-tasks/src/marker_trait.rs
@@ -66,6 +66,7 @@ macro_rules! impl_auto_marker_trait {
             where T: ::std::ops::Deref, <T as ::std::ops::Deref>::Target: $trait {}
         unsafe impl<T: $trait + ?Sized> $trait for ::std::boxed::Box<T> {}
         unsafe impl<T: $trait + ?Sized> $trait for ::std::sync::Arc<T> {}
+        unsafe impl<T: $trait + ?Sized> $trait for ::triomphe::Arc<T> {}
         unsafe impl<B: $trait + ::std::borrow::ToOwned + ?Sized> $trait
             for ::std::borrow::Cow<'_, B> {}
         unsafe impl<T: $trait, E: $trait> $trait for ::std::result::Result<T, E> {}

--- a/turbopack/crates/turbo-tasks/src/trace.rs
+++ b/turbopack/crates/turbo-tasks/src/trace.rs
@@ -157,7 +157,7 @@ impl<T: TraceRawVcs> TraceRawVcs for Vec<T> {
     }
 }
 
-impl<T: TraceRawVcs> TraceRawVcs for Box<[T]> {
+impl<T: TraceRawVcs> TraceRawVcs for [T] {
     fn trace_raw_vcs(&self, trace_context: &mut TraceRawVcsContext) {
         for item in self.iter() {
             TraceRawVcs::trace_raw_vcs(item, trace_context);
@@ -283,6 +283,12 @@ impl<T: TraceRawVcs + ?Sized> TraceRawVcs for Box<T> {
 }
 
 impl<T: TraceRawVcs + ?Sized> TraceRawVcs for Arc<T> {
+    fn trace_raw_vcs(&self, trace_context: &mut TraceRawVcsContext) {
+        TraceRawVcs::trace_raw_vcs(&**self, trace_context);
+    }
+}
+
+impl<T: TraceRawVcs + ?Sized> TraceRawVcs for triomphe::Arc<T> {
     fn trace_raw_vcs(&self, trace_context: &mut TraceRawVcsContext) {
         TraceRawVcs::trace_raw_vcs(&**self, trace_context);
     }

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -161,7 +161,7 @@ impl TurbopackBuildBuilder {
                 // Await the result to propagate any errors and capture effects.
                 let effects = wrapper_op.read_strongly_consistent().await?;
 
-                effects.apply().await?;
+                effects.apply_anyhow().await?;
 
                 let issue_reporter: Vc<Box<dyn IssueReporter>> =
                     Vc::upcast(ConsoleUi::new(TransientInstance::new(LogOptions {

--- a/turbopack/crates/turbopack-core/src/effect.rs
+++ b/turbopack/crates/turbopack-core/src/effect.rs
@@ -1,0 +1,106 @@
+use std::{
+    any::{Any, TypeId},
+    sync::Arc,
+};
+
+use anyhow::Result;
+use turbo_tasks::{
+    EffectError, EffectErrorCollection, Effects, ReadRef, ResolvedVc, TryFlatJoinIterExt, Vc,
+};
+use turbo_tasks_fs::error::FileSystemError;
+
+use crate::issue::{Issue, IssueFilter, PlainIssue, fs_error::FileSystemErrorIssue};
+
+/// A wrapper around a [`Vec`] of [`Issue`]s that has a `#[must_use]` annotation.
+#[must_use]
+pub struct IssueCollection(pub Vec<ResolvedVc<Box<dyn Issue>>>);
+
+/// A collection of [`PlainIssue`]s produced by applying effects and filtering.
+#[turbo_tasks::value(transparent, serialization = "skip")]
+pub struct PlainIssueCollection(pub Box<[ReadRef<PlainIssue>]>);
+
+/// Applies effects, converts [`FileSystemError`]s to [`Issue`]s, and returns the raw issue [`Vc`]s.
+///
+/// All [`FileSystemError`]s are converted into issues (not just the first one), and if there are
+/// any remaining non-[`FileSystemError`] errors, the first one is returned.
+///
+/// Most callers should use [`apply_effects_with_plain_issues`] instead, which also applies the
+/// issue filter and converts to [`PlainIssue`]s.
+pub async fn apply_effects_with_raw_issues(effects: &Effects) -> Result<IssueCollection> {
+    let EffectErrorCollection(errors) = effects.apply_with_raw_errors().await?;
+
+    let mut issues = Vec::new();
+    let mut remaining_errors = Vec::new();
+
+    for err in errors {
+        let err_ref: &dyn EffectError = &*err;
+        let err_ref: &dyn Any = err_ref;
+        let downcast_err = if Any::type_id(err_ref) == TypeId::of::<FileSystemError>() {
+            let ptr = Arc::into_raw(err);
+            // SAFETY: This is just an inlined version of Arc::downcast that doesn't convert to
+            // `Arc<dyn Any>` upon error.
+            unsafe { Ok(Arc::from_raw(ptr.cast())) }
+        } else {
+            Err(err)
+        };
+        match downcast_err {
+            Ok(fs_err) => {
+                // convert to Issue
+                issues.push(ResolvedVc::upcast(
+                    FileSystemErrorIssue(fs_err).resolved_cell(),
+                ));
+            }
+            Err(other_err) => {
+                remaining_errors.push(other_err);
+            }
+        }
+    }
+
+    if !remaining_errors.is_empty() {
+        // Re-throw the first non-FileSystemError
+        return Err(anyhow::Error::from(
+            remaining_errors.into_iter().next().unwrap(),
+        ));
+    }
+
+    Ok(IssueCollection(issues))
+}
+
+#[turbo_tasks::function(operation)]
+async fn filter_and_convert_issues_operation(
+    issues: Vec<ResolvedVc<Box<dyn Issue>>>,
+    filter: ReadRef<IssueFilter>,
+) -> Result<Vc<PlainIssueCollection>> {
+    let plain_issues = issues
+        .iter()
+        .map(async |issue| {
+            if filter.matches(*issue).await? {
+                Ok(Some(PlainIssue::from_issue(**issue, None).await?))
+            } else {
+                Ok(None)
+            }
+        })
+        .try_flat_join()
+        .await?;
+    Ok(PlainIssueCollection(plain_issues.into_boxed_slice()).cell())
+}
+
+/// Applies effects, converts [`FileSystemError`]s to [`Issue`]s, filters them, and returns
+/// [`PlainIssue`]s.
+///
+/// This is a regular async function (not a turbo-tasks function) intended to be called from a
+/// top-level task (e.g. inside `tt.run()` or a `subscribe()` closure). Internally it uses an
+/// operation read with strong consistency to perform the filtering and conversion.
+pub async fn apply_effects_with_plain_issues(
+    effects: &Effects,
+    filter: ReadRef<IssueFilter>,
+) -> Result<ReadRef<PlainIssueCollection>> {
+    let raw_issues = apply_effects_with_raw_issues(effects).await?;
+    if raw_issues.0.is_empty() {
+        return Ok(ReadRef::new_owned(PlainIssueCollection(Box::from([]))));
+    }
+    let plain_issues = filter_and_convert_issues_operation(raw_issues.0, filter)
+        .read_strongly_consistent()
+        .await?;
+    Ok(plain_issues)
+}

--- a/turbopack/crates/turbopack-core/src/effect.rs
+++ b/turbopack/crates/turbopack-core/src/effect.rs
@@ -13,7 +13,7 @@ use crate::issue::{Issue, IssueFilter, PlainIssue, fs_error::FileSystemErrorIssu
 
 /// A wrapper around a [`Vec`] of [`Issue`]s that has a `#[must_use]` annotation.
 #[must_use]
-pub struct IssueCollection(pub Vec<ResolvedVc<Box<dyn Issue>>>);
+pub struct IssueCollection(pub Vec<Box<dyn Issue>>);
 
 /// A collection of [`PlainIssue`]s produced by applying effects and filtering.
 #[turbo_tasks::value(transparent, serialization = "skip")]
@@ -26,7 +26,7 @@ pub struct PlainIssueCollection(pub Box<[ReadRef<PlainIssue>]>);
 ///
 /// Most callers should use [`apply_effects_with_plain_issues`] instead, which also applies the
 /// issue filter and converts to [`PlainIssue`]s.
-pub async fn apply_effects_with_raw_issues(effects: &Effects) -> Result<IssueCollection> {
+async fn apply_effects_with_raw_issues(effects: &Effects) -> Result<IssueCollection> {
     let EffectErrorCollection(errors) = effects.apply_with_raw_errors().await?;
 
     let mut issues = Vec::new();
@@ -46,9 +46,7 @@ pub async fn apply_effects_with_raw_issues(effects: &Effects) -> Result<IssueCol
         match downcast_err {
             Ok(fs_err) => {
                 // convert to Issue
-                issues.push(ResolvedVc::upcast(
-                    FileSystemErrorIssue(fs_err).resolved_cell(),
-                ));
+                issues.push(Box::new(FileSystemErrorIssue(fs_err)) as _);
             }
             Err(other_err) => {
                 remaining_errors.push(other_err);
@@ -66,23 +64,24 @@ pub async fn apply_effects_with_raw_issues(effects: &Effects) -> Result<IssueCol
     Ok(IssueCollection(issues))
 }
 
-#[turbo_tasks::function(operation)]
-async fn filter_and_convert_issues_operation(
-    issues: Vec<ResolvedVc<Box<dyn Issue>>>,
-    filter: ReadRef<IssueFilter>,
-) -> Result<Vc<PlainIssueCollection>> {
+async fn filter_and_convert_issues_iter_ref(
+    issues: impl IntoIterator<Item = &dyn Issue>,
+    filter: &IssueFilter,
+) -> Result<Vec<ReadRef<PlainIssue>>> {
     let plain_issues = issues
-        .iter()
+        .into_iter()
         .map(async |issue| {
-            if filter.matches(*issue).await? {
-                Ok(Some(PlainIssue::from_issue(**issue, None).await?))
+            if filter.matches_ref(issue).await? {
+                Ok(Some(ReadRef::new_owned(
+                    PlainIssue::from_issue_ref(issue, None).await?,
+                )))
             } else {
                 Ok(None)
             }
         })
         .try_flat_join()
         .await?;
-    Ok(PlainIssueCollection(plain_issues.into_boxed_slice()).cell())
+    Ok(plain_issues)
 }
 
 /// Applies effects, converts [`FileSystemError`]s to [`Issue`]s, filters them, and returns
@@ -93,14 +92,11 @@ async fn filter_and_convert_issues_operation(
 /// operation read with strong consistency to perform the filtering and conversion.
 pub async fn apply_effects_with_plain_issues(
     effects: &Effects,
-    filter: ReadRef<IssueFilter>,
-) -> Result<ReadRef<PlainIssueCollection>> {
+    filter: &IssueFilter,
+) -> Result<Vec<ReadRef<PlainIssue>>> {
     let raw_issues = apply_effects_with_raw_issues(effects).await?;
     if raw_issues.0.is_empty() {
-        return Ok(ReadRef::new_owned(PlainIssueCollection(Box::from([]))));
+        return Ok(Vec::new());
     }
-    let plain_issues = filter_and_convert_issues_operation(raw_issues.0, filter)
-        .read_strongly_consistent()
-        .await?;
-    Ok(plain_issues)
+    filter_and_convert_issues_iter_ref(raw_issues.0.iter().map(|issue| &**issue), filter).await
 }

--- a/turbopack/crates/turbopack-core/src/issue/fs_error.rs
+++ b/turbopack/crates/turbopack-core/src/issue/fs_error.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks_fs::{FileSystemPath, error::FileSystemError};
 
-use crate::issue::{Issue, IssueStage, StyledString};
+use crate::issue::{Issue, IssueSeverity, IssueStage, StyledString};
 
 #[turbo_tasks::value(shared)]
 pub struct FileSystemErrorIssue(pub(crate) Arc<FileSystemError>);
@@ -13,6 +13,10 @@ pub struct FileSystemErrorIssue(pub(crate) Arc<FileSystemError>);
 #[async_trait]
 #[turbo_tasks::value_impl]
 impl Issue for FileSystemErrorIssue {
+    fn severity(&self) -> IssueSeverity {
+        IssueSeverity::Fatal
+    }
+
     async fn file_path(&self) -> Result<FileSystemPath> {
         Ok(self.0.path.clone())
     }

--- a/turbopack/crates/turbopack-core/src/issue/mod.rs
+++ b/turbopack/crates/turbopack-core/src/issue/mod.rs
@@ -296,6 +296,7 @@ impl IgnoreIssuePattern {
     Encode,
     Decode,
     OperationValue,
+    Hash,
     TaskInput,
 )]
 pub struct IgnoreIssue {
@@ -427,6 +428,83 @@ impl IssueFilter {
 
         Ok(true)
     }
+
+    pub async fn matches_ref(&self, issue: &dyn Issue) -> Result<bool> {
+        Ok(self.matches_all_fast_path() || self.matches_ref_slow_path(issue).await?)
+    }
+
+    fn matches_all_fast_path(&self) -> bool {
+        self.severity == IssueSeverity::Info
+            && self.foreign_severity == IssueSeverity::Info
+            && self.ignore_rules.is_empty()
+    }
+
+    async fn matches_ref_slow_path(&self, issue: &dyn Issue) -> Result<bool> {
+        // Fetch the file path once — it's used by both severity and ignore-rule
+        // checks.
+        let file_path = issue.file_path().await?;
+
+        // Check severity first — this is cheap and avoids fetching
+        // title/description for issues that would be filtered out anyway.
+        let severity = issue.severity();
+        // NOTE: Lower severities are _more_ severe
+        let severity_allowed = if severity <= self.severity || severity <= self.foreign_severity {
+            // we need to check the path to see if it is foreign or not.  Only await the
+            // path if it might possibly matter
+            if severity <= self.severity && severity <= self.foreign_severity {
+                // it matches no matter where the path is
+                true
+            } else if ContextCondition::InNodeModules.matches(&file_path) {
+                severity <= self.foreign_severity
+            } else {
+                severity <= self.severity
+            }
+        } else {
+            // it is too low severity to match either way
+            false
+        };
+
+        if !severity_allowed {
+            return Ok(false);
+        }
+
+        // Check ignore rules — if any rule matches, the issue is dropped.
+        // Title and description are fetched lazily: only when a rule's path
+        // matches and the rule also specifies a title/description pattern.
+        if !self.ignore_rules.is_empty() {
+            let file_path_str = file_path.to_string();
+            let mut title_str: Option<String> = None;
+            let mut description_text: Option<Option<String>> = None;
+
+            for rule in &self.ignore_rules {
+                if !rule.path.matches(&file_path_str) {
+                    continue;
+                }
+                if let Some(ref title_pat) = rule.title {
+                    if title_str.is_none() {
+                        title_str = Some(issue.title().await?.to_unstyled_string());
+                    }
+                    if !title_pat.matches(title_str.as_deref().unwrap()) {
+                        continue;
+                    }
+                }
+                if let Some(ref desc_pat) = rule.description {
+                    if description_text.is_none() {
+                        description_text =
+                            Some(issue.description().await?.map(|s| s.to_unstyled_string()));
+                    }
+                    match description_text.as_ref().unwrap().as_deref() {
+                        Some(desc) if desc_pat.matches(desc) => {}
+                        _ => continue,
+                    }
+                }
+                // All specified fields matched — ignore this issue.
+                return Ok(false);
+            }
+        }
+
+        Ok(true)
+    }
 }
 
 /// A list of issues captured with [`CollectibleIssuesExt::peek_issues`].
@@ -449,7 +527,7 @@ impl CapturedIssues {
             .issues
             .iter()
             .map(async |issue| {
-                if filter.matches(*issue).await? {
+                if filter.matches(issue).await? {
                     Ok(Some(
                         PlainIssue::from_issue(**issue, Some(*self.tracer)).await?,
                     ))

--- a/turbopack/crates/turbopack-core/src/issue/mod.rs
+++ b/turbopack/crates/turbopack-core/src/issue/mod.rs
@@ -7,6 +7,7 @@ pub mod resolve;
 use std::{
     cmp::min,
     fmt::{Display, Formatter},
+    sync::Arc,
 };
 
 use anyhow::{Result, bail};
@@ -17,9 +18,9 @@ use serde::{Deserialize, Serialize};
 use turbo_esregex::EsRegex;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
-    CollectiblesSource, NonLocalValue, OperationVc, RawVc, ReadRef, ResolvedVc, TaskInput,
-    TransientValue, TryFlatJoinIterExt, TryJoinIterExt, Upcast, ValueDefault, ValueToString,
-    ValueToStringRef, Vc, emit, trace::TraceRawVcs,
+    CollectiblesSource, NonLocalValue, OperationValue, OperationVc, RawVc, ReadRef, ResolvedVc,
+    TaskInput, TransientValue, TryFlatJoinIterExt, TryJoinIterExt, Upcast, ValueDefault,
+    ValueToString, ValueToStringRef, Vc, emit, trace::TraceRawVcs,
 };
 use turbo_tasks_fs::{
     FileContent, FileLine, FileLinesContent, FileSystem, FileSystemPath, glob::Glob,
@@ -39,7 +40,17 @@ use crate::{
 
 #[turbo_tasks::value(shared)]
 #[derive(
-    PartialOrd, Ord, Copy, Clone, Hash, Debug, DeterministicHash, TaskInput, Serialize, Deserialize,
+    PartialOrd,
+    Ord,
+    Copy,
+    Clone,
+    Hash,
+    Debug,
+    DeterministicHash,
+    TaskInput,
+    Serialize,
+    Deserialize,
+    OperationValue,
 )]
 #[serde(rename_all = "camelCase")]
 pub enum IssueSeverity {
@@ -239,11 +250,20 @@ where
     }
 }
 
-#[turbo_tasks::value(transparent)]
-pub struct Issues(Vec<ResolvedVc<Box<dyn Issue>>>);
-
 /// A pattern that can match by exact string, glob, or regex.
-#[derive(Clone, Debug, PartialEq, Eq, TraceRawVcs, NonLocalValue, Encode, Decode)]
+#[derive(
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    TraceRawVcs,
+    NonLocalValue,
+    Encode,
+    Decode,
+    OperationValue,
+    Hash,
+    TaskInput,
+)]
 pub enum IgnoreIssuePattern {
     /// The value must exactly equal the pattern string.
     ExactString(RcStr),
@@ -266,7 +286,18 @@ impl IgnoreIssuePattern {
 
 /// A rule describing an issue to ignore. `path` is mandatory;
 /// `title` and `description` are optional additional filters.
-#[derive(Clone, Debug, PartialEq, Eq, TraceRawVcs, NonLocalValue, Encode, Decode)]
+#[derive(
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    TraceRawVcs,
+    NonLocalValue,
+    Encode,
+    Decode,
+    OperationValue,
+    TaskInput,
+)]
 pub struct IgnoreIssue {
     /// File-path pattern (mandatory).
     pub path: IgnoreIssuePattern,
@@ -276,7 +307,8 @@ pub struct IgnoreIssue {
     pub description: Option<IgnoreIssuePattern>,
 }
 
-#[turbo_tasks::value(shared)]
+#[turbo_tasks::value(shared, operation)]
+#[derive(TaskInput)]
 pub struct IssueFilter {
     /// The minimum severity for issues
     severity: IssueSeverity,
@@ -1122,6 +1154,31 @@ where
     fn drop_issues(self) {
         self.drop_collectibles::<Box<dyn Issue>>();
     }
+}
+
+/// Extends a sorted issue list returned by [`CapturedIssues::get_plain_issues`].
+pub fn extend_issues(
+    base: &Arc<[ReadRef<PlainIssue>]>,
+    other: &[ReadRef<PlainIssue>],
+) -> Arc<[ReadRef<PlainIssue>]> {
+    debug_assert!(
+        base.is_sorted(),
+        "extend_issues must be called with a sorted base list of issues"
+    );
+    // optimization: Return the given arc if the other one is empty
+    if other.is_empty() {
+        return base.clone();
+    }
+    if base.is_empty() {
+        let mut sorted = Box::<[_]>::from(other);
+        sorted.sort();
+        return Arc::from(sorted);
+    }
+    let mut extended = Vec::with_capacity(base.len() + other.len());
+    extended.extend_from_slice(base);
+    extended.extend_from_slice(other);
+    extended.sort();
+    Arc::from(extended)
 }
 
 /// A helper function to print out issues to the console.

--- a/turbopack/crates/turbopack-core/src/lib.rs
+++ b/turbopack/crates/turbopack-core/src/lib.rs
@@ -16,6 +16,7 @@ pub mod condition;
 pub mod context;
 pub mod data_uri_source;
 pub mod debug_id;
+pub mod effect;
 pub mod environment;
 pub mod file_source;
 pub mod generated_code_source;

--- a/turbopack/crates/turbopack-dev-server/src/http.rs
+++ b/turbopack/crates/turbopack-dev-server/src/http.rs
@@ -111,7 +111,7 @@ pub async fn process_request_with_content_source(
         effects,
         content_source_side_effects,
     } = &*wrapper_op.read_strongly_consistent().await?;
-    effects.apply().await?;
+    effects.apply_anyhow().await?;
     handle_issues(
         wrapper_op,
         issue_reporter,

--- a/turbopack/crates/turbopack-dev-server/src/lib.rs
+++ b/turbopack/crates/turbopack-dev-server/src/lib.rs
@@ -225,7 +225,7 @@ impl DevServerBuilder {
                                 get_source_with_issues_operation(source_provider.get_source());
                             let ContentSourceWithIssues { source_op, effects } =
                                 &*source_with_issues_op.read_strongly_consistent().await?;
-                            effects.apply().await?;
+                            effects.apply_anyhow().await?;
                             handle_issues(
                                 source_with_issues_op,
                                 issue_reporter,

--- a/turbopack/crates/turbopack-node/src/evaluate.rs
+++ b/turbopack/crates/turbopack-node/src/evaluate.rs
@@ -201,7 +201,7 @@ async fn create_evaluate_pool_assets_operation(
     // `mark_top_level_task` to avoid the debug assertion. The consequence is that these effects
     // might get evaluated more than once if this function is invalidated.
     mark_top_level_task();
-    effects.apply().await?;
+    effects.apply_anyhow().await?;
 
     Ok(*assets)
 }


### PR DESCRIPTION
This makes sure that we emit issues for filesystem errors at the top level, after applying the effects and collecting the errors.