### PR TITLE
output export fallbacks: bootstrap hard loads from artifacts (15/21)

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1194,5 +1194,6 @@
   "1193": "\\`experimental.offlineNavigations\\` requires \\`cacheComponents\\` to be enabled. Please update your %s accordingly.",
   "1194": "Expected staticChildren to be initialized for known dynamic siblings.",
   "1195": "Route \"%s\" used %s in a Server Component with \"output: export\". This is not supported because %s See more info here: https://nextjs.org/docs/app/guides/static-exports",
-  "1196": "Route \"%s\" used unresolved dynamic params in a Server Component with \"output: export\". This is not supported because these fallback params are only available on the client. Move param-dependent content into a Client Component or add generateStaticParams() to prerender this route. See more info here: https://nextjs.org/docs/app/guides/static-exports"
+  "1196": "Route \"%s\" used unresolved dynamic params in a Server Component with \"output: export\". This is not supported because these fallback params are only available on the client. Move param-dependent content into a Client Component or add generateStaticParams() to prerender this route. See more info here: https://nextjs.org/docs/app/guides/static-exports",
+  "1197": "Could not find an output export fallback for \"%s\"."
 }

--- a/packages/next/src/build/define-env.ts
+++ b/packages/next/src/build/define-env.ts
@@ -303,6 +303,10 @@ export function getDefineEnv({
     'process.env.__NEXT_ROUTER_BASEPATH': config.basePath,
     'process.env.__NEXT_HAS_REWRITES': hasRewrites,
     'process.env.__NEXT_CONFIG_OUTPUT': config.output,
+    'process.env.__NEXT_OUTPUT_EXPORT_DYNAMIC_FALLBACKS':
+      config.output === 'export' &&
+      config.cacheComponents === true &&
+      config.experimental.outputExportDynamicFallbacks === true,
     'process.env.__NEXT_I18N_SUPPORT': !!config.i18n,
     'process.env.__NEXT_I18N_DOMAINS': config.i18n?.domains ?? false,
     'process.env.__NEXT_I18N_CONFIG': config.i18n || '',

--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -70,11 +70,34 @@ if (process.env.__NEXT_USE_OFFLINE) {
   // Keep the offline event module out of disabled client bundles.
 }
 
+type OutputExportFallbackBootstrapModule =
+  typeof import('./output-export-fallback-bootstrap')
+type OutputExportFallbackState = ReturnType<
+  OutputExportFallbackBootstrapModule['getOutputExportFallbackState']
+>
+
+let outputExportFallbackBootstrap: OutputExportFallbackBootstrapModule | null
+let outputExportFallbackState: OutputExportFallbackState | null
+if (process.env.__NEXT_OUTPUT_EXPORT_DYNAMIC_FALLBACKS) {
+  outputExportFallbackBootstrap =
+    require('./output-export-fallback-bootstrap') as typeof import('./output-export-fallback-bootstrap')
+  outputExportFallbackState =
+    outputExportFallbackBootstrap.getOutputExportFallbackState()
+} else {
+  outputExportFallbackBootstrap = null
+  outputExportFallbackState = null
+}
+
+const isOutputExportFallbackShell =
+  process.env.__NEXT_OUTPUT_EXPORT_DYNAMIC_FALLBACKS &&
+  outputExportFallbackState?.isFallback === true
+
 const hasClientResumeShell = Boolean(window.__NEXT_CLIENT_RESUME)
 const hasLockedStaticShell =
   Boolean(instantTestStaticFetch) ||
   Boolean(offlineNavigationFallbackBootstrap) ||
-  hasClientResumeShell
+  hasClientResumeShell ||
+  isOutputExportFallbackShell
 
 const encoder = new TextEncoder()
 
@@ -163,7 +186,7 @@ function nextServerDataRegisterWriter(ctr: ReadableStreamDefaultController) {
       // Locked static shells do not have a real inline Flight stream. Closing
       // or erroring this stream causes React to report a missing-data failure,
       // but the actual hydration data arrives through a separate response:
-      // the instant test fetch, client resume fetch, or
+      // the instant test fetch, client resume fetch, export fallback fetch, or
       // offline Segment Cache reconstruction.
       if (isStreamErrorOrUnfinished(ctr)) {
         if (!hasLockedStaticShell) {
@@ -230,11 +253,16 @@ if (process.env.NODE_ENV !== 'production') {
 // truncate a clone at the static stage byte boundary and cache it. We don't
 // know if `l` is present until React decodes the payload, so always tee and
 // cancel the clone if not needed.
+//
+// Skip this for generated fallback documents. The inline `__next_f` stream
+// belongs to the fallback shell, not the actual route the user requested, so
+// seeding the cache from it can poison the initial route state.
 let initialFlightStreamForCache: ReadableStream<Uint8Array> | null = null
 if (
   process.env.__NEXT_CACHE_COMPONENTS &&
   process.env.__NEXT_EXPERIMENTAL_CACHED_NAVIGATIONS &&
-  !offlineNavigationFallbackBootstrap
+  !offlineNavigationFallbackBootstrap &&
+  !isOutputExportFallbackShell
 ) {
   const [forReact, forCache] = readable.tee()
   readable = forReact
@@ -278,6 +306,19 @@ if (instantTestStaticFetch) {
       initialRSCPayload
     )
   })
+} else if (
+  process.env.__NEXT_OUTPUT_EXPORT_DYNAMIC_FALLBACKS &&
+  outputExportFallbackBootstrap !== null &&
+  outputExportFallbackState?.isFallback
+) {
+  // This must be checked before __NEXT_CLIENT_RESUME because _fallback.html may
+  // be based on a PPR shell that also sets __NEXT_CLIENT_RESUME. Export fallback
+  // boot always fetches the RSC payload for the requested route.
+  initialServerResponse =
+    outputExportFallbackBootstrap.createOutputExportFallbackInitialResponse({
+      createFromFetch,
+      debugChannel,
+    })
 } else if (offlineNavigationFallbackBootstrap) {
   initialServerResponse =
     offlineNavigationBootstrap!.getOfflineNavigationInitialRSCPayload(
@@ -440,11 +481,12 @@ export async function hydrate(
 
   if (
     document.documentElement.id === '__next_error__' ||
-    offlineNavigationBootstrap?.isOfflineNavigationFallbackDocument()
+    offlineNavigationBootstrap?.isOfflineNavigationFallbackDocument() ||
+    isOutputExportFallbackShell
   ) {
     let element = reactEl
-    // Error documents and generated offline navigation fallback documents do
-    // not contain route HTML that can be hydrated.
+    // Error documents and generated fallback documents do not contain route
+    // HTML that can be hydrated.
     if (process.env.NODE_ENV !== 'production') {
       const { RootLevelDevOverlayElement } =
         require('../next-devtools/userspace/app/client-entry') as typeof import('../next-devtools/userspace/app/client-entry')
@@ -455,7 +497,21 @@ export async function hydrate(
       )
     }
 
-    ReactDOMClient.createRoot(appElement, reactRootOptions).render(element)
+    const root = ReactDOMClient.createRoot(appElement, reactRootOptions)
+    root.render(element)
+
+    // Remove the visibility:hidden style injected by _fallback.html to
+    // prevent flashing stale content. MutationObserver fires after React
+    // commits its first render (replaces #__next children).
+    if (
+      process.env.__NEXT_OUTPUT_EXPORT_DYNAMIC_FALLBACKS &&
+      outputExportFallbackBootstrap !== null &&
+      outputExportFallbackState?.isFallback
+    ) {
+      outputExportFallbackBootstrap.removeOutputExportFallbackStyleOnCommit(
+        appElement
+      )
+    }
   } else {
     React.startTransition(() => {
       ReactDOMClient.hydrateRoot(appElement, reactEl, {

--- a/packages/next/src/client/flight-data-helpers.ts
+++ b/packages/next/src/client/flight-data-helpers.ts
@@ -11,7 +11,12 @@ import type {
 import { PAGE_SEGMENT_KEY } from '../shared/lib/segment'
 import type { NormalizedSearch } from './components/segment-cache/cache-key'
 import {
+  NEXT_REWRITTEN_PATH_HEADER,
+  NEXT_REWRITTEN_QUERY_HEADER,
+} from './components/app-router-headers'
+import {
   getCacheKeyForDynamicParam,
+  getNextPathnamePartsIndexForParam,
   parseDynamicParamFromURLPart,
   doesStaticSegmentAppearInURL,
   getRenderedPathname,
@@ -70,7 +75,8 @@ export function getFlightDataPartsFromPath(
 
 export function createInitialRSCPayloadFromFallbackPrerender(
   response: Response,
-  fallbackInitialRSCPayload: InitialRSCPayload
+  fallbackInitialRSCPayload: InitialRSCPayload,
+  renderedUrlOverride?: URL
 ): InitialRSCPayload {
   // This is a static fallback page. In order to hydrate the page, we need to
   // parse the client params from the URL, but to account for the possibility
@@ -94,27 +100,27 @@ export function createInitialRSCPayloadFromFallbackPrerender(
 
   // Patch the Flight data sent by the server with the correct params parsed
   // from the URL + response object.
-  const renderedPathname = getRenderedPathname(response)
-  const renderedSearch = getRenderedSearch(response)
-  const canonicalUrl = createHrefFromUrl(new URL(location.href))
-  const originalFlightDataPath = fallbackInitialRSCPayload.f[0]
-  const originalFlightRouterState = originalFlightDataPath[0]
+  const renderedPathname = response.headers.has(NEXT_REWRITTEN_PATH_HEADER)
+    ? getRenderedPathname(response)
+    : ((renderedUrlOverride?.pathname ??
+        getRenderedPathname(response)) as string)
+  const renderedSearch = response.headers.has(NEXT_REWRITTEN_QUERY_HEADER)
+    ? getRenderedSearch(response)
+    : ((renderedUrlOverride?.search ??
+        getRenderedSearch(response)) as NormalizedSearch)
+  const canonicalUrl = createHrefFromUrl(
+    renderedUrlOverride ?? new URL(location.href)
+  )
+  const patchedFlightData = fillInFallbackFlightData(
+    fallbackInitialRSCPayload.f,
+    renderedPathname,
+    renderedSearch as NormalizedSearch
+  ) as FlightDataPath[]
   const payload: InitialRSCPayload = {
     c: canonicalUrl.split('/'),
     q: renderedSearch,
     i: fallbackInitialRSCPayload.i,
-    f: [
-      [
-        fillInFallbackFlightRouterState(
-          originalFlightRouterState,
-          renderedPathname,
-          renderedSearch as NormalizedSearch
-        ),
-        originalFlightDataPath[1],
-        originalFlightDataPath[2],
-        originalFlightDataPath[2],
-      ],
-    ],
+    f: patchedFlightData,
     m: fallbackInitialRSCPayload.m,
     G: fallbackInitialRSCPayload.G,
     S: fallbackInitialRSCPayload.S,
@@ -126,19 +132,91 @@ export function createInitialRSCPayloadFromFallbackPrerender(
   return payload
 }
 
-function fillInFallbackFlightRouterState(
-  flightRouterState: FlightRouterState,
+export function fillInFallbackFlightData<T extends FlightData>(
+  flightData: T,
   renderedPathname: string,
   renderedSearch: NormalizedSearch
+): T {
+  if (typeof flightData === 'string') {
+    return flightData
+  }
+
+  const pathnameParts = getPathnameParts(renderedPathname)
+  const filledFlightData = flightData.map((flightDataPath) =>
+    fillInFallbackFlightDataPath(flightDataPath, renderedSearch, pathnameParts)
+  ) as FlightDataPath[]
+
+  return filledFlightData as T
+}
+
+function fillInFallbackFlightDataPath(
+  flightDataPath: FlightDataPath,
+  renderedSearch: NormalizedSearch,
+  pathnameParts: Array<string>
+): FlightDataPath {
+  const flightDataPathLength = 4
+  const segmentPath = flightDataPath.slice(
+    0,
+    -flightDataPathLength
+  ) as FlightSegmentPath
+  const [tree, seedData, head, isHeadPartial] = flightDataPath.slice(
+    -flightDataPathLength
+  ) as [FlightRouterState, CacheNodeSeedData | null, HeadData, boolean]
+
+  return [
+    ...fillInFallbackFlightSegmentPath(
+      segmentPath,
+      renderedSearch,
+      pathnameParts
+    ),
+    fillInFallbackFlightRouterStateFromParts(
+      tree,
+      renderedSearch,
+      pathnameParts
+    ),
+    seedData,
+    head,
+    isHeadPartial,
+  ]
+}
+
+function getPathnameParts(renderedPathname: string): Array<string> {
+  return renderedPathname.split('/').filter((part) => part !== '')
+}
+
+function fillInFallbackFlightRouterStateFromParts(
+  flightRouterState: FlightRouterState,
+  renderedSearch: NormalizedSearch,
+  pathnameParts: Array<string>
 ): FlightRouterState {
-  const pathnameParts = renderedPathname.split('/').filter((p) => p !== '')
-  const index = 0
   return fillInFallbackFlightRouterStateImpl(
     flightRouterState,
     renderedSearch,
     pathnameParts,
-    index
+    0
   )
+}
+
+function fillInFallbackFlightSegmentPath(
+  segmentPath: FlightSegmentPath,
+  renderedSearch: NormalizedSearch,
+  pathnameParts: Array<string>
+): FlightSegmentPath {
+  const newSegmentPath = [...segmentPath]
+  let pathnamePartsIndex = 0
+
+  for (let i = 1; i < segmentPath.length; i += 2) {
+    const { segment, nextPathnamePartsIndex } = fillInFallbackSegment(
+      segmentPath[i] as Segment,
+      renderedSearch,
+      pathnameParts,
+      pathnamePartsIndex
+    )
+    newSegmentPath[i] = segment
+    pathnamePartsIndex = nextPathnamePartsIndex
+  }
+
+  return newSegmentPath as FlightSegmentPath
 }
 
 function fillInFallbackFlightRouterStateImpl(
@@ -147,32 +225,15 @@ function fillInFallbackFlightRouterStateImpl(
   pathnameParts: Array<string>,
   pathnamePartsIndex: number
 ): FlightRouterState {
-  const originalSegment = flightRouterState[0]
-  let newSegment: Segment
-  let doesAppearInURL: boolean
-  if (typeof originalSegment === 'string') {
-    newSegment = originalSegment
-    doesAppearInURL = doesStaticSegmentAppearInURL(originalSegment)
-  } else {
-    const paramName = originalSegment[0]
-    const paramType = originalSegment[2]
-    const staticSiblings = originalSegment[3]
-    const paramValue = parseDynamicParamFromURLPart(
-      paramType,
-      pathnameParts,
-      pathnamePartsIndex
-    )
-    const cacheKey = getCacheKeyForDynamicParam(paramValue, renderedSearch)
-    newSegment = [paramName, cacheKey, paramType, staticSiblings]
-    doesAppearInURL = true
-  }
+  const { segment: newSegment, nextPathnamePartsIndex } = fillInFallbackSegment(
+    flightRouterState[0],
+    renderedSearch,
+    pathnameParts,
+    pathnamePartsIndex
+  )
 
   // Only increment the index if the segment appears in the URL. If it's a
   // "virtual" segment, like a route group, it remains the same.
-  const childPathnamePartsIndex = doesAppearInURL
-    ? pathnamePartsIndex + 1
-    : pathnamePartsIndex
-
   const children = flightRouterState[1]
   const newChildren: { [key: string]: FlightRouterState } = {}
   for (let key in children) {
@@ -181,7 +242,7 @@ function fillInFallbackFlightRouterStateImpl(
       childFlightRouterState,
       renderedSearch,
       pathnameParts,
-      childPathnamePartsIndex
+      nextPathnamePartsIndex
     )
   }
 
@@ -193,6 +254,42 @@ function fillInFallbackFlightRouterStateImpl(
     flightRouterState[4],
   ]
   return newState
+}
+
+function fillInFallbackSegment(
+  originalSegment: Segment,
+  renderedSearch: NormalizedSearch,
+  pathnameParts: Array<string>,
+  pathnamePartsIndex: number
+): { segment: Segment; nextPathnamePartsIndex: number } {
+  if (typeof originalSegment === 'string') {
+    const doesAppearInURL = doesStaticSegmentAppearInURL(originalSegment)
+    return {
+      segment: originalSegment,
+      nextPathnamePartsIndex: doesAppearInURL
+        ? pathnamePartsIndex + 1
+        : pathnamePartsIndex,
+    }
+  }
+
+  const paramName = originalSegment[0]
+  const paramType = originalSegment[2]
+  const staticSiblings = originalSegment[3]
+  const paramValue = parseDynamicParamFromURLPart(
+    paramType,
+    pathnameParts,
+    pathnamePartsIndex
+  )
+  const cacheKey = getCacheKeyForDynamicParam(paramValue, renderedSearch)
+
+  return {
+    segment: [paramName, cacheKey, paramType, staticSiblings],
+    nextPathnamePartsIndex: getNextPathnamePartsIndexForParam(
+      paramType,
+      pathnameParts,
+      pathnamePartsIndex
+    ),
+  }
 }
 
 export function getNextFlightSegmentPath(

--- a/packages/next/src/client/output-export-fallback-bootstrap.ts
+++ b/packages/next/src/client/output-export-fallback-bootstrap.ts
@@ -1,0 +1,99 @@
+import type { InitialRSCPayload } from '../shared/lib/app-router-types'
+import { callServer } from './app-call-server'
+import { findSourceMapURL } from './app-find-source-map-url'
+import { processFetch } from './components/router-reducer/fetch-server-response'
+import { createInitialRSCPayloadFromFallbackPrerender } from './flight-data-helpers'
+import { fetchOutputExportFallbackResponse } from './output-export-fallback'
+
+type DebugChannel =
+  | { readable?: ReadableStream; writable?: WritableStream }
+  | undefined
+
+type CreateFromFetch = <T>(
+  promiseForResponse: Promise<Response>,
+  options: {
+    callServer: typeof callServer
+    findSourceMapURL: typeof findSourceMapURL
+    debugChannel?: DebugChannel
+    unstable_allowPartialStream?: boolean
+  }
+) => Promise<T>
+
+type OutputExportFallbackState = {
+  isFallback: boolean
+}
+
+declare global {
+  interface Window {
+    __NEXT_EXPORT_FALLBACK?: boolean
+  }
+}
+
+export function getOutputExportFallbackState(): OutputExportFallbackState {
+  return {
+    isFallback: Boolean(window.__NEXT_EXPORT_FALLBACK),
+  }
+}
+
+export async function createOutputExportFallbackInitialResponse({
+  createFromFetch,
+  debugChannel,
+}: {
+  createFromFetch: CreateFromFetch
+  debugChannel: DebugChannel
+}): Promise<InitialRSCPayload> {
+  const renderedUrl = new URL(window.location.href)
+  const fallbackResult = await fetchOutputExportFallbackResponse(renderedUrl, {
+    credentials: 'same-origin',
+  })
+
+  if (fallbackResult === null) {
+    throw new Error(
+      `Could not find an output export fallback for "${renderedUrl.pathname}".`
+    )
+  }
+
+  return decodeFallbackPrerenderPayload(
+    Promise.resolve(fallbackResult.response),
+    renderedUrl,
+    createFromFetch,
+    debugChannel
+  )
+}
+
+async function decodeFallbackPrerenderPayload(
+  responsePromise: Promise<Response>,
+  renderedUrl: URL | undefined,
+  createFromFetch: CreateFromFetch,
+  debugChannel: DebugChannel
+): Promise<InitialRSCPayload> {
+  const processedResponse = responsePromise
+    .then(processFetch)
+    .then(({ response: processed }) => processed)
+
+  const fallbackInitialRSCPayload = await createFromFetch<InitialRSCPayload>(
+    processedResponse,
+    {
+      callServer,
+      findSourceMapURL,
+      debugChannel,
+      unstable_allowPartialStream: true,
+    }
+  )
+
+  return createInitialRSCPayloadFromFallbackPrerender(
+    await processedResponse,
+    fallbackInitialRSCPayload,
+    renderedUrl
+  )
+}
+
+export function removeOutputExportFallbackStyleOnCommit(
+  appElement: HTMLElement | Document
+): void {
+  const observer = new MutationObserver(() => {
+    document.getElementById('__next-export-fallback-style')?.remove()
+    observer.disconnect()
+  })
+  observer.observe(appElement, { childList: true })
+}

--- a/packages/next/src/client/output-export-fallback.ts
+++ b/packages/next/src/client/output-export-fallback.ts
@@ -1,0 +1,110 @@
+import { getOutputExportFallbackPath } from '../lib/output-export-dynamic-fallback'
+import { RSC_CONTENT_TYPE_HEADER } from './components/app-router-headers'
+
+function getOutputExportCandidatePrefixes(pathname: string): string[] {
+  const segments = pathname.split('/').filter(Boolean)
+  const candidates: string[] = []
+
+  for (let i = segments.length; i >= 1; i--) {
+    candidates.push(segments.slice(0, i).join('/'))
+  }
+
+  candidates.push('')
+
+  return candidates
+}
+
+export function getOutputExportFallbackCandidates(pathname: string): string[] {
+  return getOutputExportCandidatePrefixes(pathname).map((prefix) =>
+    getOutputExportFallbackPath(prefix)
+  )
+}
+
+export function addOutputExportDataSuffix(url: URL): URL {
+  const nextUrl = new URL(url)
+  if (nextUrl.pathname.endsWith('/')) {
+    nextUrl.pathname += 'index.txt'
+  } else {
+    nextUrl.pathname += '.txt'
+  }
+  return nextUrl
+}
+
+export function isOutputExportFlightContentType(contentType: string): boolean {
+  return (
+    contentType.startsWith(RSC_CONTENT_TYPE_HEADER) ||
+    contentType.startsWith('text/plain') ||
+    contentType.startsWith('application/octet-stream')
+  )
+}
+
+function getConfiguredOutputExportDataUrl(
+  url: URL,
+  prefersTrailingSlash: boolean
+): URL {
+  const trailingSlash = process.env.__NEXT_TRAILING_SLASH
+  const configuredUrl = new URL(url)
+  const useTrailingSlash =
+    trailingSlash == null
+      ? prefersTrailingSlash
+      : String(trailingSlash) === 'true'
+  if (useTrailingSlash && !configuredUrl.pathname.endsWith('/')) {
+    configuredUrl.pathname = `${configuredUrl.pathname}/`
+  }
+  return addOutputExportDataSuffix(configuredUrl)
+}
+
+async function fetchConfiguredOutputExportDataResult(
+  renderedUrl: URL,
+  prefersTrailingSlash: boolean,
+  init?: RequestInit
+): Promise<{ response: Response; dataUrl: URL } | null> {
+  const configuredDataUrl = getConfiguredOutputExportDataUrl(
+    renderedUrl,
+    prefersTrailingSlash
+  )
+
+  const response = await fetch(configuredDataUrl, init)
+  const contentType = response.headers.get('content-type') || ''
+  if (
+    !response.ok ||
+    !response.body ||
+    !isOutputExportFlightContentType(contentType)
+  ) {
+    return null
+  }
+
+  return {
+    response,
+    dataUrl: configuredDataUrl,
+  }
+}
+
+export async function fetchOutputExportFallbackResponse(
+  renderedUrl: URL,
+  init?: RequestInit
+): Promise<{ response: Response; renderedUrl: URL; fallbackUrl: URL } | null> {
+  const prefersTrailingSlash = renderedUrl.pathname.endsWith('/')
+
+  for (const candidate of getOutputExportFallbackCandidates(
+    renderedUrl.pathname
+  )) {
+    const candidateUrl = new URL(renderedUrl)
+    candidateUrl.pathname = candidate
+
+    const result = await fetchConfiguredOutputExportDataResult(
+      candidateUrl,
+      prefersTrailingSlash,
+      init
+    )
+    if (result) {
+      return {
+        response: result.response,
+        renderedUrl,
+        fallbackUrl: candidateUrl,
+      }
+    }
+  }
+
+  return null
+}

--- a/packages/next/src/client/route-params.ts
+++ b/packages/next/src/client/route-params.ts
@@ -152,6 +152,31 @@ export function parseDynamicParamFromURLPart(
   }
 }
 
+export function getNextPathnamePartsIndexForParam(
+  paramType: DynamicParamTypesShort,
+  pathnameParts: Array<string>,
+  partIndex: number
+): number {
+  switch (paramType) {
+    case 'c':
+    case 'ci(..)(..)':
+    case 'ci(.)':
+    case 'ci(..)':
+    case 'ci(...)':
+    case 'oc':
+      return pathnameParts.length
+    case 'd':
+    case 'di(..)(..)':
+    case 'di(.)':
+    case 'di(..)':
+    case 'di(...)':
+      return partIndex + 1
+    default:
+      paramType satisfies never
+      return partIndex
+  }
+}
+
 export function doesStaticSegmentAppearInURL(segment: string): boolean {
   // This is not a parameterized segment; however, we need to determine
   // whether or not this segment appears in the URL. For example, this route

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -7991,6 +7991,8 @@ async function prerenderToStream(
             getServerInsertedHTML,
             getServerInsertedMetadata,
             deploymentId: ctx.sharedContext.deploymentId,
+            isOutputExportFallback:
+              ctx.renderOpts.nextConfigOutput === 'export',
           })
         } else {
           // Normal static prerender case, no fallback param handling needed

--- a/packages/next/src/server/app-render/stream-ops.node.ts
+++ b/packages/next/src/server/app-render/stream-ops.node.ts
@@ -813,7 +813,7 @@ export async function continueDynamicPrerender(
 
 export async function continueStaticFallbackPrerender(
   prerenderStream: AnyStream,
-  opts: import('./stream-ops.web').ContinueStaticPrerenderOptions
+  opts: import('./stream-ops.web').ContinueStaticFallbackPrerenderOptions
 ): Promise<AnyStream> {
   const webResult = await webContinueStaticFallbackPrerender(
     nodeReadableToWebReadableStream(prerenderStream),

--- a/packages/next/src/server/app-render/stream-ops.web.ts
+++ b/packages/next/src/server/app-render/stream-ops.web.ts
@@ -57,6 +57,11 @@ export type ContinueStaticPrerenderOptions = ContinueStreamSharedOptions & {
   inlinedDataStream: AnyStream
 }
 
+export type ContinueStaticFallbackPrerenderOptions =
+  ContinueStaticPrerenderOptions & {
+    isOutputExportFallback?: boolean
+  }
+
 export type ContinueDynamicHTMLResumeOptions = ContinueStreamSharedOptions & {
   inlinedDataStream: AnyStream
   delayDataUntilFirstHtmlChunk: boolean
@@ -130,7 +135,7 @@ export async function continueDynamicPrerender(
 
 export async function continueStaticFallbackPrerender(
   prerenderStream: AnyStream,
-  opts: ContinueStaticPrerenderOptions
+  opts: ContinueStaticFallbackPrerenderOptions
 ): Promise<AnyStream> {
   return webContinueStaticFallbackPrerender(
     prerenderStream as ReadableStream<Uint8Array>,

--- a/packages/next/src/server/stream-utils/node-web-streams-helper.ts
+++ b/packages/next/src/server/stream-utils/node-web-streams-helper.ts
@@ -534,6 +534,32 @@ async function createClientResumeScriptInsertionTransformStream(): Promise<
   const searchStr = `${NEXT_RSC_UNION_QUERY}=${cacheBustingHeader}`
   const NEXT_CLIENT_RESUME_SCRIPT = `<script>__NEXT_CLIENT_RESUME=fetch(location.pathname+'?${searchStr}',{credentials:'same-origin',headers:{'${RSC_HEADER}': '1','${NEXT_ROUTER_PREFETCH_HEADER}': '1','${NEXT_ROUTER_SEGMENT_PREFETCH_HEADER}': '${segmentPath}'}})</script>`
 
+  return createClientResumeScriptInsertionTransformStreamForScript(
+    NEXT_CLIENT_RESUME_SCRIPT
+  )
+}
+
+async function createOutputExportClientResumeScriptInsertionTransformStream(): Promise<
+  TransformStream<Uint8Array, Uint8Array>
+> {
+  const segmentPath = '/_full'
+  const cacheBustingHeader = await computeCacheBustingSearchParam(
+    '1', //            headers[NEXT_ROUTER_PREFETCH_HEADER]
+    '/_full', //       headers[NEXT_ROUTER_SEGMENT_PREFETCH_HEADER]
+    undefined, //      headers[NEXT_ROUTER_STATE_TREE_HEADER]
+    undefined //       headers[NEXT_URL]
+  )
+  const searchStr = `${NEXT_RSC_UNION_QUERY}=${cacheBustingHeader}`
+  const NEXT_CLIENT_RESUME_SCRIPT = `<script>if(!self.__NEXT_EXPORT_FALLBACK){__NEXT_CLIENT_RESUME=fetch(location.pathname+'?${searchStr}',{credentials:'same-origin',headers:{'${RSC_HEADER}': '1','${NEXT_ROUTER_PREFETCH_HEADER}': '1','${NEXT_ROUTER_SEGMENT_PREFETCH_HEADER}': '${segmentPath}'}})}</script>`
+
+  return createClientResumeScriptInsertionTransformStreamForScript(
+    NEXT_CLIENT_RESUME_SCRIPT
+  )
+}
+
+function createClientResumeScriptInsertionTransformStreamForScript(
+  resumeScript: string
+): TransformStream<Uint8Array, Uint8Array> {
   let didAlreadyInsert = false
   return new TransformStream({
     transform(chunk, controller) {
@@ -555,7 +581,7 @@ async function createClientResumeScriptInsertionTransformStream(): Promise<
         return
       }
 
-      const encodedInsertion = encoder.encode(NEXT_CLIENT_RESUME_SCRIPT)
+      const encodedInsertion = encoder.encode(resumeScript)
       // Get the total count of the bytes in the chunk and the insertion
       // e.g.
       // chunk = <head><meta charset="utf-8"></head>
@@ -1092,6 +1118,10 @@ type ContinueStaticPrerenderOptions = {
   deploymentId: string | undefined
 }
 
+type ContinueStaticFallbackPrerenderOptions = ContinueStaticPrerenderOptions & {
+  isOutputExportFallback?: boolean
+}
+
 export async function continueStaticPrerender(
   prerenderStream: ReadableStream<Uint8Array>,
   {
@@ -1125,7 +1155,8 @@ export async function continueStaticFallbackPrerender(
     getServerInsertedHTML,
     getServerInsertedMetadata,
     deploymentId,
-  }: ContinueStaticPrerenderOptions
+    isOutputExportFallback,
+  }: ContinueStaticFallbackPrerenderOptions
 ) {
   // Same as `continueStaticPrerender`, but also inserts an additional script
   // to instruct the client to start fetching the hydration data as early
@@ -1138,7 +1169,9 @@ export async function continueStaticFallbackPrerender(
     // Insert generated tags to head
     createHeadInsertionTransformStream(getServerInsertedHTML),
     // Insert the client resume script into the head
-    await createClientResumeScriptInsertionTransformStream(),
+    isOutputExportFallback
+      ? await createOutputExportClientResumeScriptInsertionTransformStream()
+      : await createClientResumeScriptInsertionTransformStream(),
     // Transform metadata
     createMetadataTransformStream(getServerInsertedMetadata),
     // Insert the inlined data (Flight data, form state, etc.) stream into the HTML

--- a/test/e2e/app-dir/output-export-dynamic-fallbacks/app/another/[slug]/page.tsx
+++ b/test/e2e/app-dir/output-export-dynamic-fallbacks/app/another/[slug]/page.tsx
@@ -1,7 +1,12 @@
+import { Suspense } from 'react'
+import SlugClient from './slug-client'
+
 export default function Page() {
   return (
     <main>
-      <h1>Dynamic fallback shell</h1>
+      <Suspense fallback={<h1>Loading slug...</h1>}>
+        <SlugClient />
+      </Suspense>
     </main>
   )
 }

--- a/test/e2e/app-dir/output-export-dynamic-fallbacks/app/another/[slug]/slug-client.tsx
+++ b/test/e2e/app-dir/output-export-dynamic-fallbacks/app/another/[slug]/slug-client.tsx
@@ -1,0 +1,8 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function SlugClient() {
+  const params = useParams()
+  return <h1>{params.slug}</h1>
+}

--- a/test/e2e/app-dir/output-export-dynamic-fallbacks/output-export-dynamic-fallbacks.test.ts
+++ b/test/e2e/app-dir/output-export-dynamic-fallbacks/output-export-dynamic-fallbacks.test.ts
@@ -1,12 +1,11 @@
 import { nextTestSetup } from 'e2e-utils'
+import { createReadStream } from 'fs'
 import fs from 'fs-extra'
+import http from 'http'
 import { join } from 'path'
-import {
-  fetchViaHTTP,
-  findPort,
-  startStaticServer,
-  stopApp,
-} from 'next-test-utils'
+import express from 'express'
+import webdriver from 'next-webdriver'
+import { fetchViaHTTP, findPort, retry, stopApp } from 'next-test-utils'
 
 describe('output-export-dynamic-fallbacks', () => {
   const { next } = nextTestSetup({
@@ -37,12 +36,12 @@ describe('output-export-dynamic-fallbacks', () => {
     expect(await fs.pathExists(join(outDir, '_fallback.html'))).toBe(true)
 
     const port = await findPort()
-    const app = await startStaticServer(outDir, null, port)
+    const app = await startFallbackServer(outDir, port)
 
     try {
       const res = await fetchViaHTTP(port, '/another/__fallback.html')
       expect(res.status).toBe(200)
-      expect(await res.text()).toContain('Dynamic fallback shell')
+      expect(await res.text()).toContain('Loading slug...')
 
       const globalFallbackRes = await fetchViaHTTP(port, '/_fallback.html')
       expect(globalFallbackRes.status).toBe(200)
@@ -52,8 +51,53 @@ describe('output-export-dynamic-fallbacks', () => {
 
       const rscRes = await fetchViaHTTP(port, '/another/__fallback.txt')
       expect(rscRes.status).toBe(200)
+
+      const hardLoad = await webdriver(port, '/another/alpha')
+      try {
+        await retry(async () => {
+          expect(await hardLoad.elementByCss('h1').text()).toBe('alpha')
+        })
+      } finally {
+        await hardLoad.close()
+      }
     } finally {
       await stopApp(app)
     }
   })
 })
+
+async function startFallbackServer(outDir: string, port: number) {
+  const app = express()
+  const server = http.createServer(app)
+  const fallbackHtml = join(outDir, '_fallback.html')
+
+  app.use((req, res, next) => {
+    if (req.method !== 'GET' && req.method !== 'HEAD') {
+      return next()
+    }
+
+    if (req.path.endsWith('/') || req.path.includes('.')) {
+      return next()
+    }
+
+    const htmlPath = join(outDir, `${req.path}.html`)
+    if (!fs.pathExistsSync(htmlPath)) {
+      return next()
+    }
+
+    res.sendFile(htmlPath)
+  })
+
+  app.use(
+    express.static(outDir, {
+      extensions: ['html'],
+      redirect: false,
+    })
+  )
+  app.use((_req, res) => {
+    createReadStream(fallbackHtml).pipe(res)
+  })
+
+  await new Promise<void>((resolve) => server.listen(port, resolve))
+  return server
+}


### PR DESCRIPTION
This is PR 15 of 21 in the offline navigations plus output-export fallback stack.

This stack introduces a generated fallback entrypoint and then layers the client behavior on the existing App Router, cached navigations, optimistic routing, Cache Components, and Segment Cache primitives. The offline navigations chapter adds a managed service worker and persisted Segment Cache replay. The output-export chapter emits static fallback HTML/RSC artifacts so parameterized routes can load and navigate without enumerating every param at build time.

Review guide: https://gist.github.com/feedthejim/bb440153d29dce019d1d26b6643e2a48

## Where This Sits
This PR is in the output-export fallbacks chapter, after the offline fallback-entrypoint primitives are established.
Previous PR: #93747 `output export fallbacks: enforce server-only boundaries (14/21)`.
Next PR: #93749 `output export fallbacks: resolve soft navigations through cached routes (16/21)`.

## What Changes
- Lets `_fallback.html` bootstrap the requested URL by fetching the matching fallback RSC artifact.
- Treats the generated document as a locked static shell until the client has route-specific data.

## Reviewer Focus
- The fallback bootstrap must run before normal client resume when the generated shell also contains resume markers.
- `app-index.tsx` should remain a gated handoff, with fallback-specific logic in the bootstrap helper.

## Proof In This PR
- Output-export dynamic fallback e2e covers unknown-route hard loads, search params, hash handling, and no-match behavior.
- Client unit coverage verifies fallback Flight data is turned into requested-route initial payloads.

Latest local stack verification after autosquash included:
- `git diff --check`
- `pnpm --filter=next types`
- `pnpm testonly packages/next/src/client/components/segment-cache/offline-navigation-cache.test.ts packages/next/src/client/components/segment-cache/cache.test.ts packages/next/src/client/output-export-fallback.test.ts packages/next/src/export/helpers/output-export-fallback.test.ts packages/next/src/lib/output-export-fallback-routes.test.ts packages/next/src/client/components/router-reducer/fetch-server-response.test.ts`
- `HEADLESS=true pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `HEADLESS=true pnpm test-start-turbo test/e2e/app-dir-export/test/dynamic-fallback*.test.ts`

## Deferred Coverage
Soft navigation from already-loaded pages is deferred to the next PR.

## Disabled-Flag Posture
The hard-load bootstrap is required only under `__NEXT_OUTPUT_EXPORT_DYNAMIC_FALLBACKS`; disabled bundles should not load it.

## Full Stack
1. [offline navigations: add gated build primitives (1/21)](https://github.com/vercel/next.js/pull/93736)
2. [offline navigations: generate fallback document artifacts (2/21)](https://github.com/vercel/next.js/pull/93737)
3. [offline navigations: register pass-through worker (3/21)](https://github.com/vercel/next.js/pull/93625)
4. [offline navigations: cache fallback and current-build assets (4/21)](https://github.com/vercel/next.js/pull/93626)
5. [offline navigations: serve fallback document offline (5/21)](https://github.com/vercel/next.js/pull/93627)
6. [offline navigations: add Segment Cache persistence primitives (6/21)](https://github.com/vercel/next.js/pull/93630)
7. [offline navigations: persist cached Segment Cache records (7/21)](https://github.com/vercel/next.js/pull/93640)
8. [offline navigations: bootstrap fallback from Segment Cache records (8/21)](https://github.com/vercel/next.js/pull/93644)
9. [offline navigations: support dynamic route patterns (9/21)](https://github.com/vercel/next.js/pull/93647)
10. [offline navigations: add docs and examples (10/21)](https://github.com/vercel/next.js/pull/93738)
11. [output export fallbacks: add gated build primitives (11/21)](https://github.com/vercel/next.js/pull/93744)
12. [output export fallbacks: emit fallback HTML artifacts (12/21)](https://github.com/vercel/next.js/pull/93745)
13. [output export fallbacks: emit fallback RSC artifacts (13/21)](https://github.com/vercel/next.js/pull/93746)
14. [output export fallbacks: enforce server-only boundaries (14/21)](https://github.com/vercel/next.js/pull/93747)
15. **Current PR:** [output export fallbacks: bootstrap hard loads from artifacts (15/21)](https://github.com/vercel/next.js/pull/93748)
16. [output export fallbacks: resolve soft navigations through cached routes (16/21)](https://github.com/vercel/next.js/pull/93749)
17. [output export fallbacks: resolve fallback artifacts from route manifests (17/21)](https://github.com/vercel/next.js/pull/93779)
18. [output export fallbacks: validate fallback Flight responses (18/21)](https://github.com/vercel/next.js/pull/93750)
19. [output export fallbacks: store fallback data in Segment Cache (19/21)](https://github.com/vercel/next.js/pull/93774)
20. [output export fallbacks: support known params and export variants (20/21)](https://github.com/vercel/next.js/pull/93751)
21. [output export fallbacks: add docs and review guide (21/21)](https://github.com/vercel/next.js/pull/93752)

<!-- NEXT_JS_LLM_PR -->
