### PR TITLE
doc: clarify rewrites execution order

### DIFF
--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/rewrites.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/rewrites.mdx
@@ -91,10 +91,11 @@ The order Next.js routes are checked is:
 1. [headers](/docs/app/api-reference/config/next-config-js/headers) are checked/applied
 2. [redirects](/docs/app/api-reference/config/next-config-js/redirects) are checked/applied
 3. [proxy](/docs/app/api-reference/file-conventions/proxy)
-4. `beforeFiles` rewrites are checked/applied
+4. `beforeFiles` rewrites: for each entry, if `source` matches the request, it's rewritten to `destination`.
 5. static files from the [public directory](/docs/app/api-reference/file-conventions/public-folder), `_next/static` files, and non-dynamic pages are checked/served
-6. `afterFiles` rewrites are checked/applied, if one of these rewrites is matched we check dynamic routes/static files after each match
-7. `fallback` rewrites are checked/applied, these are applied before rendering the 404 page and after dynamic routes/all static assets have been checked. If you use [fallback: true/'blocking'](/docs/pages/api-reference/functions/get-static-paths#fallback-true) in `getStaticPaths`, the fallback `rewrites` defined in your `next.config.js` will _not_ be run.
+6. `afterFiles` rewrites are tried in order. If a `source` matches the request, it's rewritten to `destination`; the first rewrite that resolves to a static file, page, or dynamic route is served.
+7. dynamic routes (e.g., `app/blog/[slug]/page.tsx`) are matched against the current path
+8. `fallback` rewrites are checked/applied, these are applied before rendering the 404 page and after dynamic routes/all static assets have been checked. If you use [fallback: true/'blocking'](/docs/pages/api-reference/functions/get-static-paths#fallback-true) in `getStaticPaths`, the fallback `rewrites` defined in your `next.config.js` will _not_ be run.
 
 </AppOnly>
 
@@ -102,10 +103,11 @@ The order Next.js routes are checked is:
 
 1. [headers](/docs/pages/api-reference/config/next-config-js/headers) are checked/applied
 2. [redirects](/docs/pages/api-reference/config/next-config-js/redirects) are checked/applied
-3. `beforeFiles` rewrites are checked/applied
+3. `beforeFiles` rewrites: for each entry, if `source` matches the request, it's rewritten to `destination`.
 4. static files from the [public directory](/docs/pages/api-reference/file-conventions/public-folder), `_next/static` files, and non-dynamic pages are checked/served
-5. `afterFiles` rewrites are checked/applied, if one of these rewrites is matched we check dynamic routes/static files after each match
-6. `fallback` rewrites are checked/applied, these are applied before rendering the 404 page and after dynamic routes/all static assets have been checked. If you use [fallback: true/'blocking'](/docs/pages/api-reference/functions/get-static-paths#fallback-true) in `getStaticPaths`, the fallback `rewrites` defined in your `next.config.js` will _not_ be run.
+5. `afterFiles` rewrites are tried in order. If a `source` matches the request, it's rewritten to `destination`; the first rewrite that resolves to a static file, page, or dynamic route is served.
+6. dynamic routes (e.g., `pages/blog/[slug].tsx`) are matched against the current path
+7. `fallback` rewrites are checked/applied, these are applied before rendering the 404 page and after dynamic routes/all static assets have been checked. If you use [fallback: true/'blocking'](/docs/pages/api-reference/functions/get-static-paths#fallback-true) in `getStaticPaths`, the fallback `rewrites` defined in your `next.config.js` will _not_ be run.
 
 </PagesOnly>
 

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/rewrites.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/rewrites.mdx
@@ -91,11 +91,11 @@ The order Next.js routes are checked is:
 1. [headers](/docs/app/api-reference/config/next-config-js/headers) are checked/applied
 2. [redirects](/docs/app/api-reference/config/next-config-js/redirects) are checked/applied
 3. [proxy](/docs/app/api-reference/file-conventions/proxy)
-4. `beforeFiles` rewrites: for each entry, if `source` matches the request, it's rewritten to `destination`.
+4. `beforeFiles` rewrites: for each entry, if `source`, `has`, and `missing` matches the request, it's rewritten to `destination`.
 5. static files from the [public directory](/docs/app/api-reference/file-conventions/public-folder), `_next/static` files, and non-dynamic pages are checked/served
-6. `afterFiles` rewrites are tried in order. If a `source` matches the request, it's rewritten to `destination`; the first rewrite that resolves to a static file, page, or dynamic route is served.
+6. `afterFiles` rewrites are tried in order. If a `source`, `has`, and `missing` matches the request, it's rewritten to `destination`; the first rewrite that resolves to a static file, page, or dynamic route is served.
 7. dynamic routes (e.g., `app/blog/[slug]/page.tsx`) are matched against the current path
-8. `fallback` rewrites are checked/applied, these are applied before rendering the 404 page and after dynamic routes/all static assets have been checked. If you use [fallback: true/'blocking'](/docs/pages/api-reference/functions/get-static-paths#fallback-true) in `getStaticPaths`, the fallback `rewrites` defined in your `next.config.js` will _not_ be run.
+8. `fallback` rewrites are checked/applied, these are applied before rendering the 404 page and after dynamic routes/all static assets have been checked. If you use [fallback: true/'blocking'](/docs/pages/api-reference/functions/get-static-paths#fallback-true) in `getStaticPaths`, those dynamic routes take priority over the fallback `rewrites` defined in your `next.config.js`.
 
 </AppOnly>
 


### PR DESCRIPTION
Rework the execution order of rewrites.

- before and after Files execution is now clearer - when a source matches and how the destination resolves
- explicit `dynamic routes` step (similar to Proxy's, https://nextjs.org/docs/app/api-reference/file-conventions/proxy#execution-order)
