### PR TITLE
output export fallbacks: add gated build primitives (11/21)

### DIFF
--- a/packages/next/src/lib/output-export-dynamic-fallback.test.ts
+++ b/packages/next/src/lib/output-export-dynamic-fallback.test.ts
@@ -1,0 +1,77 @@
+import {
+  getOutputExportFallbackPath,
+  getOutputExportFallbackStaticPrefix,
+  isOutputExportDynamicFallbackEnabled,
+  isOutputExportOptimisticRoutingEnabled,
+  isOutputExportVaryParamsEnabled,
+} from './output-export-dynamic-fallback'
+
+describe('output export dynamic fallback', () => {
+  it('derives the fallback path from a static route prefix', () => {
+    expect(getOutputExportFallbackPath('org/acme/chat')).toBe(
+      '/org/acme/chat/__fallback'
+    )
+    expect(getOutputExportFallbackPath('')).toBe('/__fallback')
+  })
+
+  it('derives the static prefix before the first dynamic segment', () => {
+    expect(
+      getOutputExportFallbackStaticPrefix('/org/[org]/chat/[thread]')
+    ).toBe('org')
+    expect(getOutputExportFallbackStaticPrefix('/[locale]/blog/[slug]')).toBe(
+      ''
+    )
+    expect(getOutputExportFallbackStaticPrefix('/org/acme/chat')).toBeNull()
+  })
+
+  it('stays behind output export, cache components, and the explicit flag', () => {
+    expect(
+      isOutputExportDynamicFallbackEnabled({
+        output: 'export',
+        cacheComponents: true,
+        experimental: { outputExportDynamicFallbacks: true },
+      })
+    ).toBe(true)
+
+    expect(
+      isOutputExportDynamicFallbackEnabled({
+        output: 'export',
+        cacheComponents: true,
+      })
+    ).toBe(false)
+
+    expect(
+      isOutputExportDynamicFallbackEnabled({
+        output: 'standalone',
+        cacheComponents: true,
+        experimental: { outputExportDynamicFallbacks: true },
+      })
+    ).toBe(false)
+  })
+
+  it('uses the fallback flag to imply the routing flags used by the client path', () => {
+    const enabledConfig = {
+      output: 'export',
+      cacheComponents: true,
+      experimental: { outputExportDynamicFallbacks: true },
+    }
+
+    expect(isOutputExportOptimisticRoutingEnabled(enabledConfig)).toBe(true)
+    expect(isOutputExportVaryParamsEnabled(enabledConfig)).toBe(true)
+
+    expect(
+      isOutputExportOptimisticRoutingEnabled({
+        output: 'export',
+        cacheComponents: true,
+        experimental: { optimisticRouting: true },
+      })
+    ).toBe(true)
+    expect(
+      isOutputExportVaryParamsEnabled({
+        output: 'export',
+        cacheComponents: true,
+        experimental: { varyParams: true },
+      })
+    ).toBe(true)
+  })
+})

--- a/packages/next/src/lib/output-export-dynamic-fallback.ts
+++ b/packages/next/src/lib/output-export-dynamic-fallback.ts
@@ -1,0 +1,61 @@
+import { parseNormalizedAppRoute } from '../shared/lib/router/routes/app'
+
+type OutputExportDynamicFallbackConfig = {
+  output?: string
+  cacheComponents?: boolean
+  experimental?: {
+    optimisticRouting?: boolean
+    outputExportDynamicFallbacks?: boolean
+    varyParams?: boolean
+  }
+}
+
+export function getOutputExportFallbackPath(staticPrefix: string): string {
+  return staticPrefix.length > 0 ? `/${staticPrefix}/__fallback` : '/__fallback'
+}
+
+export function getOutputExportFallbackStaticPrefix(
+  routePath: string
+): string | null {
+  const route = parseNormalizedAppRoute(routePath)
+  const firstDynamicIndex = route.segments.findIndex(
+    (segment) => segment.type === 'dynamic'
+  )
+
+  if (firstDynamicIndex === -1) {
+    return null
+  }
+
+  return route.segments
+    .slice(0, firstDynamicIndex)
+    .map((segment) => segment.name)
+    .join('/')
+}
+
+export function isOutputExportDynamicFallbackEnabled(
+  config: OutputExportDynamicFallbackConfig
+): boolean {
+  return (
+    config.output === 'export' &&
+    config.cacheComponents === true &&
+    config.experimental?.outputExportDynamicFallbacks === true
+  )
+}
+
+export function isOutputExportOptimisticRoutingEnabled(
+  config: OutputExportDynamicFallbackConfig
+): boolean {
+  return (
+    Boolean(config.experimental?.optimisticRouting) ||
+    isOutputExportDynamicFallbackEnabled(config)
+  )
+}
+
+export function isOutputExportVaryParamsEnabled(
+  config: OutputExportDynamicFallbackConfig
+): boolean {
+  return (
+    Boolean(config.experimental?.varyParams) ||
+    isOutputExportDynamicFallbackEnabled(config)
+  )
+}

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -221,6 +221,7 @@ export const experimentalSchema = {
   clientParamParsingOrigins: z.array(z.string()).optional(),
   cachedNavigations: z.boolean().optional(),
   partialFallbacks: z.boolean().optional(),
+  outputExportDynamicFallbacks: z.boolean().optional(),
   dynamicOnHover: z.boolean().optional(),
   offlineNavigations: z.boolean().optional(),
   useOffline: z.boolean().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -428,6 +428,11 @@ export interface ExperimentalConfig {
    * feature stabilizes.
    */
   partialFallbacks?: boolean
+  /**
+   * Enables static export fallback artifacts for dynamic App Router routes
+   * when Cache Components is enabled.
+   */
+  outputExportDynamicFallbacks?: boolean
   dynamicOnHover?: boolean
   offlineNavigations?: boolean
   useOffline?: boolean
@@ -1913,6 +1918,7 @@ export const defaultConfig = Object.freeze({
     clientParamParsingOrigins: undefined,
     cachedNavigations: false,
     partialFallbacks: true,
+    outputExportDynamicFallbacks: false,
     dynamicOnHover: false,
     offlineNavigations: false,
     useOffline: false,
@@ -2097,6 +2103,7 @@ export interface NextConfigRuntime {
     | 'maxPostponedStateSize'
     | 'cachedNavigations'
     | 'partialFallbacks'
+    | 'outputExportDynamicFallbacks'
     | 'exposeTestingApiInProductionBuild'
     | 'supportsImmutableAssets'
     | 'useNodeStreams'
@@ -2167,6 +2174,7 @@ export function getNextConfigRuntime(
     maxPostponedStateSize: ex.maxPostponedStateSize,
     cachedNavigations: ex.cachedNavigations,
     partialFallbacks: ex.partialFallbacks,
+    outputExportDynamicFallbacks: ex.outputExportDynamicFallbacks,
     exposeTestingApiInProductionBuild: ex.exposeTestingApiInProductionBuild,
     supportsImmutableAssets: ex.supportsImmutableAssets,
     useNodeStreams: ex.useNodeStreams,

--- a/test/production/next-server-nft/next-server-nft.test.ts
+++ b/test/production/next-server-nft/next-server-nft.test.ts
@@ -315,6 +315,7 @@ async function readNormalizedNFT(next, name) {
            "/node_modules/next/dist/lib/needs-experimental-react.js",
            "/node_modules/next/dist/lib/non-nullable.js",
            "/node_modules/next/dist/lib/normalize-path.js",
+           "/node_modules/next/dist/lib/output-export-dynamic-fallback.js",
            "/node_modules/next/dist/lib/oxford-comma-list.js",
            "/node_modules/next/dist/lib/page-types.js",
            "/node_modules/next/dist/lib/patch-incorrect-lockfile.js",


### PR DESCRIPTION
This is PR 11 of 21 in the offline navigations plus output-export fallback stack.

This stack introduces a generated fallback entrypoint and then layers the client behavior on the existing App Router, cached navigations, optimistic routing, Cache Components, and Segment Cache primitives. The offline navigations chapter adds a managed service worker and persisted Segment Cache replay. The output-export chapter emits static fallback HTML/RSC artifacts so parameterized routes can load and navigate without enumerating every param at build time.

Review guide: https://gist.github.com/feedthejim/bb440153d29dce019d1d26b6643e2a48

## Where This Sits
This PR is in the output-export fallbacks chapter, after the offline fallback-entrypoint primitives are established.
Previous PR: #93738 `offline navigations: add docs and examples (10/21)`.
Next PR: #93745 `output export fallbacks: emit fallback HTML artifacts (12/21)`.

## What Changes
- Adds the experimental build primitives for output-export dynamic fallbacks.
- Keeps the feature inert until fallback HTML and RSC artifacts exist.

## Reviewer Focus
- The flag should be narrow and should not affect normal export output when disabled.
- This PR should not introduce client routing changes yet.

## Proof In This PR
- Config/build assertions cover the flag plumbing and disabled no-op behavior.
- Later artifact tests continue proving disabled exports do not emit fallback files.

Latest local stack verification after autosquash included:
- `git diff --check`
- `pnpm --filter=next types`
- `pnpm testonly packages/next/src/client/components/segment-cache/offline-navigation-cache.test.ts packages/next/src/client/components/segment-cache/cache.test.ts packages/next/src/client/output-export-fallback.test.ts packages/next/src/export/helpers/output-export-fallback.test.ts packages/next/src/lib/output-export-fallback-routes.test.ts packages/next/src/client/components/router-reducer/fetch-server-response.test.ts`
- `HEADLESS=true pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `HEADLESS=true pnpm test-start-turbo test/e2e/app-dir-export/test/dynamic-fallback*.test.ts`

## Deferred Coverage
Fallback HTML emission, fallback RSC emission, server boundaries, and client routing are deferred.

## Disabled-Flag Posture
Only gated build primitives land here. Disabled apps should not emit artifacts or load client fallback code.

## Full Stack
1. [offline navigations: add gated build primitives (1/21)](https://github.com/vercel/next.js/pull/93736)
2. [offline navigations: generate fallback document artifacts (2/21)](https://github.com/vercel/next.js/pull/93737)
3. [offline navigations: register pass-through worker (3/21)](https://github.com/vercel/next.js/pull/93625)
4. [offline navigations: cache fallback and current-build assets (4/21)](https://github.com/vercel/next.js/pull/93626)
5. [offline navigations: serve fallback document offline (5/21)](https://github.com/vercel/next.js/pull/93627)
6. [offline navigations: add Segment Cache persistence primitives (6/21)](https://github.com/vercel/next.js/pull/93630)
7. [offline navigations: persist cached Segment Cache records (7/21)](https://github.com/vercel/next.js/pull/93640)
8. [offline navigations: bootstrap fallback from Segment Cache records (8/21)](https://github.com/vercel/next.js/pull/93644)
9. [offline navigations: support dynamic route patterns (9/21)](https://github.com/vercel/next.js/pull/93647)
10. [offline navigations: add docs and examples (10/21)](https://github.com/vercel/next.js/pull/93738)
11. **Current PR:** [output export fallbacks: add gated build primitives (11/21)](https://github.com/vercel/next.js/pull/93744)
12. [output export fallbacks: emit fallback HTML artifacts (12/21)](https://github.com/vercel/next.js/pull/93745)
13. [output export fallbacks: emit fallback RSC artifacts (13/21)](https://github.com/vercel/next.js/pull/93746)
14. [output export fallbacks: enforce server-only boundaries (14/21)](https://github.com/vercel/next.js/pull/93747)
15. [output export fallbacks: bootstrap hard loads from artifacts (15/21)](https://github.com/vercel/next.js/pull/93748)
16. [output export fallbacks: resolve soft navigations through cached routes (16/21)](https://github.com/vercel/next.js/pull/93749)
17. [output export fallbacks: resolve fallback artifacts from route manifests (17/21)](https://github.com/vercel/next.js/pull/93779)
18. [output export fallbacks: validate fallback Flight responses (18/21)](https://github.com/vercel/next.js/pull/93750)
19. [output export fallbacks: store fallback data in Segment Cache (19/21)](https://github.com/vercel/next.js/pull/93774)
20. [output export fallbacks: support known params and export variants (20/21)](https://github.com/vercel/next.js/pull/93751)
21. [output export fallbacks: add docs and review guide (21/21)](https://github.com/vercel/next.js/pull/93752)

<!-- NEXT_JS_LLM_PR -->
