### PR TITLE
output export fallbacks: enforce server-only boundaries (14/21)

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1191,5 +1191,8 @@
   "1190": "Route \"%s\" accessed param \"%s\" which is not defined in the \\`unstable_samples\\` of \\`unstable_instant\\`. Add it to the sample's \\`params\\` object.",
   "1191": "Route \"%s\" called %s but param%s %s %s not defined in the \\`unstable_samples\\` of \\`unstable_instant\\`. %s requires all route params to be provided.",
   "1192": "Route \"%s\" accessed root param \"%s\" which is not defined in the \\`unstable_samples\\` of \\`unstable_instant\\`. Add it to the sample's \\`params\\` object.",
-  "1193": "\\`experimental.offlineNavigations\\` requires \\`cacheComponents\\` to be enabled. Please update your %s accordingly."
+  "1193": "\\`experimental.offlineNavigations\\` requires \\`cacheComponents\\` to be enabled. Please update your %s accordingly.",
+  "1194": "Expected staticChildren to be initialized for known dynamic siblings.",
+  "1195": "Route \"%s\" used %s in a Server Component with \"output: export\". This is not supported because %s See more info here: https://nextjs.org/docs/app/guides/static-exports",
+  "1196": "Route \"%s\" used unresolved dynamic params in a Server Component with \"output: export\". This is not supported because these fallback params are only available on the client. Move param-dependent content into a Client Component or add generateStaticParams() to prerender this route. See more info here: https://nextjs.org/docs/app/guides/static-exports"
 }

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -6841,6 +6841,7 @@ async function validateInstantConfigInBuildWithSample(
     isStaticGeneration: false,
     page: outerWorkStore.page,
     route: outerWorkStore.route,
+    nextConfigOutput: outerWorkStore.nextConfigOutput,
     incrementalCache: outerWorkStore.incrementalCache,
     cacheLifeProfiles: outerWorkStore.cacheLifeProfiles,
     useCacheTimeout: outerWorkStore.useCacheTimeout,

--- a/packages/next/src/server/app-render/work-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-async-storage.external.ts
@@ -27,6 +27,7 @@ export interface WorkStore {
    * trailing `/page` or `/route` suffix.
    */
   readonly route: string
+  readonly nextConfigOutput?: 'standalone' | 'export'
 
   readonly incrementalCache?: IncrementalCache
   readonly cacheLifeProfiles?: { [profile: string]: CacheLife }

--- a/packages/next/src/server/async-storage/work-store.ts
+++ b/packages/next/src/server/async-storage/work-store.ts
@@ -61,6 +61,7 @@ export type WorkStoreContext = {
     | 'isBuildTimePrerendering'
     | 'isDraftMode'
     | 'isDebugDynamicAccesses'
+    | 'nextConfigOutput'
   > &
     RequestLifecycleOpts &
     Partial<Pick<RenderOpts, 'reactLoadableManifest'>>
@@ -125,6 +126,7 @@ export function createWorkStore({
     isStaticGeneration,
     page,
     route: normalizeAppPath(page),
+    nextConfigOutput: renderOpts.nextConfigOutput,
     incrementalCache:
       // we fallback to a global incremental cache for edge-runtime locally
       // so that it can access the fs cache without mocks

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -89,6 +89,7 @@ import type { PrerenderManifest } from '../../build'
 import { getRouteRegex } from '../../shared/lib/router/utils/route-regex'
 import type { PrerenderedRoute } from '../../build/static-paths/types'
 import { HMR_MESSAGE_SENT_TO_BROWSER } from './hot-reloader-types'
+import { isOutputExportDynamicFallbackEnabled } from '../../lib/output-export-dynamic-fallback'
 
 // Load ReactDevOverlay only when needed
 let PagesDevOverlayBridgeImpl: PagesDevOverlayBridgeType
@@ -811,6 +812,9 @@ export default class DevServer extends Server {
               this.nextConfig.experimental.partialFallbacks === true,
             configFileName,
             cacheComponents: Boolean(this.nextConfig.cacheComponents),
+            outputExportDynamicFallbacks:
+              this.nextConfig.experimental.outputExportDynamicFallbacks ===
+              true,
           },
           httpAgentOptions,
           locales,
@@ -856,9 +860,19 @@ export default class DevServer extends Server {
               )
             }
 
-            if (
-              !prerenderedRoutes.some((item) => item.pathname === urlPathname)
-            ) {
+            const hasMatchingPrerenderedRoute = prerenderedRoutes.some(
+              (item) => item.pathname === urlPathname
+            )
+            const hasFallbackPrerenderedRoute =
+              isOutputExportDynamicFallbackEnabled(this.nextConfig) &&
+              prerenderedRoutes.some(
+                (item) =>
+                  item.pathname === pathname &&
+                  item.fallbackRouteParams &&
+                  item.fallbackRouteParams.length > 0
+              )
+
+            if (!hasMatchingPrerenderedRoute && !hasFallbackPrerenderedRoute) {
               throw new Error(
                 `Page "${page}" is missing param "${pathname}" in "generateStaticParams()", which is required with "output: export" config.`
               )

--- a/packages/next/src/server/dev/static-paths-worker.ts
+++ b/packages/next/src/server/dev/static-paths-worker.ts
@@ -27,12 +27,14 @@ import { buildAppStaticPaths } from '../../build/static-paths/app'
 import { buildPagesStaticPaths } from '../../build/static-paths/pages'
 import { createIncrementalCache } from '../../export/helpers/create-incremental-cache'
 import { parseNormalizedAppRoute } from '../../shared/lib/router/routes/app'
+import { isOutputExportDynamicFallbackEnabled } from '../../lib/output-export-dynamic-fallback'
 
 type RuntimeConfig = {
   pprConfig: ExperimentalPPRConfig | undefined
   partialFallbacks: boolean
   configFileName: string
   cacheComponents: boolean
+  outputExportDynamicFallbacks: boolean
 }
 
 // we call getStaticPaths in a separate process to ensure
@@ -132,9 +134,18 @@ export async function loadStaticPaths({
       )
     }
 
+    const isOutputExportFallbackRoute =
+      isOutputExportDynamicFallbackEnabled({
+        output: nextConfigOutput,
+        cacheComponents: config.cacheComponents,
+        experimental: {
+          outputExportDynamicFallbacks: config.outputExportDynamicFallbacks,
+        },
+      }) && route.dynamicSegments.length > 0
+
     const isRoutePPREnabled =
       isAppPageRouteModule(routeModule) &&
-      checkIsRoutePPREnabled(config.pprConfig)
+      (checkIsRoutePPREnabled(config.pprConfig) || isOutputExportFallbackRoute)
 
     const rootParamKeys = collectRootParamKeys(routeModule)
 

--- a/packages/next/src/server/request/connection.ts
+++ b/packages/next/src/server/request/connection.ts
@@ -13,8 +13,12 @@ import {
   makeHangingPromise,
   makeDevtoolsIOAwarePromise,
 } from '../dynamic-rendering-utils'
-import { isRequestAPICallableInsideAfter } from './utils'
 import { applyOwnerStack } from '../dynamic-rendering-utils'
+import {
+  isRequestAPICallableInsideAfter,
+  shouldErrorForOutputExportServerRequestAPI,
+  throwForOutputExportServerRequestAPI,
+} from './utils'
 import { RenderStage } from '../app-render/staged-rendering'
 import { InvariantError } from '../../shared/lib/invariant-error'
 
@@ -43,6 +47,19 @@ export function connection(): Promise<void> {
       // When using forceStatic, we override all other logic and always just
       // return a resolving promise without tracking.
       return Promise.resolve(undefined)
+    }
+
+    if (
+      workStore.nextConfigOutput === 'export' &&
+      workUnitStore &&
+      shouldErrorForOutputExportServerRequestAPI(workUnitStore, 'connection')
+    ) {
+      throwForOutputExportServerRequestAPI(
+        workStore,
+        '`connection()`',
+        connection,
+        'this API requires a runtime server request, which is not available when exporting to static HTML.'
+      )
     }
 
     if (workStore.dynamicShouldError) {

--- a/packages/next/src/server/request/cookies.ts
+++ b/packages/next/src/server/request/cookies.ts
@@ -27,8 +27,12 @@ import {
   makeHangingPromise,
 } from '../dynamic-rendering-utils'
 import { createDedupedByCallsiteServerErrorLoggerDev } from '../create-deduped-by-callsite-server-error-logger'
-import { isRequestAPICallableInsideAfter } from './utils'
 import { applyOwnerStack } from '../dynamic-rendering-utils'
+import {
+  isRequestAPICallableInsideAfter,
+  shouldErrorForOutputExportServerRequestAPI,
+  throwForOutputExportServerRequestAPI,
+} from './utils'
 import { InvariantError } from '../../shared/lib/invariant-error'
 import { RenderStage } from '../app-render/staged-rendering'
 
@@ -54,6 +58,19 @@ export function cookies(): Promise<ReadonlyRequestCookies> {
       // cookies object without tracking
       const underlyingCookies = createEmptyCookies()
       return makeUntrackedCookies(underlyingCookies)
+    }
+
+    if (
+      workStore.nextConfigOutput === 'export' &&
+      workUnitStore &&
+      shouldErrorForOutputExportServerRequestAPI(workUnitStore, 'request-data')
+    ) {
+      throwForOutputExportServerRequestAPI(
+        workStore,
+        '`cookies()`',
+        cookies,
+        'this API requires a runtime server request, which is not available when exporting to static HTML.'
+      )
     }
 
     if (workStore.dynamicShouldError) {

--- a/packages/next/src/server/request/fallback-params.test.ts
+++ b/packages/next/src/server/request/fallback-params.test.ts
@@ -4,9 +4,16 @@ import {
   getFallbackRouteParams,
   getPlaceholderFallbackRouteParams,
 } from './fallback-params'
+import {
+  createParamsFromClient,
+  createServerParamsForServerSegment,
+} from './params'
 import type { FallbackRouteParam } from '../../build/static-paths/types'
 import type AppPageRouteModule from '../route-modules/app-page/module'
 import type { LoaderTree } from '../lib/app-dir-module'
+import { workAsyncStorage } from '../app-render/work-async-storage.external'
+import { workUnitAsyncStorage } from '../app-render/work-unit-async-storage.external'
+import { isHangingPromiseRejectionError } from '../dynamic-rendering-utils'
 
 // Helper to create LoaderTree structures for testing
 type TestLoaderTree = [
@@ -658,6 +665,130 @@ describe('getFallbackRouteParams', () => {
 
       result = getFallbackRouteParams('/sidebar/is/real', routeModule)
       expect(result).toBeNull()
+    })
+  })
+})
+
+describe('output export fallback params consumers', () => {
+  function createOutputExportWorkStore() {
+    return {
+      isStaticGeneration: true,
+      page: '/blog/[slug]/page',
+      route: '/blog/[slug]',
+      nextConfigOutput: 'export',
+      afterContext: {} as any,
+      previouslyRevalidatedTags: [],
+      refreshTagsByCacheKind: new Map(),
+      shouldTrackFetchMetrics: false,
+      buildId: 'build-id',
+      cacheComponentsEnabled: true,
+      runInCleanSnapshot: (fn: (...args: Array<any>) => any, ...args: any[]) =>
+        fn(...args),
+      reactServerErrorsByDigest: new Map(),
+    } as any
+  }
+
+  function createPrerenderStore(
+    fallbackParams: NonNullable<
+      ReturnType<typeof createOpaqueFallbackRouteParams>
+    >,
+    rootParams: Record<string, unknown> = {}
+  ) {
+    const controller = new AbortController()
+    return {
+      controller,
+      prerenderStore: {
+        type: 'prerender',
+        phase: 'render',
+        implicitTags: {} as any,
+        revalidate: 0,
+        expire: 0,
+        stale: 0,
+        tags: null,
+        renderSignal: controller.signal,
+        controller,
+        cacheSignal: null,
+        dynamicTracking: null,
+        rootParams,
+        prerenderResumeDataCache: null,
+        renderResumeDataCache: null,
+        hmrRefreshHash: undefined,
+        varyParamsAccumulator: null,
+        fallbackRouteParams: fallbackParams,
+        allowEmptyStaticShell: false,
+      } as any,
+    }
+  }
+
+  it('does not error server params for ancestors that do not receive fallback params', async () => {
+    const fallbackParams = createOpaqueFallbackRouteParams([
+      { paramName: 'slug', paramType: 'dynamic' },
+    ])!
+    const workStore = createOutputExportWorkStore()
+    const { prerenderStore } = createPrerenderStore(fallbackParams)
+
+    await workAsyncStorage.run(workStore, async () => {
+      await workUnitAsyncStorage.run(prerenderStore, async () => {
+        await expect(
+          createServerParamsForServerSegment({}, null, null, false)
+        ).resolves.toEqual({})
+        expect(() =>
+          createServerParamsForServerSegment({}, 'slug', null, false).then(
+            () => null
+          )
+        ).toThrow('output: export')
+      })
+    })
+  })
+
+  it('does not reuse server erroring params promises for client consumers', async () => {
+    const fallbackParams = createOpaqueFallbackRouteParams([
+      { paramName: 'slug', paramType: 'dynamic' },
+    ])!
+    const underlyingParams = {
+      slug: fallbackParams.get('slug')![0],
+    }
+
+    const workStore = createOutputExportWorkStore()
+    const { controller, prerenderStore } = createPrerenderStore(
+      fallbackParams,
+      underlyingParams
+    )
+
+    await workAsyncStorage.run(workStore, async () => {
+      await workUnitAsyncStorage.run(prerenderStore, async () => {
+        const serverParams = createServerParamsForServerSegment(
+          underlyingParams,
+          null,
+          null,
+          false
+        )
+        const clientParams = createParamsFromClient(underlyingParams)
+
+        expect(serverParams).not.toBe(clientParams)
+        expect(() => serverParams.then(() => null)).toThrow('output: export')
+        expect(() => clientParams.then(() => null)).not.toThrow()
+
+        let clientSettled = false
+        clientParams.then(
+          () => {
+            clientSettled = true
+          },
+          () => {
+            clientSettled = true
+          }
+        )
+        await Promise.resolve()
+        expect(clientSettled).toBe(false)
+
+        controller.abort()
+        try {
+          await clientParams
+          throw new Error('Expected client params to reject after abort')
+        } catch (error) {
+          expect(isHangingPromiseRejectionError(error)).toBe(true)
+        }
+      })
     })
   })
 })

--- a/packages/next/src/server/request/headers.ts
+++ b/packages/next/src/server/request/headers.ts
@@ -25,8 +25,12 @@ import {
   makeHangingPromise,
 } from '../dynamic-rendering-utils'
 import { createDedupedByCallsiteServerErrorLoggerDev } from '../create-deduped-by-callsite-server-error-logger'
-import { isRequestAPICallableInsideAfter } from './utils'
 import { applyOwnerStack } from '../dynamic-rendering-utils'
+import {
+  isRequestAPICallableInsideAfter,
+  shouldErrorForOutputExportServerRequestAPI,
+  throwForOutputExportServerRequestAPI,
+} from './utils'
 import { InvariantError } from '../../shared/lib/invariant-error'
 import { RenderStage } from '../app-render/staged-rendering'
 
@@ -60,6 +64,19 @@ export function headers(): Promise<ReadonlyHeaders> {
       // headers object without tracking
       const underlyingHeaders = HeadersAdapter.seal(new Headers({}))
       return makeUntrackedHeaders(underlyingHeaders)
+    }
+
+    if (
+      workStore.nextConfigOutput === 'export' &&
+      workUnitStore &&
+      shouldErrorForOutputExportServerRequestAPI(workUnitStore, 'request-data')
+    ) {
+      throwForOutputExportServerRequestAPI(
+        workStore,
+        '`headers()`',
+        headers,
+        'this API requires a runtime server request, which is not available when exporting to static HTML.'
+      )
     }
 
     if (workUnitStore) {

--- a/packages/next/src/server/request/params.ts
+++ b/packages/next/src/server/request/params.ts
@@ -41,6 +41,7 @@ import { RenderStage } from '../app-render/staged-rendering'
 
 export type ParamValue = string | Array<string> | undefined
 export type Params = Record<string, ParamValue>
+type ParamsConsumer = 'server' | 'client'
 
 export function createParamsFromClient(
   underlyingParams: Params
@@ -65,7 +66,8 @@ export function createParamsFromClient(
           null,
           workStore,
           workUnitStore,
-          varyParamsAccumulator
+          varyParamsAccumulator,
+          'client'
         )
       case 'validation-client':
         return createClientParamsInInstantValidation(
@@ -100,7 +102,8 @@ export function createParamsFromClient(
             fallbackParams,
             workStore,
             workUnitStore,
-            isRuntimePrefetchable
+            isRuntimePrefetchable,
+            'client'
           )
         } else if (workUnitStore.validationSamples) {
           return createClientParamsInInstantValidation(
@@ -154,7 +157,8 @@ export function createServerParamsForRoute(
           null,
           workStore,
           workUnitStore,
-          varyParamsAccumulator
+          varyParamsAccumulator,
+          'server'
         )
       case 'prerender-client':
       case 'validation-client':
@@ -195,7 +199,8 @@ export function createServerParamsForRoute(
             fallbackParams,
             workStore,
             workUnitStore,
-            isRuntimePrefetchable
+            isRuntimePrefetchable,
+            'server'
           )
         } else {
           return createRenderParamsInProd(underlyingParams)
@@ -229,7 +234,8 @@ export function createServerParamsForServerSegment(
           optionalCatchAllParamName,
           workStore,
           workUnitStore,
-          varyParamsAccumulator
+          varyParamsAccumulator,
+          'server'
         )
       case 'validation-client':
         throw new InvariantError(
@@ -264,7 +270,8 @@ export function createServerParamsForServerSegment(
             fallbackParams,
             workStore,
             workUnitStore,
-            isRuntimePrefetchable
+            isRuntimePrefetchable,
+            'server'
           )
         } else if (
           workUnitStore.asyncApiPromises &&
@@ -363,7 +370,8 @@ function createStaticPrerenderParams(
   optionalCatchAllParamName: string | null,
   workStore: WorkStore,
   prerenderStore: StaticPrerenderStore,
-  varyParamsAccumulator: VaryParamsAccumulator | null
+  varyParamsAccumulator: VaryParamsAccumulator | null,
+  paramsConsumer: ParamsConsumer
 ): Promise<Params> {
   const underlyingParamsWithVarying =
     varyParamsAccumulator !== null
@@ -378,36 +386,50 @@ function createStaticPrerenderParams(
     case 'prerender':
     case 'prerender-client': {
       const fallbackParams = prerenderStore.fallbackRouteParams
-      if (fallbackParams) {
-        for (const key in underlyingParams) {
-          if (fallbackParams.has(key)) {
-            // This params object has one or more fallback params, so we need
-            // to consider the awaiting of this params object "dynamic". Since
-            // we are in cacheComponents mode we encode this as a promise that never
-            // resolves.
-            return makeHangingParams(
-              underlyingParamsWithVarying,
-              workStore,
-              prerenderStore
-            )
-          }
+      const hasFallbackParams = hasFallbackRouteParams(
+        underlyingParams,
+        fallbackParams,
+        optionalCatchAllParamName
+      )
+      if (fallbackParams && hasFallbackParams) {
+        if (
+          paramsConsumer === 'server' &&
+          workStore.nextConfigOutput === 'export'
+        ) {
+          return makeErroringExportFallbackParams(
+            underlyingParamsWithVarying,
+            fallbackParams,
+            workStore
+          )
         }
+        // This params object has one or more fallback params, so we need
+        // to consider the awaiting of this params object "dynamic". Since
+        // we are in cacheComponents mode we encode this as a promise that never
+        // resolves.
+        return makeHangingParams(
+          underlyingParamsWithVarying,
+          workStore,
+          prerenderStore
+        )
       }
       break
     }
     case 'prerender-ppr': {
       const fallbackParams = prerenderStore.fallbackRouteParams
-      if (fallbackParams) {
-        for (const key in underlyingParams) {
-          if (fallbackParams.has(key)) {
-            return makeErroringParams(
-              underlyingParamsWithVarying,
-              fallbackParams,
-              workStore,
-              prerenderStore
-            )
-          }
-        }
+      if (
+        fallbackParams &&
+        hasFallbackRouteParams(
+          underlyingParams,
+          fallbackParams,
+          optionalCatchAllParamName
+        )
+      ) {
+        return makeErroringParams(
+          underlyingParamsWithVarying,
+          fallbackParams,
+          workStore,
+          prerenderStore
+        )
       }
       break
     }
@@ -449,13 +471,21 @@ function createRuntimePrerenderParams(
 
 function hasFallbackRouteParams(
   underlyingParams: Params,
-  fallbackParams: OpaqueFallbackRouteParams | null | undefined
+  fallbackParams: OpaqueFallbackRouteParams | null | undefined,
+  optionalCatchAllParamName: string | null = null
 ): boolean {
   if (fallbackParams) {
-    for (let key in underlyingParams) {
+    for (const key in underlyingParams) {
       if (fallbackParams.has(key)) {
         return true
       }
+    }
+
+    if (
+      optionalCatchAllParamName !== null &&
+      fallbackParams.has(optionalCatchAllParamName)
+    ) {
+      return true
     }
   }
   return false
@@ -508,11 +538,30 @@ function createRenderParamsInDev(
   fallbackParams: OpaqueFallbackRouteParams | null | undefined,
   workStore: WorkStore,
   requestStore: RequestStore,
-  isRuntimePrefetchable: boolean
+  isRuntimePrefetchable: boolean,
+  paramsConsumer: ParamsConsumer
 ): Promise<Params> {
+  const hasFallbackParams = hasFallbackRouteParams(
+    underlyingParams,
+    fallbackParams
+  )
+
+  if (
+    paramsConsumer === 'server' &&
+    workStore.nextConfigOutput === 'export' &&
+    fallbackParams &&
+    hasFallbackParams
+  ) {
+    return makeErroringExportFallbackParams(
+      underlyingParams,
+      fallbackParams,
+      workStore
+    )
+  }
+
   return makeDynamicallyTrackedParamsWithDevWarnings(
     underlyingParams,
-    hasFallbackRouteParams(underlyingParams, fallbackParams),
+    hasFallbackParams,
     workStore,
     requestStore,
     isRuntimePrefetchable
@@ -521,6 +570,10 @@ function createRenderParamsInDev(
 
 interface CacheLifetime {}
 const CachedParams = new WeakMap<CacheLifetime, Promise<Params>>()
+const CachedErroringExportFallbackParams = new WeakMap<
+  CacheLifetime,
+  Promise<Params>
+>()
 
 const fallbackParamsProxyHandler: ProxyHandler<Promise<Params>> = {
   get: function get(target, prop, receiver) {
@@ -571,6 +624,71 @@ function makeHangingParams(
   CachedParams.set(underlyingParams, promise)
 
   return promise
+}
+
+function makeErroringExportFallbackParams(
+  underlyingParams: Params,
+  fallbackParams: OpaqueFallbackRouteParams,
+  workStore: WorkStore
+): Promise<Params> {
+  const cachedParams = CachedErroringExportFallbackParams.get(underlyingParams)
+  if (cachedParams) {
+    return cachedParams
+  }
+
+  const augmentedUnderlying = { ...underlyingParams }
+  const error =
+    workStore.invalidDynamicUsageError ??
+    createExportFallbackServerParamsError(workStore)
+
+  const throwError = () => {
+    workStore.invalidDynamicUsageError ??= error
+    throw error
+  }
+
+  const promise = new Proxy(Promise.resolve(augmentedUnderlying), {
+    get(target, prop, receiver) {
+      if (prop === 'then' || prop === 'catch' || prop === 'finally') {
+        return () => throwError()
+      }
+
+      if (
+        typeof prop === 'string' &&
+        !wellKnownProperties.has(prop) &&
+        fallbackParams.has(prop)
+      ) {
+        return throwError()
+      }
+
+      return ReflectAdapter.get(target, prop, receiver)
+    },
+  })
+  CachedErroringExportFallbackParams.set(underlyingParams, promise)
+
+  for (const prop of fallbackParams.keys()) {
+    if (wellKnownProperties.has(prop)) {
+      continue
+    }
+
+    Object.defineProperty(augmentedUnderlying, prop, {
+      get() {
+        return throwError()
+      },
+      enumerable: true,
+    })
+  }
+
+  return promise
+}
+
+function createExportFallbackServerParamsError(workStore: WorkStore): Error {
+  const error = new Error(
+    `Route "${workStore.route}" used unresolved dynamic params in a Server Component with "output: export". This is not supported because these fallback params are only available on the client. Move param-dependent content into a Client Component or add generateStaticParams() to prerender this route. See more info here: https://nextjs.org/docs/app/guides/static-exports`
+  )
+
+  Error.captureStackTrace(error, createExportFallbackServerParamsError)
+
+  return error
 }
 
 function makeErroringParams(

--- a/packages/next/src/server/request/search-params.ts
+++ b/packages/next/src/server/request/search-params.ts
@@ -40,6 +40,7 @@ import {
 import {
   throwWithStaticGenerationBailoutErrorWithDynamicError,
   throwForSearchParamsAccessInUseCache,
+  throwForOutputExportServerRequestAPI,
 } from './utils'
 import { RenderStage } from '../app-render/staged-rendering'
 
@@ -227,6 +228,9 @@ function createStaticPrerenderSearchParams(
   switch (prerenderStore.type) {
     case 'prerender':
     case 'prerender-client':
+      if (workStore.nextConfigOutput === 'export') {
+        return makeErroringOutputExportSearchParams(workStore)
+      }
       // We are in a cacheComponents (PPR or otherwise) prerender
       return makeHangingSearchParams(workStore, prerenderStore)
     case 'prerender-ppr':
@@ -392,10 +396,17 @@ function makeErroringSearchParams(
         const expression =
           '`await searchParams`, `searchParams.then`, or similar'
         if (workStore.dynamicShouldError) {
-          throwWithStaticGenerationBailoutErrorWithDynamicError(
-            workStore.route,
-            expression
-          )
+          if (workStore.nextConfigOutput === 'export') {
+            throwForOutputExportSearchParams(
+              workStore,
+              makeErroringSearchParams
+            )
+          } else {
+            throwWithStaticGenerationBailoutErrorWithDynamicError(
+              workStore.route,
+              expression
+            )
+          }
         } else if (prerenderStore.type === 'prerender-ppr') {
           // PPR Prerender (no cacheComponents)
           postponeWithTracking(
@@ -418,6 +429,61 @@ function makeErroringSearchParams(
 
   CachedSearchParams.set(workStore, proxiedPromise)
   return proxiedPromise
+}
+
+function makeErroringOutputExportSearchParams(
+  workStore: WorkStore
+): Promise<SearchParams> {
+  const cachedSearchParams = CachedSearchParams.get(workStore)
+  if (cachedSearchParams) {
+    return cachedSearchParams
+  }
+
+  const underlyingSearchParams = {}
+  const promise = Promise.resolve(underlyingSearchParams)
+
+  const throwError = () =>
+    throwForOutputExportServerRequestAPI(
+      workStore,
+      '`searchParams`',
+      makeErroringOutputExportSearchParams,
+      'search params are only available on the client when exporting to static HTML. Read the current URL in a Client Component instead.'
+    )
+
+  const proxiedPromise = new Proxy(promise, {
+    get(target, prop, receiver) {
+      if (Object.hasOwn(promise, prop)) {
+        return ReflectAdapter.get(target, prop, receiver)
+      }
+
+      if (typeof prop === 'string') {
+        if (prop === 'then' || prop === 'status') {
+          throwError()
+        }
+      }
+
+      return ReflectAdapter.get(target, prop, receiver)
+    },
+    ownKeys() {
+      throwError()
+      return []
+    },
+  })
+
+  CachedSearchParams.set(workStore, proxiedPromise)
+  return proxiedPromise
+}
+
+function throwForOutputExportSearchParams(
+  workStore: WorkStore,
+  constructorOpt: Function
+): never {
+  return throwForOutputExportServerRequestAPI(
+    workStore,
+    '`searchParams`',
+    constructorOpt,
+    'search params are only available on the client when exporting to static HTML. Read the current URL in a Client Component instead.'
+  )
 }
 
 /**
@@ -579,11 +645,21 @@ function instrumentSearchParamsObjectWithDevWarnings(
     get(target, prop, receiver) {
       if (typeof prop === 'string' && promiseInitialized.current) {
         if (workStore.dynamicShouldError) {
-          const expression = describeStringPropertyAccess('searchParams', prop)
-          throwWithStaticGenerationBailoutErrorWithDynamicError(
-            workStore.route,
-            expression
-          )
+          if (workStore.nextConfigOutput === 'export') {
+            throwForOutputExportSearchParams(
+              workStore,
+              instrumentSearchParamsObjectWithDevWarnings
+            )
+          } else {
+            const expression = describeStringPropertyAccess(
+              'searchParams',
+              prop
+            )
+            throwWithStaticGenerationBailoutErrorWithDynamicError(
+              workStore.route,
+              expression
+            )
+          }
         }
       }
       return ReflectAdapter.get(target, prop, receiver)
@@ -591,26 +667,40 @@ function instrumentSearchParamsObjectWithDevWarnings(
     has(target, prop) {
       if (typeof prop === 'string') {
         if (workStore.dynamicShouldError) {
-          const expression = describeHasCheckingStringProperty(
-            'searchParams',
-            prop
-          )
-          throwWithStaticGenerationBailoutErrorWithDynamicError(
-            workStore.route,
-            expression
-          )
+          if (workStore.nextConfigOutput === 'export') {
+            throwForOutputExportSearchParams(
+              workStore,
+              instrumentSearchParamsObjectWithDevWarnings
+            )
+          } else {
+            const expression = describeHasCheckingStringProperty(
+              'searchParams',
+              prop
+            )
+            throwWithStaticGenerationBailoutErrorWithDynamicError(
+              workStore.route,
+              expression
+            )
+          }
         }
       }
       return Reflect.has(target, prop)
     },
     ownKeys(target) {
       if (workStore.dynamicShouldError) {
-        const expression =
-          '`{...searchParams}`, `Object.keys(searchParams)`, or similar'
-        throwWithStaticGenerationBailoutErrorWithDynamicError(
-          workStore.route,
-          expression
-        )
+        if (workStore.nextConfigOutput === 'export') {
+          throwForOutputExportSearchParams(
+            workStore,
+            instrumentSearchParamsObjectWithDevWarnings
+          )
+        } else {
+          const expression =
+            '`{...searchParams}`, `Object.keys(searchParams)`, or similar'
+          throwWithStaticGenerationBailoutErrorWithDynamicError(
+            workStore.route,
+            expression
+          )
+        }
       }
       return Reflect.ownKeys(target)
     },
@@ -636,7 +726,11 @@ function instrumentSearchParamsPromiseWithDevWarnings(
 
   return new Proxy(promise, {
     get(target, prop, receiver) {
-      if (prop === 'then' && workStore.dynamicShouldError) {
+      if (
+        prop === 'then' &&
+        workStore.dynamicShouldError &&
+        workStore.nextConfigOutput !== 'export'
+      ) {
         const expression = '`searchParams.then`'
         throwWithStaticGenerationBailoutErrorWithDynamicError(
           workStore.route,

--- a/packages/next/src/server/request/utils.ts
+++ b/packages/next/src/server/request/utils.ts
@@ -1,6 +1,9 @@
 import { StaticGenBailoutError } from '../../client/components/static-generation-bailout'
 import { afterTaskAsyncStorage } from '../app-render/after-task-async-storage.external'
 import type { WorkStore } from '../app-render/work-async-storage.external'
+import type { WorkUnitStore } from '../app-render/work-unit-async-storage.external'
+
+type OutputExportServerRequestAPIKind = 'request-data' | 'connection'
 
 export function throwWithStaticGenerationBailoutErrorWithDynamicError(
   route: string,
@@ -23,6 +26,54 @@ export function throwForSearchParamsAccessInUseCache(
   workStore.invalidDynamicUsageError ??= error
 
   throw error
+}
+
+export function throwForOutputExportServerRequestAPI(
+  workStore: WorkStore,
+  expression: string,
+  constructorOpt: Function,
+  reason: string
+): never {
+  const existingError = workStore.invalidDynamicUsageError
+  if (existingError) {
+    throw existingError
+  }
+
+  const error = new Error(
+    `Route "${workStore.route}" used ${expression} in a Server Component with "output: export". This is not supported because ${reason} See more info here: https://nextjs.org/docs/app/guides/static-exports`
+  )
+
+  Error.captureStackTrace(error, constructorOpt)
+  workStore.invalidDynamicUsageError ??= error
+
+  throw error
+}
+
+export function shouldErrorForOutputExportServerRequestAPI(
+  workUnitStore: WorkUnitStore,
+  apiKind: OutputExportServerRequestAPIKind
+): boolean {
+  switch (workUnitStore.type) {
+    case 'request':
+    case 'prerender':
+    case 'prerender-runtime':
+    case 'prerender-ppr':
+    case 'prerender-legacy':
+      return true
+    case 'prerender-client':
+      // The export fallback shell is rendered through the client prerender path.
+      // Client Components can replay request data from the browser, but
+      // connection() can only be satisfied by a live server request.
+      return apiKind === 'connection'
+    case 'validation-client':
+    case 'cache':
+    case 'private-cache':
+    case 'unstable-cache':
+    case 'generate-static-params':
+      return false
+    default:
+      return workUnitStore satisfies never
+  }
 }
 
 export function isRequestAPICallableInsideAfter() {

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params-suspense/app/layout.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params-suspense/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params-suspense/app/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params-suspense/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>home</p>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params-suspense/app/wrapped/[slug]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params-suspense/app/wrapped/[slug]/page.js
@@ -1,0 +1,15 @@
+import { Suspense } from 'react'
+
+async function ParamContent({ params }) {
+  const { slug } = await params
+
+  return <h1>{slug}</h1>
+}
+
+export default function WrappedDynamicServerPage({ params }) {
+  return (
+    <Suspense fallback={<p>loading</p>}>
+      <ParamContent params={params} />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params-suspense/next.config.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params-suspense/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  output: 'export',
+  cacheComponents: true,
+  experimental: {
+    outputExportDynamicFallbacks: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params-sync/app/another/[slug]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params-sync/app/another/[slug]/page.js
@@ -1,0 +1,5 @@
+export default function DynamicServerPage({ params }) {
+  const slug = params.slug
+
+  return <h1>{slug}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params-sync/app/layout.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params-sync/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params-sync/app/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params-sync/app/page.js
@@ -1,0 +1,3 @@
+export default function HomePage() {
+  return <h1>Home</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params-sync/next.config.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params-sync/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  output: 'export',
+  cacheComponents: true,
+  experimental: {
+    outputExportDynamicFallbacks: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params/app/another/[slug]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params/app/another/[slug]/page.js
@@ -1,0 +1,5 @@
+export default async function DynamicServerPage({ params }) {
+  const { slug } = await params
+
+  return <h1>{slug}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params/app/layout.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params/app/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params/app/page.js
@@ -1,0 +1,3 @@
+export default function HomePage() {
+  return <h1>Home</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params/next.config.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-server-params/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  output: 'export',
+  cacheComponents: true,
+  experimental: {
+    outputExportDynamicFallbacks: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir-export/fixtures/output-export-server-connection/app/layout.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-connection/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-connection/app/needs-connection/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-connection/app/needs-connection/page.js
@@ -1,0 +1,7 @@
+import { connection } from 'next/server'
+
+export default async function ConnectionPage() {
+  await connection()
+
+  return <h1>connected</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-connection/app/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-connection/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>home</p>
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-connection/next.config.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-connection/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  output: 'export',
+  cacheComponents: true,
+  experimental: {
+    outputExportDynamicFallbacks: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir-export/fixtures/output-export-server-cookies/app/layout.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-cookies/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-cookies/app/needs-cookies/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-cookies/app/needs-cookies/page.js
@@ -1,0 +1,7 @@
+import { cookies } from 'next/headers'
+
+export default async function CookiesPage() {
+  const cookieStore = await cookies()
+
+  return <h1>{cookieStore.get('theme')?.value}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-cookies/app/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-cookies/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>home</p>
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-cookies/next.config.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-cookies/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  output: 'export',
+  cacheComponents: true,
+  experimental: {
+    outputExportDynamicFallbacks: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir-export/fixtures/output-export-server-headers-suspense/app/layout.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-headers-suspense/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-headers-suspense/app/needs-headers/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-headers-suspense/app/needs-headers/page.js
@@ -1,0 +1,16 @@
+import { Suspense } from 'react'
+import { headers } from 'next/headers'
+
+async function HeadersContent() {
+  const requestHeaders = await headers()
+
+  return <h1>{requestHeaders.get('user-agent')}</h1>
+}
+
+export default function HeadersPage() {
+  return (
+    <Suspense fallback={<p>loading</p>}>
+      <HeadersContent />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-headers-suspense/app/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-headers-suspense/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>home</p>
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-headers-suspense/next.config.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-headers-suspense/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  output: 'export',
+  cacheComponents: true,
+  experimental: {
+    outputExportDynamicFallbacks: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir-export/fixtures/output-export-server-headers/app/layout.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-headers/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-headers/app/needs-headers/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-headers/app/needs-headers/page.js
@@ -1,0 +1,7 @@
+import { headers } from 'next/headers'
+
+export default async function HeadersPage() {
+  const requestHeaders = await headers()
+
+  return <h1>{requestHeaders.get('user-agent')}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-headers/app/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-headers/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>home</p>
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-headers/next.config.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-headers/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  output: 'export',
+  cacheComponents: true,
+  experimental: {
+    outputExportDynamicFallbacks: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir-export/fixtures/output-export-server-io-use-cache/app/cached-crypto/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-io-use-cache/app/cached-crypto/page.js
@@ -1,0 +1,14 @@
+async function getCachedCryptoValue() {
+  'use cache'
+
+  return crypto.randomUUID()
+}
+
+export default async function CachedCryptoPage() {
+  return (
+    <>
+      <p>Cached crypto</p>
+      <h1 id="value">{await getCachedCryptoValue()}</h1>
+    </>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-io-use-cache/app/cached-random/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-io-use-cache/app/cached-random/page.js
@@ -1,0 +1,14 @@
+async function getCachedRandom() {
+  'use cache'
+
+  return Math.random()
+}
+
+export default async function CachedRandomPage() {
+  return (
+    <>
+      <p>Cached random</p>
+      <h1 id="value">{String(await getCachedRandom())}</h1>
+    </>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-io-use-cache/app/cached-time/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-io-use-cache/app/cached-time/page.js
@@ -1,0 +1,14 @@
+async function getCachedTime() {
+  'use cache'
+
+  return Date.now()
+}
+
+export default async function CachedTimePage() {
+  return (
+    <>
+      <p>Cached time</p>
+      <h1 id="value">{String(await getCachedTime())}</h1>
+    </>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-io-use-cache/app/layout.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-io-use-cache/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-io-use-cache/app/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-io-use-cache/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>home</p>
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-io-use-cache/next.config.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-io-use-cache/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  output: 'export',
+  cacheComponents: true,
+  experimental: {
+    outputExportDynamicFallbacks: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir-export/fixtures/output-export-server-io/app/cached-request/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-io/app/cached-request/page.js
@@ -1,0 +1,12 @@
+import { headers } from 'next/headers'
+
+async function getHeadersInCache() {
+  'use cache'
+
+  const requestHeaders = await headers()
+  return requestHeaders.get('user-agent') ?? 'unknown'
+}
+
+export default async function CachedRequestPage() {
+  return <h1>{await getHeadersInCache()}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-io/app/layout.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-io/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-io/app/needs-crypto/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-io/app/needs-crypto/page.js
@@ -1,0 +1,3 @@
+export default function CryptoPage() {
+  return <h1>{crypto.randomUUID()}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-io/app/needs-random/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-io/app/needs-random/page.js
@@ -1,0 +1,3 @@
+export default function RandomPage() {
+  return <h1>{Math.random()}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-io/app/needs-time/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-io/app/needs-time/page.js
@@ -1,0 +1,3 @@
+export default function TimePage() {
+  return <h1>{Date.now()}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-io/app/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-io/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>home</p>
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-io/next.config.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-io/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  output: 'export',
+  cacheComponents: true,
+  experimental: {
+    outputExportDynamicFallbacks: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir-export/fixtures/output-export-server-search-params-suspense/app/layout.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-search-params-suspense/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-search-params-suspense/app/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-search-params-suspense/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>home</p>
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-search-params-suspense/app/search/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-search-params-suspense/app/search/page.js
@@ -1,0 +1,15 @@
+import { Suspense } from 'react'
+
+async function SearchContent({ searchParams }) {
+  const query = await searchParams
+
+  return <h1>{query.q}</h1>
+}
+
+export default function SearchPage({ searchParams }) {
+  return (
+    <Suspense fallback={<p>loading</p>}>
+      <SearchContent searchParams={searchParams} />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-search-params-suspense/next.config.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-search-params-suspense/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  output: 'export',
+  cacheComponents: true,
+  experimental: {
+    outputExportDynamicFallbacks: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir-export/fixtures/output-export-server-search-params/app/layout.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-search-params/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-search-params/app/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-search-params/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>home</p>
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-search-params/app/search/page.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-search-params/app/search/page.js
@@ -1,0 +1,5 @@
+export default async function SearchPage({ searchParams }) {
+  const query = await searchParams
+
+  return <h1>{query.q}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/output-export-server-search-params/next.config.js
+++ b/test/e2e/app-dir-export/fixtures/output-export-server-search-params/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  output: 'export',
+  cacheComponents: true,
+  experimental: {
+    outputExportDynamicFallbacks: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir-export/test/dynamic-fallback-server-params-suspense.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-fallback-server-params-suspense.test.ts
@@ -1,0 +1,70 @@
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import {
+  expectOutputExportDevRedbox,
+  startOutputExportDevServer,
+} from './utils'
+
+const { next, skipped, isNextDev } = nextTestSetup({
+  files: join(
+    __dirname,
+    '..',
+    'fixtures',
+    'dynamic-fallback-server-params-suspense'
+  ),
+  skipStart: true,
+  skipDeployment: true,
+  disableAutoSkewProtection: true,
+})
+
+if (skipped) {
+  describe.skip('app dir - output export fallback server params suspense', () => {})
+} else {
+  const describeDevelopment = isNextDev ? describe : describe.skip
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  describeDevelopment(
+    'app dir - output export fallback server params suspense',
+    () => {
+      let port: number
+
+      beforeAll(async () => {
+        port = await startOutputExportDevServer(next)
+      })
+
+      afterAll(async () => {
+        await next.destroy()
+      })
+
+      it('shows a redbox even when unresolved fallback params are only read behind Suspense', async () => {
+        await expectOutputExportDevRedbox({
+          port,
+          path: '/wrapped/first',
+          expectedMessage:
+            'used unresolved dynamic params in a Server Component with "output: export"',
+          expectedSource: 'await params',
+        })
+      })
+    }
+  )
+
+  describeProduction(
+    'app dir - output export fallback server params suspense',
+    () => {
+      afterAll(async () => {
+        await next.destroy()
+      })
+
+      it('errors even when unresolved fallback params are only read behind Suspense', async () => {
+        const { exitCode, cliOutput } = await next.build()
+
+        expect(exitCode).toBe(1)
+        expect(cliOutput).toContain(
+          'used unresolved dynamic params in a Server Component with "output: export"'
+        )
+        expect(cliOutput).toContain('/wrapped/[slug]')
+        expect(cliOutput).toContain('Client Component')
+      })
+    }
+  )
+}

--- a/test/e2e/app-dir-export/test/dynamic-fallback-server-params-sync.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-fallback-server-params-sync.test.ts
@@ -1,0 +1,71 @@
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import {
+  expectOutputExportDevRedbox,
+  startOutputExportDevServer,
+} from './utils'
+
+const { next, skipped, isNextDev } = nextTestSetup({
+  files: join(
+    __dirname,
+    '..',
+    'fixtures',
+    'dynamic-fallback-server-params-sync'
+  ),
+  skipStart: true,
+  skipDeployment: true,
+  disableAutoSkewProtection: true,
+})
+
+if (skipped) {
+  describe.skip('app dir - output export fallback server params sync access', () => {})
+} else {
+  const describeDevelopment = isNextDev ? describe : describe.skip
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  describeDevelopment(
+    'app dir - output export fallback server params sync access',
+    () => {
+      let port: number
+
+      beforeAll(async () => {
+        port = await startOutputExportDevServer(next)
+      })
+
+      afterAll(async () => {
+        await next.destroy()
+      })
+
+      it('shows a redbox when a Server Component reads unresolved fallback params synchronously', async () => {
+        await expectOutputExportDevRedbox({
+          port,
+          path: '/another/first',
+          expectedMessage:
+            'used unresolved dynamic params in a Server Component with "output: export"',
+          expectedSource: 'params.slug',
+        })
+      })
+    }
+  )
+
+  describeProduction(
+    'app dir - output export fallback server params sync access',
+    () => {
+      afterAll(async () => {
+        await next.destroy()
+      })
+
+      it('errors when a Server Component reads unresolved fallback params synchronously', async () => {
+        const { exitCode, cliOutput } = await next.build()
+
+        expect(exitCode).toBe(1)
+        expect(cliOutput).toContain(
+          'used unresolved dynamic params in a Server Component with "output: export"'
+        )
+        expect(cliOutput).toContain('/another/[slug]')
+        expect(cliOutput).toContain('generateStaticParams()')
+        expect(cliOutput).toContain('Client Component')
+      })
+    }
+  )
+}

--- a/test/e2e/app-dir-export/test/dynamic-fallback-server-params.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-fallback-server-params.test.ts
@@ -1,0 +1,60 @@
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import {
+  expectOutputExportDevRedbox,
+  startOutputExportDevServer,
+} from './utils'
+
+const { next, skipped, isNextDev } = nextTestSetup({
+  files: join(__dirname, '..', 'fixtures', 'dynamic-fallback-server-params'),
+  skipStart: true,
+  skipDeployment: true,
+  disableAutoSkewProtection: true,
+})
+
+if (skipped) {
+  describe.skip('app dir - output export fallback server params', () => {})
+} else {
+  const describeDevelopment = isNextDev ? describe : describe.skip
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  describeDevelopment('app dir - output export fallback server params', () => {
+    let port: number
+
+    beforeAll(async () => {
+      port = await startOutputExportDevServer(next)
+    })
+
+    afterAll(async () => {
+      await next.destroy()
+    })
+
+    it('shows a redbox when a Server Component awaits unresolved fallback params', async () => {
+      await expectOutputExportDevRedbox({
+        port,
+        path: '/another/first',
+        expectedMessage:
+          'used unresolved dynamic params in a Server Component with "output: export"',
+        expectedSource: 'await params',
+      })
+    })
+  })
+
+  describeProduction('app dir - output export fallback server params', () => {
+    afterAll(async () => {
+      await next.destroy()
+    })
+
+    it('errors when a Server Component awaits unresolved fallback params', async () => {
+      const { exitCode, cliOutput } = await next.build()
+
+      expect(exitCode).toBe(1)
+      expect(cliOutput).toContain(
+        'used unresolved dynamic params in a Server Component with "output: export"'
+      )
+      expect(cliOutput).toContain('/another/[slug]')
+      expect(cliOutput).toContain('generateStaticParams()')
+      expect(cliOutput).toContain('Client Component')
+    })
+  })
+}

--- a/test/e2e/app-dir-export/test/output-export-server-connection.test.ts
+++ b/test/e2e/app-dir-export/test/output-export-server-connection.test.ts
@@ -1,0 +1,59 @@
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import {
+  expectOutputExportDevRedbox,
+  startOutputExportDevServer,
+} from './utils'
+
+const { next, skipped, isNextDev } = nextTestSetup({
+  files: join(__dirname, '..', 'fixtures', 'output-export-server-connection'),
+  skipStart: true,
+  skipDeployment: true,
+  disableAutoSkewProtection: true,
+})
+
+if (skipped) {
+  describe.skip('app dir - output export server connection', () => {})
+} else {
+  const describeDevelopment = isNextDev ? describe : describe.skip
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  describeDevelopment('app dir - output export server connection', () => {
+    let port: number
+
+    beforeAll(async () => {
+      port = await startOutputExportDevServer(next)
+    })
+
+    afterAll(async () => {
+      await next.destroy()
+    })
+
+    it('shows a redbox when a Server Component awaits connection() in output export', async () => {
+      await expectOutputExportDevRedbox({
+        port,
+        path: '/needs-connection',
+        expectedMessage:
+          'used `connection()` in a Server Component with "output: export"',
+        expectedSource: 'await connection()',
+      })
+    })
+  })
+
+  describeProduction('app dir - output export server connection', () => {
+    afterAll(async () => {
+      await next.destroy()
+    })
+
+    it('errors when a Server Component awaits connection() in output export', async () => {
+      const { exitCode, cliOutput } = await next.build()
+
+      expect(exitCode).toBe(1)
+      expect(cliOutput).toContain(
+        'used `connection()` in a Server Component with "output: export"'
+      )
+      expect(cliOutput).toContain('/needs-connection')
+      expect(cliOutput).toContain('runtime server request')
+    })
+  })
+}

--- a/test/e2e/app-dir-export/test/output-export-server-cookies.test.ts
+++ b/test/e2e/app-dir-export/test/output-export-server-cookies.test.ts
@@ -1,0 +1,59 @@
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import {
+  expectOutputExportDevRedbox,
+  startOutputExportDevServer,
+} from './utils'
+
+const { next, skipped, isNextDev } = nextTestSetup({
+  files: join(__dirname, '..', 'fixtures', 'output-export-server-cookies'),
+  skipStart: true,
+  skipDeployment: true,
+  disableAutoSkewProtection: true,
+})
+
+if (skipped) {
+  describe.skip('app dir - output export server cookies', () => {})
+} else {
+  const describeDevelopment = isNextDev ? describe : describe.skip
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  describeDevelopment('app dir - output export server cookies', () => {
+    let port: number
+
+    beforeAll(async () => {
+      port = await startOutputExportDevServer(next)
+    })
+
+    afterAll(async () => {
+      await next.destroy()
+    })
+
+    it('shows a redbox when a Server Component awaits cookies() in output export', async () => {
+      await expectOutputExportDevRedbox({
+        port,
+        path: '/needs-cookies',
+        expectedMessage:
+          'used `cookies()` in a Server Component with "output: export"',
+        expectedSource: 'await cookies()',
+      })
+    })
+  })
+
+  describeProduction('app dir - output export server cookies', () => {
+    afterAll(async () => {
+      await next.destroy()
+    })
+
+    it('errors when a Server Component awaits cookies() in output export', async () => {
+      const { exitCode, cliOutput } = await next.build()
+
+      expect(exitCode).toBe(1)
+      expect(cliOutput).toContain(
+        'used `cookies()` in a Server Component with "output: export"'
+      )
+      expect(cliOutput).toContain('/needs-cookies')
+      expect(cliOutput).toContain('runtime server request')
+    })
+  })
+}

--- a/test/e2e/app-dir-export/test/output-export-server-headers-suspense.test.ts
+++ b/test/e2e/app-dir-export/test/output-export-server-headers-suspense.test.ts
@@ -1,0 +1,64 @@
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import {
+  expectOutputExportDevRedbox,
+  startOutputExportDevServer,
+} from './utils'
+
+const { next, skipped, isNextDev } = nextTestSetup({
+  files: join(
+    __dirname,
+    '..',
+    'fixtures',
+    'output-export-server-headers-suspense'
+  ),
+  skipStart: true,
+  skipDeployment: true,
+  disableAutoSkewProtection: true,
+})
+
+if (skipped) {
+  describe.skip('app dir - output export server headers suspense', () => {})
+} else {
+  const describeDevelopment = isNextDev ? describe : describe.skip
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  describeDevelopment('app dir - output export server headers suspense', () => {
+    let port: number
+
+    beforeAll(async () => {
+      port = await startOutputExportDevServer(next)
+    })
+
+    afterAll(async () => {
+      await next.destroy()
+    })
+
+    it('shows a redbox even when headers() is only read behind Suspense', async () => {
+      await expectOutputExportDevRedbox({
+        port,
+        path: '/needs-headers',
+        expectedMessage:
+          'used `headers()` in a Server Component with "output: export"',
+        expectedSource: 'await headers()',
+      })
+    })
+  })
+
+  describeProduction('app dir - output export server headers suspense', () => {
+    afterAll(async () => {
+      await next.destroy()
+    })
+
+    it('errors even when headers() is only read behind Suspense', async () => {
+      const { exitCode, cliOutput } = await next.build()
+
+      expect(exitCode).toBe(1)
+      expect(cliOutput).toContain(
+        'used `headers()` in a Server Component with "output: export"'
+      )
+      expect(cliOutput).toContain('/needs-headers')
+      expect(cliOutput).toContain('runtime server request')
+    })
+  })
+}

--- a/test/e2e/app-dir-export/test/output-export-server-headers.test.ts
+++ b/test/e2e/app-dir-export/test/output-export-server-headers.test.ts
@@ -1,0 +1,59 @@
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import {
+  expectOutputExportDevRedbox,
+  startOutputExportDevServer,
+} from './utils'
+
+const { next, skipped, isNextDev } = nextTestSetup({
+  files: join(__dirname, '..', 'fixtures', 'output-export-server-headers'),
+  skipStart: true,
+  skipDeployment: true,
+  disableAutoSkewProtection: true,
+})
+
+if (skipped) {
+  describe.skip('app dir - output export server headers', () => {})
+} else {
+  const describeDevelopment = isNextDev ? describe : describe.skip
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  describeDevelopment('app dir - output export server headers', () => {
+    let port: number
+
+    beforeAll(async () => {
+      port = await startOutputExportDevServer(next)
+    })
+
+    afterAll(async () => {
+      await next.destroy()
+    })
+
+    it('shows a redbox when a Server Component awaits headers() in output export', async () => {
+      await expectOutputExportDevRedbox({
+        port,
+        path: '/needs-headers',
+        expectedMessage:
+          'used `headers()` in a Server Component with "output: export"',
+        expectedSource: 'await headers()',
+      })
+    })
+  })
+
+  describeProduction('app dir - output export server headers', () => {
+    afterAll(async () => {
+      await next.destroy()
+    })
+
+    it('errors when a Server Component awaits headers() in output export', async () => {
+      const { exitCode, cliOutput } = await next.build()
+
+      expect(exitCode).toBe(1)
+      expect(cliOutput).toContain(
+        'used `headers()` in a Server Component with "output: export"'
+      )
+      expect(cliOutput).toContain('/needs-headers')
+      expect(cliOutput).toContain('runtime server request')
+    })
+  })
+}

--- a/test/e2e/app-dir-export/test/output-export-server-io-use-cache.test.ts
+++ b/test/e2e/app-dir-export/test/output-export-server-io-use-cache.test.ts
@@ -1,0 +1,69 @@
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import fs from 'fs-extra'
+
+const { next, skipped, isNextDev } = nextTestSetup({
+  files: join(__dirname, '..', 'fixtures', 'output-export-server-io-use-cache'),
+  skipStart: true,
+  skipDeployment: true,
+  disableAutoSkewProtection: true,
+})
+
+if (skipped) {
+  describe.skip('app dir - output export server io use cache', () => {})
+} else {
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  describeProduction('app dir - output export server io use cache', () => {
+    let cliOutput: string
+
+    beforeAll(async () => {
+      const result = await next.build()
+
+      if (result.exitCode !== 0) {
+        throw new Error(`Expected build to pass:\n${result.cliOutput}`)
+      }
+
+      cliOutput = result.cliOutput
+    })
+
+    afterAll(async () => {
+      await next.destroy()
+    })
+
+    it('exports Date.now() successfully when the read is wrapped in use cache', async () => {
+      const html = await fs.readFile(
+        join(next.testDir, 'out', 'cached-time.html'),
+        'utf8'
+      )
+
+      expect(cliOutput).not.toContain('used `Date.now()`')
+      expect(html).toContain('Cached time')
+      expect(html).toMatch(/<h1 id="value">\d+<\/h1>/)
+    })
+
+    it('exports Math.random() successfully when the read is wrapped in use cache', async () => {
+      const html = await fs.readFile(
+        join(next.testDir, 'out', 'cached-random.html'),
+        'utf8'
+      )
+
+      expect(cliOutput).not.toContain('used `Math.random()`')
+      expect(html).toContain('Cached random')
+      expect(html).toMatch(/<h1 id="value">0?\.\d+<\/h1>/)
+    })
+
+    it('exports crypto.randomUUID() successfully when the read is wrapped in use cache', async () => {
+      const html = await fs.readFile(
+        join(next.testDir, 'out', 'cached-crypto.html'),
+        'utf8'
+      )
+
+      expect(cliOutput).not.toContain('used `crypto.randomUUID()`')
+      expect(html).toContain('Cached crypto')
+      expect(html).toMatch(
+        /<h1 id="value">[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}<\/h1>/i
+      )
+    })
+  })
+}

--- a/test/e2e/app-dir-export/test/output-export-server-io.test.ts
+++ b/test/e2e/app-dir-export/test/output-export-server-io.test.ts
@@ -1,0 +1,117 @@
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import {
+  expectOutputExportDevCollapsedRedbox,
+  expectOutputExportDevRedbox,
+  startOutputExportDevServer,
+} from './utils'
+
+const { next, skipped, isNextDev } = nextTestSetup({
+  files: join(__dirname, '..', 'fixtures', 'output-export-server-io'),
+  skipStart: true,
+  skipDeployment: true,
+  disableAutoSkewProtection: true,
+})
+
+if (skipped) {
+  describe.skip('app dir - output export server io', () => {})
+} else {
+  const describeDevelopment = isNextDev ? describe : describe.skip
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  describeDevelopment('app dir - output export server io', () => {
+    let port: number
+
+    beforeAll(async () => {
+      port = await startOutputExportDevServer(next)
+    })
+
+    afterAll(async () => {
+      await next.destroy()
+    })
+
+    it('shows a redbox when Date.now() is read outside use cache', async () => {
+      await expectOutputExportDevCollapsedRedbox({
+        port,
+        path: '/needs-time',
+        expectedMessage:
+          'used `Date.now()` before accessing either uncached data',
+        expectedSource: 'Date.now()',
+      })
+    })
+
+    it('shows a redbox when Math.random() is read outside use cache', async () => {
+      await expectOutputExportDevCollapsedRedbox({
+        port,
+        path: '/needs-random',
+        expectedMessage:
+          'used `Math.random()` before accessing either uncached data',
+        expectedSource: 'Math.random()',
+      })
+    })
+
+    it('shows a redbox when crypto.randomUUID() is read outside use cache', async () => {
+      await expectOutputExportDevCollapsedRedbox({
+        port,
+        path: '/needs-crypto',
+        expectedMessage:
+          'used `crypto.randomUUID()` before accessing either uncached data',
+        expectedSource: 'crypto.randomUUID()',
+      })
+    })
+
+    it('still shows a redbox when request APIs are used inside use cache', async () => {
+      await expectOutputExportDevRedbox({
+        port,
+        path: '/cached-request',
+        expectedMessage: 'used `headers()` inside "use cache"',
+        expectedSource: 'await headers()',
+      })
+    })
+  })
+
+  describeProduction('app dir - output export server io', () => {
+    afterAll(async () => {
+      await next.destroy()
+    })
+
+    it.each([
+      [
+        '/needs-time',
+        'app/needs-time/page.js',
+        'used `Date.now()` before accessing either uncached data',
+      ],
+      [
+        '/needs-random',
+        'app/needs-random/page.js',
+        'used `Math.random()` before accessing either uncached data',
+      ],
+      [
+        '/needs-crypto',
+        'app/needs-crypto/page.js',
+        'used `crypto.randomUUID()` before accessing either uncached data',
+      ],
+    ])(
+      'errors when sync IO is used outside use cache for %s in output export',
+      async (route, buildPath, expectedMessage) => {
+        const { exitCode, cliOutput } = await next.build({
+          args: ['--debug-build-paths', buildPath],
+        })
+
+        expect(exitCode).toBe(1)
+        expect(cliOutput).toContain(expectedMessage)
+        expect(cliOutput).toContain(route)
+      }
+    )
+
+    it('still errors when request APIs are used inside use cache in output export', async () => {
+      const { exitCode, cliOutput } = await next.build({
+        args: ['--debug-build-paths', 'app/cached-request/page.js'],
+      })
+
+      expect(exitCode).toBe(1)
+      expect(cliOutput).toContain('used `headers()` inside "use cache"')
+      expect(cliOutput).toContain('/cached-request')
+    })
+  })
+}

--- a/test/e2e/app-dir-export/test/output-export-server-search-params-suspense.test.ts
+++ b/test/e2e/app-dir-export/test/output-export-server-search-params-suspense.test.ts
@@ -1,0 +1,69 @@
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import {
+  expectOutputExportDevRedbox,
+  startOutputExportDevServer,
+} from './utils'
+
+const { next, skipped, isNextDev } = nextTestSetup({
+  files: join(
+    __dirname,
+    '..',
+    'fixtures',
+    'output-export-server-search-params-suspense'
+  ),
+  skipStart: true,
+  skipDeployment: true,
+  disableAutoSkewProtection: true,
+})
+
+if (skipped) {
+  describe.skip('app dir - output export server search params suspense', () => {})
+} else {
+  const describeDevelopment = isNextDev ? describe : describe.skip
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  describeDevelopment(
+    'app dir - output export server search params suspense',
+    () => {
+      let port: number
+
+      beforeAll(async () => {
+        port = await startOutputExportDevServer(next)
+      })
+
+      afterAll(async () => {
+        await next.destroy()
+      })
+
+      it('shows a redbox even when searchParams are only read behind Suspense', async () => {
+        await expectOutputExportDevRedbox({
+          port,
+          path: '/search?q=hello',
+          expectedMessage:
+            'used `searchParams` in a Server Component with "output: export"',
+        })
+      })
+    }
+  )
+
+  describeProduction(
+    'app dir - output export server search params suspense',
+    () => {
+      afterAll(async () => {
+        await next.destroy()
+      })
+
+      it('errors even when searchParams are only read behind Suspense', async () => {
+        const { exitCode, cliOutput } = await next.build()
+
+        expect(exitCode).toBe(1)
+        expect(cliOutput).toContain(
+          'used `searchParams` in a Server Component with "output: export"'
+        )
+        expect(cliOutput).toContain('/search')
+        expect(cliOutput).toContain('Client Component')
+      })
+    }
+  )
+}

--- a/test/e2e/app-dir-export/test/output-export-server-search-params.test.ts
+++ b/test/e2e/app-dir-export/test/output-export-server-search-params.test.ts
@@ -1,0 +1,63 @@
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import {
+  expectOutputExportDevRedbox,
+  startOutputExportDevServer,
+} from './utils'
+
+const { next, skipped, isNextDev } = nextTestSetup({
+  files: join(
+    __dirname,
+    '..',
+    'fixtures',
+    'output-export-server-search-params'
+  ),
+  skipStart: true,
+  skipDeployment: true,
+  disableAutoSkewProtection: true,
+})
+
+if (skipped) {
+  describe.skip('app dir - output export server search params', () => {})
+} else {
+  const describeDevelopment = isNextDev ? describe : describe.skip
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  describeDevelopment('app dir - output export server search params', () => {
+    let port: number
+
+    beforeAll(async () => {
+      port = await startOutputExportDevServer(next)
+    })
+
+    afterAll(async () => {
+      await next.destroy()
+    })
+
+    it('shows a redbox when a Server Component awaits searchParams in output export', async () => {
+      await expectOutputExportDevRedbox({
+        port,
+        path: '/search?q=hello',
+        expectedMessage:
+          'used `searchParams` in a Server Component with "output: export"',
+      })
+    })
+  })
+
+  describeProduction('app dir - output export server search params', () => {
+    afterAll(async () => {
+      await next.destroy()
+    })
+
+    it('errors when a Server Component awaits searchParams in output export', async () => {
+      const { exitCode, cliOutput } = await next.build()
+
+      expect(exitCode).toBe(1)
+      expect(cliOutput).toContain(
+        'used `searchParams` in a Server Component with "output: export"'
+      )
+      expect(cliOutput).toContain('/search')
+      expect(cliOutput).toContain('Client Component')
+    })
+  })
+}

--- a/test/e2e/app-dir-export/test/utils.ts
+++ b/test/e2e/app-dir-export/test/utils.ts
@@ -4,20 +4,161 @@ import { join } from 'path'
 import { promisify } from 'util'
 import fs from 'fs-extra'
 import globOrig from 'glob'
+import express from 'express'
+import http from 'http'
+import { createReadStream } from 'fs'
 import {
   waitForRedbox,
   getRedboxHeader,
+  getRedboxDescription,
   getRedboxSource,
+  openRedbox,
   retry,
   findPort,
   startStaticServer,
   stopApp,
   fetchViaHTTP,
 } from 'next-test-utils'
-import { nextTestSetup } from 'e2e-utils'
+import { nextTestSetup, type NextInstance } from 'e2e-utils'
 import webdriver from 'next-webdriver'
 
 const glob = promisify(globOrig)
+
+export async function buildAndStartOutputExportServer(
+  next: Pick<NextInstance, 'build' | 'testDir'>,
+  {
+    basePath,
+    useFallbackDocument,
+  }: {
+    basePath?: string
+    useFallbackDocument: boolean
+  }
+) {
+  await next.build()
+
+  const port = await findPort()
+  const outDir = join(next.testDir, 'out')
+  const requests: string[] = []
+
+  const getRequests = () => [...requests]
+  const clearRequests = () => {
+    requests.length = 0
+  }
+
+  if (!useFallbackDocument) {
+    const app = await startStaticServer(outDir, null, port)
+    return {
+      port,
+      getRequests,
+      clearRequests,
+      stopOrKill: () => stopApp(app),
+    }
+  }
+
+  const app = express()
+  const server = http.createServer(app)
+  const fallbackHtml = join(outDir, '_fallback.html')
+
+  app.use((req, _res, nextHandler) => {
+    requests.push(req.url || '/')
+    nextHandler()
+  })
+
+  if (basePath) {
+    app.use((req, _res, nextHandler) => {
+      if (req.url === basePath) {
+        req.url = '/'
+      } else if (req.url?.startsWith(`${basePath}/`)) {
+        req.url = req.url.slice(basePath.length)
+      }
+      nextHandler()
+    })
+  }
+
+  app.use(
+    express.static(outDir, {
+      extensions: ['html'],
+      redirect: false,
+    })
+  )
+  app.use((req, res) => {
+    createReadStream(fallbackHtml).pipe(res)
+  })
+
+  await new Promise<void>((resolve) => server.listen(port, resolve))
+
+  return {
+    port,
+    getRequests,
+    clearRequests,
+    stopOrKill: () => stopApp(server),
+  }
+}
+
+export async function startOutputExportDevServer(
+  next: Pick<NextInstance, 'start' | 'appPort'>
+) {
+  await next.start()
+  return Number(next.appPort)
+}
+
+export async function expectOutputExportDevRedbox({
+  port,
+  path,
+  expectedMessage,
+  expectedSource,
+}: {
+  port: number
+  path: string
+  expectedMessage: string
+  expectedSource?: string
+}) {
+  const browser = await webdriver(port, path)
+
+  try {
+    await waitForRedbox(browser)
+
+    const header = await getRedboxHeader(browser)
+    const source = await getRedboxSource(browser)
+
+    expect(header).toContain(expectedMessage)
+
+    if (expectedSource && source !== null) {
+      expect(source).toContain(expectedSource)
+    }
+  } finally {
+    await browser.close()
+  }
+}
+
+export async function expectOutputExportDevCollapsedRedbox({
+  port,
+  path,
+  expectedMessage,
+  expectedSource,
+}: {
+  port: number
+  path: string
+  expectedMessage: string
+  expectedSource?: string
+}) {
+  const browser = await webdriver(port, path)
+
+  try {
+    await openRedbox(browser)
+
+    const description = await getRedboxDescription(browser)
+    const source = await getRedboxSource(browser)
+
+    expect(description).toContain(expectedMessage)
+
+    if (expectedSource && source !== null) {
+      expect(source).toContain(expectedSource)
+    }
+  } finally {
+    await browser.close()
+  }
+}
 
 export const expectedWhenTrailingSlashTrue = [
   '404.html',

--- a/test/lib/e2e-utils/index.ts
+++ b/test/lib/e2e-utils/index.ts
@@ -334,7 +334,9 @@ export function nextTestSetup(
       // Gracefully destroy the instance if `createNext` success.
       // If next instance is not available, it's likely beforeAll hook failed and unnecessarily throws another error
       // by attempting to destroy on undefined.
-      await next?.destroy()
+      if (next && !(next as any).isDestroyed) {
+        await next.destroy()
+      }
     })
   }
 


### PR DESCRIPTION
This is PR 14 of 21 in the offline navigations plus output-export fallback stack.

This stack introduces a generated fallback entrypoint and then layers the client behavior on the existing App Router, cached navigations, optimistic routing, Cache Components, and Segment Cache primitives. The offline navigations chapter adds a managed service worker and persisted Segment Cache replay. The output-export chapter emits static fallback HTML/RSC artifacts so parameterized routes can load and navigate without enumerating every param at build time.

Review guide: https://gist.github.com/feedthejim/bb440153d29dce019d1d26b6643e2a48

## Where This Sits
This PR is in the output-export fallbacks chapter, after the offline fallback-entrypoint primitives are established.
Previous PR: #93746 `output export fallbacks: emit fallback RSC artifacts (13/21)`.
Next PR: #93748 `output export fallbacks: bootstrap hard loads from artifacts (15/21)`.

## What Changes
- Errors when static export fallback Server Components try to read unresolved params or request-only APIs.
- Keeps the static-export contract honest: unknown params can be filled client-side, but not read by a Server Component at build time.

## Reviewer Focus
- The error should point developers toward `generateStaticParams()` or Client Components.
- This boundary should not make normal static export routes stricter than needed.

## Proof In This PR
- Server-params output-export e2e covers build errors and dev redbox behavior for unresolved fallback params.
- The dynamic fallback suite continues covering supported client-readable params.

Latest local stack verification after autosquash included:
- `git diff --check`
- `pnpm --filter=next types`
- `pnpm testonly packages/next/src/client/components/segment-cache/offline-navigation-cache.test.ts packages/next/src/client/components/segment-cache/cache.test.ts packages/next/src/client/output-export-fallback.test.ts packages/next/src/export/helpers/output-export-fallback.test.ts packages/next/src/lib/output-export-fallback-routes.test.ts packages/next/src/client/components/router-reducer/fetch-server-response.test.ts`
- `HEADLESS=true pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `HEADLESS=true pnpm test-start-turbo test/e2e/app-dir-export/test/dynamic-fallback*.test.ts`

## Deferred Coverage
Client hard-load and soft-navigation fallback consumption are deferred.

## Disabled-Flag Posture
Boundary enforcement is only active for the output-export fallback path.

## Full Stack
1. [offline navigations: add gated build primitives (1/21)](https://github.com/vercel/next.js/pull/93736)
2. [offline navigations: generate fallback document artifacts (2/21)](https://github.com/vercel/next.js/pull/93737)
3. [offline navigations: register pass-through worker (3/21)](https://github.com/vercel/next.js/pull/93625)
4. [offline navigations: cache fallback and current-build assets (4/21)](https://github.com/vercel/next.js/pull/93626)
5. [offline navigations: serve fallback document offline (5/21)](https://github.com/vercel/next.js/pull/93627)
6. [offline navigations: add Segment Cache persistence primitives (6/21)](https://github.com/vercel/next.js/pull/93630)
7. [offline navigations: persist cached Segment Cache records (7/21)](https://github.com/vercel/next.js/pull/93640)
8. [offline navigations: bootstrap fallback from Segment Cache records (8/21)](https://github.com/vercel/next.js/pull/93644)
9. [offline navigations: support dynamic route patterns (9/21)](https://github.com/vercel/next.js/pull/93647)
10. [offline navigations: add docs and examples (10/21)](https://github.com/vercel/next.js/pull/93738)
11. [output export fallbacks: add gated build primitives (11/21)](https://github.com/vercel/next.js/pull/93744)
12. [output export fallbacks: emit fallback HTML artifacts (12/21)](https://github.com/vercel/next.js/pull/93745)
13. [output export fallbacks: emit fallback RSC artifacts (13/21)](https://github.com/vercel/next.js/pull/93746)
14. **Current PR:** [output export fallbacks: enforce server-only boundaries (14/21)](https://github.com/vercel/next.js/pull/93747)
15. [output export fallbacks: bootstrap hard loads from artifacts (15/21)](https://github.com/vercel/next.js/pull/93748)
16. [output export fallbacks: resolve soft navigations through cached routes (16/21)](https://github.com/vercel/next.js/pull/93749)
17. [output export fallbacks: resolve fallback artifacts from route manifests (17/21)](https://github.com/vercel/next.js/pull/93779)
18. [output export fallbacks: validate fallback Flight responses (18/21)](https://github.com/vercel/next.js/pull/93750)
19. [output export fallbacks: store fallback data in Segment Cache (19/21)](https://github.com/vercel/next.js/pull/93774)
20. [output export fallbacks: support known params and export variants (20/21)](https://github.com/vercel/next.js/pull/93751)
21. [output export fallbacks: add docs and review guide (21/21)](https://github.com/vercel/next.js/pull/93752)

<!-- NEXT_JS_LLM_PR -->
