### PR TITLE
output export fallbacks: emit fallback HTML artifacts (12/21)

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -189,10 +189,8 @@ import { traceMemoryUsage } from '../lib/memory/trace'
 import { generateEncryptionKeyBase64 } from '../server/app-render/encryption-utils-server'
 import type { DeepReadonly } from '../shared/lib/deep-readonly'
 import uploadTrace from '../trace/upload-trace'
-import {
-  checkIsAppPPREnabled,
-  checkIsRoutePPREnabled,
-} from '../server/lib/experimental/ppr'
+import { checkIsAppPPREnabled } from '../server/lib/experimental/ppr'
+import { isOutputExportDynamicFallbackEnabled } from '../lib/output-export-dynamic-fallback'
 import { FallbackMode, fallbackModeToFallbackField } from '../lib/fallback'
 import { RenderingMode } from './rendering-mode'
 import { InvariantError } from '../shared/lib/invariant-error'
@@ -2114,6 +2112,8 @@ export default async function build(
               locales: config.i18n?.locales,
               defaultLocale: config.i18n?.defaultLocale,
               nextConfigOutput: config.output,
+              outputExportDynamicFallbacks:
+                config.experimental.outputExportDynamicFallbacks === true,
               pprConfig: config.experimental.ppr,
               partialFallbacksEnabled:
                 config.experimental.partialFallbacks === true,
@@ -2349,6 +2349,9 @@ export default async function build(
                               : config.experimental.isrFlushToDisk,
                             cacheMaxMemorySize: config.cacheMaxMemorySize,
                             nextConfigOutput: config.output,
+                            outputExportDynamicFallbacks:
+                              config.experimental
+                                .outputExportDynamicFallbacks === true,
                             pprConfig: config.experimental.ppr,
                             partialFallbacksEnabled:
                               config.experimental.partialFallbacks === true,
@@ -2413,7 +2416,8 @@ export default async function build(
                             if (
                               config.output === 'export' &&
                               isDynamic &&
-                              !hasGenerateStaticParams
+                              !hasGenerateStaticParams &&
+                              !isOutputExportDynamicFallbackEnabled(config)
                             ) {
                               throw new Error(
                                 `Page "${page}" is missing "generateStaticParams()" so it cannot be used with "output: export" config.`
@@ -2948,9 +2952,12 @@ export default async function build(
               sortedStaticPaths.forEach(([originalAppPath, routes]) => {
                 const appConfig = appDefaultConfigs.get(originalAppPath)
                 const isDynamicError = appConfig?.dynamic === 'error'
+                const normalizedAppPath =
+                  appNormalizedPaths.get(originalAppPath)
 
-                const isRoutePPREnabled: boolean = appConfig
-                  ? checkIsRoutePPREnabled(config.experimental.ppr)
+                const isRoutePPREnabled: boolean = normalizedAppPath
+                  ? (pageInfos.get(normalizedAppPath)?.isRoutePPREnabled ??
+                    false)
                   : false
 
                 routes.forEach((route) => {
@@ -3146,8 +3153,7 @@ export default async function build(
             // When this is an app page and PPR is enabled, the route supports
             // partial pre-rendering.
             const isRoutePPREnabled: true | undefined =
-              !isAppRouteHandler &&
-              checkIsRoutePPREnabled(config.experimental.ppr)
+              !isAppRouteHandler && pageInfos.get(page)?.isRoutePPREnabled
                 ? true
                 : undefined
 

--- a/packages/next/src/build/static-paths/app.ts
+++ b/packages/next/src/build/static-paths/app.ts
@@ -828,7 +828,8 @@ export async function buildAppStaticPaths({
 }): Promise<StaticPathsResult> {
   if (
     segments.some((generate) => generate.config?.dynamicParams === true) &&
-    nextConfigOutput === 'export'
+    nextConfigOutput === 'export' &&
+    !isRoutePPREnabled
   ) {
     throw new Error(
       '"dynamicParams: true" cannot be used with "output: export". See more info here: https://nextjs.org/docs/app/building-your-application/deploying/static-exports'

--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -79,6 +79,7 @@ import type {
   AppRouteRouteModule,
 } from '../server/route-modules/app-route/module'
 import type { FunctionsConfigManifest, ManifestRoute } from './index'
+import { isOutputExportDynamicFallbackEnabled } from '../lib/output-export-dynamic-fallback'
 import { getNamedRouteRegex } from '../shared/lib/router/utils/route-regex'
 import { parseNormalizedAppRoute } from '../shared/lib/router/routes/app'
 import { fillStaticMetadataSegment } from '../lib/metadata/get-metadata-route'
@@ -690,6 +691,7 @@ export async function isPageStatic({
   isrFlushToDisk,
   cacheMaxMemorySize,
   nextConfigOutput,
+  outputExportDynamicFallbacks,
   cacheHandler,
   cacheHandlers,
   cacheLifeProfiles,
@@ -724,6 +726,7 @@ export async function isPageStatic({
     [profile: string]: import('../server/use-cache/cache-life').CacheLife
   }
   nextConfigOutput: 'standalone' | 'export' | undefined
+  outputExportDynamicFallbacks: boolean
   pprConfig: ExperimentalPPRConfig | undefined
   partialFallbacksEnabled: boolean
   buildId: string
@@ -853,12 +856,22 @@ export async function isPageStatic({
 
         rootParamKeys = collectRootParamKeys(routeModule)
 
+        const route = parseNormalizedAppRoute(page)
+        const isOutputExportFallbackRoute =
+          isOutputExportDynamicFallbackEnabled({
+            output: nextConfigOutput,
+            cacheComponents,
+            experimental: {
+              outputExportDynamicFallbacks,
+            },
+          }) && route.dynamicSegments.length > 0
+
         // A page supports partial prerendering if it is an app page and either
-        // the whole app has PPR enabled or this page has PPR enabled when we're
-        // in incremental mode.
+        // the whole app has PPR enabled or this is an export-mode dynamic route
+        // using Cache Components, which reuses the fallback-shell render path.
         isRoutePPREnabled =
           routeModule.definition.kind === RouteKind.APP_PAGE &&
-          checkIsRoutePPREnabled(pprConfig)
+          (checkIsRoutePPREnabled(pprConfig) || isOutputExportFallbackRoute)
 
         // If force dynamic was set and we don't have PPR enabled, then set the
         // revalidate to 0.
@@ -866,8 +879,6 @@ export async function isPageStatic({
         if (appConfig.dynamic === 'force-dynamic' && !isRoutePPREnabled) {
           appConfig.revalidate = 0
         }
-
-        const route = parseNormalizedAppRoute(page)
 
         // If the page is dynamic and we're not in edge runtime, then we need to
         // build the static paths. The edge runtime doesn't support static

--- a/packages/next/src/export/helpers/output-export-fallback.ts
+++ b/packages/next/src/export/helpers/output-export-fallback.ts
@@ -1,0 +1,195 @@
+import { existsSync, promises as fs } from 'fs'
+import { dirname, join, relative, sep } from 'path'
+import { getPagePath } from '../../server/require'
+import { normalizePagePath } from '../../shared/lib/page-path/normalize-page-path'
+import {
+  getOutputExportFallbackPath,
+  getOutputExportFallbackStaticPrefix,
+} from '../../lib/output-export-dynamic-fallback'
+
+type OutputExportDynamicRouteInfo = {
+  fallbackSourceRoute: string | undefined
+  fallbackRouteParams:
+    | ReadonlyArray<{
+        paramName: string
+        paramType: string
+      }>
+    | undefined
+}
+
+type CopyExportedAppHtmlOptions = {
+  outDir: string
+  orig: string
+  routePath: string
+  subFolders: boolean
+  checkRouteCollision?: boolean
+}
+
+type OutputExportError = Error & {
+  code: 'NEXT_EXPORT_ERROR'
+}
+
+function createOutputExportError(message: string): OutputExportError {
+  const error = new Error(message) as OutputExportError
+  error.code = 'NEXT_EXPORT_ERROR'
+  return error
+}
+
+function formatOutputPath(outDir: string, filePath: string): string {
+  return `/${relative(outDir, filePath).split(sep).join('/')}`
+}
+
+function assertNoOutputExportPathCollision(
+  outDir: string,
+  filePaths: string[],
+  routePath: string
+): void {
+  const collisionPath = filePaths.find((filePath) => existsSync(filePath))
+  if (!collisionPath) {
+    return
+  }
+
+  throw createOutputExportError(
+    `The route "${routePath}" conflicts with the internal "__fallback" path used by dynamic route fallbacks in static export mode at "${formatOutputPath(
+      outDir,
+      collisionPath
+    )}". ` +
+      `Please rename this route or public file to something else.\n\n` +
+      `Learn more: https://nextjs.org/docs/app/guides/static-exports`
+  )
+}
+
+export async function copyExportedAppHtml({
+  outDir,
+  orig,
+  routePath,
+  subFolders,
+  checkRouteCollision = false,
+}: CopyExportedAppHtmlOptions): Promise<string> {
+  const route = normalizePagePath(routePath)
+  const flatHtmlDest = join(outDir, `${route}.html`)
+  const folderHtmlDest = join(
+    outDir,
+    `${route}${route !== '/index' ? `${sep}index` : ''}.html`
+  )
+  const htmlDest =
+    subFolders && route !== '/index' ? folderHtmlDest : flatHtmlDest
+
+  if (checkRouteCollision) {
+    assertNoOutputExportPathCollision(
+      outDir,
+      [flatHtmlDest, folderHtmlDest],
+      routePath
+    )
+  }
+
+  await fs.mkdir(dirname(htmlDest), { recursive: true })
+  await fs.copyFile(`${orig}.html`, htmlDest)
+
+  return htmlDest
+}
+
+export async function emitOutputExportFallbackHtmlFiles(
+  dynamicRoutes: Readonly<Record<string, OutputExportDynamicRouteInfo>>,
+  mapAppRouteToPage: Map<string, string>,
+  distDir: string,
+  outDir: string,
+  subFolders: boolean
+): Promise<string[]> {
+  const fallbackHtmlPaths: string[] = []
+
+  for (const [dynamicRoute, prerenderInfo] of Object.entries(dynamicRoutes)) {
+    if (
+      !prerenderInfo.fallbackSourceRoute ||
+      !prerenderInfo.fallbackRouteParams ||
+      prerenderInfo.fallbackRouteParams.length === 0
+    ) {
+      continue
+    }
+
+    const staticPrefix = getOutputExportFallbackStaticPrefix(dynamicRoute)
+    if (staticPrefix === null) {
+      continue
+    }
+
+    const appPageName = mapAppRouteToPage.get(prerenderInfo.fallbackSourceRoute)
+    if (!appPageName) {
+      continue
+    }
+
+    const pagePath = getPagePath(appPageName, distDir, undefined, true)
+    const distPagesDir = join(
+      pagePath,
+      appPageName
+        .slice(1)
+        .split('/')
+        .map(() => '..')
+        .join('/')
+    )
+
+    const sourceRoute = normalizePagePath(dynamicRoute)
+    const orig = join(distPagesDir, sourceRoute)
+    if (!existsSync(`${orig}.html`)) {
+      continue
+    }
+
+    const fallbackPath = getOutputExportFallbackPath(staticPrefix)
+    fallbackHtmlPaths.push(
+      await copyExportedAppHtml({
+        outDir,
+        orig,
+        routePath: fallbackPath,
+        subFolders,
+        checkRouteCollision: true,
+      })
+    )
+  }
+
+  return fallbackHtmlPaths
+}
+
+function getPathDepth(outDir: string, filePath: string): number {
+  return relative(outDir, filePath).split(sep).filter(Boolean).length
+}
+
+export async function writeOutputExportFallbackHtml(
+  outDir: string,
+  fallbackHtmlPaths: string[]
+): Promise<void> {
+  const genericSource = [
+    join(outDir, 'index.html'),
+    join(outDir, '404.html'),
+  ].find((candidate) => existsSync(candidate))
+
+  const sortedFallbackPaths = [...fallbackHtmlPaths].sort(
+    (a, b) =>
+      getPathDepth(outDir, a) - getPathDepth(outDir, b) || a.localeCompare(b)
+  )
+  const fallbackSource = sortedFallbackPaths[0] ?? genericSource
+  if (!fallbackSource) {
+    return
+  }
+
+  const globalFallbackPath = join(outDir, '_fallback.html')
+  if (existsSync(globalFallbackPath)) {
+    throw createOutputExportError(
+      `The route "/_fallback" conflicts with the global "_fallback.html" path used by dynamic route fallbacks in static export mode. ` +
+        `Please remove or rename this route or public file.\n\n` +
+        `Learn more: https://nextjs.org/docs/app/guides/static-exports`
+    )
+  }
+
+  const fallbackHtml = await fs.readFile(fallbackSource, 'utf8')
+  const exportFallbackScript = '<script>self.__NEXT_EXPORT_FALLBACK=1</script>'
+  const exportFallbackStyle =
+    '<style id="__next-export-fallback-style">#__next{visibility:hidden}</style>'
+  const injection = `${exportFallbackStyle}${exportFallbackScript}`
+
+  const patchedFallbackHtml = fallbackHtml.includes('<head>')
+    ? fallbackHtml.replace('<head>', `<head>${injection}`)
+    : fallbackHtml.includes('</head>')
+      ? fallbackHtml.replace('</head>', `${injection}</head>`)
+      : injection + fallbackHtml
+
+  await fs.writeFile(globalFallbackPath, patchedFallbackHtml)
+}

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -27,6 +27,7 @@ import {
   SSG_FALLBACK_EXPORT_ERROR,
 } from '../lib/constants'
 import { recursiveCopy } from '../lib/recursive-copy'
+import { isOutputExportDynamicFallbackEnabled } from '../lib/output-export-dynamic-fallback'
 import {
   BUILD_ID_FILE,
   CLIENT_PUBLIC_FILES_PATH,
@@ -70,6 +71,10 @@ import { extractInfoFromServerReferenceId } from '../shared/lib/server-reference
 import { convertSegmentPathToStaticExportFilename } from '../shared/lib/segment-cache/segment-value-encoding'
 import { getNextBuildDebuggerPortOffset } from '../lib/worker'
 import { getParams } from './helpers/get-params'
+import {
+  emitOutputExportFallbackHtmlFiles,
+  writeOutputExportFallbackHtml,
+} from './helpers/output-export-fallback'
 import { isDynamicRoute } from '../shared/lib/router/utils/is-dynamic'
 import { normalizeAppPath } from '../shared/lib/router/utils/app-paths'
 import type { Params } from '../server/request/params'
@@ -876,8 +881,11 @@ async function exportAppImpl(
     }
   }
 
-  // Export mode provide static outputs that are not compatible with PPR mode.
-  if (!options.buildExport && nextConfig.experimental.ppr) {
+  if (
+    !options.buildExport &&
+    nextConfig.experimental.ppr &&
+    !isOutputExportDynamicFallbackEnabled(nextConfig)
+  ) {
     // TODO: add message
     throw new Error('Invariant: PPR cannot be enabled in export mode')
   }
@@ -1017,6 +1025,17 @@ async function exportAppImpl(
         }
       })
     )
+
+    if (isOutputExportDynamicFallbackEnabled(nextConfig)) {
+      const fallbackHtmlPaths = await emitOutputExportFallbackHtmlFiles(
+        prerenderManifest.dynamicRoutes,
+        mapAppRouteToPage,
+        distDir,
+        outDir,
+        subFolders
+      )
+      await writeOutputExportFallbackHtml(outDir, fallbackHtmlPaths)
+    }
   }
 
   if (failedExportAttemptsByPage.size > 0) {

--- a/test/e2e/app-dir/output-export-dynamic-fallbacks/app/another/[slug]/page.tsx
+++ b/test/e2e/app-dir/output-export-dynamic-fallbacks/app/another/[slug]/page.tsx
@@ -1,0 +1,7 @@
+export default function Page() {
+  return (
+    <main>
+      <h1>Dynamic fallback shell</h1>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/output-export-dynamic-fallbacks/app/another/page.tsx
+++ b/test/e2e/app-dir/output-export-dynamic-fallbacks/app/another/page.tsx
@@ -1,0 +1,10 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <main>
+      <h1>Another</h1>
+      <Link href="/another/alpha">Alpha</Link>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/output-export-dynamic-fallbacks/app/layout.tsx
+++ b/test/e2e/app-dir/output-export-dynamic-fallbacks/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/output-export-dynamic-fallbacks/app/page.tsx
+++ b/test/e2e/app-dir/output-export-dynamic-fallbacks/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>home</p>
+}

--- a/test/e2e/app-dir/output-export-dynamic-fallbacks/next-env.d.ts
+++ b/test/e2e/app-dir/output-export-dynamic-fallbacks/next-env.d.ts
@@ -1,0 +1,7 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+import "./.next/types/routes.d.ts";
+import "./.next/types/root-params.d.ts";
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/test/e2e/app-dir/output-export-dynamic-fallbacks/next.config.js
+++ b/test/e2e/app-dir/output-export-dynamic-fallbacks/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  output: 'export',
+  cacheComponents: true,
+  experimental: {
+    outputExportDynamicFallbacks: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/output-export-dynamic-fallbacks/output-export-dynamic-fallbacks.test.ts
+++ b/test/e2e/app-dir/output-export-dynamic-fallbacks/output-export-dynamic-fallbacks.test.ts
@@ -1,0 +1,47 @@
+import { nextTestSetup } from 'e2e-utils'
+import fs from 'fs-extra'
+import { join } from 'path'
+import {
+  fetchViaHTTP,
+  findPort,
+  startStaticServer,
+  stopApp,
+} from 'next-test-utils'
+
+describe('output-export-dynamic-fallbacks', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+    skipStart: true,
+  })
+
+  it('writes route fallback HTML without emitting fallback RSC data', async () => {
+    await next.build()
+
+    const outDir = join(next.testDir, 'out')
+    expect(
+      await fs.pathExists(join(outDir, 'another', '__fallback.html'))
+    ).toBe(true)
+    expect(await fs.pathExists(join(outDir, 'another', '__fallback.txt'))).toBe(
+      false
+    )
+    expect(await fs.pathExists(join(outDir, '_fallback.html'))).toBe(true)
+
+    const port = await findPort()
+    const app = await startStaticServer(outDir, null, port)
+
+    try {
+      const res = await fetchViaHTTP(port, '/another/__fallback.html')
+      expect(res.status).toBe(200)
+      expect(await res.text()).toContain('Dynamic fallback shell')
+
+      const globalFallbackRes = await fetchViaHTTP(port, '/_fallback.html')
+      expect(globalFallbackRes.status).toBe(200)
+      expect(await globalFallbackRes.text()).toContain(
+        '__NEXT_EXPORT_FALLBACK=1'
+      )
+    } finally {
+      await stopApp(app)
+    }
+  })
+})

--- a/test/e2e/app-dir/output-export-dynamic-fallbacks/tsconfig.json
+++ b/test/e2e/app-dir/output-export-dynamic-fallbacks/tsconfig.json
@@ -1,0 +1,34 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts",
+    "**/*.mts"
+  ],
+  "exclude": ["node_modules", "**/*.test.ts", "**/*.test.tsx"]
+}


### PR DESCRIPTION
This is PR 12 of 21 in the offline navigations plus output-export fallback stack.

This stack introduces a generated fallback entrypoint and then layers the client behavior on the existing App Router, cached navigations, optimistic routing, Cache Components, and Segment Cache primitives. The offline navigations chapter adds a managed service worker and persisted Segment Cache replay. The output-export chapter emits static fallback HTML/RSC artifacts so parameterized routes can load and navigate without enumerating every param at build time.

Review guide: https://gist.github.com/feedthejim/bb440153d29dce019d1d26b6643e2a48

## Where This Sits
This PR is in the output-export fallbacks chapter, after the offline fallback-entrypoint primitives are established.
Previous PR: #93744 `output export fallbacks: add gated build primitives (11/21)`.
Next PR: #93746 `output export fallbacks: emit fallback RSC artifacts (13/21)`.

## What Changes
- Emits fallback HTML files for dynamic output-export routes that need a bootstrap document.
- Keeps this build-time only, matching the original feedback to prove initial load before client routing changes.

## Reviewer Focus
- The build should not error for supported fallback routes.
- The HTML artifact path and conflict checks should be minimal and predictable.

## Proof In This PR
- Output-export dynamic fallback e2e covers fallback HTML artifact emission and initial hard-load behavior.
- Conflict rows cover user files that collide with internal fallback paths.

Latest local stack verification after autosquash included:
- `git diff --check`
- `pnpm --filter=next types`
- `pnpm testonly packages/next/src/client/components/segment-cache/offline-navigation-cache.test.ts packages/next/src/client/components/segment-cache/cache.test.ts packages/next/src/client/output-export-fallback.test.ts packages/next/src/export/helpers/output-export-fallback.test.ts packages/next/src/lib/output-export-fallback-routes.test.ts packages/next/src/client/components/router-reducer/fetch-server-response.test.ts`
- `HEADLESS=true pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `HEADLESS=true pnpm test-start-turbo test/e2e/app-dir-export/test/dynamic-fallback*.test.ts`

## Deferred Coverage
Fallback RSC artifacts and client soft navigation are deferred.

## Disabled-Flag Posture
HTML fallback artifacts are emitted only when the output-export fallback flag is enabled.

## Full Stack
1. [offline navigations: add gated build primitives (1/21)](https://github.com/vercel/next.js/pull/93736)
2. [offline navigations: generate fallback document artifacts (2/21)](https://github.com/vercel/next.js/pull/93737)
3. [offline navigations: register pass-through worker (3/21)](https://github.com/vercel/next.js/pull/93625)
4. [offline navigations: cache fallback and current-build assets (4/21)](https://github.com/vercel/next.js/pull/93626)
5. [offline navigations: serve fallback document offline (5/21)](https://github.com/vercel/next.js/pull/93627)
6. [offline navigations: add Segment Cache persistence primitives (6/21)](https://github.com/vercel/next.js/pull/93630)
7. [offline navigations: persist cached Segment Cache records (7/21)](https://github.com/vercel/next.js/pull/93640)
8. [offline navigations: bootstrap fallback from Segment Cache records (8/21)](https://github.com/vercel/next.js/pull/93644)
9. [offline navigations: support dynamic route patterns (9/21)](https://github.com/vercel/next.js/pull/93647)
10. [offline navigations: add docs and examples (10/21)](https://github.com/vercel/next.js/pull/93738)
11. [output export fallbacks: add gated build primitives (11/21)](https://github.com/vercel/next.js/pull/93744)
12. **Current PR:** [output export fallbacks: emit fallback HTML artifacts (12/21)](https://github.com/vercel/next.js/pull/93745)
13. [output export fallbacks: emit fallback RSC artifacts (13/21)](https://github.com/vercel/next.js/pull/93746)
14. [output export fallbacks: enforce server-only boundaries (14/21)](https://github.com/vercel/next.js/pull/93747)
15. [output export fallbacks: bootstrap hard loads from artifacts (15/21)](https://github.com/vercel/next.js/pull/93748)
16. [output export fallbacks: resolve soft navigations through cached routes (16/21)](https://github.com/vercel/next.js/pull/93749)
17. [output export fallbacks: resolve fallback artifacts from route manifests (17/21)](https://github.com/vercel/next.js/pull/93779)
18. [output export fallbacks: validate fallback Flight responses (18/21)](https://github.com/vercel/next.js/pull/93750)
19. [output export fallbacks: store fallback data in Segment Cache (19/21)](https://github.com/vercel/next.js/pull/93774)
20. [output export fallbacks: support known params and export variants (20/21)](https://github.com/vercel/next.js/pull/93751)
21. [output export fallbacks: add docs and review guide (21/21)](https://github.com/vercel/next.js/pull/93752)

<!-- NEXT_JS_LLM_PR -->
