### PR TITLE
offline navigations: generate fallback document artifacts (2/21)

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -4115,7 +4115,7 @@ export default async function build(
               getOfflineNavigationFallbackFilePath(buildId)
             )
             await mkdir(path.dirname(fallbackPath), { recursive: true })
-            await writeFileUtf8(fallbackPath, fallbackDocument)
+            await writeFileUtf8(fallbackPath, fallbackDocument.html)
           })
       }
 

--- a/packages/next/src/build/offline-navigation-fallback.ts
+++ b/packages/next/src/build/offline-navigation-fallback.ts
@@ -7,9 +7,14 @@ import {
   htmlEscapeJsonString,
 } from '../shared/lib/htmlescape'
 import { CLIENT_STATIC_FILES_PATH } from '../shared/lib/constants'
-
-export const OFFLINE_NAVIGATION_FALLBACK_HTML =
-  '_offline-navigation-fallback.html'
+import { createInitialInlinedFlightDataScriptContent } from '../shared/lib/inlined-flight-data'
+import {
+  OFFLINE_NAVIGATION_BUILD_ID_META_NAME,
+  OFFLINE_NAVIGATION_FALLBACK_DOCUMENT_ATTRIBUTE,
+  OFFLINE_NAVIGATION_FALLBACK_HTML,
+  OFFLINE_NAVIGATION_FALLBACK_META_NAME,
+  OFFLINE_NAVIGATION_FALLBACK_SCRIPT_ID,
+} from '../shared/lib/offline-navigation-constants'
 
 export function getOfflineNavigationFallbackFilePath(buildId: string): string {
   return path.join(
@@ -17,6 +22,18 @@ export function getOfflineNavigationFallbackFilePath(buildId: string): string {
     buildId,
     OFFLINE_NAVIGATION_FALLBACK_HTML
   )
+}
+
+export function getOfflineNavigationFallbackDocumentHref({
+  basePath,
+  buildId,
+}: {
+  basePath: string
+  buildId: string
+}): string {
+  return `${basePath}/_next/${encodeURIPath(
+    getOfflineNavigationFallbackFilePath(buildId)
+  )}`
 }
 
 function getAssetHref(assetPrefix: string, file: string): string {
@@ -33,6 +50,77 @@ function getScriptAttributes(
   return ` crossOrigin="${htmlEscapeAttributeString(crossOrigin)}"`
 }
 
+function renderJsonScript(id: string, data: unknown): string {
+  return `<script id="${id}" type="application/json">${htmlEscapeJsonString(
+    JSON.stringify(data)
+  )}</script>`
+}
+
+function renderScriptSrc({
+  async,
+  crossOrigin,
+  noModule,
+  src,
+}: {
+  async?: boolean
+  crossOrigin: '' | 'anonymous' | 'use-credentials' | undefined
+  noModule?: boolean
+  src: string
+}): string {
+  const attributes = [
+    ` src="${htmlEscapeAttributeString(src)}"`,
+    noModule ? ' noModule' : '',
+    async ? ' async' : '',
+    getScriptAttributes(crossOrigin),
+  ].join('')
+
+  return `<script${attributes}></script>`
+}
+
+function renderInitialFlightBootstrapScript(): string {
+  // The empty fallback document still needs the initial Flight instruction so
+  // the client can mount through the same bootstrap path as a normal document.
+  return `<script>${createInitialInlinedFlightDataScriptContent(null)}</script>`
+}
+
+export interface OfflineNavigationFallbackDocument {
+  html: string
+  assetHrefs: string[]
+}
+
+function renderFallbackDocument({
+  bootstrapScripts,
+  buildId,
+  metadata,
+  polyfillScripts,
+}: {
+  bootstrapScripts: string
+  buildId: string
+  metadata: unknown
+  polyfillScripts: string
+}): string {
+  const escapedBuildId = htmlEscapeAttributeString(buildId)
+
+  return [
+    '<!DOCTYPE html>',
+    `<html ${OFFLINE_NAVIGATION_FALLBACK_DOCUMENT_ATTRIBUTE}="" data-build-id="${escapedBuildId}">`,
+    '<head>',
+    '<meta charSet="utf-8">',
+    '<meta name="viewport" content="width=device-width, initial-scale=1">',
+    `<meta name="${OFFLINE_NAVIGATION_FALLBACK_META_NAME}" content="1">`,
+    `<meta name="${OFFLINE_NAVIGATION_BUILD_ID_META_NAME}" content="${escapedBuildId}">`,
+    renderJsonScript(OFFLINE_NAVIGATION_FALLBACK_SCRIPT_ID, metadata),
+    '</head>',
+    '<body>',
+    '<div id="__next"></div>',
+    renderInitialFlightBootstrapScript(),
+    polyfillScripts,
+    bootstrapScripts,
+    '</body>',
+    '</html>',
+  ].join('')
+}
+
 // Generate the build-scoped HTML entrypoint used by offline document fallback
 // handling. It intentionally contains only the app bootstrap, not route HTML,
 // so the artifact stays request-invariant.
@@ -46,7 +134,7 @@ export function createOfflineNavigationFallbackDocument({
   buildId: string
   buildManifest: BuildManifest
   crossOrigin: '' | 'anonymous' | 'use-credentials' | undefined
-}): string | null {
+}): OfflineNavigationFallbackDocument | null {
   const rootMainFiles = buildManifest.rootMainFiles.filter((file) =>
     file.endsWith('.js')
   )
@@ -55,33 +143,43 @@ export function createOfflineNavigationFallbackDocument({
     return null
   }
 
+  const fallbackAssetHrefs = [
+    ...buildManifest.polyfillFiles
+      .filter((file) => file.endsWith('.js') && !file.endsWith('.module.js'))
+      .map((file) => getAssetHref(assetPrefix, file)),
+    ...rootMainFiles.map((file) => getAssetHref(assetPrefix, file)),
+  ]
+
   const polyfillScripts = buildManifest.polyfillFiles
     .filter((file) => file.endsWith('.js') && !file.endsWith('.module.js'))
     .map((file) => {
-      return `<script src="${htmlEscapeAttributeString(
-        getAssetHref(assetPrefix, file)
-      )}" noModule${getScriptAttributes(crossOrigin)}></script>`
+      return renderScriptSrc({
+        crossOrigin,
+        noModule: true,
+        src: getAssetHref(assetPrefix, file),
+      })
     })
     .join('')
 
   const bootstrapScripts = rootMainFiles
     .map((file) => {
-      return `<script src="${htmlEscapeAttributeString(
-        getAssetHref(assetPrefix, file)
-      )}" async${getScriptAttributes(crossOrigin)}></script>`
+      return renderScriptSrc({
+        async: true,
+        crossOrigin,
+        src: getAssetHref(assetPrefix, file),
+      })
     })
     .join('')
 
-  const metadata = {
-    buildId,
-    source: 'offline-navigation-fallback',
-  }
+  const metadata = { buildId }
 
-  return `<!DOCTYPE html><html data-next-offline-navigation-fallback="" data-build-id="${htmlEscapeAttributeString(
-    buildId
-  )}"><head><meta charSet="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><meta name="next-offline-navigation-fallback" content="1"><meta name="next-build-id" content="${htmlEscapeAttributeString(
-    buildId
-  )}"><script id="__NEXT_OFFLINE_NAVIGATION_FALLBACK" type="application/json">${htmlEscapeJsonString(
-    JSON.stringify(metadata)
-  )}</script></head><body><div id="__next"></div><script>self.__next_f=self.__next_f||[];self.__next_f.push([0])</script>${polyfillScripts}${bootstrapScripts}</body></html>`
+  return {
+    assetHrefs: fallbackAssetHrefs,
+    html: renderFallbackDocument({
+      bootstrapScripts,
+      buildId,
+      metadata,
+      polyfillScripts,
+    }),
+  }
 }

--- a/packages/next/src/server/app-render/stream-ops.node.ts
+++ b/packages/next/src/server/app-render/stream-ops.node.ts
@@ -35,6 +35,11 @@ import {
   htmlEscapeAttributeString,
   htmlEscapeJsonString,
 } from '../../shared/lib/htmlescape'
+import {
+  createInitialInlinedFlightDataScriptContent,
+  INLINE_FLIGHT_PAYLOAD_BINARY,
+  INLINE_FLIGHT_PAYLOAD_DATA,
+} from '../../shared/lib/inlined-flight-data'
 import { createInlinedDataReadableStream } from './use-flight-response'
 import type { AnyStream as AnyStreamType } from './app-render-prerender-utils'
 import { DetachedPromise } from '../../lib/detached-promise'
@@ -947,14 +952,7 @@ export function createNodeInlinedDataStream(
   const pt = new PassThrough()
 
   // Write initial bootstrap instructions
-  let scriptContents = `(self.__next_f=self.__next_f||[]).push(${htmlEscapeJsonString(
-    JSON.stringify([INLINE_FLIGHT_PAYLOAD_BOOTSTRAP])
-  )})`
-  if (formState != null) {
-    scriptContents += `;self.__next_f.push(${htmlEscapeJsonString(
-      JSON.stringify([INLINE_FLIGHT_PAYLOAD_FORM_STATE, formState])
-    )})`
-  }
+  const scriptContents = createInitialInlinedFlightDataScriptContent(formState)
   pt.push(Buffer.from(`${startScriptTag}${scriptContents}</script>`))
 
   // Pull from the flight data stream and wrap each chunk in a <script> tag
@@ -962,11 +960,6 @@ export function createNodeInlinedDataStream(
 
   return pt
 }
-
-const INLINE_FLIGHT_PAYLOAD_BOOTSTRAP = 0
-const INLINE_FLIGHT_PAYLOAD_DATA = 1
-const INLINE_FLIGHT_PAYLOAD_FORM_STATE = 2
-const INLINE_FLIGHT_PAYLOAD_BINARY = 3
 
 async function pullFlightData(
   dataStream: Readable,

--- a/packages/next/src/server/app-render/use-flight-response.tsx
+++ b/packages/next/src/server/app-render/use-flight-response.tsx
@@ -5,16 +5,16 @@ import {
   htmlEscapeAttributeString,
   htmlEscapeJsonString,
 } from '../../shared/lib/htmlescape'
+import {
+  createInitialInlinedFlightDataScriptContent,
+  INLINE_FLIGHT_PAYLOAD_BINARY,
+  INLINE_FLIGHT_PAYLOAD_DATA,
+} from '../../shared/lib/inlined-flight-data'
 import { workUnitAsyncStorage } from './work-unit-async-storage.external'
 import { InvariantError } from '../../shared/lib/invariant-error'
 import { getClientReferenceManifest } from './manifests-singleton'
 
 const isEdgeRuntime = process.env.NEXT_RUNTIME === 'edge'
-
-const INLINE_FLIGHT_PAYLOAD_BOOTSTRAP = 0
-const INLINE_FLIGHT_PAYLOAD_DATA = 1
-const INLINE_FLIGHT_PAYLOAD_FORM_STATE = 2
-const INLINE_FLIGHT_PAYLOAD_BINARY = 3
 
 const flightResponses = new WeakMap<
   Readable | BinaryStreamOf<any>,
@@ -224,16 +224,7 @@ function writeInitialInstructions(
   scriptStart: string,
   formState: unknown | null
 ) {
-  let scriptContents = `(self.__next_f=self.__next_f||[]).push(${htmlEscapeJsonString(
-    JSON.stringify([INLINE_FLIGHT_PAYLOAD_BOOTSTRAP])
-  )})`
-
-  if (formState != null) {
-    scriptContents += `;self.__next_f.push(${htmlEscapeJsonString(
-      JSON.stringify([INLINE_FLIGHT_PAYLOAD_FORM_STATE, formState])
-    )})`
-  }
-
+  const scriptContents = createInitialInlinedFlightDataScriptContent(formState)
   controller.enqueue(encoder.encode(`${scriptStart}${scriptContents}</script>`))
 }
 

--- a/packages/next/src/shared/lib/inlined-flight-data.ts
+++ b/packages/next/src/shared/lib/inlined-flight-data.ts
@@ -1,0 +1,22 @@
+import { htmlEscapeJsonString } from './htmlescape'
+
+export const INLINE_FLIGHT_PAYLOAD_BOOTSTRAP = 0
+export const INLINE_FLIGHT_PAYLOAD_DATA = 1
+export const INLINE_FLIGHT_PAYLOAD_FORM_STATE = 2
+export const INLINE_FLIGHT_PAYLOAD_BINARY = 3
+
+export function createInitialInlinedFlightDataScriptContent(
+  formState: unknown | null
+): string {
+  let scriptContents = `(self.__next_f=self.__next_f||[]).push(${htmlEscapeJsonString(
+    JSON.stringify([INLINE_FLIGHT_PAYLOAD_BOOTSTRAP])
+  )})`
+
+  if (formState != null) {
+    scriptContents += `;self.__next_f.push(${htmlEscapeJsonString(
+      JSON.stringify([INLINE_FLIGHT_PAYLOAD_FORM_STATE, formState])
+    )})`
+  }
+
+  return scriptContents
+}

--- a/packages/next/src/shared/lib/offline-navigation-constants.ts
+++ b/packages/next/src/shared/lib/offline-navigation-constants.ts
@@ -1,0 +1,9 @@
+export const OFFLINE_NAVIGATION_FALLBACK_HTML =
+  '_offline-navigation-fallback.html'
+export const OFFLINE_NAVIGATION_FALLBACK_DOCUMENT_ATTRIBUTE =
+  'data-next-offline-navigation-fallback'
+export const OFFLINE_NAVIGATION_FALLBACK_SCRIPT_ID =
+  '__NEXT_OFFLINE_NAVIGATION_FALLBACK'
+export const OFFLINE_NAVIGATION_FALLBACK_META_NAME =
+  'next-offline-navigation-fallback'
+export const OFFLINE_NAVIGATION_BUILD_ID_META_NAME = 'next-build-id'

--- a/test/production/app-dir/offline-navigations/next.config.js
+++ b/test/production/app-dir/offline-navigations/next.config.js
@@ -3,9 +3,12 @@
  */
 const nextConfig = {
   cacheComponents: true,
+  assetPrefix: 'https://cdn.example.com/app-assets',
+  basePath: '/docs',
   experimental: {
     offlineNavigations: true,
   },
+  trailingSlash: true,
 }
 
 module.exports = nextConfig

--- a/test/production/app-dir/offline-navigations/offline-navigations.test.ts
+++ b/test/production/app-dir/offline-navigations/offline-navigations.test.ts
@@ -1,45 +1,66 @@
-import { existsSync } from 'fs'
+import { existsSync, readdirSync } from 'fs'
 import { join } from 'path'
 import { nextTestSetup } from 'e2e-utils'
 
-describe('offlineNavigations fallback document', () => {
+describe('offlineNavigations build artifacts', () => {
   const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,
   })
 
-  async function getFallbackDocumentPath() {
+  async function getOfflineNavigationArtifactPaths() {
     const buildId = (await next.readFile('.next/BUILD_ID')).trim()
 
     return {
       buildId,
-      absolutePath: join(
-        next.testDir,
-        '.next',
-        'static',
-        buildId,
-        '_offline-navigation-fallback.html'
-      ),
-      relativePath: `.next/static/${buildId}/_offline-navigation-fallback.html`,
+      fallbackDocument: {
+        absolutePath: join(
+          next.testDir,
+          '.next',
+          'static',
+          buildId,
+          '_offline-navigation-fallback.html'
+        ),
+        relativePath: `.next/static/${buildId}/_offline-navigation-fallback.html`,
+      },
+      buildStaticDirectory: {
+        absolutePath: join(next.testDir, '.next', 'static', buildId),
+      },
     }
   }
 
-  it('emits a request-invariant fallback document when enabled', async () => {
+  function getOfflineNavigationBuildFileNames(directory: string): string[] {
+    return readdirSync(directory)
+      .filter((entry) => entry.startsWith('_offline-navigation-'))
+      .sort()
+  }
+
+  it('emits a request-invariant offline navigation fallback document when enabled', async () => {
     const buildResult = await next.build()
     expect(buildResult.exitCode).toBe(0)
 
-    const { buildId, relativePath } = await getFallbackDocumentPath()
-    const html = await next.readFile(relativePath)
+    const { buildId, buildStaticDirectory, fallbackDocument } =
+      await getOfflineNavigationArtifactPaths()
+    const html = await next.readFile(fallbackDocument.relativePath)
+
+    expect(
+      getOfflineNavigationBuildFileNames(buildStaticDirectory.absolutePath)
+    ).toEqual(['_offline-navigation-fallback.html'])
 
     expect(html).toContain('data-next-offline-navigation-fallback')
     expect(html).toContain('id="__NEXT_OFFLINE_NAVIGATION_FALLBACK"')
     expect(html).toContain(`"buildId":"${buildId}"`)
-    expect(html).toContain('self.__next_f')
-    expect(html).toContain('/_next/static/')
+    expect(html).not.toContain('"source"')
+    expect(html).toContain(
+      '<script>(self.__next_f=self.__next_f||[]).push([0])</script>'
+    )
+    expect(html).toContain('https://cdn.example.com/app-assets/_next/static/')
     expect(html).not.toContain('offline navigations page')
+    expect(html).not.toContain('\n')
+    expect(html.length).toBeLessThan(4096)
   })
 
-  it('does not emit a fallback document when disabled', async () => {
+  it('does not emit offline navigation artifacts when disabled', async () => {
     await next.patchFile('next.config.js', (content) =>
       content.replace('offlineNavigations: true', 'offlineNavigations: false')
     )
@@ -47,7 +68,16 @@ describe('offlineNavigations fallback document', () => {
     const buildResult = await next.build()
     expect(buildResult.exitCode).toBe(0)
 
-    const { absolutePath } = await getFallbackDocumentPath()
-    expect(existsSync(absolutePath)).toBe(false)
+    const { buildStaticDirectory, fallbackDocument } =
+      await getOfflineNavigationArtifactPaths()
+    expect(existsSync(fallbackDocument.absolutePath)).toBe(false)
+    expect(
+      existsSync(
+        join(
+          buildStaticDirectory.absolutePath,
+          '_offline-navigation-manifest.json'
+        )
+      )
+    ).toBe(false)
   })
 })


### PR DESCRIPTION
This is PR 2 of 21 in the offline navigations plus output-export fallback stack.

This stack introduces a generated fallback entrypoint and then layers the client behavior on the existing App Router, cached navigations, optimistic routing, Cache Components, and Segment Cache primitives. The offline navigations chapter adds a managed service worker and persisted Segment Cache replay. The output-export chapter emits static fallback HTML/RSC artifacts so parameterized routes can load and navigate without enumerating every param at build time.

Review guide: https://gist.github.com/feedthejim/bb440153d29dce019d1d26b6643e2a48

## Where This Sits
This PR is in the offline navigations chapter.
Previous PR: #93736 `offline navigations: add gated build primitives (1/21)`.
Next PR: #93625 `offline navigations: register pass-through worker (3/21)`.

## What Changes
- Generates one build-scoped fallback HTML document when offline navigations are enabled.
- Keeps the document request-invariant so it can bootstrap any offline document navigation for the current build.

## Reviewer Focus
- The build should only write the fallback document when the flag is enabled.
- The fallback document should contain minimal private markers and no route-specific data.

## Proof In This PR
- Production offline-navigation artifact coverage asserts the fallback document path and request-invariant markers.
- The disabled-flag artifact row asserts the fallback document is not emitted when the flag is off.

Latest local stack verification after autosquash included:
- `git diff --check`
- `pnpm --filter=next types`
- `pnpm testonly packages/next/src/client/components/segment-cache/offline-navigation-cache.test.ts packages/next/src/client/components/segment-cache/cache.test.ts packages/next/src/client/output-export-fallback.test.ts packages/next/src/export/helpers/output-export-fallback.test.ts packages/next/src/lib/output-export-fallback-routes.test.ts packages/next/src/client/components/router-reducer/fetch-server-response.test.ts`
- `HEADLESS=true pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `HEADLESS=true pnpm test-start-turbo test/e2e/app-dir-export/test/dynamic-fallback*.test.ts`

## Deferred Coverage
Service worker registration, worker caching, and offline document replay are deferred.

## Disabled-Flag Posture
The build artifact path is gated by the experimental flag. Disabled apps should not write the fallback document.

## Full Stack
1. [offline navigations: add gated build primitives (1/21)](https://github.com/vercel/next.js/pull/93736)
2. **Current PR:** [offline navigations: generate fallback document artifacts (2/21)](https://github.com/vercel/next.js/pull/93737)
3. [offline navigations: register pass-through worker (3/21)](https://github.com/vercel/next.js/pull/93625)
4. [offline navigations: cache fallback and current-build assets (4/21)](https://github.com/vercel/next.js/pull/93626)
5. [offline navigations: serve fallback document offline (5/21)](https://github.com/vercel/next.js/pull/93627)
6. [offline navigations: add Segment Cache persistence primitives (6/21)](https://github.com/vercel/next.js/pull/93630)
7. [offline navigations: persist cached Segment Cache records (7/21)](https://github.com/vercel/next.js/pull/93640)
8. [offline navigations: bootstrap fallback from Segment Cache records (8/21)](https://github.com/vercel/next.js/pull/93644)
9. [offline navigations: support dynamic route patterns (9/21)](https://github.com/vercel/next.js/pull/93647)
10. [offline navigations: add docs and examples (10/21)](https://github.com/vercel/next.js/pull/93738)
11. [output export fallbacks: add gated build primitives (11/21)](https://github.com/vercel/next.js/pull/93744)
12. [output export fallbacks: emit fallback HTML artifacts (12/21)](https://github.com/vercel/next.js/pull/93745)
13. [output export fallbacks: emit fallback RSC artifacts (13/21)](https://github.com/vercel/next.js/pull/93746)
14. [output export fallbacks: enforce server-only boundaries (14/21)](https://github.com/vercel/next.js/pull/93747)
15. [output export fallbacks: bootstrap hard loads from artifacts (15/21)](https://github.com/vercel/next.js/pull/93748)
16. [output export fallbacks: resolve soft navigations through cached routes (16/21)](https://github.com/vercel/next.js/pull/93749)
17. [output export fallbacks: resolve fallback artifacts from route manifests (17/21)](https://github.com/vercel/next.js/pull/93779)
18. [output export fallbacks: validate fallback Flight responses (18/21)](https://github.com/vercel/next.js/pull/93750)
19. [output export fallbacks: store fallback data in Segment Cache (19/21)](https://github.com/vercel/next.js/pull/93774)
20. [output export fallbacks: support known params and export variants (20/21)](https://github.com/vercel/next.js/pull/93751)
21. [output export fallbacks: add docs and review guide (21/21)](https://github.com/vercel/next.js/pull/93752)

<!-- NEXT_JS_LLM_PR -->
