### PR TITLE
Remove redundant instant navigation prefetch header

### DIFF
--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -48,7 +48,6 @@ import {
   RSC_HEADER,
   NEXT_ROUTER_PREFETCH_HEADER,
   NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
-  NEXT_INSTANT_PREFETCH_HEADER,
   NEXT_INSTANT_TEST_COOKIE,
   NEXT_IS_PRERENDER_HEADER,
   NEXT_DID_POSTPONE_HEADER,
@@ -420,17 +419,20 @@ export async function handler(
   // Enable the Instant Navigation Testing API. Renders only the prefetched
   // portion of the page, excluding dynamic content. This allows tests to
   // assert on the prefetched UI state deterministically.
-  // - Header: Used for client-side navigations where we can set request headers
-  // - Cookie: Used for MPA navigations (page reload, full page load) where we
-  //   can't set request headers. Only applies to document requests (no RSC
-  //   header) - RSC requests should proceed normally even during a locked scope,
-  //   with blocking happening on the client side.
+  //
+  // The instant test cookie is sent automatically with all requests while a
+  // navigation lock is held. We treat a request as a test render when the
+  // cookie is present and either:
+  // - it's a document request (no RSC header) — covers MPA navigations
+  // - it's a prefetch RSC request — covers client-side prefetches
+  // Regular RSC navigation requests proceed normally even during a locked
+  // scope; blocking happens on the client side.
   const isInstantNavigationTest =
     exposeTestingApi &&
-    (req.headers[NEXT_INSTANT_PREFETCH_HEADER] === '1' ||
-      (!isRSCRequestHeader(req.headers[RSC_HEADER]) &&
-        typeof req.headers.cookie === 'string' &&
-        req.headers.cookie.includes(NEXT_INSTANT_TEST_COOKIE + '=')))
+    typeof req.headers.cookie === 'string' &&
+    req.headers.cookie.includes(NEXT_INSTANT_TEST_COOKIE + '=') &&
+    (!isRSCRequestHeader(req.headers[RSC_HEADER]) ||
+      req.headers[NEXT_ROUTER_PREFETCH_HEADER] === '1')
 
   // This page supports PPR if it is marked as being `PARTIALLY_STATIC` in the
   // prerender manifest and this is an app page.

--- a/packages/next/src/client/components/app-router-headers.ts
+++ b/packages/next/src/client/components/app-router-headers.ts
@@ -16,17 +16,9 @@ export const NEXT_HMR_REFRESH_HASH_COOKIE = '__next_hmr_refresh_hash__' as const
 export const NEXT_URL = 'next-url' as const
 export const RSC_CONTENT_TYPE_HEADER = 'text/x-component' as const
 
-// Header for the Instant Navigation Testing API. In development and testing
-// builds, static pre-renders normally don't happen. This header tells the
-// server to perform a static pre-render anyway, allowing tests to assert on
-// the prefetched UI. Not exposed in production builds by default.
-export const NEXT_INSTANT_PREFETCH_HEADER =
-  'next-instant-navigation-testing-prefetch' as const
-
-// Cookie for the Instant Navigation Testing API. Used for MPA navigations
-// (page reload, full page load) where we can't set request headers. When set,
-// the server renders only the static shell. Not exposed in production builds
-// by default.
+// Cookie for the Instant Navigation Testing API. Sent automatically with all
+// requests while a navigation lock is held; the server uses its presence to
+// render only the static shell. Not exposed in production builds by default.
 export const NEXT_INSTANT_TEST_COOKIE =
   'next-instant-navigation-testing' as const
 

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -18,7 +18,6 @@ import type {
 import {
   type NEXT_ROUTER_PREFETCH_HEADER,
   type NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
-  type NEXT_INSTANT_PREFETCH_HEADER,
   NEXT_ROUTER_STATE_TREE_HEADER,
   NEXT_RSC_UNION_QUERY,
   NEXT_URL,
@@ -110,7 +109,6 @@ export type RequestHeaders = {
   'Next-Test-Fetch-Priority'?: RequestInit['priority']
   [NEXT_HTML_REQUEST_ID_HEADER]?: string // dev-only
   [NEXT_REQUEST_ID_HEADER]?: string // dev-only
-  [NEXT_INSTANT_PREFETCH_HEADER]?: '1' // testing API only
 }
 
 function doMpaNavigation(url: string): FetchServerResponseResult {

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -16,7 +16,6 @@ import {
 } from '../../../shared/lib/segment-cache/vary-params-decoding'
 import {
   NEXT_DID_POSTPONE_HEADER,
-  NEXT_INSTANT_PREFETCH_HEADER,
   NEXT_ROUTER_PREFETCH_HEADER,
   NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
   NEXT_ROUTER_STALE_TIME_HEADER,
@@ -1598,9 +1597,6 @@ export async function fetchRouteOnCacheMiss(
   if (nextUrl !== null) {
     headers[NEXT_URL] = nextUrl
   }
-  // Tell the server to perform a static pre-render for the Instant Navigation
-  // Testing API. Static pre-renders don't normally happen during development.
-  addInstantPrefetchHeaderIfLocked(headers)
 
   try {
     const url = new URL(pathname + search, location.origin)
@@ -1930,9 +1926,6 @@ export async function fetchSegmentsOnCacheMiss(
   if (nextUrl !== null) {
     headers[NEXT_URL] = nextUrl
   }
-  // Tell the server to perform a static pre-render for the Instant Navigation
-  // Testing API. Static pre-renders don't normally happen during development.
-  addInstantPrefetchHeaderIfLocked(headers)
 
   const requestUrl = isOutputExportMode
     ? // In output: "export" mode, we need to add the segment path to the URL.
@@ -2869,22 +2862,6 @@ export function canNewFetchStrategyProvideMoreContent(
   newStrategy: FetchStrategy
 ): boolean {
   return currentStrategy < newStrategy
-}
-
-/**
- * Adds the instant prefetch header if the navigation lock is active.
- * Uses a lazy require to ensure dead code elimination.
- */
-function addInstantPrefetchHeaderIfLocked(
-  headers: Record<string, string>
-): void {
-  if (process.env.__NEXT_EXPOSE_TESTING_API) {
-    const { isNavigationLocked } =
-      require('./navigation-testing-lock') as typeof import('./navigation-testing-lock')
-    if (isNavigationLocked()) {
-      headers[NEXT_INSTANT_PREFETCH_HEADER] = '1'
-    }
-  }
 }
 
 function getStaleAtFromHeader(

--- a/packages/next/src/server/stream-utils/node-web-streams-helper.ts
+++ b/packages/next/src/server/stream-utils/node-web-streams-helper.ts
@@ -19,7 +19,6 @@ import {
   NEXT_ROUTER_PREFETCH_HEADER,
   NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
   NEXT_RSC_UNION_QUERY,
-  NEXT_INSTANT_PREFETCH_HEADER,
 } from '../../client/components/app-router-headers'
 import { computeCacheBustingSearchParam } from '../../shared/lib/router/utils/cache-busting-search-param'
 import type { AnyStream } from '../app-render/stream-ops'
@@ -590,8 +589,9 @@ export async function createInstantTestScriptInsertionTransformStream(
 ): Promise<TransformStream<Uint8Array, Uint8Array>> {
   // Kick off a fetch for the static RSC payload. This is the hydration
   // source for the locked static shell — same as the __NEXT_CLIENT_RESUME
-  // fetch used for fallback routes, but with NEXT_INSTANT_PREFETCH_HEADER
-  // so the server returns static-only data.
+  // fetch used for fallback routes. The instant test cookie is sent
+  // automatically with the same-origin fetch, so the server returns
+  // static-only data.
   //
   // The fetch promise is stored as self.__next_instant_test, which doubles
   // as the feature flag (truthy = instant test mode). The client processes
@@ -610,7 +610,7 @@ export async function createInstantTestScriptInsertionTransformStream(
   // bootstrapScriptContent.
   const requestIdScript =
     requestId !== null ? `self.__next_r=${JSON.stringify(requestId)};` : ''
-  const INSTANT_TEST_SCRIPT = `<script>${requestIdScript}self.__next_instant_test=fetch(location.pathname+'?${searchStr}',{credentials:'same-origin',headers:{'${RSC_HEADER}':'1','${NEXT_ROUTER_PREFETCH_HEADER}':'1','${NEXT_ROUTER_SEGMENT_PREFETCH_HEADER}':'${segmentPath}','${NEXT_INSTANT_PREFETCH_HEADER}':'1'}})</script>`
+  const INSTANT_TEST_SCRIPT = `<script>${requestIdScript}self.__next_instant_test=fetch(location.pathname+'?${searchStr}',{credentials:'same-origin',headers:{'${RSC_HEADER}':'1','${NEXT_ROUTER_PREFETCH_HEADER}':'1','${NEXT_ROUTER_SEGMENT_PREFETCH_HEADER}':'${segmentPath}'}})</script>`
 
   let didAlreadyInsert = false
   return new TransformStream({


### PR DESCRIPTION
`NEXT_INSTANT_PREFETCH_HEADER` was replaced by `NEXT_INSTANT_TEST_COOKIE` in #89871. Deleting the dead code.

<!-- NEXT_JS_LLM_PR -->