### PR TITLE
output export fallbacks: validate fallback Flight responses (18/21)

### DIFF
--- a/packages/next/src/client/components/router-reducer/compute-changed-path.test.ts
+++ b/packages/next/src/client/components/router-reducer/compute-changed-path.test.ts
@@ -1,4 +1,4 @@
-import { computeChangedPath } from './compute-changed-path'
+import { computeChangedPath, getSelectedParams } from './compute-changed-path'
 import { PrefetchHint } from '../../../shared/lib/app-router-types'
 
 describe('computeChangedPath', () => {
@@ -57,5 +57,64 @@ describe('computeChangedPath', () => {
         ]
       )
     ).toBe('/')
+  })
+})
+
+describe('getSelectedParams', () => {
+  const originalOutput = process.env.__NEXT_CONFIG_OUTPUT
+  const originalBasePath = process.env.__NEXT_ROUTER_BASEPATH
+  const originalWindow = global.window
+
+  afterEach(() => {
+    process.env.__NEXT_CONFIG_OUTPUT = originalOutput
+    process.env.__NEXT_ROUTER_BASEPATH = originalBasePath
+    global.window = originalWindow
+  })
+
+  it('resolves deferred export fallback params from the current pathname', () => {
+    process.env.__NEXT_CONFIG_OUTPUT = 'export'
+    global.window = {
+      location: {
+        pathname: '/another/third',
+      },
+    } as Window & typeof globalThis
+
+    expect(
+      getSelectedParams([
+        '',
+        {
+          children: [
+            'another',
+            {
+              children: [['slug', '%%drp:slug:abc123%%', 'd', null], {}],
+            },
+          ],
+        },
+      ])
+    ).toEqual({ slug: 'third' })
+  })
+
+  it('resolves deferred export fallback params after removing basePath', () => {
+    process.env.__NEXT_CONFIG_OUTPUT = 'export'
+    process.env.__NEXT_ROUTER_BASEPATH = '/base'
+    global.window = {
+      location: {
+        pathname: '/base/another/third',
+      },
+    } as Window & typeof globalThis
+
+    expect(
+      getSelectedParams([
+        '',
+        {
+          children: [
+            'another',
+            {
+              children: [['slug', '%%drp:slug:abc123%%', 'd', null], {}],
+            },
+          ],
+        },
+      ])
+    ).toEqual({ slug: 'third' })
   })
 })

--- a/packages/next/src/client/components/router-reducer/compute-changed-path.ts
+++ b/packages/next/src/client/components/router-reducer/compute-changed-path.ts
@@ -4,12 +4,17 @@ import type {
 } from '../../../shared/lib/app-router-types'
 import { INTERCEPTION_ROUTE_MARKERS } from '../../../shared/lib/router/utils/interception-routes'
 import type { Params } from '../../../server/request/params'
+import { removePathPrefix } from '../../../shared/lib/router/utils/remove-path-prefix'
 import {
   isGroupSegment,
   DEFAULT_SEGMENT_KEY,
   PAGE_SEGMENT_KEY,
 } from '../../../shared/lib/segment'
 import { matchSegment } from '../match-segments'
+import {
+  doesStaticSegmentAppearInURL,
+  parseDynamicParamFromURLPart,
+} from '../../route-params'
 
 const removeLeadingSlash = (segment: string): string => {
   return segment[0] === '/' ? segment.slice(1) : segment
@@ -226,6 +231,23 @@ export function getSelectedParams(
   currentTree: FlightRouterState,
   params: Params = {}
 ): Params {
+  const basePath = process.env.__NEXT_ROUTER_BASEPATH || ''
+  const pathnameParts =
+    typeof window !== 'undefined'
+      ? removePathPrefix(window.location.pathname, basePath)
+          .split('/')
+          .filter((p) => p !== '')
+      : null
+
+  return getSelectedParamsImpl(currentTree, params, pathnameParts, 0)
+}
+
+function getSelectedParamsImpl(
+  currentTree: FlightRouterState,
+  params: Params,
+  pathnameParts: string[] | null,
+  pathnamePartsIndex: number
+): Params {
   const parallelRoutes = currentTree[1]
 
   for (const parallelRoute of Object.values(parallelRoutes)) {
@@ -234,17 +256,47 @@ export function getSelectedParams(
     const segmentValue = isDynamicParameter ? segment[1] : segment
     if (!segmentValue || segmentValue.startsWith(PAGE_SEGMENT_KEY)) continue
 
+    let childPathnamePartsIndex = pathnamePartsIndex
+
     // Ensure catchAll and optional catchall are turned into an array
     const isCatchAll =
       isDynamicParameter && (segment[2] === 'c' || segment[2] === 'oc')
 
     if (isCatchAll) {
-      params[segment[0]] = segment[1].split('/')
+      if (pathnameParts !== null && segment[1].startsWith('%%drp:')) {
+        const paramValue = parseDynamicParamFromURLPart(
+          segment[2],
+          pathnameParts,
+          pathnamePartsIndex
+        )
+        params[segment[0]] = paramValue === null ? undefined : paramValue
+      } else {
+        params[segment[0]] = segment[1].split('/')
+      }
+      childPathnamePartsIndex =
+        pathnameParts !== null ? pathnameParts.length : pathnamePartsIndex
     } else if (isDynamicParameter) {
-      params[segment[0]] = segment[1]
+      if (pathnameParts !== null && segment[1].startsWith('%%drp:')) {
+        const paramValue = parseDynamicParamFromURLPart(
+          segment[2],
+          pathnameParts,
+          pathnamePartsIndex
+        )
+        params[segment[0]] = paramValue === null ? undefined : paramValue
+      } else {
+        params[segment[0]] = segment[1]
+      }
+      childPathnamePartsIndex = pathnamePartsIndex + 1
+    } else if (doesStaticSegmentAppearInURL(segmentValue)) {
+      childPathnamePartsIndex = pathnamePartsIndex + 1
     }
 
-    params = getSelectedParams(parallelRoute, params)
+    params = getSelectedParamsImpl(
+      parallelRoute,
+      params,
+      pathnameParts,
+      childPathnamePartsIndex
+    )
   }
 
   return params

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.test.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.test.ts
@@ -1,0 +1,323 @@
+/**
+ * @jest-environment node
+ */
+
+import type { NavigationFlightResponse } from '../../../shared/lib/app-router-types'
+import { setNavigationBuildId } from '../../navigation-build-id'
+import { fetchServerResponse } from './fetch-server-response'
+
+const mockCreateFromReadableStream = jest.fn()
+const mockFetchOutputExportFallbackResponse = jest.fn()
+const mockFetchOutputExportNotFoundDataResponse = jest.fn()
+const mockFetchOutputExportNotFoundResponse = jest.fn()
+
+jest.mock('react-server-dom-webpack/client', () => ({
+  createFromFetch: jest.fn(),
+  createFromReadableStream: (...args: Array<unknown>) =>
+    mockCreateFromReadableStream(...args),
+}))
+
+jest.mock('../../output-export-fallback', () => ({
+  fetchOutputExportFallbackResponse: (...args: Array<unknown>) =>
+    mockFetchOutputExportFallbackResponse(...args),
+  fetchOutputExportNotFoundDataResponse: (...args: Array<unknown>) =>
+    mockFetchOutputExportNotFoundDataResponse(...args),
+  fetchOutputExportNotFoundResponse: (...args: Array<unknown>) =>
+    mockFetchOutputExportNotFoundResponse(...args),
+}))
+
+function withResponseUrl(response: Response, url: string): Response {
+  Object.defineProperty(response, 'url', { value: url })
+  Object.defineProperty(response, 'redirected', { value: false })
+  return response
+}
+
+function createFallbackNavigationFlightResponse({
+  buildId = 'build-id',
+}: {
+  buildId?: string | null
+} = {}): NavigationFlightResponse {
+  const response: NavigationFlightResponse = {
+    f: [
+      [
+        'children',
+        'another',
+        'children',
+        ['slug', '%%drp:slug:abc123%%', 'd', null],
+        [
+          '',
+          {
+            children: [
+              'another',
+              {
+                children: [['slug', '%%drp:slug:abc123%%', 'd', null], {}],
+              },
+            ],
+          },
+        ],
+        null,
+        null,
+        false,
+      ],
+    ],
+    S: false,
+    q: '',
+    i: false,
+    h: null,
+  }
+  if (buildId !== null) {
+    response.b = buildId
+  }
+  return response
+}
+
+function createNotFoundNavigationFlightResponse(): NavigationFlightResponse {
+  return {
+    b: 'build-id',
+    f: [
+      [
+        'children',
+        '/_not-found',
+        ['', { children: ['/_not-found', {}] }],
+        null,
+        null,
+        false,
+      ],
+    ],
+    S: false,
+    q: '',
+    i: false,
+    h: null,
+  }
+}
+
+describe('fetchServerResponse output export fallback', () => {
+  const originalNodeEnv = process.env.NODE_ENV
+  const originalOutput = process.env.__NEXT_CONFIG_OUTPUT
+  const originalOutputExportDynamicFallbacks =
+    process.env.__NEXT_OUTPUT_EXPORT_DYNAMIC_FALLBACKS
+  const originalFetch = global.fetch
+  const originalLocation = global.location
+  const processEnv = process.env as Record<string, string | undefined>
+
+  beforeEach(() => {
+    processEnv.NODE_ENV = 'production'
+    processEnv.__NEXT_CONFIG_OUTPUT = 'export'
+    processEnv.__NEXT_OUTPUT_EXPORT_DYNAMIC_FALLBACKS = 'true'
+    global.location = new URL('https://example.com/') as unknown as Location
+    setNavigationBuildId('build-id')
+    mockCreateFromReadableStream.mockReset()
+    mockFetchOutputExportFallbackResponse.mockReset()
+    mockFetchOutputExportNotFoundDataResponse.mockReset()
+    mockFetchOutputExportNotFoundResponse.mockReset()
+    mockFetchOutputExportNotFoundDataResponse.mockResolvedValue(null)
+    mockFetchOutputExportNotFoundResponse.mockResolvedValue({
+      response: withResponseUrl(
+        new Response('not found payload', {
+          status: 200,
+          headers: { 'content-type': 'text/plain' },
+        }),
+        `${global.location.origin}/_not-found.txt`
+      ),
+      renderedUrl: new URL('/_not-found', global.location.origin),
+      fallbackUrl: new URL('/_not-found', global.location.origin),
+    })
+  })
+
+  afterEach(() => {
+    processEnv.NODE_ENV = originalNodeEnv
+    processEnv.__NEXT_CONFIG_OUTPUT = originalOutput
+    if (originalOutputExportDynamicFallbacks === undefined) {
+      delete processEnv.__NEXT_OUTPUT_EXPORT_DYNAMIC_FALLBACKS
+    } else {
+      processEnv.__NEXT_OUTPUT_EXPORT_DYNAMIC_FALLBACKS =
+        originalOutputExportDynamicFallbacks
+    }
+    global.fetch = originalFetch
+    global.location = originalLocation
+    jest.restoreAllMocks()
+  })
+
+  it('reuses the discovered fallback response instead of fetching it again', async () => {
+    const origin = global.location.origin
+    const initialMiss = withResponseUrl(
+      new Response('not found', {
+        status: 404,
+        headers: { 'content-type': 'text/html' },
+      }),
+      `${origin}/another/third.txt`
+    )
+    const fallbackResponse = withResponseUrl(
+      new Response('fallback payload', {
+        status: 200,
+        headers: { 'content-type': 'text/plain' },
+      }),
+      `${origin}/another/__fallback/index.txt`
+    )
+
+    global.fetch = jest
+      .fn(async () => initialMiss)
+      .mockImplementationOnce(async () => initialMiss)
+      .mockImplementation(async () => {
+        throw new Error('unexpected extra fetch')
+      }) as typeof fetch
+
+    mockFetchOutputExportFallbackResponse.mockResolvedValue({
+      response: fallbackResponse,
+      renderedUrl: new URL('/another/third', origin),
+      fallbackUrl: new URL('/another/__fallback', origin),
+    })
+    mockCreateFromReadableStream.mockResolvedValue(
+      createFallbackNavigationFlightResponse()
+    )
+
+    const result = await fetchServerResponse(
+      new URL('/another/third', origin),
+      {
+        flightRouterState: ['', {}, null, null],
+        nextUrl: null,
+      }
+    )
+
+    expect(typeof result).not.toBe('string')
+    if (typeof result !== 'string') {
+      expect(result.canonicalUrl.href).toBe(`${origin}/another/third`)
+    }
+    expect(global.fetch).toHaveBeenCalledTimes(1)
+    expect(mockFetchOutputExportFallbackResponse).toHaveBeenCalledTimes(1)
+  })
+
+  it('allows static fallback artifacts without serialized build ids', async () => {
+    const origin = global.location.origin
+    setNavigationBuildId('deployment-id')
+    const initialMiss = withResponseUrl(
+      new Response('not found', {
+        status: 404,
+        headers: { 'content-type': 'text/html' },
+      }),
+      `${origin}/another/third.txt`
+    )
+    const fallbackResponse = withResponseUrl(
+      new Response('fallback payload', {
+        status: 200,
+        headers: { 'content-type': 'text/plain' },
+      }),
+      `${origin}/another/__fallback.txt`
+    )
+
+    global.fetch = jest.fn(async () => initialMiss) as typeof fetch
+    mockFetchOutputExportFallbackResponse.mockResolvedValue({
+      response: fallbackResponse,
+      renderedUrl: new URL('/another/third', origin),
+      fallbackUrl: new URL('/another/__fallback', origin),
+    })
+    mockCreateFromReadableStream.mockResolvedValue(
+      createFallbackNavigationFlightResponse({ buildId: null })
+    )
+
+    const result = await fetchServerResponse(
+      new URL('/another/third', origin),
+      {
+        flightRouterState: ['', {}, null, null],
+        nextUrl: null,
+      }
+    )
+
+    expect(typeof result).not.toBe('string')
+    if (typeof result !== 'string') {
+      expect(result.canonicalUrl.href).toBe(`${origin}/another/third`)
+    }
+  })
+
+  it('rejects fallback artifacts with explicit build id mismatches', async () => {
+    const origin = global.location.origin
+    const initialMiss = withResponseUrl(
+      new Response('not found', {
+        status: 404,
+        headers: { 'content-type': 'text/html' },
+      }),
+      `${origin}/another/third.txt`
+    )
+    const fallbackResponse = withResponseUrl(
+      new Response('fallback payload', {
+        status: 200,
+        headers: { 'content-type': 'text/plain' },
+      }),
+      `${origin}/another/__fallback.txt`
+    )
+
+    global.fetch = jest.fn(async () => initialMiss) as typeof fetch
+    mockFetchOutputExportFallbackResponse.mockResolvedValue({
+      response: fallbackResponse,
+      renderedUrl: new URL('/another/third', origin),
+      fallbackUrl: new URL('/another/__fallback', origin),
+    })
+    mockCreateFromReadableStream.mockResolvedValue(
+      createFallbackNavigationFlightResponse({ buildId: 'different-build-id' })
+    )
+
+    const result = await fetchServerResponse(
+      new URL('/another/third', origin),
+      {
+        flightRouterState: ['', {}, null, null],
+        nextUrl: null,
+      }
+    )
+
+    expect(result).toBe(`${origin}/another/third`)
+  })
+
+  it('validates fallback route shapes before reusing them', async () => {
+    const origin = global.location.origin
+    const initialMiss = withResponseUrl(
+      new Response('not found', {
+        status: 404,
+        headers: { 'content-type': 'text/html' },
+      }),
+      `${origin}/another/third/extra.txt`
+    )
+    const fallbackResponse = withResponseUrl(
+      new Response('fallback payload', {
+        status: 200,
+        headers: { 'content-type': 'text/plain' },
+      }),
+      `${origin}/another/__fallback.txt`
+    )
+    const notFoundResponse = withResponseUrl(
+      new Response('not found payload', {
+        status: 200,
+        headers: { 'content-type': 'text/plain' },
+      }),
+      `${origin}/_not-found.txt`
+    )
+
+    global.fetch = jest.fn(async () => initialMiss) as typeof fetch
+    mockFetchOutputExportFallbackResponse.mockResolvedValue({
+      response: fallbackResponse,
+      renderedUrl: new URL('/another/third/extra', origin),
+      fallbackUrl: new URL('/another/__fallback', origin),
+    })
+    mockFetchOutputExportNotFoundDataResponse.mockResolvedValue({
+      response: notFoundResponse,
+      renderedUrl: new URL('/another/third/extra', origin),
+      fallbackUrl: new URL('/_not-found', origin),
+    })
+    mockCreateFromReadableStream
+      .mockResolvedValueOnce(createFallbackNavigationFlightResponse())
+      .mockResolvedValueOnce(createNotFoundNavigationFlightResponse())
+
+    const result = await fetchServerResponse(
+      new URL('/another/third/extra', origin),
+      {
+        flightRouterState: ['', {}, null, null],
+        nextUrl: null,
+      }
+    )
+
+    expect(typeof result).not.toBe('string')
+    if (typeof result !== 'string') {
+      expect(result.canonicalUrl.href).toBe(`${origin}/another/third/extra`)
+    }
+    expect(mockFetchOutputExportNotFoundDataResponse).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -32,6 +32,7 @@ import {
 import { callServer } from '../../app-call-server'
 import { findSourceMapURL } from '../../app-find-source-map-url'
 import {
+  fillInAndValidateFallbackFlightData,
   fillInFallbackFlightData,
   normalizeFlightData,
   prepareFlightRouterStateForRequest,
@@ -120,6 +121,8 @@ export type FetchServerResponseResult =
   | MpaFetchServerResponseResult
   | SpaFetchServerResponseResult
 
+type OutputExportFallbackModule = typeof import('../../output-export-fallback')
+
 export type RequestHeaders = {
   [RSC_HEADER]?: '1'
   [NEXT_ROUTER_STATE_TREE_HEADER]?: string
@@ -189,6 +192,9 @@ export async function fetchServerResponse(
   const originalUrl = url
 
   try {
+    let outputExportFallbackFetchKind: OutputExportFallbackFetchKind = 'none'
+    let outputExportFallbackFetchResult: OutputExportFallbackFetchResult | null =
+      null
     if (
       process.env.NODE_ENV === 'production' &&
       process.env.__NEXT_CONFIG_OUTPUT === 'export'
@@ -213,7 +219,6 @@ export async function fetchServerResponse(
       process.env.__NEXT_PPR && !process.env.__NEXT_CACHE_COMPONENTS
     const shouldImmediatelyDecode =
       !isLegacyPPR && process.env.__NEXT_CONFIG_OUTPUT !== 'export'
-    let usedOutputExportFallback = false
     let res = await createFetch<NavigationFlightResponse>(
       url,
       headers,
@@ -247,33 +252,18 @@ export async function fetchServerResponse(
 
       if (process.env.__NEXT_OUTPUT_EXPORT_DYNAMIC_FALLBACKS) {
         if (!isFlightResponse || !res.ok || !res.body) {
-          const { fetchOutputExportFallbackResponse } =
+          const outputExportFallback =
             require('../../output-export-fallback') as typeof import('../../output-export-fallback')
-
-          const fallbackResult = await fetchOutputExportFallbackResponse(
+          const fallbackResult = await fetchOutputExportFallbackFetchResult(
+            outputExportFallback,
             originalUrl,
-            {
-              credentials: 'same-origin',
-              headers,
-            }
+            headers
           )
 
           if (fallbackResult !== null) {
-            usedOutputExportFallback = true
-            const { response: processed, cacheData } = await processFetch(
-              fallbackResult.response
-            )
-
-            res = {
-              ok: processed.ok,
-              redirected: false,
-              headers: processed.headers,
-              body: processed.body,
-              status: processed.status,
-              url: originalUrl.href,
-              flightResponsePromise: null,
-              cacheData: Promise.resolve(cacheData),
-            }
+            outputExportFallbackFetchKind = 'discovered'
+            outputExportFallbackFetchResult = fallbackResult
+            res = fallbackResult.response
             responseUrl = originalUrl
             canonicalUrl = originalUrl
             contentType = res.headers.get('content-type') || ''
@@ -332,26 +322,85 @@ export async function fetchServerResponse(
         )
     }
 
-    const [flightResponse, cacheData] = await Promise.all([
+    let [flightResponse, cacheData] = await Promise.all([
       flightResponsePromise,
       res.cacheData,
     ])
 
+    const responseBuildId =
+      res.headers.get(NEXT_NAV_DEPLOYMENT_ID_HEADER) ?? flightResponse.b
+    // Static export fallback RSC files are plain static assets. Static hosts
+    // may not attach the deployment header, and fallback payloads can omit `b`.
+    // Only allow a missing id for fallback artifacts; explicit mismatches still
+    // hard-navigate to the response URL.
+    const missingBuildIdFromOutputExportFallback =
+      responseBuildId === undefined &&
+      process.env.__NEXT_OUTPUT_EXPORT_DYNAMIC_FALLBACKS &&
+      outputExportFallbackFetchKind !== 'none'
     if (
-      (res.headers.get(NEXT_NAV_DEPLOYMENT_ID_HEADER) ?? flightResponse.b) !==
-      getNavigationBuildId()
+      !missingBuildIdFromOutputExportFallback &&
+      responseBuildId !== getNavigationBuildId()
     ) {
       // The server build does not match the client build.
       return doMpaNavigation(res.url)
     }
 
-    const fallbackFlightData = usedOutputExportFallback
-      ? fillInFallbackFlightData(
+    let fallbackFlightData: NavigationFlightResponse['f'] | null =
+      outputExportFallbackFetchResult?.fallbackFlightData ?? null
+    let shouldFetchOutputExportNotFound =
+      outputExportFallbackFetchKind === 'discovered' &&
+      outputExportFallbackFetchResult !== null &&
+      !outputExportFallbackFetchResult.matchesRenderedPathname
+    if (
+      fallbackFlightData === null &&
+      outputExportFallbackFetchKind !== 'none'
+    ) {
+      if (process.env.__NEXT_OUTPUT_EXPORT_DYNAMIC_FALLBACKS) {
+        fallbackFlightData = fillInAndValidateFallbackFlightData(
           flightResponse.f,
           originalUrl.pathname,
           originalUrl.search as NormalizedSearch
         )
-      : null
+        if (fallbackFlightData === null) {
+          shouldFetchOutputExportNotFound = true
+        }
+      } else {
+        fallbackFlightData = fillInFallbackFlightData(
+          flightResponse.f,
+          originalUrl.pathname,
+          originalUrl.search as NormalizedSearch
+        )
+      }
+    }
+
+    if (process.env.__NEXT_OUTPUT_EXPORT_DYNAMIC_FALLBACKS) {
+      if (shouldFetchOutputExportNotFound) {
+        const outputExportFallback =
+          require('../../output-export-fallback') as typeof import('../../output-export-fallback')
+        const notFoundResult = await fetchOutputExportNotFoundFetchResult(
+          outputExportFallback,
+          originalUrl,
+          headers
+        )
+
+        if (notFoundResult === null) {
+          return doMpaNavigation(originalUrl.href)
+        }
+
+        res = notFoundResult.response
+        responseUrl = originalUrl
+        canonicalUrl = originalUrl
+        contentType = res.headers.get('content-type') || ''
+        interception = !!res.headers.get('vary')?.includes(NEXT_URL)
+        postponed = true
+        isFlightResponse = true
+        flightResponse = notFoundResult.flightResponse
+        cacheData = notFoundResult.cacheData
+        fallbackFlightData = notFoundResult.fallbackFlightData
+      }
+    } else {
+      // Static export fallback route-shape checks are erased when the feature is off.
+    }
 
     const normalizedFlightData = normalizeFlightData(
       fallbackFlightData ?? flightResponse.f
@@ -450,6 +499,115 @@ type OfflineNavigationRSCResponseCache = {
 type FetchResponseCacheData = {
   isResponsePartial: boolean
   responseBodyClone?: ReadableStream<Uint8Array>
+}
+
+type OutputExportFallbackFetchKind = 'none' | 'discovered'
+
+type OutputExportFallbackFetchResult = {
+  response: RSCResponse<NavigationFlightResponse>
+  flightResponse: NavigationFlightResponse
+  cacheData: FetchResponseCacheData | null
+  fallbackFlightData: NavigationFlightResponse['f']
+  matchesRenderedPathname: boolean
+}
+
+async function createOutputExportFallbackFetchResult({
+  response,
+  renderedUrl,
+  headers,
+}: {
+  response: Response
+  renderedUrl: URL
+  headers: RequestHeaders
+}): Promise<OutputExportFallbackFetchResult | null> {
+  const { response: processed, cacheData } = await processFetch(response)
+
+  if (!processed.body) {
+    return null
+  }
+
+  const flightResponse =
+    await createFromNextReadableStream<NavigationFlightResponse>(
+      processed.body,
+      headers,
+      { allowPartialStream: true }
+    )
+  const matchedFallbackFlightData = fillInAndValidateFallbackFlightData(
+    flightResponse.f,
+    renderedUrl.pathname,
+    renderedUrl.search as NormalizedSearch
+  )
+  const fallbackFlightData =
+    matchedFallbackFlightData ??
+    fillInFallbackFlightData(
+      flightResponse.f,
+      renderedUrl.pathname,
+      renderedUrl.search as NormalizedSearch
+    )
+
+  return {
+    response: {
+      ok: processed.ok,
+      redirected: false,
+      headers: processed.headers,
+      body: processed.body,
+      status: processed.status,
+      url: renderedUrl.href,
+      flightResponsePromise: Promise.resolve(flightResponse),
+      cacheData: Promise.resolve(cacheData),
+    },
+    flightResponse,
+    cacheData,
+    fallbackFlightData,
+    matchesRenderedPathname: matchedFallbackFlightData !== null,
+  }
+}
+
+async function fetchOutputExportFallbackFetchResult(
+  outputExportFallback: OutputExportFallbackModule,
+  renderedUrl: URL,
+  headers: RequestHeaders
+): Promise<OutputExportFallbackFetchResult | null> {
+  const fallbackResult =
+    await outputExportFallback.fetchOutputExportFallbackResponse(renderedUrl, {
+      credentials: 'same-origin',
+      headers,
+    })
+
+  if (fallbackResult === null) {
+    return null
+  }
+
+  return createOutputExportFallbackFetchResult({
+    response: fallbackResult.response,
+    renderedUrl,
+    headers,
+  })
+}
+
+async function fetchOutputExportNotFoundFetchResult(
+  outputExportFallback: OutputExportFallbackModule,
+  renderedUrl: URL,
+  headers: RequestHeaders
+): Promise<OutputExportFallbackFetchResult | null> {
+  const notFoundResponse =
+    (await outputExportFallback.fetchOutputExportNotFoundDataResponse(
+      renderedUrl,
+      {
+        credentials: 'same-origin',
+        headers,
+      }
+    )) ??
+    (await outputExportFallback.fetchOutputExportNotFoundResponse(renderedUrl, {
+      credentials: 'same-origin',
+      headers,
+    }))
+
+  return createOutputExportFallbackFetchResult({
+    response: notFoundResponse.response,
+    renderedUrl,
+    headers,
+  })
 }
 
 /**

--- a/packages/next/src/client/flight-data-helpers.test.ts
+++ b/packages/next/src/client/flight-data-helpers.test.ts
@@ -1,8 +1,16 @@
-import { prepareFlightRouterStateForRequest } from './flight-data-helpers'
+import {
+  createInitialRSCPayloadFromFallbackPrerender,
+  doesFilledFallbackFlightDataMatchRenderedPathname,
+  fillInFallbackFlightData,
+  prepareFlightRouterStateForRequest,
+} from './flight-data-helpers'
 import {
   PrefetchHint,
+  type FlightData,
+  type InitialRSCPayload,
   type FlightRouterState,
 } from '../shared/lib/app-router-types'
+import type { NormalizedSearch } from './components/segment-cache/cache-key'
 
 describe('prepareFlightRouterStateForRequest', () => {
   describe('HMR refresh handling', () => {
@@ -296,5 +304,325 @@ describe('prepareFlightRouterStateForRequest', () => {
       expect(sidebarRoute[2]).toBeUndefined() // URL stripped
       expect(sidebarRoute[3]).toBeUndefined() // null marker stripped
     })
+  })
+})
+
+describe('fillInFallbackFlightData', () => {
+  const originalBasePath = process.env.__NEXT_ROUTER_BASEPATH
+
+  afterEach(() => {
+    process.env.__NEXT_ROUTER_BASEPATH = originalBasePath
+  })
+
+  it('replaces deferred route param placeholders in navigation flight data', () => {
+    const flightData = [
+      [
+        'children',
+        'another',
+        'children',
+        ['slug', '%%drp:slug:abc123%%', 'd', null],
+        [
+          '',
+          {
+            children: [
+              'another',
+              {
+                children: [['slug', '%%drp:slug:abc123%%', 'd', null], {}],
+              },
+            ],
+          },
+        ],
+        null,
+        null,
+        false,
+      ],
+    ] as FlightData
+
+    const normalizedFlightData = fillInFallbackFlightData(
+      flightData,
+      '/another/third',
+      '' as NormalizedSearch
+    )
+    const patchedFlightDataPath = normalizedFlightData[0]
+
+    expect(patchedFlightDataPath[3]).toEqual(['slug', 'third', 'd', null])
+    const patchedTree = patchedFlightDataPath[4]
+    expect(patchedTree[0]).toBe('')
+    expect(patchedTree[1].children[0]).toBe('another')
+    expect(patchedTree[1].children[1].children[0]).toEqual([
+      'slug',
+      'third',
+      'd',
+      null,
+    ])
+  })
+
+  it('fills deferred route params after removing basePath', () => {
+    process.env.__NEXT_ROUTER_BASEPATH = '/base'
+    const flightData = [
+      [
+        'children',
+        'another',
+        'children',
+        ['slug', '%%drp:slug:abc123%%', 'd', null],
+        [
+          '',
+          {
+            children: [
+              'another',
+              {
+                children: [['slug', '%%drp:slug:abc123%%', 'd', null], {}],
+              },
+            ],
+          },
+        ],
+        null,
+        null,
+        false,
+      ],
+    ] as FlightData
+
+    const normalizedFlightData = fillInFallbackFlightData(
+      flightData,
+      '/base/another/third',
+      '' as NormalizedSearch
+    )
+    const patchedFlightDataPath = normalizedFlightData[0]
+
+    expect(patchedFlightDataPath[3]).toEqual(['slug', 'third', 'd', null])
+    expect(
+      doesFilledFallbackFlightDataMatchRenderedPathname(
+        normalizedFlightData,
+        '/base/another/third'
+      )
+    ).toBe(true)
+  })
+
+  it('advances catch-all fallback params by all remaining pathname parts', () => {
+    for (const paramType of ['c', 'oc'] as const) {
+      const flightData = [
+        [
+          'children',
+          'docs',
+          'children',
+          ['slug', '%%drp:slug:abc123%%', paramType, null],
+          'children',
+          ['after', '%%drp:after:def456%%', 'd', null],
+          [
+            '',
+            {
+              children: [
+                'docs',
+                {
+                  children: [
+                    ['slug', '%%drp:slug:abc123%%', paramType, null],
+                    {
+                      children: [
+                        ['after', '%%drp:after:def456%%', 'd', null],
+                        {},
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+          null,
+          null,
+          false,
+        ],
+      ] as FlightData
+
+      const normalizedFlightData = fillInFallbackFlightData(
+        flightData,
+        '/docs/a/b/c',
+        '' as NormalizedSearch
+      )
+      const patchedFlightDataPath = normalizedFlightData[0]
+
+      expect(patchedFlightDataPath[3]).toEqual([
+        'slug',
+        'a/b/c',
+        paramType,
+        null,
+      ])
+      expect(patchedFlightDataPath[5]).toEqual(['after', '', 'd', null])
+
+      const patchedTree = patchedFlightDataPath[6]
+      expect(patchedTree[1].children[1].children[0]).toEqual([
+        'slug',
+        'a/b/c',
+        paramType,
+        null,
+      ])
+      expect(patchedTree[1].children[1].children[1].children[0]).toEqual([
+        'after',
+        '',
+        'd',
+        null,
+      ])
+    }
+  })
+})
+
+describe('createInitialRSCPayloadFromFallbackPrerender', () => {
+  it('preserves the trailing flight tuple fields while filling fallback params', () => {
+    const fallbackInitialRSCPayload: InitialRSCPayload = {
+      b: 'build-id',
+      c: ['', 'another', '%%drp:slug:abc123%%'],
+      q: '',
+      i: false,
+      f: [
+        [
+          [
+            '',
+            {
+              children: [
+                'another',
+                {
+                  children: [['slug', '%%drp:slug:abc123%%', 'd', null], {}],
+                },
+              ],
+            },
+          ],
+          null,
+          'head-node',
+          true,
+        ],
+      ],
+      m: new Set(),
+      G: [(() => null) as any, undefined],
+      S: false,
+      h: null,
+    }
+
+    const response = new Response(null, {
+      headers: { 'x-nextjs-rewritten-path': '/another/third' },
+    })
+
+    const payload = createInitialRSCPayloadFromFallbackPrerender(
+      response,
+      fallbackInitialRSCPayload,
+      new URL('https://example.com/another/third')
+    )
+
+    const patchedTree = payload.f[0][0]
+    expect(patchedTree[0]).toBe('')
+    expect(patchedTree[1].children[0]).toBe('another')
+    expect(patchedTree[1].children[1].children[0]).toEqual([
+      'slug',
+      'third',
+      'd',
+      null,
+    ])
+    expect(payload.f[0][1]).toBeNull()
+    expect(payload.f[0][2]).toBe('head-node')
+    expect(payload.f[0][3]).toBe(true)
+  })
+
+  it('prefers rewritten headers over the rendered URL override', () => {
+    const fallbackInitialRSCPayload: InitialRSCPayload = {
+      b: 'build-id',
+      c: ['', 'docs', '%%drp:slug:abc123%%'],
+      q: '',
+      i: false,
+      f: [
+        [
+          [
+            '',
+            {
+              children: [
+                'docs',
+                {
+                  children: [['slug', '%%drp:slug:abc123%%', 'd', null], {}],
+                },
+              ],
+            },
+          ],
+          null,
+          'head-node',
+          false,
+        ],
+      ],
+      m: new Set(),
+      G: [(() => null) as any, undefined],
+      S: false,
+      h: null,
+    }
+
+    const response = new Response(null, {
+      headers: {
+        'x-nextjs-rewritten-path': '/docs/rewritten',
+        'x-nextjs-rewritten-query': 'from=fetch',
+      },
+    })
+
+    const payload = createInitialRSCPayloadFromFallbackPrerender(
+      response,
+      fallbackInitialRSCPayload,
+      new URL('https://example.com/docs/original?from=document')
+    )
+
+    const patchedTree = payload.f[0][0]
+    expect(patchedTree[1].children[0]).toBe('docs')
+    expect(patchedTree[1].children[1].children[0]).toEqual([
+      'slug',
+      'rewritten',
+      'd',
+      null,
+    ])
+    expect(payload.q).toBe('?from=fetch')
+    expect(payload.c.join('/')).toBe('/docs/original?from=document')
+  })
+
+  it('falls back to the rendered URL override when no rewritten headers are present', () => {
+    const fallbackInitialRSCPayload: InitialRSCPayload = {
+      b: 'build-id',
+      c: ['', 'docs', '%%drp:slug:abc123%%'],
+      q: '',
+      i: false,
+      f: [
+        [
+          [
+            '',
+            {
+              children: [
+                'docs',
+                {
+                  children: [['slug', '%%drp:slug:abc123%%', 'd', null], {}],
+                },
+              ],
+            },
+          ],
+          null,
+          'head-node',
+          false,
+        ],
+      ],
+      m: new Set(),
+      G: [(() => null) as any, undefined],
+      S: false,
+      h: null,
+    }
+
+    const response = new Response(null, {
+      headers: {},
+    })
+
+    const payload = createInitialRSCPayloadFromFallbackPrerender(
+      response,
+      fallbackInitialRSCPayload,
+      new URL('https://example.com/docs/original?from=document')
+    )
+
+    const patchedTree = payload.f[0][0]
+    expect(patchedTree[1].children[0]).toBe('docs')
+    expect(patchedTree[1].children[1].children[0]).toEqual([
+      'slug',
+      'original',
+      'd',
+      null,
+    ])
+    expect(payload.q).toBe('?from=document')
   })
 })

--- a/packages/next/src/client/flight-data-helpers.ts
+++ b/packages/next/src/client/flight-data-helpers.ts
@@ -10,6 +10,8 @@ import type {
 } from '../shared/lib/app-router-types'
 import { PAGE_SEGMENT_KEY } from '../shared/lib/segment'
 import type { NormalizedSearch } from './components/segment-cache/cache-key'
+import { extractPathFromFlightRouterState } from './components/router-reducer/compute-changed-path'
+import { removePathPrefix } from '../shared/lib/router/utils/remove-path-prefix'
 import {
   NEXT_REWRITTEN_PATH_HEADER,
   NEXT_REWRITTEN_QUERY_HEADER,
@@ -23,6 +25,12 @@ import {
   getRenderedSearch,
 } from './route-params'
 import { createHrefFromUrl } from './components/router-reducer/create-href-from-url'
+import { normalizePathTrailingSlash } from './normalize-trailing-slash'
+
+function removeConfiguredBasePath(pathname: string): string {
+  const basePath = process.env.__NEXT_ROUTER_BASEPATH || ''
+  return basePath ? removePathPrefix(pathname, basePath) : pathname
+}
 
 export type NormalizedFlightData = {
   /**
@@ -141,12 +149,60 @@ export function fillInFallbackFlightData<T extends FlightData>(
     return flightData
   }
 
-  const pathnameParts = getPathnameParts(renderedPathname)
+  const pathnameParts = getPathnameParts(
+    removeConfiguredBasePath(renderedPathname)
+  )
   const filledFlightData = flightData.map((flightDataPath) =>
     fillInFallbackFlightDataPath(flightDataPath, renderedSearch, pathnameParts)
   ) as FlightDataPath[]
 
   return filledFlightData as T
+}
+
+export function fillInAndValidateFallbackFlightData<T extends FlightData>(
+  flightData: T,
+  renderedPathname: string,
+  renderedSearch: NormalizedSearch
+): T | null {
+  const filledFlightData = fillInFallbackFlightData(
+    flightData,
+    renderedPathname,
+    renderedSearch
+  )
+  return doesFilledFallbackFlightDataMatchRenderedPathname(
+    filledFlightData,
+    renderedPathname
+  )
+    ? filledFlightData
+    : null
+}
+
+export function doesFilledFallbackFlightDataMatchRenderedPathname(
+  flightData: FlightData,
+  renderedPathname: string
+): boolean {
+  if (typeof flightData === 'string') {
+    return true
+  }
+
+  const normalizedRenderedPathname = normalizePathTrailingSlash(
+    removeConfiguredBasePath(renderedPathname)
+  )
+
+  return flightData.some((flightDataPath) => {
+    const { tree } = getFlightDataPartsFromPath(flightDataPath)
+    const extractedPath = extractPathFromFlightRouterState(tree)
+    const extractedPathname = extractedPath === '' ? '/' : extractedPath
+
+    if (extractedPathname == null) {
+      return false
+    }
+
+    return (
+      normalizePathTrailingSlash(extractedPathname) ===
+      normalizedRenderedPathname
+    )
+  })
 }
 
 function fillInFallbackFlightDataPath(

--- a/packages/next/src/client/output-export-fallback-bootstrap.ts
+++ b/packages/next/src/client/output-export-fallback-bootstrap.ts
@@ -2,8 +2,15 @@ import type { InitialRSCPayload } from '../shared/lib/app-router-types'
 import { callServer } from './app-call-server'
 import { findSourceMapURL } from './app-find-source-map-url'
 import { processFetch } from './components/router-reducer/fetch-server-response'
-import { createInitialRSCPayloadFromFallbackPrerender } from './flight-data-helpers'
-import { fetchOutputExportFallbackResponse } from './output-export-fallback'
+import {
+  createInitialRSCPayloadFromFallbackPrerender,
+  doesFilledFallbackFlightDataMatchRenderedPathname,
+} from './flight-data-helpers'
+import {
+  fetchOutputExportFallbackResponse,
+  fetchOutputExportNotFoundDataResponse,
+  fetchOutputExportNotFoundResponse,
+} from './output-export-fallback'
 
 type DebugChannel =
   | { readable?: ReadableStream; writable?: WritableStream }
@@ -47,14 +54,37 @@ export async function createOutputExportFallbackInitialResponse({
     credentials: 'same-origin',
   })
 
-  if (fallbackResult === null) {
-    throw new Error(
-      `Could not find an output export fallback for "${renderedUrl.pathname}".`
+  if (fallbackResult !== null) {
+    const fallbackPayload = await decodeFallbackPrerenderPayload(
+      Promise.resolve(fallbackResult.response),
+      renderedUrl,
+      createFromFetch,
+      debugChannel
     )
+
+    if (
+      doesFilledFallbackFlightDataMatchRenderedPathname(
+        fallbackPayload.f,
+        renderedUrl.pathname
+      )
+    ) {
+      return fallbackPayload
+    }
   }
 
+  // If the fallback route shape does not match the requested URL, prefer a
+  // visible not-found result over hydrating a shell with params from the wrong
+  // route.
+  const notFoundResult =
+    (await fetchOutputExportNotFoundDataResponse(renderedUrl, {
+      credentials: 'same-origin',
+    })) ??
+    (await fetchOutputExportNotFoundResponse(renderedUrl, {
+      credentials: 'same-origin',
+    }))
+
   return decodeFallbackPrerenderPayload(
-    Promise.resolve(fallbackResult.response),
+    Promise.resolve(notFoundResult.response),
     renderedUrl,
     createFromFetch,
     debugChannel
@@ -63,7 +93,7 @@ export async function createOutputExportFallbackInitialResponse({
 
 async function decodeFallbackPrerenderPayload(
   responsePromise: Promise<Response>,
-  renderedUrl: URL | undefined,
+  renderedUrl: URL,
   createFromFetch: CreateFromFetch,
   debugChannel: DebugChannel
 ): Promise<InitialRSCPayload> {

--- a/packages/next/src/client/output-export-fallback.ts
+++ b/packages/next/src/client/output-export-fallback.ts
@@ -8,6 +8,7 @@ import { removePathPrefix } from '../shared/lib/router/utils/remove-path-prefix'
 import { RSC_CONTENT_TYPE_HEADER } from './components/app-router-headers'
 import { getRouteMatcher } from '../shared/lib/router/utils/route-matcher'
 import { getRouteRegex } from '../shared/lib/router/utils/route-regex'
+import { normalizePathTrailingSlash } from './normalize-trailing-slash'
 
 type OutputExportFallbackRouteManifest = {
   version: 1
@@ -64,6 +65,33 @@ function getOutputExportCandidatePrefixes(pathname: string): string[] {
 export function getOutputExportFallbackCandidates(pathname: string): string[] {
   return getOutputExportCandidatePrefixes(pathname).map((prefix) =>
     getOutputExportFallbackPath(prefix)
+  )
+}
+
+function getOutputExportNotFoundPath(prefix: string): string {
+  return prefix.length > 0 ? `/${prefix}/_not-found` : '/_not-found'
+}
+
+export function getOutputExportNotFoundCandidates(pathname: string): string[] {
+  return getOutputExportCandidatePrefixes(pathname).map((prefix) =>
+    getOutputExportNotFoundPath(prefix)
+  )
+}
+
+export function getConfiguredOutputExportNotFoundCandidate(
+  pathname: string
+): string {
+  const configuredPath = normalizeOutputExportRouteDirectory(
+    normalizePathTrailingSlash(
+      addPathPrefix('/_not-found', process.env.__NEXT_ROUTER_BASEPATH || '')
+    )
+  )
+
+  return (
+    getOutputExportNotFoundCandidates(pathname).find(
+      (candidate) =>
+        normalizeOutputExportRouteDirectory(candidate) === configuredPath
+    ) ?? getOutputExportNotFoundPath('')
   )
 }
 
@@ -143,6 +171,20 @@ async function fetchOutputExportFallbackRouteManifest(
   return routeManifestPromise
 }
 
+function getOutputExportDataCandidates(url: URL): URL[] {
+  const direct = addOutputExportDataSuffix(url)
+
+  if (url.pathname.endsWith('/')) {
+    return [direct]
+  }
+
+  const trailingSlashUrl = new URL(url)
+  trailingSlashUrl.pathname = `${trailingSlashUrl.pathname}/`
+  const trailingSlash = addOutputExportDataSuffix(trailingSlashUrl)
+
+  return [direct, trailingSlash]
+}
+
 function getConfiguredOutputExportDataUrl(
   url: URL,
   prefersTrailingSlash: boolean
@@ -157,6 +199,27 @@ function getConfiguredOutputExportDataUrl(
     configuredUrl.pathname = `${configuredUrl.pathname}/`
   }
   return addOutputExportDataSuffix(configuredUrl)
+}
+
+function normalizeOutputExportRouteDirectory(pathname: string): string {
+  if (pathname === '/') {
+    return ''
+  }
+  return pathname.endsWith('/') ? pathname.slice(0, -1) : pathname
+}
+
+async function fetchOutputExportDataResult(
+  renderedUrl: URL,
+  init?: RequestInit
+): Promise<Response | null> {
+  for (const dataUrl of getOutputExportDataCandidates(renderedUrl)) {
+    const response = await fetchOutputExportDataResponseByUrl(dataUrl, init)
+    if (response !== null) {
+      return response
+    }
+  }
+
+  return null
 }
 
 async function fetchConfiguredOutputExportDataResult(
@@ -215,6 +278,52 @@ async function fetchOutputExportDataResponseByUrl(
     status: response.status,
     statusText: response.statusText,
   })
+}
+
+export async function fetchOutputExportNotFoundDataResponse(
+  renderedUrl: URL,
+  init?: RequestInit
+): Promise<OutputExportFallbackResponseResult | null> {
+  for (const candidate of getOutputExportNotFoundCandidates(
+    renderedUrl.pathname
+  )) {
+    const candidateUrl = new URL(renderedUrl)
+    candidateUrl.pathname = candidate
+
+    const result = await fetchOutputExportDataResult(candidateUrl, init)
+    if (result !== null) {
+      return {
+        response: result,
+        renderedUrl,
+        fallbackUrl: candidateUrl,
+      }
+    }
+  }
+
+  return null
+}
+
+export async function fetchOutputExportNotFoundResponse(
+  renderedUrl: URL,
+  init?: RequestInit
+): Promise<OutputExportFallbackResponseResult> {
+  // The raw fallback should preserve the configured app root (for example a
+  // basePath) without probing deeper missing prefixes that may be served by an
+  // HTML fallback document instead of the RSC not-found payload.
+  const candidateUrl = new URL(renderedUrl)
+  candidateUrl.pathname = getConfiguredOutputExportNotFoundCandidate(
+    renderedUrl.pathname
+  )
+  const configuredDataUrl = getConfiguredOutputExportDataUrl(
+    candidateUrl,
+    renderedUrl.pathname.endsWith('/')
+  )
+
+  return {
+    response: await fetch(configuredDataUrl, init),
+    renderedUrl,
+    fallbackUrl: candidateUrl,
+  }
 }
 
 export async function fetchOutputExportFallbackResponse(


### PR DESCRIPTION
This is PR 18 of 21 in the offline navigations plus output-export fallback stack.

This stack introduces a generated fallback entrypoint and then layers the client behavior on the existing App Router, cached navigations, optimistic routing, Cache Components, and Segment Cache primitives. The offline navigations chapter adds a managed service worker and persisted Segment Cache replay. The output-export chapter emits static fallback HTML/RSC artifacts so parameterized routes can load and navigate without enumerating every param at build time.

Review guide: https://gist.github.com/feedthejim/bb440153d29dce019d1d26b6643e2a48

## Where This Sits
This PR is in the output-export fallbacks chapter, after the client can resolve the correct static fallback artifact for a requested URL.
Previous PR: #93779 `output export fallbacks: resolve fallback artifacts from route manifests (17/21)`.
Next PR: #93774 `output export fallbacks: store fallback data in Segment Cache (19/21)`.

## What Changes
- Decodes selected fallback Flight responses and fills deferred dynamic params from the requested URL.
- Validates that the filled Flight tree matches the requested pathname before reusing the fallback response.
- Replays the output-export not-found fallback when a selected fallback artifact has the wrong route shape.
- Allows static fallback artifacts to omit build ids while still rejecting explicit build-id mismatches.
- Applies the same route-shape validation to hard-load bootstrap and selected-param extraction.

## Reviewer Focus
- A fallback artifact should only hydrate when its decoded route tree can represent the requested URL.
- Wrong-shape fallbacks should become a visible not-found result, not a cached or hydrated shell from another route.
- The special missing-build-id allowance should only apply to static fallback artifacts.

## Proof In This PR
- `fetch-server-response` unit tests cover fallback reuse, missing build ids, explicit build-id mismatches, and not-found fallback handling.
- `flight-data-helpers` and `compute-changed-path` unit tests cover filled fallback params and basePath-aware selected params.
- Output-export dynamic fallback e2e coverage includes conflicting branches and not-found behavior.

Latest local verification after the split included:
- `git diff --check`
- `pnpm exec jest packages/next/src/client/output-export-fallback.test.ts packages/next/src/client/components/router-reducer/fetch-server-response.test.ts packages/next/src/client/flight-data-helpers.test.ts packages/next/src/client/components/router-reducer/compute-changed-path.test.ts packages/next/src/client/components/segment-cache/cache.test.ts packages/next/src/client/components/segment-cache/vary-path.test.ts packages/next/src/client/components/router-reducer/create-initial-router-state.test.ts --runInBand`
- `pnpm --filter=next build`
- `pnpm test-start-turbo test/e2e/app-dir-export/test/dynamic-fallback*.test.ts`

## Deferred Coverage
Storing accepted fallback facts in Segment Cache is deferred to the next PR.

## Disabled-Flag Posture
Route-shape fallback logic is behind the output-export flag and should not run for regular apps.

## Full Stack
1. [offline navigations: add gated build primitives (1/21)](https://github.com/vercel/next.js/pull/93736)
2. [offline navigations: generate fallback document artifacts (2/21)](https://github.com/vercel/next.js/pull/93737)
3. [offline navigations: register pass-through worker (3/21)](https://github.com/vercel/next.js/pull/93625)
4. [offline navigations: cache fallback and current-build assets (4/21)](https://github.com/vercel/next.js/pull/93626)
5. [offline navigations: serve fallback document offline (5/21)](https://github.com/vercel/next.js/pull/93627)
6. [offline navigations: add Segment Cache persistence primitives (6/21)](https://github.com/vercel/next.js/pull/93630)
7. [offline navigations: persist cached Segment Cache records (7/21)](https://github.com/vercel/next.js/pull/93640)
8. [offline navigations: bootstrap fallback from Segment Cache records (8/21)](https://github.com/vercel/next.js/pull/93644)
9. [offline navigations: support dynamic route patterns (9/21)](https://github.com/vercel/next.js/pull/93647)
10. [offline navigations: add docs and examples (10/21)](https://github.com/vercel/next.js/pull/93738)
11. [output export fallbacks: add gated build primitives (11/21)](https://github.com/vercel/next.js/pull/93744)
12. [output export fallbacks: emit fallback HTML artifacts (12/21)](https://github.com/vercel/next.js/pull/93745)
13. [output export fallbacks: emit fallback RSC artifacts (13/21)](https://github.com/vercel/next.js/pull/93746)
14. [output export fallbacks: enforce server-only boundaries (14/21)](https://github.com/vercel/next.js/pull/93747)
15. [output export fallbacks: bootstrap hard loads from artifacts (15/21)](https://github.com/vercel/next.js/pull/93748)
16. [output export fallbacks: resolve soft navigations through cached routes (16/21)](https://github.com/vercel/next.js/pull/93749)
17. [output export fallbacks: resolve fallback artifacts from route manifests (17/21)](https://github.com/vercel/next.js/pull/93779)
18. **Current PR:** [output export fallbacks: validate fallback Flight responses (18/21)](https://github.com/vercel/next.js/pull/93750)
19. [output export fallbacks: store fallback data in Segment Cache (19/21)](https://github.com/vercel/next.js/pull/93774)
20. [output export fallbacks: support known params and export variants (20/21)](https://github.com/vercel/next.js/pull/93751)
21. [output export fallbacks: add docs and review guide (21/21)](https://github.com/vercel/next.js/pull/93752)

<!-- NEXT_JS_LLM_PR -->
