### PR TITLE
output export fallbacks: emit fallback RSC artifacts (13/21)

### DIFF
--- a/packages/next/src/export/helpers/output-export-fallback.test.ts
+++ b/packages/next/src/export/helpers/output-export-fallback.test.ts
@@ -1,0 +1,116 @@
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { dirname, join } from 'path'
+import {
+  emitOutputExportFallbackArtifacts,
+  writeOutputExportFallbackHtml,
+} from './output-export-fallback'
+
+describe('output export fallback artifacts', () => {
+  const tmpDirs = new Set<string>()
+
+  afterEach(async () => {
+    await Promise.all(
+      [...tmpDirs].map((dir) => rm(dir, { recursive: true, force: true }))
+    )
+    tmpDirs.clear()
+  })
+
+  async function createTempDir(): Promise<string> {
+    const dir = await mkdtemp(join(tmpdir(), 'next-export-fallback-'))
+    tmpDirs.add(dir)
+    return dir
+  }
+
+  async function createFallbackSource(outDir: string): Promise<string> {
+    const orig = join(outDir, '..', 'server', 'app', 'docs', '[slug]')
+    await mkdir(dirname(orig), { recursive: true })
+    await writeFile(
+      `${orig}.html`,
+      '<html><head></head><body>docs</body></html>'
+    )
+    await writeFile(`${orig}.rsc`, 'rsc')
+    await mkdir(`${orig}.segments`, { recursive: true })
+    await writeFile(join(`${orig}.segments`, '_tree.segment.rsc'), 'tree')
+    return orig
+  }
+
+  it('does not overwrite a user-provided global fallback file', async () => {
+    const outDir = await createTempDir()
+    await mkdir(outDir, { recursive: true })
+    await writeFile(
+      join(outDir, 'index.html'),
+      '<html><head></head><body>index</body></html>'
+    )
+    await writeFile(join(outDir, '_fallback.html'), 'user fallback')
+
+    await expect(
+      writeOutputExportFallbackHtml(outDir, [])
+    ).rejects.toMatchObject({
+      code: 'NEXT_EXPORT_ERROR',
+    })
+
+    await expect(
+      readFile(join(outDir, '_fallback.html'), 'utf8')
+    ).resolves.toBe('user fallback')
+  })
+
+  it('does not overwrite a user-provided route manifest file', async () => {
+    const outDir = await createTempDir()
+    await mkdir(join(outDir, 'docs'), { recursive: true })
+    await writeFile(join(outDir, 'docs', '__fallback.meta.json'), '{}')
+
+    await expect(
+      emitOutputExportFallbackArtifacts(
+        [
+          {
+            fallbackRoute: '/docs/__fallback',
+            needsRouteManifest: true,
+            variants: [
+              {
+                route: '/docs/[slug]/[page]',
+                fallbackPath: '/docs/__fallback/__route_0',
+                orig: await createFallbackSource(outDir),
+              },
+            ],
+          },
+        ],
+        outDir,
+        true
+      )
+    ).rejects.toMatchObject({
+      code: 'NEXT_EXPORT_ERROR',
+    })
+  })
+
+  it('does not overwrite user-provided fallback segment files', async () => {
+    const outDir = await createTempDir()
+    await mkdir(join(outDir, 'docs', '__fallback'), { recursive: true })
+    await writeFile(
+      join(outDir, 'docs', '__fallback', '__next._tree.txt'),
+      'user'
+    )
+
+    await expect(
+      emitOutputExportFallbackArtifacts(
+        [
+          {
+            fallbackRoute: '/docs/__fallback',
+            needsRouteManifest: false,
+            variants: [
+              {
+                route: '/docs/[slug]',
+                fallbackPath: '/docs/__fallback',
+                orig: await createFallbackSource(outDir),
+              },
+            ],
+          },
+        ],
+        outDir,
+        true
+      )
+    ).rejects.toMatchObject({
+      code: 'NEXT_EXPORT_ERROR',
+    })
+  })
+})

--- a/packages/next/src/export/helpers/output-export-fallback.ts
+++ b/packages/next/src/export/helpers/output-export-fallback.ts
@@ -1,32 +1,43 @@
 import { existsSync, promises as fs } from 'fs'
 import { dirname, join, relative, sep } from 'path'
-import { getPagePath } from '../../server/require'
-import { normalizePagePath } from '../../shared/lib/page-path/normalize-page-path'
 import {
-  getOutputExportFallbackPath,
-  getOutputExportFallbackStaticPrefix,
-} from '../../lib/output-export-dynamic-fallback'
+  RSC_SEGMENTS_DIR_SUFFIX,
+  RSC_SEGMENT_SUFFIX,
+  RSC_SUFFIX,
+} from '../../lib/constants'
+import { getOutputExportFallbackRouteManifestPath } from '../../lib/output-export-dynamic-fallback'
+import {
+  planOutputExportFallbackRoutes,
+  type OutputExportDynamicRouteInfo,
+} from '../../lib/output-export-fallback-routes'
+import { normalizePagePath } from '../../shared/lib/page-path/normalize-page-path'
+import { getPagePath } from '../../server/require'
+import { convertSegmentPathToStaticExportFilename } from '../../shared/lib/segment-cache/segment-value-encoding'
 
-type OutputExportDynamicRouteInfo = {
-  fallbackSourceRoute: string | undefined
-  fallbackRouteParams:
-    | ReadonlyArray<{
-        paramName: string
-        paramType: string
-      }>
-    | undefined
+export type OutputExportFallbackArtifactVariant = {
+  route: string
+  fallbackPath: string
+  orig: string
 }
 
-type CopyExportedAppHtmlOptions = {
-  outDir: string
-  orig: string
-  routePath: string
-  subFolders: boolean
-  checkRouteCollision?: boolean
+export type OutputExportFallbackArtifactPlan = {
+  fallbackRoute: string
+  needsRouteManifest: boolean
+  variants: OutputExportFallbackArtifactVariant[]
 }
 
 type OutputExportError = Error & {
   code: 'NEXT_EXPORT_ERROR'
+}
+
+type CopyExportedAppArtifactsOptions = {
+  outDir: string
+  orig: string
+  routePath: string
+  segmentsRoutePath: string
+  subFolders: boolean
+  checkRouteCollision?: boolean
+  routeCollisionPath?: string
 }
 
 function createOutputExportError(message: string): OutputExportError {
@@ -59,44 +70,91 @@ function assertNoOutputExportPathCollision(
   )
 }
 
-export async function copyExportedAppHtml({
+export async function copyExportedAppArtifacts({
   outDir,
   orig,
   routePath,
+  segmentsRoutePath,
   subFolders,
   checkRouteCollision = false,
-}: CopyExportedAppHtmlOptions): Promise<string> {
+  routeCollisionPath,
+}: CopyExportedAppArtifactsOptions): Promise<string> {
   const route = normalizePagePath(routePath)
   const flatHtmlDest = join(outDir, `${route}.html`)
+  const flatJsonDest = join(outDir, `${route}.txt`)
   const folderHtmlDest = join(
     outDir,
     `${route}${route !== '/index' ? `${sep}index` : ''}.html`
   )
+  const folderJsonDest = join(
+    outDir,
+    `${route}${route !== '/index' ? `${sep}index` : ''}.txt`
+  )
   const htmlDest =
     subFolders && route !== '/index' ? folderHtmlDest : flatHtmlDest
+  const jsonDest =
+    subFolders && route !== '/index' ? folderJsonDest : flatJsonDest
+
+  const segmentsDir = `${orig}${RSC_SEGMENTS_DIR_SUFFIX}`
+  const segmentCopies: Array<{
+    src: string
+    dest: string
+  }> = []
+
+  if (existsSync(segmentsDir)) {
+    const segmentsDirDest = join(outDir, segmentsRoutePath)
+    const segmentPaths = await collectSegmentPaths(segmentsDir)
+    for (const segmentFileSrc of segmentPaths) {
+      const segmentPath =
+        '/' + segmentFileSrc.slice(0, -RSC_SEGMENT_SUFFIX.length)
+      const segmentFilename =
+        convertSegmentPathToStaticExportFilename(segmentPath)
+      segmentCopies.push({
+        src: join(segmentsDir, segmentFileSrc),
+        dest: join(segmentsDirDest, segmentFilename),
+      })
+    }
+  }
 
   if (checkRouteCollision) {
     assertNoOutputExportPathCollision(
       outDir,
-      [flatHtmlDest, folderHtmlDest],
-      routePath
+      [
+        flatHtmlDest,
+        flatJsonDest,
+        folderHtmlDest,
+        folderJsonDest,
+        ...segmentCopies.map(({ dest }) => dest),
+      ],
+      routeCollisionPath ?? routePath
     )
   }
 
   await fs.mkdir(dirname(htmlDest), { recursive: true })
+  await fs.mkdir(dirname(jsonDest), { recursive: true })
   await fs.copyFile(`${orig}.html`, htmlDest)
+  await fs.copyFile(`${orig}${RSC_SUFFIX}`, jsonDest)
+
+  await Promise.all(
+    segmentCopies.map(async ({ src, dest }) => {
+      await fs.mkdir(dirname(dest), { recursive: true })
+      await fs.copyFile(src, dest)
+    })
+  )
 
   return htmlDest
 }
 
-export async function emitOutputExportFallbackHtmlFiles(
+export function planOutputExportFallbackArtifacts(
   dynamicRoutes: Readonly<Record<string, OutputExportDynamicRouteInfo>>,
   mapAppRouteToPage: Map<string, string>,
-  distDir: string,
-  outDir: string,
-  subFolders: boolean
-): Promise<string[]> {
-  const fallbackHtmlPaths: string[] = []
+  distDir: string
+): OutputExportFallbackArtifactPlan[] {
+  const dynamicRoutesWithArtifacts: Record<
+    string,
+    OutputExportDynamicRouteInfo
+  > = {}
+  const origByRoute = new Map<string, string>()
 
   for (const [dynamicRoute, prerenderInfo] of Object.entries(dynamicRoutes)) {
     if (
@@ -104,11 +162,6 @@ export async function emitOutputExportFallbackHtmlFiles(
       !prerenderInfo.fallbackRouteParams ||
       prerenderInfo.fallbackRouteParams.length === 0
     ) {
-      continue
-    }
-
-    const staticPrefix = getOutputExportFallbackStaticPrefix(dynamicRoute)
-    if (staticPrefix === null) {
       continue
     }
 
@@ -129,23 +182,74 @@ export async function emitOutputExportFallbackHtmlFiles(
 
     const sourceRoute = normalizePagePath(dynamicRoute)
     const orig = join(distPagesDir, sourceRoute)
-    if (!existsSync(`${orig}.html`)) {
+    if (!existsSync(`${orig}.html`) || !existsSync(`${orig}${RSC_SUFFIX}`)) {
       continue
     }
 
-    const fallbackPath = getOutputExportFallbackPath(staticPrefix)
-    fallbackHtmlPaths.push(
-      await copyExportedAppHtml({
-        outDir,
-        orig,
-        routePath: fallbackPath,
-        subFolders,
-        checkRouteCollision: true,
-      })
-    )
+    dynamicRoutesWithArtifacts[dynamicRoute] = prerenderInfo
+    origByRoute.set(dynamicRoute, orig)
   }
 
-  return fallbackHtmlPaths
+  return planOutputExportFallbackRoutes(dynamicRoutesWithArtifacts).map(
+    ({ fallbackRoute, needsRouteManifest, entries }) => ({
+      fallbackRoute,
+      needsRouteManifest,
+      variants: entries.map(({ route, fallbackPath }) => ({
+        route,
+        fallbackPath,
+        orig: origByRoute.get(route)!,
+      })),
+    })
+  )
+}
+
+export async function emitOutputExportFallbackArtifacts(
+  plans: OutputExportFallbackArtifactPlan[],
+  outDir: string,
+  subFolders: boolean
+): Promise<string[]> {
+  const fallbackHtmlPathsByPlan = await Promise.all(
+    plans.map(async ({ fallbackRoute, needsRouteManifest, variants }) => {
+      if (needsRouteManifest) {
+        const manifestPath = join(
+          outDir,
+          getOutputExportFallbackRouteManifestPath(fallbackRoute)
+        )
+        assertNoOutputExportPathCollision(outDir, [manifestPath], fallbackRoute)
+        await fs.mkdir(dirname(manifestPath), { recursive: true })
+        await fs.writeFile(
+          manifestPath,
+          JSON.stringify(
+            {
+              version: 1,
+              routes: variants.map(({ route, fallbackPath }) => ({
+                route,
+                fallbackPath,
+              })),
+            },
+            null,
+            2
+          )
+        )
+      }
+
+      return Promise.all(
+        variants.map(async ({ fallbackPath, orig }) => {
+          return copyExportedAppArtifacts({
+            outDir,
+            orig,
+            routePath: fallbackPath,
+            segmentsRoutePath: fallbackPath,
+            subFolders,
+            checkRouteCollision: true,
+            routeCollisionPath: fallbackPath,
+          })
+        })
+      )
+    })
+  )
+
+  return fallbackHtmlPathsByPlan.flat()
 }
 
 function getPathDepth(outDir: string, filePath: string): number {
@@ -156,6 +260,9 @@ export async function writeOutputExportFallbackHtml(
   outDir: string,
   fallbackHtmlPaths: string[]
 ): Promise<void> {
+  // Prefer a shallow __fallback shell for the global fallback entry point so
+  // the bootstrap document still carries the right root structure and assets.
+  // Fall back to a generic document only if no __fallback shell exists.
   const genericSource = [
     join(outDir, 'index.html'),
     join(outDir, '404.html'),
@@ -165,7 +272,8 @@ export async function writeOutputExportFallbackHtml(
     (a, b) =>
       getPathDepth(outDir, a) - getPathDepth(outDir, b) || a.localeCompare(b)
   )
-  const fallbackSource = sortedFallbackPaths[0] ?? genericSource
+  const pprShellSource = sortedFallbackPaths[0]
+  const fallbackSource = pprShellSource ?? genericSource
   if (!fallbackSource) {
     return
   }
@@ -181,6 +289,9 @@ export async function writeOutputExportFallbackHtml(
 
   const fallbackHtml = await fs.readFile(fallbackSource, 'utf8')
   const exportFallbackScript = '<script>self.__NEXT_EXPORT_FALLBACK=1</script>'
+  // The global fallback document is only a bootstrap shell. Keep it hidden
+  // until the client resolves the actual route-specific fallback payload and
+  // React commits the real tree. Removed in app-index.tsx after hydration.
   const exportFallbackStyle =
     '<style id="__next-export-fallback-style">#__next{visibility:hidden}</style>'
   const injection = `${exportFallbackStyle}${exportFallbackScript}`
@@ -192,4 +303,38 @@ export async function writeOutputExportFallbackHtml(
       : injection + fallbackHtml
 
   await fs.writeFile(globalFallbackPath, patchedFallbackHtml)
+}
+
+async function collectSegmentPaths(segmentsDirectory: string) {
+  const results: Array<string> = []
+  await collectSegmentPathsImpl(segmentsDirectory, segmentsDirectory, results)
+  return results
+}
+
+async function collectSegmentPathsImpl(
+  segmentsDirectory: string,
+  directory: string,
+  results: Array<string>
+) {
+  const segmentFiles = await fs.readdir(directory, {
+    withFileTypes: true,
+  })
+  await Promise.all(
+    segmentFiles.map(async (segmentFile) => {
+      if (segmentFile.isDirectory()) {
+        await collectSegmentPathsImpl(
+          segmentsDirectory,
+          join(directory, segmentFile.name),
+          results
+        )
+        return
+      }
+      if (!segmentFile.name.endsWith(RSC_SEGMENT_SUFFIX)) {
+        return
+      }
+      results.push(
+        relative(segmentsDirectory, join(directory, segmentFile.name))
+      )
+    })
+  )
 }

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -18,16 +18,14 @@ import { existsSync, promises as fs } from 'fs'
 
 import '../server/require-hook'
 
-import { dirname, join, resolve, sep, relative } from 'path'
+import { dirname, join, resolve, sep } from 'path'
 import * as Log from '../build/output/log'
-import {
-  RSC_SEGMENT_SUFFIX,
-  RSC_SEGMENTS_DIR_SUFFIX,
-  RSC_SUFFIX,
-  SSG_FALLBACK_EXPORT_ERROR,
-} from '../lib/constants'
+import { SSG_FALLBACK_EXPORT_ERROR } from '../lib/constants'
 import { recursiveCopy } from '../lib/recursive-copy'
-import { isOutputExportDynamicFallbackEnabled } from '../lib/output-export-dynamic-fallback'
+import {
+  isOutputExportDynamicFallbackEnabled,
+  isOutputExportOptimisticRoutingEnabled,
+} from '../lib/output-export-dynamic-fallback'
 import {
   BUILD_ID_FILE,
   CLIENT_PUBLIC_FILES_PATH,
@@ -68,11 +66,12 @@ import type { DeepReadonly } from '../shared/lib/deep-readonly'
 import { isInterceptionRouteRewrite } from '../lib/is-interception-route-rewrite'
 import type { ActionManifest } from '../build/webpack/plugins/flight-client-entry-plugin'
 import { extractInfoFromServerReferenceId } from '../shared/lib/server-reference-info'
-import { convertSegmentPathToStaticExportFilename } from '../shared/lib/segment-cache/segment-value-encoding'
 import { getNextBuildDebuggerPortOffset } from '../lib/worker'
 import { getParams } from './helpers/get-params'
 import {
-  emitOutputExportFallbackHtmlFiles,
+  copyExportedAppArtifacts,
+  emitOutputExportFallbackArtifacts,
+  planOutputExportFallbackArtifacts,
   writeOutputExportFallbackHtml,
 } from './helpers/output-export-fallback'
 import { isDynamicRoute } from '../shared/lib/router/utils/is-dynamic'
@@ -516,9 +515,8 @@ async function exportAppImpl(
         nextConfig.experimental.clientParamParsingOrigins,
       dynamicOnHover: nextConfig.experimental.dynamicOnHover ?? false,
       optimisticRouting:
-        nextConfig.experimental.optimisticRouting ||
         nextConfig.experimental.offlineNavigations ||
-        false,
+        isOutputExportOptimisticRoutingEnabled(nextConfig),
       inlineCss: nextConfig.experimental.inlineCss ?? false,
       prefetchInlining: nextConfig.experimental.prefetchInlining ?? false,
       authInterrupts: !!nextConfig.experimental.authInterrupts,
@@ -755,10 +753,6 @@ async function exportAppImpl(
         initialPhaseExportPaths.push(exportPath)
       }
 
-      // Always mark routes for potential build validation. The actual
-      // decision of whether to validate is made per-route by
-      // anySegmentNeedsInstantValidationInBuild, which checks both the
-      // default validation level and per-segment level overrides.
       const route = exportPath.page
       if (!routesWithInstantValidation.has(route)) {
         exportPath._runInstantValidation = true
@@ -970,71 +964,48 @@ async function exportAppImpl(
           return
         }
 
-        const htmlDest = join(
-          outDir,
-          `${route}${
-            subFolders && route !== '/index' ? `${sep}index` : ''
-          }.html`
-        )
-        const jsonDest = isAppPath
-          ? join(
-              outDir,
-              `${route}${
-                subFolders && route !== '/index' ? `${sep}index` : ''
-              }.txt`
-            )
-          : join(pagesDataDir, `${route}.json`)
-
-        await fs.mkdir(dirname(htmlDest), { recursive: true })
-        await fs.mkdir(dirname(jsonDest), { recursive: true })
-
-        const htmlSrc = `${orig}.html`
-        const jsonSrc = `${orig}${isAppPath ? RSC_SUFFIX : '.json'}`
-
-        await fs.copyFile(htmlSrc, htmlDest)
-        await fs.copyFile(jsonSrc, jsonDest)
-
-        const segmentsDir = `${orig}${RSC_SEGMENTS_DIR_SUFFIX}`
-
-        if (isAppPath && existsSync(segmentsDir)) {
-          // Output a data file for each of this page's segments
-          //
-          // These files are requested by the client router's internal
-          // prefetcher, not the user directly. So we don't need to account for
-          // things like trailing slash handling.
-          //
-          // To keep the protocol simple, we can use the non-normalized route
-          // path instead of the normalized one (which, among other things,
-          // rewrites `/` to `/index`).
-          const segmentsDirDest = join(outDir, unnormalizedRoute)
-          const segmentPaths = await collectSegmentPaths(segmentsDir)
-          await Promise.all(
-            segmentPaths.map(async (segmentFileSrc) => {
-              const segmentPath =
-                '/' + segmentFileSrc.slice(0, -RSC_SEGMENT_SUFFIX.length)
-              const segmentFilename =
-                convertSegmentPathToStaticExportFilename(segmentPath)
-              const segmentFileDest = join(segmentsDirDest, segmentFilename)
-              await fs.mkdir(dirname(segmentFileDest), { recursive: true })
-              await fs.copyFile(
-                join(segmentsDir, segmentFileSrc),
-                segmentFileDest
-              )
-            })
+        if (isAppPath) {
+          await copyExportedAppArtifacts({
+            outDir,
+            orig,
+            routePath: unnormalizedRoute,
+            segmentsRoutePath: unnormalizedRoute,
+            subFolders,
+          })
+        } else {
+          const htmlDest = join(
+            outDir,
+            `${route}${
+              subFolders && route !== '/index' ? `${sep}index` : ''
+            }.html`
           )
+          const jsonDest = join(pagesDataDir, `${route}.json`)
+
+          await fs.mkdir(dirname(htmlDest), { recursive: true })
+          await fs.mkdir(dirname(jsonDest), { recursive: true })
+          await fs.copyFile(`${orig}.html`, htmlDest)
+          await fs.copyFile(`${orig}.json`, jsonDest)
         }
       })
     )
 
     if (isOutputExportDynamicFallbackEnabled(nextConfig)) {
-      const fallbackHtmlPaths = await emitOutputExportFallbackHtmlFiles(
+      const fallbackArtifactPlans = planOutputExportFallbackArtifacts(
         prerenderManifest.dynamicRoutes,
         mapAppRouteToPage,
-        distDir,
+        distDir
+      )
+      const fallbackHtmlPaths = await emitOutputExportFallbackArtifacts(
+        fallbackArtifactPlans,
         outDir,
         subFolders
       )
-      await writeOutputExportFallbackHtml(outDir, fallbackHtmlPaths)
+
+      if (
+        hasOutputExportDynamicFallbackRoutes(allExportPaths, prerenderManifest)
+      ) {
+        await writeOutputExportFallbackHtml(outDir, fallbackHtmlPaths)
+      }
     }
   }
 
@@ -1074,37 +1045,17 @@ async function exportAppImpl(
   return collector
 }
 
-async function collectSegmentPaths(segmentsDirectory: string) {
-  const results: Array<string> = []
-  await collectSegmentPathsImpl(segmentsDirectory, segmentsDirectory, results)
-  return results
-}
-
-async function collectSegmentPathsImpl(
-  segmentsDirectory: string,
-  directory: string,
-  results: Array<string>
-) {
-  const segmentFiles = await fs.readdir(directory, {
-    withFileTypes: true,
-  })
-  await Promise.all(
-    segmentFiles.map(async (segmentFile) => {
-      if (segmentFile.isDirectory()) {
-        await collectSegmentPathsImpl(
-          segmentsDirectory,
-          join(directory, segmentFile.name),
-          results
-        )
-        return
-      }
-      if (!segmentFile.name.endsWith(RSC_SEGMENT_SUFFIX)) {
-        return
-      }
-      results.push(
-        relative(segmentsDirectory, join(directory, segmentFile.name))
-      )
-    })
+function hasOutputExportDynamicFallbackRoutes(
+  allExportPaths: ExportPathEntry[],
+  prerenderManifest: DeepReadonly<PrerenderManifest> | undefined
+): boolean {
+  return (
+    allExportPaths.some(
+      ({ _fallbackRouteParams = [] }) => _fallbackRouteParams.length > 0
+    ) ||
+    Object.values(prerenderManifest?.dynamicRoutes ?? {}).some(
+      (route) => (route.fallbackRouteParams?.length ?? 0) > 0
+    )
   )
 }
 

--- a/packages/next/src/export/routes/app-page.ts
+++ b/packages/next/src/export/routes/app-page.ts
@@ -144,15 +144,21 @@ export async function exportAppPage(
     } else {
       const hasFallbackParams =
         fallbackRouteParams != null && fallbackRouteParams.size > 0
+      const isOutputExportFallbackShell =
+        renderOpts.nextConfigOutput === 'export' &&
+        renderOpts.cacheComponents &&
+        hasFallbackParams
       const shouldWriteRsc =
         !renderOpts.experimental.isRoutePPREnabled ||
+        isOutputExportFallbackShell ||
         (!postponed && !hasFallbackParams)
       hasStaticRsc = shouldWriteRsc
 
       // With PPR enabled, we normally skip writing .rsc because it may contain
       // dynamic data. However, for fully static outputs (no postponed state and
       // no fallback params), we can safely emit the route .rsc to support
-      // static navigations.
+      // static navigations. Static export fallback shells also need their
+      // fallback RSC artifact so exported clients can resolve dynamic routes.
       if (shouldWriteRsc) {
         fileWriter.append(
           htmlFilepath.replace(/\.html$/, RSC_SUFFIX),

--- a/packages/next/src/lib/output-export-dynamic-fallback.ts
+++ b/packages/next/src/lib/output-export-dynamic-fallback.ts
@@ -1,4 +1,5 @@
 import { parseNormalizedAppRoute } from '../shared/lib/router/routes/app'
+import { getParamProperties } from '../shared/lib/router/utils/get-segment-param'
 
 type OutputExportDynamicFallbackConfig = {
   output?: string
@@ -10,8 +11,29 @@ type OutputExportDynamicFallbackConfig = {
   }
 }
 
+export type OutputExportFallbackRouteManifestEntry = {
+  route: string
+  fallbackPath: string
+}
+
 export function getOutputExportFallbackPath(staticPrefix: string): string {
   return staticPrefix.length > 0 ? `/${staticPrefix}/__fallback` : '/__fallback'
+}
+
+export function getOutputExportFallbackRouteManifestPath(
+  fallbackPath: string
+): string {
+  // The static artifact keeps the short private `.meta.json` filename, but the
+  // source API names this a route manifest because it disambiguates route
+  // shapes that share the same public fallback entry.
+  return `${fallbackPath}.meta.json`
+}
+
+export function getOutputExportFallbackVariantPath(
+  fallbackPath: string,
+  index: number
+): string {
+  return `${fallbackPath}/__route_${index}`
 }
 
 export function getOutputExportFallbackStaticPrefix(
@@ -30,6 +52,33 @@ export function getOutputExportFallbackStaticPrefix(
     .slice(0, firstDynamicIndex)
     .map((segment) => segment.name)
     .join('/')
+}
+
+export function needsOutputExportFallbackRouteManifest(
+  routePath: string
+): boolean {
+  const route = parseNormalizedAppRoute(routePath)
+  const firstDynamicIndex = route.segments.findIndex(
+    (segment) => segment.type === 'dynamic'
+  )
+
+  if (firstDynamicIndex === -1) {
+    return false
+  }
+
+  if (route.segments.length - firstDynamicIndex <= 1) {
+    return false
+  }
+
+  // A route like /blog/[slug] can resolve from /blog/__fallback by filling the
+  // single dynamic segment from the URL. A route like /org/[org]/chat/[thread]
+  // needs a small manifest so the client can confirm which route shape the
+  // fallback artifact represents before patching params into the Flight tree.
+  const firstDynamicSegment = route.segments[firstDynamicIndex]
+  return (
+    firstDynamicSegment.type === 'dynamic' &&
+    !getParamProperties(firstDynamicSegment.param.paramType).repeat
+  )
 }
 
 export function isOutputExportDynamicFallbackEnabled(

--- a/packages/next/src/lib/output-export-fallback-routes.test.ts
+++ b/packages/next/src/lib/output-export-fallback-routes.test.ts
@@ -1,0 +1,89 @@
+import { planOutputExportFallbackRoutes } from './output-export-fallback-routes'
+
+describe('planOutputExportFallbackRoutes', () => {
+  it('uses the shared fallback path for a single dynamic segment route', () => {
+    expect(
+      planOutputExportFallbackRoutes({
+        '/docs/[slug]': {
+          fallbackSourceRoute: '/docs/[slug]',
+          fallbackRouteParams: [{ paramName: 'slug', paramType: 'd' }],
+        },
+      })
+    ).toEqual([
+      {
+        fallbackRoute: '/docs/__fallback',
+        needsRouteManifest: false,
+        entries: [
+          {
+            route: '/docs/[slug]',
+            fallbackSourceRoute: '/docs/[slug]',
+            fallbackRoute: '/docs/__fallback',
+            fallbackPath: '/docs/__fallback',
+            staticPrefix: 'docs',
+          },
+        ],
+      },
+    ])
+  })
+
+  it('keeps a route manifest for a single route with static segments after the first dynamic segment', () => {
+    expect(
+      planOutputExportFallbackRoutes({
+        '/docs/[section]/intro': {
+          fallbackSourceRoute: '/docs/[section]/intro',
+          fallbackRouteParams: [{ paramName: 'section', paramType: 'd' }],
+        },
+      })
+    ).toEqual([
+      {
+        fallbackRoute: '/docs/__fallback',
+        needsRouteManifest: true,
+        entries: [
+          {
+            route: '/docs/[section]/intro',
+            fallbackSourceRoute: '/docs/[section]/intro',
+            fallbackRoute: '/docs/__fallback',
+            fallbackPath: '/docs/__fallback',
+            staticPrefix: 'docs',
+          },
+        ],
+      },
+    ])
+  })
+
+  it('assigns deterministic variant paths for multiple routes with the same fallback route', () => {
+    expect(
+      planOutputExportFallbackRoutes({
+        '/docs/[section]/reference': {
+          fallbackSourceRoute: '/docs/[section]/reference',
+          fallbackRouteParams: [{ paramName: 'section', paramType: 'd' }],
+        },
+        '/docs/[section]/guide': {
+          fallbackSourceRoute: '/docs/[section]/guide',
+          fallbackRouteParams: [{ paramName: 'section', paramType: 'd' }],
+        },
+      })
+    ).toEqual([
+      {
+        fallbackRoute: '/docs/__fallback',
+        needsRouteManifest: true,
+        entries: [
+          {
+            route: '/docs/[section]/guide',
+            fallbackSourceRoute: '/docs/[section]/guide',
+            fallbackRoute: '/docs/__fallback',
+            fallbackPath: '/docs/__fallback/__route_0',
+            staticPrefix: 'docs',
+          },
+          {
+            route: '/docs/[section]/reference',
+            fallbackSourceRoute: '/docs/[section]/reference',
+            fallbackRoute: '/docs/__fallback',
+            fallbackPath: '/docs/__fallback/__route_1',
+            staticPrefix: 'docs',
+          },
+        ],
+      },
+    ])
+  })
+})

--- a/packages/next/src/lib/output-export-fallback-routes.ts
+++ b/packages/next/src/lib/output-export-fallback-routes.ts
@@ -1,0 +1,109 @@
+import { getSortedRoutes } from '../shared/lib/router/utils'
+import {
+  getOutputExportFallbackPath,
+  getOutputExportFallbackStaticPrefix,
+  getOutputExportFallbackVariantPath,
+  needsOutputExportFallbackRouteManifest,
+} from './output-export-dynamic-fallback'
+
+export type OutputExportDynamicRouteInfo = {
+  fallbackSourceRoute: string | undefined
+  fallbackRouteParams:
+    | ReadonlyArray<{
+        paramName: string
+        paramType: string
+      }>
+    | undefined
+}
+
+export type OutputExportFallbackRouteEntry = {
+  route: string
+  fallbackSourceRoute: string
+  fallbackRoute: string
+  fallbackPath: string
+  staticPrefix: string
+}
+
+export type OutputExportFallbackRoutePlan = {
+  fallbackRoute: string
+  needsRouteManifest: boolean
+  entries: OutputExportFallbackRouteEntry[]
+}
+
+export function planOutputExportFallbackRoutes(
+  dynamicRoutes: Readonly<Record<string, OutputExportDynamicRouteInfo>>
+): OutputExportFallbackRoutePlan[] {
+  const fallbackEntriesByRoute = new Map<
+    string,
+    Array<Omit<OutputExportFallbackRouteEntry, 'fallbackPath'>>
+  >()
+
+  for (const [dynamicRoute, prerenderInfo] of Object.entries(dynamicRoutes)) {
+    if (
+      !prerenderInfo.fallbackSourceRoute ||
+      !prerenderInfo.fallbackRouteParams ||
+      prerenderInfo.fallbackRouteParams.length === 0
+    ) {
+      continue
+    }
+
+    const staticPrefix = getOutputExportFallbackStaticPrefix(dynamicRoute)
+    if (staticPrefix === null) {
+      continue
+    }
+
+    const fallbackRoute = getOutputExportFallbackPath(staticPrefix)
+    const entries = fallbackEntriesByRoute.get(fallbackRoute)
+    const entry = {
+      route: dynamicRoute,
+      fallbackSourceRoute: prerenderInfo.fallbackSourceRoute,
+      fallbackRoute,
+      staticPrefix,
+    }
+
+    if (entries) {
+      entries.push(entry)
+    } else {
+      fallbackEntriesByRoute.set(fallbackRoute, [entry])
+    }
+  }
+
+  return Array.from(fallbackEntriesByRoute.entries())
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    .map(([fallbackRoute, entries]) => {
+      if (entries.length === 1) {
+        return {
+          fallbackRoute,
+          needsRouteManifest: needsOutputExportFallbackRouteManifest(
+            entries[0].route
+          ),
+          entries: [
+            {
+              ...entries[0],
+              fallbackPath: fallbackRoute,
+            },
+          ],
+        }
+      }
+
+      const entriesByRoute = new Map(
+        entries.map((entry) => [entry.route, entry])
+      )
+      // Multiple dynamic routes can share the same static prefix and therefore
+      // the same public fallback entry, e.g. /docs/[slug] and /docs/[...rest].
+      // Store each real fallback under a deterministic private path, ordered the
+      // same way the router would match the route at runtime.
+      const sortedRoutes = getSortedRoutes(entries.map((entry) => entry.route))
+      return {
+        fallbackRoute,
+        needsRouteManifest: true,
+        entries: sortedRoutes.map((route, index) => ({
+          ...entriesByRoute.get(route)!,
+          fallbackPath: getOutputExportFallbackVariantPath(
+            fallbackRoute,
+            index
+          ),
+        })),
+      }
+    })
+}

--- a/test/e2e/app-dir/output-export-dynamic-fallbacks/output-export-dynamic-fallbacks.test.ts
+++ b/test/e2e/app-dir/output-export-dynamic-fallbacks/output-export-dynamic-fallbacks.test.ts
@@ -15,7 +15,7 @@ describe('output-export-dynamic-fallbacks', () => {
     skipStart: true,
   })
 
-  it('writes route fallback HTML without emitting fallback RSC data', async () => {
+  it('writes route fallback HTML and RSC artifacts', async () => {
     await next.build()
 
     const outDir = join(next.testDir, 'out')
@@ -23,7 +23,16 @@ describe('output-export-dynamic-fallbacks', () => {
       await fs.pathExists(join(outDir, 'another', '__fallback.html'))
     ).toBe(true)
     expect(await fs.pathExists(join(outDir, 'another', '__fallback.txt'))).toBe(
-      false
+      true
+    )
+
+    const segmentFiles = await fs.readdir(join(outDir, 'another', '__fallback'))
+    expect(segmentFiles).toEqual(
+      expect.arrayContaining([
+        '__next._full.txt',
+        '__next._tree.txt',
+        '__next.another.$d$slug.__PAGE__.txt',
+      ])
     )
     expect(await fs.pathExists(join(outDir, '_fallback.html'))).toBe(true)
 
@@ -40,6 +49,9 @@ describe('output-export-dynamic-fallbacks', () => {
       expect(await globalFallbackRes.text()).toContain(
         '__NEXT_EXPORT_FALLBACK=1'
       )
+
+      const rscRes = await fetchViaHTTP(port, '/another/__fallback.txt')
+      expect(rscRes.status).toBe(200)
     } finally {
       await stopApp(app)
     }

--- a/test/production/next-server-nft/next-server-nft.test.ts
+++ b/test/production/next-server-nft/next-server-nft.test.ts
@@ -316,6 +316,7 @@ async function readNormalizedNFT(next, name) {
            "/node_modules/next/dist/lib/non-nullable.js",
            "/node_modules/next/dist/lib/normalize-path.js",
            "/node_modules/next/dist/lib/output-export-dynamic-fallback.js",
+           "/node_modules/next/dist/lib/output-export-fallback-routes.js",
            "/node_modules/next/dist/lib/oxford-comma-list.js",
            "/node_modules/next/dist/lib/page-types.js",
            "/node_modules/next/dist/lib/patch-incorrect-lockfile.js",


### PR DESCRIPTION
This is PR 13 of 21 in the offline navigations plus output-export fallback stack.

This stack introduces a generated fallback entrypoint and then layers the client behavior on the existing App Router, cached navigations, optimistic routing, Cache Components, and Segment Cache primitives. The offline navigations chapter adds a managed service worker and persisted Segment Cache replay. The output-export chapter emits static fallback HTML/RSC artifacts so parameterized routes can load and navigate without enumerating every param at build time.

Review guide: https://gist.github.com/feedthejim/bb440153d29dce019d1d26b6643e2a48

## Where This Sits
This PR is in the output-export fallbacks chapter, after the offline fallback-entrypoint primitives are established.
Previous PR: #93745 `output export fallbacks: emit fallback HTML artifacts (12/21)`.
Next PR: #93747 `output export fallbacks: enforce server-only boundaries (14/21)`.

## What Changes
- Generates the fallback RSC files the client router can search during soft navigation.
- Builds the artifacts from the loader-tree route structure, including route-manifest entries where branches conflict.

## Reviewer Focus
- The build-time route planner should be understandable without client-side routing context.
- The emitted manifest should exist only when route ambiguity requires it.

## Proof In This PR
- `packages/next/src/export/helpers/output-export-fallback.test.ts` covers artifact emission and collision behavior.
- `packages/next/src/lib/output-export-fallback-routes.test.ts` covers route planning and manifest requirements.

Latest local stack verification after autosquash included:
- `git diff --check`
- `pnpm --filter=next types`
- `pnpm testonly packages/next/src/client/components/segment-cache/offline-navigation-cache.test.ts packages/next/src/client/components/segment-cache/cache.test.ts packages/next/src/client/output-export-fallback.test.ts packages/next/src/export/helpers/output-export-fallback.test.ts packages/next/src/lib/output-export-fallback-routes.test.ts packages/next/src/client/components/router-reducer/fetch-server-response.test.ts`
- `HEADLESS=true pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `HEADLESS=true pnpm test-start-turbo test/e2e/app-dir-export/test/dynamic-fallback*.test.ts`

## Deferred Coverage
Client hard-load and soft-navigation consumption of the artifacts are deferred.

## Disabled-Flag Posture
Fallback RSC artifacts and private route manifests are emitted only when the flag is enabled.

## Full Stack
1. [offline navigations: add gated build primitives (1/21)](https://github.com/vercel/next.js/pull/93736)
2. [offline navigations: generate fallback document artifacts (2/21)](https://github.com/vercel/next.js/pull/93737)
3. [offline navigations: register pass-through worker (3/21)](https://github.com/vercel/next.js/pull/93625)
4. [offline navigations: cache fallback and current-build assets (4/21)](https://github.com/vercel/next.js/pull/93626)
5. [offline navigations: serve fallback document offline (5/21)](https://github.com/vercel/next.js/pull/93627)
6. [offline navigations: add Segment Cache persistence primitives (6/21)](https://github.com/vercel/next.js/pull/93630)
7. [offline navigations: persist cached Segment Cache records (7/21)](https://github.com/vercel/next.js/pull/93640)
8. [offline navigations: bootstrap fallback from Segment Cache records (8/21)](https://github.com/vercel/next.js/pull/93644)
9. [offline navigations: support dynamic route patterns (9/21)](https://github.com/vercel/next.js/pull/93647)
10. [offline navigations: add docs and examples (10/21)](https://github.com/vercel/next.js/pull/93738)
11. [output export fallbacks: add gated build primitives (11/21)](https://github.com/vercel/next.js/pull/93744)
12. [output export fallbacks: emit fallback HTML artifacts (12/21)](https://github.com/vercel/next.js/pull/93745)
13. **Current PR:** [output export fallbacks: emit fallback RSC artifacts (13/21)](https://github.com/vercel/next.js/pull/93746)
14. [output export fallbacks: enforce server-only boundaries (14/21)](https://github.com/vercel/next.js/pull/93747)
15. [output export fallbacks: bootstrap hard loads from artifacts (15/21)](https://github.com/vercel/next.js/pull/93748)
16. [output export fallbacks: resolve soft navigations through cached routes (16/21)](https://github.com/vercel/next.js/pull/93749)
17. [output export fallbacks: resolve fallback artifacts from route manifests (17/21)](https://github.com/vercel/next.js/pull/93779)
18. [output export fallbacks: validate fallback Flight responses (18/21)](https://github.com/vercel/next.js/pull/93750)
19. [output export fallbacks: store fallback data in Segment Cache (19/21)](https://github.com/vercel/next.js/pull/93774)
20. [output export fallbacks: support known params and export variants (20/21)](https://github.com/vercel/next.js/pull/93751)
21. [output export fallbacks: add docs and review guide (21/21)](https://github.com/vercel/next.js/pull/93752)

<!-- NEXT_JS_LLM_PR -->
