### PR TITLE
Deduplicate middleware Set-Cookie headers by cookie identity

### DIFF
--- a/packages/next/src/server/lib/patch-set-header.test.ts
+++ b/packages/next/src/server/lib/patch-set-header.test.ts
@@ -1,0 +1,76 @@
+import { addRequestMeta } from '../request-meta'
+import { patchSetHeaderWithCookieSupport } from './patch-set-header'
+
+function createResponse() {
+  const headers = new Map<string, string | string[]>()
+
+  return {
+    headers,
+    res: {
+      setHeader(key: string, value: string | string[]) {
+        headers.set(key, value)
+        return this
+      },
+    },
+  }
+}
+
+describe('patchSetHeaderWithCookieSupport', () => {
+  it('does not dedupe set-cookie values when middleware did not set cookies', () => {
+    const req = {}
+    const { headers, res } = createResponse()
+
+    patchSetHeaderWithCookieSupport(req as any, res)
+
+    res.setHeader('Set-Cookie', [
+      'session=from-action-1; Path=/',
+      'session=from-action-2; Path=/',
+    ])
+
+    expect(headers.get('Set-Cookie')).toEqual([
+      'session=from-action-1; Path=/',
+      'session=from-action-2; Path=/',
+    ])
+  })
+
+  it('lets later set-cookie values replace matching middleware cookies', () => {
+    const req = {}
+    const { headers, res } = createResponse()
+
+    addRequestMeta(req as any, 'middlewareCookie', [
+      'middleware-repro=from-middleware; Path=/',
+      'middleware-only=from-middleware; Path=/',
+    ])
+    patchSetHeaderWithCookieSupport(req as any, res)
+
+    res.setHeader('Set-Cookie', [
+      'middleware-repro=from-action; Path=/',
+      'action-repro=from-action-2; Path=/',
+    ])
+
+    expect(headers.get('Set-Cookie')).toEqual([
+      'middleware-repro=from-action; Path=/',
+      'middleware-only=from-middleware; Path=/',
+      'action-repro=from-action-2; Path=/',
+    ])
+  })
+
+  it('keeps cookies with the same name but different path or domain', () => {
+    const req = {}
+    const { headers, res } = createResponse()
+
+    addRequestMeta(req as any, 'middlewareCookie', [
+      'session=from-middleware; Path=/admin',
+      'session=from-middleware-domain; Path=/; Domain=example.com',
+    ])
+    patchSetHeaderWithCookieSupport(req as any, res)
+
+    res.setHeader('Set-Cookie', 'session=from-action; Path=/')
+
+    expect(headers.get('Set-Cookie')).toEqual([
+      'session=from-middleware; Path=/admin',
+      'session=from-middleware-domain; Path=/; Domain=example.com',
+      'session=from-action; Path=/',
+    ])
+  })
+})

--- a/packages/next/src/server/lib/patch-set-header.ts
+++ b/packages/next/src/server/lib/patch-set-header.ts
@@ -1,4 +1,6 @@
 import { getRequestMeta, type NextIncomingMessage } from '../request-meta'
+import { parseSetCookie } from '../web/spec-extension/cookies'
+import { splitCookiesString } from '../web/utils'
 
 const PATCHED_SET_HEADER = Symbol('next.patchSetHeaderWithCookieSupport')
 
@@ -6,6 +8,44 @@ type PatchableResponse = {
   setHeader(key: string, value: string | string[]): PatchableResponse
   headersSent?: boolean
   [PATCHED_SET_HEADER]?: true
+}
+
+function normalizeSetCookieHeader(value: string | string[]): string[] {
+  if (typeof value === 'string') {
+    return splitCookiesString(value)
+  }
+
+  return value.flatMap((cookie) => splitCookiesString(cookie))
+}
+
+function getSetCookieKey(cookie: string): string {
+  const parsed = parseSetCookie(cookie)
+
+  if (!parsed) {
+    return cookie
+  }
+
+  return [
+    parsed.name,
+    parsed.domain?.toLowerCase() ?? '',
+    parsed.path ?? '',
+  ].join(';')
+}
+
+function mergeSetCookieHeadersWithPrecedence(
+  middlewareValue: string[] | undefined,
+  value: string | string[]
+): string[] {
+  const cookies = new Map<string, string>()
+
+  for (const cookie of [
+    ...(middlewareValue || []),
+    ...normalizeSetCookieHeader(value),
+  ]) {
+    cookies.set(getSetCookieKey(cookie), cookie)
+  }
+
+  return Array.from(cookies.values())
 }
 
 /**
@@ -43,21 +83,11 @@ export function patchSetHeaderWithCookieSupport(
       const middlewareValue = getRequestMeta(req, 'middlewareCookie')
 
       if (
-        !middlewareValue ||
-        !Array.isArray(value) ||
-        !value.every((item, idx) => item === middlewareValue[idx])
+        middlewareValue &&
+        (!Array.isArray(value) ||
+          !value.every((item, idx) => item === middlewareValue[idx]))
       ) {
-        value = [
-          // TODO: (wyattjoh) find out why this is called multiple times resulting in duplicate cookies being added
-          ...new Set([
-            ...(middlewareValue || []),
-            ...(typeof value === 'string'
-              ? [value]
-              : Array.isArray(value)
-                ? value
-                : []),
-          ]),
-        ]
+        value = mergeSetCookieHeadersWithPrecedence(middlewareValue, value)
       }
     }
 

--- a/packages/next/src/server/web/spec-extension/cookies.ts
+++ b/packages/next/src/server/web/spec-extension/cookies.ts
@@ -1,4 +1,5 @@
 export {
+  parseSetCookie,
   RequestCookies,
   ResponseCookies,
   stringifyCookie,


### PR DESCRIPTION
## What changed

This updates the middleware cookie merge path so later `Set-Cookie` values replace matching middleware cookies by cookie identity: name, domain, and path.

That means when middleware sets a cookie and a later Server Action sets the same cookie, the final response only includes the later value instead of sending duplicate `Set-Cookie` headers for the same cookie.

## Why

Fixes #69785.

Middleware cookies are stored on request metadata and later merged into response `Set-Cookie` headers. The previous merge only deduped exact string matches, so values like `session=from-middleware; Path=/` and `session=from-action; Path=/` both survived even though the latter should take precedence.

## Notes

The identity-based merge is only applied when middleware cookies are present. Non-middleware `Set-Cookie` behavior is preserved, including multiple same-name cookies set by other response paths.

## Validation

- `pnpm testonly packages/next/src/server/lib/patch-set-header.test.ts --runInBand`
- `pnpm prettier --check packages/next/src/server/lib/patch-set-header.ts packages/next/src/server/lib/patch-set-header.test.ts packages/next/src/server/web/spec-extension/cookies.ts`
- `pnpm --filter next build`
