### PR TITLE
Add an info panel for the existing "Cache disabled" indicator

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/cache-disabled.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/cache-disabled.tsx
@@ -1,0 +1,21 @@
+import type { ComponentProps } from 'react'
+
+export function CacheDisabledBody(props: ComponentProps<'div'>) {
+  return (
+    <article className="dev-tools-info-article" {...props}>
+      <p className="dev-tools-info-paragraph">
+        While loading this page, all caches were bypassed.
+      </p>
+      <p className="dev-tools-info-paragraph">
+        This is the case when the cache was disabled in the browser's devtools,
+        the page was hard-reloaded, or draft mode is enabled.
+      </p>
+      <p className="dev-tools-info-paragraph">
+        As a result, the loading experience might not be the same as in
+        production. React's DevTools will also not accurately show information
+        about what would normally suspend in the page, and Next.js cannot
+        validate whether a navigation to this page would be instant or blocking.
+      </p>
+    </article>
+  )
+}

--- a/packages/next/src/next-devtools/dev-overlay/menu/context.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/menu/context.tsx
@@ -11,6 +11,8 @@ export type PanelStateKind =
   | 'segment-explorer'
   | 'panel-selector'
   | 'instant-navs'
+  | 'turbo-info'
+  | 'cache-disabled'
 
 export const PanelRouterContext = createContext<{
   panel: PanelStateKind | null

--- a/packages/next/src/next-devtools/dev-overlay/menu/panel-router.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/menu/panel-router.tsx
@@ -30,6 +30,7 @@ import { useUpdateAllPanelPositions } from '../components/devtools-indicator/dev
 import { saveDevToolsConfig } from '../utils/save-devtools-config'
 import { InstantNavsPanel } from '../components/instant-navs/instant-navs-panel'
 import './panel-router.css'
+import { CacheDisabledBody } from '../components/errors/dev-tools-indicator/dev-tools-info/cache-disabled'
 
 const MenuPanel = () => {
   const { setPanel, setSelectedIndex } = usePanelRouterContext()
@@ -117,6 +118,16 @@ const MenuPanel = () => {
               'data-instant-nav': true,
             },
           },
+        state.cacheIndicator === 'bypass' && {
+          title:
+            'Caching is currently disabled (bypassed). Click to learn more.',
+          label: 'Cache',
+          value: 'Disabled',
+          onClick: () => setPanel('cache-disabled'),
+          attributes: {
+            'data-cache-disabled': true,
+          },
+        },
         isAppRouter && {
           label: 'Route Info',
           value: <ChevronRight />,
@@ -271,6 +282,25 @@ export const PanelRouter = () => {
             header={<DevToolsHeader title="Instant Navs" />}
           >
             <InstantNavsPanel />
+          </DynamicPanel>
+        </PanelRoute>
+      )}
+
+      {state.cacheIndicator === 'bypass' && (
+        <PanelRoute name="cache-disabled">
+          <DynamicPanel
+            sharePanelSizeGlobally={false}
+            sizeConfig={{
+              kind: 'fixed',
+              height: 340 / state.scale,
+              width: 480 / state.scale,
+            }}
+            closeOnClickOutside
+            header={<DevToolsHeader title="Cache disabled" />}
+          >
+            <div className="panel-content">
+              <CacheDisabledBody />
+            </div>
           </DynamicPanel>
         </PanelRoute>
       )}

--- a/test/development/app-dir/cache-indicator/cache-indicator.test.ts
+++ b/test/development/app-dir/cache-indicator/cache-indicator.test.ts
@@ -163,6 +163,43 @@ describe('cache-indicator', () => {
       })
     })
 
+    it('opens cache-disabled info panel from the devtools menu', async () => {
+      const browser = await next.browser('/', {
+        extraHTTPHeaders: { 'cache-control': 'no-cache' },
+      })
+
+      await retry(async () => {
+        const hasCacheBypassBadge = await browser.hasElementByCss(
+          '[data-cache-bypass-badge]'
+        )
+        expect(hasCacheBypassBadge).toBe(true)
+      })
+
+      // Open the devtools menu via the cache-bypass badge (the regular
+      // indicator is hidden when caches are bypassed).
+      await browser
+        .elementByCss('[data-cache-bypass-badge] [data-issues-open]')
+        .click()
+
+      await retry(async () => {
+        const hasMenu = await browser.hasElementByCss('#nextjs-dev-tools-menu')
+        expect(hasMenu).toBe(true)
+      })
+
+      await browser.elementByCss('[data-cache-disabled]').click()
+
+      await retry(async () => {
+        const article = await browser.elementByCss('.dev-tools-info-article')
+        expect(await article.text()).toMatchInlineSnapshot(`
+         "While loading this page, all caches were bypassed.
+
+         This is the case when the cache was disabled in the browser's devtools, the page was hard-reloaded, or draft mode is enabled.
+
+         As a result, the loading experience might not be the same as in production. React's DevTools will also not accurately show information about what would normally suspend in the page, and Next.js cannot validate whether a navigation to this page would be instant or blocking."
+        `)
+      })
+    })
+
     it('can dismiss cache-bypassing badge', async () => {
       const browser = await next.browser('/', {
         extraHTTPHeaders: { 'cache-control': 'no-cache' },


### PR DESCRIPTION
The dev tools already showed an orange `Cache disabled` badge when caches were bypassed in development, but offered no explanation of what that meant or why it appeared. This adds a `Cache: Disabled` entry to the dev tools menu (also shown only when caches are bypassed) that opens an info panel. The panel explains the three triggers (the browser's "Disable cache" toggle, a hard reload, or draft mode), that the loading experience may differ from production, that React DevTools annotations will not accurately reflect what would normally suspend, and that Next.js cannot validate whether a navigation would be instant or blocking while caches are bypassed.

<img width="265" height="270" alt="Screenshot 2026-05-11 at 12 14 26" src="https://github.com/user-attachments/assets/f4ab5d25-7f20-487e-934c-dbbef7df3256" />

<img width="501" height="404" alt="Screenshot 2026-05-11 at 12 32 46" src="https://github.com/user-attachments/assets/79e434fa-02d0-40e9-9f51-a6b8ffa20dcb" />

closes NAR-467