### PR TITLE
output export fallbacks: add docs and review guide (21/21)

### DIFF
--- a/docs/01-app/02-guides/static-exports.mdx
+++ b/docs/01-app/02-guides/static-exports.mdx
@@ -146,6 +146,95 @@ export default function Page() {
 }
 ```
 
+### Dynamic Routes with Cache Components
+
+By default, a static export requires every App Router dynamic route to be known at build time through [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params). If you enable [Cache Components](/docs/app/api-reference/config/next-config-js/cacheComponents), you can also opt into experimental dynamic fallback artifacts for params that were not returned by `generateStaticParams`.
+
+```ts filename="next.config.ts" switcher
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  output: 'export',
+  cacheComponents: true,
+  experimental: {
+    outputExportDynamicFallbacks: true,
+  },
+}
+
+export default nextConfig
+```
+
+```js filename="next.config.js" switcher
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  output: 'export',
+  cacheComponents: true,
+  experimental: {
+    outputExportDynamicFallbacks: true,
+  },
+}
+
+module.exports = nextConfig
+```
+
+With `outputExportDynamicFallbacks`, `next build` writes fallback files for dynamic route shapes. A static host can serve regular exported files first, then serve `_fallback.html` for unmatched document requests. The client router uses the exported fallback data for hard loads and client-side navigations.
+
+This is useful when a route has many possible params, but the route can still render from static files and Client Components:
+
+```tsx filename="app/blog/[slug]/page.tsx" switcher
+import { Suspense } from 'react'
+import BlogPost from './blog-post'
+
+export default function Page() {
+  return (
+    <Suspense fallback={<p>Loading...</p>}>
+      <BlogPost />
+    </Suspense>
+  )
+}
+```
+
+```jsx filename="app/blog/[slug]/page.js" switcher
+import { Suspense } from 'react'
+import BlogPost from './blog-post'
+
+export default function Page() {
+  return (
+    <Suspense fallback={<p>Loading...</p>}>
+      <BlogPost />
+    </Suspense>
+  )
+}
+```
+
+```tsx filename="app/blog/[slug]/blog-post.tsx" switcher
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function BlogPost() {
+  const { slug } = useParams<{ slug: string }>()
+
+  return <h1>{slug}</h1>
+}
+```
+
+```jsx filename="app/blog/[slug]/blog-post.js" switcher
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function BlogPost() {
+  const { slug } = useParams()
+
+  return <h1>{slug}</h1>
+}
+```
+
+You can still return a subset of params from `generateStaticParams`. Those params are prerendered as regular files, while other params use the fallback files.
+
+For params that were not returned by `generateStaticParams`, Server Components cannot `await params`, because there is no server request to resolve those values during a static export. Read the params from Client Components with [`useParams`](/docs/app/api-reference/functions/use-params), or include the values in `generateStaticParams` when the Server Component needs them at build time.
+
 </AppOnly>
 
 <PagesOnly>
@@ -278,7 +367,7 @@ Features that require a Node.js server, or dynamic logic that cannot be computed
 <AppOnly>
 
 - [Dynamic Routes](/docs/app/api-reference/file-conventions/dynamic-routes) with `dynamicParams: true`
-- [Dynamic Routes](/docs/app/api-reference/file-conventions/dynamic-routes) without `generateStaticParams()`
+- [Dynamic Routes](/docs/app/api-reference/file-conventions/dynamic-routes) without `generateStaticParams()`, unless you enable experimental [`outputExportDynamicFallbacks`](/docs/app/api-reference/config/next-config-js/outputExportDynamicFallbacks) with Cache Components
 - [Route Handlers](/docs/app/api-reference/file-conventions/route) that rely on Request
 - [Cookies](/docs/app/api-reference/functions/cookies)
 - [Rewrites](/docs/app/api-reference/config/next-config-js/rewrites)
@@ -358,10 +447,34 @@ server {
 }
 ```
 
+If you use experimental `outputExportDynamicFallbacks`, serve exported files first, then rewrite unmatched document requests to `_fallback.html`. Missing assets should still return `404`, so adapt the rule to your static host:
+
+```nginx filename="nginx.conf"
+server {
+  listen 80;
+  server_name acme.com;
+
+  root /var/www/out;
+
+  location / {
+      try_files $uri $uri.html $uri/ @next_fallback;
+  }
+
+  location @next_fallback {
+      if ($http_accept !~* "text/html") {
+          return 404;
+      }
+
+      rewrite ^ /_fallback.html break;
+  }
+}
+```
+
 ## Version History
 
 | Version   | Changes                                                                                                              |
 | --------- | -------------------------------------------------------------------------------------------------------------------- |
+| `v16.3.0` | Experimental `outputExportDynamicFallbacks` support added for App Router static exports with Cache Components.       |
 | `v14.0.0` | `next export` has been removed in favor of `"output": "export"`                                                      |
 | `v13.4.0` | App Router (Stable) adds enhanced static export support, including using React Server Components and Route Handlers. |
 | `v13.3.0` | `next export` is deprecated and replaced with `"output": "export"`                                                   |

--- a/docs/01-app/03-api-reference/03-file-conventions/dynamic-routes.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/dynamic-routes.mdx
@@ -152,6 +152,8 @@ Without `generateStaticParams`, param values are unknown during prerendering, ma
 
 With `generateStaticParams`, you provide sample param values that can be used at build time. The build process validates that dynamic content and other runtime APIs are correctly handled, then generates static HTML files for the samples. Pages rendered with runtime params are saved to disk after a successful first request.
 
+Static export has different runtime behavior because there is no server request after the build. By default, dynamic params must be returned from `generateStaticParams`. For experimental fallback support with Cache Components, see [Static Exports](/docs/app/guides/static-exports#dynamic-routes-with-cache-components).
+
 The sections below demonstrate both patterns.
 
 #### Without `generateStaticParams`

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/outputExportDynamicFallbacks.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/outputExportDynamicFallbacks.mdx
@@ -1,0 +1,79 @@
+---
+title: outputExportDynamicFallbacks
+description: Enable dynamic route fallback files for static exports.
+version: experimental
+related:
+  title: Next Steps
+  description: Learn how dynamic fallbacks fit into static exports.
+  links:
+    - app/guides/static-exports
+    - app/api-reference/file-conventions/dynamic-routes
+    - app/api-reference/config/next-config-js/cacheComponents
+---
+
+`outputExportDynamicFallbacks` lets an App Router static export serve dynamic route params that were not returned by [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params), as long as the route can be represented by static fallback files and Client Components.
+
+```ts filename="next.config.ts" switcher
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  output: 'export',
+  cacheComponents: true,
+  experimental: {
+    outputExportDynamicFallbacks: true,
+  },
+}
+
+export default nextConfig
+```
+
+```js filename="next.config.js" switcher
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  output: 'export',
+  cacheComponents: true,
+  experimental: {
+    outputExportDynamicFallbacks: true,
+  },
+}
+
+module.exports = nextConfig
+```
+
+## Reference
+
+| Option                         | Type      | Default | Description                                                                 |
+| ------------------------------ | --------- | ------- | --------------------------------------------------------------------------- |
+| `outputExportDynamicFallbacks` | `boolean` | `false` | Emits static fallback files for App Router dynamic routes in static export. |
+
+## Requirements
+
+`outputExportDynamicFallbacks` requires:
+
+- [`output: 'export'`](/docs/app/guides/static-exports)
+- [`cacheComponents: true`](/docs/app/api-reference/config/next-config-js/cacheComponents)
+- App Router dynamic routes
+
+When this option is enabled, Next.js also configures the client router features needed to resolve fallback route data. You do not need to enable those separately.
+
+## Behavior
+
+During `next build`, Next.js emits:
+
+- regular static files for routes and params returned by `generateStaticParams`
+- fallback files for supported dynamic route shapes
+- a root `_fallback.html` document that a static host can serve for unmatched document requests
+
+On a hard load to an unenumerated dynamic URL, the static host serves `_fallback.html`, and the client router resolves the matching fallback route data. During client-side navigation, the router prefetches and reuses the same exported fallback data.
+
+## Limitations
+
+For params that were not returned by `generateStaticParams`, Server Components cannot `await params` during a static export. Use [`useParams`](/docs/app/api-reference/functions/use-params) in a Client Component, or return the param from `generateStaticParams` when the Server Component needs it at build time.
+
+Static export limitations still apply. Request-time server APIs, rewrites, redirects, Proxy, Server Actions, and default Image Optimization require a server and are not supported.
+
+## Version History
+
+| Version   | Changes                                        |
+| --------- | ---------------------------------------------- |
+| `v16.3.0` | `outputExportDynamicFallbacks` was introduced. |


### PR DESCRIPTION
This is PR 21 of 21 in the offline navigations plus output-export fallback stack.

This stack introduces a generated fallback entrypoint and then layers the client behavior on the existing App Router, cached navigations, optimistic routing, Cache Components, and Segment Cache primitives. The offline navigations chapter adds a managed service worker and persisted Segment Cache replay. The output-export chapter emits static fallback HTML/RSC artifacts so parameterized routes can load and navigate without enumerating every param at build time.

Review guide: https://gist.github.com/feedthejim/bb440153d29dce019d1d26b6643e2a48

## Where This Sits
This PR is in the output-export fallbacks chapter, after the offline fallback-entrypoint primitives are established.
Previous PR: #93751 `output export fallbacks: support known params and export variants (20/21)`.
Next PR: none, this is the top of the stack.

## What Changes
- Adds developer-facing docs for output-export fallback semantics.
- Adds the human review guide that maps the full offline plus output-export stack for reviewers.

## Reviewer Focus
- Docs should describe what developers perceive and how to reason about the feature, not internal plumbing.
- The review guide should help reviewers understand the stack without reading private chat history.

## Proof In This PR
- Docs and review guide were reviewed against the latest local stack verification.
- The full verification ladder covers focused unit tests, offline production e2e, and output-export dynamic fallback e2e.

Latest local stack verification after autosquash included:
- `git diff --check`
- `pnpm --filter=next types`
- `pnpm testonly packages/next/src/client/components/segment-cache/offline-navigation-cache.test.ts packages/next/src/client/components/segment-cache/cache.test.ts packages/next/src/client/output-export-fallback.test.ts packages/next/src/export/helpers/output-export-fallback.test.ts packages/next/src/lib/output-export-fallback-routes.test.ts packages/next/src/client/components/router-reducer/fetch-server-response.test.ts`
- `HEADLESS=true pnpm test-start-turbo test/production/app-dir/offline-navigations/offline-navigations.test.ts`
- `HEADLESS=true pnpm test-start-turbo test/e2e/app-dir-export/test/dynamic-fallback*.test.ts`

## Deferred Coverage
No feature behavior is intentionally deferred by this PR; remaining work is CI triage and reviewer feedback.

## Disabled-Flag Posture
Docs should keep the feature framed as experimental and opt-in unless the rollout plan changes.

## Full Stack
1. [offline navigations: add gated build primitives (1/21)](https://github.com/vercel/next.js/pull/93736)
2. [offline navigations: generate fallback document artifacts (2/21)](https://github.com/vercel/next.js/pull/93737)
3. [offline navigations: register pass-through worker (3/21)](https://github.com/vercel/next.js/pull/93625)
4. [offline navigations: cache fallback and current-build assets (4/21)](https://github.com/vercel/next.js/pull/93626)
5. [offline navigations: serve fallback document offline (5/21)](https://github.com/vercel/next.js/pull/93627)
6. [offline navigations: add Segment Cache persistence primitives (6/21)](https://github.com/vercel/next.js/pull/93630)
7. [offline navigations: persist cached Segment Cache records (7/21)](https://github.com/vercel/next.js/pull/93640)
8. [offline navigations: bootstrap fallback from Segment Cache records (8/21)](https://github.com/vercel/next.js/pull/93644)
9. [offline navigations: support dynamic route patterns (9/21)](https://github.com/vercel/next.js/pull/93647)
10. [offline navigations: add docs and examples (10/21)](https://github.com/vercel/next.js/pull/93738)
11. [output export fallbacks: add gated build primitives (11/21)](https://github.com/vercel/next.js/pull/93744)
12. [output export fallbacks: emit fallback HTML artifacts (12/21)](https://github.com/vercel/next.js/pull/93745)
13. [output export fallbacks: emit fallback RSC artifacts (13/21)](https://github.com/vercel/next.js/pull/93746)
14. [output export fallbacks: enforce server-only boundaries (14/21)](https://github.com/vercel/next.js/pull/93747)
15. [output export fallbacks: bootstrap hard loads from artifacts (15/21)](https://github.com/vercel/next.js/pull/93748)
16. [output export fallbacks: resolve soft navigations through cached routes (16/21)](https://github.com/vercel/next.js/pull/93749)
17. [output export fallbacks: resolve fallback artifacts from route manifests (17/21)](https://github.com/vercel/next.js/pull/93779)
18. [output export fallbacks: validate fallback Flight responses (18/21)](https://github.com/vercel/next.js/pull/93750)
19. [output export fallbacks: store fallback data in Segment Cache (19/21)](https://github.com/vercel/next.js/pull/93774)
20. [output export fallbacks: support known params and export variants (20/21)](https://github.com/vercel/next.js/pull/93751)
21. **Current PR:** [output export fallbacks: add docs and review guide (21/21)](https://github.com/vercel/next.js/pull/93752)

<!-- NEXT_JS_LLM_PR -->
