### PR TITLE
Craigandrews/ensure isr lru is written if requests collapsed

### DIFF
--- a/packages/next/src/server/response-cache/index.test.ts
+++ b/packages/next/src/server/response-cache/index.test.ts
@@ -1,0 +1,116 @@
+import ResponseCache from './index'
+import { CachedRouteKind, type ResponseCacheEntry } from './types'
+import { RouteKind } from '../route-kind'
+import RenderResult from '../render-result'
+import { HTML_CONTENT_TYPE_HEADER } from '../../lib/constants'
+
+function mockIncrementalCache() {
+  return {
+    get: jest.fn().mockResolvedValue(null),
+    set: jest.fn().mockResolvedValue(undefined),
+  }
+}
+
+function makeCacheEntry(html: string): ResponseCacheEntry {
+  return {
+    value: {
+      kind: CachedRouteKind.APP_PAGE,
+      html: RenderResult.fromStatic(html, HTML_CONTENT_TYPE_HEADER),
+      rscData: Buffer.from('rsc-payload'),
+      postponed: undefined,
+      status: 200,
+      headers: undefined,
+      segmentData: undefined,
+    },
+    cacheControl: { revalidate: 60, expire: undefined },
+  }
+}
+
+describe('ResponseCache', () => {
+  describe('minimal mode LRU population for batched invocations', () => {
+    it('should populate LRU for all batched invocationIDs, not just the winner', async () => {
+      const cache = new ResponseCache(true)
+      const incrementalCache = mockIncrementalCache()
+
+      let renderCount = 0
+      let resolveRender: () => void
+      const renderStarted = new Promise<void>((r) => {
+        resolveRender = r
+      })
+
+      const responseGenerator = jest.fn(async () => {
+        renderCount++
+        if (renderCount === 1) {
+          resolveRender()
+          // Simulate a slow render
+          await new Promise((r) => setTimeout(r, 50))
+        }
+        return makeCacheEntry(`render-${renderCount}`)
+      })
+
+      // Invocation A starts a render
+      const promiseA = cache.get('/test', responseGenerator, {
+        routeKind: RouteKind.APP_PAGE,
+        incrementalCache,
+        invocationID: 'invocation-a',
+      })
+
+      // Wait for render to start, then send invocation B
+      await renderStarted
+
+      const promiseB = cache.get('/test', responseGenerator, {
+        routeKind: RouteKind.APP_PAGE,
+        incrementalCache,
+        invocationID: 'invocation-b',
+      })
+
+      const [resultA, resultB] = await Promise.all([promiseA, promiseB])
+
+      // Both should get the same render result (only 1 render executed)
+      expect(renderCount).toBe(1)
+      expect(resultA).not.toBeNull()
+      expect(resultB).not.toBeNull()
+
+      // Now simulate follow-up requests (e.g. RSC format) for each invocation.
+      // These should hit the LRU and NOT trigger a new render.
+      const followUpB = await cache.get('/test', responseGenerator, {
+        routeKind: RouteKind.APP_PAGE,
+        incrementalCache,
+        invocationID: 'invocation-b',
+      })
+
+      // If the fix works, invocation-b's follow-up hits the LRU
+      // and does NOT trigger a second render.
+      expect(renderCount).toBe(1)
+      expect(followUpB).not.toBeNull()
+    })
+
+    it('should not write to LRU when invocationID is absent', async () => {
+      const cache = new ResponseCache(true)
+      const incrementalCache = mockIncrementalCache()
+
+      let renderCount = 0
+      const responseGenerator = jest.fn(async () => {
+        renderCount++
+        return makeCacheEntry(`render-${renderCount}`)
+      })
+
+      await cache.get('/test', responseGenerator, {
+        routeKind: RouteKind.APP_PAGE,
+        incrementalCache,
+        // No invocationID — TTL mode
+      })
+
+      // Second request without invocationID should use TTL-based lookup,
+      // not invocationID-scoped lookup
+      await cache.get('/test', responseGenerator, {
+        routeKind: RouteKind.APP_PAGE,
+        incrementalCache,
+      })
+
+      // The TTL path already works (handleRevalidate writes with TTL_SENTINEL key).
+      // Just verify no crash.
+      expect(renderCount).toBeGreaterThanOrEqual(1)
+    })
+  })
+})

--- a/packages/next/src/server/response-cache/index.test.ts
+++ b/packages/next/src/server/response-cache/index.test.ts
@@ -42,20 +42,17 @@ describe('ResponseCache', () => {
         renderCount++
         if (renderCount === 1) {
           resolveRender()
-          // Simulate a slow render
           await new Promise((r) => setTimeout(r, 50))
         }
         return makeCacheEntry(`render-${renderCount}`)
       })
 
-      // Invocation A starts a render
       const promiseA = cache.get('/test', responseGenerator, {
         routeKind: RouteKind.APP_PAGE,
         incrementalCache,
         invocationID: 'invocation-a',
       })
 
-      // Wait for render to start, then send invocation B
       await renderStarted
 
       const promiseB = cache.get('/test', responseGenerator, {
@@ -66,26 +63,22 @@ describe('ResponseCache', () => {
 
       const [resultA, resultB] = await Promise.all([promiseA, promiseB])
 
-      // Both should get the same render result (only 1 render executed)
       expect(renderCount).toBe(1)
       expect(resultA).not.toBeNull()
       expect(resultB).not.toBeNull()
 
-      // Now simulate follow-up requests (e.g. RSC format) for each invocation.
-      // These should hit the LRU and NOT trigger a new render.
+      // Follow-up request for invocation-b should hit the LRU
       const followUpB = await cache.get('/test', responseGenerator, {
         routeKind: RouteKind.APP_PAGE,
         incrementalCache,
         invocationID: 'invocation-b',
       })
 
-      // If the fix works, invocation-b's follow-up hits the LRU
-      // and does NOT trigger a second render.
       expect(renderCount).toBe(1)
       expect(followUpB).not.toBeNull()
     })
 
-    it('should not write to LRU when invocationID is absent', async () => {
+    it('should use TTL-based LRU when invocationID is absent', async () => {
       const cache = new ResponseCache(true)
       const incrementalCache = mockIncrementalCache()
 
@@ -98,19 +91,15 @@ describe('ResponseCache', () => {
       await cache.get('/test', responseGenerator, {
         routeKind: RouteKind.APP_PAGE,
         incrementalCache,
-        // No invocationID — TTL mode
       })
 
-      // Second request without invocationID should use TTL-based lookup,
-      // not invocationID-scoped lookup
-      await cache.get('/test', responseGenerator, {
+      const followUp = await cache.get('/test', responseGenerator, {
         routeKind: RouteKind.APP_PAGE,
         incrementalCache,
       })
 
-      // The TTL path already works (handleRevalidate writes with TTL_SENTINEL key).
-      // Just verify no crash.
-      expect(renderCount).toBeGreaterThanOrEqual(1)
+      expect(renderCount).toBe(1)
+      expect(followUp).not.toBeNull()
     })
   })
 })

--- a/packages/next/src/server/response-cache/index.ts
+++ b/packages/next/src/server/response-cache/index.ts
@@ -295,6 +295,21 @@ export default class ResponseCache implements ResponseCacheBase {
       }
     )
 
+    if (
+      this.minimal_mode &&
+      response &&
+      invocationID &&
+      response.cacheControl
+    ) {
+      const cacheKey = createCacheKey(key, invocationID)
+      if (!this.cache.get(cacheKey)) {
+        this.cache.set(cacheKey, {
+          entry: response,
+          expiresAt: Date.now() + this.ttl,
+        })
+      }
+    }
+
     return toResponseCacheEntry(response)
   }
 

--- a/packages/next/src/server/response-cache/index.ts
+++ b/packages/next/src/server/response-cache/index.ts
@@ -295,19 +295,12 @@ export default class ResponseCache implements ResponseCacheBase {
       }
     )
 
-    if (
-      this.minimal_mode &&
-      response &&
-      invocationID &&
-      response.cacheControl
-    ) {
+    if (this.minimal_mode && response?.cacheControl) {
       const cacheKey = createCacheKey(key, invocationID)
-      if (!this.cache.get(cacheKey)) {
-        this.cache.set(cacheKey, {
-          entry: response,
-          expiresAt: Date.now() + this.ttl,
-        })
-      }
+      this.cache.set(cacheKey, {
+        entry: response,
+        expiresAt: Date.now() + this.ttl,
+      })
     }
 
     return toResponseCacheEntry(response)
@@ -377,9 +370,7 @@ export default class ResponseCache implements ResponseCacheBase {
         context.isFallback,
         responseGenerator,
         previousIncrementalCacheEntry,
-        resolved,
-        undefined,
-        context.invocationID
+        resolved
       )
 
       // Handle null response
@@ -432,8 +423,7 @@ export default class ResponseCache implements ResponseCacheBase {
     responseGenerator: ResponseGenerator,
     previousIncrementalCacheEntry: IncrementalResponseCacheEntry | null,
     hasResolved: boolean,
-    waitUntil?: (prom: Promise<any>) => void,
-    invocationID?: string
+    waitUntil?: (prom: Promise<any>) => void
   ) {
     return this.revalidateBatcher.batch(key, () => {
       const promise = this.handleRevalidate(
@@ -443,8 +433,7 @@ export default class ResponseCache implements ResponseCacheBase {
         isFallback,
         responseGenerator,
         previousIncrementalCacheEntry,
-        hasResolved,
-        invocationID
+        hasResolved
       )
 
       // We need to ensure background revalidates are passed to waitUntil.
@@ -461,8 +450,7 @@ export default class ResponseCache implements ResponseCacheBase {
     isFallback: boolean,
     responseGenerator: ResponseGenerator,
     previousIncrementalCacheEntry: IncrementalResponseCacheEntry | null,
-    hasResolved: boolean,
-    invocationID: string | undefined
+    hasResolved: boolean
   ) {
     try {
       // Generate the response cache entry using the response generator.
@@ -482,24 +470,14 @@ export default class ResponseCache implements ResponseCacheBase {
       })
 
       // We want to persist the result only if it has a cache control value
-      // defined.
-      if (incrementalResponseCacheEntry.cacheControl) {
-        if (this.minimal_mode) {
-          // Set TTL expiration for cache hit validation. Entries are validated
-          // by invocationID when available, with TTL as a fallback for providers
-          // that don't send x-invocation-id. Memory is managed by LRU eviction.
-          const cacheKey = createCacheKey(key, invocationID)
-          this.cache.set(cacheKey, {
-            entry: incrementalResponseCacheEntry,
-            expiresAt: Date.now() + this.ttl,
-          })
-        } else {
-          await incrementalCache.set(key, incrementalResponseCacheEntry.value, {
-            cacheControl: incrementalResponseCacheEntry.cacheControl,
-            isRoutePPREnabled,
-            isFallback,
-          })
-        }
+      // defined. The minimal mode LRU write is handled in get() so that
+      // every caller — including batched invocations — populates the cache.
+      if (incrementalResponseCacheEntry.cacheControl && !this.minimal_mode) {
+        await incrementalCache.set(key, incrementalResponseCacheEntry.value, {
+          cacheControl: incrementalResponseCacheEntry.cacheControl,
+          isRoutePPREnabled,
+          isFallback,
+        })
       }
 
       return incrementalResponseCacheEntry


### PR DESCRIPTION
Adopted from: #93699

## Summary

When multiple ISR revalidation invocations (different `x-invocation-id`) arrive concurrently for the same path, the Batcher correctly deduplicates them into a single render. The LRU is only written inside `handleRevalidate`, and only the winning invocation executes this code. Batched invocations return the shared promise directly and never write to the LRU. Their follow-up requests miss the LRU and trigger a new render, cascading under load.

Moved the minimal mode LRU write from `handleRevalidate` to `get()`, after the Batcher resolves. Every caller now writes to the LRU under its own invocation key, so follow-up requests always find a cache entry.

## Test Plan

- Unit test: concurrent invocations with different `invocationID` values verify only one render executes and follow-up requests hit the LRU
