### PR TITLE
docs: add next/root-params API reference

### DIFF
--- a/docs/01-app/02-guides/upgrading/version-16.mdx
+++ b/docs/01-app/02-guides/upgrading/version-16.mdx
@@ -1254,4 +1254,4 @@ For more on Cache Components, see [Migrating to Cache Components](/docs/app/guid
 
 ### `unstable_rootParams`
 
-The `unstable_rootParams` function has been removed. We are working on an alternative API that we will ship in an upcoming minor release.
+The `unstable_rootParams` function has been removed. Use [`next/root-params`](/docs/app/api-reference/functions/next-root-params) instead.

--- a/docs/01-app/03-api-reference/01-directives/use-cache.mdx
+++ b/docs/01-app/03-api-reference/01-directives/use-cache.mdx
@@ -96,6 +96,8 @@ async function Component({ userId }: { userId: string }) {
 
 In the snippet above, `userId` is captured from the outer scope and `filter` is passed as an argument, so both become part of the `getData` function's cache key. This means different user and filter combinations will have separate cache entries.
 
+> **Good to know:** When a cached function reads [root parameters](/docs/app/api-reference/functions/next-root-params), only the ones it actually reads become part of its cache key.
+
 ## Serialization
 
 Arguments to cached functions and their return values must be serializable.

--- a/docs/01-app/03-api-reference/03-file-conventions/dynamic-routes.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/dynamic-routes.mdx
@@ -41,6 +41,8 @@ Dynamic Segments are passed as the `params` prop to [`layout`](/docs/app/api-ref
 | `app/blog/[slug]/page.js` | `/blog/b`   | `{ slug: 'b' }` |
 | `app/blog/[slug]/page.js` | `/blog/c`   | `{ slug: 'c' }` |
 
+Dynamic segments that appear before the [root layout](/docs/app/api-reference/file-conventions/layout#root-layout) are **root parameters**, which can additionally be read from any Server Component with [`next/root-params`](/docs/app/api-reference/functions/next-root-params).
+
 ### In Client Components
 
 In a Client Component **page**, dynamic segments from props can be accessed using the [`use`](https://react.dev/reference/react/use) API.

--- a/docs/01-app/03-api-reference/03-file-conventions/layout.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/layout.mdx
@@ -143,7 +143,7 @@ export default function RootLayout({ children }) {
   - Using [route groups](/docs/app/api-reference/file-conventions/route-groups) like `app/(shop)/layout.js` and `app/(marketing)/layout.js`
   - Omitting `app/layout.js` so layouts in subdirectories like `app/dashboard/layout.js` and `app/blog/layout.js` each become root layouts for their respective directories.
   - Navigating **across multiple root layouts** will cause a **full page load** (as opposed to a client-side navigation).
-- The root layout can be under a **dynamic segment**, for example when implementing [internationalization](/docs/app/guides/internationalization) with `app/[lang]/layout.js`.
+- The root layout can be under a **dynamic segment**, for example when implementing [internationalization](/docs/app/guides/internationalization) with `app/[lang]/layout.js`. Dynamic segments before the root layout are **root parameters** and can be read from any Server Component with [`next/root-params`](/docs/app/api-reference/functions/next-root-params).
 
 ## Caveats
 

--- a/docs/01-app/03-api-reference/04-functions/generate-static-params.mdx
+++ b/docs/01-app/03-api-reference/04-functions/generate-static-params.mdx
@@ -512,6 +512,8 @@ export default function Page({ params }) {
 
 Notice that the params argument can be accessed synchronously and includes only parent segment params.
 
+> **Good to know:** When a parent dynamic segment is a [root parameter](/docs/app/api-reference/functions/next-root-params), you can also read it inside a nested `generateStaticParams` by calling its getter from the `next/root-params` module.
+
 For type completion, you can make use of the TypeScript `Awaited` helper in combination with either [`Page Props helper`](/docs/app/api-reference/file-conventions/page#page-props-helper) or [`Layout Props helper`](/docs/app/api-reference/file-conventions/layout#layout-props-helper):
 
 ```ts filename="app/products/[category]/[product]/page.tsx" switcher

--- a/docs/01-app/03-api-reference/04-functions/next-root-params.mdx
+++ b/docs/01-app/03-api-reference/04-functions/next-root-params.mdx
@@ -355,6 +355,6 @@ The exception is [multiple root layouts](#multiple-root-layouts). When different
 
 ## Version History
 
-| Version   | Changes                                                |
-| --------- | ------------------------------------------------------ |
+| Version   | Changes                        |
+| --------- | ------------------------------ |
 | `v16.3.0` | `next/root-params` introduced. |

--- a/docs/01-app/03-api-reference/04-functions/next-root-params.mdx
+++ b/docs/01-app/03-api-reference/04-functions/next-root-params.mdx
@@ -2,7 +2,6 @@
 title: next/root-params
 nav_title: root-params
 description: API Reference for the next/root-params module that provides access to root-level route parameters.
-version: experimental
 related:
   description: Related API references and conventions.
   links:
@@ -48,27 +47,8 @@ Root parameters are the [dynamic segments](/docs/app/api-reference/file-conventi
 >
 > - Root parameter names must be valid JavaScript function identifiers. Kebab-cased segment names (e.g. `[post-slug]`) are not supported and will cause an error at dev time or during build.
 > - `next/root-params` can be used in Server Components. It cannot be used in Client Components, Server Actions, or [Route Handlers](/docs/app/api-reference/file-conventions/route). Support for Route Handlers is planned for a future release.
+> - With [Cache Components](/docs/app/api-reference/config/next-config-js/cacheComponents) enabled, [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params) must return at least one value for each root parameter. Providing values makes them static route parameters, required for prerendering static shells.
 > - The examples on this page use [`PageProps`](/docs/app/api-reference/file-conventions/page#page-props-helper) and [`LayoutProps`](/docs/app/api-reference/file-conventions/layout#layout-props-helper), which are auto-generated type helpers based on your route structure.
-
-## Configuration
-
-Enable the `rootParams` experimental flag in your Next config file:
-
-```js filename="next.config.js"
-/** @type {import('next').NextConfig} */
-const nextConfig = {
-  experimental: {
-    rootParams: true,
-  },
-}
-
-module.exports = nextConfig
-```
-
-> **Good to know:**
->
-> - If you have [`cacheComponents`](/docs/app/api-reference/config/next-config-js/cacheComponents) enabled, `rootParams` is automatically enabled as well.
-> - With Cache Components, [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params) must return at least one value for each root parameter. Providing values makes it a static route parameter, which is required for prerendering static shells.
 
 ## Root parameters and other route parameters
 

--- a/docs/01-app/03-api-reference/04-functions/next-root-params.mdx
+++ b/docs/01-app/03-api-reference/04-functions/next-root-params.mdx
@@ -387,7 +387,7 @@ app/
 
 In this example, `lang` is the only root parameter. The `page.tsx` directly under the root layout has no `slug` at all. The blog and store branches both define `slug`, but with different segment types (`[slug]` vs `[...slug]`). Each route only knows about its own route parameters. The same name can have different types, different meanings, or not exist at all depending on the route. This is why route parameters below the root layout are accessed through the `params` prop rather than as global getters.
 
-The exception is [multiple root layouts](#multiple-root-layouts). When different root layouts define different route parameters, the getter functions include `undefined` in their return type to account for routes where a given parameter may not exist. Navigating between routes in different root layouts is a full-page (MPA) navigation, so the root parameters resolve once per root layout and remain stable for every route rendered underneath it.
+The exception is [multiple root layouts](#multiple-root-layouts). When different root layouts define different route parameters, the getter functions include `undefined` in their return type to account for routes where a given parameter may not exist.
 
 ## Version History
 

--- a/docs/01-app/03-api-reference/04-functions/next-root-params.mdx
+++ b/docs/01-app/03-api-reference/04-functions/next-root-params.mdx
@@ -1,0 +1,360 @@
+---
+title: next/root-params
+nav_title: root-params
+description: API Reference for the next/root-params module that provides access to root-level route parameters.
+version: draft
+related:
+  description: Related API references and conventions.
+  links:
+    - app/api-reference/file-conventions/layout
+    - app/api-reference/functions/generate-static-params
+    - app/api-reference/directives/use-cache
+    - app/api-reference/file-conventions/dynamic-routes
+---
+
+The `next/root-params` module provides getter functions for accessing root-level [parameters](/docs/app/api-reference/file-conventions/dynamic-routes) in [**Server Components**](/docs/app/glossary#server-component). Each root parameter is exported as an async function that resolves to the parameter value for the current route.
+
+The export names are generated from your dynamic segment folder names. For example, if your root layout is inside `app/[locale]`, you import `locale` from `next/root-params`.
+
+This is useful for values like a language or locale segment that need to be accessed across your application, for example in shared utilities, layouts, and deeply nested components, without passing them down as props.
+
+```tsx filename="app/[lang]/layout.tsx" highlight={1,5} switcher
+import { lang } from 'next/root-params'
+
+export default async function RootLayout(props: LayoutProps<'/[lang]'>) {
+  return (
+    <html lang={await lang()}>
+      <body>{props.children}</body>
+    </html>
+  )
+}
+```
+
+```jsx filename="app/[lang]/layout.js" highlight={1,5} switcher
+import { lang } from 'next/root-params'
+
+export default async function RootLayout({ children }) {
+  return (
+    <html lang={await lang()}>
+      <body>{children}</body>
+    </html>
+  )
+}
+```
+
+Root parameters are the [dynamic segments](/docs/app/api-reference/file-conventions/dynamic-routes) that appear before the [root layout](/docs/app/api-reference/file-conventions/layout#root-layout). Unlike the regular [`params` prop](/docs/app/api-reference/file-conventions/page#params-optional), root parameter getters can be called from any Server Component in your application without prop drilling. See [Why root parameters are special](#why-root-parameters-are-special) for more details.
+
+> **Good to know:**
+>
+> - Root parameter names must be valid JavaScript function identifiers. Kebab-cased segment names (e.g. `[post-slug]`) are not supported and will cause an error at dev time or during build.
+> - `next/root-params` can be used in Server Components. It cannot be used in Client Components, Server Actions, or [Route Handlers](/docs/app/api-reference/file-conventions/route). Support for Route Handlers is planned for a future release.
+> - The examples on this page use [`PageProps`](/docs/app/api-reference/file-conventions/page#page-props-helper) and [`LayoutProps`](/docs/app/api-reference/file-conventions/layout#layout-props-helper), which are auto-generated type helpers based on your route structure.
+
+## Configuration
+
+Enable the `rootParams` experimental flag in your Next config file:
+
+```js filename="next.config.js"
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    rootParams: true,
+  },
+}
+
+module.exports = nextConfig
+```
+
+> **Good to know:**
+>
+> - If you have [`cacheComponents`](/docs/app/api-reference/config/next-config-js/cacheComponents) enabled, `rootParams` is automatically enabled as well.
+> - With Cache Components, [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params) must return at least one value for each root parameter. Providing values makes it a static route parameter, which is required for prerendering static shells.
+
+## Root parameters and other route parameters
+
+Root parameters are the route parameters from [dynamic segments](/docs/app/glossary#dynamic-route-segments) that appear in the path up to the root layout file. Other route parameters deeper in the route tree are accessed through the [`params` prop](/docs/app/api-reference/file-conventions/page#params-optional).
+
+Given this file structure:
+
+- `app/[lang]/layout.tsx` (root layout)
+- `app/[lang]/posts/[slug]/page.tsx`
+
+Only `lang` is a root parameter. `slug` is a regular route parameter:
+
+```tsx filename="app/[lang]/posts/[slug]/page.tsx" highlight={1,5} switcher
+import { lang } from 'next/root-params'
+
+export default async function PostPage(
+  props: PageProps<'/[lang]/posts/[slug]'>
+) {
+  const { slug } = await props.params
+  const language = await lang()
+
+  return (
+    <article>
+      <p>Language: {language}</p>
+      <p>Post: {slug}</p>
+    </article>
+  )
+}
+```
+
+```jsx filename="app/[lang]/posts/[slug]/page.js" highlight={1,5} switcher
+import { lang } from 'next/root-params'
+
+export default async function PostPage({ params }) {
+  const { slug } = await params
+  const language = await lang()
+
+  return (
+    <article>
+      <p>Language: {language}</p>
+      <p>Post: {slug}</p>
+    </article>
+  )
+}
+```
+
+## Accessing root parameters in shared code
+
+Root parameter getters are module imports, they can be called from any Server Component or server-side utility, not just layouts and pages:
+
+```tsx filename="lib/get-translations.ts" highlight={4}
+import { lang } from 'next/root-params'
+
+export async function getTranslations() {
+  const language = await lang()
+  // Load translations based on the root language parameter
+  return import(`@/locales/${language}.json`)
+}
+```
+
+> **Good to know:** You do not need to add `import 'server-only'` to files that use `next/root-params`. The import already fails at build time if used in a Client Component.
+
+## Behavior with caching directives
+
+Because root parameter getters are imported functions, Next.js can track which ones a [cached](/docs/app/api-reference/directives/use-cache) function uses. Only those root parameters become part of the [cache key](/docs/app/api-reference/directives/use-cache#cache-keys), so cache entries are not split across unrelated parameter values.
+
+```tsx filename="app/[lang]/components/cached-nav.tsx" highlight={7} switcher
+import { lang } from 'next/root-params'
+
+// The cache key for this function only includes `lang`,
+// not every dynamic segment in the route.
+async function getNavigation() {
+  'use cache'
+  const language = await lang()
+  const res = await fetch(`https://api.example.com/nav?lang=${language}`)
+  return res.json()
+}
+
+export default async function CachedNav() {
+  const nav = await getNavigation()
+  return <nav>{/* render nav items */}</nav>
+}
+```
+
+```jsx filename="app/[lang]/components/cached-nav.js" highlight={7} switcher
+import { lang } from 'next/root-params'
+
+// The cache key for this function only includes `lang`,
+// not every dynamic segment in the route.
+async function getNavigation() {
+  'use cache'
+  const language = await lang()
+  const res = await fetch(`https://api.example.com/nav?lang=${language}`)
+  return res.json()
+}
+
+export default async function CachedNav() {
+  const nav = await getNavigation()
+  return <nav>{/* render nav items */}</nav>
+}
+```
+
+With the regular `params` prop, you would need to `await params` outside the cached function and pass the value in as an argument:
+
+```tsx filename="app/[lang]/page.tsx" highlight={6,17} switcher
+import { lang } from 'next/root-params'
+
+// With root params: call directly inside the cached function
+async function getDataWithRootParams() {
+  'use cache'
+  const language = await lang()
+  return fetch(`https://api.example.com/data?lang=${language}`)
+}
+
+// Without root params: await params outside, pass as argument
+async function getDataWithParams(language: string) {
+  'use cache'
+  return fetch(`https://api.example.com/data?lang=${language}`)
+}
+
+export default async function Page(props: PageProps<'/[lang]'>) {
+  const { lang: language } = await props.params
+  const data = await getDataWithParams(language)
+  // ...
+}
+```
+
+```jsx filename="app/[lang]/page.js" highlight={6,17} switcher
+import { lang } from 'next/root-params'
+
+// With root params: call directly inside the cached function
+async function getDataWithRootParams() {
+  'use cache'
+  const language = await lang()
+  return fetch(`https://api.example.com/data?lang=${language}`)
+}
+
+// Without root params: await params outside, pass as argument
+async function getDataWithParams(language) {
+  'use cache'
+  return fetch(`https://api.example.com/data?lang=${language}`)
+}
+
+export default async function Page({ params }) {
+  const { lang: language } = await params
+  const data = await getDataWithParams(language)
+  // ...
+}
+```
+
+## Multiple root layouts
+
+When an application has multiple root layouts with different parameters, getter functions are typed to account for usage in any of all possible routes. A parameter that does not exist in every root layout has the type `string | undefined`.
+
+Given this file structure:
+
+- `app/dashboard/[id]/layout.tsx` (root layout with `id`)
+- `app/marketing/layout.tsx` (root layout without `id`)
+
+```tsx filename="app/dashboard/[id]/page.tsx" highlight={4} switcher
+import { id } from 'next/root-params'
+
+export default async function DashboardPage() {
+  const dashboardId = await id() // string | undefined
+  return <div>Dashboard: {dashboardId}</div>
+}
+```
+
+```jsx filename="app/dashboard/[id]/page.js" highlight={4} switcher
+import { id } from 'next/root-params'
+
+export default async function DashboardPage() {
+  const dashboardId = await id() // string | undefined
+  return <div>Dashboard: {dashboardId}</div>
+}
+```
+
+Since `id` does not exist in the marketing root layout, `await id()` returns `undefined` when accessed from marketing routes.
+
+## Catch-all and optional catch-all segments
+
+Root parameters work with [catch-all and optional catch-all](/docs/app/api-reference/file-conventions/dynamic-routes#catch-all-segments) segments:
+
+```tsx filename="app/docs/[...path]/layout.tsx" highlight={4} switcher
+import { path } from 'next/root-params'
+
+export default async function DocsLayout(
+  props: LayoutProps<'/docs/[...path]'>
+) {
+  const segments = await path() // string[] | undefined
+  return (
+    <div>
+      <nav>Path: {segments?.join(' / ')}</nav>
+      {props.children}
+    </div>
+  )
+}
+```
+
+```jsx filename="app/docs/[...path]/layout.js" highlight={4} switcher
+import { path } from 'next/root-params'
+
+export default async function DocsLayout({ children }) {
+  const segments = await path() // string[] | undefined
+  return (
+    <div>
+      <nav>Path: {segments?.join(' / ')}</nav>
+      {children}
+    </div>
+  )
+}
+```
+
+## Returns
+
+Each root parameter getter returns a `Promise` that resolves to one of the following:
+
+| Segment type       | Example       | Return type             |
+| ------------------ | ------------- | ----------------------- |
+| Dynamic            | `[id]`        | `string`                |
+| Catch-all          | `[...path]`   | `string[]`              |
+| Optional catch-all | `[[...path]]` | `string[] \| undefined` |
+
+If the parameter does not exist in the current route's root layout (see [Multiple root layouts](#multiple-root-layouts)), the return type includes `undefined`.
+
+## Restrictions
+
+### Server Components only
+
+Root parameter getters can only be used in Server Components:
+
+```tsx
+// This will cause a build error
+'use client'
+
+import { lang } from 'next/root-params' // Error: Cannot import in Client Component
+```
+
+### Not available in `unstable_cache`
+
+Calling a root parameter getter inside `unstable_cache` will throw a runtime error. Use [`"use cache"`](/docs/app/api-reference/directives/use-cache) instead.
+
+```tsx
+import { lang } from 'next/root-params'
+import { unstable_cache } from 'next/cache'
+
+const getCachedData = unstable_cache(async () => {
+  const language = await lang() // Error: Not supported inside unstable_cache
+  return fetch(`https://api.example.com/data?lang=${language}`)
+})
+```
+
+### Not available in Server Actions
+
+```tsx
+import { lang } from 'next/root-params'
+
+async function submitForm() {
+  'use server'
+  const language = await lang() // Error: Not supported in Server Actions
+}
+```
+
+## Why root parameters are special
+
+The [root layout](/docs/app/api-reference/file-conventions/layout#root-layout) is the top-level rendering boundary. The route parameters before it are shared by all routes under that root layout, which is what makes them safe to access from any Server Component in that tree. Route parameters deeper in the route vary depending on which child page is being rendered, so they are only available through the [`params` prop](/docs/app/api-reference/file-conventions/page#params-optional) in the page or layout that defines them.
+
+```txt
+app/
+  [lang]/              ← root parameter (shared by all routes below)
+    layout.tsx         ← root layout
+    page.tsx           ← has no slug, doesn't know about blog or store
+    blog/
+      [slug]/          ← route parameter
+        page.tsx
+    store/
+      [...slug]/       ← catch-all route parameter with the same name
+        page.tsx
+```
+
+In this example, `lang` is the only root parameter. The `page.tsx` directly under the root layout has no `slug` at all. The blog and store branches both define `slug`, but with different segment types (`[slug]` vs `[...slug]`). Each route only knows about its own route parameters. The same name can have different types, different meanings, or not exist at all depending on the route. This is why route parameters below the root layout are accessed through the `params` prop rather than as global getters.
+
+The exception is [multiple root layouts](#multiple-root-layouts). When different root layouts define different route parameters, the getter functions include `undefined` in their return type to account for routes where a given parameter may not exist. Navigating between routes in different root layouts is a full-page (MPA) navigation, so the root parameters resolve once per root layout and remain stable for every route rendered underneath it.
+
+## Version History
+
+| Version   | Changes                                                |
+| --------- | ------------------------------------------------------ |
+| `v16.3.0` | `next/root-params` introduced. |

--- a/docs/01-app/03-api-reference/04-functions/next-root-params.mdx
+++ b/docs/01-app/03-api-reference/04-functions/next-root-params.mdx
@@ -2,7 +2,7 @@
 title: next/root-params
 nav_title: root-params
 description: API Reference for the next/root-params module that provides access to root-level route parameters.
-version: draft
+version: experimental
 related:
   description: Related API references and conventions.
   links:
@@ -215,6 +215,42 @@ async function getDataWithParams(language) {
 export default async function Page({ params }) {
   const { lang: language } = await params
   const data = await getDataWithParams(language)
+  // ...
+}
+```
+
+## Use in `generateStaticParams` for nested segments
+
+Inside a nested segment's [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params), you can read a root parameter directly with its getter, instead of destructuring it from the `params` argument:
+
+```tsx filename="app/[lang]/posts/[slug]/page.tsx" highlight={1,4} switcher
+import { lang } from 'next/root-params'
+
+export async function generateStaticParams() {
+  const language = await lang()
+  const posts = await fetch(
+    `https://api.example.com/posts?lang=${language}`
+  ).then((res) => res.json())
+  return posts.map((post) => ({ slug: post.slug }))
+}
+
+export default async function Page() {
+  // ...
+}
+```
+
+```jsx filename="app/[lang]/posts/[slug]/page.js" highlight={1,4} switcher
+import { lang } from 'next/root-params'
+
+export async function generateStaticParams() {
+  const language = await lang()
+  const posts = await fetch(
+    `https://api.example.com/posts?lang=${language}`
+  ).then((res) => res.json())
+  return posts.map((post) => ({ slug: post.slug }))
+}
+
+export default async function Page() {
   // ...
 }
 ```


### PR DESCRIPTION
Continuation of: https://github.com/vercel/next.js/pull/82244

Closes: https://linear.app/vercel/issue/DOC-4924/nextroot-params-documentation

## TODO

- [x] adjust code snippets
- [x] wait for a couple more features to land (type safety support)
- [x] Route Handlers
- [x] Supported inside generateStaticParams for nested segments
- [x] x-ref for discoverability
- [x] enabled/available without a flag - the experimental flag has been removed