### PR TITLE
output export fallbacks: support known params and export variants (20/21)

### DIFF
--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/(grouped)/grouped/[slug]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/(grouped)/grouped/[slug]/page.js
@@ -1,0 +1,18 @@
+import Link from 'next/link'
+import { Suspense } from 'react'
+import GroupedSlugClient from './slug-client'
+
+export default function GroupedSlugPage() {
+  return (
+    <main>
+      <Suspense fallback={<h1>Loading grouped slug...</h1>}>
+        <GroupedSlugClient />
+      </Suspense>
+      <ul>
+        <li>
+          <Link href="/grouped">Visit grouped index</Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/(grouped)/grouped/[slug]/slug-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/(grouped)/grouped/[slug]/slug-client.js
@@ -1,0 +1,9 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function GroupedSlugClient() {
+  const params = useParams()
+
+  return <h1>{params.slug}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/(grouped)/grouped/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/(grouped)/grouped/page.js
@@ -1,0 +1,14 @@
+import Link from 'next/link'
+
+export default function GroupedIndexPage() {
+  return (
+    <main>
+      <h1>Grouped index</h1>
+      <ul>
+        <li>
+          <Link href="/grouped/from-group">Visit grouped fallback page</Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/another/[slug]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/another/[slug]/page.js
@@ -1,0 +1,23 @@
+import Link from 'next/link'
+import { Suspense } from 'react'
+import SlugClient from './slug-client'
+
+export default function Page() {
+  return (
+    <main>
+      <Suspense fallback={<h1>Loading slug...</h1>}>
+        <SlugClient />
+      </Suspense>
+      <ul>
+        <li>
+          <Link href="/another">Visit another page</Link>
+        </li>
+        <li>
+          <Link href="/org/acme/chat/thread-cross">
+            Visit org thread (cross-subtree)
+          </Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/another/[slug]/slug-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/another/[slug]/slug-client.js
@@ -1,0 +1,9 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function SlugClient() {
+  const params = useParams()
+
+  return <h1>{params.slug}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/another/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/another/page.js
@@ -1,0 +1,20 @@
+import Link from 'next/link'
+
+export default function Another() {
+  return (
+    <main>
+      <h1>Another</h1>
+      <ul>
+        <li>
+          <Link href="/">Visit the home page</Link>
+        </li>
+        <li>
+          <Link href="/another">another page</Link>
+        </li>
+        <li>
+          <Link href="/another/third">another third page</Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/components/link-accordion.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/components/link-accordion.js
@@ -1,0 +1,26 @@
+'use client'
+
+import Link from 'next/link'
+import { useState } from 'react'
+
+export function LinkAccordion({ href, children, prefetch }) {
+  const [isVisible, setIsVisible] = useState(false)
+
+  return (
+    <>
+      <input
+        type="checkbox"
+        checked={isVisible}
+        onChange={() => setIsVisible(!isVisible)}
+        data-link-accordion={href}
+      />
+      {isVisible ? (
+        <Link href={href} prefetch={prefetch} data-accordion-link={href}>
+          {children}
+        </Link>
+      ) : (
+        `${children} (link is hidden)`
+      )}
+    </>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/docs/[...slug]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/docs/[...slug]/page.js
@@ -1,0 +1,18 @@
+import Link from 'next/link'
+import { Suspense } from 'react'
+import DocsSlugClient from './slug-client'
+
+export default function DocsCatchAllPage() {
+  return (
+    <main>
+      <Suspense fallback={<h1>Loading docs...</h1>}>
+        <DocsSlugClient />
+      </Suspense>
+      <ul>
+        <li>
+          <Link href="/docs">Visit docs index</Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/docs/[...slug]/slug-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/docs/[...slug]/slug-client.js
@@ -1,0 +1,11 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function DocsSlugClient() {
+  const params = useParams()
+
+  return (
+    <h1>{Array.isArray(params.slug) ? params.slug.join('/') : 'missing'}</h1>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/docs/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/docs/page.js
@@ -1,0 +1,19 @@
+import Link from 'next/link'
+
+export default function DocsIndex() {
+  return (
+    <main>
+      <h1>Docs</h1>
+      <ul>
+        <li>
+          <Link href="/docs/reference/export">docs reference page</Link>
+        </li>
+        <li>
+          <Link href="/docs/guides/export/fallback">
+            docs export fallback page
+          </Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/docs/reference/[topic]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/docs/reference/[topic]/page.js
@@ -1,0 +1,18 @@
+import Link from 'next/link'
+import { Suspense } from 'react'
+import ReferenceTopicClient from './topic-client'
+
+export default function DocsReferenceTopicPage() {
+  return (
+    <main>
+      <Suspense fallback={<h1>Loading reference...</h1>}>
+        <ReferenceTopicClient />
+      </Suspense>
+      <ul>
+        <li>
+          <Link href="/docs">Visit docs index</Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/docs/reference/[topic]/topic-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/docs/reference/[topic]/topic-client.js
@@ -1,0 +1,9 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function ReferenceTopicClient() {
+  const params = useParams()
+
+  return <h1>{`reference:${params.topic ?? 'missing'}`}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/hydrated/[thread]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/hydrated/[thread]/page.js
@@ -1,0 +1,29 @@
+import Link from 'next/link'
+import { Suspense } from 'react'
+import { LinkAccordion } from '../../components/link-accordion'
+import HydratedThreadClient from './thread-client'
+
+export default function HydratedThreadPage() {
+  return (
+    <>
+      <Suspense fallback={<h1>Loading hydrated thread...</h1>}>
+        <HydratedThreadClient />
+      </Suspense>
+      <ul>
+        <li>
+          <Link href="/">Visit the home page</Link>
+        </li>
+        <li>
+          <LinkAccordion href="/hydrated/second">
+            Visit hydrated thread second
+          </LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/hydrated/third">
+            Visit hydrated thread third
+          </LinkAccordion>
+        </li>
+      </ul>
+    </>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/hydrated/[thread]/thread-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/hydrated/[thread]/thread-client.js
@@ -1,0 +1,9 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function HydratedThreadClient() {
+  const params = useParams()
+
+  return <h1>{params.thread}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/inbox/@modal/[thread]/modal-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/inbox/@modal/[thread]/modal-client.js
@@ -1,0 +1,9 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function InboxModalClient() {
+  const params = useParams()
+
+  return <p id="modal-thread">Modal {params.thread}</p>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/inbox/@modal/[thread]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/inbox/@modal/[thread]/page.js
@@ -1,0 +1,10 @@
+import { Suspense } from 'react'
+import InboxModalClient from './modal-client'
+
+export default function InboxModalPage() {
+  return (
+    <Suspense fallback={<p id="modal-thread">Loading modal...</p>}>
+      <InboxModalClient />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/inbox/@modal/default.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/inbox/@modal/default.js
@@ -1,0 +1,3 @@
+export default function InboxModalDefault() {
+  return <p id="modal-thread">No modal</p>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/inbox/[thread]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/inbox/[thread]/page.js
@@ -1,0 +1,18 @@
+import Link from 'next/link'
+import { Suspense } from 'react'
+import InboxThreadClient from './thread-client'
+
+export default function InboxThreadPage() {
+  return (
+    <>
+      <Suspense fallback={<h1>Loading inbox thread...</h1>}>
+        <InboxThreadClient />
+      </Suspense>
+      <ul>
+        <li>
+          <Link href="/inbox">Visit inbox index</Link>
+        </li>
+      </ul>
+    </>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/inbox/[thread]/thread-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/inbox/[thread]/thread-client.js
@@ -1,0 +1,9 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function InboxThreadClient() {
+  const params = useParams()
+
+  return <h1>{params.thread}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/inbox/layout.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/inbox/layout.js
@@ -1,0 +1,8 @@
+export default function InboxLayout({ children, modal }) {
+  return (
+    <main>
+      {children}
+      <section id="modal-slot">{modal}</section>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/inbox/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/inbox/page.js
@@ -1,0 +1,14 @@
+import Link from 'next/link'
+
+export default function InboxIndexPage() {
+  return (
+    <main>
+      <h1>Inbox</h1>
+      <ul>
+        <li>
+          <Link href="/inbox/thread-123">Visit inbox thread</Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/isolated/[slug]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/isolated/[slug]/page.js
@@ -1,0 +1,12 @@
+import { Suspense } from 'react'
+import IsolatedSlugClient from './slug-client'
+
+export default function Page() {
+  return (
+    <main>
+      <Suspense fallback={<h1>Loading isolated slug...</h1>}>
+        <IsolatedSlugClient />
+      </Suspense>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/isolated/[slug]/slug-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/isolated/[slug]/slug-client.js
@@ -1,0 +1,8 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function IsolatedSlugClient() {
+  const params = useParams()
+  return <h1>{params.slug}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/isolated/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/isolated/page.js
@@ -1,0 +1,26 @@
+import { LinkAccordion } from '../components/link-accordion'
+
+export default function Isolated() {
+  return (
+    <main>
+      <h1>Isolated</h1>
+      <ul>
+        <li>
+          <LinkAccordion href="/isolated/third" prefetch={true}>
+            prefetched isolated third page
+          </LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/isolated/fourth" prefetch={true}>
+            prefetched isolated fourth page
+          </LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/isolated/third/extra" prefetch={true}>
+            invalid isolated third page
+          </LinkAccordion>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/layout.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/not-found.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/not-found.js
@@ -1,0 +1,3 @@
+export default function NotFound() {
+  return <h1>My custom not found page</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/optional/[[...slug]]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/optional/[[...slug]]/page.js
@@ -1,0 +1,18 @@
+import Link from 'next/link'
+import { Suspense } from 'react'
+import OptionalSlugClient from './slug-client'
+
+export default function OptionalCatchAllPage() {
+  return (
+    <main>
+      <Suspense fallback={<h1>Loading optional...</h1>}>
+        <OptionalSlugClient />
+      </Suspense>
+      <ul>
+        <li>
+          <Link href="/optional/deep/path">Visit optional deep path</Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/optional/[[...slug]]/slug-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/optional/[[...slug]]/slug-client.js
@@ -1,0 +1,10 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function OptionalSlugClient() {
+  const params = useParams()
+  const slug = params.slug
+
+  return <h1>{Array.isArray(slug) ? slug.join('/') : 'optional index'}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/org/[org]/chat/[thread]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/org/[org]/chat/[thread]/page.js
@@ -1,0 +1,23 @@
+import Link from 'next/link'
+import { Suspense } from 'react'
+import OrgThreadClient from './thread-client'
+
+export default function OrgThreadPage() {
+  return (
+    <>
+      <Suspense fallback={<h1>Loading org thread...</h1>}>
+        <OrgThreadClient />
+      </Suspense>
+      <ul>
+        <li>
+          <Link href="/org">Visit org index</Link>
+        </li>
+        <li>
+          <Link href="/org/acme/chat/thread-456">
+            Visit org chat thread 456
+          </Link>
+        </li>
+      </ul>
+    </>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/org/[org]/chat/[thread]/thread-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/org/[org]/chat/[thread]/thread-client.js
@@ -1,0 +1,13 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function OrgThreadClient() {
+  const params = useParams()
+
+  return (
+    <h1>
+      {params.org}:{params.thread}
+    </h1>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/org/[org]/layout.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/org/[org]/layout.js
@@ -1,0 +1,13 @@
+import { Suspense } from 'react'
+import OrgClient from './org-client'
+
+export default function OrgLayout({ children }) {
+  return (
+    <main>
+      <Suspense fallback={<p id="org-name">Loading org...</p>}>
+        <OrgClient />
+      </Suspense>
+      {children}
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/org/[org]/org-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/org/[org]/org-client.js
@@ -1,0 +1,9 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function OrgClient() {
+  const params = useParams()
+
+  return <p id="org-name">Org {params.org}</p>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/org/layout.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/org/layout.js
@@ -1,0 +1,8 @@
+export default function OrgSectionLayout({ children }) {
+  return (
+    <section>
+      <p id="org-section">Org section layout</p>
+      {children}
+    </section>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/org/not-found.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/org/not-found.js
@@ -1,0 +1,16 @@
+import Link from 'next/link'
+
+export default function OrgNotFound() {
+  return (
+    <main>
+      <h1>Org section not found</h1>
+      <ul>
+        <li>
+          <Link href="/org/acme/missing-two">
+            Visit another missing org route
+          </Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/org/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/org/page.js
@@ -1,0 +1,19 @@
+import Link from 'next/link'
+
+export default function OrgIndexPage() {
+  return (
+    <main>
+      <h1>Org index</h1>
+      <ul>
+        <li>
+          <Link href="/org/acme/chat/thread-123">
+            Visit org chat thread 123
+          </Link>
+        </li>
+        <li>
+          <Link href="/org/acme/missing-one">Visit missing org route</Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/app/page.js
@@ -1,0 +1,14 @@
+import Link from 'next/link'
+
+export default function Home() {
+  return (
+    <main>
+      <h1>Home</h1>
+      <ul>
+        <li>
+          <Link href="/hydrated/first">Visit hydrated thread first</Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/next.config.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-cache-components/next.config.js
@@ -1,0 +1,12 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  output: 'export',
+  trailingSlash: true,
+  cacheComponents: true,
+  experimental: {
+    outputExportDynamicFallbacks: true,
+    optimisticRouting: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/app/docs/[...slug]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/app/docs/[...slug]/page.js
@@ -1,0 +1,12 @@
+import { Suspense } from 'react'
+import DocsCatchAllClient from './slug-client'
+
+export default function DocsCatchAllPage() {
+  return (
+    <main>
+      <Suspense fallback={<h1>Loading docs catch-all...</h1>}>
+        <DocsCatchAllClient />
+      </Suspense>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/app/docs/[...slug]/slug-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/app/docs/[...slug]/slug-client.js
@@ -1,0 +1,15 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function DocsCatchAllClient() {
+  const params = useParams()
+
+  return (
+    <h1>
+      {Array.isArray(params.slug)
+        ? `catchall:${params.slug.join('/')}`
+        : 'catchall:missing'}
+    </h1>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/app/docs/[section]/[page]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/app/docs/[section]/[page]/page.js
@@ -1,0 +1,16 @@
+import { Suspense } from 'react'
+import DocsSectionPageClient from './params-client'
+
+export function generateStaticParams() {
+  return [{ section: 'api', page: 'reference' }]
+}
+
+export default function DocsSectionPage() {
+  return (
+    <main>
+      <Suspense fallback={<h1>Loading docs section page...</h1>}>
+        <DocsSectionPageClient />
+      </Suspense>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/app/docs/[section]/[page]/params-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/app/docs/[section]/[page]/params-client.js
@@ -1,0 +1,13 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function DocsSectionPageClient() {
+  const params = useParams()
+
+  return (
+    <h1>
+      {params.section}:{params.page}
+    </h1>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/app/docs/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/app/docs/page.js
@@ -1,0 +1,3 @@
+export default function DocsIndexPage() {
+  return <h1>Docs</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/app/layout.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/app/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/app/page.js
@@ -1,0 +1,10 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <main>
+      <h1>Home</h1>
+      <Link href="/docs/guides/export/fallback">Visit docs fallback route</Link>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/next.config.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-conflict/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  output: 'export',
+  cacheComponents: true,
+  experimental: {
+    outputExportDynamicFallbacks: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-internal-path-conflict/app/docs/[...slug]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-internal-path-conflict/app/docs/[...slug]/page.js
@@ -1,0 +1,12 @@
+import { Suspense } from 'react'
+import DocsCatchAllClient from './slug-client'
+
+export default function DocsCatchAllPage() {
+  return (
+    <main>
+      <Suspense fallback={<h1>Loading docs catch-all...</h1>}>
+        <DocsCatchAllClient />
+      </Suspense>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-internal-path-conflict/app/docs/[...slug]/slug-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-internal-path-conflict/app/docs/[...slug]/slug-client.js
@@ -1,0 +1,8 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function DocsCatchAllClient() {
+  const { slug } = useParams()
+  return <h1>{`catchall:${slug.join('/')}`}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-internal-path-conflict/app/docs/[section]/[page]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-internal-path-conflict/app/docs/[section]/[page]/page.js
@@ -1,0 +1,16 @@
+import { Suspense } from 'react'
+import DocsSectionPageClient from './params-client'
+
+export function generateStaticParams() {
+  return [{ section: 'api', page: 'reference' }]
+}
+
+export default function DocsSectionPage() {
+  return (
+    <main>
+      <Suspense fallback={<h1>Loading docs section page...</h1>}>
+        <DocsSectionPageClient />
+      </Suspense>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-internal-path-conflict/app/docs/[section]/[page]/params-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-internal-path-conflict/app/docs/[section]/[page]/params-client.js
@@ -1,0 +1,8 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function DocsSectionPageClient() {
+  const { section, page } = useParams()
+  return <h1>{`${section}:${page}`}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-internal-path-conflict/app/docs/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-internal-path-conflict/app/docs/page.js
@@ -1,0 +1,3 @@
+export default function DocsPage() {
+  return <p>docs</p>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-internal-path-conflict/app/layout.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-internal-path-conflict/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-internal-path-conflict/app/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-internal-path-conflict/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>home</p>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-internal-path-conflict/next.config.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-internal-path-conflict/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  output: 'export',
+  cacheComponents: true,
+  experimental: {
+    outputExportDynamicFallbacks: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-internal-path-conflict/public/docs/__fallback/__route_0.html
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-internal-path-conflict/public/docs/__fallback/__route_0.html
@@ -1,0 +1,1 @@
+reserved fallback variant path

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/another/[slug]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/another/[slug]/page.js
@@ -1,0 +1,25 @@
+import Link from 'next/link'
+import { Suspense } from 'react'
+import SlugClient from './slug-client'
+
+export function generateStaticParams() {
+  return [{ slug: 'first' }, { slug: 'second' }]
+}
+
+export default function Page() {
+  return (
+    <main>
+      <Suspense fallback={<h1>Loading slug...</h1>}>
+        <SlugClient />
+      </Suspense>
+      <ul>
+        <li>
+          <Link href="/another">Visit another page</Link>
+        </li>
+        <li>
+          <Link href="/another/third">Visit another third (fallback)</Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/another/[slug]/slug-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/another/[slug]/slug-client.js
@@ -1,0 +1,9 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function SlugClient() {
+  const params = useParams()
+
+  return <h1>{params.slug}</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/another/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/another/page.js
@@ -1,0 +1,26 @@
+import Link from 'next/link'
+
+export default function Another() {
+  return (
+    <main>
+      <h1>Another</h1>
+      <ul>
+        <li>
+          <Link href="/">Visit the home page</Link>
+        </li>
+        <li>
+          <Link href="/another">another page</Link>
+        </li>
+        <li>
+          <Link href="/another/first">another first page</Link>
+        </li>
+        <li>
+          <Link href="/another/second">another second page</Link>
+        </li>
+        <li>
+          <Link href="/another/third">another third page</Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/layout.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/not-found.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/not-found.js
@@ -1,0 +1,3 @@
+export default function NotFound() {
+  return <h1>My custom not found page</h1>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/org/[org]/chat/[thread]/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/org/[org]/chat/[thread]/page.js
@@ -1,0 +1,30 @@
+import Link from 'next/link'
+import { Suspense } from 'react'
+import OrgThreadClient from './thread-client'
+
+export function generateStaticParams() {
+  return [
+    { org: 'acme', thread: 'thread-123' },
+    { org: 'acme', thread: 'thread-456' },
+  ]
+}
+
+export default function OrgThreadPage() {
+  return (
+    <>
+      <Suspense fallback={<h1>Loading org thread...</h1>}>
+        <OrgThreadClient />
+      </Suspense>
+      <ul>
+        <li>
+          <Link href="/org">Visit org index</Link>
+        </li>
+        <li>
+          <Link href="/org/acme/chat/thread-789">
+            Visit fallback org chat thread
+          </Link>
+        </li>
+      </ul>
+    </>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/org/[org]/chat/[thread]/thread-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/org/[org]/chat/[thread]/thread-client.js
@@ -1,0 +1,13 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function OrgThreadClient() {
+  const params = useParams()
+
+  return (
+    <h1>
+      {params.org}:{params.thread}
+    </h1>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/org/[org]/layout.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/org/[org]/layout.js
@@ -1,0 +1,13 @@
+import { Suspense } from 'react'
+import OrgClient from './org-client'
+
+export default function OrgLayout({ children }) {
+  return (
+    <main>
+      <Suspense fallback={<p id="org-name">Loading org...</p>}>
+        <OrgClient />
+      </Suspense>
+      {children}
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/org/[org]/org-client.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/org/[org]/org-client.js
@@ -1,0 +1,9 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function OrgClient() {
+  const params = useParams()
+
+  return <p id="org-name">Org {params.org}</p>
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/org/page.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/app/org/page.js
@@ -1,0 +1,21 @@
+import Link from 'next/link'
+
+export default function OrgIndexPage() {
+  return (
+    <main>
+      <h1>Org index</h1>
+      <ul>
+        <li>
+          <Link href="/org/acme/chat/thread-123">
+            Visit known org chat thread
+          </Link>
+        </li>
+        <li>
+          <Link href="/org/acme/chat/thread-789">
+            Visit fallback org chat thread
+          </Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/next.config.js
+++ b/test/e2e/app-dir-export/fixtures/dynamic-fallback-known-params-cache-components/next.config.js
@@ -1,0 +1,11 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  output: 'export',
+  trailingSlash: true,
+  cacheComponents: true,
+  experimental: {
+    outputExportDynamicFallbacks: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir-export/test/dynamic-fallback-cache-components-basepath.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-fallback-cache-components-basepath.test.ts
@@ -1,0 +1,112 @@
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+import webdriver from 'next-webdriver'
+import { buildAndStartOutputExportServer } from './utils'
+
+const { next, skipped, isNextDev } = nextTestSetup({
+  files: join(__dirname, '..', 'fixtures', 'dynamic-fallback-cache-components'),
+  skipDeployment: true,
+  skipStart: true,
+  disableAutoSkewProtection: true,
+})
+
+if (skipped) {
+  describe.skip('app dir - output export dynamic routes with Cache Components and basePath', () => {})
+} else {
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  describeProduction(
+    'app dir - output export dynamic routes with Cache Components and basePath',
+    () => {
+      let port: number
+      let stopOrKill: (() => Promise<void>) | undefined
+      let getRequests: () => string[]
+      let clearRequests: () => void
+
+      beforeAll(async () => {
+        await next.patchFile('next.config.js', (content) =>
+          content.replace(
+            'cacheComponents: true,',
+            "cacheComponents: true,\n  basePath: '/base',"
+          )
+        )
+        ;({ port, stopOrKill, getRequests, clearRequests } =
+          await buildAndStartOutputExportServer(next, {
+            basePath: '/base',
+            useFallbackDocument: true,
+          }))
+      })
+
+      afterAll(async () => {
+        await stopOrKill?.()
+        await next.destroy()
+      })
+
+      it('renders an unenumerated dynamic route after removing basePath from fallback params', async () => {
+        const browser = await webdriver(port, '/base/another/third/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('third')
+            expect(await browser.eval('window.location.pathname')).toBe(
+              '/base/another/third/'
+            )
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('client navigates to an unenumerated dynamic route under the basePath', async () => {
+        const browser = await webdriver(port, '/base/another/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('Another')
+            expect(await browser.eval('window.location.pathname')).toBe(
+              '/base/another/'
+            )
+          })
+
+          await browser.elementByCss('a[href^="/base/another/third"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('third')
+            expect(await browser.eval('window.location.pathname')).toBe(
+              '/base/another/third/'
+            )
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('keeps unmatched fallback not-found fetches under the basePath', async () => {
+        clearRequests()
+        const browser = await webdriver(port, '/base/missing/route/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'My custom not found page'
+            )
+          })
+
+          const requests = getRequests()
+          expect(
+            requests.some((requestPath) =>
+              requestPath.startsWith('/base/_not-found/index.txt')
+            )
+          ).toBe(true)
+          expect(
+            requests.some((requestPath) =>
+              requestPath.startsWith('/_not-found.txt')
+            )
+          ).toBe(false)
+        } finally {
+          await browser.close()
+        }
+      })
+    }
+  )
+}

--- a/test/e2e/app-dir-export/test/dynamic-fallback-cache-components-flat.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-fallback-cache-components-flat.test.ts
@@ -1,0 +1,121 @@
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+import webdriver from 'next-webdriver'
+import fs from 'fs-extra'
+import { buildAndStartOutputExportServer } from './utils'
+
+const { next, skipped, isNextDev } = nextTestSetup({
+  files: join(__dirname, '..', 'fixtures', 'dynamic-fallback-cache-components'),
+  skipDeployment: true,
+  skipStart: true,
+  disableAutoSkewProtection: true,
+})
+
+if (skipped) {
+  it('skips unsupported mode', () => {})
+} else {
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  describeProduction(
+    'app dir - output export dynamic routes with Cache Components without trailing slashes',
+    () => {
+      let port: number
+      let stopOrKill: (() => Promise<void>) | undefined
+
+      beforeAll(async () => {
+        await next.patchFile('next.config.js', (content) =>
+          content
+            .replace('trailingSlash: true,', 'trailingSlash: false,')
+            .replace('    optimisticRouting: true,\n', '')
+        )
+        ;({ port, stopOrKill } = await buildAndStartOutputExportServer(next, {
+          useFallbackDocument: true,
+        }))
+      })
+
+      afterAll(async () => {
+        if (stopOrKill) {
+          await stopOrKill()
+        }
+        await next.destroy()
+      })
+
+      it('writes flat fallback artifacts for trailingSlash false', async () => {
+        const outDir = join(next.testDir, 'out')
+
+        expect(await fs.pathExists(join(outDir, '_fallback.html'))).toBe(true)
+        expect(
+          await fs.pathExists(join(outDir, 'another', '__fallback.html'))
+        ).toBe(true)
+        expect(
+          await fs.pathExists(join(outDir, 'another', '__fallback.txt'))
+        ).toBe(true)
+        expect(await fs.pathExists(join(outDir, 'org', '__fallback.txt'))).toBe(
+          true
+        )
+        expect(
+          await fs.pathExists(
+            join(outDir, 'another', '__fallback', 'index.html')
+          )
+        ).toBe(false)
+      })
+
+      it('renders an unenumerated slug on hard load and client navigation without adding a trailing slash', async () => {
+        const browser = await webdriver(port, '/another/third')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('third')
+            expect(await browser.eval('window.location.pathname')).toBe(
+              '/another/third'
+            )
+          })
+
+          await browser.elementByCss('a[href="/another"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('Another')
+            expect(await browser.eval('window.location.pathname')).toBe(
+              '/another'
+            )
+          })
+
+          await browser.elementByCss('a[href="/another/third"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('third')
+            expect(await browser.eval('window.location.pathname')).toBe(
+              '/another/third'
+            )
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('preserves search params and hash for nested fallback routes without trailing slashes', async () => {
+        const browser = await webdriver(
+          port,
+          '/org/umbrella/chat/thread-flat?view=full#messages'
+        )
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('#org-name').text()).toBe(
+              'Org umbrella'
+            )
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'umbrella:thread-flat'
+            )
+            expect(
+              await browser.eval(
+                'window.location.pathname + window.location.search + window.location.hash'
+              )
+            ).toBe('/org/umbrella/chat/thread-flat?view=full#messages')
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+    }
+  )
+}

--- a/test/e2e/app-dir-export/test/dynamic-fallback-cache-components.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-fallback-cache-components.test.ts
@@ -1,0 +1,380 @@
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+import webdriver from 'next-webdriver'
+import type * as Playwright from 'playwright'
+import { createRouterAct } from 'router-act'
+import fs from 'fs-extra'
+import { buildAndStartOutputExportServer } from './utils'
+
+const { next, skipped, isNextDev } = nextTestSetup({
+  files: join(__dirname, '..', 'fixtures', 'dynamic-fallback-cache-components'),
+  skipDeployment: true,
+  skipStart: true,
+  disableAutoSkewProtection: true,
+})
+
+if (skipped) {
+  it('skips unsupported mode', () => {})
+} else {
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  describeProduction(
+    'app dir - output export dynamic routes with Cache Components',
+    () => {
+      let port: number
+      let stopOrKill: (() => Promise<void>) | undefined
+      let getRequests: () => string[]
+      let clearRequests: () => void
+
+      beforeAll(async () => {
+        ;({ port, stopOrKill, getRequests, clearRequests } =
+          await buildAndStartOutputExportServer(next, {
+            useFallbackDocument: true,
+          }))
+      })
+
+      afterAll(async () => {
+        if (stopOrKill) {
+          await stopOrKill()
+        }
+        await next.destroy()
+      })
+
+      it('writes fallback artifacts instead of per-param prerenders', async () => {
+        const outDir = join(next.testDir, 'out')
+
+        expect(await fs.pathExists(join(outDir, '_fallback.html'))).toBe(true)
+        expect(
+          await fs.readFile(join(outDir, '_fallback.html'), 'utf8')
+        ).toContain('__NEXT_EXPORT_FALLBACK=1')
+        expect(
+          await fs.pathExists(
+            join(outDir, 'another', '__fallback', 'index.html')
+          )
+        ).toBe(true)
+        expect(
+          await fs.pathExists(
+            join(outDir, 'another', '__fallback', 'index.txt')
+          )
+        ).toBe(true)
+        expect(
+          await fs.pathExists(join(outDir, 'another', 'first', 'index.html'))
+        ).toBe(false)
+      })
+
+      it('renders an unenumerated slug on hard load and client navigation', async () => {
+        clearRequests()
+        const browser = await webdriver(port, '/another/third/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('third')
+          })
+
+          expect(
+            getRequests().some((requestPath) =>
+              requestPath.startsWith('/another/__fallback/index.html')
+            )
+          ).toBe(false)
+
+          await browser.elementByCss('a[href="/another/"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('Another')
+          })
+
+          await browser.elementByCss('a[href="/another/third/"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('third')
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('prefetches fallback payloads for unknown-param links before navigation', async () => {
+        let act!: ReturnType<typeof createRouterAct>
+        const browser = await webdriver(port, '/isolated/', {
+          beforePageLoad(page: Playwright.Page) {
+            act = createRouterAct(page)
+          },
+        })
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('Isolated')
+          })
+
+          await act(async () => {
+            const toggle = await browser.elementByCss(
+              'input[data-link-accordion="/isolated/third"]'
+            )
+            await toggle.click()
+          })
+
+          clearRequests()
+
+          await browser
+            .elementByCss('a[data-accordion-link="/isolated/third"]')
+            .click()
+
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('third')
+          })
+
+          const clickRequests = getRequests()
+          expect(
+            clickRequests.some((requestPath) =>
+              requestPath.startsWith('/isolated/__fallback.meta.json')
+            )
+          ).toBe(false)
+          expect(
+            clickRequests.some((requestPath) =>
+              requestPath.startsWith('/isolated/__fallback/index.txt')
+            )
+          ).toBe(false)
+          expect(
+            clickRequests.some((requestPath) =>
+              requestPath.startsWith('/isolated/third/index.txt')
+            )
+          ).toBe(false)
+          expect(
+            clickRequests.some((requestPath) =>
+              requestPath.startsWith('/isolated/third/__next.')
+            )
+          ).toBe(false)
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('reuses a learned fallback route for sibling unknown-param prefetches', async () => {
+        let act!: ReturnType<typeof createRouterAct>
+        const browser = await webdriver(port, '/isolated/', {
+          beforePageLoad(page: Playwright.Page) {
+            act = createRouterAct(page)
+          },
+        })
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('Isolated')
+          })
+
+          clearRequests()
+
+          await act(async () => {
+            await browser
+              .elementByCss('input[data-link-accordion="/isolated/third"]')
+              .click()
+          })
+
+          const learnedRouteRequests = getRequests()
+          expect(
+            learnedRouteRequests.filter((requestPath) =>
+              requestPath.startsWith('/isolated/__fallback/index.txt')
+            )
+          ).toHaveLength(1)
+          expect(
+            learnedRouteRequests.some((requestPath) =>
+              requestPath.startsWith('/isolated/third/index.txt')
+            )
+          ).toBe(false)
+
+          clearRequests()
+
+          await browser
+            .elementByCss('input[data-link-accordion="/isolated/fourth"]')
+            .click()
+          await retry(async () => {
+            expect(
+              await browser
+                .elementByCss('a[data-accordion-link="/isolated/fourth"]')
+                .text()
+            ).toBe('prefetched isolated fourth page')
+          })
+          await browser
+            .elementByCss('a[data-accordion-link="/isolated/fourth"]')
+            .click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('fourth')
+          })
+
+          const siblingRequests = getRequests()
+          expect(
+            siblingRequests.some(
+              (requestPath) =>
+                requestPath.startsWith('/isolated/__fallback/index.txt') ||
+                requestPath.startsWith('/isolated/third/index.txt') ||
+                requestPath.startsWith('/isolated/fourth/index.txt')
+            )
+          ).toBe(false)
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('renders the app not-found page when no fallback route matches', async () => {
+        const browser = await webdriver(port, '/missing/route/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'My custom not found page'
+            )
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('renders not-found for a prefetched invalid fallback route shape', async () => {
+        let act!: ReturnType<typeof createRouterAct>
+        const browser = await webdriver(port, '/isolated/', {
+          beforePageLoad(page: Playwright.Page) {
+            act = createRouterAct(page)
+          },
+        })
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('Isolated')
+          })
+
+          await act(async () => {
+            const toggle = await browser.elementByCss(
+              'input[data-link-accordion="/isolated/third/extra"]'
+            )
+            await toggle.click()
+          })
+
+          const prefetchRequests = getRequests()
+          expect(
+            prefetchRequests.some((requestPath) =>
+              requestPath.startsWith('/isolated/__fallback/index.txt')
+            )
+          ).toBe(true)
+
+          clearRequests()
+
+          await browser
+            .elementByCss('a[data-accordion-link="/isolated/third/extra"]')
+            .click()
+
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'My custom not found page'
+            )
+          })
+
+          const clickRequests = getRequests()
+          expect(
+            clickRequests.some((requestPath) =>
+              requestPath.startsWith('/_not-found/index.txt')
+            )
+          ).toBe(true)
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('generates _fallback.html from a PPR shell instead of index.html', async () => {
+        const outDir = join(next.testDir, 'out')
+        const fallbackHtml = await fs.readFile(
+          join(outDir, '_fallback.html'),
+          'utf8'
+        )
+
+        expect(fallbackHtml).toContain('__NEXT_EXPORT_FALLBACK=1')
+        expect(fallbackHtml).not.toContain('>Home<')
+        expect(fallbackHtml).toContain('__next-export-fallback-style')
+      })
+
+      it('supports browser back/forward between fallback routes', async () => {
+        const browser = await webdriver(port, '/another/slug-a/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('slug-a')
+          })
+
+          await browser.elementByCss('a[href="/another/"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('Another')
+          })
+
+          await browser.back()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('slug-a')
+          })
+
+          await browser.forward()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('Another')
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('handles consecutive hard navigations to different params', async () => {
+        const browser = await webdriver(port, '/another/param-one/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('param-one')
+          })
+
+          await browser.get(`http://localhost:${port}/another/param-two/`)
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('param-two')
+          })
+
+          await browser.get(`http://localhost:${port}/another/param-three/`)
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('param-three')
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('preserves search params and hash across fallback hard loads', async () => {
+        const browser = await webdriver(
+          port,
+          '/another/query-param/?tab=notes#anchor'
+        )
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('query-param')
+            expect(
+              await browser.eval(
+                'window.location.pathname + window.location.search + window.location.hash'
+              )
+            ).toBe('/another/query-param/?tab=notes#anchor')
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('does not leave fallback shell UI after hard load of a fallback route', async () => {
+        const browser = await webdriver(port, '/another/suspense-test/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'suspense-test'
+            )
+          })
+
+          const html = await browser.eval('document.documentElement.innerHTML')
+          expect(html).not.toContain('Loading slug...')
+        } finally {
+          await browser.close()
+        }
+      })
+    }
+  )
+}

--- a/test/e2e/app-dir-export/test/dynamic-fallback-conflict.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-fallback-conflict.test.ts
@@ -1,0 +1,155 @@
+import { join } from 'path'
+import fs from 'fs-extra'
+import { nextTestSetup } from 'e2e-utils'
+import webdriver from 'next-webdriver'
+import { retry } from 'next-test-utils'
+import { buildAndStartOutputExportServer } from './utils'
+
+describe('app dir - output export fallback conflicts', () => {
+  const { next, skipped } = nextTestSetup({
+    files: join(__dirname, '..', 'fixtures', 'dynamic-fallback-conflict'),
+    skipStart: true,
+    skipDeployment: true,
+    disableAutoSkewProtection: true,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  let port: number
+  let stopOrKill: (() => Promise<void>) | undefined
+  let getRequests: () => string[]
+  let clearRequests: () => void
+
+  beforeAll(async () => {
+    ;({ port, stopOrKill, getRequests, clearRequests } =
+      await buildAndStartOutputExportServer(next, {
+        useFallbackDocument: true,
+      }))
+  })
+
+  afterAll(async () => {
+    await stopOrKill?.()
+  })
+
+  it('emits route manifest and branch-specific fallback artifacts', async () => {
+    const outDir = join(next.testDir, 'out')
+    const manifestPath = join(outDir, 'docs', '__fallback.meta.json')
+    const knownSpecificParamExists =
+      (await fs.pathExists(
+        join(outDir, 'docs', 'api', 'reference', 'index.html')
+      )) || (await fs.pathExists(join(outDir, 'docs', 'api', 'reference.html')))
+    const unknownSpecificParamExists =
+      (await fs.pathExists(
+        join(outDir, 'docs', 'api', 'guide', 'index.html')
+      )) || (await fs.pathExists(join(outDir, 'docs', 'api', 'guide.html')))
+
+    expect(await fs.pathExists(join(outDir, '_fallback.html'))).toBe(true)
+    expect(await fs.pathExists(manifestPath)).toBe(true)
+    expect(knownSpecificParamExists).toBe(true)
+    expect(unknownSpecificParamExists).toBe(false)
+
+    const manifest = await fs.readJson(manifestPath)
+    expect(manifest).toEqual({
+      version: 1,
+      routes: [
+        {
+          route: '/docs/[section]/[page]',
+          fallbackPath: '/docs/__fallback/__route_0',
+        },
+        {
+          route: '/docs/[...slug]',
+          fallbackPath: '/docs/__fallback/__route_1',
+        },
+      ],
+    })
+
+    for (const entry of manifest.routes) {
+      const relativeFallbackPath = entry.fallbackPath.slice(1)
+      const hasBranchPayload =
+        (await fs.pathExists(join(outDir, `${relativeFallbackPath}.txt`))) ||
+        (await fs.pathExists(join(outDir, relativeFallbackPath, 'index.txt')))
+
+      expect(hasBranchPayload).toBe(true)
+    }
+  })
+
+  it('keeps known params prerendered while unknown params on the same branch fall back', async () => {
+    const browser = await webdriver(port, '/docs/api/reference/')
+
+    try {
+      await retry(async () => {
+        expect(await browser.elementByCss('h1').text()).toBe('api:reference')
+      })
+
+      await browser.get(`http://localhost:${port}/docs/api/guide/`)
+      await retry(async () => {
+        expect(await browser.elementByCss('h1').text()).toBe('api:guide')
+      })
+    } finally {
+      await browser.close()
+    }
+  })
+
+  it('prefers the more specific route when multiple fallback branches match', async () => {
+    clearRequests()
+    const browser = await webdriver(port, '/docs/api/guide/')
+
+    try {
+      await retry(async () => {
+        expect(await browser.elementByCss('h1').text()).toBe('api:guide')
+      })
+
+      expect(
+        getRequests().some((requestPath) =>
+          requestPath.startsWith('/docs/__fallback/__route_0.html')
+        )
+      ).toBe(false)
+    } finally {
+      await browser.close()
+    }
+  })
+
+  it('falls through to the catch-all branch when the specific route does not match', async () => {
+    const browser = await webdriver(port, '/docs/guides/export/fallback/')
+
+    try {
+      await retry(async () => {
+        expect(await browser.elementByCss('h1').text()).toBe(
+          'catchall:guides/export/fallback'
+        )
+      })
+    } finally {
+      await browser.close()
+    }
+  })
+})
+
+describe('app dir - output export fallback internal path collisions', () => {
+  const { next, skipped } = nextTestSetup({
+    files: join(
+      __dirname,
+      '..',
+      'fixtures',
+      'dynamic-fallback-internal-path-conflict'
+    ),
+    skipStart: true,
+    skipDeployment: true,
+    disableAutoSkewProtection: true,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  it('errors when a multi-route fallback artifact path is already occupied', async () => {
+    const { exitCode, cliOutput } = await next.build()
+
+    expect(exitCode).toBe(1)
+    expect(cliOutput).toContain(
+      'conflicts with the internal "__fallback" path used by dynamic route fallbacks in static export mode'
+    )
+    expect(cliOutput).toContain('/docs/__fallback/__route_0')
+  })
+})

--- a/test/e2e/app-dir-export/test/dynamic-fallback-known-params-cache-components.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-fallback-known-params-cache-components.test.ts
@@ -1,0 +1,188 @@
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+import webdriver from 'next-webdriver'
+import fs from 'fs-extra'
+import { buildAndStartOutputExportServer } from './utils'
+
+const { next, skipped, isNextDev } = nextTestSetup({
+  files: join(
+    __dirname,
+    '..',
+    'fixtures',
+    'dynamic-fallback-known-params-cache-components'
+  ),
+  skipDeployment: true,
+  skipStart: true,
+  disableAutoSkewProtection: true,
+})
+
+if (skipped) {
+  it('skips unsupported mode', () => {})
+} else {
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  describeProduction(
+    'app dir - output export dynamic routes with Cache Components and known prerenders',
+    () => {
+      let port: number
+      let stopOrKill: (() => Promise<void>) | undefined
+
+      beforeAll(async () => {
+        ;({ port, stopOrKill } = await buildAndStartOutputExportServer(next, {
+          useFallbackDocument: true,
+        }))
+      })
+
+      afterAll(async () => {
+        if (stopOrKill) {
+          await stopOrKill()
+        }
+        await next.destroy()
+      })
+
+      it('emits both prerendered known params and fallback artifacts', async () => {
+        const outDir = join(next.testDir, 'out')
+
+        expect(await fs.pathExists(join(outDir, '_fallback.html'))).toBe(true)
+        expect(
+          await fs.pathExists(
+            join(outDir, 'another', '__fallback', 'index.txt')
+          )
+        ).toBe(true)
+        expect(
+          await fs.pathExists(join(outDir, 'org', '__fallback', 'index.txt'))
+        ).toBe(true)
+        expect(
+          await fs.pathExists(join(outDir, 'another', 'first', 'index.html'))
+        ).toBe(true)
+        expect(
+          await fs.pathExists(join(outDir, 'another', 'second', 'index.html'))
+        ).toBe(true)
+        expect(
+          await fs.pathExists(join(outDir, 'another', 'third', 'index.html'))
+        ).toBe(false)
+        expect(
+          await fs.pathExists(
+            join(outDir, 'org', 'acme', 'chat', 'thread-123', 'index.html')
+          )
+        ).toBe(true)
+        expect(
+          await fs.pathExists(
+            join(outDir, 'org', 'acme', 'chat', 'thread-789', 'index.html')
+          )
+        ).toBe(false)
+      })
+
+      it('serves both prerendered and fallback params', async () => {
+        const browser = await webdriver(port, '/another/first/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('first')
+          })
+
+          await browser.get(`http://localhost:${port}/another/third/`)
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('third')
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('serves both prerendered and fallback params for nested dynamic routes', async () => {
+        const browser = await webdriver(port, '/org/acme/chat/thread-123/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('#org-name').text()).toBe(
+              'Org acme'
+            )
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'acme:thread-123'
+            )
+          })
+
+          await browser.get(
+            `http://localhost:${port}/org/acme/chat/thread-789/`
+          )
+          await retry(async () => {
+            expect(await browser.elementByCss('#org-name').text()).toBe(
+              'Org acme'
+            )
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'acme:thread-789'
+            )
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('client navigates from a prerendered page to a fallback route', async () => {
+        // Start on a prerendered page (known from generateStaticParams)
+        const browser = await webdriver(port, '/another/first/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('first')
+          })
+
+          // Client navigate to an unenumerated slug (fallback)
+          await browser.elementByCss('a[href="/another/third/"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('third')
+          })
+
+          // Navigate back to the prerendered page
+          await browser.elementByCss('a[href="/another/"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('Another')
+          })
+
+          // Navigate to a different prerendered page
+          await browser.elementByCss('a[href="/another/first/"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('first')
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('client navigates from a fallback route to a prerendered page', async () => {
+        // Start on a fallback route (not in generateStaticParams)
+        const browser = await webdriver(port, '/org/acme/chat/thread-789/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'acme:thread-789'
+            )
+          })
+
+          // Client navigate to a prerendered page (known from generateStaticParams)
+          await browser.elementByCss('a[href="/org/"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('Org index')
+          })
+
+          await browser
+            .elementByCss('a[href="/org/acme/chat/thread-123/"]')
+            .click()
+          await retry(async () => {
+            expect(await browser.elementByCss('#org-name').text()).toBe(
+              'Org acme'
+            )
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'acme:thread-123'
+            )
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+    }
+  )
+}

--- a/test/e2e/app-dir-export/test/dynamic-fallback-optimizations-cache-components.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-fallback-optimizations-cache-components.test.ts
@@ -1,0 +1,204 @@
+import { join } from 'path'
+import { createNext, isNextDeploy, isNextDev, NextInstance } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+import webdriver from 'next-webdriver'
+import type * as Playwright from 'playwright'
+import { createRouterAct } from 'router-act'
+import { buildAndStartOutputExportServer } from './utils'
+
+if (isNextDeploy) {
+  it('skips deploy mode', () => {})
+} else {
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  describeProduction(
+    'app dir - output export dynamic route optimizations with Cache Components',
+    () => {
+      let next: NextInstance
+      let port: number
+      let stopOrKill: (() => Promise<void>) | undefined
+      let getRequests: () => string[]
+      let clearRequests: () => void
+
+      beforeAll(async () => {
+        next = await createNext({
+          files: join(
+            __dirname,
+            '..',
+            'fixtures',
+            'dynamic-fallback-cache-components'
+          ),
+          skipStart: true,
+          disableAutoSkewProtection: true,
+        })
+        ;({ port, stopOrKill, getRequests, clearRequests } =
+          await buildAndStartOutputExportServer(next, {
+            useFallbackDocument: true,
+          }))
+      })
+
+      afterAll(async () => {
+        if (stopOrKill) {
+          await stopOrKill()
+        }
+        await next.destroy()
+      })
+
+      it('falls through from a concrete route-tree probe to the hydrated fallback tree', async () => {
+        let act!: ReturnType<typeof createRouterAct>
+        const browser = await webdriver(port, '/hydrated/first/', {
+          beforePageLoad(page: Playwright.Page) {
+            act = createRouterAct(page)
+          },
+        })
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('first')
+          })
+
+          await act(async () => {}, 'no-requests')
+          clearRequests()
+
+          await act(async () => {
+            await browser
+              .elementByCss('input[data-link-accordion="/hydrated/second"]')
+              .click()
+          })
+
+          const prefetchRequests = getRequests()
+
+          expect(prefetchRequests.length).toBeGreaterThan(0)
+          expect(
+            prefetchRequests.some((requestPath) =>
+              requestPath.startsWith('/hydrated/second/?_rsc=')
+            )
+          ).toBe(false)
+          expect(
+            prefetchRequests.some((requestPath) =>
+              requestPath.startsWith('/hydrated/second/index.txt')
+            )
+          ).toBe(false)
+          expect(
+            prefetchRequests.some((requestPath) =>
+              requestPath.startsWith('/hydrated/second/__fallback/index.txt')
+            )
+          ).toBe(true)
+          expect(
+            prefetchRequests.some((requestPath) =>
+              requestPath.startsWith('/hydrated/second/__fallback.meta.json')
+            )
+          ).toBe(true)
+          expect(
+            prefetchRequests.some((requestPath) =>
+              requestPath.startsWith('/hydrated/__fallback/__next.')
+            )
+          ).toBe(true)
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('reuses the same hydrated fallback tree endpoint across sibling prefetches', async () => {
+        let act!: ReturnType<typeof createRouterAct>
+        const browser = await webdriver(port, '/hydrated/first/', {
+          beforePageLoad(page: Playwright.Page) {
+            act = createRouterAct(page)
+          },
+        })
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('first')
+          })
+
+          clearRequests()
+
+          await act(async () => {
+            await browser
+              .elementByCss('input[data-link-accordion="/hydrated/second"]')
+              .click()
+            await browser
+              .elementByCss('input[data-link-accordion="/hydrated/third"]')
+              .click()
+          })
+
+          const prefetchRequests = getRequests()
+          const fallbackTreeRequests = prefetchRequests.filter((requestPath) =>
+            requestPath.startsWith('/hydrated/__fallback/__next.')
+          )
+
+          expect(
+            prefetchRequests.some((requestPath) =>
+              requestPath.startsWith('/hydrated/second/?_rsc=')
+            )
+          ).toBe(false)
+          expect(
+            prefetchRequests.some((requestPath) =>
+              requestPath.startsWith('/hydrated/third/?_rsc=')
+            )
+          ).toBe(false)
+          expect(
+            prefetchRequests.some((requestPath) =>
+              requestPath.startsWith('/hydrated/second/index.txt')
+            )
+          ).toBe(false)
+          expect(
+            prefetchRequests.some((requestPath) =>
+              requestPath.startsWith('/hydrated/third/index.txt')
+            )
+          ).toBe(false)
+          expect(fallbackTreeRequests.length).toBeGreaterThanOrEqual(1)
+          expect(
+            fallbackTreeRequests.every((requestPath) =>
+              requestPath.startsWith('/hydrated/__fallback/__next.')
+            )
+          ).toBe(true)
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('loads nested fallback routes without concrete route retries', async () => {
+        clearRequests()
+        const browser = await webdriver(port, '/org/umbrella/chat/thread-789/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('#org-name').text()).toBe(
+              'Org umbrella'
+            )
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'umbrella:thread-789'
+            )
+          })
+
+          const requests = getRequests()
+
+          expect(
+            requests.some((requestPath) =>
+              requestPath.startsWith('/org/umbrella/chat/thread-789/?_rsc=')
+            )
+          ).toBe(false)
+          expect(
+            requests.some((requestPath) =>
+              requestPath.startsWith('/org/__fallback.txt')
+            )
+          ).toBe(false)
+          expect(
+            requests.filter((requestPath) =>
+              requestPath.startsWith('/org/__fallback.meta.json')
+            )
+          ).toHaveLength(1)
+          expect(
+            requests.some((requestPath) =>
+              requestPath.startsWith('/org/__fallback/index.txt')
+            )
+          ).toBe(true)
+        } finally {
+          await browser.close()
+        }
+      })
+    }
+  )
+}

--- a/test/e2e/app-dir-export/test/dynamic-fallback-route-shapes-cache-components.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-fallback-route-shapes-cache-components.test.ts
@@ -1,0 +1,224 @@
+import { join } from 'path'
+import { createNext, isNextDeploy, isNextDev, NextInstance } from 'e2e-utils'
+import fs from 'fs-extra'
+import { retry } from 'next-test-utils'
+import webdriver from 'next-webdriver'
+import { buildAndStartOutputExportServer } from './utils'
+
+if (isNextDeploy) {
+  it('skips deploy mode', () => {})
+} else {
+  const describeProduction = isNextDev ? describe.skip : describe
+
+  describeProduction(
+    'app dir - output export fallback route shapes with Cache Components',
+    () => {
+      let next: NextInstance
+      let port: number
+      let stopOrKill: (() => Promise<void>) | undefined
+
+      beforeAll(async () => {
+        next = await createNext({
+          files: join(
+            __dirname,
+            '..',
+            'fixtures',
+            'dynamic-fallback-cache-components'
+          ),
+          skipStart: true,
+          disableAutoSkewProtection: true,
+        })
+        ;({ port, stopOrKill } = await buildAndStartOutputExportServer(next, {
+          useFallbackDocument: true,
+        }))
+      })
+
+      afterAll(async () => {
+        if (stopOrKill) {
+          await stopOrKill()
+        }
+        await next.destroy()
+      })
+
+      it('emits fallback artifacts for catch-all, optional, grouped, parallel, and nested multi-segment route shapes', async () => {
+        const outDir = join(next.testDir, 'out')
+
+        expect(
+          await fs.pathExists(join(outDir, 'docs', '__fallback', 'index.txt'))
+        ).toBe(true)
+        expect(
+          await fs.pathExists(
+            join(outDir, 'optional', '__fallback', 'index.txt')
+          )
+        ).toBe(true)
+        expect(
+          await fs.pathExists(
+            join(outDir, 'grouped', '__fallback', 'index.txt')
+          )
+        ).toBe(true)
+        expect(
+          await fs.pathExists(join(outDir, 'inbox', '__fallback', 'index.txt'))
+        ).toBe(true)
+        expect(
+          await fs.pathExists(join(outDir, 'org', '__fallback', 'index.txt'))
+        ).toBe(true)
+      })
+
+      it('renders catch-all fallback routes on hard load and client navigation', async () => {
+        const browser = await webdriver(port, '/docs/guides/export/fallback/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'guides/export/fallback'
+            )
+          })
+
+          await browser.elementByCss('a[href="/docs/"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('Docs')
+          })
+
+          await browser.eval('window.__routeShapeSentinel = 1')
+          await browser
+            .elementByCss('a[href="/docs/guides/export/fallback/"]')
+            .click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'guides/export/fallback'
+            )
+            expect(await browser.eval('window.__routeShapeSentinel')).toBe(1)
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('renders optional catch-all fallback routes for empty and nested params', async () => {
+        const browser = await webdriver(port, '/optional/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'optional index'
+            )
+          })
+
+          await browser.elementByCss('a[href="/optional/deep/path/"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('deep/path')
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('renders grouped dynamic fallback routes', async () => {
+        const browser = await webdriver(port, '/grouped/from-group/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('from-group')
+          })
+
+          await browser.elementByCss('a[href="/grouped/"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'Grouped index'
+            )
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('renders fallback params consistently across parallel routes', async () => {
+        const browser = await webdriver(port, '/inbox/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('Inbox')
+            expect(await browser.elementByCss('#modal-thread').text()).toBe(
+              'No modal'
+            )
+          })
+
+          await browser.elementByCss('a[href="/inbox/thread-123/"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('thread-123')
+            expect(await browser.elementByCss('#modal-thread').text()).toBe(
+              'Modal thread-123'
+            )
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+      it('renders nested fallback params across multiple dynamic segments with optimistic routing', async () => {
+        const browser = await webdriver(port, '/org/umbrella/chat/thread-789/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('#org-name').text()).toBe(
+              'Org umbrella'
+            )
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'umbrella:thread-789'
+            )
+          })
+
+          await browser.elementByCss('a[href="/org/"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('Org index')
+          })
+
+          await browser
+            .elementByCss('a[href="/org/acme/chat/thread-123/"]')
+            .click()
+          await retry(async () => {
+            expect(await browser.elementByCss('#org-name').text()).toBe(
+              'Org acme'
+            )
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'acme:thread-123'
+            )
+          })
+
+          await browser
+            .elementByCss('a[href="/org/acme/chat/thread-456/"]')
+            .click()
+          await retry(async () => {
+            expect(await browser.elementByCss('#org-name').text()).toBe(
+              'Org acme'
+            )
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'acme:thread-456'
+            )
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+
+      it('client navigates to the global not-found route instead of caching a mismatched fallback shell', async () => {
+        const browser = await webdriver(port, '/org/')
+
+        try {
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe('Org index')
+          })
+
+          await browser.elementByCss('a[href="/org/acme/missing-one/"]').click()
+          await retry(async () => {
+            expect(await browser.elementByCss('h1').text()).toBe(
+              'My custom not found page'
+            )
+            expect(await browser.hasElementByCss('#org-section')).toBe(false)
+          })
+        } finally {
+          await browser.close()
+        }
+      })
+    }
+  )
+}

--- a/test/e2e/app-dir-export/test/utils.ts
+++ b/test/e2e/app-dir-export/test/utils.ts
@@ -7,6 +7,7 @@ import globOrig from 'glob'
 import express from 'express'
 import http from 'http'
 import { createReadStream } from 'fs'
+import type { Socket } from 'net'
 import {
   waitForRedbox,
   getRedboxHeader,
@@ -57,7 +58,15 @@ export async function buildAndStartOutputExportServer(
 
   const app = express()
   const server = http.createServer(app)
+  const sockets = new Set<Socket>()
   const fallbackHtml = join(outDir, '_fallback.html')
+
+  server.on('connection', (socket) => {
+    sockets.add(socket)
+    socket.on('close', () => {
+      sockets.delete(socket)
+    })
+  })
 
   app.use((req, _res, nextHandler) => {
     requests.push(req.url || '/')
@@ -91,7 +100,10 @@ export async function buildAndStartOutputExportServer(
     port,
     getRequests,
     clearRequests,
-    stopOrKill: () => stopApp(server),
+    stopOrKill: async () => {
+      sockets.forEach((socket) => socket.destroy())
+      await stopApp(server)
+    },
   }
 }
 


### PR DESCRIPTION
This is PR 20 of 21 in the offline navigations plus output-export fallback stack.

This stack introduces a generated fallback entrypoint and then layers the client behavior on the existing App Router, cached navigations, optimistic routing, Cache Components, and Segment Cache primitives. The offline navigations chapter adds a managed service worker and persisted Segment Cache replay. The output-export chapter emits static fallback HTML/RSC artifacts so parameterized routes can load and navigate without enumerating every param at build time.

Review guide: https://gist.github.com/feedthejim/bb440153d29dce019d1d26b6643e2a48

## Where This Sits
This PR is in the output-export fallbacks chapter, after the offline fallback-entrypoint primitives are established.
Previous PR: #93774 `output export fallbacks: store fallback data in Segment Cache (19/21)`.
Next PR: #93752 `output export fallbacks: add docs and review guide (21/21)`.

## What Changes
- Widens coverage for generateStaticParams values, nested dynamic routes, basePath, flat output, and conflicting fallback branches.
- Verifies fallback artifacts coexist with fully prerendered known params.

## Reviewer Focus
- This PR should harden the matrix without changing the core architecture introduced earlier.
- basePath and flat output behavior should be explained where it is not locally obvious.

## Proof In This PR
- `test/e2e/app-dir-export/test/dynamic-fallback*.test.ts` covers known params, basePath, flat output, and branch conflicts.
- The full output-export dynamic fallback suite passed locally after autosquash.

Latest local stack verification after autosquash included:
- `git diff --check`
- `pnpm --filter=next types`
- `pnpm testonly packages/next/src/client/components/segment-cache/offline-navigation-cache.test.ts packages/next/src/client/components/segment-cache/cache.test.ts packages/next/src/client/output-export-fallback.test.ts packages/next/src/export/helpers/output-export-fallback.test.ts packages/next/src/lib/output-export-fallback-routes.test.ts packages/next/src/client/components/router-reducer/fetch-server-response.test.ts`
- `HEADLESS=true pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `HEADLESS=true pnpm test-start-turbo test/e2e/app-dir-export/test/dynamic-fallback*.test.ts`

## Deferred Coverage
Only docs and review-guide updates remain after this PR.

## Disabled-Flag Posture
All variant behavior still depends on the output-export fallback flag.

## Full Stack
1. [offline navigations: add gated build primitives (1/21)](https://github.com/vercel/next.js/pull/93736)
2. [offline navigations: generate fallback document artifacts (2/21)](https://github.com/vercel/next.js/pull/93737)
3. [offline navigations: register pass-through worker (3/21)](https://github.com/vercel/next.js/pull/93625)
4. [offline navigations: cache fallback and current-build assets (4/21)](https://github.com/vercel/next.js/pull/93626)
5. [offline navigations: serve fallback document offline (5/21)](https://github.com/vercel/next.js/pull/93627)
6. [offline navigations: add Segment Cache persistence primitives (6/21)](https://github.com/vercel/next.js/pull/93630)
7. [offline navigations: persist cached Segment Cache records (7/21)](https://github.com/vercel/next.js/pull/93640)
8. [offline navigations: bootstrap fallback from Segment Cache records (8/21)](https://github.com/vercel/next.js/pull/93644)
9. [offline navigations: support dynamic route patterns (9/21)](https://github.com/vercel/next.js/pull/93647)
10. [offline navigations: add docs and examples (10/21)](https://github.com/vercel/next.js/pull/93738)
11. [output export fallbacks: add gated build primitives (11/21)](https://github.com/vercel/next.js/pull/93744)
12. [output export fallbacks: emit fallback HTML artifacts (12/21)](https://github.com/vercel/next.js/pull/93745)
13. [output export fallbacks: emit fallback RSC artifacts (13/21)](https://github.com/vercel/next.js/pull/93746)
14. [output export fallbacks: enforce server-only boundaries (14/21)](https://github.com/vercel/next.js/pull/93747)
15. [output export fallbacks: bootstrap hard loads from artifacts (15/21)](https://github.com/vercel/next.js/pull/93748)
16. [output export fallbacks: resolve soft navigations through cached routes (16/21)](https://github.com/vercel/next.js/pull/93749)
17. [output export fallbacks: resolve fallback artifacts from route manifests (17/21)](https://github.com/vercel/next.js/pull/93779)
18. [output export fallbacks: validate fallback Flight responses (18/21)](https://github.com/vercel/next.js/pull/93750)
19. [output export fallbacks: store fallback data in Segment Cache (19/21)](https://github.com/vercel/next.js/pull/93774)
20. **Current PR:** [output export fallbacks: support known params and export variants (20/21)](https://github.com/vercel/next.js/pull/93751)
21. [output export fallbacks: add docs and review guide (21/21)](https://github.com/vercel/next.js/pull/93752)

<!-- NEXT_JS_LLM_PR -->
