### PR TITLE
output export fallbacks: resolve soft navigations through cached routes (16/21)

### DIFF
--- a/packages/next/src/build/define-env.ts
+++ b/packages/next/src/build/define-env.ts
@@ -7,6 +7,11 @@ import type { ProxyMatcher } from './analysis/get-page-static-info'
 import type { Rewrite } from '../lib/load-custom-routes'
 import path from 'node:path'
 import { needsExperimentalReact } from '../lib/needs-experimental-react'
+import {
+  isOutputExportDynamicFallbackEnabled,
+  isOutputExportOptimisticRoutingEnabled,
+  isOutputExportVaryParamsEnabled,
+} from '../lib/output-export-dynamic-fallback'
 import { checkIsAppPPREnabled } from '../server/lib/experimental/ppr'
 import {
   getNextConfigEnv,
@@ -125,6 +130,13 @@ export function getDefineEnv({
   const isCacheComponentsEnabled = !!config.cacheComponents
   const isUseCacheEnabled = !!config.experimental.useCache
   const isUseNodeStreamsEnabled = !!config.experimental.useNodeStreams
+  const isOutputExportFallbackEnabled =
+    isOutputExportDynamicFallbackEnabled(config)
+  const isCachedNavigationsEnabled = Boolean(
+    config.experimental.cachedNavigations ||
+      config.experimental.offlineNavigations ||
+      isOutputExportFallbackEnabled
+  )
 
   const defineEnv: DefineEnv = {
     // internal field to identify the plugin config
@@ -174,9 +186,8 @@ export function getDefineEnv({
     ),
     'process.env.__NEXT_PPR': isPPREnabled,
     'process.env.__NEXT_CACHE_COMPONENTS': isCacheComponentsEnabled,
-    'process.env.__NEXT_EXPERIMENTAL_CACHED_NAVIGATIONS': Boolean(
-      config.experimental.cachedNavigations
-    ),
+    'process.env.__NEXT_EXPERIMENTAL_CACHED_NAVIGATIONS':
+      isCachedNavigationsEnabled,
     'process.env.__NEXT_INSTANT_NAV_TOGGLE':
       !!config.experimental.instantNavigationDevToolsToggle,
     'process.env.__NEXT_USE_CACHE': isUseCacheEnabled,
@@ -304,9 +315,7 @@ export function getDefineEnv({
     'process.env.__NEXT_HAS_REWRITES': hasRewrites,
     'process.env.__NEXT_CONFIG_OUTPUT': config.output,
     'process.env.__NEXT_OUTPUT_EXPORT_DYNAMIC_FALLBACKS':
-      config.output === 'export' &&
-      config.cacheComponents === true &&
-      config.experimental.outputExportDynamicFallbacks === true,
+      isOutputExportFallbackEnabled,
     'process.env.__NEXT_I18N_SUPPORT': !!config.i18n,
     'process.env.__NEXT_I18N_DOMAINS': config.i18n?.domains ?? false,
     'process.env.__NEXT_I18N_CONFIG': config.i18n || '',
@@ -387,11 +396,11 @@ export function getDefineEnv({
       config.experimental.transitionIndicator ?? false,
     'process.env.__NEXT_GESTURE_TRANSITION':
       config.experimental.gestureTransition ?? false,
-    'process.env.__NEXT_OPTIMISTIC_ROUTING':
-      config.experimental.optimisticRouting ||
+    'process.env.__NEXT_OPTIMISTIC_ROUTING': Boolean(
       config.experimental.offlineNavigations ||
-      false,
-    'process.env.__NEXT_VARY_PARAMS': config.experimental.varyParams ?? false,
+        isOutputExportOptimisticRoutingEnabled(config)
+    ),
+    'process.env.__NEXT_VARY_PARAMS': isOutputExportVaryParamsEnabled(config),
     'process.env.__NEXT_EXPOSE_TESTING_API':
       dev || config.experimental.exposeTestingApiInProductionBuild === true,
     'process.env.__NEXT_CACHE_LIFE': config.cacheLife,

--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -31,6 +31,10 @@ import {
 import { checkIsAppPPREnabled } from '../../server/lib/experimental/ppr' with { 'turbopack-transition': 'next-server-utility' }
 import { isRSCRequestHeader } from '../../server/lib/is-rsc-request' with { 'turbopack-transition': 'next-server-utility' }
 import {
+  isOutputExportDynamicFallbackEnabled,
+  isOutputExportOptimisticRoutingEnabled,
+} from '../../lib/output-export-dynamic-fallback' with { 'turbopack-transition': 'next-server-utility' }
+import {
   getFallbackRouteParams,
   getPlaceholderFallbackRouteParams,
   buildDynamicSegmentPlaceholder,
@@ -890,15 +894,17 @@ export async function handler(
             staleTimes: nextConfig.experimental.staleTimes,
             dynamicOnHover: Boolean(nextConfig.experimental.dynamicOnHover),
             optimisticRouting: Boolean(
-              nextConfig.experimental.optimisticRouting ||
-                nextConfig.experimental.offlineNavigations
+              nextConfig.experimental.offlineNavigations ||
+                isOutputExportOptimisticRoutingEnabled(nextConfig)
             ),
             inlineCss: Boolean(nextConfig.experimental.inlineCss),
             prefetchInlining: nextConfig.experimental.prefetchInlining ?? false,
             authInterrupts: Boolean(nextConfig.experimental.authInterrupts),
             useCacheTimeout: nextConfig.experimental.useCacheTimeout,
             cachedNavigations: Boolean(
-              nextConfig.experimental.cachedNavigations
+              nextConfig.experimental.cachedNavigations ||
+                nextConfig.experimental.offlineNavigations ||
+                isOutputExportDynamicFallbackEnabled(nextConfig)
             ),
             clientTraceMetadata:
               nextConfig.experimental.clientTraceMetadata || ([] as any),

--- a/packages/next/src/build/templates/edge-ssr-app.ts
+++ b/packages/next/src/build/templates/edge-ssr-app.ts
@@ -23,6 +23,10 @@ import type RenderResult from '../../server/render-result'
 import { getIsPossibleServerAction } from '../../server/lib/server-action-request-meta'
 import { getBotType } from '../../shared/lib/router/utils/is-bot'
 import { interopDefault } from '../../lib/interop-default'
+import {
+  isOutputExportDynamicFallbackEnabled,
+  isOutputExportOptimisticRoutingEnabled,
+} from '../../lib/output-export-dynamic-fallback'
 import { normalizeAppPath } from '../../shared/lib/router/utils/app-paths'
 import { checkIsOnDemandRevalidate } from '../../server/api-utils'
 import { CloseController } from '../../server/web/web-on-close'
@@ -166,14 +170,18 @@ async function requestHandler(
         staleTimes: nextConfig.experimental.staleTimes,
         dynamicOnHover: Boolean(nextConfig.experimental.dynamicOnHover),
         optimisticRouting: Boolean(
-          nextConfig.experimental.optimisticRouting ||
-            nextConfig.experimental.offlineNavigations
+          nextConfig.experimental.offlineNavigations ||
+            isOutputExportOptimisticRoutingEnabled(nextConfig)
         ),
         inlineCss: Boolean(nextConfig.experimental.inlineCss),
         prefetchInlining: nextConfig.experimental.prefetchInlining ?? false,
         authInterrupts: Boolean(nextConfig.experimental.authInterrupts),
         useCacheTimeout: nextConfig.experimental.useCacheTimeout,
-        cachedNavigations: Boolean(nextConfig.experimental.cachedNavigations),
+        cachedNavigations: Boolean(
+          nextConfig.experimental.cachedNavigations ||
+            nextConfig.experimental.offlineNavigations ||
+            isOutputExportDynamicFallbackEnabled(nextConfig)
+        ),
         clientTraceMetadata:
           nextConfig.experimental.clientTraceMetadata || ([] as any),
         clientParamParsingOrigins:

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -32,6 +32,7 @@ import {
 import { callServer } from '../../app-call-server'
 import { findSourceMapURL } from '../../app-find-source-map-url'
 import {
+  fillInFallbackFlightData,
   normalizeFlightData,
   prepareFlightRouterStateForRequest,
   type NormalizedFlightData,
@@ -188,18 +189,21 @@ export async function fetchServerResponse(
   const originalUrl = url
 
   try {
-    if (process.env.NODE_ENV === 'production') {
-      if (process.env.__NEXT_CONFIG_OUTPUT === 'export') {
-        // In "output: export" mode, we can't rely on headers to distinguish
-        // between HTML and RSC requests. Instead, we append an extra prefix
-        // to the request.
-        url = new URL(url)
-        if (url.pathname.endsWith('/')) {
-          url.pathname += 'index.txt'
-        } else {
-          url.pathname += '.txt'
-        }
+    if (
+      process.env.NODE_ENV === 'production' &&
+      process.env.__NEXT_CONFIG_OUTPUT === 'export'
+    ) {
+      // In "output: export" mode, we can't rely on headers to distinguish
+      // between HTML and RSC requests. Instead, we append an extra prefix
+      // to the request.
+      url = new URL(url)
+      if (url.pathname.endsWith('/')) {
+        url.pathname += 'index.txt'
+      } else {
+        url.pathname += '.txt'
       }
+    } else {
+      // Static export fallback URL remapping is erased from non-export bundles.
     }
 
     // Typically, during a navigation, we decode the response using Flight's
@@ -207,8 +211,10 @@ export async function fetchServerResponse(
     // TODO: Remove this check once the old PPR flag is removed
     const isLegacyPPR =
       process.env.__NEXT_PPR && !process.env.__NEXT_CACHE_COMPONENTS
-    const shouldImmediatelyDecode = !isLegacyPPR
-    const res = await createFetch<NavigationFlightResponse>(
+    const shouldImmediatelyDecode =
+      !isLegacyPPR && process.env.__NEXT_CONFIG_OUTPUT !== 'export'
+    let usedOutputExportFallback = false
+    let res = await createFetch<NavigationFlightResponse>(
       url,
       headers,
       'auto',
@@ -223,20 +229,68 @@ export async function fetchServerResponse(
       notifyOnline()
     }
 
-    const responseUrl = urlToUrlWithoutFlightMarker(new URL(res.url))
-    const canonicalUrl = res.redirected ? responseUrl : originalUrl
+    let responseUrl = urlToUrlWithoutFlightMarker(new URL(res.url))
+    let canonicalUrl = res.redirected ? responseUrl : originalUrl
 
-    const contentType = res.headers.get('content-type') || ''
-    const interception = !!res.headers.get('vary')?.includes(NEXT_URL)
-    const postponed = !!res.headers.get(NEXT_DID_POSTPONE_HEADER)
+    let contentType = res.headers.get('content-type') || ''
+    let interception = !!res.headers.get('vary')?.includes(NEXT_URL)
+    let postponed = !!res.headers.get(NEXT_DID_POSTPONE_HEADER)
     let isFlightResponse = contentType.startsWith(RSC_CONTENT_TYPE_HEADER)
 
-    if (process.env.NODE_ENV === 'production') {
-      if (process.env.__NEXT_CONFIG_OUTPUT === 'export') {
-        if (!isFlightResponse) {
-          isFlightResponse = contentType.startsWith('text/plain')
-        }
+    if (
+      process.env.NODE_ENV === 'production' &&
+      process.env.__NEXT_CONFIG_OUTPUT === 'export'
+    ) {
+      if (!isFlightResponse) {
+        isFlightResponse = contentType.startsWith('text/plain')
       }
+
+      if (process.env.__NEXT_OUTPUT_EXPORT_DYNAMIC_FALLBACKS) {
+        if (!isFlightResponse || !res.ok || !res.body) {
+          const { fetchOutputExportFallbackResponse } =
+            require('../../output-export-fallback') as typeof import('../../output-export-fallback')
+
+          const fallbackResult = await fetchOutputExportFallbackResponse(
+            originalUrl,
+            {
+              credentials: 'same-origin',
+              headers,
+            }
+          )
+
+          if (fallbackResult !== null) {
+            usedOutputExportFallback = true
+            const { response: processed, cacheData } = await processFetch(
+              fallbackResult.response
+            )
+
+            res = {
+              ok: processed.ok,
+              redirected: false,
+              headers: processed.headers,
+              body: processed.body,
+              status: processed.status,
+              url: originalUrl.href,
+              flightResponsePromise: null,
+              cacheData: Promise.resolve(cacheData),
+            }
+            responseUrl = originalUrl
+            canonicalUrl = originalUrl
+            contentType = res.headers.get('content-type') || ''
+            interception = !!res.headers.get('vary')?.includes(NEXT_URL)
+            // Static export fallback payloads are partial-by-construction, but
+            // static hosts cannot attach the normal postpone header. Treat them as
+            // partial so Flight decoding accepts the closed stream and the router
+            // keeps the fallback shell suspended until dynamic holes resolve.
+            postponed = true
+            isFlightResponse = true
+          }
+        }
+      } else {
+        // Static export fallback discovery is erased when the feature is off.
+      }
+    } else {
+      // Static export fallback discovery is erased from non-export bundles.
     }
 
     // If fetch returns something different than flight response handle it like a mpa navigation
@@ -291,7 +345,17 @@ export async function fetchServerResponse(
       return doMpaNavigation(res.url)
     }
 
-    const normalizedFlightData = normalizeFlightData(flightResponse.f)
+    const fallbackFlightData = usedOutputExportFallback
+      ? fillInFallbackFlightData(
+          flightResponse.f,
+          originalUrl.pathname,
+          originalUrl.search as NormalizedSearch
+        )
+      : null
+
+    const normalizedFlightData = normalizeFlightData(
+      fallbackFlightData ?? flightResponse.f
+    )
     if (typeof normalizedFlightData === 'string') {
       return doMpaNavigation(normalizedFlightData)
     }
@@ -333,9 +397,9 @@ export async function fetchServerResponse(
     //
     // Note: when the user navigates multiple times while offline, each
     // navigation queues a separate retry here. Once connectivity returns,
-    // all pending retries resume simultaneously. This is mitigated in PR 3
-    // by reusing back-forward cache entries during offline navigation, which
-    // avoids issuing new fetches in the first place.
+    // all pending retries resume simultaneously. Reusing back-forward cache
+    // entries during offline navigation avoids issuing new fetches in the
+    // first place.
     if (process.env.__NEXT_USE_OFFLINE && !isPageUnloading) {
       const { checkOfflineError, getOffline, waitForConnection } =
         require('../offline') as typeof import('../offline')

--- a/packages/next/src/client/output-export-fallback.ts
+++ b/packages/next/src/client/output-export-fallback.ts
@@ -58,7 +58,7 @@ async function fetchConfiguredOutputExportDataResult(
   renderedUrl: URL,
   prefersTrailingSlash: boolean,
   init?: RequestInit
-): Promise<{ response: Response; dataUrl: URL } | null> {
+): Promise<Response | null> {
   const configuredDataUrl = getConfiguredOutputExportDataUrl(
     renderedUrl,
     prefersTrailingSlash
@@ -74,10 +74,7 @@ async function fetchConfiguredOutputExportDataResult(
     return null
   }
 
-  return {
-    response,
-    dataUrl: configuredDataUrl,
-  }
+  return response
 }
 
 export async function fetchOutputExportFallbackResponse(
@@ -92,14 +89,14 @@ export async function fetchOutputExportFallbackResponse(
     const candidateUrl = new URL(renderedUrl)
     candidateUrl.pathname = candidate
 
-    const result = await fetchConfiguredOutputExportDataResult(
+    const response = await fetchConfiguredOutputExportDataResult(
       candidateUrl,
       prefersTrailingSlash,
       init
     )
-    if (result) {
+    if (response) {
       return {
-        response: result.response,
+        response,
         renderedUrl,
         fallbackUrl: candidateUrl,
       }

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -521,7 +521,11 @@ async function exportAppImpl(
       prefetchInlining: nextConfig.experimental.prefetchInlining ?? false,
       authInterrupts: !!nextConfig.experimental.authInterrupts,
       useCacheTimeout: nextConfig.experimental.useCacheTimeout,
-      cachedNavigations: nextConfig.experimental.cachedNavigations ?? false,
+      cachedNavigations: Boolean(
+        nextConfig.experimental.cachedNavigations ||
+          nextConfig.experimental.offlineNavigations ||
+          isOutputExportDynamicFallbackEnabled(nextConfig)
+      ),
       maxPostponedStateSizeBytes: parseMaxPostponedStateSize(
         nextConfig.experimental.maxPostponedStateSize
       ),

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -50,6 +50,10 @@ import { format as formatUrl } from 'url'
 import { formatHostname } from './lib/format-hostname'
 import { isRSCRequestHeader } from './lib/is-rsc-request'
 import {
+  isOutputExportDynamicFallbackEnabled,
+  isOutputExportOptimisticRoutingEnabled,
+} from '../lib/output-export-dynamic-fallback'
+import {
   APP_PATHS_MANIFEST,
   NEXT_BUILTIN_DOCUMENT,
   PAGES_MANIFEST,
@@ -577,17 +581,20 @@ export default abstract class Server<
         clientParamParsingOrigins:
           this.nextConfig.experimental.clientParamParsingOrigins,
         dynamicOnHover: this.nextConfig.experimental.dynamicOnHover ?? false,
-        optimisticRouting:
-          this.nextConfig.experimental.optimisticRouting ||
+        optimisticRouting: Boolean(
           this.nextConfig.experimental.offlineNavigations ||
-          false,
+            isOutputExportOptimisticRoutingEnabled(this.nextConfig)
+        ),
         inlineCss: this.nextConfig.experimental.inlineCss ?? false,
         prefetchInlining:
           this.nextConfig.experimental.prefetchInlining ?? false,
         authInterrupts: !!this.nextConfig.experimental.authInterrupts,
         useCacheTimeout: this.nextConfig.experimental.useCacheTimeout,
-        cachedNavigations:
-          this.nextConfig.experimental.cachedNavigations ?? false,
+        cachedNavigations: Boolean(
+          this.nextConfig.experimental.cachedNavigations ||
+            this.nextConfig.experimental.offlineNavigations ||
+            isOutputExportDynamicFallbackEnabled(this.nextConfig)
+        ),
         maxPostponedStateSizeBytes: parseMaxPostponedStateSize(
           this.nextConfig.experimental.maxPostponedStateSize
         ),

--- a/test/e2e/app-dir/output-export-dynamic-fallbacks/app/another/page.tsx
+++ b/test/e2e/app-dir/output-export-dynamic-fallbacks/app/another/page.tsx
@@ -1,10 +1,10 @@
-import Link from 'next/link'
+import { LinkAccordion } from '../components/link-accordion'
 
 export default function Page() {
   return (
     <main>
       <h1>Another</h1>
-      <Link href="/another/alpha">Alpha</Link>
+      <LinkAccordion href="/another/alpha">Alpha</LinkAccordion>
     </main>
   )
 }

--- a/test/e2e/app-dir/output-export-dynamic-fallbacks/app/components/link-accordion.tsx
+++ b/test/e2e/app-dir/output-export-dynamic-fallbacks/app/components/link-accordion.tsx
@@ -1,0 +1,26 @@
+'use client'
+
+import Link from 'next/link'
+import { useState } from 'react'
+
+export function LinkAccordion({
+  children,
+  href,
+}: {
+  children: React.ReactNode
+  href: string
+}) {
+  const [isVisible, setIsVisible] = useState(false)
+
+  return (
+    <>
+      <input
+        type="checkbox"
+        checked={isVisible}
+        onChange={() => setIsVisible(!isVisible)}
+        data-link-accordion={href}
+      />
+      {isVisible ? <Link href={href}>{children}</Link> : children}
+    </>
+  )
+}

--- a/test/e2e/app-dir/output-export-dynamic-fallbacks/output-export-dynamic-fallbacks.test.ts
+++ b/test/e2e/app-dir/output-export-dynamic-fallbacks/output-export-dynamic-fallbacks.test.ts
@@ -6,6 +6,7 @@ import { join } from 'path'
 import express from 'express'
 import webdriver from 'next-webdriver'
 import { fetchViaHTTP, findPort, retry, stopApp } from 'next-test-utils'
+import { createRouterAct } from 'router-act'
 
 describe('output-export-dynamic-fallbacks', () => {
   const { next } = nextTestSetup({
@@ -14,7 +15,7 @@ describe('output-export-dynamic-fallbacks', () => {
     skipStart: true,
   })
 
-  it('writes route fallback HTML and RSC artifacts', async () => {
+  it('writes fallback artifacts and resolves hard loads and prefetched soft navigations', async () => {
     await next.build()
 
     const outDir = join(next.testDir, 'out')
@@ -59,6 +60,29 @@ describe('output-export-dynamic-fallbacks', () => {
         })
       } finally {
         await hardLoad.close()
+      }
+
+      let act: ReturnType<typeof createRouterAct>
+      const softNav = await webdriver(port, '/another', {
+        beforePageLoad(page) {
+          act = createRouterAct(page)
+        },
+      })
+      try {
+        const toggle = await softNav.elementByCss(
+          'input[data-link-accordion="/another/alpha"]'
+        )
+
+        await act!(async () => {
+          await toggle.click()
+          await softNav.elementByCss('a[href="/another/alpha"]').click()
+        })
+
+        await retry(async () => {
+          expect(await softNav.elementByCss('h1').text()).toBe('alpha')
+        })
+      } finally {
+        await softNav.close()
       }
     } finally {
       await stopApp(app)


### PR DESCRIPTION
This is PR 16 of 21 in the offline navigations plus output-export fallback stack.

This stack introduces a generated fallback entrypoint and then layers the client behavior on the existing App Router, cached navigations, optimistic routing, Cache Components, and Segment Cache primitives. The offline navigations chapter adds a managed service worker and persisted Segment Cache replay. The output-export chapter emits static fallback HTML/RSC artifacts so parameterized routes can load and navigate without enumerating every param at build time.

Review guide: https://gist.github.com/feedthejim/bb440153d29dce019d1d26b6643e2a48

## Where This Sits
This PR is in the output-export fallbacks chapter, after the offline fallback-entrypoint primitives are established.
Previous PR: #93748 `output export fallbacks: bootstrap hard loads from artifacts (15/21)`.
Next PR: #93779 `output export fallbacks: resolve fallback artifacts from route manifests (17/21)`.

## What Changes
- Teaches `fetchServerResponse` to resolve missing static export data through the matching fallback RSC artifact.
- Keeps the accepted fallback response on the normal router result so later slices can store the learned route fact in Segment Cache.

## Reviewer Focus
- The soft-navigation path should be an additive fallback from the normal server-response fetch, not a separate router.
- The fallback response should be reused rather than fetched twice.

## Proof In This PR
- `packages/next/src/client/components/router-reducer/fetch-server-response.test.ts` covers fallback response reuse and static artifact acceptance.
- Output-export dynamic fallback e2e covers client navigation into fallback routes.

Latest local stack verification after autosquash included:
- `git diff --check`
- `pnpm --filter=next types`
- `pnpm testonly packages/next/src/client/components/segment-cache/offline-navigation-cache.test.ts packages/next/src/client/components/segment-cache/cache.test.ts packages/next/src/client/output-export-fallback.test.ts packages/next/src/export/helpers/output-export-fallback.test.ts packages/next/src/lib/output-export-fallback-routes.test.ts packages/next/src/client/components/router-reducer/fetch-server-response.test.ts`
- `HEADLESS=true pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `HEADLESS=true pnpm test-start-turbo test/e2e/app-dir-export/test/dynamic-fallback*.test.ts`

## Deferred Coverage
Route-shape validation and Segment Cache storage of the learned fallback pathname are deferred.

## Disabled-Flag Posture
Fallback discovery is behind the output-export flag and should be erased from non-export bundles.

## Full Stack
1. [offline navigations: add gated build primitives (1/21)](https://github.com/vercel/next.js/pull/93736)
2. [offline navigations: generate fallback document artifacts (2/21)](https://github.com/vercel/next.js/pull/93737)
3. [offline navigations: register pass-through worker (3/21)](https://github.com/vercel/next.js/pull/93625)
4. [offline navigations: cache fallback and current-build assets (4/21)](https://github.com/vercel/next.js/pull/93626)
5. [offline navigations: serve fallback document offline (5/21)](https://github.com/vercel/next.js/pull/93627)
6. [offline navigations: add Segment Cache persistence primitives (6/21)](https://github.com/vercel/next.js/pull/93630)
7. [offline navigations: persist cached Segment Cache records (7/21)](https://github.com/vercel/next.js/pull/93640)
8. [offline navigations: bootstrap fallback from Segment Cache records (8/21)](https://github.com/vercel/next.js/pull/93644)
9. [offline navigations: support dynamic route patterns (9/21)](https://github.com/vercel/next.js/pull/93647)
10. [offline navigations: add docs and examples (10/21)](https://github.com/vercel/next.js/pull/93738)
11. [output export fallbacks: add gated build primitives (11/21)](https://github.com/vercel/next.js/pull/93744)
12. [output export fallbacks: emit fallback HTML artifacts (12/21)](https://github.com/vercel/next.js/pull/93745)
13. [output export fallbacks: emit fallback RSC artifacts (13/21)](https://github.com/vercel/next.js/pull/93746)
14. [output export fallbacks: enforce server-only boundaries (14/21)](https://github.com/vercel/next.js/pull/93747)
15. [output export fallbacks: bootstrap hard loads from artifacts (15/21)](https://github.com/vercel/next.js/pull/93748)
16. **Current PR:** [output export fallbacks: resolve soft navigations through cached routes (16/21)](https://github.com/vercel/next.js/pull/93749)
17. [output export fallbacks: resolve fallback artifacts from route manifests (17/21)](https://github.com/vercel/next.js/pull/93779)
18. [output export fallbacks: validate fallback Flight responses (18/21)](https://github.com/vercel/next.js/pull/93750)
19. [output export fallbacks: store fallback data in Segment Cache (19/21)](https://github.com/vercel/next.js/pull/93774)
20. [output export fallbacks: support known params and export variants (20/21)](https://github.com/vercel/next.js/pull/93751)
21. [output export fallbacks: add docs and review guide (21/21)](https://github.com/vercel/next.js/pull/93752)

<!-- NEXT_JS_LLM_PR -->
